### PR TITLE
Uncorrelated gmf

### DIFF
--- a/java/org/gem/calc/GroundMotionFieldCalculator.java
+++ b/java/org/gem/calc/GroundMotionFieldCalculator.java
@@ -288,9 +288,10 @@ public class GroundMotionFieldCalculator {
     }
 
     private static void checkRandomNumberIsNotNull(Random rn) {
-        if (rn == null)
+        if (rn == null) {
             throw new IllegalArgumentException(
                     "Random number generator cannot be null");
+        }
     }
 
     /**

--- a/java_tests/org/gem/calc/GroundMotionFieldCalculatorTest.java
+++ b/java_tests/org/gem/calc/GroundMotionFieldCalculatorTest.java
@@ -53,6 +53,14 @@ public class GroundMotionFieldCalculatorTest {
     long seed = 123456789;
     int numRealizations = 3000;
 
+    private final ParameterChangeWarningListener testParamChangeListener =
+            new ParameterChangeWarningListener() {
+                @Override
+                public void parameterChangeWarning(
+                        ParameterChangeWarningEvent event) {
+                }
+            };
+
     @Before
     public void setUp() {
         setIml();
@@ -716,13 +724,5 @@ public class GroundMotionFieldCalculatorTest {
         EqkRupture rup = new EqkRupture(mag, aveRake, rupSurf, hypo);
         return rup;
     }
-
-    private final ParameterChangeWarningListener testParamChangeListener =
-            new ParameterChangeWarningListener() {
-                @Override
-                public void parameterChangeWarning(
-                        ParameterChangeWarningEvent event) {
-                }
-            };
 
 }


### PR DESCRIPTION
Added capability to compute non-correlated ground motion fields using inter and intra event standard deviations separately (that is generate a single inter-event residual for all sites, and then generate intra-event residuals for each site independently, as suggested by Helen Crowley). In case of a GMPE that supports only total standard deviation, generate residual according to total standard deviation only. Added test to check for this situation.
Refactored code in GroundMotionFieldCalculator class (to improve readability) and added more documentation.
Reduced computation time associated with GroundMotionFieldCalculatorTest class (many of these tests utilize Monte Carlo sampling; I reduced the number of samples generated by the tests, but I keep a sufficient number of samples realizations so that the tests pass)
