### PR TITLE
Simplified db schema enumeration types

### DIFF
--- a/db/schema/comments.sql
+++ b/db/schema/comments.sql
@@ -89,6 +89,12 @@ COMMENT ON COLUMN pshai.rupture.magnitude_type IS 'Magnitude type i.e. one of:
     - local magnitude (Ml)
     - surface wave magnitude (Ms)
     - moment magnitude (Mw)';
+COMMENT ON COLUMN pshai.rupture.tectonic_region IS 'Tectonic region type i.e. one of:
+    - Active Shallow Crust (active)
+    - Stable Shallow Crust (stable)
+    - Subduction Interface (interface)
+    - Subduction IntraSlab (intraslab)
+    - Volcanic             (volcanic)';
 
 COMMENT ON TABLE pshai.simple_fault IS 'A simple fault geometry.';
 COMMENT ON COLUMN pshai.simple_fault.dip IS 'The fault''s inclination angle with respect to the plane.';
@@ -98,5 +104,9 @@ COMMENT ON COLUMN pshai.simple_fault.outline IS 'The outline of the fault surfac
 
 COMMENT ON TABLE pshai.source IS 'A seismic source, can be based on a point, area or a complex or simple fault.';
 COMMENT ON COLUMN pshai.source.si_type IS 'The source''s seismic input type: can be one of: area, point, complex or simple.';
-
-COMMENT ON TABLE pshai.tectonic_region IS 'Enumeration of tectonic region types';
+COMMENT ON COLUMN pshai.source.tectonic_region IS 'Tectonic region type i.e. one of:
+    - Active Shallow Crust (active)
+    - Stable Shallow Crust (stable)
+    - Subduction Interface (interface)
+    - Subduction IntraSlab (intraslab)
+    - Volcanic             (volcanic)';

--- a/db/schema/indexes.sql
+++ b/db/schema/indexes.sql
@@ -52,4 +52,3 @@ CREATE INDEX pshai_r_rate_mdl_owner_id_idx on pshai.r_rate_mdl(owner_id);
 CREATE INDEX pshai_rupture_owner_id_idx on pshai.rupture(owner_id);
 CREATE INDEX pshai_simple_fault_owner_id_idx on pshai.simple_fault(owner_id);
 CREATE INDEX pshai_source_owner_id_idx on pshai.source(owner_id);
-CREATE INDEX pshai_tectonic_region_owner_id_idx on pshai.tectonic_region(owner_id);

--- a/db/schema/load.sql
+++ b/db/schema/load.sql
@@ -21,9 +21,3 @@
 
 INSERT INTO admin.organization(name) VALUES('GEM Foundation');
 INSERT INTO admin.oq_user(user_name, full_name, organization_id) VALUES('openquake', 'Default user', 1);
-
-INSERT INTO pshai.tectonic_region(name, owner_id) VALUES('Active Shallow Crust', 1);
-INSERT INTO pshai.tectonic_region(name, owner_id) VALUES('Stable Shallow Crust', 1);
-INSERT INTO pshai.tectonic_region(name, owner_id) VALUES('Subduction Interface', 1);
-INSERT INTO pshai.tectonic_region(name, owner_id) VALUES('Subduction IntraSlab', 1);
-INSERT INTO pshai.tectonic_region(name, owner_id) VALUES('Volcanic', 1);

--- a/db/schema/openquake.sql
+++ b/db/schema/openquake.sql
@@ -126,7 +126,15 @@ CREATE TABLE pshai.rupture (
     -- seismic input type
     si_type VARCHAR NOT NULL DEFAULT 'simple'
         CONSTRAINT si_type CHECK (si_type IN ('complex', 'point', 'simple')),
-    tectonic_region_id INTEGER NOT NULL,
+    -- Tectonic region type, one of:
+    --      Active Shallow Crust (active)
+    --      Stable Shallow Crust (stable)
+    --      Subduction Interface (interface)
+    --      Subduction IntraSlab (intraslab)
+    --      Volcanic             (volcanic)
+    tectonic_region VARCHAR NOT NULL CONSTRAINT tect_region_val
+        CHECK(tectonic_region IN (
+            'active', 'stable', 'interface', 'intraslab', 'volcanic')),
     rake float,
         CONSTRAINT rake_value CHECK (
             rake is NULL OR ((rake >= -180.0) AND (rake <= 180.0))),
@@ -159,7 +167,15 @@ CREATE TABLE pshai.source (
     si_type VARCHAR NOT NULL DEFAULT 'simple'
         CONSTRAINT si_type CHECK
         (si_type IN ('area', 'point', 'complex', 'simple')),
-    tectonic_region_id INTEGER NOT NULL,
+    -- Tectonic region type, one of:
+    --      Active Shallow Crust (active)
+    --      Stable Shallow Crust (stable)
+    --      Subduction Interface (interface)
+    --      Subduction IntraSlab (intraslab)
+    --      Volcanic             (volcanic)
+    tectonic_region VARCHAR NOT NULL CONSTRAINT tect_region_val
+        CHECK(tectonic_region IN (
+            'active', 'stable', 'interface', 'intraslab', 'volcanic')),
     simple_fault_id INTEGER,
     complex_fault_id INTEGER,
     rake float,
@@ -350,14 +366,6 @@ CREATE TABLE pshai.focal_mechanism (
 ) TABLESPACE pshai_ts;
 
 
--- Enumeration of tectonic region types
-CREATE TABLE pshai.tectonic_region (
-    id SERIAL PRIMARY KEY,
-    owner_id INTEGER NOT NULL,
-    name VARCHAR NOT NULL
-) TABLESPACE pshai_ts;
-
-
 ------------------------------------------------------------------------
 -- Constraints (foreign keys etc.) go here
 ------------------------------------------------------------------------
@@ -379,9 +387,6 @@ FOREIGN KEY (owner_id) REFERENCES admin.oq_user(id) ON DELETE RESTRICT;
 ALTER TABLE pshai.fault_edge ADD CONSTRAINT pshai_fault_edge_owner_fk
 FOREIGN KEY (owner_id) REFERENCES admin.oq_user(id) ON DELETE RESTRICT;
 
-ALTER TABLE pshai.tectonic_region ADD CONSTRAINT pshai_tectonic_region_owner_fk
-FOREIGN KEY (owner_id) REFERENCES admin.oq_user(id) ON DELETE RESTRICT;
-
 ALTER TABLE pshai.mfd_evd ADD CONSTRAINT pshai_mfd_evd_owner_fk
 FOREIGN KEY (owner_id) REFERENCES admin.oq_user(id) ON DELETE RESTRICT;
 
@@ -396,9 +401,6 @@ FOREIGN KEY (owner_id) REFERENCES admin.oq_user(id) ON DELETE RESTRICT;
 
 ALTER TABLE pshai.r_rate_mdl ADD CONSTRAINT pshai_r_rate_mdl_owner_fk
 FOREIGN KEY (owner_id) REFERENCES admin.oq_user(id) ON DELETE RESTRICT;
-
-ALTER TABLE pshai.source ADD CONSTRAINT pshai_source_tectonic_region_fk
-FOREIGN KEY (tectonic_region_id) REFERENCES pshai.tectonic_region(id) ON DELETE RESTRICT;
 
 ALTER TABLE pshai.complex_fault ADD CONSTRAINT pshai_complex_fault_fault_edge_fk
 FOREIGN KEY (fault_edge_id) REFERENCES pshai.fault_edge(id) ON DELETE RESTRICT;
@@ -441,9 +443,6 @@ FOREIGN KEY (simple_fault_id) REFERENCES pshai.simple_fault(id) ON DELETE RESTRI
 
 ALTER TABLE pshai.rupture ADD CONSTRAINT pshai_rupture_complex_fault_fk
 FOREIGN KEY (complex_fault_id) REFERENCES pshai.complex_fault(id) ON DELETE RESTRICT;
-
-ALTER TABLE pshai.rupture ADD CONSTRAINT pshai_rupture_tectonic_region_fk
-FOREIGN KEY (tectonic_region_id) REFERENCES pshai.tectonic_region(id) ON DELETE RESTRICT;
 
 CREATE TRIGGER pshai_rupture_before_insert_update_trig
 BEFORE INSERT OR UPDATE ON pshai.rupture

--- a/db/schema/security.sql
+++ b/db/schema/security.sql
@@ -116,6 +116,3 @@ GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.simple_fault TO oq_pshai_writer;
 GRANT SELECT ON pshai.source TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.source TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.source TO oq_pshai_writer;
-
--- pshai.tectonic_region
-GRANT SELECT ON pshai.tectonic_region TO GROUP openquake;


### PR DESCRIPTION
The solution to place enumeration-like data in static tables proved to be too awkward. This is a simple refactoring to introduce constrained columns for magnitude and tectonic region types.
