### PR TITLE
add version info to the database

### DIFF
--- a/db/schema/comments.sql
+++ b/db/schema/comments.sql
@@ -28,6 +28,9 @@ COMMENT ON SCHEMA pshai IS 'PSHA input model';
 COMMENT ON TABLE admin.organization IS 'An organization that is utilising the OpenQuake database';
 COMMENT ON TABLE admin.oq_user IS 'An OpenQuake user that is utilising the OpenQuake database';
 COMMENT ON COLUMN admin.oq_user.data_is_open IS 'Whether the data owned by the user is visible to the general public.';
+COMMENT ON TABLE admin.revision_info IS 'Facilitates the keeping of revision information for the OpenQuake database and/or its artefacts (schemas, tables etc.)';
+COMMENT ON COLUMN admin.revision_info.artefact IS 'The name of the database artefact for which we wish to store revision information.';
+COMMENT ON COLUMN admin.revision_info.revision IS 'The revision information for the associated database artefact.';
 
 COMMENT ON TABLE eqcat.catalog IS 'Table with earthquake catalog data, the magnitude(s) and the event surface is kept in separate tables.';
 COMMENT ON COLUMN eqcat.catalog.depth IS 'Earthquake depth (in km)';

--- a/db/schema/indexes.sql
+++ b/db/schema/indexes.sql
@@ -21,6 +21,9 @@
 -- admin.oq_user
 CREATE UNIQUE INDEX admin_oq_user_user_name_uniq_idx ON admin.oq_user(user_name);
 
+-- admin.revision_info
+CREATE UNIQUE INDEX admin_revision_info_artefact_uniq_idx ON admin.revision_info(artefact);
+
 -- eqcat.catalog
 CREATE INDEX eqcat_catalog_agency_idx on eqcat.catalog(agency);
 CREATE INDEX eqcat_catalog_time_idx on eqcat.catalog(time);

--- a/db/schema/load.sql
+++ b/db/schema/load.sql
@@ -21,3 +21,7 @@
 
 INSERT INTO admin.organization(name) VALUES('GEM Foundation');
 INSERT INTO admin.oq_user(user_name, full_name, organization_id) VALUES('openquake', 'Default user', 1);
+
+INSERT INTO admin.revision_info(artefact, revision) VALUES('database:openquake', '0.3.8-2');
+INSERT INTO admin.revision_info(artefact, revision) VALUES('schema:openquake.eqcat', '0.3.8-2');
+INSERT INTO admin.revision_info(artefact, revision) VALUES('schema:openquake.pshai', '0.3.8-2');

--- a/db/schema/openquake.sql
+++ b/db/schema/openquake.sql
@@ -56,6 +56,16 @@ CREATE TABLE admin.oq_user (
 ) TABLESPACE admin_ts;
 
 
+-- Revision information
+CREATE TABLE admin.revision_info (
+    id SERIAL PRIMARY KEY,
+    artefact VARCHAR NOT NULL,
+    revision VARCHAR NOT NULL,
+    last_update timestamp without time zone
+        DEFAULT timezone('UTC'::text, now()) NOT NULL
+) TABLESPACE admin_ts;
+
+
 -- Earthquake catalog
 CREATE TABLE eqcat.catalog (
     id SERIAL PRIMARY KEY,


### PR DESCRIPTION
The added table makes it possible to keep version information pertaining to the database schema in the database (best practice, eases schema and data migration).
