### PR TITLE
Revision info fixes to db schema

### DIFF
--- a/db/schema/comments.sql
+++ b/db/schema/comments.sql
@@ -49,9 +49,9 @@ COMMENT ON COLUMN eqcat.surface.semi_major IS 'Semi-major axis: The longest radi
 
 COMMENT ON TABLE pshai.complex_fault IS 'A complex (fault) geometry, in essence a sequence of fault edges. However, we only support a single fault edge at present.';
 COMMENT ON COLUMN pshai.complex_fault.gid IS 'An alpha-numeric identifier for this complex fault geometry.';
-COMMENT ON COLUMN pshai.complex_fault.mfd_evd_id IS 'Foreign key to a magnitude frequency distribution (truncated Gutenberg-Richter).';
+COMMENT ON COLUMN pshai.complex_fault.mfd_tgr_id IS 'Foreign key to a magnitude frequency distribution (truncated Gutenberg-Richter).';
 COMMENT ON COLUMN pshai.complex_fault.mfd_evd_id IS 'Foreign key to a magnitude frequency distribution (evenly discretized).';
-COMMENT ON COLUMN pshai.complex_fault.mfd_evd_id IS 'Foreign key to a fault edge.';
+COMMENT ON COLUMN pshai.complex_fault.fault_edge_id IS 'Foreign key to a fault edge.';
 COMMENT ON COLUMN pshai.complex_fault.outline IS 'The outline of the fault surface, computed by using the top/bottom fault edges.';
 
 COMMENT ON VIEW pshai.complex_rupture IS 'A complex rupture view, needed for opengeo server integration.';
@@ -70,6 +70,8 @@ COMMENT ON COLUMN pshai.mfd_evd.magnitude_type IS 'Magnitude type i.e. one of:
     - local magnitude (Ml)
     - surface wave magnitude (Ms)
     - moment magnitude (Mw)';
+COMMENT ON COLUMN pshai.mfd_evd.min_val IS 'Minimum magnitude value.';
+COMMENT ON COLUMN pshai.mfd_evd.max_val IS 'Maximum magnitude value (will be derived/calculated for evenly discretized magnitude frequency distributions).';
 
 COMMENT ON TABLE pshai.mfd_tgr IS 'Magnitude frequency distribution, truncated Gutenberg-Richter.';
 COMMENT ON COLUMN pshai.mfd_tgr.magnitude_type IS 'Magnitude type i.e. one of:
@@ -78,6 +80,8 @@ COMMENT ON COLUMN pshai.mfd_tgr.magnitude_type IS 'Magnitude type i.e. one of:
     - local magnitude (Ml)
     - surface wave magnitude (Ms)
     - moment magnitude (Mw)';
+COMMENT ON COLUMN pshai.mfd_tgr.min_val IS 'Minimum magnitude value.';
+COMMENT ON COLUMN pshai.mfd_tgr.max_val IS 'Maximum magnitude value.';
 
 COMMENT ON TABLE pshai.r_depth_distr IS 'Rupture depth distribution.';
 COMMENT ON COLUMN pshai.r_depth_distr.magnitude_type IS 'Magnitude type i.e. one of:

--- a/db/schema/load.sql
+++ b/db/schema/load.sql
@@ -22,6 +22,6 @@
 INSERT INTO admin.organization(name) VALUES('GEM Foundation');
 INSERT INTO admin.oq_user(user_name, full_name, organization_id) VALUES('openquake', 'Default user', 1);
 
-INSERT INTO admin.revision_info(artefact, revision) VALUES('schema/openquake.admin', '0.3.8-3');
-INSERT INTO admin.revision_info(artefact, revision) VALUES('schema/openquake.eqcat', '0.3.8-3');
-INSERT INTO admin.revision_info(artefact, revision) VALUES('schema/openquake.pshai', '0.3.8-3');
+INSERT INTO admin.revision_info(artefact, revision) VALUES('openquake/admin', '0.3.8-3');
+INSERT INTO admin.revision_info(artefact, revision) VALUES('openquake/eqcat', '0.3.8-3');
+INSERT INTO admin.revision_info(artefact, revision) VALUES('openquake/pshai', '0.3.8-3');

--- a/db/schema/openquake.sql
+++ b/db/schema/openquake.sql
@@ -333,6 +333,10 @@ CREATE TABLE pshai.mfd_evd (
     magnitude_type VARCHAR(2) NOT NULL DEFAULT 'Mw' CONSTRAINT mage_type_val
         CHECK(magnitude_type IN ('Mb', 'Md', 'Ml', 'Ms', 'Mw')),
     min_val float NOT NULL,
+    -- The maximum magnitude value will be derived/calculated for evenly
+    -- discretized magnitude frequency distributions.
+    -- It is initialized with a value that should never occur in practice.
+    max_val float NOT NULL DEFAULT -1.0,
     bin_size float NOT NULL,
     mfd_values float[] NOT NULL,
     total_cumulative_rate float,


### PR DESCRIPTION
Hello there!

This branch adds a 'step' column to the 'revision_info' table. This will make
it easier to perform controlled database schema upgrades.

The upgrade tool will query the revision and step of the respective database
schema and apply all upgrade actions with a step greater than the one found in
the database.

Let's assume we have the following data in the database:

openquake=# SELECT revision, step FROM admin.revision_info WHERE artefact='openquake/pshai';
 revision | step 
----------+------
 0.3.8-3  |    0
(1 row)

and the following files on the file system:

```
db/schema/upgrades/openquake/pshai/0.3.8-3/1/01-fix-mfds.sql
db/schema/upgrades/openquake/pshai/0.3.8-3/1/02-add-xxx.sql
```

This would result in the files above being applied (in order) to the database
and the step being increased to 1 for 'openquake/pshai'.

Other than that this branch
    - fixes a few comments/documentation entries
    - adds a maximum magnitude value for evenly discretized magnitude frequency
      distributions
