### PR TITLE
Grant read/write permissions on the pshai tables to role oq_uiapi_writer.

### DIFF
--- a/db/schema/load.sql
+++ b/db/schema/load.sql
@@ -24,5 +24,5 @@ INSERT INTO admin.oq_user(user_name, full_name, organization_id) VALUES('openqua
 
 INSERT INTO admin.revision_info(artefact, revision) VALUES('openquake/admin', '0.3.9-1');
 INSERT INTO admin.revision_info(artefact, revision) VALUES('openquake/eqcat', '0.3.9-1');
-INSERT INTO admin.revision_info(artefact, revision, step) VALUES('openquake/pshai', '0.3.9-1', 3);
+INSERT INTO admin.revision_info(artefact, revision, step) VALUES('openquake/pshai', '0.3.9-1', 4);
 INSERT INTO admin.revision_info(artefact, revision, step) VALUES('openquake/uiapi', '0.3.9-1', 1);

--- a/db/schema/security.sql
+++ b/db/schema/security.sql
@@ -81,51 +81,61 @@ GRANT SELECT,INSERT,UPDATE,DELETE ON eqcat.surface TO oq_eqcat_writer;
 GRANT SELECT ON pshai.complex_fault TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.complex_fault TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.complex_fault TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.complex_fault TO oq_uiapi_writer;
 
 -- pshai.fault_edge
 GRANT SELECT ON pshai.fault_edge TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.fault_edge TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.fault_edge TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.fault_edge TO oq_uiapi_writer;
 
 -- pshai.focal_mechanism
 GRANT SELECT ON pshai.focal_mechanism TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.focal_mechanism TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.focal_mechanism TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.focal_mechanism TO oq_uiapi_writer;
 
 -- pshai.mfd_evd
 GRANT SELECT ON pshai.mfd_evd TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.mfd_evd TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.mfd_evd TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.mfd_evd TO oq_uiapi_writer;
 
 -- pshai.mfd_tgr
 GRANT SELECT ON pshai.mfd_tgr TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.mfd_tgr TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.mfd_tgr TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.mfd_tgr TO oq_uiapi_writer;
 
 -- pshai.r_depth_distr
 GRANT SELECT ON pshai.r_depth_distr TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.r_depth_distr TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.r_depth_distr TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.r_depth_distr TO oq_uiapi_writer;
 
 -- pshai.r_rate_mdl
 GRANT SELECT ON pshai.r_rate_mdl TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.r_rate_mdl TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.r_rate_mdl TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.r_rate_mdl TO oq_uiapi_writer;
 
 -- pshai.rupture
 GRANT SELECT ON pshai.rupture TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.rupture TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.rupture TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.rupture TO oq_uiapi_writer;
 
 -- pshai.simple_fault
 GRANT SELECT ON pshai.simple_fault TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.simple_fault TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.simple_fault TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.simple_fault TO oq_uiapi_writer;
 
 -- pshai.source
 GRANT SELECT ON pshai.source TO GROUP openquake;
 GRANT SELECT,INSERT,UPDATE ON pshai.source TO oq_pshai_etl;
 GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.source TO oq_pshai_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.source TO oq_uiapi_writer;
 
 -- uiapi.input
 GRANT SELECT ON uiapi.input TO GROUP openquake;

--- a/db/schema/upgrades/openquake/pshai/0.3.9-1/4/01-grant-write-access-to-uiapi-writer.sql
+++ b/db/schema/upgrades/openquake/pshai/0.3.9-1/4/01-grant-write-access-to-uiapi-writer.sql
@@ -1,0 +1,30 @@
+/*
+    Copyright (c) 2010-2011, GEM Foundation.
+
+    OpenQuake is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    OpenQuake is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details
+    (a copy is included in the LICENSE file that accompanied this code).
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with OpenQuake.  If not, see
+    <http://www.gnu.org/licenses/lgpl-3.0.txt> for a copy of the LGPLv3 License.
+*/
+
+-- Grant read/write permissions on the pshai tables to role oq_uiapi_writer.
+
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.complex_fault TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.fault_edge TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.focal_mechanism TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.mfd_evd TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.mfd_tgr TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.r_depth_distr TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.r_rate_mdl TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.rupture TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.simple_fault TO oq_uiapi_writer;
+GRANT SELECT,INSERT,UPDATE,DELETE ON pshai.source TO oq_uiapi_writer;


### PR DESCRIPTION
This way the contents of the source model files uploaded in the GUI can be written to the database.
