### PR TITLE
Updated job types in db schema

### DIFF
--- a/db/schema/comments.sql
+++ b/db/schema/comments.sql
@@ -138,7 +138,7 @@ COMMENT ON COLUMN uiapi.input.size IS 'Number of bytes in file';
 COMMENT ON TABLE uiapi.oq_job IS 'Date related to an OpenQuake job that was created in the UI.';
 COMMENT ON COLUMN uiapi.oq_job.description IS 'A description of the OpenQuake job, allows users to browse jobs and their inputs/outputs at a later point.';
 COMMENT ON COLUMN uiapi.upload.job_pid IS 'The process id (PID) of the OpenQuake engine runner process';
-COMMENT ON COLUMN uiapi.oq_job.job_type IS 'One of: classical, probabilistic or deterministic.';
+COMMENT ON COLUMN uiapi.oq_job.job_type IS 'One of: classical, event-based or deterministic.';
 COMMENT ON COLUMN uiapi.oq_job.status IS 'One of: pending, running, failed or succeeded.';
 COMMENT ON COLUMN uiapi.oq_job.duration IS 'The job''s duration in seconds (only available once the jobs terminates).';
 

--- a/db/schema/openquake.sql
+++ b/db/schema/openquake.sql
@@ -486,10 +486,11 @@ CREATE TABLE uiapi.oq_job (
     description VARCHAR NOT NULL,
     -- One of:
     --      classical (Classical PSHA)
-    --      probabilistic (Probabilistic event based)
+    --      event-based (Probabilistic event based)
     --      deterministic (Deterministic)
+    -- Note: 'classical' and 'event-based' are both probabilistic methods
     job_type VARCHAR NOT NULL CONSTRAINT job_type_value
-        CHECK(job_type IN ('classical', 'probabilistic', 'deterministic')),
+        CHECK(job_type IN ('classical', 'event-based', 'deterministic')),
     -- One of: pending, running, failed, succeeded
     status VARCHAR NOT NULL DEFAULT 'pending' CONSTRAINT job_status_value
         CHECK(status IN ('pending', 'running', 'failed', 'succeeded')),
@@ -505,7 +506,7 @@ CREATE TABLE uiapi.oq_job (
 CREATE TABLE uiapi.oq_params (
     id SERIAL PRIMARY KEY,
     job_type VARCHAR NOT NULL CONSTRAINT job_type_value
-        CHECK(job_type IN ('classical', 'probabilistic', 'deterministic')),
+        CHECK(job_type IN ('classical', 'event-based', 'deterministic')),
     upload_id INTEGER NOT NULL,
     region_grid_spacing float NOT NULL,
     min_magnitude float CONSTRAINT min_magnitude_set
@@ -553,8 +554,8 @@ CREATE TABLE uiapi.oq_params (
     -- Number of seismicity histories
     histories integer CONSTRAINT histories_is_set
         CHECK(
-            ((job_type = 'probabilistic') AND (histories IS NOT NULL))
-            OR ((job_type != 'probabilistic') AND (histories IS NULL))),
+            ((job_type = 'event-based') AND (histories IS NOT NULL))
+            OR ((job_type != 'event-based') AND (histories IS NULL))),
     -- ground motion correlation flag
     gm_correlated boolean CONSTRAINT gm_correlated_is_set
         CHECK(


### PR DESCRIPTION
Hi,

This patch is related to this issue: https://github.com/gem/openquake/issues/190

Basically, we want to use 'event-based' instead of 'probabilistic', since 'classical' and 'event-based' are both technically probabilistic methods.
