### PR TITLE
Set the 'follow' properties of the ConsoleAppender to make it honor System.out reassignments.

### DIFF
--- a/log4j.properties
+++ b/log4j.properties
@@ -8,5 +8,6 @@
 log4j.rootLogger=DEBUG, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.follow=true
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d %-5p [%c] - %m%n


### PR DESCRIPTION
Without this change logs_unittests fails for me (checked on a clean checkout) because ConsoleAppender uses the original System.out and not the one set by log initialization.
