### PR TITLE
Excluded packaged version of the OQ classes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
 	<property name="tests.report.dir" value="${dist.dir}/tests_result" />
 
 	<path id="dependencies">
-		<fileset dir="${syslib.dir}" includes="*.jar" />
+		<fileset dir="${syslib.dir}" excludes="java-oq*" includes="*.jar" />
 	</path>
 
     <target name="help" description="Display detailed usage information">


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/openquake/+bug/805829.
