### PR TITLE
Stops the whole create_oq_schema script as soon as a SQL batch fails

### DIFF
--- a/bin/create_oq_schema
+++ b/bin/create_oq_schema
@@ -144,6 +144,10 @@ if [ "$check_table_spaces" == "on" ]; then
     done
 fi
 
+# Starting from here this script is executing many batches
+# Stopping as soon as one fails makes the error stand out
+set -e
+
 # Create the OpenQuake database
 echo ".. Creating database $db_name .."
 psql -d postgres -U $db_admin_user -c "CREATE DATABASE $db_name"


### PR DESCRIPTION
As suggested in https://bugs.launchpad.net/openquake/+bug/802413
