### PR TITLE
Risk Side: Removed the call that plots loss curve/loss ratio curves

### DIFF
--- a/openquake/risk/job/general.py
+++ b/openquake/risk/job/general.py
@@ -151,13 +151,6 @@ class RiskJobMixin(mixins.Mixin):
                                       serialize_filename)
         results = [_serialize(serialize_path, **kwargs)]
 
-        curve_filename = "%s-block-%s.svg" % (
-                                self['LOSS_CURVES_OUTPUT_PREFIX'], block_id)
-        curve_results_path = os.path.join(self.base_path,
-                                          self['OUTPUT_DIR'],
-                                          curve_filename)
-
-        results.extend(_plot(serialize_path, curve_results_path, **kwargs))
         return results
 
     def _write_output_for_block(self, job_id, block_id):


### PR DESCRIPTION
Continuing on optimization pull request "serie", as I commented here: https://bugs.launchpad.net/openquake/+bug/797615/comments/3 and as I got feedback from Helen, we can remove the SVG plots (they slow down a lot the serialization process) calls

In this pull I'm maintaining though, the plotting code (openquake/output/curve.py -- RiskCurvePlotter) for possible future use/implementations
