### PR TITLE
Setup.py now builds a source package with the correct version num

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import os
 
 import openquake
 
-from distutils.core import setup
+from setuptools import setup
 
 scripts = ["bin/%s" % x for x in os.listdir('bin')]
 scripts.append('celeryconfig.py')


### PR DESCRIPTION
Our CI server is runing `python setup.py sdist` to build an openquake source archive (tar ball). The version number was hard coded into setup.py (0.11).

I corrected that so now it gets the version info from `openquake/__init__.py`.
