### PR TITLE
trivial: db user group 'openquake' needs SELECT on geography_columns

### DIFF
--- a/db/schema/security.sql
+++ b/db/schema/security.sql
@@ -60,7 +60,9 @@ GRANT ALL ON SEQUENCE uiapi.oq_params_id_seq to GROUP openquake;
 GRANT ALL ON SEQUENCE uiapi.output_id_seq to GROUP openquake;
 GRANT ALL ON SEQUENCE uiapi.upload_id_seq to GROUP openquake;
 
+GRANT SELECT ON geography_columns TO GROUP openquake;
 GRANT SELECT ON geometry_columns TO GROUP openquake;
+
 GRANT SELECT ON pshai.complex_source TO GROUP openquake;
 GRANT SELECT ON pshai.simple_source TO GROUP openquake;
 GRANT SELECT ON pshai.complex_rupture TO GROUP openquake;


### PR DESCRIPTION
trivial: db user group 'openquake' needs SELECT permissions for the geography_columns table.
