### PR TITLE
minor fix to memoizer tests

### DIFF
--- a/tests/utils_general_unittest.py
+++ b/tests/utils_general_unittest.py
@@ -65,11 +65,11 @@ class MemoizerTestCase(unittest.TestCase):
 
         # not cached
         my_memoized_method([1, 2, 3],
-                           {'key1', 'value1', 'key2', 'value2'})
+                           {'key1': 'value1', 'key2': 'value2'})
 
         # cached with return values
         self.assertEqual(1, my_memoized_method([1, 2, 3],
-                           {'key1', 'value1', 'key2', 'value2'}))
+                           {'key1': 'value1', 'key2': 'value2'}))
 
         # should be called only one time
         self.assertEqual(self.counter, 1)


### PR DESCRIPTION
this fixes a typo inside the tests which run on python 2.7 but not on python 2.6
