### PR TITLE
removed superfluous nosetests option from test run script

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 
         args = sys.argv
         args.remove('run_tests.py')
-        args = ['nosetests', '-x', '-e', 'do_test.+'] + args
+        args = ['nosetests', '-x'] + args
 
         if FLAGS.speed_tests:
             print "Running speed tests with %s" % args


### PR DESCRIPTION
I removed the `-e do_test.+` nosetests option; it served no purpose.

Basically, this means that any public method in a test class beginning with `do_test` would be excluded. If you grep the code base for instances of `do_test`, however, you get 0 results.
