### PR TITLE
Classical psha optimisation in _compute_pes_from_imls

### DIFF
--- a/openquake/utils/general.py
+++ b/openquake/utils/general.py
@@ -41,9 +41,7 @@ def singleton(cls):
 
 # Memoize taken from the Python Cookbook that handles also unhashable types
 class MemoizeMutable:
-    """ This decorator enables method/function caching in memory
-        It is a bit slower than Memoize because uses pickle
-    """
+    """ This decorator enables method/function caching in memory """
     def __init__(self, fun):
         self.fun = fun
         self.memo = {}

--- a/tests/utils_general_unittest.py
+++ b/tests/utils_general_unittest.py
@@ -48,7 +48,7 @@ class SingletonTestCase(unittest.TestCase):
         self.assertTrue(instance3 is instance1)
 
 
-class MemoizerMutableTestCase(unittest.TestCase):
+class MemoizerTestCase(unittest.TestCase):
     """Tests the behaviour of utils.general.MemoizeMutable"""
 
     def setUp(self):


### PR DESCRIPTION
instead of iterating through the imls and do an ordinate_for for every single imls, we do only in one pass
