### PR TITLE
Avoid using the database in a test located in tests/*

### DIFF
--- a/tests/risk_job_unittest.py
+++ b/tests/risk_job_unittest.py
@@ -239,7 +239,7 @@ class RiskJobGeneralTestCase(unittest.TestCase):
         """
         job_config_file = helpers.smoketest_file('simplecase/config.gem')
 
-        test_job = job.Job.from_file(job_config_file, 'xml')
+        test_job = helpers.job_from_file(job_config_file)
 
         expected_sites = [
             shapes.Site(-118.077721, 33.852034),


### PR DESCRIPTION
Now that each job has a record in the database, tests located in tests/\* (that are supposed not to use the database) must create jobs through helpers.job_from_file() instead of through Job.from_file()
