### PR TITLE
Trivial: Fixed the catch all/raise idiom in run_job.

### DIFF
--- a/openquake/job/__init__.py
+++ b/openquake/job/__init__.py
@@ -77,10 +77,10 @@ def run_job(job_file, output_type):
 
         try:
             results = a_job.launch()
-        except Exception as e:
+        except:
             a_job.set_status('failed')
 
-            raise e
+            raise
         else:
             a_job.set_status('succeeded')
 


### PR DESCRIPTION
The broken one was discarding the stack trace.
