### PR TITLE
Stop at the first error inside a SQL batch run by dbmaint

### DIFF
--- a/tools/dbmaint.py
+++ b/tools/dbmaint.py
@@ -88,7 +88,8 @@ def psql(config, script=None, cmd=None, ignore_dryrun=False, runner=run_cmd):
     if config['host'] in ["localhost", "127.0.0.1"]:
         psql_cmd = "psql --set ON_ERROR_STOP=1 -d %(db)s -U %(user)s" % config
     else:
-        psql_cmd = "psql --set ON_ERROR_STOP=1 -d %(db)s -U %(user)s -h %(host)s" % config
+        psql_cmd =\
+        "psql --set ON_ERROR_STOP=1 -d %(db)s -U %(user)s -h %(host)s" % config
 
     cmds = psql_cmd.split()
 


### PR DESCRIPTION
This patch closes the second part (relative to dbmaint) of https://bugs.launchpad.net/openquake/+bug/802413

The first part (relative to create_oq_schema) was already closed by a previous pull request.
