### PR TITLE
Version info now uses utc time

### DIFF
--- a/openquake/utils/version.py
+++ b/openquake/utils/version.py
@@ -64,6 +64,6 @@ def info(version_data):
     if end > seconds_since_epoch > start:
         release_date = datetime.utcfromtimestamp(
             seconds_since_epoch).isoformat()
-        result += ", released %s UTC" % release_date
+        result += ", released %sZ" % release_date
 
     return result

--- a/tests/utils_version_unittest.py
+++ b/tests/utils_version_unittest.py
@@ -55,7 +55,7 @@ class VersionInfoTestCase(unittest.TestCase):
     def test_info_with_all_data_in_place(self):
         """All the version information is in place."""
         self.assertEqual(
-            "OpenQuake version 0.3.2, released 2011-04-08T06:04:11 UTC",
+            "OpenQuake version 0.3.2, released 2011-04-08T06:04:11Z",
             version.info((0, 3, 2, 1302242651)))
 
     def test_info_with_malformed_version_information(self):


### PR DESCRIPTION
Fixes this bug: https://bugs.launchpad.net/openquake/+bug/825120
