### PR TITLE
Trivial: set the python path in bin/openquake_supervisor

### DIFF
--- a/bin/openquake_supervisor
+++ b/bin/openquake_supervisor
@@ -26,6 +26,9 @@ import os
 import signal
 import sys
 
+import oqpath
+oqpath.set_oq_path()
+
 try:
     # setproctitle is optional external dependency
     # apt-get installl python-setproctitle or


### PR DESCRIPTION
Avoid import errors that were appearing while running the supervisor on some machines.
