### PR TITLE
Declare signalling exchange before running the full job hazard test

### DIFF
--- a/tests/hazard_unittest.py
+++ b/tests/hazard_unittest.py
@@ -44,7 +44,6 @@ from openquake.hazard import opensha
 import openquake.hazard.job
 
 from tests.utils import helpers
-from tests.kvs_unittest import ONE_CURVE_MODEL
 
 LOG = logs.LOG
 
@@ -102,6 +101,10 @@ class HazardEngineTestCase(unittest.TestCase):
     def setUp(self):
         self.generated_files = []
         self.kvs_client = kvs.get_client()
+
+        # We will run a full test using amqp logging, as configured in
+        # openquake.cfg
+        helpers.declare_signalling_exchange()
 
     def tearDown(self):
         for cfg in self.generated_files:

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -40,6 +40,7 @@ from openquake import flags
 from openquake import logs
 from openquake.job import Job
 from openquake import producer
+from openquake import signalling
 from openquake.utils import config
 
 from openquake.db.alchemy.db_utils import get_db_session
@@ -569,3 +570,21 @@ class DbTestMixin(TestMixin):
             session.commit()
         if teardown_job:
             self.teardown_job(job, filesystem_only=filesystem_only)
+
+
+def declare_signalling_exchange():
+    """
+    Ensure the signalling exchange exists.
+
+    It is safe to call this function multiple times, even if the exchange
+    already exists.
+
+    On the other hand, if rabbitmq has just been restarted, the exchange will
+    not exists and calling this function is required before tests using the
+    amqp logging (for example the hazard_unittest which runs a complete job).
+    """
+    # connecting will implicitly create the exchange if it doesn't exits yet
+    conn, chn = signalling.connect()
+
+    chn.close()
+    conn.close()


### PR DESCRIPTION
Related bug https://bugs.launchpad.net/openquake/+bug/836670
