### PR TITLE
amqp routing keys are now lowercase

### DIFF
--- a/java/org/gem/log/AMQPAppender.java
+++ b/java/org/gem/log/AMQPAppender.java
@@ -158,7 +158,7 @@ public class AMQPAppender extends AppenderSkeleton {
     protected void sendMessage(Event event) {
         String routingKey;
         if (routingKeyPattern != null)
-            routingKey = routingKeyPattern.format(event.event);
+            routingKey = routingKeyPattern.format(event.event).toLowerCase();
         else
             routingKey = "";
 

--- a/java_tests/org/gem/log/AMQPAppenderTest.java
+++ b/java_tests/org/gem/log/AMQPAppenderTest.java
@@ -125,8 +125,8 @@ public class AMQPAppenderTest {
 
         assertThat(dummyConnection, is(not(equalTo(null))));
         assertThat(dummyConnection.entries.size(), is(equalTo(2)));
-        assertThat(entry(0).routingKey, is(equalTo("log.INFO")));
-        assertThat(entry(1).routingKey, is(equalTo("log.WARN")));
+        assertThat(entry(0).routingKey, is(equalTo("log.info")));
+        assertThat(entry(1).routingKey, is(equalTo("log.warn")));
     }
 
     // test that throwable handling is left to the layout if required

--- a/openquake/logs.py
+++ b/openquake/logs.py
@@ -274,7 +274,7 @@ class AMQPHandler(logging.Handler):  # pylint: disable=R0902
         channel = self._connect()
         full_record = self._update_record(record)
         msg = amqp.Message(body=self.format(full_record))
-        routing_key = self.routing_key.format(full_record)
+        routing_key = self.routing_key.format(full_record).lower()
 
         channel.basic_publish(msg, exchange=self.exchange,
                               routing_key=routing_key)

--- a/openquake/signalling.py
+++ b/openquake/signalling.py
@@ -43,7 +43,7 @@ def generate_routing_key(job_id, type_):
     :rtype: string
     """
     assert type_ in ('*', 'failed', 'succeeded',
-                     'FATAL', 'ERROR', 'WARN', 'INFO', 'DEBUG'), \
+                     'fatal', 'error', 'warn', 'info', 'debug'), \
            'invalid routing type %r' % type_
 
     assert isinstance(job_id, (int, long)) or job_id == '*', \
@@ -130,7 +130,7 @@ class LogMessageConsumer(object):
         :param levels: the logging levels we are interested in
         :type levels: None for all the levels (translated to a '*' in the
                       routing_key) or an iterable of stings
-                      (e.g. ['ERROR', 'FATAL'])
+                      (e.g. ['error', 'fatal'])
         :param timeout: the optional timeout in seconds. When it expires the
                         `timeout_callback` will be called.
         :type timeout: None or float

--- a/openquake/supervising/supervisor.py
+++ b/openquake/supervising/supervisor.py
@@ -174,7 +174,7 @@ def bind_supervisor_queue(job_id):
     bindings already exists, this function won't create them again.
     """
     return signalling.declare_and_bind_queue(
-        job_id, ('ERROR', 'FATAL'), get_supervisor_queue_name(job_id))
+        job_id, ('error', 'fatal'), get_supervisor_queue_name(job_id))
 
 
 def supervise(pid, job_id):
@@ -190,7 +190,7 @@ def supervise(pid, job_id):
     logging.info('Entering supervisor for job %s', job_id)
 
     with SupervisorLogMessageConsumer(
-        job_id, pid, levels=('ERROR', 'FATAL'),
+        job_id, pid, levels=('error', 'fatal'),
         timeout=0.1) as message_consumer:
         message_consumer.run()
 

--- a/tests/logs_unittest.py
+++ b/tests/logs_unittest.py
@@ -268,11 +268,11 @@ class JavaAMQPLogTestCase(AMQPLogTestBase):
         self.assertEquals(2, len(messages))
 
         self.assertEquals('INFO - Info message', messages[0].body)
-        self.assertEquals('oq-unittest-log.INFO',
+        self.assertEquals('oq-unittest-log.info',
                           messages[0].delivery_info['routing_key'])
 
         self.assertEquals('WARN - Warn message', messages[1].body)
-        self.assertEquals('oq-unittest-log.WARN',
+        self.assertEquals('oq-unittest-log.warn',
                           messages[1].delivery_info['routing_key'])
 
 
@@ -318,11 +318,11 @@ class PythonAMQPLogTestCase(AMQPLogTestBase):
         self.assertEquals(2, len(messages))
 
         self.assertEquals('Info message', messages[0].body)
-        self.assertEquals('oq-unittest-log.INFO',
+        self.assertEquals('oq-unittest-log.info',
                           messages[0].delivery_info['routing_key'])
 
         self.assertEquals('Warn message', messages[1].body)
-        self.assertEquals('oq-unittest-log.WARNING',
+        self.assertEquals('oq-unittest-log.warning',
                           messages[1].delivery_info['routing_key'])
 
 
@@ -406,7 +406,7 @@ class AMQPLogSetupTestCase(PreserveJavaIO, AMQPLogTestBase):
         for i, source in enumerate(['Java', 'Python']):
             for j, level in enumerate(['debug', 'info', 'warn',
                                        'error', 'fatal']):
-                expected = 'log.%s.123' % level.upper()
+                expected = 'log.%s.123' % level
                 got = messages[i * 5 + j].delivery_info['routing_key']
 
                 self.assertEquals(


### PR DESCRIPTION
Related bug https://bugs.launchpad.net/openquake/+bug/831788

Note to the kind reviewer: rebuild your jar :)
