### PR TITLE
trivial change needed to make celeryd start with python-celery_2.3.1 on u

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -30,7 +30,7 @@ import sys
 from openquake.utils import config
 
 
-sys.path.append('.')
+sys.path.insert(0, os.path.dirname(__file__))
 
 amqp = config.get_section("amqp")
 


### PR DESCRIPTION
trivial change needed to make celeryd start with python-celery_2.3.1 on ubuntu 11.04
