### PR TITLE
Leave jvm mem_max alone

### DIFF
--- a/openquake/java.py
+++ b/openquake/java.py
@@ -230,7 +230,7 @@ def init_logs(log_type='console', level='warn'):
         log4j_properties)
 
 
-def jvm(max_mem=None):
+def jvm():
     """Return the jpype module, after guaranteeing the JVM is running and
     the classpath has been loaded properly."""
     jarpaths = (os.path.abspath(
@@ -238,7 +238,6 @@ def jvm(max_mem=None):
                 '/usr/share/java')
 
     if not jpype.isJVMStarted():
-        max_mem = get_jvm_max_mem(max_mem)
         jpype.startJVM(jpype.getDefaultJVMPath(),
             "-Djava.ext.dirs=%s:%s" % jarpaths,
             # force the default Xerces parser configuration, otherwise
@@ -249,33 +248,6 @@ def jvm(max_mem=None):
         init_logs(level=FLAGS.debug, log_type=config.get("logging", "backend"))
 
     return jpype
-
-
-# The default JVM max. memory size to be used in the absence of any other
-# setting or configuration.
-DEFAULT_JVM_MAX_MEM = 4000
-
-
-def get_jvm_max_mem(max_mem):
-    """
-    Determine what the JVM maximum memory size should be.
-
-    :param max_mem: the `max_mem` parameter value actually passed to the
-        caller.
-    :type max_mem: integer or None
-
-    :returns: the maximum JVM memory size considering the possible sources in
-        the following order
-        * the actual value passed
-        * TODO: the value in the config file
-        * the value of the `OQ_JVM_MAX_MEM` environment variable
-        * a fixed default (`4000`).
-    """
-    if max_mem:
-        return max_mem
-    if os.environ.get("OQ_JVM_MAXMEM"):
-        return int(os.environ.get("OQ_JVM_MAXMEM"))
-    return DEFAULT_JVM_MAX_MEM
 
 
 def _unpickle_javaexception(message, trace):

--- a/tests/java_unittest.py
+++ b/tests/java_unittest.py
@@ -35,58 +35,6 @@ from tests.utils.tasks import jtask_task, failing_jtask_task
 class JvmMaxMemTestCase(unittest.TestCase):
     """Tests related to the JVM's maximum memory setting"""
 
-    def setUp(self):
-        self.orig_env = os.environ.copy()
-        # Make sure all tests start with a clean environment
-        os.environ.pop("OQ_JVM_MAXMEM", None)
-
-    def tearDown(self):
-        os.environ.clear()
-        os.environ.update(self.orig_env)
-
-    def test_jvm_maxmem_with_no_environ_var_and_no_param(self):
-        """
-        If the OQ_JVM_MAXMEM environment variable is not set and the `max_mem`
-        parameter is not passed the default value should be used to determine
-        the maximum.
-        """
-        self.assertTrue(os.environ.get("OQ_JVM_MAXMEM") is None)
-        self.assertEqual(java.DEFAULT_JVM_MAX_MEM, java.get_jvm_max_mem(None))
-
-    def test_jvm_maxmem_without_maxmem_environ_var_but_with_param(self):
-        """
-        If the OQ_JVM_MAXMEM environment variable is not set and the `max_mem`
-        parameter is passed its value should be used to determine the maximum.
-        """
-        self.assertTrue(os.environ.get("OQ_JVM_MAXMEM") is None)
-        self.assertEqual(1111, java.get_jvm_max_mem(1111))
-
-    def test_jvm_maxmem_environ_var_honoured_without_param(self):
-        """
-        The value of the OQ_JVM_MAXMEM environment variable is honoured
-        when no `max_mem` parameter is passed.
-        """
-        os.environ["OQ_JVM_MAXMEM"] = "2222"
-        self.assertEqual("2222", os.environ.get("OQ_JVM_MAXMEM"))
-        self.assertEqual(2222, java.get_jvm_max_mem(None))
-
-    def test_jvm_maxmem_passed_param_trumps_environ_var(self):
-        """
-        If both the OQ_JVM_MAXMEM environment variable as well as the `max_mem`
-        parameter are present the latter wins.
-        """
-        os.environ["OQ_JVM_MAXMEM"] = "2222"
-        self.assertEqual("2222", os.environ.get("OQ_JVM_MAXMEM"))
-        self.assertEqual(1111, java.get_jvm_max_mem(1111))
-
-    def test_jvm_maxmem_invalid_environ_var(self):
-        """
-        If the OQ_JVM_MAXMEM environment variable has an invalid/non-numeric
-        value a :class:`ValueError` will be raised.
-        """
-        os.environ["OQ_JVM_MAXMEM"] = "I hate numbers!"
-        self.assertRaises(ValueError, java.get_jvm_max_mem, None)
-
     def test_jvm_memmax_setting_is_not_passed(self):
         """Do not pass -Xmx to the jvm."""
         with helpers.patch("jpype.startJVM") as startjvm_mock:


### PR DESCRIPTION
We should leave the jvm's max. memory setting at its default setting.
