### PR TITLE
Job launch now records some initial job stats

### DIFF
--- a/openquake/job/__init__.py
+++ b/openquake/job/__init__.py
@@ -25,6 +25,7 @@ import subprocess
 import urlparse
 
 from ConfigParser import ConfigParser, RawConfigParser
+from datetime import datetime
 from django.db import transaction
 from django.contrib.gis.geos import GEOSGeometry
 
@@ -34,7 +35,7 @@ from openquake import kvs
 from openquake import logs
 from openquake import OPENQUAKE_ROOT
 from openquake import shapes
-from openquake.db.models import OqJob, OqParams, OqUser
+from openquake.db.models import OqJob, OqParams, OqUser, JobStats
 from openquake.supervising import supervisor
 from openquake.job.handlers import resolve_handler
 from openquake.job import config as conf
@@ -478,6 +479,8 @@ class Job(object):
         """ Based on the behaviour specified in the configuration, mix in the
         correct behaviour for the tasks and then execute them.
         """
+        self._record_initial_stats()
+
         output_dir = os.path.join(self.base_path, self['OUTPUT_DIR'])
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
@@ -614,3 +617,16 @@ class Job(object):
         "Return the intensity measure levels as specified in the config file"
         return self.extract_values_from_config('INTENSITY_MEASURE_LEVELS',
                                                separator=',')
+
+    def _record_initial_stats(self):
+        '''
+        Report initial job stats (such as start time) by adding a
+        uiapi.job_stats record to the db.
+        '''
+        oq_job = OqJob.objects.get(id=self.job_id)
+
+        stats = JobStats(oq_job=oq_job)
+        stats.start_time = datetime.utcnow()
+        stats.num_sites = len(self.sites_to_compute())
+
+        stats.save()


### PR DESCRIPTION
Addresses this bug: https://bugs.launchpad.net/openquake/+bug/838841

Summary:

This change adds a `_record_initial_stats` method to the Job class to report start time and number of sites in the calculation. This can be expanded later to report more information as necessary.
