### PR TITLE
Handle empty array in SumPerGroundMotionField.sum_losses().

### DIFF
--- a/openquake/risk/deterministic_event_based.py
+++ b/openquake/risk/deterministic_event_based.py
@@ -135,7 +135,7 @@ class SumPerGroundMotionField(object):
         self.lr_calculator = lr_calculator
         self.epsilon_provider = epsilon_provider
 
-        self.losses = None
+        self.losses = numpy.array([])
 
         if lr_calculator is None:
             self.lr_calculator = prob.compute_loss_ratios
@@ -183,10 +183,13 @@ class SumPerGroundMotionField(object):
 
         :param losses: an array of loss values (1 per realization)
         :type losses: 1-dimensional :py:class:`numpy.ndarray`
+
+        The `losses` arrays passed to this function must be empty or
+        all the same lenght.
         """
-        if self.losses is None:
+        if len(self.losses) == 0:
             self.losses = losses
-        else:
+        elif len(losses) > 0:
             self.losses = self.losses + losses
 
     @property

--- a/tests/risk_unittest.py
+++ b/tests/risk_unittest.py
@@ -1123,7 +1123,7 @@ class DeterministicEventBasedTestCase(unittest.TestCase):
         calculator = det.SumPerGroundMotionField(
             vuln_model, None, lr_calculator=loss_ratios_calculator)
 
-        self.assertEqual(None, calculator.losses)
+        self.assertTrue(numpy.allclose([], calculator.losses))
 
         calculator.add(None, asset)
         asset = {"assetValue": 300, "vulnerabilityFunctionReference": "ID"}
@@ -1135,6 +1135,20 @@ class DeterministicEventBasedTestCase(unittest.TestCase):
                         166.2920523, 84.25372286, 23.10280904]
 
         self.assertTrue(numpy.allclose(expected_sum, calculator.losses))
+
+    def test_handles_empty_losses_correctly(self):
+        calculator = det.SumPerGroundMotionField(None, None)
+        losses = numpy.array([1.0, 2.0])
+
+        self.assertTrue(numpy.allclose([], calculator.losses))
+
+        calculator.sum_losses(numpy.array([]))
+        calculator.sum_losses(losses)
+        calculator.sum_losses(numpy.array([]))
+        calculator.sum_losses(losses)
+        calculator.sum_losses(numpy.array([]))
+
+        self.assertTrue(numpy.allclose([2.0, 4.0], calculator.losses))
 
     def test_computes_the_mean_from_the_current_sum(self):
         calculator = det.SumPerGroundMotionField(None, None)
@@ -1169,9 +1183,9 @@ class DeterministicEventBasedTestCase(unittest.TestCase):
 
         calculator = det.SumPerGroundMotionField(vuln_model, None)
 
-        self.assertEqual(None, calculator.losses)
+        self.assertTrue(numpy.allclose([], calculator.losses))
 
         calculator.add(None, asset)
 
         # still None, no losses are added
-        self.assertEqual(None, calculator.losses)
+        self.assertTrue(numpy.allclose([], calculator.losses))


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/openquake/+bug/838983
