### PR TITLE
Informative error message when configuration file does not exists

### DIFF
--- a/openquake/job/__init__.py
+++ b/openquake/job/__init__.py
@@ -166,6 +166,10 @@ def parse_config_files(config_file, default_configuration_files):
     sections = []
 
     for each_config_file in default_configuration_files + [config_file]:
+        if not os.path.exists(each_config_file):
+            raise conf.ValidationException(
+                ["File '%s' not found" % each_config_file])
+
         new_sections, new_params = parse_config_file(each_config_file)
         sections.extend(new_sections)
         params.update(new_params)
@@ -338,10 +342,6 @@ class Job(object):
         # This is not documented in the public interface because it is
         # essentially a detail of our current tests and ci infrastructure.
         assert output_type in ('db', 'xml', 'xml_without_db')
-
-        if not os.path.exists(config_file):
-            raise conf.ValidationException(
-                ["File '%s' not found" % config_file])
 
         params, sections = parse_config_files(
             config_file, Job.default_configs())

--- a/tests/job_unittest.py
+++ b/tests/job_unittest.py
@@ -265,6 +265,19 @@ class ConfigParseTestCase(unittest.TestCase, helpers.TestMixin):
             params)
         self.assertEquals(['GENERAL', 'HAZARD'], sorted(sections))
 
+    def test_parse_missing_files(self):
+        content = '''
+            [GENERAL]
+            CALCULATION_MODE = Event Based
+
+            [HAZARD]
+            MINIMUM_MAGNITUDE = 5.0
+            '''
+        config_path = self.touch(content=textwrap.dedent(content))
+
+        self.assertRaises(config.ValidationException, parse_config_files,
+                          config_path, ['/tmp/foo'])
+
     def test_parse_files_defaults(self):
         content = '''
             [GENERAL]


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/openquake/+bug/845493
