### PR TITLE
removed import of geo_unittest from tests/__init__.py (there is no such file anymore)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,7 +23,6 @@ from db_loader_unittest import *
 from db_routers_unittest import *
 from deterministic_hazard_unittest import *
 from deterministic_risk_unittest import *
-from geo_unittest import *
 from handlers_unittest import *
 from hazard_classical_unittest import *
 from hazard_nrml_unittest import *


### PR DESCRIPTION
call "find -name '*pyc' -delete" more often :)
