### PR TITLE
Fix for 862538

### DIFF
--- a/openquake/job/__init__.py
+++ b/openquake/job/__init__.py
@@ -201,8 +201,10 @@ def get_source_models(logic_tree):
     uncert_mdl_tag = xml.NRML + 'uncertaintyModel'
 
     for _event, elem in etree.iterparse(logic_tree):
-        if elem.tag == uncert_mdl_tag and elem.text.endswith('.xml'):
-            model_files.append(os.path.join(base_path, elem.text))
+        if elem.tag == uncert_mdl_tag:
+            e_text = elem.text.strip()
+            if e_text.endswith('.xml'):
+                model_files.append(os.path.join(base_path, e_text))
 
     return model_files
 


### PR DESCRIPTION
Addresses: https://bugs.launchpad.net/openquake/+bug/862538

It turns out that instantiating the JVM using jpype prior to os.fork() is a big no-no. The solution (thanks to al-maisan) was to simply re-write the offending portion of code with pure Python (no java/jpype business).

The problem is very subtle; it can be reproduced as follows:

1) Start JVM
2) Fork
3) In the forked process, instantiate a LogicTreeReader with jpype

Note: Some object instantiation _will_ work in the forked process (ArrayLists, for example). I'm curious to know what exactly in the LogicTreeReader is causing this crash.

Please try running smoketests to confirm that the issue is resolved.
