### PR TITLE
Avoid failure while reraising an exception

### DIFF
--- a/openquake/utils/tasks.py
+++ b/openquake/utils/tasks.py
@@ -158,23 +158,16 @@ def _handle_subtasks(subtasks, flatten_results):
     """
     result = TaskSet(tasks=subtasks).apply_async()
 
-    def instantiate_exception(eclass, exc):
-        """Only pass the *original* exception message string if present."""
-        if exc.args:
-            return eclass(exc.args[0])
-        else:
-            return eclass()
-
     # Wait for all subtasks to complete.
     while not result.ready():
         time.sleep(0.25)
     try:
         the_results = result.join()
     except TypeError, exc:
-        raise instantiate_exception(WrongTaskParameters, exc)
+        raise WrongTaskParameters(str(exc))
     except Exception, exc:
         # At least one subtask failed.
-        raise instantiate_exception(TaskFailed, exc)
+        raise TaskFailed(str(exc))
 
     if flatten_results:
         if the_results:

--- a/tests/utils_tasks_unittest.py
+++ b/tests/utils_tasks_unittest.py
@@ -172,7 +172,7 @@ class DistributeTestCase(unittest.TestCase):
                 m2.return_value.join.side_effect = TypeError
                 tasks.distribute(2, single_arg_called_a, ("a", range(5)))
         except tasks.WrongTaskParameters, exc:
-            self.assertFalse(exc.args)
+            self.assertEqual(("",), exc.args)
         else:
             raise Exception("Exception not raised.")
 


### PR DESCRIPTION
This solves the _immediate_ failure in https://bugs.launchpad.net/openquake/+bug/877992
Why the TypeError gets raised in first place (the root cause) still needs to be investigated.
