### PR TITLE
leave exceptions raised by celery tasks alone

### DIFF
--- a/openquake/utils/tasks.py
+++ b/openquake/utils/tasks.py
@@ -31,14 +31,6 @@ from openquake.job import Job
 from openquake import logs
 
 
-class WrongTaskParameters(Exception):
-    """The user specified wrong paramaters for the celery task function."""
-
-
-class TaskFailed(Exception):
-    """At least on (sub)task failed."""
-
-
 def distribute(cardinality, the_task, (name, data), other_args=None,
                flatten_results=False):
     """Runs `the_task` in a task set with the given `cardinality`.
@@ -161,18 +153,12 @@ def _handle_subtasks(subtasks, flatten_results):
     # Wait for all subtasks to complete.
     while not result.ready():
         time.sleep(0.25)
-    try:
-        the_results = result.join()
-    except TypeError, exc:
-        raise WrongTaskParameters(str(exc))
-    except Exception, exc:
-        # At least one subtask failed.
-        raise TaskFailed(str(exc))
 
-    if flatten_results:
-        if the_results:
-            if isinstance(the_results, list) or isinstance(the_results, tuple):
-                the_results = list(itertools.chain(*the_results))
+    the_results = result.join()
+
+    if flatten_results and the_results:
+        if isinstance(the_results, list) or isinstance(the_results, tuple):
+            the_results = list(itertools.chain(*the_results))
 
     return the_results
 

--- a/tests/utils_tasks_unittest.py
+++ b/tests/utils_tasks_unittest.py
@@ -152,7 +152,7 @@ class DistributeTestCase(unittest.TestCase):
         """
         try:
             tasks.distribute(2, single_arg_called_a, ("data", range(5)))
-        except tasks.WrongTaskParameters, exc:
+        except Exception, exc:
             self.assertEqual(
                 "single_arg_called_a() got an unexpected keyword argument "
                 "'data'",
@@ -171,8 +171,8 @@ class DistributeTestCase(unittest.TestCase):
                 m2.return_value = mock.Mock(spec=TaskSetResult)
                 m2.return_value.join.side_effect = TypeError
                 tasks.distribute(2, single_arg_called_a, ("a", range(5)))
-        except tasks.WrongTaskParameters, exc:
-            self.assertEqual(("",), exc.args)
+        except Exception, exc:
+            self.assertEqual((), exc.args)
         else:
             raise Exception("Exception not raised.")
 
@@ -180,7 +180,7 @@ class DistributeTestCase(unittest.TestCase):
         """At least one subtask failed, a `TaskFailed` exception is raised."""
         try:
             tasks.distribute(1, failing_task, ("data", range(5)))
-        except tasks.TaskFailed, exc:
+        except Exception, exc:
             self.assertEqual(range(5), exc.args[0])
         else:
             raise Exception("Exception not raised.")
@@ -251,7 +251,7 @@ class ParallelizeTestCase(unittest.TestCase):
         try:
             tasks.parallelize(2, single_arg_called_a, dict(data=range(5)),
             index_tasks=False)
-        except tasks.WrongTaskParameters, exc:
+        except Exception, exc:
             self.assertEqual(
                 "single_arg_called_a() got an unexpected keyword argument "
                 "'data'",
@@ -264,7 +264,7 @@ class ParallelizeTestCase(unittest.TestCase):
         try:
             tasks.parallelize(1, failing_task, dict(data=range(5)),
             index_tasks=False)
-        except tasks.TaskFailed, exc:
+        except Exception, exc:
             self.assertEqual(range(5), exc.args[0])
         else:
             raise Exception("Exception not raised.")
@@ -341,5 +341,5 @@ class CheckJobStatusTestCase(unittest.TestCase):
             except tasks.JobCompletedError as exc:
                 self.assertEqual(exc.message, 31)
             else:
-                self.fail('JobCompletedError wasn\'t raised')
+                self.fail("JobCompletedError wasn't raised")
             self.assertEqual(mock.call_args_list, [((31, ), {})])


### PR DESCRIPTION
Please see also https://bugs.launchpad.net/openquake/+bug/878736
