### PR TITLE
hazard/disagg/core: remove temporary file with full 5d matrix

### DIFF
--- a/openquake/hazard/disagg/core.py
+++ b/openquake/hazard/disagg/core.py
@@ -390,7 +390,6 @@ class DisaggMixin(Mixin):
         subset_types = config_text_to_list(
             the_job['DISAGGREGATION_RESULTS'], lambda x: x.lower())
 
-        # imt = the_job['INTENSITY_MEASURE_TYPE']
         rlz_poe_task_data = []
 
         for rlz, poe, data_list in full_disagg_results:


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/openquake/+bug/886037
