### PR TITLE
UHS NRML Model

### DIFF
--- a/openquake/nrml/schema/examples/uhs.xml
+++ b/openquake/nrml/schema/examples/uhs.xml
@@ -2,17 +2,18 @@
 <nrml xmlns:gml="http://www.opengis.net/gml"
       xmlns="http://openquake.org/xmlns/nrml/0.2"
       gml:id="IDXXX">
-    <uhsResultField>
+    <uhsResultSet>
         <!-- X-axis values for all curves in this result set -->
         <uhsPeriods>
             0.0 0.1 0.5
         </uhsPeriods>
+        <timeSpan>50.0</timeSpan>
 
         <!-- 1 result node per Probability of Exceedance -->
         <!-- Each file (indicated by 'path') is an HDF5 file containing data
              for all sites and all logic tree samples.  -->
-        <uhsResultNode poE="0.02" path="some/filea"/>
-        <uhsResultNode poE="0.1" path="some/fileb"/>
-        <uhsResultNode poE="0.2" path="some/filec"/>
-    </uhsResultField>
+        <uhsResult poE="0.02" path="some/filea"/>
+        <uhsResult poE="0.1" path="some/fileb"/>
+        <uhsResult poE="0.2" path="some/filec"/>
+    </uhsResultSet>
 </nrml>

--- a/openquake/nrml/schema/nrml.xsd
+++ b/openquake/nrml/schema/nrml.xsd
@@ -38,7 +38,7 @@
                         <xs:element ref="vulnerabilityModel"/>
                         <xs:element ref="logicTree"/>
                         <xs:element ref="disaggregationResultField"/>
-                        <xs:element ref="uhsResultField"/>
+                        <xs:element ref="uhsResultSet"/>
                     </xs:choice>
                 </xs:sequence>
             </xs:extension>

--- a/openquake/nrml/schema/nrml_hazard.xsd
+++ b/openquake/nrml/schema/nrml_hazard.xsd
@@ -317,16 +317,17 @@
 
     <!-- Uniform Hazard Spectra -->
 
-    <!-- UHS Result Field: the top-level element for UHS results -->
-    <xs:element name="uhsResultField" type="UHSResultFieldType"/>
-    <xs:complexType name="UHSResultFieldType">
+    <!-- UHS Result Set: the top-level element for UHS results -->
+    <xs:element name="uhsResultSet" type="UHSResultSetType"/>
+    <xs:complexType name="UHSResultSetType">
         <xs:sequence>
             <xs:element ref="uhsPeriods" minOccurs="1" maxOccurs="1"/>
-            <xs:element ref="uhsResultNode" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element ref="timeSpan" minOccurs="1" maxOccurs="1"/>
+            <xs:element ref="uhsResult" minOccurs="1" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
-    <!-- List of UHS periods for a uhsResultField (float values) -->
+    <!-- List of UHS periods for a uhsResultSet (float values) -->
     <xs:element name="uhsPeriods">
         <xs:simpleType>
             <xs:restriction base="gml:doubleList">
@@ -335,8 +336,10 @@
         </xs:simpleType>
     </xs:element>
 
+    <xs:element name="timeSpan" type="NonNegativeDoubleType"/>
+
     <!-- UHS result node -->
-    <xs:element name="uhsResultNode"> 
+    <xs:element name="uhsResult"> 
         <xs:complexType>
             <xs:attribute name="poE" type="NonNegativeDoubleType" use="required"/>
             <xs:attribute name="path" type="xs:string" use="required"/>


### PR DESCRIPTION
Addresses: https://bugs.launchpad.net/openquake/+bug/888173

This patch simply introduces some small changes to the NRML schema definition and a sample file to match.

`xmllint` can be used to check the file against the nrml.xsd.
