### PR TITLE
prevent kombu.messaging.Consumer() from redeclaring the queue

### DIFF
--- a/openquake/signalling.py
+++ b/openquake/signalling.py
@@ -73,7 +73,8 @@ class AMQPMessageConsumer(object):
                                    routing_key=routing_key, exclusive=True)
         queue.queue_declare()
         queue.queue_bind()
-        consumer = kombu.messaging.Consumer(self.channel, queue)
+        consumer = kombu.messaging.Consumer(
+            self.channel, queue, auto_declare=False)
         consumer.register_callback(self._message_callback)
         consumer.consume()
 

--- a/tests/logs_unittest.py
+++ b/tests/logs_unittest.py
@@ -180,8 +180,8 @@ class PythonAMQPLogTestCase(unittest.TestCase):
                                         exclusive=True)
         self.queue.queue_declare()
         self.queue.queue_bind()
-        self.consumer = kombu.messaging.Consumer(self.channel, self.queue,
-                                                 no_ack=True)
+        self.consumer = kombu.messaging.Consumer(
+            self.channel, self.queue, no_ack=True, auto_declare=False)
         self.producer = kombu.messaging.Producer(self.channel, self.exchange,
                                                  serializer='json')
 


### PR DESCRIPTION
Hello there!

This fixes: https://bugs.launchpad.net/openquake/+bug/893600

The upgrade to kombu-1.4.3 breaks openquake code that uses exclusive
queues and kombu.messaging.Consumer(). The latter apparently now also
declares the queues in question which breaks for exclusive queues.

Could you please test the branch in question (just run the test suite
and a simple openquake job) and let me know whether it works with kombu
revisions predating 1.4.3.

If the branch _does_ break openquake with kombu (< 1.4.3) we all need to
upgrade before this branch lands on master.
