### PR TITLE
UHS task: 'touch' result HDF5 file and initialize empty datasets

### DIFF
--- a/openquake/hazard/uhs/__init__.py
+++ b/openquake/hazard/uhs/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2010-2011, GEM Foundation.
+#
+# OpenQuake is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# only, as published by the Free Software Foundation.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License version 3 for more details
+# (a copy is included in the LICENSE file that accompanied this code).
+#
+# You should have received a copy of the GNU Lesser General Public License
+# version 3 along with OpenQuake.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.txt> for a copy of the LGPLv3 License.
+
+"""Uniform Hazard Spectra calculator."""

--- a/openquake/hazard/uhs/core.py
+++ b/openquake/hazard/uhs/core.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2010-2011, GEM Foundation.
+#
+# OpenQuake is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# only, as published by the Free Software Foundation.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License version 3 for more details
+# (a copy is included in the LICENSE file that accompanied this code).
+#
+# You should have received a copy of the GNU Lesser General Public License
+# version 3 along with OpenQuake.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.txt> for a copy of the LGPLv3 License.
+
+
+"""Core functionality of the Uniform Hazard Spectra calculator."""
+
+
+import h5py
+import numpy
+
+from celery.task import task
+
+
+@task(ignore_result=True)
+def touch_result_file(path, sites, n_samples, n_periods):
+    """Given a path (including the file name), create an empty HDF5 result file
+    containing 1 empty data set for each site. Each dataset will be a matrix
+    with the number of rows = number of samples and number of cols = number of
+    UHS periods.
+
+    :param str path:
+        Location (including a file name) on an NFS where the empty
+        result file should be created.
+    :param sites:
+        List of :class:`openquake.shapes.Site` objects.
+    :param int n_samples:
+        Number of logic tree samples (the y-dimension of each dataset).
+    :param int n_periods:
+        Number of UHS periods (the x-dimension of each dataset).
+    """
+    with h5py.File(path, 'w') as h5_file:
+        for site in sites:
+            ds_name = 'lon:%s-lat:%s' % (site.longitude, site.latitude)
+            ds_shape = (n_samples, n_periods)
+            h5_file.create_dataset(ds_name, dtype=numpy.float64,
+                                   shape=ds_shape)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -57,6 +57,7 @@ from signalling_unittest import *
 from supervisor_unittest import *
 from tools_dbmaint_unittest import *
 from tools_oqbugs_unittest import *
+from uhs_unittest import *
 from utils_config_unittest import *
 from utils_general_unittest import *
 from utils_stats_unittest import *

--- a/tests/uhs_unittest.py
+++ b/tests/uhs_unittest.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2010-2011, GEM Foundation.
+#
+# OpenQuake is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# only, as published by the Free Software Foundation.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License version 3 for more details
+# (a copy is included in the LICENSE file that accompanied this code).
+#
+# You should have received a copy of the GNU Lesser General Public License
+# version 3 along with OpenQuake.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.txt> for a copy of the LGPLv3 License.
+
+
+import h5py
+import numpy
+import os
+import tempfile
+import unittest
+
+from openquake.shapes import Site
+from openquake.hazard.uhs.core import touch_result_file
+
+
+class UHSCoreTestCase(unittest.TestCase):
+    """Tests for core UHS tasks and other functions."""
+
+    def test_touch_result_file(self):
+        """Call the :function:`openquake.hazard.uhs.core.touch_result_file` and
+        verify that the result file is properly created with the correct number
+        of datasets.
+
+        We also want to verify the name (since it is associated with a specific
+        site of interest) as well as the size and datatype of each dataset.
+        """
+        _, path = tempfile.mkstemp()
+        sites = [Site(-122.000, 38.113), Site(-122.114, 38.113)]
+        n_samples = 4
+        n_periods = 3
+
+        touch_result_file(path, sites, n_samples, n_periods)
+
+        # Does the resulting file exist?
+        self.assertTrue(os.path.exists(path))
+
+        # Read the file and check the names, sizes, and datatypes of each
+        # dataset.
+        with h5py.File(path, 'r') as h5_file:
+            # There should be exactly 2 datasets.
+            self.assertEquals(2, len(h5_file))
+
+            for site in sites:
+                ds_name = 'lon:%s-lat:%s' % (site.longitude, site.latitude)
+                ds = h5_file.get(ds_name)
+                self.assertIsNotNone(ds)
+                self.assertEquals(numpy.float64, ds.dtype)
+                self.assertEquals((n_samples, n_periods), ds.shape)
+
+        # Clean up the test file.
+        os.unlink(path)


### PR DESCRIPTION
Addresses: https://bugs.launchpad.net/openquake/+bug/897149.

This patch introduces a function (implemented as a celery task) which creates an HDF result file and properly initializes empty datasets. Please read the bug description for a more detailed explanation of why this feature is necessary.
