### PR TITLE
Prepare to parallelize the serialization of hazard curves

### DIFF
--- a/openquake/hazard/opensha.py
+++ b/openquake/hazard/opensha.py
@@ -142,7 +142,7 @@ class ClassicalMixin(BasePSHAMixin):
                 flatten_results=True)
 
             if serializer:
-                serializer(realization, sites)
+                serializer(sites, realization)
 
     # pylint: disable=R0913
     def do_means(self, sites, realizations,
@@ -299,14 +299,14 @@ class ClassicalMixin(BasePSHAMixin):
             map_func=classical_psha.compute_quantile_hazard_maps,
             map_serializer=self.serialize_quantile_hazard_map)
 
-    def serialize_hazard_curve_of_realization(self, realization, sites):
+    def serialize_hazard_curve_of_realization(self, sites, realization):
         """
         Serialize the hazard curves of a set of sites for a given realization.
 
-        :param realization: the realization to be serialized
-        :type realization: :py:class:`int`
         :param sites: the sites of which the curves will be serialized
         :type sites: list of :py:class:`openquake.shapes.Site`
+        :param realization: the realization to be serialized
+        :type realization: :py:class:`int`
         """
         hc_attrib_update = {'endBranchLabel': realization}
         nrml_file = self.hazard_curve_filename(realization)

--- a/tests/hazard_classical_unittest.py
+++ b/tests/hazard_classical_unittest.py
@@ -92,7 +92,7 @@ class DoCurvesTestCase(helpers.TestMixin, unittest.TestCase):
     def test_serializer_called_when_passed(self):
         """The passed serialization function is called for each realization."""
 
-        def fake_serializer(realization, sites):
+        def fake_serializer(sites, realization):
             """Fake serialization function to be used in this test."""
             self.assertEqual(self.sites, sites)
 


### PR DESCRIPTION
Hello there!

This is the second piece of https://bugs.launchpad.net/openquake/+bug/894398.
For tasks whose results are ignored we now may pass a post-processing function
to utils.tasks.distribute(). It will receive the same parameters as the task
function.

If more parameters are needed (e.g. the realization number in case of
serializing hazard curves the post-processing function can be curried
using functools.partial() before being passed to distribute())

N.B.: the post-processing function is likely to execute in parallel with
longer running tasks.

Please let me know what you think!
