### PR TITLE
Base Calculator class.

### DIFF
--- a/openquake/calculators/__init__.py
+++ b/openquake/calculators/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2010-2011, GEM Foundation.
+#
+# OpenQuake is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# only, as published by the Free Software Foundation.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License version 3 for more details
+# (a copy is included in the LICENSE file that accompanied this code).
+#
+# You should have received a copy of the GNU Lesser General Public License
+# version 3 along with OpenQuake.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.txt> for a copy of the LGPLv3 License.
+
+
+"""This package contains Hazard and Risk calculator classes."""

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2010-2011, GEM Foundation.
+#
+# OpenQuake is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# only, as published by the Free Software Foundation.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License version 3 for more details
+# (a copy is included in the LICENSE file that accompanied this code).
+#
+# You should have received a copy of the GNU Lesser General Public License
+# version 3 along with OpenQuake.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.txt> for a copy of the LGPLv3 License.
+
+
+"""Base code for calculator classes."""
+
+
+class Calculator(object):
+    """Base abstract class for all calculators."""
+
+    def __init__(self, job_profile):
+        """
+        :param job_profile: :class:`openquake.job.Job` instance.
+        """
+        self.job_profile = job_profile
+
+    def analyze(self):
+        """Implement this method in subclasses to record pre-execution stats,
+        estimate the calculation size, etc."""
+
+    def pre_execute(self):
+        """Implement this method in subclasses to perform pre-execution
+        functions, such as instantiating objects need for the calculation and
+        loading calculation data into a cache."""
+
+    def execute(self):
+        """This is only method that subclasses are required to implement. This
+        should contain all of the calculation logic."""
+        raise NotImplementedError()
+
+    def post_execute(self):
+        """Implement this method in subclasses to perform post-execution
+        functions, such as result serialization and garbage collection."""


### PR DESCRIPTION
This branch addresses https://bugs.launchpad.net/openquake/+bug/909663.

This introduces the openquake/calculators/ package, which will be the container for all other calculator code (see https://bugs.launchpad.net/openquake/+bug/907243). The current 'Mixin' calculators will be refactored and moved into this package.
