### PR TITLE
Finishing touches on Classical BCR Risk QA test

### DIFF
--- a/qa_tests/bcr_unittest.py
+++ b/qa_tests/bcr_unittest.py
@@ -58,7 +58,6 @@ class BCRQATestCase(unittest.TestCase):
                     'a1':   (0.009379,  0.006586,  0.483091)
             }
         }
-        delta = 1e-5
 
         helpers.run_job(CONFIG)
         calc_record = OqCalculation.objects.latest("id")


### PR DESCRIPTION
This bug: https://bugs.launchpad.net/openquake/+bug/914710

Vitor Silva has given the thumbs-up to this test case (with respect to the value, precision deltas, etc.).
