### PR TITLE
Fixed run_tests to search the tests dir more deeply to find test cases

### DIFF
--- a/openquake/calculators/hazard/disagg/core.py
+++ b/openquake/calculators/hazard/disagg/core.py
@@ -220,8 +220,8 @@ class DisaggHazardCalculator(Calculator):
 
         For example:
         >>> DisaggHazardCalculator.create_result_dir(
-        ... '/var/lib/openquake', 2847)
-        '/var/lib/openquake/disagg-results/job-2847'
+        ... '/var/lib/openquake', 123456789)
+        '/var/lib/openquake/disagg-results/job-123456789'
 
         :param base_path: base result storage directory (a path to an NFS
             mount, for example)

--- a/run_tests
+++ b/run_tests
@@ -2,4 +2,6 @@
 # First, purge all .pyc files to clean the source tree,
 # in case some modules were deleted or removed.
 find . -name "*.pyc" -delete
-(export DJANGO_SETTINGS_MODULE="openquake.settings"; nosetests "$@" `find tests/ -name "*_unittest.py"` 2>&1 | tee last_test_run.log)
+# We look for tests by recursively searching into the tests/ dir,
+# in addition to doctests within the openquake codebase.
+(export DJANGO_SETTINGS_MODULE="openquake.settings"; nosetests --with-doctest "$@" `find tests/ -name "*_unittest.py"` openquake 2>&1 | tee last_test_run.log)


### PR DESCRIPTION
Recently, some tests were added into the tests/calculators/risk/ dir. The `run_tests` script was not discovering these tests.

That should be resolved now.
