### PR TITLE
Fix an intermittent test failure

### DIFF
--- a/tests/engine_unittest.py
+++ b/tests/engine_unittest.py
@@ -217,9 +217,10 @@ class EngineAPITestCase(unittest.TestCase):
         for act_inp in actual_inputs:
             exp_inp = expected_inputs_map[act_inp.input_type]
             self.assertTrue(
-                models.model_equals(exp_inp, act_inp,
-                                    ignore=("id",  "last_update", "path",
-                                            "model", "_owner_cache")))
+                models.model_equals(
+                    exp_inp, act_inp, ignore=(
+                        "id",  "last_update", "path", "model", "_owner_cache",
+                        "owner_id")))
 
     def test_import_job_profile_as_specified_user(self):
         # Test importing of a job profile when a user is specified


### PR DESCRIPTION
This error:

<pre>
test_import_job_profile (tests.engine_unittest.EngineAPITestCase) ... FAIL

======================================================================
FAIL: test_import_job_profile (tests.engine_unittest.EngineAPITestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/larsbutler/proj/oq-engine/tests/engine_unittest.py", line 222, in test_import_job_profile
    "model", "_owner_cache")))
AssertionError: False is not True
</pre>


This error only appears if you run the QA test suite and then the unit test suite. If you rebuild the database in between, the error does not occur.
