### PR TITLE
Remove obsolete GRANT statements 

### DIFF
--- a/openquake/db/schema/security.sql
+++ b/openquake/db/schema/security.sql
@@ -193,17 +193,14 @@ GRANT SELECT,INSERT,UPDATE,DELETE ON hzrdr.uh_spectrum_data TO oq_reslt_writer;
 
 -- oqmif.exposure_data
 GRANT SELECT ON oqmif.exposure_data TO GROUP openquake;
-GRANT SELECT,INSERT,DELETE ON oqmif.exposure_data TO oq_ged4gem;
 GRANT SELECT,INSERT,DELETE ON oqmif.exposure_data TO oq_job_init;
 
 -- oqmif.exposure_model
 GRANT SELECT ON oqmif.exposure_model TO GROUP openquake;
-GRANT SELECT,INSERT,DELETE ON oqmif.exposure_model TO oq_ged4gem;
 GRANT SELECT,INSERT,DELETE ON oqmif.exposure_model TO oq_job_init;
 
 -- oqmif.occupancy
 GRANT SELECT ON oqmif.occupancy TO GROUP openquake;
-GRANT SELECT,INSERT,UPDATE,DELETE ON oqmif.occupancy TO oq_ged4gem;
 GRANT SELECT,INSERT,UPDATE,DELETE ON oqmif.occupancy TO oq_job_init;
 
 -- riski.ffc


### PR DESCRIPTION
The oq_ged4gem user is no longer used. I discovered this bug while trying to bootstrap the oq-engine database on ci2.openquake.org.

Related to this bug: https://bugs.launchpad.net/openquake/+bug/977810

Here's the error I was getting:

<pre>
$ sudo -u postgres bin/create_oq_schema --db-name=openquake --schema-path=openquake/db/schema/
... blah blah, lots of output ...
psql:openquake/db/schema/security.sql:196: ERROR:  role "oq_ged4gem" does not exist
</pre>
