### PR TITLE
The default argument value for --force-inputs was reversed

### DIFF
--- a/bin/openquake
+++ b/bin/openquake
@@ -83,7 +83,7 @@ def set_up_arg_parser():
     general_grp.add_argument(
         '--version', action='store_true', help='display version information')
     general_grp.add_argument(
-        '--force-inputs', action='store_false',
+        '--force-inputs', action='store_true',
         help='parse model inputs and write them to the db no matter what')
 
     calc_grp = parser.add_argument_group('Run calculations')


### PR DESCRIPTION
This caused a rather obscure bug which only appeared during
the CI build. Here's an excerpt from the error reported by Jenkins:

http://pastie.org/3809219

This should fix the recent Jenkins failures: http://ci.openquake.org/job/oq-engine/516/testReport/

We uncovered another issue as well: https://bugs.launchpad.net/openquake/+bug/984700
