### PR TITLE
Allow the bin/create_oq_schema script to be run as a normal user in non-interactive (--yes) mode.

### DIFF
--- a/bin/create_oq_schema
+++ b/bin/create_oq_schema
@@ -122,8 +122,6 @@ if [ "$(id -u)" != "0" ]; then
     if [ "$user_interaction" = "on" ]; then
         echo "!! Press <enter> to continue, or <ctrl>-C to abort"
         read
-    else
-        exit 4
     fi
 fi
 


### PR DESCRIPTION
Fix for http://ci.openquake.org/job/oq-engine-LRT/4/.
