### PR TITLE
Remove usage of the oqmif database user

### DIFF
--- a/openquake.cfg
+++ b/openquake.cfg
@@ -52,9 +52,6 @@ job_init_user = oq_job_init
 job_superv_password = openquake
 job_superv_user = oq_job_superv
 
-oqmif_password = openquake
-oqmif_user = oq_job_init
-
 reslt_writer_password = openquake
 reslt_writer_user = oq_reslt_writer
 

--- a/openquake/db/routers.py
+++ b/openquake/db/routers.py
@@ -55,10 +55,10 @@ class OQRouter(object):
         '''
         schema = self._schema_table_from_model(model)[0]
 
-        if schema in ("admin", "oqmif"):
+        if schema in ("admin",):
             # The db name for these is the same as the schema
             return schema
-        elif schema in ("hzrdr", "riskr"):
+        elif schema in ("hzrdr", "riskr", "oqmif"):
             return "job_init"
         elif schema in ("hzrdi", "riski", "uiapi"):
             return "reslt_writer"
@@ -72,12 +72,12 @@ class OQRouter(object):
         '''
         schema, table = self._schema_table_from_model(model)
 
-        if schema in ('admin', 'oqmif'):
+        if schema in ('admin',):
             # The db name for these is the same as the schema
             return schema
         elif schema == "uiapi" and table == "output":
             return "reslt_writer"
-        elif schema in ("hzrdi", "riski", "uiapi"):
+        elif schema in ("hzrdi", "riski", "uiapi", "oqmif"):
             return "job_init"
         elif schema in ("hzrdr", "riskr"):
             return "reslt_writer"

--- a/openquake/settings.py
+++ b/openquake/settings.py
@@ -60,7 +60,6 @@ _DB_NAMES = (
     'admin',
     'job_init',
     'job_superv',
-    'oqmif',
     'reslt_writer',
 )
 

--- a/tests/db_routers_unittest.py
+++ b/tests/db_routers_unittest.py
@@ -181,7 +181,7 @@ class OQRouterTestCase(unittest.TestCase):
         for read operations.
         '''
         classes = [ExposureModel, ExposureData]
-        expected_db = 'oqmif'
+        expected_db = 'job_init'
 
         self._db_for_read_helper(classes, expected_db)
 
@@ -191,7 +191,7 @@ class OQRouterTestCase(unittest.TestCase):
         for write operations.
         '''
         classes = [ExposureModel, ExposureData]
-        expected_db = 'oqmif'
+        expected_db = 'job_init'
 
         self._db_for_write_helper(classes, expected_db)
 


### PR DESCRIPTION
This completes the removal of the "oqmif" database user, please see also:
    https://bugs.launchpad.net/openquake/+bug/993256
