### PR TITLE
Associations between logic tree and hazard sources

### DIFF
--- a/openquake/db/models.py
+++ b/openquake/db/models.py
@@ -678,6 +678,24 @@ class Input2job(djm.Model):
         db_table = 'uiapi\".\"input2job'
 
 
+class Src2ltsrc(djm.Model):
+    '''
+    Associate an "lt_source" type input (a logic tree source) with "source"
+    type inputs (hazard sources referenced by the logic tree source).
+    This is needed for worker-side logic tree processing.
+    '''
+    hzrd_src = djm.ForeignKey("Input", related_name='+',
+                              help_text="Hazard source input referenced "
+                                        "by the logic tree source")
+    lt_src = djm.ForeignKey("Input", related_name='+',
+                            help_text="Logic tree source input")
+    filename = djm.TextField(
+        help_text="Name of the referenced hazard source file")
+
+    class Meta:
+        db_table = 'uiapi\".\"src2ltsrc'
+
+
 class Input2upload(djm.Model):
     '''
     Associates input model files and uploads.

--- a/openquake/db/schema/comments.sql
+++ b/openquake/db/schema/comments.sql
@@ -433,6 +433,10 @@ COMMENT ON COLUMN uiapi.output.output_type IS 'Output type, one of:
     - bcr_distribution';
 COMMENT ON COLUMN uiapi.output.shapefile_path IS 'The full path of the shapefile generated for a hazard or loss map (optional).';
 
+COMMENT ON TABLE uiapi.src2ltsrc IS '
+Associate an "lt_source" type input (a logic tree source) with "source"
+type inputs (hazard sources referenced by the logic tree source).
+This is needed for worker-side logic tree processing.';
 
 COMMENT ON TABLE uiapi.upload IS 'A batch of OpenQuake input files uploaded by the user';
 COMMENT ON COLUMN uiapi.upload.job_pid IS 'The process id (PID) of the NRML loader process';

--- a/openquake/db/schema/openquake.sql
+++ b/openquake/db/schema/openquake.sql
@@ -1202,6 +1202,22 @@ CREATE TABLE uiapi.input2job (
 ) TABLESPACE uiapi_ts;
 
 
+-- Associate an 'lt_source' type input (a logic tree source) with 'source'
+-- type inputs (hazard sources referenced by the logic tree source).
+-- This is needed for worker-side logic tree processing.
+CREATE TABLE uiapi.src2ltsrc (
+    id SERIAL PRIMARY KEY,
+    -- foreign key to the input of type 'source'
+    hzrd_src_id INTEGER NOT NULL,
+    -- foreign key to the input of type 'lt_source'
+    lt_src_id INTEGER NOT NULL,
+    -- Due to input file reuse, the original file name may deviate from
+    -- the current. We hence need to capture the latter.
+    filename VARCHAR NOT NULL,
+    UNIQUE (hzrd_src_id, lt_src_id)
+) TABLESPACE uiapi_ts;
+
+
 -- Associate inputs and uploads
 CREATE TABLE uiapi.input2upload (
     id SERIAL PRIMARY KEY,
@@ -1824,6 +1840,12 @@ FOREIGN KEY (input_id) REFERENCES uiapi.input(id) ON DELETE CASCADE;
 
 ALTER TABLE uiapi.input2job ADD CONSTRAINT  uiapi_input2job_oq_job_fk
 FOREIGN KEY (oq_job_id) REFERENCES uiapi.oq_job(id) ON DELETE CASCADE;
+
+ALTER TABLE uiapi.src2ltsrc ADD CONSTRAINT  uiapi_src2ltsrc_src_fk
+FOREIGN KEY (hzrd_src_id) REFERENCES uiapi.input(id) ON DELETE CASCADE;
+
+ALTER TABLE uiapi.src2ltsrc ADD CONSTRAINT  uiapi_src2ltsrc_ltsrc_fk
+FOREIGN KEY (lt_src_id) REFERENCES uiapi.input(id) ON DELETE CASCADE;
 
 ALTER TABLE uiapi.job2profile ADD CONSTRAINT
 uiapi_job2profile_oq_job_profile_fk FOREIGN KEY (oq_job_profile_id) REFERENCES

--- a/openquake/db/schema/security.sql
+++ b/openquake/db/schema/security.sql
@@ -88,6 +88,7 @@ GRANT ALL ON SEQUENCE uiapi.output_id_seq to GROUP openquake;
 GRANT ALL ON SEQUENCE uiapi.upload_id_seq to GROUP openquake;
 GRANT ALL ON SEQUENCE uiapi.error_msg_id_seq to GROUP openquake;
 GRANT ALL ON SEQUENCE uiapi.input2job_id_seq to GROUP openquake;
+GRANT ALL ON SEQUENCE uiapi.src2ltsrc_id_seq to GROUP openquake;
 GRANT ALL ON SEQUENCE uiapi.input2upload_id_seq to GROUP openquake;
 GRANT ALL ON SEQUENCE uiapi.job2profile_id_seq to GROUP openquake;
 
@@ -306,6 +307,10 @@ GRANT SELECT,INSERT,DELETE ON uiapi.model_content to oq_job_init;
 -- uiapi.input2job
 GRANT SELECT ON uiapi.input2job TO GROUP openquake;
 GRANT SELECT,INSERT,DELETE ON uiapi.input2job TO oq_job_init;
+
+-- uiapi.src2ltsrc
+GRANT SELECT ON uiapi.src2ltsrc TO GROUP openquake;
+GRANT SELECT,INSERT,DELETE ON uiapi.src2ltsrc TO oq_job_init;
 
 -- uiapi.input2upload
 GRANT SELECT ON uiapi.input2upload TO GROUP openquake;

--- a/tests/engine_unittest.py
+++ b/tests/engine_unittest.py
@@ -513,6 +513,12 @@ class InsertInputFilesTestCase(unittest.TestCase, helpers.DbTestCase):
         self.assertNotEqual(self.glt_i.id, glt_i.id)
         [slt_i] = models.inputs4job(self.job.id, input_type="lt_source")
         self.assertEqual(self.slt_i.id, slt_i.id)
+        # Make sure the LT and the hazard source have been associated.
+        [src_link] = models.Src2ltsrc.objects.filter(lt_src=slt_i)
+        self.assertEqual("dissFaultModel.xml", src_link.filename)
+        self.assertEqual(slt_i, src_link.lt_src)
+        [hzrd_i] = models.inputs4job(self.job.id, input_type="source")
+        self.assertEqual(hzrd_i, src_link.hzrd_src)
 
     def test_model_content_single_file(self):
         # The contents of input files (such as logic trees, exposure models,


### PR DESCRIPTION
Good morning!

This branch adds an association between logic tree and hazard sources enabling
us to push logic tree processing to the workers.

Please see also: https://bugs.launchpad.net/openquake/+bug/1003863
