### PR TITLE
Source model DB loader: Use proper polygon wkt...

### DIFF
--- a/openquake/input/source.py
+++ b/openquake/input/source.py
@@ -353,10 +353,9 @@ class SourceDBWriter(object):
             )
             geom = nhlib_src.get_rupture_enclosing_polygon()
             # Resample and initialize the `shapely` polygon
-            geom._init_polygon2d()
 
             ps = models.ParsedSource(
                 input=self.inp, source_type=_source_type(src), blob=blob,
-                polygon=geom._polygon2d.wkt
+                polygon=geom.wkt
             )
             ps.save()

--- a/tests/input/source_test.py
+++ b/tests/input/source_test.py
@@ -24,6 +24,7 @@ from nhlib import pmf
 from nhlib import scalerel
 from nhlib import source
 from nrml import parsers as nrml_parsers
+from shapely import wkt
 
 from openquake.db import models
 from openquake.input import source as source_input
@@ -291,5 +292,16 @@ class SourceDBWriterTestCase(unittest.TestCase):
             )
 
             nhlib_poly = nhlib_src.get_rupture_enclosing_polygon()
-            nhlib_poly._init_polygon2d()
-            self.assertEquals(ps.polygon.wkt, nhlib_poly._polygon2d.wkt)
+            # nhlib tests the generation of wkt from a polygon, so we can trust
+            # that it is well-formed.
+
+            # Since we save the rupture enclosing polygon as geometry (not wkt)
+            # in the database, the WKT we get back from the DB might have
+            # slightly different coordinate values (a difference in precision).
+            # shapely can help us compare two polygons (generated from wkt)
+            # at a specific level of precision (default=6 digits after the
+            # decimal point).
+            expected_poly = wkt.loads(ps.polygon.wkt)
+            actual_poly = wkt.loads(nhlib_poly.wkt)
+
+            self.assertTrue(expected_poly.almost_equals(actual_poly))


### PR DESCRIPTION
... for the rupture enclosing polygon we store in the `parsed_source` table.

This change depends on https://github.com/gem/nhlib/pull/41
