### PR TITLE
increasing the java redis timeout to 60 secs solved the problem on MF cluster

### DIFF
--- a/java/org/gem/engine/hazard/redis/Cache.java
+++ b/java/org/gem/engine/hazard/redis/Cache.java
@@ -74,7 +74,7 @@ public class Cache {
                 .setDatabase(db);
 
         // The default timeout should be 10 seconds.
-        connectionSpec.setSocketProperty(SO_TIMEOUT, 10000);
+        connectionSpec.setSocketProperty(SO_TIMEOUT, 60000);
 
         return connectionSpec;
     }


### PR DESCRIPTION
https://bugs.launchpad.net/bugs/1015597
