### PR TITLE
GMF correlation fixes

### DIFF
--- a/openquake/calculators/hazard/event_based/core_next.py
+++ b/openquake/calculators/hazard/event_based/core_next.py
@@ -188,7 +188,6 @@ def ses_and_gmfs(job_id, lt_rlz_id, src_ids, task_seed):
         logs.LOG.debug('< done computing stochastic event set %s of %s'
                        % (_, hc.ses_per_logic_tree_path))
 
-
     logs.LOG.debug('< task complete, signalling completion')
     haz_general.signal_task_complete(job_id, len(src_ids))
 


### PR DESCRIPTION
Ground motion correlation matrices are now only computed once per task.

(Before, they were being computed inside of a loop; this is unnecessary.)

Also, I fixed a more serious issue:
I was calling the wrong method in the ground motion correlation model. I was calling `get_correlation_matrix`; this has been corrected to `get_lower_triangle_correlation_matrix`.

I have discussed these changes with Dr. Monelli. The previous implementation was incorrect.
