### PR TITLE
avoid reporting the same percentage more than once

### DIFF
--- a/openquake/logs.py
+++ b/openquake/logs.py
@@ -88,10 +88,11 @@ def log_percent_complete(job_id, ctype):
         return 0
 
     percent = total / 100.0
-    percent_complete = done / percent
+    # Store percentage complete as well as the last value reported as integers
+    # in order to avoid reporting the same percentage more than once.
+    percent_complete = int(done / percent)
     # Get the last value reported
-    lvr = stats.pk_get(job_id, "lvr", cast2int=False)
-    lvr = float(lvr) if lvr else 0.0
+    lvr = stats.pk_get(job_id, "lvr")
 
     # Only report the percentage completed if it is above the last value shown
     if percent_complete > lvr:

--- a/tests/logs_test.py
+++ b/tests/logs_test.py
@@ -427,3 +427,16 @@ class LogPercentCompleteTestCase(unittest.TestCase):
             self.assertEqual(1, lpm.call_count)
             self.assertEqual("hazard  20% complete",
                              lpm.call_args_list[0][0][0])
+
+    def test_log_percent_complete_with_almost_same_percentage_value(self):
+        # only 1 value is reported when the percentage complete value is
+        # almost the same (12.6 versus 12).
+        job_id = 12
+        stats.pk_set(job_id, "nhzrd_total", 366)
+        stats.pk_set(job_id, "nhzrd_done", 46)
+        stats.pk_set(job_id, "lvr", 12)
+
+        with mock.patch("openquake.logs.log_progress") as lpm:
+            rv = logs.log_percent_complete(job_id, "hazard")
+            self.assertEqual(12, rv)
+            self.assertEqual(0, lpm.call_count)


### PR DESCRIPTION
Store percentage complete as well as the last value reported as integers in order to avoid reporting the same percentage more than once.

See also https://bugs.launchpad.net/openquake/+bug/1041258
