### PR TITLE
Fixes to LogicTreeProcessor tests

### DIFF
--- a/tests/input/logictree_test.py
+++ b/tests/input/logictree_test.py
@@ -1009,7 +1009,7 @@ class GMPELogicTreeBrokenInputTestCase(unittest.TestCase):
         exc = self._assert_logic_tree_error('gmpe', gmpe, 'base',
                                             set(['Volcanic']),
                                             logictree.ValidationError)
-        error = "module 'nhlib.gsim' does not contain name 'GMPE'"
+        error = "module 'nhlib.gsim' does not contain name 'FakeGMPE'"
         self.assertEqual(exc.message, error,
                         "wrong exception message: %s" % exc.message)
         self.assertEqual(exc.lineno, 7)


### PR DESCRIPTION
Due to some recent minor changes in nhlib, a few tests broke. Nothing major.
