### PR TITLE
All hazard calculators can automatically export results

### DIFF
--- a/demos/event_based_hazard/job.ini
+++ b/demos/event_based_hazard/job.ini
@@ -48,6 +48,7 @@ ground_motion_correlation_params = {"vs30_clustering": true}
 
 [output]
 
+export_dir = /tmp/xxx
 complete_logic_tree_ses = true
 complete_logic_tree_gmf = true
 ground_motion_fields = true

--- a/openquake/calculators/hazard/classical/core.py
+++ b/openquake/calculators/hazard/classical/core.py
@@ -353,15 +353,6 @@ class ClassicalHazardCalculator(haz_general.BaseHazardCalculatorNext):
             lt_realization__hazard_calculation=hc.id).delete()
         models.SiteData.objects.filter(hazard_calculation=hc.id).delete()
 
-    def export(self, *args, **kwargs):
-        """Export to NRML"""
-        logs.LOG.debug('> starting exports')
-
-        if "exports" in kwargs and "xml" in kwargs["exports"]:
-            hexp.curves2nrml(self.job.hazard_calculation.export_dir, self.job)
-
-        logs.LOG.debug('< done with exports')
-
 
 def update_result_matrix(current, new):
     """


### PR DESCRIPTION
The `export` phase of the hazard calculations is now the same for all
calculators. If the user requests it, all results will be exported
at the end of the calculation.

This functionality is general to all hazard calculators and should require very little modification (if any) to support future hazard calculators (scenario, disaggregation, etc.).
