### PR TITLE
lt_realization counters: race condition fix

### DIFF
--- a/openquake/calculators/hazard/classical/core.py
+++ b/openquake/calculators/hazard/classical/core.py
@@ -28,7 +28,6 @@ from openquake import logs
 from openquake import writer
 from openquake.calculators.hazard import general as haz_general
 from openquake.db import models
-from openquake.export import hazard as hexp
 from openquake.input import logictree
 from openquake.utils import stats
 from openquake.utils import tasks as utils_tasks


### PR DESCRIPTION
Address an intermittent race condition which would prevent realization
counters from updating properly.

This is something I noticed a while back while playing around a with a large-ish calculation. I just now got around to submitting the patch.
