### PR TITLE
Complete logic tree GMF cannot be produced with end branch enumeration

### DIFF
--- a/openquake/job/validation.py
+++ b/openquake/job/validation.py
@@ -278,8 +278,19 @@ class EventBasedHazardCalculationForm(BaseOQModelForm):
         hc = self.instance
 
         # contextual validation
-        # for the case where the user has requested to post-process GMFs into
-        # hazard curves
+
+        # It doesn't make sense to capture/export the `complete_logic_tree_gmf`
+        # when we're doing end-branch enumeration:
+        if (hc.number_of_logic_tree_samples == 0
+            and hc.complete_logic_tree_gmf is True):
+
+            msg = '`%s` is not available with end branch enumeration'
+            msg %= 'complete_logic_tree_gmf'
+            self._add_error('complete_logic_tree_gmf', msg)
+            all_valid = False
+
+        # For the case where the user has requested to post-process GMFs into
+        # hazard curves:
         if hc.hazard_curves_from_gmfs is True:
             # 1) We need to make sure `intensity_measure_types_and_levels` is
             #    defined (and valid)

--- a/tests/job/validation_test.py
+++ b/tests/job/validation_test.py
@@ -772,3 +772,50 @@ class EventBasedHazardCalculationFormTestCase(unittest.TestCase):
         self.assertFalse(form.is_valid())
         equal, err = helpers.deep_eq(expected_errors, dict(form.errors))
         self.assertTrue(equal, err)
+
+    def test_invalid_params_complet_lt_gmf_with_eb_enum(self):
+        # When the `complete_logic_tree_gmf` is requested with end-branch
+        # enumeration, this is not allowed. (The complete LT GMF is not a
+        # useful artifact in this case.)
+        expected_errors = {
+            'complete_logic_tree_gmf': [
+                '`complete_logic_tree_gmf` is not available with end branch '
+                'enumeration'],
+        }
+
+        hc = models.HazardCalculation(
+            owner=helpers.default_user(),
+            description='',
+            region=(
+                'POLYGON((-122.0 38.113, -122.114 38.113, -122.57 38.111, '
+                '-122.0 38.113))'
+            ),
+            region_grid_spacing=0.001,
+            calculation_mode='event_based',
+            random_seed=37,
+            number_of_logic_tree_samples=0,
+            rupture_mesh_spacing=0.001,
+            width_of_mfd_bin=0.001,
+            area_source_discretization=0.001,
+            reference_vs30_value=0.001,
+            reference_vs30_type='measured',
+            reference_depth_to_2pt5km_per_sec=0.001,
+            reference_depth_to_1pt0km_per_sec=0.001,
+            investigation_time=1.0,
+            intensity_measure_types=VALID_IML_IMT.keys(),
+            truncation_level=0.0,
+            maximum_distance=100.0,
+            ses_per_logic_tree_path=5,
+            ground_motion_correlation_model='JB2009',
+            ground_motion_correlation_params={"vs30_clustering": True},
+            complete_logic_tree_ses=False,
+            complete_logic_tree_gmf=True,
+            ground_motion_fields=True,
+        )
+        form = validation.EventBasedHazardCalculationForm(
+            instance=hc, files=None
+        )
+
+        self.assertFalse(form.is_valid())
+        equal, err = helpers.deep_eq(expected_errors, dict(form.errors))
+        self.assertTrue(equal, err)


### PR DESCRIPTION
Added a check so that the `complete_logic_tree_gmf` cannot be produced
when doing end-branch logic tree enumeration.

This requirement came out of a discussion with Dr. Monelli about GMF-to-hazard curve post processing.
