### PR TITLE
Trivial fix to a validation error message

### DIFF
--- a/openquake/job/validation.py
+++ b/openquake/job/validation.py
@@ -196,7 +196,7 @@ class BaseOQModelForm(ModelForm):
             # calculation i.e. an 'export_dir' parameter must be present.
             if not hc.export_dir:
                 all_valid = False
-                err = ('--export specified on the command line but the '
+                err = ('--exports specified on the command line but the '
                        '"export_dir" parameter is missing in the .ini file')
                 self._add_error('export_dir', err)
 

--- a/tests/job/validation_test.py
+++ b/tests/job/validation_test.py
@@ -466,7 +466,7 @@ class ClassicalHazardCalculationFormTestCase(unittest.TestCase):
     def test_hazard_calculation_is_not_valid_missing_export_dir(self):
         # When the user specifies '--exports' on the command line the
         # 'export_dir' parameter must be present in the .ini file.
-        err = ('--export specified on the command line but the '
+        err = ('--exports specified on the command line but the '
                '"export_dir" parameter is missing in the .ini file')
         expected_errors = {
             'export_dir': [err],


### PR DESCRIPTION
Fixed a typo in an error message. The message was referring to the
"--export" command-line option, where it should have referred to
"--exports".
