### PR TITLE
Fix initial stats calculation (number of tasks)

### DIFF
--- a/openquake/calculators/hazard/general.py
+++ b/openquake/calculators/hazard/general.py
@@ -1145,6 +1145,10 @@ class BaseHazardCalculatorNext(base.CalculatorNext):
         block_size = int(config.get('hazard', 'block_size'))
         num_tasks = 0
         for lt_rlz in realizations:
+            # Each realization has the potential to choose a random source
+            # model, and thus there may be a variable number of tasks for each
+            # realization (depending on the number of the sources in the model
+            # which was chosen for the realization).
             num_sources = models.SourceProgress.objects.filter(
                 lt_realization=lt_rlz).count()
             num_tasks += math.ceil(float(num_sources) / block_size)


### PR DESCRIPTION
Computation of the number of tasks didn't work in the case of multiple source models.

This is also fixes the following error: http://ci.openquake.org/job/oq-engine-nhlib-integration/11/testReport/qa_tests.hazard.classical.case_7.test/ClassicalHazardCase7TestCase/test/
