### PR TITLE
Fix for https://bugs.launchpad.net/openquake/+bug/1062387

### DIFF
--- a/openquake/db/models.py
+++ b/openquake/db/models.py
@@ -812,10 +812,8 @@ class HazardCalculation(djm.Model):
         expected after a full computation of the hazard calculation
         has been performed
         """
-
         realizations_nr = self.ltrealization_set.count()
-        imt_nr = len(self.intensity_measure_types_and_levels)
-        return realizations_nr * imt_nr
+        return realizations_nr
 
     def should_compute_mean_curves(self):
         """


### PR DESCRIPTION
Fixed computation of _number of curves per location_ (the number of
hazard curves used to compute statistical aggregates for a single
site).

Previously, it was computed such that two issues were present:
1. Aggregates were being computed for a given over all logic tree
    samples AND intensity measure types. This is not correct. The
    statistical aggregates (means, quantiles, etc.) for each
    intensity measure type need to be computed separately.
2. The post-processing for certain geometries (most geometries,
    in fact) would break and throw an exception. See bug description for
    https://bugs.launchpad.net/openquake/+bug/1062387. The root
    cause is described in point #1 above. The "intermediate" cause
    of this error is basically and off-by-one with respect to the
    division of post-processing tasks, and thus numpy is unable to
    re-dimension data into the expected shape.
