### PR TITLE
Explicit celery queues

### DIFF
--- a/openquake.cfg
+++ b/openquake.cfg
@@ -31,6 +31,8 @@ user = guest
 password = guest
 vhost = /
 exchange = oq.signalling
+# This is where tasks will be enqueued.
+celery_queue = celery
 
 [logging]
 backend = amqp

--- a/openquake/utils/tasks.py
+++ b/openquake/utils/tasks.py
@@ -28,6 +28,7 @@ from celery.task import task
 
 from openquake import logs
 from openquake.db import models
+from openquake.utils import config
 
 
 def distribute(task_func, (name, data), tf_args=None, ath=None, ath_args=None,
@@ -215,4 +216,5 @@ def oqtask(task_func):
             logs.LOG.exception(err)
             raise
 
-    return task(wrapped, ignore_result=True)
+    celery_queue = config.get('amqp', 'celery_queue')
+    return task(wrapped, ignore_result=True, queue=celery_queue)


### PR DESCRIPTION
We can now specify the celery work queue in the config file (using the
`celery_queue` parameter). This is useful if there are multiple users
on a single machine, each with its own pool of workers. We can use this
new feature to separate the work simply by running celeryd like so:

$ celeryd -Q foo

and changing `celery_queue` to "foo".
