### PR TITLE
Stabilize Event-Base Hazard QA test, case 12

### DIFF
--- a/qa_tests/hazard/event_based/case_12/test.py
+++ b/qa_tests/hazard/event_based/case_12/test.py
@@ -42,6 +42,6 @@ class EventBasedHazardCase12TestCase(qa_utils.BaseQATestCase):
             [curve] = models.HazardCurveData.objects.filter(
                 hazard_curve__output__oq_job=job.id)
 
-            aaae(expected_curve_poes, curve.poes, decimal=3)
+            aaae(expected_curve_poes, curve.poes, decimal=2)
         finally:
             shutil.rmtree(result_dir)


### PR DESCRIPTION
Adjusted test precision from 3 to 2 digits. Changing the task
distribution and random seeding made the results change slightly,
so we have to adjust the test to stabilize things.
