### PR TITLE
make imt a mandatory parameter in individual curve chunks getter

### DIFF
--- a/openquake/db/models.py
+++ b/openquake/db/models.py
@@ -1391,31 +1391,31 @@ class HazardCurveDataManager(djm.Manager):
     Manager class to filter and create HazardCurveData objects
     """
 
-    def individual_curves(self, job, imt=None):
+    def individual_curves(self, job, imt):
         """
         Returns all the individual hazard curve data objects. If `imt`
         is given the results are filtered by intensity measure type.
         Here imt is given in the long format.
         """
+        hc_im_type, sa_period, sa_damping = parse_imt(imt)
+
         query_args = {'hazard_curve__statistics__isnull': True,
                       'hazard_curve__output__oq_job': job,
-                      'hazard_curve__output__output_type': "hazard_curve"}
-        if imt:
-            hc_im_type, sa_period, sa_damping = parse_imt(imt)
-            query_args['hazard_curve__imt'] = hc_im_type
-            query_args['hazard_curve__sa_period'] = sa_period
-            query_args['hazard_curve__sa_damping'] = sa_damping
+                      'hazard_curve__output__output_type': "hazard_curve",
+                      'hazard_curve__imt': hc_im_type,
+                      'hazard_curve__sa_period': sa_period,
+                      'hazard_curve__sa_damping': sa_damping}
 
         queryset = self.filter(**query_args)
         return queryset
 
-    def individual_curves_ordered(self, job, imt=None):
+    def individual_curves_ordered(self, job, imt):
         """
         Same as #individual_curves but the results are ordered by location
         """
         return self.individual_curves(job, imt).order_by('location')
 
-    def individual_curves_nr(self, job, imt=None):
+    def individual_curves_nr(self, job, imt):
         """
         Returns the number of individual curves. If `imt` is given, it
         returns the number of individual curves with intensity measure
@@ -1440,7 +1440,7 @@ class HazardCurveDataManager(djm.Manager):
 
         return values[offset: block_size + offset]
 
-    def individual_curves_chunks(self, job, imt=None, location_block_size=1):
+    def individual_curves_chunks(self, job, imt, location_block_size=1):
         """
         Return a list of chunk of individual curves. A chunk is a
         tuple with all the ingredients needed to get a chunk of

--- a/tests/db/models_manager_test.py
+++ b/tests/db/models_manager_test.py
@@ -134,7 +134,7 @@ class HazardCurveDataManagerTestCase(TestCaseWithAJob):
                              self.job, "PGA")))
 
         self.assertEqual(2,
-                         len(self.manager.individual_curves(self.job)))
+                         len(self.manager.individual_curves(self.job, "PGA")))
 
     def test_individual_curves_nr(self):
         """
@@ -146,13 +146,13 @@ class HazardCurveDataManagerTestCase(TestCaseWithAJob):
                              self.job, "fake imt"))
 
         self.assertEqual(2,
-                         self.manager.individual_curves_nr(self.job))
+                         self.manager.individual_curves_nr(self.job, "PGA"))
 
     def test_individual_curves_ordered(self):
         """
         Test getting individual curves ordered by location
         """
-        curves = self.manager.individual_curves_ordered(self.job)
+        curves = self.manager.individual_curves_ordered(self.job, "PGA")
 
         self.assertEqual(2, len(curves))
         self.assertTrue(curves[0].location < curves[1].location)
@@ -163,7 +163,7 @@ class HazardCurveDataManagerTestCase(TestCaseWithAJob):
         """
         block_size = 1
         chunks = self.manager.individual_curves_chunks(
-            self.job, location_block_size=block_size)
+            self.job, "PGA", location_block_size=block_size)
         self.assertEqual(1, len(chunks))
 
         chunk = chunks[0].locations


### PR DESCRIPTION
Individual Chunks Getter are used in post processing to get bunch of curves for a specific Intensity Measure Type (IMT).

The current implementation allows also to get them without specifying an IMT but it is broken at this moment.

In this pull request we remove the possibility of getting individual chunk of curves without specifying an IMT.
