### PR TITLE
Fix for Risk QA test collection

### DIFF
--- a/qa_tests/risk/__init__.py
+++ b/qa_tests/risk/__init__.py
@@ -61,7 +61,7 @@ class BaseRiskQATestCase(qa_utils.BaseQATestCase):
         self.assertEqual('complete', completed_job.status)
         return completed_job
 
-    def run_test(self):
+    def _run_test(self):
         result_dir = tempfile.mkdtemp()
 
         try:

--- a/qa_tests/risk/classical/case_1/test.py
+++ b/qa_tests/risk/classical/case_1/test.py
@@ -87,7 +87,7 @@ class ClassicalRiskCase1TestCase(risk.BaseRiskQATestCase):
 
     @noseattr('qa', 'risk', 'classical')
     def test(self):
-        self.run_test()
+        self._run_test()
 
     def hazard_id(self):
         job = helpers.get_hazard_job(

--- a/qa_tests/risk/classical/case_2/test.py
+++ b/qa_tests/risk/classical/case_2/test.py
@@ -57,7 +57,7 @@ class ClassicalRiskCase2TestCase(risk.BaseRiskQATestCase):
 
     @noseattr('qa', 'risk', 'classical')
     def test(self):
-        self.run_test()
+        self._run_test()
 
     def hazard_id(self):
         job = helpers.get_hazard_job(

--- a/qa_tests/risk/classical_bcr/case_1/test.py
+++ b/qa_tests/risk/classical_bcr/case_1/test.py
@@ -42,7 +42,7 @@ class ClassicalBCRCase1TestCase(risk.BaseRiskQATestCase):
 
     @attr('qa', 'risk', 'classical_bcr')
     def test(self):
-        self.run_test()
+        self._run_test()
 
     def hazard_id(self):
         job = helpers.get_hazard_job(

--- a/qa_tests/risk/event_based/case_1/test.py
+++ b/qa_tests/risk/event_based/case_1/test.py
@@ -53,7 +53,7 @@ class EventBasedRiskCase1TestCase(risk.BaseRiskQATestCase):
 
     @noseattr('qa', 'risk', 'event_based')
     def test(self):
-        self.run_test()
+        self._run_test()
 
     def hazard_id(self):
         job = helpers.get_hazard_job(

--- a/qa_tests/risk/event_based_bcr/case_1/test.py
+++ b/qa_tests/risk/event_based_bcr/case_1/test.py
@@ -55,7 +55,7 @@ class EventBasedRiskCase1TestCase(risk.BaseRiskQATestCase):
 
     @noseattr('qa', 'risk', 'event_based_bcr')
     def test(self):
-        self.run_test()
+        self._run_test()
 
     def hazard_id(self):
         job = helpers.get_hazard_job(


### PR DESCRIPTION
Fixed the base risk QA test case class so that nose attributes work
properly. The involved simply renaming `run_tests` to `_run_tests`.

Without this fix, all of the risk QA tests are run even is you specify
`nosetests -a '!qa'`.
