### PR TITLE
Supervisor support for `no_distribute`

### DIFF
--- a/openquake/supervising/supervisor.py
+++ b/openquake/supervising/supervisor.py
@@ -306,6 +306,9 @@ class SupervisorLogMessageConsumer(logs.AMQPLogSource):
             if failures:
                 message = "job terminated with failures: %s" % failures
             else:
+                # Don't check for failed nodes if distribution is disabled.
+                # In this case, we don't expect any nodes to be present, and
+                # thus, there are none that can fail.
                 if not openquake.no_distribute():
                     failed_nodes = abort_due_to_failed_nodes(self.job_id)
                     if failed_nodes:


### PR DESCRIPTION
For large calculations, I observed that the engine runs into issues with --no-distribute enabled. If a task takes a long time to complete, the supervisor will check to make sure all workers are running. In the `no_distribute` case, we want to skip this check.
