### PR TITLE
Optimized hazard curve export

### DIFF
--- a/openquake/export/hazard.py
+++ b/openquake/export/hazard.py
@@ -163,6 +163,7 @@ def export_hazard_curves(output, target_dir):
     # faster and more lean in terms of memory consumption.
     curves = models.HazardCurveData.objects\
             .filter(hazard_curve=hc.id)\
+            .order_by('id')\
             .extra(select={'x': 'ST_X(location)', 'y': 'ST_Y(location)'})\
             .values_list('x', 'y', 'poes')\
             .iterator()


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/openquake/+bug/1099763.

See bug description and comments for detailed information about the profiling and optimizations I've done here.

Note: https://github.com/gem/oq-engine/pull/1007 should land first for a clean diff.
