### PR TITLE
Add timestamps to calculation summary output

### DIFF
--- a/bin/openquake
+++ b/bin/openquake
@@ -55,17 +55,20 @@ import getpass
 import os
 import sys
 
+from os.path import abspath
+from os.path import dirname
 from os.path import expanduser
+from os.path import join
 
 from django.core.exceptions import ObjectDoesNotExist
 
 # just in the case that are you using oq-engine from sources
 # with the rest of oq libraries installed into the system (or a
 # virtual environment) you must set this environment variable
-if os.environ.get("OQ_ENGINE_USE_SRCDIR") != None:
+if os.environ.get("OQ_ENGINE_USE_SRCDIR") is not None:
     sys.modules['openquake'].__dict__["__path__"].insert(
-            0, os.path.join(os.path.dirname(
-                            os.path.dirname(__file__)), "openquake"))
+        0, join(dirname(dirname(__file__)), "openquake")
+    )
 
 from openquake.engine.utils import config
 
@@ -83,12 +86,14 @@ except ImportError:
     pass
 
 import openquake.engine
+
 from openquake.engine import __version__
-from openquake.engine import engine2, utils
+from openquake.engine import engine2
 from openquake.engine.db import models
 from openquake.engine.export import hazard as hazard_export
 from openquake.engine.export import risk as risk_export
 from openquake.engine.job.validation import validate
+from openquake.engine.utils import version
 
 
 HAZARD_OUTPUT_ARG = "--hazard-output-id"
@@ -276,7 +281,8 @@ def _print_calcs_summary(calcs):
     if len(calcs) == 0:
         print 'None'
     else:
-        print 'calc_id | num_jobs | latest_job_status | last_update | description'
+        print ('calc_id | num_jobs | latest_job_status | last_update | '
+               'description')
         for calc in calcs:
             jobs = calc.oqjob_set.all()
 
@@ -299,7 +305,7 @@ def _print_calcs_summary(calcs):
                 )
 
             print '%s | %s | %s | %s | %s' % (
-                calc.id, len(jobs), status,last_update, calc.description
+                calc.id, len(jobs), status, last_update, calc.description
             )
 
 
@@ -443,7 +449,7 @@ def _touch_log_file(log_file):
     """If a log file destination is specified, attempt to open the file in
     'append' mode ('a'). If the specified file is not writable, an
     :exc:`IOError` will be raised."""
-    open(os.path.abspath(log_file), 'a').close()
+    open(abspath(log_file), 'a').close()
 
 
 def complain_and_exit(msg, exit_code=0):
@@ -457,7 +463,7 @@ def main():
     args = arg_parser.parse_args()
 
     if args.version:
-        complain_and_exit(utils.version.info(__version__))
+        complain_and_exit(version.info(__version__))
 
     if args.no_distribute:
         os.environ[openquake.engine.NO_DISTRIBUTE_VAR] = '1'
@@ -488,7 +494,8 @@ def main():
     elif args.run_risk is not None:
         if args.hazard_output_id is None and args.hazard_calculation_id is None:
             complain_and_exit(MISSING_HAZARD_MSG)
-        log_file = expanduser(args.log_file) if args.log_file is not None else None
+        log_file = expanduser(args.log_file) \
+            if args.log_file is not None else None
         run_risk(expanduser(args.run_risk), args.log_level, log_file,
                  args.force_inputs, args.exports,
                  hazard_output_id=args.hazard_output_id,


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/openquake/+bug/1129271

The formatting of calculation and output summaries has changed as well. It's cleaner and more consistent now. For example:

<pre>
$ bin/openquake  --lhc
calc_id | num_jobs | latest_job_status | last_update | description
1 | 1 | pending | 2013-02-19 09:25:57  | Simple Fault Demo, Classical PSHA
2 | 1 | pending | 2013-02-19 09:26:05  | Simple Fault Demo, Classical PSHA
3 | 1 | failed | 2013-02-19 09:26:06  | Simple Fault Demo, Classical PSHA
4 | 1 | failed | 2013-02-19 09:26:07  | Simple Fault Demo, Classical PSHA
5 | 1 | failed | 2013-02-19 09:26:08  | Simple Fault Demo, Classical PSHA
6 | 1 | failed | 2013-02-19 09:26:09  | Simple Fault Demo, Classical PSHA
7 | 1 | failed | 2013-02-19 09:26:10  | Simple Fault Demo, Classical PSHA
9 | 1 | failed | 2013-02-19 09:26:22  | Simple Fault Demo, Classical PSHA
24 | 1 | successful | 2013-02-19 09:27:16  | Simple Fault Demo, Classical PSHA
10 | 1 | pending | 2013-02-19 09:26:22  | Simple Fault Demo, Classical PSHA
11 | 1 | failed | 2013-02-19 09:26:31  | Simple Fault Demo, Classical PSHA
12 | 1 | successful | 2013-02-19 09:26:32  | Hazard Map test job, 1 realization, no mean/quantile
25 | 1 | successful | 2013-02-19 09:27:28  | Simple Fault Demo, Classical PSHA
</pre>


<pre>
$ bin/openquake --lho 75
id | output_type | name
218 | ses | ses-coll-rlz-104
219 | gmf | gmf-rlz-104
220 | ses | ses-coll-rlz-105
221 | gmf | gmf-rlz-105
222 | complete_lt_ses | complete logic tree SES
223 | complete_lt_gmf | complete logic tree GMF
224 | hazard_curve | hazard-curve-rlz-104-SA(0.1)
225 | hazard_curve | hazard-curve-rlz-105-SA(0.1)
226 | hazard_curve | hazard-curve-rlz-104-PGA
227 | hazard_curve | hazard-curve-rlz-105-PGA
228 | hazard_curve | mean curve for SA(0.1)
229 | hazard_curve | quantile curve (poe >= 0.15) for imt SA(0.1)
230 | hazard_curve | quantile curve (poe >= 0.5) for imt SA(0.1)
231 | hazard_curve | quantile curve (poe >= 0.85) for imt SA(0.1)
232 | hazard_curve | mean curve for PGA
233 | hazard_curve | quantile curve (poe >= 0.15) for imt PGA
234 | hazard_curve | quantile curve (poe >= 0.5) for imt PGA
235 | hazard_curve | quantile curve (poe >= 0.85) for imt PGA
</pre>
