### PR TITLE
"openquake --version broked" fix

### DIFF
--- a/bin/openquake
+++ b/bin/openquake
@@ -66,6 +66,7 @@ if os.environ.get("OQ_ENGINE_USE_SRCDIR") != None:
                             os.path.dirname(__file__)), "openquake"))
 
 from openquake.engine.utils import config
+import openquake.engine.utils.version
  
 config.abort_if_no_config_available()
 
@@ -441,7 +442,7 @@ def main():
     args = arg_parser.parse_args()
 
     if args.version:
-        complain_and_exit(utils.version.info(__version__))
+        complain_and_exit(openquake.engine.utils.version.info(__version__))
 
     if args.no_distribute:
         os.environ[openquake.engine.NO_DISTRIBUTE_VAR] = '1'

--- a/tests/engine2_test.py
+++ b/tests/engine2_test.py
@@ -364,3 +364,25 @@ class ReadJobProfileFromConfigFileTestCase(unittest.TestCase):
             instance=calculation, files=files
         )
         self.assertTrue(form.is_valid())
+
+
+class OpenquakeCliTestCase(unittest.TestCase):
+    """
+    Run "openquake --version" as a separate
+    process using `subprocess`.
+    """
+
+    def test_run_version(self, silence=False):
+        args = [helpers.RUNNER, "--version"]
+
+        devnull = None
+        if silence:
+            devnull = open(os.devnull, 'wb')
+
+        print 'Running:', ' '.join(args)  # this is useful for debugging
+        try:
+            return subprocess.check_call(args, stderr=devnull, stdout=devnull)
+        finally:
+            if devnull is not None:
+                devnull.close()
+


### PR DESCRIPTION
introducing a new level of packaging break intermediate packages usage like 'from openquake.engine import utils' and than use 'utils.version.info(**version**)', fix it for the --version particular case
