### PR TITLE
Fix Scenario Risk calculator

### DIFF
--- a/openquake/engine/calculators/risk/scenario/core.py
+++ b/openquake/engine/calculators/risk/scenario/core.py
@@ -133,7 +133,7 @@ class ScenarioRiskCalculator(general.BaseRiskCalculator):
         super(ScenarioRiskCalculator, self).pre_execute()
 
         if self.rc.insured_losses:
-            queryset = self.exposure_model.exposuredata_set.filter(
+            queryset = self.rc.exposure_model.exposuredata_set.filter(
                 (db.models.Q(deductible__isnull=True) |
                  db.models.Q(ins_limit__isnull=True)))
             if queryset.exists():


### PR DESCRIPTION
Addresses the bug preventing any scenario risk calculation with insured losses to run due to a bug in validation phase.
