### PR TITLE
Add hazard nose attribute to the hazard QA test

### DIFF
--- a/qa_tests/hazard/classical/case_1/test.py
+++ b/qa_tests/hazard/classical/case_1/test.py
@@ -55,7 +55,7 @@ class ClassicalHazardCase1TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_10/test.py
+++ b/qa_tests/hazard/classical/case_10/test.py
@@ -55,7 +55,7 @@ class ClassicalHazardCase10TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_11/test.py
+++ b/qa_tests/hazard/classical/case_11/test.py
@@ -110,7 +110,7 @@ class ClassicalHazardCase11TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
         aaae = numpy.testing.assert_array_almost_equal

--- a/qa_tests/hazard/classical/case_12/test.py
+++ b/qa_tests/hazard/classical/case_12/test.py
@@ -40,7 +40,7 @@ class ClassicalHazardCase12TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
         aaae = numpy.testing.assert_array_almost_equal

--- a/qa_tests/hazard/classical/case_2/test.py
+++ b/qa_tests/hazard/classical/case_2/test.py
@@ -41,7 +41,7 @@ class ClassicalHazardCase2TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_3/test.py
+++ b/qa_tests/hazard/classical/case_3/test.py
@@ -41,7 +41,7 @@ class ClassicalHazardCase3TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_4/test.py
+++ b/qa_tests/hazard/classical/case_4/test.py
@@ -41,7 +41,7 @@ class ClassicalHazardCase4TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_5/test.py
+++ b/qa_tests/hazard/classical/case_5/test.py
@@ -41,7 +41,7 @@ class ClassicalHazardCase5TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_6/test.py
+++ b/qa_tests/hazard/classical/case_6/test.py
@@ -41,7 +41,7 @@ class ClassicalHazardCase6TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_7/test.py
+++ b/qa_tests/hazard/classical/case_7/test.py
@@ -69,7 +69,7 @@ class ClassicalHazardCase7TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_8/test.py
+++ b/qa_tests/hazard/classical/case_8/test.py
@@ -69,7 +69,7 @@ class ClassicalHazardCase8TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 

--- a/qa_tests/hazard/classical/case_9/test.py
+++ b/qa_tests/hazard/classical/case_9/test.py
@@ -55,7 +55,7 @@ class ClassicalHazardCase9TestCase(qa_utils.BaseQATestCase):
 </nrml>
 """
 
-    @attr('qa', 'classical')
+    @attr('qa', 'hazard', 'classical')
     def test(self):
         result_dir = tempfile.mkdtemp()
 


### PR DESCRIPTION
In order to allow:

nosetests -a 'qa,hazard,classical'

instead of

nosetests -a 'qa,classical'

that spawns also the risk tests of the classical risk calculator
