### PR TITLE
Improved the error message for unavailable gsims

### DIFF
--- a/openquake/engine/input/logictree.py
+++ b/openquake/engine/input/logictree.py
@@ -80,7 +80,7 @@ class ValidationError(LogicTreeError):
 
     def __str__(self):
         return 'basepath %r, filename %r, line %r: %s' % (
-                self.basepath, self.filename, self.lineno, self.message)
+            self.basepath, self.filename, self.lineno, self.message)
 
 
 class Branch(object):
@@ -238,10 +238,9 @@ class BranchSet(object):
                 elif value == 'point':
                     # area source extends point source
                     if (not isinstance(
-                            source, openquake.hazardlib.source.PointSource) \
-                            or isinstance(
-                                    source,
-                                    openquake.hazardlib.source.AreaSource)):
+                            source, openquake.hazardlib.source.PointSource)
+                        or isinstance(
+                            source, openquake.hazardlib.source.AreaSource)):
                         return False
                 elif value == 'simpleFault':
                     if not isinstance(
@@ -442,7 +441,7 @@ class BaseLogicTree(object):
         """
         new_open_ends = set()
         branchsets = branchinglevel_node.findall('{%s}logicTreeBranchSet' %
-                                                self.NRML)
+                                                 self.NRML)
         for number, branchset_node in enumerate(branchsets):
             branchset = self.parse_branchset(branchset_node, depth, number,
                                              validate)
@@ -513,7 +512,7 @@ class BaseLogicTree(object):
                 self.validate_uncertainty_value(value_node, branchset,
                                                 value_node.text.strip())
             value = self.parse_uncertainty_value(value_node, branchset,
-                                                value_node.text.strip())
+                                                 value_node.text.strip())
             branch_id = branchnode.get('branchID')
             branch = Branch(branch_id, weight, value)
             if branch_id in self.branches:
@@ -749,7 +748,7 @@ class SourceModelLogicTree(BaseLogicTree):
                     in self.tectonic_region_types:
                 raise ValidationError(
                     branchset_node, self.filename, self.basepath,
-                    "source models don't define sources of tectonic region " \
+                    "source models don't define sources of tectonic region "
                     "type %r" % filters['applyToTectonicRegionType']
                 )
         if 'applyToSourceType' in filters:
@@ -774,7 +773,7 @@ class SourceModelLogicTree(BaseLogicTree):
                     or not len(filters['applyToSources'].split()) == 1:
                 raise ValidationError(
                     branchset_node, self.filename, self.basepath,
-                    "uncertainty of type %r must define 'applyToSources' " \
+                    "uncertainty of type %r must define 'applyToSources' "
                     "with only one source id" % uncertainty_type
                 )
 
@@ -923,17 +922,16 @@ class GMPELogicTree(BaseLogicTree):
         """
         See superclass' method for description and signature specification.
 
-        Checks that the value is the name of a class that extends the
-        :attr:`BASE_GMPE` abstract base class.
+        Checks that the value is a class name in the dictionary reported
+        by get_available_gsims, i.e. a GSIM class.
         """
         try:
-            gmpe_class = GSIM[value]
+            GSIM[value]
         except KeyError:
-            raise ValidationError(node, self.filename, self.basepath,
-                                  'unknown class %r' % value)
-        if not issubclass(gmpe_class, self.BASE_GMPE):
-            raise ValidationError(node, self.filename, self.basepath,
-                                  '%r is not a gmpe class' % gmpe_class)
+            raise ValidationError(
+                node, self.filename, self.basepath,
+                'unknown class %r; available classes are: %s' % (
+                    value, list(GSIM)))
 
     def parse_filters(self, node, uncertainty_type, filters):
         """
@@ -982,7 +980,7 @@ class GMPELogicTree(BaseLogicTree):
         models there is a branchset defined.
         """
         missing_trts = self.tectonic_region_types \
-                       - self.defined_tectonic_region_types
+            - self.defined_tectonic_region_types
         if missing_trts:
             raise ValidationError(
                 tree_node, self.filename, self.basepath,
@@ -1047,10 +1045,12 @@ class LogicTreeProcessor(object):
         ID of a :class:`openquake.engine.db.models.HazardCalculation`.
     """
     def __init__(self, calc_id):
-        [smlt_input] = models.inputs4hcalc(calc_id, input_type='source_model_logic_tree')
+        [smlt_input] = models.inputs4hcalc(
+            calc_id, input_type='source_model_logic_tree')
         smlt_content = smlt_input.model_content.raw_content_ascii
 
-        [gmpelt_input] = models.inputs4hcalc(calc_id, input_type='gsim_logic_tree')
+        [gmpelt_input] = models.inputs4hcalc(
+            calc_id, input_type='gsim_logic_tree')
         gmpelt_content = gmpelt_input.model_content.raw_content_ascii
 
         self.source_model_lt = SourceModelLogicTree(

--- a/tests/input/logictree_test.py
+++ b/tests/input/logictree_test.py
@@ -945,7 +945,7 @@ class GMPELogicTreeBrokenInputTestCase(unittest.TestCase):
                          "wrong exception message: %s" % exc.message)
         self.assertEqual(exc.lineno, 15)
 
-    def test_unavailable_gmpe_not_subclass_of_base_class(self):
+    def test_unavailable_gsim(self):
         gmpe = _make_nrml("""\
         <logicTree logicTreeID="lt1">
             <logicTreeBranchingLevel branchingLevelID="bl1">
@@ -963,9 +963,10 @@ class GMPELogicTreeBrokenInputTestCase(unittest.TestCase):
         exc = self._assert_logic_tree_error('gmpe', gmpe, 'base',
                                             set(['Volcanic']),
                                             logictree.ValidationError)
-        error = "unknown class 'Site'"
-        self.assertEqual(exc.message, error,
-                         "wrong exception message: %s" % exc.message)
+        error = "unknown class 'Site'; available classes are: ["
+        if not exc.message.startswith(error):
+            raise RuntimeError("%s, expected something starting with %r" %
+                               (exc.message, error))
         self.assertEqual(exc.lineno, 7)
 
     def test_wrong_filters(self):
@@ -1668,8 +1669,9 @@ class BranchSetApplyUncertaintyMethodSignaturesTestCase(unittest.TestCase):
         mfd = Mock()
         bs = logictree.BranchSet('maxMagGRRelative', {})
         bs._apply_uncertainty_to_mfd(mfd, 32.1)
-        self.assertEqual(mfd.method_calls,
-                    [('modify', ('increment_max_mag', {'value': 32.1}), {})])
+        self.assertEqual(
+            mfd.method_calls,
+            [('modify', ('increment_max_mag', {'value': 32.1}), {})])
 
     def test_apply_uncertainty_mmax_absolute(self):
         mfd = Mock()
@@ -1688,8 +1690,8 @@ class BranchSetApplyUncertaintyTestCase(unittest.TestCase):
     def setUp(self):
         self.point_source = openquake.hazardlib.source.PointSource(
             source_id='point', name='point',
-            tectonic_region_type=openquake.hazardlib.const.TRT.\
-ACTIVE_SHALLOW_CRUST,
+            tectonic_region_type=
+            openquake.hazardlib.const.TRT.ACTIVE_SHALLOW_CRUST,
             mfd=TruncatedGRMFD(a_val=3.1, b_val=0.9, min_mag=5.0,
                                max_mag=6.5, bin_width=0.1),
             nodal_plane_distribution=PMF(
@@ -1697,8 +1699,8 @@ ACTIVE_SHALLOW_CRUST,
             ),
             hypocenter_distribution=PMF([(1, 10)]),
             upper_seismogenic_depth=0.0, lower_seismogenic_depth=10.0,
-            magnitude_scaling_relationship=openquake.hazardlib.scalerel.\
-PeerMSR(),
+            magnitude_scaling_relationship=
+            openquake.hazardlib.scalerel.PeerMSR(),
             rupture_aspect_ratio=1, location=openquake.hazardlib.geo.Point(
                 5, 6),
             rupture_mesh_spacing=1.0
@@ -1745,8 +1747,8 @@ class BranchSetFilterTestCase(unittest.TestCase):
     def setUp(self):
         self.point = openquake.hazardlib.source.PointSource(
             source_id='point', name='point',
-            tectonic_region_type=openquake.hazardlib.const.TRT.\
-ACTIVE_SHALLOW_CRUST,
+            tectonic_region_type=
+            openquake.hazardlib.const.TRT.ACTIVE_SHALLOW_CRUST,
             mfd=TruncatedGRMFD(a_val=3.1, b_val=0.9, min_mag=5.0,
                                max_mag=6.5, bin_width=0.1),
             nodal_plane_distribution=PMF(
@@ -1754,16 +1756,16 @@ ACTIVE_SHALLOW_CRUST,
             ),
             hypocenter_distribution=PMF([(1, 10)]),
             upper_seismogenic_depth=0.0, lower_seismogenic_depth=10.0,
-            magnitude_scaling_relationship=openquake.hazardlib.scalerel.\
-PeerMSR(),
+            magnitude_scaling_relationship=
+            openquake.hazardlib.scalerel.PeerMSR(),
             rupture_aspect_ratio=1, location=openquake.hazardlib.geo.Point(
                 5, 6),
             rupture_mesh_spacing=1.0
         )
         self.area = openquake.hazardlib.source.AreaSource(
             source_id='area', name='area',
-            tectonic_region_type=openquake.hazardlib.const.TRT.\
-ACTIVE_SHALLOW_CRUST,
+            tectonic_region_type=
+            openquake.hazardlib.const.TRT.ACTIVE_SHALLOW_CRUST,
             mfd=TruncatedGRMFD(a_val=3.1, b_val=0.9, min_mag=5.0,
                                max_mag=6.5, bin_width=0.1),
             nodal_plane_distribution=PMF(
@@ -1771,8 +1773,8 @@ ACTIVE_SHALLOW_CRUST,
             ),
             hypocenter_distribution=PMF([(1, 10)]),
             upper_seismogenic_depth=0.0, lower_seismogenic_depth=10.0,
-            magnitude_scaling_relationship=openquake.hazardlib.scalerel.\
-PeerMSR(),
+            magnitude_scaling_relationship=
+            openquake.hazardlib.scalerel.PeerMSR(),
             rupture_aspect_ratio=1,
             polygon=openquake.hazardlib.geo.Polygon(
                 [openquake.hazardlib.geo.Point(0, 0),
@@ -1786,8 +1788,8 @@ PeerMSR(),
             mfd=TruncatedGRMFD(a_val=3.1, b_val=0.9, min_mag=5.0,
                                max_mag=6.5, bin_width=0.1),
             upper_seismogenic_depth=0.0, lower_seismogenic_depth=10.0,
-            magnitude_scaling_relationship=openquake.hazardlib.scalerel.\
-                PeerMSR(),
+            magnitude_scaling_relationship=
+            openquake.hazardlib.scalerel.PeerMSR(),
             rupture_aspect_ratio=1, rupture_mesh_spacing=2.0,
             fault_trace=openquake.hazardlib.geo.Line(
                 [openquake.hazardlib.geo.Point(0, 0),
@@ -1799,13 +1801,13 @@ PeerMSR(),
             tectonic_region_type=openquake.hazardlib.const.TRT.VOLCANIC,
             mfd=TruncatedGRMFD(a_val=3.1, b_val=0.9, min_mag=5.0,
                                max_mag=6.5, bin_width=0.1),
-            magnitude_scaling_relationship=openquake.hazardlib.scalerel.\
-                PeerMSR(),
+            magnitude_scaling_relationship=
+            openquake.hazardlib.scalerel.PeerMSR(),
             rupture_aspect_ratio=1, rupture_mesh_spacing=2.0, rake=0,
             edges=[openquake.hazardlib.geo.Line(
-                    [openquake.hazardlib.geo.Point(0, 0, 1),
-                     openquake.hazardlib.geo.Point(1, 1, 1)]),
-                   openquake.hazardlib.geo.Line(
+                [openquake.hazardlib.geo.Point(0, 0, 1),
+                 openquake.hazardlib.geo.Point(1, 1, 1)]),
+                openquake.hazardlib.geo.Line(
                     [openquake.hazardlib.geo.Point(0, 0, 2),
                      openquake.hazardlib.geo.Point(1, 1, 2)])]
         )


### PR DESCRIPTION
If the user mispells the GSIM class name the error message displays the list of available classes. 
Fixed some PEP8 issues and renamed one test. Notice that by construction
get_available_gsims cannot return classes which are not subclasses of GroundShakingIntensityModel. See also https://github.com/gem/oq-hazardlib/pull/109
