### PR TITLE
Minor simplification of the hazard_getter query

### DIFF
--- a/openquake/engine/calculators/risk/hazard_getters.py
+++ b/openquake/engine/calculators/risk/hazard_getters.py
@@ -244,8 +244,7 @@ class GroundMotionValuesGetter(HazardGetter):
      AND location && %s
      GROUP BY location) AS gmf_table
   ON ST_DWithin(oqmif.exposure_data.site, gmf_table.location, %s)
-  WHERE oqmif.exposure_data.site && %s
-  AND taxonomy = %s AND exposure_model_id = %s
+  WHERE taxonomy = %s AND exposure_model_id = %s
   AND array_length(gmf_table.allgmvs_arr, 1) > 0
   ORDER BY oqmif.exposure_data.id,
            ST_Distance(oqmif.exposure_data.site, gmf_table.location, false)
@@ -254,7 +253,6 @@ class GroundMotionValuesGetter(HazardGetter):
         assets_extent = self._assets_mesh.get_convex_hull()
         args += (assets_extent.dilate(self.max_distance).wkt,
                  self.max_distance * KILOMETERS_TO_METERS,
-                 assets_extent.wkt,
                  self.assets[0].taxonomy,
                  self.assets[0].exposure_model_id)
 
@@ -295,8 +293,7 @@ class GroundMotionScenarioGetter(HazardGetter):
            AND hzrdr.gmf_scenario.output_id = %s
            AND hzrdr.gmf_scenario.location && %s) gmf_table
   ON ST_DWithin(oqmif.exposure_data.site, gmf_table.location, %s)
-  WHERE oqmif.exposure_data.site && %s
-    AND taxonomy = %s AND exposure_model_id = %s
+  WHERE taxonomy = %s AND exposure_model_id = %s
   ORDER BY oqmif.exposure_data.id,
     ST_Distance(oqmif.exposure_data.site, gmf_table.location, false)
            """
@@ -305,10 +302,9 @@ class GroundMotionScenarioGetter(HazardGetter):
         args = (self._imt, self.hazard_id,
                 assets_extent.dilate(self.max_distance).wkt,
                 self.max_distance * KILOMETERS_TO_METERS,
-                assets_extent.wkt,
                 self.assets[0].taxonomy,
                 self.assets[0].exposure_model_id)
 
         cursor.execute(query, args)
-
+        # print cursor.mogrify(query, args)
         return OrderedDict(cursor.fetchall())

--- a/openquake/engine/calculators/risk/scenario_damage/core.py
+++ b/openquake/engine/calculators/risk/scenario_damage/core.py
@@ -28,6 +28,7 @@ from openquake.risklib import api, scientific
 from openquake.risklib.models.input import FragilityModel
 
 from openquake.engine.calculators.risk import general
+from openquake.engine.performance import EnginePerformanceMonitor
 from openquake.engine.utils import tasks
 from openquake.engine.db import models
 from openquake.engine import logs
@@ -60,9 +61,8 @@ def scenario_damage(job_id, hazard,
 
     # Scenario Damage works only on one hazard
     hazard_getter = hazard.values()[0][0]
-
-    assets, ground_motion_values, missings = hazard_getter()
-
+    with EnginePerformanceMonitor('hazard_getter', job_id, scenario_damage):
+        assets, ground_motion_values, missings = hazard_getter()
     if not len(assets):
         logs.LOG.warn("Exit from task as no asset could be processed")
         base.signal_task_complete(


### PR DESCRIPTION
Removing the polygon constraint in the inner query in the hazard getters it is impossible without killing the performance; removing the polygon constraint in the outer query instead is possible and slightly beneficial  (~3% faster and a bit less memory occupation) so I did it.
I have also left in place the PerformanceMonitor measuring the hazard getters so that
one can see the figures with the following query:

select sum(duration) as duration, sum(pymemory) as pymemory, sum(pgmemory) as pgmemory from uiapi.performance where oq_job_id=%s and operation='hazard_getter';
