### PR TITLE
Trivial fix for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             "db/schema/*", "openquake.cfg", "README", "LICENSE"]},
     exclude_package_data={"": ["bin/oqpath.py", "bin/oq_check_monitors",
                                "bin/oq_log_sink"]},
-    scripts=["openquake/engine/bin/oq_create_db", "openquake/engine/bin/oq_restart_workers"],
+    scripts=["openquake/engine/bin/oq_create_db"],
 
     namespace_packages=['openquake'],
 


### PR DESCRIPTION
Removed `oq_restart_workers` reference from setup.py.
