### PR TITLE
Fix char source logic tree validation

### DIFF
--- a/openquake/engine/input/logictree.py
+++ b/openquake/engine/input/logictree.py
@@ -649,7 +649,8 @@ class SourceModelLogicTree(BaseLogicTree):
     """
     Source model logic tree parser.
     """
-    SOURCE_TYPES = ('point', 'area', 'complexFault', 'simpleFault')
+    SOURCE_TYPES = ('point', 'area', 'complexFault', 'simpleFault',
+                    'characteristicFault')
 
     def __init__(self, *args, **kwargs):
         self.source_ids = set()


### PR DESCRIPTION
Characteristic sources are no longer ignored when validating logic trees.

See https://bugs.launchpad.net/oq-engine/+bug/1166756.
