### PR TITLE
Fix setup.py version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "0.9.2"
+version = "1.0.0"
 url = "http://openquake.org/"
 
 README = """


### PR DESCRIPTION
Updated version number to 1.0.0.

This is to address a build failure: http://ci.openquake.org/job/oq-engine/257.
