### PR TITLE
release updated

### DIFF
--- a/openquake/engine/__init__.py
+++ b/openquake/engine/__init__.py
@@ -55,9 +55,9 @@ from openquake.engine.utils import general as general_utils
 # master branch. It will only be set to a meaningful value in *packaged* and
 # released OpenQuake code.
 __version_tuple__ = (
-    1,  # major
-    0,  # minor
-    0,  # sprint number
+    0,  # major
+    9,  # minor
+    2,  # sprint number
     0)  # release date (seconds since the "Epoch"), do *not* set in master!
 
 __version__ = '.'.join(str(x) for x in __version_tuple__[:3])

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "1.0.0"
+version = "0.9.2"
 url = "http://openquake.org/"
 
 README = """


### PR DESCRIPTION
As we decided to update the `__version__` variable only when the official release will be announced, we need to rollback the version changes contained in:

https://github.com/gem/oq-engine/pull/1120 and https://github.com/gem/oq-engine/pull/1118
