### PR TITLE
Lower the parameter ses_per_logic_tree_path in the event_based QA tests to make them much faster

### DIFF
--- a/qa_tests/hazard/event_based/case_1/job.ini
+++ b/qa_tests/hazard/event_based/case_1/job.ini
@@ -43,7 +43,7 @@ maximum_distance = 200.0
 
 [event_based_params]
 
-ses_per_logic_tree_path = 4500
+ses_per_logic_tree_path = 1500
 ground_motion_correlation_model =
 ground_motion_correlation_params =
 

--- a/qa_tests/hazard/event_based/case_12/job.ini
+++ b/qa_tests/hazard/event_based/case_12/job.ini
@@ -43,7 +43,7 @@ maximum_distance = 200.0
 
 [event_based_params]
 
-ses_per_logic_tree_path = 5000
+ses_per_logic_tree_path = 2000
 ground_motion_correlation_model =
 ground_motion_correlation_params =
 

--- a/qa_tests/hazard/event_based/case_13/job.ini
+++ b/qa_tests/hazard/event_based/case_13/job.ini
@@ -43,7 +43,7 @@ maximum_distance = 200.0
 
 [event_based_params]
 
-ses_per_logic_tree_path = 4500
+ses_per_logic_tree_path = 1500
 ground_motion_correlation_model =
 ground_motion_correlation_params =
 

--- a/qa_tests/hazard/event_based/case_2/job.ini
+++ b/qa_tests/hazard/event_based/case_2/job.ini
@@ -42,7 +42,7 @@ maximum_distance = 200.0
 
 [event_based_params]
 
-ses_per_logic_tree_path = 100
+ses_per_logic_tree_path = 75
 ground_motion_correlation_model =
 ground_motion_correlation_params =
 

--- a/qa_tests/hazard/event_based/case_4/job.ini
+++ b/qa_tests/hazard/event_based/case_4/job.ini
@@ -43,7 +43,7 @@ maximum_distance = 200.0
 
 [event_based_params]
 
-ses_per_logic_tree_path = 200
+ses_per_logic_tree_path = 100
 ground_motion_correlation_model =
 ground_motion_correlation_params =
 

--- a/qa_tests/hazard/event_based/spatial_correlation/case_1/job.ini
+++ b/qa_tests/hazard/event_based/spatial_correlation/case_1/job.ini
@@ -40,7 +40,7 @@ maximum_distance = 200.0
 
 [event_based_params]
 
-ses_per_logic_tree_path = 300
+ses_per_logic_tree_path = 75
 ground_motion_correlation_model = JB2009
 ground_motion_correlation_params = {"vs30_clustering": false}
 

--- a/qa_tests/hazard/event_based/spatial_correlation/case_2/job.ini
+++ b/qa_tests/hazard/event_based/spatial_correlation/case_2/job.ini
@@ -40,7 +40,7 @@ maximum_distance = 200.0
 
 [event_based_params]
 
-ses_per_logic_tree_path = 300
+ses_per_logic_tree_path = 75
 ground_motion_correlation_model = JB2009
 ground_motion_correlation_params = {"vs30_clustering": true}
 


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1169883

This patch halves the running time. 
