### PR TITLE
Some work to fix qa_tests/risk/event_based_bcr

### DIFF
--- a/openquake/engine/calculators/risk/hazard_getters.py
+++ b/openquake/engine/calculators/risk/hazard_getters.py
@@ -330,8 +330,8 @@ class GroundMotionValuesGetter(HazardGetter):
                 assets_extent.wkt) + args
 
         cursor.execute(query, args)
+        # print cursor.mogrify(query, args)
         data = cursor.fetchall()
-
         assets, gmf_ids = [], []
         for asset_id, gmf_id in data:
             # the query may return spurious assets outside the considered block

--- a/qa_tests/risk/__init__.py
+++ b/qa_tests/risk/__init__.py
@@ -68,6 +68,7 @@ class BaseRiskQATestCase(qa_utils.BaseQATestCase):
             job = self.run_risk(self.cfg, self.hazard_id())
 
             actual_data = self.actual_data(job)
+            assert actual_data, 'Got no actual data!'
 
             for i, actual in enumerate(actual_data):
                 numpy.testing.assert_allclose(
@@ -130,6 +131,7 @@ class End2EndRiskQATestCase(BaseRiskQATestCase):
             job = self.run_risk(self.risk_cfg, self.hazard_id())
 
             actual_data = self.actual_data(job)
+            assert actual_data, 'Got no actual data!'
 
             for i, actual in enumerate(actual_data):
                 numpy.testing.assert_allclose(
@@ -140,11 +142,8 @@ class End2EndRiskQATestCase(BaseRiskQATestCase):
                 expected_outputs = self.expected_outputs()
                 for i, output in enumerate(self.actual_xml_outputs(job)):
                     [exported_file] = export.risk.export(output.id, result_dir)
-                    try:
-                        self.assert_xml_equal(
-                            StringIO.StringIO(expected_outputs[i]),
-                            exported_file)
-                    except:
-                        import pdb; pdb.set_trace()
+                    self.assert_xml_equal(
+                        StringIO.StringIO(expected_outputs[i]),
+                        exported_file)
         finally:
             shutil.rmtree(result_dir)

--- a/qa_tests/risk/event_based_bcr/case_1/job.ini
+++ b/qa_tests/risk/event_based_bcr/case_1/job.ini
@@ -16,5 +16,6 @@ asset_life_expectancy = 40
 region_constraint = -123 39, -119 39, -119 37, -123 37
 
 master_seed = 3
+maximum_distance = 200
 
 export_dir = /tmp/

--- a/qa_tests/risk/event_based_bcr/case_1/test.py
+++ b/qa_tests/risk/event_based_bcr/case_1/test.py
@@ -52,42 +52,19 @@ class EventBasedRiskCase1TestCase(risk.BaseRiskQATestCase):
             investigation_time=50,
             ses_per_logic_tree_path=1)
         job.save()
-        hc = job.hazard_calculation
 
-        gmf_set = models.GmfSet.objects.create(
-            gmf_collection=models.GmfCollection.objects.create(
-                output=models.Output.objects.create_output(
-                    job, "Test Hazard output", "gmf"),
-                lt_realization=models.LtRealization.objects.create(
-                    hazard_calculation=job.hazard_calculation,
-                    ordinal=1, seed=1, weight=None,
-                    sm_lt_path="test_sm", gsim_lt_path="test_gsim",
-                    is_complete=False, total_items=1, completed_items=1)),
-            investigation_time=hc.investigation_time,
-            ses_ordinal=1)
+        gmf_coll = helpers.create_gmf_from_csv(
+            job, os.path.join(os.path.dirname(__file__), 'gmf.csv'))
 
-        with open(os.path.join(
-                os.path.dirname(__file__), 'gmf.csv'), 'rb') as csvfile:
-            gmfreader = csv.reader(csvfile, delimiter=',')
-            locations = gmfreader.next()
-
-            for i, gmvs in enumerate(
-                    numpy.array([[float(x) * 10 for x in row]
-                                 for row in gmfreader]).transpose()):
-                models.Gmf.objects.create(
-                    gmf_set=gmf_set,
-                    imt="PGA", gmvs=gmvs,
-                    result_grp_ordinal=1,
-                    location="POINT(%s)" % locations[i])
-
-        return gmf_set.gmf_collection.output.id
+        return gmf_coll.output.id
 
     def actual_data(self, job):
-        return [(result.average_annual_loss_original,
+        data = [(result.average_annual_loss_original,
                  result.average_annual_loss_retrofitted, result.bcr)
                 for result in models.BCRDistributionData.objects.filter(
                     bcr_distribution__output__oq_job=job).order_by(
                         'asset_ref')]
+        return data
 
     def expected_data(self):
         return [[1.37096021, 0.95967214, 71.12525504],

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -161,6 +161,8 @@ def run_hazard_job(cfg, exports=None):
 def run_risk_job(cfg, exports=None, hazard_calculation_id=None,
                  hazard_output_id=None):
     """
+    Given the path to a risk job config file and a hazard_calculation_id
+    or a output, run the job.
     """
     if exports is None:
         exports = []


### PR DESCRIPTION
The test was passing by accident: it was returning an empty list of results and we were looping on that list. I have added an assert to check that the list is non-empty and updated the test to use helpers.create_gmf_from_csv.

https://bugs.launchpad.net/oq-nrmllib/+bug/1188497
