### PR TITLE
Fix get_asset_chunk unit test

### DIFF
--- a/tests/db/models_manager_test.py
+++ b/tests/db/models_manager_test.py
@@ -130,20 +130,6 @@ class AssetManagerTestCase(unittest.TestCase):
     def setUp(self):
         self.manager = models.ExposureData.objects
 
-    def test_get_asset_chunk(self):
-        p = mock.patch(self.base + '_get_asset_chunk_query_args')
-        m = p.start()
-        m.return_value = (
-            "select id from riski.exposure_data where 1 = %s", (1,))
-        try:
-            self.assertEqual(
-                models.ExposureData.objects.count(),
-                len(
-                    self.manager.get_asset_chunk(
-                        mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock())))
-        finally:
-            p.stop()
-
     def test_get_asset_chunk_query_args(self):
         rc = mock.Mock()
         rc.exposure_model.id = 0


### PR DESCRIPTION
The root cause of recent build failures on our CI system is a test that relies on some content already present in the DB that supports our testcase. 

As the "functional" part of the code has already been extracted and unit tested properly, this pull request removes the offending testt that just checks that a query is made.
