### PR TITLE
Event loss csv: fix delimiting character

### DIFF
--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -274,7 +274,7 @@ def export_event_loss_csv(output, target_dir):
                                 output.id))
 
     with open(filepath, 'wb') as csvfile:
-        writer = csv.writer(csvfile, delimiter='|')
+        writer = csv.writer(csvfile)
         writer.writerow(['Rupture', 'Magnitude', 'Aggregate Loss'])
 
         for event_loss in models.EventLoss.objects.filter(


### PR DESCRIPTION
`event_loss` tables (csv) are now actually comma-delimited (instead of
pipe delimited).

Addresses https://bugs.launchpad.net/oq-engine/+bug/1192179.
