### PR TITLE
Minor fix to risk QA test collection

### DIFF
--- a/qa_tests/risk/__init__.py
+++ b/qa_tests/risk/__init__.py
@@ -234,7 +234,3 @@ class FixtureBasedQATestCase(LogicTreeBasedTestCase, BaseRiskQATestCase):
             raise SkipTest
         else:
             return self._get_queryset()[0].oqjob
-
-    def test(self):
-        raise NotImplementedError
-


### PR DESCRIPTION
Removed a base testcase class `test` method, to avoid breaking nosetest
test collection.
