### PR TITLE
Minor test fixture fix

### DIFF
--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -341,29 +341,6 @@ class CreateRiskCalculationTestCase(unittest.TestCase):
              '-0.5000000000000000 0.5000000000000000))'))
 
 
-class ReadJobProfileFromConfigFileTestCase(unittest.TestCase):
-    """Integration test for basic engine functions.
-
-    Test reading/generating a hazard job profile from a config file, then run
-    through the validation form.
-    """
-
-    def test_read_and_validate_hazard_config(self):
-        cfg = helpers.get_data_path('simple_fault_demo_hazard/job.ini')
-        job = engine.prepare_job(getpass.getuser())
-        params, files = engine.parse_config(open(cfg, 'r'))
-        calculation = engine.create_hazard_calculation(
-            job.owner.user_name, params, files.values()
-        )
-        job.hazard_calculation = calculation
-        job.save()
-
-        form = validation.ClassicalHazardForm(
-            instance=calculation, files=files
-        )
-        self.assertTrue(form.is_valid())
-
-
 class OpenquakeCliTestCase(unittest.TestCase):
     """
     Run "openquake --version" as a separate


### PR DESCRIPTION
Fixed a FK relationship in a test fixture to prevent spurious
crashes when running bin/openquake --lhc.

The problem manifests itself like so:

<pre>
$ bin/openquake --lhc
calc_id | status | last_update | description
38 | pending | 2013-07-29 08:58:14  | Simple Fault Demo, Classical PSHA
39 | pending | 2013-07-29 08:58:23  | Simple Fault Demo, Classical PSHA
40 | failed | 2013-07-29 08:58:23  | Simple Fault Demo, Classical PSHA
41 | failed | 2013-07-29 08:58:23  | Simple Fault Demo, Classical PSHA
42 | failed | 2013-07-29 08:58:24  | Simple Fault Demo, Classical PSHA
43 | failed | 2013-07-29 08:58:24  | Simple Fault Demo, Classical PSHA
44 | failed | 2013-07-29 08:58:24  | Simple Fault Demo, Classical PSHA
46 | failed | 2013-07-29 08:58:26  | Simple Fault Demo, Classical PSHA
47 | failed | 2013-07-29 08:58:27  | Simple Fault Demo, Classical PSHA
50 | failed | 2013-07-29 08:58:37  | Disaggregation Hazard Demo
51 | failed | 2013-07-29 08:58:37  | Disaggregation Hazard Demo
52 | failed | 2013-07-29 08:58:51  | Probabilistic Event-Based Hazard Demo
54 | failed | 2013-07-29 08:58:59  | Probabilistic Event-Based Hazard Demo
55 | failed | 2013-07-29 08:58:59  | Probabilistic Event-Based Hazard Demo
56 | failed | 2013-07-29 08:58:59  | Probabilistic Event-Based Hazard Demo
57 | failed | 2013-07-29 08:59:00  | Probabilistic Event-Based Hazard Demo
58 | failed | 2013-07-29 08:59:00  | Probabilistic Event-Based Hazard Demo
89 | failed | 2013-07-29 08:59:06  | Scenario QA Test, Case 1
137 | successful | 2013-07-29 09:03:52  | Simple Fault Demo, Classical PSHA
138 | successful | 2013-07-29 09:03:52  | Simple Fault Demo, Classical PSHA
139 | successful | 2013-07-29 09:03:52  | Simple Fault Demo, Classical PSHA
Traceback (most recent call last):
  File "bin/openquake", line 506, in <module>
    main()
  File "bin/openquake", line 453, in main
    list_hazard_calculations()
  File "bin/openquake", line 293, in list_hazard_calculations
    _print_calcs_summary(hcs)
  File "bin/openquake", line 316, in _print_calcs_summary
    latest_job = calc.oqjob
  File "/Users/larsbutler/.virtualenvs/openquake/lib/python2.7/site-packages/django/db/models/fields/related.py", line 239, in __get__
    rel_obj = self.related.model._base_manager.using(db).get(**params)
  File "/Users/larsbutler/.virtualenvs/openquake/lib/python2.7/site-packages/django/db/models/query.py", line 349, in get
    % self.model._meta.object_name)
openquake.engine.db.models.DoesNotExist: OqJob matching query does not exist.
</pre>


I narrowed down the issue to this single test.
