### PR TITLE
Small fix in dump_hazards.py: the filenames list contained duplicates

### DIFF
--- a/openquake/engine/tools/dump_hazards.py
+++ b/openquake/engine/tools/dump_hazards.py
@@ -90,7 +90,8 @@ class Copier(object):
         log.info('%s\n(-> %s)', query, fname)
         with gzip.open(fname, mode) as f:
             self._cursor.copy_expert(query, f)
-            self.filenames.append(fname)
+            if fname not in self.filenames:
+                self.filenames.append(fname)
 
 
 class HazardDumper(object):

--- a/openquake/engine/tools/restore_hazards.py
+++ b/openquake/engine/tools/restore_hazards.py
@@ -103,10 +103,11 @@ def hazard_restore(conn, tar):
             log.info('Importing %s...', fname)
             imported, total = safe_restore(curs, f, tname)
             if imported != total:
-                log.warn('%s: could not import %d row(s), id(s) already taken',
-                         fname, total - imported)
+                log.warn(
+                    '%s:%s:\ncould not import %d row(s), id(s) already taken',
+                    tf.name, fname, total - imported)
             else:
-                log.info('Imported %d/%d new rows', imported, total)
+                log.info('Imported %d new rows', imported)
     log.info('Restored %s', tar)
 
 


### PR DESCRIPTION
dump_hazards.py generates a file FILENAMES.txt with the list of files to restore. Due to a small bug the list contained duplicates, so restore_hazards.py was trying to restore the same file twice, thus giving false warnings.
I have also improved the warning message to print the filename of the .tar file being restored.
