### PR TITLE
Minor loss map export fix

### DIFF
--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -178,8 +178,6 @@ def _export_loss_map(output, target, writer_class, file_ext):
     """
     General loss map export code.
     """
-    core.makedirs(target)
-
     risk_calculation = output.oq_job.risk_calculation
     args = _export_common(output, output.loss_map.loss_type)
 
@@ -195,6 +193,7 @@ def _export_loss_map(output, target, writer_class, file_ext):
     return dest
 
 
+@core.makedirsdeco
 def export_loss_map_xml(output, target):
     """
     Serialize a loss map to NRML/XML.
@@ -203,6 +202,7 @@ def export_loss_map_xml(output, target):
                             'xml')
 
 
+@core.makedirsdeco
 def export_loss_map_geojson(output, target):
     """
     Serialize a loss map to geojson.


### PR DESCRIPTION
Refactored the risk loss map export so that export to a file-like
object works properly and doesn't break because it's expecting a
file path. (So for example, this fixes the export if you want to
export to a StringIO object instead of the filesystem.)

Note: This is needed for oq-engine-server, which doesn't export to the filesystem but rather, writes to StringIO objects and streams them via http.
