### PR TITLE
Review Risk demos

### DIFF
--- a/demos/risk/ClassicalBCR/README.txt
+++ b/demos/risk/ClassicalBCR/README.txt
@@ -1,0 +1,13 @@
+Classical PSHA-based Benefit Cost Ratio Risk Demo
+
+The demo consists of two parts: hazard and risk. The hazard and risk
+calculations are defined in separate .ini files and were designed to be
+run together to form a complete end-to-end demonstration of the workflow.
+
+--Hazard--
+Expected runtime: <2 minutes
+Outputs: Hazard Curves
+
+--Risk--
+Expected runtime: ~27 minutes
+Outputs: Benefit Cost Ratio Maps

--- a/demos/risk/ClassicalPSHA/README.txt
+++ b/demos/risk/ClassicalPSHA/README.txt
@@ -1,0 +1,13 @@
+Classical PSHA-based Risk Demo
+
+The demo consists of two parts: hazard and risk. The hazard and risk
+calculations are defined in separate .ini files and were designed to be
+run together to form a complete end-to-end demonstration of the workflow.
+
+--Hazard--
+Expected runtime: <2 minutes
+Outputs: Hazard Curves
+
+--Risk--
+Expected runtime: ~17 minutes
+Outputs: Loss Curves

--- a/demos/risk/ProbabilisticEventBased/README.txt
+++ b/demos/risk/ProbabilisticEventBased/README.txt
@@ -1,0 +1,14 @@
+Probabilistic Event-based Risk Demo
+
+The demo consists of two parts: hazard and risk. The hazard and risk
+calculations are defined in separate .ini files and were designed to be
+run together to form a complete end-to-end demonstration of the workflow.
+
+--Hazard--
+Expected runtime: ~30 minutes
+Outputs: Ground Motion Fields and Stochastic Event Sets
+
+--Risk--
+Expected runtime: ~3 minutes
+Outputs: Loss Curves, Aggregate Loss Curves, Event Loss Table
+

--- a/demos/risk/ScenarioDamage/README.txt
+++ b/demos/risk/ScenarioDamage/README.txt
@@ -1,0 +1,14 @@
+Scenario Damage Risk Demo
+
+The demo consists of two parts: hazard and risk. The hazard and risk
+calculations are defined in separate .ini files and were designed to be
+run together to form a complete end-to-end demonstration of the workflow.
+
+--Hazard--
+Expected runtime: <1 minute
+Outputs: Ground Motion Fields
+
+--Risk--
+Expected runtime: ~1 hour
+Outputs: Damage Distribution Maps, Collapse Maps
+


### PR DESCRIPTION
The goal of this pull request is to review risk demos (both hazard and risk part) in order to analyze possible performance problems. To this aim, I have added a README.txt in every risk demo folder. I have used the oats3 service to run the demos (on a standard laptop with 4 cores and 4Gb they have comparable ram/cpu consumptions).

The gist is that no demo takes more than one hour (Scenario Damage is the longest one and completes in about an hour) an no demo requires more than 250Mb of RAM per core.
