### PR TITLE
Correction of baseline DB revision.

### DIFF
--- a/openquake/engine/db/schema/load.sql
+++ b/openquake/engine/db/schema/load.sql
@@ -19,4 +19,4 @@
 INSERT INTO admin.organization(name) VALUES('GEM Foundation');
 INSERT INTO admin.oq_user(user_name, full_name, organization_id) VALUES('openquake', 'Default user', 1);
 -- If a new database is being built, explicitly set the oq-engine DB schema version:
-INSERT INTO admin.revision_info(artefact, revision, step) VALUES('oq-engine', '1.0.1', 1);
+INSERT INTO admin.revision_info(artefact, revision, step) VALUES('oq-engine', '1.0.1', 4);


### PR DESCRIPTION
Set the initial DB revision, if the database is being set up freshly. We need to update this each time we add upgrade scripts.
