### PR TITLE
Create job and calculation objects in a transaction

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -942,31 +942,3 @@ def get_risk_outputs(rc_id):
         A sequence of :class:`openquake.engine.db.models.Output` objects
     """
     return models.Output.objects.filter(oq_job__risk_calculation=rc_id)
-
-
-def get_hazard_calculations(username):
-    """
-    Get all hazard calculations belonging to the given ``username``.
-    """
-    # FIXME(lp). As it might happen to have an HazardCalculation
-    # without a OqJob instance (e.g. when the user imports outputs
-    # directly from files) we filter out the calculation without the
-    # corresponding job
-
-    return models.HazardCalculation.objects.filter(
-        owner__user_name=username, oqjob__isnull=False).order_by(
-            'oqjob__last_update')
-
-
-def get_risk_calculations(username):
-    """
-    Get all risk calculations belonging to the given ``username``.
-    """
-    # FIXME(lp). As it might happen to have a RiskCalculation without
-    # a OqJob instance (e.g. when the user imports outputs directly
-    # from files) we filter out the calculation without the
-    # corresponding job
-
-    return models.RiskCalculation.objects.filter(
-        owner__user_name=username, oqjob__isnull=False).order_by(
-            'oqjob__last_update')


### PR DESCRIPTION
This pull request fixes https://bugs.launchpad.net/oq-engine/+bug/1227502

Theoretically, it still possible to create an hazard calculation without a job and use that with a risk calculation. In order to avoid that we need a more intrusive refactoring (e.g. remove OqJob).
