### PR TITLE
Removed parsed_rupture_model from the db

### DIFF
--- a/openquake/engine/calculators/hazard/scenario/core.py
+++ b/openquake/engine/calculators/hazard/scenario/core.py
@@ -44,17 +44,17 @@ AVAILABLE_GSIMS = openquake.hazardlib.gsim.get_available_gsims()
 
 @tasks.oqtask
 @stats.count_progress('h')
-def gmfs(job_id, sites, rupture_id, gmfcoll_id, task_seed, realizations):
+def gmfs(job_id, sites, rupture, gmf_id, task_seed, realizations):
     """
     A celery task wrapper function around :func:`compute_gmfs`.
     See :func:`compute_gmfs` for parameter definitions.
     """
     numpy.random.seed(task_seed)
-    compute_gmfs(job_id, sites, rupture_id, gmfcoll_id, realizations)
+    compute_gmfs(job_id, sites, rupture, gmf_id, realizations)
     base.signal_task_complete(job_id=job_id, num_items=len(sites))
 
 
-def compute_gmfs(job_id, sites, rupture_id, gmfcoll_id, realizations):
+def compute_gmfs(job_id, sites, rupture, gmf_id, realizations):
     """
     Compute ground motion fields and store them in the db.
 
@@ -62,19 +62,15 @@ def compute_gmfs(job_id, sites, rupture_id, gmfcoll_id, realizations):
         ID of the currently running job.
     :param sites:
         The subset of the full SiteCollection scanned by this task
-    :param rupture_id:
-        The parsed rupture model from which we will generate
+    :param rupture:
+        The hazardlib rupture from which we will generate
         ground motion fields.
-    :param gmfcoll_id:
+    :param gmf_id:
         the id of a :class:`openquake.engine.db.models.Gmf` record
     :param realizations:
         Number of realizations to create.
     """
-
     hc = models.HazardCalculation.objects.get(oqjob=job_id)
-    rupture_mdl = source.nrml_to_hazardlib(
-        models.ParsedRupture.objects.get(id=rupture_id).nrml,
-        hc.rupture_mesh_spacing, None, None)
     imts = [haz_general.imt_to_hazardlib(x)
             for x in hc.intensity_measure_types]
     gsim = AVAILABLE_GSIMS[hc.gsim]()  # instantiate the GSIM class
@@ -82,19 +78,19 @@ def compute_gmfs(job_id, sites, rupture_id, gmfcoll_id, realizations):
 
     with EnginePerformanceMonitor('computing gmfs', job_id, gmfs):
         gmf = ground_motion_fields(
-            rupture_mdl, sites, imts, gsim,
+            rupture, sites, imts, gsim,
             hc.truncation_level, realizations=realizations,
             correlation_model=correlation_model)
     with EnginePerformanceMonitor('saving gmfs', job_id, gmfs):
-        save_gmf(gmfcoll_id, gmf, sites)
+        save_gmf(gmf_id, gmf, sites)
 
 
 @transaction.commit_on_success(using='reslt_writer')
-def save_gmf(gmfcoll_id, gmf_dict, sites):
+def save_gmf(gmf_id, gmf_dict, sites):
     """
     Helper method to save computed GMF data to the database.
 
-    :param int gmfcoll_id:
+    :param int gmf_id:
         the id of a :class:`openquake.engine.db.models.Gmf` record
     :param dict gmf_dict:
         The GMF results during the calculation
@@ -120,7 +116,7 @@ def save_gmf(gmfcoll_id, gmf_dict, sites):
 
         for i, site in enumerate(sites):
             inserter.add(models.GmfData(
-                gmf_id=gmfcoll_id,
+                gmf_id=gmf_id,
                 ses_id=None,
                 imt=imt_name,
                 sa_period=sa_period,
@@ -142,20 +138,17 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
 
     def __init__(self, *args, **kwargs):
         super(ScenarioHazardCalculator, self).__init__(*args, **kwargs)
-        self.gmfcoll = None
+        self.gmf = None
+        self.rupture = None
 
     def initialize_sources(self):
         """
-        Get the rupture_model file from the job.ini file, and store a
-        parsed version of it in the database (see
-        :class:`openquake.engine.db.models.ParsedRupture``) in pickle format.
+        Get the rupture_model file from the job.ini file, and set the
+        attribute self.rupture.
         """
-
-        # Get the rupture model in input
-        src_db_writer = source.RuptureDBWriter(
-            self.job, RuptureModelParser(
-                self.hc.inputs['rupture_model']).parse())
-        src_db_writer.serialize()
+        nrml = RuptureModelParser(self.hc.inputs['rupture_model']).parse()
+        rms = self.job.hazard_calculation.rupture_mesh_spacing
+        self.rupture = source.nrml_to_hazardlib(nrml, rms, None, None)
 
     def pre_execute(self):
         """
@@ -187,7 +180,7 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
             output_type="gmf_scenario")
 
         # create an associated gmf record
-        self.gmfcoll = models.Gmf.objects.create(output=output)
+        self.gmf = models.Gmf.objects.create(output=output)
 
     def task_arg_gen(self, block_size, _check_num_task=True):
         """
@@ -195,7 +188,7 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
         task arg tuples. Each tuple of args applies to a single task.
 
         Yielded results are 6-uples of the form (job_id,
-        sites, rupture_id, gmfcoll_id, task_seed, realizations)
+        sites, rupture_id, gmf_id, task_seed, realizations)
         (task_seed will be used to seed numpy for temporal occurence sampling).
 
         :param int block_size:
@@ -203,11 +196,8 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
         """
         rnd = random.Random()
         rnd.seed(self.hc.random_seed)
-
-        rupture_id = self.job.parsedrupture.id
-
         for sites in block_splitter(self.hc.site_collection, BLOCK_SIZE):
             task_seed = rnd.randint(0, models.MAX_SINT_32)
             yield (self.job.id, models.SiteCollection(sites),
-                   rupture_id, self.gmfcoll.id, task_seed,
+                   self.rupture, self.gmf.id, task_seed,
                    self.hc.number_of_ground_motion_fields)

--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -325,21 +325,6 @@ class SiteModel(djm.Model):
         db_table = 'hzrdi\".\"site_model'
 
 
-class ParsedRupture(djm.Model):
-    """Stores parsed hazard rupture model in serialized python object
-       tree format."""
-    job = djm.OneToOneField('OqJob')
-    RUPTURE_TYPE_CHOICES = (
-        (u'complex_fault', u'Complex Fault'),
-        (u'simple_fault', u'Simple Fault'),)
-    rupture_type = djm.TextField(choices=RUPTURE_TYPE_CHOICES)
-    nrml = fields.PickleField(help_text="NRML object representing the rupture"
-                                        " model")
-
-    class Meta:
-        db_table = 'hzrdi\".\"parsed_rupture_model'
-
-
 ## Tables in the 'uiapi' schema.
 
 class OqJob(djm.Model):

--- a/openquake/engine/db/schema/comments.sql
+++ b/openquake/engine/db/schema/comments.sql
@@ -41,12 +41,6 @@ COMMENT ON COLUMN hzrdi.parsed_source.nrml IS 'NRML object representing the sour
 COMMENT ON COLUMN hzrdi.parsed_source.source_type IS 'The source''s seismic input type: can be one of: area, point, complex or simple.';
 
 
-COMMENT ON TABLE hzrdi.parsed_rupture_model IS 'Stores parsed hazard rupture model in serialized python object tree format';
-COMMENT ON COLUMN hzrdi.parsed_rupture_model.nrml IS 'NRML object representing the rupture';
-COMMENT ON COLUMN hzrdi.parsed_rupture_model.rupture_type IS 'The rupture''s seismic input type: can be one of: complex_fault or simple_fault.';
-
-
-
 -- hzrdr schema tables ------------------------------------------
 COMMENT ON TABLE hzrdr.hazard_curve IS 'A collection of hazard curves. This table defines common attributes for the collection.';
 COMMENT ON COLUMN hzrdr.hazard_curve.output_id IS 'The foreign key to the output record that represents the corresponding hazard curve.';

--- a/openquake/engine/db/schema/indexes.sql
+++ b/openquake/engine/db/schema/indexes.sql
@@ -31,7 +31,6 @@ CREATE INDEX hzrdi_site_model_job_id_idx ON hzrdi.site_model(job_id);
 
 -- hzrdi.parsed_source
 CREATE INDEX hzrdi_parsed_source_job_id_idx ON hzrdi.parsed_source(job_id);
-CREATE INDEX hzrdi_parsed_rupture_model_job_id_idx ON hzrdi.parsed_rupture_model(job_id);
 
 -- indexes for the uiapi.performance table
 CREATE INDEX uiapi_performance_oq_job_id_idx ON uiapi.performance(oq_job_id);

--- a/openquake/engine/db/schema/openquake.sql
+++ b/openquake/engine/db/schema/openquake.sql
@@ -95,19 +95,6 @@ CREATE TABLE hzrdi.parsed_source (
 ) TABLESPACE hzrdi_ts;
 
 
--- Parsed Rupture models
-CREATE TABLE hzrdi.parsed_rupture_model (
-    id SERIAL PRIMARY KEY,
-    job_id INTEGER NOT NULL,
-    rupture_type VARCHAR NOT NULL
-        CONSTRAINT enforce_rupture_type CHECK
-        (rupture_type IN ('complex_fault', 'simple_fault')),
-    nrml BYTEA NOT NULL,
-    last_update timestamp without time zone
-        DEFAULT timezone('UTC'::text, now()) NOT NULL
-) TABLESPACE hzrdi_ts;
-
-
 -- An OpenQuake engine run started by the user
 CREATE TABLE uiapi.oq_job (
     id SERIAL PRIMARY KEY,

--- a/openquake/engine/db/schema/security.sql
+++ b/openquake/engine/db/schema/security.sql
@@ -70,7 +70,6 @@ GRANT SELECT,INSERT,UPDATE,DELETE ON htemp.hazard_curve_progress TO oq_reslt_wri
 -- hzrdi schema
 GRANT SELECT,INSERT ON hzrdi.hazard_site            TO oq_job_init;
 GRANT SELECT,INSERT ON hzrdi.parsed_source        TO oq_job_init;
-GRANT SELECT,INSERT ON hzrdi.parsed_rupture_model TO oq_job_init;
 GRANT SELECT,INSERT ON hzrdi.site_model           TO oq_job_init;
 
 -- hzrdr schema

--- a/openquake/engine/db/schema/upgrades/1.0.1/7/01-simplify.sql
+++ b/openquake/engine/db/schema/upgrades/1.0.1/7/01-simplify.sql
@@ -50,17 +50,7 @@ ALTER TABLE hzrdi.parsed_source ALTER source_model_filename SET NOT NULL;
 ALTER TABLE hzrdi.parsed_source DROP input_id;
 
 -- parsed_rupture_model
-ALTER TABLE hzrdi.parsed_rupture_model ADD job_id INTEGER NULL;
-CREATE INDEX hzrdi_parsed_rupture_model_job_id_idx ON hzrdi.parsed_rupture_model(job_id);
-UPDATE hzrdi.parsed_rupture_model SET job_id=(
-       SELECT job.id FROM uiapi.oq_job AS job
-       JOIN uiapi.hazard_calculation AS hc ON hc.id = job.hazard_calculation_id
-       JOIN uiapi.input2hcalc AS i2h ON i2h.hazard_calculation_id = hc.id
-       WHERE i2h.input_id = hzrdi.parsed_rupture_model.input_id)
-WHERE job_id IS NULL;
-ALTER TABLE hzrdi.parsed_rupture_model ADD CONSTRAINT hzrdi_parsed_rupture_model_job_fk
-FOREIGN KEY (job_id) REFERENCES uiapi.oq_job(id) ON DELETE RESTRICT;
-ALTER TABLE hzrdi.parsed_rupture_model DROP input_id;
+DROP TABLE hzrdi.parsed_rupture_model;
 
 -- risk_calculation. Here we replace exposure_input_id with
 -- preloaded_exposure_model_id

--- a/openquake/engine/input/source.py
+++ b/openquake/engine/input/source.py
@@ -534,42 +534,6 @@ class SourceDBWriter(object):
                     source_model_filename=self.source_model_filename)
 
 
-class RuptureDBWriter(object):
-    """Takes a rupture and saves it to the
-    `hzrdi.parsed_rupture_model` table in the database, in pickled blob form.
-
-    :param inp:
-        :class:`~openquake.engine.db.models.OqJob` object, the top-level
-        container for the sources written to the database. Should have an
-        `input_type` of 'simple_fault' or 'complex_fault'.
-    :param rupture_model:
-        :class:`openquake.nrmllib.models.SimpleFaultRuptureModel` object or
-        :class:`openquake.nrmllib.models.ComplexFaultRuptureModel`
-    """
-
-    def __init__(self, job, rupture_model):
-        self.job = job
-        self.rupture_model = rupture_model
-
-    @transaction.commit_on_success(router.db_for_write(models.ParsedRupture))
-    def serialize(self):
-        """
-        Serialize the rupture_model in hzrdi.parsed_rupture_model, with a
-        reference to the `openquake.engine.db.models.OqJob` object.
-        """
-        src = self.rupture_model
-        if isinstance(src, openquake.nrmllib.models.SimpleFaultRuptureModel):
-            rupture_type = 'simple_fault'
-        elif isinstance(src,
-                        openquake.nrmllib.models.ComplexFaultRuptureModel):
-            rupture_type = 'complex_fault'
-        else:
-            raise TypeError(
-                'Expected Simple or Complex FaultRuptureModel, got %r' % src)
-        models.ParsedRupture(
-            job=self.job, rupture_type=rupture_type, nrml=src).save()
-
-
 def area_source_to_point_sources(area_src, area_src_disc):
     """
     Split an area source into a generator of point sources.


### PR DESCRIPTION
Yet another useless table removed. See https://bugs.launchpad.net/oq-engine/+bug/1248173. All tests are green: http://ci.openquake.org/job/zdevel_oq-engine/171/
