### PR TITLE
Improve the table job_stats

### DIFF
--- a/openquake/engine/calculators/hazard/disaggregation/core.py
+++ b/openquake/engine/calculators/hazard/disaggregation/core.py
@@ -341,14 +341,6 @@ class DisaggHazardCalculator(haz_general.BaseHazardCalculator):
         num_points = len(self.hc.points_to_compute())
         self.progress['total'] += num_rlzs * num_points
 
-        # Update stats to consider the disagg tasks as well:
-        [job_stats] = models.JobStats.objects.filter(oq_job=self.job.id)
-        block_size = self.block_size()
-        job_stats.num_tasks += int(
-            math.ceil(float(num_points) * num_rlzs / block_size)
-        )
-        job_stats.save()
-
         # Update the progress info on the realizations, to include the disagg
         # phase:
         for rlz in realizations:
@@ -358,8 +350,7 @@ class DisaggHazardCalculator(haz_general.BaseHazardCalculator):
         self.initialize_pr_data()
 
     def task_arg_gen(self, block_size):
-        arg_gen = super(DisaggHazardCalculator, self).task_arg_gen(
-            block_size, check_num_task=False)
+        arg_gen = super(DisaggHazardCalculator, self).task_arg_gen(block_size)
         for args in arg_gen:
             yield args + ('hazard_curve', )
 

--- a/openquake/engine/calculators/hazard/general.py
+++ b/openquake/engine/calculators/hazard/general.py
@@ -269,7 +269,7 @@ class BaseHazardCalculator(base.Calculator):
         """
         return int(config.get('hazard', 'concurrent_tasks'))
 
-    def task_arg_gen(self, block_size, check_num_task=True):
+    def task_arg_gen(self, block_size):
         """
         Loop through realizations and sources to generate a sequence of
         task arg tuples. Each tuple of args applies to a single task.
@@ -308,13 +308,6 @@ class BaseHazardCalculator(base.Calculator):
                 task_args = (self.job.id, block, lt_rlz.id, ltp)
                 yield task_args
                 n += 1
-
-        # this sanity check should go into a unit test, and will likely
-        # go there in the future
-        if check_num_task:
-            num_tasks = models.JobStats.objects.get(
-                oq_job=self.job.id).num_tasks
-            assert num_tasks == n, 'Expected %d tasks, got %d' % (num_tasks, n)
 
     def _get_realizations(self):
         """

--- a/openquake/engine/calculators/hazard/scenario/core.py
+++ b/openquake/engine/calculators/hazard/scenario/core.py
@@ -189,7 +189,7 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
         # create an associated gmf record
         self.gmfcoll = models.Gmf.objects.create(output=output)
 
-    def task_arg_gen(self, block_size, _check_num_task=True):
+    def task_arg_gen(self, block_size):
         """
         Loop through realizations and sources to generate a sequence of
         task arg tuples. Each tuple of args applies to a single task.

--- a/openquake/engine/calculators/risk/base.py
+++ b/openquake/engine/calculators/risk/base.py
@@ -217,7 +217,6 @@ class RiskCalculator(base.Calculator):
 
         job_stats = models.JobStats.objects.get(oq_job=self.job)
         job_stats.num_sites = total
-        job_stats.num_tasks = self.expected_tasks(self.block_size())
         job_stats.save()
 
     def get_risk_models(self, retrofitted=False):

--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -420,11 +420,8 @@ class JobStats(djm.Model):
     stop_time = djm.DateTimeField(editable=False)
     # The number of total sites in job
     num_sites = djm.IntegerField(null=True)
-    # The total number of tasks in a job
-    num_tasks = djm.IntegerField(null=True)
-    # The number of logic tree samples
-    # (for hazard jobs of all types except scenario)
-    num_realizations = djm.IntegerField(null=True)
+    # The disk space occupation in bytes
+    disk_space = djm.IntegerField(null=True)
 
     class Meta:
         db_table = 'uiapi\".\"job_stats'

--- a/openquake/engine/db/schema/comments.sql
+++ b/openquake/engine/db/schema/comments.sql
@@ -159,7 +159,7 @@ COMMENT ON COLUMN uiapi.performance.pgmemory IS 'Memory occupation in Postgres (
 
 COMMENT ON TABLE uiapi.job_stats IS 'Tracks various job statistics';
 COMMENT ON COLUMN uiapi.job_stats.num_sites IS 'The number of total sites in the calculation';
-COMMENT ON COLUMN uiapi.job_stats.num_realizations IS 'The number of logic tree samples in the calculation';
+COMMENT ON COLUMN uiapi.job_stats.disk_space IS 'How much the disk space occupation increased during the computation (in bytes)';
 
 
 COMMENT ON TABLE uiapi.output IS 'A single OpenQuake calculation engine output. The data may reside in a file or in the database.';

--- a/openquake/engine/db/schema/openquake.sql
+++ b/openquake/engine/db/schema/openquake.sql
@@ -156,10 +156,8 @@ CREATE TABLE uiapi.job_stats (
     stop_time timestamp without time zone,
     -- The number of total sites in the calculation
     num_sites INTEGER,
-    -- The number of tasks in a job
-    num_tasks INTEGER,
-    -- The number of logic tree samples
-    num_realizations INTEGER
+    disk_space BIGINT
+    -- The disk space occupation in bytes
 ) TABLESPACE uiapi_ts;
 
 

--- a/openquake/engine/db/schema/upgrades/1.0.1/8/3-improve-job_stats.sql
+++ b/openquake/engine/db/schema/upgrades/1.0.1/8/3-improve-job_stats.sql
@@ -1,0 +1,3 @@
+ALTER TABLE uiapi.job_stats DROP COLUMN num_tasks;
+ALTER TABLE uiapi.job_stats DROP COLUMN num_realizations;
+ALTER TABLE uiapi.job_stats ADD COLUMN disk_space BIGINT;

--- a/tests/calculators/hazard/classical/core_test.py
+++ b/tests/calculators/hazard/classical/core_test.py
@@ -225,9 +225,7 @@ store_site_model'
         # Test the job stats:
         job_stats = models.JobStats.objects.get(oq_job=self.job.id)
         # num sources * num lt samples / block size (items per task):
-        self.assertEqual(236, job_stats.num_tasks)
         self.assertEqual(120, job_stats.num_sites)
-        self.assertEqual(2, job_stats.num_realizations)
 
         # Check the calculator total/progress counters as well:
         self.assertEqual(0, self.calc.progress['computed'])

--- a/tests/calculators/hazard/disagg/core_test.py
+++ b/tests/calculators/hazard/disagg/core_test.py
@@ -206,12 +206,7 @@ class DisaggHazardCalculatorTestcase(unittest.TestCase):
 
     def setUp(self):
         self.job, self.calc = self._setup_a_new_calculator()
-        models.JobStats.objects.create(
-            oq_job=self.job,
-            num_sites=0,
-            num_tasks=0,
-            num_realizations=0
-        )
+        models.JobStats.objects.create(oq_job=self.job, num_sites=0)
 
     def _setup_a_new_calculator(self):
         cfg = helpers.get_data_path('disaggregation/job.ini')
@@ -252,9 +247,7 @@ class DisaggHazardCalculatorTestcase(unittest.TestCase):
         self.calc.pre_execute()
 
         job_stats = models.JobStats.objects.get(oq_job=self.job.id)
-        self.assertEqual(2, job_stats.num_realizations)
         self.assertEqual(2, job_stats.num_sites)
-        self.assertEqual(12, job_stats.num_tasks)
 
         self.assertEqual(
             {'hc_computed': 0, 'total': 12, 'hc_total': 8, 'computed': 0,

--- a/tests/calculators/hazard/general_test.py
+++ b/tests/calculators/hazard/general_test.py
@@ -405,8 +405,7 @@ class TaskArgGenTestCase(unittest.TestCase):
         expected = [exp + (ltp_mock.return_value,) for exp in expected]
 
         try:
-            actual = list(calc.task_arg_gen(
-                          block_size=2, check_num_task=False))
+            actual = list(calc.task_arg_gen(block_size=2))
             self.assertEqual(expected, actual)
             self.assertEqual(1, pt_src_block_size_mock.call_count)
             self.assertEqual(1, get_rlz_mock.call_count)


### PR DESCRIPTION
Another small simplification step. This pull request remove two fields from the table job_stats, i.e. num_tasks and num_realizations, that are misleading and can be inferred from the performance table anyway. It adds instead a disk_space field, that will contain the change in database size during the given calculation (of course this number will be reliable only if the calculation runs alone). A future pull request will populate the disk_space field.
See https://bugs.launchpad.net/oq-engine/+bug/1239529
