### PR TITLE
Removed calc_num task properly

### DIFF
--- a/openquake/engine/calculators/base.py
+++ b/openquake/engine/calculators/base.py
@@ -76,12 +76,6 @@ class Calculator(object):
         """
         raise NotImplementedError()
 
-    def calc_num_tasks(self):
-        """
-        Number of tasks to spawn.
-        Subclasses must implement this.
-        """
-
     def record_init_stats(self):
         """
         Record some basic job stats, including the number of sites,

--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -286,66 +286,6 @@ class EventBasedHazardCalculator(haz_general.BaseHazardCalculator):
     """
     core_calc_task = compute_ses
 
-    preferred_block_size = 1  # will be overridden in calc_num_tasks
-
-    def calc_num_tasks(self):
-        """
-        The number of tasks is inferred from the configuration parameter
-        concurrent_tasks (c), from the number of sources per realization
-        (n) and from the number of stochastic event sets (s) by using
-        the formula::
-
-                     N * n
-         num_tasks = ----- * s
-                       b
-
-        where N is the number of realizations and b is the block_size,
-        defined as::
-
-             N * n * s
-         b = ---------
-              10 * c
-
-        The divisions are intended rounded to the closest upper integer
-        (ceil). The mechanism is intended to generate a number of tasks
-        close to 10 * c independently on the number of sources and SES.
-        For instance, with c = 512, you should expect the engine to
-        generate at most 5120 tasks; they could be much less in case
-        of few sources and few SES; the minimum number of tasks generated
-        is::
-
-          num_tasks_min = N * n * s
-
-        To have good concurrency the number of tasks must be bigger than
-        the number of the cores (which is essentially c) but not too big,
-        otherwise all the time would be wasted in passing arguments.
-        Generating 10 times more tasks than cores gives a nice progress
-        percentage. There is no more motivation than that.
-        """
-        preferred_num_tasks = self.concurrent_tasks() * 10
-        num_ses = self.hc.ses_per_logic_tree_path
-
-        num_sources = []  # number of sources per realization
-        for lt_rlz in self._get_realizations():
-            n = models.SourceProgress.objects.filter(
-                lt_realization=lt_rlz).count()
-            num_sources.append(n)
-            logs.LOG.info('Found %d sources for realization %d',
-                          n, lt_rlz.id)
-        total_sources = sum(num_sources)
-
-        if len(num_sources) > 1:
-            logs.LOG.info('Total number of sources: %d', total_sources)
-
-        self.preferred_block_size = int(
-            math.ceil(float(total_sources * num_ses) / preferred_num_tasks))
-        logs.LOG.warn('Using block size: %d', self.preferred_block_size)
-
-        num_tasks = [math.ceil(float(n) / self.preferred_block_size) * num_ses
-                     for n in num_sources]
-
-        return int(sum(num_tasks))
-
     def task_arg_gen(self, _block_size=None):
         """
         Loop through realizations and sources to generate a sequence of
@@ -369,7 +309,11 @@ class EventBasedHazardCalculator(haz_general.BaseHazardCalculator):
                            ses_collection__lt_realization=lt_rlz,
                            ordinal__isnull=False).order_by('ordinal'))
 
-            for src_ids in block_splitter(sources, self.preferred_block_size):
+            preferred_block_size = int(
+                math.ceil(float(len(sources) * len(all_ses)) /
+                          (self.concurrent_tasks() * 10)))
+            logs.LOG.info('Using block size %d', preferred_block_size)
+            for src_ids in block_splitter(sources, preferred_block_size):
                 for ses in all_ses:
                     # compute seeds for the sources
                     src_seeds = [rnd.randint(0, models.MAX_SINT_32)

--- a/openquake/engine/calculators/hazard/general.py
+++ b/openquake/engine/calculators/hazard/general.py
@@ -772,44 +772,6 @@ class BaseHazardCalculator(base.Calculator):
         """
         return hazard_export.export(output_id, export_dir, export_type)
 
-    def calc_num_tasks(self):
-        """
-        The number of tasks is inferred from the number of sources
-        per realization by using the formula::
-
-                     N * n   N * n0
-         num_tasks = ----- + ------
-                       b       b0
-
-        where:
-
-          N is the number of realizations
-          n is the number of complex source
-          n0 is the number of point sources
-          b is the the block_size
-          b0 is the the point_source_block_size
-
-        The divisions are intended rounded to the closest upper integer
-        (ceil).
-        """
-        num_tasks = 0
-        block_size = self.block_size()
-        point_source_block_size = self.point_source_block_size()
-        total_sources = 0
-        for lt_rlz in self._get_realizations():
-            n = len(self._get_source_ids(lt_rlz))
-            n0 = len(self._get_point_source_ids(lt_rlz))
-            logs.LOG.debug('complex sources: %s, point sources: %d', n, n0)
-            total_sources += n + n0
-            ntasks = math.ceil(float(n) / block_size)
-            ntasks0 = math.ceil(float(n0) / point_source_block_size)
-            logs.LOG.debug(
-                'complex sources tasks: %s, point sources tasks: %d',
-                ntasks, ntasks0)
-            num_tasks += ntasks + ntasks0
-        logs.LOG.info('Total number of sources: %d', total_sources)
-        return int(num_tasks)
-
     @EnginePerformanceMonitor.monitor
     def do_aggregate_post_proc(self):
         """

--- a/openquake/engine/supervising/supervisor.py
+++ b/openquake/engine/supervising/supervisor.py
@@ -277,12 +277,7 @@ class SupervisorLogMessageConsumer(logs.AMQPLogSource):
         """
         Wrap superclass' method just to add cleanup.
         """
-        started = datetime.utcnow()
         super(SupervisorLogMessageConsumer, self).run()
-        stopped = datetime.utcnow()
-        self.selflogger.info('%s calc %s finished in %s'
-                             % (self.calc_domain, self.calc_id,
-                                stopped - started))
         self.joblogger.removeHandler(self.jobhandler)
         self.selflogger.debug('Exiting supervisor for %s calc %s'
                               % (self.calc_domain, self.calc_id))

--- a/qa_tests/hazard/event_based/blocksize/test.py
+++ b/qa_tests/hazard/event_based/blocksize/test.py
@@ -85,6 +85,7 @@ GMF(imt=PGA sa_period=None sa_damping=None rupture_id=rlz=00|ses=0001|src=1|i=00
             open('/tmp/64-exp.txt', 'w').write(self.expected_gmfs)
         self.assertEqual(gmfs_64, self.expected_gmfs)
 
+    @attr('qa', 'hazard', 'event_based')
     def test_32(self):
         tags_32, gmfs_32 = self.run_with_concurrent_tasks(32)
         self.assertEqual(tags_32, self.expected_tags)


### PR DESCRIPTION
PR https://github.com/gem/oq-engine/pull/1306 removed the column num_tasks from the job_stats table, since it was redundant. It also removed a call to calc_num_tasks that (as a side effect) was determining the preferred_block_size in the event based calculator. That broke qa_tests/hazard/event_based/case_12.So it seems that there is still a hidden dependency from the block size that requires further investigation. This PR removes num_tasks properly and fixes the test.
