### PR TITLE
A simple fix for engine_test.py

### DIFF
--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -662,7 +662,8 @@ class RunCalcTestCase(unittest.TestCase):
         )
 
         self.assertEqual(1, mm['cleanup'].call_count)
-        self.assertEqual(((1984, ), {}), mm['cleanup'].call_args)
+        self.assertEqual(((1984, ), {'terminate': False}),
+                         mm['cleanup'].call_args)
 
         self.assertEqual(1, mm['get_job'].call_count)
         self.assertEqual(((1984, ), {}), mm['get_job'].call_args)


### PR DESCRIPTION
This is currently broken on master, build 624, http://ci.openquake.org/job/master_oq-engine/lastCompletedBuild/testReport/tests.engine_test/RunCalcTestCase/test_unsupervised/
