### PR TITLE
Various small fixes for oq_create_db script

### DIFF
--- a/openquake/engine/bin/oq_create_db
+++ b/openquake/engine/bin/oq_create_db
@@ -244,7 +244,7 @@ fi
 
 # Create OpenQuake database users/roles if/as needed.
 for role in $db_roles; do
-    role_present=`psql -p $db_port -U $db_admin_user -d postgres $psql_batch_options -A -t -c "SELECT COUNT(*) FROM pg_users WHERE usename = '$role';"`
+    role_present=`psql -p $db_port -U $db_admin_user -d postgres $psql_batch_options -A -t -c "SELECT COUNT(*) FROM pg_user WHERE usename = '$role';"`
     if [ $role_present -eq 0 ]; then
         psql -p $db_port -d postgres -U $db_admin_user -c "CREATE ROLE $role WITH LOGIN IN GROUP openquake" $psql_batch_options
     fi


### PR DESCRIPTION
Addresses:
- grep needs a -w constrain otherwise the 'if' will fail is there's already stuff with a similar name (like openquake -> openquakeuser)
-  Remove an explicit path duplication

These fix will simplify the patch I use for CentOS 5/6.
