### PR TITLE
Remove a reference to the removed view hzrdr.gmf_family

### DIFF
--- a/openquake/engine/db/schema/security.sql
+++ b/openquake/engine/db/schema/security.sql
@@ -126,6 +126,3 @@ GRANT SELECT,INSERT        ON uiapi.risk_calculation   TO oq_job_init;
 GRANT SELECT,INSERT,UPDATE ON uiapi.cnode_stats        TO oq_job_init;
 GRANT SELECT,INSERT,UPDATE ON uiapi.output             TO oq_job_init;
 GRANT SELECT,INSERT,DELETE ON uiapi.performance        TO oq_job_init;
-
--- helper views
-GRANT SELECT               ON hzrdr.gmf_family TO oq_job_init;


### PR DESCRIPTION
I forgot to remove this grant when removing the view hzrdr.gmf_family 
