### PR TITLE
Fixed an upgrade script

### DIFF
--- a/openquake/engine/db/schema/upgrades/1.0.1/10/01-add-grants.sql
+++ b/openquake/engine/db/schema/upgrades/1.0.1/10/01-add-grants.sql
@@ -1,4 +1,3 @@
-GRANT SELECT,INSERT,UPDATE,DELETE ON htemp.source_progress       TO oq_job_init;
 GRANT SELECT,INSERT,UPDATE,DELETE ON htemp.hazard_curve_progress TO oq_job_init;
 GRANT SELECT,INSERT        ON hzrdr.hazard_curve      TO oq_job_init;
 GRANT SELECT,INSERT,UPDATE ON hzrdr.hazard_curve_data TO oq_job_init;


### PR DESCRIPTION
The table htemp.source_progress has been removed, so the GRANT should be removed too.
