### PR TITLE
BROKER_POOL_LIMIT is causing problem so set it to none

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -51,8 +51,9 @@ BROKER_VHOST = amqp.get("vhost")
 # BROKER_POOL_LIMIT enables a connections pool so Celery can reuse
 # a single connection to RabbitMQ. Value 10 is the default from
 # Celery 2.5 where this feature is enabled by default.
-# Fixes https://bugs.launchpad.net/oq-engine/+bug/1250402
-BROKER_POOL_LIMIT = 10
+# Actually disabled because it's not stable in production.
+# See https://bugs.launchpad.net/oq-engine/+bug/1250402
+BROKER_POOL_LIMIT = None
 
 CELERY_RESULT_BACKEND = "amqp"
 


### PR DESCRIPTION
BROKER_POOL_LIMIT is causing random strange connection errors and issues if it's enabled also on the workers and on a single machine (where celeryconfig.py is used by both celery and the openquake main process).

We need to address the bug in another way. See https://bugs.launchpad.net/oq-engine/+bug/1250402
