### PR TITLE
Raised the tolerance in ClassicalHazardCase13TestCase

### DIFF
--- a/qa_tests/hazard/classical/case_13/test.py
+++ b/qa_tests/hazard/classical/case_13/test.py
@@ -42,9 +42,9 @@ class ClassicalHazardCase13TestCase(BaseQATestCase):
             fname = '%s_%s_expected_curves_PGA.dat' % (sm_path, gsim_path)
             compare_hazard_curve_with_csv(
                 hc, [sm_path], [gsim_path], 'PGA', None, None,
-                os.path.join(csvdir, fname), ' ', rtol=0.2)
+                os.path.join(csvdir, fname), ' ', rtol=0.3)
 
             fname = '%s_%s_expected_curves_SA02.dat' % (sm_path, gsim_path)
             compare_hazard_curve_with_csv(
                 hc, [sm_path], [gsim_path], 'SA', 0.2, 5.0,
-                os.path.join(csvdir, fname), ' ', rtol=0.2)
+                os.path.join(csvdir, fname), ' ', rtol=0.3)


### PR DESCRIPTION
The change in the Rx distance in hazardlib (https://github.com/gem/oq-hazardlib/pull/150) broke this test. Damiano says it is okay to raise the tolerance to 30%.
