### PR TITLE
Remove time_span from disaggregation calculator

### DIFF
--- a/openquake/engine/calculators/hazard/disaggregation/core.py
+++ b/openquake/engine/calculators/hazard/disaggregation/core.py
@@ -111,7 +111,6 @@ def compute_disagg(job_id, sites, sources, lt_rlz, ltp):
                     'imt': imt,
                     'iml': iml,
                     'gsims': gsims,
-                    'time_span': hc.investigation_time,
                     'truncation_level': hc.truncation_level,
                     'n_epsilons': hc.num_epsilon_bins,
                     'mag_bin_width': hc.mag_bin_width,
@@ -123,7 +122,7 @@ def compute_disagg(job_id, sites, sources, lt_rlz, ltp):
                 with EnginePerformanceMonitor(
                         'computing disaggregation', job_id, compute_disagg):
                     bin_edges, diss_matrix = openquake.hazardlib.calc.\
-                        disagg.disaggregation_poissonian(**calc_kwargs)
+                        disagg.disaggregation(**calc_kwargs)
                     if not bin_edges:  # no ruptures generated
                         continue
 

--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -805,7 +805,7 @@ class HazardCalculation(djm.Model):
         # NB: the sites MUST be ordered. The issue is that the disaggregation
         # calculator has a for loop of kind
         # for site in sites:
-        #     bin_edge, disagg_matrix = disaggregation_poissonian(site, ...)
+        #     bin_edge, disagg_matrix = disaggregation(site, ...)
         # the generated ruptures are random if the order of the sites
         # is random, even if the seed is fixed; in particular for some
         # ordering no ruptures are generated and the test

--- a/openquake/engine/tests/calculators/hazard/disagg/core_test.py
+++ b/openquake/engine/tests/calculators/hazard/disagg/core_test.py
@@ -83,7 +83,7 @@ class DisaggHazardCalculatorTestcase(unittest.TestCase):
         base_path = 'openquake.engine.calculators.hazard.disaggregation.core'
 
         disagg_calc_func = (
-            'openquake.hazardlib.calc.disagg.disaggregation_poissonian'
+            'openquake.hazardlib.calc.disagg.disaggregation'
         )
         with mock.patch(disagg_calc_func) as disagg_mock:
             disagg_mock.return_value = (None, None)


### PR DESCRIPTION
This is the companion pull request to https://github.com/gem/oq-hazardlib/pull/162.
The tests are green: http://ci.openquake.org/job/zdevel_oq-engine/273/
