### PR TITLE
Fixed test_initialize_sources

### DIFF
--- a/openquake/engine/tests/calculators/hazard/classical/core_test.py
+++ b/openquake/engine/tests/calculators/hazard/classical/core_test.py
@@ -71,7 +71,7 @@ class ClassicalHazardCalculatorTestCase(unittest.TestCase):
         self.calc.initialize_sources()
         # after splitting/grouping the source model contains 22 blocks
         blocks = self.calc.source_blocks_per_ltpath[('b1',)]
-        self.assertEqual(22, len(blocks))
+        self.assertEqual(21, len(blocks))
 
     @attr('slow')
     def test_initialize_site_model(self):


### PR DESCRIPTION
Having changed the grouping algorithm, now 21 blocks are generated instead of 21 in test_initialize_sources.
