### PR TITLE
Exclude tests folder from pylint check

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -22,6 +22,9 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=
 
+# Add <file or directory> to the black list. It should be a base name, not a
+# path. You may set this option multiple times.
+ignore=tests
 
 [MESSAGES CONTROL]
 


### PR DESCRIPTION
Exclude tests folder from pylint check. See CI pylint violations.
