### PR TITLE
Fixed a missing loss_type in export_loss_fraction_xml

### DIFF
--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -145,6 +145,7 @@ def _export_common(output, loss_type):
                     loss_type),
                 loss_type=loss_type)
 
+
 @core.makedirsdeco
 def export_agg_loss_curve_xml(output, target):
     """
@@ -229,9 +230,8 @@ def export_loss_fraction_xml(output, target):
     poe = output.loss_fraction.poe
     variable = output.loss_fraction.variable
     loss_category = risk_calculation.exposure_model.category
-    loss_type = output.loss_fraction.loss_type
     writers.LossFractionsWriter(
-        dest, variable, args['unit'], loss_type,
+        dest, variable, args['unit'], args['loss_type'],
         loss_category, hazard_metadata, poe).serialize(
         output.loss_fraction.total_fractions(),
         output.loss_fraction)


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1287230

We need to add a test for this functionality and to make sure that the same mistakes is not repeated in other exporters.
