### PR TITLE
Increase the tolerance in the disaggregation test

### DIFF
--- a/qa_tests/hazard/disagg/case_1/test.py
+++ b/qa_tests/hazard/disagg/case_1/test.py
@@ -30,7 +30,7 @@ from openquake.engine.export import hazard as haz_export
 from qa_tests import _utils as qa_utils
 from qa_tests.hazard.disagg.case_1 import _test_data as test_data
 
-aac = lambda a, b: numpy.testing.assert_allclose(a, b, atol=1e-5)
+aac = lambda a, b: numpy.testing.assert_allclose(a, b, atol=5e-3)
 
 
 class DisaggHazardCase1TestCase(qa_utils.BaseQATestCase):


### PR DESCRIPTION
Due to the changes in the arrange algorithm in hazardlib (see https://github.com/gem/oq-hazardlib/pull/187) the numbers in the disaggregation QA test are slightly different, so I have raised the tolerance.
Notice that this is only temporary, since the QA tests have been completely rewritten in the disaggregation branch, soon to appear in a separate pull request.
