### PR TITLE
Turn SIGTERM into SIGINT

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -22,6 +22,7 @@ import getpass
 import os
 import sys
 import time
+import signal
 import logging
 import warnings
 from contextlib import contextmanager
@@ -60,6 +61,15 @@ LOG_FORMAT = ('[%(asctime)s %(calc_domain)s #%(calc_id)s %(hostname)s '
 
 TERMINATE = general.str2bool(
     config.get('celery', 'terminate_workers_on_revoke'))
+
+
+def keyboard_interrupt(_signum, _stack):
+    """
+    When a SIGTERM is received, raise a KeyboardInterrupt
+    """
+    raise KeyboardInterrupt
+
+signal.signal(signal.SIGTERM, keyboard_interrupt)
 
 
 def cleanup_after_job(job, terminate):


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1282561
We tested this with Daniele and it works as expected: now killing a job has the effect as sending a CTRL-C, i.e. the tasks are revoked and the calculation is marked as failed.
