### PR TITLE
Fix branch var to be compliant within the new CI git plugin

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -742,11 +742,13 @@ while [ $# -gt 0 ]; do
             break
             ;;
         devtest)
+            # Sed removes 'origin/' from the branch name
             devtest_run $(echo "$2" | sed 's@.*/@@g')
             exit $?
             break
             ;;
         pkgtest)
+            # Sed removes 'origin/' from the branch name
             pkgtest_run $(echo "$2" | sed 's@.*/@@g')
             exit $?
             break


### PR DESCRIPTION
The `$GIT_BRANCH` var provided by the current Jenkins' git plugin contains `origin/branch` instead of just `branch`
