### PR TITLE
Improvements to the CeleryNodeMonitor

### DIFF
--- a/openquake/engine/celery_node_monitor.py
+++ b/openquake/engine/celery_node_monitor.py
@@ -93,21 +93,20 @@ class CeleryNodeMonitor(object):
         Check that the expected celery nodes are all up. The loop
         continues until the main thread keeps running.
         """
-        while self.main_is_running(sleep=self.interval):
+        while self.job_is_running(sleep=self.interval):
             live_nodes = set(celery.task.control.inspect().ping() or {})
             if live_nodes < self.live_nodes:
                 print >> sys.stderr, 'Cluster nodes not accessible: %s' % (
                     self.live_nodes - live_nodes)
                 os.kill(os.getpid(), signal.SIGABRT)  # commit suicide
-                break
 
-    def main_is_running(self, sleep):
+    def job_is_running(self, sleep):
         """
-        Check for 50 times during the sleep interval if the flag
+        Check for 100 times during the sleep interval if the flag
         self.job_running becomes false and then exit.
         """
-        for _ in range(50):
+        for _ in range(100):
             if not self.job_running:
                 break
-            time.sleep(sleep / 50.)
+            time.sleep(sleep / 100.)
         return self.job_running

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -545,7 +545,7 @@ def run_job(cfg_file, log_level, log_file, exports, hazard_output_id=None,
     :param str hazard_calculation_id:
         The Hazard Calculation ID used by the risk calculation (can be None)
     """
-    with CeleryNodeMonitor(openquake.engine.no_distribute(), interval=5):
+    with CeleryNodeMonitor(openquake.engine.no_distribute(), interval=30):
         hazard = hazard_output_id is None and hazard_calculation_id is None
         if log_file is not None:
             touch_log_file(log_file)

--- a/openquake/engine/tests/celery_node_monitor_test.py
+++ b/openquake/engine/tests/celery_node_monitor_test.py
@@ -1,0 +1,56 @@
+import os
+import time
+import mock
+import signal
+import unittest
+from openquake.engine.celery_node_monitor import CeleryNodeMonitor
+
+
+class CeleryNodeMonitorTestCase(unittest.TestCase):
+    def setUp(self):
+        self.patch = mock.patch('celery.task.control.inspect')
+        self.inspect = self.patch.start()
+
+    def test_all_nodes_were_down(self):
+        ping = self.inspect().ping
+        ping.return_value = {}
+        mon = CeleryNodeMonitor(no_distribute=False, interval=1)
+        with self.assertRaises(SystemExit), mock.patch('sys.stderr') as stderr:
+            mon.__enter__()
+        self.assertEqual(ping.call_count, 1)  # called only once
+        self.assertTrue(stderr.write.called)  # an error message was printed
+
+    def test_all_nodes_are_up(self):
+        ping = self.inspect().ping
+        ping.return_value = {'node1': []}
+        mon = CeleryNodeMonitor(no_distribute=False, interval=1)
+        with mon:
+            time.sleep(1.1)
+        # one ping was done in the thread, plus one at the beginning
+        self.assertEqual(ping.call_count, 2)
+
+    def test_one_node_went_down(self):
+        ping = self.inspect().ping
+        ping.return_value = {'node1': []}
+        mon = CeleryNodeMonitor(no_distribute=False, interval=1)
+        with mon, mock.patch('os.kill') as kill, \
+                mock.patch('sys.stderr') as stderr:
+            time.sleep(1.1)
+            ping.return_value = {}
+            time.sleep(1)
+            # two pings was done in the thread, plus 1 at the beginning
+            self.assertEqual(ping.call_count, 3)
+
+            # check that kill was called with a SIGABRT
+            pid, signum = kill.call_args[0]
+            self.assertEqual(pid, os.getpid())
+            self.assertEqual(signum, signal.SIGABRT)
+            self.assertTrue(stderr.write.called)
+
+    def test_no_distribute(self):
+        with CeleryNodeMonitor(no_distribute=True, interval=0.1):
+            time.sleep(0.5)
+        self.assertIsNone(self.inspect.call_args)
+
+    def tearDown(self):
+        self.patch.stop()

--- a/openquake/engine/tests/engine_test.py
+++ b/openquake/engine/tests/engine_test.py
@@ -21,15 +21,11 @@ import subprocess
 import tempfile
 import unittest
 import warnings
-import time
-import mock
-import signal
 
 from openquake.engine.db import models
 from django.core import exceptions
 
 from openquake.engine import engine
-from openquake.engine.celery_node_monitor import CeleryNodeMonitor
 from openquake.engine.tests.utils import helpers
 
 
@@ -437,53 +433,3 @@ class DeleteRiskCalcTestCase(unittest.TestCase):
         risk_calc = risk_job.risk_calculation
 
         self.assertRaises(RuntimeError, engine.del_risk_calc, risk_calc.id)
-
-
-class CeleryNodeMonitorTestCase(unittest.TestCase):
-    def setUp(self):
-        self.patch = mock.patch('celery.task.control.inspect')
-        self.inspect = self.patch.start()
-
-    def test_all_nodes_were_down(self):
-        ping = self.inspect().ping
-        ping.return_value = {}
-        mon = CeleryNodeMonitor(no_distribute=False, interval=0.1)
-        with self.assertRaises(SystemExit), mock.patch('sys.stderr') as stderr:
-            mon.__enter__()
-        self.assertEqual(ping.call_count, 1)  # called only once
-        self.assertTrue(stderr.write.called)  # an error message was printed
-
-    def test_all_nodes_are_up(self):
-        ping = self.inspect().ping
-        ping.return_value = {'node1': []}
-        mon = CeleryNodeMonitor(no_distribute=False, interval=0.1)
-        with mon:
-            time.sleep(.21)
-        # three ping were done in the thread, plus 1 at the beginning
-        self.assertEqual(ping.call_count, 4)
-
-    def test_one_node_went_down(self):
-        ping = self.inspect().ping
-        ping.return_value = {'node1': []}
-        mon = CeleryNodeMonitor(no_distribute=False, interval=0.1)
-        with mon, mock.patch('os.kill') as kill, \
-                mock.patch('sys.stderr') as stderr:
-            time.sleep(.11)
-            ping.return_value = {}
-            time.sleep(.1)
-            # two ping were done in the thread, plus 1 at the beginning
-            self.assertEqual(ping.call_count, 3)
-
-            # check that kill was called with a SIGABRT
-            pid, signum = kill.call_args[0]
-            self.assertEqual(pid, os.getpid())
-            self.assertEqual(signum, signal.SIGABRT)
-            self.assertTrue(stderr.write.called)
-
-    def test_no_distribute(self):
-        with CeleryNodeMonitor(no_distribute=True, interval=0.1):
-            time.sleep(0.5)
-        self.assertIsNone(self.inspect.call_args)
-
-    def tearDown(self):
-        self.patch.stop()


### PR DESCRIPTION
Improved the responsiveness of the monitoring thread and moved the CeleryNodeMonitor tests to their own module. Now the thread checks every 0.3 seconds if the main job ended and exits early in the regular case, while at it checks for node failure only every 30 seconds.

Tests are running: https://ci.openquake.org/job/zdevel_oq-engine/356
