### PR TITLE
Add support in the engine for a local_settings.py

### DIFF
--- a/openquake/engine/settings.py
+++ b/openquake/engine/settings.py
@@ -92,3 +92,8 @@ SECRET_KEY = 'change-me-in-production'
 
 USE_I18N = False
 USE_L10N = False
+
+try:
+    from local_settings import *
+except ImportError:
+    pass


### PR DESCRIPTION
In the CentOS port I need to set a custom `GEOS_LIBRARY_PATH` in `openquake/engine/settings.py` but I would prefer to not touch that versioned file. I want to use the local_settings.py instead. This PR add support for adding a `local_settings.py` file.
