### PR TITLE
Log a warning when more than 80% of the memory is used

### DIFF
--- a/openquake/engine/utils/tasks.py
+++ b/openquake/engine/utils/tasks.py
@@ -39,15 +39,15 @@ from openquake.engine.performance import EnginePerformanceMonitor, \
 ONE_MB = 1024 * 1024
 
 
-def check_mem_usage(used_mem_percent=80):
+def check_mem_usage(mem_percent=80):
     """
     Display a warning if we are running out of memory
 
-    :param int used_mem_percent: the memory limit as a percentage
+    :param int mem_percent: the memory limit as a percentage
     """
-    mem_percent = psutil.phymem_usage().percent
-    if mem_percent > used_mem_percent:
-        logs.LOG.warn('Using over %d%% of the memory!', mem_percent)
+    used_mem_percent = psutil.phymem_usage().percent
+    if used_mem_percent > mem_percent:
+        logs.LOG.warn('Using over %d%% of the memory!', used_mem_percent)
 
 
 class Pickled(object):


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1307913.
The percentage could become a parameter in the configuration file, but for the moment it is fixed to 80%. It is trivial to change if needed.
