### PR TITLE
Fix the export of GmfSets in the case of multiple source models

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -1891,7 +1891,7 @@ class Gmf(djm.Model):
         for ses_coll in SESCollection.objects.filter(
                 output__oq_job=self.output.oq_job):
             for ses in ses_coll:
-                query = """
+                query = """\
         SELECT imt, sa_period, sa_damping, tag,
                array_agg(gmv) AS gmvs,
                array_agg(ST_X(location::geometry)) AS xs,
@@ -1900,11 +1900,13 @@ class Gmf(djm.Model):
              unnest(rupture_ids) as rupture_id, location, unnest(gmvs) AS gmv
            FROM hzrdr.gmf_data, hzrdi.hazard_site
             WHERE site_id = hzrdi.hazard_site.id AND hazard_calculation_id=%s
-           AND gmf_id=%d) AS x, hzrdr.ses_rupture AS y
-        WHERE x.rupture_id = y.id AND y.ses_id=%d
+           AND gmf_id=%d) AS x, hzrdr.ses_rupture AS y,
+           hzrdr.probabilistic_rupture AS z
+        WHERE x.rupture_id = y.id AND y.rupture_id=z.id
+        AND y.ses_id=%d AND z.ses_collection_id=%d
         GROUP BY imt, sa_period, sa_damping, tag
         ORDER BY imt, sa_period, sa_damping, tag;
-        """ % (hc.id, self.id, ses.ordinal)
+        """ % (hc.id, self.id, ses.ordinal, ses_coll.id)
                 with transaction.commit_on_success(using='job_init'):
                     curs = getcursor('job_init')
                     curs.execute(query)

--- a/openquake/engine/tests/db/models_test.py
+++ b/openquake/engine/tests/db/models_test.py
@@ -244,6 +244,9 @@ class GmfsPerSesTestCase(unittest.TestCase):
         lt_model = models.LtSourceModel.objects.create(
             hazard_calculation=job.hazard_calculation,
             ordinal=1, sm_lt_path="test_sm")
+        lt_model_2 = models.LtSourceModel.objects.create(
+            hazard_calculation=job.hazard_calculation,
+            ordinal=2, sm_lt_path="test_sm_2")
         rlz1 = models.LtRealization.objects.create(
             lt_model=lt_model, ordinal=1, seed=1, weight=None,
             gsim_lt_path="test_gsim")
@@ -253,20 +256,27 @@ class GmfsPerSesTestCase(unittest.TestCase):
         ses_coll = models.SESCollection.objects.create(
             output=models.Output.objects.create_output(
                 job, "Test SES Collection 1", "ses"),
-            lt_model=lt_model, ordinal=0)
+            lt_model=lt_model, ordinal=1)
+        # create a second SESCollection; this is to avoid regressions
+        # in models.Gmf.__iter__ which should yield a single
+        # GmfSet even if there are several SES collections
+        models.SESCollection.objects.create(
+            output=models.Output.objects.create_output(
+                job, "Test SES Collection 2", "ses"),
+            lt_model=lt_model_2, ordinal=2)
 
         gmf_data1 = helpers.create_gmf_data_records(job, rlz1, ses_coll)[0]
         points = [(15.3, 38.22), (15.7, 37.22),
                   (15.4, 38.09), (15.56, 38.1), (15.2, 38.2)]
         gmf_data2 = helpers.create_gmf_data_records(
             job, rlz2, ses_coll, points)[0]
-        cls.gmf_coll1 = gmf_data1.gmf
+        cls.gmf1 = gmf_data1.gmf  # a Gmf instance
         cls.ruptures1 = tuple(get_tags(gmf_data1))
         cls.ruptures2 = tuple(get_tags(gmf_data2))
         cls.investigation_time = job.hazard_calculation.investigation_time
 
     def test_branch_lt(self):
-        [gmfs] = self.gmf_coll1
+        [gmfset] = self.gmf1  # exhaust Gmf.__iter__
         expected = """\
 GMFsPerSES(investigation_time=%f, stochastic_event_set_id=1,
 GMF(imt=PGA sa_period=None sa_damping=None rupture_id=%s
@@ -288,7 +298,7 @@ GMF(imt=PGA sa_period=None sa_damping=None rupture_id=%s
 <X= 15.56500, Y= 38.17000, GMV=0.3000000>
 <X= 15.71000, Y= 37.22500, GMV=0.3000000>))""" % (
             (self.investigation_time,) + self.ruptures1)
-        self.assertEqual(str(gmfs), expected)
+        self.assertEqual(str(gmfset), expected)
 
 
 class PrepGeometryTestCase(unittest.TestCase):


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1312071, this was reported by Sriram on the users mailing list.

The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/368/
