### PR TITLE
Fixed underflow error in postgres

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -135,6 +135,20 @@ SourceRuptureSites = collections.namedtuple(
     'source rupture sites')
 
 
+############## Fix FloatField underflow error ##################
+# http://stackoverflow.com/questions/9556586/floating-point-numbers-of-python-float-and-postgresql-double-precision
+
+def _get_prep_value(self, value):
+    if value is None:
+        return None
+    val = float(value)
+    if val < 1E-300:
+        return 0.
+    return val
+
+djm.FloatField.get_prep_value = _get_prep_value
+
+
 def required_imts(risk_models):
     """
     Get all the intensity measure types required by `risk_models`

--- a/openquake/engine/tests/db/models_test.py
+++ b/openquake/engine/tests/db/models_test.py
@@ -22,6 +22,8 @@ import numpy
 
 from nose.plugins.attrib import attr
 
+from django.contrib.gis.db import models as djm
+
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo.surface.planar import PlanarSurface
@@ -316,6 +318,12 @@ class PrepGeometryTestCase(unittest.TestCase):
         }
 
         self.assertEqual(expected, models._prep_geometry(the_input))
+
+
+class FloatFieldTestCase(unittest.TestCase):
+    def test_truncate_small_numbers(self):
+        # workaround a postgres error "out of range for type double precision"
+        self.assertEqual(djm.FloatField().get_prep_value(1e-301), 0)
 
 
 class GetSiteCollectionTestCase(unittest.TestCase):


### PR DESCRIPTION
Floats smaller than 1e-300 are rounded to zero. This fixes an error found by Catalina.
