### PR TITLE
Added a cache on the GSIMs for the probabilities of no exceedence in the classical calculator

### DIFF
--- a/openquake/engine/calculators/hazard/disaggregation/core.py
+++ b/openquake/engine/calculators/hazard/disaggregation/core.py
@@ -73,7 +73,9 @@ def _collect_bins_data(mon, trt_num, source_ruptures, site, curves,
 
                 pne_dict = {}
                 # a dictionary rlz.id, poe, imt_str -> prob_no_exceed
-                for rlz, gsim in gsim_by_rlz.items():
+                for rlz, gsim_cls in gsim_by_rlz.items():
+                    # NB: cache for gsims not implemented yet
+                    gsim = gsim_cls()
                     with make_ctxt:
                         sctx, rctx, dctx = gsim.make_contexts(sitecol, rupture)
                     for imt_str, imls in imtls.iteritems():

--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -236,12 +236,13 @@ class GmfCollector(object):
         :param seed:
             an integer to be used as stochastic seed
         """
+        # NB: cache for gsims not implemented yet
         for rlz, gsim in self.gsim_by_rlz.items():
             gmf_calc_kwargs = {
                 'rupture': rupture,
                 'sites': r_sites,
                 'imts': self.imts,
-                'gsim': gsim,
+                'gsim': gsim(),
                 'truncation_level': self.params['truncation_level'],
                 'realizations': DEFAULT_GMF_REALIZATIONS,
                 'correlation_model': self.params['correl_model'],

--- a/openquake/engine/calculators/hazard/general.py
+++ b/openquake/engine/calculators/hazard/general.py
@@ -44,7 +44,7 @@ from openquake.engine.calculators.post_processing import (
 from openquake.engine.export import core as export_core
 from openquake.engine.export import hazard as hazard_export
 from openquake.engine.input import logictree
-from openquake.engine.utils import config, tasks
+from openquake.engine.utils import config
 from openquake.engine.utils.general import block_splitter, ceil
 from openquake.engine.performance import EnginePerformanceMonitor
 

--- a/openquake/engine/input/logictree.py
+++ b/openquake/engine/input/logictree.py
@@ -227,34 +227,28 @@ class BranchSet(object):
         Apply filters to ``source`` and return ``True`` if uncertainty should
         be applied to it.
         """
+        ohs = openquake.hazardlib.source
         for key, value in self.filters.items():
             if key == 'applyToTectonicRegionType':
                 if value != source.tectonic_region_type:
                     return False
             elif key == 'applyToSourceType':
                 if value == 'area':
-                    if not isinstance(source,
-                                      openquake.hazardlib.source.AreaSource):
+                    if not isinstance(source, ohs.AreaSource):
                         return False
                 elif value == 'point':
                     # area source extends point source
-                    if (not isinstance(
-                            source, openquake.hazardlib.source.PointSource)
-                        or isinstance(
-                            source, openquake.hazardlib.source.AreaSource)):
+                    if (not isinstance(source, ohs.PointSource)
+                            or isinstance(source, ohs.AreaSource)):
                         return False
                 elif value == 'simpleFault':
-                    if not isinstance(
-                        source, openquake.hazardlib.source.SimpleFaultSource):
+                    if not isinstance(source, ohs.SimpleFaultSource):
                         return False
                 elif value == 'complexFault':
-                    if not isinstance(
-                        source, openquake.hazardlib.source.ComplexFaultSource):
+                    if not isinstance(source, ohs.ComplexFaultSource):
                         return False
                 elif value == 'characteristicFault':
-                    if not isinstance(
-                        source,
-                        openquake.hazardlib.source.CharacteristicFaultSource):
+                    if not isinstance(source, ohs.CharacteristicFaultSource):
                         return False
                 else:
                     raise AssertionError('unknown source type %r' % value)
@@ -978,7 +972,7 @@ class GMPELogicTree(BaseLogicTree):
 
         Convert gmpe import path to a gmpe object.
         """
-        return GSIM[classname]()
+        return GSIM[classname]
 
     def validate_uncertainty_value(self, node, branchset, value):
         """

--- a/openquake/engine/tests/calculators/hazard/event_based/core_test.py
+++ b/openquake/engine/tests/calculators/hazard/event_based/core_test.py
@@ -82,7 +82,7 @@ class GmfCollectorTestCase(unittest.TestCase):
         hc.maximum_distance = 200.
 
         trt = 'Subduction Interface'
-        gsim = get_available_gsims()['AkkarBommer2010']()
+        gsim = get_available_gsims()['AkkarBommer2010']
         num_sites = 5
         site_coll = make_site_coll(-78, 15.5, num_sites)
         params = dict(truncation_level=3,

--- a/openquake/engine/tests/input/logictree_test.py
+++ b/openquake/engine/tests/input/logictree_test.py
@@ -1279,10 +1279,8 @@ class SourceModelLogicTreeTestCase(unittest.TestCase):
         lt = _TestableSourceModelLogicTree(
             'lt', {'lt': source_model_logic_tree, 'sm': sm},
             '/base', validate=False)
-        self.assert_branchset_equal(lt.root_branchset,
-            'sourceModel', {},
-            [('b1', '1.0', 'sm')]
-        )
+        self.assert_branchset_equal(
+            lt.root_branchset, 'sourceModel', {}, [('b1', '1.0', 'sm')])
 
 
 class GMPELogicTreeTestCase(unittest.TestCase):
@@ -1293,7 +1291,7 @@ class GMPELogicTreeTestCase(unittest.TestCase):
             self.assertNotEqual(len(branchset.branches), 0)
             trt = branchset.filters['applyToTectonicRegionType']
             actual_result[trt] = [
-                (branch.branch_id, str(branch.weight), type(branch.value))
+                (branch.branch_id, str(branch.weight), branch.value)
                 for branch in branchset.branches
             ]
             next_branchset = branchset.branches[0].child_branchset
@@ -1302,7 +1300,7 @@ class GMPELogicTreeTestCase(unittest.TestCase):
             branchset = next_branchset
             self.assertTrue(trt in result)
             self.assertEqual(actual_result[trt], result[trt])
-        self.assertEqual(set(actual_result.keys()), set(result.keys()))
+        self.assertEqual(set(actual_result), set(result))
         self.assertEqual(actual_result, result)
 
     def test(self):
@@ -1843,17 +1841,14 @@ class LogicTreeProcessorParsePathTestCase(unittest.TestCase):
         from openquake.hazardlib.gsim.sadigh_1997 import SadighEtAl1997
         from openquake.hazardlib.gsim.chiou_youngs_2008 import ChiouYoungs2008
         gmpes = self.proc.parse_gmpe_logictree_path(['b2', 'b3'])
-        self.assertIsInstance(gmpes.pop('Active Shallow Crust'),
-                              ChiouYoungs2008)
-        self.assertIsInstance(gmpes.pop('Subduction Interface'),
-                              SadighEtAl1997)
+        self.assertIs(gmpes.pop('Active Shallow Crust'), ChiouYoungs2008)
+        self.assertIs(gmpes.pop('Subduction Interface'),
+                      SadighEtAl1997)
         self.assertEqual(gmpes, {})
 
         gmpes = self.proc.parse_gmpe_logictree_path(['b1', 'b3'])
-        self.assertIsInstance(gmpes.pop('Active Shallow Crust'),
-                              SadighEtAl1997)
-        self.assertIsInstance(gmpes.pop('Subduction Interface'),
-                              SadighEtAl1997)
+        self.assertIs(gmpes.pop('Active Shallow Crust'), SadighEtAl1997)
+        self.assertIs(gmpes.pop('Subduction Interface'), SadighEtAl1997)
         self.assertEqual(gmpes, {})
 
 


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1314016
This helps a lot for complex logic trees where the same sources are recomputed with the same GSIM several times. An example is the SHARE computation of FMGlobal with 1280 realizations. Here are the times on gemsun02 with 3 sites (speedup of 66x):

```
    -- without the cache
   description  job_type    calculation_id  hazard_calculation_id   stop_time   status  num_sites   num_sources     disk_space_mb   duration
   SHARE ASC [Area Source Model (23/01/2013)]   hazard  51  None    2014-05-04T17:10:31     complete    None    None    38  8:15:52

   operation    tot_duration    pymemory    counts
   total compute_hazard_curves  237,575     23  65
   computing poes   211,822     None    65
   execute  28,869  85  1
   making contexts  25,110  None    65
   total hazard_curves_to_hazard_map    1,474   0.027   15360
   save_hazard_curves   365     0.000   1
   initialize_sources   62  71  1
   generating ruptures  32  None    65
   filtering ruptures   27  None    65
   task_completed   23  0.129   65

    -- with the cache
   description  job_type    calculation_id  hazard_calculation_id   stop_time   status  num_sites   num_sources     disk_space_mb   duration
   SHARE ASC [Area Source Model (23/01/2013)]   hazard  50  None    2014-05-04T08:44:51     complete    None    None    40  0:22:06

   operation    tot_duration    pymemory    counts
   total compute_hazard_curves  3,606   22  65
   total hazard_curves_to_hazard_map    1,477   0.027   15360
   computing poes   705     None    65
   execute  478     85  1
   save_hazard_curves   381     0.121   1
   making contexts  128     None    65
   initialize_sources   61  70  1
   filtering ruptures   36  None    65
   generating ruptures  30  None    65
   task_completed   20  0.176   65
```

The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/379
