### PR TITLE
Fixed a critical ordering bug

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -2214,6 +2214,7 @@ class LtSourceModel(djm.Model):
 
     class Meta:
         db_table = 'hzrdr\".\"lt_source_model'
+        ordering = ['ordinal']
 
     def __iter__(self):
         """


### PR DESCRIPTION
This bug affects all the computations with more than one source model in the logic tree. Since the ordering was unspecified, the weights of the logic tree could end up mismatched in the realizations. As a consequence the statistics outputs (i.e. the mean hazard curves) could be different in two runs of the same computation.
This solves a very tricky bug in the QA test classical/case_7 which was some times passing and some times not (the two weights 0.7 and 0.3 could flip).
