### PR TITLE
Fixed a tricky bug in the scenario calculator with duplicate imts

### DIFF
--- a/openquake/engine/calculators/hazard/scenario/core.py
+++ b/openquake/engine/calculators/hazard/scenario/core.py
@@ -45,7 +45,9 @@ def gmfs(job_id, seeds, sitecol, rupture, gmf_id, task_no):
     See :func:`compute_gmfs` for parameter definitions.
     """
     hc = models.HazardCalculation.objects.get(oqjob=job_id)
-    imts = [from_string(x) for x in hc.intensity_measure_types]
+    # distinct is here to make sure that IMTs such as
+    # SA(0.8) and SA(0.80) are considered the same
+    imts = general.distinct(from_string(x) for x in hc.intensity_measure_types)
     gsim = AVAILABLE_GSIMS[hc.gsim]()  # instantiate the GSIM class
     realizations = 1  # one realization for each seed
     correlation_model = haz_general.get_correl_model(hc)

--- a/openquake/engine/tests/data/scenario_hazard/job.ini
+++ b/openquake/engine/tests/data/scenario_hazard/job.ini
@@ -23,7 +23,7 @@ reference_depth_to_1pt0km_per_sec = 100.0
 [calculation]
 
 rupture_model_file = rupture_model.xml
-intensity_measure_types = PGA, SA(0.1)
+intensity_measure_types = PGA, SA(0.1), SA(0.10)
 truncation_level = 1.0
 # km
 maximum_distance = 200


### PR DESCRIPTION
I found this bug in the scenario_damage calculation for Portugal. In that calculation the IMTs are inferred from the exposure file and they are written in an inconsistent way: sometimes one finds the string SA(0.8), sometimes the string SA(0.80). The engine consider them as distinct IMTs and save the same ground motion values twice. The solution is to collapse the IMTs to the really distinct ones. See https://bugs.launchpad.net/oq-engine/+bug/1320115.
