### PR TITLE
Reducing the celery timeout from 30s to 3s

### DIFF
--- a/openquake/engine/celery_node_monitor.py
+++ b/openquake/engine/celery_node_monitor.py
@@ -127,11 +127,11 @@ class CeleryNodeMonitor(object):
 
     def job_is_running(self, sleep):
         """
-        Check for 100 times during the sleep interval if the flag
+        Check for 10 times during the sleep interval if the flag
         self.job_running becomes false and then exit.
         """
-        for _ in range(100):
+        for _ in range(10):
             if not self.job_running:
                 break
-            time.sleep(sleep / 100.)
+            time.sleep(sleep / 10.)
         return self.job_running

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -545,7 +545,7 @@ def run_job(cfg_file, log_level, log_file, exports, hazard_output_id=None,
     :param str hazard_calculation_id:
         The Hazard Calculation ID used by the risk calculation (can be None)
     """
-    with CeleryNodeMonitor(openquake.engine.no_distribute(), interval=30):
+    with CeleryNodeMonitor(openquake.engine.no_distribute(), interval=3):
         hazard = hazard_output_id is None and hazard_calculation_id is None
         if log_file is not None:
             touch_log_file(log_file)


### PR DESCRIPTION
After a job has finished, the computation is still blocked for up to 30s while pinging the celery nodes. This is annoying during development, for small jobs, so I am reducing the timeout.

https://bugs.launchpad.net/oq-engine/+bug/1316061
