### PR TITLE
Add a debug flag to enable set -x in packager.sh

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -35,7 +35,9 @@
 #
 
 # export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
-# set -x
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 set -e
 GEM_GIT_REPO="git://github.com/gem"
 GEM_GIT_PACKAGE="oq-engine"


### PR DESCRIPTION
This PR allows to enable the `packager.sh` debug just setting the environment var `$GEM_SET_DEBUG` in Jenkins.
