### PR TITLE
Hide the SES output from a scenario calculator

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -1244,6 +1244,7 @@ class Output(djm.Model):
 
     class Meta:
         db_table = 'uiapi\".\"output'
+        ordering = ['id']
 
     def is_hazard_curve(self):
         return self.output_type in ['hazard_curve', 'hazard_curve_multi']

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -498,7 +498,11 @@ def list_hazard_outputs(hc_id):
     :param hc_id:
         ID of a hazard calculation.
     """
-    print_outputs_summary(get_outputs('hazard', hc_id))
+    outputs = get_outputs('hazard', hc_id)
+    hc = models.HazardCalculation.objects.get(pk=hc_id)
+    if hc.calculation_mode == 'scenario':  # ignore SES output
+        outputs = outputs.filter(output_type='gmf_scenario')
+    print_outputs_summary(outputs)
 
 
 def touch_log_file(log_file):


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1327696. Also sets a default ordering on the outputs.
