### PR TITLE
Fixed the ordering of the ruptures in the event based calculator

### DIFF
--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -33,6 +33,7 @@ For more information on computing ground motion fields, see
 
 import time
 import random
+import operator
 import collections
 
 import numpy.random
@@ -136,7 +137,7 @@ def compute_ruptures(
         # NB: the number of occurrences is very low, << 1, so it is
         # more efficient to filter only the ruptures that occur, i.e.
         # to call sample_number_of_occurrences() *before* the filtering
-        for rup in ses_num_occ.keys():
+        for rup in sorted(ses_num_occ, key=operator.attrgetter('rup_no')):
             with filter_ruptures_mon:  # filtering ruptures
                 r_sites = filters.filter_sites_by_distance_to_rupture(
                     rup, hc.maximum_distance, s_sites


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1329674. The tests are running here: https://ci2.openquake.org/job/zdevel_oq-engine/403
