### PR TITLE
Added a missing integer cast

### DIFF
--- a/openquake/engine/calculators/hazard/scenario/core.py
+++ b/openquake/engine/calculators/hazard/scenario/core.py
@@ -100,7 +100,8 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
         super(ScenarioHazardCalculator, self).__init__(*args, **kwargs)
         self.gmf = None
         self.rupture = None
-        self.rupture_block_size = config.get('hazard', 'rupture_block_size')
+        self.rupture_block_size = int(
+            config.get('hazard', 'rupture_block_size'))
 
     def initialize_sources(self):
         """


### PR DESCRIPTION
For some reason splitting with a string instead of an integer worked: the system was simply not splitting and generating a single task, but all tests were green. The issue is that calculator was not parallel and thus slow.

The tests are green https://ci2.openquake.org/job/zdevel_oq-engine/413
