### PR TITLE
Retrieved the correct output directly, not via an order by

### DIFF
--- a/qa_tests/risk/event_based/qatest_1/test.py
+++ b/qa_tests/risk/event_based/qatest_1/test.py
@@ -93,9 +93,11 @@ class EventBaseQATestCase1(risk.CompleteTestCase, risk.FixtureBasedQATestCase):
         # for loss_type=structural and branch b2
         tags = [row[0] for row in self.expected_elt_b2]
 
-        el_b1, el_b2 = models.EventLoss.objects.filter(
-            output__output_type='event_loss', output__oq_job=job,
-            loss_type='structural').order_by('output')
+        el_b2 = models.EventLoss.objects.get(
+            hazard_output__gmf__lt_realization__gsim_lt_path=['b2'],
+            output__output_type='event_loss',
+            output__oq_job=job,
+            loss_type='structural')
         elt = models.EventLossData.objects.filter(
             event_loss=el_b2.id, rupture__tag__in=tags
         ).order_by('-aggregate_loss')


### PR DESCRIPTION
This fix will solve the issue with the test which is breaking master. The order_by('output') was not enough to guarantee the correct ordering: the order of the hazard output is unspecified, the first output could be associated to branch b1 and the second to branch b2 on a machine, but they can be switched on another machine.
