### PR TITLE
Moved parse_config from the engine to commonlib

### DIFF
--- a/openquake/engine/tests/calculators/hazard/general_test.py
+++ b/openquake/engine/tests/calculators/hazard/general_test.py
@@ -18,6 +18,7 @@
 import unittest
 
 from openquake.hazardlib import geo as hazardlib_geo
+from openquake.commonlib import readini
 
 from openquake.engine import engine
 from openquake.engine.calculators.hazard import general
@@ -130,7 +131,7 @@ class ParseRiskModelsTestCase(unittest.TestCase):
         job = engine.prepare_job(username)
 
         cfg = helpers.get_data_path('classical_job-sd-imt.ini')
-        params = engine.parse_config(open(cfg, 'r'))
+        params = readini.parse_config(open(cfg, 'r'))
 
         haz_calc = engine.create_calculation(models.HazardCalculation, params)
         haz_calc = models.HazardCalculation.objects.get(id=haz_calc.id)

--- a/openquake/engine/tests/engine_test.py
+++ b/openquake/engine/tests/engine_test.py
@@ -13,12 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import StringIO
+
 import getpass
-import os
-import shutil
 import subprocess
-import tempfile
 import unittest
 import warnings
 
@@ -64,110 +61,6 @@ class PrepareJobTestCase(unittest.TestCase):
         job = engine.prepare_job(log_level='debug')
 
         self.assertEqual('debug', job.log_level)
-
-
-class ParseConfigTestCase(unittest.TestCase):
-
-    def test_parse_config_no_files(self):
-        # sections are there just for documentation
-        # when we parse the file, we ignore these
-        source = StringIO.StringIO("""
-[general]
-CALCULATION_MODE = classical
-region = 1 1 2 2 3 3
-[foo]
-bar = baz
-""")
-        # Add a 'name' to make this look like a real file:
-        source.name = 'path/to/some/job.ini'
-        exp_base_path = os.path.dirname(
-            os.path.join(os.path.abspath('.'), source.name))
-
-        expected_params = {
-            'base_path': exp_base_path,
-            'calculation_mode': 'classical',
-            'region': '1 1 2 2 3 3',
-            'bar': 'baz',
-            'inputs': {},
-        }
-
-        params = engine.parse_config(source)
-
-        self.assertEqual(expected_params, params)
-
-    def test_parse_config_with_files(self):
-        temp_dir = tempfile.mkdtemp()
-        site_model_input = helpers.touch(dir=temp_dir, content="foo")
-        job_config = helpers.touch(dir=temp_dir, content="""
-[general]
-calculation_mode = classical
-[site]
-site_model_file = %s
-maximum_distance=0
-truncation_level=0
-random_seed=0
-    """ % site_model_input)
-
-        try:
-            exp_base_path = os.path.dirname(job_config)
-
-            expected_params = {
-                'base_path': exp_base_path,
-                'calculation_mode': 'classical',
-                'truncation_level': '0',
-                'random_seed': '0',
-                'maximum_distance': '0',
-                'inputs': {'site_model': site_model_input},
-            }
-
-            params = engine.parse_config(open(job_config, 'r'))
-            self.assertEqual(expected_params, params)
-            self.assertEqual(['site_model'], params['inputs'].keys())
-            self.assertEqual([site_model_input], params['inputs'].values())
-        finally:
-            shutil.rmtree(temp_dir)
-
-    def test__parse_sites_csv(self):
-        expected_wkt = 'MULTIPOINT(0.1 0.2, 2 3, 4.1 5.6)'
-        source = StringIO.StringIO("""\
-0.1,0.2
-2,3
-4.1,5.6
-""")
-        wkt = engine._parse_sites_csv(source)
-        self.assertEqual(expected_wkt, wkt)
-
-    def test_parse_config_with_sites_csv(self):
-        sites_csv = helpers.touch(content='1.0,2.1\n3.0,4.1\n5.0,6.1')
-        try:
-            source = StringIO.StringIO("""
-[general]
-calculation_mode = classical
-[geometry]
-sites_csv = %s
-[misc]
-maximum_distance=0
-truncation_level=3
-random_seed=5
-""" % sites_csv)
-            source.name = 'path/to/some/job.ini'
-            exp_base_path = os.path.dirname(
-                os.path.join(os.path.abspath('.'), source.name))
-
-            expected_params = {
-                'base_path': exp_base_path,
-                'sites': 'MULTIPOINT(1.0 2.1, 3.0 4.1, 5.0 6.1)',
-                'calculation_mode': 'classical',
-                'truncation_level': '3',
-                'random_seed': '5',
-                'maximum_distance': '0',
-                'inputs': {},
-            }
-
-            params = engine.parse_config(source)
-            self.assertEqual(expected_params, params)
-        finally:
-            os.unlink(sites_csv)
 
 
 class CreateHazardCalculationTestCase(unittest.TestCase):

--- a/openquake/engine/tests/job/validation_test.py
+++ b/openquake/engine/tests/job/validation_test.py
@@ -27,6 +27,7 @@ from openquake.engine.tests.utils import helpers
 from openquake.engine.tests.utils.helpers import get_data_path
 
 from openquake.commonlib.general import deep_eq
+from openquake.commonlib import readini
 
 
 VALID_IML_IMT = {
@@ -919,7 +920,7 @@ class ValidateTestCase(unittest.TestCase):
         # warning should be raised.
         cfg_file = helpers.get_data_path('simple_fault_demo_hazard/job.ini')
         job = engine.prepare_job()
-        params = engine.parse_config(open(cfg_file, 'r'))
+        params = readini.parse_config(open(cfg_file, 'r'))
         # Add a few superfluous parameters:
         params['ses_per_logic_tree_path'] = 5
         params['ground_motion_correlation_model'] = 'JB2009'

--- a/openquake/engine/tests/utils/helpers.py
+++ b/openquake/engine/tests/utils/helpers.py
@@ -34,19 +34,20 @@ import tempfile
 import textwrap
 import time
 
+from django.core import exceptions
+
 from openquake.hazardlib.source.rupture import ParametricProbabilisticRupture
 from openquake.hazardlib.geo import Point
 from openquake.hazardlib.geo.surface.planar import PlanarSurface
 from openquake.hazardlib.tom import PoissonTOM
-
-from django.core import exceptions
+from openquake.commonlib.general import writetmp as touch
+from openquake.commonlib import readini
 
 from openquake.engine.db import models
 from openquake.engine import engine
 from openquake.engine import logs
 from openquake.engine.utils import config
 from openquake.engine.job.validation import validate
-
 
 CD = os.path.dirname(__file__)  # current directory
 
@@ -261,28 +262,6 @@ def cleanup_loggers():
     sys.stderr = STDERR
 
 
-def touch(content=None, dir=None, prefix="tmp", suffix="tmp"):
-    """Create temporary file with the given content.
-
-    Please note: the temporary file must be deleted bu the caller.
-
-    :param string content: the content to write to the temporary file.
-    :param string dir: directory where the file should be created
-    :param string prefix: file name prefix
-    :param string suffix: file name suffix
-    :returns: a string with the path to the temporary file
-    """
-    if dir is not None:
-        if not os.path.exists(dir):
-            os.makedirs(dir)
-    fh, path = tempfile.mkstemp(dir=dir, prefix=prefix, suffix=suffix)
-    if content:
-        fh = os.fdopen(fh, "w")
-        fh.write(content)
-        fh.close()
-    return path
-
-
 class ConfigTestCase(object):
     """Class which contains various configuration- and environment-related
     testing helpers."""
@@ -341,7 +320,7 @@ def get_job(cfg, username="openquake", hazard_calculation_id=None,
         return engine.job_from_file(cfg, username, 'error', [])
 
     job = engine.prepare_job(username)
-    params = engine.parse_config(open(cfg, 'r'))
+    params = readini.parse_config(open(cfg, 'r'))
 
     params.update(
         dict(hazard_output_id=hazard_output_id,
@@ -553,7 +532,7 @@ def get_fake_risk_job(risk_cfg, hazard_cfg, output_type="curve",
     hazard_job.status = "complete"
     hazard_job.save()
     job = engine.prepare_job(username)
-    params = engine.parse_config(open(risk_cfg, 'r'))
+    params = readini.parse_config(open(risk_cfg, 'r'))
 
     params.update(dict(hazard_output_id=hazard_output.output.id))
 


### PR DESCRIPTION
This is another step on the road to make it possible to implement calculators directly from commonlib, without passing from the engine. The immediate goal is to get an event based risk calculator working directly from the ruptures, https://bugs.launchpad.net/oq-engine/+bug/1321681
