### PR TITLE
Add a file openquake_worker.cfg to be read in the workers

### DIFF
--- a/openquake_worker.cfg
+++ b/openquake_worker.cfg
@@ -1,0 +1,49 @@
+# Copyright (c) 2010-2014, GEM Foundation.
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+# THIS FILE WILL BE READ BY THE WORKER NODES IN A CLUSTER
+
+[amqp]
+host = localhost
+port = 5672
+user = guest
+password = guest
+vhost = /
+# This is where tasks will be enqueued.
+celery_queue = celery
+
+[database]
+name = openquake
+host = localhost
+port = 5432
+
+admin_password = openquake
+admin_user = oq_admin
+
+job_init_password = openquake
+job_init_user = oq_job_init
+
+[hazard]
+# collect sources in blocks until their weight exceeds 'source_max_weight'
+source_max_weight = 20000
+# maximum number of tasks to spawn concurrently
+concurrent_tasks = 64
+
+[risk]
+# change the following parameter to a smaller integer if you have
+# memory issues with the epsilon matrix; beware however that you will
+# introduce a stronger seed dependency
+# epsilon_sampling = 0 means no sampling
+epsilon_sampling = 1000


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1339712. The trick is to set OQ_LOCAL_CFG_PATH="openquake_worker.cfg"
