### PR TITLE
Introduced a variable OQ_TERMINATE_JOB_WHEN_CELERY_IS_DOWN

### DIFF
--- a/openquake.cfg
+++ b/openquake.cfg
@@ -18,11 +18,6 @@ terminate_workers_on_revoke = true
 # this is good for a single user situation, but turn this off on a cluster
 # otherwise a CTRL-C will kill the computations of other users
 
-terminate_job_when_celery_is_down = true
-# this is good generally, but it may be necessary to turn it off in
-# heavy computations (i.e. celery could not respond to pings and still
-# not be really down).
-
 [amqp]
 host = localhost
 port = 5672

--- a/openquake/engine/celery_node_monitor.py
+++ b/openquake/engine/celery_node_monitor.py
@@ -119,7 +119,10 @@ class CeleryNodeMonitor(object):
     def check_nodes(self):
         """
         Check that the expected celery nodes are all up. The loop
-        continues until the main thread keeps running.
+        continues until the main thread keeps running. In case of
+        heavy computations it is best to set the environment variable
+        OQ_TERMINATE_JOB_WHEN_CELERY_IS_DOWN=false, otherwise if any
+        node does not respond to the ping the calculation is killed.
         """
         while self.job_is_running(sleep=self.interval):
             live_nodes = self.ping(timeout=self.interval)
@@ -127,8 +130,8 @@ class CeleryNodeMonitor(object):
                 dead_nodes = list(self.live_nodes - live_nodes)
                 logs.LOG.critical(
                     'Cluster nodes not accessible: %s', dead_nodes)
-                terminate = str2bool(
-                    config.get('celery', 'terminate_job_when_celery_is_down'))
+                terminate = os.environ.get(
+                    'OQ_TERMINATE_JOB_WHEN_CELERY_IS_DOWN', True)
                 if terminate:
                     os.kill(os.getpid(), signal.SIGABRT)  # commit suicide
 


### PR DESCRIPTION
I am removing terminate_job_when_celery_is_down from the configuration and making it an environment variable.
In this way we can disable it on Jenkins without having to change the source code.
