### PR TITLE
Reintroduce the 'terminate_job_when_celery_is_down' config option

### DIFF
--- a/openquake.cfg
+++ b/openquake.cfg
@@ -18,6 +18,11 @@ terminate_workers_on_revoke = true
 # this is good for a single user situation, but turn this off on a cluster
 # otherwise a CTRL-C will kill the computations of other users
 
+terminate_job_when_celery_is_down = true
+# this is good generally, but it may be necessary to turn it off in
+# heavy computations (i.e. celery could not respond to pings and still
+# not be really down).
+
 [amqp]
 host = localhost
 port = 5672


### PR DESCRIPTION
Since the new behaviour (env var) doesn't work in any case, I would prefer to keep the old config option. It's more intelligible and much easy to manage: the old env var can be cached in a user profile causing troubles.
