### PR TITLE
Added the column uniq_ruptures to the table source_info

### DIFF
--- a/openquake/engine/calculators/hazard/classical/core.py
+++ b/openquake/engine/calculators/hazard/classical/core.py
@@ -254,7 +254,6 @@ def compute_hazard_curves(
                               source_class=source.__class__.__name__,
                               num_sites=num_sites,
                               num_ruptures=num_ruptures,
-                              occ_ruptures=num_ruptures,
                               calc_time=time.time() - t0))
 
     make_ctxt_mon.flush()

--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -250,8 +250,9 @@ def compute_ruptures(
                               source_id=src.source_id,
                               source_class=src.__class__.__name__,
                               num_sites=len(s_sites),
-                              num_ruptures=num_ruptures,
+                              num_ruptures=rup_no,
                               occ_ruptures=occ_ruptures,
+                              uniq_ruptures=num_ruptures,
                               calc_time=time.time() - t0))
 
     filter_sites_mon.flush()

--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -2392,7 +2392,8 @@ class SourceInfo(djm.Model):
     source_class = djm.TextField(null=False)
     num_sites = djm.IntegerField(null=False)
     num_ruptures = djm.IntegerField(null=False)
-    occ_ruptures = djm.IntegerField(null=False)
+    occ_ruptures = djm.IntegerField(null=True)
+    uniq_ruptures = djm.IntegerField(null=True)
     calc_time = djm.FloatField(null=False)
 
     class Meta:

--- a/openquake/engine/db/schema/upgrades/0001-uniq-ruptures.sql
+++ b/openquake/engine/db/schema/upgrades/0001-uniq-ruptures.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hzrdr.source_info ALTER COLUMN occ_ruptures DROP NOT NULL;
+ALTER TABLE hzrdr.source_info ADD COLUMN uniq_ruptures INTEGER;


### PR DESCRIPTION
Now the table source_info contains three kind of rupture counters:

num_ruptures = total number of ruptures that could be generated
uniq_ruptures = number of unique ruptures occurring in an event_based calculation
occ_ruptures =  total number of ruptures occurring in an event_based calculation

In generale occ_ruptures >= uniq_ruptures since the same rupture can occur more than once in an event based
calculation. In a classical calculation uniq_ruptures e occ_ruptures are NULL, only num_ruptures is stored.

Tests running here: https://ci.openquake.org/job/zdevel_oq-engine/572
