### PR TITLE
Removed --schema-path from oq_create_db

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -133,7 +133,7 @@ if [ -f /usr/lib/postgresql/9.1/bin/postgres ]; then
     pgport=`cat /etc/postgresql/9.1/main/postgresql.conf | perl -wane ' if ($_ =~ /^\s*port\s*=/) { s/^\s*port\s*=\s*(\d+).*$/$1/; print $_; }'`
     LOGFILE=/var/tmp/openquake-db-installation
     rm -f $LOGFILE
-    su -c "/usr/bin/oq_create_db --yes --db-name=openquake2 --db-port=$pgport --schema-path=$IDIR/db/schema > $LOGFILE 2>&1" postgres
+    su -c "/usr/bin/oq_create_db --yes --db-name=openquake2 --db-port=$pgport > $LOGFILE 2>&1" postgres
     for dbu in oq_admin oq_job_init
     do
         su -c "psql -p $pgport -c \"ALTER ROLE $dbu WITH PASSWORD 'openquake'\" >> $LOGFILE 2>&1" postgres

--- a/openquake/engine/bin/oq_create_db
+++ b/openquake/engine/bin/oq_create_db
@@ -4,8 +4,7 @@
 help() {
 cat <<HSD
 This script must be run as postgres user.
-`basename $0` initialises the given database with the OpenQuake schema.
-Also, table space paths are created as needed (unless this is turned off
+Table space paths are created as needed (unless this is turned off
 by the user).
 
 !! The database must not exist already !!
@@ -15,7 +14,6 @@ The command line arguments are as follows:
     --db-name=name         The name of the database to set up.
     --db-port=port         The postgresql server port (default: 5432)
     --no-tab-spaces        Don't check/create table spaces and their paths
-    --schema-path=path     Absolute path to directory with the schema files.
     --tab-spaces-only      Check/create table spaces and their paths and exit
     --verbose              Enable verbose output
     --load-fixtures=path   Load test fixtures from path
@@ -36,7 +34,6 @@ tspace_path='/var/lib/postgresql/9.1/main/ts'
 tspace_list="hzrdi hzrdr riski riskr uiapi"
 
 db_port=5432
-schema_path=`dirname $0`/../openquake/engine/db/schema
 db_name=`python -c "from openquake.engine.settings import DATABASES; print DATABASES['default']['NAME']"`
 user_interaction="on"
 check_table_spaces="on"
@@ -58,14 +55,6 @@ EOF
 for i in $*
 do
     case $i in
-    --schema-path=*)
-        schema_path=`echo $i | sed 's/[-a-zA-Z0-9]*=//'`
-        test \( -d "$schema_path" -a -r "$schema_path" \)
-        if [ $? -ne 0 ]; then
-            echo "!! Schema path $schema_path does not exist or is not readable."
-            exit 1
-        fi
-        ;;
     --db-name=*)
         db_name=`echo $i | sed 's/[-a-zA-Z0-9]*=//'`
         ;;

--- a/packager.sh
+++ b/packager.sh
@@ -214,7 +214,7 @@ _wait_ssh () {
 #                     - builds oq-hazardlib speedups
 #                     - installs oq-engine sources on lxc
 #                     - set up postgres
-#                     - creates database schema
+#                     - upgrade db
 #                     - runs celeryd
 #                     - runs tests
 #                     - runs coverage
@@ -283,7 +283,7 @@ _devtest_innervm_run () {
     ssh $lxc_ip "sudo sed -i 's/#standard_conforming_strings = on/standard_conforming_strings = off/g' /etc/postgresql/9.1/main/postgresql.conf"
 
     ssh $lxc_ip "sudo service postgresql restart"
-    ssh $lxc_ip "set -e ; sudo su postgres -c \"cd oq-engine ; openquake/engine/bin/oq_create_db --yes --db-name=openquake2 --schema-path=openquake/engine/db/schema\""
+    ssh $lxc_ip "set -e ; sudo su postgres -c \"cd oq-engine ; openquake/engine/bin/oq_create_db --yes --db-name=openquake2\""
     ssh $lxc_ip "set -e ; export PYTHONPATH=\"\$PWD/oq-engine:\$PWD/oq-nrmllib:\$PWD/oq-hazardlib:\$PWD/oq-risklib:\$PWD/oq-commonlib\" ; cd oq-engine ; bin/openquake --upgrade-db"
 
     # run celeryd daemon
@@ -358,7 +358,7 @@ celeryd_wait $GEM_MAXLOOP"
 #                     - adds repositories to apt sources on lxc
 #                     - performs package tests (install, remove, reinstall ..)
 #                     - set up postgres
-#                     - creates database schema
+#                     - upgrade db
 #                     - runs celeryd
 #                     - executes demos
 #


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1361231.
This parameter is now useless. It was a leftover from the previous implementation.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/589
