### PR TITLE
The parameter concurrent_tasks must be available to the workers too

### DIFF
--- a/openquake_worker.cfg
+++ b/openquake_worker.cfg
@@ -17,7 +17,7 @@
 
 [celery]
 # maximum number of tasks to spawn concurrently
-concurrent_tasks = 64]
+concurrent_tasks = 64
 
 [amqp]
 host = localhost


### PR DESCRIPTION
This is needed on the cluster, otherwise celery will not start.
