### PR TITLE
Remove a try finally in engine server task.py

### DIFF
--- a/openquake/server/tasks.py
+++ b/openquake/server/tasks.py
@@ -175,10 +175,9 @@ def update_calculation(callback_url=None, **query):
     """
     if callback_url is None:
         return
-    try:  # post to an external service
-        url = urllib2.urlopen(callback_url, data=urllib.urlencode(query))
-    finally:
-        url.close()
+    # post to an external service
+    url = urllib2.urlopen(callback_url, data=urllib.urlencode(query))
+    url.close()
 
 
 #: Simple structure that holds all the query components needed to


### PR DESCRIPTION
This throws a real exception and avoids misleading error:

``` python
ERROR local variable 'url' referenced before assignment
Traceback (most recent call last):
  File "/home/openquake/GEM/openquake/oq-engine/openquake/server/tasks.py", line 69, in safely_call
    func(*args)
  File "/home/openquake/GEM/openquake/oq-engine/openquake/server/tasks.py", line 100, in run_calc
    update_calculation(callback_url, status="started", engine_id=calc_id)
  File "/home/openquake/GEM/openquake/oq-engine/openquake/server/tasks.py", line 182, in update_calculation
    url.close()
UnboundLocalError: local variable 'url' referenced before assignment
```
