### PR TITLE
Keep set -x off in postinst for production

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -3,7 +3,7 @@
 #
 # see: dh_installdeb(1)
 
-set -x
+# set -x
 set -e
 
 # summary of how this script can be called:


### PR DESCRIPTION
In production `set -x` in the postinst script should left off since it's spamming system logs and could confuse the users.
