### PR TITLE
Enable 'set -x' when $GEM_SET_DEBUG is true

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -3,7 +3,9 @@
 #
 # see: dh_installdeb(1)
 
-set -x
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 set -e
 
 # summary of how this script can be called:

--- a/debian/postrm
+++ b/debian/postrm
@@ -4,8 +4,11 @@
 # Skeleton maintainer script showing all the possible cases.
 # Written by Charles Briscoe-Smith, March-April 1998.  Public Domain.
 
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
+
 # Abort if any command returns an error value
-#set -x
 set -e
 
 # This script is called twice during the removal of the package; once

--- a/debian/preinst
+++ b/debian/preinst
@@ -3,7 +3,9 @@
 #
 # see: dh_installdeb(1)
 
-#set -x
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 set -e
 
 GEM_DEB_PACKAGE="python-oq-engine"

--- a/openquake/engine/bin/oq_create_db
+++ b/openquake/engine/bin/oq_create_db
@@ -1,5 +1,8 @@
 #!/bin/bash
-# set -x
+
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 
 help() {
 cat <<HSD

--- a/tools/oqrev
+++ b/tools/oqrev
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-# set -x
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 
 help() {
 cat <<HSD


### PR DESCRIPTION
This PR will activate the `set -x` flag in all oq-engine bash scripts when `$GEM_SET_DEBUG` is declared as true.

The LXC container used by our CI has been updated to use this feature.

Supersedes https://github.com/gem/oq-engine/pull/1531 
