### PR TITLE
Renamed nrml_version->commonlib_version

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -271,7 +271,7 @@ class OqJob(djm.Model):
     status = djm.TextField(choices=STATUS_CHOICES, default='pre_executing')
     oq_version = djm.TextField(null=True, blank=True)
     hazardlib_version = djm.TextField(null=True, blank=True)
-    nrml_version = djm.TextField(null=True, blank=True)
+    commonlib_version = djm.TextField(null=True, blank=True)
     risklib_version = djm.TextField(null=True, blank=True)
     is_running = djm.BooleanField(default=False)
     duration = djm.IntegerField(default=0)

--- a/openquake/engine/db/schema/upgrades/0009-commonlib_version.sql
+++ b/openquake/engine/db/schema/upgrades/0009-commonlib_version.sql
@@ -1,0 +1,4 @@
+-- nrmllib is dead; the version number has not been updated from the time of
+-- 1.0, so it is meaningless and can be set to NULL to avoid confusion
+UPDATE uiapi.oq_job SET nrml_version=NULL;
+ALTER TABLE uiapi.oq_job RENAME COLUMN nrml_version TO commonlib_version;

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -41,8 +41,7 @@ from openquake.engine.settings import DATABASES
 from openquake.engine.db.models import Performance
 from openquake.engine.db.schema.upgrades import upgrader
 
-from openquake import hazardlib
-from openquake import risklib
+from openquake import hazardlib, risklib, commonlib
 
 from openquake.commonlib import readini, valid
 
@@ -129,6 +128,7 @@ def prepare_job(user_name="openquake", log_level='progress'):
         oq_version=openquake.engine.__version__,
         hazardlib_version=hazardlib.__version__,
         risklib_version=risklib.__version__,
+        commonlib_version=commonlib.__version__,
     )
 
 


### PR DESCRIPTION
nrmllib is no more. Tests running here: https://ci.openquake.org/job/zdevel_oq-engine/749
