### PR TITLE
Fixed the name of the SES file

### DIFF
--- a/openquake/engine/export/hazard.py
+++ b/openquake/engine/export/hazard.py
@@ -162,7 +162,7 @@ def _get_result_export_dest(calc_id, target, result, file_ext='xml'):
     elif output_type == 'ses':
         sm_ltp = core.LT_PATH_JOIN_TOKEN.join(result.sm_lt_path)
         filename = '%s-%s-smltp_%s.%s' % (
-            output_type, output.ses.ordinal, sm_ltp, file_ext
+            output_type, result.ordinal, sm_ltp, file_ext
         )
     elif output_type == 'disagg_matrix':
         # only logic trees, no stats

--- a/openquake/engine/tests/export/hazard_test.py
+++ b/openquake/engine/tests/export/hazard_test.py
@@ -243,7 +243,7 @@ class GetResultExportDestTestCase(unittest.TestCase):
 
         ses = self.FakeSES(output, 1, self.ltr_mc.sm_lt_path)
         expected_path = (
-            '%s/calc_8/ses/ses-smltp_B1_B3.xml'
+            '%s/calc_8/ses/ses-1-smltp_B1_B3.xml'
             % self.target_dir
         )
         self.assertEqual(


### PR DESCRIPTION
The problem is that different SESCollections are written on the same file, see https://bugs.launchpad.net/oq-engine/+bug/1389144. The tests are running here: 
https://ci.openquake.org/job/zdevel_oq-engine/790
