### PR TITLE
Rollback only if a transaction is on

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -96,7 +96,7 @@ def job_stats(job):
         yield
     except:
         conn = django_db.connections['job_init']
-        if conn.transaction_state:
+        if conn.is_dirty():
             conn.rollback()
         raise
     finally:


### PR DESCRIPTION
This avoids "could not rollback" error messages covering the real error, as it happened to Sevgi.
The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/797/
