### PR TITLE
Check that the hazard calculation mode is consistent with risk calculation mode

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -381,7 +381,7 @@ def run_job(cfg_file, log_level, log_file, exports=(), hazard_output_id=None,
 
 def check_hazard_risk_consistency(haz_job, risk_mode):
     """
-    Make sure that the retrieve hazard job is the right one for the
+    Make sure that the provided hazard job is the right one for the
     current risk calculator.
 
     :param job:


### PR DESCRIPTION
This avoids a common problem when the user provide a wrong hazard calculation ID.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/805/
