### PR TITLE
Added an API to retrieve the engine version

### DIFF
--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -13,6 +13,7 @@ from django.test.client import RequestFactory
 from django.utils import unittest
 
 from openquake.commonlib.general import writetmp
+from openquake import engine
 from openquake.engine.utils.tasks import oqtask
 from openquake.server import views, executor, tasks
 from openquake.server._test_utils import MultiMock
@@ -50,6 +51,11 @@ class UtilsTestCase(BaseViewTestCase):
         self.request.META['HTTP_HOST'] = 'www.openquake.org'
         self.assertEqual('https://www.openquake.org',
                          views._get_base_url(self.request))
+
+    def test_engine_version(self):
+        request = self.factory.get('/engine_version')
+        response = views.get_engine_version(request)
+        self.assertEqual(response.content, engine.__version__)
 
 
 class CalcHazardTestCase(BaseViewTestCase):
@@ -576,3 +582,4 @@ class SubmitJobTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         executor.shutdown()
+        

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -4,5 +4,6 @@ from django.conf.urls.defaults import url
 
 urlpatterns = patterns(
     '',
+    url(r'^engine_version$', 'openquake.server.views.get_engine_version'),
     url(r'^v1/calc/', include('openquake.server.v1.calc_urls')),
 )

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -15,7 +15,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
 from openquake.commonlib import nrml
-from openquake.engine import engine as oq_engine
+from openquake.engine import engine as oq_engine, __version__ as oqversion
 from openquake.engine.db import models as oqe_models
 from openquake.engine.export import core
 from openquake.engine.utils.tasks import safely_call
@@ -135,6 +135,15 @@ def _is_source_model(tempfile):
     if model_elem.tag == '{%s}sourceModel' % nrml.NAMESPACE:
         return True
     return False
+
+
+@cross_domain_ajax
+@require_http_methods(['GET'])
+def get_engine_version(request):
+    """
+    Return a string with the openquake.engine version
+    """
+    return HttpResponse(oqversion)
 
 
 @require_http_methods(['GET'])


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1340182.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/859
