### PR TITLE
Update packager and postinst to use the openquake2 db (new default one)

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -165,7 +165,7 @@ if [ -f /usr/lib/postgresql/9.1/bin/postgres ]; then
         mv $PG_ROOT/pg_hba.conf $PG_ROOT/pg_hba.conf.orig
         for dbu in oq_admin oq_job_init
         do
-            echo "local   openquake   $dbu                   md5" >> $PG_ROOT/pg_hba.conf
+            echo "local   openquake2   $dbu                   md5" >> $PG_ROOT/pg_hba.conf
         done
         cat $PG_ROOT/pg_hba.conf.orig | grep -v 'local..*oq_' >> $PG_ROOT/pg_hba.conf
         /etc/init.d/postgresql reload 9.1

--- a/packager.sh
+++ b/packager.sh
@@ -277,7 +277,7 @@ _devtest_innervm_run () {
     # configure the machine to run tests
     ssh $lxc_ip "set -e
         for dbu in oq_job_init oq_admin; do
-            sudo sed -i \"1ilocal   openquake   \$dbu                   md5\" /etc/postgresql/9.1/main/pg_hba.conf
+            sudo sed -i \"1ilocal   openquake2   \$dbu                   md5\" /etc/postgresql/9.1/main/pg_hba.conf
         done"
 
     ssh $lxc_ip "sudo sed -i 's/#standard_conforming_strings = on/standard_conforming_strings = off/g' /etc/postgresql/9.1/main/postgresql.conf"


### PR DESCRIPTION
Tests: https://ci.openquake.org/job/zdevel_oq-engine/861/
