### PR TITLE
Renamed commonlib.general -> baselib.general

### DIFF
--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -21,7 +21,7 @@ file formats."""
 import os
 from openquake.engine.db import models
 from openquake.engine.logs import LOG
-from openquake.commonlib.general import CallableDict
+from openquake.baselib.general import CallableDict
 
 export_output = CallableDict()
 

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.test.client import RequestFactory
 from django.utils import unittest
 
-from openquake.commonlib.general import writetmp
+from openquake.baselib.general import writetmp
 from openquake import engine
 from openquake.engine.utils.tasks import oqtask
 from openquake.server import views, executor, tasks


### PR DESCRIPTION
Those two were not renamed because export/core.py and views_test.py were changed in another branch, and the branch tested on Jenkins was not updated.
