### PR TITLE
Moved the expected outputs of the ScenarioDamage QA tests in qa_tests_data

### DIFF
--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -245,13 +245,12 @@ def export_dmg_dist(key, output, target):
     """
     job = output.oq_job
     dest = _get_result_export_dest(target, output)
-    damage_states = [
-        ds.dmg_state for ds in models.DmgState.objects.filter(
-            risk_calculation__id=job.id).order_by('lsi')]
+    damage_states = list(models.DmgState.objects.filter(
+        risk_calculation__id=job.id).order_by('lsi'))
     writer = risk_writers.DamageWriter(damage_states)
     damagecls = DAMAGE[key[0]]
     if key[0] == 'collapse_map':
-        data = damagecls.objects.filter(dmg_state__dmg_state=damage_states[-1])
+        data = damagecls.objects.filter(dmg_state=damage_states[-1])
     else:
         data = damagecls.objects.filter(dmg_state__risk_calculation__id=job.id)
     writer.to_nrml(key[0], data, dest)

--- a/qa_tests/risk/__init__.py
+++ b/qa_tests/risk/__init__.py
@@ -15,7 +15,6 @@
 
 import tempfile
 import os
-import sys
 import warnings
 import numpy
 import StringIO
@@ -23,6 +22,7 @@ import shutil
 
 from django.core.exceptions import ObjectDoesNotExist
 
+from openquake.commonlib.tests import check_equal
 from qa_tests import _utils as qa_utils
 from openquake.engine.tests.utils import helpers
 
@@ -35,10 +35,19 @@ class BaseRiskQATestCase(qa_utils.BaseQATestCase):
     """
     Base abstract class for risk QA tests.
     """
-
     def _test_path(self, relative_path):
         return os.path.join(
             os.path.dirname(self.module.__file__), relative_path)
+
+    def compare_xml_outputs(self, job, expected_fnames):
+        result_dir = tempfile.mkdtemp()
+        for output in self.actual_xml_outputs(job):
+            exported_file = export.core.export(output.id, result_dir)
+            actual = os.path.basename(exported_file)
+            for expected in expected_fnames:
+                if actual.startswith(os.path.basename(expected)[:-4]):
+                    check_equal(self.module.__file__, expected, exported_file)
+        shutil.rmtree(result_dir)
 
     #: QA test must override this params to feed the risk job with
     #: the proper hazard output
@@ -82,35 +91,32 @@ class BaseRiskQATestCase(qa_utils.BaseQATestCase):
     def _run_test(self):
         result_dir = tempfile.mkdtemp()
 
-        try:
-            haz_job = self.get_hazard_job()
-            job = self.run_risk(
-                self._test_path('job_risk.ini'),
-                self.hazard_id(haz_job))
+        haz_job = self.get_hazard_job()
+        job = self.run_risk(
+            self._test_path('job_risk.ini'),
+            self.hazard_id(haz_job))
 
-            for attr in dir(self):
-                if attr.startswith('check_'):
-                    getattr(self, attr)(job)
+        for attr in dir(self):
+            if attr.startswith('check_'):
+                getattr(self, attr)(job)
 
-            if hasattr(self, 'expected_outputs'):
-                expected_outputs = self.expected_outputs()
-                for i, output in enumerate(self.actual_xml_outputs(job)):
-                    try:
-                        exported_file = export.core.export(
-                            output.id, result_dir)
-                    except:
-                        print "Error in exporting %s" % output
-                        raise
+        if hasattr(self, 'expected_outputs'):
+            expected_outputs = self.expected_outputs()
+            for i, output in enumerate(self.actual_xml_outputs(job)):
+                try:
+                    exported_file = export.core.export(
+                        output.id, result_dir)
+                except:
+                    print "Error in exporting %s" % output
+                    raise
 
-                    msg = "not enough outputs (expected=%d, got=%s)" % (
-                        len(expected_outputs), self.actual_xml_outputs(job))
-                    assert i < len(expected_outputs), msg
+                msg = "not enough outputs (expected=%d, got=%s)" % (
+                    len(expected_outputs), self.actual_xml_outputs(job))
+                assert i < len(expected_outputs), msg
+                self.assert_xml_equal(
+                    StringIO.StringIO(expected_outputs[i]), exported_file)
 
-                    self.assert_xml_equal(
-                        StringIO.StringIO(expected_outputs[i]), exported_file)
-        finally:
-            shutil.rmtree(result_dir)
-
+        shutil.rmtree(result_dir)
         return job
 
     def actual_xml_outputs(self, job):

--- a/qa_tests/risk/scenario_damage/test.py
+++ b/qa_tests/risk/scenario_damage/test.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import copy
 from nose.plugins.attrib import attr
 
 from qa_tests import risk
@@ -22,331 +24,36 @@ from openquake.engine.tests.utils import helpers
 from openquake.engine.db import models
 
 
-class ScenarioDamageRiskCase1TestCase(risk.BaseRiskQATestCase):
-    module = case_1
+class ScenarioDamageTestCase(risk.BaseRiskQATestCase):
     output_type = "gmf_scenario"
 
-    EXPECTED_DMG_DIST_PER_ASSET = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <dmgDistPerAsset>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <DDNode>
-      <gml:Point>
-        <gml:pos>15.48 38.09</gml:pos>
-      </gml:Point>
-      <asset assetRef="a1">
-        <damage ds="no_damage" mean="875.81199" stddev="757.540852525"/>
-        <damage ds="LS1" mean="1448.2960791" stddev="256.15318195"/>
-        <damage ds="LS2" mean="675.8919309" stddev="556.765558354"/>
-      </asset>
-    </DDNode>
-    <DDNode>
-      <gml:Point>
-        <gml:pos>15.56 38.17</gml:pos>
-      </gml:Point>
-      <asset assetRef="a2">
-        <damage ds="no_damage" mean="344.90869" stddev="300.611885456"/>
-        <damage ds="LS1" mean="747.62374" stddev="144.648244809"/>
-        <damage ds="LS2" mean="907.46757" stddev="417.307715071"/>
-      </asset>
-    </DDNode>
-    <DDNode>
-      <gml:Point>
-        <gml:pos>15.48 38.25</gml:pos>
-      </gml:Point>
-      <asset assetRef="a3">
-        <damage ds="no_damage" mean="224.41751" stddev="220.650927184"/>
-        <damage ds="LS1" mean="465.6442715" stddev="136.927805797"/>
-        <damage ds="LS2" mean="309.9382185" stddev="246.84411292"/>
-      </asset>
-    </DDNode>
-  </dmgDistPerAsset>
-</nrml>
-'''
-
-    EXPECTED_DMG_DIST_PER_TAXONOMY = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <dmgDistPerTaxonomy>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <DDNode>
-      <taxonomy>RM</taxonomy>
-      <damage ds="no_damage" mean="1100.2295" stddev="880.276624388"/>
-      <damage ds="LS1" mean="1913.9403506" stddev="296.218619036"/>
-      <damage ds="LS2" mean="985.8301494" stddev="616.562370911"/>
-    </DDNode>
-    <DDNode>
-      <taxonomy>RC</taxonomy>
-      <damage ds="no_damage" mean="344.90869" stddev="300.611885456"/>
-      <damage ds="LS1" mean="747.62374" stddev="144.648244809"/>
-      <damage ds="LS2" mean="907.46757" stddev="417.307715071"/>
-    </DDNode>
-  </dmgDistPerTaxonomy>
-</nrml>
-'''
-
-    EXPECTED_DMG_DIST_TOTAL = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <totalDmgDist>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <damage ds="no_damage" mean="1445.13819" stddev="824.78005267"/>
-    <damage ds="LS1" mean="2661.5640906" stddev="373.99997281"/>
-    <damage ds="LS2" mean="1893.2977194" stddev="661.810775842"/>
-  </totalDmgDist>
-</nrml>
-'''
-
-    EXPECTED_COLLAPSE_MAP = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <collapseMap>
-    <CMNode>
-      <gml:Point>
-        <gml:pos>15.48 38.09</gml:pos>
-      </gml:Point>
-      <cf assetRef="a1" mean="675.8919309" stdDev="556.765558354"/>
-    </CMNode>
-    <CMNode>
-      <gml:Point>
-        <gml:pos>15.56 38.17</gml:pos>
-      </gml:Point>
-      <cf assetRef="a2" mean="907.46757" stdDev="417.307715071"/>
-    </CMNode>
-    <CMNode>
-      <gml:Point>
-        <gml:pos>15.48 38.25</gml:pos>
-      </gml:Point>
-      <cf assetRef="a3" mean="309.9382185" stdDev="246.84411292"/>
-    </CMNode>
-  </collapseMap>
-</nrml>
-'''
-
-    @attr('qa', 'risk', 'scenario_damage')
-    def test(self):
-        self._run_test()
+    def _test(self, module):
+        testcase = copy.copy(self)
+        testcase.module = module
+        job = testcase._run_test()
+        testcase.compare_xml_outputs(
+            job,
+            ['expected/dmg_dist_per_asset.xml',
+             'expected/collapse_map.xml',
+             'expected/dmg_dist_per_taxonomy.xml',
+             'expected/dmg_dist_total.xml'])
 
     def get_hazard_job(self):
         job = helpers.get_job(
             helpers.get_data_path("scenario_hazard/job.ini"))
-        fname = self._test_path('gmf_scenario.csv')
+        fname = os.path.join(os.path.dirname(case_1.__file__),
+                             'gmf_scenario.csv')
         helpers.create_gmf_from_csv(job, fname, 'gmf_scenario')
         return job
 
-    def expected_outputs(self):
-        return [self.EXPECTED_DMG_DIST_PER_ASSET,
-                self.EXPECTED_COLLAPSE_MAP,
-                self.EXPECTED_DMG_DIST_PER_TAXONOMY,
-                self.EXPECTED_DMG_DIST_TOTAL]
+    def test_case_1(self):
+        self._test(case_1)
 
+    def test_case_2(self):
+        self._test(case_2)
 
-class ScenarioDamageRiskCase2TestCase(risk.BaseRiskQATestCase):
-    module = case_2
-    output_type = "gmf_scenario"
-
-    EXPECTED_DMG_DIST_PER_ASSET = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <dmgDistPerAsset>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <DDNode>
-      <gml:Point>
-        <gml:pos>15.48 38.09</gml:pos>
-      </gml:Point>
-      <asset assetRef="a1">
-        <damage ds="no_damage" mean="1562.60873676" stddev="968.935196007"/>
-        <damage ds="LS1" mean="1108.0179559" stddev="652.736659161"/>
-        <damage ds="LS2" mean="329.37330734" stddev="347.391647796"/>
-      </asset>
-    </DDNode>
-    <DDNode>
-      <gml:Point>
-        <gml:pos>15.56 38.17</gml:pos>
-      </gml:Point>
-      <asset assetRef="a2">
-        <damage ds="no_damage" mean="56.7203646693" stddev="117.780724159"/>
-        <damage ds="LS1" mean="673.104377189" stddev="485.202354464"/>
-        <damage ds="LS2" mean="1270.17525814" stddev="575.872927586"/>
-      </asset>
-    </DDNode>
-    <DDNode>
-      <gml:Point>
-        <gml:pos>15.48 38.25</gml:pos>
-      </gml:Point>
-      <asset assetRef="a3">
-        <damage ds="no_damage" mean="417.329450348" stddev="304.476603429"/>
-        <damage ds="LS1" mean="387.208726145" stddev="181.141228526"/>
-        <damage ds="LS2" mean="195.461823506" stddev="253.91290672"/>
-      </asset>
-    </DDNode>
-  </dmgDistPerAsset>
-</nrml>
-'''
-
-    EXPECTED_DMG_DIST_PER_TAXONOMY = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <dmgDistPerTaxonomy>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <DDNode>
-      <taxonomy>RM</taxonomy>
-      <damage ds="no_damage" mean="1979.93818711" stddev="1103.59950218"/>
-      <damage ds="LS1" mean="1495.22668204" stddev="745.325447387"/>
-      <damage ds="LS2" mean="524.835130846" stddev="401.918282572"/>
-    </DDNode>
-    <DDNode>
-      <taxonomy>RC</taxonomy>
-      <damage ds="no_damage" mean="56.7203646693" stddev="117.780724159"/>
-      <damage ds="LS1" mean="673.104377189" stddev="485.202354464"/>
-      <damage ds="LS2" mean="1270.17525814" stddev="575.872927586"/>
-    </DDNode>
-  </dmgDistPerTaxonomy>
-</nrml>
-'''
-
-    EXPECTED_DMG_DIST_TOTAL = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <totalDmgDist>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <damage ds="no_damage" mean="2036.65855178" stddev="1075.31798196"/>
-    <damage ds="LS1" mean="2168.33105923" stddev="1076.43488958"/>
-    <damage ds="LS2" mean="1795.01038899" stddev="687.09098615"/>
-  </totalDmgDist>
-</nrml>
-'''
-
-    EXPECTED_COLLAPSE_MAP = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <collapseMap>
-    <CMNode>
-      <gml:Point>
-        <gml:pos>15.48 38.09</gml:pos>
-      </gml:Point>
-      <cf assetRef="a1" mean="329.37330734" stdDev="347.391647796"/>
-    </CMNode>
-    <CMNode>
-      <gml:Point>
-        <gml:pos>15.56 38.17</gml:pos>
-      </gml:Point>
-      <cf assetRef="a2" mean="1270.17525814" stdDev="575.872927586"/>
-    </CMNode>
-    <CMNode>
-      <gml:Point>
-        <gml:pos>15.48 38.25</gml:pos>
-      </gml:Point>
-      <cf assetRef="a3" mean="195.461823506" stdDev="253.91290672"/>
-    </CMNode>
-  </collapseMap>
-</nrml>
-'''
-
-    @attr('qa', 'risk', 'scenario_damage')
-    def test(self):
-        self._run_test()
-
-    def get_hazard_job(self):
-        job = helpers.get_job(
-            helpers.get_data_path("scenario_hazard/job.ini"))
-        fname = self._test_path('../case_1/gmf_scenario.csv')
-        helpers.create_gmf_from_csv(job, fname, 'gmf_scenario')
-        return job
-
-    def expected_outputs(self):
-        return [self.EXPECTED_DMG_DIST_PER_ASSET,
-                self.EXPECTED_COLLAPSE_MAP,
-                self.EXPECTED_DMG_DIST_PER_TAXONOMY,
-                self.EXPECTED_DMG_DIST_TOTAL]
-
-
-class ScenarioDamageRiskCase3TestCase(risk.BaseRiskQATestCase):
-    """
-    There are not enough taxonomies in the fragility_function (RM is missing)
-    but the parameter taxonomies_from_model is set, so assets of
-    unknown taxonomy are simply ignored.
-    """
-    output_type = "gmf_scenario"
-    module = case_3
-
-    EXPECTED_DMG_DIST_PER_ASSET = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <dmgDistPerAsset>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <DDNode>
-      <gml:Point>
-        <gml:pos>15.56 38.17</gml:pos>
-      </gml:Point>
-      <asset assetRef="a2">
-        <damage ds="no_damage" mean="344.90869" stddev="300.611885456"/>
-        <damage ds="LS1" mean="747.62374" stddev="144.648244809"/>
-        <damage ds="LS2" mean="907.46757" stddev="417.307715071"/>
-      </asset>
-    </DDNode>
-  </dmgDistPerAsset>
-</nrml>
-'''
-
-    EXPECTED_DMG_DIST_PER_TAXONOMY = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <dmgDistPerTaxonomy>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <DDNode>
-      <taxonomy>RC</taxonomy>
-      <damage ds="no_damage" mean="344.90869" stddev="300.611885456"/>
-      <damage ds="LS1" mean="747.62374" stddev="144.648244809"/>
-      <damage ds="LS2" mean="907.46757" stddev="417.307715071"/>
-    </DDNode>
-  </dmgDistPerTaxonomy>
-</nrml>
-'''
-
-    EXPECTED_DMG_DIST_TOTAL = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <totalDmgDist>
-    <damageStates>no_damage LS1 LS2</damageStates>
-    <damage ds="no_damage" mean="344.90869" stddev="300.611885456"/>
-    <damage ds="LS1" mean="747.62374" stddev="144.648244809"/>
-    <damage ds="LS2" mean="907.46757" stddev="417.307715071"/>
-  </totalDmgDist>
-</nrml>
-'''
-
-    EXPECTED_COLLAPSE_MAP = '''<?xml version='1.0' encoding='UTF-8'?>
-<nrml xmlns:gml="http://www.opengis.net/gml"
-      xmlns="http://openquake.org/xmlns/nrml/0.4">
-  <collapseMap>
-    <CMNode>
-      <gml:Point>
-        <gml:pos>15.56 38.17</gml:pos>
-      </gml:Point>
-      <cf assetRef="a2" mean="907.46757" stdDev="417.307715071"/>
-    </CMNode>
-  </collapseMap>
-</nrml>
-'''
-
-    @attr('qa', 'risk', 'scenario_damage')
-    def test(self):
-        self._run_test()
-
-    def get_hazard_job(self):
-        job = helpers.get_job(
-            helpers.get_data_path("scenario_hazard/job.ini"))
-        helpers.create_gmf_from_csv(
-            job, self._test_path('../case_1/gmf_scenario.csv'), 'gmf_scenario')
-        return job
-
-    def expected_outputs(self):
-        return [self.EXPECTED_DMG_DIST_PER_ASSET,
-                self.EXPECTED_COLLAPSE_MAP,
-                self.EXPECTED_DMG_DIST_PER_TAXONOMY,
-                self.EXPECTED_DMG_DIST_TOTAL]
+    def test_case_3(self):
+        self._test(case_3)
 
 
 # FIXME(lp). This is a regression test meant to exercise the sd-imt


### PR DESCRIPTION
And changed the export routines to make use of the new DamageWriter class. The pull request https://github.com/gem/oq-risklib/pull/93 is needed. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/895
This is a preliminary step for https://bugs.launchpad.net/oq-engine/+bug/1389260
