### PR TITLE
Now the engine logs on a file always

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -346,12 +346,13 @@ def run_job(cfg_file, log_level, log_file, exports='', hazard_output_id=None,
     upgrader.check_versions(django_db.connections['admin'])
     with CeleryNodeMonitor(openquake.engine.no_distribute(), interval=3):
         hazard = hazard_output_id is None and hazard_calculation_id is None
-        if log_file is not None:
-            touch_log_file(log_file)
-
         job = job_from_file(
             cfg_file, getpass.getuser(), log_level, exports, hazard_output_id,
             hazard_calculation_id)
+        if log_file is None:
+            edir = job.get_param('export_dir')
+            log_file = os.path.join(edir, 'calc_%d.log' % job.id)
+        touch_log_file(log_file)  # check if writeable
 
         # Instantiate the calculator and run the calculation.
         t0 = time.time()

--- a/openquake/engine/logs.py
+++ b/openquake/engine/logs.py
@@ -131,16 +131,19 @@ def handle(job, log_level='info', log_file=None):
     :param log_level:
          one of debug, info, warn, progress, error, critical
     :param log_file:
-         log file path (if None, logs on stdout)
+         log file path (if None, logs on stdout only)
     """
-    handler = (LogFileHandler(job, log_file) if log_file
-               else LogStreamHandler(job))
-    logging.root.addHandler(handler)
+    handlers = [LogStreamHandler(job)]
+    if log_file:
+        handlers.append(LogFileHandler(job, log_file))
+    for handler in handlers:
+        logging.root.addHandler(handler)
     set_level(log_level)
     try:
-        yield handler
+        yield
     finally:
-        logging.root.removeHandler(handler)
+        for handler in handlers:
+            logging.root.removeHandler(handler)
 
 
 class tracing(object):


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1249759. Now the recommended way to run the engine is without specifying the --log-file option. Then the engine will create a file `calc_<ID>.log` in the `export_dir`. If the user specify a `--log-file` the engine will log there and will not create the file `calc_<ID>.log`. The engine will log on stdout in any case. Just redirect to `/dev/null` if you don't want to see any output.
Tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/904/
