### PR TITLE
Removed the logging from the tests

### DIFF
--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -72,7 +72,7 @@ def set_up_arg_parser():
         '--log-file', '-L',
         help=('Location to store log messages; if not specified, log messages'
               ' will be printed to the console (to stderr)'),
-        required=False, metavar='LOG_FILE')
+        required=False, metavar='LOG_FILE', default='stderr')
     general_grp.add_argument(
         '--log-level', '-l',
         help='Defaults to "info"', required=False,

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -21,6 +21,7 @@ import sys
 import time
 import getpass
 import itertools
+import logging
 import operator
 from contextlib import contextmanager
 from datetime import datetime
@@ -349,10 +350,12 @@ def run_job(cfg_file, log_level, log_file, exports='', hazard_output_id=None,
         job = job_from_file(
             cfg_file, getpass.getuser(), log_level, exports, hazard_output_id,
             hazard_calculation_id)
-        if log_file is None:
+        if log_file is 'stderr':
             edir = job.get_param('export_dir')
             log_file = os.path.join(edir, 'calc_%d.log' % job.id)
-        touch_log_file(log_file)  # check if writeable
+            logging.root.addHandler(logs.LogStreamHandler(job))
+        if log_file:
+            touch_log_file(log_file)  # check if writeable
 
         # Instantiate the calculator and run the calculation.
         t0 = time.time()

--- a/openquake/engine/logs.py
+++ b/openquake/engine/logs.py
@@ -133,16 +133,12 @@ def handle(job, log_level='info', log_file=None):
     :param log_file:
          log file path (if None, logs on stdout only)
     """
-    handlers = [LogStreamHandler(job)]
-    if log_file:
-        handlers.append(LogFileHandler(job, log_file))
-    for handler in handlers:
-        logging.root.addHandler(handler)
+    handler = LogFileHandler(job, log_file) if log_file else None
     set_level(log_level)
     try:
         yield
     finally:
-        for handler in handlers:
+        if handler:
             logging.root.removeHandler(handler)
 
 


### PR DESCRIPTION
Recently we introduced logging both on the log file and on stderr. This is fine for the command-line usage of the engine, but not for the tests. The tests should only log on file, to avoid cluttering the test output.
See https://ci.openquake.org/job/zdevel_oq-engine/909/console
