### PR TITLE
Added a missing logging handler

### DIFF
--- a/openquake/engine/logs.py
+++ b/openquake/engine/logs.py
@@ -134,6 +134,8 @@ def handle(job, log_level='info', log_file=None):
          log file path (if None, logs on stdout only)
     """
     handler = LogFileHandler(job, log_file) if log_file else None
+    if handler:
+        logging.root.addHandler(handler)
     set_level(log_level)
     try:
         yield


### PR DESCRIPTION
Who knows why, this was forgotten. NB: this bug _affects the release 1-2_: we need to backport it with
a `git cherry-pick 123c4dc1016492c716b5306f08cd9f11bf2d13c5`
