### PR TITLE
Ignore the user-provided export_dir in the context of the engine server

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -444,10 +444,9 @@ def job_from_file(cfg_file_path, username, log_level='info', exports='',
         # read calculation params and create the calculation profile
         params = readinput.get_params(cfg_file_path)
         if not exports:  # when called from the engine server
-            if 'export_dir' in params:
-                # ignore export_dir: the engine server will export on demand
-                # with its own mechanism and will use a temporary directory
-                params['export_dir'] = tempfile.gettempdir()
+            # ignore the user-provided export_dir: the engine server will
+            # export on demand with its own mechanism on a temporary directory
+            params['export_dir'] = tempfile.gettempdir()
         params.update(extras)
         if haz_job:  # for risk calculations
             check_hazard_risk_consistency(haz_job, params['calculation_mode'])


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/oq-engine/+bug/1393436. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/946
