### PR TITLE
Don't trap too much errors in the engine server

### DIFF
--- a/openquake/server/dbsettings.py
+++ b/openquake/server/dbsettings.py
@@ -1,5 +1,5 @@
 PLATFORM_DATABASES = {
-    'platform': {
+    'oq-platform': {
         'HOST': 'localhost',
         'NAME': "oqplatform",
         'USER': 'oqplatform',

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -2,7 +2,7 @@ import os
 
 from openquake.engine import settings as oqe_settings
 
-DEBUG = True
+DEBUG = False  # NB: when True, test_haz_risk_ok breaks!
 TEMPLATE_DEBUG = DEBUG
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -2,7 +2,7 @@ import os
 
 from openquake.engine import settings as oqe_settings
 
-DEBUG = False
+DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/openquake/server/tasks.py
+++ b/openquake/server/tasks.py
@@ -33,7 +33,9 @@ from openquake.engine.db import models as oqe_models
 from openquake.server.dbsettings import PLATFORM_DATABASES as DATABASES
 from openquake.server.settings import DEBUG
 
-DEFAULT_LOG_LEVEL = 'debug' if DEBUG else 'info'
+# all the logs are sent to the platform; one would need a different logger
+# to discriminate between progress logs and debug logs written in the file
+DEFAULT_LOG_LEVEL = 'debug' if DEBUG else 'progress'
 
 
 # FIXME. Configure logging by using the configuration stored in settings

--- a/openquake/server/tasks.py
+++ b/openquake/server/tasks.py
@@ -104,14 +104,11 @@ def run_calc(job_id, calc_dir,
         exctype, exc, tb = sys.exc_info()
         einfo = ''.join(traceback.format_tb(tb))
         einfo += '%s: %s' % (exctype.__name__, exc)
-        #print einfo, '*******************8'
-        #logging.root.error(einfo)
         update_calculation(callback_url, status="failed", einfo=einfo)
         raise
     finally:
         logging.root.removeHandler(progress_handler)
-
-    shutil.rmtree(calc_dir)
+        shutil.rmtree(calc_dir)
 
     # If requested to, signal job completion and trigger a migration of
     # results.
@@ -211,17 +208,6 @@ DBINTERFACE = {
            icebox_hazardmap(output_layer_id, iml, location)
            SELECT %s, iml, ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
            FROM temp_icebox_hazardmap"""),
-    'ses': DbInterface(
-        """SELECT tag, magnitude FROM hzrdr.ses_rupture r
-           JOIN hzrdr.probabilistic_rupture pr ON r.id = r.rupture_id
-           JOIN hzrdr.ses_collection sc ON pr.ses_collection_id = sc.id
-           JOIN uiapi.output o ON o.id = sc.output_id
-           WHERE o.id = %(output_id)d""",
-        "icebox_ses",
-        "tag varchar, magnitude float",
-        """INSERT INTO
-           icebox_ses(output_layer_id, rupture_tag, magnitude)
-           SELECT %s, tag, magnitude FROM temp_icebox_ses"""),
     # TODO: instead of the region_constraint, we should specify the convex
     # hull of the exposure
     'aggregate_loss': DbInterface(

--- a/openquake/server/tasks.py
+++ b/openquake/server/tasks.py
@@ -31,9 +31,9 @@ from openquake.engine import engine
 from openquake.engine.db import models as oqe_models
 
 from openquake.server.dbsettings import PLATFORM_DATABASES as DATABASES
+from openquake.server.settings import DEBUG
 
-
-DEFAULT_LOG_LEVEL = 'progress'
+DEFAULT_LOG_LEVEL = 'debug' if DEBUG else 'info'
 
 
 # FIXME. Configure logging by using the configuration stored in settings
@@ -104,7 +104,10 @@ def run_calc(job_id, calc_dir,
         exctype, exc, tb = sys.exc_info()
         einfo = ''.join(traceback.format_tb(tb))
         einfo += '%s: %s' % (exctype.__name__, exc)
+        #print einfo, '*******************8'
+        #logging.root.error(einfo)
         update_calculation(callback_url, status="failed", einfo=einfo)
+        raise
     finally:
         logging.root.removeHandler(progress_handler)
 


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1414044. Also, I removed the SES table from the database transfer, since it cannot be visualized anyway.
The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/973