### PR TITLE
Fixed ClassicalHazardCase17TestCase

### DIFF
--- a/qa_tests/hazard/classical/test.py
+++ b/qa_tests/hazard/classical/test.py
@@ -680,9 +680,9 @@ class ClassicalHazardCase17TestCase(qa_utils.BaseQATestCase):
     def test(self):
         cfg = os.path.join(os.path.dirname(case_17.__file__), 'job.ini')
         expected_curves_pga = [
-            [1.0, 1.0, 0.0],
-            [1.0, 1.0, 0.0],
             [0.27612144, 0.035435631, 0.011434286],
+            [1.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
             [1.0, 1.0, 0.0],
             [1.0, 1.0, 0.0]]
 


### PR DESCRIPTION
Companion to gem/oq-risklib#147, solves https://bugs.launchpad.net/oq-engine/+bug/1420747.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1013.