### PR TITLE
Change the 'default' Django db to use cfg settings.

### DIFF
--- a/openquake/engine/settings.py
+++ b/openquake/engine/settings.py
@@ -53,7 +53,7 @@ def _db_cfg(db_name):
         NAME=DB_SECTION.get('name', 'openquake'),
         USER=DB_SECTION.get('%s_user' % db_name, 'openquake'),
         PASSWORD=DB_SECTION.get('%s_password' % db_name, ''),
-        HOST=DB_SECTION.get('host', ''),
+        HOST=DB_SECTION.get('host', 'localhost'),
         PORT=DB_SECTION.get('port', '5432'),
     )
 
@@ -72,8 +72,8 @@ DATABASES['default'] = {
     'NAME': DB_SECTION.get('name', 'openquake'),
     'USER': DB_SECTION.get('%s_user' % DEFAULT_USER, 'oq_admin'),
     'PASSWORD': DB_SECTION.get('%s_password' % DEFAULT_USER, 'openquake'),
-    'HOST': '',
-    'PORT': '5432',
+    'HOST' : DB_SECTION.get('host', 'localhost'),
+    'PORT' : DB_SECTION.get('port', '5432'),
 }
 
 DATABASE_ROUTERS = ['openquake.engine.db.routers.OQRouter']

--- a/openquake/engine/settings.py
+++ b/openquake/engine/settings.py
@@ -72,8 +72,8 @@ DATABASES['default'] = {
     'NAME': DB_SECTION.get('name', 'openquake'),
     'USER': DB_SECTION.get('%s_user' % DEFAULT_USER, 'oq_admin'),
     'PASSWORD': DB_SECTION.get('%s_password' % DEFAULT_USER, 'openquake'),
-    'HOST' : DB_SECTION.get('host', 'localhost'),
-    'PORT' : DB_SECTION.get('port', '5432'),
+    'HOST': DB_SECTION.get('host', 'localhost'),
+    'PORT': DB_SECTION.get('port', '5432'),
 }
 
 DATABASE_ROUTERS = ['openquake.engine.db.routers.OQRouter']


### PR DESCRIPTION
In this way we always use only one method to connect to PostgreSQL (via TCP) instead of mixing TCP and sockets.

This conforms better to Ubuntu where connections to `localhost` are already set with `md5` authentication in the `pg_hba.conf`.

Tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1014/