### PR TITLE
Reflected change in oq-lite

### DIFF
--- a/openquake/engine/calculators/hazard/general.py
+++ b/openquake/engine/calculators/hazard/general.py
@@ -334,7 +334,7 @@ class BaseHazardCalculator(base.Calculator):
             for rlz in rlzs:
                 gsim_by_trt = rlzs_assoc.gsim_by_trt[rlz]
                 lt_rlz = models.LtRealization.objects.create(
-                    lt_model=lt_model, gsim_lt_path=rlz.gsim_uid,
+                    lt_model=lt_model, gsim_lt_path=rlz.gsim_rlz.lt_uid,
                     weight=rlz.weight, ordinal=rlz.ordinal)
                 self._realizations.append(lt_rlz)
                 for trt_model in lt_model.trtmodel_set.all():


### PR DESCRIPTION
Companion to https://github.com/gem/oq-risklib/pull/155. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1032