### PR TITLE
New vers mgmt2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.globalquakemodel.org/openquake/
 Package: python-oq-engine
 Architecture: all
 Conflicts: python-noq, python-oq
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-lxml, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-django16 (>=1.6.1), python-setuptools, python-psutil, python-mock, python-oq-hazardlib (>=0.13.0), python-oq-risklib (>=0.6.0), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-lxml, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-django16 (>=1.6.1), python-setuptools, python-psutil, python-mock, python-oq-hazardlib (>=0.14.0), python-oq-risklib (>=0.7.0), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
 Recommends: postgresql-9.1, postgresql-client, postgresql-9.1-postgis
 Description: computes seismic hazard and physical risk
  based on the hazard and risk libraries (python-oq-hazardlib,

--- a/openquake/engine/__init__.py
+++ b/openquake/engine/__init__.py
@@ -59,7 +59,7 @@ from openquake.hazardlib.general import git_suffix
 #  "-" + <pkg-version> + "+dev" + <secs_since_epoch> + "-" + <commit-id>
 # NB: the next line is managed by packager.sh script (we retrieve the version
 #     using sed and optionally replace it)
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 __version__ += git_suffix(__file__)
 
 # The path to the OpenQuake root directory

--- a/packager.sh
+++ b/packager.sh
@@ -853,7 +853,7 @@ ini_suf="$(echo "$ini_vers" | sed -n 's/^[0-9]\+\.[0-9]\+\.[0-9]\+\(.*\)/\1/gp')
 # echo "ini [] [$ini_maj] [$ini_min] [$ini_bfx] [$ini_suf]"
 
 # version info from debian/changelog
-h="$(head -n1 debian/changelog)"
+h="$(grep "^$GEM_DEB_PACKAGE" debian/changelog | head -n 1)"
 # pkg_vers="$(echo "$h" | cut -d ' ' -f 2 | cut -d '(' -f 2 | cut -d ')' -f 1 | sed -n 's/[-+].*//gp')"
 pkg_name="$(echo "$h" | cut -d ' ' -f 1)"
 pkg_vers="$(echo "$h" | cut -d ' ' -f 2 | cut -d '(' -f 2 | cut -d ')' -f 1)"
@@ -876,22 +876,24 @@ if [ $BUILD_DEVEL -eq 1 ]; then
     if [ "$pkg_maj" = "$ini_maj" -a "$pkg_min" = "$ini_min" -a \
          "$pkg_bfx" = "$ini_bfx" -a "$pkg_deb" != "" ]; then
         deb_ct="$(echo "$pkg_deb" | sed 's/^-//g')"
-        pkg_deb="-$(( deb_ct + 1 ))"
+        pkg_deb="-$(( deb_ct ))"
     else
         pkg_maj="$ini_maj"
         pkg_min="$ini_min"
         pkg_bfx="$ini_bfx"
-        pkg_deb="-1"
+        pkg_deb="-0"
     fi
 
     ( echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~dev${dt}-${hash}) $pkg_rest"
       echo
+      echo "  [Automatic Script]"
       echo "  * Development version from $hash commit"
       echo
+      cat debian/changelog.orig | sed -n "/^$GEM_DEB_PACKAGE/q;p"
       echo " -- $DEBFULLNAME <$DEBEMAIL>  $(date -d@$dt -R)"
       echo
     )  > debian/changelog
-    cat debian/changelog.orig >> debian/changelog
+    cat debian/changelog.orig | sed -n "/^$GEM_DEB_PACKAGE/,\$ p" >> debian/changelog
     rm debian/changelog.orig
 
     sed -i "s/^__version__[  ]*=.*/__version__ = '${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~dev${dt}-${hash}'/g" openquake/engine/__init__.py

--- a/packager.sh
+++ b/packager.sh
@@ -470,8 +470,7 @@ _pkgtest_innervm_run () {
     ssh $lxc_ip "oq-engine --make-html-report today"
     scp "${lxc_ip}:jobs-*.html" .
 
-    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}/changelog*" .
-    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}/README*" .
+    scp -r "$lxc_ip:/usr/share/doc/${GEM_DEB_PACKAGE}/changelog*" .
 
     trap ERR
 

--- a/packager.sh
+++ b/packager.sh
@@ -468,6 +468,10 @@ _pkgtest_innervm_run () {
     fi
     ssh $lxc_ip "oq-engine --make-html-report today"
     scp "${lxc_ip}:jobs-*.html" .
+
+    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}/changelog*" .
+    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}/README*" .
+
     trap ERR
 
     return

--- a/packager.sh
+++ b/packager.sh
@@ -105,6 +105,7 @@ sig_hand () {
     if [ -f /tmp/packager.eph.$$.log ]; then
         rm /tmp/packager.eph.$$.log
     fi
+    exit 1
 }
 
 


### PR DESCRIPTION
- implemented the new guideline for version management, on master branch we will have always the release version after the current released.
- development packages will use ```~gem...``` suffix to be **lesser than** version **without** suffix (Debian - behavior for suffixes starting with ```~``` character).
- changelog and README are copied back to jenkins folders to be able to check them, an example at:
  ```jenkins@ci.openquake.org:jobs/zdevel_oq-engine/workspace_new_vers_mgmt2_1066```
Tests green at: https://ci.openquake.org/job/zdevel_oq-engine/1066/