### PR TITLE
Not using Django when deleting calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Bypassed Django when deleting calculations from the database: this avoids
+    running out of memory for large calculations
   * Fixed an issue in the scenario calculator: the GMFs were not filtered
     according to the distance to the rupture
   * Now critical errors appear in the log file

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -268,7 +268,9 @@ def del_calc(job_id):
 
         # No risk calculation are referencing what we want to delete.
         # Carry on with the deletion.
-        job.delete(using='admin')
+
+        curs = models.getcursor('admin')
+        curs.execute('DELETE FROM uiapi.oq_job WHERE id=%s', (job_id,))
     else:
         # this doesn't belong to the current user
         raise RuntimeError(UNABLE_TO_DEL_HC_FMT % 'Access denied')

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -267,8 +267,10 @@ def del_calc(job_id):
                 msg % ', '.join(str(x.id) for x in assoc_outputs))
 
         # No risk calculation are referencing what we want to delete.
-        # Carry on with the deletion.
-
+        # Carry on with the deletion. Notice that we cannot use job.delete()
+        # directly because Django is so stupid that it reads from the database
+        # all the records to delete before deleting them: thus, it runs out
+        # of memory for large calculations
         curs = models.getcursor('admin')
         curs.execute('DELETE FROM uiapi.oq_job WHERE id=%s', (job_id,))
     else:


### PR DESCRIPTION
This solves the out of memory issue which was reported by our users (https://bugs.launchpad.net/oq-engine/+bug/1430360).
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1092