### PR TITLE
Use python2.7/dist-packages instead of pyshared

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -40,7 +40,7 @@ if [ -f /usr/sbin/rabbitmqctl ]; then
 fi
 
 HDIR=/usr/openquake/engine
-IDIR=/usr/share/pyshared/openquake/engine
+IDIR=/usr/lib/python2.7/dist-packages/openquake/engine
 mkdir -p $HDIR
 chmod 1777 $HDIR
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -23,7 +23,7 @@ case "$1" in
     # This package has been removed, but its configuration has not yet
     # been purged.
     :
-    for dir in  /usr/share/pyshared/openquake/engine /usr/share/doc/${GEM_DEB_PACKAGE} /usr/share/pyshared/openquake.engine-*egg-info
+    for dir in  /usr/lib/python2.7/dist-packages/openquake/engine /usr/share/doc/${GEM_DEB_PACKAGE} /usr/lib/python2.7/dist-packages/openquake.engine-*egg-info
     do
         rm -rf $dir
     done
@@ -39,7 +39,7 @@ case "$1" in
     # This package has previously been removed and is now having
     # its configuration purged from the system.
     :
-    for dir in  /etc/openquake /usr/share/pyshared/openquake/engine /usr/share/doc/${GEM_DEB_PACKAGE} /usr/share/pyshared/openquake.engine-*egg-info
+    for dir in  /etc/openquake /usr/lib/python2.7/dist-packages/openquake/engine /usr/share/doc/${GEM_DEB_PACKAGE} /usr/lib/python2.7/dist-packages/openquake.engine-*egg-info
     do
         rm -rf $dir
     done

--- a/debian/preinst
+++ b/debian/preinst
@@ -10,7 +10,7 @@ set -e
 
 GEM_DEB_PACKAGE="python-oq-engine"
 
-for dir in  /usr/share/pyshared/openquake/engine /usr/share/doc/${GEM_DEB_PACKAGE} /usr/share/pyshared/openquake.engine-*egg-info
+for dir in  /usr/lib/python2.7/dist-packages/openquake/engine /usr/share/doc/${GEM_DEB_PACKAGE} /usr/lib/python2.7/dist-packages/openquake.engine-*egg-info
 do
     rm -rf $dir
 done


### PR DESCRIPTION
python3 is currently not officially supported by oq-engine, so `python2.7/dist-packages`
is the right place where to put our code. In Trusty the use of `pyshared`
is even more restricted.

Tests (for 12.04) are running here: https://ci.openquake.org/job/zdevel_oq-engine/1106/