### PR TITLE
Make it impossible to run classical_risk from classical_tiling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,4 @@
   [Michele Simionato]
-  * Fixed a bug in the risk_hazard_map: now it is possible to run a risk
-    calculation on top of a classical_tiling one
   * Added a resource /v1/calc/:calc_id/traceback to get the traceback of a
     failed calculation
   * Now the logs are stored also in the database, both for the controller node

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -61,9 +61,9 @@ class InvalidHazardCalculationID(Exception):
 RISK_HAZARD_MAP = dict(
     scenario_risk=['scenario'],
     scenario_damage=['scenario'],
-    classical_risk=['classical', 'classical_tiling'],
-    classical_bcr=['classical', 'classical_tiling'],
-    classical_damage=['classical', 'classical_tiling'],
+    classical_risk=['classical'],
+    classical_bcr=['classical'],
+    classical_damage=['classical'],
     event_based_risk=['event_based'],
     event_based_bcr=['event_based'])
 

--- a/openquake/engine/tests/engine_test.py
+++ b/openquake/engine/tests/engine_test.py
@@ -66,7 +66,7 @@ class CheckHazardRiskConsistencyTestCase(unittest.TestCase):
         self.assertEqual(
             msg, "In order to run a risk calculation of kind "
             "'classical_risk', you need to provide a hazard "
-            "calculation of kind ['classical', 'classical_tiling'], "
+            "calculation of kind ['classical'], "
             "but you provided a 'scenario' instead")
 
 


### PR DESCRIPTION
Unfortunately, the risk does not work with an ugly error. So let's forbid the user to do that in the first place.
The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/1123