### PR TITLE
Fixed the engine tests to work with the backarc param

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -238,6 +238,7 @@ class SiteModel(djm.Model):
     # Depth to shear wave velocity of 2.5 km/s. Units km.
     z2pt5 = djm.FloatField()
     location = djm.PointField(srid=DEFAULT_SRID)
+    backarc = False  # TODO: change the database
 
     @property
     def measured(self):

--- a/openquake/engine/tests/calculators/hazard/event_based/core_test.py
+++ b/openquake/engine/tests/calculators/hazard/event_based/core_test.py
@@ -37,7 +37,7 @@ def make_site_coll(lon, lat, n):
     sites = []
     for i in range(n):
         site = Site(Point(lon - float(i) / 1000, lat),
-                    800., 'measured', 50., 2.5, i)
+                    800., 'measured', 50., 2.5, False, i)
         sites.append(site)
     return SiteCollection(sites)
 

--- a/openquake/engine/tests/calculators/hazard/general_test.py
+++ b/openquake/engine/tests/calculators/hazard/general_test.py
@@ -136,10 +136,10 @@ class ClosestSiteModelTestCase(unittest.TestCase):
 
         sm1 = SiteParam(
             measured=True, vs30=0.0000001,
-            z1pt0=0.0000001, z2pt5=0.0000001, lon=-1, lat=0)
+            z1pt0=0.0000001, z2pt5=0.0000001, backarc=False, lon=-1, lat=0)
         sm2 = SiteParam(
             measured=False, vs30=0.0000002,
-            z1pt0=0.0000002, z2pt5=0.0000002, lon=1, lat=0)
+            z1pt0=0.0000002, z2pt5=0.0000002, backarc=False, lon=1, lat=0)
 
         job = models.OqJob.objects.create(user_name="openquake")
         siteparams = general.SiteModelParams(job, [sm1, sm2])


### PR DESCRIPTION
This is the last step needed before we can merge https://github.com/gem/oq-hazardlib/pull/308 and https://github.com/gem/oq-risklib/pull/189/
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1133/