### PR TITLE
Fixed the issue with DJANGO_SETTINGS_MODULE in the engine server

### DIFF
--- a/openquake/engine/__init__.py
+++ b/openquake/engine/__init__.py
@@ -85,7 +85,7 @@ def no_distribute():
 
 
 def set_django_settings_module():
-    if not os.getenv('DJANGO_SETTINGS_MODULE', False):
-        os.environ['DJANGO_SETTINGS_MODULE'] = 'openquake.engine.settings'
+    os.environ.setdefault(
+        'DJANGO_SETTINGS_MODULE', 'openquake.engine.settings')
 
 set_django_settings_module()

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -5,8 +5,6 @@ import celery
 import subprocess
 from django.core.management import execute_from_command_line
 from openquake.server import executor
-from openquake.engine.db import models
-
 if celery.__version__ < '3.0.0':
     CELERY = [sys.executable, '-m', 'celery.bin.celeryd', '-l', 'INFO',
               '--purge', '--logfile', '/tmp/celery.log']
@@ -28,7 +26,10 @@ if __name__ == "__main__":
         cel = subprocess.Popen(CELERY)
         print 'Starting celery, logging on /tmp/celery.log'
 
-    # cleanup on the db, if some tests left is_running=True
+    # notice that the import must be done here. to avoid the irritating
+    # CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.
+    from openquake.engine.db import models
+    # cleanup on the field oq_job.is_running
     models.getcursor('job_init').execute(
         'UPDATE uiapi.oq_job SET is_running=false WHERE is_running')
     try:

--- a/packager.sh
+++ b/packager.sh
@@ -331,7 +331,7 @@ celeryd_wait $GEM_MAXLOOP"
         # run tests (in this case we omit 'set -e' to be able to read all tests outputs)
         ssh $lxc_ip "export PYTHONPATH=\"\$PWD/oq-engine:\$PWD/oq-hazardlib:\$PWD/oq-risklib\" ;
                  cd oq-engine
-                 DJANGO_SETTINGS_MODULE=openquake.server.settings nosetests -v -a '${skip_tests}' --with-xunit --xunit-file=xunit-server.xml --with-coverage --cover-package=openquake.server --with-doctest openquake/server/tests/
+                 nosetests -v -a '${skip_tests}' --with-xunit --xunit-file=xunit-server.xml --with-coverage --cover-package=openquake.server --with-doctest openquake/server/tests/
                  nosetests -v -a '${skip_tests}' --with-xunit --xunit-file=xunit-engine.xml --with-coverage --cover-package=openquake.engine --with-doctest openquake/engine/tests/
 
                  # OQ Engine QA tests (splitted into multiple execution to track the performance)


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1438117. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1137