### PR TITLE
engineweb: fix missing server files (static and templates directories)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,11 @@ setup(
     include_package_data=True,
     package_data={"openquake.engine": [
         "db/schema/upgrades/*.sql",
-        "openquake.cfg", "openquake_worker.cfg", "README", "LICENSE"]},
+        "openquake.cfg", "openquake_worker.cfg", "README", "LICENSE"],
+        "openquake.server": [
+        "templates/*.html", "templates/*/*.html", "static/css/*.css",
+        "static/*/*.js", "static/*/*/*.js", "static/*/*/*/*.js",
+        "static/*/*.map", "static/*/*/*.map", "static/*/*/*/*.map"]},
     scripts=["openquake/engine/bin/oq_create_db",
              "openquake/engine/bin/openquake"],
 


### PR DESCRIPTION
To test it:
```
cd /usr/openquake/engine
python /usr/lib/python2.7/dist-packages/openquake/server/manage.py runserver 0.0.0.0:8800 celery
```
At this point you can connect to the server with a browser at the address:
```http://localhost:8800/engineweb``` .

**Note**: remember to add some information about server and engineweb in the documentation (discuss later).