### PR TITLE
Fixed a bug affecting celery 2 only when nose is used to run the tests

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -89,3 +89,8 @@ CELERY_IMPORTS = get_core_modules(engine) + [
     ]
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "openquake.engine.settings"
+
+try:
+    from openquake.engine.utils import tasks
+except ImportError:  # circular import with celery 2, only affecting nose
+    pass

--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -92,5 +92,7 @@ os.environ["DJANGO_SETTINGS_MODULE"] = "openquake.engine.settings"
 
 try:
     from openquake.engine.utils import tasks
+    # as a side effect, this import replaces the litetask with oqtask
+    # this is hackish, but bear with until we remove the old calculators
 except ImportError:  # circular import with celery 2, only affecting nose
     pass

--- a/openquake.cfg
+++ b/openquake.cfg
@@ -18,7 +18,7 @@ terminate_workers_on_revoke = true
 # this is good for a single user situation, but turn this off on a cluster
 # otherwise a CTRL-C will kill the computations of other users
 
-terminate_job_when_celery_is_down = true
+terminate_job_when_celery_is_down = false
 # this is good generally, but it may be necessary to turn it off in
 # heavy computations (i.e. celery could not respond to pings and still
 # not be really down).

--- a/openquake.cfg
+++ b/openquake.cfg
@@ -18,7 +18,7 @@ terminate_workers_on_revoke = true
 # this is good for a single user situation, but turn this off on a cluster
 # otherwise a CTRL-C will kill the computations of other users
 
-terminate_job_when_celery_is_down = false
+terminate_job_when_celery_is_down = true
 # this is good generally, but it may be necessary to turn it off in
 # heavy computations (i.e. celery could not respond to pings and still
 # not be really down).


### PR DESCRIPTION
This seems to work. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1178/