### PR TITLE
Added a CSV exporter for the aggregated loss curves

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * the aggregate loss curves can be exported in CSV format
+
   [Matteo Nastasi]
   * added '/v1/calc/<id>/status' API command
   * added 'engineweb' django application as local web client for oq-engine

--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -152,7 +152,7 @@ def export_agg_loss_curve_csv(key, output, target):
     """
     Export `output` to `target` in csv format
     """
-    dest = _get_result_export_dest(target, output)
+    dest = _get_result_export_dest(target, output)[:-3] + 'csv'
     row = output.loss_curve.aggregatelosscurvedata
     data = ('aggregate', row.losses, row.poes, row.average_loss,
             row.stddev_loss)

--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -147,6 +147,18 @@ def export_agg_loss_curve_xml(key, output, target):
     return dest
 
 
+@core.export_output.add(('agg_loss_curve', 'csv'))
+def export_agg_loss_curve_csv(key, output, target):
+    """
+    Export `output` to `target` in csv format
+    """
+    dest = _get_result_export_dest(target, output)
+    row = output.loss_curve.aggregatelosscurvedata
+    data = ('aggregate', row.losses, row.poes, row.average_loss,
+            row.stddev_loss)
+    return writers.save_csv(dest, [data])
+
+
 @core.export_output.add(('loss_curve', 'xml'), ('event_loss_curve', 'xml'))
 def export_loss_curve_xml(key, output, target):
     """

--- a/packager.sh
+++ b/packager.sh
@@ -479,7 +479,7 @@ _pkgtest_innervm_run () {
             oq-engine --run-hazard job_hazard.ini -l info
             job_id=\$(oq-engine --list-hazard-calculations | tail -1 | awk '{print \$1}')
             echo \"Running \$demo_dir/job_risk.ini\"
-            oq-engine --run-risk job_risk.ini --exports xml,csv --hazard-calculation-id \$job_id -l info
+            oq-engine --run-risk job_risk.ini --exports csv,xml --hazard-calculation-id \$job_id -l info
             cd -
             fi
         done"


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1442534. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1180/