### PR TITLE
webui: added 'outtypes' attribute to items result list API command

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Matteo Nastasi]
+  * added 'outtypes' attribute with list of possible output types for
+    each output item in outputs list API command
   * added '/v1/calc/<id>/status' API command
   * added 'engineweb' django application as local web client for oq-engine
 

--- a/engine_api.md
+++ b/engine_api.md
@@ -101,10 +101,10 @@ Parameters: None
 
 Response:
 
-    [{"url": "http://localhost:8000/v1/calc/hazard/result/12", "type": "hazard_curve", "name": "hc-rlz-22", "id": 12},
-     {"url": "http://localhost:8000/v1/calc/hazard/result/14", "type": "hazard_curve", "name": "hc-rlz-23", "id": 14},
-     {"url": "http://localhost:8000/v1/calc/hazard/result/16", "type": "hazard_curve", "name": "hc-rlz-24", "id": 16},
-     {"url": "http://localhost:8000/v1/calc/hazard/result/18", "type": "hazard_curve", "name": "hc-rlz-25", "id": 18}]
+    [{"url": "http://localhost:8000/v1/calc/hazard/result/12", "type": "hazard_curve", "outtypes": [ "xml" ], "name": "hc-rlz-22", "id": 12},
+     {"url": "http://localhost:8000/v1/calc/hazard/result/14", "type": "hazard_curve", "outtypes": [ "xml" ], "name": "hc-rlz-23", "id": 14},
+     {"url": "http://localhost:8000/v1/calc/hazard/result/16", "type": "hazard_curve", "outtypes": [ "xml" ], "name": "hc-rlz-24", "id": 16},
+     {"url": "http://localhost:8000/v1/calc/hazard/result/18", "type": "hazard_curve", "outtypes": [ "xml" ], "name": "hc-rlz-25", "id": 18}]
 
 
 #### GET /v1/calc/result/:result_id

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -162,3 +162,10 @@ footer.footer form label {
      width: 90%;
      margin-left: -45%;
 }
+
+td .nopretty {
+     padding: 2px;
+     border: 0;
+     line-height: 12px;
+     margin: 0px;
+}

--- a/openquake/server/static/js/engine_get_outputs.js
+++ b/openquake/server/static/js/engine_get_outputs.js
@@ -71,7 +71,7 @@
     var refresh_outputs;
 
     function setTimer() {
-        refresh_outputs = setInterval(function() { outputs.fetch({reset: true}) }, 10000);
+        refresh_outputs = setInterval(function() { outputs.fetch({reset: true}) }, 30000);
     }
 
     /* classic event management */

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -34,8 +34,12 @@
           <td><%= output.get('name') %></td>
           <td><%= output.get('type') %></td>
           <td>
-            <a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>" class="btn btn-sm">View</a>
-            <a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=xml" class="btn btn-sm">Download</a>
+            <table>
+            <% _.each(output.get('outtypes'), function(outtype) { %>
+            <tr><td class="nopretty"><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&dload=false" class="btn btn-sm">View <%= outtype %></a></td>
+            <td class="nopretty"><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&dload=true" class="btn btn-sm">Download <%= outtype %></a></td></tr>
+            <% }); %>
+            </table>
           </td>
         </tr>
         <% }); %>

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -32,11 +32,13 @@ from django.views.decorators.http import require_http_methods
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 
+from openquake.baselib.general import groupby
 from openquake.commonlib import nrml, readinput, valid
 from openquake.engine import engine as oq_engine, __version__ as oqversion
 from openquake.engine.db import models as oqe_models
 from openquake.engine.export import core
 from openquake.engine.utils.tasks import safely_call
+from openquake.engine.export.core import export_output
 from openquake.server import tasks, executor
 
 METHOD_NOT_ALLOWED = 405
@@ -370,6 +372,8 @@ def calc_results(request, calc_id):
         return HttpResponseNotFound()
     base_url = _get_base_url(request)
 
+    output_types = dict(groupby(export_output, lambda pair: pair[0], lambda pairs: [pair[1] for pair in pairs]))
+
     results = oq_engine.get_outputs(calc_id)
     if not results:
         return HttpResponseNotFound()
@@ -381,6 +385,7 @@ def calc_results(request, calc_id):
             id=result.id,
             name=result.display_name,
             type=result.output_type,
+            outtypes=output_types[result.output_type],
             url=url,
         )
         response_data.append(datum)
@@ -442,6 +447,15 @@ def get_result(request, result_id):
     etype = request.GET.get('export_type')
     export_type = etype or DEFAULT_EXPORT_TYPE
 
+    dload = request.GET.get('dload')
+    download = False
+    if dload is None:
+        if etype is not None:
+            download = True
+    else:
+        if dload == "true":
+            download = True
+
     tmpdir = tempfile.mkdtemp()
     exported = core.export(result_id, tmpdir, export_type=export_type)
     if exported is None:
@@ -457,7 +471,7 @@ def get_result(request, result_id):
         data = open(exported).read()
         response = HttpResponse(data, content_type=content_type)
         response['Content-Length'] = len(data)
-        if etype:  # download as a file
+        if download:  # download as a file
             response['Content-Disposition'] = 'attachment; filename=%s' % fname
         return response
     finally:


### PR DESCRIPTION
enriched output of results list to obtain possible output types for each item
webui: use the new API extension to create download and view buttons for any allowed output type
this PR fix https://bugs.launchpad.net/oq-engine/+bug/1442687