### PR TITLE
webui: make css more bootstrap compliant

### DIFF
--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -163,7 +163,26 @@ footer.footer form label {
      margin-left: -45%;
 }
 
-td .nopretty {
+.table-disable-hover tbody tr:hover td,
+.table-disable-hover tbody tr:hover th {
+    background-color: inherit;
+}
+
+.table .table {
+    background-color: inherit;
+}
+
+.table .table td,
+.table .table th {
+    border: 0;
+}
+
+.table-condensed {
+    margin: 0;
+}
+
+.table-condensed tbody tr td,
+.table-condensed tbody tr th {
      padding: 2px;
      border: 0;
      line-height: 12px;

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -34,10 +34,12 @@
           <td><%= output.get('name') %></td>
           <td><%= output.get('type') %></td>
           <td>
-            <table>
+            <table class="table table-disable-hover table-condensed">
             <% _.each(output.get('outtypes'), function(outtype) { %>
-            <tr><td class="nopretty"><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&dload=false" class="btn btn-sm">View <%= outtype %></a></td>
-            <td class="nopretty"><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&dload=true" class="btn btn-sm">Download <%= outtype %></a></td></tr>
+              <tr>
+                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&dload=false" class="btn btn-sm">View <%= outtype %></a></td>
+                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&dload=true" class="btn btn-sm">Download <%= outtype %></a></td>
+              </tr>
             <% }); %>
             </table>
           </td>

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -37,8 +37,8 @@
             <table class="table table-disable-hover table-condensed">
             <% _.each(output.get('outtypes'), function(outtype) { %>
               <tr>
-                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&dload=false" class="btn btn-sm">View <%= outtype %></a></td>
-                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&dload=true" class="btn btn-sm">Download <%= outtype %></a></td>
+                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&amp;dload=false" class="btn btn-sm">View <%= outtype %></a></td>
+                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&amp;dload=true" class="btn btn-sm">Download <%= outtype %></a></td>
               </tr>
             <% }); %>
             </table>


### PR DESCRIPTION
This will 
- make more easy to reuse the new custom css code
- allow better buttons alignment
- remove color change on hover on the second level `<td>`

from
![screenshot from 2015-04-12 12 30 53](https://cloud.githubusercontent.com/assets/1818657/7105251/0a2aac10-e110-11e4-9a0c-b3877b49bf53.png)

to
![screenshot from 2015-04-12 12 22 54](https://cloud.githubusercontent.com/assets/1818657/7105223/cdf58a68-e10e-11e4-885b-332136e7e028.png)
