### PR TITLE
Reflected the changes in risklib

### DIFF
--- a/openquake/engine/calculators/risk/classical_bcr/core.py
+++ b/openquake/engine/calculators/risk/classical_bcr/core.py
@@ -55,7 +55,7 @@ def classical_bcr(workflow, getter, outputdict, params, monitor):
             for out in outputs:
                 outputdict.write(
                     workflow.assets,
-                    out.output,
+                    out.data,
                     output_type="bcr_distribution",
                     hazard_output_id=out.hid)
 

--- a/openquake/engine/calculators/risk/classical_damage/core.py
+++ b/openquake/engine/calculators/risk/classical_damage/core.py
@@ -48,7 +48,7 @@ def classical_damage(workflow, getter, outputdict, params, monitor):
                 damage = models.Damage.objects.get(
                     risk_calculation=params.job_id, hazard_output=out.hid)
                 writers.classical_damage(
-                    out.output.assets, out.output.damages,
+                    out.assets, out.damages,
                     params.damage_state_ids, damage.id)
         # TODO: statistical outputs
 

--- a/openquake/engine/calculators/risk/classical_risk/core.py
+++ b/openquake/engine/calculators/risk/classical_risk/core.py
@@ -54,7 +54,7 @@ def classical(workflow, getter, outputdict, params, monitor):
                 save_individual_outputs(
                     outputdict.with_args(
                         loss_type=loss_type, hazard_output_id=out.hid),
-                    out.output, params)
+                    out, params)
             if stats is not None:
                 save_statistical_output(
                     outputdict.with_args(

--- a/openquake/engine/calculators/risk/event_based_bcr/core.py
+++ b/openquake/engine/calculators/risk/event_based_bcr/core.py
@@ -53,7 +53,7 @@ def event_based_bcr(workflow, getter, outputdict, params, monitor):
             for out in outputs:
                 outputdict.write(
                     workflow.assets,
-                    out.output,
+                    out.data,
                     output_type="bcr_distribution",
                     hazard_output_id=out.hid)
 

--- a/openquake/engine/calculators/risk/event_based_risk/core.py
+++ b/openquake/engine/calculators/risk/event_based_risk/core.py
@@ -85,11 +85,11 @@ def event_based(workflow, getter, outputdict, params, monitor):
                 # the statistics we can save memory by keeping only one
                 # hazard realization at the time
         for out in outputs:
-            event_loss_table[loss_type, out.hid] = out.output.event_loss_table
+            event_loss_table[loss_type, out.hid] = out.event_loss_table
             disagg_outputs = None  # changed if params.sites_disagg is set
             if specific_assets:
                 loss_matrix, assets = _filter_loss_matrix_assets(
-                    out.output.loss_matrix, out.output.assets, specific_assets)
+                    out.loss_matrix, out.assets, specific_assets)
                 if len(assets):
                     # compute the loss per rupture per asset
                     event_loss = models.EventLoss.objects.get(
@@ -118,14 +118,13 @@ def event_based(workflow, getter, outputdict, params, monitor):
                             ruptures = [models.SESRupture.objects.get(pk=rid)
                                         for rid in getter.rupture_ids]
                             disagg_outputs = disaggregate(
-                                out.output, [r.rupture for r in ruptures],
-                                params)
+                                out, [r.rupture for r in ruptures], params)
 
             with monitor('saving individual risk', autoflush=True):
                 save_individual_outputs(
                     outputdict.with_args(hazard_output_id=out.hid,
                                          loss_type=loss_type),
-                    out.output, disagg_outputs, params)
+                    out, disagg_outputs, params)
 
         if statistics and len(outputs) > 1:
             stats = workflow.statistics(

--- a/openquake/engine/calculators/risk/scenario_damage/core.py
+++ b/openquake/engine/calculators/risk/scenario_damage/core.py
@@ -55,16 +55,16 @@ def scenario_damage(workflow, getter, outputdict, params, monitor):
     # and no output containers
     assert len(outputdict) == 0, outputdict
     with monitor('computing risk', autoflush=True):
-        assets, fractions = workflow(
+        out = workflow(
             'damage', getter.assets, getter.get_data(), None)
-        aggfractions = sum(fractions[i] * asset.number_of_units
-                           for i, asset in enumerate(assets))
+        aggfractions = sum(out.damages[i] * asset.number_of_units
+                           for i, asset in enumerate(out.assets))
 
     with monitor('saving damage per assets', autoflush=True):
         writers.damage_distribution(
-            getter.assets, fractions, params.damage_state_ids)
+            getter.assets, out.damages, params.damage_state_ids)
 
-    return {assets[0].taxonomy: aggfractions}
+    return {getter.assets[0].taxonomy: aggfractions}
 
 
 @calculators.add('scenario_damage')


### PR DESCRIPTION
Companion to https://github.com/gem/oq-risklib/pull/212. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1186