### PR TITLE
Add binary package support for both Precise and Trusty

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Add binary package support for both Ubuntu 12.04 (Precise)
+    and Ubuntu 14.04 (Trusty)
+
   [Michele Simionato]
   * the aggregate loss curves can be exported in CSV format
 

--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Homepage: http://www.globalquakemodel.org/openquake/
 Package: python-oq-engine
 Architecture: all
 Conflicts: python-noq, python-oq
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-lxml, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-django16 (>=1.6.1), python-setuptools, python-psutil, python-mock, python-oq-hazardlib (>=0.14.0), python-oq-risklib (>=0.7.0), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
-Recommends: postgresql-9.1, postgresql-client, postgresql-9.1-postgis
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-lxml, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-mock, python-oq-hazardlib (>=0.14.0), python-oq-risklib (>=0.7.0), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02), ${dist:Depends}
+Recommends: postgresql-client, ${dist:Recommends}
 Description: computes seismic hazard and physical risk
  based on the hazard and risk libraries (python-oq-hazardlib,
  python-oq-risklib) developed by the GEM foundation.

--- a/debian/postinst
+++ b/debian/postinst
@@ -24,19 +24,29 @@ set -e
 . /usr/share/debconf/confmodule
 
 GEM_DEB_PACKAGE="python-oq-engine"
-PG_CONF="/etc/postgresql/9.1/main/postgresql.conf"
+LSB_RELEASE=$(lsb_release --codename --short)
+if [ "$LSB_RELEASE" == "precise" ]; then
+    PG_VERSION="9.1"
+elif [ "$LSB_RELEASE" == "trusty" ]; then
+    PG_VERSION="9.3"
+else
+    echo "This operating system release is not supported"
+    exit 1
+fi
+
+PG_CONF="/etc/postgresql/$PG_VERSION/main/postgresql.conf"
 
 if [ -f /usr/sbin/rabbitmqctl ]; then
     # create rabbitmq configuration for python-celery
     celeryuser_count=`rabbitmqctl list_users | grep celeryuser | wc -l`
     if [ $celeryuser_count -eq 0 ]; then
         rabbitmqctl add_user celeryuser celery
-    fi;
+    fi
     celeryvhost_count=`rabbitmqctl list_vhosts | grep celeryvhost | wc -l`
     if [ $celeryvhost_count -eq 0 ]; then
         rabbitmqctl add_vhost celeryvhost
         rabbitmqctl set_permissions -p celeryvhost celeryuser ".*" ".*" ".*"
-    fi;
+    fi
 fi
 
 HDIR=/usr/openquake/engine
@@ -72,7 +82,7 @@ do
 done
 chown -R root.openquake $SDIR
 
-if [ -f /usr/lib/postgresql/9.1/bin/postgres ]; then
+if [ -f /usr/lib/postgresql/$PG_VERSION/bin/postgres ]; then
     # postgres is installed, flatten and recreate the database.
 
     # Restart postgres in order to get rid of idle/open connections
@@ -92,9 +102,9 @@ if [ -f /usr/lib/postgresql/9.1/bin/postgres ]; then
         kill -9 $pid
     done
 
-    /etc/init.d/postgresql restart 9.1
+    /etc/init.d/postgresql restart $PG_VERSION
 
-    pgport=`cat /etc/postgresql/9.1/main/postgresql.conf | perl -wane ' if ($_ =~ /^\s*port\s*=/) { s/^\s*port\s*=\s*(\d+).*$/$1/; print $_; }'`
+    pgport=`cat $PG_CONF | perl -wane ' if ($_ =~ /^\s*port\s*=/) { s/^\s*port\s*=\s*(\d+).*$/$1/; print $_; }'`
     LOGFILE=/var/tmp/openquake-db-installation
     rm -f $LOGFILE
     su -c "/usr/bin/oq_create_db --yes --db-name=openquake2 --db-port=$pgport > $LOGFILE 2>&1" postgres
@@ -115,7 +125,7 @@ if [ -f /usr/lib/postgresql/9.1/bin/postgres ]; then
         exit 1
     fi
 
-    PG_ROOT=/etc/postgresql/9.1/main
+    PG_ROOT=/etc/postgresql/$PG_VERSION/main
     # Do we already have oq_* database users configured and how many?
     oq_config_lines=`grep oq_ $PG_ROOT/pg_hba.conf | grep -v '^#' | wc -l`
     # Do we already have oq_* database users *auto-configured* and how many?

--- a/debian/postinst
+++ b/debian/postinst
@@ -25,9 +25,9 @@ set -e
 
 GEM_DEB_PACKAGE="python-oq-engine"
 LSB_RELEASE=$(lsb_release --codename --short)
-if [ "$LSB_RELEASE" == "precise" ]; then
+if [ "$LSB_RELEASE" = "precise" ]; then
     PG_VERSION="9.1"
-elif [ "$LSB_RELEASE" == "trusty" ]; then
+elif [ "$LSB_RELEASE" = "trusty" ]; then
     PG_VERSION="9.3"
 else
     echo "This operating system release is not supported"

--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,6 @@ TRUSTY_REC = "postgresql-9.3, postgresql-9.3-postgis-2.1"
 PRECISE_DEP = "python-django16"
 PRECISE_REC = "postgresql-9.1, postgresql-9.1-postgis"
 
-
 ifeq ($(shell lsb_release --codename --short),trusty)
 	DEPENDS = -Vdist:Depends=$(TRUSTY_DEP)
 	RECOMMENDS = -Vdist:Recommends=$(TRUSTY_REC)

--- a/debian/rules
+++ b/debian/rules
@@ -17,6 +17,13 @@ export DH_OPTIONS
 bd=openquake/bin
 
 
+ifeq ($(shell lsb_release --codename --short),trusty)
+	DEPENDS = -Vdist:Depends="python-amqp, python-django"
+	RECOMMENDS = -Vdist:Recommends="postgresql-9.3, postgresql-9.3-postgis-2.1"
+else
+	DEPENDS = -Vdist:Depends="python-django16"
+	RECOMMENDS = -Vdist:Recommends="postgresql-9.1, postgresql-9.1-postgis"
+
 %:
 	dh --with python2 --with quilt --buildsystem=python_distutils $@
 
@@ -24,3 +31,6 @@ override_dh_quilt_patch:
 	dh_quilt_patch
 	cp openquake/__init__.py /tmp
 	cat /tmp/__init__.py | sed -e "s/0)  #.*$$/`date +'%s'`)/" > openquake/__init__.py
+
+override_dh_gencontrol:
+	dh_gencontrol -- $(DEPENDS) $(RECOMMENDS)

--- a/debian/rules
+++ b/debian/rules
@@ -16,13 +16,18 @@ export DH_OPTIONS
 
 bd=openquake/bin
 
+TRUSTY_DEP = "python-amqp, python-django"
+TRUSTY_REC = "postgresql-9.3, postgresql-9.3-postgis-2.1"
+PRECISE_DEP = "python-django16"
+PRECISE_REC = "postgresql-9.1, postgresql-9.1-postgis"
+
 
 ifeq ($(shell lsb_release --codename --short),trusty)
-	DEPENDS = -Vdist:Depends="python-amqp, python-django"
-	RECOMMENDS = -Vdist:Recommends="postgresql-9.3, postgresql-9.3-postgis-2.1"
+	DEPENDS = -Vdist:Depends=$(TRUSTY_DEP)
+	RECOMMENDS = -Vdist:Recommends=$(TRUSTY_REC)
 else
-	DEPENDS = -Vdist:Depends="python-django16"
-	RECOMMENDS = -Vdist:Recommends="postgresql-9.1, postgresql-9.1-postgis"
+	DEPENDS = -Vdist:Depends=$(PRECISE_DEP)
+	RECOMMENDS = -Vdist:Recommends=$(PRECISE_REC)
 endif
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -23,6 +23,7 @@ ifeq ($(shell lsb_release --codename --short),trusty)
 else
 	DEPENDS = -Vdist:Depends="python-django16"
 	RECOMMENDS = -Vdist:Recommends="postgresql-9.1, postgresql-9.1-postgis"
+endif
 
 %:
 	dh --with python2 --with quilt --buildsystem=python_distutils $@

--- a/packager.sh
+++ b/packager.sh
@@ -65,8 +65,7 @@ if [ "$GEM_EPHEM_NAME" = "" ]; then
     GEM_EPHEM_NAME="ubuntu-lxc-eph"
 fi
 
-
-LSB_RELEASE=$(lsb_release --id --short)
+LSB_RELEASE=$(lsb_release --codename --short)
 
 if command -v lxc-shutdown &> /dev/null; then
     # Older lxc (< 1.0.0) with lxc-shutdown

--- a/packager.sh
+++ b/packager.sh
@@ -524,15 +524,18 @@ _pkgtest_innervm_run () {
 deps_list() {
     local old_ifs out_list skip i d listtype="$1" filename="$2"
 
+    rules_dep=$(grep "^${LSB_RELEASE^^}_DEP =" debian/rules | cut -d '"' -f 2 | tr -d ",")
+    rules_rec=$(grep "^${LSB_RELEASE^^}_REC =" debian/rules | cut -d '"' -f 2 | tr -d ",")
+
     out_list=""
     if [ "$listtype" = "all" ]; then
-        in_list="$(cat "$filename" | egrep '^Depends:|^Recommends:|Build-Depends:' | sed 's/^\(Build-\)\?Depends://g;s/^Recommends://g' | tr '\n' ',')"
+        in_list="$(cat "$filename" | egrep '^Depends:|^Recommends:|Build-Depends:' | sed 's/^\(Build-\)\?Depends://g;s/^Recommends://g' | tr '\n' ',') $rules_dep $rules_rec"
     elif [  "$listtype" = "deprec" ]; then
-        in_list="$(cat "$filename" | egrep '^Depends:|^Recommends:' | sed 's/^Depends://g;s/^Recommends://g' | tr '\n' ',')"
+        in_list="$(cat "$filename" | egrep '^Depends:|^Recommends:' | sed 's/^Depends://g;s/^Recommends://g' | tr '\n' ',') $rules_dep $rules_rec"
     elif [  "$listtype" = "build" ]; then
-        in_list="$(cat "$filename" | egrep '^Depends:|^Build-Depends:' | sed 's/^\(Build-\)\?Depends://g' | tr '\n' ',')"
+        in_list="$(cat "$filename" | egrep '^Depends:|^Build-Depends:' | sed 's/^\(Build-\)\?Depends://g' | tr '\n' ',') $rules_dep"
     else
-        in_list="$(cat "$filename" | egrep "^Depends:" | sed 's/^Depends: //g')"
+        in_list="$(cat "$filename" | egrep "^Depends:" | sed 's/^Depends: //g') $rules_dep"
     fi
 
     old_ifs="$IFS"

--- a/packager.sh
+++ b/packager.sh
@@ -65,6 +65,9 @@ if [ "$GEM_EPHEM_NAME" = "" ]; then
     GEM_EPHEM_NAME="ubuntu-lxc-eph"
 fi
 
+
+LSB_RELEASE=$(lsb_release --id --short)
+
 if command -v lxc-shutdown &> /dev/null; then
     # Older lxc (< 1.0.0) with lxc-shutdown
     LXC_TERM="lxc-shutdown -t 10 -w"
@@ -309,7 +312,7 @@ _devtest_innervm_run () {
     # configure the machine to run tests
     ssh $lxc_ip "set -e
         for dbu in oq_job_init oq_admin; do
-            sudo sed -i \"1ilocal   openquake2   \$dbu                   md5\" /etc/postgresql/9.1/main/pg_hba.conf
+            sudo sed -i \"1ilocal   openquake2   \$dbu                   md5\" /etc/postgresql/*/main/pg_hba.conf
         done"
 
     ssh $lxc_ip "sudo service postgresql restart"
@@ -712,9 +715,9 @@ pkgtest_run () {
     dpkg-scansources . > Sources
     cat Sources | gzip > Sources.gz
     cat > Release <<EOF
-Archive: precise
+Archive: $LSB_RELEASE
 Origin: Ubuntu
-Label: Local Ubuntu Precise Repository
+Label: Local Ubuntu ${LSB_RELEASE^} Repository
 Architecture: amd64
 MD5Sum:
 EOF


### PR DESCRIPTION
Tests on `precise`: https://ci.openquake.org/job/zdevel_oq-engine_fast/25/
Tests on `trusty`:  https://ci-dev.openquake.org/job/zdevel_oq-engine_fast/19/