### PR TITLE
Using the memory-efficient representation of the GMFs

### DIFF
--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -297,7 +297,6 @@ class GmfCalculator(object):
         for rupid, gmfa in zip(rupids, computer.compute(seeds)):
             for gname in gmfa.dtype.fields:
                 gmf_by_imt = gmfa[gname]
-                print gmf_by_imt
                 for imt in self.sorted_imts:
                     for site_id, gmv in zip(r_sites.sids, gmf_by_imt[imt]):
                         self.gmvs_per_site[

--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -293,9 +293,10 @@ class GmfCalculator(object):
         computer = gmf.GmfComputer(
             rupture, r_sites, self.sorted_imts, self.sorted_gsims,
             self.truncation_level, self.correl_model)
+        gnames = map(str, computer.gsims)
         rupids, seeds = zip(*rupid_seed_pairs)
         for rupid, gmfa in zip(rupids, computer.compute(seeds)):
-            for gname in gmfa.dtype.fields:
+            for gname in gnames:
                 gmf_by_imt = gmfa[gname]
                 for imt in self.sorted_imts:
                     for site_id, gmv in zip(r_sites.sids, gmf_by_imt[imt]):

--- a/openquake/engine/calculators/hazard/scenario/core.py
+++ b/openquake/engine/calculators/hazard/scenario/core.py
@@ -49,7 +49,8 @@ def calculate_gmfs(tag_seed_pairs, computer, monitor):
     :returns:
         a dictionary tag -> key -> imt -> gmf
     """
-    return {tag: computer.compute(seed)[0] for tag, seed in tag_seed_pairs}
+    tags, seeds = zip(*tag_seed_pairs)
+    return dict(zip(tags, computer.compute(seeds)))
 
 
 def create_db_ruptures(rupture, ses_coll, tags, seed):

--- a/openquake/engine/calculators/hazard/scenario/core.py
+++ b/openquake/engine/calculators/hazard/scenario/core.py
@@ -49,7 +49,7 @@ def calculate_gmfs(tag_seed_pairs, computer, monitor):
     :returns:
         a dictionary tag -> key -> imt -> gmf
     """
-    return {tag: dict(computer.compute(seed)) for tag, seed in tag_seed_pairs}
+    return {tag: computer.compute(seed)[0] for tag, seed in tag_seed_pairs}
 
 
 def create_db_ruptures(rupture, ses_coll, tags, seed):
@@ -165,7 +165,7 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
             models.OqJob.objects.get(pk=self.job.id))
         gsim = valid.gsim(oqparam.gsim)
         self.computer = GmfComputer(
-            self.rupture, self.sites, self.imts, [gsim],
+            self.rupture, self.sites, oqparam.imtls, [gsim],
             trunc_level, correlation_model)
 
     @EnginePerformanceMonitor.monitor
@@ -185,9 +185,9 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
         """
         gmf_id = self.gmf.id
         inserter = writer.CacheInserter(models.GmfData, max_cache_size=1000)
+        gsim = self.oqparam.gsim
         for imt in self.imts:
-            # self.acc[tag].values() is a one-dimensional list (1 GSIM)
-            gmfs = numpy.array([self.acc[tag].values()[0][str(imt)]
+            gmfs = numpy.array([self.acc[tag][gsim][str(imt)]
                                 for tag in self.tags]).transpose()
             for site_id, gmvs in zip(self.sites.sids, gmfs):
                 inserter.add(

--- a/openquake/engine/tests/calculators/hazard/event_based/core_test.py
+++ b/openquake/engine/tests/calculators/hazard/event_based/core_test.py
@@ -74,14 +74,13 @@ class GmfCalculatorTestCase(unittest.TestCase):
         site_coll = make_site_coll(-78, 15.5, num_sites)
         rup_id, rup_seed = 42, 44
         rup = FakeRupture(rup_id, trt)
-        pga = PGA()
         rlz = mock.Mock()
         rlz.id = 1
         ses_coll = mock.Mock()
         ses_coll.ordinal = 0
         ses_coll.trt_model.id = 1
         calc = core.GmfCalculator(
-            [pga], [gsim], ses_coll, truncation_level=3)
+            ['PGA'], [gsim], ses_coll, truncation_level=3)
         calc.calc_gmfs(site_coll, rup, [(rup.id, rup_seed)])
         expected_rups = {
             ('AkkarBommer2010', 'PGA', 0): [rup_id],

--- a/openquake/engine/tests/calculators/hazard/event_based/core_test.py
+++ b/openquake/engine/tests/calculators/hazard/event_based/core_test.py
@@ -19,7 +19,6 @@ import unittest
 import mock
 import numpy
 
-from openquake.hazardlib.imt import PGA
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo.mesh import Mesh

--- a/qa_tests/hazard/event_based/test.py
+++ b/qa_tests/hazard/event_based/test.py
@@ -121,7 +121,7 @@ class EBHazardSpatialCorrelCase1TestCase(qa_utils.BaseQATestCase):
             gmvs_site_1, gmvs_site_2, 1.0, hc.investigation_time,
             hc.ses_per_logic_tree_path
         )
-
+        import pdb; pdb.set_trace()
         numpy.testing.assert_almost_equal(joint_prob_0_5, 0.99, decimal=1)
         numpy.testing.assert_almost_equal(joint_prob_1_0, 0.41, decimal=1)
 

--- a/qa_tests/hazard/event_based/test.py
+++ b/qa_tests/hazard/event_based/test.py
@@ -121,7 +121,6 @@ class EBHazardSpatialCorrelCase1TestCase(qa_utils.BaseQATestCase):
             gmvs_site_1, gmvs_site_2, 1.0, hc.investigation_time,
             hc.ses_per_logic_tree_path
         )
-        import pdb; pdb.set_trace()
         numpy.testing.assert_almost_equal(joint_prob_0_5, 0.99, decimal=1)
         numpy.testing.assert_almost_equal(joint_prob_1_0, 0.41, decimal=1)
 


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1438212. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1197