### PR TITLE
Special case when saving GSIMs into the database

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -356,6 +356,8 @@ class OqJob(djm.Model):
         :param params: a dictionary {name: string} of parameters
         """
         for name, value in params.iteritems():
+            if name == 'gsim':  # special case
+                value = str(value)
             JobParam.objects.create(job=self, name=name, value=repr(value))
 
     def save_hazard_sites(self):


### PR DESCRIPTION
This is needed since I change the gsim parameter from a string into a GSIM instance in https://github.com/gem/oq-risklib/pull/227/
Tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1206