### PR TITLE
Fixed the --load_gmf command

### DIFF
--- a/openquake/engine/tools/import_gmf_scenario.py
+++ b/openquake/engine/tools/import_gmf_scenario.py
@@ -170,7 +170,8 @@ def import_gmf_scenario(fileobj):
             calculation_mode='scenario',
             hazard_imtls=dict.fromkeys(imts),
             inputs={},
-            number_of_ground_motion_fields=len(rows) // len(imts)
+            number_of_ground_motion_fields=len(rows) // len(imts),
+            maximum_distance=1000.,
             ))
 
     job.duration = time.time() - t0


### PR DESCRIPTION
The maximum distance is mandatory, so it must be set, even if to a fake value.
In a subsequent pull request I will add a test for the feature, but I have already checked manually that the fix works. See https://bugs.launchpad.net/oq-engine/+bug/1451853