### PR TITLE
Updated hazard_curves_to_hazard_map

### DIFF
--- a/openquake/engine/calculators/hazard/post_processing.py
+++ b/openquake/engine/calculators/hazard/post_processing.py
@@ -70,7 +70,7 @@ def hazard_curves_to_hazard_map(hazard_curves, poes, monitor):
 
         # Gather all of the curves and compute the maps, for all PoEs
         curves = [_poes for _, _, _poes in hcd]
-        hazard_maps = calc.compute_hazard_maps(curves, hc.imls, poes)
+        hazard_maps = calc.compute_hazard_maps(curves, hc.imls, poes).T
 
         # Prepare the maps to be saved to the DB
         for i, poe in enumerate(poes):

--- a/openquake/engine/tests/calculators/hazard/post_processing_test.py
+++ b/openquake/engine/tests/calculators/hazard/post_processing_test.py
@@ -49,7 +49,7 @@ class HazardMapTaskFuncTestCase(unittest.TestCase):
     MOCK_HAZARD_MAP = numpy.array([
         [0.0098, 0.0084],
         [0.0091, 0.00687952],
-    ])
+    ]).T
 
     TEST_POES = [0.1, 0.02]
 


### PR DESCRIPTION
Because there was an API change in https://github.com/gem/oq-risklib/pull/236.
The tests are passing: https://ci.openquake.org/job/zdevel_oq-engine/1216/