### PR TITLE
debian/control: fix dependencies order

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Homepage: http://www.globalquakemodel.org/openquake/
 Package: python-oq-engine
 Architecture: all
 Conflicts: python-noq, python-oq
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-lxml, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-mock, python-oq-hazardlib (>=0.14.0), python-oq-risklib (>=0.7.0), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02), ${dist:Depends}
-Recommends: postgresql-client, ${dist:Recommends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, ${dist:Depends}, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-lxml, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-mock, python-oq-hazardlib (>=0.14.0), python-oq-risklib (>=0.7.0), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
+Recommends: ${dist:Recommends}, postgresql-client
 Description: computes seismic hazard and physical risk
  based on the hazard and risk libraries (python-oq-hazardlib,
  python-oq-risklib) developed by the GEM foundation.


### PR DESCRIPTION
Fixes an issue with dependencies order and segfault of `librabbitmq`.
This error can be reproduced only on "non-fast" LXC in CI.

Bad: https://ci.openquake.org/job/zdevel_oq-engine_nofast/1/
Good: https://ci.openquake.org/job/zdevel_oq-engine_nofast/2/