### PR TITLE
server: default user is now stored in settings

### DIFF
--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -128,6 +128,8 @@ LOGGING = {
 
 FILE_UPLOAD_MAX_MEMORY_SIZE = 1
 
+DEFAULT_USER = 'platform'
+
 try:
     from local_settings import *
 except ImportError:

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -128,7 +128,8 @@ LOGGING = {
 
 FILE_UPLOAD_MAX_MEMORY_SIZE = 1
 
-DEFAULT_USER = 'platform'
+# Enable this setting if used as backend for the OpenQuake Platform
+# DEFAULT_USER = 'platform'
 
 try:
     from local_settings import *

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from openquake.engine import __version__ as oqversion
 
 
@@ -9,7 +10,7 @@ def getusername(request):
     """
 
     user_name = (request.user.username if hasattr(request, 'user') and
-                 request.user.is_authenticated() else 'platform')
+                 request.user.is_authenticated() else settings.DEFAULT_USER)
 
     return user_name
 

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -1,3 +1,5 @@
+import getpass
+
 from django.conf import settings
 from openquake.engine import __version__ as oqversion
 
@@ -10,7 +12,8 @@ def getusername(request):
     """
 
     user_name = (request.user.username if hasattr(request, 'user') and
-                 request.user.is_authenticated() else settings.DEFAULT_USER)
+                 request.user.is_authenticated() else settings.DEFAULT_USER if
+                 hasattr(settings, 'DEFAULT_USER') else getpass.getuser())
 
     return user_name
 


### PR DESCRIPTION
I need this to use the "openquake" users on the VMs.

I also don't like to have a username in the code...