### PR TITLE
Specified concurrent_tasks explicitly

### DIFF
--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -473,4 +473,5 @@ class EventBasedHazardCalculator(general.BaseHazardCalculator):
         return tasks.apply_reduce(
             compute_gmfs_and_curves,
             (sesruptures, sitecol, self.rlzs_assoc, self.monitor),
-            base_agg, zeros, key=lambda sr: sr.col_idx)
+            base_agg, zeros, key=lambda sr: sr.col_idx,
+            concurrent_tasks=self.concurrent_tasks)

--- a/openquake/engine/calculators/hazard/general.py
+++ b/openquake/engine/calculators/hazard/general.py
@@ -107,7 +107,8 @@ class BaseHazardCalculator(base.Calculator):
             self.core_calc_task,
             (list(csm.sources), self.site_collection, csm.info, self.monitor),
             agg=self.agg_curves, acc=self.acc,
-            weight=attrgetter('weight'), key=attrgetter('trt_model_id'))
+            weight=attrgetter('weight'), key=attrgetter('trt_model_id'),
+            concurrent_tasks=self.concurrent_tasks)
 
     @EnginePerformanceMonitor.monitor
     def agg_curves(self, acc, result):
@@ -530,6 +531,7 @@ class BaseHazardCalculator(base.Calculator):
             with self.monitor('generating hazard maps', autoflush=True) as mon:
                 tasks.apply_reduce(
                     hazard_curves_to_hazard_map,
-                    (self._hazard_curves, self.oqparam.poes, mon))
+                    (self._hazard_curves, self.oqparam.poes, mon),
+                    concurrent_tasks=self.concurrent_tasks)
         if self.oqparam.uniform_hazard_spectra:
             do_uhs_post_proc(self.job)

--- a/openquake/engine/calculators/hazard/scenario/core.py
+++ b/openquake/engine/calculators/hazard/scenario/core.py
@@ -177,7 +177,8 @@ class ScenarioHazardCalculator(haz_general.BaseHazardCalculator):
         """
         self.acc = tasks.apply_reduce(
             self.core_calc_task,
-            (zip(self.tags, self.seeds), self.computer, self.monitor))
+            (zip(self.tags, self.seeds), self.computer, self.monitor),
+            concurrent_tasks=self.concurrent_tasks)
 
     @EnginePerformanceMonitor.monitor
     def post_execute(self, result=None):

--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -191,7 +191,7 @@ def export_loss_curve_csv(key, output, target):
     return dest
 
 
-@core.export_output.add(('loss_curve', 'csv'))
+@core.export_output.add(('loss_curve', 'csv'), ('event_loss_curve', 'csv'))
 def export_avgloss_csv(key, output, target):
     """
     Export `output` to `target` in csv format for a given loss type


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1455342. A refactoring of few weeks ago made OqTaskManager to inherits the default value for concurrent_tasks from oq-lite (i.e. the number of cores): so, instead of the concurrent_tasks defined in openquake.cfg the hazard calculators were using the number of cores of the controller machine. The solution is to not use the default.

You can see that the fix works by looking at the demos logs here: https://ci.openquake.org/job/zdevel_oq-engine/1228/console