### PR TITLE
Improve the python packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ include openquake.cfg openquake_worker.cfg
 include README.md LICENSE CONTRIBUTORS.txt
 
 recursive-include openquake/engine/db *.sql
-recursive-include openquake/engine/tests *.xml *.ini *.sql
+recursive-include openquake/engine/tests *.xml *.ini *.sql *.csv
 
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include openquake.cfg  openquake_worker.cfg
-include README.md  LICENSE  contributors.txt
+include openquake.cfg openquake_worker.cfg
+include README.md LICENSE CONTRIBUTORS.txt
 
 recursive-include openquake/engine/db *.sql
 recursive-include openquake/engine/tests *.xml *.ini *.sql

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include openquake.cfg  openquake_worker.cfg
+include README.md  LICENSE  contributors.txt
+
+recursive-include openquake/engine/db *.sql
+recursive-include openquake/engine/tests *.xml *.ini *.sql
+
+recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf

--- a/debian/postinst
+++ b/debian/postinst
@@ -49,7 +49,7 @@ if [ -f /usr/sbin/rabbitmqctl ]; then
     fi
 fi
 
-HDIR=/usr/openquake/engine
+HDIR=/usr/share/openquake/engine
 IDIR=/usr/lib/python2.7/dist-packages/openquake/engine
 mkdir -p $HDIR
 chmod 1777 $HDIR
@@ -169,7 +169,7 @@ if [ -f /usr/lib/postgresql/$PG_VERSION/bin/postgres ]; then
 fi
 
 # Last but not least delete obsolete .pyc files in /usr/openquake/engine
-find /usr/openquake/engine -type f -name \*.pyc -exec rm -f {} \;
+find /usr/share/openquake/engine -type f -name \*.pyc -exec rm -f {} \;
 
 #touch /tmp/mop-pause
 #while [ 1 ]; do

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -28,6 +28,11 @@ from openquake.engine.utils import config
 
 config.abort_if_no_config_available()
 
+try:
+    import celeryconfig
+except ImportError:
+    sys.path.append('/usr/share/openquake/engine')
+
 import openquake.engine
 
 from openquake.engine import __version__

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -28,6 +28,12 @@ from openquake.engine.utils import config
 
 config.abort_if_no_config_available()
 
+"""
+Please note: the /usr/bin/oq-engine script requires a celeryconfig.py file in
+the PYTHONPATH; when using binary packages, if a celeryconfig.py is not
+available the OpenQuake Engine default celeryconfig.py, located in
+/usr/share/openquake/engine, is used.
+"""
 try:
     import celeryconfig
 except ImportError:

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -28,11 +28,6 @@ from openquake.engine.utils import config
 
 config.abort_if_no_config_available()
 
-try:
-    import celeryconfig
-except ImportError:
-    sys.path.append('/usr/openquake/engine')
-
 import openquake.engine
 
 from openquake.engine import __version__

--- a/packager.sh
+++ b/packager.sh
@@ -493,7 +493,7 @@ _pkgtest_innervm_run () {
     ssh $lxc_ip "set -e; oq-engine --upgrade-db --yes"
 
     # run celeryd daemon
-    ssh $lxc_ip "cd /usr/openquake/engine ; celeryd >/tmp/celeryd.log 2>&1 3>&1 &"
+    ssh $lxc_ip "cd /usr/share/openquake/engine ; celeryd >/tmp/celeryd.log 2>&1 3>&1 &"
 
     if [ -z "$GEM_PKGTEST_SKIP_DEMOS" ]; then
         # run all of the hazard and risk demos

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
     package_data={"openquake.engine": [
         "openquake.cfg", "openquake_worker.cfg",
         "README.md", "LICENSE", "CONTRIBUTORS.txt"]},
+    namespace_packages=['openquake'],
     scripts=["openquake/engine/bin/oq_create_db",
              "openquake/engine/bin/openquake"],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     maintainer_email='devops@openquake.org',
     description=("Computes hazard, risk and socio-economic impact of "
                  "earthquakes."),
-    license="GNU AGPL v3",
+    license="AGPL3",
     keywords="earthquake seismic hazard risk",
     url=url,
     long_description=README,

--- a/setup.py
+++ b/setup.py
@@ -76,16 +76,12 @@ setup(
                                     "openquake.engine.bin",
                                     "openquake.engine.bin.*"]),
     py_modules=PY_MODULES,
-
     include_package_data=True,
     scripts=["openquake/engine/bin/oq_create_db",
              "openquake/engine/bin/openquake"],
-
     package_data={"openquake.engine": [
         "openquake.cfg", "openquake_worker.cfg",
-        "README.md", "LICENSE", "contributors.txt"]},
-
+        "README.md", "LICENSE", "CONTRIBUTORS.txt"]},
     namespace_packages=['openquake'],
-
     zip_safe=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,18 @@
+# The OpenQuake Engine
+# Copyright (C) 2012-2015, GEM Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import re
 import sys
 from setuptools import setup, find_packages
@@ -43,13 +58,18 @@ setup(
     author_email="devops@openquake.org",
     description=("Computes hazard, risk and socio-economic impact of "
                  "earthquakes."),
-    license="AGPL3",
+    license="GNU AGPL v3",
     keywords="earthquake seismic hazard risk",
     url=url,
     long_description=README,
     classifiers=[
-        "Development Status :: 4 - Beta",
-        "Topic :: Scientific/Engineering",
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Education',
+        'Intended Audience :: Science/Research',
+        'Programming Language :: Python :: 2',
+        'License :: OSI Approved :: GNU Affero General Public License v3',
+        'Operating System :: OS Independent',
+        'Topic :: Scientific/Engineering',
     ],
     packages=find_packages(exclude=["qa_tests", "qa_tests.*",
                                     "tools",

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,6 @@ README = """
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
 
-Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
-file in the PYTHONPATH.  Please make sure this is the case and that your
-celeryconfig.py file works with your python-celery setup.
-
-Feel free to copy /usr/share/openquake/engine/celeryconfig.py and revise it
-as needed.
-
 Copyright (C) 2010-2015, GEM Foundation.
 """
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # The OpenQuake Engine
-# Copyright (C) 2012-2015, GEM Foundation
+# Copyright (C) 2010-2015, GEM Foundation
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ celeryconfig.py file works with your python-celery setup.
 
 Feel free to copy /usr/share/engine/celeryconfig.py and revise it
 as needed.
+
+Copyright (C) 2010-2015, GEM Foundation.
 """
 
 PY_MODULES = ['openquake.engine.bin.openquake_cli']

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ url = "https://github.com/gem/oq-engine"
 README = """
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
+
 Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
 file in the PYTHONPATH.  Please make sure this is the case and that your
 celeryconfig.py file works with your python-celery setup.

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,10 @@ setup(
     scripts=["openquake/engine/bin/oq_create_db",
              "openquake/engine/bin/openquake"],
 
+    package_data={"openquake.engine": [
+        "openquake.cfg", "openquake_worker.cfg",
+        "README.md", "LICENSE", "contributors.txt"]},
+
     namespace_packages=['openquake'],
 
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -65,14 +65,6 @@ setup(
     py_modules=PY_MODULES,
 
     include_package_data=True,
-    package_data={"openquake.engine": [
-        "db/schema/upgrades/*.sql",
-        "openquake.cfg", "openquake_worker.cfg", "README", "LICENSE"],
-        "openquake.server": [
-        "templates/*.html", "templates/*/*.html", "static/css/*.css",
-        "static/*/*.js", "static/*/*/*.js", "static/*/*/*/*.js",
-        "static/*/*.map", "static/*/*/*.map", "static/*/*/*/*.map",
-        "static/font/*.ttf", "static/font/*.css", "static/img/*.png"]},
     scripts=["openquake/engine/bin/oq_create_db",
              "openquake/engine/bin/openquake"],
 

--- a/setup.py
+++ b/setup.py
@@ -84,11 +84,10 @@ setup(
                                     "openquake.engine.bin.*"]),
     py_modules=PY_MODULES,
     include_package_data=True,
-    scripts=["openquake/engine/bin/oq_create_db",
-             "openquake/engine/bin/openquake"],
     package_data={"openquake.engine": [
         "openquake.cfg", "openquake_worker.cfg",
         "README.md", "LICENSE", "CONTRIBUTORS.txt"]},
-    namespace_packages=['openquake'],
+    scripts=["openquake/engine/bin/oq_create_db",
+             "openquake/engine/bin/openquake"],
     zip_safe=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -20,17 +20,17 @@ def get_version():
 
 version = get_version()
 
-url = "http://openquake.org/"
+url = "https://github.com/gem/oq-engine"
 
 README = """
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
 
-Please note: the /usr/bin/openquake script requires a celeryconfig.py
+Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
 file in the PYTHONPATH.  Please make sure this is the case and that your
 celeryconfig.py file works with your python-celery setup.
 
-Feel free to copy /usr/openquake/engine/celeryconfig.py and revise it
+Feel free to copy /usr/share/engine/celeryconfig.py and revise it
 as needed.
 """
 
@@ -53,8 +53,8 @@ setup(
     url=url,
     long_description=README,
     classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Topic :: Utilities",
+        "Development Status :: 4 - Beta",
+        "Topic :: Scientific/Engineering",
     ],
     packages=find_packages(exclude=["qa_tests", "qa_tests.*",
                                     "tools",

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,10 @@ setup(
     },
     name="openquake.engine",
     version=version,
-    author="The OpenQuake team",
+    author="GEM Foundation",
     author_email="devops@openquake.org",
+    maintainer='GEM Foundation',
+    maintainer_email='devops@openquake.org',
     description=("Computes hazard, risk and socio-economic impact of "
                  "earthquakes."),
     license="GNU AGPL v3",

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,11 @@ url = "https://github.com/gem/oq-engine"
 README = """
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
+Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
+file in the PYTHONPATH.  Please make sure this is the case and that your
+celeryconfig.py file works with your python-celery setup.
+Feel free to copy /usr/share/openquake/engine/celeryconfig.py and revise it
+as needed.
 
 Copyright (C) 2010-2015, GEM Foundation.
 """

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
 file in the PYTHONPATH.  Please make sure this is the case and that your
 celeryconfig.py file works with your python-celery setup.
 
-Feel free to copy /usr/share/engine/celeryconfig.py and revise it
+Feel free to copy /usr/share/openquake/engine/celeryconfig.py and revise it
 as needed.
 
 Copyright (C) 2010-2015, GEM Foundation.

--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,10 @@ README = """
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
 
-Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
-file in the PYTHONPATH.  Please make sure this is the case and that your
-celeryconfig.py file works with your python-celery setup.
-Feel free to copy /usr/share/openquake/engine/celeryconfig.py and revise it
-as needed.
+Please note: the /usr/bin/oq-engine script requires a celeryconfig.py file in
+the PYTHONPATH; when using binary packages, if a celeryconfig.py is not
+available the OpenQuake Engine default celeryconfig.py, located in
+/usr/share/openquake/engine, is used.
 
 Copyright (C) 2010-2015, GEM Foundation.
 """


### PR DESCRIPTION
Making RPM packages I discovered some issues with the Python packaging and the `setup.py`. Apart from outdated information, we were producing packages (even Ubuntu ones) with missing pieces to run the tests: some time ago we moved the tests inside the `openquake.engine` python package, but by default only `.py` files are kept in the package. The `MANIFEST.in` allows us to include all the data needed to run tests (csv, xml...) located in specific folders.
A similar issue was already solved with the engine server static files, but we did it in the bad way: instead of adding them in a `MANIFEST.in` we forced them to be part in the `openquake.server` package using the `package_data=` option in `setup.py`. This should be used only to include in a package files that are out of the scope (aka out of the `openquake` folder).

I also moved the `celeryconfig.py` from `/usr/openquake/engine` to `/usr/share/openquake/engine` to be more compliant with the UNIX FHS.

Full suite of tests for both precise and trusty: https://ci.openquake.org/job/zdevel_oq-engine/1245/

_Please note:_ https://github.com/gem/oq-engine/commit/d72ab988e041eafd72464cd586bab1a4fc62306f must be kept, otherwise demos will not run when binary package is used

See also: https://github.com/gem/oq-hazardlib/pull/339 and https://github.com/gem/oq-risklib/pull/262