### PR TITLE
Removed a confusing log message

### DIFF
--- a/openquake/engine/calculators/hazard/disaggregation/core.py
+++ b/openquake/engine/calculators/hazard/disaggregation/core.py
@@ -370,7 +370,7 @@ class DisaggHazardCalculator(ClassicalHazardCalculator):
             all_args.append((sitecol, srcs, trt_model_id, trt_num,
                              curves_dict, self.bin_edges, self.monitor))
 
-        res = tasks.starmap(compute_disagg, all_args, logs.LOG.progress)
+        res = tasks.starmap(compute_disagg, all_args)
         self.save_disagg_results(res.reduce(self.agg_result))
 
     def post_execute(self, result=None):


### PR DESCRIPTION
This will replace logs like
```
[2015-06-03 14:13:10,468 hazard job #3 - PROGRESS MainProcess/1111] **  Submitting task <function _log_progress at 0x31fe230> #1
```

with

```
[2015-06-03 14:13:10,468 hazard job #3 - PROGRESS MainProcess/1111] **  Submitting task compute_disagg #1
```

See https://ci.openquake.org/job/zdevel_oq-engine/1252/console