### PR TITLE
oq-lite integration

### DIFF
--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -510,14 +510,14 @@ def main():
 
         if len(job_inis) == 2:
             # run hazard
-            job = run_job([job_inis[0]], args.log_level,
+            job = run_job(job_inis[0], args.log_level,
                           log_file, args.exports)
             # run risk
-            run_job([job_inis[1]], args.log_level, log_file,
+            run_job(job_inis[1], args.log_level, log_file,
                     args.exports, hazard_calculation_id=job.id)
         else:
             run_job(
-                [expanduser(args.run)], args.log_level, log_file,
+                expanduser(args.run), args.log_level, log_file,
                 args.exports, hazard_output_id=args.hazard_output_id,
                 hazard_calculation_id=args.hazard_calculation_id)
     # hazard
@@ -526,7 +526,7 @@ def main():
     elif args.run_hazard is not None:
         log_file = expanduser(args.log_file) \
             if args.log_file is not None else None
-        run_job([expanduser(args.run_hazard)], args.log_level,
+        run_job(expanduser(args.run_hazard), args.log_level,
                 log_file, args.exports)
     elif args.delete_hazard_calculation is not None:
         del_calc(args.delete_hazard_calculation, args.yes)
@@ -540,7 +540,7 @@ def main():
         log_file = expanduser(args.log_file) \
             if args.log_file is not None else None
         run_job(
-            [expanduser(args.run_risk)],
+            expanduser(args.run_risk),
             args.log_level, log_file, args.exports,
             hazard_output_id=args.hazard_output_id,
             hazard_calculation_id=args.hazard_calculation_id)

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -492,6 +492,8 @@ def main():
         print upgrade_manager.what_if_I_upgrade(conn)
         sys.exit(0)
 
+    run_job = engine.run_job_lite if args.lite else engine.run_job
+
     if args.list_inputs:
         list_inputs(args.list_inputs)
 
@@ -505,26 +507,27 @@ def main():
             open(job_ini).read()  # raise an IOError if the file does not exist
         log_file = expanduser(args.log_file) \
             if args.log_file is not None else None
-        if args.lite:
-            # run hazard and risk together
-            engine.run_job_lite(job_inis, args.log_level,
-                                log_file, args.exports)
-        else:
+
+        if len(job_inis) == 2:
             # run hazard
-            job = engine.run_job(job_inis[0], args.log_level,
-                                 log_file, args.exports)
+            job = run_job([job_inis[0]], args.log_level,
+                          log_file, args.exports)
             # run risk
-            if len(job_inis) == 2:
-                engine.run_job(job_inis[1], args.log_level, log_file,
-                               args.exports, hazard_calculation_id=job.id)
+            run_job([job_inis[1]], args.log_level, log_file,
+                    args.exports, hazard_calculation_id=job.id)
+        else:
+            run_job(
+                [expanduser(args.run)], args.log_level, log_file,
+                args.exports, hazard_output_id=args.hazard_output_id,
+                hazard_calculation_id=args.hazard_calculation_id)
     # hazard
     elif args.list_hazard_calculations:
         list_calculations('hazard')
     elif args.run_hazard is not None:
         log_file = expanduser(args.log_file) \
             if args.log_file is not None else None
-        engine.run_job(expanduser(args.run_hazard), args.log_level,
-                       log_file, args.exports)
+        run_job([expanduser(args.run_hazard)], args.log_level,
+                log_file, args.exports)
     elif args.delete_hazard_calculation is not None:
         del_calc(args.delete_hazard_calculation, args.yes)
     # risk
@@ -536,9 +539,9 @@ def main():
             sys.exit(MISSING_HAZARD_MSG)
         log_file = expanduser(args.log_file) \
             if args.log_file is not None else None
-        engine.run_job(
-            expanduser(args.run_risk), args.log_level, log_file,
-            args.exports,
+        run_job(
+            [expanduser(args.run_risk)],
+            args.log_level, log_file, args.exports,
             hazard_output_id=args.hazard_output_id,
             hazard_calculation_id=args.hazard_calculation_id)
     elif args.delete_risk_calculation is not None:

--- a/openquake/engine/calculators/base.py
+++ b/openquake/engine/calculators/base.py
@@ -109,19 +109,16 @@ class Calculator(object):
         """
         exported_files = []
 
-        with logs.tracing('exports'):
+        with self.monitor('exports', autoflush=True):
             export_dir = self.job.get_param('export_dir')
             export_type = kwargs['exports']
             if export_type:
                 outputs = self._get_outputs_for_export()
                 for output in outputs:
-                    with self.monitor('exporting %s to %s'
-                                      % (output.output_type, export_type)):
-                        fname = core.export(output.id, export_dir, export_type)
-                        if fname:
-                            logs.LOG.info('exported %s', fname)
-                            exported_files.append(fname)
-
+                    fname = core.export(output.id, export_dir, export_type)
+                    if fname:
+                        logs.LOG.info('exported %s', fname)
+                        exported_files.append(fname)
         return exported_files
 
     def clean_up(self, *args, **kwargs):


### PR DESCRIPTION
Now it is possible to reuse a previous hazard calculation:

```bash
$ oq-engine --lite --run job_haz.ini
$ oq-engine --lite --run job_risk.ini  --hc <hc_id>
```

Nothing was broken: https://ci.openquake.org/job/zdevel_oq-engine/1258/