### PR TITLE
packager.sh: more consistent versioning management [fix]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Matteo Nastasi]
+  * Packaging system improvement
+
 python-oq-engine (1.4.1-0~precise01) precise; urgency=low
 
   [Michele Simionato]

--- a/packager.sh
+++ b/packager.sh
@@ -971,6 +971,14 @@ ini_suf="$(echo "$ini_vers" | sed -n 's/^[0-9]\+\.[0-9]\+\.[0-9]\+\(.*\)/\1/gp')
 
 # version info from debian/changelog
 h="$(grep "^$GEM_DEB_PACKAGE" debian/changelog | head -n 1)"
+
+# is it the first item of changelog ?
+h_first="$(cat debian/changelog | head -n 1)"
+h_is_first=0
+if [ "$h" = "$h_first" ]; then
+    h_is_first=1
+fi
+
 # pkg_vers="$(echo "$h" | cut -d ' ' -f 2 | cut -d '(' -f 2 | cut -d ')' -f 1 | sed -n 's/[-+].*//gp')"
 pkg_name="$(echo "$h" | cut -d ' ' -f 1)"
 pkg_vers="$(echo "$h" | cut -d ' ' -f 2 | cut -d '(' -f 2 | cut -d ')' -f 1)"

--- a/packager.sh
+++ b/packager.sh
@@ -34,8 +34,8 @@
 # file system (in-memory or disk)
 #
 
-# export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
-if [ $GEM_SET_DEBUG ]; then
+if [ -n "$GEM_SET_DEBUG" -a "$GEM_SET_DEBUG" != "false" ]; then
+    export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
     set -x
 fi
 set -e
@@ -992,8 +992,12 @@ if [ $BUILD_DEVEL -eq 1 ]; then
 
     if [ "$pkg_maj" = "$ini_maj" -a "$pkg_min" = "$ini_min" -a \
          "$pkg_bfx" = "$ini_bfx" -a "$pkg_deb" != "" ]; then
-        deb_ct="$(echo "$pkg_deb" | sed 's/^-//g')"
-        pkg_deb="-$(( deb_ct ))"
+        deb_ct="$(echo "$pkg_deb" | sed 's/^-//g;s/~.*//g')"
+        if [ $h_is_first -eq 1 ]; then
+            pkg_deb="-$(( deb_ct ))"
+        else
+            pkg_deb="-$(( deb_ct + 1))"
+        fi
     else
         pkg_maj="$ini_maj"
         pkg_min="$ini_min"


### PR DESCRIPTION
Test passed: https://ci.openquake.org/job/zdevel_oq-engine/1261/console