### PR TITLE
Improvements to the source processing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 python-oq-engine (1.4.1-0~precise01) precise; urgency=low
 
   [Michele Simionato]
+  * Parallelized the source splitting procedure
   * Fixed a bug in the hazard calculators which were not using the parameter
     concurrent_tasks from the configuration file
 

--- a/openquake/engine/calculators/hazard/disaggregation/core.py
+++ b/openquake/engine/calculators/hazard/disaggregation/core.py
@@ -327,7 +327,7 @@ class DisaggHazardCalculator(ClassicalHazardCalculator):
                            for site in self.site_collection)
         all_args = []
         for trt_model_id, srcs in groupby(
-                self.composite_model.sources,
+                self.composite_model.get_sources(),
                 attrgetter('trt_model_id')).iteritems():
             lt_model = models.TrtModel.objects.get(pk=trt_model_id).lt_model
             trt_num = dict((trt, i) for i, trt in enumerate(

--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -406,7 +406,7 @@ class EventBasedHazardCalculator(general.BaseHazardCalculator):
         weights = super(EventBasedHazardCalculator, self).pre_execute()
         hc = self.oqparam
         rnd = random.Random(hc.random_seed)
-        for src in self.composite_model.sources:
+        for src in self.composite_model.get_sources():
             src.seed = rnd.randint(0, models.MAX_SINT_32)
         for trt_id, idx, col_id in self.composite_model.info.get_triples():
             self.initialize_ses_db_records(trt_id, col_id)

--- a/openquake/engine/calculators/hazard/general.py
+++ b/openquake/engine/calculators/hazard/general.py
@@ -102,7 +102,7 @@ class BaseHazardCalculator(base.Calculator):
         csm = self.composite_model
         self.acc = tasks.apply_reduce(
             self.core_calc_task,
-            (list(csm.sources), self.site_collection, csm.info, self.monitor),
+            (csm.get_sources(), self.site_collection, csm.info, self.monitor),
             agg=self.agg_curves, acc=self.acc,
             weight=attrgetter('weight'), key=attrgetter('trt_model_id'),
             concurrent_tasks=self.concurrent_tasks)
@@ -209,7 +209,7 @@ class BaseHazardCalculator(base.Calculator):
         """
         logs.LOG.progress("initializing sources")
         self.composite_model = readinput.get_composite_source_model(
-            self.oqparam, self.site_collection, self.prefilter)
+            self.oqparam, self.site_collection, in_memory=self.prefilter)
         for sm in self.composite_model:
             # create an LtSourceModel for each distinct source model
             lt_model = models.LtSourceModel.objects.create(


### PR DESCRIPTION
Companion of https://github.com/gem/oq-risklib/pull/269, see https://bugs.launchpad.net/oq-engine/+bug/1462783. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1265