### PR TITLE
Fixed the datastore export

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,8 @@
 python-oq-engine (1.4.1-0~precise01) precise; urgency=low
 
   [Michele Simionato]
+  * Fixed the engine core export: now it can export datastore outputs as
+    zip files
   * Parallelized the source splitting procedure
   * Fixed a bug in the hazard calculators which were not using the parameter
     concurrent_tasks from the configuration file

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -19,6 +19,7 @@ calculations."""
 import os
 import sys
 import time
+import shutil
 import getpass
 import itertools
 import operator
@@ -168,11 +169,15 @@ def run_calc(job, log_level, log_file, exports, lite=False):
     :param lite:
         Flag set when the oq-lite calculators are used
     """
-    # let's import the calculator classes here, when they are needed
+    # let's import the calculator classes here, when they are needed;
     # the reason is that the command `$ oq-engine --upgrade-db`
     # does not need them and would raise strange errors during installation
     # time if the PYTHONPATH is not set and commonlib is not visible
     if lite:
+        calc_dir = os.path.join(datastore.DATADIR, 'calc_%d' % job.id)
+        if os.path.exists(calc_dir):
+            shutil.rmtree(calc_dir)
+            print 'Removed pre-existing', calc_dir
         from openquake.commonlib.calculators import base
         calculator = base.calculators(job.get_oqparam(), calc_id=job.id)
         calculator.job = job

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -176,8 +176,8 @@ def run_calc(job, log_level, log_file, exports, lite=False):
     if lite:
         calc_dir = os.path.join(datastore.DATADIR, 'calc_%d' % job.id)
         if os.path.exists(calc_dir):
-            shutil.rmtree(calc_dir)
-            print 'Removed pre-existing', calc_dir
+            os.rename(calc_dir, calc_dir + '.bak')
+            print 'Generated %s.bak' % calc_dir
         from openquake.commonlib.calculators import base
         calculator = base.calculators(job.get_oqparam(), calc_id=job.id)
         calculator.job = job

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -39,13 +39,11 @@ def zipfiles(fnames, archive):
 
     :param fnames: list of path names
     :param archive: path of the archive
-    :returns: the given archive path
     """
     z = zipfile.ZipFile(archive, 'w')
     for f in fnames:
         z.write(f)
     z.close()
-    return archive
 
 
 @export_output.add(('datastore', 'csv'), ('datastore', 'xml'))
@@ -67,7 +65,8 @@ def export_from_datastore(output_key, output, target):
             'Nothing to export for %s' % output.ds_key)
     elif len(exported) > 1:
         archname = output.ds_key.lstrip('/') + '-' + fmt + '.zip'
-        return zipfiles(exported, os.path.join(target, archname))
+        zipfiles(exported, os.path.join(target, archname))
+        return archname
     else:  # single file
         return exported[0]
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -37,7 +37,7 @@ from openquake.engine import engine as oq_engine, __version__ as oqversion
 from openquake.engine.db import models as oqe_models
 from openquake.engine.export import core
 from openquake.engine.utils.tasks import safely_call
-from openquake.engine.export.core import export_output
+from openquake.engine.export.core import export_output, DataStoreExportError
 from openquake.server import tasks, executor, utils
 
 METHOD_NOT_ALLOWED = 405
@@ -483,7 +483,8 @@ def get_result(request, result_id):
     tmpdir = tempfile.mkdtemp()
     try:
         exported = core.export(result_id, tmpdir, export_type=export_type)
-    except Exception as exc:
+    except DataStoreExportError as exc:
+        # TODO: there should be a better error page
         return HttpResponse(content='%s: %s' % (exc.__class__.__name__, exc),
                             content_type='text/plain', status=500)
     if exported is None:

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -481,7 +481,11 @@ def get_result(request, result_id):
             download = True
 
     tmpdir = tempfile.mkdtemp()
-    exported = core.export(result_id, tmpdir, export_type=export_type)
+    try:
+        exported = core.export(result_id, tmpdir, export_type=export_type)
+    except Exception as exc:
+        return HttpResponse(content='%s: %s' % (exc.__class__.__name__, exc),
+                            content_type='text/plain', status=500)
     if exported is None:
         # Throw back a 404 if the exact export parameters are not supported
         return HttpResponseNotFound(


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1463859.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1270
The remaining problem is that the "view" button should not appear if the export is a zipfile.
I am opening a different bug for that: https://bugs.launchpad.net/oq-engine/+bug/1464947