### PR TITLE
Now the engine reads concurrent_tasks from the job.ini file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,7 @@
 python-oq-engine (1.4.1-0~precise01) precise; urgency=low
 
   [Michele Simionato]
+  * Now the parameter concurrent_tasks is read from the .ini file
   * Parallelized the source splitting procedure
   * Fixed a bug in the hazard calculators which were not using the parameter
     concurrent_tasks from the configuration file

--- a/openquake.cfg
+++ b/openquake.cfg
@@ -23,9 +23,6 @@ terminate_job_when_celery_is_down = true
 # heavy computations (i.e. celery could not respond to pings and still
 # not be really down).
 
-# maximum number of tasks to spawn concurrently
-concurrent_tasks = 64
-
 [memory]
 # above this quantity (in %) of memory used a warning will be printed
 soft_mem_limit = 80

--- a/openquake/engine/calculators/base.py
+++ b/openquake/engine/calculators/base.py
@@ -41,8 +41,7 @@ class Calculator(object):
         self.num_tasks = None
         self._task_args = []
         # parameters from openquake.cfg
-        self.concurrent_tasks = int(
-            config.get('celery', 'concurrent_tasks'))
+        self.concurrent_tasks = self.oqparam.concurrent_tasks
         self.max_input_weight = float(
             config.get('hazard', 'max_input_weight'))
         self.max_output_weight = float(

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -592,8 +592,6 @@ def job_from_file_lite(cfg_file, username, log_level='info', exports='',
         params.update(extras)
         # build and validate an OqParam object
         oqparam = readinput.get_oqparam(params, calculators=base.calculators)
-        oqparam.concurrent_tasks = int(
-            config.get('celery', 'concurrent_tasks'))
         job.save_params(vars(oqparam))
         job.save()
     return job

--- a/openquake/engine/utils/tasks.py
+++ b/openquake/engine/utils/tasks.py
@@ -29,8 +29,6 @@ from openquake.engine.db import models
 from openquake.engine.utils import config
 from openquake.engine.writer import CacheInserter
 
-CONCURRENT_TASKS = int(config.get('celery', 'concurrent_tasks'))
-
 SOFT_MEM_LIMIT = int(config.get('memory', 'soft_mem_limit'))
 HARD_MEM_LIMIT = int(config.get('memory', 'hard_mem_limit'))
 check_mem_usage.__defaults__ = (SOFT_MEM_LIMIT, HARD_MEM_LIMIT)

--- a/openquake_worker.cfg
+++ b/openquake_worker.cfg
@@ -15,10 +15,6 @@
 
 # THIS FILE WILL BE READ BY THE WORKER NODES IN A CLUSTER
 
-[celery]
-# maximum number of tasks to spawn concurrently
-concurrent_tasks = 64
-
 [memory]
 # above this quantity (in %) of memory used a warning will be printed
 soft_mem_limit = 80


### PR DESCRIPTION
Companion to https://github.com/gem/oq-risklib/pull/282. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1276