### PR TITLE
Updated to the API change in risklib

### DIFF
--- a/openquake/engine/calculators/risk/scenario_risk/core.py
+++ b/openquake/engine/calculators/risk/scenario_risk/core.py
@@ -88,8 +88,8 @@ def scenario(workflow, getter, outputdict, params, monitor):
         with monitor('saving risk', autoflush=True):
             outputdict.write(
                 assets,
-                out.loss_matrix.mean(axis=1),
-                out.loss_matrix.std(ddof=1, axis=1),
+                out.loss_ratio_matrix.mean(axis=1),
+                out.loss_ratio_matrix.std(ddof=1, axis=1),
                 hazard_output_id=getter.hid,
                 insured=False)
 


### PR DESCRIPTION
Companion to https://github.com/gem/oq-risklib/pull/293. The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/1288/