### PR TITLE
Fixed a bug for missing celery configuration parameters

### DIFF
--- a/openquake/engine/celery_node_monitor.py
+++ b/openquake/engine/celery_node_monitor.py
@@ -127,7 +127,8 @@ class CeleryNodeMonitor(object):
                 logs.LOG.critical(
                     'Cluster nodes not accessible: %s', dead_nodes)
                 terminate = boolean(
-                    config.get('celery', 'terminate_job_when_celery_is_down'))
+                    config.get('celery', 'terminate_job_when_celery_is_down')
+                    or 'false')
                 if terminate:
                     os.kill(os.getpid(), signal.SIGABRT)  # commit suicide
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -19,7 +19,6 @@ calculations."""
 import os
 import sys
 import time
-import shutil
 import getpass
 import itertools
 import operator
@@ -55,7 +54,8 @@ INPUT_TYPES = set(dict(models.INPUT_TYPE_CHOICES))
 UNABLE_TO_DEL_HC_FMT = 'Unable to delete hazard calculation: %s'
 UNABLE_TO_DEL_RC_FMT = 'Unable to delete risk calculation: %s'
 
-TERMINATE = valid.boolean(config.get('celery', 'terminate_workers_on_revoke'))
+TERMINATE = valid.boolean(
+    config.get('celery', 'terminate_workers_on_revoke') or 'false')
 
 
 class InvalidHazardCalculationID(Exception):


### PR DESCRIPTION
There was a problem due to the removal of `terminate_job_when_celery_is_down` and `terminate_workers_on_revoke` on `openquake_worker.cfg`