### PR TITLE
The engine does not eat errors anymore

### DIFF
--- a/openquake/engine/tests/engine_test.py
+++ b/openquake/engine/tests/engine_test.py
@@ -146,18 +146,25 @@ class JobFromFileTestCase(unittest.TestCase):
 
 class RunCalcTestCase(unittest.TestCase):
     """
-    Test engine.run_calc in case of error
+    Test engine.run_calc in case of errors
     """
     def test(self):
         cfg = helpers.get_data_path('event_based_hazard/job.ini')
         job = engine.job_from_file(cfg, 'test_user')
         with tempfile.NamedTemporaryFile() as temp:
             with self.assertRaises(ZeroDivisionError), mock.patch(
-                    'openquake.engine.engine._do_run_calc', lambda *args: 1/0):
+                    'openquake.engine.engine._do_run_calc', lambda *args: 1/0
+            ), mock.patch('openquake.engine.engine.cleanup_after_job',
+                          lambda job: None):
                 engine.run_calc(job, 'info', temp.name, exports=[])
-            # make sure the error has been logged
-            self.assertIn('integer division or modulo by zero',
-                          open(temp.name).read())
+            logged = open(temp.name).read()
+
+            # make sure the real error has been logged
+            self.assertIn('integer division or modulo by zero', logged)
+
+            # also check the spurious cleanup error
+            self.assertIn('TypeError: <lambda>() got an unexpected keyword '
+                          "argument 'terminate'",  logged)
 
 
 class OpenquakeCliTestCase(unittest.TestCase):

--- a/openquake/engine/tests/engine_test.py
+++ b/openquake/engine/tests/engine_test.py
@@ -16,6 +16,7 @@
 import sys
 import getpass
 import subprocess
+import tempfile
 import unittest
 from StringIO import StringIO
 import mock
@@ -141,6 +142,22 @@ class JobFromFileTestCase(unittest.TestCase):
 
         # make sure the hazard job is associated correctly
         self.assertEqual(risk_job.hazard_calculation.id, haz_job.id)
+
+
+class RunCalcTestCase(unittest.TestCase):
+    """
+    Test engine.run_calc in case of error
+    """
+    def test(self):
+        cfg = helpers.get_data_path('event_based_hazard/job.ini')
+        job = engine.job_from_file(cfg, 'test_user')
+        with tempfile.NamedTemporaryFile() as temp:
+            with self.assertRaises(ZeroDivisionError), mock.patch(
+                    'openquake.engine.engine._do_run_calc', lambda *args: 1/0):
+                engine.run_calc(job, 'info', temp.name, exports=[])
+            # make sure the error has been logged
+            self.assertIn('integer division or modulo by zero',
+                          open(temp.name).read())
 
 
 class OpenquakeCliTestCase(unittest.TestCase):


### PR DESCRIPTION
Solves https://bugs.launchpad.net/oq-engine/+bug/1469124.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1301