### PR TITLE
Moved git_suffix in baselib

### DIFF
--- a/openquake/engine/__init__.py
+++ b/openquake/engine/__init__.py
@@ -49,7 +49,7 @@ along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
-from openquake.hazardlib.general import git_suffix
+from openquake.baselib.general import git_suffix
 
 
 # version number follows the syntax <major>.<minor>.<patchlevel>[<suffix>]


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1469519.
The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/1302/