### PR TITLE
Fixes classical.test_case_15

### DIFF
--- a/qa_tests/hazard/classical/test.py
+++ b/qa_tests/hazard/classical/test.py
@@ -626,10 +626,10 @@ class ClassicalHazardCase15TestCase(BaseQATestCase):
             [['SM1'], ['BA2008', 'T2002']],
             [['SM1'], ['CB2008', 'C2003']],
             [['SM1'], ['CB2008', 'T2002']],
-            [['SM2', 'a3pt2b0pt8'], ['BA2008', '*']],
-            [['SM2', 'a3pt2b0pt8'], ['CB2008', '*']],
-            [['SM2', 'a3b1'], ['BA2008', '*']],
-            [['SM2', 'a3b1'], ['CB2008', '*']],
+            [['SM2', 'a3pt2b0pt8'], ['BA2008', '@']],
+            [['SM2', 'a3pt2b0pt8'], ['CB2008', '@']],
+            [['SM2', 'a3b1'], ['BA2008', '@']],
+            [['SM2', 'a3b1'], ['CB2008', '@']],
         ]
 
         csvdir = os.path.join(self.CURRENTDIR, 'expected_results')


### PR DESCRIPTION
This is due to the change of wildchar character in the file names from "*" to "@". Solves the breakage in Jenkins: https://ci.openquake.org/job/master_oq-engine/1837/console