### PR TITLE
Support for Django >= 1.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+[Michele Simionato]
+  * Initial support for Django 1.7
+
 [Daniele Viganò]
   * Remove the bin/openquake wrapper: now only bin/oq-engine is
     available

--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -36,10 +36,8 @@ import numpy
 from scipy import interpolate
 
 import django
-try:
+if hasattr(django, 'setup'):
     django.setup()  # for Django >= 1.7
-except AttributeError:
-    pass  # there is not django.setup in old Django versions
 from django.db import connections
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.gis.db import models as djm

--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -35,9 +35,13 @@ from datetime import datetime
 import numpy
 from scipy import interpolate
 
+import django
+try:
+    django.setup()  # for Django >= 1.7
+except AttributeError:
+    pass  # there is not django.setup in old Django versions
 from django.db import connections
 from django.core.exceptions import ObjectDoesNotExist
-
 from django.contrib.gis.db import models as djm
 
 from openquake.hazardlib.imt import from_string


### PR DESCRIPTION
Tests with Django 1.6 are running here: https://ci.openquake.org/job/zdevel_oq-engine/1304.
We should also do a running with Django 1.7. On my laptop the QA tests work.