### PR TITLE
Removed hazard_investigation_time

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -729,12 +729,11 @@ class Output(djm.Model):
 
         """
         oq = self.oq_job.get_oqparam()
-        investigation_time = oq.hazard_investigation_time
 
         statistics, quantile = self.statistical_params
         gsim_lt_path, sm_lt_path = self.lt_realization_paths
 
-        return self.HazardMetadata(investigation_time,
+        return self.HazardMetadata(oq.investigation_time,
                                    statistics, quantile,
                                    sm_lt_path, gsim_lt_path)
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -556,7 +556,6 @@ def job_from_file(cfg_file_path, username, log_level='info', exports='',
         for name, value in hc:
             if name not in params:
                 params[name] = value
-        params['hazard_investigation_time'] = hc.investigation_time
         params['hazard_imtls'] = dict(hc.imtls)
         cfd = hc.continuous_fragility_discretization
         if cfd and cfd != oqparam.continuous_fragility_discretization:


### PR DESCRIPTION
Companion to https://github.com/gem/oq-risklib/pull/309. See https://bugs.launchpad.net/oq-engine/+bug/1470134. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1311