### PR TITLE
Fixed a broken export test

### DIFF
--- a/openquake/engine/tests/export/core_test.py
+++ b/openquake/engine/tests/export/core_test.py
@@ -26,7 +26,7 @@ def number_of(elem_name, tree):
     return the number of occurrences of the element in a given XML document.
     """
     expr = '//%s' % elem_name
-    return len(tree.xpath(expr, namespaces=nrml.PARSE_NS_MAP))
+    return len(tree.xpath(expr, namespaces={'nrml': nrml.NRML05}))
 
 
 class BaseExportTestCase(unittest.TestCase):


### PR DESCRIPTION
The problem is that now the engine exports the GMFs in NRML 0.5, due to the change in https://github.com/gem/oq-risklib/pull/331. This was breaking Jenkins: https://ci.openquake.org/job/master_oq-engine/1891/