### PR TITLE
packager.sh: wait some seconds to allow celery to come up

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -497,6 +497,10 @@ _pkgtest_innervm_run () {
     # run celeryd daemon
     ssh $lxc_ip "cd /usr/share/openquake/engine ; celeryd >/tmp/celeryd.log 2>&1 3>&1 &"
 
+    # FIXME
+    echo "Wait some seconds to allow celery come alive..."
+    sleep 30s
+
     if [ -z "$GEM_PKGTEST_SKIP_DEMOS" ]; then
         # run all of the hazard and risk demos
         ssh $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG


### PR DESCRIPTION
This is a temporary fix and should be removed in the future.
Workaround for:
- https://ci.openquake.org/job/master_oq-engine/1901/
- https://ci.openquake.org/job/master_oq-engine/1900/

Test:
- https://ci.openquake.org/job/zdevel_oq-engine/1379/ (it works!)