### PR TITLE
Renamed LossFraction.iteritems

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -1866,7 +1866,7 @@ class LossFraction(djm.Model):
                 key=operator.attrgetter('loss'),
                 reverse=True))
 
-    def iteritems(self):
+    def items(self):
         """
         Yields tuples with two elements. The first one is a location
         (described by a lon/lat tuple), the second one is a dictionary


### PR DESCRIPTION
Companion to https://github.com/gem/oq-risklib/pull/338. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1383