### PR TITLE
Renamed openquake.commonlib.calculators -> openquake.calculators

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -79,13 +79,13 @@ CELERY_ACCEPT_CONTENT = ['pickle', 'json']
 CELERY_IMPORTS = get_core_modules(engine) + [
     "openquake.engine.calculators.hazard.general",
     "openquake.engine.tests.utils.tasks"] + [
-    "openquake.commonlib.calculators.classical",
-    "openquake.commonlib.calculators.classical_risk",
-    "openquake.commonlib.calculators.classical_damage",
-    "openquake.commonlib.calculators.event_based",
-    "openquake.commonlib.calculators.event_based_risk",
-    "openquake.commonlib.calculators.scenario_risk",
-    "openquake.commonlib.calculators.scenario_damage",
+    "openquake.calculators.classical",
+    "openquake.calculators.classical_risk",
+    "openquake.calculators.classical_damage",
+    "openquake.calculators.event_based",
+    "openquake.calculators.event_based_risk",
+    "openquake.calculators.scenario_risk",
+    "openquake.calculators.scenario_damage",
     ]
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "openquake.engine.settings"

--- a/openquake/engine/calculators/hazard/classical/core.py
+++ b/openquake/engine/calculators/hazard/classical/core.py
@@ -61,7 +61,7 @@ from openquake.hazardlib.geo.utils import get_spherical_bounding_box
 from openquake.hazardlib.geo.utils import get_longitudinal_extent
 from openquake.hazardlib.geo.geodetic import npoints_between
 
-from openquake.commonlib.calculators.calc import gen_ruptures
+from openquake.calculators.calc import gen_ruptures
 
 from openquake.engine import writer
 from openquake.engine.calculators import calculators

--- a/openquake/engine/calculators/hazard/disaggregation/core.py
+++ b/openquake/engine/calculators/hazard/disaggregation/core.py
@@ -28,7 +28,7 @@ from openquake.hazardlib.imt import from_string
 from openquake.hazardlib.site import SiteCollection
 
 from openquake.baselib.general import groupby
-from openquake.commonlib.calculators.calc import gen_ruptures_for_site
+from openquake.calculators.calc import gen_ruptures_for_site
 
 from openquake.engine import logs
 from openquake.engine.db import models

--- a/openquake/engine/calculators/hazard/event_based/core.py
+++ b/openquake/engine/calculators/hazard/event_based/core.py
@@ -43,7 +43,7 @@ from openquake.hazardlib.calc import gmf
 from openquake.hazardlib.imt import from_string
 from openquake.hazardlib.site import FilteredSiteCollection
 
-from openquake.commonlib.calculators.event_based import (
+from openquake.calculators.event_based import (
     sample_ruptures, build_ses_ruptures)
 
 from openquake.engine import writer

--- a/openquake/engine/calculators/hazard/post_processing.py
+++ b/openquake/engine/calculators/hazard/post_processing.py
@@ -25,7 +25,7 @@ import numpy
 
 from itertools import izip
 
-from openquake.commonlib.calculators import calc
+from openquake.calculators import calc
 from openquake.engine.db import models
 from openquake.engine.utils import tasks
 from openquake.engine.writer import CacheInserter

--- a/openquake/engine/calculators/risk/event_based_risk/core.py
+++ b/openquake/engine/calculators/risk/event_based_risk/core.py
@@ -24,7 +24,7 @@ import numpy
 from openquake.hazardlib.geo import mesh
 from openquake.risklib import scientific
 from openquake.risklib.utils import numpy_map
-from openquake.commonlib.calculators import ebr
+from openquake.calculators import ebr
 
 from openquake.engine.calculators.risk import (
     base, hazard_getters, validation, writers)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -205,7 +205,7 @@ def run_calc(job, log_level, log_file, exports, lite=False):
         if os.path.exists(calc_dir):
             os.rename(calc_dir, calc_dir + '.bak')
             print 'Generated %s.bak' % calc_dir
-        from openquake.commonlib.calculators import base
+        from openquake.calculators import base
         calculator = base.calculators(job.get_oqparam(), calc_id=job.id)
         calculator.job = job
         calculator.monitor = EnginePerformanceMonitor('', job.id)
@@ -609,7 +609,7 @@ def job_from_file_lite(cfg_file, username, log_level='info', exports='',
     :raises:
         `RuntimeError` if the input job configuration is not valid
     """
-    from openquake.commonlib.calculators import base
+    from openquake.calculators import base
     # create the current job
     job = create_job(user_name=username, log_level=log_level)
     models.JobStats.objects.create(oq_job=job)

--- a/openquake/engine/tests/calculators/hazard/post_processing_test.py
+++ b/openquake/engine/tests/calculators/hazard/post_processing_test.py
@@ -41,7 +41,7 @@ aaae = numpy.testing.assert_array_almost_equal
 
 
 # package prefix used for mock.patching
-MOCK_PREFIX = "openquake.commonlib.calculators.calc"
+MOCK_PREFIX = "openquake.calculators.calc"
 
 
 class HazardMapTaskFuncTestCase(unittest.TestCase):

--- a/qa_tests/hazard/scenario/test.py
+++ b/qa_tests/hazard/scenario/test.py
@@ -25,7 +25,7 @@ from openquake.engine import export
 from openquake.engine.db import models
 from openquake.commonlib.tests import check_equal
 from qa_tests import _utils as qa_utils
-from openquake.commonlib.tests.calculators.scenario_test import count_close
+from openquake.calculators.tests.scenario_test import count_close
 from openquake.qa_tests_data.scenario import (
     case_1, case_2, case_3, case_4, case_5, case_6, case_7, case_8)
 


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1469347 for the motivation. The tests are running here: 
https://ci.openquake.org/job/zdevel_oq-engine/1388/
Companion of https://github.com/gem/oq-risklib/pull/347