### PR TITLE
debian/control: re-add quild build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: python-oq-engine
 Section: python
 Priority: extra
 Maintainer: Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>
-Build-Depends: debhelper (>= 7.0.50~), lsb-release, python-support, python (>=2.7), python-setuptools, python-coverage
+Build-Depends: debhelper (>= 7.0.50~), lsb-release, quilt, python-support, python (>=2.7), python-setuptools, python-coverage
 Standards-Version: 3.9.3
 Homepage: http://www.globalquakemodel.org/openquake/
 


### PR DESCRIPTION
quilt is needed by lauchpad to build the package:

```
dpkg-buildpackage
─────────────────

dpkg-buildpackage: source package python-oq-engine
dpkg-buildpackage: source version 1.5.0-0~trusty01~dev1440628557+29dd596
dpkg-buildpackage: source distribution trusty
 dpkg-source --before-build python-oq-engine-1.5.0
dpkg-buildpackage: host architecture i386
 fakeroot debian/rules clean
dh --with python2 --with quilt --buildsystem=python_distutils clean
dh: unable to load addon quilt: Can't locate Debian/Debhelper/Sequence/quilt.pm in @INC (you may need to install the Debian::Debhelper::Sequence::quilt module) (@INC contains: /etc/perl /usr/local/lib/perl/5.18.2 /usr/local/share/perl/5.18.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.18 /usr/share/perl/5.18 /usr/local/lib/site_perl .) at (eval 4) line 2.
BEGIN failed--compilation aborted at (eval 4) line 2.
```

The build error is not trapped by CI because the environment used by Lauchpad is extremely minimal and does not include quild by default.