### PR TITLE
Remove lxml from the engine

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.globalquakemodel.org/openquake/
 Package: python-oq-engine
 Architecture: all
 Conflicts: python-noq, python-oq
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, ${dist:Depends}, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-lxml, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-nose, python-mock, python-requests (>=0.8.2), python-oq-hazardlib (>=0.15.0-0~), python-oq-risklib (>=0.8.0-0~), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, ${dist:Depends}, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-nose, python-mock, python-requests (>=0.8.2), python-oq-hazardlib (>=0.15.0-0~), python-oq-risklib (>=0.8.0-0~), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
 Recommends: ${dist:Recommends}, postgresql-client
 Description: computes seismic hazard and physical risk
  based on the hazard and risk libraries (python-oq-hazardlib,

--- a/doc/engine/Installing-the-OpenQuake-Engine-from-source-code-on-14.04.md
+++ b/doc/engine/Installing-the-OpenQuake-Engine-from-source-code-on-14.04.md
@@ -5,7 +5,7 @@ This page describes the additional steps necessary to run the current developmen
 
 ```bash
 sudo apt-get update
-sudo apt-get install git python debconf python-amqp python-celery python-geohash python-lxml python-numpy python-scipy python-shapely python-psycopg2 python-django python-setuptools python-psutil python-mock python-concurrent.futures python-h5py rabbitmq-server postgresql-9.3 postgresql-client postgresql-9.3-postgis-2.1
+sudo apt-get install git python debconf python-amqp python-celery python-geohash python-numpy python-scipy python-shapely python-psycopg2 python-django python-setuptools python-psutil python-mock python-concurrent.futures python-h5py rabbitmq-server postgresql-9.3 postgresql-client postgresql-9.3-postgis-2.1
 
 ```
 

--- a/doc/engine/Installing-the-OpenQuake-Engine-from-source-code-on-Fedora-and-RHEL.md
+++ b/doc/engine/Installing-the-OpenQuake-Engine-from-source-code-on-Fedora-and-RHEL.md
@@ -16,7 +16,7 @@ $ curl -s http://ftp.openquake.org/rhel/7/openquake.repo | sudo tee /etc/yum.rep
 ### Install the OpenQuake Engine dependencies
 
 ```bash
-$ sudo yum install sudo git gcc python-amqp python-celery python-lxml numpy python-paramiko scipy python-shapely python-psycopg2 python-django python-setuptools python-psutil python-mock python-futures rabbitmq-server postgresql-server postgis h5py
+$ sudo yum install sudo git gcc python-amqp python-celery numpy python-paramiko scipy python-shapely python-psycopg2 python-django python-setuptools python-psutil python-mock python-futures rabbitmq-server postgresql-server postgis h5py
 ```
 
 ## PostgreSQL initialization

--- a/doc/engine/Installing-the-OpenQuake-Engine-from-source-code.md
+++ b/doc/engine/Installing-the-OpenQuake-Engine-from-source-code.md
@@ -15,7 +15,7 @@ sudo apt-get remove --purge python-oq.*
 
 The complete list of dependencies is:
 ```
-python python-celery python-geohash python-lxml python-numpy python-paramiko python-scipy python-shapely python-psycopg2 python-setuptools python-psutil python-mock python-h5py python-concurrent.futures rabbitmq-server python-django16 postgresql-9.1 postgresql-9.1-postgis
+python python-celery python-geohash python-numpy python-paramiko python-scipy python-shapely python-psycopg2 python-setuptools python-psutil python-mock python-h5py python-concurrent.futures rabbitmq-server python-django16 postgresql-9.1 postgresql-9.1-postgis
 ```
 
 

--- a/doc/engine/Installing-the-OpenQuake-Engine-on-RHEL-and-clones.md
+++ b/doc/engine/Installing-the-OpenQuake-Engine-on-RHEL-and-clones.md
@@ -10,7 +10,7 @@ Supported releases: **RHEL/Scientific Linux/CentOS 7**.
 The following dependencies are required. They will be installed automatically by the `oq-engine` package:
 
 ```
-sudo python-amqp python-celery python-lxml numpy scipy python-shapely python-psycopg2 python-django python-setuptools python-psutil python-mock python-futures rabbitmq-server postgresql-server postgis
+sudo python-amqp python-celery numpy scipy python-shapely python-psycopg2 python-django python-setuptools python-psutil python-mock python-futures rabbitmq-server postgresql-server postgis
 ```
 
 

--- a/doc/engine/Technology-stack-and-requirements.md
+++ b/doc/engine/Technology-stack-and-requirements.md
@@ -26,6 +26,5 @@ Django | 1.6
 Numpy | 1.6 to 1.8
 Scipy | 0.9 to 0.13
 h5py | 2.0 to 2.0
-lxml2 | 2.3, 3.3
 futures |
 psutil |

--- a/openquake/engine/tests/export/core_test.py
+++ b/openquake/engine/tests/export/core_test.py
@@ -26,7 +26,7 @@ def number_of(elem_name, tree):
     return the number of occurrences of the element in a given XML document.
     """
     expr = '//%s' % elem_name
-    return len(tree.xpath(expr, namespaces={'nrml': nrml.NRML05}))
+    return len(tree.findall(expr, namespaces={'nrml': nrml.NRML05}))
 
 
 class BaseExportTestCase(unittest.TestCase):

--- a/openquake/engine/tests/export/hazard_test.py
+++ b/openquake/engine/tests/export/hazard_test.py
@@ -17,8 +17,8 @@ import mock
 import os
 import shutil
 import tempfile
+from xml.etree import ElementTree as etree
 
-from lxml import etree
 from nose.plugins.attrib import attr
 
 from openquake.commonlib import nrml

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -140,7 +140,7 @@ class EngineServerTestCase(unittest.TestCase):
     def test_err_2(self):
         # the file logic-tree-source-model.xml is missing
         tb_str = self.postzip('archive_err_2.zip')
-        self.assertIn('failed to load external entity', tb_str)
+        self.assertIn('No such file', tb_str)
 
     def test_err_3(self):
         # there is no file job.ini, job_hazard.ini or job_risk.ini

--- a/qa_tests/_utils.py
+++ b/qa_tests/_utils.py
@@ -64,8 +64,8 @@ class BaseQATestCase(unittest.TestCase):
             Paths to XML files, or a file-like object containing the XML
             contents.
         """
-        contents_a = tostring(et.parse(a).getroot(), PARSE_NS_MAP)
-        contents_b = tostring(et.parse(b).getroot(), PARSE_NS_MAP)
+        contents_a = tostring(et.parse(a).getroot(), nsmap=PARSE_NS_MAP)
+        contents_b = tostring(et.parse(b).getroot(), nsmap=PARSE_NS_MAP)
         self.assertEqual(contents_a, contents_b)
 
     def assert_equals_var_tolerance(self, expected, actual):

--- a/qa_tests/_utils.py
+++ b/qa_tests/_utils.py
@@ -23,9 +23,10 @@ import filecmp
 from nose.plugins.attrib import attr
 
 from openquake.commonlib.nrml import PARSE_NS_MAP
+from openquake.commonlib.writers import tostring
 from openquake.engine.db import models
 
-from lxml import etree
+from xml.etree import ElementTree as et
 
 from openquake.engine.tests.utils import helpers
 
@@ -61,8 +62,8 @@ class BaseQATestCase(unittest.TestCase):
             Paths to XML files, or a file-like object containing the XML
             contents.
         """
-        contents_a = etree.tostring(etree.parse(a), pretty_print=True)
-        contents_b = etree.tostring(etree.parse(b), pretty_print=True)
+        contents_a = tostring(et.parse(a).getroot(), nsmap=PARSE_NS_MAP)
+        contents_b = tostring(et.parse(b).getroot(), nsmap=PARSE_NS_MAP)
 
         self.assertEqual(contents_a, contents_b)
 
@@ -166,8 +167,8 @@ class DisaggHazardTestCase(BaseQATestCase):
             Paths to XML files, or file-like objects containing the XML
             contents.
         """
-        exp_tree = etree.parse(expected)
-        act_tree = etree.parse(actual)
+        exp_tree = et.parse(expected)
+        act_tree = et.parse(actual)
 
         # First, compare the <disaggMatrices> container element, check attrs,
         # etc.

--- a/qa_tests/_utils.py
+++ b/qa_tests/_utils.py
@@ -22,13 +22,15 @@ import filecmp
 
 from nose.plugins.attrib import attr
 
-from openquake.commonlib.nrml import PARSE_NS_MAP
+from openquake.commonlib.nrml import PARSE_NS_MAP, NRML05
 from openquake.commonlib.writers import tostring
 from openquake.engine.db import models
 
 from xml.etree import ElementTree as et
 
 from openquake.engine.tests.utils import helpers
+
+PARSE_NS_MAP['nrml'] = NRML05  # temporary hack until we remove NRML 0.4
 
 
 class BaseQATestCase(unittest.TestCase):
@@ -62,9 +64,8 @@ class BaseQATestCase(unittest.TestCase):
             Paths to XML files, or a file-like object containing the XML
             contents.
         """
-        contents_a = tostring(et.parse(a).getroot(), nsmap=PARSE_NS_MAP)
-        contents_b = tostring(et.parse(b).getroot(), nsmap=PARSE_NS_MAP)
-
+        contents_a = tostring(et.parse(a).getroot(), PARSE_NS_MAP)
+        contents_b = tostring(et.parse(b).getroot(), PARSE_NS_MAP)
         self.assertEqual(contents_a, contents_b)
 
     def assert_equals_var_tolerance(self, expected, actual):
@@ -172,20 +173,20 @@ class DisaggHazardTestCase(BaseQATestCase):
 
         # First, compare the <disaggMatrices> container element, check attrs,
         # etc.
-        [exp_dms] = exp_tree.xpath(
+        [exp_dms] = exp_tree.findall(
             '//nrml:disaggMatrices', namespaces=PARSE_NS_MAP
         )
-        [act_dms] = act_tree.xpath(
+        [act_dms] = act_tree.findall(
             '//nrml:disaggMatrices', namespaces=PARSE_NS_MAP
         )
         self.assertEqual(exp_dms.attrib, act_dms.attrib)
 
         # Then, loop over each <disaggMatrix>, check attrs, then loop over each
         # <prob> and compare indices and values.
-        exp_dm = exp_tree.xpath(
+        exp_dm = exp_tree.findall(
             '//nrml:disaggMatrix', namespaces=PARSE_NS_MAP
         )
-        act_dm = act_tree.xpath(
+        act_dm = act_tree.findall(
             '//nrml:disaggMatrix', namespaces=PARSE_NS_MAP
         )
         self.assertEqual(len(exp_dm), len(act_dm))
@@ -199,8 +200,8 @@ class DisaggHazardTestCase(BaseQATestCase):
             aac(float(act_matrix.attrib['iml']), float(matrix.attrib['iml']))
 
             # compare probabilities
-            exp_probs = matrix.xpath('./nrml:prob', namespaces=PARSE_NS_MAP)
-            act_probs = act_matrix.xpath(
+            exp_probs = matrix.findall('./nrml:prob', namespaces=PARSE_NS_MAP)
+            act_probs = act_matrix.findall(
                 './nrml:prob', namespaces=PARSE_NS_MAP
             )
             self.assertEqual(len(exp_probs), len(act_probs))

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -17,7 +17,7 @@ BuildArch: noarch
 Vendor: The GEM OpenQuake team <devops@openquake.org>
 Url: http://github.com/gem/oq-engine
 
-%define common_deps python numpy scipy python-shapely python-psutil python-lxml python-mock python-futures h5py python-amqp python-celery python-psycopg2 python-django rabbitmq-server postgresql-server postgis sudo
+%define common_deps python numpy scipy python-shapely python-psutil python-mock python-futures h5py python-amqp python-celery python-psycopg2 python-django rabbitmq-server postgresql-server postgis sudo
 %define oqlib_deps python-oq-hazardlib >= 0.15.0 python-oq-risklib >= 0.8.0
 %define dev_deps python-nose python-coverage
 Requires: %{common_deps}


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1339445. This the companion of https://github.com/gem/oq-risklib/pull/353. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1405