### PR TITLE
Fixed the --load-curve command

### DIFF
--- a/openquake/engine/tools/import_hazard_curves.py
+++ b/openquake/engine/tools/import_hazard_curves.py
@@ -35,6 +35,7 @@ def import_hazard_curves(fileobj):
         base_path=os.path.dirname(fname),
         intensity_measure_types_and_levels={imt_str: imls},
         description='HazardCurve importer, file %s' % os.path.basename(fname),
+        maximum_distance=1000.,
         calculation_mode='classical'))
 
     out = models.Output.objects.create(


### PR DESCRIPTION
When loading a hazard curve using the `--load-curve` command, the `maximum_distance` parameter is not set, even though it is a mandatory parameter. This fix sets the parameter `maximum_distance` to a default value of 1000 km, which is the same value used when loading a gmf using the `--load-gmf` command.