### PR TITLE
packager.sh: checks on the debian/rules file did not work on dependencies

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -282,7 +282,7 @@ _devtest_innervm_run () {
     IFS=" "
     for dep in $GEM_GIT_DEPS; do
         # extract dependencies for source dependencies
-        pkgs_list="$(deps_list "deprec" _jenkins_deps/$dep/debian/control)"
+        pkgs_list="$(deps_list "deprec" _jenkins_deps/$dep/debian)"
         ssh $lxc_ip "sudo apt-get install -y ${pkgs_list}"
 
         # install source dependencies
@@ -293,7 +293,7 @@ _devtest_innervm_run () {
     IFS="$old_ifs"
 
     # extract dependencies for this package
-    pkgs_list="$(deps_list "all" debian/control)"
+    pkgs_list="$(deps_list "all" debian)"
     ssh $lxc_ip "sudo apt-get install -y ${pkgs_list}"
 
     # build oq-hazardlib speedups and put in the right place
@@ -559,23 +559,23 @@ _pkgtest_innervm_run () {
 #  deps_list <listtype> <filename> - retrieve dependencies list from debian/control
 #                                    to be able to install them without the package
 #      listtype    inform deps_list which control lines use to get dependencies
-#      filename    control file used for input
+#      dir         the folder containing control and rules files
 #
 deps_list() {
-    local old_ifs out_list skip i d listtype="$1" filename="$2"
+    local old_ifs out_list skip i d listtype="$1" control_file="$2"/control rules_file="$2"/rules
 
-    rules_dep=$(grep "^${BUILD_UBUVER^^}_DEP *= *" debian/rules | sed 's/^.*= *//g')
-    rules_rec=$(grep "^${BUILD_UBUVER^^}_REC *= *" debian/rules | sed 's/^.*= *//g')
+    rules_dep=$(grep "^${BUILD_UBUVER^^}_DEP *= *" $rules_file | sed 's/^.*= *//g')
+    rules_rec=$(grep "^${BUILD_UBUVER^^}_REC *= *" $rules_file | sed 's/^.*= *//g')
 
     out_list=""
     if [ "$listtype" = "all" ]; then
-        in_list="$((cat "$filename" | egrep '^Depends:|^Recommends:|Build-Depends:' | sed 's/^\(Build-\)\?Depends://g;s/^Recommends://g' ; echo ", $rules_dep, $rules_rec") | tr '\n' ','| sed 's/,\+/,/g')"
+        in_list="$((cat "$control_file" | egrep '^Depends:|^Recommends:|Build-Depends:' | sed 's/^\(Build-\)\?Depends://g;s/^Recommends://g' ; echo ", $rules_dep, $rules_rec") | tr '\n' ','| sed 's/,\+/,/g')"
     elif [  "$listtype" = "deprec" ]; then
-        in_list="$((cat "$filename" | egrep '^Depends:|^Recommends:' | sed 's/^Depends://g;s/^Recommends://g' ; echo ", $rules_dep, $rules_rec") | tr '\n' ','| sed 's/,\+/,/g')"
+        in_list="$((cat "$control_file" | egrep '^Depends:|^Recommends:' | sed 's/^Depends://g;s/^Recommends://g' ; echo ", $rules_dep, $rules_rec") | tr '\n' ','| sed 's/,\+/,/g')"
     elif [  "$listtype" = "build" ]; then
-        in_list="$((cat "$filename" | egrep '^Depends:|^Build-Depends:' | sed 's/^\(Build-\)\?Depends://g' ; echo ", $rules_dep") | tr '\n' ','| sed 's/,\+/,/g')"
+        in_list="$((cat "$control_file" | egrep '^Depends:|^Build-Depends:' | sed 's/^\(Build-\)\?Depends://g' ; echo ", $rules_dep") | tr '\n' ','| sed 's/,\+/,/g')"
     else
-        in_list="$((cat "$filename" | egrep "^Depends:" | sed 's/^Depends: //g'; echo ", $rules_dep") | tr '\n' ','| sed 's/,\+/,/g')"
+        in_list="$((cat "$control_file" | egrep "^Depends:" | sed 's/^Depends: //g'; echo ", $rules_dep") | tr '\n' ','| sed 's/,\+/,/g')"
     fi
 
     old_ifs="$IFS"


### PR DESCRIPTION
The check on the `debian/rules` dependencies did not work correctly for the GIT dependencies. We never found this error because the GIT deps (hazardlib, risklib) do not use that file to select packages dynamically, but the error was discovered with the `oq-risk-tests` where also the engine is treated as a GIT dependency.

Tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1406/ (is red due a bug in the XUnit reports, but the fix worked)