### PR TITLE
packager.sh: use the proper celery command based on the celery version

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -335,7 +335,7 @@ celeryd_wait() {
     if command -v celeryctl &> /dev/null; then
         # celery 2.4
         celery=celeryctl
-    elseif if command -v celery &> /dev/null; then
+    elif command -v celery &> /dev/null; then
         # celery 3
         celery=celery
     else

--- a/packager.sh
+++ b/packager.sh
@@ -332,8 +332,19 @@ _devtest_innervm_run () {
 celeryd_wait() {
     local cw_nloop=\"\$1\" cw_ret cw_i
 
+    if command -v celeryctl &> /dev/null; then
+        # celery 2.4
+        celery=celeryctl
+    elseif if command -v celery &> /dev/null; then
+        # celery 3
+        celery=celery
+    else
+        echo \"ERROR: no Celery available\"
+        return 1
+    fi
+
     for cw_i in \$(seq 1 \$cw_nloop); do
-        cw_ret=\"\$(celeryctl status)\"
+        cw_ret=\"\$(\$celery status)\"
         if echo \"\$cw_ret\" | grep -iq '^error:'; then
             if echo \"\$cw_ret\" | grep -ivq '^error: no nodes replied'; then
                 return 1


### PR DESCRIPTION
Looking at the Trusty CI outputs I discovered that the `celeryd_wait` did not work with Celery 3 because the `celeryctl` command has been replaced by `celery`. Luckily celery has been always fast enough to start before it was actually used (because we run some tests that are not using it before running any computation)... until now: with `oq-risk-tests` celery is needed by the very first test, thus we need to wait it to be ready. 

Tests: https://ci.openquake.org/job/zdevel_oq-engine/1407/