### PR TITLE
Increase the engine server warmup time in the tests

### DIFF
--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -92,7 +92,7 @@ class EngineServerTestCase(unittest.TestCase):
             [sys.executable, '-m', 'openquake.server.manage', 'runserver',
              cls.hostport, '--noreload'], env=env,
             stdout=subprocess.PIPE)
-        time.sleep(2)
+        time.sleep(5)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
To avoid broken builds like \#1970 - \#1972 (https://ci.openquake.org/job/master_oq-engine/)