### PR TITLE
Improved view_mean_avg_losses

### DIFF
--- a/openquake/engine/views.py
+++ b/openquake/engine/views.py
@@ -68,7 +68,7 @@ def view_mean_avg_losses(key, job_id):
         ins_losses.fill(numpy.nan)
     for loss, iloss in zip(losses, ins_losses):
         row = [loss['asset_ref']] + [
-            (loss[lt], iloss[lt]) for lt in names[1:]]
+            numpy.array([loss[lt], iloss[lt]]) for lt in names[1:]]
         rows.append(row)
     if len(rows) > 1:
         rows.append(sum_table(rows))

--- a/openquake/engine/views.py
+++ b/openquake/engine/views.py
@@ -21,7 +21,7 @@ from openquake.engine.utils import tasks  # really UGLY hack:
 # we need to monkey patch commonlib.parallel *before* importing
 # calculators.views; the ugliness will disappear when the engine
 # calculators will disappear
-from openquake.calculators.views import rst_table
+from openquake.calculators.views import rst_table, sum_table
 from openquake.engine.db import models
 
 import numpy
@@ -70,4 +70,6 @@ def view_mean_avg_losses(key, job_id):
         row = [loss['asset_ref']] + [
             (loss[lt], iloss[lt]) for lt in names[1:]]
         rows.append(row)
+    if len(rows) > 1:
+        rows.append(sum_table(rows))
     return rst_table(rows, header=names, fmt='%8.6E')


### PR DESCRIPTION
We also print the total losses if there is more than one assets, in accordance with what it is done in the Julia calculation (https://github.com/gem/oq-risk-tests/pull/7). This requires https://github.com/gem/oq-risklib/pull/364/
The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/1426/