### PR TITLE
Fixed a terribly hard to debug ordering bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Optimization: we do not generate the full epsilon matrix if all
+    coefficients of variation are zero
   * Fixed two subtle bugs in the management of the epsilons: it means that
     all event based risk calculations with nonzero coefficients of variations
     will produce slightly different numbers with respect to before

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
   [Michele Simionato]
-  * Fixed a distribution bug in the epsilons: it means that all event based
-    risk calculations with nonzero coefficients of variations will produce
-    slightly different numbers with respect to before
+  * Fixed two subtle bugs in the management of the epsilons: it means that
+    all event based risk calculations with nonzero coefficients of variations
+    will produce slightly different numbers with respect to before
   * Removed excessive checking on the exposure attributes `deductible` and
     `insuredLimit` that made it impossible to run legitimate calculations
   * Changed the meaning of `average_loss` for the aggregated curves: now it

--- a/openquake/engine/calculators/risk/hazard_getters.py
+++ b/openquake/engine/calculators/risk/hazard_getters.py
@@ -220,7 +220,7 @@ class GroundMotionGetter(HazardGetter):
             self.hazards[ho] = self._get_gmv_dict(ho)
             for sc in haz_out_to_ses_coll(ho):
                 sescolls.add(sc)
-        for sc in sorted(sescolls):
+        for sc in sorted(sescolls, key=operator.attrgetter('ordinal')):
             rids = sc.get_ruptures().values_list('id', flat=True)
             self.rupture_ids.extend(rids)
         num_ruptures = len(self.rupture_ids)


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1495177. The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/1427. With this change there is full consistency with oq-lite: https://ci.openquake.org/job/zdevel_oq-risk-tests/63/console.
See also the companion https://github.com/gem/oq-risklib/pull/367