### PR TITLE
Distinguish hazard and risk calculations with the --lite option too

### DIFF
--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -597,7 +597,7 @@ def main():
         export(int(output_id), expanduser(target_dir), exports)
 
     elif args.export_risk_output is not None:
-        deprecate('--export-hazard-output', '--export-output')
+        deprecate('--export-risk-output', '--export-output')
         output_id, target_dir = args.export_risk_output
         export(int(output_id), expanduser(target_dir), exports)
 

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -513,6 +513,10 @@ def main():
 
     run_job = engine.run_job_lite if args.lite else engine.run_job
 
+    if args.lite and args.hazard_output_id:
+        sys.exit('The --hazard-output-id option is not supported with the '
+                 '--lite option')
+
     if args.list_inputs:
         list_inputs(args.list_inputs)
 

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -364,9 +364,15 @@ def get_hc_id(hc_id):
 
 def export_outputs(hc_id, target_dir, export_type):
     # make it possible commands like `oq-engine --eos -1 /tmp`
-    for output in models.Output.objects.filter(oq_job=hc_id):
+    outputs = models.Output.objects.filter(oq_job=hc_id)
+    if not outputs:
+        sys.exit('Found nothing to export for job %s' % hc_id)
+    for output in outputs:
         print 'Exporting %s...' % output
-        export(output.id, target_dir, export_type)
+        try:
+            export(output.id, target_dir, export_type)
+        except Exception as exc:
+            print exc
 
 
 def export_stats(job_id, target_dir, output_type, export_type):

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -326,7 +326,7 @@ def list_outputs(job_id, full=True):
     outputs = get_outputs(job_id)
     if models.oqparam(job_id).calculation_mode == 'scenario':
         # ignore SES output
-        outputs = outputs.filter(output_type='gmf_scenario')
+        outputs = [o for o in outputs if o.output_type != 'ses']
     print_outputs_summary(outputs, full)
 
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -169,7 +169,7 @@ def create_job(user_name="openquake", log_level='progress', hc_id=None):
         :class:`openquake.engine.db.models.OqJob` instance.
     """
     job = models.OqJob.objects.create(
-        id=get_calc_id(hc_id),
+        id=get_calc_id() + 1,
         user_name=user_name,
         log_level=log_level,
         oq_version=openquake.engine.__version__,


### PR DESCRIPTION
The issue was reported by Cata. ``oq-engine --lhc`` was also returning risk calculations executed with the ``--lite`` option. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1433

I also fixed a number of small issues, all reported by Cata.