### PR TITLE
Move PostgreSQL packages from 'Recommends' to 'Depends'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Homepage: http://www.globalquakemodel.org/openquake/
 Package: python-oq-engine
 Architecture: all
 Conflicts: python-noq, python-oq
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, ${dist:Depends}, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-nose, python-mock, python-requests (>=0.8.2), python-oq-hazardlib (>=0.15.0-0~), python-oq-risklib (>=0.8.0-0~), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
-Recommends: ${dist:Recommends}, postgresql-client
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, ${dist:Depends}, postgresql-client, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-nose, python-mock, python-requests (>=0.8.2), python-oq-hazardlib (>=0.15.0-0~), python-oq-risklib (>=0.8.0-0~), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
+Recommends: ${dist:Recommends}
 Description: computes seismic hazard and physical risk
  based on the hazard and risk libraries (python-oq-hazardlib,
  python-oq-risklib) developed by the GEM foundation.

--- a/debian/rules
+++ b/debian/rules
@@ -16,10 +16,10 @@ export DH_OPTIONS
 
 bd=openquake/bin
 
-TRUSTY_DEP = python-amqp, python-django
-TRUSTY_REC = postgresql-9.3, postgresql-9.3-postgis-2.1
-PRECISE_DEP = python-django16
-PRECISE_REC = postgresql-9.1, postgresql-9.1-postgis
+TRUSTY_DEP = python-amqp, python-django, postgresql-9.3, postgresql-9.3-postgis-2.1
+TRUSTY_REC =
+PRECISE_DEP = python-django16, postgresql-9.1, postgresql-9.1-postgis
+PRECISE_REC =
 
 ifeq ($(shell lsb_release --codename --short),trusty)
 	DEPENDS = -Vdist:Depends="$(TRUSTY_DEP)"


### PR DESCRIPTION
This fixes a race condition in the installation phase when the Engine is configured before PostgreSQL has been setup.

I left the packager.sh untouched, so this "Recommends" feature can be easily re-introduced in the future (i.e. for multi-packaging)

See: https://bugs.launchpad.net/oq-engine/+bug/1498372

Tests: https://ci.openquake.org/job/zdevel_oq-engine/1443/ and https://ci.openquake.org/job/zdevel_oq-engine/1444/