### PR TITLE
Removed the epsilon sampling "feature" from the scenario_risk calculator

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the epsilon sampling "feature" from the scenario_risk calculator
   * Replaced the event based calculators based on Postgres with the new ones
     based on the HDF5 technology
 

--- a/openquake/engine/calculators/risk/base.py
+++ b/openquake/engine/calculators/risk/base.py
@@ -86,7 +86,7 @@ def prepare_risk(counts_taxonomy, calc, monitor):
 
         # initializing epsilons
         with init_mon:
-            initializer.init_epsilons(eps_sampling)
+            initializer.init_epsilons(calc.epsilon_sampling)
 
 
 @tasks.oqtask
@@ -127,7 +127,7 @@ def run_risk(sorted_assocs, calc, monitor):
             imt = it.imt.imt_str
             with get_haz_mon:
                 getter = calc.getter_class(
-                    imt, taxonomy, hazard_outputs, assets, eps_sampling)
+                    imt, taxonomy, hazard_outputs, assets, calc.epsilon_sampling)
             logs.LOG.info(
                 'Read %d data for %d assets of taxonomy %s, imt=%s',
                 len(set(getter.site_ids)), len(assets), taxonomy, imt)
@@ -175,6 +175,12 @@ class RiskCalculator(base.Calculator):
         self.best_maximum_distance = dist
         self.time_event = self.oqparam.time_event
         self.taxonomies_from_model = self.oqparam.taxonomies_from_model
+        if hasattr(self.oqparam, 'number_of_ground_motion_fields'):
+            # scenario_risk
+            self.epsilon_sampling = self.oqparam.number_of_ground_motion_fields
+        else:
+            # event_based_risk
+            self.epsilon_sampling = eps_sampling
 
     def get_hazard_outputs(self):
         """


### PR DESCRIPTION
This was the reason for the discrepancies between oq-lite and the engine. This is needed for https://github.com/gem/oq-engine/issues/1853. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1467