### PR TITLE
Turned off the self-termination "feature"

### DIFF
--- a/openquake.cfg
+++ b/openquake.cfg
@@ -18,7 +18,7 @@ terminate_workers_on_revoke = true
 # this is good for a single user situation, but turn this off on a cluster
 # otherwise a CTRL-C will kill the computations of other users
 
-terminate_job_when_celery_is_down = true
+terminate_job_when_celery_is_down = false
 # this is good generally, but it may be necessary to turn it off in
 # heavy computations (i.e. celery could not respond to pings and still
 # not be really down).


### PR DESCRIPTION
Now Jenkins should not commit suicide as it happens frequently with an error

```python
openquake.engine.celery_node_monitor.MasterKilled: The openquake master process was killed by the CeleryNodeMonitor because some node failed
```