### PR TITLE
Made CeleryNodeMonitorTestCase independent from the configuration file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Disabled the self-termination feature `terminate_job_when_celery_is_down`
   * Removed the epsilon sampling "feature" from the scenario_risk calculator
   * Replaced the event based calculators based on Postgres with the new ones
     based on the HDF5 technology

--- a/openquake/engine/tests/celery_node_monitor_test.py
+++ b/openquake/engine/tests/celery_node_monitor_test.py
@@ -4,10 +4,12 @@ import mock
 import signal
 import unittest
 from openquake.engine.celery_node_monitor import CeleryNodeMonitor
+from openquake.engine.utils.config import cfg
 
 
 class CeleryNodeMonitorTestCase(unittest.TestCase):
     def setUp(self):
+        cfg.get('celery')['terminate_job_when_celery_is_down'] = 'true'
         self.patch = mock.patch('celery.task.control.inspect')
         self.inspect = self.patch.start()
 


### PR DESCRIPTION
This fixes the error in https://ci.openquake.org/job/master_oq-engine/2028/console introduced by https://github.com/gem/oq-engine/pull/1857.