### PR TITLE
Fixed the region_constraint management in the association queries

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a very subtle bug in the association queries: some sites outside
+    of the region constraint were not discarded in some situations
   * Removed the self-termination feature `terminate_job_when_celery_is_down`
   * Removed the epsilon sampling "feature" from the scenario_risk calculator
   * Replaced the event based calculators based on Postgres with the new ones

--- a/openquake/engine/calculators/risk/base.py
+++ b/openquake/engine/calculators/risk/base.py
@@ -127,7 +127,8 @@ def run_risk(sorted_assocs, calc, monitor):
             imt = it.imt.imt_str
             with get_haz_mon:
                 getter = calc.getter_class(
-                    imt, taxonomy, hazard_outputs, assets, calc.epsilon_sampling)
+                    imt, taxonomy, hazard_outputs, assets,
+                    calc.epsilon_sampling)
             logs.LOG.info(
                 'Read %d data for %d assets of taxonomy %s, imt=%s',
                 len(set(getter.site_ids)), len(assets), taxonomy, imt)

--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -238,8 +238,7 @@ def export_loss_map_csv(key, output, target):
     """
     dest = _get_result_export_dest(target, output, file_ext=key[1])
     data = []
-    for row in models.order_by_location(
-            output.loss_map.lossmapdata_set.all().order_by('asset_ref')):
+    for row in output.loss_map.lossmapdata_set.order_by('asset_ref'):
         data.append(LossMapPerAsset(row.asset_ref, row.value))
     header = [data[0]._fields]
     writers.write_csv(dest, header + data, fmt='%10.6E')

--- a/openquake/engine/tests/calculators/risk/hazard_getters_test.py
+++ b/openquake/engine/tests/calculators/risk/hazard_getters_test.py
@@ -104,7 +104,25 @@ class GroundMotionGetterTestCase(HazardCurveGetterTestCase):
 
 
 class ScenarioTestCase(GroundMotionGetterTestCase):
+    """
+    Here is some info about this test. Here are the assets::
+   
+      asset_ref | taxonomy | st_x  | st_y  
+     -----------+----------+-------+-------
+      a1        | RM       | 15.48 | 38.09
+      a2        | RC       | 15.56 | 38.17
+      a3        | RM       | 15.48 | 38.25
 
+    Here are the sites::
+
+       lon   |    lat     
+     --------+------------
+      15.565 |      38.17
+      15.481 |      38.25
+       15.48 | 38.0900001
+   
+    The maximum_distance is 200 km.
+    """
     hazard_demo = get_data_path('scenario_hazard/job.ini')
     risk_demo = get_data_path('scenario_risk/job.ini')
     hazard_output_type = 'gmf_scenario'
@@ -113,14 +131,13 @@ class ScenarioTestCase(GroundMotionGetterTestCase):
     def test_nbytes(self):
         # I am not populating the table ses_rupture
         self.assertEqual(len(self.getter.rupture_ids), 0)
-        self.assertEqual(self.nbytes, 80)
+        self.assertEqual(self.nbytes, 160)
 
     def test_call(self):
         # the exposure model in this example has two assets of taxonomy RM
-        # (a1 and a3) but the asset a3 has no hazard data within the
-        # maximum distance; there are 10 realizations
-        a1, = self.assets
-        self.assertEqual(self.getter.assets, [a1])
+        # (a1 and a3) within the maximum distance; there are 10 realizations
+        a1, a3 = self.assets
+        self.assertEqual(self.getter.assets, [a1, a3])
         [hazard] = self.getter.hazards.values()
         self.assertEqual(hazard.values()[0], {0: 0.1, 1: 0.2, 2: 0.3})
 


### PR DESCRIPTION
Fix https://github.com/gem/oq-engine/issues/1862. The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/1471/

NB: I am also fixing the export order in the loss maps csv representation, to match the one in oq-lite
(lexicographic on the asset names).