### PR TITLE
Fixed a wrong test

### DIFF
--- a/openquake/engine/tests/data/end-to-end-hazard-risk/job_haz_classical.ini
+++ b/openquake/engine/tests/data/end-to-end-hazard-risk/job_haz_classical.ini
@@ -6,7 +6,7 @@ random_seed = 1024
 
 [geometry]
 
-sites = -78.182 15.615
+sites = -78.180 15.613
 
 [logic_tree]
 


### PR DESCRIPTION
The build https://ci.openquake.org/job/master_oq-engine/2037/ is broken because the ClassicalRiskExportTestCase is broken: there is a site which is outside of the region_constraint. Because of the long standing bug fixed in https://github.com/gem/oq-engine/pull/1863 that site was included, even if in reality it was outside the region! To get back the test to work, I am moving the site inside the region constraint.

The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1472