### PR TITLE
server: fix celeryconfig.py path when server is installed by packages

### DIFF
--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -28,12 +28,10 @@ from openquake.engine.utils import config
 
 config.abort_if_no_config_available()
 
-"""
-Please note: the /usr/bin/oq-engine script requires a celeryconfig.py file in
-the PYTHONPATH; when using binary packages, if a celeryconfig.py is not
-available the OpenQuake Engine default celeryconfig.py, located in
-/usr/share/openquake/engine, is used.
-"""
+# Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
+# file in the PYTHONPATH; when using binary packages, if a celeryconfig.py
+# is not available the OpenQuake Engine default celeryconfig.py, located
+# in /usr/share/openquake/engine, is used.
 try:
     import celeryconfig
 except ImportError:

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -22,6 +22,16 @@ if __name__ == "__main__":
     # the issue is that importing openquake.engine sets a wrong
     # DJANGO_SETTINGS_MODULE environment variable, causing the irritating
     # CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.
+
+    # Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
+    # file in the PYTHONPATH; when using binary packages, if a celeryconfig.py
+    # is not available the OpenQuake Engine default celeryconfig.py, located
+    # in /usr/share/openquake/engine, is used.
+    try:
+        import celeryconfig
+    except ImportError:
+        sys.path.append('/usr/share/openquake/engine')
+
     from openquake.engine.db import models
     models.getcursor('job_init').execute(
         # cleanup of the flag oq_job.is_running

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     # DJANGO_SETTINGS_MODULE environment variable, causing the irritating
     # CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.
 
-    # Please note: the /usr/bin/oq-engine script requires a celeryconfig.py
+    # Please note: the OpenQuake Engine server requires a celeryconfig.py
     # file in the PYTHONPATH; when using binary packages, if a celeryconfig.py
     # is not available the OpenQuake Engine default celeryconfig.py, located
     # in /usr/share/openquake/engine, is used.


### PR DESCRIPTION
The engine server, when installed by packages, is unable to find the `celeryconfig.py` giving this error when a calculation is launched:

```python
  File "/usr/lib/python2.7/dist-packages/openquake/engine/engine.py", line 218, in run_calc
    _do_run_calc(calculator, exports)
  File "/usr/lib/python2.7/dist-packages/openquake/engine/engine.py", line 257, in _do_run_calc
    result = calc.execute()
  File "/usr/lib/python2.7/dist-packages/openquake/calculators/scenario.py", line 101, in execute
    concurrent_tasks=self.oqparam.concurrent_tasks)
  File "/usr/lib/python2.7/dist-packages/openquake/commonlib/parallel.py", line 294, in apply_reduce
    return self.reduce(agg, acc)
  File "/usr/lib/python2.7/dist-packages/openquake/commonlib/parallel.py", line 377, in reduce
    agg_result = self.aggregate_result_set(agg_and_percent, acc)
  File "/usr/lib/python2.7/dist-packages/openquake/engine/utils/tasks.py", line 73, in aggregate_result_set
    for task_id, result_dict in rset.iter_native():
  File "/usr/lib/python2.7/dist-packages/celery/result.py", line 572, in iter_native
    return results[0].backend.get_many(
AttributeError: 'DisabledBackend' object has no attribute 'get_many'
```
that's a bit strange because a `celeryconfig.py` is present in `/usr/lib/python2.7/dist-packages/openquake/engine` which is a location well known to python. Probably we have an issue (again) with the "openquake" python package prefix.

I added to the server's `manage.py` the same code we are using in the `openquake_cli.py`: this snippet will add `/usr/share/openquake/engine` to the application `PYTHONPATH` (see the comment for more info)

```python
try:
     import celeryconfig
except ImportError:
     sys.path.append('/usr/share/openquake/engine')
```

To fix previous installations (without making a new stable release) this simple workaround solves the issue:

```bash
$ sudo ln -s /usr/share/openquake/engine/celeryconfig.py /usr/lib/python2.7/dist-packages/openquake/server/celeryconfig.py
```