### PR TITLE
server: move celeryconfig.py import in a better place

### DIFF
--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -23,15 +23,6 @@ if __name__ == "__main__":
     # DJANGO_SETTINGS_MODULE environment variable, causing the irritating
     # CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.
 
-    # Please note: the OpenQuake Engine server requires a celeryconfig.py
-    # file in the PYTHONPATH; when using binary packages, if a celeryconfig.py
-    # is not available the OpenQuake Engine default celeryconfig.py, located
-    # in /usr/share/openquake/engine, is used.
-    try:
-        import celeryconfig
-    except ImportError:
-        sys.path.append('/usr/share/openquake/engine')
-
     from openquake.engine.db import models
     models.getcursor('job_init').execute(
         # cleanup of the flag oq_job.is_running

--- a/openquake/server/tasks.py
+++ b/openquake/server/tasks.py
@@ -42,6 +42,16 @@ DEFAULT_LOG_LEVEL = 'debug' if DEBUG else 'progress'
 logger = logging.getLogger(__name__)
 
 
+# Please note: the OpenQuake Engine server requires a celeryconfig.py
+# file in the PYTHONPATH; when using binary packages, if a celeryconfig.py
+# is not available the OpenQuake Engine default celeryconfig.py, located
+# in /usr/share/openquake/engine, is used.
+try:
+    import celeryconfig
+except ImportError:
+    sys.path.append('/usr/share/openquake/engine')
+
+
 class ProgressHandler(logging.Handler):
     """
     A logging handler to update the status of the job as seen


### PR DESCRIPTION
With the fix done by #1867 the Engine server in development mode (using sources) does not start anymore with the error

```python
CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.
```
because the import of `celeryconfig` is messing up the `DJANGO_SETTINGS_MODULE` causing the Engine settings to be loaded instead of the Server ones (even if the import is after `os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openquake.server.settings")`).

Moving the import to `tasks.py` solved both the issues.

Tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1478/