### PR TITLE
Now the engine server closes the datastore

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -271,7 +271,7 @@ def _do_run_calc(calc, exports):
     CacheInserter.flushall()  # flush caches into the db
 
     if hasattr(calc, 'datastore'):
-        calc.datastore.hdf5.close()
+        calc.datastore.close()
 
     log_status(job, "complete")
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -270,6 +270,9 @@ def _do_run_calc(calc, exports):
 
     CacheInserter.flushall()  # flush caches into the db
 
+    if hasattr(calc, 'datastore'):
+        calc.datastore.hdf5.close()
+
     log_status(job, "complete")
 
 

--- a/openquake/server/tasks.py
+++ b/openquake/server/tasks.py
@@ -187,9 +187,8 @@ def update_calculation(callback_url=None, **query):
     url.close()
 
 
-#: Simple structure that holds all the query components needed to
-#transfer calculation outputs from the engine database to the platform
-#one
+# Simple structure that holds all the query components needed to
+# transfer calculation outputs from the engine database to the platform
 DbInterface = collections.namedtuple(
     'DbInterface',
     'export_query target_table fields import_query')


### PR DESCRIPTION
See https://github.com/gem/oq-engine/issues/1870. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1479
Companion of https://github.com/gem/oq-risklib/pull/448