### PR TITLE
Hide non-exportable outputs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Made visible to the engine db only the exportable outputs of the datastore
+  * Closed explicitly the datastore after each calculation
   * Fixed a very subtle bug in the association queries: some sites outside
     of the region constraint were not discarded in some situations
   * Removed the self-termination feature `terminate_job_when_celery_is_down`

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -46,7 +46,7 @@ from openquake.engine.db.schema.upgrades import upgrader
 
 from openquake import hazardlib, risklib, commonlib
 
-from openquake.commonlib import readinput, valid, datastore
+from openquake.commonlib import readinput, valid, datastore, export
 
 
 def get_calc_id(job_id=None):
@@ -441,11 +441,13 @@ def expose_outputs(dstore, job):
     :param dstore: a datastore instance
     :param job: an OqJob instance
     """
+    exportable = set(ekey[0] for ekey in export.export)
     for key in dstore:
-        out = models.Output.objects.create_output(
-            job, key, output_type='datastore')
-        out.ds_key = key
-        out.save()
+        if key in exportable:
+            out = models.Output.objects.create_output(
+                job, key, output_type='datastore')
+            out.ds_key = key
+            out.save()
 
 
 def check_hazard_risk_consistency(haz_job, risk_mode):

--- a/openquake/engine/performance.py
+++ b/openquake/engine/performance.py
@@ -37,10 +37,8 @@ class EnginePerformanceMonitor(PerformanceMonitor):
 
     def __init__(self, operation, job_id, task=None, tracing=False,
                  measuremem=True, autoflush=False):
-        self.measuremem = measuremem
-        pid = os.getpid() if measuremem else None
         super(EnginePerformanceMonitor, self).__init__(
-            operation, pid, autoflush=autoflush)
+            operation, autoflush=autoflush, measuremem=measuremem)
         self.job_id = job_id
         if task:
             self.task = task


### PR DESCRIPTION
As requested by the risk team. Also, I am fixing a monitoring bug (the memory consumption was not saved). The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1481