### PR TITLE
Flattened the files exported in a single zip

### DIFF
--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -42,7 +42,7 @@ def zipfiles(fnames, archive):
     """
     z = zipfile.ZipFile(archive, 'w')
     for f in fnames:
-        z.write(f)
+        z.write(f, os.path.basename(f))
     z.close()
 
 


### PR DESCRIPTION
As requested by Catalina. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1482. See https://github.com/gem/oq-engine/issues/1875