### PR TITLE
The ProbabilisticEventBased calculator is no more special

### DIFF
--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -300,8 +300,10 @@ class OqJob(djm.Model):
         """
         'hazard' or 'risk'
         """
-        cmode = self.get_param('calculation_mode')
-        return 'risk' if cmode in RISK_CALCULATORS else 'hazard'
+        calcmode = self.get_param('calculation_mode', 'unknown')
+        # the calculation mode can be unknown if the job parameters
+        # have not been written on the database yet
+        return 'risk' if calcmode in RISK_CALCULATORS else 'hazard'
 
     def get_or_create_output(self, display_name, output_type):
         """
@@ -367,7 +369,6 @@ class OqJob(djm.Model):
         Populate the table HazardSite by inferring the points from
         the sites, region, or exposure.
         """
-        assert self.job_type == 'hazard', self.job_type
         oqparam = self.get_oqparam()
         if 'exposure' in oqparam.inputs:
             assets = self.exposuremodel.exposuredata_set.all()

--- a/openquake/engine/db/models.py
+++ b/openquake/engine/db/models.py
@@ -47,7 +47,7 @@ from openquake.hazardlib import geo, correlation
 
 from openquake.commonlib.riskmodels import loss_type_to_cost_type
 from openquake.commonlib.readinput import get_mesh
-from openquake.commonlib.oqvalidation import OqParam
+from openquake.commonlib.oqvalidation import OqParam, RISK_CALCULATORS
 from openquake.commonlib import logictree, valid
 
 from openquake.engine.db import fields
@@ -300,9 +300,8 @@ class OqJob(djm.Model):
         """
         'hazard' or 'risk'
         """
-        # only if the job is of kind 'risk' the field hazard_calculation_id
-        # is not null and contains a reference to the previous hazard job
-        return 'hazard' if self.hazard_calculation is None else 'risk'
+        cmode = self.get_param('calculation_mode')
+        return 'risk' if cmode in RISK_CALCULATORS else 'hazard'
 
     def get_or_create_output(self, display_name, output_type):
         """

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -273,8 +273,7 @@ def run_calc(request):
     hazard_output_id = request.POST.get('hazard_output_id')
     hazard_job_id = request.POST.get('hazard_job_id')
 
-    is_risk = hazard_output_id or hazard_job_id
-    if is_risk:
+    if hazard_output_id or hazard_job_id:
         candidates = ("job_risk.ini", "job.ini")
     else:
         candidates = ("job_hazard.ini", "job.ini")

--- a/packager.sh
+++ b/packager.sh
@@ -523,10 +523,6 @@ _pkgtest_innervm_run () {
 
         cd /usr/share/doc/python-oq-risklib/examples/demos
 
-        ## comment this demo is you get a segmentation fault!        
-        echo \"Running ProbabilisticEventBased/job_risk.ini\"
-        oq-engine --run ProbabilisticEventBased/job_risk.ini
-
         for ini in \$(find . -name job.ini | sort); do
             echo \"Running \$ini\"
             for loop in \$(seq 1 $GEM_MAXLOOP); do


### PR DESCRIPTION
Now the file is called job.ini. The rule to determine if a job is of kind hazard or risk has changed and it is now based (more correctly) on the calculation_mode. This is needed to run single file risk jobs on the Web UI. This requires the companion https://github.com/gem/oq-risklib/pull/453.

The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1484/