### PR TITLE
webui: change the run calculation button label

### DIFF
--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -6,7 +6,7 @@
                         enctype="multipart/form-data"
                         method="post" action="{{ oq_engine_server_url }}/v1/calc/run">
                     <input type="hidden" name="calculation_type" value="hazard"/>
-                    <label for="hazard_archive">Run a Hazard Calculation</label>
+                    <label for="hazard_archive">Run a Calculation</label>
                     <input id="hazard_archive" type="file" name="archive" style="display: none;" />
                     <input type="hidden" name="foreign_calculation_id" value=""/>
                     <input type="hidden" name="database" value="openquake2"/>


### PR DESCRIPTION
Now it's possible to run a single calculation that runs both hazard and risk at the same time, thus the old "Run a Hazard Calculation" button label is now misleading.