### PR TITLE
Small improvements to the the engine outputs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
   * Made customizable the display_name of datastore outputs (before it was
-    identical to the output type)
+    identical to the datastore key)
   * The zip files generated for internal use of the Web UI are now hidden
   * Made visible to the engine db only the exportable outputs of the datastore
   * Closed explicitly the datastore after each calculation

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,7 @@
   [Michele Simionato]
+  * Made customizable the display_name of datastore outputs (before it was
+    identical to the output type)
+  * The zip files generated for internal use of the Web UI are now hidden
   * Made visible to the engine db only the exportable outputs of the datastore
   * Closed explicitly the datastore after each calculation
   * Fixed a very subtle bug in the association queries: some sites outside

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -435,6 +435,9 @@ def run_job_lite(cfg_file, log_level, log_file, exports='',
             sys.exit('Calculation %s failed' % job.id)
     return job
 
+DISPLAY_NAME = dict(
+    dmg_by_asset='dmg_by_asset_and_collapse_map')
+
 
 def expose_outputs(dstore, job):
     """
@@ -448,7 +451,7 @@ def expose_outputs(dstore, job):
     for key in dstore:
         if key in exportable:
             out = models.Output.objects.create_output(
-                job, key, output_type='datastore')
+                job, DISPLAY_NAME.get(key, key), output_type='datastore')
             out.ds_key = key
             out.save()
 

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -85,7 +85,6 @@ def export(output_id, target, export_type='xml,geojson,csv'):
     specified `target` directory in the specified `export_type`.
     """
     output = models.Output.objects.get(id=output_id)
-    job_id = output.oq_job.id
     if isinstance(target, basestring):  # create target directory
         makedirs(target)
     for exptype in export_type.split(','):

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -65,6 +65,9 @@ def export_from_datastore(output_key, output, target):
         raise DataStoreExportError(
             'Nothing to export for %s' % output.ds_key)
     elif len(exported) > 1:
+        # NB: I am hiding the archive by putting a '.' in front
+        # to now confuse the users; the archive is used internally
+        # by the WebUI so it must be there
         archname = '.' + output.ds_key + '-' + fmt + '.zip'
         zipfiles(exported, os.path.join(target, archname))
         return os.path.join(target, archname)

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -65,7 +65,7 @@ def export_from_datastore(output_key, output, target):
         raise DataStoreExportError(
             'Nothing to export for %s' % output.ds_key)
     elif len(exported) > 1:
-        archname = output.ds_key.lstrip('/') + '-' + fmt + '.zip'
+        archname = '.' + output.ds_key + '-' + fmt + '.zip'
         zipfiles(exported, os.path.join(target, archname))
         return os.path.join(target, archname)
     else:  # single file
@@ -82,6 +82,7 @@ def export(output_id, target, export_type='xml,geojson,csv'):
     specified `target` directory in the specified `export_type`.
     """
     output = models.Output.objects.get(id=output_id)
+    job_id = output.oq_job.id
     if isinstance(target, basestring):  # create target directory
         makedirs(target)
     for exptype in export_type.split(','):


### PR DESCRIPTION
1. the .zip archives are now hidden to the final user (except Cata who is using FileZilla)
2. the display_name of the output type  `dmg_by_asset` is now `dmg_by_asset_and_collapse_map`.

Multi-file outputs are downloaded from the Web UI as a single zip file. In particular by clicking on
`dmg_by_asset_and_collapse_map` one gets a zip file containing two files `dmg_dist_per_asset.xml` and `collapse_map.xml`.

The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1489