### PR TITLE
Extended del_calc to remove the .hdf5 file

### DIFF
--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -404,7 +404,7 @@ def export(output_id, target_dir, export_type):
         the_file = core.export(output_id, target_dir, export_type)
         print 'File Exported:'
         print the_file
-    except NotImplementedError, err:
+    except NotImplementedError as err:
         print err
         print 'This feature is probably not implemented yet'
 

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -405,7 +405,7 @@ def export(output_id, target_dir, export_type):
         print 'File Exported:'
         print the_file
     except NotImplementedError, err:
-        print err.message
+        print err
         print 'This feature is probably not implemented yet'
 
 
@@ -432,8 +432,8 @@ def del_calc(job_id, confirmed=False):
             'associated outputs?\nThis action cannot be undone. (y/n): '):
         try:
             engine.del_calc(job_id)
-        except RuntimeError, err:
-            print err.message
+        except RuntimeError as err:
+            print err
 
 
 def confirm(prompt):

--- a/openquake/engine/calculators/hazard/disaggregation/core.py
+++ b/openquake/engine/calculators/hazard/disaggregation/core.py
@@ -106,7 +106,7 @@ def _collect_bins_data(trt_num, source_ruptures, site, curves,
         except Exception as err:
             etype, err, tb = sys.exc_info()
             msg = 'An error occurred with source id=%s. Error: %s'
-            msg %= (source.source_id, err.message)
+            msg %= (source.source_id, err)
             raise etype, msg, tb
 
     calc_dist.flush()

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -313,6 +313,12 @@ def del_calc(job_id):
     else:
         # this doesn't belong to the current user
         raise RuntimeError(UNABLE_TO_DEL_HC_FMT % 'Access denied')
+    try:
+        os.remove(job.ds_calc_dir + '.hdf5')
+    except:
+        pass
+    else:
+        print('Removed %s' % job.ds_calc_dir + '.hdf5')
 
 
 def list_outputs(job_id, full=True):

--- a/openquake/engine/tests/utils/helpers.py
+++ b/openquake/engine/tests/utils/helpers.py
@@ -178,7 +178,7 @@ def assertDeepAlmostEqual(test_case, expected, actual, *args, **kwargs):
         exc.__dict__.setdefault('traces', []).append(trace)
         if is_root:
             trace = ' -> '.join(reversed(exc.traces))
-            exc = AssertionError("%s\nTRACE: %s" % (exc.message, trace))
+            exc = AssertionError("%s\nTRACE: %s" % (exc, trace))
         raise exc
 
 


### PR DESCRIPTION
Also, I am removing the `exception.message` attribute, which is deprecated. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1499