### PR TITLE
Remove the view button

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the 'view' button from the Web UI
   * Removed the epsilon_sampling configuration parameter
   * Made customizable the display_name of datastore outputs (before it was
     identical to the datastore key)

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -37,8 +37,7 @@
             <table class="table table-disable-hover table-condensed">
             <% _.each(output.get('outtypes'), function(outtype) { %>
               <tr>
-                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&amp;dload=false" class="btn btn-sm">View <%= outtype %></a></td>
-                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>&amp;dload=true" class="btn btn-sm">Download <%= outtype %></a></td>
+                <td><a href="/v1/calc/{{ calc_id }}/result/<%= output.get('id') %>?export_type=<%= outtype %>" class="btn btn-sm">Download <%= outtype %></a></td>
               </tr>
             <% }); %>
             </table>

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -474,15 +474,6 @@ def get_result(request, result_id):
     etype = request.GET.get('export_type')
     export_type = etype or DEFAULT_EXPORT_TYPE
 
-    dload = request.GET.get('dload')
-    download = False
-    if dload is None:
-        if etype is not None:
-            download = True
-    else:
-        if dload == "true":
-            download = True
-
     tmpdir = tempfile.mkdtemp()
     try:
         exported = core.export(result_id, tmpdir, export_type=export_type)
@@ -503,8 +494,7 @@ def get_result(request, result_id):
         data = open(exported).read()
         response = HttpResponse(data, content_type=content_type)
         response['Content-Length'] = len(data)
-        if download:  # download as a file
-            response['Content-Disposition'] = 'attachment; filename=%s' % fname
+        response['Content-Disposition'] = 'attachment; filename=%s' % fname
         return response
     finally:
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
A proposal to close https://github.com/gem/oq-engine/issues/1826 with a minimal effort so that we do not block the release 1.6. The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/1501/