### PR TITLE
Fixed the monitoring of children

### DIFF
--- a/openquake/engine/performance.py
+++ b/openquake/engine/performance.py
@@ -61,6 +61,7 @@ class EnginePerformanceMonitor(PerformanceMonitor):
         new = self.__class__(operation, self.job_id, task or self.task,
                              self.tracing, self.measuremem, self.autoflush)
         vars(new).update(kw)
+        self.children.append(new)
         return new
 
     def __enter__(self):

--- a/openquake/engine/performance.py
+++ b/openquake/engine/performance.py
@@ -35,7 +35,7 @@ class EnginePerformanceMonitor(PerformanceMonitor):
         newmeth.__name__ = method.__name__
         return newmeth
 
-    def __init__(self, operation, job_id, task=None, tracing=False,
+    def __init__(self, operation, job_id=None, task=None, tracing=False,
                  measuremem=True, autoflush=False):
         super(EnginePerformanceMonitor, self).__init__(
             operation, autoflush=autoflush, measuremem=measuremem)
@@ -52,17 +52,6 @@ class EnginePerformanceMonitor(PerformanceMonitor):
     def task_id(self):
         """Return the celery task ID or None"""
         return None if self.task is None else self.task.request.id
-
-    def __call__(self, operation, task=None, **kw):
-        """
-        Return a copy of the monitor usable for a different operation
-        in the same task.
-        """
-        new = self.__class__(operation, self.job_id, task or self.task,
-                             self.tracing, self.measuremem, self.autoflush)
-        vars(new).update(kw)
-        self.children.append(new)
-        return new
 
     def __enter__(self):
         # start measuring time and memory
@@ -88,15 +77,16 @@ class EnginePerformanceMonitor(PerformanceMonitor):
         """Save a row in the performance table for each child"""
         monitors = [self] + self.children
         for mon in monitors:
-            models.Performance.objects.create(
-                oq_job_id=mon.job_id,
-                task_id=mon.task_id,
-                task=getattr(mon.task, '__name__', None),
-                operation=mon.operation,
-                start_time=mon.start_time,
-                duration=mon.duration,
-                pymemory=mon.mem if mon.measuremem else None,
-                pgmemory=None)
+            if mon.duration:  # the monitor has been used
+                models.Performance.objects.create(
+                    oq_job_id=mon.job_id,
+                    task_id=mon.task_id,
+                    task=getattr(mon.task, '__name__', None),
+                    operation=mon.operation,
+                    start_time=mon.start_time,
+                    duration=mon.duration,
+                    pymemory=mon.mem if mon.measuremem else None,
+                    pgmemory=None)
             mon.mem = 0
             mon.duration = 0
 

--- a/openquake/engine/utils/tasks.py
+++ b/openquake/engine/utils/tasks.py
@@ -119,7 +119,7 @@ def oqtask(task_func):
             # run the task
             try:
                 total = 'total ' + task_func.__name__
-                with monitor(total, task=tsk, autoflush=True):
+                with monitor(total, task=tsk):
                     with GroundShakingIntensityModel.forbid_instantiation():
                         return task_func(*args)
             finally:


### PR DESCRIPTION
Just reusing the parent `PerformanceMonitor.__call__` takes care of the children properly. You can see the difference by looking at http://artifacts.openquake.org/demos/oq-engine/master/precise/2089/jobs-2015-11-07.html#tabs-15 (without monitoring of the children, "getting hazard" and "computing individual risk" were missing) contrasted with http://artifacts.openquake.org/demos/oq-engine/zdevel/precise/1512/jobs-2015-11-08.html#tabs-15 (with monitoring).