### PR TITLE
The datastore must be closed only by the engine server

### DIFF
--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -558,8 +558,8 @@ def main():
     elif args.list_risk_calculations:
         list_calculations('risk')
     elif args.run_risk is not None:
-        if (args.hazard_output_id is None
-                and args.hazard_calculation_id is None):
+        if (args.hazard_output_id is None and
+                args.hazard_calculation_id is None):
             sys.exit(MISSING_HAZARD_MSG)
         log_file = expanduser(args.log_file) \
             if args.log_file is not None else None

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -269,9 +269,6 @@ def _do_run_calc(calc, exports):
 
     CacheInserter.flushall()  # flush caches into the db
 
-    if hasattr(calc, 'datastore'):
-        calc.datastore.close()
-
     log_status(job, "complete")
 
 

--- a/openquake/server/tasks.py
+++ b/openquake/server/tasks.py
@@ -110,7 +110,7 @@ def run_calc(job_id, calc_dir,
     progress_handler = ProgressHandler(callback_url, job)
     logging.root.addHandler(progress_handler)
     try:
-        engine.run_calc(job, DEFAULT_LOG_LEVEL, log_file, exports='')
+        calc = engine.run_calc(job, DEFAULT_LOG_LEVEL, log_file, exports='')
     except:  # catch the errors before task spawning
         # do not log the errors, since the engine already does that
         exctype, exc, tb = sys.exc_info()
@@ -120,7 +120,9 @@ def run_calc(job_id, calc_dir,
         raise
     finally:
         logging.root.removeHandler(progress_handler)
-        shutil.rmtree(calc_dir)
+    if hasattr(calc, 'datastore'):
+        calc.datastore.close()
+    shutil.rmtree(calc_dir)
 
     # If requested to, signal job completion and trigger a migration of
     # results.


### PR DESCRIPTION
Before the datastore was closed also by the engine, and was closed *before* the `expose_outputs` function, so it was impossible to expose the outputs when running `oq-engine --lite`, with an error like this one:

```python
[2015-11-24 06:40:44,839 hazard job #2587 - PROGRESS MainProcess/21821] **  complete (hazard)
Traceback (most recent call last):
  File "/usr/local/openquake/oq-engine/bin/oq-engine", line 640, in <module>
    main()
  File "/usr/local/openquake/oq-engine/bin/oq-engine", line 546, in main
    hazard_calculation_id=hc_id)
  File "/usr/local/openquake/oq-engine/openquake/engine/engine.py", line 435, in run_job_lite
    expose_outputs(calc.datastore, job)
  File "/usr/local/openquake/oq-engine/openquake/engine/engine.py", line 462, in expose_outputs
    for key in dstore:
  File "/usr/local/openquake/oq-risklib/openquake/commonlib/datastore.py", line 277, in __iter__
    for path in sorted(self.hdf5):
  File "/usr/lib/python2.7/dist-packages/h5py/_hl/group.py", line 279, in __len__
    return self.id.get_num_objs()
  File "h5g.pyx", line 320, in h5py.h5g.GroupID.get_num_objs (h5py/h5g.c:4015)
ValueError: not a location ID (Invalid arguments to routine: Inappropriate type)
```