### PR TITLE
Open the DataStore in read mode when exporting

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Fixed an export bug: it is now possible to export the outputs generated
+    by another user, if the read permissions are set correctly
+
 python-oq-engine (1.6.0-0~precise01) precise; urgency=low
 
   [Daniele Viganò]

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -54,7 +54,8 @@ def export_from_datastore(output_key, output, target):
     """
     ds_key, fmt = output_key
     assert ds_key == output.ds_key, (ds_key, output.ds_key)
-    dstore = DataStore(output.oq_job.id, mode='r')
+    datadir = os.path.dirname(output.oq_job.ds_calc_dir)
+    dstore = DataStore(output.oq_job.id, datadir, mode='r')
     dstore.export_dir = target
     try:
         exported = ds_export((output.ds_key, fmt), dstore)

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -54,7 +54,7 @@ def export_from_datastore(output_key, output, target):
     """
     ds_key, fmt = output_key
     assert ds_key == output.ds_key, (ds_key, output.ds_key)
-    dstore = DataStore(output.oq_job.id)
+    dstore = DataStore(output.oq_job.id, mode='r')
     dstore.export_dir = target
     try:
         exported = ds_export((output.ds_key, fmt), dstore)


### PR DESCRIPTION
This should solve the problem that it is impossible to export the results of a calculation ran by another user on Wilson.