### PR TITLE
doc: make celeryconfig.py path more explicit

### DIFF
--- a/doc/engine/Installing-the-OpenQuake-Engine-Nightly.md
+++ b/doc/engine/Installing-the-OpenQuake-Engine-Nightly.md
@@ -138,12 +138,12 @@ Some outputs where not shown. You can see the full list with the command
 From the directory `/usr/share/openquake/engine`, launch celery worker processes like so:
 ##### Ubuntu 12.04 / Celery 2
 <pre>
-celeryd --purge &
+cd /usr/share/openquake/engine && celeryd --purge &
 </pre>
 
 ##### Ubuntu 14.04 / Celery 3
 <pre>
-celery worker --purge -Ofair &
+cd /usr/share/openquake/engine && celery worker --purge -Ofair &
 </pre>
 
 Then run `oq-engine` without the `--no-distribute` option:

--- a/doc/engine/Installing-the-OpenQuake-Engine.md
+++ b/doc/engine/Installing-the-OpenQuake-Engine.md
@@ -147,12 +147,12 @@ Some outputs where not shown. You can see the full list with the command
 From the directory `/usr/share/openquake/engine`, launch celery worker processes like so:
 ##### Ubuntu 12.04 / Celery 2
 <pre>
-celeryd --purge &
+cd /usr/share/openquake/engine && celeryd --purge &
 </pre>
 
 ##### Ubuntu 14.04 / Celery 3
 <pre>
-celery worker --purge -Ofair &
+cd /usr/share/openquake/engine && celery worker --purge -Ofair &
 </pre>
 
 Then run `oq-engine` without the `--no-distribute` option:


### PR DESCRIPTION
It seems that users do not read text that is not in command blocks, so moving the `cd` to  `celeryconfig.py` on the same line as the `celery` command.