### PR TITLE
Fixed the ordering of the assets in the loss map XML exporter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Now the loss maps are exported with a fixed ordering of the assets
   * Replaced the old disaggregation calculator with the oq-lite one
 
 python-oq-engine (1.7.0-0~precise01) precise; urgency=low

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Now the loss maps are exported with a fixed ordering of the assets
+  * Now the loss maps and curves are exported with a fixed ordering: first
+    by lon-lat, then by asset ID
   * Replaced the old disaggregation calculator with the oq-lite one
 
 python-oq-engine (1.7.0-0~precise01) precise; urgency=low

--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -175,7 +175,10 @@ def export_loss_curve_xml(key, output, target):
     dest = _get_result_export_dest(target, output)
     args['insured'] = output.loss_curve.insured
 
-    data = output.loss_curve.losscurvedata_set.all().order_by('asset_ref')
+    data = output.loss_curve.losscurvedata_set.extra(
+        select={'x': 'ST_X(geometry(location))',
+                'y': 'ST_Y(geometry(location))'},
+        order_by=["x", "y", 'asset_ref'])
     risk_writers.LossCurveXMLWriter(dest, **args).serialize(data)
     return dest
 

--- a/openquake/engine/export/risk.py
+++ b/openquake/engine/export/risk.py
@@ -226,8 +226,10 @@ def export_loss_map(key, output, target):
     writercls = (risk_writers.LossMapXMLWriter if key[1] == 'xml'
                  else risk_writers.LossMapGeoJSONWriter)
     writercls(dest, **args).serialize(
-        models.order_by_location(
-            output.loss_map.lossmapdata_set.all().order_by('asset_ref')))
+        output.loss_map.lossmapdata_set.extra(
+            select={'x': 'ST_X(geometry(location))',
+                    'y': 'ST_Y(geometry(location))'},
+            order_by=["x", "y", 'asset_ref']))
     return dest
 
 


### PR DESCRIPTION
In this way the exported XML files are easier to compare with the ones produced by oq-lite.

NB: there is the same problem also in the loss curve exporter.