### PR TITLE
Enabled Zip64 extensions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * The engine can now zip files larger than 2 GB (used in the export)
   * Now the loss maps and curves are exported with a fixed ordering: first
     by lon-lat, then by asset ID
   * Replaced the old disaggregation calculator with the oq-lite one

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -40,7 +40,7 @@ def zipfiles(fnames, archive):
     :param fnames: list of path names
     :param archive: path of the archive
     """
-    z = zipfile.ZipFile(archive, 'w')
+    z = zipfile.ZipFile(archive, 'w', allowZip64=True)
     for f in fnames:
         z.write(f, os.path.basename(f))
     z.close()

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -40,7 +40,7 @@ def zipfiles(fnames, archive):
     :param fnames: list of path names
     :param archive: path of the archive
     """
-    z = zipfile.ZipFile(archive, 'w', allowZip64=True)
+    z = zipfile.ZipFile(archive, 'w', zipfile.ZIP_DEFLATED, allowZip64=True)
     for f in fnames:
         z.write(f, os.path.basename(f))
     z.close()


### PR DESCRIPTION
Let's do that experimentally. We can always go back if there are issues and the unzipped files are always available. Now at least the users of 64 bit machines will be happy.