### PR TITLE
Made UHS curves exportable from the engine

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed the site-ordering in the UHS exporter (by lon-lat)
+
   [Paolo Tormene]
   * Added API to validate NRML
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -456,6 +456,13 @@ def expose_outputs(dstore, job):
     calcmode = job.get_param('calculation_mode')
     if 'scenario' in calcmode and 'sescollection' in exportable:
         exportable.remove('sescollection')
+    uhs = job.get_param('uniform_hazard_spectra')
+    if uhs and 'hmaps' in dstore:
+        out = models.Output.objects.create_output(
+            job, 'uhs', output_type='datastore')
+        out.ds_key = 'uhs'
+        out.save()
+
     for key in dstore:
         if key in exportable:
             out = models.Output.objects.create_output(

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -456,7 +456,7 @@ def expose_outputs(dstore, job):
     calcmode = job.get_param('calculation_mode')
     if 'scenario' in calcmode and 'sescollection' in exportable:
         exportable.remove('sescollection')
-    uhs = job.get_param('uniform_hazard_spectra')
+    uhs = job.get_param('uniform_hazard_spectra', False)
     if uhs and 'hmaps' in dstore:
         out = models.Output.objects.create_output(
             job, 'uhs', output_type='datastore')

--- a/openquake/engine/utils/tasks.py
+++ b/openquake/engine/utils/tasks.py
@@ -18,6 +18,8 @@
 
 """Utility functions related to splitting work into tasks."""
 
+import types
+
 from celery.result import ResultSet
 from celery.app import current_app
 from celery.task import task
@@ -54,6 +56,8 @@ class OqTaskManager(TaskManager):
 
     def _submit(self, pickled_args):
         # submit tasks by using celery
+        if isinstance(self.oqtask, types.FunctionType):
+            self.oqtask = oqtask(self.oqtask)
         return self.oqtask.delay(*pickled_args)
 
     def aggregate_result_set(self, agg, acc):


### PR DESCRIPTION
Companion of https://github.com/gem/oq-risklib/pull/604, closes https://github.com/gem/oq-risklib/issues/557. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1565