### PR TITLE
Fixed a few tests

### DIFF
--- a/openquake/engine/tests/calculators/hazard/classical/core_test.py
+++ b/openquake/engine/tests/calculators/hazard/classical/core_test.py
@@ -207,4 +207,4 @@ class NoSourcesTestCase(unittest.TestCase):
         cfg = helpers.get_data_path('classical_job.ini')
         with mock.patch.dict(os.environ, {'OQ_NO_DISTRIBUTE': '1'}):
             with self.assertRaises(RuntimeError):
-                helpers.run_job(cfg, maximum_distance=1)
+                helpers.run_job(cfg, maximum_distance='1')

--- a/openquake/engine/tests/calculators/hazard/general_test.py
+++ b/openquake/engine/tests/calculators/hazard/general_test.py
@@ -108,7 +108,7 @@ class NonEmptyQuantileTestCase(unittest.TestCase):
     def test(self):
         cfg = helpers.get_data_path('simple_fault_demo_hazard/job.ini')
         with mock.patch('openquake.engine.logs.LOG.warn') as warn:
-            helpers.run_job(cfg, number_of_logic_tree_samples=1,
+            helpers.run_job(cfg, number_of_logic_tree_samples='1',
                             quantile_hazard_curves='0.1 0.2',
                             hazard_maps='', uniform_hazard_spectra='')
         msg = warn.call_args[0][0]

--- a/openquake/engine/tests/export/hazard_test.py
+++ b/openquake/engine/tests/export/hazard_test.py
@@ -159,10 +159,10 @@ class EventBasedExportTestCase(BaseExportTestCase):
 
             # run the calculation in process to create something to export
             with mock.patch.dict(os.environ, {'OQ_NO_DISTRIBUTE': '1'}):
-                job = helpers.run_job(cfg, maximum_distance=1,
-                                      ses_per_logic_tree_path=1,
-                                      investigation_time=12,
-                                      number_of_logic_tree_samples=1).job
+                job = helpers.run_job(cfg, maximum_distance='1',
+                                      ses_per_logic_tree_path='1',
+                                      investigation_time='12',
+                                      number_of_logic_tree_samples='1').job
             self.assertEqual(job.status, 'complete')
 
             dstore = datastore.DataStore(job.id)


### PR DESCRIPTION
Fixes the breakage of https://ci.openquake.org/job/master_oq-engine/2196/ induced by a change in risklib https://github.com/gem/oq-risklib/pull/621. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1578