### PR TITLE
Use a celery-aware default for concurrent_tasks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * If `use_celery` is true, use celery to determine a good default for
+    the parameter `concurrent_tasks`
   * Made celery required only in cluster situations
   * Replaced all classical calculators with their lite counterparts
   * Fixed the site-ordering in the UHS exporter (by lon-lat)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -38,7 +38,6 @@ from openquake.engine import logs
 from openquake.server.db import models
 from openquake.engine.utils import config, tasks
 from openquake.engine.celery_node_monitor import CeleryNodeMonitor
-from openquake.engine.settings import DATABASES
 from openquake.server.db.schema.upgrades import upgrader
 
 from openquake import hazardlib, risklib, commonlib


### PR DESCRIPTION
This feature has been requested by Daniele for years: the default number of concurrent_tasks should be decided dynamically by the application, by asking celery how many cores are available, and by multiplying it by two, thus following an ancient tradition of the engine.
Notice that:

1. is `use_celery` is false in `openquake.cfg` this feature is not used
2. if the user passes an explicit `concurrent_tasks` in the `job.ini` file the default is set but not used