### PR TITLE
Fixed make_html_report for non-ASCII characters

### DIFF
--- a/openquake/engine/tools/make_html_report.py
+++ b/openquake/engine/tools/make_html_report.py
@@ -177,7 +177,8 @@ def make_report(conn, isodate='today'):
         (job_id, user, start_time, stop_time, status, duration) = stats[0]
         try:
             ds = read(job_id, datadir=os.path.dirname(ds_calc))
-            report = html_parts(view_fullreport('fullreport', ds))
+            txt = view_fullreport('fullreport', ds).decode('utf-8')
+            report = html_parts(txt)
         except Exception as exc:
             report = dict(
                 html_title='Could not generate report: %s' % cgi.escape(
@@ -197,5 +198,5 @@ def make_report(conn, isodate='today'):
         'Report last updated: %s' % datetime.datetime.now())
     fname = 'jobs-%s.html' % isodate
     with open(fname, 'w') as f:
-        f.write(PAGE_TEMPLATE % page)
+        f.write(PAGE_TEMPLATE % page.encode('utf-8'))
     return fname

--- a/openquake/engine/tools/make_html_report.py
+++ b/openquake/engine/tools/make_html_report.py
@@ -112,8 +112,10 @@ ORDER BY stop_time
 '''
 
 PAGE_TEMPLATE = '''\
+<!DOCTYPE html>
 <html>
 <head>
+<meta charset="UTF-8">
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css" />
 <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>


### PR DESCRIPTION
Companion of https://github.com/gem/oq-risklib/pull/703. The reports have been generated here https://ci.openquake.org/job/zdevel_oq-engine/1635 and are visible here: http://artifacts.openquake.org/demos/oq-engine/zdevel/precise/1635/jobs-2016-02-23.html