### PR TITLE
Fixed the ordering of the logs in the Web UI

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the ordering of the logs in the Web UI
   * Removed the dependency from PostGIS
   * Restored the monitoring which was accidentally removed
   * Removed the obsolete option `--hazard-output-id`

--- a/openquake/server/db/models.py
+++ b/openquake/server/db/models.py
@@ -25,7 +25,6 @@
 Model representations of the OpenQuake DB tables.
 '''
 import os
-import collections
 from datetime import datetime
 
 from openquake.commonlib import datastore
@@ -214,6 +213,7 @@ class Log(djm.Model):
 
     class Meta:
         db_table = 'log'
+        ordering = ['id']
 
 
 def extract_from(objlist, attr):


### PR DESCRIPTION
I forgot to set the ordering at the Django level in the migration to the new tables.