### PR TITLE
Fixed the double log bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a bug such that in some circumstances the logging stream handler
+    was instantiated twice, resulting in duplicated logs
   * Changed the default job status to 'executing' (was 'pre_executing')
   * Fixed the ordering of the logs in the Web UI
   * Removed the dependency from PostGIS

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -41,6 +41,7 @@ from openquake.engine.celery_node_monitor import CeleryNodeMonitor
 from openquake.server.db.schema.upgrades import upgrader
 
 from openquake.commonlib import readinput, valid, datastore, export
+from openquake.commonlib.oqvalidation import OqParam
 from openquake.calculators import base
 
 
@@ -391,12 +392,9 @@ def job_from_file(cfg_file, username, log_level='info', exports='',
     # read calculation params and create the calculation profile
     params = readinput.get_params([cfg_file])
     params.update(extras)
-
-    class oq:  # fake OqParam object
-        calculation_mode = params['calculation_mode']
-        description = params['description']
-        export_dir = params.get('export_dir', os.path.expanduser('~'))
-
+    oq = OqParam(calculation_mode=params['calculation_mode'],
+                 description=params['description'],
+                 export_dir=params.get('export_dir', os.path.expanduser('~')))
     # create a job and a calculator
     job = create_job(oq.calculation_mode, username, hazard_calculation_id)
     monitor = PerformanceMonitor('total runtime', measuremem=True)


### PR DESCRIPTION
You can see the bug by running

```bash
$ oq-engine --run demos/risk/ClassicalDamage/job_hazard.ini 
```

in the current master. The lines of log are duplicated. This PR fixes the issue, that happened because an additional stream handler was automatically generated by the line `readinput.get_oqparam(params)`
that needed to log the fact that in this demo the export_dir is missing.

Tests and demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/1637/

PS: while at that, I added storing the total runtime of the calculation in the performance table.