### PR TITLE
Reflected changes in the Monitor

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -29,7 +29,7 @@ from datetime import datetime
 from django.core import exceptions
 from django import db as django_db
 
-from openquake.baselib.performance import PerformanceMonitor
+from openquake.baselib.performance import Monitor
 from openquake.engine import logs
 from openquake.server.db import models
 from openquake.engine.utils import config, tasks
@@ -407,7 +407,7 @@ def job_from_file(cfg_file, username, log_level='info', exports='',
     # create a job and a calculator
     job = create_job(oq.calculation_mode, oq.description, username,
                      hazard_calculation_id)
-    monitor = PerformanceMonitor('total runtime', measuremem=True)
+    monitor = Monitor('total runtime', measuremem=True)
     job.calc = base.calculators(oq, monitor, calc_id=job.id)
     with logs.handle(job, log_level):
         job.calc.oqparam = readinput.get_oqparam(params)

--- a/openquake/engine/utils/tasks.py
+++ b/openquake/engine/utils/tasks.py
@@ -19,6 +19,7 @@
 """Utility functions related to splitting work into tasks."""
 import types
 
+from openquake.baselib.performance import Monitor
 from openquake.commonlib import parallel, valid
 from openquake.engine import logs
 from openquake.engine.utils import config
@@ -28,7 +29,8 @@ celery_queue = config.get('amqp', 'celery_queue')
 SOFT_MEM_LIMIT = int(config.get('memory', 'soft_mem_limit'))
 HARD_MEM_LIMIT = int(config.get('memory', 'hard_mem_limit'))
 USE_CELERY = valid.boolean(config.get('celery', 'use_celery') or 'false')
-parallel.check_mem_usage.__defaults__ = (SOFT_MEM_LIMIT, HARD_MEM_LIMIT)
+parallel.check_mem_usage.__defaults__ = (
+    Monitor(), SOFT_MEM_LIMIT, HARD_MEM_LIMIT)
 
 if USE_CELERY:
     from celery.result import ResultSet


### PR DESCRIPTION
`PerformanceMonitor` has been renamed to `Monitor` and the function `check_mem_usage` now depends on the monitor to send back warnings as desired in https://github.com/gem/oq-risklib/issues/732. This the companion of https://github.com/gem/oq-risklib/pull/733.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1663