### PR TITLE
deb: always replace the old celeryconfig.py

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -55,12 +55,8 @@ mkdir -p $HDIR
 chmod 1777 $HDIR
 
 rm -f $HDIR/celeryconfig.py.new_in_this_release
-if [ -f $HDIR/celeryconfig.py ]; then
-    diff $IDIR/celeryconfig.py $HDIR/celeryconfig.py >/dev/null || cp $IDIR/celeryconfig.py $HDIR/celeryconfig.py.new_in_this_release
-else
-    cp $IDIR/celeryconfig.py $HDIR
-    chmod 666 $HDIR/celeryconfig.py
-fi
+cp $IDIR/celeryconfig.py $HDIR
+chmod 644 $HDIR/celeryconfig.py
 
 if [ `cat /etc/group | grep ^openquake: | wc -l` -eq 0 ]; then
     addgroup --system openquake


### PR DESCRIPTION
Since the user should not change the `celeryconfig.py` is fine if the binary package always replaces it. This will simplify the upgrade and will avoid strange errors when using celery with an old config file.

Tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1666/