### PR TITLE
deb: make the postinst working on usupported distros

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-  [Daniele Viganò]
+  [Daniele Viganò, Matteo Nastasi]
   * Allow installation of the binary package on Ubuntu derivatives
 
   [Michele Simionato]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Daniele Viganò]
+  * Allow installation of the binary package on Ubuntu derivatives
+
   [Michele Simionato]
   * Removed openquake/engine/settings.py
   * Made the dependency on celery required only in cluster installations

--- a/debian/postinst
+++ b/debian/postinst
@@ -37,14 +37,8 @@ else
         exit 1
     fi
 
-    echo "=========================================================="
-    echo "WARNING!! You are running an unsupported version of Linux."
-    echo "WARNING!! Use this package at your own risk!"
-    echo "WARNING!! Press ENTER to continue:"
-    echo "=========================================================="
-    if tty -s; then
-        read -n 1 -s
-    fi
+    db_input high python-oq-engine/distro_alert || true
+    db_go
 fi
 
 PG_CONF="/etc/postgresql/$PG_VERSION/main/postgresql.conf"

--- a/debian/postinst
+++ b/debian/postinst
@@ -30,8 +30,21 @@ if [ "$LSB_RELEASE" = "precise" ]; then
 elif [ "$LSB_RELEASE" = "trusty" ]; then
     PG_VERSION="9.3"
 else
-    echo "This operating system release is not supported"
-    exit 1
+    PG_VERSION=$(sudo -u postgres psql -c'show server_version' -At)
+    PG_VERSION=$(echo "$PG_VERSION" | sed 's/^\([0-9]\+\.[0-9]\+\).*/\1/')
+    if [ -z "$PG_VERSION" ]; then
+        echo "ERROR!! This operating system is running an unsupported version of Postgres."
+        exit 1
+    fi
+
+    echo "=========================================================="
+    echo "WARNING!! You are running an unsupported version of Linux."
+    echo "WARNING!! Use this package at your own risk!"
+    echo "WARNING!! Press ENTER to continue:"
+    echo "=========================================================="
+    if tty -s; then
+        read -n 1 -s
+    fi
 fi
 
 PG_CONF="/etc/postgresql/$PG_VERSION/main/postgresql.conf"

--- a/debian/postinst
+++ b/debian/postinst
@@ -32,8 +32,8 @@ elif [ "$LSB_RELEASE" = "trusty" ]; then
 else
     PG_VERSION=$(sudo -u postgres psql -c'show server_version' -At)
     PG_VERSION=$(echo "$PG_VERSION" | sed 's/^\([0-9]\+\.[0-9]\+\).*/\1/')
-    if [ -z "$PG_VERSION" ]; then
-        echo "ERROR!! This operating system is running an unsupported version of Postgres."
+    if [ -z "$PG_VERSION" -o ! -f "/etc/postgresql/$PG_VERSION/main/postgresql.conf" ]; then
+        echo "This operating system is running an unsupported version of Postgres."
         exit 1
     fi
 

--- a/debian/templates
+++ b/debian/templates
@@ -1,0 +1,4 @@
+Template: python-oq-engine/distro_alert
+Type: note
+Description: You are running an unsupported Linux distribution.
+ Use this package at your own risk!


### PR DESCRIPTION
This PR makes the `postinst` (and the `.deb` package) working for Ubuntu derivates like Mint as an unsupported system.

A warning is printed is the OS is unsupported.

Test for both 12.04 and 14.04 are running: https://ci.openquake.org/job/zdevel_oq-engine/1670/console
Manual testing on Mint 17 passed.