### PR TITLE
deb: use the postgresql meta package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+  [Daniele Viganò]
+  * Use the 'postgresql' meta package as dependency of the .deb
+    package to support newer versions of Postgres; this makes
+    Trusty package installable on Ubuntu 16.04 and Debian 8
+
   [Daniele Viganò, Matteo Nastasi]
   * Allow installation of the binary package on Ubuntu derivatives
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.globalquakemodel.org/openquake/
 Package: python-oq-engine
 Architecture: all
 Conflicts: python-noq, python-oq
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, ${dist:Depends}, postgresql-client, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-nose, python-mock, python-requests (>=0.8.2), python-docutils, python-oq-hazardlib (>=0.20.0-0~), python-oq-risklib (>=0.13.0-0~), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), debconf, ${dist:Depends}, postgresql, postgresql-client, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-numpy, python-paramiko, python-scipy, python-shapely, python-psycopg2, python-setuptools, python-psutil, python-nose, python-mock, python-requests (>=0.8.2), python-docutils, python-oq-hazardlib (>=0.20.0-0~), python-oq-risklib (>=0.13.0-0~), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02)
 Recommends: ${dist:Recommends}
 Description: computes seismic hazard and physical risk
  based on the hazard and risk libraries (python-oq-hazardlib,

--- a/debian/rules
+++ b/debian/rules
@@ -16,9 +16,9 @@ export DH_OPTIONS
 
 bd=openquake/bin
 
-TRUSTY_DEP = python-amqp, python-django, postgresql-9.3
+TRUSTY_DEP = python-amqp, python-django
 TRUSTY_REC =
-PRECISE_DEP = python-django16, postgresql-9.1
+PRECISE_DEP = python-django16
 PRECISE_REC =
 
 ifeq ($(shell lsb_release --codename --short),trusty)


### PR DESCRIPTION
While we are awaiting for the postgresql removal, let's use the meta package instead of a specific version. We are not even using postgis anymore, just base functions of postgresql. This makes the Trusty deb packages working also on Debian Jessie and Ubuntu 16.04 (even if we do not officially support this).

Tests: https://ci.openquake.org/job/zdevel_oq-engine/1683/