### PR TITLE
Fix output exports (--eos)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Daniele Viganò, Michele Simionato]
+  * Fixed a bug in `oq-engine --export-outputs`
+
   [Daniele Viganò, Matteo Nastasi]
   * Allow installation of the binary package on Ubuntu derivatives
 

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -342,11 +342,11 @@ def main():
     elif args.export_output is not None:
         output_id, target_dir = args.export_output
         dbcmd('export_output', int(output_id), expanduser(target_dir),
-                 exports)
+              exports)
 
     elif args.export_outputs is not None:
-        hc_id = dbcmd('get_hc_id', args.export_outputs[0])
         job_id, target_dir = args.export_outputs
+        hc_id = dbcmd('get_hc_id', job_id)
         dbcmd('export_outputs', hc_id, expanduser(target_dir), exports)
 
     elif args.delete_uncompleted_calculations:

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -345,7 +345,7 @@ def main():
                  exports)
 
     elif args.export_outputs is not None:
-        hc_id = dbcmd('get_hc_id', args.list_outputs)
+        hc_id = dbcmd('get_hc_id', args.export_outputs[0])
         job_id, target_dir = args.export_outputs
         dbcmd('export_outputs', hc_id, expanduser(target_dir), exports)
 

--- a/packager.sh
+++ b/packager.sh
@@ -586,6 +586,9 @@ celeryd_wait $GEM_MAXLOOP"
             fi
         done
 
+        # Try to export a set of results AFTER the calculation
+        oq-engine --eos 1 /tmp/eos_1
+
         for demo_dir in \$(find . -type d | sort); do
             if [ -f \$demo_dir/job_hazard.ini ]; then
             cd \$demo_dir

--- a/packager.sh
+++ b/packager.sh
@@ -587,6 +587,7 @@ celeryd_wait $GEM_MAXLOOP"
         done
 
         # Try to export a set of results AFTER the calculation
+        echo \"Exporting calculation #1\"
         oq-engine --eos 1 /tmp/eos_1
 
         for demo_dir in \$(find . -type d | sort); do


### PR DESCRIPTION
With https://github.com/gem/oq-engine/pull/1978 we introduced a bug and now isn't possible to export outputs with the command `--eos ###`. The error is:

```python
Traceback (most recent call last):
  File "/usr/local/openquake/oq-engine/bin/oq-engine", line 359, in <module>
    main()
  File "/usr/local/openquake/oq-engine/bin/oq-engine", line 348, in main
    hc_id = dbcmd('get_hc_id', args.list_outputs)
  File "/usr/local/openquake/oq-engine/openquake/engine/logs.py", line 55, in dbcmd
    return getattr(actions, action)(*args)
  File "/usr/local/openquake/oq-engine/openquake/server/db/actions.py", line 91, in get_hc_id
    hc_id = int(hc_id)
TypeError: int() argument must be a string or a number, not 'NoneType'
```

This PR fixes the issue (I don't know if it's the best way, but it works) and also adds a test in `packager.sh` that tries to export outputs from calculation 1. The build was green because as now we do the export together with the calculation, not afterwards.

Thanks to @vup1120 for reporting the bug.
Tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1686/ 