### PR TITLE
Improved the validation of NRML files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved the validation of NRML files
   * Added a command `oq-engine --show-log <job_id>`
 
   [Daniele Viganò]

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -181,7 +181,7 @@ def validate_nrml(request):
             'Please provide the "xml_text" parameter')
     xml_file = writetmp(xml_text, suffix='.xml')
     try:
-        nrml.read(xml_file)
+        nrml.parse(xml_file)
     except etree.ParseError as exc:
         return _make_response(error_msg=exc.message.message,
                               error_line=exc.message.lineno,


### PR DESCRIPTION
`nrml.parse` performs a lot more validations than `nrml.read`.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1688/