### PR TITLE
Celery not used bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a critical bug with celery not being used even when `use_celery`
+    was true.
   * Improved the validation of NRML files
   * Added a command `oq-engine --show-log <job_id>`
 

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -39,6 +39,7 @@ if os.environ.get("OQ_ENGINE_USE_SRCDIR") is not None:
         0, join(dirname(dirname(__file__)), "openquake")
     )
 
+import openquake.engine.utils.tasks  # really ugly import with side effects
 from openquake.engine import utils
 from openquake.engine.logs import dbcmd
 

--- a/openquake/engine/utils/tasks.py
+++ b/openquake/engine/utils/tasks.py
@@ -21,7 +21,6 @@ import types
 
 from openquake.baselib.performance import Monitor
 from openquake.commonlib import parallel, valid
-from openquake.engine import logs
 from openquake.engine.utils import config
 
 litetask = parallel.litetask
@@ -48,7 +47,6 @@ if USE_CELERY:
 
         Progress report is built-in.
         """
-        progress = staticmethod(logs.LOG.progress)
         task_ids = []
 
         def _submit(self, pickled_args):
@@ -106,7 +104,3 @@ if USE_CELERY:
     parallel.litetask = oqtask
     parallel.apply_reduce = OqTaskManager.apply_reduce
     parallel.starmap = OqTaskManager.starmap
-
-else:  # no celery
-
-    parallel.TaskManager.progress = staticmethod(logs.LOG.progress)


### PR DESCRIPTION
Solves https://github.com/gem/oq-engine/issues/1987. A second set of pull requests will solve the issue in a robust way and will add a regression test. You can check that nothing is broken: https://ci.openquake.org/job/zdevel_oq-engine/1716