### PR TITLE
Change the default log level in the server

### DIFF
--- a/openquake/server/db/models.py
+++ b/openquake/server/db/models.py
@@ -196,7 +196,6 @@ class Log(djm.Model):
     LOG_LEVEL_CHOICES = (
         (u'debug', u'Debug'),
         (u'info', u'Info'),
-        (u'progress', u'Progress'),
         (u'warn', u'Warn'),
         (u'error', u'Error'),
         (u'critical', u'Critical'),

--- a/openquake/server/tasks.py
+++ b/openquake/server/tasks.py
@@ -27,7 +27,7 @@ from openquake.server.settings import DEBUG
 
 # all the logs are sent to the platform; one would need a different logger
 # to discriminate between progress logs and debug logs written in the file
-DEFAULT_LOG_LEVEL = 'debug' if DEBUG else 'progress'
+DEFAULT_LOG_LEVEL = 'debug' if DEBUG else 'info'
 
 
 # FIXME. Configure logging by using the configuration stored in settings


### PR DESCRIPTION
The 'progress' log level has been removed recently.

I thought the issue was fixed by the previous PR but the problem disappeared only because I enabled the debug mode (it sets the log level to 'debug')

Closes #1992.

https://ci.openquake.org/job/zdevel_oq-engine/1726/