### PR TITLE
Fixed in a more robust way the duplicated log bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed in a more robust way the duplicated log bug
   * Made more robust the killing of processes by patching concurrent.futures
   * Fixed a critical bug with celery not being used even when `use_celery`
     was true.

--- a/openquake/engine/logs.py
+++ b/openquake/engine/logs.py
@@ -135,8 +135,9 @@ def handle(job_id, log_level='info', log_file=None):
     """
     handlers = [LogDatabaseHandler(job_id)]  # log on db always
     if log_file is None:
-        if not logging.root.handlers:
-            # add a StreamHandler if not already there
+        # add a StreamHandler if not already there
+        if not any(h for h in logging.root.handlers
+                   if isinstance(h, logging.StreamHandler)):
             handlers.append(LogStreamHandler(job_id))
     else:
         handlers.append(LogFileHandler(job_id, log_file))

--- a/openquake/engine/logs.py
+++ b/openquake/engine/logs.py
@@ -135,7 +135,9 @@ def handle(job_id, log_level='info', log_file=None):
     """
     handlers = [LogDatabaseHandler(job_id)]  # log on db always
     if log_file is None:
-        handlers.append(LogStreamHandler(job_id))
+        if not logging.root.handlers:
+            # add a StreamHandler if not already there
+            handlers.append(LogStreamHandler(job_id))
     else:
         handlers.append(LogFileHandler(job_id, log_file))
     for handler in handlers:


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/1989. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1727