### PR TITLE
Fixed an issue of the signal handling with the Django development server

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -87,7 +87,15 @@ def raiseMasterKilled(signum, _stack):
         msg = 'Received a signal %d' % signum
     raise MasterKilled(msg)
 
-signal.signal(signal.SIGTERM, raiseMasterKilled)
+
+# register the raiseMasterKilled callback for SIGTERM
+# when using the Django development server this module is imported by a thread,
+# so one gets a `ValueError: signal only works in main thread` that
+# can be safely ignored
+try:
+    signal.signal(signal.SIGTERM, raiseMasterKilled)
+except ValueError:
+    pass
 
 
 # used by bin/openquake and openquake.server.views


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2003. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1756 and here for the remove-postgres branch: https://ci.openquake.org/job/zdevel_oq-engine/1757