### PR TITLE
Fixed a small export bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Fixed the export: first the xml exporter is tried and then the csv exporter;
+    if both are available, only the first is used, not both of them
+
   [Daniele Viganò]
   * Removed the openquake_worker.cfg file because it is not used anymore
 


### PR DESCRIPTION
The problem is that an output can be exported in more than one format it is now exported in all formats. We must revert to the previous situation, when only the format with highest priority is used. 
The issue https://github.com/gem/oq-engine/issues/2008 is more and more relevant.
The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/1777