### PR TITLE
Removed the .txt outputs from the WebUI page engine/<output_id>/outputs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Removed the .txt outputs from the WebUI page engine/<output_id>/outputs
+    (they are useful only internally)
   * Fixed the export: first the xml exporter is tried and then the csv exporter;
     if both are available, only the first is used, not both of them
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -405,7 +405,8 @@ def calc_results(request, calc_id):
     for result in results:
         try:  # output from the datastore
             rtype = result.ds_key
-            outtypes = output_types[rtype]
+            # Catalina asked to remove the .txt outputs (used for the GMFs)
+            outtypes = [ot for ot in output_types[rtype] if ot != 'txt']
         except KeyError:
             continue  # non-exportable outputs should not be shown
         url = urlparse.urljoin(base_url, 'v1/calc/result/%d' % result.id)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2004. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1783