### PR TITLE
deb: move some logic away from packager/postinst

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,5 @@
+openquake.cfg   /etc/openquake
+LICENSE         /usr/share/openquake/engine
+README.md       /usr/share/openquake/engine
+celeryconfig.py /usr/share/openquake/engine
+

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -1,7 +1,7 @@
-Index: oq-engine/openquake/engine/openquake.cfg
+Index: oq-engine/openquake.cfg
 ===================================================================
---- oq-engine.orig/openquake/engine/openquake.cfg	2016-05-06 14:06:06.000000000 +0000
-+++ oq-engine/openquake/engine/openquake.cfg	2016-05-06 16:23:04.006138759 +0000
+--- oq-engine.orig/openquake.cfg	2016-05-06 14:06:06.000000000 +0000
++++ oq-engine/openquake.cfg	2016-05-06 16:23:04.006138759 +0000
 @@ -40,8 +40,8 @@
  
  [dbserver]

--- a/debian/postinst
+++ b/debian/postinst
@@ -52,29 +52,9 @@ if [ $(cat /etc/passwd | grep ^openquake: | wc -l) -eq 0 ]; then
     adduser --system --home /var/lib/$USER --group --shell /bin/bash $USER
 fi
 
-HDIR=/usr/share/openquake/engine
-IDIR=/usr/lib/python2.7/dist-packages/openquake/engine
-mkdir -p $HDIR
-
-rm -f $HDIR/celeryconfig.py.new_in_this_release
-cp $IDIR/celeryconfig.py $HDIR
+HDIR=/usr/share/openquake
+mkdir -p ${HDIR}/engine
 chown -R $USER.$USER $HDIR
-
-SDIR=/etc/openquake
-for cfg in openquake.cfg
-do
-    rm -f $SDIR/$cfg.new_in_this_release
-    if [ -f $SDIR/$cfg ]; then
-        if ! diff $IDIR/$cfg $SDIR/$cfg >/dev/null; then
-            cp $IDIR/$cfg $SDIR/$cfg.new_in_this_release
-        fi
-    else
-        mkdir -p $SDIR
-        cp $IDIR/$cfg $SDIR
-        chmod 644 $SDIR/$cfg
-    fi
-done
-chown -R $USER.$USER $SDIR
 
 # create the database. This is run as "openquake" by default
 /usr/bin/oq_create_db

--- a/debian/postinst
+++ b/debian/postinst
@@ -52,8 +52,8 @@ if [ $(cat /etc/passwd | grep ^openquake: | wc -l) -eq 0 ]; then
     adduser --system --home /var/lib/$USER --group --shell /bin/bash $USER
 fi
 
-HDIR=/usr/share/openquake
-mkdir -p ${HDIR}/engine
+HDIR=/usr/share/openquake/engine
+mkdir -p $HDIR
 chown -R $USER.$USER $HDIR
 
 # create the database. This is run as "openquake" by default

--- a/packager.sh
+++ b/packager.sh
@@ -1259,12 +1259,6 @@ fi
 
 sed -i "s/^\([ ${TB}]*\)[^)]*\()  # release date .*\)/\1${dt}\2/g" openquake/__init__.py
 
-# mods pre-packaging
-mv LICENSE         openquake/engine
-mv README.md       openquake/engine/README
-mv celeryconfig.py openquake/engine
-mv openquake.cfg   openquake/engine
-
 if [ $BUILD_ON_LXC -eq 1 ]; then
     sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
     _lxc_name_and_ip_get /tmp/packager.eph.$$.log

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -58,9 +58,7 @@ exit 0
 %prep
 %setup -n %{oqrepo}-%{oqversion}-%{oqrelease} -n %{oqrepo}-%{oqversion}-%{oqrelease}
 
-# this should be -p1, but is -p3 to keep compatibility with the debian patch,
-# which is generated usign some hacks
-%patch1 -p3
+%patch1 -p1
 
 %build
 python setup.py build


### PR DESCRIPTION
Removes some "manual" steps in the packager required to have the deb package and also removes some logic from the postinst.

Ubuntu: https://ci.openquake.org/job/zdevel_oq-engine/1814/
RedHat: https://ci.openquake.org/job/redhat_oq-engine/27/

Closes #2023 