### PR TITLE
The export must be run by the current user

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Another export fix: made sure it is run by the current user
   * Fixed the export: if the export directory does not exists, it is created
   * Introduced the configuration variable `multi_user`, false for source
     installations and true for package installations

--- a/openquake/engine/bin/openquake_cli.py
+++ b/openquake/engine/bin/openquake_cli.py
@@ -57,6 +57,7 @@ from openquake.engine.utils import confirm, config
 import openquake.engine
 from openquake.engine import engine, logs
 from openquake.engine.tools.make_html_report import make_report
+from openquake.engine.export import core
 from openquake.commonlib import datastore, valid
 from openquake.calculators import views
 
@@ -391,15 +392,16 @@ def main():
 
     elif args.export_output is not None:
         output_id, target_dir = args.export_output
-        for line in logs.dbcmd('@export_output', int(output_id),
-                               expanduser(target_dir), exports):
+        dskey, calc_id, datadir = logs.dbcmd('get_output', int(output_id))
+        for line in core.export_output(
+                dskey, calc_id, datadir, expanduser(target_dir), exports):
             print line
 
     elif args.export_outputs is not None:
         job_id, target_dir = args.export_outputs
         hc_id = get_job_id(job_id)
-        for line in logs.dbcmd('@export_outputs', hc_id,
-                               expanduser(target_dir), exports):
+        for line in core.export_outputs(
+                hc_id, expanduser(target_dir), exports):
             print line
 
     elif args.delete_uncompleted_calculations:

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -167,60 +167,6 @@ def list_calculations(job_type, user_name):
                 job.id, status, start_time, descr)).encode('utf-8')
 
 
-def export_outputs(job_id, target_dir, export_type):
-    # make it possible commands like `oq-engine --eos -1 /tmp`
-    outputs = models.Output.objects.filter(oq_job=job_id)
-    if not outputs:
-        yield('Found nothing to export for job %s' % job_id)
-    for output in outputs:
-        yield('Exporting %s...' % output)
-        try:
-            for line in export_output(output.id, target_dir, export_type):
-                yield line
-        except Exception as exc:
-            yield(exc)
-
-
-def get_outkey(dskey, export_types):
-    """
-    Extract the first pair (dskey, exptype) found in export
-    """
-    for exptype in export_types:
-        if (dskey, exptype) in export:
-            return (dskey, exptype)
-
-
-def export_output(output_id, target_dir, export_type):
-    """
-    Simple UI wrapper around
-    :func:`openquake.engine.export.core.export_from_datastore` yielding
-    a summary of files exported, if any.
-    """
-    queryset = models.Output.objects.filter(pk=output_id)
-    if not queryset.exists():
-        yield('No output found for OUTPUT_ID %s' % output_id)
-        return
-
-    if queryset.all()[0].oq_job.status != "complete":
-        yield("Exporting output produced by a job which did not run "
-              "successfully. Results might be uncomplete")
-
-    dskey, calc_id, datadir = get_output(output_id)
-    outkey = get_outkey(dskey, export_type.split(','))
-    if not outkey:
-        yield 'There is not exporter for %s, %s' % (dskey, export_type)
-        return
-    the_file = core.export_from_datastore(outkey, calc_id, datadir, target_dir)
-    if the_file.endswith('.zip'):
-        dname = os.path.dirname(the_file)
-        fnames = zipfile.ZipFile(the_file).namelist()
-        yield('Files exported:')
-        for fname in fnames:
-            yield(os.path.join(dname, fname))
-    else:
-        yield('File exported: %s' % the_file)
-
-
 def list_outputs(job_id, full=True):
     """
     List the outputs for a given
@@ -529,3 +475,12 @@ def get_result(result_id):
     output = models.get(models.Output, pk=result_id)
     job = output.oq_job
     return job.id, job.status, os.path.dirname(job.ds_calc_dir), output.ds_key
+
+
+def get_results(job_id):
+    """
+    :returns: (datadir, datastore_keys)
+    """
+    job = models.get(models.OqJob, pk=job_id)
+    datadir = os.path.dirname(job.ds_calc_dir)
+    return datadir, [output.ds_key for output in get_outputs(job_id)]

--- a/packager.sh
+++ b/packager.sh
@@ -591,9 +591,9 @@ celeryd_wait $GEM_MAXLOOP"
         # Try to export a set of results AFTER the calculation
         # automatically creates a directory called out
         echo \"Exporting output #1\"
-        oq-engine --eo 1 output
+        oq-engine --eo 1 /tmp/output
         echo \"Exporting calculation #2\"
-        oq-engine --eos 2 out/eos_2
+        oq-engine --eos 2 /tmp/out/eos_2
 
         for demo_dir in \$(find . -type d | sort); do
             if [ -f \$demo_dir/job_hazard.ini ]; then

--- a/packager.sh
+++ b/packager.sh
@@ -591,9 +591,9 @@ celeryd_wait $GEM_MAXLOOP"
         # Try to export a set of results AFTER the calculation
         # automatically creates a directory called out
         echo \"Exporting output #1\"
-        oq-engine --eo 1 /tmp/output
+        oq-engine --eo 1 output
         echo \"Exporting calculation #2\"
-        oq-engine --eos 2 /tmp/out/eos_2
+        oq-engine --eos 2 out/eos_2
 
         for demo_dir in \$(find . -type d | sort); do
             if [ -f \$demo_dir/job_hazard.ini ]; then


### PR DESCRIPTION
Before, it was run by the dbserver, i.e. by the openquake user and there were errors when exporting, like the `.` directory being expanded to the current directory for the dbserver, not for the user.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1824