### PR TITLE
webui: if no path is requested, go to /engine

### DIFF
--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -18,11 +18,11 @@
 
 from django.conf import settings
 from django.conf.urls import patterns, url, include
-
+from django.views.generic.base import RedirectView
 
 urlpatterns = patterns(
     '',
-
+    url(r'^$', RedirectView.as_view(url='/engine/')),
     url(r'^engine_version$', 'openquake.server.views.get_engine_version'),
     url(r'^v1/calc/', include('openquake.server.v1.calc_urls')),
     url(r'^v1/valid/', 'openquake.server.views.validate_nrml'),


### PR DESCRIPTION
Avoid the `Page not found` if any sub-url isn't requested (i.e. `http://localhost:8000`). If no sub-url is requested the public frontend (`/engine`) is provided via a redirect.

This was already done on production systems where nginx is used. Now the same behavior is applied using the embedded django server. 