### PR TITLE
webui: suppress a django warning

### DIFF
--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -22,7 +22,7 @@ from django.views.generic.base import RedirectView
 
 urlpatterns = patterns(
     '',
-    url(r'^$', RedirectView.as_view(url='/engine/')),
+    url(r'^$', RedirectView.as_view(url='/engine/', permanent=True)),
     url(r'^engine_version$', 'openquake.server.views.get_engine_version'),
     url(r'^v1/calc/', include('openquake.server.v1.calc_urls')),
     url(r'^v1/valid/', 'openquake.server.views.validate_nrml'),


### PR DESCRIPTION
```
RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
```