### PR TITLE
webui: open files in binary mode

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -489,7 +489,8 @@ def get_result(request, result_id):
         export_type, DEFAULT_CONTENT_TYPE)
     try:
         fname = 'output-%s-%s' % (result_id, os.path.basename(exported))
-        data = open(exported).read()
+        # 'b' is needed when running the WebUI on Windows
+        data = open(exported, 'rb').read()
         response = HttpResponse(data, content_type=content_type)
         response['Content-Length'] = len(data)
         response['Content-Disposition'] = 'attachment; filename=%s' % fname


### PR DESCRIPTION
To avoid corruption of zip files when running the WebUI on Windows. This does not affect Linux.

See https://docs.python.org/2/library/functions.html#open
@ptormene had a similar issues with the QGIS plugin...