### PR TITLE
Provided a better error message in the case of absence of openquake.cfg

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Provided a better error message in the case of absence of openquake.cfg
   * Removed the check on the export_dir when using the WebUI
 
   [Daniele Viganò]

--- a/openquake/engine/config.py
+++ b/openquake/engine/config.py
@@ -84,9 +84,12 @@ class _Config(object):
     def _load_from_file(self):
         """Load the config files, set up the section dictionaries."""
         config = ConfigParser.SafeConfigParser()
-        config.read(self._get_paths())
+        paths = self._get_paths()
+        config.read(paths)
         for section in config.sections():
             self.cfg[section] = dict(config.items(section))
+        if not self.cfg:
+            raise IOError('Found no configuration file, tried %s' % paths)
 
     def is_readable(self):
         """Return `True` if at least one config file is readable."""

--- a/openquake/engine/config.py
+++ b/openquake/engine/config.py
@@ -85,11 +85,10 @@ class _Config(object):
         """Load the config files, set up the section dictionaries."""
         config = ConfigParser.SafeConfigParser()
         paths = self._get_paths()
+
         config.read(paths)
         for section in config.sections():
             self.cfg[section] = dict(config.items(section))
-        if not self.cfg:
-            raise IOError('Found no configuration file, tried %s' % paths)
 
     def is_readable(self):
         """Return `True` if at least one config file is readable."""
@@ -124,6 +123,7 @@ def context(section, **kw):
 
 def get_section(section):
     """A dictionary of key/value pairs for the given `section` or `None`."""
+    abort_if_no_config_available()
     return cfg.get(section)
 
 

--- a/openquake/engine/config.py
+++ b/openquake/engine/config.py
@@ -84,9 +84,7 @@ class _Config(object):
     def _load_from_file(self):
         """Load the config files, set up the section dictionaries."""
         config = ConfigParser.SafeConfigParser()
-        paths = self._get_paths()
-
-        config.read(paths)
+        config.read(self._get_paths())
         for section in config.sections():
             self.cfg[section] = dict(config.items(section))
 

--- a/openquake/server/tests/helpers.py
+++ b/openquake/server/tests/helpers.py
@@ -37,7 +37,6 @@ from django.core import exceptions
 
 from openquake.baselib.general import writetmp as touch
 
-from openquake.server.db import actions
 from openquake.engine import engine, logs, config
 
 CD = os.path.dirname(__file__)  # current directory

--- a/openquake/server/tests/utils_config_test.py
+++ b/openquake/server/tests/utils_config_test.py
@@ -169,7 +169,7 @@ class ConfigTestCase(ConfigTestCase, unittest.TestCase):
         # get() will return `None` for a section name that is not known
         config.cfg.cfg.clear()
         config.cfg._load_from_file()
-        self.assertTrue(config.cfg.get("Anything") is None)
+        self.assertIsNone(config.cfg.get("Anything"))
 
     def test_get_with_known_section(self):
         # get() will correctly return configuration data for known sections


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2037. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1840/