### PR TITLE
Support django 1.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Supported all versions of Django >= 1.5
   * Provided a better error message in the case of absence of openquake.cfg
   * Removed the check on the export_dir when using the WebUI
   * Reduce the data transfer of the realization association object

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.globalquakemodel.org/openquake/
 
 Package: python-oq-engine
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, python-scipy, python-numpy, python-psutil, python-decorator, python-prctl, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-paramiko, python-shapely, python-setuptools, python-nose, python-mock, python-requests (>=0.8.2), python-docutils, python-oq-hazardlib (>=0.20.0-0~), python-concurrent.futures (>=2.1.2), rabbitmq-server (>=2.8.0-2~gem02), supervisor
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, python-scipy, python-numpy, python-psutil, python-decorator, python-prctl, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-paramiko, python-shapely, python-setuptools, python-nose, python-mock, python-requests (>=0.8.2), python-docutils, python-oq-hazardlib (>=0.20.0-0~), python-concurrent.futures (>=2.1.2), python-django, rabbitmq-server (>=2.8.0-2~gem02), supervisor
 Conflicts: python-oq-risklib, python-noq, python-oq
 Replaces: python-oq-risklib
 Recommends: ${dist:Recommends}

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ bd=openquake/bin
 
 DEFAULT_DEP = python-amqp, python-django, python-h5py (>= 2.2.1)
 DEFAULT_REC =
-PRECISE_DEP = python-django16, python-h5py (= 2.2.1-1build3~precise03)
+PRECISE_DEP = python-django, python-h5py (= 2.2.1-1build3~precise03)
 PRECISE_REC =
 
 ifeq ($(shell lsb_release --codename --short),precise)

--- a/debian/rules
+++ b/debian/rules
@@ -16,9 +16,9 @@ export DH_OPTIONS
 
 bd=openquake/bin
 
-DEFAULT_DEP = python-amqp, python-django, python-h5py (>= 2.2.1)
+DEFAULT_DEP = python-amqp, python-h5py (>= 2.2.1)
 DEFAULT_REC =
-PRECISE_DEP = python-django, python-h5py (= 2.2.1-1build3~precise03)
+PRECISE_DEP = python-h5py (= 2.2.1-1build3~precise03)
 PRECISE_REC =
 
 ifeq ($(shell lsb_release --codename --short),precise)

--- a/openquake/engine/tools/make_html_report.py
+++ b/openquake/engine/tools/make_html_report.py
@@ -90,12 +90,12 @@ class HtmlTable(object):
 
 
 JOB_STATS = '''
-SELECT id, user_name, start_time, stop_time, status FROM job WHERE id=?;
+SELECT id, user_name, start_time, stop_time, status FROM job WHERE id=%s;
 '''
 
 ALL_JOBS = '''
 SELECT id, user_name, status, ds_calc_dir FROM job
-WHERE start_time >= ? AND start_time < ? ORDER BY stop_time
+WHERE start_time >= %s AND start_time < %s ORDER BY stop_time
 '''
 
 PAGE_TEMPLATE = '''\

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import os
-import zipfile
 import operator
 from datetime import datetime
 
@@ -24,9 +23,7 @@ from django.core import exceptions
 from django import db
 
 from openquake.commonlib import datastore, valid
-from openquake.commonlib.export import export
 from openquake.server.db import models
-from openquake.engine.export import core
 from openquake.server.db.schema.upgrades import upgrader
 from openquake.server.db import upgrade_manager
 
@@ -304,7 +301,7 @@ def log(job_id, timestamp, level, process, message):
     """
     db.connection.cursor().execute(
         'INSERT INTO log (job_id, timestamp, level, process, message) VALUES'
-        '(?, ?, ?, ?, ?)', (job_id, timestamp, level, process, message))
+        '(%s, %s, %s, %s, %s)', (job_id, timestamp, level, process, message))
 
 
 def get_log(job_id):

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -26,7 +26,6 @@ import sys
 import json
 import time
 import unittest
-import platform
 import subprocess
 import tempfile
 import requests
@@ -35,9 +34,6 @@ if requests.__version__ < '1.0.0':
     requests.Response.text = property(lambda self: self.content)
 if hasattr(django, 'setup'):
     django.setup()  # for Django >= 1.7
-
-
-UBUNTU12 = platform.dist() == ('Ubuntu', '12.04', 'precise')
 
 
 class EngineServerTestCase(unittest.TestCase):
@@ -105,6 +101,10 @@ class EngineServerTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        if django.get_version() < '1.5':
+            # the WebUI is unsupported
+            raise unittest.SkipTest
+
         cls.job_ids = []
         env = os.environ.copy()
         env['OQ_DISTRIBUTE'] = 'no'
@@ -141,9 +141,6 @@ class EngineServerTestCase(unittest.TestCase):
         assert resp.status_code == 404, resp
 
     def test_ok(self):
-        if UBUNTU12:
-            # this test is broken for unknown reasons
-            raise unittest.SkipTest
         job_id = self.postzip('archive_ok.zip')
         self.wait()
         log = self.get('%s/log/:' % job_id)


### PR DESCRIPTION
This is needed to support the platform (our version of geonode uses Django 1.5.5). See the runs for Ubuntu 12.04 and 14.04: https://ci.openquake.org/job/zdevel_oq-engine/1854

When using Django 1.3.1 the dbserver and the engine work, but the WebUI does not (this is why its tests have been skipped): it is the user responsability to upgrade to a newer version of Django. Django 1.5 is enough to run the WebUI, 1.4 has not been tried.