### PR TITLE
Update oq_*_db scripts

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -52,14 +52,17 @@ if [ $(cat /etc/passwd | grep ^openquake: | wc -l) -eq 0 ]; then
     adduser --system --home /var/lib/$USER --group --shell /bin/bash $USER
 fi
 
-HDIR=/usr/share/openquake/engine
-mkdir -p $HDIR
-chown -R $USER.$USER $HDIR
+DIRS=('/var/lib/openquake' '/usr/share/openquake/engine' '/var/log/openquake')
 
-# create logs directory
-LDIR=/var/log/openquake
-mkdir -p $LDIR
-chown -R $USER.adm $LDIR
+for d in ${DIRS[@]}; do
+    if [ ! -d $d ]; then
+        mkdir -p $d
+    fi
+    # make sure that permissions are fine
+    chown -R $USER.$USER $d
+done
+# custom permissions
+chgrp adm /var/log/openquake
 
 # create the database. This is run as "openquake" by default
 /usr/bin/oq_create_db

--- a/debian/postinst
+++ b/debian/postinst
@@ -52,17 +52,17 @@ if [ $(cat /etc/passwd | grep ^openquake: | wc -l) -eq 0 ]; then
     adduser --system --home /var/lib/$USER --group --shell /bin/bash $USER
 fi
 
-DIRS=('/var/lib/openquake' '/usr/share/openquake/engine' '/var/log/openquake')
+DIR=/var/lib/openquake
+mkdir -p $DIR
+chown -R $USER.$USER $DIR
 
-for d in ${DIRS[@]}; do
-    if [ ! -d $d ]; then
-        mkdir -p $d
-    fi
-    # make sure that permissions are fine
-    chown -R $USER.$USER $d
-done
-# custom permissions
-chgrp adm /var/log/openquake
+DIR=/usr/share/openquake/engine
+mkdir -p $DIR
+chown -R $USER.$USER $DIR
+
+DIR=/var/log/openquake
+mkdir -p $DIR
+chown -R $USER.adm $DIR
 
 # create the database. This is run as "openquake" by default
 /usr/bin/oq_create_db

--- a/openquake/engine/bin/oq_create_db
+++ b/openquake/engine/bin/oq_create_db
@@ -27,11 +27,11 @@ for c in ${OQ_CFG_FILES[@]}; do
     fi
 done
 
-# Fallback: create the database in the user's home folder
-if [ -z "$OQ_DB" ]; then
-    OQ_DB=$(eval echo "~${OQ_USER}/oqdata/db.sqlite3")
-else
+if [ -n "$OQ_DB" ]; then
     OQ_DB=${OQ_DB#*=}
+else
+    # Fallback: create the database in the user's home folder
+    OQ_DB=$(eval echo "~${OQ_USER}/oqdata/db.sqlite3")
 fi
 
 while (( "$#" )); do

--- a/openquake/engine/bin/oq_create_db
+++ b/openquake/engine/bin/oq_create_db
@@ -7,14 +7,27 @@ if [ $GEM_SET_DEBUG ]; then
 fi
 set -e
 
-OQ_USER='openquake'
-OQ_DB_SCRIPT='-m openquake.server.db.upgrade_manager'
-OQ_DB=$(eval echo "~${OQ_USER}/db.sqlite3")
-
 help() {
     echo "Syntax: $(basename "$0") [-u user] [-s /custom/python/script.py] [-d /custom/db/path/to/db.sqlite3]"
     exit 0
 }
+
+OQ_USER='openquake'
+OQ_DB_SCRIPT='-m openquake.server.db.upgrade_manager'
+OQ_CFG_FILES=('/etc/openquake/openquake.cfg' '../openquake.cfg' '../../../openquake.cfg')
+
+for c in ${OQ_CFG_FILES[@]}; do
+    if [ -f $c ]; then
+        OQ_DB=$(grep file $c)
+        OQ_DB=${OQ_DB#*=}
+        break
+    fi
+done
+
+# Fallback: create the database in the user's home folder
+if [ -z $OQ_DB ]; then
+    OQ_DB=$(eval echo "~${OQ_USER}/oqdata/db.sqlite3")
+fi
 
 while (( "$#" )); do
     case "$1" in

--- a/openquake/engine/bin/oq_create_db
+++ b/openquake/engine/bin/oq_create_db
@@ -12,21 +12,26 @@ help() {
     exit 0
 }
 
+OQ_BASE=$(dirname $(readlink -e "$0"))
 OQ_USER='openquake'
 OQ_DB_SCRIPT='-m openquake.server.db.upgrade_manager'
-OQ_CFG_FILES=('/etc/openquake/openquake.cfg' '../openquake.cfg' '../../../openquake.cfg')
+OQ_CFG_FILES=('/etc/openquake/openquake.cfg' '../etc/openquake.cfg' '../openquake.cfg' '../../../openquake.cfg')
 
 for c in ${OQ_CFG_FILES[@]}; do
-    if [ -f $c ]; then
+    if [ -f "$c" ]; then
         OQ_DB=$(grep file $c)
-        OQ_DB=${OQ_DB#*=}
+        break
+    elif [ -f "$OQ_BASE/$c" ]; then
+        OQ_DB=$(grep file $OQ_BASE/$c)
         break
     fi
 done
 
 # Fallback: create the database in the user's home folder
-if [ -z $OQ_DB ]; then
+if [ -z "$OQ_DB" ]; then
     OQ_DB=$(eval echo "~${OQ_USER}/oqdata/db.sqlite3")
+else
+    OQ_DB=${OQ_DB#*=}
 fi
 
 while (( "$#" )); do

--- a/openquake/engine/bin/oq_reset_db
+++ b/openquake/engine/bin/oq_reset_db
@@ -35,11 +35,11 @@ for c in ${OQ_CFG_FILES[@]}; do
     fi
 done
 
-# Fallback: create the database in the user's home folder
-if [ -z "$OQ_DB" ]; then
-    OQ_DB=$(eval echo "~${OQ_USER}/oqdata/db.sqlite3")
-else
+if [ -n "$OQ_DB" ]; then
     OQ_DB=${OQ_DB#*=}
+else
+    # Fallback: create the database in the user's home folder
+    OQ_DB=$(eval echo "~${OQ_USER}/oqdata/db.sqlite3")
 fi
 
 command -v oq_create_db &> /dev/null || {

--- a/openquake/engine/bin/oq_reset_db
+++ b/openquake/engine/bin/oq_reset_db
@@ -22,7 +22,20 @@ BOLD=`tput bold`
 NORMAL=`tput sgr0`
 OQ_CREATE_DB='oq_create_db'
 OQ_USER='openquake'
-OQ_DB=$(eval echo "~${OQ_USER}/db.sqlite3")
+OQ_CFG_FILES=('/etc/openquake/openquake.cfg' '../openquake.cfg' '../../../openquake.cfg')
+
+for c in ${OQ_CFG_FILES[@]}; do
+    if [ -f $c ]; then
+        OQ_DB=$(grep file $c)
+        OQ_DB=${OQ_DB#*=}
+        break
+    fi
+done
+
+# Fallback: create the database in the user's home folder
+if [ -z $OQ_DB ]; then
+    OQ_DB=$(eval echo "~${OQ_USER}/oqdata/db.sqlite3")
+fi
 
 command -v oq_create_db &> /dev/null || {
     if [ -x "./${OQ_CREATE_DB}" ]; then

--- a/openquake/engine/bin/oq_reset_db
+++ b/openquake/engine/bin/oq_reset_db
@@ -20,21 +20,26 @@ HSD
 
 BOLD=`tput bold`
 NORMAL=`tput sgr0`
+OQ_BASE=$(dirname $(readlink -e "$0"))
 OQ_CREATE_DB='oq_create_db'
 OQ_USER='openquake'
-OQ_CFG_FILES=('/etc/openquake/openquake.cfg' '../openquake.cfg' '../../../openquake.cfg')
+OQ_CFG_FILES=('/etc/openquake/openquake.cfg' '../etc/openquake.cfg' '../openquake.cfg' '../../../openquake.cfg')
 
 for c in ${OQ_CFG_FILES[@]}; do
-    if [ -f $c ]; then
+    if [ -f "$c" ]; then
         OQ_DB=$(grep file $c)
-        OQ_DB=${OQ_DB#*=}
+        break
+    elif [ -f "$OQ_BASE/$c" ]; then
+        OQ_DB=$(grep file $OQ_BASE/$c)
         break
     fi
 done
 
 # Fallback: create the database in the user's home folder
-if [ -z $OQ_DB ]; then
+if [ -z "$OQ_DB" ]; then
     OQ_DB=$(eval echo "~${OQ_USER}/oqdata/db.sqlite3")
+else
+    OQ_DB=${OQ_DB#*=}
 fi
 
 command -v oq_create_db &> /dev/null || {


### PR DESCRIPTION
In `oq_create_db` and `oq_reset_db` take the DB path from the `openquake.cfg` (looking first in `/etc` and then in the relative path to the scripts based on the repo structure) and do not guess that by default the location of the db is always the openquake user's home.

This makes the packages work also on "strange" setup like the VM.

Tests: https://ci.openquake.org/job/zdevel_oq-engine/1902/