### PR TITLE
debian/postinst: setup rabbitmq only if it's running

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -31,7 +31,7 @@ if [ "$LSB_RELEASE" != "precise" -a "$LSB_RELEASE" != "trusty" -a "$LSB_RELEASE"
     db_go
 fi
 
-if [ -f /usr/sbin/rabbitmqctl ]; then
+if [ -f /usr/sbin/rabbitmqctl -a -f /run/rabbitmq/pid ]; then
     # create rabbitmq configuration for python-celery
     celeryuser_count=`rabbitmqctl list_users | grep celeryuser | wc -l`
     if [ $celeryuser_count -eq 0 ]; then


### PR DESCRIPTION
The RabbitMQ queues can be set only if it is running. At the first installation RabbitMQ is started automatically, so queues are created. Then if RabbitMQ is disabled because unused (i.e. single user) without this fix the engine cannot be upgraded:

```bash
Setting up python-oq-engine (2.0.0-0~trusty01~dev1465338130+cc6f441) ...
Error: unable to connect to node 'rabbit@oq-1404': nodedown

DIAGNOSTICS
===========

nodes in question: ['rabbit@oq-1404']

hosts, their running nodes and ports:
- oq-1404: [{rabbitmqctl2516,34922}]

current node details:
- node name: 'rabbitmqctl2516@oq-1404'
- home dir: /var/lib/rabbitmq
- cookie hash: lAWXXs9NQm8KKak89LRXpA==

Creating user "celeryuser" ...
Error: unable to connect to node 'rabbit@oq-1404': nodedown
```

A better fix would be a multi-package installation with different dependencies, but for now this works.

https://ci.openquake.org/job/zdevel_oq-engine/1906/