### PR TITLE
Simplified the source manager

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -627,9 +627,9 @@ class RiskCalculator(HazardCalculator):
         rlz_ids = getattr(self.oqparam, 'rlz_ids', ())
         if rlz_ids:
             self.rlzs_assoc = self.rlzs_assoc.extract(rlz_ids)
-        all_args = [(riskinput, self.riskmodel, self.rlzs_assoc) +
+        all_args = ((riskinput, self.riskmodel, self.rlzs_assoc) +
                     self.extra_args + (self.monitor,)
-                    for riskinput in self.riskinputs]
+                    for riskinput in self.riskinputs)
         res = starmap(self.core_task.__func__, all_args).reduce()
         return res
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -339,7 +339,7 @@ class HazardCalculator(BaseCalculator):
             self.init()
             if 'source' in self.oqparam.inputs:
                 with self.monitor('managing sources', autoflush=True):
-                    self.tm = self.send_sources()
+                    self.taskman = self.send_sources()
                 attrs = self.datastore.hdf5['composite_source_model'].attrs
                 attrs['weight'] = self.csm.weight
                 attrs['filtered_weight'] = self.csm.filtered_weight

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -513,16 +513,11 @@ class HazardCalculator(BaseCalculator):
             logging.info('Generating %d tiles of %d sites each',
                          num_tiles, len(tiles[0]))
         self.manager = source.SourceManager(
-            self.csm, self.core_task.__func__,
-            oq.maximum_distance, self.datastore,
-            self.monitor.new(oqparam=oq),
-            self.random_seed, oq.filter_sources, num_tiles=num_tiles)
-        siteidx = 0
-        for i, tile in enumerate(tiles, 1):
-            if num_tiles > 1:
-                logging.info('Processing tile %d', i)
-            self.manager.submit_sources(tile, siteidx)
-            siteidx += len(tile)
+            self.csm, oq.maximum_distance, self.datastore,
+            self.monitor.new(oqparam=oq), self.random_seed,
+            oq.filter_sources, num_tiles=num_tiles)
+        self.tm = starmap(self.core_task.__func__,
+                          self.manager.gen_args(tiles))
 
     def save_data_transfer(self, taskmanager):
         """

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -339,8 +339,7 @@ class HazardCalculator(BaseCalculator):
             self.init()
             if 'source' in self.oqparam.inputs:
                 with self.monitor('managing sources', autoflush=True):
-                    self.send_sources()
-                self.manager.store_source_info(self.datastore)
+                    self.tm = self.send_sources()
                 attrs = self.datastore.hdf5['composite_source_model'].attrs
                 attrs['weight'] = self.csm.weight
                 attrs['filtered_weight'] = self.csm.filtered_weight
@@ -501,23 +500,25 @@ class HazardCalculator(BaseCalculator):
 
     def send_sources(self):
         """
-        Filter/split and send the sources to the worker tasks.
+        Filter/split and send the sources to the workers.
+        :returns: a :class:`openquake.commonlib.parallel.TaskManager`
         """
         oq = self.oqparam
         tiles = [self.sitecol]
-        num_tiles = 1
+        self.num_tiles = 1
         if self.is_tiling():
             hint = math.ceil(len(self.sitecol) / oq.sites_per_tile)
             tiles = self.sitecol.split_in_tiles(hint)
-            num_tiles = len(tiles)
+            self.num_tiles = len(tiles)
             logging.info('Generating %d tiles of %d sites each',
-                         num_tiles, len(tiles[0]))
-        self.manager = source.SourceManager(
+                         self.num_tiles, len(tiles[0]))
+        manager = source.SourceManager(
             self.csm, oq.maximum_distance, self.datastore,
             self.monitor.new(oqparam=oq), self.random_seed,
-            oq.filter_sources, num_tiles=num_tiles)
-        self.tm = starmap(self.core_task.__func__,
-                          self.manager.gen_args(tiles))
+            oq.filter_sources, num_tiles=self.num_tiles)
+        tm = starmap(self.core_task.__func__, manager.gen_args(tiles))
+        manager.store_source_info(self.datastore)
+        return tm
 
     def save_data_transfer(self, taskmanager):
         """

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -235,8 +235,8 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         monitor = self.monitor.new(self.core_task.__name__)
         monitor.oqparam = self.oqparam
-        curves_by_trt_id = self.tm.reduce(
-            self.agg_dicts, self.zerodict(), posthook=self.save_data_transfer)
+        curves_by_trt_id = self.tm.reduce(self.agg_dicts, self.zerodict())
+        self.save_data_transfer(self.tm)
         with self.monitor('store source_info', autoflush=True):
             self.store_source_info(curves_by_trt_id)
         self.rlzs_assoc = self.csm.info.get_rlzs_assoc(

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -210,8 +210,7 @@ class ClassicalCalculator(base.HazardCalculator):
         :param result_dict: a dictionary with keys (trt_id, gsim)
         :param trt_model: a TrtModel instance
         """
-        return (result_dict.eff_ruptures.get(trt_model.id, 0) /
-                self.manager.num_tiles)
+        return (result_dict.eff_ruptures.get(trt_model.id, 0) / self.num_tiles)
 
     def zerodict(self):
         """

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -234,8 +234,8 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         monitor = self.monitor.new(self.core_task.__name__)
         monitor.oqparam = self.oqparam
-        curves_by_trt_id = self.tm.reduce(self.agg_dicts, self.zerodict())
-        self.save_data_transfer(self.tm)
+        curves_by_trt_id = self.taskman.reduce(self.agg_dicts, self.zerodict())
+        self.save_data_transfer(self.taskman)
         with self.monitor('store source_info', autoflush=True):
             self.store_source_info(curves_by_trt_id)
         self.rlzs_assoc = self.csm.info.get_rlzs_assoc(
@@ -245,9 +245,9 @@ class ClassicalCalculator(base.HazardCalculator):
 
     def store_source_info(self, curves_by_trt_id):
         # store the information about received data
-        received = self.tm.received
+        received = self.taskman.received
         if received:
-            tname = self.tm.name
+            tname = self.taskman.name
             self.datastore.save('job_info', {
                 tname + '_max_received_per_task': max(received),
                 tname + '_tot_received': sum(received),

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -235,7 +235,7 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         monitor = self.monitor.new(self.core_task.__name__)
         monitor.oqparam = self.oqparam
-        curves_by_trt_id = self.manager.tm.reduce(
+        curves_by_trt_id = self.tm.reduce(
             self.agg_dicts, self.zerodict(), posthook=self.save_data_transfer)
         with self.monitor('store source_info', autoflush=True):
             self.store_source_info(curves_by_trt_id)
@@ -246,9 +246,9 @@ class ClassicalCalculator(base.HazardCalculator):
 
     def store_source_info(self, curves_by_trt_id):
         # store the information about received data
-        received = self.manager.tm.received
+        received = self.tm.received
         if received:
-            tname = self.manager.tm.name
+            tname = self.tm.name
             self.datastore.save('job_info', {
                 tname + '_max_received_per_task': max(received),
                 tname + '_tot_received': sum(received),

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -325,7 +325,9 @@ class EventBasedRiskCalculator(base.RiskCalculator):
                 ((riskinput, self.riskmodel, self.rlzs_assoc,
                   self.assetcol, self.monitor.new('task'))
                  for riskinput in riskinputs))
-        return tm.reduce(agg=self.agg, posthook=self.save_data_transfer)
+        res = tm.reduce(agg=self.agg)
+        self.save_data_transfer(tm)
+        return res
 
     def agg(self, acc, result):
         """

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -257,7 +257,7 @@ class TaskManager(object):
                      concurrent_tasks=executor._max_workers,
                      weight=lambda item: 1,
                      key=lambda item: 'Unspecified',
-                     name=None, posthook=None):
+                     name=None):
         """
         Apply a task to a tuple of the form (sequence, \*other_args)
         by first splitting the sequence in chunks, according to the weight
@@ -295,7 +295,7 @@ class TaskManager(object):
             return acc
         logging.info('Starting %d tasks', len(chunks))
         self = cls.starmap(task, [(chunk,) + args for chunk in chunks], name)
-        return self.reduce(agg, acc, posthook)
+        return self.reduce(agg, acc)
 
     def __init__(self, oqtask, name=None):
         self.oqtask = oqtask
@@ -381,7 +381,7 @@ class TaskManager(object):
                 acc = agg(acc, result.unpickle())
             return acc
 
-    def reduce(self, agg=operator.add, acc=None, posthook=None):
+    def reduce(self, agg=operator.add, acc=None):
         """
         Loop on a set of results and update the accumulator
         by using the aggregation function.
@@ -418,8 +418,6 @@ class TaskManager(object):
             self.progress('Received %s of data, maximum per task %s',
                           humansize(sum(self.received)),
                           humansize(max(self.received)))
-        if posthook:
-            posthook(self)
         self.results = []
         return agg_result
 

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -20,6 +20,7 @@
 TODO: write documentation.
 """
 from __future__ import print_function
+from functools import reduce
 import os
 import sys
 import socket
@@ -486,9 +487,13 @@ def litetask_futures(func):
         with monitor('total ' + func.__name__, measuremem=True), \
                 GroundShakingIntensityModel.forbid_instantiation():
             result = func(*args)
+        # NB: flush must not be called in the workers - they must not
+        # have access to the datastore - so we remove it
         rec_delattr(monitor, 'flush')
         return result
-    # NB: we need pickle=True because celery is using the worst possible
+
+    # NB: the returned function must have the same signature of func;
+    # we need pickle=True because celery is using the worst possible
     # protocol; once we remove celery we can try to remove pickle=True
     return FunctionMaker.create(
         func, 'return _s_(_w_, (%(shortsignature)s,), pickle=True)',

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -928,7 +928,8 @@ class SourceManager(object):
 
     def gen_args(self, tiles):
         """
-        Yield the arguments for the calculator
+        Yield (sources, sitecol, siteidx, rlzs_assoc, monitor) by
+        looping on the tiles and on the source blocks.
         """
         siteidx = 0
         for i, sitecol in enumerate(tiles, 1):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -972,6 +972,7 @@ class SourceManager(object):
             attrs['maxweight'] = self.csm.maxweight
             self.infos.clear()
 
+
 @parallel.litetask
 def count_eff_ruptures(sources, sitecol, siteidx, rlzs_assoc, monitor):
     """

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -827,21 +827,14 @@ source_info_dt = numpy.dtype([
 ])
 
 
-source_chunk_dt = numpy.dtype([
-    ('num_sources', numpy.uint32),
-    ('weight', numpy.float32),
-    ('sent', numpy.int32)])
-
-
 class SourceManager(object):
     """
     Manager associated to a CompositeSourceModel instance.
     Filter and split sources and send them to the worker tasks.
     """
-    def __init__(self, csm, taskfunc, maximum_distance,
+    def __init__(self, csm, maximum_distance,
                  dstore, monitor, random_seed=None,
                  filter_sources=True, num_tiles=1):
-        self.tm = parallel.TaskManager(taskfunc)
         self.csm = csm
         self.maximum_distance = maximum_distance
         self.random_seed = random_seed
@@ -851,7 +844,6 @@ class SourceManager(object):
         self.num_tiles = num_tiles
         self.rlzs_assoc = csm.info.get_rlzs_assoc()
         self.split_map = {}  # trt_model_id, source_id -> split sources
-        self.source_chunks = []
         self.infos = {}  # trt_model_id, source_id -> SourceInfo tuple
         if random_seed is not None:
             # generate unique seeds for each rupture with numpy.arange
@@ -934,32 +926,34 @@ class SourceManager(object):
                     ss.serial = src.serial[start:start + nr]
                     start += nr
 
-    def submit_sources(self, sitecol, siteidx=0):
+    def gen_args(self, tiles):
         """
-        Submit the light sources and then the (split) heavy sources.
-        Only the sources affecting the sitecol as considered.
+        Yield the arguments for the calculator
         """
-        tile = Tile(sitecol, self.maximum_distance)
-        for kind in ('light', 'heavy'):
-            if self.filter_sources:
-                logging.info('Filtering %s sources', kind)
-            sources = list(self.get_sources(kind, tile))
-            if not sources:
-                continue
-            for src in sources:
-                self.csm.filtered_weight += src.weight
-            nblocks = 0
-            for block in block_splitter(
-                    sources, self.maxweight,
-                    operator.attrgetter('weight'),
-                    operator.attrgetter('trt_model_id')):
-                sent = self.tm.submit(block, sitecol, siteidx,
-                                      self.rlzs_assoc, self.monitor.new())
-                self.source_chunks.append(
-                    (len(block), block.weight, sum(sent.values())))
-                nblocks += 1
-            logging.info('Sent %d sources in %d block(s)',
-                         len(sources), nblocks)
+        siteidx = 0
+        for i, sitecol in enumerate(tiles, 1):
+            if len(tiles) > 1:
+                logging.info('Processing tile %d', i)
+            tile = Tile(sitecol, self.maximum_distance)
+            for kind in ('light', 'heavy'):
+                if self.filter_sources:
+                    logging.info('Filtering %s sources', kind)
+                sources = list(self.get_sources(kind, tile))
+                if not sources:
+                    continue
+                for src in sources:
+                    self.csm.filtered_weight += src.weight
+                nblocks = 0
+                for block in block_splitter(
+                        sources, self.maxweight,
+                        operator.attrgetter('weight'),
+                        operator.attrgetter('trt_model_id')):
+                    yield (block, sitecol, siteidx,
+                           self.rlzs_assoc, self.monitor.new())
+                    nblocks += 1
+                logging.info('Sent %d sources in %d block(s)',
+                             len(sources), nblocks)
+            siteidx += len(sitecol)
 
     def store_source_info(self, dstore):
         """
@@ -976,15 +970,6 @@ class SourceManager(object):
             attrs = dstore['source_info'].attrs
             attrs['maxweight'] = self.csm.maxweight
             self.infos.clear()
-        if self.source_chunks:
-            dstore['source_chunks'] = sc = numpy.array(
-                self.source_chunks, source_chunk_dt)
-            attrs = dstore['source_chunks'].attrs
-            attrs['nbytes'] = sc.nbytes
-            attrs['sent'] = sc['sent'].sum()
-            attrs['task_name'] = self.tm.name
-            del self.source_chunks
-
 
 @parallel.litetask
 def count_eff_ruptures(sources, sitecol, siteidx, rlzs_assoc, monitor):


### PR DESCRIPTION
This is a small refactoring. Now the SourceManager is decoupled from the task function. Moreover the posthook has been removed from the TaskManager.reduce method (it is unneeded now).

The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1907/