### PR TITLE
The DbServer automatically create and upgrade the database

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Now the DbServer automatically upgrades the database if needed
   * Renamed oq-lite -> oq and added a subcommand `oq engine`
   * Added a CSV reader for the hazard curves
   * Having time_event=None in the hazard part of a calculation is now valid

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -28,7 +28,6 @@ from openquake.engine import config
 from openquake.server.db import actions
 from openquake.server.settings import DATABASE
 from django.db import connection
-
 import django
 if hasattr(django, 'setup'):  # >= 1.7
     django.setup()

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -121,7 +121,7 @@ def runserver(dbpathport=None, logfile=DATABASE['LOG'], loglevel='WARN'):
     else:
         addr = config.DBS_ADDRESS
 
-    # upgrade the db if needed
+    # create and upgrade the db if needed
     connection.cursor()  # bind the db
     actions.upgrade_db()
 

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -28,6 +28,7 @@ from openquake.engine import config
 from openquake.server.db import actions
 from openquake.server.settings import DATABASE
 from django.db import connection
+
 import django
 if hasattr(django, 'setup'):  # >= 1.7
     django.setup()
@@ -61,7 +62,6 @@ def run_commands():
     """
     Execute the received commands in a queue.
     """
-    connection.cursor()  # bind the db
     while True:
         conn, cmd, args = queue.get()
         if cmd == 'stop':
@@ -120,6 +120,12 @@ def runserver(dbpathport=None, logfile=DATABASE['LOG'], loglevel='WARN'):
         DATABASE['PORT'] = int(port)
     else:
         addr = config.DBS_ADDRESS
+
+    # upgrade the db if needed
+    connection.cursor()  # bind the db
+    actions.upgrade_db()
+
+    # start the server
     DbServer(addr, config.DBS_AUTHKEY).loop()
 
 parser = sap.Parser(runserver)

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -25,16 +25,11 @@ from openquake.engine import logs
 
 
 def use_tmp_db(tmpfile_port):
-    from django.db import connection
     from openquake.engine import config
     from openquake.server.settings import DATABASE
-    from openquake.server.db import upgrade_manager
     tmpfile, port_str = tmpfile_port.rsplit(':', 1)
     DATABASE['NAME'] = tmpfile
     DATABASE['PORT'] = port = int(port_str)
-    connection.cursor()  # connect to the db
-    upgrade_manager.upgrade_db(connection.connection)
-    connection.close()
     # make sure we use the server on the temporary db
     config.DBS_ADDRESS = ('localhost', port)
 

--- a/packager.sh
+++ b/packager.sh
@@ -561,7 +561,7 @@ celeryd_wait $GEM_MAXLOOP"
             echo \"There's no 'openquake' user on this system. Installation may have failed.\"
             exit 1
         fi
-        sudo -u openquake python -m openquake.server.db.upgrade_manager ~openquake/db.sqlite3
+        ######## sudo -u openquake python -m openquake.server.db.upgrade_manager ~openquake/db.sqlite3
         
         # dbserver should be already started by supervisord. Let's have a check
         # FIXME instead of using a 'sleep' we should use a better way to check that

--- a/packager.sh
+++ b/packager.sh
@@ -561,7 +561,6 @@ celeryd_wait $GEM_MAXLOOP"
             echo \"There's no 'openquake' user on this system. Installation may have failed.\"
             exit 1
         fi
-        ######## sudo -u openquake python -m openquake.server.db.upgrade_manager ~openquake/db.sqlite3
         
         # dbserver should be already started by supervisord. Let's have a check
         # FIXME instead of using a 'sleep' we should use a better way to check that


### PR DESCRIPTION
This was requested by Daniele and it is a good idea now that the migrations are fast and safe.
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1927/