### PR TITLE
Fixed a segfault in the WebUI when exporting files with h5py >= 2.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a segfault in the WebUI when exporting files with h5py >= 2.4
   * Added a command `oq dbserver` to start/stop the database server
   * The engine exports the hazard curves one file per IMT
   * Exported lon and lat with 5 digits after the decimal point

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -56,28 +56,28 @@ def export_from_db(output_key, calc_id, datadir, target):
     makedirs(target)
     export.from_db = True
     ds_key, fmt = output_key
-    dstore = datastore.read(calc_id, datadir=datadir)
-    dstore.export_dir = target
-    try:
-        exported = export(output_key, dstore)
-    except KeyError:
-        raise DataStoreExportError(
-            'Could not export %s in %s' % output_key)
-    if not exported:
-        raise DataStoreExportError(
-            'Nothing to export for %s' % ds_key)
-    elif len(exported) > 1:
-        # NB: I am hiding the archive by starting its name with a '.',
-        # to avoid confusing the users, since the unzip files are
-        # already in the target directory; the archive is used internally
-        # by the WebUI, so it must be there; it would be nice not to
-        # generate it when not using the Web UI, but I will leave that
-        # feature for after the removal of the old calculators
-        archname = '.' + ds_key + '-' + fmt + '.zip'
-        zipfiles(exported, os.path.join(target, archname))
-        return os.path.join(target, archname)
-    else:  # single file
-        return exported[0]
+    with datastore.read(calc_id, datadir=datadir) as dstore:
+        dstore.export_dir = target
+        try:
+            exported = export(output_key, dstore)
+        except KeyError:
+            raise DataStoreExportError(
+                'Could not export %s in %s' % output_key)
+        if not exported:
+            raise DataStoreExportError(
+                'Nothing to export for %s' % ds_key)
+        elif len(exported) > 1:
+            # NB: I am hiding the archive by starting its name with a '.',
+            # to avoid confusing the users, since the unzip files are
+            # already in the target directory; the archive is used internally
+            # by the WebUI, so it must be there; it would be nice not to
+            # generate it when not using the Web UI, but I will leave that
+            # feature for after the removal of the old calculators
+            archname = '.' + ds_key + '-' + fmt + '.zip'
+            zipfiles(exported, os.path.join(target, archname))
+            return os.path.join(target, archname)
+        else:  # single file
+            return exported[0]
 
 #: Used to separate node labels in a logic tree path
 LT_PATH_JOIN_TOKEN = '_'

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -160,12 +160,6 @@ class EngineServerTestCase(unittest.TestCase):
             if res['type'] == 'gmfs':
                 continue  # exporting the GMFs would be too slow
             etype = res['outtypes'][0]  # get the first export type
-            if res['type'] == 'sescollection':
-                # it does not work for XML for mysterious reasons
-                # this happens only in Ubuntu 16.04
-                # perhaps the file is too big? is it an error with
-                # the version of request??
-                continue
             text = self.get_text(
                 'result/%s' % res['id'], export_type=etype)
             self.assertGreater(len(text), 0)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2103.
See https://ci-dev.openquake.org/job/zdevel_oq-engine/1771 and https://ci.openquake.org/job/zdevel_oq-engine/1950