### PR TITLE
Remove the explicit quoting of the taxonomy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed the escaping of the taxonomies
+  * Fixed the names of the exported risk files
   * Fixed a segfault in the WebUI when exporting files with h5py >= 2.4
   * Added a command `oq dbserver` to start/stop the database server
   * The engine exports the hazard curves one file per IMT

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -243,7 +243,11 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         if self.close:  # in the engine we close later
             try:
                 self.datastore.close()
-            except RuntimeError:  # there could be a mysterious HDF5 error
+            except (RuntimeError, ValueError):
+                # there could be a mysterious HDF5 error
+                # the ValueError: Unrecognized type code -1
+                # happens with the command
+                # $ oq run event_based_risk/case_master/job.ini --exports csv
                 logging.warn('', exc_info=True)
 
 

--- a/openquake/commonlib/risk_writers.py
+++ b/openquake/commonlib/risk_writers.py
@@ -20,7 +20,6 @@
 Module containing writers for risk output artifacts.
 """
 import json
-import urllib
 import operator
 import collections
 import numpy
@@ -990,7 +989,7 @@ class DamageWriter(object):
         :param stddevs: array of stddevs, one per damage state
         :returns: a `DDNode` node
         """
-        taxonomy = Node('taxonomy', text=urllib.unquote_plus(taxonomy))
+        taxonomy = Node('taxonomy', text=taxonomy)
         dd = Node('DDNode', nodes=[taxonomy] +
                   self.damage_nodes(means, stddevs))
         return dd

--- a/openquake/commonlib/riskmodels.py
+++ b/openquake/commonlib/riskmodels.py
@@ -20,7 +20,6 @@
 Reading risk models for risk calculators
 """
 import re
-import urllib
 import collections
 
 import numpy
@@ -134,7 +133,7 @@ def get_risk_models(oqparam, kind=None):
                 # limit states; this may change in the future
                 assert limit_states == fm.limitStates, (
                     limit_states, fm.limitStates)
-                rdict[urllib.quote_plus(taxo)][loss_type] = ffl
+                rdict[taxo][loss_type] = ffl
                 # TODO: see if it is possible to remove the attribute
                 # below, used in classical_damage
                 ffl.steps_per_interval = oqparam.steps_per_interval
@@ -147,6 +146,6 @@ def get_risk_models(oqparam, kind=None):
         # to make sure they are strictly increasing
         for loss_type, rm in rmodels.items():
             for (imt, taxo), rf in rm.items():
-                rdict[urllib.quote_plus(taxo)][loss_type] = (
+                rdict[taxo][loss_type] = (
                     rf.strictly_increasing() if cl_risk else rf)
     return rdict

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -18,7 +18,6 @@
 
 from __future__ import division
 import inspect
-import urllib
 import functools
 import numpy
 
@@ -150,7 +149,7 @@ class Asset(object):
             asset collection ordinal
         """
         self.id = asset_id
-        self.taxonomy = urllib.quote_plus(taxonomy)
+        self.taxonomy = taxonomy
         self.number = number
         self.location = location
         self.values = values


### PR DESCRIPTION
It was done incorrectly, at least with two bugs:
1) the taxonomy was quoted twice (found by Desmond in a calculation for Burundi)
2) the exported taxonomy was quoted
Now the quoting is done inside hazardlib: https://github.com/gem/oq-hazardlib/pull/466

The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1960