### PR TITLE
Webui command

### DIFF
--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -24,9 +24,9 @@ from openquake.server.dbserver import get_status
 from openquake.commands.dbserver import runserver
 
 
-def rundjango(subcmd='runserver', hostport='127.0.0.1:8800'):
+def rundjango(subcmd, hostport='127.0.0.1:8800'):
     args = [sys.executable, '-m', 'openquake.server.manage', subcmd]
-    if host:
+    if hostport:
         args.append(hostport)
     subprocess.call(args)
 
@@ -44,10 +44,11 @@ def webui(cmd):
         runserver()
 
     if cmd == 'start':
-        rundjango()
+        rundjango('runserver')
     elif cmd == 'syncdb':
-        rundjango(cmd)
+        rundjango('syncdb')
 
 parser = sap.Parser(webui)
 parser.arg('cmd', 'webui command',
            choices='start syncdb'.split())
+parser.arg('hostport', 'a string of the form <hostname:port>')

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -21,7 +21,7 @@ from openquake.risklib import valid
 from openquake.commonlib import sap
 from openquake.engine import config
 from openquake.server.dbserver import get_status
-from openquake.commands.dbserver import runserver
+from openquake.commands import dbserver
 
 
 def rundjango(subcmd, hostport=None):
@@ -41,7 +41,7 @@ def webui(cmd, hostport='127.0.0.1:8800'):
         if valid.boolean(config.get('dbserver', 'multi_user')):
             sys.exit('Please start the DbServer: '
                      'see the documentation for details')
-        rundjango('runserver', hostport)
+        dbserver.runserver()
 
     if cmd == 'start':
         rundjango('runserver', hostport)

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -1,0 +1,50 @@
+#  -*- coding: utf-8 -*-
+#  vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#  Copyright (c) 2016, GEM Foundation
+
+#  OpenQuake is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+#  OpenQuake is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+import sys
+import subprocess
+from openquake.risklib import valid
+from openquake.commonlib import sap
+from openquake.engine import config
+from openquake.server.dbserver import get_status
+from openquake.commands.dbserver import runserver
+
+
+def rundjango(subcmd):
+    subprocess.call([sys.executable, '-m', 'openquake.server.manage', subcmd])
+
+
+def webui(cmd):
+    """
+    start the webui server in foreground or perform other operation on the
+    django application
+    """
+    dbstatus = get_status()
+    if dbstatus == 'not-running':
+        if valid.boolean(config.get('dbserver', 'multi_user')):
+            sys.exit('Please start the DbServer: '
+                     'see the documentation for details')
+        runserver()
+
+    if cmd == 'start':
+        rundjango('runserver')
+    elif cmd == 'syncdb':
+        rundjango(cmd)
+
+parser = sap.Parser(webui)
+parser.arg('cmd', 'webui command',
+           choices='start syncdb'.split())

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -24,14 +24,14 @@ from openquake.server.dbserver import get_status
 from openquake.commands.dbserver import runserver
 
 
-def rundjango(subcmd, hostport='127.0.0.1:8800'):
+def rundjango(subcmd, hostport=None):
     args = [sys.executable, '-m', 'openquake.server.manage', subcmd]
     if hostport:
         args.append(hostport)
     subprocess.call(args)
 
 
-def webui(cmd):
+def webui(cmd, hostport='127.0.0.1:8800'):
     """
     start the webui server in foreground or perform other operation on the
     django application
@@ -41,14 +41,13 @@ def webui(cmd):
         if valid.boolean(config.get('dbserver', 'multi_user')):
             sys.exit('Please start the DbServer: '
                      'see the documentation for details')
-        runserver()
+        rundjango('runserver', hostport)
 
     if cmd == 'start':
-        rundjango('runserver')
+        rundjango('runserver', hostport)
     elif cmd == 'syncdb':
         rundjango('syncdb')
 
 parser = sap.Parser(webui)
-parser.arg('cmd', 'webui command',
-           choices='start syncdb'.split())
+parser.arg('cmd', 'webui command', choices='start syncdb'.split())
 parser.arg('hostport', 'a string of the form <hostname:port>')

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -24,10 +24,10 @@ from openquake.server.dbserver import get_status
 from openquake.commands.dbserver import runserver
 
 
-def rundjango(subcmd, host=''):
+def rundjango(subcmd='runserver', hostport='127.0.0.1:8800'):
     args = [sys.executable, '-m', 'openquake.server.manage', subcmd]
     if host:
-        args.append(host)
+        args.append(hostport)
     subprocess.call(args)
 
 
@@ -44,7 +44,7 @@ def webui(cmd):
         runserver()
 
     if cmd == 'start':
-        rundjango('runserver', '127.0.0.1:8800')
+        rundjango()
     elif cmd == 'syncdb':
         rundjango(cmd)
 

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -24,8 +24,11 @@ from openquake.server.dbserver import get_status
 from openquake.commands.dbserver import runserver
 
 
-def rundjango(subcmd):
-    subprocess.call([sys.executable, '-m', 'openquake.server.manage', subcmd])
+def rundjango(subcmd, host=''):
+    args = [sys.executable, '-m', 'openquake.server.manage', subcmd]
+    if host:
+        args.append(host)
+    subprocess.call(args)
 
 
 def webui(cmd):
@@ -41,7 +44,7 @@ def webui(cmd):
         runserver()
 
     if cmd == 'start':
-        rundjango('runserver')
+        rundjango('runserver', '127.0.0.1:8800')
     elif cmd == 'syncdb':
         rundjango(cmd)
 


### PR DESCRIPTION
Add a command to start the WebUI using `oq`. The django development server is started in foreground (that's a feature, not a bug) on localhost:8800. Meant to be used with `multi_user = false` but works also if true.

I want this to simplify the start of the WebUI in the 'opt' packages and also in development, it's shorter than `python -m openquake.server.manage ecc...` and it also checks that DbServer is running. If the DbServer is not started and `manage.py runserver` is fired no errors appear on the screen and the django server remains locked until `CTRL-C` is issued.

This feature is currently not tested by CI.

Closes https://github.com/gem/oq-installers/issues/20