### PR TITLE
Fixed a bug with the `realizations` array

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Fixed a bug with the `realizations` array, which in hazard calculations
+    was empty in the datastore
+
 python-oq-engine (2.0.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -142,7 +142,8 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
             if pre_execute:
                 self.pre_execute()
             result = self.execute()
-            self.post_execute(result)
+            if result:
+                self.post_execute(result)
             exported = self.export(kw.get('exports', ''))
         except KeyboardInterrupt:
             pids = ' '.join(str(p.pid) for p in executor._processes)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -235,6 +235,9 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         Collect the realizations and the monitoring information,
         then close the datastore.
         """
+        self.datastore['realizations'] = numpy.array(
+            [(r.uid, gsim_names(r), r.weight)
+             for r in self.rlzs_assoc.realizations], rlz_dt)
         if 'hcurves' in self.datastore:
             self.datastore.set_nbytes('hcurves')
         if 'hmaps' in self.datastore:
@@ -387,9 +390,6 @@ class HazardCalculator(BaseCalculator):
         else:  # build a fake; used by risk-from-file calculators
             self.datastore['csm_info'] = fake = source.CompositionInfo.fake()
             self.rlzs_assoc = fake.get_rlzs_assoc()
-        self.datastore['realizations'] = numpy.array(
-            [(r.uid, gsim_names(r), r.weight)
-             for r in self.rlzs_assoc.realizations], rlz_dt)
 
     def read_exposure(self):
         """


### PR DESCRIPTION
In hazard calculations it was empty, as discovered by Graeme. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1980