### PR TITLE
Cast numpy.uint32 to int in random.Random

### DIFF
--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -23,7 +23,6 @@ import math
 import logging
 import operator
 import collections
-import random
 
 import numpy
 
@@ -635,7 +634,7 @@ class CompositionInfo(object):
             else:
                 gsim_lt = self.gsim_lt
             if self.num_samples:  # sampling
-                rnd = random.Random(random_seed + idx)
+                rnd = numpy.random.random(random_seed + idx)
                 rlzs = logictree.sample(gsim_lt, smodel.samples, rnd)
             else:  # full enumeration
                 rlzs = logictree.get_effective_rlzs(gsim_lt)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -23,6 +23,7 @@ import math
 import logging
 import operator
 import collections
+import random
 
 import numpy
 
@@ -634,7 +635,8 @@ class CompositionInfo(object):
             else:
                 gsim_lt = self.gsim_lt
             if self.num_samples:  # sampling
-                rnd = numpy.random.random(random_seed + idx)
+                # the int is needed on Windows to convert numpy.uint32 objects
+                rnd = random.Random(int(random_seed + idx))
                 rlzs = logictree.sample(gsim_lt, smodel.samples, rnd)
             else:  # full enumeration
                 rlzs = logictree.get_effective_rlzs(gsim_lt)


### PR DESCRIPTION
Avoids a Windows problem discovered by Daniele. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/1996/