### PR TITLE
Fix the MANIFEST, files used by tests were missing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include README.md LICENSE CONTRIBUTORS.txt
 recursive-include openquake/server/db *.sql
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf
 
-recursive-include openquake/*/tests *.xml
+recursive-include openquake/*/tests *.xml *.csv
 recursive-include openquake/*/tests/data *.*
 recursive-include openquake/qa_tests_data *.*
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,9 @@ include README.md LICENSE CONTRIBUTORS.txt
 
 recursive-include openquake/server/db *.sql
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf
-recursive-include openquake/server/tests *.xml *.csv *.ini *.txt *.zip *.sql README
-recursive-include openquake/qa_tests_data *.xml *.csv *.ini *.txt *.hdf5 README
+
+recursive-include openquake/*/tests *.xml
+recursive-include openquake/*/tests/data *.*
+recursive-include openquake/qa_tests_data *.*
+
 recursive-include openquake/commonlib/nrml_examples *.xml *.csv *.geojson


### PR DESCRIPTION
This is needed to run tests from an installation (using setuptools or whatever)