### PR TITLE
Fixed an export bug for the hazard curves in .geojson format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed an export bug for the hazard curves in .geojson format
   * Removed the array cost_types from the datastore
   * Taxonomies with chars not in the range a-z0-9 were incorrectly rejected
   * Improved the XML parsing utilities in speed, memory, portability and

--- a/openquake/calculators/tests/classical_tiling_test.py
+++ b/openquake/calculators/tests/classical_tiling_test.py
@@ -43,6 +43,6 @@ class ClassicalTilingTestCase(CalculatorTestCase):
 
     @attr('qa', 'hazard', 'classical_tiling')
     def test_case_2(self):
-        out = self.run_calc(case_2.__file__, 'job.ini', exports='csv')
+        out = self.run_calc(case_2.__file__, 'job.ini', exports='csv,geojson')
         [fname] = out['hmaps', 'csv']
         self.assertEqualFiles('expected/hazard_map-mean.csv', fname)

--- a/openquake/commonlib/hazard_writers.py
+++ b/openquake/commonlib/hazard_writers.py
@@ -238,7 +238,7 @@ class HazardCurveGeoJSONWriter(BaseCurveWriter):
                 oqmetadata['IMLs'] = value
             if value is not None:
                 if key == 'imls':
-                    oqmetadata['IMLs'] = value
+                    oqmetadata['IMLs'] = list(value)
                 else:
                     oqmetadata[_ATTR_MAP.get(key)] = scientificformat(value)
 


### PR DESCRIPTION
The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/2012/