### PR TITLE
Python3 travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ install:
 # the full 'openquake' namespace is overwritten and then hazardlib and baselib are not found
 script:
   # FIXME --with-doctest does not work
-  - PYTHONPATH=. nosetests -vsx -a'!slow' --with-xunit --nologcapture
+  # - PYTHONPATH=. nosetests -vsx -a'!slow' --with-xunit --nologcapture
+  - PYTHONPATH=. nosetests -v -a'!slow'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 
 before_install:
   - wget http://ftp.openquake.org/travis/openquake-env-setup-py3-linux64.run
-  - chmox +x openquake-env-setup-py3-linux64.run
+  - chmod +x openquake-env-setup-py3-linux64.run
 
 env:
     LD_LIBRARY_PATH=$HOME/openquake/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ install:
 # We must set the PYTHONPATH to the root oq-engine (insted of oq-engine/openquake) because otherwise
 # the full 'openquake' namespace is overwritten and then hazardlib and baselib are not found
 script:
-  - PYTHONPATH=. nosetests -vsx -a'!slow' --with-xunit --nologcapture --with-doctest
+  # FIXME --with-doctest does not work
+  - PYTHONPATH=. nosetests -vsx -a'!slow' --with-xunit --nologcapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 
 env:
     LD_LIBRARY_PATH=$HOME/openquake/lib
-    PATH=$HOME/openquake/lib:$PATH
+    PATH=$HOME/openquake/bin:$PATH
 
 install:
   - ./openquake-env-setup-py3-linux64.run -- -d ~

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ addons:
     - wget
 
 before_install:
-  - wget http://ftp.openquake.org/travis/openquake-env-setup-py3-linux64.run
-  - chmod +x openquake-env-setup-py3-linux64.run
+  - wget http://ftp.openquake.org/travis/openquake-env-setup-py3-precise64.run
+  - chmod +x openquake-env-setup-py3-precise64.run
 
 env:
     LD_LIBRARY_PATH=$HOME/openquake/lib
     PATH=$HOME/openquake/bin:$PATH
 
 install:
-  - ./openquake-env-setup-py3-linux64.run -- -d ~
+  - ./openquake-env-setup-py3-precise64.run -- -d ~
   - pip install https://github.com/gem/oq-hazardlib/archive/python3.zip
   - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ env:
 install:
   - ./openquake-env-setup-py3-precise64.run -- -d ~
   - pip install https://github.com/gem/oq-hazardlib/archive/python3.zip
-  - pip install .
 
+# We must set the PYTHONPATH to the root oq-engine (insted of oq-engine/openquake) because otherwise
+# the full 'openquake' namespace is overwritten and then hazardlib and baselib are not found
 script:
-  - nosetests -vsx -a'!slow' --with-xunit --nologcapture --with-doctest
+  - PYTHONPATH=. nosetests -vsx -a'!slow' --with-xunit --nologcapture --with-doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
 
-language: python
-
-python:
- - "3.5"
+# We are using our own python
+language: c
 
 addons:
   apt:
@@ -12,6 +10,7 @@ addons:
 
 before_install:
   - wget http://ftp.openquake.org/travis/openquake-env-setup-py3-linux64.run
+  - chmox +x openquake-env-setup-py3-linux64.run
 
 env:
     LD_LIBRARY_PATH=$HOME/openquake/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,24 @@ sudo: false
 language: python
 
 python:
- - "2.7"
+ - "3.5"
 
 addons:
   apt:
     packages:
-    - parallel
+    - wget
+
+before_install:
+  - wget http://ftp.openquake.org/travis/openquake-env-setup-py3-linux64.run
+
+env:
+    LD_LIBRARY_PATH=$HOME/openquake/lib
+    PATH=$HOME/openquake/lib:$PATH
 
 install:
-  - pip install futures
-  - pip install http://ftp.openquake.org/python-wheels/numpy-1.8.2-cp27-none-linux_x86_64.whl
-  - pip install http://ftp.openquake.org/python-wheels/scipy-0.16.0-cp27-none-linux_x86_64.whl
-  - pip install http://ftp.openquake.org/python-wheels/Cython-0.22.1-cp27-none-linux_x86_64.whl
-  - pip install http://ftp.openquake.org/python-wheels/Shapely-1.5.9-py2-none-any.whl
-  - pip install http://ftp.openquake.org/python-wheels/h5py-2.2.1-cp27-none-linux_x86_64.whl
-  - pip install https://github.com/gem/oq-hazardlib/archive/master.zip
-  - python setup.py install
+  - ./openquake-env-setup-py3-linux64.run -- -d ~
+  - pip install https://github.com/gem/oq-hazardlib/archive/python3.zip
+  - pip install .
 
 script:
-  - PYTHONPATH=. nosetests -vsx -a'!slow' --with-xunit --nologcapture --with-doctest
-  - # cd bin; python slowtests ../nosetests.xml
+  - nosetests -vsx -a'!slow' --with-xunit --nologcapture --with-doctest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ six==1.10.0
 django==1.8.7
 docutils==0.12
 decorator==4.0.6
+requests==2.9.1


### PR DESCRIPTION
Tests will run on travis using our python 3.5 distribution: see https://travis-ci.org/daniviga/oq-engine/builds/141671970

Marked as WIP since there are a couple of tests failing (import of commonlib, engine from baselib) because nose get mess when tries to import packages from the same namespace (openquake) and the namespace is located in two different locations (ie mixing sources and installed).