### PR TITLE
Back to bytestrings in source_info_dt

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -23,6 +23,7 @@ from functools import partial
 import numpy
 
 from openquake.baselib import hdf5
+from openquake.baselib.python3compat import encode
 from openquake.baselib.general import AccumDict
 from openquake.hazardlib.geo.utils import get_spherical_bounding_box
 from openquake.hazardlib.geo.utils import get_longitudinal_extent
@@ -262,7 +263,7 @@ class ClassicalCalculator(base.HazardCalculator):
                          for rec in self.source_info}
             for src_idx, dt in calc_times:
                 src = sources[src_idx]
-                info = info_dict[src.src_group_id, src.source_id]
+                info = info_dict[src.src_group_id, encode(src.source_id)]
                 info['calc_time'] += dt
             rows = sorted(
                 info_dict.values(), key=operator.itemgetter(7), reverse=True)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -966,11 +966,7 @@ class SourceManager(object):
             values.sort(
                 key=lambda info: info.filter_time + info.split_time,
                 reverse=True)
-            array = numpy.zeros(len(values), source_info_dt)
-            for i, row in enumerate(values):
-                for j, name in enumerate(source_info_dt.names):
-                    array[i][name] = row[j]
-            dstore['source_info'] = array
+            dstore['source_info'] = numpy.array(values, source_info_dt)
             attrs = dstore['source_info'].attrs
             attrs['maxweight'] = self.csm.maxweight
             self.infos.clear()

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -33,7 +33,6 @@ from openquake.baselib.general import (
     AccumDict, groupby, block_splitter, group_array)
 from openquake.hazardlib.site import Tile
 from openquake.hazardlib.probability_map import ProbabilityMap
-from openquake.risklib import valid
 from openquake.commonlib import logictree, sourceconverter, parallel
 from openquake.commonlib import nrml, node
 
@@ -817,8 +816,8 @@ SourceInfo.__iadd__ = source_info_iadd
 
 source_info_dt = numpy.dtype([
     ('src_group_id', numpy.uint32),  # 0
-    ('source_id', hdf5.vstr),        # 1
-    ('source_class', hdf5.vstr),     # 2
+    ('source_id', (bytes, 100)),     # 1
+    ('source_class', (bytes, 30)),   # 2
     ('weight', numpy.float32),       # 3
     ('split_num', numpy.uint32),     # 4
     ('filter_time', numpy.float32),  # 5

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -967,7 +967,11 @@ class SourceManager(object):
             values.sort(
                 key=lambda info: info.filter_time + info.split_time,
                 reverse=True)
-            dstore['source_info'] = numpy.array(values, source_info_dt)
+            array = numpy.zeros(len(values), source_info_dt)
+            for i, row in enumerate(values):
+                for j, name in enumerate(source_info_dt.names):
+                    array[i][name] = row[j]
+            dstore['source_info'] = array
             attrs = dstore['source_info'].attrs
             attrs['maxweight'] = self.csm.maxweight
             self.infos.clear()


### PR DESCRIPTION
This solves a bug discovered by Catalina. The tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/2022/

This was the error:
```python
  File "/usr/local/openquake/oq-engine/openquake/commonlib/source.py", line 970, in store_source_info
    dstore['source_info'] = numpy.array(values, source_info_dt)
  File "/usr/local/openquake/oq-engine/openquake/commonlib/datastore.py", line 347, in __setitem__
    self.hdf5[key] = val
  File "/usr/local/openquake/oq-hazardlib/openquake/baselib/hdf5.py", line 225, in __setitem__
    a = super(File, self).__getitem__(path).attrs
  File "/usr/lib/python2.7/dist-packages/h5py/_hl/group.py", line 153, in __getitem__
    oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
  File "h5o.pyx", line 173, in h5py.h5o.open (h5py/h5o.c:3403)
KeyError: "unable to open object (Symbol table: Can't open object)"
```