### PR TITLE
Restored the early check on missing taxonomies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Restored the early check on missing taxonomies
   * Raise an early error if an user forget the `rupture_mesh_spacing` parameter
   * Fixed a bug while deleting jobs from the db in Ubuntu 12.04
   * Ported the shapefile converter from the nrml_converters

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -417,13 +417,6 @@ class HazardCalculator(BaseCalculator):
         self.oqparam.set_risk_imtls(rmdict)
         self.save_params()  # re-save oqparam
         self.riskmodel = rm = readinput.get_risk_model(self.oqparam, rmdict)
-        if 'taxonomies' in self.datastore:
-            # check that we are covering all the taxonomies in the exposure
-            missing = set(self.taxonomies) - set(rm.taxonomies)
-            if rm and missing:
-                raise RuntimeError('The exposure contains the taxonomies %s '
-                                   'which are not in the risk model' % missing)
-
         # save the risk models and loss_ratios in the datastore
         for taxonomy, rmodel in rm.items():
             self.datastore['composite_risk_model/' + taxonomy] = (
@@ -494,6 +487,13 @@ class HazardCalculator(BaseCalculator):
                     sorted(self.exposure.time_events)))
         elif hasattr(self, '_assetcol'):
             self.assets_by_site = self.assetcol.assets_by_site()
+
+        if self.oqparam.job_type == 'risk':
+            # check that we are covering all the taxonomies in the exposure
+            missing = set(self.taxonomies) - set(self.riskmodel.taxonomies)
+            if self.riskmodel and missing:
+                raise RuntimeError('The exposure contains the taxonomies %s '
+                                   'which are not in the risk model' % missing)
 
     def is_tiling(self):
         """

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -96,6 +96,12 @@ class EventBasedRiskTestCase(CalculatorTestCase):
             'expected/agg_losses-b1,b1-structural.csv', fname)
 
     @attr('qa', 'risk', 'event_based_risk')
+    def test_missing_taxonomy(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.run_calc(case_2.__file__, 'job_err.ini')
+        self.assertIn('not in the risk model', str(ctx.exception))
+
+    @attr('qa', 'risk', 'event_based_risk')
     def test_case_3(self):
         # this is a test with statistics and without conditional_loss_poes
         out = self.run_calc(case_3.__file__, 'job.ini',

--- a/openquake/qa_tests_data/event_based_risk/case_2/job_err.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_2/job_err.ini
@@ -1,5 +1,5 @@
 [general]
-description = Event Loss Test
+description = Test with a vulnerability model missing a taxonomy
 
 calculation_mode = event_based_risk
 

--- a/openquake/qa_tests_data/event_based_risk/case_2/job_err.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_2/job_err.ini
@@ -7,7 +7,7 @@ random_seed = 23
 
 [geometry]
 
-structural_vulnerability_file=vulnerability_model_stco.xml
+structural_vulnerability_file=vulnerability_model_wrong.xml
 
 [logic_tree]
 

--- a/openquake/qa_tests_data/event_based_risk/case_2/vulnerability_model_wrong.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_2/vulnerability_model_wrong.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <nrml
 xmlns="http://openquake.org/xmlns/nrml/0.5"
->   <!-- this is wrong because it is missing the taxonomy RC which is in
+>   <!-- this is wrong because it is missing the taxonomy RM which is in
          the exposure -->
     <vulnerabilityModel
     assetCategory="buildings"

--- a/openquake/qa_tests_data/event_based_risk/case_2/vulnerability_model_wrong.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_2/vulnerability_model_wrong.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+>   <!-- this is wrong because it is missing the taxonomy RC which is in
+         the exposure -->
+    <vulnerabilityModel
+    assetCategory="buildings"
+    id="Nepal"
+    lossCategory="structural"
+    >
+        <vulnerabilityFunction
+        dist="LN"
+        id="RC+"
+        >
+            <imls
+            imt="SA(0.2)"
+            >
+                2.0000000E-01 5.0000000E-01 9.0000000E-01 1.1000000E+00 1.3000000E+00
+            </imls>
+            <meanLRs>
+                3.5000000E-02 7.0000000E-02 1.4000000E-01 2.8000000E-01 5.6000000E-01
+            </meanLRs>
+            <covLRs>
+                1.0000000E-04 1.0000000E-04 1.0000000E-04 1.0000000E-04 1.0000000E-04
+            </covLRs>
+        </vulnerabilityFunction>
+        <vulnerabilityFunction
+        dist="LN"
+        id="W"
+        >
+            <imls
+            imt="SA(0.5)"
+            >
+                3.0000000E-02 7.0000000E-02 1.5000000E-01 2.2000000E-01 9.5000000E-01
+            </imls>
+            <meanLRs>
+                6.3000000E-02 1.2500000E-01 2.5000000E-01 5.0000000E-01 1.0000000E+00
+            </meanLRs>
+            <covLRs>
+                1.0000000E-04 1.0000000E-04 1.0000000E-04 1.0000000E-04 0.0000000E+00
+            </covLRs>
+        </vulnerabilityFunction>
+    </vulnerabilityModel>
+</nrml>


### PR DESCRIPTION
The check was there, but has been broken by a refactoring in the engine 2.0 branch. I have restored it and added a test. Closes https://github.com/gem/oq-engine/issues/2145.