### PR TITLE
Fixed bug in the UCERF calculator

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -372,9 +372,10 @@ class EventBasedRuptureCalculator(PSHACalculator):
         :param ruptures_by_grp_id: a dictionary with key grp_id
         :param src_group: a SourceGroup instance
         """
-        return sum(
+        nr = sum(
             len(ruptures) for grp_id, ruptures in ruptures_by_grp_id.items()
             if src_group.id == grp_id)
+        return nr
 
     def zerodict(self):
         """


### PR DESCRIPTION
The SourceGroup .id was always zeros, whereas it should have been equal to the branch ordinal.