### PR TITLE
Fixed a bug in the case of tectonic region types filtered away

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed a bug for tectonic region types filtered away
+
 python-oq-engine (2.0.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -279,15 +279,16 @@ class ClassicalCalculator(base.HazardCalculator):
         curves_by_trt_gsim = {}
 
         with self.monitor('saving probability maps', autoflush=True):
-            for trt_id in curves_by_trt_id:
-                key = 'poes/%04d' % trt_id
-                self.datastore[key] = curves_by_trt_id[trt_id]
-                self.datastore.set_attrs(
-                    key, trt=self.csm.info.get_trt(trt_id))
-                gsims = self.rlzs_assoc.gsims_by_trt_id[trt_id]
-                for i, gsim in enumerate(gsims):
-                    curves_by_trt_gsim[trt_id, gsim] = (
-                        curves_by_trt_id[trt_id].extract(i))
+            for trt_id, poes in curves_by_trt_id.items():
+                if poes:
+                    key = 'poes/%04d' % trt_id
+                    self.datastore[key] = curves_by_trt_id[trt_id]
+                    self.datastore.set_attrs(
+                        key, trt=self.csm.info.get_trt(trt_id))
+                    gsims = self.rlzs_assoc.gsims_by_trt_id[trt_id]
+                    for i, gsim in enumerate(gsims):
+                        curves_by_trt_gsim[trt_id, gsim] = (
+                            curves_by_trt_id[trt_id].extract(i))
             self.datastore.set_nbytes('poes')
 
         with self.monitor('combine curves_by_rlz', autoflush=True):


### PR DESCRIPTION
Backport of https://github.com/gem/oq-engine/pull/2158. The tests and demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2050