### PR TITLE
Fixed job_info

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -125,7 +125,6 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
     """
     sitecol = datastore.persistent_attribute('sitecol')
     assetcol = datastore.persistent_attribute('assetcol')
-    job_info = datastore.persistent_attribute('job_info')
     performance = datastore.persistent_attribute('performance')
     csm = datastore.persistent_attribute('composite_source_model')
     pre_calculator = None  # to be overridden
@@ -389,7 +388,7 @@ class HazardCalculator(BaseCalculator):
         If yes, read the inputs by invoking the precalculator or by retrieving
         the previous calculation; if not, read the inputs directly.
         """
-        job_info = hdf5.LiteralAttrs()
+        job_info = {}
         if self.pre_calculator is not None:
             # the parameter hazard_calculation_id is only meaningful if
             # there is a precalculator
@@ -402,13 +401,15 @@ class HazardCalculator(BaseCalculator):
         else:  # we are in a basic calculator
             self.basic_pre_execute()
             if 'source' in self.oqparam.inputs:
-                vars(job_info).update(readinput.get_job_info(
+                job_info.update(readinput.get_job_info(
                     self.oqparam, self.csm, self.sitecol))
 
-        job_info.hostname = socket.gethostname()
+        job_info['hostname'] = socket.gethostname()
         if hasattr(self, 'riskmodel'):
-            job_info.require_epsilons = bool(self.riskmodel.covs)
-        self.job_info = job_info
+            job_info['require_epsilons'] = bool(self.riskmodel.covs)
+        if 'job_info' not in self.datastore:
+            self.datastore['job_info'] = hdf5.LiteralAttrs()
+        self.datastore.save('job_info', job_info)
         self.datastore.flush()
         try:
             csm_info = self.datastore['csm_info']

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -43,7 +43,7 @@ class ClassicalTestCase(CalculatorTestCase):
             ['hazard_curve-smltp_b1-gsimltp_b1.csv'],
             case_1.__file__)
 
-        # test we saved the data transfer informatio in job_info
+        # make sure we saved the data transfer information in job_info
         keys = set(self.calc.datastore['job_info'].__dict__)
         self.assertIn('classical_max_received_per_task', keys)
         self.assertIn('classical_tot_received', keys)

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -43,6 +43,12 @@ class ClassicalTestCase(CalculatorTestCase):
             ['hazard_curve-smltp_b1-gsimltp_b1.csv'],
             case_1.__file__)
 
+        # test we saved the data transfer informatio in job_info
+        keys = set(self.calc.datastore['job_info'].__dict__)
+        self.assertIn('classical_max_received_per_task', keys)
+        self.assertIn('classical_tot_received', keys)
+        self.assertIn('classical_sent', keys)
+
     @attr('qa', 'hazard', 'classical')
     def test_sa_period_too_big(self):
         imtls = '{"SA(4.1)": [0.1, 0.4, 0.6]}'


### PR DESCRIPTION
The table `job_info` contains the data transfer information. Due to a refactoring error, such information was not saved anymore. I have added a test to keep this feature under control.