### PR TITLE
Fixed the names of exported files for hazard maps in .geojson format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the names of exported files for hazard maps in .geojson format
   * Added an header with metadata to the exported hazard curves and maps
   * Avoid storing filtered-away probability maps, thus fixing a bug
   * Restored the precalculation consistency check that was disabled during the

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -182,6 +182,22 @@ hazard_uhs-smltp_SM2_a3pt2b0pt8-gsimltp_CB2008_@.csv'''.split(),
         self.assertEqualFiles('expected/hazard_uhs-mean-0.1.xml', fnames[1])
         self.assertEqualFiles('expected/hazard_uhs-mean-0.2.xml', fnames[2])
 
+        # test hmaps geojson export
+        fnames = [f for f in export(('hmaps', 'geojson'), self.calc.datastore)
+                  if 'mean' in f]
+        self.assertEqualFiles(
+            'expected/hazard_map-mean-0.01-PGA.geojson', fnames[0])
+        self.assertEqualFiles(
+            'expected/hazard_map-mean-0.01-SA(0.1).geojson', fnames[1])
+        self.assertEqualFiles(
+            'expected/hazard_map-mean-0.1-PGA.geojson', fnames[2])
+        self.assertEqualFiles(
+            'expected/hazard_map-mean-0.1-SA(0.1).geojson', fnames[3])
+        self.assertEqualFiles(
+            'expected/hazard_map-mean-0.2-PGA.geojson', fnames[4])
+        self.assertEqualFiles(
+            'expected/hazard_map-mean-0.2-SA(0.1).geojson', fnames[5])
+
     @attr('qa', 'hazard', 'classical')
     def test_case_16(self):   # sampling
         self.assert_curves_ok(

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -303,11 +303,8 @@ def hazard_curve_name(dstore, ekey, kind, rlzs_assoc):
     key, fmt = ekey
     prefix = {'hcurves': 'hazard_curve', 'hmaps': 'hazard_map',
               'uhs': 'hazard_uhs'}[key]
-    if kind.startswith('rlz-'):
-        rlz = rlzs_assoc.get_rlz(kind)
-        fname = dstore.build_fname(prefix, rlz, fmt)
-    elif kind.startswith('mean'):
-        fname = dstore.build_fname(prefix, kind, ekey[1])
+    if kind.startswith(('rlz-', 'mean')):
+        fname = dstore.build_fname(prefix, kind, fmt)
     elif kind.startswith('quantile-'):
         # strip the 7 characters 'hazard_'
         fname = dstore.build_fname('quantile_' + prefix[7:], kind[9:], fmt)

--- a/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.01-PGA.geojson
+++ b/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.01-PGA.geojson
@@ -1,0 +1,53 @@
+{
+    "features": [
+        {
+            "geometry": {
+                "coordinates": [
+                    -0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.0,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        }
+    ],
+    "oqmetadata": {
+        "IMT": "PGA",
+        "gsimTreePath": "",
+        "investigationTime": "50.0",
+        "poE": "0.01",
+        "sourceModelTreePath": ""
+    },
+    "oqnrmlversion": "0.4",
+    "oqtype": "HazardMap",
+    "type": "FeatureCollection"
+}

--- a/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.01-SA(0.1).geojson
+++ b/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.01-SA(0.1).geojson
@@ -1,0 +1,53 @@
+{
+    "features": [
+        {
+            "geometry": {
+                "coordinates": [
+                    -0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.800000011920929
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.0,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.800000011920929
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.800000011920929
+            },
+            "type": "Feature"
+        }
+    ],
+    "oqmetadata": {
+        "IMT": "SA(0.1)",
+        "gsimTreePath": "",
+        "investigationTime": "50.0",
+        "poE": "0.01",
+        "sourceModelTreePath": ""
+    },
+    "oqnrmlversion": "0.4",
+    "oqtype": "HazardMap",
+    "type": "FeatureCollection"
+}

--- a/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.1-PGA.geojson
+++ b/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.1-PGA.geojson
@@ -1,0 +1,53 @@
+{
+    "features": [
+        {
+            "geometry": {
+                "coordinates": [
+                    -0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.0,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        }
+    ],
+    "oqmetadata": {
+        "IMT": "PGA",
+        "gsimTreePath": "",
+        "investigationTime": "50.0",
+        "poE": "0.1",
+        "sourceModelTreePath": ""
+    },
+    "oqnrmlversion": "0.4",
+    "oqtype": "HazardMap",
+    "type": "FeatureCollection"
+}

--- a/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.1-SA(0.1).geojson
+++ b/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.1-SA(0.1).geojson
@@ -1,0 +1,53 @@
+{
+    "features": [
+        {
+            "geometry": {
+                "coordinates": [
+                    -0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.800000011920929
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.0,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.800000011920929
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.800000011920929
+            },
+            "type": "Feature"
+        }
+    ],
+    "oqmetadata": {
+        "IMT": "SA(0.1)",
+        "gsimTreePath": "",
+        "investigationTime": "50.0",
+        "poE": "0.1",
+        "sourceModelTreePath": ""
+    },
+    "oqnrmlversion": "0.4",
+    "oqtype": "HazardMap",
+    "type": "FeatureCollection"
+}

--- a/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.2-PGA.geojson
+++ b/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.2-PGA.geojson
@@ -1,0 +1,53 @@
+{
+    "features": [
+        {
+            "geometry": {
+                "coordinates": [
+                    -0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.0,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.20000000298023224
+            },
+            "type": "Feature"
+        }
+    ],
+    "oqmetadata": {
+        "IMT": "PGA",
+        "gsimTreePath": "",
+        "investigationTime": "50.0",
+        "poE": "0.2",
+        "sourceModelTreePath": ""
+    },
+    "oqnrmlversion": "0.4",
+    "oqtype": "HazardMap",
+    "type": "FeatureCollection"
+}

--- a/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.2-SA(0.1).geojson
+++ b/openquake/qa_tests_data/classical/case_15/expected/hazard_map-mean-0.2-SA(0.1).geojson
@@ -1,0 +1,53 @@
+{
+    "features": [
+        {
+            "geometry": {
+                "coordinates": [
+                    -0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.6348296999931335
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.0,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.5942485332489014
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    0.10000000149011612,
+                    0.0
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "iml": 0.7474831342697144
+            },
+            "type": "Feature"
+        }
+    ],
+    "oqmetadata": {
+        "IMT": "SA(0.1)",
+        "gsimTreePath": "",
+        "investigationTime": "50.0",
+        "poE": "0.2",
+        "sourceModelTreePath": ""
+    },
+    "oqnrmlversion": "0.4",
+    "oqtype": "HazardMap",
+    "type": "FeatureCollection"
+}


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2161