### PR TITLE
Transmit attrs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Transmitted the attributes of a SourceGroup to the underlying sources
   * Fixed the names of exported files for hazard maps in .geojson format
   * Added an header with metadata to the exported hazard curves and maps
   * Avoid storing filtered-away probability maps, thus fixing a bug

--- a/openquake/commonlib/nrml.py
+++ b/openquake/commonlib/nrml.py
@@ -576,6 +576,7 @@ validators = {
     'lon': valid.longitude,
     'lat': valid.latitude,
     'spacing': valid.positivefloat,
+    'srcs_weights': valid.weights,
 }
 
 

--- a/openquake/commonlib/sourceconverter.py
+++ b/openquake/commonlib/sourceconverter.py
@@ -820,7 +820,7 @@ class SourceConverter(RuptureConverter):
         grp_attrs = {k: v for k, v in node.attrib.items()
                      if k not in ('name', 'src_interdep', 'srcs_weights')}
         srcs = []
-        for n, src_node in enumerate(node):
+        for src_node in node:
             src = self.convert_node(src_node)
             # transmit the group attributes to the underlying source
             for attr, value in grp_attrs.items():
@@ -831,8 +831,9 @@ class SourceConverter(RuptureConverter):
             srcs.append(src)
         sg = SourceGroup(trt, srcs)
         if srcs_weights is not None:
-            assert len(srcs_weights) == n, 'Expected %d sources, got %d' % (
-                len(srcs_weights), n)
+            if len(srcs_weights) != len(node):
+                raise ValueError('Expected %d sources, got %d' % (
+                    len(srcs_weights), len(node)))
         sg.name = node.attrib.get('name')
         sg.src_interdep = node.attrib.get('src_interdep')
         sg.srcs_weights = srcs_weights

--- a/openquake/commonlib/sourceconverter.py
+++ b/openquake/commonlib/sourceconverter.py
@@ -660,7 +660,7 @@ class SourceConverter(RuptureConverter):
         return source.AreaSource(
             source_id=node['id'],
             name=node['name'],
-            tectonic_region_type=node['tectonicRegion'],
+            tectonic_region_type=node.attrib.get('tectonicRegion'),
             mfd=self.convert_mfdist(node),
             rupture_mesh_spacing=self.rupture_mesh_spacing,
             magnitude_scaling_relationship=msr,
@@ -686,7 +686,7 @@ class SourceConverter(RuptureConverter):
         return source.PointSource(
             source_id=node['id'],
             name=node['name'],
-            tectonic_region_type=node['tectonicRegion'],
+            tectonic_region_type=node.attrib.get('tectonicRegion'),
             mfd=self.convert_mfdist(node),
             rupture_mesh_spacing=self.rupture_mesh_spacing,
             magnitude_scaling_relationship=msr,
@@ -722,7 +722,7 @@ class SourceConverter(RuptureConverter):
             simple = source.SimpleFaultSource(
                 source_id=node['id'],
                 name=node['name'],
-                tectonic_region_type=node['tectonicRegion'],
+                tectonic_region_type=node.attrib.get('tectonicRegion'),
                 mfd=mfd,
                 rupture_mesh_spacing=self.rupture_mesh_spacing,
                 magnitude_scaling_relationship=msr,
@@ -753,7 +753,7 @@ class SourceConverter(RuptureConverter):
             cmplx = source.ComplexFaultSource(
                 source_id=node['id'],
                 name=node['name'],
-                tectonic_region_type=node['tectonicRegion'],
+                tectonic_region_type=node.attrib.get('tectonicRegion'),
                 mfd=mfd,
                 rupture_mesh_spacing=self.complex_fault_mesh_spacing,
                 magnitude_scaling_relationship=msr,
@@ -776,7 +776,7 @@ class SourceConverter(RuptureConverter):
         char = source.CharacteristicFaultSource(
             source_id=node['id'],
             name=node['name'],
-            tectonic_region_type=node['tectonicRegion'],
+            tectonic_region_type=node.attrib.get('tectonicRegion'),
             mfd=self.convert_mfdist(node),
             surface=self.convert_surfaces(node.surface),
             rake=~node.rake,
@@ -794,7 +794,7 @@ class SourceConverter(RuptureConverter):
             a :class:`openquake.hazardlib.source.NonParametricSeismicSource`
             instance
         """
-        trt = node['tectonicRegion']
+        trt = node.attrib.get('tectonicRegion')
         rup_pmf_data = []
         for rupnode in node:
             probs = pmf.PMF(rupnode['probs_occur'])
@@ -816,8 +816,27 @@ class SourceConverter(RuptureConverter):
             instance
         """
         trt = node['tectonicRegion']
-        srcs = [self.convert_node(src_node) for src_node in node]
-        return SourceGroup(trt, srcs)
+        srcs_weights = node.attrib.get('srcs_weights')
+        grp_attrs = {k: v for k, v in node.attrib.items()
+                     if k not in ('name', 'src_interdep', 'srcs_weights')}
+        srcs = []
+        for n, src_node in enumerate(node):
+            src = self.convert_node(src_node)
+            # transmit the group attributes to the underlying source
+            for attr, value in grp_attrs.items():
+                if attr == 'tectonicRegion':
+                    src.tectonic_region_type = value
+                else:  # transmit as it is
+                    setattr(src, attr, node[attr])
+            srcs.append(src)
+        sg = SourceGroup(trt, srcs)
+        if srcs_weights is not None:
+            assert len(srcs_weights) == n, 'Expected %d sources, got %d' % (
+                len(srcs_weights), n)
+        sg.name = node.attrib.get('name')
+        sg.src_interdep = node.attrib.get('src_interdep')
+        sg.srcs_weights = srcs_weights
+        return sg
 
 
 def parse_ses_ruptures(fname):

--- a/openquake/commonlib/sourceconverter.py
+++ b/openquake/commonlib/sourceconverter.py
@@ -832,8 +832,8 @@ class SourceConverter(RuptureConverter):
         sg = SourceGroup(trt, srcs)
         if srcs_weights is not None:
             if len(srcs_weights) != len(node):
-                raise ValueError('Expected %d sources, got %d' % (
-                    len(srcs_weights), len(node)))
+                raise ValueError('There are %d srcs_weights but %d source(s)'
+                                 % (len(srcs_weights), len(node)))
         sg.name = node.attrib.get('name')
         sg.src_interdep = node.attrib.get('src_interdep')
         sg.srcs_weights = srcs_weights

--- a/openquake/commonlib/tests/nrml_test.py
+++ b/openquake/commonlib/tests/nrml_test.py
@@ -123,7 +123,7 @@ xmlns:gml="http://www.opengis.net/gml"
         self.assertIn('Could not convert imt->intensity_measure_type: '
                       "Invalid IMT: 'SA', line 8", str(ctx.exception))
 
-    def test_invalid_srcs_weights(self):
+    def test_invalid_srcs_weights_length(self):
         fname = writetmp('''\
 <?xml version="1.0" encoding="utf-8"?>
 <nrml
@@ -183,4 +183,5 @@ xmlns:gml="http://www.opengis.net/gml"
         converter = SourceConverter(50., 1., 10, 0.1, 10.)
         with self.assertRaises(ValueError) as ctx:
             parse(fname, converter)
-        self.assertEqual('Expected 2 sources, got 1', str(ctx.exception))
+        self.assertEqual('There are 2 srcs_weights but 1 source(s)',
+                         str(ctx.exception))

--- a/openquake/commonlib/tests/nrml_test.py
+++ b/openquake/commonlib/tests/nrml_test.py
@@ -19,7 +19,8 @@
 import unittest
 import io
 from openquake.baselib.general import writetmp
-from openquake.commonlib.nrml import read, node_to_xml, get_tag_version
+from openquake.commonlib.sourceconverter import SourceConverter
+from openquake.commonlib.nrml import read, parse, node_to_xml, get_tag_version
 
 
 class NrmlTestCase(unittest.TestCase):
@@ -121,3 +122,65 @@ xmlns:gml="http://www.opengis.net/gml"
             read(fname)
         self.assertIn('Could not convert imt->intensity_measure_type: '
                       "Invalid IMT: 'SA', line 8", str(ctx.exception))
+
+    def test_invalid_srcs_weights(self):
+        fname = writetmp('''\
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    name="Classical Hazard QA Test, Case 1 source model"
+    >
+        <sourceGroup
+        name="group 1"
+        tectonicRegion="active shallow crust"
+        srcs_weights="0.5 0.5"
+        >
+            <pointSource
+            id="1"
+            name="point source"
+            >           
+                <pointGeometry>
+                    <gml:Point>
+                        <gml:pos>
+                            0.0000000E+00 0.0000000E+00
+                        </gml:pos>
+                    </gml:Point>
+                    <upperSeismoDepth>
+                        0.0000000E+00
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        1.0000000E+01
+                    </lowerSeismoDepth>
+                </pointGeometry>
+                <magScaleRel>
+                    PeerMSR
+                </magScaleRel>
+                <ruptAspectRatio>
+                    1.0000000E+00
+                </ruptAspectRatio>
+                <incrementalMFD
+                binWidth="1.0000000E+00"
+                minMag="4.0000000E+00"
+                >
+                    <occurRates>
+                        1.0000000E+00
+                    </occurRates>
+                </incrementalMFD>
+                <nodalPlaneDist>
+                    <nodalPlane dip="90" probability="1" rake="0" strike="0"/>
+                </nodalPlaneDist>
+                <hypoDepthDist>
+                    <hypoDepth depth="4" probability="1"/>
+                </hypoDepthDist>
+            </pointSource>
+        </sourceGroup>
+    </sourceModel>
+</nrml>
+''')
+        converter = SourceConverter(50., 1., 10, 0.1, 10.)
+        with self.assertRaises(ValueError) as ctx:
+            parse(fname, converter)
+        self.assertEqual('Expected 2 sources, got 1', str(ctx.exception))

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -33,8 +33,7 @@ from openquake.hazardlib.tom import PoissonTOM
 
 from openquake.commonlib import tests, nrml_examples, readinput
 from openquake.commonlib import sourceconverter as s
-from openquake.commonlib.source import (
-    SourceModelParser, DuplicatedID, CompositionInfo)
+from openquake.commonlib.source import SourceModelParser, CompositionInfo
 from openquake.commonlib import nrml
 from openquake.baselib.general import assert_close
 
@@ -79,9 +78,7 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             width_of_mfd_bin=1.,  # for Truncated GR MFDs
             area_source_discretization=1.,  # km
         ))
-        grp_nodes = nrml.parse(MIXED_SRC_MODEL).nodes
-        groups = [
-            cls.parser.converter.convert_node(gnode) for gnode in grp_nodes]
+        groups = cls.parser.parse_groups(MIXED_SRC_MODEL)
         ([cls.point], [cls.cmplx], [cls.area, cls.simple],
          [cls.char_simple, cls.char_complex, cls.char_multi]) = groups
         # the parameters here would typically be specified in the job .ini
@@ -377,7 +374,7 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             width_of_mfd_bin=0.1,
             area_source_discretization=10,
         ))
-        with self.assertRaises(DuplicatedID):
+        with self.assertRaises(nrml.DuplicatedID):
             parser.parse_groups(DUPLICATE_ID_SRC_MODEL)
 
     def test_raises_useful_error_1(self):

--- a/openquake/qa_tests_data/classical/case_1/source_model.xml
+++ b/openquake/qa_tests_data/classical/case_1/source_model.xml
@@ -1,31 +1,61 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
-      xmlns:gml="http://www.opengis.net/gml">
-    <sourceModel name="Classical Hazard QA Test, Case 1 source model">
-        <pointSource id="1" name="point source" tectonicRegion="active shallow crust">
-            <pointGeometry>
-                <gml:Point>
-                    <gml:pos>0.0 0.0</gml:pos>
-                </gml:Point>
-
-                <upperSeismoDepth>0.0</upperSeismoDepth>
-                <lowerSeismoDepth>10.0</lowerSeismoDepth>
-            </pointGeometry>
-
-            <magScaleRel>PeerMSR</magScaleRel>
-            <ruptAspectRatio>1.0</ruptAspectRatio>
-
-            <incrementalMFD minMag="4.0" binWidth="1.0">
-                <occurRates>1.0</occurRates>
-            </incrementalMFD>
-
-            <nodalPlaneDist>
-                <nodalPlane probability="1.0" strike="0.0" dip="90.0" rake="0.0" />
-            </nodalPlaneDist>
-
-            <hypoDepthDist>
-                <hypoDepth probability="1.0" depth="4.0" />
-            </hypoDepthDist>
-        </pointSource>
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    name="Classical Hazard QA Test, Case 1 source model"
+    >
+        
+        <sourceGroup
+        name="group 1"
+        tectonicRegion="active shallow crust"
+        srcs_weights="1.0"
+        >
+            <pointSource
+            id="1"
+            name="point source"
+            >
+                
+                <pointGeometry>
+                    
+                    <gml:Point>
+                        
+                        <gml:pos>
+                            0.0000000E+00 0.0000000E+00
+                        </gml:pos>
+                    </gml:Point>
+                    <upperSeismoDepth>
+                        0.0000000E+00
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        1.0000000E+01
+                    </lowerSeismoDepth>
+                </pointGeometry>
+                <magScaleRel>
+                    PeerMSR
+                </magScaleRel>
+                <ruptAspectRatio>
+                    1.0000000E+00
+                </ruptAspectRatio>
+                <incrementalMFD
+                binWidth="1.0000000E+00"
+                minMag="4.0000000E+00"
+                >
+                    
+                    <occurRates>
+                        1.0000000E+00
+                    </occurRates>
+                </incrementalMFD>
+                <nodalPlaneDist>
+                    
+                    <nodalPlane dip="9.0000000E+01" probability="1.0000000E+00" rake="0.0000000E+00" strike="0.0000000E+00"/>
+                </nodalPlaneDist>
+                <hypoDepthDist>
+                    
+                    <hypoDepth depth="4.0000000E+00" probability="1.0000000E+00"/>
+                </hypoDepthDist>
+            </pointSource>
+        </sourceGroup>
     </sourceModel>
 </nrml>

--- a/openquake/risklib/valid.py
+++ b/openquake/risklib/valid.py
@@ -725,7 +725,7 @@ def check_weights(nodes_with_a_weight):
     """
     weights = [n['weight'] for n in nodes_with_a_weight]
     if abs(sum(weights) - 1.) > 1E-12:
-        raise ValueError('The weights do not sum up to 1!', weights)
+        raise ValueError('The weights %s do not sum up to 1!' % weights)
     return nodes_with_a_weight
 
 
@@ -833,6 +833,18 @@ def positiveints(value):
         if val < 0:
             raise ValueError('%d is negative in %r' % (val, value))
     return ints
+
+
+def weights(value):
+    """
+    >>> weights('0.4 0.3')
+    Traceback (most recent call last):
+       ...
+    ValueError: the weights [0.4, 0.3] do not sum up to 1!
+    """
+    ws = probabilities(value)
+    if abs(sum(ws) - 1.) > 1E-12:
+        raise ValueError('the weights %s do not sum up to 1!' % ws)
 
 
 # ############################## site model ################################ #

--- a/openquake/risklib/valid.py
+++ b/openquake/risklib/valid.py
@@ -845,7 +845,7 @@ def weights(value):
     ws = probabilities(value)
     if abs(sum(ws) - 1.) > 1E-12:
         raise ValueError('the weights %s do not sum up to 1!' % ws)
-
+    return ws
 
 # ############################## site model ################################ #
 


### PR DESCRIPTION
Closes the last remaining points in https://github.com/gem/oq-engine/issues/2099: now group attributes are transmitted to the sources and the srcs_weights are recognized. Moreover, now `nrml.parse(fname, converter)` parses the given file with the given source converter. The demos are running: https://ci.openquake.org/job/zdevel_oq-engine/2073