### PR TITLE
Reduce the memory consumption when computing statistics for the hazard curves

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -348,12 +348,15 @@ class ClassicalCalculator(PSHACalculator):
                 gsims = self.rlzs_assoc.gsims_by_grp_id[grp_id]
                 for i, gsim in enumerate(gsims):
                     pmap_by_grp_gsim[grp_id, gsim] = poes.extract(i)
-        return {rlz: self.rlzs_assoc.combine_curves(rlz, pmap_by_grp_gsim)
-                for rlz in self.rlzs_assoc.realizations}
 
-    def post_execute(self, pmap_by_rlz):
+        return ((rlz, self.rlzs_assoc.combine_curves(rlz, pmap_by_grp_gsim))
+                for rlz in self.rlzs_assoc.realizations)
+
+    def post_execute(self, rlz_pmap):
         """
-        Combine the curves and store them
+        Combine the curves and store them.
+
+        :param rlz_pmap: an iterable of pairs (rlz, pmap)
         """
         oq = self.oqparam
         nsites = len(self.sitecol)
@@ -361,8 +364,8 @@ class ClassicalCalculator(PSHACalculator):
         nsites = len(self.sitecol)
         dic = {}
         with self.monitor('combine curves_by_rlz', autoflush=True):
-            for rlz in sorted(pmap_by_rlz):
-                curves = array_of_curves(pmap_by_rlz[rlz], nsites, oq.imtls)
+            for rlz, pmap in rlz_pmap:
+                curves = array_of_curves(pmap, nsites, oq.imtls)
                 dic[rlz] = curves
                 if oq.individual_curves:
                     self.store_curves('rlz-%03d' % rlz.ordinal, curves, rlz)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -168,14 +168,12 @@ class BoundingBox(object):
 
 
 @parallel.litetask
-def classical(sources, sitecol, siteidx, rlzs_assoc, monitor):
+def classical(sources, sitecol, rlzs_assoc, monitor):
     """
     :param sources:
         a non-empty sequence of sources of homogeneous tectonic region type
     :param sitecol:
         a SiteCollection instance
-    :param siteidx:
-        index of the first site (0 if there is a single tile)
     :param rlzs_assoc:
         a RlzsAssoc instance
     :param monitor:
@@ -194,7 +192,6 @@ def classical(sources, sitecol, siteidx, rlzs_assoc, monitor):
     max_dist = monitor.oqparam.maximum_distance[trt]
 
     dic = AccumDict()
-    dic.siteslice = slice(siteidx, siteidx + len(sitecol))
     if monitor.oqparam.poes_disagg:
         sm_id = rlzs_assoc.sm_ids[src_group_id]
         dic.bbs = [BoundingBox(sm_id, sid) for sid in sitecol.sids]

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -17,6 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division
+import logging
 import operator
 import collections
 from functools import partial
@@ -365,6 +366,7 @@ class ClassicalCalculator(PSHACalculator):
         dic = {}
         with self.monitor('combine curves_by_rlz', autoflush=True):
             for rlz, pmap in rlz_pmap:
+                logging.info('building hazard curves for rlz %s', rlz)
                 curves = array_of_curves(pmap, nsites, oq.imtls)
                 dic[rlz] = curves
                 if oq.individual_curves:
@@ -377,7 +379,7 @@ class ClassicalCalculator(PSHACalculator):
 
     def compute_stats(self, curves_by_rlz):
         """
-        Save the dictionary curves_by_rlz
+        :param curves_by_rlz: dictionary rlz -> hazard curves
         """
         oq = self.oqparam
         rlzs = self.rlzs_assoc.realizations

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -371,9 +371,9 @@ class ClassicalCalculator(PSHACalculator):
         if len(rlzs) == 1:  # cannot compute statistics
             self.mean_curves = curves
         else:
-            self.save_curves(dic)
+            self.save_curve_stats(dic)
 
-    def save_curves(self, curves_by_rlz):
+    def save_curve_stats(self, curves_by_rlz):
         """
         Save the dictionary curves_by_rlz
         """
@@ -399,7 +399,6 @@ class ClassicalCalculator(PSHACalculator):
                     curves = [curves_by_rlz[rlz][imt] for rlz in rlzs]
                     qc[imt] = scientific.quantile_curve(
                         curves, q, weights).reshape((nsites, -1))
-
             if oq.mean_hazard_curves:
                 self.store_curves('mean', self.mean_curves)
             for q in self.quantile:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -30,8 +30,7 @@ from openquake.baselib.python3compat import encode
 from openquake.baselib.general import AccumDict, group_array
 from openquake.hazardlib.calc.filters import \
     filter_sites_by_distance_to_rupture
-from openquake.hazardlib.calc.hazard_curve import (
-    array_of_curves, ProbabilityMap)
+from openquake.hazardlib.calc.hazard_curve import ProbabilityMap
 from openquake.hazardlib import geo
 from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.commonlib import readinput, parallel, calc
@@ -577,8 +576,8 @@ class EventBasedCalculator(ClassicalCalculator):
             return
         elif oq.hazard_curves_from_gmfs:
             rlzs = self.rlzs_assoc.realizations
-            dic = {rlzs[rlzi]: result[rlzi] for rlzi in result}
-            ClassicalCalculator.post_execute(self, dic)
+            ClassicalCalculator.post_execute(
+                self, ((rlzs[i], result[i]) for i in result))
         if oq.compare_with_classical:  # compute classical curves
             export_dir = os.path.join(oq.export_dir, 'cl')
             if not os.path.exists(export_dir):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -579,9 +579,12 @@ class EventBasedCalculator(ClassicalCalculator):
             rlzs = self.rlzs_assoc.realizations
             dic = {}
             for rlzi in result:
-                dic[rlzs[rlzi]] = array_of_curves(
+                rlz = rlzs[rlzi]
+                dic[rlz] = array_of_curves(
                     result[rlzi], len(self.sitecol), oq.imtls)
-            self.save_curves(dic)
+                if oq.individual_curves:
+                    self.store_curves('rlz-%03d' % rlz.ordinal, dic[rlz], rlz)
+            self.save_curve_stats(dic)
         if oq.compare_with_classical:  # compute classical curves
             export_dir = os.path.join(oq.export_dir, 'cl')
             if not os.path.exists(export_dir):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -217,14 +217,12 @@ class EBRupture(object):
 
 
 @parallel.litetask
-def compute_ruptures(sources, sitecol, siteidx, rlzs_assoc, monitor):
+def compute_ruptures(sources, sitecol, rlzs_assoc, monitor):
     """
     :param sources:
         List of commonlib.source.Source tuples
     :param sitecol:
         a :class:`openquake.hazardlib.site.SiteCollection` instance
-    :param siteidx:
-        always equal to 0
     :param rlzs_assoc:
         a :class:`openquake.commonlib.source.RlzsAssoc` instance
     :param monitor:
@@ -232,9 +230,6 @@ def compute_ruptures(sources, sitecol, siteidx, rlzs_assoc, monitor):
     :returns:
         a dictionary src_group_id -> [Rupture instances]
     """
-    assert siteidx == 0, (
-        'siteidx can be nonzero only for the classical_tiling calculations: '
-        'tiling with the EventBasedRuptureCalculator is an error')
     # NB: by construction each block is a non-empty list with
     # sources of the same src_group_id
     src_group_id = sources[0].src_group_id

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -577,14 +577,8 @@ class EventBasedCalculator(ClassicalCalculator):
             return
         elif oq.hazard_curves_from_gmfs:
             rlzs = self.rlzs_assoc.realizations
-            dic = {}
-            for rlzi in result:
-                rlz = rlzs[rlzi]
-                dic[rlz] = array_of_curves(
-                    result[rlzi], len(self.sitecol), oq.imtls)
-                if oq.individual_curves:
-                    self.store_curves('rlz-%03d' % rlz.ordinal, dic[rlz], rlz)
-            self.save_curve_stats(dic)
+            dic = {rlzs[rlzi]: result[rlzi] for rlzi in result}
+            ClassicalCalculator.post_execute(self, dic)
         if oq.compare_with_classical:  # compute classical curves
             export_dir = os.path.join(oq.export_dir, 'cl')
             if not os.path.exists(export_dir):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -304,15 +304,15 @@ class RlzsAssoc(collections.Mapping):
         return assoc
 
     # used in classical and event_based calculators
-    def combine_curves(self, results):
+    def combine_curves(self, rlz, results):
         """
         :param results: dictionary (src_group_id, gsim) -> curves
         :returns: a dictionary rlz -> aggregate curves
         """
-        acc = {rlz: ProbabilityMap() for rlz in self.realizations}
+        acc = ProbabilityMap()
         for key in results:
-            for rlz in self.rlzs_assoc[key]:
-                acc[rlz] |= results[key]
+            if rlz in self.rlzs_assoc[key]:
+                acc |= results[key]
         return acc
 
     # used in riskinput

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -177,7 +177,7 @@ class RlzsAssoc(collections.Mapping):
     but only via the method :meth:
     `openquake.commonlib.source.CompositeSourceModel.get_rlzs_assoc`.
 
-    :attr realizations: list of LtRealization objects
+    :attr realizations: list of :class:`LtRealization` objects
     :attr gsim_by_trt: list of dictionaries {trt: gsim}
     :attr rlzs_assoc: dictionary {src_group_id, gsim: rlzs}
     :attr rlzs_by_smodel: list of lists of realizations
@@ -306,6 +306,7 @@ class RlzsAssoc(collections.Mapping):
     # used in classical and event_based calculators
     def combine_curves(self, rlz, results):
         """
+        :param rlz: a :class:`LtRealization` object
         :param results: dictionary (src_group_id, gsim) -> curves
         :returns: a dictionary rlz -> aggregate curves
         """

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -830,10 +830,9 @@ class SourceManager(object):
 
     def gen_args(self, tiles):
         """
-        Yield (sources, sitecol, siteidx, rlzs_assoc, monitor) by
+        Yield (sources, sitecol, rlzs_assoc, monitor) by
         looping on the tiles and on the source blocks.
         """
-        siteidx = 0
         for i, sitecol in enumerate(tiles, 1):
             if len(tiles) > 1:
                 logging.info('Processing tile %d', i)
@@ -851,12 +850,10 @@ class SourceManager(object):
                         sources, self.maxweight,
                         operator.attrgetter('weight'),
                         operator.attrgetter('src_group_id')):
-                    yield (block, sitecol, siteidx,
-                           self.rlzs_assoc, self.monitor.new())
+                    yield block, sitecol, self.rlzs_assoc, self.monitor.new()
                     nblocks += 1
                 logging.info('Sent %d sources in %d block(s)',
                              len(sources), nblocks)
-            siteidx += len(sitecol)
 
     def store_source_info(self, dstore):
         """
@@ -876,7 +873,7 @@ class SourceManager(object):
 
 
 @parallel.litetask
-def count_eff_ruptures(sources, sitecol, siteidx, rlzs_assoc, monitor):
+def count_eff_ruptures(sources, sitecol, rlzs_assoc, monitor):
     """
     Count the number of ruptures contained in the given sources and return
     a dictionary src_group_id -> num_ruptures. All sources belong to the


### PR DESCRIPTION
With this change it is possible to compute the stats for the SHARE computation with ~10 GB of RAM, before it was running out of memory on the cluster.

PS: I have also removed the `siteidx` concept that was a leftover of the past and not needed anymore.