### PR TITLE
Fixed an horrible bug with hdf5.array_of_vstr

### DIFF
--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -76,7 +76,7 @@ class AssetCollection(object):
     def __getitem__(self, indices):
         if isinstance(indices, int):  # single asset
             a = self.array[indices]
-            values = {lt: a[lt] for lt in self.loss_types}
+            values = {lt: a[str(lt)] for lt in self.loss_types}
             if 'occupants' in self.array.dtype.names:
                 values['occupants_' + str(self.time_event)] = a['occupants']
             return riskmodels.Asset(


### PR DESCRIPTION
For some reason on Wilson the loss_type turns out to be a numpy array instead of a string, therefore a cast is needed. TODO: add a test reduced from Alehandro's files, since the issue never happens with the current tests.
The demos run: https://ci.openquake.org/job/zdevel_oq-engine/2083/

NB: the problem affects only Ubuntu 14.04:
```
> /home/michele/py2/oq-engine/openquake/risklib/riskinput.py(80)__getitem__()
-> values = {lt: a[lt] for lt in self.loss_types}
(Pdb)  self.loss_types[0]
structural
(Pdb)  type(self.loss_types[0])
<type 'numpy.object_'>
```

there is no issue in Ubuntu 16.04, where `self.loss_types[0]` is just a string.