### PR TITLE
Moved the SourceManager logic in the execute phase

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -17,6 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division
+import math
 import logging
 import operator
 import collections
@@ -33,7 +34,7 @@ from openquake.hazardlib.calc.filters import source_site_distance_filter
 from openquake.hazardlib.calc.hazard_curve import (
     hazard_curves_per_trt, zero_curves, array_of_curves, ProbabilityMap)
 from openquake.risklib import scientific
-from openquake.commonlib import datastore, source
+from openquake.commonlib import datastore, source, parallel
 from openquake.calculators import base
 
 U16 = numpy.uint16
@@ -267,21 +268,37 @@ class PSHACalculator(base.HazardCalculator):
         tectonic region type.
         """
         monitor = self.monitor.new(self.core_task.__name__)
-        monitor.oqparam = self.oqparam
-        pmap_by_grp_id = self.taskman.reduce(self.agg_dicts, self.zerodict())
-        self.save_data_transfer(self.taskman)
+        monitor.oqparam = oq = self.oqparam
+        tiles = [self.sitecol]
+        self.num_tiles = 1
+        if self.is_tiling():
+            hint = math.ceil(len(self.sitecol) / oq.sites_per_tile)
+            tiles = self.sitecol.split_in_tiles(hint)
+            self.num_tiles = len(tiles)
+            logging.info('Generating %d tiles of %d sites each',
+                         self.num_tiles, len(tiles[0]))
+        with self.monitor('managing sources', autoflush=True):
+            srcman = source.SourceManager(
+                self.csm, oq.maximum_distance, oq.concurrent_tasks,
+                self.datastore, self.monitor.new(oqparam=oq),
+                self.random_seed, oq.filter_sources, num_tiles=self.num_tiles)
+            tm = parallel.starmap(
+                self.core_task.__func__, srcman.gen_args(tiles))
+            srcman.pre_store_source_info(self.datastore)
+        pmap_by_grp_id = tm.reduce(self.agg_dicts, self.zerodict())
+        self.save_data_transfer(tm)
         with self.monitor('store source_info', autoflush=True):
-            self.store_source_info(pmap_by_grp_id)
+            self.store_source_info(tm, srcman.maxweight, pmap_by_grp_id)
         self.rlzs_assoc = self.csm.info.get_rlzs_assoc(
             partial(self.count_eff_ruptures, pmap_by_grp_id))
         self.datastore['csm_info'] = self.csm.info
         return pmap_by_grp_id
 
-    def store_source_info(self, pmap_by_grp_id):
+    def store_source_info(self, taskman, maxweight, pmap_by_grp_id):
         # store the information about received data
-        received = self.taskman.received
+        received = taskman.received
         if received:
-            tname = self.taskman.name
+            tname = taskman.name
             self.datastore.save('job_info', {
                 tname + '_max_received_per_task': max(received),
                 tname + '_tot_received': sum(received),
@@ -289,7 +306,7 @@ class PSHACalculator(base.HazardCalculator):
         # then save the calculation times per each source
         calc_times = getattr(pmap_by_grp_id, 'calc_times', [])
         if calc_times:
-            sources = self.csm.get_sources(self.taskman.maxweight, 'all')
+            sources = self.csm.get_sources(maxweight, 'all')
             info_dict = {(rec['src_group_id'], rec['source_id']): rec
                          for rec in self.source_info}
             for src_idx, dt in calc_times:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -288,13 +288,13 @@ class PSHACalculator(base.HazardCalculator):
         pmap_by_grp_id = tm.reduce(self.agg_dicts, self.zerodict())
         self.save_data_transfer(tm)
         with self.monitor('store source_info', autoflush=True):
-            self.store_source_info(tm, srcman.maxweight, pmap_by_grp_id)
+            self.store_source_info(tm, pmap_by_grp_id)
         self.rlzs_assoc = self.csm.info.get_rlzs_assoc(
             partial(self.count_eff_ruptures, pmap_by_grp_id))
         self.datastore['csm_info'] = self.csm.info
         return pmap_by_grp_id
 
-    def store_source_info(self, taskman, maxweight, pmap_by_grp_id):
+    def store_source_info(self, taskman, pmap_by_grp_id):
         # store the information about received data
         received = taskman.received
         if received:
@@ -306,7 +306,7 @@ class PSHACalculator(base.HazardCalculator):
         # then save the calculation times per each source
         calc_times = getattr(pmap_by_grp_id, 'calc_times', [])
         if calc_times:
-            sources = self.csm.get_sources(maxweight, 'all')
+            sources = self.csm.get_sources()
             info_dict = {(rec['src_group_id'], rec['source_id']): rec
                          for rec in self.source_info}
             for src_idx, dt in calc_times:
@@ -444,10 +444,3 @@ class ClassicalCalculator(PSHACalculator):
             dset.attrs['uid'] = rlz.uid
         for k, v in kw.items():
             dset.attrs[k] = v
-
-
-def nonzero(val):
-    """
-    :returns: the sum of the composite array `val`
-    """
-    return sum(val[k].sum() for k in val.dtype.names)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -857,12 +857,16 @@ class SourceManager(object):
                 logging.info('Sent %d sources in %d block(s)',
                              len(sources), nblocks)
 
-    def store_source_info(self, dstore):
+    def pre_store_source_info(self, dstore):
         """
         Save the `source_info` array and its attributes in the datastore.
 
         :param dstore: the datastore
         """
+        attrs = dstore.hdf5['composite_source_model'].attrs
+        attrs['weight'] = self.csm.weight
+        attrs['filtered_weight'] = self.csm.filtered_weight
+
         if self.infos:
             values = list(self.infos.values())
             values.sort(

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -618,11 +618,14 @@ class CompositeSourceModel(collections.Sequence):
             for src_group in sm.src_groups:
                 yield src_group
 
-    def get_sources(self, maxweight, kind):
+    def get_sources(self, kind='all', maxweight=None):
         """
         Extract the sources contained in the source models by optionally
         filtering and splitting them, depending on the passed parameters.
         """
+        if kind != 'all':
+            assert kind in ('light', 'heavy') and maxweight is not None, (
+                kind, maxweight)
         sources = []
         for src_group in self.src_groups:
             for src in src_group:
@@ -760,7 +763,7 @@ class SourceManager(object):
             n = sum(sg.tot_ruptures() for sg in self.csm.src_groups)
             rup_serial = numpy.arange(n, dtype=numpy.uint32)
             start = 0
-            for src in self.csm.get_sources(self.maxweight, 'all'):
+            for src in self.csm.get_sources():
                 nr = src.num_ruptures
                 self.src_serial[src.id] = rup_serial[start:start + nr]
                 start += nr
@@ -773,7 +776,7 @@ class SourceManager(object):
         """
         filter_mon = self.monitor('filtering sources')
         split_mon = self.monitor('splitting sources')
-        for src in self.csm.get_sources(self.maxweight, kind):
+        for src in self.csm.get_sources(kind, self.maxweight):
             filter_time = split_time = 0
             if self.filter_sources:
                 with filter_mon:


### PR DESCRIPTION
Before it was in the `pre_execute` method of the base calculator, but since it is needed only in the `execute` method of the `psha` calculator it is best to move it there. The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2099/