### PR TITLE
Simplified the RiskInputs

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -314,8 +314,9 @@ class EventBasedRiskCalculator(base.RiskCalculator):
 
         with self.monitor('building riskinputs', autoflush=True):
             riskinputs = self.riskmodel.build_inputs_from_ruptures(
-                self.sitecol.complete, all_ruptures, oq.truncation_level,
-                correl_model, min_iml, eps, oq.concurrent_tasks or 1)
+                list(oq.imtls), self.sitecol.complete, all_ruptures,
+                oq.truncation_level, correl_model, min_iml, eps,
+                oq.concurrent_tasks or 1)
             # NB: I am using generators so that the tasks are submitted one at
             # the time, without keeping all of the arguments in memory
             tm = starmap(

--- a/openquake/commonlib/tests/riskinput_test.py
+++ b/openquake/commonlib/tests/riskinput_test.py
@@ -66,24 +66,9 @@ idx:uint32,lon,lat,site_id:uint32,taxonomy:uint32:,number,area,occupants:float64
         pickle.loads(pickle.dumps(assetcol))
 
     def test_get_hazard(self):
-        self.assertEqual(
-            list(self.riskmodel.get_imt_taxonomies()),
-            [('PGA', set(['RM'])), ('SA(0.2)', set(['RC+'])),
-             ('SA(0.5)', set(['W']))])
         self.assertEqual(len(self.sitecol), 2)
         hazard_by_site = [{}] * 2
-
-        ri_PGA = self.riskmodel.build_input(
-            'PGA', hazard_by_site, self.assets_by_site, {})
-        haz = ri_PGA.get_hazard(rlzs_assoc)
-        self.assertEqual(len(haz), 2)
-
-        ri_SA_02 = self.riskmodel.build_input(
-            'SA(0.2)', hazard_by_site, self.assets_by_site, {})
-        haz = ri_SA_02.get_hazard(rlzs_assoc)
-        self.assertEqual(len(haz), 2)
-
-        ri_SA_05 = self.riskmodel.build_input(
-            'SA(0.5)', hazard_by_site, self.assets_by_site, {})
-        haz = ri_SA_05.get_hazard(rlzs_assoc)
+        ri = self.riskmodel.build_input(
+            hazard_by_site, self.assets_by_site, {})
+        haz = ri.get_hazard(rlzs_assoc)
         self.assertEqual(len(haz), 2)

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -253,7 +253,7 @@ class RiskModel(object):
         return [lt for lt in self.loss_types
                 if self.risk_functions[lt].imt == imt]
 
-    def out_by_lr(self, imt, assets, hazard, epsgetter):
+    def out_by_lr(self, assets, hazard, epsgetter):
         """
         :param imt: restrict the risk functions to this IMT
         :param assets: an array of assets of homogeneous taxonomy
@@ -263,13 +263,14 @@ class RiskModel(object):
         """
         out_by_lr = AccumDict()
         out_by_lr.assets = assets
-        loss_types = self.get_loss_types(imt)
-        for rlz in sorted(hazard):
-            haz = hazard[rlz]
-            if len(haz) == 0:
-                continue
-            r = rlz.ordinal
-            for loss_type in loss_types:
+        for loss_type in self.loss_types:
+            imt = self.risk_functions[loss_type].imt
+            haz_by_rlz = hazard[imt]
+            for rlz in sorted(haz_by_rlz):
+                haz = haz_by_rlz[rlz]
+                if len(haz) == 0:
+                    continue
+                r = rlz.ordinal
                 out = self(loss_type, assets, haz, epsgetter)
                 if out:  # can be None in scenario_risk with no valid values
                     l = self.compositemodel.lti[loss_type]

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -255,9 +255,8 @@ class RiskModel(object):
 
     def out_by_lr(self, assets, hazard, epsgetter):
         """
-        :param imt: restrict the risk functions to this IMT
         :param assets: an array of assets of homogeneous taxonomy
-        :param hazard: a dictionary rlz -> hazard
+        :param hazard: a dictionary imt -> rlz -> hazard
         :param epsgetter: a callable returning epsilons for the given eids
         :returns: a dictionary (l, r) -> output
         """


### PR DESCRIPTION
Instead of having a RiskInput object for each IMT, now a RiskInput object contains multiple IMTs. This is a first step towards https://github.com/gem/oq-engine/issues/2017, where it is natural to read the GMFs for all IMTs at the same time. It also allows to reduce the complexity and the number of line of code for all calculators, since the method .get_imt_taxonomies becomes now unneeded.
The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2108