### PR TITLE
Fixed disagg when a source group has been filtered away

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a bug in the disaggregation calculator when a source group has
+    been filtered away by the maximum distance criterium
   * Fixed an encoding error in the reports when the description contains a
     non-ASCII character
   * Changed the distribution framework: celery is supported in a way more

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -272,6 +272,8 @@ class DisaggregationCalculator(classical.ClassicalCalculator):
             logging.info('%d mag bins from %s to %s', len(mag_edges) - 1,
                          min_mag, max_mag)
             for src_group in smodel.src_groups:
+                if src_group.id not in self.rlzs_assoc.gsims_by_grp_id:
+                    continue  # the group has been filtered away
                 for sid, site in zip(sitecol.sids, sitecol):
                     curves = curves_dict[sid]
                     if not curves:


### PR DESCRIPTION
The bug was signaled in the mailing list: 
https://groups.google.com/d/msg/openquake-users/KgzyA15ideo/Nf4MbCXGBAAJ
A test will be added later.