### PR TITLE
Fixed loss curve XML export

### DIFF
--- a/openquake/commonlib/export/risk.py
+++ b/openquake/commonlib/export/risk.py
@@ -827,7 +827,10 @@ def export_loss_curves_rlzs(ekey, dstore):
             losses = data['losses' + ins]
             poes = data['poes' + ins]
             avg = data['avg' + ins]
-            loss_ratios = losses / ass['value-' + lt]
+            if lt == 'occupants':
+                loss_ratios = losses / ass['occupants']
+            else:
+                loss_ratios = losses / ass['value-' + lt]
             curve = LossCurve(loc, aref[ass['idx']], poes,
                               losses, loss_ratios, avg, None)
             curves.append(curve)


### PR DESCRIPTION
This caused the breakage in https://ci.openquake.org/job/master_oq-engine/2687/
The demos are green now: https://ci.openquake.org/job/zdevel_oq-engine/2162