### PR TITLE
Avoid race conditions when starting webui using oq

### DIFF
--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -17,6 +17,7 @@
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import sys
 import subprocess
+from time import sleep
 from openquake.risklib import valid
 from openquake.baselib import sap
 from openquake.engine import config
@@ -42,6 +43,14 @@ def webui(cmd, hostport='127.0.0.1:8800'):
             sys.exit('Please start the DbServer: '
                      'see the documentation for details')
         subprocess.Popen([sys.executable, '-m', 'openquake.server.dbserver'])
+        counter = 0
+        while dbstatus == 'not-running':
+            if counter >= 10:
+                sys.exit('The DbServer cannot be started. '
+                         'Please check the configuration')
+            sleep(1)
+            dbstatus = get_status()
+            counter += 1
 
     if cmd == 'start':
         rundjango('runserver', hostport)

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -43,14 +43,14 @@ def webui(cmd, hostport='127.0.0.1:8800'):
             sys.exit('Please start the DbServer: '
                      'see the documentation for details')
         subprocess.Popen([sys.executable, '-m', 'openquake.server.dbserver'])
-        counter = 0
+        waiting_seconds = 5
         while dbstatus == 'not-running':
-            if counter >= 5:
+            if waiting_seconds == 0:
                 sys.exit('The DbServer cannot be started. '
                          'Please check the configuration')
             sleep(1)
             dbstatus = get_status()
-            counter += 1
+            waiting_seconds -= 1
 
     if cmd == 'start':
         rundjango('runserver', hostport)

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -45,7 +45,7 @@ def webui(cmd, hostport='127.0.0.1:8800'):
         subprocess.Popen([sys.executable, '-m', 'openquake.server.dbserver'])
         counter = 0
         while dbstatus == 'not-running':
-            if counter >= 10:
+            if counter >= 5:
                 sys.exit('The DbServer cannot be started. '
                          'Please check the configuration')
             sleep(1)


### PR DESCRIPTION
Since #2152 the dbserver is started by `oq webui start` in background. This could cause a race condition when the webui starts before the db server is accepting connections:

```bash
$ oq webui start
Traceback (most recent call last):
  File "/home/daniele/openquake/lib/python3.5/site-packages/openquake/engine/logs.py", line 51, in dbcmd
    client = Client(config.DBS_ADDRESS, authkey=config.DBS_AUTHKEY)
  File "/usr/lib64/python3.5/multiprocessing/connection.py", line 487, in Client
    c = SocketClient(address)
  File "/usr/lib64/python3.5/multiprocessing/connection.py", line 614, in SocketClient
    s.connect(address)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/daniele/openquake/lib/python3.5/site-packages/openquake/server/manage.py", line 52, in <module>
    logs.dbcmd('upgrade_db')  # make sure the DB exists
  File "/home/daniele/openquake/lib/python3.5/site-packages/openquake/engine/logs.py", line 53, in dbcmd
    raise RuntimeError('Cannot connect on %s:%s' % config.DBS_ADDRESS)
RuntimeError: Cannot connect on localhost:1999
```

This PR adds a loop with a timeout of 10secs to make the webui start sync'ed with the dbserver.