### PR TITLE
Reduce the data transfer in realizations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced the data transfer due to the `rlzs_by_gsim` parameter
   * Added an HDF5 export for scenario GMFs
   * If `filter_sources` if false, the light sources are not filtered, but the
     heavy sources are always filtered

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -289,8 +289,9 @@ class PSHACalculator(base.HazardCalculator):
                          self.num_tiles, len(tiles[0]))
         with self.monitor('managing sources', autoflush=True):
             srcman = source.SourceManager(
-                self.csm, oq.concurrent_tasks, self.datastore,
-                monitor, oq.filter_sources, self.num_tiles)
+                self.csm, oq.maximum_distance, oq.concurrent_tasks,
+                self.datastore, monitor, self.random_seed, oq.filter_sources,
+                num_tiles=self.num_tiles)
             tm = parallel.starmap(
                 self.core_task.__func__, srcman.gen_args(self.sitecol, tiles))
             iter_result = tm.submit_all()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -289,9 +289,8 @@ class PSHACalculator(base.HazardCalculator):
                          self.num_tiles, len(tiles[0]))
         with self.monitor('managing sources', autoflush=True):
             srcman = source.SourceManager(
-                self.csm, oq.maximum_distance, oq.concurrent_tasks,
-                self.datastore, monitor, self.random_seed, oq.filter_sources,
-                num_tiles=self.num_tiles)
+                self.csm, oq.concurrent_tasks, self.datastore,
+                monitor, oq.filter_sources, self.num_tiles)
             tm = parallel.starmap(
                 self.core_task.__func__, srcman.gen_args(self.sitecol, tiles))
             iter_result = tm.submit_all()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -168,14 +168,14 @@ class BoundingBox(object):
     __nonzero__ = __bool__
 
 
-def classical(sources, sitecol, rlzs_by_gsim, monitor):
+def classical(sources, sitecol, gsims, monitor):
     """
     :param sources:
         a non-empty sequence of sources of homogeneous tectonic region type
     :param sitecol:
         a SiteCollection instance
-    :param rlzs_by_gsim:
-        a dictionary of realizations by GSIM
+    :param gsims:
+        a list of GSIMs for the current tectonic region type
     :param monitor:
         a monitor instance
     :returns:
@@ -187,13 +187,12 @@ def classical(sources, sitecol, rlzs_by_gsim, monitor):
     # sanity check: the src_group must be the same for all sources
     for src in sources[1:]:
         assert src.src_group_id == src_group_id
-    gsims = list(rlzs_by_gsim)
     trt = sources[0].tectonic_region_type
     max_dist = monitor.maximum_distance[trt]
 
     dic = AccumDict()
     if monitor.poes_disagg:
-        sm_id = rlzs_by_gsim.sm_id
+        sm_id = monitor.sm_id
         dic.bbs = [BoundingBox(sm_id, sid) for sid in sitecol.sids]
     else:
         dic.bbs = []

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -216,14 +216,14 @@ class EBRupture(object):
                                         self.serial, self.grp_id)
 
 
-def compute_ruptures(sources, sitecol, rlzs_by_gsim, monitor):
+def compute_ruptures(sources, sitecol, gsims, monitor):
     """
     :param sources:
         List of commonlib.source.Source tuples
     :param sitecol:
         a :class:`openquake.hazardlib.site.SiteCollection` instance
     :param rlzs_by_gsim:
-        a dictionary gsim -> realizations of that GSIM
+        a list of GSIMs for the current tectonic region model
     :param monitor:
         monitor instance
     :returns:
@@ -234,7 +234,7 @@ def compute_ruptures(sources, sitecol, rlzs_by_gsim, monitor):
     src_group_id = sources[0].src_group_id
     trt = sources[0].tectonic_region_type
     max_dist = monitor.maximum_distance[trt]
-    cmaker = ContextMaker(rlzs_by_gsim)
+    cmaker = ContextMaker(gsims)
     params = sorted(cmaker.REQUIRES_RUPTURE_PARAMETERS)
     rup_data_dt = numpy.dtype(
         [('rupserial', U32), ('multiplicity', U16),
@@ -244,7 +244,7 @@ def compute_ruptures(sources, sitecol, rlzs_by_gsim, monitor):
     rup_data = []
     calc_times = []
     rup_mon = monitor('filtering ruptures', measuremem=False)
-    num_samples = rlzs_by_gsim.samples
+    num_samples = monitor.samples
 
     # Compute and save stochastic event sets
     for src in sources:
@@ -257,7 +257,7 @@ def compute_ruptures(sources, sitecol, rlzs_by_gsim, monitor):
             integration_distance=max_dist, sites=s_sites)
         num_occ_by_rup = sample_ruptures(
             src, monitor.ses_per_logic_tree_path, num_samples,
-            rlzs_by_gsim.seed)
+            monitor.seed)
         # NB: the number of occurrences is very low, << 1, so it is
         # more efficient to filter only the ruptures that occur, i.e.
         # to call sample_ruptures *before* the filtering

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -38,7 +38,7 @@ def indent(text):
     return '  ' + '\n  '.join(text.splitlines())
 
 
-def count_eff_ruptures(sources, sitecol, rlzs_by_gsim, monitor):
+def count_eff_ruptures(sources, sitecol, gsims, monitor):
     """
     Count the number of ruptures contained in the given sources and return
     a dictionary src_group_id -> num_ruptures. All sources belong to the

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -861,8 +861,11 @@ class SourceManager(object):
                     operator.attrgetter('weight'),
                     operator.attrgetter('src_group_id')):
                 grp_id = block[0].src_group_id
-                rlzs_by_gsim = self.rlzs_assoc.get_rlzs_by_gsim(grp_id)
-                yield block, sites, rlzs_by_gsim, mon
+                gsims = self.rlzs_assoc.gsims_by_grp_id[grp_id]
+                mon.sm_id = self.rlzs_assoc.sm_ids[grp_id]
+                mon.seed = self.rlzs_assoc.seed
+                mon.samples = self.rlzs_assoc.samples[grp_id]
+                yield block, sites, gsims, mon
 
     def _gen_src_light(self, tiles):
         filter_mon = self.monitor('filtering sources')

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -280,7 +280,6 @@ class RlzsAssoc(collections.Mapping):
             rlzs_by_gsim[gsim] = self[grp_id, str(gsim)]
             rlzs.update(rlzs_by_gsim[gsim])
         rlzs_by_gsim.realizations = sorted(rlzs)
-        rlzs_by_gsim.sm_id = self.sm_ids[grp_id]
         rlzs_by_gsim.samples = self.samples[grp_id]
         rlzs_by_gsim.seed = self.seed
         return rlzs_by_gsim
@@ -862,7 +861,8 @@ class SourceManager(object):
                     operator.attrgetter('src_group_id')):
                 grp_id = block[0].src_group_id
                 gsims = self.rlzs_assoc.gsims_by_grp_id[grp_id]
-                mon.sm_id = self.rlzs_assoc.sm_ids[grp_id]
+                if self.monitor.poes_disagg:  # only for disaggregation
+                    mon.sm_id = self.rlzs_assoc.sm_ids[grp_id]
                 mon.seed = self.rlzs_assoc.seed
                 mon.samples = self.rlzs_assoc.samples[grp_id]
                 yield block, sites, gsims, mon

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -280,7 +280,6 @@ class RlzsAssoc(collections.Mapping):
             rlzs_by_gsim[gsim] = self[grp_id, str(gsim)]
             rlzs.update(rlzs_by_gsim[gsim])
         rlzs_by_gsim.realizations = sorted(rlzs)
-        rlzs_by_gsim.sm_id = self.sm_ids[grp_id]
         rlzs_by_gsim.samples = self.samples[grp_id]
         rlzs_by_gsim.seed = self.seed
         return rlzs_by_gsim
@@ -779,13 +778,13 @@ class SourceManager(object):
     Manager associated to a CompositeSourceModel instance.
     Filter and split sources and send them to the worker tasks.
     """
-    def __init__(self, csm, maximum_distance, concurrent_tasks,
-                 dstore, monitor, random_seed=None,
-                 filter_sources=True, num_tiles=1):
+    def __init__(self, csm, concurrent_tasks, dstore,
+                 monitor, filter_sources=True, num_tiles=1):
         self.csm = csm
-        self.maximum_distance = maximum_distance
+        self.maximum_distance = monitor.maximum_distance
         self.concurrent_tasks = concurrent_tasks or 1
-        self.random_seed = random_seed
+        self.random_seed = monitor.random_seed
+        self.poes_disagg = monitor.poes_disagg
         self.dstore = dstore
         self.monitor = monitor
         self.filter_sources = filter_sources
@@ -798,7 +797,7 @@ class SourceManager(object):
             self.maxweight = max(self.maxweight / num_tiles, MAXWEIGHT)
         logging.info('Instantiated SourceManager with maxweight=%.1f',
                      self.maxweight)
-        if random_seed is not None:
+        if self.random_seed is not None:
             # generate unique seeds for each rupture with numpy.arange
             n = sum(sg.tot_ruptures() for sg in self.csm.src_groups)
             rup_serial = numpy.arange(n, dtype=numpy.uint32)
@@ -862,7 +861,8 @@ class SourceManager(object):
                     operator.attrgetter('src_group_id')):
                 grp_id = block[0].src_group_id
                 gsims = self.rlzs_assoc.gsims_by_grp_id[grp_id]
-                mon.sm_id = self.rlzs_assoc.sm_ids[grp_id]
+                if self.poes_disagg:  # only for disaggregation
+                    mon.sm_id = self.rlzs_assoc.sm_ids[grp_id]
                 mon.seed = self.rlzs_assoc.seed
                 mon.samples = self.rlzs_assoc.samples[grp_id]
                 yield block, sites, gsims, mon


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2214. The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2174.
In the case of `demos/hazard/LogicTreeCase2ClassicalPSHA`, with 324 realizations, the data transfer in rlzs_by_gsim goes down by a factor of 7, from 177,390 bytes to  25,434  bytes. In more realistic cases you can gain several orders of magnitude. Here is a real case with an improvement of over 10,000 times:

```
   (master)
   count_eff_ruptures_num_tasks             56
   count_eff_ruptures_sent.monitor          52,248
   count_eff_ruptures_sent.rlzs_by_gsim     850,059,977
   count_eff_ruptures_sent.sitecol          27,608
   count_eff_ruptures_sent.sources          13,651,404

   (this branch)
   count_eff_ruptures_num_tasks             56
   count_eff_ruptures_sent.monitor          53,536
   count_eff_ruptures_sent.gsims            79,958
   count_eff_ruptures_sent.sitecol          27,608
   count_eff_ruptures_sent.sources          13,651,404
```

This is a computation for Switzerland by Laurentiu with 82,944 realizations which was totally dominated by the rlzs_by_gsim data transfer (811 MB vs 13 MB of sources) which goes down to 7 k. There are computations with much larger logic trees where the effect is even bigger.