### PR TITLE
Fixed the case of OQ_DISTRIBUTE=no

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -68,15 +68,13 @@ def get_effective_rlzs(rlzs):
     and yield the first representative of each group.
     """
     effective = []
-    ordinal = 0
     for uid, group in groupby(rlzs, operator.attrgetter('uid')).items():
         rlz = group[0]
         if all(path == '@' for path in rlz.lt_uid):  # empty realization
             continue
         effective.append(
             Realization(rlz.value, sum(r.weight for r in group),
-                        rlz.lt_path, ordinal, rlz.lt_uid))
-        ordinal += 1
+                        rlz.lt_path, rlz.ordinal, rlz.lt_uid))
     return effective
 
 

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -349,7 +349,7 @@ class TaskManager(object):
         # log a warning if too much memory is used
         if self.distribute == 'no':
             sent = {}
-            res = (self.task_func(*args), None, args[-1])
+            res = safely_call(self.task_func, args)
         else:
             piks = pickle_sequence(args)
             sent = {arg: len(p) for arg, p in zip(self.argnames, piks)}


### PR DESCRIPTION
When disabling the task distribution there was an error when flushing the monitor. This has been solved here. I am also changing `logictree.get_effective_rlzs` to keep the original ordinal, which is useful when debugging the reduction of logic trees,