### PR TITLE
Reduced a big log message

### DIFF
--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -583,7 +583,7 @@ class UCERFSESControl(object):
             rates = hdf5[self.idx_set["rate_idx"]][:]
             occurrences = self.tom.sample_number_of_occurrences(rates)
             indices = numpy.where(occurrences)[0]
-            logging.info('Considering %s %s', branch_id, indices)
+            logging.info('Considering %s %d ruptures', branch_id, len(indices))
 
             # get ruptures from the indices
             ruptures = []


### PR DESCRIPTION
When a lot of ruptures are sampled,  `logging.info('Considering %s %s', branch_id, indices)` is trying to log a lot of stuff and the DbServer becomes unresponsive, with the error

```
   RuntimeError: Cannot connect on localhost:1999
```

This was discovered by Anirudh. Now we only log the number of ruptures, not the indices.