### PR TITLE
Copy deb files only if binaries are built in _pkgbuild_innervm_run

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -245,7 +245,10 @@ _pkgbuild_innervm_run () {
     ssh $lxc_ip "sudo mk-build-deps --install --tool 'apt-get -y' build-deb/debian/control"
 
     ssh $lxc_ip "cd build-deb && dpkg-buildpackage $DPBP_FLAG"
-    scp -r ${lxc_ip}:*.{tar.gz,deb,changes,dsc} ../
+    scp $lxc_ip:*.{tar.gz,changes,dsc} ../
+    if echo "$DPBP_FLAG" | grep -q -v -- '-S'; then
+        scp $lxc_ip:*.deb ../
+    fi
 
     return
 }


### PR DESCRIPTION
Fixes build issue on Xenial (see also https://github.com/gem/oq-hazardlib/pull/490)