### PR TITLE
Fixed task_info in the reportwriter

### DIFF
--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -126,8 +126,9 @@ class ReportWriter(object):
         if 'source_info' in ds:
             self.add('short_source_info')
             self.add('times_by_source_class')
-        if 'performance_data' in ds:
+        if 'task_info' in ds:
             self.add('taskinfo')
+        if 'performance_data' in ds:
             self.add('performance')
         return self.text
 


### PR DESCRIPTION
This was breaking master https://ci.openquake.org/job/master_oq-engine/2729/
https://ci.openquake.org/job/zdevel_oq-engine/2190/ is green.