### PR TITLE
Removed .hid and .weight from Output when not needed

### DIFF
--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -46,7 +46,7 @@ def classical_bcr(riskinput, riskmodel, rlzs_assoc, bcr_dt, monitor):
         for (l, r), out in sorted(out_by_lr.items()):
             for asset, (eal_orig, eal_retro, bcr) in zip(out.assets, out.data):
                 aval = asset.value(out.loss_type)
-                result[asset.ordinal, out.loss_type, out.hid] = numpy.array([
+                result[asset.ordinal, out.loss_type, r] = numpy.array([
                     (eal_orig * aval, eal_retro * aval, bcr)], bcr_dt)
     return result
 

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -45,7 +45,7 @@ def classical_risk(riskinput, riskmodel, rlzs_assoc, monitor):
     """
     oq = monitor.oqparam
     ins = oq.insured_losses
-    R = len(rlzs_assoc.realizations)
+    rlzs = rlzs_assoc.realizations
     result = dict(
         loss_curves=[], loss_maps=[], stat_curves=[], stat_maps=[])
     for out_by_lr in riskmodel.gen_outputs(riskinput, rlzs_assoc, monitor):
@@ -71,9 +71,13 @@ def classical_risk(riskinput, riskmodel, rlzs_assoc, monitor):
                     (l, r, aid, out.loss_maps[:, i]))
 
         # compute statistics
-        if R > 1:
+        if len(rlzs) > 1:
             for l, lrs in groupby(out_by_lr, operator.itemgetter(0)).items():
-                outs = [out_by_lr[lr] for lr in lrs]
+                outs = []
+                for l, r in lrs:
+                    out = out_by_lr[l, r]
+                    out.weight = rlzs[r].weight
+                    outs.append(out)
                 curve_resolution = outs[0].loss_curves.shape[-1]
                 statsbuilder = scientific.StatsBuilder(
                     oq.quantile_loss_curves,

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -273,8 +273,6 @@ class RiskModel(object):
                 out = self(loss_type, assets, haz, epsgetter)
                 if out:  # can be None in scenario_risk with no valid values
                     l = self.compositemodel.lti[loss_type]
-                    out.hid = r
-                    out.weight = rlz.weight
                     out_by_lr[l, r] = out
         return out_by_lr
 


### PR DESCRIPTION
This is a minor simplification of the risk calculators. The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2198/