### PR TITLE
Xenial needs python-celery-common to run tests using celery

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.globalquakemodel.org/openquake/
 
 Package: python-oq-engine
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, python-scipy, python-numpy, python-psutil, python-decorator, python-prctl, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-paramiko, python-shapely, python-setuptools, python-nose, python-mock, python-pyshp, python-requests (>=0.8.2), python-docutils, python-oq-hazardlib (>=0.21.0-0~), python-concurrent.futures (>=2.1.2), python-django, rabbitmq-server (>=2.8.0-2~gem02), supervisor
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-psutil, python-decorator, python-prctl, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-paramiko, python-shapely, python-setuptools, python-nose, python-mock, python-pyshp, python-requests (>=0.8.2), python-docutils, python-oq-hazardlib (>=0.21.0-0~), python-concurrent.futures (>=2.1.2), python-django, rabbitmq-server (>=2.8.0-2~gem02), supervisor, ${dist:Depends}
 Conflicts: python-oq-risklib, python-noq, python-oq
 Replaces: python-oq-risklib
 Recommends: ${dist:Recommends}

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.globalquakemodel.org/openquake/
 
 Package: python-oq-engine
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-psutil, python-decorator, python-prctl, python-celery (>=2.4.6-1ubuntu0.2~gem03), python-geohash, python-paramiko, python-shapely, python-setuptools, python-nose, python-mock, python-pyshp, python-requests (>=0.8.2), python-docutils, python-oq-hazardlib (>=0.21.0-0~), python-concurrent.futures (>=2.1.2), python-django, rabbitmq-server (>=2.8.0-2~gem02), supervisor, ${dist:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-scipy, python-numpy, python-psutil, python-decorator, python-prctl, python-geohash, python-paramiko, python-shapely, python-setuptools, python-nose, python-mock, python-pyshp, python-requests (>=0.8.2), python-docutils, python-oq-hazardlib (>=0.21.0-0~), python-concurrent.futures (>=2.1.2), python-django, rabbitmq-server (>=2.8.0-2~gem02), supervisor, ${dist:Depends}
 Conflicts: python-oq-risklib, python-noq, python-oq
 Replaces: python-oq-risklib
 Recommends: ${dist:Recommends}

--- a/debian/rules
+++ b/debian/rules
@@ -16,12 +16,22 @@ export DH_OPTIONS
 
 bd=openquake/bin
 
-DEFAULT_DEP = python-amqp, python-h5py (>= 2.2.1)
-DEFAULT_REC =
+COMMON_DEP = python-amqp, python-h5py (>= 2.2.1)
+COMMON_REC =
+XENIAL_DEP = python-celery-common
+XENIAL_REC =
+TRUSTY_DEP =
+TRUSTY_REC =
 PRECISE_DEP = python-h5py (= 2.2.1-1build3~precise03)
 PRECISE_REC =
 
-ifeq ($(shell lsb_release --codename --short),precise)
+ifeq ($(shell lsb_release --codename --short),xenial)
+	DEPENDS = -Vdist:Depends="$(XENIAL_DEP), $(COMMON_DEP)"
+	RECOMMENDS = -Vdist:Recommends="$(XENIAL_REC)"
+else ifeq ($(shell lsb_release --codename --short),trusty)
+	DEPENDS = -Vdist:Depends="$(TRUSTY_DEP), $(COMMON_DEP)"
+	RECOMMENDS = -Vdist:Recommends="$(TRUSTY_REC)"
+else ifeq ($(shell lsb_release --codename --short),precise)
 	DEPENDS = -Vdist:Depends="$(PRECISE_DEP)"
 	RECOMMENDS = -Vdist:Recommends="$(PRECISE_REC)"
 else

--- a/debian/rules
+++ b/debian/rules
@@ -16,20 +16,20 @@ export DH_OPTIONS
 
 bd=openquake/bin
 
-COMMON_DEP = python-amqp, python-h5py (>= 2.2.1)
+COMMON_DEP = python-h5py (>= 2.2.1), python-celery, python-amqp
 COMMON_REC =
 XENIAL_DEP = python-celery-common
 XENIAL_REC =
-TRUSTY_DEP =
+TRUSTY_DEP = 
 TRUSTY_REC =
-PRECISE_DEP = python-h5py (= 2.2.1-1build3~precise03)
+PRECISE_DEP = python-celery (>=2.4.6-1ubuntu0.2~gem03), python-h5py (= 2.2.1-1build3~precise03)
 PRECISE_REC =
 
 ifeq ($(shell lsb_release --codename --short),xenial)
-	DEPENDS = -Vdist:Depends="$(XENIAL_DEP), $(COMMON_DEP)"
+	DEPENDS = -Vdist:Depends="$(COMMON_DEP), $(XENIAL_DEP)"
 	RECOMMENDS = -Vdist:Recommends="$(XENIAL_REC)"
 else ifeq ($(shell lsb_release --codename --short),trusty)
-	DEPENDS = -Vdist:Depends="$(TRUSTY_DEP), $(COMMON_DEP)"
+	DEPENDS = -Vdist:Depends="$(COMMON_DEP), $(TRUSTY_DEP)"
 	RECOMMENDS = -Vdist:Recommends="$(TRUSTY_REC)"
 else ifeq ($(shell lsb_release --codename --short),precise)
 	DEPENDS = -Vdist:Depends="$(PRECISE_DEP)"

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ COMMON_DEP = python-h5py (>= 2.2.1), python-celery, python-amqp
 COMMON_REC =
 XENIAL_DEP = python-celery-common
 XENIAL_REC =
-TRUSTY_DEP = 
+TRUSTY_DEP =
 TRUSTY_REC =
 PRECISE_DEP = python-celery (>=2.4.6-1ubuntu0.2~gem03), python-h5py (= 2.2.1-1build3~precise03)
 PRECISE_REC =

--- a/packager.sh
+++ b/packager.sh
@@ -513,7 +513,7 @@ _pkgtest_innervm_run () {
     # configure the machine to run tests
     if [ -z "$GEM_PKGTEST_SKIP_DEMOS" ]; then
         # use celery to run the demos
-        ssh $lxc_ip "cd /usr/share/openquake/engine ; celeryd --config openquake.engine.celeryconfig >/tmp/celeryd.log 2>&1 3>&1 &"
+        ssh $lxc_ip "celeryd --config openquake.engine.celeryconfig >/tmp/celeryd.log 2>&1 3>&1 &"
 
         # wait for celeryd startup time
         ssh $lxc_ip "
@@ -530,8 +530,6 @@ celeryd_wait() {
         echo \"ERROR: no Celery available\"
         return 1
     fi
-
-    cd /usr/share/openquake/engine
 
     for cw_i in \$(seq 1 \$cw_nloop); do
         cw_ret=\"\$(\$celery status)\"

--- a/packager.sh
+++ b/packager.sh
@@ -643,8 +643,8 @@ deps_list() {
         rules_rec=$(grep "^${BUILD_UBUVER^^}_REC *= *" $rules_file | sed 's/([^)]*)//g' | sed 's/^.*= *//g')
     else
         # Otherwise use the default values in debian/rules
-        rules_dep=$(grep "^DEFAULT_DEP *= *" $rules_file | sed 's/([^)]*)//g' | sed 's/^.*= *//g')
-        rules_rec=$(grep "^DEFAULT_REC *= *" $rules_file | sed 's/([^)]*)//g' | sed 's/^.*= *//g')
+        rules_dep=$(grep "^COMMON_DEP *= *" $rules_file | sed 's/([^)]*)//g' | sed 's/^.*= *//g')
+        rules_rec=$(grep "^COMMON_REC *= *" $rules_file | sed 's/([^)]*)//g' | sed 's/^.*= *//g')
     fi
 
     out_list=""


### PR DESCRIPTION
The `celery` utility is now provided by `python-celery-common`.
We must be very careful with the order of the dependencies: if we install `common` before celery, python3 version of celery is installed.

Fixes master.

Tests: https://ci.openquake.org/job/zdevel_oq-engine/2205/