### PR TITLE
Filter the source model upfront when there are less sites

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Filtered the sources up front when there are few sites (<= 10)
   * Reduced the number of tasks generated when filter_sources is False
   * Saved engine_version and hazardlib_version as attributes of the datastore
   * Avoided saving the ruptures when ground_motion_fields is True

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -52,7 +52,9 @@ Site = collections.namedtuple('Site', 'sid lon lat')
 F32 = numpy.float32
 
 def is_small(sitecol):
-    # if the site collection has up to 10 sites, filter it
+    """
+    Returns True if the site collection contains up to 10 sites
+    """
     return len(sitecol) <= 10
 
 
@@ -378,6 +380,7 @@ class HazardCalculator(BaseCalculator):
                     'reading composite source model', autoflush=True):
                 csm = readinput.get_composite_source_model(self.oqparam)
                 if is_small(self.sitecol):
+                    # filter the CompositeSourceModel upfront
                     ss_filter = SourceSitesFilter(self.oqparam.maximum_distance)
                     self.csm = csm.filter(self.sitecol, ss_filter)
                 else:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -29,9 +29,8 @@ from openquake.baselib.general import AccumDict
 from openquake.hazardlib.geo.utils import get_spherical_bounding_box
 from openquake.hazardlib.geo.utils import get_longitudinal_extent
 from openquake.hazardlib.geo.geodetic import npoints_between
-from openquake.hazardlib.calc.filters import source_site_distance_filter
 from openquake.hazardlib.calc.hazard_curve import (
-    hazard_curves_per_trt, ProbabilityMap)
+    pmap_from_grp, ProbabilityMap)
 from openquake.hazardlib.probability_map import PmapStats
 from openquake.commonlib import parallel, datastore, source, calc
 from openquake.calculators import base
@@ -197,13 +196,12 @@ def classical(sources, sitecol, gsims, monitor):
     else:
         dic.bbs = []
     # NB: the source_site_filter below is ESSENTIAL for performance inside
-    # hazard_curves_per_trt, since it reduces the full site collection
+    # pmap_from_grp, since it reduces the full site collection
     # to a filtered one *before* doing the rupture filtering
-    dic[src_group_id] = hazard_curves_per_trt(
+    dic[src_group_id] = pmap_from_grp(
         sources, sitecol, imtls, gsims, truncation_level,
-        source_site_filter=source_site_distance_filter(max_dist),
         maximum_distance=max_dist, bbs=dic.bbs, monitor=monitor)
-    dic.calc_times = monitor.calc_times  # added by hazard_curves_per_trt
+    dic.calc_times = monitor.calc_times  # added by pmap_from_grp
     dic.eff_ruptures = {src_group_id: monitor.eff_ruptures}  # idem
     return dic
 

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -67,7 +67,7 @@ def get_pstats(pstatfile, n):
     # 1      25.166  calculators/classical.py:115(execute)
     # 1      25.104  commonlib/parallel.py:249(apply_reduce)
     # 1      25.099  calculators/classical.py:41(classical)
-    # 1      25.099  hazardlib/calc/hazard_curve.py:164(hazard_curves_per_trt)
+    # 1      25.099  hazardlib/calc/hazard_curve.py:164(pmap_from_grp)
     return views.rst_table(rows, header='ncalls cumtime path'.split())
 
 

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -32,8 +32,6 @@ import numpy
 from openquake.baselib import hdf5
 from openquake.baselib.python3compat import decode, raise_
 from openquake.baselib.general import groupby, block_splitter, group_array
-from openquake.hazardlib.site import Tile
-from openquake.hazardlib.calc.filters import context
 from openquake.commonlib import logictree, sourceconverter
 from openquake.commonlib import nrml, node, parallel
 
@@ -605,6 +603,37 @@ class CompositeSourceModel(collections.Sequence):
             self.source_model_lt.num_samples,
             [sm.get_skeleton() for sm in self.source_models])
 
+    def filter(self, sitecol, src_sites_filter):
+        """
+        Generate a new CompositeSourceModel by filtering the sources on
+        the given site collection. Warning: this is slow, so use it only
+        for small site collections (i.e. in disaggregation calculations).
+
+        :param sitecol: a SiteCollection instance
+        :para src_sites_filter: a SourceSitesFilter instance
+        """
+        source_models = []
+        weight = 0
+        idx = 0
+        for sm in self.source_models:
+            src_groups = map(copy.copy, sm.src_groups)
+            for src_group in src_groups:
+                sources = []
+                for src, sites in src_sites_filter(src_group.sources, sitecol):
+                    sources.append(src)
+                    src.id = idx
+                    weight += src.weight
+                    idx += 1
+                src_group.sources = sources
+            newsm = SourceModel(sm.name, sm.weight, sm.path, src_groups,
+                                sm.num_gsim_paths, sm.ordinal, sm.samples)
+            source_models.append(newsm)
+        new = self.__class__(self.gsim_lt, self.source_model_lt, source_models,
+                             set_weight=False)
+        new.weight = weight
+        new.filtered_weight = weight
+        return new
+
     @property
     def src_groups(self):
         """
@@ -728,11 +757,11 @@ source_info_dt = numpy.dtype([
 ])
 
 
-def split_filter(src, sites, max_dist, random_seed):
+def split_filter(src, sites, ss_filter, random_seed):
     """
     :param src: an heavy source
     :param sites: the sites affected by the source
-    :param max_dist: maximum distance for the current TRT
+    :param ss_filter: SourceSitesFilter instance
     :random_seed: used only for event based calculations
     :returns:
         a list [(src, sites, split_sources, filter_time, split_time), ...]
@@ -746,9 +775,8 @@ def split_filter(src, sites, max_dist, random_seed):
             ss.serial = src.serial[start:start + nr]
             start += nr
         ss.id = src.id
-        with context(ss):
-            s = ss.filter_sites_by_distance_to_source(max_dist, sites)
-        if s is not None:
+        ss_sites = ss_filter.affected(ss, sites)
+        if ss_sites is not None:
             split_sources.append(ss)
     return [(src, sites, split_sources, 0, time.time() - t0)]
 
@@ -758,22 +786,20 @@ class SourceManager(object):
     Manager associated to a CompositeSourceModel instance.
     Filter and split sources and send them to the worker tasks.
     """
-    def __init__(self, csm, maximum_distance, concurrent_tasks,
-                 dstore, monitor, random_seed=None,
-                 filter_sources=True, num_tiles=1):
+    def __init__(self, csm, ss_filter, concurrent_tasks,
+                 dstore, monitor, random_seed=None, num_tiles=1):
         self.csm = csm
-        self.maximum_distance = maximum_distance
+        self.ss_filter = ss_filter
         self.concurrent_tasks = concurrent_tasks or 1
         self.random_seed = random_seed
         self.dstore = dstore
         self.monitor = monitor
-        self.filter_sources = filter_sources
         self.num_tiles = num_tiles
         self.rlzs_assoc = csm.info.get_rlzs_assoc()
         self.infos = {}  # src_group_id, source_id -> SourceInfo tuple
 
         maxweight = math.ceil(csm.weight / self.concurrent_tasks / (
-            num_tiles if filter_sources else 1))
+            num_tiles if self.ss_filter.integration_distance else 1))
         # if there are S filtered sources and there are T tiles, only S/T
         # sources contribute to a given tile; by reducing the maxweight
         # by T we generate the same number of "concurrent_tasks" per tile
@@ -833,10 +859,9 @@ class SourceManager(object):
             logging.info('Generated %d tasks from the light sources', ntasks)
 
         # this blocks for a long time, so it is best to do it later
-        tile = Tile(sitecol, self.maximum_distance)
         ntasks = 0
         for src_data in self._gen_src_heavy(sitecol):
-            for args in self._gen_args(src_data, [tile]):
+            for args in self._gen_args(src_data, [sitecol]):
                 yield args
                 ntasks += 1
         if ntasks:
@@ -859,20 +884,13 @@ class SourceManager(object):
 
     def _gen_src_light(self, tiles):
         filter_mon = self.monitor('filtering sources')
-        tiles = [Tile(tile, self.maximum_distance) for tile in tiles]
-        if self.filter_sources and self.num_tiles == 1:
+        if self.ss_filter.integration_distance and self.num_tiles == 1:
             logging.info('Filtering light sources')
         sources = self.csm.get_sources('light', self.maxweight)
         for i, tile in enumerate(tiles):
             data = []
-            for src in sources:
-                if self.filter_sources:
-                    with filter_mon, context(src):
-                        ok = src in tile
-                else:  # accept all sources
-                    ok = True
-                if ok:
-                    data.append((src, i, [], filter_mon.dt, 0))
+            for src, sites in self.ss_filter(sources, tile):
+                data.append((src, i, [], filter_mon.dt, 0))
                 self.csm.filtered_weight += src.weight
             filter_mon.flush()
             if len(tiles) > 1:
@@ -881,16 +899,13 @@ class SourceManager(object):
             yield data
 
     def _gen_src_heavy(self, sitecol):
+        ss_filter = self.ss_filter
         sources = self.csm.get_sources('heavy', self.maxweight)
         data = []
-        for src in sources:
+        for src, sites in ss_filter(sources, sitecol):
             self.csm.filtered_weight += src.weight
-            with context(src):
-                sites = src.filter_sites_by_distance_to_source(
-                    self.maximum_distance[src.tectonic_region_type], sitecol)
-            if sites is not None:
-                max_dist = self.maximum_distance[src.tectonic_region_type]
-                data.append((src, sites, max_dist, self.random_seed))
+            max_dist = ss_filter.integration_distance[src.tectonic_region_type]
+            data.append((src, sites, self.ss_filter, self.random_seed))
         return parallel.starmap(split_filter, data)
 
     def pre_store_source_info(self, dstore):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -17,7 +17,6 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division
-from contextlib import contextmanager
 import re
 import sys
 import copy
@@ -34,6 +33,7 @@ from openquake.baselib import hdf5
 from openquake.baselib.python3compat import decode, raise_
 from openquake.baselib.general import groupby, block_splitter, group_array
 from openquake.hazardlib.site import Tile
+from openquake.hazardlib.calc.filters import context
 from openquake.commonlib import logictree, sourceconverter
 from openquake.commonlib import nrml, node, parallel
 
@@ -43,27 +43,6 @@ U16 = numpy.uint16
 U32 = numpy.uint32
 I32 = numpy.int32
 F32 = numpy.float32
-
-
-@contextmanager
-def context(src):
-    """
-    Used to add the source_id to the error message. To be used as
-
-    with context(src):
-        operation_with(src)
-
-    Typically the operation is filtering a source, that can fail for
-    tricky geometries.
-    """
-    try:
-        yield
-    except:
-        etype, err, tb = sys.exc_info()
-        msg = 'An error occurred with source id=%s. Error: %s'
-        msg %= (src.source_id, err)
-        raise_(etype, msg, tb)
-
 
 class LtRealization(object):
     """
@@ -616,7 +595,7 @@ class CompositeSourceModel(collections.Sequence):
         self.gsim_lt = gsim_lt
         self.source_model_lt = source_model_lt
         self.source_models = source_models
-        self.source_info = ()  # set by the SourceFilterSplitter
+        self.source_info = ()  # set by the SourceSitesFilterSplitter
         self.split_map = {}
         if set_weight:
             self.set_weights()

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -31,11 +31,10 @@ from openquake.hazardlib import pmf
 from openquake.hazardlib import scalerel
 from openquake.hazardlib import source
 from openquake.hazardlib.tom import PoissonTOM
-
+from openquake.hazardlib.calc.filters import context
 from openquake.commonlib import tests, nrml_examples, readinput
 from openquake.commonlib import sourceconverter as s
-from openquake.commonlib.source import (
-    SourceModelParser, CompositionInfo, context)
+from openquake.commonlib.source import SourceModelParser, CompositionInfo
 from openquake.commonlib import nrml
 from openquake.baselib.general import assert_close
 


### PR DESCRIPTION
Disaggregation calculations produce not enough tasks (for instance the recent on for Brasil produced 57 tasks instead of the wanted 512). The reason is that the splitting in tasks is based on the total weight of the source model, while we should considered only the filtered weight (i.e. the discard the weight of the sources outside the integration distance).
This is the companion of https://github.com/gem/oq-hazardlib/pull/491/
The tests are green: https://ci.openquake.org/job/zdevel_oq-engine/2203/