### PR TITLE
Make sure python-amqp is installed _before_ python-celery

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,9 +16,9 @@ export DH_OPTIONS
 
 bd=openquake/bin
 
-XENIAL_DEP = python-h5py, python-celery, python-celery-common, python-amqp
+XENIAL_DEP = python-h5py, python-amqp, python-celery, python-celery-common
 XENIAL_REC =
-TRUSTY_DEP = python-h5py, python-celery, python-amqp
+TRUSTY_DEP = python-h5py, python-amqp, python-celery
 TRUSTY_REC =
 PRECISE_DEP = python-celery (>=2.4.6-1ubuntu0.2~gem03), python-h5py (= 2.2.1-1build3~precise03)
 PRECISE_REC =


### PR DESCRIPTION
Otherwise, on Trusty, `python-librabbitmq` is installed and it's known to be broken (it causes segfaults).

`python-librabbitmq` is more optimized (has C speedups) but it's broken and works with Python 2 only.

Xenial has same deps. order just to be in sync with Trusty.
See: https://ci.openquake.org/job/zdevel_oq-engine/2216