### PR TITLE
Use the celery backend defined in the celeryconfig.py

### DIFF
--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -50,8 +50,8 @@ if OQ_DISTRIBUTE == 'celery':
     from celery.result import ResultSet
     from celery import Celery
     from celery.task import task
-    from openquake.engine.celeryconfig import BROKER_URL
-    app = Celery('openquake', backend='amqp://', broker=BROKER_URL)
+    from openquake.engine.celeryconfig import BROKER_URL, CELERY_RESULT_BACKEND
+    app = Celery('openquake', backend=CELERY_RESULT_BACKEND, broker=BROKER_URL)
 
 elif OQ_DISTRIBUTE == 'ipython':
     import ipyparallel as ipp

--- a/openquake/engine/celeryconfig.py
+++ b/openquake/engine/celeryconfig.py
@@ -58,7 +58,7 @@ BROKER_URL = 'amqp://%(user)s:%(password)s@%(host)s:%(port)s/%(vhost)s' % \
 BROKER_POOL_LIMIT = None
 
 # RabbitMQ result backend (default)
-CELERY_RESULT_BACKEND = 'amqp'
+CELERY_RESULT_BACKEND = 'amqp://'
 
 # Redis result backend (works only on Trusty)
 # CELERY_RESULT_BACKEND = 'redis://%(host)s:6379/0' % amqp


### PR DESCRIPTION
This allows us to test redis. We probably will need also to switch from `amqp://` to `rpc://` as recommended in the documentation:
http://docs.celeryproject.org/en/latest/configuration.html#amqp-backend-settings (tkt #2259)

Tests: https://ci.openquake.org/job/zdevel_oq-engine/2230/
