### PR TITLE
Switch the default backend from amqp:// (deprecated) to rpc://

### DIFF
--- a/openquake/engine/celeryconfig.py
+++ b/openquake/engine/celeryconfig.py
@@ -57,8 +57,9 @@ BROKER_URL = 'amqp://%(user)s:%(password)s@%(host)s:%(port)s/%(vhost)s' % \
 # See https://bugs.launchpad.net/oq-engine/+bug/1250402
 BROKER_POOL_LIMIT = None
 
-# RabbitMQ result backend (default)
-CELERY_RESULT_BACKEND = 'amqp://'
+# AMQP result backend (default)
+CELERY_RESULT_BACKEND = 'rpc://'
+CELERY_RESULT_PERSISTENT = False
 
 # Redis result backend (works only on Trusty)
 # CELERY_RESULT_BACKEND = 'redis://%(host)s:6379/0' % amqp


### PR DESCRIPTION
Closes #2259 
Tests: https://ci.openquake.org/job/zdevel_oq-engine/2241/