### PR TITLE
Extend the `oq show` command to work in a multi_user situation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Extended the `oq show` command to work in a multi-user environment
   * Improved the test coverage of the exports in the WebUI
   * Removed the SourceManager: now the sources are filtered in the workers
     and we do not split in tiles anymore

--- a/openquake/commands/show.py
+++ b/openquake/commands/show.py
@@ -19,6 +19,7 @@
 from __future__ import print_function
 import io
 import os
+import getpass
 import logging
 
 from openquake.hazardlib.calc.hazard_curve import zero_curves
@@ -34,7 +35,7 @@ MULTI_USER = valid.boolean(config.get('dbserver', 'multi_user') or 'false')
 if MULTI_USER:
     # get the datastore of the user who run the job
     def read(calc_id):
-        job = logs.dbcmd('get_job', calc_id)
+        job = logs.dbcmd('get_job', calc_id, getpass.getuser())
         datadir = os.path.dirname(job.ds_calc_dir)
         return datastore.read(job.id, datadir=datadir)
 else:  # get the datastore of the current user

--- a/openquake/commands/show.py
+++ b/openquake/commands/show.py
@@ -33,7 +33,7 @@ from openquake.calculators.views import view
 
 MULTI_USER = valid.boolean(config.get('dbserver', 'multi_user') or 'false')
 if MULTI_USER:
-    # get the datastore of the user who run the job
+    # get the datastore of the user who ran the job
     def read(calc_id):
         job = logs.dbcmd('get_job', calc_id, getpass.getuser())
         datadir = os.path.dirname(job.ds_calc_dir)

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -558,9 +558,11 @@ def get_job(db, job_id, username):
         user name
     :returns: the full path to the datastore
     """
-    if job_id < 0:
-        job_id = get_job_id(db, job_id, username)
-    return db('SELECT * FROM job WHERE id=?x', job_id, one=True)
+    job_id = get_job_id(db, job_id, username)
+    if job_id is None:  # get latest
+        return db('SELECT * FROM job ORDER BY id DESC LIMIT 1', one=True)
+    else:
+        return db('SELECT * FROM job WHERE id=?x', job_id, one=True)
 
 
 def get_results(db, job_id):

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -17,7 +17,6 @@
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
 import os
-import getpass
 import operator
 from datetime import datetime, timedelta
 
@@ -549,15 +548,18 @@ def get_result(db, result_id):
     return job.id, job.status, os.path.dirname(job.ds_calc_dir), job.ds_key
 
 
-def get_job(db, job_id):
+def get_job(db, job_id, username):
     """
     :param db:
         a :class:`openquake.server.dbapi.Db` instance
     :param job_id:
         ID of the current job
+    :param username:
+        user name
     :returns: the full path to the datastore
     """
-    job_id = get_job_id(db, job_id, getpass.getuser())
+    if job_id < 0:
+        job_id = get_job_id(db, job_id, username)
     return db('SELECT * FROM job WHERE id=?x', job_id, one=True)
 
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -129,13 +129,12 @@ def get_job_id(db, job_id, username):
     job_id = int(job_id)
     if job_id > 0:
         return job_id
-    my_jobs = db('SELECT id FROM job WHERE user_name=?x ORDER BY id',
-                 username)
-    n = len(my_jobs)
-    if n == 0:  # no jobs
+    joblist = db('SELECT id FROM job WHERE user_name=?x '
+                 'ORDER BY id DESC LIMIT 1', username)
+    if not joblist:  # no jobs
         return
-    else:  # typically job_id is -1
-        return my_jobs[n + job_id].id
+    else:
+        return joblist[0].id
 
 
 def get_calc_id(db, datadir, job_id=None):
@@ -558,11 +557,8 @@ def get_job(db, job_id, username):
         user name
     :returns: the full path to the datastore
     """
-    job_id = get_job_id(db, job_id, username)
-    if job_id is None:  # get latest
-        return db('SELECT * FROM job ORDER BY id DESC LIMIT 1', one=True)
-    else:
-        return db('SELECT * FROM job WHERE id=?x', job_id, one=True)
+    calc_id = get_job_id(db, job_id, username) or job_id
+    return db('SELECT * FROM job WHERE id=?x', calc_id, one=True)
 
 
 def get_results(db, job_id):

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -17,6 +17,7 @@
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
 import os
+import getpass
 import operator
 from datetime import datetime, timedelta
 
@@ -556,6 +557,7 @@ def get_job(db, job_id):
         ID of the current job
     :returns: the full path to the datastore
     """
+    job_id = get_job_id(db, job_id, getpass.getuser())
     return db('SELECT * FROM job WHERE id=?x', job_id, one=True)
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -20,6 +20,7 @@ import shutil
 import json
 import logging
 import os
+import getpass
 import tempfile
 try:
     import urllib.parse as urlparse
@@ -502,7 +503,7 @@ def get_datastore(request, job_id):
         of the requested artifact, if present, else throws a 404
     """
     try:
-        job = logs.dbcmd('get_job', int(job_id))
+        job = logs.dbcmd('get_job', int(job_id), getpass.getuser())
     except dbapi.NotFound:
         return HttpResponseNotFound()
 


### PR DESCRIPTION
`oq show <something> -1` returns info about the latest job of the current user. `oq show <something> <job_id>` returns info about the given job_id, even if owned by another user. The main usage is to make it possible to see the performance of a given job, even if it was not run by me. This feature could be restricted to the super user, but in our use case it is more convenient to make the jobs visible to everybody knowing the ID. The same trick could be used for `oq export`.