### PR TITLE
Use rtree wheels made by us

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ addons:
   apt:
     packages:
     - git
-    - libspatialindex-dev
 
 install:
   - pip install -r requirements-py35-linux64.txt
-  - pip install Rtree==0.8.2
   - python setup.py develop
   - if [ "$(git ls-remote --heads https://github.com/gem/oq-hazardlib.git ${TRAVIS_BRANCH})" != "" ]; then BRANCH=$TRAVIS_BRANCH; else BRANCH='master'; fi; git clone -b ${BRANCH} --depth=1 https://github.com/gem/oq-hazardlib.git && echo "Running on oq-hazardlib/${BRANCH}"
 

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -24,6 +24,8 @@ http://ftp.openquake.org/python-new-wheels/futures-3.0.5-py2-none-any.whl
 http://ftp.openquake.org/python-new-wheels/Django-1.8.7-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/requests-2.9.1-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/pyshp-1.2.3-cp27-none-any.whl
+# Experimental wheel
+http://ftp.openquake.org/python-new-wheels/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl
 
 # Celery support
 # uncomment the following lines to install celery

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -24,6 +24,8 @@ http://ftp.openquake.org/python-new-wheels/futures-3.0.5-py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/Django-1.8.7-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/requests-2.9.1-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/pyshp-1.2.3-py3-none-any.whl
+# Experimental wheel
+http://ftp.openquake.org/python-new-wheels/Rtree-0.8.2-cp35-cp35m-manylinux1_x86_64.whl
 
 # Celery support
 # uncomment the following lines to install celery


### PR DESCRIPTION
This wheels are experimental, but should work. These are not generated automatically because .so lib requires some patchwork using `patchelf`:

```bash
patchelf --set-rpath \$ORIGIN/.libs --force-rpath _wrapper_lib.so
```

An mock extension is used to be compatible with the `manylinux1` profile: https://github.com/gem/rtree/compare/master...gem:mock-wheel

Companion of: https://github.com/gem/oq-hazardlib/pull/502