### PR TITLE
Make the openquake namespace compatible with old setuptools

### DIFF
--- a/openquake/__init__.py
+++ b/openquake/__init__.py
@@ -16,4 +16,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-__import__('pkg_resources').declare_namespace(__name__)
+# Make the namespace compatible with old setuptools, like the one
+# provided by QGIS 2.1x on Windows
+try:
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    __path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
This is needed when using the `openquake` namespace in QGIS on Windows.