### PR TITLE
Added a flag save_ruptures in the job.ini

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * There is now a flag `save_ruptures` that can be turned off on demand;
+    by default the ruptures are always saved in the event based calculators
   * Optimized the memory consumption when using a ProcessPoolExecutor (i.e
     fork before reading the source model) by means of a `wakeup` task
   * Reduced the splitting of the fault sources

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -412,7 +412,7 @@ class EventBasedRuptureCalculator(PSHACalculator):
                         events.append(rec)
                         self.eid[sm_id] += 1
                         i += 1
-                    if self.oqparam.calculation_mode == 'event_based':
+                    if self.oqparam.save_ruptures:
                         self.datastore['sescollection/%s' % ebr.serial] = ebr
                 if events:
                     ev = 'events/sm-%04d' % sm_id

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -141,6 +141,7 @@ class OqParam(valid.ParamSet):
     ruptures_per_block = valid.Param(valid.positiveint, 1000)
     complex_fault_mesh_spacing = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
+    save_ruptures = valid.Param(valid.boolean, True)
     ses_per_logic_tree_path = valid.Param(valid.positiveint, 1)
     sites = valid.Param(valid.NoneOr(valid.coordinates), None)
     sites_disagg = valid.Param(valid.NoneOr(valid.coordinates), [])


### PR DESCRIPTION
By the default the flag is true, so the SES collection is always saved.