### PR TITLE
DO NOT remove /etc/openquake/ but only /etc/openquake/openquake.cfg

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -42,10 +42,11 @@ case "$1" in
     # This package has previously been removed and is now having
     # its configuration purged from the system.
     :
-    for dir in  /etc/openquake /usr/share/openquake/engine /usr/lib/python2.7/dist-packages/openquake/engine /usr/share/doc/${GEM_DEB_PACKAGE} /usr/lib/python2.7/dist-packages/openquake.engine-*egg-info
+    for dir in /usr/share/openquake/engine /usr/lib/python2.7/dist-packages/openquake/engine /usr/share/doc/${GEM_DEB_PACKAGE} /usr/lib/python2.7/dist-packages/openquake.engine-*egg-info
     do
         rm -rf $dir
     done
+    rm -f /etc/openquake/openquake.cfg
     ;;
 esac
 


### PR DESCRIPTION
By default `apt remove --purge` deletes the whole `/etc/openquake`: THIS IS BAD.

Since `/etc/openquake` is the entire namespace for all OQ releated apps, not just the engine, `/etc/openquake/openquake.cfg` should be removed alone.

This caused the drop of the entire OQ Platform configuration after a removal of `python-oq-engine` (see https://github.com/gem/oq-platform/issues/615)