### PR TITLE
Fixed a bug when splitting the fault sources by magnitude

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed a bug when splitting the fault sources by magnitude
+
 python-oq-engine (2.1.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]

--- a/openquake/commonlib/sourceconverter.py
+++ b/openquake/commonlib/sourceconverter.py
@@ -212,9 +212,7 @@ def split_fault_source_by_magnitude(src):
             continue
         new_src = copy.copy(src)
         new_src.source_id = '%s:%s' % (src.source_id, i)
-        new_src.mfd = mfd.EvenlyDiscretizedMFD(
-            min_mag=mag, bin_width=src.mfd.bin_width,
-            occurrence_rates=[rate])
+        new_src.mfd = mfd.ArbitraryMFD([mag], [rate])
         i += 1
         splitlist.append(new_src)
     return splitlist


### PR DESCRIPTION
On Graeme's suggestion, now the splitting procedure produces ArbitraryMFD instances.