### PR TITLE
Automatic "for release" RPM generation and custom git version in __init.py__

### DIFF
--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -6,7 +6,6 @@
 %define oqtimestamp ##_timestamp_##
 %define oquser openquake
 
-
 Summary: Computes hazard, risk and socio-economic impact of earthquakes
 Name: %{oqname}
 Version: %{oqversion}

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -1,3 +1,4 @@
+%define oqstable ##_stable_##
 %define oqrepo ##_repo_##
 %define oqversion ##_version_##
 %define oqrelease ##_release_##
@@ -5,14 +6,21 @@
 %define oqtimestamp ##_timestamp_##
 %define oquser openquake
 
+
 Summary: Computes hazard, risk and socio-economic impact of earthquakes
 Name: %{oqname}
 Version: %{oqversion}
-Release: %{oqtimestamp}_%{oqrelease}
-Source0: %{oqrepo}-%{oqversion}-%{oqrelease}.tar.gz
 License: AGPLv3
 Group: Applications/Engineering
+%if %{oqstable} == 1
+Release: %{oqrelease}
+Source0: %{oqrepo}-%{oqversion}.tar.gz
+BuildRoot: %{_tmppath}/%{oqname}-%{oqversion}-buildroot
+%else
+Release: %{oqtimestamp}_%{oqrelease}
+Source0: %{oqrepo}-%{oqversion}-%{oqrelease}.tar.gz
 BuildRoot: %{_tmppath}/%{oqname}-%{oqversion}-%{oqrelease}-buildroot
+%endif
 Prefix: %{_prefix}
 BuildArch: noarch
 Vendor: The GEM OpenQuake team <devops@openquake.org>
@@ -55,7 +63,11 @@ getent passwd %{oquser} >/dev/null || \
 exit 0
 
 %prep
+%if %{oqstable} == 1
+%setup -n %{oqrepo}-%{oqversion} -n %{oqrepo}-%{oqversion}
+%else
 %setup -n %{oqrepo}-%{oqversion}-%{oqrelease} -n %{oqrepo}-%{oqversion}-%{oqrelease}
+%endif
 
 %patch1 -p1
 
@@ -106,5 +118,10 @@ rm -rf %{buildroot}
 %{_unitdir}/openquake-celery.service
 
 %changelog
+%if %{oqstable} == 1
+* %(date -d @%{oqtimestamp} '+%a %b %d %Y') GEM Automatic Packager <gem-autopack@openquake.org> %{oqversion}-%{oqrelease}
+– Stable release of %{oqname}
+%else
 * %(date -d @%{oqtimestamp} '+%a %b %d %Y') GEM Automatic Packager <gem-autopack@openquake.org> %{oqversion}-%{oqtimestamp}_%{oqrelease}
 – Unstable release of %{oqname}
+%endif

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -78,6 +78,7 @@ python setup.py build
 #nosetests -v -a '!slow' --with-doctest --with-coverage --cover-package=openquake.engine
 
 %install
+sed -i "s/^__version__[  ]*=.*/__version__ = '%{oqversion}-%{oqrelease}'/g" openquake/risklib/__init__.py
 python setup.py install --single-version-externally-managed -O1 --root=%{buildroot} --record=INSTALLED_FILES
 # create directories where the files will be located
 mkdir -p %{buildroot}%{_sysconfdir}/openquake


### PR DESCRIPTION
This PR adds two features:
- enhancement: generation of a "for release" RPM package is fully automatic now (as it was for "master" packages) using the `-r N` flag where N is the number of the package release (1, 2...)
- bug fix: a custom version, which includes the git short commit, is put in the `__init.py__`

Closes #2098 
Companion of: https://github.com/gem/oq-hazardlib/pull/518

Test: https://ci.openquake.org/job/redhat_oq-engine/41/