### PR TITLE
Skip UCERF tests with h5py < 2.6.0

### DIFF
--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -28,7 +28,7 @@ from nose.plugins.attrib import attr
 class UcerfTestCase(CalculatorTestCase):
     @attr('qa', 'hazard', 'ucerf')
     def test_event_based(self):
-        if h5py.__version__ < '2.3.0':
+        if h5py.__version__ < '2.6.0':
             raise unittest.SkipTest  # UCERF requires vlen arrays
         out = self.run_calc(ucerf.__file__, 'job.ini', exports='txt')
         num_exported = len(out['gmf_data', 'txt'])
@@ -37,7 +37,7 @@ class UcerfTestCase(CalculatorTestCase):
 
     @attr('qa', 'hazard', 'ucerf')
     def test_classical(self):
-        if h5py.__version__ < '2.3.0':
+        if h5py.__version__ < '2.6.0':
             raise unittest.SkipTest  # UCERF requires vlen arrays
         out = self.run_calc(ucerf.__file__, 'job_classical_redux.ini',
                             exports='csv')
@@ -47,7 +47,7 @@ class UcerfTestCase(CalculatorTestCase):
 
     @attr('qa', 'risk', 'ucerf')
     def test_event_based_risk(self):
-        if h5py.__version__ < '2.3.0':
+        if h5py.__version__ < '2.6.0':
             raise unittest.SkipTest  # UCERF requires vlen arrays
         self.run_calc(ucerf.__file__, 'job_ebr.ini',
                       number_of_logic_tree_samples='2')


### PR DESCRIPTION
A user reported failing tests on RedHat 7. That's partially true since the UCERF calculator tests are failing: the tests are not correctly skipped.
RHEL 7 provides `h5py` 2.3.1 which was satisfying the test requirements, but 2.3 is actually too old for UCERF. I have increased the required `h5py` version to 2.6.0 which is currently our target for UCERF.