### PR TITLE
Removed the ruptures as pickled objects

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Serialized the ruptures in the HDF5 properly (no pickle)
   * Introduced a parameter `iml_disagg` in the disaggregation calculator
   * Fixed `oq reduce` to preserve the NRML version
   * Fixed a bug when splitting the fault sources by magnitude

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -25,24 +25,15 @@ import collections
 
 import numpy
 
-from openquake.baselib import hdf5
-from openquake.baselib.python3compat import encode
 from openquake.baselib.general import AccumDict, split_in_blocks
+from openquake.hazardlib.gsim.base import ContextMaker
+from openquake.hazardlib.probability_map import ProbabilityMap, PmapStats
 from openquake.hazardlib.calc.filters import \
     filter_sites_by_distance_to_rupture
-from openquake.hazardlib.geo.mesh import RectangularMesh, build_array
-from openquake.hazardlib.calc.hazard_curve import ProbabilityMap
-from openquake.hazardlib.probability_map import PmapStats
-from openquake.hazardlib import geo, tom
-from openquake.hazardlib.geo.point import Point
-from openquake.hazardlib.gsim.base import ContextMaker
-from openquake.commonlib import parallel, calc
-from openquake.commonlib.util import max_rel_diff_index, Rupture
+from openquake.commonlib import parallel, calc, util
 from openquake.risklib.riskinput import GmfGetter, str2rsi, rsi2str
 from openquake.calculators import base
 from openquake.calculators.classical import ClassicalCalculator, PSHACalculator
-
-# ######################## rupture calculator ############################ #
 
 U8 = numpy.uint8
 U16 = numpy.uint16
@@ -50,226 +41,7 @@ U32 = numpy.uint32
 F32 = numpy.float32
 F64 = numpy.float64
 
-event_dt = numpy.dtype([('eid', U32), ('ses', U32), ('occ', U32),
-                        ('sample', U32)])
-
-stored_event_dt = numpy.dtype([
-    ('rupserial', U32), ('ses', U32), ('occ', U32),
-    ('sample', U32), ('grp_id', U16), ('source_id', 'S30')])
-
-
-def get_geom(surface, is_from_fault_source, is_multi_surface):
-    """
-    The following fields can be interpreted different ways,
-    depending on the value of `is_from_fault_source`. If
-    `is_from_fault_source` is True, each of these fields should
-    contain a 2D numpy array (all of the same shape). Each triple
-    of (lon, lat, depth) for a given index represents the node of
-    a rectangular mesh. If `is_from_fault_source` is False, each
-    of these fields should contain a sequence (tuple, list, or
-    numpy array, for example) of 4 values. In order, the triples
-    of (lon, lat, depth) represent top left, top right, bottom
-    left, and bottom right corners of the the rupture's planar
-    surface. Update: There is now a third case. If the rupture
-    originated from a characteristic fault source with a
-    multi-planar-surface geometry, `lons`, `lats`, and `depths`
-    will contain one or more sets of 4 points, similar to how
-    planar surface geometry is stored (see above).
-
-    :param rupture: an instance of :class:`openquake.hazardlib.source.rupture.BaseProbabilisticRupture`
-    :param is_from_fault_source: a boolean
-    :param is_multi_surface: a boolean
-    """
-    if is_from_fault_source:
-        # for simple and complex fault sources,
-        # rupture surface geometry is represented by a mesh
-        surf_mesh = surface.get_mesh()
-        lons = surf_mesh.lons
-        lats = surf_mesh.lats
-        depths = surf_mesh.depths
-    else:
-        if is_multi_surface:
-            # `list` of
-            # openquake.hazardlib.geo.surface.planar.PlanarSurface
-            # objects:
-            surfaces = surface.surfaces
-
-            # lons, lats, and depths are arrays with len == 4*N,
-            # where N is the number of surfaces in the
-            # multisurface for each `corner_*`, the ordering is:
-            #   - top left
-            #   - top right
-            #   - bottom left
-            #   - bottom right
-            lons = numpy.concatenate([x.corner_lons for x in surfaces])
-            lats = numpy.concatenate([x.corner_lats for x in surfaces])
-            depths = numpy.concatenate([x.corner_depths for x in surfaces])
-        else:
-            # For area or point source,
-            # rupture geometry is represented by a planar surface,
-            # defined by 3D corner points
-            lons = numpy.zeros((4))
-            lats = numpy.zeros((4))
-            depths = numpy.zeros((4))
-
-            # NOTE: It is important to maintain the order of these
-            # corner points. TODO: check the ordering
-            for i, corner in enumerate((surface.top_left,
-                                        surface.top_right,
-                                        surface.bottom_left,
-                                        surface.bottom_right)):
-                lons[i] = corner.longitude
-                lats[i] = corner.latitude
-                depths[i] = corner.depth
-    return lons, lats, depths
-
-
-class EBRupture(object):
-    """
-    An event based rupture. It is a wrapper over a hazardlib rupture
-    object, containing an array of site indices affected by the rupture,
-    as well as the tags of the corresponding seismic events.
-    """
-    params = ['mag', 'rake', 'tectonic_region_type', 'hypo',
-              'source_class', 'pmf', 'occurrence_rate',
-              'time_span', 'rupture_slip_direction']
-
-    def __init__(self, rupture, indices, events, source_id, grp_id, serial):
-        self.rupture = rupture
-        self.indices = indices
-        self.events = events
-        self.source_id = source_id
-        self.grp_id = grp_id
-        self.serial = serial
-        self.weight = len(indices) * len(events)
-
-    @property
-    def etags(self):
-        """
-        An array of tags for the underlying seismic events
-        """
-        tags = []
-        for (eid, ses, occ, sampleid) in self.events:
-            tag = 'trt=%02d~ses=%04d~src=%s~rup=%d-%02d' % (
-                self.grp_id, ses, self.source_id, self.serial, occ)
-            if sampleid > 0:
-                tag += '~sample=%d' % sampleid
-            tags.append(encode(tag))
-        return numpy.array(tags)
-
-    @property
-    def eids(self):
-        """
-        An array with the underlying event IDs
-        """
-        return self.events['eid']
-
-    @property
-    def multiplicity(self):
-        """
-        How many times the underlying rupture occurs.
-        """
-        return len(self.events)
-
-    def export(self, mesh):
-        """
-        Yield :class:`openquake.commonlib.util.Rupture` objects, with all the
-        attributes set, suitable for export in XML format.
-        """
-        rupture = self.rupture
-        for etag in self.etags:
-            new = Rupture(etag, self.indices)
-            new.mesh = mesh[self.indices]
-            new.etag = etag
-            new.rupture = new
-            new.is_from_fault_source = iffs = isinstance(
-                rupture.surface, (geo.ComplexFaultSurface,
-                                  geo.SimpleFaultSurface))
-            new.is_multi_surface = ims = isinstance(
-                rupture.surface, geo.MultiSurface)
-            new.lons, new.lats, new.depths = get_geom(
-                rupture.surface, iffs, ims)
-            new.surface = rupture.surface
-            new.strike = rupture.surface.get_strike()
-            new.dip = rupture.surface.get_dip()
-            new.rake = rupture.rake
-            new.hypocenter = rupture.hypocenter
-            new.tectonic_region_type = rupture.tectonic_region_type
-            new.magnitude = new.mag = rupture.mag
-            new.top_left_corner = None if iffs or ims else (
-                new.lons[0], new.lats[0], new.depths[0])
-            new.top_right_corner = None if iffs or ims else (
-                new.lons[1], new.lats[1], new.depths[1])
-            new.bottom_left_corner = None if iffs or ims else (
-                new.lons[2], new.lats[2], new.depths[2])
-            new.bottom_right_corner = None if iffs or ims else (
-                new.lons[3], new.lats[3], new.depths[3])
-            yield new
-
-    def __toh5__(self):
-        rup = self.rupture
-        attrs = dict(source_id=self.source_id, grp_id=self.grp_id,
-                     serial=self.serial)
-        for par in self.params:
-            val = getattr(self.rupture, par, None)
-            if val is not None:
-                attrs[par] = val
-        if hasattr(rup, 'temporal_occurrence_model'):
-            attrs['time_span'] = rup.temporal_occurrence_model.time_span
-        #if hasattr(rup, 'pmf'):
-        #    attrs['pmf'] = rup.pmf
-        attrs['hypo'] = rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z
-        attrs['source_class'] = hdf5.cls2dotname(rup.source_typology)
-        attrs['rupture_class'] = hdf5.cls2dotname(rup.__class__)
-        attrs['surface_class'] = hdf5.cls2dotname(rup.surface.__class__)
-        mesh = self.rupture.surface.mesh
-        if mesh is None:  # planar surface
-            s = self.rupture.surface
-            shp = (2, 2)
-            arr = build_array(
-                shp,
-                s.corner_lons.reshape(shp),
-                s.corner_lats.reshape(shp),
-                s.corner_depths.reshape(shp))
-            attrs['mesh_spacing'] = s.mesh_spacing
-        else:  # general surface
-            arr = build_array(mesh.shape, mesh.lons, mesh.lats, mesh.depths)
-        return dict(sids=self.indices, events=self.events, mesh=arr), attrs
-
-    def __fromh5__(self, dic, attrs):
-        self.indices = dic['sids']
-        self.events = dic['events']
-        surface_class = attrs['surface_class']
-        surface_cls = hdf5.dotname2cls(surface_class)
-        self.rupture = object.__new__(hdf5.dotname2cls(attrs['rupture_class']))
-        self.rupture.surface = surface = object.__new__(surface_cls)
-        m = dic['mesh'].value
-        if 'mesh_spacing' in attrs:  # PlanarSurface
-            self.rupture.surface = (
-                geo.surface.planar.PlanarSurface.from4points(
-                    attrs.pop('mesh_spacing'), m.flatten()))
-        else:  # general surface
-            surface.strike = surface.dip = None  # they will be computed
-            surface.mesh = RectangularMesh(m['lon'], m['lat'], m['depth'])
-        time_span = attrs.pop('time_span')
-        if time_span:
-            self.rupture.temporal_occurrence_model = tom.PoissonTOM(time_span)
-        self.rupture.hypocenter = Point(*attrs.pop('hypo'))
-        self.rupture.source_typology = hdf5.dotname2cls(
-            attrs.pop('source_class'))
-        self.source_id = attrs.pop('source_id')
-        self.grp_id = attrs.pop('grp_id')
-        self.serial = attrs.pop('serial')
-        del attrs['rupture_class']
-        del attrs['surface_class']
-        vars(self.rupture).update(attrs)
-
-    def __lt__(self, other):
-        return self.serial < other.serial
-
-    def __repr__(self):
-        return '<%s #%d, grp_id=%d>' % (self.__class__.__name__,
-                                        self.serial, self.grp_id)
+# ######################## rupture calculator ############################ #
 
 
 def compute_ruptures(sources, sitecol, gsims, monitor):
@@ -320,7 +92,7 @@ def compute_ruptures(sources, sitecol, gsims, monitor):
         # to call sample_ruptures *before* the filtering
         for ebr in build_eb_ruptures(
                 src, num_occ_by_rup, rupture_filter, monitor.seed, rup_mon):
-            nsites = len(ebr.indices)
+            nsites = len(ebr.sids)
             try:
                 rate = ebr.rupture.occurrence_rate
             except AttributeError:  # for nonparametric sources
@@ -394,9 +166,10 @@ def build_eb_ruptures(
                 events.append((eid, ses_idx, occ_no, sampleid))
                 eid += 1
         if events:
-            yield EBRupture(rup, r_sites.indices,
-                            numpy.array(events, event_dt),
-                            src.source_id, src.src_group_id, serial)
+            yield calc.EBRupture(
+                rup, r_sites.indices,
+                numpy.array(events, calc.event_dt),
+                src.source_id, src.src_group_id, serial)
 
 
 @base.calculators.add('event_based_rupture')
@@ -482,7 +255,7 @@ class EventBasedRuptureCalculator(PSHACalculator):
                 if events:
                     ev = 'events/sm-%04d' % sm_id
                     self.datastore.extend(
-                        ev, numpy.array(events, stored_event_dt))
+                        ev, numpy.array(events, calc.stored_event_dt))
 
             # save rup_data
             if hasattr(ruptures_by_grp_id, 'rup_data'):
@@ -713,7 +486,7 @@ class EventBasedCalculator(ClassicalCalculator):
             cl_mean_curves = get_mean_curves(self.cl.datastore)
             eb_mean_curves = get_mean_curves(self.datastore)
             for imt in eb_mean_curves.dtype.names:
-                rdiff, index = max_rel_diff_index(
+                rdiff, index = util.max_rel_diff_index(
                     cl_mean_curves[imt], eb_mean_curves[imt])
                 logging.warn('Relative difference with the classical '
                              'mean curves for IMT=%s: %d%% at site index %d',

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -705,9 +705,9 @@ def compute_ruptures_gmfs_curves(
                     eid += 1
                 if events:
                     ses_ruptures.append(
-                        event_based.EBRupture(
+                        calc.EBRupture(
                             rup, indices,
-                            numpy.array(events, event_based.event_dt),
+                            numpy.array(events, calc.event_dt),
                             ucerf.source_id, grp_id, serial))
                     serial += 1
                     rupdic.num_events += len(events)

--- a/openquake/calculators/ucerf_risk.py
+++ b/openquake/calculators/ucerf_risk.py
@@ -21,8 +21,8 @@ import numpy
 
 from openquake.baselib.general import AccumDict
 from openquake.risklib import riskinput
-from openquake.commonlib import parallel
-from openquake.calculators import base, event_based
+from openquake.commonlib import parallel, calc
+from openquake.calculators import base
 from openquake.calculators.ucerf_event_based import (
     UCERFEventBasedCalculator, DEFAULT_TRT)
 from openquake.calculators.event_based_risk import (

--- a/openquake/calculators/ucerf_risk.py
+++ b/openquake/calculators/ucerf_risk.py
@@ -68,9 +68,9 @@ def compute_ruptures(sources, sitecol, gsims, monitor):
                 eid += 1
             if events:
                 ebruptures.append(
-                    event_based.EBRupture(
+                    calc.EBRupture(
                         rup, indices,
-                        numpy.array(events, event_based.event_dt),
+                        numpy.array(events, calc.event_dt),
                         src.source_id, src.src_group_id, serial))
                 serial += 1
                 res.num_events += len(events)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -529,7 +529,7 @@ def get_max_gmf_size(dstore):
         grp_id = ebr.grp_id
         n_ruptures[grp_id] += 1
         # there are 4 bytes per float
-        size[grp_id] += (len(ebr.indices) * ebr.multiplicity *
+        size[grp_id] += (len(ebr.sids) * ebr.multiplicity *
                          len(rlzs_by_grp_id[grp_id]) * n_imts) * 4
     [(grp_id, maxsize)] = size.most_common(1)
     return dict(n_imts=n_imts, size=maxsize, n_ruptures=n_ruptures[grp_id],

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -519,17 +519,20 @@ class EBRupture(object):
         attrs['surface_class'] = hdf5.cls2dotname(rup.surface.__class__)
         surface = self.rupture.surface
         if isinstance(surface, geo.MultiSurface):  # multiplanar surfaces
+            n = len(surface.surfaces)
             arr = build_array([[s.corner_lons, s.corner_lats, s.corner_depths]
-                               for s in surface.surfaces])
+                               for s in surface.surfaces]).reshape(n, 2, 2)
         else:
             mesh = surface.mesh
             if mesh is None:  # planar surface
                 arr = build_array([[surface.corner_lons,
                                     surface.corner_lats,
-                                    surface.corner_depths]])
+                                    surface.corner_depths]]).reshape(1, 2, 2)
                 attrs['mesh_spacing'] = surface.mesh_spacing
             else:  # general surface
-                arr = build_array([[mesh.lons, mesh.lats, mesh.depths]])
+                shp = (1,) + mesh.lons.shape
+                arr = build_array(
+                    [[mesh.lons, mesh.lats, mesh.depths]]).reshape(shp)
         attrs['nbytes'] = self.sids.nbytes + self.events.nbytes + arr.nbytes
         return dict(sids=self.sids, events=self.events, mesh=arr), attrs
 

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -18,8 +18,6 @@
 
 from __future__ import division
 import collections
-import itertools
-import operator
 import logging
 import copy
 
@@ -27,11 +25,14 @@ import numpy
 
 from openquake.baselib.general import get_array, group_array, AccumDict
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib.calc import filters
 from openquake.hazardlib.probability_map import ProbabilityMap
-from openquake.hazardlib.site import SiteCollection
-from openquake.commonlib import readinput, oqvalidation
+from openquake.commonlib import readinput, oqvalidation, util
 
+from openquake.baselib import hdf5
+from openquake.baselib.python3compat import encode
+from openquake.hazardlib.geo.mesh import RectangularMesh, build_array
+from openquake.hazardlib import geo, tom
+from openquake.hazardlib.geo.point import Point
 
 MAX_INT = 2 ** 31 - 1  # this is used in the random number generator
 # in this way even on 32 bit machines Python will not have to convert
@@ -42,6 +43,13 @@ U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
 F64 = numpy.float64
+
+event_dt = numpy.dtype([('eid', U32), ('ses', U32), ('occ', U32),
+                        ('sample', U32)])
+
+stored_event_dt = numpy.dtype([
+    ('rupserial', U32), ('ses', U32), ('occ', U32),
+    ('sample', U32), ('grp_id', U16), ('source_id', 'S30')])
 
 # ############## utilities for the classical calculator ############### #
 
@@ -343,3 +351,220 @@ def check_overflow(calc):
             raise ValueError(
                 'The event based calculator is restricted to '
                 '%d %s, got %d' % (max_[var], var, num_[var]))
+
+
+def get_geom(surface, is_from_fault_source, is_multi_surface):
+    """
+    The following fields can be interpreted different ways,
+    depending on the value of `is_from_fault_source`. If
+    `is_from_fault_source` is True, each of these fields should
+    contain a 2D numpy array (all of the same shape). Each triple
+    of (lon, lat, depth) for a given index represents the node of
+    a rectangular mesh. If `is_from_fault_source` is False, each
+    of these fields should contain a sequence (tuple, list, or
+    numpy array, for example) of 4 values. In order, the triples
+    of (lon, lat, depth) represent top left, top right, bottom
+    left, and bottom right corners of the the rupture's planar
+    surface. Update: There is now a third case. If the rupture
+    originated from a characteristic fault source with a
+    multi-planar-surface geometry, `lons`, `lats`, and `depths`
+    will contain one or more sets of 4 points, similar to how
+    planar surface geometry is stored (see above).
+
+    :param rupture: an instance of :class:`openquake.hazardlib.source.rupture.BaseProbabilisticRupture`
+    :param is_from_fault_source: a boolean
+    :param is_multi_surface: a boolean
+    """
+    if is_from_fault_source:
+        # for simple and complex fault sources,
+        # rupture surface geometry is represented by a mesh
+        surf_mesh = surface.get_mesh()
+        lons = surf_mesh.lons
+        lats = surf_mesh.lats
+        depths = surf_mesh.depths
+    else:
+        if is_multi_surface:
+            # `list` of
+            # openquake.hazardlib.geo.surface.planar.PlanarSurface
+            # objects:
+            surfaces = surface.surfaces
+
+            # lons, lats, and depths are arrays with len == 4*N,
+            # where N is the number of surfaces in the
+            # multisurface for each `corner_*`, the ordering is:
+            #   - top left
+            #   - top right
+            #   - bottom left
+            #   - bottom right
+            lons = numpy.concatenate([x.corner_lons for x in surfaces])
+            lats = numpy.concatenate([x.corner_lats for x in surfaces])
+            depths = numpy.concatenate([x.corner_depths for x in surfaces])
+        else:
+            # For area or point source,
+            # rupture geometry is represented by a planar surface,
+            # defined by 3D corner points
+            lons = numpy.zeros((4))
+            lats = numpy.zeros((4))
+            depths = numpy.zeros((4))
+
+            # NOTE: It is important to maintain the order of these
+            # corner points. TODO: check the ordering
+            for i, corner in enumerate((surface.top_left,
+                                        surface.top_right,
+                                        surface.bottom_left,
+                                        surface.bottom_right)):
+                lons[i] = corner.longitude
+                lats[i] = corner.latitude
+                depths[i] = corner.depth
+    return lons, lats, depths
+
+
+class EBRupture(object):
+    """
+    An event based rupture. It is a wrapper over a hazardlib rupture
+    object, containing an array of site indices affected by the rupture,
+    as well as the tags of the corresponding seismic events.
+    """
+    params = ['mag', 'rake', 'tectonic_region_type', 'hypo',
+              'source_class', 'pmf', 'occurrence_rate',
+              'time_span', 'rupture_slip_direction']
+
+    def __init__(self, rupture, sids, events, source_id, grp_id, serial):
+        self.rupture = rupture
+        self.sids = sids
+        self.events = events
+        self.source_id = source_id
+        self.grp_id = grp_id
+        self.serial = serial
+        self.weight = len(sids) * len(events)
+
+    @property
+    def etags(self):
+        """
+        An array of tags for the underlying seismic events
+        """
+        tags = []
+        for (eid, ses, occ, sampleid) in self.events:
+            tag = 'trt=%02d~ses=%04d~src=%s~rup=%d-%02d' % (
+                self.grp_id, ses, self.source_id, self.serial, occ)
+            if sampleid > 0:
+                tag += '~sample=%d' % sampleid
+            tags.append(encode(tag))
+        return numpy.array(tags)
+
+    @property
+    def eids(self):
+        """
+        An array with the underlying event IDs
+        """
+        return self.events['eid']
+
+    @property
+    def multiplicity(self):
+        """
+        How many times the underlying rupture occurs.
+        """
+        return len(self.events)
+
+    def export(self, mesh):
+        """
+        Yield :class:`openquake.commonlib.util.Rupture` objects, with all the
+        attributes set, suitable for export in XML format.
+        """
+        rupture = self.rupture
+        for etag in self.etags:
+            new = util.Rupture(etag, self.sids)
+            new.mesh = mesh[self.sids]
+            new.etag = etag
+            new.rupture = new
+            new.is_from_fault_source = iffs = isinstance(
+                rupture.surface, (geo.ComplexFaultSurface,
+                                  geo.SimpleFaultSurface))
+            new.is_multi_surface = ims = isinstance(
+                rupture.surface, geo.MultiSurface)
+            new.lons, new.lats, new.depths = get_geom(
+                rupture.surface, iffs, ims)
+            new.surface = rupture.surface
+            new.strike = rupture.surface.get_strike()
+            new.dip = rupture.surface.get_dip()
+            new.rake = rupture.rake
+            new.hypocenter = rupture.hypocenter
+            new.tectonic_region_type = rupture.tectonic_region_type
+            new.magnitude = new.mag = rupture.mag
+            new.top_left_corner = None if iffs or ims else (
+                new.lons[0], new.lats[0], new.depths[0])
+            new.top_right_corner = None if iffs or ims else (
+                new.lons[1], new.lats[1], new.depths[1])
+            new.bottom_left_corner = None if iffs or ims else (
+                new.lons[2], new.lats[2], new.depths[2])
+            new.bottom_right_corner = None if iffs or ims else (
+                new.lons[3], new.lats[3], new.depths[3])
+            yield new
+
+    def __toh5__(self):
+        rup = self.rupture
+        attrs = dict(source_id=self.source_id, grp_id=self.grp_id,
+                     serial=self.serial)
+        for par in self.params:
+            val = getattr(self.rupture, par, None)
+            if val is not None:
+                attrs[par] = val
+        if hasattr(rup, 'temporal_occurrence_model'):
+            attrs['time_span'] = rup.temporal_occurrence_model.time_span
+        #if hasattr(rup, 'pmf'):
+        #    attrs['pmf'] = rup.pmf
+        attrs['hypo'] = rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z
+        attrs['source_class'] = hdf5.cls2dotname(rup.source_typology)
+        attrs['rupture_class'] = hdf5.cls2dotname(rup.__class__)
+        attrs['surface_class'] = hdf5.cls2dotname(rup.surface.__class__)
+        mesh = self.rupture.surface.mesh
+        if mesh is None:  # planar surface
+            s = self.rupture.surface
+            shp = (2, 2)
+            arr = build_array(
+                shp,
+                s.corner_lons.reshape(shp),
+                s.corner_lats.reshape(shp),
+                s.corner_depths.reshape(shp))
+            attrs['mesh_spacing'] = s.mesh_spacing
+        else:  # general surface
+            arr = build_array(mesh.shape, mesh.lons, mesh.lats, mesh.depths)
+        return dict(sids=self.sids, events=self.events, mesh=arr), attrs
+
+    def __fromh5__(self, dic, attrs):
+        attrs = dict(attrs)
+        self.sids = dic['sids']
+        self.events = dic['events']
+        surface_class = attrs['surface_class']
+        surface_cls = hdf5.dotname2cls(surface_class)
+        self.rupture = object.__new__(hdf5.dotname2cls(attrs['rupture_class']))
+        self.rupture.surface = surface = object.__new__(surface_cls)
+        m = dic['mesh'].value
+        if 'mesh_spacing' in attrs:  # PlanarSurface
+            self.rupture.surface = (
+                geo.surface.planar.PlanarSurface.from_array(
+                    attrs.pop('mesh_spacing'), m.flatten()))
+        else:  # general surface
+            surface.strike = surface.dip = None  # they will be computed
+            surface.mesh = RectangularMesh(m['lon'], m['lat'], m['depth'])
+        time_span = attrs.pop('time_span')
+        if time_span:
+            self.rupture.temporal_occurrence_model = tom.PoissonTOM(time_span)
+        self.rupture.surface_nodes = ()
+        self.rupture.rupture_slip_direction = None
+        self.rupture.hypocenter = Point(*attrs.pop('hypo'))
+        self.rupture.source_typology = hdf5.dotname2cls(
+            attrs.pop('source_class'))
+        self.source_id = attrs.pop('source_id')
+        self.grp_id = attrs.pop('grp_id')
+        self.serial = attrs.pop('serial')
+        del attrs['rupture_class']
+        del attrs['surface_class']
+        vars(self.rupture).update(attrs)
+
+    def __lt__(self, other):
+        return self.serial < other.serial
+
+    def __repr__(self):
+        return '<%s #%d, grp_id=%d>' % (self.__class__.__name__,
+                                        self.serial, self.grp_id)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -532,6 +532,7 @@ class EBRupture(object):
                 attrs['mesh_spacing'] = surface.mesh_spacing
             else:  # general surface
                 arr = build_array([[mesh.lons, mesh.lats, mesh.depths]])
+        attrs['nbytes'] = self.sids.nbytes + self.events.nbytes + arr.nbytes
         return dict(sids=self.sids, events=self.events, mesh=arr), attrs
 
     def __fromh5__(self, dic, attrs):

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -557,6 +557,8 @@ class EBRupture(object):
         if time_span:
             self.rupture.temporal_occurrence_model = tom.PoissonTOM(time_span)
         self.rupture.surface_nodes = ()
+        if 'rupture_slip_direction' in attrs:
+            logging.error('rupture_slip_direction not implemented yet')
         self.rupture.rupture_slip_direction = None
         self.rupture.hypocenter = Point(*attrs.pop('hypo'))
         self.rupture.source_typology = hdf5.dotname2cls(

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -521,14 +521,12 @@ class EBRupture(object):
         if isinstance(surface, geo.MultiSurface):  # multiplanar surfaces
             arr = build_array([[s.corner_lons, s.corner_lats, s.corner_depths]
                                for s in surface.surfaces])
-            arr.reshape((len(surface.surfaces), 2, 2))
         else:
             mesh = surface.mesh
             if mesh is None:  # planar surface
                 arr = build_array([[surface.corner_lons,
                                     surface.corner_lats,
                                     surface.corner_depths]])
-                arr.reshape((1, 2, 2))
                 attrs['mesh_spacing'] = surface.mesh_spacing
             else:  # general surface
                 arr = build_array([[mesh.lons, mesh.lats, mesh.depths]])

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -200,8 +200,9 @@ class DataStore(collections.MutableMapping):
         """
         Set the HDF5 attributes of the given key
         """
+        attrs = h5py.File.__getitem__(self.hdf5, key).attrs
         for k, v in kw.items():
-            h5py.File.__getitem__(self.hdf5, key).attrs[k] = v
+            attrs[k] = v
 
     def get_attr(self, key, name, default=None):
         """

--- a/openquake/commonlib/tests/calc_test.py
+++ b/openquake/commonlib/tests/calc_test.py
@@ -1,0 +1,45 @@
+import os
+import tempfile
+import unittest
+import numpy
+from openquake.baselib import hdf5
+from openquake.commonlib import nrml_examples, calc, source
+from openquake.commonlib.sourceconverter import SourceConverter
+
+NRML_DIR = os.path.dirname(nrml_examples.__file__)
+MIXED_SRC_MODEL = os.path.join(NRML_DIR, 'source_model/mixed.xml')
+parser = source.SourceModelParser(SourceConverter(
+    investigation_time=50.,
+    rupture_mesh_spacing=1,  # km
+    complex_fault_mesh_spacing=1,  # km
+    width_of_mfd_bin=1.,  # for Truncated GR MFDs
+    area_source_discretization=1.,  # km
+))
+
+
+class SerializeRuptureTestCase(unittest.TestCase):
+    def test(self):
+        groups = parser.parse_groups(MIXED_SRC_MODEL)
+        ([point], [cmplx], [area, simple],
+         [char_simple, char_complex, char_multi]) = groups
+        fh, self.path = tempfile.mkstemp(suffix='.hdf5')
+        os.close(fh)
+        print('Writing on %s' % self.path)
+        self.i = 0
+        self.sids = numpy.array([0], numpy.uint32)
+        self.events = numpy.array([(0, 1, 1, 0)], calc.event_dt)
+        self.write_read(point)
+        self.write_read(char_simple)
+        self.write_read(char_complex)
+        self.write_read(char_multi)
+
+    def write_read(self, src):
+        with hdf5.File(self.path, 'r+') as f:
+            for rup in src.iter_ruptures():
+                ebr = calc.EBRupture(
+                    rup, self.sids, self.events, src.source_id, 0, self.i)
+                f[str(self.i)] = ebr
+                self.i += 1
+        with hdf5.File(self.path, 'r') as f:
+            for key in f:
+                f[key]

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -534,7 +534,7 @@ class GmfGetter(object):
         self.sids = sitecol.sids
         self.computers = []
         for ebr in ebruptures:
-            sites = site.FilteredSiteCollection(ebr.indices, sitecol.complete)
+            sites = site.FilteredSiteCollection(ebr.sids, sitecol.complete)
             computer = calc.gmf.GmfComputer(
                 ebr, sites, imts, set(gsims),
                 truncation_level, correlation_model)


### PR DESCRIPTION
Requires https://github.com/gem/oq-hazardlib/pull/521. The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2275. After this change, the saving time of the ruptures will increase sevenfold, so one should consider setting the flag `saving_ruptures=false`.

