### PR TITLE
Now by default we do not save the ruptures anymore

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Now by default we do not save the ruptures anymore
   * Simplified classical_risk (the numbers can be slightly different now)
   * Serialized the ruptures in the HDF5 properly (no pickle)
   * Introduced a parameter `iml_disagg` in the disaggregation calculator

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -251,7 +251,7 @@ class EventBasedRuptureCalculator(PSHACalculator):
                         self.eid[sm_id] += 1
                         i += 1
                     if self.oqparam.save_ruptures:
-                        self.datastore['sescollection/%s' % ebr.serial] = ebr
+                        self.datastore['ruptures/%s' % ebr.serial] = ebr
                 if events:
                     ev = 'events/sm-%04d' % sm_id
                     self.datastore.extend(
@@ -270,8 +270,8 @@ class EventBasedRuptureCalculator(PSHACalculator):
         nr = sum(len(result[grp_id]) for grp_id in result)
         logging.info('Saved %d ruptures, %d events',
                      nr, sum(self.eid.values()))
-        if 'sescollection' in self.datastore:
-            self.datastore.set_nbytes('sescollection')
+        if 'ruptures' in self.datastore:
+            self.datastore.set_nbytes('ruptures')
         self.datastore.set_nbytes('events')
 
         for dset in self.rup_data.values():
@@ -420,8 +420,8 @@ class EventBasedCalculator(ClassicalCalculator):
                 for sr in sesruptures:
                     self.sesruptures.append(sr)
         else:  # read the ruptures from the datastore
-            for serial in self.datastore['sescollection']:
-                sr = self.datastore['sescollection/' + serial]
+            for serial in self.datastore['ruptures']:
+                sr = self.datastore['ruptures/' + serial]
                 self.sesruptures.append(sr)
         self.sesruptures.sort(key=operator.attrgetter('serial'))
         if self.oqparam.ground_motion_fields:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -244,8 +244,8 @@ class EventBasedRiskCalculator(base.RiskCalculator):
                 for sr in sesruptures:
                     all_ruptures.append(sr)
         else:  # read the ruptures from the datastore
-            for serial in self.datastore['sescollection']:
-                rup = self.datastore['sescollection/' + serial]
+            for serial in self.datastore['ruptures']:
+                rup = self.datastore['ruptures/' + serial]
                 all_ruptures.append(rup)
         all_ruptures.sort(key=operator.attrgetter('serial'))
         if not self.riskmodel.covs:

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -117,10 +117,10 @@ class ReportWriter(object):
             self.add('ruptures_per_trt')
         if 'scenario' not in oq.calculation_mode:
             self.add('job_info')
-        if 'sescollection' in ds:
+        if 'ruptures' in ds:
             self.add('ruptures_events')
         if oq.calculation_mode in ('event_based_risk',):
-            if 'sescollection' in ds:
+            if 'ruptures' in ds:
                 self.add('biggest_ebr_gmf')
             self.add('avglosses_data_transfer')
         if 'exposure' in oq.inputs:

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -268,7 +268,7 @@ gmf-smltp_b3-gsimltp_@_@_@_b4_1.txt'''.split()
 
         # check that a single rupture file is exported even if there are
         # several collections
-        [fname] = export(('sescollection', 'xml'), self.calc.datastore)
+        [fname] = export(('ruptures', 'xml'), self.calc.datastore)
         self.assertEqualFiles('expected/ses.xml', fname)
 
     @attr('qa', 'hazard', 'event_based')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -524,8 +524,8 @@ def get_max_gmf_size(dstore):
     rlzs_by_grp_id = dstore['csm_info'].get_rlzs_assoc().get_rlzs_by_grp_id()
     n_ruptures = collections.Counter()
     size = collections.Counter()  # by grp_id
-    for serial in dstore['sescollection']:
-        ebr = dstore['sescollection/' + serial]
+    for serial in dstore['ruptures']:
+        ebr = dstore['ruptures/' + serial]
         grp_id = ebr.grp_id
         n_ruptures[grp_id] += 1
         # there are 4 bytes per float
@@ -550,7 +550,7 @@ def view_biggest_ebr_gmf(token, dstore):
 
 @view.add('ruptures_events')
 def view_ruptures_events(token, dstore):
-    num_ruptures = len(dstore['sescollection'])
+    num_ruptures = len(dstore['ruptures'])
     num_events = len(dstore['events'])
     mult = round(num_events / num_ruptures, 3)
     lst = [('Total number of ruptures', num_ruptures),

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -105,7 +105,7 @@ class SESCollection(object):
             yield SES(sesruptures, self.investigation_time, idx)
 
 
-@export.add(('sescollection', 'xml'), ('sescollection', 'csv'))
+@export.add(('ruptures', 'xml'), ('ruptures', 'csv'))
 def export_ses_xml(ekey, dstore):
     """
     :param ekey: export key, i.e. a pair (datastore key, fmt)
@@ -115,8 +115,8 @@ def export_ses_xml(ekey, dstore):
     oq = dstore['oqparam']
     mesh = get_mesh(dstore['sitecol'])
     ruptures = []
-    for serial in dstore['sescollection']:
-        sr = dstore['sescollection/' + serial]
+    for serial in dstore['ruptures']:
+        sr = dstore['ruptures/' + serial]
         ruptures.extend(sr.export(mesh))
     ses_coll = SESCollection(
         groupby(ruptures, operator.attrgetter('ses_idx')),
@@ -736,7 +736,7 @@ def _calc_gmfs(dstore, serial, eid):
     rlzs = rlzs_assoc.realizations
     sitecol = dstore['sitecol'].complete
     N = len(sitecol.complete)
-    rup = dstore['sescollection/' + serial]
+    rup = dstore['ruptures/' + serial]
     correl_model = oq.get_correl_model()
     realizations = rlzs_assoc.get_rlzs_by_grp_id()[rup.grp_id]
     gmf_dt = numpy.dtype([('%03d' % rlz.ordinal, F64) for rlz in realizations])

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -142,7 +142,7 @@ class OqParam(valid.ParamSet):
     ruptures_per_block = valid.Param(valid.positiveint, 1000)
     complex_fault_mesh_spacing = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
-    save_ruptures = valid.Param(valid.boolean, True)
+    save_ruptures = valid.Param(valid.boolean, False)
     ses_per_logic_tree_path = valid.Param(valid.positiveint, 1)
     sites = valid.Param(valid.NoneOr(valid.coordinates), None)
     sites_disagg = valid.Param(valid.NoneOr(valid.coordinates), [])

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -81,7 +81,7 @@ def expose_outputs(dstore):
     """
     oq = dstore['oqparam']
     exportable = set(ekey[0] for ekey in export.export)
-    # small hack: remove the sescollection outputs from scenario
+    # small hack: remove the ruptures from scenario
     # calculators, as requested by Vitor
     calcmode = oq.calculation_mode
     dskeys = set(dstore) & exportable  # exportable datastore keys
@@ -95,8 +95,8 @@ def expose_outputs(dstore):
         rlzs = []
     if 'realizations' in dskeys and len(rlzs) <= 1:
         dskeys.remove('realizations')  # do not export a single realization
-    if 'sescollection' in dskeys and 'scenario' in calcmode:
-        exportable.remove('sescollection')  # do not export
+    if 'ruptures' in dskeys and 'scenario' in calcmode:
+        exportable.remove('ruptures')  # do not export
     logs.dbcmd('create_outputs', dstore.calc_id, sorted(dskeys))
 
 

--- a/openquake/qa_tests_data/event_based/case_17/job.ini
+++ b/openquake/qa_tests_data/event_based/case_17/job.ini
@@ -1,19 +1,15 @@
 [general]
-
 description = Event Based Hazard QA Test, Case 17
 calculation_mode = event_based
 random_seed = 106
 
 [geometry]
-
 sites = 0.0 0.0
 
 [logic_tree]
-
 number_of_logic_tree_samples = 5
 
 [erf]
-
 # km
 rupture_mesh_spacing = 1.0
 # Not used in this test case:
@@ -22,14 +18,12 @@ width_of_mfd_bin = 1.0
 area_source_discretization = 10
 
 [site_params]
-
 reference_vs30_type = measured
 reference_vs30_value = 800.0
 reference_depth_to_2pt5km_per_sec = 2.5
 reference_depth_to_1pt0km_per_sec = 50.0
 
 [calculation]
-
 source_model_logic_tree_file = source_model_logic_tree.xml
 gsim_logic_tree_file = gsim_logic_tree.xml
 # years
@@ -39,9 +33,9 @@ intensity_measure_types_and_levels = {"PGA": [0.1, 0.4, 0.6]}
 truncation_level = 2.0
 # km
 maximum_distance = 200.0
+save_ruptures = true
 ground_motion_fields = false
 hazard_curves_from_gmfs = True
 
 [output]
-
 export_dir = /tmp


### PR DESCRIPTION
To save time after the change in https://github.com/gem/oq-engine/pull/2314. I am renaming sescollection->ruptures inside the HDF5 file.
The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2278/