### PR TITLE
Fix for Ubuntu 14.04

### DIFF
--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -536,8 +536,8 @@ class EBRupture(object):
 
     def __fromh5__(self, dic, attrs):
         attrs = dict(attrs)
-        self.sids = dic['sids']
-        self.events = dic['events']
+        self.sids = dic['sids'].value
+        self.events = dic['events'].value
         surface_class = attrs['surface_class']
         surface_cls = hdf5.dotname2cls(surface_class)
         self.rupture = object.__new__(hdf5.dotname2cls(attrs['rupture_class']))


### PR DESCRIPTION
Jenkins is broken: https://ci.openquake.org/job/master_oq-engine/2866/console

Until the `opt` distribution is a reality, I suggest to change Jenkins to run Ubuntu 14.04 during the day and Ubuntu 16.04 during the night. Here you can see that the fix works: https://ci.openquake.org/job/zdevel_oq-engine/2280/