### PR TITLE
Fixed a memory leak recently introduced in parallel.py

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a memory leak recently introduced in parallel.py
   * Simplified classical_risk (the numbers can be slightly different now)
   * Serialized the ruptures in the HDF5 properly (no pickle)
   * Introduced a parameter `iml_disagg` in the disaggregation calculator

--- a/openquake/commonlib/parallel.py
+++ b/openquake/commonlib/parallel.py
@@ -253,7 +253,7 @@ class IterResult(object):
 
     def __iter__(self):
         self.received = []
-        for fut in as_completed(self.futures):
+        for fut in self.futures:
             check_mem_usage()  # log a warning if too much memory is used
             if hasattr(fut, 'result'):
                 result = fut.result()
@@ -444,7 +444,7 @@ class TaskManager(object):
                 yield fut
 
         else:  # future interface
-            for fut in self.results:
+            for fut in as_completed(self.results):
                 yield fut
 
     def reduce(self, agg=operator.add, acc=None):
@@ -499,7 +499,7 @@ class TaskManager(object):
         if not task_no:
             self.progress('No %s tasks were submitted', self.name)
         # NB: keep self._iterfutures() an iterator, especially with celery!
-        ir = IterResult(list(self._iterfutures()), self.name, task_no,
+        ir = IterResult(self._iterfutures(), self.name, task_no,
                         self.progress)
         ir.sent = self.sent  # for information purposes
         if self.sent:


### PR DESCRIPTION
The problem was NOT solved by https://github.com/gem/oq-engine/pull/2313. This attempt instead seems to be successful. Also the progress log works properly and there are no issues with Ubuntu 14.04: https://ci.openquake.org/job/zdevel_oq-engine/2281