### PR TITLE
Simplified the risk calculators

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -613,6 +613,7 @@ class RiskCalculator(HazardCalculator):
                              "from the IMTs in the hazard (%s)" % (rsk, haz))
         num_tasks = math.ceil((self.oqparam.concurrent_tasks or 1) /
                               len(imtls))
+        rlzs = sorted(hazards_by_rlz)
         with self.monitor('building riskinputs', autoflush=True):
             riskinputs = []
             idx_weight_pairs = [
@@ -639,7 +640,7 @@ class RiskCalculator(HazardCalculator):
                             hdata[i][imt][rlz] = haz
                 # build the riskinputs
                 ri = self.riskmodel.build_input(
-                    hdata, reduced_assets, reduced_eps)
+                    rlzs, hdata, reduced_assets, reduced_eps)
                 if ri.weight > 0:
                     riskinputs.append(ri)
             assert riskinputs

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -656,7 +656,7 @@ class RiskCalculator(HazardCalculator):
         rlz_ids = getattr(self.oqparam, 'rlz_ids', ())
         if rlz_ids:
             self.rlzs_assoc = self.rlzs_assoc.extract(rlz_ids)
-        all_args = ((riskinput, self.riskmodel, self.rlzs_assoc) +
+        all_args = ((riskinput, self.riskmodel) +
                     self.extra_args + (self.monitor,)
                     for riskinput in self.riskinputs)
         res = starmap(self.core_task.__func__, all_args).reduce()

--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -26,7 +26,7 @@ bcr_dt = numpy.dtype([('annual_loss_orig', F32), ('annual_loss_retro', F32),
                       ('bcr', F32)])
 
 
-def classical_bcr(riskinput, riskmodel, rlzs_assoc, bcr_dt, monitor):
+def classical_bcr(riskinput, riskmodel, bcr_dt, monitor):
     """
     Compute and return the average losses for each asset.
 
@@ -34,15 +34,13 @@ def classical_bcr(riskinput, riskmodel, rlzs_assoc, bcr_dt, monitor):
         a :class:`openquake.risklib.riskinput.RiskInput` object
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
-    :param rlzs_assoc:
-        associations (grp_id, gsim) -> realizations
     :param bcr_dt:
         data type with fields annual_loss_orig, annual_loss_retro, bcr
     :param monitor:
         :class:`openquake.baselib.performance.Monitor` instance
     """
     result = {}  # (N, R) -> data
-    for out in riskmodel.gen_outputs(riskinput, rlzs_assoc, monitor):
+    for out in riskmodel.gen_outputs(riskinput, monitor):
         l, r = out.lr
         for asset, (eal_orig, eal_retro, bcr) in zip(out.assets, out.data):
             aval = asset.value(out.loss_type)

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -23,7 +23,7 @@ from openquake.commonlib import datastore
 from openquake.calculators import base, classical_risk
 
 
-def classical_damage(riskinput, riskmodel, rlzs_assoc, monitor):
+def classical_damage(riskinput, riskmodel, monitor):
     """
     Core function for a classical damage computation.
 
@@ -31,16 +31,14 @@ def classical_damage(riskinput, riskmodel, rlzs_assoc, monitor):
         a :class:`openquake.risklib.riskinput.RiskInput` object
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
-    :param rlzs_assoc:
-        associations (grp_id, gsim) -> realizations
     :param monitor:
         :class:`openquake.baselib.performance.Monitor` instance
     :returns:
         a nested dictionary rlz_idx -> asset -> <damage array>
     """
     with monitor:
-        result = {i: AccumDict() for i in range(len(rlzs_assoc))}
-        for out in riskmodel.gen_outputs(riskinput, rlzs_assoc, monitor):
+        result = {i: AccumDict() for i in range(len(riskinput.rlzs))}
+        for out in riskmodel.gen_outputs(riskinput, monitor):
             l, r = out.lr
             ordinals = [a.ordinal for a in out.assets]
             result[r] += dict(zip(ordinals, out.damages))

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -73,7 +73,7 @@ def dist_total(data, multi_stat_dt):
     return out
 
 
-def scenario_damage(riskinput, riskmodel, rlzs_assoc, monitor):
+def scenario_damage(riskinput, riskmodel, monitor):
     """
     Core function for a damage computation.
 
@@ -81,8 +81,6 @@ def scenario_damage(riskinput, riskmodel, rlzs_assoc, monitor):
         a :class:`openquake.risklib.riskinput.RiskInput` object
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
-    :param rlzs_assoc:
-        a class:`openquake.commonlib.source.RlzsAssoc` instance
     :param monitor:
         :class:`openquake.baselib.performance.Monitor` instance
     :returns:
@@ -98,14 +96,14 @@ def scenario_damage(riskinput, riskmodel, rlzs_assoc, monitor):
     """
     c_models = monitor.consequence_models
     L = len(riskmodel.loss_types)
-    R = len(rlzs_assoc.realizations)
+    R = len(riskinput.rlzs)
     D = len(riskmodel.damage_states)
     E = monitor.oqparam.number_of_ground_motion_fields
     T = len(monitor.taxonomies)
     taxo2idx = {taxo: i for i, taxo in enumerate(monitor.taxonomies)}
     result = dict(d_asset=[], d_taxon=numpy.zeros((T, L, R, E, D), F64),
                   c_asset=[], c_taxon=numpy.zeros((T, L, R, E), F64))
-    for out in riskmodel.gen_outputs(riskinput, rlzs_assoc, monitor):
+    for out in riskmodel.gen_outputs(riskinput, monitor):
         l, r = out.lr
         c_model = c_models.get(out.loss_type)
         for asset, fraction in zip(out.assets, out.damages):

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -29,7 +29,7 @@ F32 = numpy.float32
 F64 = numpy.float64  # higher precision to avoid task order dependency
 
 
-def scenario_risk(riskinput, riskmodel, rlzs_assoc, monitor):
+def scenario_risk(riskinput, riskmodel, monitor):
     """
     Core function for a scenario computation.
 
@@ -37,8 +37,6 @@ def scenario_risk(riskinput, riskmodel, rlzs_assoc, monitor):
         a of :class:`openquake.risklib.riskinput.RiskInput` object
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
-    :param rlzs_assoc:
-        a class:`openquake.commonlib.source.RlzsAssoc` instance
     :param monitor:
         :class:`openquake.baselib.performance.Monitor` instance
     :returns:
@@ -52,9 +50,9 @@ def scenario_risk(riskinput, riskmodel, rlzs_assoc, monitor):
     """
     E = monitor.oqparam.number_of_ground_motion_fields
     L = len(riskmodel.loss_types)
-    R = len(rlzs_assoc.realizations)
+    R = len(riskinput.rlzs)
     result = dict(agg=numpy.zeros((E, L, R, 2), F64), avg=[])
-    for out in riskmodel.gen_outputs(riskinput, rlzs_assoc, monitor):
+    for out in riskmodel.gen_outputs(riskinput, monitor):
         l, r = out.lr
         stats = numpy.zeros((len(out.assets), 4), F32)
         # this is ugly but using a composite array (i.e.

--- a/openquake/calculators/ucerf_risk.py
+++ b/openquake/calculators/ucerf_risk.py
@@ -107,10 +107,9 @@ def compute_losses(ssm, sitecol, assetcol, riskmodel,
     rlzs_assoc = ssm.info.get_rlzs_assoc()
     num_rlzs = len(rlzs_assoc.realizations)
     ri = riskinput.RiskInputFromRuptures(
-        DEFAULT_TRT, imts, sitecol, ruptures, trunc_level, correl_model,
-        min_iml)
-    res.append(
-        losses_by_taxonomy(ri, riskmodel, rlzs_assoc, assetcol, monitor))
+        DEFAULT_TRT, rlzs_assoc, imts, sitecol, ruptures, trunc_level,
+        correl_model, min_iml)
+    res.append(losses_by_taxonomy(ri, riskmodel, assetcol, monitor))
     res.sm_id = ssm.sm_id
     res.num_events = len(ri.eids)
     start = res.sm_id * num_rlzs

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -351,9 +351,11 @@ class CompositeRiskModel(collections.Mapping):
         return RiskInput(hazards_by_site, assetcol, eps_dict)
 
     def build_inputs_from_ruptures(
-            self, grp_trt, imts, sitecol, all_ruptures, trunc_level,
-            correl_model, min_iml, eps, hint):
+            self, grp_trt, rlzs_assoc, imts, sitecol, all_ruptures,
+            trunc_level, correl_model, min_iml, eps, hint):
         """
+        :param grp_trt: a dictionary src_group_id -> tectonic region type
+        :param rlzs_assoc: a RlzsAssoc instance
         :param imts: list of intensity measure type strings
         :param sitecol: a SiteCollection instance
         :param all_ruptures: the complete list of EBRupture instances
@@ -375,19 +377,17 @@ class CompositeRiskModel(collections.Mapping):
             idxs = numpy.arange(start, start + num_events)
             start += num_events
             yield RiskInputFromRuptures(
-                grp_trt[grp_id], imts, sitecol, ses_ruptures,
+                grp_trt[grp_id], rlzs_assoc, imts, sitecol, ses_ruptures,
                 trunc_level, correl_model, min_iml,
                 eps[:, idxs] if eps is not None else None)
 
-    def gen_outputs(self, riskinput, rlzs_assoc, monitor,
-                    assetcol=None):
+    def gen_outputs(self, riskinput, monitor, assetcol=None):
         """
         Group the assets per taxonomy and compute the outputs by using the
         underlying riskmodels. Yield the outputs generated as dictionaries
         out_by_lr.
 
         :param riskinput: a RiskInput instance
-        :param rlzs_assoc: a RlzsAssoc instance
         :param monitor: a monitor object used to measure the performance
         :param assetcol: not None only for event based risk
         """
@@ -398,7 +398,7 @@ class CompositeRiskModel(collections.Mapping):
             assets_by_site = (riskinput.assets_by_site if assetcol is None
                               else assetcol.assets_by_site())
             hazard_getter = riskinput.hazard_getter(
-                rlzs_assoc, mon_hazard(measuremem=False))
+                mon_hazard(measuremem=False))
 
         # group the assets by taxonomy
         taxonomies = set()
@@ -412,12 +412,7 @@ class CompositeRiskModel(collections.Mapping):
                     dic[taxonomy].append((i, group[taxonomy], epsgetter))
                     taxonomies.add(taxonomy)
 
-        if hasattr(riskinput, 'ses_ruptures'):  # event based
-            grp_id = riskinput.ses_ruptures[0].grp_id
-            rlzs = rlzs_assoc.get_rlzs_by_grp_id()[grp_id]
-        else:
-            rlzs = rlzs_assoc.realizations
-        for rlz in rlzs:
+        for rlz in riskinput.rlzs:
             with mon_hazard:
                 hazard = hazard_getter(rlz)
             for taxonomy in sorted(taxonomies):
@@ -446,9 +441,7 @@ class PoeGetter(object):
     Callable returning a list of N dictionaries imt -> curve
     when called on a realization.
     """
-    def __init__(self, hazard_by_site, rlzs_assoc):
-        self.rlzs_assoc = rlzs_assoc
-        self.rlzs = rlzs_assoc.realizations
+    def __init__(self, hazard_by_site):
         self.hazard_by_site = hazard_by_site
 
     def __call__(self, rlz):
@@ -550,16 +543,14 @@ class RiskInput(object):
             [self.eps[aid] for aid in asset_ordinals]
             if self.eps else None)
 
-    def hazard_getter(self, rlzs_assoc, monitor=Monitor()):
+    def hazard_getter(self, monitor=Monitor()):
         """
-        :param rlzs_assoc:
-            :class:`openquake.commonlib.source.RlzsAssoc` instance
         :param monitor:
             a :class:`openquake.baselib.performance.Monitor` instance
         :returns:
             list of hazard dictionaries imt -> rlz -> haz per each site
         """
-        return PoeGetter(self.hazard_by_site, rlzs_assoc)
+        return PoeGetter(self.hazard_by_site)
 
     def __repr__(self):
         return '<%s taxonomy=%s, %d asset(s)>' % (
@@ -633,27 +624,30 @@ class RiskInputFromRuptures(object):
     Contains all the assets associated to the given IMT and a subsets of
     the ruptures for a given calculation.
 
+    :param trt: a tectonic region type string
+    :param rlzs_assoc: a RlzsAssoc instance
     :param imts: a list of intensity measure type strings
     :param sitecol: SiteCollection instance
-    :param assets_by_site: list of list of assets
     :param ses_ruptures: ordered array of EBRuptures
-    :param gsims: list of GSIM instances
     :param trunc_level: truncation level for the GSIMs
     :param correl_model: correlation model for the GSIMs
     :param min_iml: an array with the minimum intensity per IMT
     :params epsilons: a matrix of epsilons (or None)
-    :param eids: an array of event IDs (or None)
     """
-    def __init__(self, trt, imts, sitecol, ses_ruptures,
+    def __init__(self, trt, rlzs_assoc, imts, sitecol, ses_ruptures,
                  trunc_level, correl_model, min_iml, epsilons=None):
+        self.imts = imts
         self.sitecol = sitecol
         self.ses_ruptures = numpy.array(ses_ruptures)
+        grp_id = ses_ruptures[0].grp_id
         self.trt = trt
         self.trunc_level = trunc_level
         self.correl_model = correl_model
         self.min_iml = min_iml
+        self.gsims = [dic[trt] for dic in rlzs_assoc.gsim_by_trt]
+        self.samples = rlzs_assoc.samples[grp_id]
+        self.rlzs = rlzs_assoc.get_rlzs_by_grp_id()[grp_id]
         self.weight = sum(sr.weight for sr in ses_ruptures)
-        self.imts = imts
         self.eids = numpy.concatenate([r.events['eid'] for r in ses_ruptures])
         if epsilons is not None:
             self.eps = epsilons  # matrix N x E, events in this block
@@ -671,20 +665,16 @@ class RiskInputFromRuptures(object):
             return self.eps[aid, [self.eid2idx[eid] for eid in eids]]
         return geteps
 
-    def hazard_getter(self, rlzs_assoc, monitor=Monitor()):
+    def hazard_getter(self, monitor=Monitor()):
         """
-        :param rlzs_assoc:
-            :class:`openquake.commonlib.source.RlzsAssoc` instance
         :param monitor:
             a :class:`openquake.baselib.performance.Monitor` instance
         :returns:
             lists of N hazard dictionaries imt -> rlz -> Gmvs
         """
-        grp_id = self.ses_ruptures[0].grp_id
-        gsims = [dic[self.trt] for dic in rlzs_assoc.gsim_by_trt]
-        gg = GmfGetter(gsims, self.ses_ruptures, self.sitecol,
+        gg = GmfGetter(self.gsims, self.ses_ruptures, self.sitecol,
                        self.imts, self.min_iml, self.trunc_level,
-                       self.correl_model, rlzs_assoc.samples[grp_id])
+                       self.correl_model, self.samples)
         return gg
 
     def __repr__(self):

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -341,14 +341,15 @@ class CompositeRiskModel(collections.Mapping):
     def __len__(self):
         return len(self._riskmodels)
 
-    def build_input(self, hazards_by_site, assetcol, eps_dict):
+    def build_input(self, rlzs, hazards_by_site, assetcol, eps_dict):
         """
+        :param rlzs: a list of realizations
         :param hazards_by_site: an array of hazards per each site
         :param assetcol: AssetCollection instance
         :param eps_dict: a dictionary of epsilons
         :returns: a :class:`RiskInput` instance
         """
-        return RiskInput(hazards_by_site, assetcol, eps_dict)
+        return RiskInput(rlzs, hazards_by_site, assetcol, eps_dict)
 
     def build_inputs_from_ruptures(
             self, grp_trt, rlzs_assoc, imts, sitecol, all_ruptures,
@@ -509,12 +510,14 @@ class RiskInput(object):
     Contains all the assets and hazard values associated to a given
     imt and site.
 
+    :param rlzs: the realizations
     :param imt_taxonomies: a pair (IMT, taxonomies)
     :param hazard_by_site: array of hazards, one per site
     :param assets_by_site: array of assets, one per site
     :param eps_dict: dictionary of epsilons
     """
-    def __init__(self, hazard_by_site, assets_by_site, eps_dict):
+    def __init__(self, rlzs, hazard_by_site, assets_by_site, eps_dict):
+        self.rlzs = rlzs
         self.hazard_by_site = hazard_by_site
         self.assets_by_site = assets_by_site
         self.eps = eps_dict


### PR DESCRIPTION
I am removing the argument `rlzs_assoc` from the tasks, since it is not used anymore after the changes in  https://github.com/gem/oq-engine/pull/2272. The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2282/