### PR TITLE
Renamed trt->grp when needed

### DIFF
--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -65,7 +65,7 @@ class Print(object):
 
 class InfoTestCase(unittest.TestCase):
     EXPECTED = '''<CompositionInfo
-b1, x15.xml, trt=[0], weight=1.00: 1 realization(s)>
+b1, x15.xml, grp=[0], weight=1.00: 1 realization(s)>
 See https://github.com/gem/oq-risklib/blob/master/doc/effective-realizations.rst for an explanation
 <RlzsAssoc(size=1, rlzs=1)
 0,AkkarBommer2010(): ['<0,b1~@_AkkarBommer2010_@_@_@_@_@,w=1.0>']>

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -454,7 +454,7 @@ class EBRupture(object):
         """
         tags = []
         for (eid, ses, occ, sampleid) in self.events:
-            tag = 'trt=%02d~ses=%04d~src=%s~rup=%d-%02d' % (
+            tag = 'grp=%02d~ses=%04d~src=%s~rup=%d-%02d' % (
                 self.grp_id, ses, self.source_id, self.serial, occ)
             if sampleid > 0:
                 tag += '~sample=%d' % sampleid

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -511,7 +511,7 @@ class CompositionInfo(object):
                 [sg.id for sg in sm.src_groups],
                 sm.weight,
                 self.get_num_rlzs(sm))
-        summary = ['%s, %s, trt=%s, weight=%s: %d realization(s)' % ibm
+        summary = ['%s, %s, grp=%s, weight=%s: %d realization(s)' % ibm
                    for ibm in info_by_model.values()]
         return '<%s\n%s>' % (
             self.__class__.__name__, '\n'.join(summary))

--- a/openquake/commonlib/util.py
+++ b/openquake/commonlib/util.py
@@ -135,7 +135,7 @@ def get_assets(dstore):
 
 def get_ses_idx(etag):
     """
-    >>> get_ses_idx("trt=00~ses=0007~src=1-3~rup=018-01")
+    >>> get_ses_idx("grp=00~ses=0007~src=1-3~rup=018-01")
     7
     """
     return int(decode(etag).split('~')[1][4:])
@@ -143,7 +143,7 @@ def get_ses_idx(etag):
 
 def get_serial(etag):
     """
-    >>> print(get_serial("trt=00~ses=0007~src=1-3~rup=018-01"))
+    >>> print(get_serial("grp=00~ses=0007~src=1-3~rup=018-01"))
     018
     """
     trt, ses, src, rup = decode(etag).split('~')

--- a/openquake/qa_tests_data/event_based/case_17/expected/ses.xml
+++ b/openquake/qa_tests_data/event_based/case_17/expected/ses.xml
@@ -10,7 +10,7 @@ xmlns:gml="http://www.opengis.net/gml"
         >
             <rupture
             dip="90.0"
-            id="trt=01~ses=0001~src=2~rup=44-01"
+            id="grp=01~ses=0001~src=2~rup=44-01"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -25,7 +25,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0001~src=2~rup=44-02"
+            id="grp=01~ses=0001~src=2~rup=44-02"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -40,7 +40,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0001~src=2~rup=45-01"
+            id="grp=01~ses=0001~src=2~rup=45-01"
             magnitude="6.05"
             rake="0.0"
             strike="0.0"
@@ -55,7 +55,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0001~src=2~rup=46-01"
+            id="grp=01~ses=0001~src=2~rup=46-01"
             magnitude="6.3"
             rake="0.0"
             strike="0.0"
@@ -70,7 +70,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0001~src=2~rup=46-01~sample=1"
+            id="grp=01~ses=0001~src=2~rup=46-01~sample=1"
             magnitude="6.3"
             rake="0.0"
             strike="0.0"
@@ -85,7 +85,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0001~src=2~rup=46-02~sample=1"
+            id="grp=01~ses=0001~src=2~rup=46-02~sample=1"
             magnitude="6.3"
             rake="0.0"
             strike="0.0"
@@ -105,7 +105,7 @@ xmlns:gml="http://www.opengis.net/gml"
         >
             <rupture
             dip="90.0"
-            id="trt=01~ses=0002~src=2~rup=44-01"
+            id="grp=01~ses=0002~src=2~rup=44-01"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -120,7 +120,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0002~src=2~rup=44-01~sample=2"
+            id="grp=01~ses=0002~src=2~rup=44-01~sample=2"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -135,7 +135,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0002~src=2~rup=44-01~sample=3"
+            id="grp=01~ses=0002~src=2~rup=44-01~sample=3"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -150,7 +150,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0002~src=2~rup=44-02~sample=3"
+            id="grp=01~ses=0002~src=2~rup=44-02~sample=3"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -165,7 +165,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0002~src=2~rup=45-01"
+            id="grp=01~ses=0002~src=2~rup=45-01"
             magnitude="6.05"
             rake="0.0"
             strike="0.0"
@@ -180,7 +180,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0002~src=2~rup=45-01~sample=1"
+            id="grp=01~ses=0002~src=2~rup=45-01~sample=1"
             magnitude="6.05"
             rake="0.0"
             strike="0.0"
@@ -195,7 +195,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0002~src=2~rup=45-02~sample=1"
+            id="grp=01~ses=0002~src=2~rup=45-02~sample=1"
             magnitude="6.05"
             rake="0.0"
             strike="0.0"
@@ -210,7 +210,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0002~src=2~rup=46-01~sample=3"
+            id="grp=01~ses=0002~src=2~rup=46-01~sample=3"
             magnitude="6.3"
             rake="0.0"
             strike="0.0"
@@ -230,7 +230,7 @@ xmlns:gml="http://www.opengis.net/gml"
         >
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=44-01"
+            id="grp=01~ses=0003~src=2~rup=44-01"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -245,7 +245,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=44-01~sample=2"
+            id="grp=01~ses=0003~src=2~rup=44-01~sample=2"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -260,7 +260,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=44-01~sample=3"
+            id="grp=01~ses=0003~src=2~rup=44-01~sample=3"
             magnitude="5.8"
             rake="0.0"
             strike="0.0"
@@ -275,7 +275,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=45-01~sample=1"
+            id="grp=01~ses=0003~src=2~rup=45-01~sample=1"
             magnitude="6.05"
             rake="0.0"
             strike="0.0"
@@ -290,7 +290,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=45-01~sample=3"
+            id="grp=01~ses=0003~src=2~rup=45-01~sample=3"
             magnitude="6.05"
             rake="0.0"
             strike="0.0"
@@ -305,7 +305,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=46-01"
+            id="grp=01~ses=0003~src=2~rup=46-01"
             magnitude="6.3"
             rake="0.0"
             strike="0.0"
@@ -320,7 +320,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=46-01~sample=2"
+            id="grp=01~ses=0003~src=2~rup=46-01~sample=2"
             magnitude="6.3"
             rake="0.0"
             strike="0.0"
@@ -335,7 +335,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=46-01~sample=3"
+            id="grp=01~ses=0003~src=2~rup=46-01~sample=3"
             magnitude="6.3"
             rake="0.0"
             strike="0.0"
@@ -350,7 +350,7 @@ xmlns:gml="http://www.opengis.net/gml"
             </rupture>
             <rupture
             dip="90.0"
-            id="trt=01~ses=0003~src=2~rup=46-02~sample=3"
+            id="grp=01~ses=0003~src=2~rup=46-02~sample=3"
             magnitude="6.3"
             rake="0.0"
             strike="0.0"


### PR DESCRIPTION
Catarina discovered that the SES exporter was still using `trt` instead of `grp`, thus being inconsistent with the other exporters.
