### PR TITLE
Some fixes to the ucerf calculators

### DIFF
--- a/openquake/calculators/ucerf_risk.py
+++ b/openquake/calculators/ucerf_risk.py
@@ -102,7 +102,8 @@ def compute_losses(ssm, sitecol, assetcol, riskmodel,
     """
     [grp] = ssm.src_groups
     res = List()
-    res.ruptures_by_grp = compute_ruptures(grp, sitecol, None, monitor)
+    gsims = ssm.gsim_lt.values[DEFAULT_TRT]
+    res.ruptures_by_grp = compute_ruptures(grp, sitecol, gsims, monitor)
     [(grp_id, ruptures)] = res.ruptures_by_grp.items()
     rlzs_assoc = ssm.info.get_rlzs_assoc()
     num_rlzs = len(rlzs_assoc.realizations)
@@ -118,15 +119,6 @@ def compute_losses(ssm, sitecol, assetcol, riskmodel,
 
 
 @base.calculators.add('ucerf_risk')
-class UCERFRiskCalculator(EbriskCalculator):
-    """
-    Event based risk calculator for UCERF, parallelizing on the source models
-    """
-    pre_execute = UCERFEventBasedCalculator.__dict__['pre_execute']
-    compute_ruptures = staticmethod(compute_ruptures)
-
-
-@base.calculators.add('ucerf_risk_fast')
 class UCERFRiskFastCalculator(EbriskCalculator):
     """
     Event based risk calculator for UCERF, parallelizing on the source models

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -628,7 +628,10 @@ def export_gmf(ekey, dstore):
                 continue
             etags = build_etags(events, [key])
         for rlz in rlzs:
-            gmf_arr = gmf_data['%04d' % rlz.ordinal].value
+            try:
+                gmf_arr = gmf_data['%04d' % rlz.ordinal].value
+            except KeyError:  # there could be realizations with no data
+                continue
             ruptures = []
             for eid, gmfa in group_array(gmf_arr, 'eid').items():
                 rup = util.Rupture(etags[eid], sorted(set(gmfa['sid'])))

--- a/openquake/qa_tests_data/ucerf/job_ebr.ini
+++ b/openquake/qa_tests_data/ucerf/job_ebr.ini
@@ -1,6 +1,6 @@
 [general]
 description = Ucerf Event Based Risk Fast
-calculation_mode = ucerf_risk_fast
+calculation_mode = ucerf_risk
 random_seed = 1066
 
 [logic_tree]


### PR DESCRIPTION
And a fix to the GMF exporter. It is right to have no data from some realization, and this happens in an ucerf test with this error discovered by Daniele:

```python
  File "/home/michele/oq-engine/openquake/commonlib/export/hazard.py", line 631, in export_gmf
    gmf_arr = gmf_data['%04d' % rlz.ordinal].value
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/build/h5py-nQFNYZ/h5py-2.6.0/h5py/_objects.c:2577)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/build/h5py-nQFNYZ/h5py-2.6.0/h5py/_objects.c:2536)
  File "/usr/lib/python2.7/dist-packages/h5py/_hl/group.py", line 166, in __getitem__
    oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/build/h5py-nQFNYZ/h5py-2.6.0/h5py/_objects.c:2577)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/build/h5py-nQFNYZ/h5py-2.6.0/h5py/_objects.c:2536)
  File "h5py/h5o.pyx", line 190, in h5py.h5o.open (/build/h5py-nQFNYZ/h5py-2.6.0/h5py/h5o.c:3407)
KeyError: "Unable to open object (Object '0000' doesn't exist)"
```

I am also renaming `ucerf_risk_fast -> ucerf_risk` and removing the unused calculator `ucerf_risk`