### PR TITLE
Fixed the management of negative calculation IDs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the management of negative calculation IDs
   * Relaxed the tolerance so that the tests pass on Mac OS X
   * Implemented csv exporter for the ruptures
   * Optimized the epsilon generation in the ebrisk calculator for

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -115,7 +115,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
         os.makedirs(datastore.DATADIR)
 
     dbserver.ensure_on()
-    
+
     if upgrade_db:
         logs.set_level('info')
         msg = logs.dbcmd('what_if_I_upgrade', 'read_scripts')

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -130,11 +130,11 @@ def get_job_id(db, job_id, username):
     if job_id > 0:
         return job_id
     joblist = db('SELECT id FROM job WHERE user_name=?x '
-                 'ORDER BY id DESC LIMIT 1', username)
+                 'ORDER BY id DESC LIMIT ?x', username, - job_id)
     if not joblist:  # no jobs
         return
     else:
-        return joblist[0].id
+        return joblist[-1].id
 
 
 def get_calc_id(db, datadir, job_id=None):


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2323. I am not adding a test since this is a undocumented convenience with an easy workaround, should it break. It is not worth the effort of adding an automatic test. Closes https://github.com/gem/oq-engine/issues/2323.