### PR TITLE
Make sure all tests data is included in the py package 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include README.md LICENSE CONTRIBUTORS.txt
 recursive-include openquake/server/db *.sql
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf
 
-recursive-include openquake/*/tests *.*
-recursive-include openquake/qa_tests_data *.*
+recursive-include openquake/*/tests *.* README
+recursive-include openquake/qa_tests_data *.* README
 
 recursive-include openquake/commonlib/nrml_examples *.xml *.csv *.geojson

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,8 +4,7 @@ include README.md LICENSE CONTRIBUTORS.txt
 recursive-include openquake/server/db *.sql
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf
 
-recursive-include openquake/*/tests *.xml *.csv
-recursive-include openquake/*/tests/data *.*
+recursive-include openquake/*/tests *.*
 recursive-include openquake/qa_tests_data *.*
 
 recursive-include openquake/commonlib/nrml_examples *.xml *.csv *.geojson

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+  [Daniele Viganò]
+  * MANIFEST now includes all files, with any extension located in the
+    tests folders. It is now possible to run tests from an installation
+    made with packages
+
   [Michele Simionato]
   * Improved error message when the user gives a source model file instead of
     a source model logic tree file


### PR DESCRIPTION
This PR simplifies the MANIFEST and all the extensions under tests/ will be included

Add also "README" to include some missing files in qa_test and to be aligned with hazardlib

https://ci.openquake.org/job/zdevel_mac_oq-engine/33/console (this run uses pip pkgs)