### PR TITLE
Reduce the data transfer in ruptures in UCERF calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
   * Added an `ucerf_rupture` calculator able to store seismic events and
-  rupture data and reduced the data transfer
+    rupture data and reduced the data transfer
 
   [Daniele Viganò]
   * MANIFEST now includes all files, with any extension located in the

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Added an `ucerf_rupture` calculator able to store seismic events and rupture data
+
   [Daniele Viganò]
   * MANIFEST now includes all files, with any extension located in the
     tests folders. It is now possible to run tests from an installation

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Added an `ucerf_rupture` calculator able to store seismic events and rupture data
+  * Added an `ucerf_rupture` calculator able to store seismic events and
+  rupture data and reduced the data transfer
 
   [Daniele Viganò]
   * MANIFEST now includes all files, with any extension located in the

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -229,7 +229,7 @@ class EventBasedRuptureCalculator(PSHACalculator):
                                event['ses'],
                                event['occ'],
                                event['sample'],
-                               ebr.grp_id,
+                               grp_id,
                                ebr.source_id)
                         events.append(rec)
                         self.eid[sm_id] += 1

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -120,8 +120,6 @@ class ReportWriter(object):
         if 'events' in ds:
             self.add('ruptures_events')
         if oq.calculation_mode in ('event_based_risk',):
-            if 'events' in ds:
-                self.add('biggest_ebr_gmf')
             self.add('avglosses_data_transfer')
         if 'exposure' in oq.inputs:
             self.add('exposure_info')

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -662,7 +662,7 @@ def _copy_grp(src_group, grp_id, branch_name, branch_id):
 
 
 @base.calculators.add('ucerf_rupture')
-class UCERFEventBasedCalculator(event_based.EventBasedRuptureCalculator):
+class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
     """
     Event based PSHA calculator generating the ruptures only
     """
@@ -787,7 +787,11 @@ def compute_ruptures(sources, sitecol, gsims, monitor):
 
 def compute_events(sources, sitecol, gsims, monitor):
     """
-    Returns reduced information about the ruptures
+    :param sources: a sequence of UCERF sources
+    :param sitecol: a SiteCollection instance
+    :param gsims: a list of GSIMs
+    :param monitor: a Monitor instance
+    :returns: an AccumDict grp_id -> EBRs
     """
     ruptures_by_grp = compute_ruptures(sources, sitecol, gsims, monitor)
     for grp_id in ruptures_by_grp:
@@ -840,12 +844,12 @@ class UCERFRiskCalculator(EbriskCalculator):
     """
     Event based risk calculator for UCERF, parallelizing on the source models
     """
-    pre_execute = UCERFEventBasedCalculator.__dict__['pre_execute']
+    pre_execute = UCERFRuptureCalculator.__dict__['pre_execute']
 
     def execute(self):
         num_rlzs = len(self.rlzs_assoc.realizations)
         self.grp_trt = {
-            i: DEFAULT_TRT for i in range(len(self.csm.source_models))}
+            sm.ordinal: DEFAULT_TRT for sm in self.csm.source_models}
         allres = parallel.starmap(compute_losses, self.gen_args()).submit_all()
         num_events = self.save_results(allres, num_rlzs)
         self.save_data_transfer(allres)

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -825,17 +825,20 @@ def compute_losses(ssm, sitecol, assetcol, riskmodel,
     res = List()
     gsims = ssm.gsim_lt.values[DEFAULT_TRT]
     res.ruptures_by_grp = compute_ruptures(grp, sitecol, gsims, monitor)
-    [(grp_id, ruptures)] = res.ruptures_by_grp.items()
+    [(grp_id, ebruptures)] = res.ruptures_by_grp.items()
     rlzs_assoc = ssm.info.get_rlzs_assoc()
     num_rlzs = len(rlzs_assoc.realizations)
     ri = riskinput.RiskInputFromRuptures(
-        DEFAULT_TRT, rlzs_assoc, imts, sitecol, ruptures, trunc_level,
+        DEFAULT_TRT, rlzs_assoc, imts, sitecol, ebruptures, trunc_level,
         correl_model, min_iml)
     res.append(losses_by_taxonomy(ri, riskmodel, assetcol, monitor))
     res.sm_id = ssm.sm_id
     res.num_events = len(ri.eids)
     start = res.sm_id * num_rlzs
     res.rlz_slice = slice(start, start + num_rlzs)
+    # don't return back the ruptures, only the events and rup_data
+    res.ruptures_by_grp[grp_id] = [EBR(ebr.serial, ebr.source_id, ebr.events)
+                                   for ebr in ebruptures]
     return res
 
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -515,42 +515,9 @@ def view_assetcol(token, dstore):
     return write_csv(io.StringIO(), [header] + list(zip(*columns)))
 
 
-def get_max_gmf_size(dstore):
-    """
-    Upper limit for the size of the GMFs
-    """
-    oq = dstore['oqparam']
-    n_imts = len(oq.imtls)
-    rlzs_by_grp_id = dstore['csm_info'].get_rlzs_assoc().get_rlzs_by_grp_id()
-    n_ruptures = collections.Counter()
-    size = collections.Counter()  # by grp_id
-    for serial in dstore['ruptures']:
-        ebr = dstore['ruptures/' + serial]
-        grp_id = ebr.grp_id
-        n_ruptures[grp_id] += 1
-        # there are 4 bytes per float
-        size[grp_id] += (len(ebr.sids) * ebr.multiplicity *
-                         len(rlzs_by_grp_id[grp_id]) * n_imts) * 4
-    [(grp_id, maxsize)] = size.most_common(1)
-    return dict(n_imts=n_imts, size=maxsize, n_ruptures=n_ruptures[grp_id],
-                n_rlzs=len(rlzs_by_grp_id[grp_id]),
-                grp_id=grp_id, humansize=humansize(maxsize))
-
-
-@view.add('biggest_ebr_gmf')
-def view_biggest_ebr_gmf(token, dstore):
-    """
-    Returns the size of the biggest GMF in an event based risk calculation
-    """
-    msg = ('The largest GMF block is for src_group_id=%(grp_id)d, '
-           'contains %(n_imts)d IMT(s), %(n_rlzs)d '
-           'realization(s)\nand has a size of %(humansize)s / num_tasks')
-    return msg % get_max_gmf_size(dstore)
-
-
 @view.add('ruptures_events')
 def view_ruptures_events(token, dstore):
-    num_ruptures = len(dstore['ruptures'])
+    num_ruptures = sum(len(v) for v in dstore['rup_data'].values())
     num_events = len(dstore['events'])
     mult = round(num_events / num_ruptures, 3)
     lst = [('Total number of ruptures', num_ruptures),


### PR DESCRIPTION
We need to store information about seismic events and some rupture data, however at the moment we return back from the workers the ruptures, which are a lot more than needed. By reducing the data transfer we can save an order of magnitude in memory and reduce by half the runtime. Here is an example run on gemmicro02:

```
master
Received 83.34 GB of data
Calculation 62 finished correctly in 4790 seconds
```

versus

```
this branch
Received 5.83 GB of data
Calculation 63 finished correctly in 2278 seconds
```

The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2287