### PR TITLE
Fixed excessive strictness when validating `consequenceFunction.id`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed excessive strictness when validating `consequenceFunction.id`
   * Added an `ucerf_rupture` calculator able to store seismic events and
     rupture data and reduced the data transfer
 

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -213,14 +213,14 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
         dskey, calc_id, datadir = logs.dbcmd('get_output', int(output_id))
         for line in core.export_output(
                 dskey, calc_id, datadir, os.path.expanduser(target_dir),
-                exports or 'xml,csv'):
+                exports or 'csv,xml'):
             print(line)
 
     elif export_outputs is not None:
         job_id, target_dir = export_outputs
         hc_id = get_job_id(job_id)
         for line in core.export_outputs(
-                hc_id, os.path.expanduser(target_dir), exports or 'xml,csv'):
+                hc_id, os.path.expanduser(target_dir), exports or 'csv,xml'):
             print(line)
 
     elif delete_uncompleted_calculations:

--- a/openquake/commonlib/nrml.py
+++ b/openquake/commonlib/nrml.py
@@ -521,6 +521,7 @@ validators = {
     'magnitudes': valid.positivefloats,
     'fragilityFunction.id': valid.utf8,  # taxonomy
     'vulnerabilityFunction.id': valid.utf8,  # taxonomy
+    'consequenceFunction.id': valid.utf8,  # taxonomy
     'id': valid.simple_id,
     'rupture.id': valid.utf8,  # event tag
     'discretization': valid.compose(valid.positivefloat, valid.nonzero),

--- a/openquake/qa_tests_data/scenario_damage/case_1h/consequence_model.xml
+++ b/openquake/qa_tests_data/scenario_damage/case_1h/consequence_model.xml
@@ -6,7 +6,7 @@
   <description>ln cf | tax1 | zcov</description>
   <limitStates>ds1 ds2 ds3 ds4</limitStates>
 
-  <consequenceFunction id="tax1" dist="LN">
+  <consequenceFunction id="tax1+" dist="LN">
     <params ls="ds1" mean="0.04" stddev="0.00"/>
     <params ls="ds2" mean="0.16" stddev="0.00"/>
     <params ls="ds3" mean="0.32" stddev="0.00"/>

--- a/openquake/qa_tests_data/scenario_damage/case_1h/expected/csq_by_asset.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_1h/expected/csq_by_asset.csv
@@ -1,2 +1,2 @@
 asset_ref,taxonomy,lon,lat,structural~mean,structural~stddev
-a1,"tax1",-122.00000,38.11300,2.26318E+03,1.43303E+03
+a1,"tax1+",-122.00000,38.11300,2.26318E+03,1.43303E+03

--- a/openquake/qa_tests_data/scenario_damage/case_1h/expected/csq_by_taxon.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_1h/expected/csq_by_taxon.csv
@@ -1,2 +1,2 @@
 taxonomy,structural~mean,structural~stddev
-"tax1",2.26318E+03,1.43303E+03
+"tax1+",2.26318E+03,1.43303E+03

--- a/openquake/qa_tests_data/scenario_damage/case_1h/exposure_model.xml
+++ b/openquake/qa_tests_data/scenario_damage/case_1h/exposure_model.xml
@@ -14,7 +14,7 @@
     </costTypes>
   </conversions>
   <assets>
-    <asset id="a1" number="1" area="100" taxonomy="tax1" >
+    <asset id="a1" number="1" area="100" taxonomy="tax1+" >
       <location lon="-122.000" lat="38.113" />
       <costs>
         <cost type="structural" value="10000" />

--- a/openquake/qa_tests_data/scenario_damage/case_1h/fragility_model.xml
+++ b/openquake/qa_tests_data/scenario_damage/case_1h/fragility_model.xml
@@ -16,7 +16,7 @@ xmlns:gml="http://www.opengis.net/gml"
         </limitStates>
         <fragilityFunction
         format="continuous"
-        id="tax1"
+        id="tax1+"
         shape="logncdf"
         >
             <imls imt="PGA" maxIML="5.0" minIML="0.0" noDamageLimit="0"/>


### PR DESCRIPTION
Catalina reported this bug:

```
ValueError: node consequenceFunction: Could not convert id->SimpleId(100, ^[\w_\-]+$): Invalid ID 'CR+PCPS/LFM': the only accepted chars are a-zA-Z0-9_-, line 9, line 9 of /home/cyepes/colombia/consequence_model.xml
```

The solution is to relax the check on `consequenceFunction.id`.
Moreover, at Catalina's request, I am changing the default export format from 'xml,csv' to 'csv,xml' i.e. try the CSV export first, the XML export later.