### PR TITLE
The source ID were silently truncated to 30 characters

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Lowered the limit on the length of source IDs to 60 chars
   * Fixed excessive strictness when validating `consequenceFunction.id`
   * Added an `ucerf_rupture` calculator able to store seismic events and
     rupture data and reduced the data transfer

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -31,6 +31,7 @@ from openquake.hazardlib import geo, tom
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.commonlib import readinput, oqvalidation, util
+from openquake.risklib import valid
 
 
 MAX_INT = 2 ** 31 - 1  # this is used in the random number generator
@@ -47,7 +48,8 @@ event_dt = numpy.dtype([('eid', U32), ('ses', U32), ('occ', U32),
                         ('sample', U32)])
 stored_event_dt = numpy.dtype([
     ('rupserial', U32), ('ses', U32), ('occ', U32),
-    ('sample', U32), ('grp_id', U16), ('source_id', 'S30')])
+    ('sample', U32), ('grp_id', U16),
+    ('source_id', 'S%d' % valid.MAX_ID_LENGTH)])
 
 # ############## utilities for the classical calculator ############### #
 

--- a/openquake/risklib/valid.py
+++ b/openquake/risklib/valid.py
@@ -215,7 +215,7 @@ class SimpleId(object):
         raise ValueError(
             "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-" % value)
 
-MAX_ID_LENGTH = 50
+MAX_ID_LENGTH = 60
 ASSET_ID_LENGTH = 100
 
 simple_id = SimpleId(MAX_ID_LENGTH)

--- a/openquake/risklib/valid.py
+++ b/openquake/risklib/valid.py
@@ -215,7 +215,7 @@ class SimpleId(object):
         raise ValueError(
             "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-" % value)
 
-MAX_ID_LENGTH = 100
+MAX_ID_LENGTH = 50
 ASSET_ID_LENGTH = 100
 
 simple_id = SimpleId(MAX_ID_LENGTH)


### PR DESCRIPTION
I have raised the limit to 60 characters: if a source model contains a source ID longer than the limit a clear error message is displayed, including the number of the line in the source model where the offending ID is.
The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2288