### PR TITLE
Restored the CSV exporters for the GMFs - event_based

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a CSV exporter for the GMFs in the event based calculator
   * Added a CSV exporter for the rup_data output
   * Added a CSV exporter for the disaggregation output
   * Stored the disaggregation matrices directly (no pickle)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -342,9 +342,12 @@ def compute_gmfs_and_curves(getter, rlzs, monitor):
                 for imti, imt in enumerate(getter.imts):
                     if oq.hazard_curves_from_gmfs:
                         try:
-                            haz[sid][imt, rlz] = gmvdict[imt]
+                            gmv = gmvdict[imt]
                         except KeyError:
+                            # no gmv for the given imt, this may happen
                             pass
+                        else:
+                            haz[sid][imt, rlz] = gmv
                     for rec in gmvdict.get(imt, []):
                         gmfcoll[rlz].append(
                             (sid, rec['eid'], imti, rec['gmv']))

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -341,8 +341,11 @@ def compute_gmfs_and_curves(getter, rlzs, monitor):
             if gmvdict:
                 for imti, imt in enumerate(getter.imts):
                     if oq.hazard_curves_from_gmfs:
-                        haz[sid][imt, rlz] = gmvdict[imt]
-                    for rec in gmvdict[imt]:
+                        try:
+                            haz[sid][imt, rlz] = gmvdict[imt]
+                        except KeyError:
+                            pass
+                    for rec in gmvdict.get(imt, []):
                         gmfcoll[rlz].append(
                             (sid, rec['eid'], imti, rec['gmv']))
     for rlz in gmfcoll:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -501,6 +501,10 @@ class EventBasedCalculator(ClassicalCalculator):
         if ('gmf_data' in self.datastore and 'nbytes' not
                 in self.datastore['gmf_data'].attrs):
             self.datastore.set_nbytes('gmf_data')
+            for sm_id in self.datastore['gmf_data']:
+                for rlzno in self.datastore['gmf_data/' + sm_id]:
+                    self.datastore.set_nbytes(
+                        'gmf_data/%s/%s' % (sm_id, rlzno))
 
         if oq.compare_with_classical:  # compute classical curves
             export_dir = os.path.join(oq.export_dir, 'cl')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -389,7 +389,8 @@ class EventBasedCalculator(ClassicalCalculator):
             with sav_mon:
                 for rlz, array in res['gmfcoll'].items():
                     if len(array):
-                        key = 'gmf_data/%04d' % rlz.ordinal
+                        sm_id = self.sm_id[rlz.sm_lt_path]
+                        key = 'gmf_data/sm-%04d/%04d' % (sm_id, rlz.ordinal)
                         self.datastore.extend(key, array)
         slicedic = self.oqparam.imtls.slicedic
         with agg_mon:
@@ -451,7 +452,8 @@ class EventBasedCalculator(ClassicalCalculator):
         self.sesruptures.sort(key=operator.attrgetter('serial'))
         if self.oqparam.ground_motion_fields:
             calc.check_overflow(self)
-
+        self.sm_id = {sm.path: sm.ordinal
+                      for sm in self.csm.info.source_models}
         L = len(oq.imtls.array)
         res = parallel.starmap(
             self.core_task.__func__, self.gen_args(self.sesruptures)

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -92,7 +92,7 @@ class ScenarioCalculator(base.HazardCalculator):
         """
         with self.monitor('saving gmfs', autoflush=True):
             for rlzi, gsim in enumerate(self.gsims):
-                rlzstr = 'gmf_data/%04d' % rlzi
+                rlzstr = 'gmf_data/sm-0000/%04d' % rlzi
                 self.datastore[rlzstr] = gmfa_by_rlzi[rlzi]
                 self.datastore.set_attrs(rlzstr, gsim=str(gsim))
             self.datastore.set_nbytes('gmf_data')

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -90,7 +90,7 @@ class EventBasedTestCase(CalculatorTestCase):
             oq = self.calc.oqparam
             self.assertEqual(list(oq.imtls), ['PGA'])
             dstore = read(self.calc.datastore.calc_id)
-            gmf = group_array(dstore['gmf_data/0000'], 'sid')
+            gmf = group_array(dstore['gmf_data/sm-0000/0000'], 'sid')
             gmvs_site_0 = gmf[0]['gmv']
             gmvs_site_1 = gmf[1]['gmv']
             joint_prob_0_5 = joint_prob_of_occurrence(

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -128,7 +128,7 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles(
             'expected/0-SadighEtAl1997.txt', fname, sorted)
 
-        [fname] = out['hcurves', 'csv']
+        [fname] = export(('hcurves', 'csv'), self.calc.datastore)
         self.assertEqualFiles(
             'expected/hazard_curve-smltp_b1-gsimltp_b1.csv', fname)
 

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -90,7 +90,7 @@ class EventBasedTestCase(CalculatorTestCase):
             oq = self.calc.oqparam
             self.assertEqual(list(oq.imtls), ['PGA'])
             dstore = read(self.calc.datastore.calc_id)
-            gmf = group_array(dstore['gmf_data/sm-0000/0000'], 'sid')
+            gmf = group_array(dstore['gmf_data/0000'], 'sid')
             gmvs_site_0 = gmf[0]['gmv']
             gmvs_site_1 = gmf[1]['gmv']
             joint_prob_0_5 = joint_prob_of_occurrence(
@@ -127,6 +127,10 @@ class EventBasedTestCase(CalculatorTestCase):
         [fname] = out['gmf_data', 'txt']
         self.assertEqualFiles(
             'expected/0-SadighEtAl1997.txt', fname, sorted)
+
+        [fname] = out['hcurves', 'csv']
+        self.assertEqualFiles(
+            'expected/hazard_curve-smltp_b1-gsimltp_b1.csv', fname)
 
         [fname] = export(('gmf_data:0', 'csv'), self.calc.datastore)
         self.assertEqualFiles(

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -122,15 +122,15 @@ class EventBasedTestCase(CalculatorTestCase):
 
     @attr('qa', 'hazard', 'event_based')
     def test_case_1(self):
-        out = self.run_calc(case_1.__file__, 'job.ini', exports='csv,txt,xml')
+        out = self.run_calc(case_1.__file__, 'job.ini', exports='txt,xml')
 
         [fname] = out['gmf_data', 'txt']
         self.assertEqualFiles(
             'expected/0-SadighEtAl1997.txt', fname, sorted)
 
-        [fname] = out['hcurves', 'csv']
+        [fname] = export(('gmf_data:0', 'csv'), self.calc.datastore)
         self.assertEqualFiles(
-            'expected/hazard_curve-smltp_b1-gsimltp_b1.csv', fname)
+            'expected/gmf-grp=00~ses=0002~src=1~rup=1-01-rlz-000.csv', fname)
 
         [fname] = out['hcurves', 'xml']
         self.assertEqualFiles(

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -291,7 +291,7 @@ def get_gmfs(dstore, precalc=None):
 
     # else read from the datastore
     for i, rlz in enumerate(rlzs):
-        data = group_array(dstore['gmf_data/%04d' % i], 'sid')
+        data = group_array(dstore['gmf_data/sm-0000/%04d' % i], 'sid')
         for sid, array in data.items():
             if sid in risk_indices:
                 for imti, imt in enumerate(oq.imtls):

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -655,7 +655,7 @@ def export_gmf(ekey, dstore):
             etags = build_etags(events[key])
         for rlz in rlzs:
             try:
-                gmf_arr = gmf_data['%04d' % rlz.ordinal].value
+                gmf_arr = gmf_data['%s/%04d' % (key, rlz.ordinal)].value
             except KeyError:  # no GMFs for the given realization
                 continue
             ruptures = []
@@ -776,7 +776,7 @@ def export_gmf_data_csv(ekey, dstore):
         return writer.getsaved()
     else:  # event based
         rlzs = dstore['csm_info'].get_rlzs_assoc().realizations
-        sitecol = dstore['sitecol']
+        sitecol = dstore['sitecol'].complete
         fnames = []
         imts = list(oq.imtls)
         for sm_id in dstore['gmf_data']:
@@ -796,6 +796,7 @@ def export_gmf_data_csv(ekey, dstore):
                                 oq.investigation_time))
                     fname = dstore.build_fname(
                         'gmf', '%s-rlz-%03d' % (etag[eid], rlz.ordinal), 'csv')
+                    logging.info('Exporting %s', fname)
                     writers.write_csv(fname, data, comment=comment)
                     fnames.append(fname)
         return fnames

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -757,15 +757,15 @@ def get_sm_id_eid(key):
     Extracts sm_id and eid from the export key.
 
     >>> get_sm_id_eid('gmf:1:2')
-    [1, '2']
+    ['1', '2']
     >>> get_sm_id_eid('gmf:3')
-    [0, '3']
+    ['0', '3']
     >>> get_sm_id_eid('gmf')
     [None, None]
     """
     n = key.count(':')
     if n == 1:  # passed the eid, sm_id assumed to be zero
-        return [0, key.split(':')[1]]
+        return ['0', key.split(':')[1]]
     elif n == 2:  # passed both eid and sm_id
         return key.split(':')[1:]
     else:  # eid and sm_id both unspecified, exporting nothing

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -767,7 +767,7 @@ def get_sm_id_eid(key):
     if n == 1:  # passed the eid, sm_id assumed to be zero
         return [0, int(key.split(':')[1])]
     elif n == 2:  # passed both eid and sm_id
-        return map(int, key.split(':')[1:])
+        return [int(k) for k in key.split(':')[1:]]
     else:  # eid and sm_id both unspecified, exporting nothing
         return [None, None]
 

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -757,17 +757,17 @@ def get_sm_id_eid(key):
     Extracts sm_id and eid from the export key.
 
     >>> get_sm_id_eid('gmf:1:2')
-    [1, 2]
+    [1, '2']
     >>> get_sm_id_eid('gmf:3')
-    [0, 3]
+    [0, '3']
     >>> get_sm_id_eid('gmf')
     [None, None]
     """
     n = key.count(':')
     if n == 1:  # passed the eid, sm_id assumed to be zero
-        return [0, int(key.split(':')[1])]
+        return [0, key.split(':')[1]]
     elif n == 2:  # passed both eid and sm_id
-        return [int(k) for k in key.split(':')[1:]]
+        return key.split(':')[1:]
     else:  # eid and sm_id both unspecified, exporting nothing
         return [None, None]
 
@@ -797,10 +797,15 @@ def export_gmf_data_csv(ekey, dstore):
     else:  # event based
         exporter = GmfExporter(dstore)
         sm_id, eid = get_sm_id_eid(ekey[0])
-        if sm_id is None:
+        if eid is None:
+            logging.info('Exporting only the first event')
+            logging.info('Use the command `oq export gmf_data:*:* %d` '
+                         'to export everything', dstore.calc_id)
+            return exporter.export_one(0, 0)
+        elif eid == '*':
             return exporter.export_all()
         else:
-            return exporter.export_one(sm_id, eid)
+            return exporter.export_one(sm_id, int(eid))
 
 
 class GmfExporter(object):

--- a/openquake/commonlib/export/hazard.py
+++ b/openquake/commonlib/export/hazard.py
@@ -805,7 +805,7 @@ def export_gmf_data_csv(ekey, dstore):
         elif eid == '*':
             return exporter.export_all()
         else:
-            return exporter.export_one(sm_id, int(eid))
+            return exporter.export_one(int(sm_id), int(eid))
 
 
 class GmfExporter(object):

--- a/openquake/commonlib/export/risk.py
+++ b/openquake/commonlib/export/risk.py
@@ -245,6 +245,7 @@ def export_ass_losses_ebr(ekey, dstore):
     sm_id, eid = get_sm_id_eid(ekey[0])
     if sm_id is None:
         return []
+    eid = int(eid)
     sm_ids = [sm_id]
     zero = [0, 0] if oq.insured_losses else 0
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)

--- a/openquake/commonlib/export/risk.py
+++ b/openquake/commonlib/export/risk.py
@@ -245,7 +245,7 @@ def export_ass_losses_ebr(ekey, dstore):
     sm_id, eid = get_sm_id_eid(ekey[0])
     if sm_id is None:
         return []
-    eid = int(eid)
+    sm_id, eid = int(sm_id), int(eid)
     sm_ids = [sm_id]
     zero = [0, 0] if oq.insured_losses else 0
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)

--- a/openquake/commonlib/export/risk.py
+++ b/openquake/commonlib/export/risk.py
@@ -24,7 +24,7 @@ import numpy
 from openquake.baselib.general import AccumDict, get_array, group_array
 from openquake.risklib import scientific
 from openquake.commonlib.export import export
-from openquake.commonlib.export.hazard import build_etags
+from openquake.commonlib.export.hazard import build_etags, get_sm_id_eid
 from openquake.commonlib import writers, risk_writers
 from openquake.commonlib.util import get_assets, compose_arrays
 from openquake.commonlib.risk_writers import (
@@ -242,14 +242,10 @@ def export_ass_losses_ebr(ekey, dstore):
               ('aid', U32)] + oq.loss_dt_list()
     elt_dt = numpy.dtype(dtlist)
     rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
-    n = ekey[0].count(':')
-    if n == 1:  # passed the eid, sm_id assumed to be zero
-        sm_ids, eid = (0,), int(ekey[0].split(':')[1])
-    elif n == 2:  # passed both eid and sm_id
-        sm_id, eid = map(int, ekey[0].split(':')[1:])
-        sm_ids = (sm_id,)
-    else:  # eid and sm_id both unspecified, exporting nothing
+    sm_id, eid = get_sm_id_eid(ekey[0])
+    if sm_id is None:
         return []
+    sm_ids = [sm_id]
     zero = [0, 0] if oq.insured_losses else 0
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     for sm_id in sm_ids:

--- a/openquake/qa_tests_data/event_based/case_1/expected/gmf-grp=00~ses=0002~src=1~rup=1-01-rlz-000.csv
+++ b/openquake/qa_tests_data/event_based/case_1/expected/gmf-grp=00~ses=0002~src=1~rup=1-01-rlz-000.csv
@@ -1,0 +1,3 @@
+# smlt_path=b1, gsimlt_path=b1, investigation_time=1.0
+lon,lat,PGA
+0.00000,0.00000,9.349059E-02


### PR DESCRIPTION
Since the GMFs are stored by realization, the exporter can work one realization at the time and it will not run out of memory. However, since we are exporting a file per realization and per seismic event (as required by the specs), we will easily generate million of files. For this reason, by default only the GMFs generated by the first event are exported. It is possible to export the GMFs generated by a different event with the syntax

`oq export gmf_data:<sm_id>:<eid>`

where `sm_id` is the ordinal of the source model (starting from 0) and `eid` is the ordinal of the event (starting from 0) and to export everything with the syntax

`oq export gmf_data:*:*`

This will be ultra-slow, but still faster than the XML export.

The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2296