### PR TITLE
Add missing setuptool wheel

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,8 @@
 # Ubuntu 16.04 stack
 # !! update pip first! so wheels will be used !!
 
-pkgconfig==1.1.0
+setuptools
+pkgconfig
 Cython==0.23.4
 mock==1.3.0
 h5py==2.6.0

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -6,6 +6,7 @@
 # We also provide pre-compiled manylinux1 wheels for
 # h5py, Shapely and Rtree
 
+http://ftp.openquake.org/python-new-wheels/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/pkgconfig-1.1.0-cp27-none-any.whl
 http://ftp.openquake.org/python-new-wheels/Cython-0.23.4-cp27-cp27mu-manylinux1_x86_64.whl
 http://ftp.openquake.org/python-new-wheels/mock-1.3.0-py2.py3-none-any.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -6,6 +6,7 @@
 # We also provide pre-compiled manylinux1 wheels for
 # h5py, Shapely and Rtree
 
+http://ftp.openquake.org/python-new-wheels/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/pkgconfig-1.1.0-py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/Cython-0.23.4-cp35-cp35m-manylinux1_x86_64.whl
 http://ftp.openquake.org/python-new-wheels/mock-1.3.0-py2.py3-none-any.whl


### PR DESCRIPTION
This PR adds a local copy of the `setuptool` wheel which is needed when `--no-index` is used during wheels installation.

```bash
pip install --no-index --force-reinstall --ignore-installed --upgrade --prefix /opt/openquake -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt
Ignoring indexes: https://pypi.python.org/simple
Collecting setuptools==28.8.0 from http://ftp.openquake.org/python-new-wheels/setuptools-28.8.0-py2.py3-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 9))
  Downloading http://ftp.openquake.org/python-new-wheels/setuptools-28.8.0-py2.py3-none-any.whl (472kB)
    100% |################################| 481kB 881kB/s 
Collecting pkgconfig==1.1.0 from http://ftp.openquake.org/python-new-wheels/pkgconfig-1.1.0-cp27-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 10))
  Downloading http://ftp.openquake.org/python-new-wheels/pkgconfig-1.1.0-cp27-none-any.whl
Collecting Cython==0.23.4 from http://ftp.openquake.org/python-new-wheels/Cython-0.23.4-cp27-cp27mu-manylinux1_x86_64.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 11))
  Downloading http://ftp.openquake.org/python-new-wheels/Cython-0.23.4-cp27-cp27mu-manylinux1_x86_64.whl (5.6MB)
    100% |################################| 5.6MB 878kB/s 
Collecting mock==1.3.0 from http://ftp.openquake.org/python-new-wheels/mock-1.3.0-py2.py3-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 12))
  Downloading http://ftp.openquake.org/python-new-wheels/mock-1.3.0-py2.py3-none-any.whl (56kB)
    100% |################################| 61kB 133kB/s 
Collecting h5py==2.6.0 from http://ftp.openquake.org/python-new-wheels/h5py-2.6.0-1-cp27-cp27mu-manylinux1_x86_64.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 13))
  Downloading http://ftp.openquake.org/python-new-wheels/h5py-2.6.0-1-cp27-cp27mu-manylinux1_x86_64.whl (4.0MB)
    100% |################################| 4.0MB 1.9MB/s 
Collecting nose==1.3.7 from http://ftp.openquake.org/python-new-wheels/nose-1.3.7-py2-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 14))
  Downloading http://ftp.openquake.org/python-new-wheels/nose-1.3.7-py2-none-any.whl (154kB)
    100% |################################| 163kB 2.9MB/s 
Collecting numpy==1.11.1 from http://ftp.openquake.org/python-new-wheels/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 15))
  Downloading http://ftp.openquake.org/python-new-wheels/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl (15.3MB)
    100% |################################| 15.3MB 1.4MB/s 
Collecting scipy==0.17.1 from http://ftp.openquake.org/python-new-wheels/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 16))
  Downloading http://ftp.openquake.org/python-new-wheels/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl (39.5MB)
    100% |################################| 39.5MB 6.2MB/s 
Collecting psutil==3.4.2 from http://ftp.openquake.org/python-new-wheels/psutil-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 17))
  Downloading http://ftp.openquake.org/python-new-wheels/psutil-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl (101kB)
    100% |################################| 102kB 1.2MB/s 
Collecting Shapely==1.5.13 from http://ftp.openquake.org/python-new-wheels/Shapely-1.5.13-cp27-cp27mu-manylinux1_x86_64.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 18))
  Downloading http://ftp.openquake.org/python-new-wheels/Shapely-1.5.13-cp27-cp27mu-manylinux1_x86_64.whl (8.3MB)
    100% |################################| 8.3MB 2.3MB/s 
Collecting docutils==0.12 from http://ftp.openquake.org/python-new-wheels/docutils-0.12-cp27-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 19))
  Downloading http://ftp.openquake.org/python-new-wheels/docutils-0.12-cp27-none-any.whl (509kB)
    100% |################################| 512kB 1.5MB/s 
Collecting decorator==4.0.10 from http://ftp.openquake.org/python-new-wheels/decorator-4.0.10-py2.py3-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 20))
  Downloading http://ftp.openquake.org/python-new-wheels/decorator-4.0.10-py2.py3-none-any.whl
Collecting funcsigs==1.0.2 from http://ftp.openquake.org/python-new-wheels/funcsigs-1.0.2-py2.py3-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 21))
  Downloading http://ftp.openquake.org/python-new-wheels/funcsigs-1.0.2-py2.py3-none-any.whl
Collecting pbr==1.8.0 from http://ftp.openquake.org/python-new-wheels/pbr-1.8.0-py2.py3-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 22))
  Downloading http://ftp.openquake.org/python-new-wheels/pbr-1.8.0-py2.py3-none-any.whl (87kB)
    100% |################################| 92kB 2.0MB/s 
Collecting six==1.10.0 from http://ftp.openquake.org/python-new-wheels/six-1.10.0-py2.py3-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 23))
  Downloading http://ftp.openquake.org/python-new-wheels/six-1.10.0-py2.py3-none-any.whl
Collecting futures==3.0.5 from http://ftp.openquake.org/python-new-wheels/futures-3.0.5-py2-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 24))
  Downloading http://ftp.openquake.org/python-new-wheels/futures-3.0.5-py2-none-any.whl
Collecting Django==1.8.7 from http://ftp.openquake.org/python-new-wheels/Django-1.8.7-py2.py3-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 25))
  Downloading http://ftp.openquake.org/python-new-wheels/Django-1.8.7-py2.py3-none-any.whl (6.2MB)
    100% |################################| 6.2MB 3.3MB/s 
Collecting requests==2.9.1 from http://ftp.openquake.org/python-new-wheels/requests-2.9.1-py2.py3-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 26))
  Downloading http://ftp.openquake.org/python-new-wheels/requests-2.9.1-py2.py3-none-any.whl (501kB)
    100% |################################| 501kB 3.2MB/s 
Collecting pyshp==1.2.3 from http://ftp.openquake.org/python-new-wheels/pyshp-1.2.3-cp27-none-any.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 27))
  Downloading http://ftp.openquake.org/python-new-wheels/pyshp-1.2.3-cp27-none-any.whl
Collecting Rtree==0.8.2 from http://ftp.openquake.org/python-new-wheels/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl (from -r https://raw.githubusercontent.com/gem/oq-engine/update-whl/requirements-py27-linux64.txt (line 29))
  Downloading http://ftp.openquake.org/python-new-wheels/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl (1.2MB)
    100% |################################| 1.2MB 65.9MB/s 
Installing collected packages: setuptools, pkgconfig, Cython, pbr, funcsigs, six, mock, numpy, h5py, nose, scipy, psutil, Shapely, docutils, decorator, futures, Django, requests, pyshp, Rtree
Successfully installed Cython Django Rtree Shapely decorator docutils funcsigs futures h5py mock nose numpy pbr pkgconfig psutil pyshp requests scipy setuptools-0.9.8 six
```