### PR TITLE
Rewrite the auth middleware and make compatible with py3

### DIFF
--- a/openquake/server/middleware.py
+++ b/openquake/server/middleware.py
@@ -16,13 +16,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import re
+
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from re import compile
 
-EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
+EXEMPT_URLS = [re.compile(settings.LOGIN_URL.lstrip('/'))]
 if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
-    EXEMPT_URLS += [compile(expr.lstrip('/')) for expr in
+    EXEMPT_URLS += [re.compile(expr.lstrip('/')) for expr in
                     settings.LOGIN_EXEMPT_URLS]
 
 

--- a/openquake/server/middleware.py
+++ b/openquake/server/middleware.py
@@ -17,33 +17,33 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from re import compile
 
-try:
-    reverse_login = reverse('login')
-    white_list_paths = (reverse_login,)
-except:  # caused by nosetests3 openquake/server/ --with-doctest (??)
-    reverse_login = None
-    white_list_paths = ()
+EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
+if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
+    EXEMPT_URLS += [compile(expr.lstrip('/')) for expr in
+                    settings.LOGIN_EXEMPT_URLS]
 
 
-class LoginRequiredMiddleware(object):
+class LoginRequiredMiddleware:
+    """
+    Middleware that requires a user to be authenticated to view any page other
+    than LOGIN_URL. Exemptions to this requirement can be specified in
+    settings via a list of regular expressions in LOGIN_EXEMPT_URLS.
 
-    white_list = map(
-        compile,
-        white_list_paths +
-        getattr(
-            settings,
-            "AUTH_EXEMPT_URLS",
-            ()))
-    redirect_to = reverse_login
+    Requires authentication middleware and template context processors to be
+    loaded. You'll get an error if they aren't.
+    """
 
     def process_request(self, request):
+        assert hasattr(request, 'user'), "The Login Required middleware\
+ requires authentication middleware to be installed. Edit your\
+ MIDDLEWARE_CLASSES setting to insert\
+ 'django.contrib.auth.middlware.AuthenticationMiddleware'. If that doesn't\
+ work, ensure your TEMPLATE_CONTEXT_PROCESSORS setting includes\
+ 'django.core.context_processors.auth'."
         if not request.user.is_authenticated():
-            if not any(path.match(request.path) for path in self.white_list):
-                return HttpResponseRedirect(
-                    '{login_path}?next={request_path}'.format(
-                        login_path=self.redirect_to,
-                        request_path=request.path))
+            path = request.path_info.lstrip('/')
+            if not any(m.match(path) for m in EXEMPT_URLS):
+                return HttpResponseRedirect(settings.LOGIN_URL)

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -183,4 +183,4 @@ if LOCKDOWN:
 
     LOGIN_REDIRECT_URL = '/engine'
 
-    AUTH_EXEMPT_URLS = ('/accounts/ajax_login/', )
+    LOGIN_EXEMPT_URLS = ('/accounts/ajax_login/', )


### PR DESCRIPTION
The previous middleware (an adaption of the one coming from the Platform) was not working with Python 3

Tests: https://ci.openquake.org/job/zdevel_oq-engine/2307/