### PR TITLE
Added a command `oq to_hdf5` to convert .npz files into .hdf5 files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a command `oq to_hdf5` to convert .npz files into .hdf5 files
   * Moved commonlib.parallel into baselib
   * Merged the experimental calculator ebrisk into event_based_risk and
     used correctly the random_seed for generating the GMFs (not the master_seed)

--- a/openquake/commands/to_hdf5.py
+++ b/openquake/commands/to_hdf5.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import numpy
+from openquake.baselib import sap, hdf5
+
+
+def convert_npz_hdf5(input_file, output_file):
+    with hdf5.File(output_file, 'w') as out:
+        with numpy.load(input_file) as inp:
+            for key in inp:
+                out[key] = inp[key]
+    return output_file
+
+
+@sap.Script
+def to_hdf5(input):
+    """
+    Convert .npz files to .hdf5 files.
+    """
+    for input_file in input:
+        if input_file.endswith('.npz'):
+            output = convert_npz_hdf5(input_file, input_file[:-3] + 'hdf5')
+            print('Generated %s' % output)
+
+to_hdf5.arg('input', '.npz file to convert', nargs='*')


### PR DESCRIPTION
While there are libraries to read .npy files from other languages, they are not as mature as the HDF5 libraries. Fortunately it is rather trivial to convert .npz files to .hdf5 files. In particular, the conversion make it possible to explore the outputs with `hdfview`.