### PR TITLE
Force UTF-8 encoding in supervisord

### DIFF
--- a/debian/supervisord/openquake-celery.conf
+++ b/debian/supervisord/openquake-celery.conf
@@ -1,6 +1,6 @@
 [program:openquake-celery]
 priority=998
-environment=LOGNAME=openquake
+environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake
 ## With Celery 3 (Ubuntu >= 14.04)
 command=celery worker --config openquake.engine.celeryconfig --purge -Ofair
 ## With Celery 2 (Ubuntu 12.04)

--- a/debian/supervisord/openquake-dbserver.conf
+++ b/debian/supervisord/openquake-dbserver.conf
@@ -1,6 +1,6 @@
 [program:openquake-dbserver]
 priority=997
-environment=LOGNAME=openquake
+environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake
 directory=/usr/lib/python2.7/dist-packages/openquake/server
 command=python dbserver.py
 user=openquake

--- a/debian/supervisord/openquake-webui.conf
+++ b/debian/supervisord/openquake-webui.conf
@@ -1,6 +1,6 @@
 [program:openquake-webui]
 priority=999
-environment=LOGNAME=openquake
+environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake
 directory=/usr/lib/python2.7/dist-packages/openquake/server
 ; Using embedded django server
 command=python manage.py runserver 127.0.0.1:8800 --noreload


### PR DESCRIPTION
By default supervisord starts daemons with `LANG=C` causing troubles when a job that contains `UTF-8` characters is uploaded through the API/QGIS

Demos: https://ci.openquake.org/job/zdevel_oq-engine/2324/