### PR TITLE
Wrong order of operations in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 
 install:
   - pip install -r requirements-py35-linux64.txt
-  - python setup.py develop
   - if [ "$(git ls-remote --heads https://github.com/gem/oq-hazardlib.git ${TRAVIS_BRANCH})" != "" ]; then BRANCH=$TRAVIS_BRANCH; else BRANCH='master'; fi; git clone -b ${BRANCH} --depth=1 https://github.com/gem/oq-hazardlib.git && echo "Running on oq-hazardlib/${BRANCH}"
 
 # We must set the PYTHONPATH to the root oq-engine (insted of oq-engine/openquake) because otherwise


### PR DESCRIPTION
`python setup.py develop` is useless since we are using PYTHONPATH and we are on pure python (no extensions). This was also made before hazardlib was actually available causing the download of a wrong version from pypi (now removed)