### PR TITLE
Store all scenario losses on demand

### DIFF
--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -24,7 +24,8 @@ import numpy
 from openquake.baselib.general import AccumDict, get_array, group_array
 from openquake.risklib import scientific, riskinput
 from openquake.calculators.export import export
-from openquake.calculators.export.hazard import build_etags, get_sm_id_eid
+from openquake.calculators.export.hazard import (
+    build_etags, get_sm_id_eid, savez)
 from openquake.commonlib import writers, risk_writers
 from openquake.commonlib.util import get_assets, compose_arrays
 from openquake.commonlib.risk_writers import (
@@ -166,6 +167,21 @@ def export_losses_by_asset(ekey, dstore):
         data = compose_arrays(assets, losses)
         writer.save(data, dest)
     return writer.getsaved()
+
+
+# used by scenario_risk
+@export.add(('all_losses-rlzs', 'npz'))
+def export_all_losses_npz(ekey, dstore):
+    rlzs = dstore['csm_info'].get_rlzs_assoc().realizations
+    assets = get_assets(dstore)
+    losses = dstore['all_losses-rlzs']
+    dic = {}
+    for rlz in rlzs:
+        data = compose_arrays(assets, losses[:, :, rlz.ordinal])
+        dic['all_losses-%03d' % rlz.ordinal] = data
+    fname = dstore.build_fname('all_losses', 'rlzs', 'npz')
+    savez(fname, **dic)
+    return [fname]
 
 
 # this is used by classical_risk

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -784,6 +784,7 @@ agg_dt = numpy.dtype([('unit', (bytes, 6)), ('mean', F32), ('stddev', F32)])
 # this is used by scenario_risk
 @export.add(('agglosses-rlzs', 'csv'))
 def export_agglosses(ekey, dstore):
+    I = dstore['oqparam'].insured_losses + 1
     cc = dstore['assetcol/cost_calculator']
     unit_by_lt = cc.units
     unit_by_lt['occupants'] = 'people'
@@ -793,7 +794,7 @@ def export_agglosses(ekey, dstore):
         gsim, = rlz.gsim_rlz.value
         loss = agglosses[rlz.ordinal]
         losses = numpy.zeros(
-            1, numpy.dtype([(lt, agg_dt) for lt in loss.dtype.names]))
+            I, numpy.dtype([(lt, agg_dt) for lt in loss.dtype.names]))
         header = []
         for lt in loss.dtype.names:
             losses[lt]['unit'] = unit_by_lt[lt]

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -68,7 +68,7 @@ def scenario_risk(riskinput, riskmodel, monitor):
             result['agg'][:, l, r, i] += agglosses[:, i]
         if all_losses:
             aids = [asset.ordinal for asset in out.assets]
-            result['all_losses'][l, r] = dict(zip(aids, out.loss_matrix))
+            result['all_losses'][l, r] = AccumDict(zip(aids, out.loss_matrix))
     return result
 
 

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -51,24 +51,25 @@ def scenario_risk(riskinput, riskmodel, monitor):
     E = monitor.oqparam.number_of_ground_motion_fields
     L = len(riskmodel.loss_types)
     R = len(riskinput.rlzs)
-    result = dict(agg=numpy.zeros((E, L, R, 2), F64), avg=[])
+    I = monitor.oqparam.insured_losses + 1
+    result = dict(agg=numpy.zeros((E, L, R, I), F64), avg=[])
     for out in riskmodel.gen_outputs(riskinput, monitor):
         l, r = out.lr
-        stats = numpy.zeros((len(out.assets), 4), F32)
+        stats = numpy.zeros((len(out.assets), 2), (F32, I))
         # this is ugly but using a composite array (i.e.
         # stats['mean'], stats['stddev'], ...) may return
         # bogus numbers! even with the SAME version of numpy,
         # hdf5 and h5py!! the numbers are around 1E-300 and
         # different on different systems; we found issues
         # with Ubuntu 12.04 and Red Hat 7 (MS and DV)
-        stats[:, 0] = out.loss_matrix.mean(axis=1)
+
+        stats[:, 0] = out.loss_matrix.mean(axis=1)  # shape (N, I)
         stats[:, 1] = out.loss_matrix.std(ddof=1, axis=1)
-        stats[:, 2] = out.insured_loss_matrix.mean(axis=1)
-        stats[:, 3] = out.insured_loss_matrix.std(ddof=1, axis=1)
         for asset, stat in zip(out.assets, stats):
             result['avg'].append((l, r, asset.ordinal, stat))
-        result['agg'][:, l, r, 0] += out.aggregate_losses
-        result['agg'][:, l, r, 1] += out.insured_losses
+        agglosses = out.loss_matrix.sum(axis=0)  # shape E, I
+        for i in range(I):
+            result['agg'][:, l, r, i] += agglosses[:, i]
     return result
 
 
@@ -107,25 +108,22 @@ class ScenarioRiskCalculator(base.RiskCalculator):
         the results on the datastore.
         """
         ltypes = self.riskmodel.loss_types
-        dt_list = [('mean', F32), ('stddev', F32)]
-        if self.oqparam.insured_losses:
-            dt_list.extend([('mean_ins', F32), ('stddev_ins', F32)])
-        stat_dt = numpy.dtype(dt_list)
+        I = self.oqparam.insured_losses + 1
+        stat_dt = numpy.dtype([('mean', (F32, I)), ('stddev', (F32, I))])
         multi_stat_dt = numpy.dtype([(lt, stat_dt) for lt in ltypes])
         with self.monitor('saving outputs', autoflush=True):
-            R = len(self.rlzs_assoc.realizations)
             N = len(self.assetcol)
 
             # agg losses
+            res = result['agg']
+            E, L, R, I = res.shape
+            if I == 1:
+                res = res.reshape(E, L, R)
+            mean, std = scientific.mean_std(res)
             agglosses = numpy.zeros(R, multi_stat_dt)
-            mean, std = scientific.mean_std(result['agg'])
             for l, lt in enumerate(ltypes):
-                agg = agglosses[lt]
-                agg['mean'] = numpy.float32(mean[l, :, 0])
-                agg['stddev'] = numpy.float32(std[l, :, 0])
-                if self.oqparam.insured_losses:
-                    agg['mean_ins'] = numpy.float32(mean[l, :, 1])
-                    agg['stddev_ins'] = numpy.float32(std[l, :, 1])
+                agglosses[lt]['mean'] = numpy.float32(mean[l])
+                agglosses[lt]['stddev'] = numpy.float32(std[l])
 
             # average losses
             avglosses = numpy.zeros((N, R), multi_stat_dt)

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -58,14 +58,7 @@ def scenario_risk(riskinput, riskmodel, monitor):
                   all_losses=AccumDict(accum={}))
     for out in riskmodel.gen_outputs(riskinput, monitor):
         l, r = out.lr
-        stats = numpy.zeros((len(out.assets), 2), (F32, I))
-        # this is ugly but using a composite array (i.e.
-        # stats['mean'], stats['stddev'], ...) may return
-        # bogus numbers! even with the SAME version of numpy,
-        # hdf5 and h5py!! the numbers are around 1E-300 and
-        # different on different systems; we found issues
-        # with Ubuntu 12.04 and Red Hat 7 (MS and DV)
-
+        stats = numpy.zeros((len(out.assets), 2), (F32, I))  # mean, stddev
         stats[:, 0] = out.loss_matrix.mean(axis=1)  # shape (A, I)
         stats[:, 1] = out.loss_matrix.std(ddof=1, axis=1)
         for asset, stat in zip(out.assets, stats):

--- a/openquake/calculators/tests/scenario_risk_test.py
+++ b/openquake/calculators/tests/scenario_risk_test.py
@@ -110,6 +110,9 @@ class ScenarioRiskTestCase(CalculatorTestCase):
         fname = writetmp(view('totlosses', dstore))
         self.assertEqualFiles('expected/totlosses.txt', fname)
 
+        # testing the npz export runs
+        export(('all_losses-rlzs', 'npz'), self.calc.datastore)
+
     @attr('qa', 'risk', 'scenario_risk')
     def test_case_1g(self):
         out = self.run_calc(case_1g.__file__, 'job_haz.ini,job_risk.ini',

--- a/openquake/calculators/tests/scenario_risk_test.py
+++ b/openquake/calculators/tests/scenario_risk_test.py
@@ -20,7 +20,7 @@ from nose.plugins.attrib import attr
 
 from openquake.qa_tests_data.scenario_risk import (
     case_1, case_2, case_2d, case_1g, case_3, case_4, case_5, occupants,
-    case_6a)
+    case_6a, case_master)
 
 from openquake.baselib.general import writetmp
 from openquake.calculators.tests import CalculatorTestCase
@@ -119,3 +119,7 @@ class ScenarioRiskTestCase(CalculatorTestCase):
                             exports='csv')
         [fname] = out['agglosses-rlzs', 'csv']
         self.assertEqualFiles('expected/agg-gsimltp_@.csv', fname)
+
+    @attr('qa', 'risk', 'scenario_risk')
+    def test_case_master(self):
+        self.run_calc(case_master.__file__, 'job.ini', exports='npz')

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -68,6 +68,7 @@ class OqParam(valid.ParamSet):
         z2pt5='reference_depth_to_2pt5km_per_sec',
         backarc='reference_backarc',
     )
+    all_losses = valid.Param(valid.boolean, False)
     area_source_discretization = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
     asset_correlation = valid.Param(valid.NoneOr(valid.FloatRange(0, 1)), 0)

--- a/openquake/commonlib/util.py
+++ b/openquake/commonlib/util.py
@@ -112,7 +112,7 @@ def compose_arrays(a1, a2, firstfield='etag'):
         return composite
 
     fields2 = [(f, a2.dtype.fields[f][0]) for f in a2.dtype.names]
-    composite = numpy.zeros(a1.shape, numpy.dtype(fields1 + fields2))
+    composite = numpy.zeros(a2.shape, numpy.dtype(fields1 + fields2))
     for f1 in dict(fields1):
         composite[f1] = a1[f1]
     for f2 in dict(fields2):

--- a/openquake/commonlib/util.py
+++ b/openquake/commonlib/util.py
@@ -112,7 +112,7 @@ def compose_arrays(a1, a2, firstfield='etag'):
         return composite
 
     fields2 = [(f, a2.dtype.fields[f][0]) for f in a2.dtype.names]
-    composite = numpy.zeros(a2.shape, numpy.dtype(fields1 + fields2))
+    composite = numpy.zeros(a1.shape, numpy.dtype(fields1 + fields2))
     for f1 in dict(fields1):
         composite[f1] = a1[f1]
     for f2 in dict(fields2):

--- a/openquake/qa_tests_data/scenario_risk/case_1/expected/agg.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_1/expected/agg.csv
@@ -1,2 +1,3 @@
 structural-unit,structural-mean,structural-stddev
 USD,4.322255E+02,1.868645E+02
+USD,1.048596E+02,1.453698E+02

--- a/openquake/qa_tests_data/scenario_risk/case_1/expected/ins.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_1/expected/ins.csv
@@ -1,2 +1,0 @@
-LossType,Unit,Mean,Standard Deviation
-structural,USD,1.0485958E+02,1.4536984E+02

--- a/openquake/qa_tests_data/scenario_risk/case_1/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_1/job_risk.ini
@@ -11,5 +11,5 @@ region_constraint =  15.48 38.30, 15.63 38.30,  15.63 38.01,  15.48 38.01
 
 export_dir = /tmp/
 
-
-insured_losses = True
+insured_losses = true
+all_losses = true

--- a/openquake/qa_tests_data/scenario_risk/case_6a/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_6a/job_risk.ini
@@ -17,5 +17,5 @@ structural_vulnerability_file = structural_vulnerability_model.xml
 
 [calculation]
 insured_losses = False
-
+all_losses = True
 export_dir = /tmp

--- a/openquake/qa_tests_data/scenario_risk/case_master/contents_vulnerability_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/contents_vulnerability_model.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<vulnerabilityModel id="vm1" assetCategory="buildings" lossCategory="contents">
+
+  <description>ln vf | tax3 | imt3 | contents</description>
+
+  <vulnerabilityFunction id="tax1" dist="LN">
+    <imls imt="PGA">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.02 0.10 0.33 0.66 0.90 0.98 1.00 1.00 1.00 1.00 1.00</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.24 0.12 0.03 0.00 0.00 0.00 0.00 0.00</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax2" dist="LN">
+    <imls imt="SA(0.1)">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.02 0.10 0.33 0.66 0.90 0.98 1.00 1.00 1.00 1.00 1.00</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.24 0.12 0.03 0.00 0.00 0.00 0.00 0.00</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax3" dist="LN">
+    <imls imt="SA(0.4)">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.02 0.10 0.33 0.66 0.90 0.98 1.00 1.00 1.00 1.00 1.00</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.24 0.12 0.03 0.00 0.00 0.00 0.00 0.00</covLRs>
+  </vulnerabilityFunction>
+
+</vulnerabilityModel>
+  
+</nrml>

--- a/openquake/qa_tests_data/scenario_risk/case_master/downtime_vulnerability_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/downtime_vulnerability_model.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<vulnerabilityModel id="vm1" assetCategory="buildings" lossCategory="business_interruption">
+
+  <description>ln vf | tax3 | downtime</description>
+
+  <vulnerabilityFunction id="tax1" dist="LN">
+    <imls imt="PGA">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.01 0.04 0.10 0.20 0.33 0.50 0.67 0.80 0.90 0.96 0.99</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax2" dist="LN">
+    <imls imt="PGA">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.01 0.04 0.10 0.20 0.33 0.50 0.67 0.80 0.90 0.96 0.99</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax3" dist="LN">
+    <imls imt="PGA">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.01 0.04 0.10 0.20 0.33 0.50 0.67 0.80 0.90 0.96 0.99</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+
+</vulnerabilityModel>
+  
+</nrml>

--- a/openquake/qa_tests_data/scenario_risk/case_master/exposure_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/exposure_model.xml
@@ -1,0 +1,126 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<nrml xmlns:gml="http://www.opengis.net/gml" 
+      xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<exposureModel id="exp1" category="buildings">
+  <description>multiple assets em w/ insurance</description>
+  <conversions>
+    <area type="per_asset" unit="SQM" />
+    <costTypes>
+      <costType name="structural" type="per_asset" unit="USD" />
+      <costType name="nonstructural" type="per_asset" unit="USD" />
+      <costType name="contents" type="per_asset" unit="USD" />
+      <costType name="business_interruption" type="per_asset" unit="USD/month" />
+    </costTypes>
+  </conversions>
+  
+  <assets>
+    <asset id="a1" number="1" area="100" taxonomy="tax1" >
+      <location lon="-122.000" lat="38.113" />
+      <costs>
+        <cost type="structural" value="10000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="nonstructural" value="15000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="contents" value="5000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="business_interruption" value="2000" deductible="0.1" insuranceLimit="0.8" />
+      </costs>
+      <occupancies>
+        <occupancy occupants="2" period="day" />
+        <occupancy occupants="4" period="transit" />
+        <occupancy occupants="6" period="night" />
+      </occupancies>
+    </asset>
+    
+    <asset id="a2" number="1" area="100" taxonomy="tax2" >
+      <location lon="-122.114" lat="38.113" />
+      <costs>
+        <cost type="structural" value="10000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="nonstructural" value="15000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="contents" value="5000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="business_interruption" value="2000" deductible="0.1" insuranceLimit="0.8" />
+      </costs>
+      <occupancies>
+        <occupancy occupants="2" period="day" />
+        <occupancy occupants="4" period="transit" />
+        <occupancy occupants="6" period="night" />
+      </occupancies>
+    </asset>
+    
+    <asset id="a3" number="1" area="100" taxonomy="tax1" >
+      <location lon="-122.570" lat="38.113" />
+      <costs>
+        <cost type="structural" value="10000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="nonstructural" value="15000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="contents" value="5000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="business_interruption" value="2000" deductible="0.1" insuranceLimit="0.8" />
+      </costs>
+      <occupancies>
+        <occupancy occupants="2" period="day" />
+        <occupancy occupants="4" period="transit" />
+        <occupancy occupants="6" period="night" />
+      </occupancies>
+    </asset>
+    
+    <asset id="a4" number="1" area="100" taxonomy="tax3" >
+      <location lon="-122.000" lat="38.000" />
+      <costs>
+        <cost type="structural" value="10000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="nonstructural" value="15000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="contents" value="5000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="business_interruption" value="2000" deductible="0.1" insuranceLimit="0.8" />
+      </costs>
+      <occupancies>
+        <occupancy occupants="2" period="day" />
+        <occupancy occupants="4" period="transit" />
+        <occupancy occupants="6" period="night" />
+      </occupancies>
+    </asset>
+    
+    <asset id="a5" number="1" area="100" taxonomy="tax1" >
+      <location lon="-122.000" lat="37.910" />
+      <costs>
+        <cost type="structural" value="10000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="nonstructural" value="15000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="contents" value="5000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="business_interruption" value="2000" deductible="0.1" insuranceLimit="0.8" />
+      </costs>
+      <occupancies>
+        <occupancy occupants="2" period="day" />
+        <occupancy occupants="4" period="transit" />
+        <occupancy occupants="6" period="night" />
+      </occupancies>
+    </asset>
+    
+    <asset id="a6" number="1" area="100" taxonomy="tax2" >
+      <location lon="-122.000" lat="38.225" />
+      <costs>
+        <cost type="structural" value="10000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="nonstructural" value="15000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="contents" value="5000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="business_interruption" value="2000" deductible="0.1" insuranceLimit="0.8" />
+      </costs>
+      <occupancies>
+        <occupancy occupants="2" period="day" />
+        <occupancy occupants="4" period="transit" />
+        <occupancy occupants="6" period="night" />
+      </occupancies>
+    </asset>
+    
+    <asset id="a7" number="1" area="100" taxonomy="tax1" >
+      <location lon="-121.886" lat="38.113" />
+      <costs>
+        <cost type="structural" value="10000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="nonstructural" value="15000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="contents" value="5000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="business_interruption" value="2000" deductible="0.1" insuranceLimit="0.8" />
+      </costs>
+      <occupancies>
+        <occupancy occupants="2" period="day" />
+        <occupancy occupants="4" period="transit" />
+        <occupancy occupants="6" period="night" />
+      </occupancies>
+    </asset>
+    
+  </assets>
+</exposureModel>
+
+</nrml>

--- a/openquake/qa_tests_data/scenario_risk/case_master/gsim_logic_tree.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/gsim_logic_tree.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<logicTree logicTreeID='lt1'>
+  <logicTreeBranchingLevel branchingLevelID="bl1">
+    <logicTreeBranchSet uncertaintyType="gmpeModel" 
+                        branchSetID="bs1" 
+                        applyToTectonicRegionType="Active Shallow Crust">
+
+      <logicTreeBranch branchID="b1">
+        <uncertaintyModel>BooreAtkinson2008</uncertaintyModel>
+        <uncertaintyWeight>0.75</uncertaintyWeight>
+      </logicTreeBranch>
+
+      <logicTreeBranch branchID="b2">
+        <uncertaintyModel>ChiouYoungs2008</uncertaintyModel>
+        <uncertaintyWeight>0.25</uncertaintyWeight>
+      </logicTreeBranch>
+
+    </logicTreeBranchSet>
+  </logicTreeBranchingLevel>
+</logicTree>
+
+</nrml>

--- a/openquake/qa_tests_data/scenario_risk/case_master/job.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_master/job.ini
@@ -1,0 +1,54 @@
+[general]
+description = scenario risk
+calculation_mode = scenario_risk
+
+[exposure]
+exposure_file = exposure_model.xml
+
+[boundaries]
+region_constraint = -122.6 38.3, -121.5 38.3, -121.5 37.9, -122.6 37.9
+
+[rupture]
+rupture_model_file = rupture_model.xml
+rupture_mesh_spacing = 2.0
+
+[site_params]
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 5.0
+reference_depth_to_1pt0km_per_sec = 100.0
+
+[correlation]
+ground_motion_correlation_model = JB2009
+ground_motion_correlation_params = {"vs30_clustering": True}
+
+[hazard_calculation]
+#intensity_measure_types = PGA
+random_seed = 42
+truncation_level = 3.0
+maximum_distance = 200.0
+gsim_logic_tree_file = gsim_logic_tree.xml
+number_of_ground_motion_fields = 100
+
+[hazard_outputs]
+ground_motion_fields = true
+
+[vulnerability]
+structural_vulnerability_file = structural_vulnerability_model.xml
+nonstructural_vulnerability_file = nonstructural_vulnerability_model.xml
+contents_vulnerability_file = contents_vulnerability_model.xml
+business_interruption_vulnerability_file = downtime_vulnerability_model.xml
+occupants_vulnerability_file = occupants_vulnerability_model.xml
+
+[risk_calculation]
+master_seed = 42
+time_event = night
+#asset_hazard_distance = 20
+asset_correlation = 0.0
+
+[risk_outputs]
+insured_losses = true
+all_losses = true
+
+[export]
+export_dir = ./

--- a/openquake/qa_tests_data/scenario_risk/case_master/nonstructural_vulnerability_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/nonstructural_vulnerability_model.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<vulnerabilityModel id="vm1" assetCategory="buildings" lossCategory="nonstructural">
+
+  <description>ln vf | tax3 | imt3 | nonstructural</description>
+
+  <vulnerabilityFunction id="tax1" dist="LN">
+    <imls imt="PGA">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.01 0.05 0.12 0.24 0.40 0.60 0.80 0.96 1.00 1.00 1.00</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.32 0.24 0.12 0.03 0.00 0.00 0.00</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax2" dist="LN">
+    <imls imt="SA(0.1)">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.01 0.05 0.12 0.24 0.40 0.60 0.80 0.96 1.00 1.00 1.00</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.32 0.24 0.12 0.03 0.00 0.00 0.00</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax3" dist="LN">
+    <imls imt="SA(0.3)">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.01 0.05 0.12 0.24 0.40 0.60 0.80 0.96 1.00 1.00 1.00</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.32 0.24 0.12 0.03 0.00 0.00 0.00</covLRs>
+  </vulnerabilityFunction>
+
+</vulnerabilityModel>
+  
+</nrml>

--- a/openquake/qa_tests_data/scenario_risk/case_master/occupants_vulnerability_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/occupants_vulnerability_model.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<vulnerabilityModel id="vm1" assetCategory="buildings" lossCategory="occupants">
+
+  <description>ln vf | tax3 | occupants</description>
+
+  <vulnerabilityFunction id="tax1" dist="LN">
+    <imls imt="PGA">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.0001 0.0004 0.0010 0.0020 0.0033 0.0050 0.0067 0.0080 0.0090 0.0096 0.0099</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax2" dist="LN">
+    <imls imt="PGA">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.0001 0.0004 0.0010 0.0020 0.0033 0.0050 0.0067 0.0080 0.0090 0.0096 0.0099</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax3" dist="LN">
+    <imls imt="PGA">0.005 0.15 0.4 0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0</imls>
+    <meanLRs>0.0001 0.0004 0.0010 0.0020 0.0033 0.0050 0.0067 0.0080 0.0090 0.0096 0.0099</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+
+</vulnerabilityModel>
+  
+</nrml>

--- a/openquake/qa_tests_data/scenario_risk/case_master/rupture_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/rupture_model.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<simpleFaultRupture>
+  <magnitude>6.7</magnitude>
+  <rake>90.0</rake>
+  <hypocenter lat="38.1124" lon="-122.0000" depth="10.0"/>
+  <simpleFaultGeometry>
+    <gml:LineString>
+      <gml:posList>
+        -122.0000 38.0000
+        -122.0000 38.2248
+      </gml:posList>
+    </gml:LineString>
+    <dip>90.0</dip>
+    <upperSeismoDepth>0.0</upperSeismoDepth>
+    <lowerSeismoDepth>20.0</lowerSeismoDepth>
+  </simpleFaultGeometry>
+</simpleFaultRupture>
+
+</nrml>

--- a/openquake/qa_tests_data/scenario_risk/case_master/structural_vulnerability_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/structural_vulnerability_model.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<vulnerabilityModel id="vm1" assetCategory="buildings" lossCategory="structural">
+
+  <description>ln vf | tax3 | nzcov</description>
+
+  <vulnerabilityFunction id="tax1" dist="LN">
+    <imls imt="PGA">0.05 0.20 0.40 0.60 0.80 1.00 1.20 1.40 1.60 1.80 2.00</imls>
+    <meanLRs>0.01 0.04 0.10 0.20 0.33 0.50 0.67 0.80 0.90 0.96 0.99</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax2" dist="LN">
+    <imls imt="PGA">0.05 0.20 0.40 0.60 0.80 1.00 1.20 1.40 1.60 1.80 2.00</imls>
+    <meanLRs>0.01 0.02 0.05 0.11 0.18 0.26 0.36 0.41 0.46 0.49 0.51</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+  
+  <vulnerabilityFunction id="tax3" dist="LN">
+    <imls imt="PGA">0.05 0.20 0.40 0.60 0.80 1.00 1.20 1.40 1.60 1.80 2.00</imls>
+    <meanLRs>0.01 0.04 0.09 0.18 0.28 0.47 0.58 0.71 0.79 0.85 0.91</meanLRs>
+    <covLRs>0.03 0.12 0.24 0.32 0.38 0.40 0.38 0.32 0.24 0.12 0.03</covLRs>
+  </vulnerabilityFunction>
+
+</vulnerabilityModel>
+  
+</nrml>


### PR DESCRIPTION
As requested by the risk team. In order to store all the losses the flag `all_losses` must be set to True (the default is False). There is also an .npz export for the losses. The demos are green: https://ci.openquake.org/job/zdevel_oq-engine/2333/