### PR TITLE
avg_losses-rlzs KeyError

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -211,7 +211,7 @@ class EbrPostCalculator(base.RiskCalculator):
         if R > 1:
             weights = self.datastore['realizations']['weight']
             quantiles = self.oqparam.quantile_loss_curves
-            if self.oqparam.avg_losses:
+            if 'avg_losses-rlzs' in self.datastore:
                 with self.monitor('computing avg_losses-stats'):
                     self.datastore['avg_losses-stats'] = compute_stats2(
                         self.datastore['avg_losses-rlzs'], quantiles, weights)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -211,9 +211,10 @@ class EbrPostCalculator(base.RiskCalculator):
         if R > 1:
             weights = self.datastore['realizations']['weight']
             quantiles = self.oqparam.quantile_loss_curves
-            with self.monitor('computing avg_losses-stats'):
-                self.datastore['avg_losses-stats'] = compute_stats2(
-                    self.datastore['avg_losses-rlzs'], quantiles, weights)
+            if self.oqparam.avg_losses:
+                with self.monitor('computing avg_losses-stats'):
+                    self.datastore['avg_losses-stats'] = compute_stats2(
+                        self.datastore['avg_losses-rlzs'], quantiles, weights)
             with self.monitor('computing rcurves-stats'):
                 self.datastore['rcurves-stats'] = compute_stats2(
                     rcurves, quantiles, weights)


### PR DESCRIPTION
Solve the ```KeyError: "No 'avg_losses-rlzs' found in <DataStore XXX>"``` happening when the user has not set `avg_losses=True`. In that case the statistical avg_losses should not be computed.