### PR TITLE
More refactoring of the risk calculators and removed the class scientific.Output

### DIFF
--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -41,10 +41,12 @@ def classical_bcr(riskinput, riskmodel, bcr_dt, monitor):
     """
     result = {}  # (N, R) -> data
     for outputs in riskmodel.gen_outputs(riskinput, monitor):
+        assets = outputs.assets
         for l, out in enumerate(outputs):
-            for asset, (eal_orig, eal_retro, bcr) in zip(out.assets, out.data):
-                aval = asset.value(out.loss_type)
-                result[asset.ordinal, out.loss_type, outputs.r] = numpy.array([
+            loss_type = riskmodel.loss_types[l]
+            for asset, (eal_orig, eal_retro, bcr) in zip(assets, out):
+                aval = asset.value(loss_type)
+                result[asset.ordinal, loss_type, outputs.r] = numpy.array([
                     (eal_orig * aval, eal_retro * aval, bcr)], bcr_dt)
     return result
 

--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -40,12 +40,13 @@ def classical_bcr(riskinput, riskmodel, bcr_dt, monitor):
         :class:`openquake.baselib.performance.Monitor` instance
     """
     result = {}  # (N, R) -> data
-    for out in riskmodel.gen_outputs(riskinput, monitor):
-        l, r = out.lr
-        for asset, (eal_orig, eal_retro, bcr) in zip(out.assets, out.data):
-            aval = asset.value(out.loss_type)
-            result[asset.ordinal, out.loss_type, r] = numpy.array([
-                (eal_orig * aval, eal_retro * aval, bcr)], bcr_dt)
+    for outputs in riskmodel.gen_outputs(riskinput, monitor):
+        for out in outputs:
+            l, r = out.lr
+            for asset, (eal_orig, eal_retro, bcr) in zip(out.assets, out.data):
+                aval = asset.value(out.loss_type)
+                result[asset.ordinal, out.loss_type, r] = numpy.array([
+                    (eal_orig * aval, eal_retro * aval, bcr)], bcr_dt)
     return result
 
 

--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -41,11 +41,10 @@ def classical_bcr(riskinput, riskmodel, bcr_dt, monitor):
     """
     result = {}  # (N, R) -> data
     for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        for out in outputs:
-            l, r = out.lr
+        for l, out in enumerate(outputs):
             for asset, (eal_orig, eal_retro, bcr) in zip(out.assets, out.data):
                 aval = asset.value(out.loss_type)
-                result[asset.ordinal, out.loss_type, r] = numpy.array([
+                result[asset.ordinal, out.loss_type, outputs.r] = numpy.array([
                     (eal_orig * aval, eal_retro * aval, bcr)], bcr_dt)
     return result
 

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -39,8 +39,8 @@ def classical_damage(riskinput, riskmodel, monitor):
         result = {i: AccumDict() for i in range(len(riskinput.rlzs))}
         for outputs in riskmodel.gen_outputs(riskinput, monitor):
             for l, out in enumerate(outputs):
-                ordinals = [a.ordinal for a in out.assets]
-                result[outputs.r] += dict(zip(ordinals, out.damages))
+                ordinals = [a.ordinal for a in outputs.assets]
+                result[outputs.r] += dict(zip(ordinals, out))
     return result
 
 

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -19,7 +19,6 @@
 import numpy
 
 from openquake.baselib.general import AccumDict
-from openquake.commonlib import datastore
 from openquake.calculators import base, classical_risk
 
 
@@ -38,10 +37,11 @@ def classical_damage(riskinput, riskmodel, monitor):
     """
     with monitor:
         result = {i: AccumDict() for i in range(len(riskinput.rlzs))}
-        for out in riskmodel.gen_outputs(riskinput, monitor):
-            l, r = out.lr
-            ordinals = [a.ordinal for a in out.assets]
-            result[r] += dict(zip(ordinals, out.damages))
+        for outputs in riskmodel.gen_outputs(riskinput, monitor):
+            for out in outputs:
+                l, r = out.lr
+                ordinals = [a.ordinal for a in out.assets]
+                result[r] += dict(zip(ordinals, out.damages))
     return result
 
 

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -38,10 +38,9 @@ def classical_damage(riskinput, riskmodel, monitor):
     with monitor:
         result = {i: AccumDict() for i in range(len(riskinput.rlzs))}
         for outputs in riskmodel.gen_outputs(riskinput, monitor):
-            for out in outputs:
-                l, r = out.lr
+            for l, out in enumerate(outputs):
                 ordinals = [a.ordinal for a in out.assets]
-                result[r] += dict(zip(ordinals, out.damages))
+                result[outputs.r] += dict(zip(ordinals, out.damages))
     return result
 
 

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -74,6 +74,10 @@ def classical_risk(riskinput, riskmodel, monitor):
                     avgs = numpy.array([r.average_losses[l] for r in rows])
                     avg_stats = compute_stats(
                         avgs, oq.quantile_loss_curves, weights)
+                    # row is index by the loss type index l and row[l]
+                    # is a pair loss_curves, insured_loss_curves
+                    # loss_curves[i, 0] are the i-th losses,
+                    # loss_curves[i, 1] are the i-th poes
                     losses = row[l][0][i, 0]
                     poes_stats = compute_stats(
                         numpy.array([row[l][0][i, 1] for row in rows]),

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -20,7 +20,7 @@ import logging
 
 import numpy
 
-from openquake.baselib.general import groupby
+from openquake.baselib.general import groupby, AccumDict
 from openquake.hazardlib.stats import compute_stats
 from openquake.risklib import scientific, riskinput
 from openquake.commonlib import readinput, source
@@ -47,21 +47,17 @@ def classical_risk(riskinput, riskmodel, monitor):
     all_outputs = list(riskmodel.gen_outputs(riskinput, monitor))
     for outputs in all_outputs:
         r = outputs.r
-        for l, out in enumerate(outputs):
-            out.average_losses = []
-            for i, asset in enumerate(out.assets):
+        outputs.average_losses = AccumDict(accum=[])  # l -> array
+        for l, (loss_curves, insured_curves) in enumerate(outputs):
+            for i, asset in enumerate(outputs.assets):
                 aid = asset.ordinal
-                avg = scientific.average_loss(out.loss_curves[i])
-                out.average_losses.append(avg)
-                lcurve = (
-                    out.loss_curves[i, 0],
-                    out.loss_curves[i, 1],
-                    avg)
+                avg = scientific.average_loss(loss_curves[i])
+                outputs.average_losses[l].append(avg)
+                lcurve = (loss_curves[i, 0], loss_curves[i, 1], avg)
                 if ins:
                     lcurve += (
-                        out.insured_curves[i, 0],
-                        out.insured_curves[i, 1],
-                        scientific.average_loss(out.insured_curves[i]))
+                        insured_curves[i, 0], insured_curves[i, 1],
+                        scientific.average_loss(insured_curves[i]))
                 else:
                     lcurve += (None, None, None)
                 result['loss_curves'].append((l, r, aid, lcurve))
@@ -75,13 +71,12 @@ def classical_risk(riskinput, riskmodel, monitor):
             row = rows[0]
             for l in l_idxs:
                 for i, asset in enumerate(assets):
+                    avgs = numpy.array([r.average_losses[l] for r in rows])
                     avg_stats = compute_stats(
-                        numpy.array([row[l].average_losses for row in rows]),
-                        oq.quantile_loss_curves, weights)
-                    losses = row[l].loss_curves[i, 0]
+                        avgs, oq.quantile_loss_curves, weights)
+                    losses = row[l][0][i, 0]
                     poes_stats = compute_stats(
-                        numpy.array([row[l].loss_curves[i, 1]
-                                     for row in rows]),
+                        numpy.array([row[l][0][i, 1] for row in rows]),
                         oq.quantile_loss_curves, weights)
                     result['stat_curves'].append(
                         (l, asset.ordinal, losses, poes_stats, avg_stats))

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -97,32 +97,33 @@ def build_rcurves(cb_inputs, assets, monitor):
 def _aggregate(outputs, compositemodel, agg, ass, idx, result, monitor):
     # update the result dictionary and the agg array with each output
     lrs = set()
-    for out in outputs:
-        l, r = out.lr
-        lrs.add(out.lr)
-        loss_type = compositemodel.loss_types[l]
-        indices = numpy.array([idx[eid] for eid in out.eids])
-        agglr = agg[l, r]
-        for i, asset in enumerate(out.assets):
-            aid = asset.ordinal
-            loss_ratios = out.loss_ratios[i]
-            losses = loss_ratios * asset.value(loss_type)
+    for outs in outputs:
+        for out in outs:
+            l, r = out.lr
+            lrs.add(out.lr)
+            loss_type = compositemodel.loss_types[l]
+            indices = numpy.array([idx[eid] for eid in out.eids])
+            agglr = agg[l, r]
+            for i, asset in enumerate(out.assets):
+                aid = asset.ordinal
+                loss_ratios = out.loss_ratios[i]
+                losses = loss_ratios * asset.value(loss_type)
 
-            # average losses
-            if monitor.avg_losses:
-                result['avglosses'][l, r][aid] += (
-                    loss_ratios.sum(axis=0) * monitor.ses_ratio)
+                # average losses
+                if monitor.avg_losses:
+                    result['avglosses'][l, r][aid] += (
+                        loss_ratios.sum(axis=0) * monitor.ses_ratio)
 
-            # asset losses
-            if monitor.loss_ratios:
-                data = [(eid, aid, loss)
-                        for eid, loss in zip(out.eids, loss_ratios)
-                        if loss.sum() > 0]
-                if data:
-                    ass[l, r].append(numpy.array(data, monitor.ela_dt))
+                # asset losses
+                if monitor.loss_ratios:
+                    data = [(eid, aid, loss)
+                            for eid, loss in zip(out.eids, loss_ratios)
+                            if loss.sum() > 0]
+                    if data:
+                        ass[l, r].append(numpy.array(data, monitor.ela_dt))
 
-            # agglosses
-            agglr[indices] += losses
+                # agglosses
+                agglr[indices] += losses
     return sorted(lrs)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -102,24 +102,25 @@ def _aggregate(outputs, compositemodel, agg, ass, idx, result, monitor):
         for l, out in enumerate(outs):
             if out is None:  # for GMFs below the minimum_intensity
                 continue
+            loss_ratios, eids = out
             lrs.add((l, r))
             loss_type = compositemodel.loss_types[l]
-            indices = numpy.array([idx[eid] for eid in out.eids])
+            indices = numpy.array([idx[eid] for eid in eids])
             agglr = agg[l, r]
-            for i, asset in enumerate(out.assets):
+            for i, asset in enumerate(outs.assets):
+                ratios = loss_ratios[i]
                 aid = asset.ordinal
-                loss_ratios = out.loss_ratios[i]
-                losses = loss_ratios * asset.value(loss_type)
+                losses = ratios * asset.value(loss_type)
 
                 # average losses
                 if monitor.avg_losses:
                     result['avglosses'][l, r][aid] += (
-                        loss_ratios.sum(axis=0) * monitor.ses_ratio)
+                        ratios.sum(axis=0) * monitor.ses_ratio)
 
                 # asset losses
                 if monitor.loss_ratios:
                     data = [(eid, aid, loss)
-                            for eid, loss in zip(out.eids, loss_ratios)
+                            for eid, loss in zip(eids, ratios)
                             if loss.sum() > 0]
                     if data:
                         ass[l, r].append(numpy.array(data, monitor.ela_dt))

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -98,9 +98,11 @@ def _aggregate(outputs, compositemodel, agg, ass, idx, result, monitor):
     # update the result dictionary and the agg array with each output
     lrs = set()
     for outs in outputs:
-        for out in outs:
-            l, r = out.lr
-            lrs.add(out.lr)
+        r = outs.r
+        for l, out in enumerate(outs):
+            if out is None:  # for GMFs below the minimum_intensity
+                continue
+            lrs.add((l, r))
             loss_type = compositemodel.loss_types[l]
             indices = numpy.array([idx[eid] for eid in out.eids])
             agglr = agg[l, r]

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -103,25 +103,26 @@ def scenario_damage(riskinput, riskmodel, monitor):
     taxo2idx = {taxo: i for i, taxo in enumerate(monitor.taxonomies)}
     result = dict(d_asset=[], d_taxon=numpy.zeros((T, L, R, E, D), F64),
                   c_asset=[], c_taxon=numpy.zeros((T, L, R, E), F64))
-    for out in riskmodel.gen_outputs(riskinput, monitor):
-        l, r = out.lr
-        c_model = c_models.get(out.loss_type)
-        for asset, fraction in zip(out.assets, out.damages):
-            t = taxo2idx[asset.taxonomy]
-            damages = fraction * asset.number
-            if c_model:  # compute consequences
-                means = [par[0] for par in c_model[asset.taxonomy].params]
-                # NB: we add a 0 in front for nodamage state
-                c_ratio = numpy.dot(fraction, [0] + means)
-                consequences = c_ratio * asset.value(out.loss_type)
-                result['c_asset'].append(
-                    (l, r, asset.ordinal,
-                     scientific.mean_std(consequences)))
-                result['c_taxon'][t, l, r, :] += consequences
-                # TODO: consequences for the occupants
-            result['d_asset'].append(
-                (l, r, asset.ordinal, scientific.mean_std(damages)))
-            result['d_taxon'][t, l, r, :] += damages
+    for outputs in riskmodel.gen_outputs(riskinput, monitor):
+        for out in outputs:
+            l, r = out.lr
+            c_model = c_models.get(out.loss_type)
+            for asset, fraction in zip(out.assets, out.damages):
+                t = taxo2idx[asset.taxonomy]
+                damages = fraction * asset.number
+                if c_model:  # compute consequences
+                    means = [par[0] for par in c_model[asset.taxonomy].params]
+                    # NB: we add a 0 in front for nodamage state
+                    c_ratio = numpy.dot(fraction, [0] + means)
+                    consequences = c_ratio * asset.value(out.loss_type)
+                    result['c_asset'].append(
+                        (l, r, asset.ordinal,
+                         scientific.mean_std(consequences)))
+                    result['c_taxon'][t, l, r, :] += consequences
+                    # TODO: consequences for the occupants
+                result['d_asset'].append(
+                    (l, r, asset.ordinal, scientific.mean_std(damages)))
+                result['d_taxon'][t, l, r, :] += damages
     return result
 
 

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -105,16 +105,17 @@ def scenario_damage(riskinput, riskmodel, monitor):
                   c_asset=[], c_taxon=numpy.zeros((T, L, R, E), F64))
     for outputs in riskmodel.gen_outputs(riskinput, monitor):
         r = outputs.r
-        for l, out in enumerate(outputs):
-            c_model = c_models.get(out.loss_type)
-            for asset, fraction in zip(out.assets, out.damages):
+        for l, damages in enumerate(outputs):
+            loss_type = riskmodel.loss_types[l]
+            c_model = c_models.get(loss_type)
+            for asset, fraction in zip(outputs.assets, damages):
                 t = taxo2idx[asset.taxonomy]
                 damages = fraction * asset.number
                 if c_model:  # compute consequences
                     means = [par[0] for par in c_model[asset.taxonomy].params]
                     # NB: we add a 0 in front for nodamage state
                     c_ratio = numpy.dot(fraction, [0] + means)
-                    consequences = c_ratio * asset.value(out.loss_type)
+                    consequences = c_ratio * asset.value(loss_type)
                     result['c_asset'].append(
                         (l, r, asset.ordinal,
                          scientific.mean_std(consequences)))

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -104,8 +104,8 @@ def scenario_damage(riskinput, riskmodel, monitor):
     result = dict(d_asset=[], d_taxon=numpy.zeros((T, L, R, E, D), F64),
                   c_asset=[], c_taxon=numpy.zeros((T, L, R, E), F64))
     for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        for out in outputs:
-            l, r = out.lr
+        r = outputs.r
+        for l, out in enumerate(outputs):
             c_model = c_models.get(out.loss_type)
             for asset, fraction in zip(out.assets, out.damages):
                 t = taxo2idx[asset.taxonomy]

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -58,21 +58,21 @@ def scenario_risk(riskinput, riskmodel, monitor):
                   all_losses=AccumDict(accum={}))
     for outputs in riskmodel.gen_outputs(riskinput, monitor):
         r = outputs.r
+        assets = outputs.assets
         for l, out in enumerate(outputs):
             if out is None:  # this may happen
                 continue
-            stats = numpy.zeros((len(out.assets), 2), (F32, I))  # mean, stddev
-            stats[:, 0] = out.loss_matrix.mean(axis=1)  # shape (A, I)
-            stats[:, 1] = out.loss_matrix.std(ddof=1, axis=1)
-            for asset, stat in zip(out.assets, stats):
+            stats = numpy.zeros((len(assets), 2), (F32, I))  # mean, stddev
+            stats[:, 0] = out.mean(axis=1)  # shape (A, I)
+            stats[:, 1] = out.std(ddof=1, axis=1)
+            for asset, stat in zip(assets, stats):
                 result['avg'].append((l, r, asset.ordinal, stat))
-            agglosses = out.loss_matrix.sum(axis=0)  # shape E, I
+            agglosses = out.sum(axis=0)  # shape E, I
             for i in range(I):
                 result['agg'][:, l, r, i] += agglosses[:, i]
             if all_losses:
-                aids = [asset.ordinal for asset in out.assets]
-                result['all_losses'][l, r] = AccumDict(
-                    zip(aids, out.loss_matrix))
+                aids = [asset.ordinal for asset in outputs.assets]
+                result['all_losses'][l, r] = AccumDict(zip(aids, out))
     return result
 
 

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -56,19 +56,21 @@ def scenario_risk(riskinput, riskmodel, monitor):
     all_losses = monitor.oqparam.all_losses
     result = dict(agg=numpy.zeros((E, L, R, I), F64), avg=[],
                   all_losses=AccumDict(accum={}))
-    for out in riskmodel.gen_outputs(riskinput, monitor):
-        l, r = out.lr
-        stats = numpy.zeros((len(out.assets), 2), (F32, I))  # mean, stddev
-        stats[:, 0] = out.loss_matrix.mean(axis=1)  # shape (A, I)
-        stats[:, 1] = out.loss_matrix.std(ddof=1, axis=1)
-        for asset, stat in zip(out.assets, stats):
-            result['avg'].append((l, r, asset.ordinal, stat))
-        agglosses = out.loss_matrix.sum(axis=0)  # shape E, I
-        for i in range(I):
-            result['agg'][:, l, r, i] += agglosses[:, i]
-        if all_losses:
-            aids = [asset.ordinal for asset in out.assets]
-            result['all_losses'][l, r] = AccumDict(zip(aids, out.loss_matrix))
+    for outputs in riskmodel.gen_outputs(riskinput, monitor):
+        for out in outputs:
+            l, r = out.lr
+            stats = numpy.zeros((len(out.assets), 2), (F32, I))  # mean, stddev
+            stats[:, 0] = out.loss_matrix.mean(axis=1)  # shape (A, I)
+            stats[:, 1] = out.loss_matrix.std(ddof=1, axis=1)
+            for asset, stat in zip(out.assets, stats):
+                result['avg'].append((l, r, asset.ordinal, stat))
+            agglosses = out.loss_matrix.sum(axis=0)  # shape E, I
+            for i in range(I):
+                result['agg'][:, l, r, i] += agglosses[:, i]
+            if all_losses:
+                aids = [asset.ordinal for asset in out.assets]
+                result['all_losses'][l, r] = AccumDict(
+                    zip(aids, out.loss_matrix))
     return result
 
 

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -57,8 +57,10 @@ def scenario_risk(riskinput, riskmodel, monitor):
     result = dict(agg=numpy.zeros((E, L, R, I), F64), avg=[],
                   all_losses=AccumDict(accum={}))
     for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        for out in outputs:
-            l, r = out.lr
+        r = outputs.r
+        for l, out in enumerate(outputs):
+            if out is None:  # this may happen
+                continue
             stats = numpy.zeros((len(out.assets), 2), (F32, I))  # mean, stddev
             stats[:, 0] = out.loss_matrix.mean(axis=1)  # shape (A, I)
             stats[:, 1] = out.loss_matrix.std(ddof=1, axis=1)

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -422,6 +422,7 @@ class CompositeRiskModel(collections.Mapping):
                 riskmodel = self[taxonomy]
                 with mon_risk:
                     for i, assets, epsgetter in dic[taxonomy]:
+                        outs = []
                         for lt in self.loss_types:
                             imt = riskmodel.risk_functions[lt].imt
                             haz = hazard[i].get(imt, ())
@@ -429,7 +430,8 @@ class CompositeRiskModel(collections.Mapping):
                                 out = riskmodel(lt, assets, haz, epsgetter)
                                 if out:  # can be None in scenario_risk
                                     out.lr = self.lti[lt], rlz.ordinal
-                                    yield out
+                                    outs.append(out)
+                        yield outs
         if hasattr(hazard_getter, 'gmfbytes'):  # for event based risk
             monitor.gmfbytes = hazard_getter.gmfbytes
 

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -420,10 +420,10 @@ class CompositeRiskModel(collections.Mapping):
                 hazard = hazard_getter(rlz)
             for taxonomy in sorted(taxonomies):
                 riskmodel = self[taxonomy]
-                for lt in self.loss_types:
-                    imt = riskmodel.risk_functions[lt].imt
-                    with mon_risk:
-                        for i, assets, epsgetter in dic[taxonomy]:
+                with mon_risk:
+                    for i, assets, epsgetter in dic[taxonomy]:
+                        for lt in self.loss_types:
+                            imt = riskmodel.risk_functions[lt].imt
                             haz = hazard[i].get(imt, ())
                             if len(haz):
                                 out = riskmodel(lt, assets, haz, epsgetter)

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -39,6 +39,15 @@ FIELDS = ('site_id', 'lon', 'lat', 'idx', 'taxonomy_id', 'area', 'number',
 by_taxonomy = operator.attrgetter('taxonomy')
 
 
+class MultiLoss(object):
+    def __init__(self, loss_types, values):
+        self.loss_types = loss_types
+        self.values = values
+
+    def __getitem__(self, l):
+        return self.values[l]
+
+
 class AssetCollection(object):
     D, I, R = len('deductible-'), len('insurance_limit-'), len('retrofitted-')
 
@@ -422,16 +431,17 @@ class CompositeRiskModel(collections.Mapping):
                 riskmodel = self[taxonomy]
                 with mon_risk:
                     for i, assets, epsgetter in dic[taxonomy]:
-                        outs = []
+                        outs = [None] * len(self.lti)
                         for lt in self.loss_types:
                             imt = riskmodel.risk_functions[lt].imt
                             haz = hazard[i].get(imt, ())
                             if len(haz):
                                 out = riskmodel(lt, assets, haz, epsgetter)
-                                if out:  # can be None in scenario_risk
-                                    out.lr = self.lti[lt], rlz.ordinal
-                                    outs.append(out)
-                        yield outs
+                                outs[self.lti[lt]] = out
+                        row = MultiLoss(self.loss_types, outs)
+                        row.r = rlz.ordinal
+                        row.assets = assets
+                        yield row
         if hasattr(hazard_getter, 'gmfbytes'):  # for event based risk
             monitor.gmfbytes = hazard_getter.gmfbytes
 

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -398,8 +398,6 @@ class Classical(RiskModel):
         lrcurves = numpy.array(
             [scientific.classical(
                 vf, imls, hazard_curve, self.lrem_steps_per_interval)] * n)
-        curves = rescale(lrcurves, values)
-        average_losses = utils.numpy_map(scientific.average_loss, curves)
 
         if self.insured_losses:
             deductibles = [a.deductible(loss_type) for a in assets]
@@ -407,16 +405,12 @@ class Classical(RiskModel):
             insured_curves = rescale(
                 utils.numpy_map(scientific.insured_loss_curve,
                                 lrcurves, deductibles, limits), values)
-            average_insured_losses = utils.numpy_map(
-                scientific.average_loss, insured_curves)
         else:
             insured_curves = None
-            average_insured_losses = None
 
         return scientific.Output(
-            assets, loss_type, loss_curves=curves,
-            average_losses=average_losses, insured_curves=insured_curves,
-            average_insured_losses=average_insured_losses)
+            assets, loss_type, loss_curves=rescale(lrcurves, values),
+            insured_curves=insured_curves)
 
 
 @registry.add('event_based_risk', 'event_based', 'event_based_rupture',

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -440,7 +440,7 @@ class ClassicalBCR(RiskModel):
         :param hazard: an hazard curve
         :param _eps: dummy parameter, unused
         :param _eids: dummy parameter, unused
-        :returns: a :class:`openquake.risklib.scientific.Output` instance
+        :returns: a list of triples (eal_orig, eal_retro, bcr_result)
         """
         n = len(assets)
         self.assets = assets

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -282,63 +282,7 @@ def rescale(curves, values):
 @registry.add('classical_risk', 'classical', 'disaggregation')
 class Classical(RiskModel):
     """
-    Classical PSHA-Based RiskModel.
-
-    1) Compute loss curves, loss maps for each realization.
-    2) Compute (if more than one realization is given) mean and
-       quantiles loss curves and maps.
-
-    Per-realization Outputs contain the following fields:
-
-    :attr assets:
-      an iterable over N assets the outputs refer to
-    :attr loss_curves:
-      a numpy array of N loss curves. If the curve resolution is C, the final
-      shape of the array will be (N, 2, C), where the `two` accounts for
-      the losses/poes dimensions
-    :attr average_losses:
-      a numpy array of N average loss values
-    :attr insured_curves:
-      a numpy array of N insured loss curves, shaped (N, 2, C)
-    :attr average_insured_losses:
-      a numpy array of N average insured loss values
-    :attr loss_maps:
-      a numpy array of P elements holding N loss maps where P is the
-      number of `conditional_loss_poes` considered. Shape: (P, N)
-
-    The statistical outputs are stored into
-    :class:`openquake.risklib.scientific.Output`,
-    which holds the following fields:
-
-    :attr assets:
-      an iterable of N assets the outputs refer to
-    :attr mean_curves:
-       A numpy array with N mean loss curves. Shape: (N, 2)
-    :attr mean_average_losses:
-       A numpy array with N mean average loss values
-    :attr mean_maps:
-       A numpy array with P mean loss maps. Shape: (P, N)
-    :attr mean_fractions:
-       A numpy array with F mean fractions, where F is the number of PoEs
-       used for disaggregation. Shape: (F, N)
-    :attr quantile_curves:
-       A numpy array with Q quantile curves (Q = number of quantiles).
-       Shape: (Q, N, 2, C)
-    :attr quantile_average_losses:
-       A numpy array shaped (Q, N) with average losses
-    :attr quantile_maps:
-       A numpy array with Q quantile maps shaped (Q, P, N)
-    :attr quantile_fractions:
-       A numpy array with Q quantile maps shaped (Q, F, N)
-    :attr mean_insured_curves:
-       A numpy array with N mean insured loss curves. Shape: (N, 2)
-    :attr mean_average_insured_losses:
-       A numpy array with N mean average insured loss values
-    :attr quantile_insured_curves:
-       A numpy array with Q quantile insured curves (Q = number of quantiles).
-       Shape: (Q, N, 2, C)
-    :attr quantile_average_insured_losses:
-       A numpy array shaped (Q, N) with average insured losses
+    Classical PSHA-Based RiskModel. Computes loss curves and insured curves.
     """
     kind = 'vulnerability'
 
@@ -408,56 +352,15 @@ class Classical(RiskModel):
         else:
             insured_curves = None
 
-        return scientific.Output(
-            assets, loss_type, loss_curves=rescale(lrcurves, values),
-            insured_curves=insured_curves)
+        return rescale(lrcurves, values), insured_curves
 
 
 @registry.add('event_based_risk', 'event_based', 'event_based_rupture',
               'ebrisk', 'ucerf_rupture', 'ucerf_risk')
 class ProbabilisticEventBased(RiskModel):
     """
-    Implements the Probabilistic Event Based riskmodel
-
-    Per-realization Output are saved into
-    :class:`openquake.risklib.scientific.ProbabilisticEventBased.Output`
-    which contains the several fields:
-
-    :attr assets:
-      an iterable over N assets the outputs refer to
-
-    :attr loss_matrix:
-      an array of losses shaped N x T (where T is the number of events)
-
-    :attr loss_curves:
-      a numpy array of N loss curves. If the curve resolution is C, the final
-      shape of the array will be (N, 2, C), where the `two` accounts for
-      the losses/poes dimensions
-
-    :attr average_losses:
-      a numpy array of N average loss values
-
-    :attr stddev_losses:
-      a numpy array holding N standard deviation of losses
-
-    :attr insured_curves:
-      a numpy array of N insured loss curves, shaped (N, 2, C)
-
-    :attr average_insured_losses:
-      a numpy array of N average insured loss values
-
-    :attr stddev_insured_losses:
-      a numpy array holding N standard deviation of losses
-
-    :attr loss_maps:
-      a numpy array of P elements holding N loss maps where P is the
-      number of `conditional_loss_poes` considered. Shape: (P, N)
-
-    :attr dict event_loss_table:
-      a dictionary mapping event ids to aggregate loss values
-
-    The statistical outputs are stored into
-    :class:`openquake.risklib.scientific.Output` objects.
+    Implements the Probabilistic Event Based riskmodel.
+    Computes loss ratios and event IDs.
     """
     kind = 'vulnerability'
 
@@ -507,8 +410,7 @@ class ProbabilisticEventBased(RiskModel):
                 loss_ratios[i, idxs, 1] = scientific.insured_losses(
                     ratios,  asset.deductible(loss_type),
                     asset.insurance_limit(loss_type))
-        return scientific.Output(
-            assets, loss_type, loss_ratios=loss_ratios, eids=eids)
+        return loss_ratios, eids
 
 
 @registry.add('classical_bcr')
@@ -565,15 +467,13 @@ class ClassicalBCR(RiskModel):
                 asset.value(loss_type), asset.retrofitted(loss_type))
             for i, asset in enumerate(assets)]
 
-        return scientific.Output(
-            assets, loss_type,
-            data=list(zip(eal_original, eal_retrofitted, bcr_results)))
+        return list(zip(eal_original, eal_retrofitted, bcr_results))
 
 
 @registry.add('scenario_risk', 'scenario')
 class Scenario(RiskModel):
     """
-    Implements the Scenario riskmodel
+    Implements the Scenario riskmodel. Computes the loss matrix.
     """
     kind = 'vulnerability'
 
@@ -619,13 +519,13 @@ class Scenario(RiskModel):
                 deductibles, limits)
             loss_matrix[:, :, 1] = (insured_loss_ratio_matrix.T * values).T
 
-        return scientific.Output(assets, loss_type, loss_matrix=loss_matrix)
+        return loss_matrix
 
 
 @registry.add('scenario_damage')
 class Damage(RiskModel):
     """
-    Implements the ScenarioDamage riskmodel
+    Implements the ScenarioDamage riskmodel. Computes the damages.
     """
     kind = 'fragility'
 
@@ -648,13 +548,13 @@ class Damage(RiskModel):
         ffs = self.risk_functions[loss_type]
         damages = numpy.array(
             [scientific.scenario_damage(ffs, gmv) for gmv in gmvs])
-        return scientific.Output(assets, loss_type, damages=[damages] * n)
+        return [damages] * n
 
 
 @registry.add('classical_damage')
 class ClassicalDamage(Damage):
     """
-    Implements the ClassicalDamage riskmodel
+    Implements the ClassicalDamage riskmodel. Computes the damages.
     """
     kind = 'fragility'
 
@@ -682,8 +582,7 @@ class ClassicalDamage(Damage):
             ffl, hazard_imls, hazard_curve,
             investigation_time=self.investigation_time,
             risk_investigation_time=self.risk_investigation_time)
-        return scientific.Output(
-            assets, loss_type, damages=[a.number * damage for a in assets])
+        return [a.number * damage for a in assets]
 
 
 # NB: the approach used here relies on the convention of having the

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -55,36 +55,6 @@ def build_dtypes(curve_resolution, conditional_loss_poes, insured=False):
     return loss_curve_dt, loss_maps_dt
 
 
-class Output(object):
-    """
-    A generic container of attributes. Only assets, loss_type, hid and weight
-    are always defined.
-
-    :param assets: a list of assets with the same taxonomy
-    :param loss_type: a loss type string
-    :param hid: ordinal of the hazard realization (can be None)
-    :param weight: weight of the realization (can be None)
-    """
-    def __init__(self, assets, loss_type, hid=None, weight=0, **attrs):
-        self.assets = assets
-        self.loss_type = loss_type
-        self.hid = hid
-        self.weight = weight
-        vars(self).update(attrs)
-
-    @property
-    def taxonomy(self):
-        return self.assets[0].taxonomy
-
-    def __repr__(self):
-        return '<%s %s, hid=%s>' % (
-            self.__class__.__name__, self.loss_type, self.hid)
-
-    def __str__(self):
-        items = '\n'.join('%s=%s' % item for item in vars(self).items())
-        return '<%s\n%s>' % (self.__class__.__name__, items)
-
-
 def fine_graining(points, steps):
     """
     :param points: a list of floats


### PR DESCRIPTION
~120 lines were removed thanks to this simplification, mostly in the docstrings describing the overcomplicated structure of the returned outputs.
The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2336/