### PR TITLE
Fix build timeout in Jenkins when tests fail

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -59,10 +59,10 @@ GEM_MAXLOOP=20
 GEM_ALWAYS_YES=false
 
 if [ "$GEM_EPHEM_CMD" = "" ]; then
-    GEM_EPHEM_CMD="lxc-start-ephemeral"
+    GEM_EPHEM_CMD="lxc-copy"
 fi
 if [ "$GEM_EPHEM_NAME" = "" ]; then
-    GEM_EPHEM_NAME="ubuntu-lxc-eph"
+    GEM_EPHEM_NAME="ubuntu16-lxc-eph"
 fi
 
 LXC_VER=$(lxc-ls --version | cut -d '.' -f 1)

--- a/packager.sh
+++ b/packager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# packager.sh  Copyright (C) 2014-2016 GEM Foundation
+# packager.sh  Copyright (C) 2014-2017 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published
@@ -30,8 +30,8 @@
 #
 # ephemeral containers are "clones" of a base container and have a
 # temporary file system that reflects the contents of the base container
-# but any modifications are stored in another overlayed
-# file system (in-memory or disk)
+# but any modifications are stored in an overlayed, in-memory
+# file system
 #
 
 if [ -n "$GEM_SET_DEBUG" -a "$GEM_SET_DEBUG" != "false" ]; then
@@ -705,7 +705,7 @@ _lxc_name_and_ip_get()
     if [ $e -eq 40 ]; then
         return 1
     fi
-    echo "SUCCESSFULY RUNNED $lxc_name ($lxc_ip)"
+    echo "SUCCESSFULLY RUN $lxc_name ($lxc_ip)"
 
     return 0
 }

--- a/packager.sh
+++ b/packager.sh
@@ -709,7 +709,7 @@ _lxc_name_and_ip_get()
     if [ $e -eq 40 ]; then
         return 1
     fi
-    echo "SUCCESSFULLY RUN $lxc_name ($lxc_ip)"
+    echo "SUCCESSFULLY STARTED: $lxc_name ($lxc_ip)"
 
     return 0
 }

--- a/packager.sh
+++ b/packager.sh
@@ -307,14 +307,18 @@ _devtest_innervm_run () {
             skip_tests="!slow,"
         fi
 
-        # run tests (in this case we omit 'set -e' to be able to read all tests outputs)
+        ssh $lxc_ip "set -e
+                 export PYTHONPATH=\"\$PWD/oq-hazardlib:\$PWD/oq-engine\"
+                 echo 'Starting DbServer. Log is saved to /tmp/dbserver.log'
+                 cd oq-engine; nohup bin/oq dbserver start &>/tmp/dbserver.log < /dev/null &"
+
         ssh $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG
                  set -e
                  if [ -n \"\$GEM_SET_DEBUG\" -a \"\$GEM_SET_DEBUG\" != \"false\" ]; then
                      export PS4='+\${BASH_SOURCE}:\${LINENO}:\${FUNCNAME[0]}: '
                      set -x
                  fi
-                 export PYTHONPATH=\"\$PWD/oq-hazardlib:\$PWD/oq-engine\" ;
+                 export PYTHONPATH=\"\$PWD/oq-hazardlib:\$PWD/oq-engine\"
                  cd oq-engine; bin/oq dbserver start &
                  nosetests -v -a '${skip_tests}' --with-xunit --xunit-file=xunit-engine.xml --with-coverage --cover-package=openquake.engine --with-doctest openquake/engine/tests/
                  nosetests -v -a '${skip_tests}' --with-xunit --xunit-file=xunit-server.xml --with-coverage --cover-package=openquake.server --with-doctest openquake/server/tests/
@@ -331,6 +335,7 @@ _devtest_innervm_run () {
         bin/oq dbserver stop"
         scp "${lxc_ip}:oq-engine/xunit-*.xml" "out_${BUILD_UBUVER}/" || true
         scp "${lxc_ip}:oq-engine/coverage.xml" "out_${BUILD_UBUVER}/" || true
+        scp "${lxc_ip}:/tmp/dbserver.log" "out_${BUILD_UBUVER}/" || true
     else
         if [ -d $HOME/fake-data/$GEM_GIT_PACKAGE ]; then
             cp $HOME/fake-data/$GEM_GIT_PACKAGE/* "out_${BUILD_UBUVER}/"

--- a/packager.sh
+++ b/packager.sh
@@ -64,6 +64,10 @@ fi
 if [ "$GEM_EPHEM_NAME" = "" ]; then
     GEM_EPHEM_NAME="ubuntu16-lxc-eph"
 fi
+# FIXME this is currently unused, but left as reference
+if [ "$GEM_EPHEM_USER" = "" ]; then
+    GEM_EPHEM_USER="ubuntu"
+fi
 
 LXC_VER=$(lxc-ls --version | cut -d '.' -f 1)
 

--- a/packager.sh
+++ b/packager.sh
@@ -314,7 +314,7 @@ _devtest_innervm_run () {
         ssh $lxc_ip "set -e
                  export PYTHONPATH=\"\$PWD/oq-hazardlib:\$PWD/oq-engine\"
                  echo 'Starting DbServer. Log is saved to /tmp/dbserver.log'
-                 cd oq-engine; nohup bin/oq dbserver start &>/tmp/dbserver.log < /dev/null &"
+                 cd oq-engine; nohup bin/oq dbserver start &>/tmp/dbserver.log </dev/null &"
 
         ssh $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG
                  set -e


### PR DESCRIPTION
This was caused by the `oq dbserver start` command which is run in background leaving the ssh session active even if `set -e` and an exit code =1 from nose.

Remove also some old code from the `packager.sh`

With an error: https://ci.openquake.org/job/zdevel_oq-engine/2345/console
Clean test: https://ci.openquake.org/job/zdevel_oq-engine/2347/