### PR TITLE
Fix an if in packager.sh: demos were run even if not asked to

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -547,7 +547,6 @@ celeryd_wait() {
 }
 
 celeryd_wait $GEM_MAXLOOP"
-        fi
 
         # run all of the hazard and risk demos
         ssh $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG
@@ -615,11 +614,12 @@ celeryd_wait $GEM_MAXLOOP"
         echo 'Listing risk calculations'
         oq engine --lrc"
 
-    ssh $lxc_ip "oq engine --make-html-report today
-    oq engine --delete-calculation 1 --yes
-    oq engine --dc 1 --yes
-    oq purge -1; oq purge 0"
-    scp "${lxc_ip}:jobs-*.html" "out_${BUILD_UBUVER}/"
+        ssh $lxc_ip "oq engine --make-html-report today
+        oq engine --delete-calculation 1 --yes
+        oq engine --dc 1 --yes
+        oq purge -1; oq purge 0"
+        scp "${lxc_ip}:jobs-*.html" "out_${BUILD_UBUVER}/"
+    fi
 
     scp -r "${lxc_ip}:/usr/share/doc/${GEM_DEB_PACKAGE}/changelog*" "out_${BUILD_UBUVER}/"
 


### PR DESCRIPTION
A bug was introduced in `packager.sh` (when?): even if on CI `run_pkg_demos` was __off__.

See for example: https://ci.openquake.org/job/zdevel_oq-engine/2351/parameters/ the computation was stuck because CI was trying to run the demos but celery was not started because `run_pkg_demos` was not set. It shouldn't had run any demo.

Fixed run: https://ci.openquake.org/job/zdevel_oq-engine/2354