### PR TITLE
Port WebUI to Django 1.9 and 1.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Port WebUI/API server to Django 1.9 and 1.10
+  * Add dependencies to setup.py
+
   [Michele Simionato]
   * Increased the splitting of ComplexFaultSources
   * Added a way to reuse the CompositeSourceModel from a previous computation

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,6 @@
   [Daniele Viganò]
   * Port WebUI/API server to Django 1.9 and 1.10
   * Add dependencies to setup.py
-  * Add dependencies to setup.py
   * Update Copyright to 2017
 
   [Michele Simionato]

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -19,8 +19,6 @@
 import os
 import getpass
 
-from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS
-
 from openquake.commonlib import config
 
 DB_SECTION = config.get_section('dbserver')
@@ -30,13 +28,31 @@ INSTALLED_APPS = ('openquake.server.db',)
 OQSERVER_ROOT = os.path.dirname(__file__)
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-TEMPLATE_CONTEXT_PROCESSORS += (
-    'django.contrib.messages.context_processors.messages',
-    'openquake.server.utils.oq_server_context_processor',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            # insert any extra TEMPLATE_DIRS here
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                # list if you haven't customized them:
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+                'openquake.server.utils.oq_server_context_processor',
+            ],
+        },
+    },
+]
 
 STATIC_URL = '/static/'
 
@@ -101,8 +117,12 @@ AUTH_EXEMPT_URLS = ()
 
 ROOT_URLCONF = 'openquake.server.urls'
 
-INSTALLED_APPS += ('django.contrib.staticfiles',
-                   'openquake.server',)
+INSTALLED_APPS += (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.staticfiles',
+    'openquake.server',
+)
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
@@ -174,7 +194,6 @@ if LOCKDOWN:
     )
 
     INSTALLED_APPS += (
-        'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.messages',
         'django.contrib.sessions',

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -39,8 +39,6 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
-                # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
-                # list if you haven't customized them:
                 'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
@@ -64,7 +62,6 @@ STATICFILES_DIRS = [
     os.path.join(OQSERVER_ROOT, 'static'),
 ]
 
-# We need a 'default' database to make Django happy:
 DATABASE = {
     'ENGINE': 'django.db.backends.sqlite3',
     'NAME': os.path.expanduser(DB_SECTION.get('file')),
@@ -86,7 +83,7 @@ AUTHENTICATION_BACKENDS = ()
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'Europe/Zurich'
+TIME_ZONE = 'Europe/Rome'
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
@@ -168,9 +165,6 @@ LOGGING = {
 }
 
 FILE_UPLOAD_MAX_MEMORY_SIZE = 1
-
-# Enable this setting if used as backend for the OpenQuake Platform
-# DEFAULT_USER = 'platform'
 
 try:
     from local_settings import *

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -188,7 +188,6 @@ if LOCKDOWN:
     )
 
     INSTALLED_APPS += (
-        'django.contrib.contenttypes',
         'django.contrib.messages',
         'django.contrib.sessions',
         'django.contrib.admin',

--- a/openquake/server/templates/account/login.html
+++ b/openquake/server/templates/account/login.html
@@ -1,6 +1,5 @@
 {% extends "engine/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Log in" %}{% endblock %}

--- a/openquake/server/templates/account/logout.html
+++ b/openquake/server/templates/account/logout.html
@@ -1,6 +1,5 @@
 {{% extends "engine/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Log in" %}{% endblock %}

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -17,33 +17,34 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf import settings
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.views.generic.base import RedirectView
+from django.contrib.auth.views import login, logout
 
-urlpatterns = patterns(
-    '',
+from openquake.server import views as oqserver
+
+urlpatterns = [
     url(r'^$', RedirectView.as_view(url='/engine/', permanent=True)),
-    url(r'^engine_version$', 'openquake.server.views.get_engine_version'),
+    url(r'^engine_version$', oqserver.get_engine_version),
     url(r'^v1/calc/', include('openquake.server.v1.calc_urls')),
-    url(r'^v1/valid/', 'openquake.server.views.validate_nrml'),
-    url(r'^engine/?$', 'openquake.server.views.web_engine', name="index"),
+    url(r'^v1/valid/', oqserver.validate_nrml),
+    url(r'^engine/?$', oqserver.web_engine, name="index"),
     url(r'^engine/(\d+)/outputs$',
-        'openquake.server.views.web_engine_get_outputs', name="outputs"),
-    url(r'^engine/license$', 'openquake.server.views.license',
+        oqserver.web_engine_get_outputs, name="outputs"),
+    url(r'^engine/license$', oqserver.license,
         name="license"),
-)
+]
 
 if settings.LOCKDOWN:
     from django.contrib import admin
 
     admin.autodiscover()
-    urlpatterns += patterns(
-        '',
+    urlpatterns += [
         url(r'^admin/', include(admin.site.urls)),
-        url(r'^accounts/login/$', 'django.contrib.auth.views.login',
+        url(r'^accounts/login/$', login,
             {'template_name': 'account/login.html'}, name="login"),
-        url(r'^accounts/logout/$', 'django.contrib.auth.views.logout',
+        url(r'^accounts/logout/$', logout,
             {'template_name': 'account/logout.html'}, name="logout"),
-        url(r'^accounts/ajax_login/$', 'openquake.server.views.ajax_login'),
-        url(r'^accounts/ajax_logout/$', 'openquake.server.views.ajax_logout'),
-    )
+        url(r'^accounts/ajax_login/$', oqserver.ajax_login),
+        url(r'^accounts/ajax_logout/$', oqserver.ajax_logout),
+    ]

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -21,17 +21,17 @@ from django.conf.urls import url, include
 from django.views.generic.base import RedirectView
 from django.contrib.auth.views import login, logout
 
-from openquake.server import views as oqserver
+from openquake.server import views
 
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url='/engine/', permanent=True)),
-    url(r'^engine_version$', oqserver.get_engine_version),
+    url(r'^engine_version$', views.get_engine_version),
     url(r'^v1/calc/', include('openquake.server.v1.calc_urls')),
-    url(r'^v1/valid/', oqserver.validate_nrml),
-    url(r'^engine/?$', oqserver.web_engine, name="index"),
+    url(r'^v1/valid/', views.validate_nrml),
+    url(r'^engine/?$', views.web_engine, name="index"),
     url(r'^engine/(\d+)/outputs$',
-        oqserver.web_engine_get_outputs, name="outputs"),
-    url(r'^engine/license$', oqserver.license,
+        views.web_engine_get_outputs, name="outputs"),
+    url(r'^engine/license$', views.license,
         name="license"),
 ]
 
@@ -45,6 +45,6 @@ if settings.LOCKDOWN:
             {'template_name': 'account/login.html'}, name="login"),
         url(r'^accounts/logout/$', logout,
             {'template_name': 'account/logout.html'}, name="logout"),
-        url(r'^accounts/ajax_login/$', oqserver.ajax_login),
-        url(r'^accounts/ajax_logout/$', oqserver.ajax_logout),
+        url(r'^accounts/ajax_login/$', views.ajax_login),
+        url(r'^accounts/ajax_logout/$', views.ajax_logout),
     ]

--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -18,22 +18,22 @@
 
 from django.conf.urls import url
 
-from openquake.server import views as oqserver
+from openquake.server import views
 
 # each url is prefixed with /v1/calc/
 urlpatterns = [
-    url(r'^list$', oqserver.calc),
-    url(r'^(\d+)$', oqserver.calc_info),
-    url(r'^(\d+)/datastore$', oqserver.get_datastore),
-    url(r'^(\d+)/status$', oqserver.calc),
-    url(r'^(\d+)/results$', oqserver.calc_results),
-    url(r'^(\d+)/traceback$', oqserver.get_traceback),
-    url(r'^(\d+)/log/size$', oqserver.get_log_size),
-    url(r'^(\d+)/log/(\d*):(\d*)$', oqserver.get_log_slice),
-    url(r'^(\d+)/remove$', oqserver.calc_remove),
-    url(r'^result/(\d+)$', oqserver.get_result),
-    url(r'^run$', oqserver.run_calc),
+    url(r'^list$', views.calc),
+    url(r'^(\d+)$', views.calc_info),
+    url(r'^(\d+)/datastore$', views.get_datastore),
+    url(r'^(\d+)/status$', views.calc),
+    url(r'^(\d+)/results$', views.calc_results),
+    url(r'^(\d+)/traceback$', views.get_traceback),
+    url(r'^(\d+)/log/size$', views.get_log_size),
+    url(r'^(\d+)/log/(\d*):(\d*)$', views.get_log_slice),
+    url(r'^(\d+)/remove$', views.calc_remove),
+    url(r'^result/(\d+)$', views.get_result),
+    url(r'^run$', views.run_calc),
 
-    url(r'^(\d+)/result/list$', oqserver.calc_results),
-    url(r'^\d+/result/(\d+)$', oqserver.get_result),
+    url(r'^(\d+)/result/list$', views.calc_results),
+    url(r'^\d+/result/(\d+)$', views.get_result),
 ]

--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -16,23 +16,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+
+from openquake.server import views as oqserver
 
 # each url is prefixed with /v1/calc/
-urlpatterns = patterns(
-    'openquake.server.views',
-    url(r'^list$', 'calc'),
-    url(r'^(\d+)$', 'calc_info'),
-    url(r'^(\d+)/datastore$', 'get_datastore'),
-    url(r'^(\d+)/status$', 'calc'),
-    url(r'^(\d+)/results$', 'calc_results'),
-    url(r'^(\d+)/traceback$', 'get_traceback'),
-    url(r'^(\d+)/log/size$', 'get_log_size'),
-    url(r'^(\d+)/log/(\d*):(\d*)$', 'get_log_slice'),
-    url(r'^(\d+)/remove$', 'calc_remove'),
-    url(r'^result/(\d+)$', 'get_result'),
-    url(r'^run$', 'run_calc'),
+urlpatterns = [
+    url(r'^list$', oqserver.calc),
+    url(r'^(\d+)$', oqserver.calc_info),
+    url(r'^(\d+)/datastore$', oqserver.get_datastore),
+    url(r'^(\d+)/status$', oqserver.calc),
+    url(r'^(\d+)/results$', oqserver.calc_results),
+    url(r'^(\d+)/traceback$', oqserver.get_traceback),
+    url(r'^(\d+)/log/size$', oqserver.get_log_size),
+    url(r'^(\d+)/log/(\d*):(\d*)$', oqserver.get_log_slice),
+    url(r'^(\d+)/remove$', oqserver.calc_remove),
+    url(r'^result/(\d+)$', oqserver.get_result),
+    url(r'^run$', oqserver.run_calc),
 
-    url(r'^(\d+)/result/list$', 'calc_results'),
-    url(r'^\d+/result/(\d+)$', 'get_result'),
-)
+    url(r'^(\d+)/result/list$', oqserver.calc_results),
+    url(r'^\d+/result/(\d+)$', oqserver.get_result),
+]

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -33,7 +33,7 @@ from django.http import (
     HttpResponse, HttpResponseNotFound, HttpResponseBadRequest)
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.contrib.auth import authenticate, login, logout
 try:
@@ -563,20 +563,17 @@ def get_datastore(request, job_id):
 
 
 def web_engine(request, **kwargs):
-    return render_to_response("engine/index.html",
-                              dict(),
-                              context_instance=RequestContext(request))
+    return render(request, "engine/index.html",
+                  dict())
 
 
 @cross_domain_ajax
 @require_http_methods(['GET'])
 def web_engine_get_outputs(request, calc_id, **kwargs):
-    return render_to_response("engine/get_outputs.html",
-                              dict([('calc_id', calc_id)]),
-                              context_instance=RequestContext(request))
+    return render(request, "engine/get_outputs.html",
+                  dict([('calc_id', calc_id)]))
 
 
 @require_http_methods(['GET'])
 def license(request, **kwargs):
-    return render_to_response("engine/license.html",
-                              context_instance=RequestContext(request))
+    return render(request, "engine/license.html")

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     'shapely >=1.3, <1.6',
     'docutils >=0.11, <0.14',
     'decorator >=3.4, <4.1',
-    'django >=1.6, <1.9',
+    'django >=1.6, <1.11',
     'requests >=2.2, <2.13',
     # pyshp is fragile, we want only versions we have tested
     'pyshp >=1.2.3, <1.2.11',


### PR DESCRIPTION
Keeps backward compatibility with any Django >= 1.6

Some manual testing would be great.

https://ci.openquake.org/job/zdevel_oq-engine/2355/ (could be red, because of https://github.com/gem/oq-engine/pull/2435, look only at server tests)
https://ci.openquake.org/view/macOS/job/macos/job/zdevel_mac_oq-engine/80/