### PR TITLE
Remove blank lines at the end of py files

### DIFF
--- a/bin/__init__.py
+++ b/bin/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/engine/tests/utils/__init__.py
+++ b/openquake/engine/tests/utils/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/__init__.py
+++ b/openquake/qa_tests_data/__init__.py
@@ -15,5 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-
- 

--- a/openquake/qa_tests_data/classical/__init__.py
+++ b/openquake/qa_tests_data/classical/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_1/__init__.py
+++ b/openquake/qa_tests_data/classical/case_1/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_10/__init__.py
+++ b/openquake/qa_tests_data/classical/case_10/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_11/__init__.py
+++ b/openquake/qa_tests_data/classical/case_11/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_12/__init__.py
+++ b/openquake/qa_tests_data/classical/case_12/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_2/__init__.py
+++ b/openquake/qa_tests_data/classical/case_2/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_3/__init__.py
+++ b/openquake/qa_tests_data/classical/case_3/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_4/__init__.py
+++ b/openquake/qa_tests_data/classical/case_4/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_5/__init__.py
+++ b/openquake/qa_tests_data/classical/case_5/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_6/__init__.py
+++ b/openquake/qa_tests_data/classical/case_6/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_7/__init__.py
+++ b/openquake/qa_tests_data/classical/case_7/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_8/__init__.py
+++ b/openquake/qa_tests_data/classical/case_8/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical/case_9/__init__.py
+++ b/openquake/qa_tests_data/classical/case_9/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical_bcr/__init__.py
+++ b/openquake/qa_tests_data/classical_bcr/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical_bcr/case_1/__init__.py
+++ b/openquake/qa_tests_data/classical_bcr/case_1/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical_risk/__init__.py
+++ b/openquake/qa_tests_data/classical_risk/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical_risk/case_1/__init__.py
+++ b/openquake/qa_tests_data/classical_risk/case_1/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical_risk/case_2/__init__.py
+++ b/openquake/qa_tests_data/classical_risk/case_2/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical_risk/case_3/__init__.py
+++ b/openquake/qa_tests_data/classical_risk/case_3/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/classical_risk/case_4/__init__.py
+++ b/openquake/qa_tests_data/classical_risk/case_4/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/disagg/__init__.py
+++ b/openquake/qa_tests_data/disagg/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/disagg/case_1/__init__.py
+++ b/openquake/qa_tests_data/disagg/case_1/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/__init__.py
+++ b/openquake/qa_tests_data/event_based/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/case_1/__init__.py
+++ b/openquake/qa_tests_data/event_based/case_1/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/case_12/__init__.py
+++ b/openquake/qa_tests_data/event_based/case_12/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/case_13/__init__.py
+++ b/openquake/qa_tests_data/event_based/case_13/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/case_2/__init__.py
+++ b/openquake/qa_tests_data/event_based/case_2/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/case_4/__init__.py
+++ b/openquake/qa_tests_data/event_based/case_4/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/spatial_correlation/__init__.py
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_1/__init__.py
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_1/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_2/__init__.py
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_2/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_3/__init__.py
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_3/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based_risk/__init__.py
+++ b/openquake/qa_tests_data/event_based_risk/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based_risk/case_1/__init__.py
+++ b/openquake/qa_tests_data/event_based_risk/case_1/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/event_based_risk/case_2/__init__.py
+++ b/openquake/qa_tests_data/event_based_risk/case_2/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/scenario/__init__.py
+++ b/openquake/qa_tests_data/scenario/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/scenario/case_1/__init__.py
+++ b/openquake/qa_tests_data/scenario/case_1/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/scenario/case_2/__init__.py
+++ b/openquake/qa_tests_data/scenario/case_2/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/scenario/case_3/__init__.py
+++ b/openquake/qa_tests_data/scenario/case_3/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/scenario/case_9/__init__.py
+++ b/openquake/qa_tests_data/scenario/case_9/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/qa_tests_data/scenario_risk/occupants/__init__.py
+++ b/openquake/qa_tests_data/scenario_risk/occupants/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/risklib/tests/__init__.py
+++ b/openquake/risklib/tests/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-

--- a/openquake/server/tests/db/__init__.py
+++ b/openquake/server/tests/db/__init__.py
@@ -15,4 +15,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-


### PR DESCRIPTION
Makes flake8 and @micheles happy

```bash
$ find -name "*.py" -exec sed -i ':a;/^[ \n]*$/{$d;N;ba}' {} \;
```