### PR TITLE
Add matplotlib to extras

### DIFF
--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -26,14 +26,27 @@ http://ftp.openquake.org/wheelhouse/linux/py27/futures-3.0.5-py2-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/Django-1.8.17-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/requests-2.9.1-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py27/pyshp-1.2.3-cp27-none-any.whl
-# Experimental wheel
+
+## Extra ##
+
+### Rtree ###
+# comment the following lines to skip installation
+# of Rtree (experimental wheel, optional feature)
 http://ftp.openquake.org/wheelhouse/linux/py27/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl
 
-# Celery support
-# uncomment the following lines to install celery
-# and its dependencies
-#http://ftp.openquake.org/wheelhouse/linux/py27/anyjson-0.3.3-cp27-none-any.whl
-#http://ftp.openquake.org/wheelhouse/linux/py/amqp-1.4.9-py2.py3-none-any.whl
-#http://ftp.openquake.org/wheelhouse/linux/py/kombu-3.0.33-py2.py3-none-any.whl
-#http://ftp.openquake.org/wheelhouse/linux/py27/billiard-3.3.0.22-cp27-cp27mu-linux_x86_64.whl
-#http://ftp.openquake.org/wheelhouse/linux/py/celery-3.1.20-py2.py3-none-any.whl
+### Celery ###
+# comment the following lines to skip installation
+# of celery (optional feature)
+http://ftp.openquake.org/wheelhouse/linux/py27/anyjson-0.3.3-cp27-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/amqp-1.4.9-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/kombu-3.0.33-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py27/billiard-3.3.0.22-cp27-cp27mu-linux_x86_64.whl
+http://ftp.openquake.org/wheelhouse/linux/py/celery-3.1.20-py2.py3-none-any.whl
+
+### Plotting ###
+# comment the following lines to skip installation
+# of the plotting libraries (optional feature)
+http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py27/matplotlib-1.5.3-cp27-cp27mu-manylinux1_x86_64.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -25,14 +25,27 @@ http://ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/Django-1.8.17-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/requests-2.9.1-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py35/pyshp-1.2.3-py3-none-any.whl
-# Experimental wheel
+
+## Extra ##
+
+### Rtree ###
+# comment the following lines to skip installation
+# of Rtree (experimental wheel, optional feature)
 http://ftp.openquake.org/wheelhouse/linux/py35/Rtree-0.8.2-cp35-cp35m-manylinux1_x86_64.whl
 
-# Celery support
-# uncomment the following lines to install celery
-# and its dependencies
-#http://ftp.openquake.org/wheelhouse/linux/py35/anyjson-0.3.3-py3-none-any.whl
-#http://ftp.openquake.org/wheelhouse/linux/py/amqp-1.4.9-py2.py3-none-any.whl
-#http://ftp.openquake.org/wheelhouse/linux/py/kombu-3.0.33-py2.py3-none-any.whl
-#http://ftp.openquake.org/wheelhouse/linux/py35/billiard-3.3.0.22-py3-none-any.whl
-#http://ftp.openquake.org/wheelhouse/linux/py/celery-3.1.20-py2.py3-none-any.whl
+### Celery ###
+# comment the following lines to skip installation
+# of celery (optional feature)
+http://ftp.openquake.org/wheelhouse/linux/py35/anyjson-0.3.3-py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/amqp-1.4.9-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/kombu-3.0.33-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py35/billiard-3.3.0.22-py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/celery-3.1.20-py2.py3-none-any.whl
+
+### Plotting ###
+# comment the following lines to skip installation
+# of the plotting libraries (optional feature)
+http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py35/matplotlib-1.5.3-cp35-cp35m-manylinux1_x86_64.whl

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if sys.version < '3':
     )
 
 extras_require = {
-    'rtree':  ["Rtree==0.8.2"],
+    'rtree':  ["Rtree >=0.8.2, <0.8.4"],
     'celery':  ["celery >=3.1, <4.0"],
     'plotting':  ["matplotlib >=1.5"],
 }

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ if sys.version < '3':
 extras_require = {
     'rtree':  ["Rtree==0.8.2"],
     'celery':  ["celery >=3.1, <4.0"],
+    'plotting':  ["matplotlib >=1.5"],
 }
 
 setup(


### PR DESCRIPTION
And allow usage of Rtree==0.8.3

Closes #2447 

Now, by default, "extra" deps are installed when `pip install -r requirements-py[27,35]-linux64.txt` is used on Linux.