### PR TITLE
Python 3 fix in upgrade_nrml

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -472,6 +472,7 @@ class HazardCalculator(BaseCalculator):
             self.exposure = readinput.get_exposure(self.oqparam)
             arefs = numpy.array(self.exposure.asset_refs, hdf5.vstr)
             self.datastore['asset_refs'] = arefs
+            self.datastore.flush()
             self.datastore.set_attrs('asset_refs', nbytes=arefs.nbytes)
             self.cost_calculator = readinput.get_cost_calculator(self.oqparam)
             self.sitecol, self.assets_by_site = (

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -472,7 +472,6 @@ class HazardCalculator(BaseCalculator):
             self.exposure = readinput.get_exposure(self.oqparam)
             arefs = numpy.array(self.exposure.asset_refs, hdf5.vstr)
             self.datastore['asset_refs'] = arefs
-            self.datastore.flush()
             self.datastore.set_attrs('asset_refs', nbytes=arefs.nbytes)
             self.cost_calculator = readinput.get_cost_calculator(self.oqparam)
             self.sitecol, self.assets_by_site = (

--- a/openquake/commands/upgrade_nrml.py
+++ b/openquake/commands/upgrade_nrml.py
@@ -28,8 +28,7 @@ from openquake.baselib.general import groupby
 from openquake.baselib.node import context, striptag, Node
 from openquake.hazardlib.nrml import NRML05
 from openquake.hazardlib import InvalidFile, nrml
-from openquake.risklib import scientific
-from openquake.commonlib import riskmodels
+from openquake.risklib import scientific, read_nrml
 
 
 def get_vulnerability_functions_04(fname):
@@ -94,10 +93,10 @@ def upgrade_file(path):
         # below I am converting into a NRML 0.5 vulnerabilityModel
         node0 = Node(
             'vulnerabilityModel', cat_dict,
-            nodes=list(map(riskmodels.obj_to_node, vf_dict.values())))
+            nodes=list(map(read_nrml.obj_to_node, vf_dict.values())))
         gml = False
     elif tag == 'fragilityModel':
-        node0 = riskmodels.convert_fragility_model_04(
+        node0 = read_nrml.convert_fragility_model_04(
             nrml.read(path)[0], path)
         gml = False
     elif tag == 'sourceModel':
@@ -107,7 +106,7 @@ def upgrade_file(path):
                             dict(tectonicRegion=trt, name="group %s" % i),
                             nodes=srcs)
                        for i, (trt, srcs) in enumerate(dic.items(), 1)]
-    with open(path, 'w') as f:
+    with open(path, 'wb') as f:
         nrml.write([node0], f, gml=gml)
 
 


### PR DESCRIPTION
The python 3 fix is a change from `open(path, 'w')` to  `open(path, 'wb') ` (we want a bynary stream, not a text stream). Moreover there are some import changes since the function `convert_fragility_model_04` has been moved.