### PR TITLE
Commented a tricky line and updated the risk validators

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -472,7 +472,12 @@ class HazardCalculator(BaseCalculator):
             self.exposure = readinput.get_exposure(self.oqparam)
             arefs = numpy.array(self.exposure.asset_refs, hdf5.vstr)
             self.datastore['asset_refs'] = arefs
-            self.datastore.set_attrs('asset_refs', nbytes=arefs.nbytes)
+            # the line below is commented out since it fails in computations
+            # with extra-large exposures (ex. PT_Scenario with 200,000+ assets)
+            # the reason is totally mysterious, the error is a KeyError:
+            # 'Unable to open object (Bad object header version number)'
+            # and the datastore becomes corrupt :-(
+            # self.datastore.set_attrs('asset_refs', nbytes=arefs.nbytes)
             self.cost_calculator = readinput.get_cost_calculator(self.oqparam)
             self.sitecol, self.assets_by_site = (
                 readinput.get_sitecol_assets(self.oqparam, self.exposure))

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -39,6 +39,8 @@ from openquake.baselib.general import groupby, writetmp
 from openquake.baselib.python3compat import unicode
 from openquake.baselib.parallel import Starmap, safely_call
 from openquake.hazardlib import nrml
+from openquake.risklib import read_nrml
+
 from openquake.commonlib import readinput, oqvalidation
 from openquake.calculators.export import export
 from openquake.engine import __version__ as oqversion
@@ -59,6 +61,7 @@ try:
 except ImportError:
     from django.core.servers.basehttp import FileWrapper
 
+read_nrml.update_validators()  # update risk validators
 
 METHOD_NOT_ALLOWED = 405
 NOT_IMPLEMENTED = 501


### PR DESCRIPTION
I discovered that the computation PT_Scenario/onshore failed at the line `self.datastore.set_attrs('asset_refs', nbytes=arefs.nbytes)` because of a bug in the HDF5 libraries, a bug happening only with an extra-large exposure (200,000+ assets). The solution is to remove that line that was not used by the computation anyway. The ostrich approach wins!

I am also adding two lines in the `server.views` to make sure that the risk validators are used.