### PR TITLE
Cython isn't needed, get rid of it

### DIFF
--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -9,7 +9,6 @@
 http://ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py27/pkgconfig-1.1.0-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/Cython-0.23.4-cp27-cp27mu-manylinux1_x86_64.whl
 http://ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py27/h5py-2.6.0-1-cp27-cp27mu-manylinux1_x86_64.whl
 http://ftp.openquake.org/wheelhouse/linux/py27/nose-1.3.7-py2-none-any.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -9,7 +9,6 @@
 http://ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py35/pkgconfig-1.1.0-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/Cython-0.23.4-cp35-cp35m-manylinux1_x86_64.whl
 http://ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py35/h5py-2.6.0-1-cp35-cp35m-manylinux1_x86_64.whl
 http://ftp.openquake.org/wheelhouse/linux/py35/nose-1.3.7-py3-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ Copyright (C) 2010-2017 GEM Foundation
 PY_MODULES = ['openquake.commands.__main__']
 
 install_requires = [
-    'Cython >=0.20, <0.26',
     'mock >=1.0, <1.4',
     'h5py >=2.2, <2.7',
     'nose >=1.3, <1.4',


### PR DESCRIPTION
In setup and requirements we had Cython, but it isn't used anymore and installed by binary packages.

This was causing, for example, compilation of cython during installation of those apps that have `openquake.engine` in their requirements and are installed on a system which uses only binary packages.

(an example: https://ci.openquake.org/job/zdevel_oq-platform-standalone/63/console)

Companion:

- https://github.com/gem/oq-hazardlib/pull/564
