### PR TITLE
Add requirements with local wheels copy for macOS

### DIFF
--- a/requirements-py27-macos.txt
+++ b/requirements-py27-macos.txt
@@ -34,4 +34,4 @@ http://ftp.openquake.org/wheelhouse/macos/py27/pyshp-1.2.3-cp27-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py/pyparsing-2.1.10-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py/python_dateutil-2.6.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/matplotlib-1.5.3-cp27-cp27mu-manylinux1_x86_64.whl
+http://ftp.openquake.org/wheelhouse/mac/py27/matplotlib-1.5.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl

--- a/requirements-py27-macos.txt
+++ b/requirements-py27-macos.txt
@@ -1,0 +1,37 @@
+# Suggested versions for development based on
+# Ubuntu 16.04 stack
+# !! these are meant to be used with Apple shipped python !!
+# !!    must update pip first! so wheels will be used     !!
+
+# GEM Mirror
+
+http://ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/pkgconfig-1.1.0-cp27-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/h5py-2.6.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/nose-1.3.7-py2-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/numpy-1.11.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/scipy-0.17.1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/psutil-4.4.2-cp27-cp27m-macosx_10_11_intel.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/Shapely-1.5.17.post1-cp27-cp27m-macosx_10_6_intel.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/docutils-0.12-cp27-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.10-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/futures-3.0.5-py2-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/Django-1.8.17-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/requests-2.9.1-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/pyshp-1.2.3-cp27-none-any.whl
+
+## Extra ##
+
+### Rtree wheel is not currently available for macOS ###
+
+### Plotting ###
+# comment the following lines to skip installation
+# of the plotting libraries (optional feature)
+http://ftp.openquake.org/wheelhouse/macos/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py/cycler-0.10.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/matplotlib-1.5.3-cp27-cp27mu-manylinux1_x86_64.whl


### PR DESCRIPTION
As we do for linux, this is our reference.
Python 2.7 only since currently Apple does not ship Python 3 by default.

Companion on hazardlib https://github.com/gem/oq-hazardlib/pull/565