### PR TITLE
Use a differnt port, with a better reputation for dbserver

### DIFF
--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -13,5 +13,5 @@ Index: oq-engine/openquake.cfg
 +file = /var/lib/openquake/db.sqlite3
 +log = /var/lib/openquake/dbserver.log
  host = localhost
- port = 1999
+ port = 1908
  authkey = changeme

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -44,7 +44,7 @@ multi_user = true
 file = /var/lib/openquake/db.sqlite3
 log = /var/lib/openquake/dbserver.log
 host = w.x.y.z
-port = 1999
+port = 1908
 authkey = changeme
 ```
 
@@ -78,10 +78,10 @@ Additionally, access to the RabbitMQ, and DbServer ports should be limited (agai
 The following ports must be open on the **master node**:
 
 * 5672 for RabbitMQ
-* 1999 for DbServer
+* 1908 for DbServer
 * 8800 for the API/WebUI (optional)
 
-The **worker nodes** must be able to connect to the master on port 5672, and port 1999.
+The **worker nodes** must be able to connect to the master on port 5672, and port 1908.
 
 
 ## Storage requirements

--- a/openquake.cfg
+++ b/openquake.cfg
@@ -44,7 +44,7 @@ multi_user = false
 file = ~/oqdata/db.sqlite3
 log = ~/oqdata/dbserver.log
 host = localhost
-port = 1999
+port = 1908
 authkey = changeme
 
 [directory]

--- a/openquake.cfg
+++ b/openquake.cfg
@@ -44,6 +44,8 @@ multi_user = false
 file = ~/oqdata/db.sqlite3
 log = ~/oqdata/dbserver.log
 host = localhost
+# port 1908 has a good reputation:
+# https://isc.sans.edu/port.html?port=1908
 port = 1908
 authkey = changeme
 


### PR DESCRIPTION
Currently it's `1999` which is used by some Cisco network equipment and has then a bad reputation (see http://www.speedguide.net/port.php?port=1999), so firewall are locking it even on the `loopback` interface. This PR changes the default port to `1908` (the [Great Messina earthquake](http://emidius.mi.ingv.it/CPTI15-DBMI15/eq/19081228_0420_000)) which has a far better reputation (http://www.speedguide.net/port.php?port=1908).