### PR TITLE
Fixed bug when running `oq info job.ini` with NRML 0.5 source models + bug with oq info --report in event based risk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed bug when running `oq info job.ini` with NRML 0.5 source models
+
 python-oq-engine (2.2.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -479,6 +479,8 @@ class HazardCalculator(BaseCalculator):
             self.cost_calculator = readinput.get_cost_calculator(self.oqparam)
             self.sitecol, self.assets_by_site = (
                 readinput.get_sitecol_assets(self.oqparam, self.exposure))
+            logging.info('Read %d assets on %d sites',
+                         len(arefs), len(self.assets_by_site))
 
     def get_min_iml(self, oq):
         # set the minimum_intensity

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -159,6 +159,9 @@ def build_report(job_ini, output_dir=None):
     # some taken is care so that the real calculation is not run:
     # the goal is to extract information about the source management only
     with mock.patch.object(PSHACalculator, 'core_task', count_eff_ruptures):
+        if calc.pre_calculator == 'ebrisk':
+            # compute the ruptures only, not the risk
+            calc.pre_calculator = 'event_based_rupture'
         calc.pre_execute()
     if hasattr(calc, '_composite_source_model'):
         calc.datastore['csm_info'] = calc.csm.info

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -32,6 +32,7 @@ from openquake.calculators.export import export
 from openquake.calculators import base, reportwriter
 from openquake.calculators.views import view, rst_table
 
+
 def print_csm_info(fname):
     """
     Parse the composite source model without instantiating the sources and

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -403,12 +403,12 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
         else:  # just collect the TRT models
             smodel = nrml.read(fname).sourceModel
             src_groups = []
-            if smodel[0].tag.endswith('sourceGroup'):
+            if smodel[0].tag.endswith('sourceGroup'):  # NRML 0.5 format
                 for sg_node in smodel:
                     sg = sourceconverter.SourceGroup(sg_node['tectonicRegion'])
                     sg.sources = sg_node.nodes
                     src_groups.append(sg)
-            else:  # smodel is a list of source nodes
+            else:  # NRML 0.4 format: smodel is a list of source nodes
                 src_groups.extend(sourceconverter.SourceGroup.collect(smodel))
         sm.src_groups = src_groups
         trts = [mod.trt for mod in src_groups]

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -402,7 +402,14 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
                     raise
         else:  # just collect the TRT models
             smodel = nrml.read(fname).sourceModel
-            src_groups = sourceconverter.SourceGroup.collect(smodel)
+            src_groups = []
+            if smodel[0].tag.endswith('sourceGroup'):
+                for sg_node in smodel:
+                    sg = sourceconverter.SourceGroup(sg_node['tectonicRegion'])
+                    sg.sources = sg_node.nodes
+                    src_groups.append(sg)
+            else:  # smodel is a list of source nodes
+                src_groups.extend(sourceconverter.SourceGroup.collect(smodel))
         sm.src_groups = src_groups
         trts = [mod.trt for mod in src_groups]
         source_model_lt.tectonic_region_types.update(trts)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -740,8 +740,6 @@ def get_exposure(oqparam):
                      len(exposure.assets), out_of_region)
         if len(exposure.assets) == 0:
             raise RuntimeError('Could not find any asset within the region!')
-    else:
-        logging.info('Read %d assets', len(exposure.assets))
 
     # sanity check
     values = any(len(ass.values) + ass.number for ass in exposure.assets)

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -29,6 +29,7 @@ from numpy.testing import assert_allclose
 from openquake.hazardlib import valid
 from openquake.commonlib import readinput, writers
 from openquake.baselib import general
+from openquake.qa_tests_data.classical import case_1, case_2
 
 TMP = tempfile.gettempdir()
 DATADIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -786,3 +787,19 @@ class TestLoadCurvesTestCase(unittest.TestCase):
         self.assertEqual(str(hcurves), '''\
 [([0.098727, 0.098265, 0.094956], [0.098728, 0.098216, 0.094945, 0.092947])
  ([0.98728, 0.98266, 0.94957], [0.98728, 0.98226, 0.94947, 0.92947])]''')
+
+
+class GetCompositeSourceModelTestCase(unittest.TestCase):
+    # test the case in_memory=False, used when running `oq info job.ini`
+
+    def test_nrml05(self):
+        oq = readinput.get_oqparam('job.ini', case_1)
+        csm = readinput.get_composite_source_model(oq, in_memory=False)
+        srcs = csm.get_sources()  # a single PointSource
+        self.assertEqual(len(srcs), 1)
+
+    def test_nrml04(self):
+        oq = readinput.get_oqparam('job.ini', case_2)
+        csm = readinput.get_composite_source_model(oq, in_memory=False)
+        srcs = csm.get_sources()  # a single PointSource
+        self.assertEqual(len(srcs), 1)


### PR DESCRIPTION
`oq info job.ini` calls `get_composite_source_model` with the flag `in_memory=False`. There was no test for this case and it was broken in the case of source models in the new format NRML 0.5. This PR fixes the bug and adds a test.

PS: I am also fixing a bug with `oq info --report` running the ebrisk calculator instead of the `event_based_rupture` calculator.

See https://ci.openquake.org/job/zdevel_oq-engine/2370/