### PR TITLE
Fixed `oq engine --make-html-report` when using Python 3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed `oq engine --make-html-report` when using Python 3
   * Fixed bug when running `oq info job.ini` with NRML 0.5 source models
 
 python-oq-engine (2.2.0-0~precise01) precise; urgency=low

--- a/openquake/engine/tools/make_html_report.py
+++ b/openquake/engine/tools/make_html_report.py
@@ -186,5 +186,5 @@ def make_report(isodate='today'):
         'Report last updated: %s' % datetime.now())
     fname = 'jobs-%s.html' % isodate
     with open(fname, 'w') as f:
-        f.write(PAGE_TEMPLATE % page.encode('utf-8'))
+        f.write(PAGE_TEMPLATE % page)
     return fname

--- a/openquake/engine/tools/make_html_report.py
+++ b/openquake/engine/tools/make_html_report.py
@@ -17,6 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
 import cgi
 import time
 from datetime import date, datetime, timedelta
@@ -184,6 +185,8 @@ def make_report(isodate='today'):
 
     page = make_tabs(tag_ids, tag_status, tag_contents) + (
         'Report last updated: %s' % datetime.now())
+    if sys.version[0] == '2':  # Python 2
+        page = page.encode('utf-8')
     fname = 'jobs-%s.html' % isodate
     with open(fname, 'w') as f:
         f.write(PAGE_TEMPLATE % page)


### PR DESCRIPTION
This was the reason for the ugly reports in http://performance.openquake.org/jobs-2017-01-24.html
Since this is a minor issue, it is best to just wait; when Jenkins will be updated to use Python 3 this part will be tested automatically too.