### PR TITLE
Do not try to export the loss_maps if conditional_loss_poes is empty

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * If there are no conditional_loss_poes, the engine does not try to
+    export the loss maps anymore
   * Fixed `oq engine --make-html-report` when using Python 3
   * Fixed bug when running `oq info job.ini` with NRML 0.5 source models
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -87,10 +87,11 @@ def expose_outputs(dstore):
         dskeys.add('uhs')  # export them
     if oq.hazard_maps:
         dskeys.add('hmaps')  # export them
-    if 'rcurves-rlzs' in dstore or 'loss_curves-rlzs' in dstore:
-        dskeys.add('loss_maps-rlzs')
-    if 'rcurves-stats' in dstore or 'loss_curves-stats' in dstore:
-        dskeys.add('loss_maps-stats')
+    if oq.conditional_loss_poes:  # expose loss_maps outputs
+        if 'rcurves-rlzs' in dstore or 'loss_curves-rlzs' in dstore:
+            dskeys.add('loss_maps-rlzs')
+        if 'rcurves-stats' in dstore or 'loss_curves-stats' in dstore:
+            dskeys.add('loss_maps-stats')
     try:
         rlzs = dstore['realizations']
     except KeyError:


### PR DESCRIPTION
This happens to users with a wrong configuration file. The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2374/