### PR TITLE
If there is a single realization, do not compute the statistics

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * If there is a single realization, do not compute the statistics
   * Changed the separator from comma to tab for the output `ruptures`
   * If there are no conditional_loss_poes, the engine does not try to
     export the loss maps anymore

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -421,9 +421,11 @@ def build_hcurves_and_stats(pmap_by_grp, sids, pstats, rlzs_assoc, monitor):
     rlzs = rlzs_assoc.realizations
     with monitor('combine pmaps'):
         pmap_by_rlz = calc.combine_pmaps(rlzs_assoc, pmap_by_grp)
-    with monitor('compute stats'):
-        pmap_by_kind = dict(
-            pstats.compute(sids, [pmap_by_rlz[rlz] for rlz in rlzs]))
+    pmap_by_kind = {}
+    if len(rlzs) > 1:
+        with monitor('compute stats'):
+            pmap_by_kind.update(
+                pstats.compute(sids, [pmap_by_rlz[rlz] for rlz in rlzs]))
     if monitor.individual_curves:
         for rlz in rlzs:
             pmap_by_kind['rlz-%03d' % rlz.ordinal] = pmap_by_rlz[rlz]


### PR DESCRIPTION
@mmpagani discovered that setting `mean_hazard_curves=true` in a calculation with a single realization was raising a `KeyError: "Unable to open object (Object 'mean' doesn't exist)"`. Now we just skip computing the statistics in the single realization case.
