### PR TITLE
Add prctl to optional deps

### DIFF
--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -28,6 +28,11 @@ http://ftp.openquake.org/wheelhouse/linux/py27/pyshp-1.2.3-cp27-none-any.whl
 
 ## Extra ##
 
+### pythn-prctl ###
+# comment the following lines to skip installation
+# of pythn-prctl (optional feature)
+http://ftp.openquake.org/wheelhouse/linux/py27/python_prctl-1.6.1-cp27-cp27mu-manylinux1_x86_64.whl
+
 ### Rtree ###
 # comment the following lines to skip installation
 # of Rtree (experimental wheel, optional feature)

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -30,7 +30,7 @@ http://ftp.openquake.org/wheelhouse/linux/py27/pyshp-1.2.3-cp27-none-any.whl
 
 ### pythn-prctl ###
 # comment the following lines to skip installation
-# of pythn-prctl (optional feature)
+# of python-prctl (optional feature)
 http://ftp.openquake.org/wheelhouse/linux/py27/python_prctl-1.6.1-cp27-cp27mu-manylinux1_x86_64.whl
 
 ### Rtree ###

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -29,7 +29,7 @@ http://ftp.openquake.org/wheelhouse/linux/py35/pyshp-1.2.3-py3-none-any.whl
 
 ### pythn-prctl ###
 # comment the following lines to skip installation
-# of pythn-prctl (optional feature)
+# of python-prctl (optional feature)
 http://ftp.openquake.org/wheelhouse/linux/py35/python_prctl-1.6.1-cp35-cp35m-manylinux1_x86_64.whl
 
 ### Rtree ###

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -27,6 +27,11 @@ http://ftp.openquake.org/wheelhouse/linux/py35/pyshp-1.2.3-py3-none-any.whl
 
 ## Extra ##
 
+### pythn-prctl ###
+# comment the following lines to skip installation
+# of pythn-prctl (optional feature)
+http://ftp.openquake.org/wheelhouse/linux/py35/python_prctl-1.6.1-cp35-cp35m-manylinux1_x86_64.whl
+
 ### Rtree ###
 # comment the following lines to skip installation
 # of Rtree (experimental wheel, optional feature)

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ if sys.version < '3':
     )
 
 extras_require = {
+    'prctl': ["python-prctl ==1.6.1"],
     'rtree':  ["Rtree >=0.8.2, <0.8.4"],
     'celery':  ["celery >=3.1, <4.0"],
     'plotting':  ["matplotlib >=1.5"],


### PR DESCRIPTION
And include its wheel (a `manylinux1` with embedded `libcap` made by us) in requirements for linux.

We still have the issue with orphan children when a calculation is stopped with `CTRL-C` or `SIGTERM`; adding `prctl` mitigates the issue.