### PR TITLE
Do not save boundary info into `rup_data` for ucerf event based

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced the data transfer back and disk space for UCERF event based risk
   * Tasks meant to be used with a shared directory are now marked with a
     boolean attribute `.shared_dir_on`
   * Added a warning when running event based risk calculations with sampling

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -31,7 +31,7 @@ from openquake.hazardlib.calc.filters import \
     filter_sites_by_distance_to_rupture
 from openquake.risklib.riskinput import GmfGetter, str2rsi, rsi2str
 from openquake.baselib import parallel
-from openquake.commonlib import calc, util
+from openquake.commonlib import calc, util, datastore
 from openquake.calculators import base
 from openquake.calculators.classical import ClassicalCalculator, PSHACalculator
 
@@ -276,8 +276,9 @@ class EventBasedRuptureCalculator(PSHACalculator):
                 multiplicity = dset['multiplicity']
                 spr = numpy.average(numsites, weights=multiplicity)
                 mul = numpy.average(multiplicity, weights=numsites)
-                self.datastore.set_attrs(dset.name, sites_per_rupture=spr,
-                                         multiplicity=mul)
+                self.datastore.set_attrs(
+                    dset.name, sites_per_rupture=spr,
+                    multiplicity=mul, nbytes=datastore.get_nbytes(dset))
         self.datastore.set_nbytes('rup_data')
 
 

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -783,8 +783,9 @@ def compute_ruptures(sources, sitecol, gsims, monitor):
     res[src.src_group_id] = ebruptures
     res.calc_times[src.src_group_id] = (
         src.source_id, len(sitecol), time.time() - t0)
-    res.rup_data = {src.src_group_id:
-                    calc.RuptureData(DEFAULT_TRT, gsims).to_array(ebruptures)}
+    # not returning the boundary to save data transfer and disk space
+    res.rup_data = {src.src_group_id: calc.RuptureData(DEFAULT_TRT, gsims)
+                    .to_array(ebruptures, boundary='')}
     return res
 
 

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -383,10 +383,11 @@ class RuptureData(object):
             point = rup.surface.get_middle_point()
             multi_lons, multi_lats = rup.surface.get_surface_boundaries()
             if boundary is None:
-                coords = ['((%s))' % ','.join(
+                bounds = ','.join('((%s))' % ','.join(
                     '%.5f %.5f' % (lon, lat) for lon, lat in zip(lons, lats))
-                        for lons, lats in zip(multi_lons, multi_lats)]
-                boundary = ','.join(coords)
+                    for lons, lats in zip(multi_lons, multi_lats))
+            else:
+                bounds = boundary
             try:
                 rate = ebr.rupture.occurrence_rate
             except AttributeError:  # for nonparametric sources
@@ -394,7 +395,7 @@ class RuptureData(object):
             data.append((ebr.serial, ebr.multiplicity, len(ebr.sids),
                          rate, rup.mag, point.x, point.y, point.z,
                          rup.surface.get_strike(), rup.surface.get_dip(),
-                         rup.rake, decode(boundary)) + ruptparams)
+                         rup.rake, decode(bounds)) + ruptparams)
         return numpy.array(data, self.dt)
 
 

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -371,7 +371,10 @@ class RuptureData(object):
             ('strike', F64), ('dip', F64), ('rake', F64),
             ('boundary', hdf5.vstr)] + [(param, F64) for param in self.params])
 
-    def to_array(self, ebruptures):
+    def to_array(self, ebruptures, boundary=None):
+        """
+        Convert a list of ebruptures into an array of dtype RuptureRata.dt
+        """
         data = []
         for ebr in ebruptures:
             rup = ebr.rupture
@@ -379,9 +382,11 @@ class RuptureData(object):
             ruptparams = tuple(getattr(rc, param) for param in self.params)
             point = rup.surface.get_middle_point()
             multi_lons, multi_lats = rup.surface.get_surface_boundaries()
-            boundary = ','.join('((%s))' % ','.join(
-                '%.5f %.5f' % (lon, lat) for lon, lat in zip(lons, lats))
-                                for lons, lats in zip(multi_lons, multi_lats))
+            if boundary is None:
+                coords = ['((%s))' % ','.join(
+                    '%.5f %.5f' % (lon, lat) for lon, lat in zip(lons, lats))
+                        for lons, lats in zip(multi_lons, multi_lats)]
+                boundary = ','.join(coords)
             try:
                 rate = ebr.rupture.occurrence_rate
             except AttributeError:  # for nonparametric sources


### PR DESCRIPTION
As discovered by Anirudh, the  datastore files for UCERF event based calculations are a lot larger than before (for instance from ~2 GB to ~8 GB in typical calculations for California). The reason is that in engine 2.2 we added information to the event loss table exporter (i.e. magnitude and centroid for each rupture). Such information is stored in the `rup_data` table; keeping such information takes a lot of space.
Actually, the `rup_data` also contains a `boundary` string which is pretty large and it is not needed by the event loss table exporter. This PR strips that information (only for UCERF) and reduces the data transfer and data storage. Here are some numbers:

```
    [#13044 INFO] Received 5.67 GB of data # master
    /home/openquake/michele/oqdata/calc_13044.hdf5 : 8.67 GB

    [#13045 INFO] Received 2.38 GB of data  # this branch
    /home/openquake/michele/oqdata/calc_13045.hdf5 : 5.34 GB
```

We could remove `rup_data` entirely at the cost of removing information from the event loss table exporter (i.e. centroid_lon, centroid_lat, centroid_depth, magnitude would became numpy.nan fields). Not sure if we want to go that way, though.