### PR TITLE
Removed rup_data from ucerf event based calculators

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
   [Michele Simionato]
   * Added a command `oq reset` to reset database and datastores
-  * Reduced the data transfer back and disk space for UCERF event based risk
+  * Reduced the data transfer back and disk space occupation for UCERF
+    event based risk calculations
   * Tasks meant to be used with a shared directory are now marked with a
     boolean attribute `.shared_dir_on`
   * Added a warning when running event based risk calculations with sampling

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -269,7 +269,8 @@ class EventBasedRuptureCalculator(PSHACalculator):
         if 'ruptures' in self.datastore:
             self.datastore.set_nbytes('ruptures')
         self.datastore.set_nbytes('events')
-
+        if 'rup_data' not in self.datastore:
+            return
         for dset in self.datastore['rup_data'].values():
             if len(dset):
                 numsites = dset['numsites']

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -714,6 +714,7 @@ class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
                 ses_per_logic_tree_path=oq.ses_per_logic_tree_path,
                 maximum_distance=oq.maximum_distance,
                 samples=ssm.source_models[0].samples,
+                save_ruptures=oq.save_ruptures,
                 seed=ssm.source_model_lt.seed)
             gsims = ssm.gsim_lt.values[DEFAULT_TRT]
             yield ssm.get_sources(), self.sitecol.complete, gsims, monitor
@@ -783,9 +784,9 @@ def compute_ruptures(sources, sitecol, gsims, monitor):
     res[src.src_group_id] = ebruptures
     res.calc_times[src.src_group_id] = (
         src.source_id, len(sitecol), time.time() - t0)
-    # not returning the boundary to save data transfer and disk space
-    res.rup_data = {src.src_group_id: calc.RuptureData(DEFAULT_TRT, gsims)
-                    .to_array(ebruptures, boundary='')}
+    if monitor.save_ruptures:
+        res.rup_data = {src.src_group_id: calc.RuptureData(DEFAULT_TRT, gsims)
+                        .to_array(ebruptures)}
     return res
 
 
@@ -841,7 +842,7 @@ def compute_losses(ssm, sitecol, assetcol, riskmodel,
     res.num_events = len(ri.eids)
     start = res.sm_id * num_rlzs
     res.rlz_slice = slice(start, start + num_rlzs)
-    # don't return back the ruptures, only the events and rup_data
+    # don't return back the ruptures, only the events
     res.ruptures_by_grp[grp_id] = [EBR(ebr.serial, ebr.source_id, ebr.events)
                                    for ebr in ebruptures]
     return res
@@ -875,6 +876,7 @@ class UCERFRiskCalculator(EbriskCalculator):
                 ses_per_logic_tree_path=oq.ses_per_logic_tree_path,
                 maximum_distance=oq.maximum_distance,
                 samples=sm.samples,
+                save_ruptures=oq.save_ruptures,
                 seed=self.oqparam.random_seed)
             ssm = self.csm.get_model(sm.ordinal)
             yield (ssm, self.sitecol, self.assetcol, self.riskmodel,

--- a/openquake/qa_tests_data/ucerf/expected/agg_losses-rlz-000.csv
+++ b/openquake/qa_tests_data/ucerf/expected/agg_losses-rlz-000.csv
@@ -1,12 +1,12 @@
-event_tag,year,tectonic_region_type,magnitude,centroid_lon,centroid_lat,centroid_depth,structural
-grp=00~ses=0001~src=ltbr1299~rup=29-00,222,Active Shallow Crust,6.85000E+00,-1.22100E+02,3.71000E+01,7.50000E+00,9.07347E+06
-grp=00~ses=0001~src=ltbr1299~rup=26-00,1179,Active Shallow Crust,5.95000E+00,-1.22000E+02,3.72000E+01,3.78812E+00,1.40565E+06
-grp=00~ses=0001~src=ltbr1299~rup=17-01,1203,Active Shallow Crust,5.75000E+00,-1.21800E+02,3.73000E+01,9.00000E+00,7.05051E+04
-grp=00~ses=0001~src=ltbr1299~rup=17-00,3506,Active Shallow Crust,5.75000E+00,-1.21800E+02,3.73000E+01,9.00000E+00,4.10128E+05
-grp=00~ses=0001~src=ltbr1299~rup=26-01,4242,Active Shallow Crust,5.95000E+00,-1.22000E+02,3.72000E+01,3.78812E+00,2.09058E+04
-grp=00~ses=0001~src=ltbr1299~rup=23-00,5167,Active Shallow Crust,5.85000E+00,-1.21800E+02,3.73000E+01,6.00000E+00,6.34420E+05
-grp=00~ses=0001~src=ltbr1299~rup=22-00,5602,Active Shallow Crust,5.85000E+00,-1.22000E+02,3.72000E+01,6.00000E+00,1.99221E+06
-grp=00~ses=0001~src=ltbr1299~rup=5-00,8185,Active Shallow Crust,5.55000E+00,-1.21800E+02,3.73000E+01,9.00000E+00,3.27863E+05
-grp=00~ses=0001~src=ltbr1299~rup=17-02,8373,Active Shallow Crust,5.75000E+00,-1.21800E+02,3.73000E+01,9.00000E+00,1.27294E+06
-grp=00~ses=0001~src=ltbr1299~rup=28-00,8652,Active Shallow Crust,6.05000E+00,-1.22000E+02,3.72000E+01,6.00000E+00,2.04430E+05
-grp=00~ses=0001~src=ltbr1299~rup=22-01,9747,Active Shallow Crust,5.85000E+00,-1.22000E+02,3.72000E+01,6.00000E+00,3.25749E+04
+event_tag,year,structural
+grp=00~ses=0001~src=ltbr1299~rup=29-00,222,9.07347E+06
+grp=00~ses=0001~src=ltbr1299~rup=26-00,1179,1.40565E+06
+grp=00~ses=0001~src=ltbr1299~rup=17-01,1203,7.05051E+04
+grp=00~ses=0001~src=ltbr1299~rup=17-00,3506,4.10128E+05
+grp=00~ses=0001~src=ltbr1299~rup=26-01,4242,2.09058E+04
+grp=00~ses=0001~src=ltbr1299~rup=23-00,5167,6.34420E+05
+grp=00~ses=0001~src=ltbr1299~rup=22-00,5602,1.99221E+06
+grp=00~ses=0001~src=ltbr1299~rup=5-00,8185,3.27863E+05
+grp=00~ses=0001~src=ltbr1299~rup=17-02,8373,1.27294E+06
+grp=00~ses=0001~src=ltbr1299~rup=28-00,8652,2.04430E+05
+grp=00~ses=0001~src=ltbr1299~rup=22-01,9747,3.25749E+04

--- a/openquake/qa_tests_data/ucerf/expected/agg_losses-rlz-001.csv
+++ b/openquake/qa_tests_data/ucerf/expected/agg_losses-rlz-001.csv
@@ -1,11 +1,11 @@
-event_tag,year,tectonic_region_type,magnitude,centroid_lon,centroid_lat,centroid_depth,structural
-grp=01~ses=0001~src=ltbr0723~rup=26-00,741,Active Shallow Crust,6.15000E+00,-1.22100E+02,3.71000E+01,6.00000E+00,1.13253E+05
-grp=01~ses=0001~src=ltbr0723~rup=24-00,1288,Active Shallow Crust,5.95000E+00,-1.22000E+02,3.72000E+01,6.00000E+00,1.56092E+05
-grp=01~ses=0001~src=ltbr0723~rup=17-02,2142,Active Shallow Crust,5.75000E+00,-1.21800E+02,3.73000E+01,3.00000E+00,1.35586E+06
-grp=01~ses=0001~src=ltbr0723~rup=16-00,3054,Active Shallow Crust,5.75000E+00,-1.22000E+02,3.72000E+01,9.00000E+00,1.02708E+06
-grp=01~ses=0001~src=ltbr0723~rup=4-01,3776,Active Shallow Crust,5.55000E+00,-1.21800E+02,3.73000E+01,6.00000E+00,2.32531E+05
-grp=01~ses=0001~src=ltbr0723~rup=27-00,4404,Active Shallow Crust,6.85000E+00,-1.21600E+02,3.74000E+01,7.50000E+00,9.81918E+06
-grp=01~ses=0001~src=ltbr0723~rup=4-02,4780,Active Shallow Crust,5.55000E+00,-1.21800E+02,3.73000E+01,6.00000E+00,1.19389E+05
-grp=01~ses=0001~src=ltbr0723~rup=4-03,7064,Active Shallow Crust,5.55000E+00,-1.21800E+02,3.73000E+01,6.00000E+00,2.09764E+05
-grp=01~ses=0001~src=ltbr0723~rup=4-00,7616,Active Shallow Crust,5.55000E+00,-1.21800E+02,3.73000E+01,6.00000E+00,3.74045E+06
-grp=01~ses=0001~src=ltbr0723~rup=17-00,9724,Active Shallow Crust,5.75000E+00,-1.21800E+02,3.73000E+01,3.00000E+00,5.17435E+05
+event_tag,year,structural
+grp=01~ses=0001~src=ltbr0723~rup=26-00,741,1.13253E+05
+grp=01~ses=0001~src=ltbr0723~rup=24-00,1288,1.56092E+05
+grp=01~ses=0001~src=ltbr0723~rup=17-02,2142,1.35586E+06
+grp=01~ses=0001~src=ltbr0723~rup=16-00,3054,1.02708E+06
+grp=01~ses=0001~src=ltbr0723~rup=4-01,3776,2.32531E+05
+grp=01~ses=0001~src=ltbr0723~rup=27-00,4404,9.81918E+06
+grp=01~ses=0001~src=ltbr0723~rup=4-02,4780,1.19389E+05
+grp=01~ses=0001~src=ltbr0723~rup=4-03,7064,2.09764E+05
+grp=01~ses=0001~src=ltbr0723~rup=4-00,7616,3.74045E+06
+grp=01~ses=0001~src=ltbr0723~rup=17-00,9724,5.17435E+05

--- a/openquake/qa_tests_data/ucerf/job.ini
+++ b/openquake/qa_tests_data/ucerf/job.ini
@@ -27,6 +27,7 @@ source_model_file = dummy_ucerf_bg_source_redux.xml
 gsim_logic_tree_file = gmpe_logic_tree_ucerf_mean.xml
 maximum_distance = 200.0
 investigation_time = 10000
+minimum_intensity = 0.1
 intensity_measure_types_and_levels = {'PGA': [1E-3, 1E-2, 0.05, 0.1, 0.2, 0.3]}
 
 [event_based_params]
@@ -38,4 +39,4 @@ ground_motion_correlation_params =
 export_dir = /tmp
 ground_motion_fields = true
 hazard_curves_from_gmfs = true
-minimum_intensity = 0.1
+save_ruptures = true


### PR DESCRIPTION
To save data transfer and disk space. This continuing the work started in https://github.com/gem/oq-engine/pull/2502. Here as some numbers for the computation `bay_area_usgs`:

```
    [#13044 INFO] Received 5.67 GB of data # old
    /home/openquake/michele/oqdata/calc_13044.hdf5 : 8.67 GB

    [#13045 INFO] Received 2.38 GB of data  # master
    /home/openquake/michele/oqdata/calc_13045.hdf5 : 5.34 GB

    [#13051 INFO] Received 1.24 GB of data  # this branch
    /home/openquake/michele/oqdata/calc_13051.hdf5 : 4.14 GB
```
