### PR TITLE
Fix RabbitMQ user and vhost creation, update openquake.cfg

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -31,24 +31,22 @@ if [ "$LSB_RELEASE" != "precise" -a "$LSB_RELEASE" != "trusty" -a "$LSB_RELEASE"
     db_go
 fi
 
-if [ -f /usr/sbin/rabbitmqctl -a -f /run/rabbitmq/pid ]; then
-    # create rabbitmq configuration for python-celery
-    celeryuser_count=`rabbitmqctl list_users | grep celeryuser | wc -l`
-    if [ $celeryuser_count -eq 0 ]; then
-        rabbitmqctl add_user celeryuser celery
+if [ -f /run/rabbitmq/pid -o -f /var/lib/rabbitmq/mnesia/rabbit@$(hostname -s).pid ]; then
+    if ! rabbitmqctl list_users | grep openquake; then
+        rabbitmqctl add_user openquake openquake
     fi
-    celeryvhost_count=`rabbitmqctl list_vhosts | grep celeryvhost | wc -l`
-    if [ $celeryvhost_count -eq 0 ]; then
-        rabbitmqctl add_vhost celeryvhost
-        rabbitmqctl set_permissions -p celeryvhost celeryuser ".*" ".*" ".*"
+    if ! rabbitmqctl list_vhosts | grep openquake; then
+        rabbitmqctl add_vhost openquake
+        rabbitmqctl set_permissions -p openquake openquake ".*" ".*" ".*"
     fi
 fi
 
 USER=openquake
-if [ $(cat /etc/group | grep ^openquake: | wc -l) -eq 0 ]; then
+
+if ! getent group $USER; then
     addgroup --system $USER
 fi
-if [ $(cat /etc/passwd | grep ^openquake: | wc -l) -eq 0 ]; then
+if  ! getent passwd $USER; then
     adduser --system --home /var/lib/$USER --group --shell /bin/bash $USER
 fi
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -31,7 +31,7 @@ if [ "$LSB_RELEASE" != "precise" -a "$LSB_RELEASE" != "trusty" -a "$LSB_RELEASE"
     db_go
 fi
 
-if [ -f /run/rabbitmq/pid -o -f /var/lib/rabbitmq/mnesia/rabbit@$(hostname -s).pid ]; then
+(if [ -f /run/rabbitmq/pid -o -f /var/lib/rabbitmq/mnesia/rabbit@$(hostname -s).pid ]; then
     if ! rabbitmqctl list_users | grep openquake; then
         rabbitmqctl add_user openquake openquake
     fi
@@ -39,14 +39,14 @@ if [ -f /run/rabbitmq/pid -o -f /var/lib/rabbitmq/mnesia/rabbit@$(hostname -s).p
         rabbitmqctl add_vhost openquake
         rabbitmqctl set_permissions -p openquake openquake ".*" ".*" ".*"
     fi
-fi
+fi) >/dev/null || true # Do not hard fail if something went wrong
 
 USER=openquake
 
-if ! getent group $USER; then
+if ! getent group $USER >/dev/null; then
     addgroup --system $USER
 fi
-if  ! getent passwd $USER; then
+if  ! getent passwd $USER >/dev/null; then
     adduser --system --home /var/lib/$USER --group --shell /bin/bash $USER
 fi
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -58,3 +58,59 @@ This happens when the **Celery support is enabled but RabbitMQ server is not run
 ```bash
 $ sudo service rabbitmq-server start
 ``` 
+
+***
+
+### error: [Errno 104] Connection reset by peer
+
+A more detailed stack trace:
+
+```python
+Traceback (most recent call last):
+  File "/usr/lib/python2.7/dist-packages/celery/worker/__init__.py", line 206, in start
+    self.blueprint.start(self)
+  File "/usr/lib/python2.7/dist-packages/celery/bootsteps.py", line 119, in start
+    self.on_start()
+  File "/usr/lib/python2.7/dist-packages/celery/apps/worker.py", line 165, in on_start
+    self.purge_messages()
+  File "/usr/lib/python2.7/dist-packages/celery/apps/worker.py", line 189, in purge_messages
+    count = self.app.control.purge()
+  File "/usr/lib/python2.7/dist-packages/celery/app/control.py", line 145, in purge
+    return self.app.amqp.TaskConsumer(conn).purge()
+  File "/usr/lib/python2.7/dist-packages/celery/app/amqp.py", line 375, in __init__
+    **kw
+  File "/usr/lib/python2.7/dist-packages/kombu/messaging.py", line 364, in __init__
+    self.revive(self.channel)
+  File "/usr/lib/python2.7/dist-packages/kombu/messaging.py", line 369, in revive
+    channel = self.channel = maybe_channel(channel)
+  File "/usr/lib/python2.7/dist-packages/kombu/connection.py", line 1054, in maybe_channel
+    return channel.default_channel
+  File "/usr/lib/python2.7/dist-packages/kombu/connection.py", line 756, in default_channel
+    self.connection
+  File "/usr/lib/python2.7/dist-packages/kombu/connection.py", line 741, in connection
+    self._connection = self._establish_connection()
+  File "/usr/lib/python2.7/dist-packages/kombu/connection.py", line 696, in _establish_connection
+    conn = self.transport.establish_connection()
+  File "/usr/lib/python2.7/dist-packages/kombu/transport/pyamqp.py", line 116, in establish_connection
+    conn = self.Connection(**opts)
+  File "/usr/lib/python2.7/dist-packages/amqp/connection.py", line 180, in __init__
+    (10, 30),  # tune
+  File "/usr/lib/python2.7/dist-packages/amqp/abstract_channel.py", line 67, in wait
+    self.channel_id, allowed_methods, timeout)
+  File "/usr/lib/python2.7/dist-packages/amqp/connection.py", line 241, in _wait_method
+    channel, method_sig, args, content = read_timeout(timeout)
+  File "/usr/lib/python2.7/dist-packages/amqp/connection.py", line 330, in read_timeout
+    return self.method_reader.read_method()
+  File "/usr/lib/python2.7/dist-packages/amqp/method_framing.py", line 189, in read_method
+    raise m
+error: [Errno 104] Connection reset by peer
+```
+
+This means that RabbiMQ _user_ and _vhost_ have not been created or set correctly. Please refer to [cluster documentation](installing/cluster.md#rabbitmq) to fix it.
+
+***
+
+## Getting help
+If you need help or have questions/comments/feedback for us, you can:
+  * Subscribe to the OpenQuake users mailing list: https://groups.google.com/forum/?fromgroups#!forum/openquake-users
+  * Contact us on IRC: irc.freenode.net, channel #openquake

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -32,9 +32,9 @@ On all worker nodes, the `/etc/openquake/openquake.cfg` file should be also modi
 [amqp]
 host = w.x.y.z
 port = 5672
-user = guest
-password = guest
-vhost = /
+user = openquake
+password = openquake
+vhost = /openquake
 # This is where tasks will be enqueued.
 celery_queue = celery
 
@@ -57,6 +57,35 @@ The required daemons are:
 - RabbitMQ
 - OpenQuake Engine DbServer
 - OpenQuake Engine WebUI (optional)
+
+
+##### RabbitMQ
+
+A _user_ and _vhost_ are automatically added to the RabbitMQ configuration during the installation on `python-oq-engine`.
+
+You can verify that the `openquake` user and vhost exist running:
+
+```bash
+# Check the user
+sudo rabbitmqctl list_users | grep openquake 
+
+# Check the vhost
+sudo rabbitmqctl list_vhosts | grep openquake 
+```
+
+If, for any reason, the `openquake` user and vhost are missing they can be set up running:
+
+```bash
+# Add the user
+sudo rabbitmqctl add_user openquake openquake
+
+# Add the vhost
+sudo rabbitmqctl add_vhost openquake
+sudo rabbitmqctl set_permissions -p openquake openquake ".*" ".*" ".*"
+```
+
+For more information please refer to https://www.rabbitmq.com/man/rabbitmqctl.1.man.html.
+
 
 #### Worker nodes
 - Celery

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -34,7 +34,7 @@ host = w.x.y.z
 port = 5672
 user = openquake
 password = openquake
-vhost = /openquake
+vhost = openquake
 # This is where tasks will be enqueued.
 celery_queue = celery
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -34,7 +34,7 @@ host = localhost
 port = 5672
 user = openquake
 password = openquake
-vhost = /openquake
+vhost = openquake
 # This is where tasks will be enqueued.
 celery_queue = celery
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -32,9 +32,9 @@ hard_mem_limit = 100
 [amqp]
 host = localhost
 port = 5672
-user = guest
-password = guest
-vhost = /
+user = openquake
+password = openquake
+vhost = /openquake
 # This is where tasks will be enqueued.
 celery_queue = celery
 

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -105,7 +105,6 @@ systemctl stop rabbitmq-server.service
 %systemd_post openquake-webui.service
 %systemd_post openquake-celery.service
 
-
 %clean
 rm -rf %{buildroot}
 

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -91,7 +91,7 @@ cp -R demos %{buildroot}/%{_datadir}/openquake/engine
 cp -R utils %{buildroot}/%{_datadir}/openquake/engine
 
 %post
-if [ -f /run/rabbitmq/pid -o -f /var/lib/rabbitmq/mnesia/rabbit@$(hostname -s).pid ]; then
+(if [ -f /run/rabbitmq/pid -o -f /var/lib/rabbitmq/mnesia/rabbit@$(hostname -s).pid ]; then
     if ! rabbitmqctl list_users | grep openquake; then
         rabbitmqctl add_user openquake openquake
     fi
@@ -99,7 +99,7 @@ if [ -f /run/rabbitmq/pid -o -f /var/lib/rabbitmq/mnesia/rabbit@$(hostname -s).p
         rabbitmqctl add_vhost openquake
         rabbitmqctl set_permissions -p openquake openquake ".*" ".*" ".*"
     fi
-fi
+fi) >/dev/null || true
 systemctl stop rabbitmq-server.service
 %systemd_post openquake-dbserver.service
 %systemd_post openquake-webui.service

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -54,13 +54,6 @@ compute seismic hazard and seismic risk of earthquakes on a global scale.
 
 Copyright (C) 2010-2017 GEM Foundation
 
-%pre
-getent group %{oquser} >/dev/null || groupadd -r %{oquser}
-getent passwd %{oquser} >/dev/null || \
-    useradd -r -g %{oquser} -m -d /var/lib/%{oquser} -s /bin/bash \
-    -c "The OpenQuake user" %{oquser}
-exit 0
-
 %prep
 %if %{oqstable} == 1
 %setup -n %{oqrepo}-%{oqversion} -n %{oqrepo}-%{oqversion}
@@ -75,6 +68,13 @@ python setup.py build
 
 %check
 #nosetests -v -a '!slow' --with-doctest --with-coverage --cover-package=openquake.engine
+
+%pre
+getent group %{oquser} >/dev/null || groupadd -r %{oquser}
+getent passwd %{oquser} >/dev/null || \
+    useradd -r -g %{oquser} -m -d /var/lib/%{oquser} -s /bin/bash \
+    -c "The OpenQuake user" %{oquser}
+systemctl start rabbitmq-server.service
 
 %install
 sed -i "s/^__version__[  ]*=.*/__version__ = '%{oqversion}-%{oqrelease}'/g" openquake/risklib/__init__.py
@@ -91,9 +91,20 @@ cp -R demos %{buildroot}/%{_datadir}/openquake/engine
 cp -R utils %{buildroot}/%{_datadir}/openquake/engine
 
 %post
+if [ -f /run/rabbitmq/pid -o -f /var/lib/rabbitmq/mnesia/rabbit@$(hostname -s).pid ]; then
+    if ! rabbitmqctl list_users | grep openquake; then
+        rabbitmqctl add_user openquake openquake
+    fi
+    if ! rabbitmqctl list_vhosts | grep openquake; then
+        rabbitmqctl add_vhost openquake
+        rabbitmqctl set_permissions -p openquake openquake ".*" ".*" ".*"
+    fi
+fi
+systemctl stop rabbitmq-server.service
 %systemd_post openquake-dbserver.service
 %systemd_post openquake-webui.service
 %systemd_post openquake-celery.service
+
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
This PR fixes #2505, an issue discovered by FMGlobal on their cluster.

On Xenial, RabbitMQ does not allow `guest` connection from the network. This PR makes these changes:

1. The `pid` of RabbitMQ has a new path, so the old code for creating host and users was not working on Xenial and CentOS 7
2. The `openquake.cfg` now uses these credentials. RabbitMQ + Celery are normally used only through packages, so no manual steps (creating user/vhost) are usually needed; anyway this info has been added to the documentation
3. The vhost/user creation has been added to the RPM package too

Now any issue with user/vhost creation or with wrong settings in `openquake.cfg` are caught by Jenkins since if something is wrong the demos will fail with error `error: [Errno 104] Connection reset by peer` (even if demos are run on a single node).

Marked as critical because it actually prevents a working installation on a cluster with current LTS.

https://ci.openquake.org/job/zdevel_oq-engine/2381/