### PR TITLE
Change what is include in deb docs

### DIFF
--- a/debian/docs
+++ b/debian/docs
@@ -1,1 +1,8 @@
-doc/*
+README.md
+CONTRIBUTORS.txt
+LICENSE
+doc/*.md
+doc/img/*
+doc/installing/*
+doc/running/*
+doc/upgrading/*


### PR DESCRIPTION
In the deb package we are including the sphinx and latex sources (after #2511) which are almost unreadable and useless to final users (as sources), instead we were missing the README, CONTRIBUTORS and LICENSE.

My proposal is to include just the *.md files and in the future we'll add the manual in the form of a pdf (see #2512 ) and eventually the html generated by sphinx.

https://ci.openquake.org/job/zdevel_oq-engine/2385/