### PR TITLE
Deleting from the Web UI now works

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Now deleting a calculation from the Web UI really deletes it, before
+    if was only hiding it
+
   [Daniele Viganò]
   * Moved the OpenQuake Engine manual sources inside doc/manual
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -17,6 +17,7 @@
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
 import os
+import glob
 import operator
 from datetime import datetime, timedelta
 
@@ -273,14 +274,29 @@ def del_calc(db, job_id, user):
     if dependent:
         return ('Cannot delete calculation %d: there are calculations '
                 'dependent from it: %s' % (job_id, [j.id for j in dependent]))
-    found = db('SELECT count(id) FROM job WHERE id=?x', job_id, scalar=True)
-    if not found:
+    try:
+        path = db('SELECT ds_calc_dir FROM job WHERE id=?x', job_id,
+                  scalar=True)
+    except NotFound:
         return ('Cannot delete calculation %d: ID does not exist' % job_id)
+
     deleted = db('DELETE FROM job WHERE id=?x AND user_name=?x',
                  job_id, user).rowcount
     if not deleted:
         return ('Cannot delete calculation %d: belongs to a different user'
                 % job_id)
+
+    # try to delete datastore and associated files
+    # path has typically the form /home/user/oqdata/calc_XXX
+    fnames = []
+    for fname in glob.glob(path + '.*'):
+        try:
+            os.remove(fname)
+        except OSError as exc:  # permission error
+            print('Could not remove %s: %s' % (fname, exc))
+        else:
+            fnames.append(fname)
+    return fnames
 
 
 def log(db, job_id, timestamp, level, process, message):

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -308,10 +308,11 @@ def calc(request, id=None):
 @require_http_methods(['POST'])
 def calc_remove(request, calc_id):
     """
-    Remove the calculation id by setting the field oq_job.relevant to False.
+    Remove the calculation id
     """
+    user = utils.get_user_data(request)['name']
     try:
-        logs.dbcmd('set_relevant', calc_id, False)
+        logs.dbcmd('del_calc', calc_id, user)
     except dbapi.NotFound:
         return HttpResponseNotFound()
     return HttpResponse(content=json.dumps([]),


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2466. We need a confirmation dialog when used manually since the deletion if definitive. The API is meant to be called also from REST clients (i.e. the QGIS plugin).