### PR TITLE
The names of the files downloaded by the Web UI must contain no slashes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed the name of the files downloaded by the Web UI: they must not
+    contain slashes
   * Now deleting a calculation from the Web UI really deletes it, before
     if was only hiding it
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -538,7 +538,8 @@ def get_result(request, result_id):
         data = open(exported, 'rb').read()
         response = HttpResponse(data, content_type=content_type)
         response['Content-Length'] = len(data)
-        response['Content-Disposition'] = 'attachment; filename=%s' % fname
+        response['Content-Disposition'] = (
+            'attachment; filename=%s' % os.path.basename(fname))
         return response
     finally:
         shutil.rmtree(tmpdir)
@@ -566,7 +567,8 @@ def get_datastore(request, job_id):
     fname = job.ds_calc_dir + '.hdf5'
     response = FileResponse(
         FileWrapper(open(fname, 'rb')), content_type=HDF5)
-    response['Content-Disposition'] = 'attachment; filename=%s' % fname
+    response['Content-Disposition'] = (
+        'attachment; filename=%s' % os.path.basename(fname))
     return response
 
 


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2521.