### PR TITLE
Changed the UCERF classical calculators to run one branch at the time

### DIFF
--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -207,7 +207,7 @@ class UcerfPSHACalculator(classical.PSHACalculator):
             args = (bckgnd_sources, self.src_filter, oq.imtls,
                     gsims, self.oqparam.truncation_level, (), monitor)
             bg_res = parallel.Starmap.apply(
-                pmap_from_grp, args, name='pmap_from_grp_%d' % grp_id,
+                pmap_from_grp, args, name='background_sources_%d' % grp_id,
                 concurrent_tasks=self.oqparam.concurrent_tasks).submit_all()
 
             # parallelize by rupture subsets

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -662,9 +662,8 @@ class UcerfSource(object):
             grid_loc = "/".join(["Grid", self.idx_set["grid_key"]])
             mags = hdf5[grid_loc + "/Magnitude"].value
             mmax = hdf5[grid_loc + "/MMax"][background_sids]
-            rates = hdf5[grid_loc + "/RateArray"][
-                background_sids, :]
-            locations = hdf5["Grid/Locations"][background_sids]
+            rates = hdf5[grid_loc + "/RateArray"][background_sids, :]
+            locations = hdf5["Grid/Locations"][background_sids, :]
             sources = []
             for i, bg_idx in enumerate(background_sids):
                 src_id = "_".join([self.idx_set["grid_key"], str(bg_idx)])
@@ -673,7 +672,7 @@ class UcerfSource(object):
                 mag_idx = numpy.logical_and(
                     mags >= ctl.min_mag, mags < mmax[i])
                 src_mags = mags[mag_idx]
-                src_rates = rates[i]
+                src_rates = rates[i, :]
                 src_mfd = EvenlyDiscretizedMFD(
                     src_mags[0], src_mags[1] - src_mags[0],
                     src_rates[mag_idx].tolist())

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -689,10 +689,11 @@ class UcerfSource(object):
         ctl = self.control
         with h5py.File(ctl.source_file, "r") as hdf5:
             grid_loc = "/".join(["Grid", self.idx_set["grid_key"]])
-            mags = hdf5[grid_loc + "/Magnitude"][:]
+            mags = hdf5[grid_loc + "/Magnitude"].value
             mmax = hdf5[grid_loc + "/MMax"][background_sids]
-            rates = hdf5[grid_loc + "/RateArray"][background_sids, :]
-            locations = hdf5["Grid/Locations"][background_sids, :]
+            rates = hdf5[grid_loc + "/RateArray"][
+                background_sids, :]
+            locations = hdf5["Grid/Locations"][background_sids]
             sources = []
             for i, bg_idx in enumerate(background_sids):
                 src_id = "_".join([self.idx_set["grid_key"], str(bg_idx)])
@@ -701,7 +702,7 @@ class UcerfSource(object):
                 mag_idx = numpy.logical_and(
                     mags >= ctl.min_mag, mags < mmax[i])
                 src_mags = mags[mag_idx]
-                src_rates = rates[i, :]
+                src_rates = rates[i]
                 src_mfd = EvenlyDiscretizedMFD(
                     src_mags[0], src_mags[1] - src_mags[0],
                     src_rates[mag_idx].tolist())


### PR DESCRIPTION
Then each branch is parallelised by ruptures. This allows a big simplification and the function `ucerf_classical_hazard_by_branch` becomes redundant.