### PR TITLE
Add support for standalone apps in server

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md LICENSE CONTRIBUTORS.txt
 include openquake/engine/openquake.cfg
+include openquake/server/local_settings.py.standalone
 
 recursive-include openquake/server/db *.sql
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf

--- a/openquake/server/local_settings.py.standalone
+++ b/openquake/server/local_settings.py.standalone
@@ -1,0 +1,17 @@
+STANDALONE = True
+
+INSTALLED_APPS += (
+    'openquakeplatform',
+)
+
+STANDALONE_APPS += (
+    'openquakeplatform_ipt',
+    'openquakeplatform_taxtweb',
+)
+
+INSTALLED_APPS += STANDALONE_APPS
+
+FILE_PATH_FIELD_DIRECTORY = os.path.join(os.path.expanduser('~'), 'oqdata')
+
+CONTEXT_PROCESSORS = TEMPLATES[0]['OPTIONS']['context_processors']
+CONTEXT_PROCESSORS.append('openquakeplatform.utils.oq_context_processor')

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -115,6 +115,8 @@ INSTALLED_APPS += (
     'openquake.server',
 )
 
+STANDALONE_APPS = ()
+
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error.

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
         name="license"),
 ]
 
+for app in settings.STANDALONE_APPS:
+    app_name = app.split('_')[1]
+    urlpatterns.append(url(r'^%s/' % app_name, include('%s.urls' % app,
+                       namespace='%s' % app_name)))
+
 if settings.LOCKDOWN:
     from django.contrib import admin
     from django.contrib.auth.views import login, logout


### PR DESCRIPTION
This is a preliminary work needed to be able to run our standalone apps (mainly `ipt` and `taxtweb`) using `openquake.server`.

This will simplify a lot the integration of such apps inside a single installer (which is a task of this sprint), specially on Windows where spawning to django instances in background requires some tricks.

Only few changes are required in the 'main' code everything else is hosted in the `local_settings.py` (a template is provided).

Minor changes to the template (of the apps) may be required. We'll see.