### PR TITLE
Added a command `run_tiles` to run multiple jobs at once

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a command `oq run_tiles` (experimental)
   * Fixed the event based calculator so that it can run UCERF ruptures
   * Fixed a bug in the scenario_risk calculator in case of multiple assets
     of the same taxonomy on the same site with no insurance losses

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -66,6 +66,9 @@ class AssetSiteAssociationError(Exception):
 rlz_dt = numpy.dtype([('uid', hdf5.vstr), ('model', hdf5.vstr),
                       ('gsims', hdf5.vstr), ('weight', F32)])
 
+logversion = True
+
+
 PRECALC_MAP = dict(
     classical=['psha'],
     disaggregation=['psha'],
@@ -171,10 +174,13 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         """
         Run the calculation and return the exported outputs.
         """
+        global logversion
         self.close = close
         self.set_log_format()
-        logging.info('Using engine version %s', engine_version)
-        logging.info('Using hazardlib version %s', hazardlib_version)
+        if logversion:  # make sure this is logged only once
+            logging.info('Using engine version %s', engine_version)
+            logging.info('Using hazardlib version %s', hazardlib_version)
+            logversion = False
         if concurrent_tasks is None:  # use the default
             pass
         elif concurrent_tasks == 0:  # disable distribution temporarily

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -66,8 +66,6 @@ class AssetSiteAssociationError(Exception):
 rlz_dt = numpy.dtype([('uid', hdf5.vstr), ('model', hdf5.vstr),
                       ('gsims', hdf5.vstr), ('weight', F32)])
 
-logversion = {True}
-
 PRECALC_MAP = dict(
     classical=['psha'],
     disaggregation=['psha'],
@@ -175,10 +173,8 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         """
         self.close = close
         self.set_log_format()
-        if logversion:  # make sure this is logged only once
-            logging.info('Using engine version %s', engine_version)
-            logging.info('Using hazardlib version %s', hazardlib_version)
-            logversion.pop()
+        logging.info('Using engine version %s', engine_version)
+        logging.info('Using hazardlib version %s', hazardlib_version)
         if concurrent_tasks is None:  # use the default
             pass
         elif concurrent_tasks == 0:  # disable distribution temporarily

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -288,6 +288,10 @@ class PSHACalculator(base.HazardCalculator):
             allargs = self.gen_args(self.csm, monitor)
             iterargs = saving_sources_by_task(allargs, self.datastore)
             if isinstance(allargs, list):
+                # there is a trick here: if the arguments are known
+                # (a list, not an iterator), keep them as a list
+                # then the Starmap will understand the case of a single
+                # argument tuple and it will run in core the task
                 iterargs = list(iterargs)
             res = parallel.Starmap(
                 self.core_task.__func__, iterargs).submit_all()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -285,8 +285,10 @@ class PSHACalculator(base.HazardCalculator):
             ses_per_logic_tree_path=oq.ses_per_logic_tree_path,
             seed=oq.random_seed)
         with self.monitor('managing sources', autoflush=True):
-            iterargs = saving_sources_by_task(
-                self.gen_args(self.csm, monitor), self.datastore)
+            allargs = self.gen_args(self.csm, monitor)
+            iterargs = saving_sources_by_task(allargs, self.datastore)
+            if isinstance(allargs, list):
+                iterargs = list(iterargs)
             res = parallel.Starmap(
                 self.core_task.__func__, iterargs).submit_all()
         acc = reduce(self.agg_dicts, res, self.zerodict())

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -337,7 +337,7 @@ def compute_gmfs_and_curves(getter, rlzs, monitor):
         a dictionary with keys gmfcoll and hcurves
    """
     oq = monitor.oqparam
-    with monitor('GmfGetter.init', measuremem=True):
+    with monitor('making contexts', measuremem=True):
         getter.init()
     haz = {sid: {} for sid in getter.sids}
     gmfcoll = {}  # rlz -> gmfa

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -337,6 +337,8 @@ def compute_gmfs_and_curves(getter, rlzs, monitor):
         a dictionary with keys gmfcoll and hcurves
    """
     oq = monitor.oqparam
+    with monitor('GmfGetter.init', measuremem=True):
+        getter.init()
     haz = {sid: {} for sid in getter.sids}
     gmfcoll = {}  # rlz -> gmfa
     for rlz in rlzs:

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -877,6 +877,7 @@ def export_gmf_scenario_npz(ekey, dstore):
                 gmfa[imt] = arr[imti]
             dic[str(gsim)] = util.compose_arrays(sitemesh, gmfa)
     elif 'gmf_data' in dstore:  # event_based
+        dic['sitemesh'] = get_mesh(dstore['sitecol'])
         for sm_id in sorted(dstore['gmf_data']):
             for rlzno in sorted(dstore['gmf_data/' + sm_id]):
                 dic['rlz-' + rlzno] = dstore['gmf_data/%s/%s' % (sm_id, rlzno)]

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -849,6 +849,8 @@ class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
         Generate a task for each branch
         """
         oq = self.oqparam
+        allargs = []  # it is better to return a list; if there is single
+        # branch then `parallel.Starmap` will run the task in core
         for sm_id in range(len(csm.source_models)):
             ssm = csm.get_model(sm_id)
             mon = monitor.new(
@@ -858,7 +860,8 @@ class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
                 save_ruptures=oq.save_ruptures,
                 seed=ssm.source_model_lt.seed)
             gsims = ssm.gsim_lt.values[DEFAULT_TRT]
-            yield ssm.get_sources(), self.src_filter, gsims, mon
+            allargs.append((ssm.get_sources(), self.src_filter, gsims, mon))
+        return allargs
 
 
 class List(list):

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -742,86 +742,6 @@ def build_idx_set(branch_id, start_date):
 # #################################################################### #
 
 
-@base.calculators.add('ucerf_rupture')
-class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
-    """
-    Event based PSHA calculator generating the ruptures only
-    """
-    is_stochastic = True
-
-    def pre_execute(self):
-        """
-        parse the logic tree and source model input
-        """
-        logging.warn('%s is still experimental', self.__class__.__name__)
-        oq = self.oqparam
-        self.read_risk_data()  # read the site collection
-        self.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
-        self.gsim_lt = readinput.get_gsim_lt(oq, [DEFAULT_TRT])
-        self.smlt = readinput.get_source_model_lt(oq)
-        job_info = dict(hostname=socket.gethostname())
-        self.datastore.save('job_info', job_info)
-        parser = nrml.SourceModelParser(
-            SourceConverter(oq.investigation_time, oq.rupture_mesh_spacing))
-        [src_group] = parser.parse_src_groups(oq.inputs["source_model"])
-        [src] = src_group
-        branches = sorted(self.smlt.branches.items())
-        source_models = []
-        num_gsim_paths = self.gsim_lt.get_num_paths()
-        for grp_id, rlz in enumerate(self.smlt):
-            [name] = rlz.lt_path
-            sg = copy.copy(src_group)
-            sg.id = grp_id
-            # i.e, branch_name='ltbr0001'
-            # branch_id='FM3_1/ABM/Shaw09Mod/DsrUni_CharConst_M5Rate6.5_MMaxOff7.3_NoFix_SpatSeisU2'
-            sg.sources = [UcerfSource(src, grp_id, name, rlz.value)]
-            sm = logictree.SourceModel(
-                name, rlz.weight, [name], [sg], num_gsim_paths, grp_id, 1)
-            source_models.append(sm)
-        self.csm = source.CompositeSourceModel(
-            self.gsim_lt, self.smlt, source_models, set_weight=True)
-        self.datastore['csm_info'] = self.csm.info
-        logging.info('Found %d x %d logic tree branches', len(branches),
-                     self.gsim_lt.get_num_paths())
-        self.rlzs_assoc = self.csm.info.get_rlzs_assoc()
-        self.infos = []
-        self.eid = collections.Counter()  # sm_id -> event_id
-        self.sm_by_grp = self.csm.info.get_sm_by_grp()
-        if not self.oqparam.imtls:
-            raise ValueError('Missing intensity_measure_types!')
-
-    def gen_args(self):
-        oq = self.oqparam
-        for sm_id in range(len(self.csm.source_models)):
-            ssm = self.csm.get_model(sm_id)
-            monitor = self.monitor.new(
-                ses_per_logic_tree_path=oq.ses_per_logic_tree_path,
-                maximum_distance=oq.maximum_distance,
-                samples=ssm.source_models[0].samples,
-                save_ruptures=oq.save_ruptures,
-                seed=ssm.source_model_lt.seed)
-            gsims = ssm.gsim_lt.values[DEFAULT_TRT]
-            yield ssm.get_sources(), self.src_filter, gsims, monitor
-
-    def execute(self):
-        """
-        Run the ucerf calculation
-        """
-        res = parallel.Starmap(compute_ruptures, self.gen_args()).submit_all()
-        acc = self.zerodict()
-        num_ruptures = {}
-        for ruptures_by_grp in res:
-            [(grp_id, ruptures)] = ruptures_by_grp.items()
-            num_ruptures[grp_id] = len(ruptures)
-            acc.calc_times.extend(ruptures_by_grp.calc_times[grp_id])
-            self.save_events(ruptures_by_grp)
-        self.save_data_transfer(res)
-        with self.monitor('store source_info', autoflush=True):
-            self.store_source_info(self.infos)
-        self.datastore['csm_info'] = self.csm.info
-        return num_ruptures
-
-
 def compute_ruptures(sources, src_filter, gsims, monitor):
     """
     :param sources: a sequence of UCERF sources
@@ -876,6 +796,71 @@ def compute_ruptures(sources, src_filter, gsims, monitor):
 compute_ruptures.shared_dir_on = config.SHARED_DIR_ON
 
 
+@base.calculators.add('ucerf_rupture')
+class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
+    """
+    Event based PSHA calculator generating the ruptures only
+    """
+    core_task = compute_ruptures
+
+    def pre_execute(self):
+        """
+        parse the logic tree and source model input
+        """
+        logging.warn('%s is still experimental', self.__class__.__name__)
+        oq = self.oqparam
+        self.read_risk_data()  # read the site collection
+        self.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
+        self.gsim_lt = readinput.get_gsim_lt(oq, [DEFAULT_TRT])
+        self.smlt = readinput.get_source_model_lt(oq)
+        job_info = dict(hostname=socket.gethostname())
+        self.datastore.save('job_info', job_info)
+        parser = nrml.SourceModelParser(
+            SourceConverter(oq.investigation_time, oq.rupture_mesh_spacing))
+        [src_group] = parser.parse_src_groups(oq.inputs["source_model"])
+        [src] = src_group
+        branches = sorted(self.smlt.branches.items())
+        source_models = []
+        num_gsim_paths = self.gsim_lt.get_num_paths()
+        for grp_id, rlz in enumerate(self.smlt):
+            [name] = rlz.lt_path
+            sg = copy.copy(src_group)
+            sg.id = grp_id
+            # i.e, branch_name='ltbr0001'
+            # branch_id='FM3_1/ABM/Shaw09Mod/DsrUni_CharConst_M5Rate6.5_MMaxOff7.3_NoFix_SpatSeisU2'
+            sg.sources = [UcerfSource(src, grp_id, name, rlz.value)]
+            sm = logictree.SourceModel(
+                name, rlz.weight, [name], [sg], num_gsim_paths, grp_id, 1)
+            source_models.append(sm)
+        self.csm = source.CompositeSourceModel(
+            self.gsim_lt, self.smlt, source_models, set_weight=True)
+        self.datastore['csm_info'] = self.csm.info
+        logging.info('Found %d x %d logic tree branches', len(branches),
+                     self.gsim_lt.get_num_paths())
+        self.rlzs_assoc = self.csm.info.get_rlzs_assoc()
+        self.infos = []
+        self.eid = collections.Counter()  # sm_id -> event_id
+        self.sm_by_grp = self.csm.info.get_sm_by_grp()
+        if not self.oqparam.imtls:
+            raise ValueError('Missing intensity_measure_types!')
+
+    def gen_args(self, csm, monitor):
+        """
+        Generate a task for each branch
+        """
+        oq = self.oqparam
+        for sm_id in range(len(csm.source_models)):
+            ssm = csm.get_model(sm_id)
+            mon = monitor.new(
+                ses_per_logic_tree_path=oq.ses_per_logic_tree_path,
+                maximum_distance=oq.maximum_distance,
+                samples=ssm.source_models[0].samples,
+                save_ruptures=oq.save_ruptures,
+                seed=ssm.source_model_lt.seed)
+            gsims = ssm.gsim_lt.values[DEFAULT_TRT]
+            yield ssm.get_sources(), self.src_filter, gsims, mon
+
+
 class List(list):
     """Trivial container returned by compute_losses"""
 
@@ -914,6 +899,14 @@ def compute_losses(ssm, src_filter, assetcol, riskmodel,
     res.rlz_slice = slice(start, start + num_rlzs)
     return res
 compute_losses.shared_dir_on = config.SHARED_DIR_ON
+
+
+@base.calculators.add('ucerf_hazard')
+class UCERFHazardCalculator(event_based.EventBasedCalculator):
+    """
+    Runs a standard event based calculation starting from UCERF ruptures
+    """
+    pre_calculator = 'ucerf_rupture'
 
 
 @base.calculators.add('ucerf_risk')

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -40,8 +40,8 @@ def get_job_id(job_id, username=None):
     return job_id
 
 
-def run_job(cfg_file, log_level, log_file, exports='',
-            hazard_calculation_id=None):
+def run_job(cfg_file, log_level='info', log_file=None, exports='',
+            hazard_calculation_id=None, **kw):
     """
     Run a job using the specified config file and other options.
 
@@ -61,7 +61,7 @@ def run_job(cfg_file, log_level, log_file, exports='',
     job_id, oqparam = eng.job_from_file(
         job_ini, getpass.getuser(), hazard_calculation_id)
     calc = eng.run_calc(job_id, oqparam, log_level, log_file, exports,
-                        hazard_calculation_id=hazard_calculation_id)
+                        hazard_calculation_id=hazard_calculation_id, **kw)
     calc.monitor.flush()
     for line in logs.dbcmd('list_outputs', job_id, False):
         print(line)

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -68,6 +68,13 @@ def run_job(cfg_file, log_level='info', log_file=None, exports='',
     return job_id
 
 
+def run_tile(job_ini, sites_slice):
+    """
+    Used in tiling calculations
+    """
+    return run_job(job_ini, sites_slice=(sites_slice.start, sites_slice.stop))
+
+
 def del_calculation(job_id, confirmed=False):
     """
     Delete a calculation and all associated outputs.

--- a/openquake/commands/run_tiles.py
+++ b/openquake/commands/run_tiles.py
@@ -26,7 +26,7 @@ from openquake.commands import engine
 
 
 @sap.Script
-def with_tiles(num_tiles, job_ini, poolsize=0):
+def run_tiles(num_tiles, job_ini, poolsize=0):
     """
     Run a calculation by splitting the sites into tiles.
     WARNING: this is experimental and meant only for GEM users
@@ -57,9 +57,9 @@ def with_tiles(num_tiles, job_ini, poolsize=0):
         print(os.path.join(datastore.DATADIR, 'calc_%d.hdf5' % calc_id))
     print('Total calculation time: %.1f h' % ((time.time() - t0) / 3600.))
 
-with_tiles.arg('num_tiles', 'number of tiles to generate',
-               type=valid.positiveint)
-with_tiles.arg('job_ini', 'calculation configuration file '
-               '(or files, comma-separated)')
-with_tiles.opt('poolsize', 'size of the pool (default 0, no pool)',
-               type=valid.positiveint)
+run_tiles.arg('num_tiles', 'number of tiles to generate',
+              type=valid.positiveint)
+run_tiles.arg('job_ini', 'calculation configuration file '
+              '(or files, comma-separated)')
+run_tiles.opt('poolsize', 'size of the pool (default 0, no pool)',
+              type=valid.positiveint)

--- a/openquake/commands/with_tiles.py
+++ b/openquake/commands/with_tiles.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import division
+import logging
+from openquake.baselib import sap, general
+from openquake.hazardlib import valid
+from openquake.commonlib import readinput
+from openquake.commands import engine
+
+
+@sap.Script
+def with_tiles(num_tiles, job_ini):
+    """
+    Run a calculation by splitting the sites into tiles
+    """
+    oq = readinput.get_oqparam(job_ini)
+    num_sites = len(readinput.get_mesh(oq))
+    tiles = general.split_in_blocks(num_sites, num_tiles)
+    for t, sites_slice in enumerate(tiles, 1):
+        ss = sites_slice.start, sites_slice.stop
+        engine.run_job(job_ini, sites_slice=ss)
+        logging.warn('Finished tile %d of %d', t, num_tiles)
+
+with_tiles.arg('num_tiles', 'number of tiles to generate',
+               type=valid.positiveint)
+with_tiles.arg('job_ini', 'calculation configuration file '
+               '(or files, comma-separated)')

--- a/openquake/commands/with_tiles.py
+++ b/openquake/commands/with_tiles.py
@@ -17,11 +17,13 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 from __future__ import division
 import os
+import time
 import logging
 from openquake.baselib import sap, general, parallel
 from openquake.hazardlib import valid
 from openquake.commonlib import readinput, datastore
 from openquake.commands import engine
+from openquake.server.manage import db
 
 
 @sap.Script
@@ -30,6 +32,7 @@ def with_tiles(num_tiles, job_ini, poolsize=0):
     Run a calculation by splitting the sites into tiles.
     WARNING: this is experimental and meant only for GEM users
     """
+    t0 = time.time()
     oq = readinput.get_oqparam(job_ini)
     num_sites = len(readinput.get_mesh(oq))
     task_args = [(job_ini, slc)
@@ -40,14 +43,21 @@ def with_tiles(num_tiles, job_ini, poolsize=0):
         Starmap = parallel.Processmap  # celery plays only with processes
     else:  # multiprocessing plays only with threads
         Starmap = parallel.Threadmap
+    parent_child = [None, None]
 
     def agg(calc_ids, calc_id):
+        if not calc_ids:  # first calculation
+            parent_child[0] = calc_id
+        parent_child[1] = calc_id
         logging.warn('Finished %d calculation(s) out of %d',
                      len(calc_ids) + 1, num_tiles)
+        db('UPDATE job SET hazard_calculation_id=?x WHERE id=?x',
+           *parent_child)
         return calc_ids + [calc_id]
     calc_ids = Starmap(engine.run_tile, task_args, poolsize).reduce(agg, [])
     for calc_id in calc_ids:
         print(os.path.join(datastore.DATADIR, 'calc_%d.hdf5' % calc_id))
+    print('Total calculation time: %s h' % ((time.time() - t0) / 3600.))
 
 with_tiles.arg('num_tiles', 'number of tiles to generate',
                type=valid.positiveint)

--- a/openquake/commands/with_tiles.py
+++ b/openquake/commands/with_tiles.py
@@ -18,6 +18,7 @@
 from __future__ import division
 import os
 import time
+import logging
 from openquake.baselib import sap, general, parallel
 from openquake.hazardlib import valid
 from openquake.commonlib import readinput, datastore, logs
@@ -48,6 +49,8 @@ def with_tiles(num_tiles, job_ini, poolsize=0):
             parent_child[0] = calc_id
         parent_child[1] = calc_id
         logs.dbcmd('update_parent_child', parent_child)
+        logging.warn('Finished calculation %d of %d',
+                     len(calc_ids) + 1, num_tiles)
         return calc_ids + [calc_id]
     calc_ids = Starmap(engine.run_tile, task_args, poolsize).reduce(agg, [])
     for calc_id in calc_ids:

--- a/openquake/commands/with_tiles.py
+++ b/openquake/commands/with_tiles.py
@@ -57,7 +57,7 @@ def with_tiles(num_tiles, job_ini, poolsize=0):
     calc_ids = Starmap(engine.run_tile, task_args, poolsize).reduce(agg, [])
     for calc_id in calc_ids:
         print(os.path.join(datastore.DATADIR, 'calc_%d.hdf5' % calc_id))
-    print('Total calculation time: %s h' % ((time.time() - t0) / 3600.))
+    print('Total calculation time: %.1f h' % ((time.time() - t0) / 3600.))
 
 with_tiles.arg('num_tiles', 'number of tiles to generate',
                type=valid.positiveint)

--- a/openquake/commands/with_tiles.py
+++ b/openquake/commands/with_tiles.py
@@ -37,7 +37,7 @@ def with_tiles(num_tiles, job_ini):
         Starmap = parallel.Processmap  # celery plays only with processes
     else:  # multiprocessing plays only with threads
         Starmap = parallel.Threadmap
-    Starmap(engine.run_tile, task_args).reduce()
+    Starmap(engine.run_tile, task_args, poolsize=4).reduce()
 
 with_tiles.arg('num_tiles', 'number of tiles to generate',
                type=valid.positiveint)

--- a/openquake/commands/with_tiles.py
+++ b/openquake/commands/with_tiles.py
@@ -21,9 +21,8 @@ import time
 import logging
 from openquake.baselib import sap, general, parallel
 from openquake.hazardlib import valid
-from openquake.commonlib import readinput, datastore
+from openquake.commonlib import readinput, datastore, logs
 from openquake.commands import engine
-from openquake.server.manage import db
 
 
 @sap.Script
@@ -51,8 +50,7 @@ def with_tiles(num_tiles, job_ini, poolsize=0):
         parent_child[1] = calc_id
         logging.warn('Finished %d calculation(s) out of %d',
                      len(calc_ids) + 1, num_tiles)
-        db('UPDATE job SET hazard_calculation_id=?x WHERE id=?x',
-           *parent_child)
+        logs.dbcmd('update_parent_child', parent_child)
         return calc_ids + [calc_id]
     calc_ids = Starmap(engine.run_tile, task_args, poolsize).reduce(agg, [])
     for calc_id in calc_ids:

--- a/openquake/commands/with_tiles.py
+++ b/openquake/commands/with_tiles.py
@@ -26,12 +26,13 @@ from openquake.commands import engine
 @sap.Script
 def with_tiles(num_tiles, job_ini):
     """
-    Run a calculation by splitting the sites into tiles
+    Run a calculation by splitting the sites into tiles.
+    WARNING: this is experimental and meant only for GEM users
     """
     oq = readinput.get_oqparam(job_ini)
     num_sites = len(readinput.get_mesh(oq))
-    tiles = general.split_in_blocks(num_sites, num_tiles)
-    for t, sites_slice in enumerate(tiles, 1):
+    slices = general.split_in_slices(num_sites, num_tiles)
+    for t, sites_slice in enumerate(slices, 1):
         ss = sites_slice.start, sites_slice.stop
         engine.run_job(job_ini, sites_slice=ss)
         logging.warn('Finished tile %d of %d', t, num_tiles)

--- a/openquake/commands/with_tiles.py
+++ b/openquake/commands/with_tiles.py
@@ -18,7 +18,6 @@
 from __future__ import division
 import os
 import time
-import logging
 from openquake.baselib import sap, general, parallel
 from openquake.hazardlib import valid
 from openquake.commonlib import readinput, datastore, logs
@@ -48,8 +47,6 @@ def with_tiles(num_tiles, job_ini, poolsize=0):
         if not calc_ids:  # first calculation
             parent_child[0] = calc_id
         parent_child[1] = calc_id
-        logging.warn('Finished %d calculation(s) out of %d',
-                     len(calc_ids) + 1, num_tiles)
         logs.dbcmd('update_parent_child', parent_child)
         return calc_ids + [calc_id]
     calc_ids = Starmap(engine.run_tile, task_args, poolsize).reduce(agg, [])

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -148,6 +148,7 @@ class OqParam(valid.ParamSet):
     ses_per_logic_tree_path = valid.Param(valid.positiveint, 1)
     sites = valid.Param(valid.NoneOr(valid.coordinates), None)
     sites_disagg = valid.Param(valid.NoneOr(valid.coordinates), [])
+    sites_slice = valid.Param(valid.simple_slice, (None, None))
     specific_assets = valid.Param(valid.namelist, [])
     taxonomies_from_model = valid.Param(valid.boolean, False)
     time_event = valid.Param(str, None)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -188,7 +188,8 @@ def get_mesh(oqparam):
         csv_data = open(oqparam.inputs['sites'], 'U').read()
         coords = valid.coordinates(
             csv_data.strip().replace(',', ' ').replace('\n', ','))
-        return geo.Mesh.from_coords(coords)
+        start, stop = oqparam.sites_slice
+        return geo.Mesh.from_coords(coords[start:stop])
     elif oqparam.region:
         # close the linear polygon ring by appending the first
         # point to the end

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -158,7 +158,7 @@ def job_from_file(cfg_file, username, hazard_calculation_id=None):
 
 
 def run_calc(job_id, oqparam, log_level, log_file, exports,
-             hazard_calculation_id=None):
+             hazard_calculation_id=None, **kw):
     """
     Run a calculation.
 
@@ -183,7 +183,7 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
         tb = 'None\n'
         try:
             logs.dbcmd('set_status', job_id, 'executing')
-            _do_run_calc(calc, exports, hazard_calculation_id)
+            _do_run_calc(calc, exports, hazard_calculation_id, **kw)
             expose_outputs(calc.datastore)
             records = views.performance_view(calc.datastore)
             logs.dbcmd('save_performance', job_id, records)
@@ -213,7 +213,7 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
     return calc
 
 
-def _do_run_calc(calc, exports, hazard_calculation_id):
+def _do_run_calc(calc, exports, hazard_calculation_id, **kw):
     with calc.monitor:
         calc.run(exports=exports, hazard_calculation_id=hazard_calculation_id,
-                 close=False)  # don't close the datastore too soon
+                 close=False, **kw)  # don't close the datastore too soon

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -495,7 +495,7 @@ def set_relevant(db, job_id, flag):
     db('UPDATE job SET relevant=?x WHERE id=?x', flag, job_id)
 
 
-def update_parent(db, parent_child):
+def update_parent_child(db, parent_child):
     """
     Set hazard_calculation_id (parent) on a job_id (child)
     """

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -495,6 +495,14 @@ def set_relevant(db, job_id, flag):
     db('UPDATE job SET relevant=?x WHERE id=?x', flag, job_id)
 
 
+def update_parent(db, parent_child):
+    """
+    Set hazard_calculation_id (parent) on a job_id (child)
+    """
+    db('UPDATE job SET hazard_calculation_id=?x WHERE id=?x',
+       *parent_child)
+
+
 def get_log_slice(db, job_id, start, stop):
     """
     Get a slice of the calculation log as a JSON list of rows


### PR DESCRIPTION
Companion of https://github.com/gem/oq-hazardlib/pull/590. Here is an example of usage:
```bash
$ oq run_tiles 10 job.ini --poolsize 5
```
will split the .csv sites in 10 tiles, produce 10 jobs and submit them to the workers, by making sure that at most 5 jobs runs concurrently.