### PR TITLE
Store properly the logic tree in the datastore

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1181,7 +1181,7 @@ class GsimLogicTree(object):
         """
         :returns: an XML string representing the logic tree
         """
-        return node.tostring(self._ltnode).decode('utf-8')
+        return nrml.convert(self._ltnode)
 
     def reduce(self, trts):
         """

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -329,8 +329,20 @@ class CompositionInfo(object):
         vars(self).update(attrs)
         self.gsim_fname = decode(self.gsim_fname)
         if self.gsim_fname.endswith('.xml'):
-            tmp = writetmp(self.gsim_lt_xml, suffix='.xml')
-            self.gsim_lt = logictree.GsimLogicTree(tmp, sorted(self.trts))
+            trts = sorted(self.trts)
+            if 'gmpe_table' in self.gsim_lt_xml:
+                # the canadian gsims depends on external files which are not
+                # in the datastore; I am storing the path to the original
+                # file so that the external files can be found; unfortunately,
+                # this means that copying the datastore on a different machine
+                # and exporting from there works only if the gmpe file and all
+                # the external files are copied in the exact same place
+                self.gsim_lt = logictree.GsimLogicTree(self.gsim_fname, trts)
+            else:
+                # regular case: read the logic tree from self.gsim_lt_xml,
+                # so that you do not need to copy anything except the datastore
+                tmp = writetmp(self.gsim_lt_xml, suffix='.xml')
+                self.gsim_lt = logictree.GsimLogicTree(tmp, trts)
         else:  # fake file with the name of the GSIM
             self.gsim_lt = logictree.GsimLogicTree.from_(self.gsim_fname)
         self.source_models = []

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -29,7 +29,8 @@ import numpy
 
 from openquake.baselib import hdf5, node
 from openquake.baselib.python3compat import decode
-from openquake.baselib.general import groupby, group_array, block_splitter
+from openquake.baselib.general import (
+    groupby, group_array, block_splitter, writetmp)
 from openquake.hazardlib import nrml, sourceconverter, InvalidFile
 from openquake.commonlib import logictree
 
@@ -328,8 +329,8 @@ class CompositionInfo(object):
         vars(self).update(attrs)
         self.gsim_fname = decode(self.gsim_fname)
         if self.gsim_fname.endswith('.xml'):
-            self.gsim_lt = logictree.GsimLogicTree(
-                self.gsim_fname, sorted(self.trts))
+            tmp = writetmp(self.gsim_lt_xml, suffix='.xml')
+            self.gsim_lt = logictree.GsimLogicTree(tmp, sorted(self.trts))
         else:  # fake file with the name of the GSIM
             self.gsim_lt = logictree.GsimLogicTree.from_(self.gsim_fname)
         self.source_models = []

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -335,7 +335,7 @@ class CompositionInfo(object):
                 # in the datastore; I am storing the path to the original
                 # file so that the external files can be found; unfortunately,
                 # this means that copying the datastore on a different machine
-                # and exporting from there works only if the gmpe file and all
+                # and exporting from there works only if the gsim_fname and all
                 # the external files are copied in the exact same place
                 self.gsim_lt = logictree.GsimLogicTree(self.gsim_fname, trts)
             else:


### PR DESCRIPTION
 I discovered two distinct bugs:

1) the logic tree was not stored properly as a string in the datastore (it was missing the `<nrml>...</nrml>` tags)

2) the engine was no reading the string, was reading the filename!

This is a disaster, it means that it is impossible to copy a datastore on a different machine and then toexport anything, since the exporter will complain that it cannot find the logic tree file (which of course is in the original machine). This goes again the design: the logic tree file is stored as an attribute in the datastore exactly to avoid that issue.

The case of the Canadian GSIMs (i.e. GSIMs stored in external .hdf5 files) is problematic, so we ignore it for the moment, being special.