### PR TITLE
Put PDF manual inside RPM

### DIFF
--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -110,7 +110,13 @@ rm -rf %{buildroot}
 
 %files -f INSTALLED_FILES
 %defattr(-,root,root)
-%doc README.md LICENSE CONTRIBUTORS.txt doc
+%doc README.md LICENSE CONTRIBUTORS.txt
+%doc doc/oq-manual.pdf
+%doc doc/*.md
+%doc doc/img/*
+%doc doc/installing/*
+%doc doc/running/*
+%doc doc/upgrading/*
 %{_bindir}/oq
 %{_datadir}/openquake/engine
 %{_sysconfdir}/openquake/openquake.cfg


### PR DESCRIPTION
This PR includes a PDF generated by CI only in stable packages. The job have to be manually run before.