### PR TITLE
SeisDepthNRML

### DIFF
--- a/openquake/qa_tests_data/classical/case_25/source_model.xml
+++ b/openquake/qa_tests_data/classical/case_25/source_model.xml
@@ -22,8 +22,8 @@
                         </gml:LinearRing>
                     </gml:exterior>
                 </gml:Polygon>
-                <upperSeismoDepth>0.0</upperSeismoDepth>
-                <lowerSeismoDepth>3.0</lowerSeismoDepth>
+                <upperSeismoDepth>-1.0</upperSeismoDepth>
+                <lowerSeismoDepth>6.0</lowerSeismoDepth>
             </areaGeometry>
             <magScaleRel>WC1994</magScaleRel>
             <ruptAspectRatio>1.5</ruptAspectRatio>


### PR DESCRIPTION
This updates the classical qa test#25, now testing that a negative seismogenic depth can be used in the source_model.xml 

Companion of: https://github.com/gem/oq-hazardlib/pull/594