### PR TITLE
DbServer is started twice in packager.sh

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -323,7 +323,7 @@ _devtest_innervm_run () {
                      set -x
                  fi
                  export PYTHONPATH=\"\$PWD/oq-hazardlib:\$PWD/oq-engine\"
-                 cd oq-engine; bin/oq dbserver start &
+                 cd oq-engine
                  nosetests -v -a '${skip_tests}' --with-xunit --xunit-file=xunit-engine.xml --with-coverage --cover-package=openquake.engine --with-doctest openquake/engine/tests/
                  nosetests -v -a '${skip_tests}' --with-xunit --xunit-file=xunit-server.xml --with-coverage --cover-package=openquake.server --with-doctest openquake/server/tests/
 


### PR DESCRIPTION
This could cause the stall in CI builds when a test is broken since the DbServer is locking the ssh session. Anyway, it's wrong.

https://ci.openquake.org/job/zdevel_oq-engine/2401/console