### PR TITLE
Generate sphinx doc in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,8 @@ script:
   - cat /tmp/webui*
   - bin/oq info -r demos/hazard
   - bin/oq reset --yes
+
+after_success:
+  - pip install sphinx==1.3.6
+  - cd doc/sphinx
+  - make html


### PR DESCRIPTION
It's fast and it does not impact on the overall build time. On the other side it's very usefull to identify broken docstrings during a PR, before merging into master.