### PR TITLE
Change oq-manual cover image opacity

### DIFF
--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -3,6 +3,7 @@
 if [ $GEM_SET_DEBUG ]; then
     set -x
 fi
+set -e
 
 inkscape -A figures/oq_manual_cover.pdf figures/oq_manual_cover.svg
 pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex &> log.md

--- a/doc/manual/figures/oq_manual_cover.svg
+++ b/doc/manual/figures/oq_manual_cover.svg
@@ -438,7 +438,7 @@
        height="318.46399"
        width="358.65601"
        transform="scale(1,-1)"
-       style="opacity:0.6" /><g
+       style="opacity:0.8" /><g
        style="opacity:0.3"
        id="g336"
        clip-path="url(#clipPath88)"


### PR DESCRIPTION
As requested by @raoanirudh 

See [oq_manual_cover.pdf](https://github.com/gem/oq-engine/files/787462/oq_manual_cover.pdf)

Make also build.sh hard-fail if an error occurs.