### PR TITLE
Escape underscores in sourcegroups example [skip CI]

### DIFF
--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -3,25 +3,30 @@
 if [ $GEM_SET_DEBUG ]; then
     set -x
 fi
+set -e
 
 inkscape -A figures/oq_manual_cover.pdf figures/oq_manual_cover.svg
 
-pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex &> log.md
-bibtex oq-manual > log.md
-pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex &> log.md
-pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex &> log.md
+(pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex
+bibtex oq-manual
+pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex
+pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex
 makeindex oq-manual.idx
-makeglossaries oq-manual &> log.md
-pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex &> log.md
-cat log.md | egrep "Error|Warning"
-./clean.sh
-if [ "$1" == "--compress" ]; then
-    pdfinfo "oq-manual.pdf" | sed -e 's/^ *//;s/ *$//;s/ \{1,\}/ /g' -e 's/^/  \//' -e '/CreationDate/,$d' -e 's/$/)/' -e 's/: / (/' > .pdfmarks
-    sed -i '1s/^ /[/' .pdfmarks
-    sed -i '/:)$/d' .pdfmarks
-    echo "  /DOCINFO pdfmark" >> .pdfmarks
+makeglossaries oq-manual
+pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex) | egrep -i "error|warning|missing"
 
-    gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/printer -dNOPAUSE -dQUIET -dBATCH -sOutputFile=compressed-oq-manual.pdf oq-manual.pdf .pdfmarks
+if [ -f oq-manual.pdf ]; then
+    ./clean.sh
+    if [ "$1" == "--compress" ]; then
+        pdfinfo "oq-manual.pdf" | sed -e 's/^ *//;s/ *$//;s/ \{1,\}/ /g' -e 's/^/  \//' -e '/CreationDate/,$d' -e 's/$/)/' -e 's/: / (/' > .pdfmarks
+        sed -i '1s/^ /[/' .pdfmarks
+        sed -i '/:)$/d' .pdfmarks
+        echo "  /DOCINFO pdfmark" >> .pdfmarks
 
-    mv -f compressed-oq-manual.pdf oq-manual.pdf
+        gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/printer -dNOPAUSE -dQUIET -dBATCH -sOutputFile=compressed-oq-manual.pdf oq-manual.pdf .pdfmarks
+
+        mv -f compressed-oq-manual.pdf oq-manual.pdf
+    fi
+else
+    exit 1
 fi

--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -16,7 +16,7 @@ makeglossaries oq-manual
 pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex) | egrep -i "error|warning|missing"
 
 if [ -f oq-manual.pdf ]; then
-    ./clean.sh
+    ./clean.sh || true
     if [ "$1" == "--compress" ]; then
         pdfinfo "oq-manual.pdf" | sed -e 's/^ *//;s/ *$//;s/ \{1,\}/ /g' -e 's/^/  \//' -e '/CreationDate/,$d' -e 's/$/)/' -e 's/: / (/' > .pdfmarks
         sed -i '1s/^ /[/' .pdfmarks

--- a/doc/manual/oqum/hazard/verbatim/output_sourcegroups.tex
+++ b/doc/manual/oqum/hazard/verbatim/output_sourcegroups.tex
@@ -4,7 +4,7 @@
 
 \hline
 \rowcolor{lightgray}
-\bf{grp_id} & \bf{trt} & \bf{eff_ruptures} \\
+\bf{grp\_id} & \bf{trt} & \bf{eff\_ruptures} \\
 \hline
 0 & Active Shallow Crust & 283 \\
 1 & Stable Shallow Crust & 24 \\


### PR DESCRIPTION
Resolves the "There's no line here to end" LaTeX error in the previous build: https://ci.openquake.org/job/builders/job/doc-builder/23/console vs https://ci.openquake.org/job/builders/job/doc-builder/24/console