### PR TITLE
Changed the `build_rcurves` procedure to read the data directly from the workers

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -26,6 +26,7 @@ from openquake.baselib.python3compat import zip
 from openquake.baselib.general import (
     AccumDict, humansize, block_splitter, group_array)
 from openquake.hazardlib.stats import compute_stats, compute_stats2
+from openquake.commonlib import config
 from openquake.calculators import base, event_based
 from openquake.baselib import parallel
 from openquake.risklib import riskinput, scientific
@@ -96,6 +97,7 @@ def build_rcurves(h5path, rlzname, cbs, assets, monitor):
         if len(aids):
             result[cb.loss_type] = aids, curves
     return result
+build_rcurves.shared_dir_on = config.SHARED_DIR_ON
 
 
 def _aggregate(outputs, compositemodel, agg, ass, idx, result, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -21,6 +21,7 @@ import operator
 import collections
 import numpy
 
+from openquake.baselib import hdf5
 from openquake.baselib.python3compat import zip
 from openquake.baselib.general import (
     AccumDict, humansize, block_splitter, group_array)
@@ -80,14 +81,14 @@ def build_agg_curve(cb_inputs, monitor):
     return result
 
 
-def build_rcurves(rlzname, data, cbs, assets, monitor):
+def build_rcurves(h5path, rlzname, cbs, assets, monitor):
     """
     :param rlzname: string of the form `rlz-\d\d\d\d`
-    :param data: `all_loss_ratios` data for the realization
     :param cbs: list of `L` CurveBuilders instances
-    :param assets: full list of assets
     :param monitor: Monitor instance
     """
+    with hdf5.File(h5path, 'r') as f:
+        data = f['all_loss_ratios/' + rlzname].value
     result = {'rlzno': int(rlzname[4:])}  # strip rlz-
     losses_by_aid = group_array(data, 'aid')
     for cb in cbs:
@@ -207,7 +208,6 @@ class EbrPostCalculator(base.RiskCalculator):
             A = len(self.assetcol)
             I = self.oqparam.insured_losses + 1
             assets = list(self.assetcol)
-            table = self.datastore['all_loss_ratios']
             mon = self.monitor('build_rcurves')
             ltypes = self.riskmodel.loss_types
             cbs = self.riskmodel.curve_builders
@@ -215,9 +215,12 @@ class EbrPostCalculator(base.RiskCalculator):
                                             for ltype, cb in zip(ltypes, cbs)])
             rcurves = self.datastore.create_dset(
                 'rcurves-rlzs', self.multi_lr_dt, (A, R, I), fillvalue=None)
-            iterargs = ((rlzname, table[rlzname].value, cbs, assets, mon)
-                        for rlzname in table)
-            parallel.Starmap(build_rcurves, iterargs).reduce(self.save_rcurves)
+            ext5path = self.datastore.hdf5path.replace('.hdf5', '.ext5')
+            with hdf5.File(ext5path, 'r') as ext5:
+                table = ext5['all_loss_ratios']
+                allargs = [(ext5path, rlzname, cbs, assets, mon)
+                           for rlzname in table]
+            parallel.Starmap(build_rcurves, allargs).reduce(self.save_rcurves)
 
         # build rcurves-stats (sequentially)
         # this is a fundamental output, being used to compute loss_maps-stats
@@ -410,6 +413,7 @@ class EbriskCalculator(base.RiskCalculator):
         Yield the arguments required by build_ruptures, i.e. the
         source models, the asset collection, the riskmodel and others.
         """
+        self.ext5path = self.datastore.hdf5path.replace('.hdf5', '.ext5')
         oq = self.oqparam
         correl_model = oq.get_correl_model()
         min_iml = self.get_min_iml(oq)
@@ -537,7 +541,7 @@ class EbriskCalculator(base.RiskCalculator):
                 self.datastore.extend(key, agglosses[r])
             for r in asslosses:
                 key = 'all_loss_ratios/rlz-%03d' % (r + offset)
-                self.datastore.extend(key, asslosses[r])
+                hdf5.extend3(self.ext5path, key, asslosses[r])
 
     def post_execute(self, num_events):
         """

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -82,13 +82,15 @@ def build_agg_curve(cb_inputs, monitor):
     return result
 
 
-def build_rcurves(h5path, rlzname, cbs, assets, monitor):
+def build_rcurves(ext5path, rlzname, cbs, assets, monitor):
     """
+    :param ext5path: path of the .hdf5 file containing the loss ratios
     :param rlzname: string of the form `rlz-\d\d\d\d`
     :param cbs: list of `L` CurveBuilders instances
+    :param assets: list of Asset instances
     :param monitor: Monitor instance
     """
-    with hdf5.File(h5path, 'r') as f:
+    with hdf5.File(ext5path, 'r') as f:
         data = f['all_loss_ratios/' + rlzname].value
     result = {'rlzno': int(rlzname[4:])}  # strip rlz-
     losses_by_aid = group_array(data, 'aid')

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -248,7 +248,6 @@ def export_all_loss_ratios(ekey, dstore):
     """
     loss_types = dstore.get_attr('composite_risk_model', 'loss_types')
     name, ext = export.keyfunc(ekey)
-    ext5path = dstore.hdf5path.replace('.hdf5', '.ext5')
     assetcol = dstore['assetcol']
     oq = dstore['oqparam']
     dtlist = [('event_tag', (numpy.string_, 100)), ('year', U32),
@@ -273,7 +272,7 @@ def export_all_loss_ratios(ekey, dstore):
             dest = dstore.build_fname(exportname, rlz, 'csv')
             losses_by_aid = AccumDict()
             rlzname = 'rlz-%03d' % rlz.ordinal
-            with hdf5.File(ext5path) as ext5:
+            with dstore.ext5() as ext5:
                 ass_losses = ext5['all_loss_ratios'][rlzname].value
             data = get_array(ass_losses, eid=eid)
             losses_by_aid = group_array(data, 'aid')

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -21,6 +21,7 @@ import collections
 
 import numpy
 
+from openquake.baselib import hdf5
 from openquake.baselib.python3compat import decode
 from openquake.baselib.general import AccumDict, get_array, group_array
 from openquake.risklib import scientific, riskinput
@@ -247,7 +248,7 @@ def export_all_loss_ratios(ekey, dstore):
     """
     loss_types = dstore.get_attr('composite_risk_model', 'loss_types')
     name, ext = export.keyfunc(ekey)
-    ass_losses = dstore[name]
+    ext5path = dstore.hdf5path.replace('.hdf5', '.ext5')
     assetcol = dstore['assetcol']
     oq = dstore['oqparam']
     dtlist = [('event_tag', (numpy.string_, 100)), ('year', U32),
@@ -272,7 +273,9 @@ def export_all_loss_ratios(ekey, dstore):
             dest = dstore.build_fname(exportname, rlz, 'csv')
             losses_by_aid = AccumDict()
             rlzname = 'rlz-%03d' % rlz.ordinal
-            data = get_array(ass_losses[rlzname], eid=eid)
+            with hdf5.File(ext5path) as ext5:
+                ass_losses = ext5['all_loss_ratios'][rlzname].value
+            data = get_array(ass_losses, eid=eid)
             losses_by_aid = group_array(data, 'aid')
             elt = numpy.zeros(len(losses_by_aid), elt_dt)
             elt['event_tag'] = event_tag

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -182,11 +182,18 @@ class DataStore(collections.MutableMapping):
         self.calc_dir = os.path.join(datadir, 'calc_%s' % self.calc_id)
         self.export_dir = export_dir
         self.hdf5path = self.calc_dir + '.hdf5'
+        self.ext5path = self.calc_dir + '.ext5'
         mode = mode or 'r+' if os.path.exists(self.hdf5path) else 'w'
         self.hdf5 = hdf5.File(self.hdf5path, mode, libver='latest')
         self.attrs = self.hdf5.attrs
         for name, value in params:
             self.attrs[name] = value
+
+    def ext5(self, mode='r'):
+        """
+        Return the calc_XXX.ext5 file
+        """
+        return hdf5.File(self.ext5path, mode)
 
     def getitem(self, name):
         """


### PR DESCRIPTION
This reduces enormously the data transfer via Python. The gain depends on the data stored in `all_loss_ratios`; it could go from 100 GB to zero. It requires to store the `all_loss_ratios` array in a separate HDF5 file opened in read mode: the datastore is opened in read-write mode and therefore its content is not accessible to the workers. It cannot be closed, since the risk curves are being saved while the workers work.

As an example, I ran a computation for Chile with 5,000 years of investigation time and 3.8 GB of loss ratios generated; the memory occupation in `build_rcurves` went down from 104 MB to 18 MB (there is no more unpickling). Also now the data transfer time is measured (it is the reading time inside the task). The total computation time improved by 40 seconds. Of course, the effect would be a lot bigger with a longer investigation time (i.e. 50,000 years, as wanted).