### PR TITLE
Used cmaker.get_closest in ucerf_rupture calculator

### DIFF
--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -51,7 +51,7 @@ from openquake.hazardlib.scalerel.wc1994 import WC1994
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.mfd import EvenlyDiscretizedMFD
 from openquake.hazardlib.sourceconverter import SourceConverter
-
+from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 
 # ######################## rupture calculator ############################ #
 
@@ -762,17 +762,17 @@ def compute_ruptures(sources, src_filter, gsims, monitor):
     numpy.random.seed(monitor.seed + src.src_group_id)
     ebruptures = []
     eid = 0
-    integration_distance = src_filter.integration_distance[DEFAULT_TRT]
     background_sids = src.get_background_sids(src_filter)
     sitecol = src_filter.sitecol
+    cmaker = ContextMaker([], src_filter.integration_distance)
     for ses_idx in range(1, monitor.ses_per_logic_tree_path + 1):
         with event_mon:
             rups, n_occs = src.generate_event_set(background_sids, src_filter)
         for rup, n_occ in zip(rups, n_occs):
             rup.seed = monitor.seed  # to think
-            rrup = rup.surface.get_min_distance(sitecol.mesh)
-            r_sites = sitecol.filter(rrup <= integration_distance)
-            if r_sites is None:
+            try:
+                r_sites, rrup = cmaker.get_closest(sitecol, rup)
+            except FarAwayRupture:
                 continue
             indices = r_sites.indices
             events = []


### PR DESCRIPTION
Companion of https://github.com/gem/oq-hazardlib/pull/599. The big advantage is that now UCERF uses the same filtering mechanism as all the other calculators. It means that magnitude-distance filtering works for free in UCERF too.