### PR TITLE
Fix a bug when deleting a calculation from the WebUI

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a TypeError when deleting a calculation from the WebUI
   * Extended the command `oq to_hdf5` to manage source model files too
   * Improved significantly the performance of the event based calculator
     when computing the GMFs and not the hazard curves

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -281,7 +281,6 @@ def del_calc(db, job_id, user):
     except NotFound:
         return ('Cannot delete calculation %d: ID does not exist' % job_id)
 
-    print(owner, user)
     deleted = db('DELETE FROM job WHERE id=?x AND user_name=?x',
                  job_id, user).rowcount
     if not deleted:

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -276,16 +276,16 @@ def del_calc(db, job_id, user):
         return ('Cannot delete calculation %d: there are calculations '
                 'dependent from it: %s' % (job_id, [j.id for j in dependent]))
     try:
-        path = db('SELECT ds_calc_dir FROM job WHERE id=?x', job_id,
-                  scalar=True)
+        user, path = db('SELECT user_name, ds_calc_dir FROM job WHERE id=?x',
+                        job_id, one=True)
     except NotFound:
         return ('Cannot delete calculation %d: ID does not exist' % job_id)
 
     deleted = db('DELETE FROM job WHERE id=?x AND user_name=?x',
                  job_id, user).rowcount
     if not deleted:
-        return ('Cannot delete calculation %d: belongs to a different user'
-                % job_id)
+        return ('Cannot delete calculation %d: belongs to a different user '
+                '(%s)' % (job_id, user))
 
     # try to delete datastore and associated files
     # path has typically the form /home/user/oqdata/calc_XXX

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -265,7 +265,7 @@ def del_calc(db, job_id, user):
     Delete a calculation and all associated outputs, if possible.
 
     :param db: a :class:`openquake.server.dbapi.Db` instance
-    :param job_id: job ID
+    :param job_id: job ID, can be an integer or a string
     :param user: username
     :returns: None if everything went fine or an error message
     """

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -276,16 +276,17 @@ def del_calc(db, job_id, user):
         return ('Cannot delete calculation %d: there are calculations '
                 'dependent from it: %s' % (job_id, [j.id for j in dependent]))
     try:
-        user, path = db('SELECT user_name, ds_calc_dir FROM job WHERE id=?x',
-                        job_id, one=True)
+        owner, path = db('SELECT user_name, ds_calc_dir FROM job WHERE id=?x',
+                         job_id, one=True)
     except NotFound:
         return ('Cannot delete calculation %d: ID does not exist' % job_id)
 
+    print(owner, user)
     deleted = db('DELETE FROM job WHERE id=?x AND user_name=?x',
                  job_id, user).rowcount
     if not deleted:
-        return ('Cannot delete calculation %d: belongs to a different user '
-                '(%s)' % (job_id, user))
+        return ('Cannot delete calculation %d: it belongs to '
+                '%s and you are %s' % (job_id, owner, user))
 
     # try to delete datastore and associated files
     # path has typically the form /home/user/oqdata/calc_XXX

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -269,6 +269,7 @@ def del_calc(db, job_id, user):
     :param user: username
     :returns: None if everything went fine or an error message
     """
+    job_id = int(job_id)
     dependent = db(
         'SELECT id FROM job WHERE hazard_calculation_id=?x', job_id)
     if dependent:

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -319,6 +319,7 @@ def calc_remove(request, calc_id):
         return HttpResponse(content=json.dumps(message),
                             content_type=JSON, status=200)
     else:  # FIXME: the error is not passed properly to the javascript
+        logging.error(message)
         return HttpResponse(content=message,
                             content_type='text/plain', status=500)
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -312,11 +312,15 @@ def calc_remove(request, calc_id):
     """
     user = utils.get_user_data(request)['name']
     try:
-        logs.dbcmd('del_calc', calc_id, user)
+        message = logs.dbcmd('del_calc', calc_id, user)
     except dbapi.NotFound:
         return HttpResponseNotFound()
-    return HttpResponse(content=json.dumps([]),
-                        content_type=JSON, status=200)
+    if isinstance(message, list):  # list of removed files
+        return HttpResponse(content=json.dumps(message),
+                            content_type=JSON, status=200)
+    else:  # FIXME: the error is not passed properly to the javascript
+        return HttpResponse(content=message,
+                            content_type='text/plain', status=500)
 
 
 def log_to_json(log):


### PR DESCRIPTION
Paolo found this error:

```python
  File "/home/paolo/projects/oq-engine/openquake/server/db/actions.py", line 276, in del_calc
    'dependent from it: %s' % (job_id, [j.id for j in dependent]))
TypeError: %d format: a number is required, not unicode
ERROR Internal Server Error: /v1/calc/73/remove
```
