### PR TITLE
Use a ThreadPoolExecutor instead of a ProcessPoolExecutor in dbserver.py

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Daniele Viganò]
   * Use threads instead of processes in DbServer because SQLite3
-    isn't fork-safe on macOS
+    isn't fork-safe on macOS Sierra
 
   [Michele Simionato]
   * Extended the command `oq to_hdf5` to manage source model files too

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Use threads instead of processes in DbServer because SQLite3
+    isn't fork-safe on macOS
+
   [Michele Simionato]
   * Extended the command `oq to_hdf5` to manage source model files too
   * Improved significantly the performance of the event based calculator

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -24,7 +24,7 @@ import os.path
 import logging
 import subprocess
 from multiprocessing.connection import Listener
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 from openquake.baselib import sap
 from openquake.baselib.parallel import safely_call
@@ -34,7 +34,7 @@ from openquake.server.db import actions
 from openquake.server import dbapi
 from openquake.server.settings import DATABASE
 
-executor = ProcessPoolExecutor(1)  # there is a single db process
+executor = ThreadPoolExecutor(1)  # there is a single db process
 
 
 class DbServer(object):

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -34,7 +34,9 @@ from openquake.server.db import actions
 from openquake.server import dbapi
 from openquake.server.settings import DATABASE
 
-executor = ThreadPoolExecutor(1)  # there is a single db process
+# using a ThreadPool because SQLite3 isn't fork-safe on macOS Sierra
+# ref: https://bugs.python.org/issue27126
+executor = ThreadPoolExecutor(1)
 
 
 class DbServer(object):


### PR DESCRIPTION
because SQLite in macOS is not fork-safe; using the ProcessPoolExecutor a 'ProgrammingError: Cannot operate on a closed database' error is raised. Se also https://bugs.python.org/issue27126

I would like to make some extensive manual testing on other platforms before merging this code.

lin: https://ci.openquake.org/job/zdevel_oq-engine/2432/
mac: https://ci.openquake.org/job/macos/job/zdevel_mac_oq-engine/88/
win: https://ci.openquake.org/job/windows/job/zdevel_oq-engine/4/