### PR TITLE
Moved the matplotlib imports to toplevel

### DIFF
--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -17,6 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+import matplotlib.pyplot as plt
 from openquake.baselib import sap
 from openquake.commonlib import datastore
 from openquake.commands.show import get_hcurves_and_means
@@ -30,10 +31,6 @@ def make_figure(indices, imtls, spec_curves, curves=(), label=''):
     :param curves: a dictionary of dictionaries IMT -> array
     :param label: the label associated to `spec_curves`
     """
-    # NB: matplotlib is imported inside, otherwise nosetest would fail in an
-    # installation without matplotlib
-    import matplotlib.pyplot as plt
-
     fig = plt.figure()
     n_imts = len(imtls)
     n_sites = len(indices)

--- a/openquake/commands/plot_agg_curve.py
+++ b/openquake/commands/plot_agg_curve.py
@@ -17,14 +17,12 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+import matplotlib.pyplot as plt
 from openquake.baselib import sap
 from openquake.commonlib import datastore
 
 
 def make_figure(curves):
-    # NB: matplotlib is imported inside, otherwise nosetest would fail in an
-    # installation without matplotlib
-    import matplotlib.pyplot as plt
     loss_types = curves.dtype.names
     I, R = curves.shape
     num_lt = len(loss_types)

--- a/openquake/commands/plot_lc.py
+++ b/openquake/commands/plot_lc.py
@@ -17,15 +17,13 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+import matplotlib.pyplot as plt
 import numpy
 from openquake.baselib import sap
 from openquake.commonlib import datastore
 
 
 def make_figure(asset, loss_ratios, rcurves):
-    # NB: matplotlib is imported inside, otherwise nosetest would fail in an
-    # installation without matplotlib
-    import matplotlib.pyplot as plt
     loss_types = rcurves.dtype.names
     S, I = rcurves.shape
     num_lt = len(loss_types)

--- a/openquake/commands/plot_sites.py
+++ b/openquake/commands/plot_sites.py
@@ -1,4 +1,5 @@
 from __future__ import division
+import matplotlib.pyplot as p
 from openquake.baselib import sap
 from openquake.commonlib import datastore
 from openquake.hazardlib.calc.filters import SourceFilter
@@ -10,7 +11,6 @@ def plot_sites(calc_id):
     Plot the sites and the bounding boxes of the sources, enlarged by
     the maximum distance
     """
-    import matplotlib.pyplot as p
     from matplotlib.patches import Rectangle
     dstore = datastore.read(calc_id)
     sitecol = dstore['sitecol']

--- a/openquake/commands/plot_uhs.py
+++ b/openquake/commands/plot_uhs.py
@@ -17,6 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+import matplotlib.pyplot as plt
 from openquake.baselib import sap
 from openquake.commonlib import datastore, calc
 
@@ -29,10 +30,6 @@ def make_figure(indices, n_sites, imtls, poes, pmap_by_rlz):
     :param poes: PoEs used to compute the hazard maps
     :param pmap_by_rlz: a dictionary realization tag -> pmap
     """
-    # NB: matplotlib is imported inside, otherwise nosetest would fail in an
-    # installation without matplotlib
-    import matplotlib.pyplot as plt
-
     fig = plt.figure()
     n_poes = len(poes)
     uhs_by_rlz = {rlz: calc.make_uhs(pmap_by_rlz[rlz], imtls, poes, n_sites)


### PR DESCRIPTION
This is causing a very ugly error: https://ci.openquake.org/job/zdevel_oq-engine/2434/console
My guess is that matplotlib is not available on Jenkins and we are getting an error masking the real issue.