### PR TITLE
Do not return the ruptures in ucerf_risk, only the events

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Now the ucerf_risk calculators transfer only the events, not the ruptures,
+    thus reducing the data transfer of several orders of magnitude
   * Added a view `get_available_gsims` to the WebUI and fixed the API docs
   * Introduced a configuration parameter `max_site_model_distance` with default of
     5 km

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -193,6 +193,20 @@ def _count(ruptures):
     return sum(ebr.multiplicity for ebr in ruptures)
 
 
+def get_events(ebruptures):
+    """
+    Extract an array of dtype stored_event_dt from a list of EBRuptures
+    """
+    events = []
+    year = 0  # to be set later
+    for ebr in ebruptures:
+        for event in ebr.events:
+            rec = (event['eid'], ebr.serial, year, event['ses'], event['occ'],
+                   event['sample'], ebr.grp_id)
+            events.append(rec)
+    return numpy.array(events, calc.stored_event_dt)
+
+
 @base.calculators.add('event_based_rupture')
 class EventBasedRuptureCalculator(PSHACalculator):
     """
@@ -247,32 +261,22 @@ class EventBasedRuptureCalculator(PSHACalculator):
         if hasattr(ruptures_by_grp_id, 'eff_ruptures'):
             acc.eff_ruptures += ruptures_by_grp_id.eff_ruptures
         acc += ruptures_by_grp_id
-        self.save_events(ruptures_by_grp_id)
+        self.save_ruptures(ruptures_by_grp_id)
         return acc
 
-    def save_events(self, ruptures_by_grp_id):
+    def save_ruptures(self, ruptures_by_grp_id):
         """Extend the 'events' dataset with the given ruptures"""
         with self.monitor('saving ruptures', autoflush=True):
             for grp_id, ebrs in ruptures_by_grp_id.items():
-                events = []
                 sm_id = self.sm_by_grp[grp_id]
-                for ebr in ebrs:
-                    for event in ebr.events:
-                        rec = (event['eid'],
-                               ebr.serial,
-                               0,  # year to be set
-                               event['ses'],
-                               event['occ'],
-                               event['sample'],
-                               grp_id)
-                        events.append(rec)
-                    if self.oqparam.save_ruptures:
+                if self.oqparam.save_ruptures:
+                    for ebr in ebrs:
                         key = 'ruptures/grp-%02d/%s' % (grp_id, ebr.serial)
                         self.datastore[key] = ebr
-                if events:
+                events = get_events(ebrs)
+                if len(events):
                     ev = 'events/sm-%04d' % sm_id
-                    self.datastore.extend(
-                        ev, numpy.array(events, calc.stored_event_dt))
+                    self.datastore.extend(ev, events)
 
             # save rup_data
             if hasattr(ruptures_by_grp_id, 'rup_data'):
@@ -458,7 +462,7 @@ class EventBasedCalculator(ClassicalCalculator):
         agg_mon.flush()
         self.datastore.flush()
         if 'ruptures' in res:
-            vars(EventBasedRuptureCalculator)['save_events'](
+            vars(EventBasedRuptureCalculator)['save_ruptures'](
                 self, res['ruptures'])
         return acc
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -291,7 +291,8 @@ class EbrPostCalculator(base.RiskCalculator):
 
 elt_dt = numpy.dtype([('eid', U64), ('loss', F32)])
 
-save_events = event_based.EventBasedRuptureCalculator.__dict__['save_events']
+save_ruptures = event_based.EventBasedRuptureCalculator.__dict__[
+    'save_ruptures']
 
 
 class EpsilonMatrix0(object):
@@ -513,7 +514,12 @@ class EbriskCalculator(base.RiskCalculator):
                 'Saving results for source model #%d, realizations %d:%d',
                 res.sm_id + 1, start, stop)
             if hasattr(res, 'ruptures_by_grp'):
-                save_events(self, res.ruptures_by_grp)
+                save_ruptures(self, res.ruptures_by_grp)
+            elif hasattr(res, 'events_by_grp'):
+                for grp_id in res.events_by_grp:
+                    events = res.events_by_grp[grp_id]
+                    ev = 'events/sm-%04d' % self.sm_by_grp[grp_id]
+                    self.datastore.extend(ev, events)
             num_events[res.sm_id] += res.num_events
         self.datastore['events'].attrs['num_events'] = sum(num_events.values())
         event_based.save_gmdata(self, num_rlzs)


### PR DESCRIPTION
Currently we are returning back the ruptures even if we are saving only the events. So Anirudh's calculations can use up to 750 GB of data transfer when a lot less should be required, at least 300 times less.