### PR TITLE
Replace `use_celery` with `oq_distribute`

### DIFF
--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -20,9 +20,9 @@ In all the nodes, the following file should be modified to enable the *Celery* s
 `/etc/openquake/openquake.cfg:`
 
 ```
-[celery]
+[distribution]
 # enable celery only if you have a cluster
-use_celery = true
+oq_distribute = celery
 ```
 
 ## OpenQuake Engine 'worker' node configuration File

--- a/openquake/commands/__main__.py
+++ b/openquake/commands/__main__.py
@@ -26,7 +26,7 @@ from openquake.commonlib import __version__
 from openquake import commands
 from openquake.commonlib import config
 
-USE_CELERY = config.flag_set('celery', 'use_celery')
+USE_CELERY = config.get('distribution', 'oq_distribute') == 'celery'
 
 # the environment variable has the precedence over the configuration file
 if 'OQ_DISTRIBUTE' not in os.environ and USE_CELERY:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -35,7 +35,7 @@ from openquake.commonlib import logs
 TERMINATE = valid.boolean(
     config.get('celery', 'terminate_workers_on_revoke') or 'false')
 
-USE_CELERY = valid.boolean(config.get('celery', 'use_celery') or 'false')
+USE_CELERY = config.get('distribution', 'oq_distribute') == 'celery'
 
 if USE_CELERY:
     import celery.task.control

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -33,7 +33,7 @@ from openquake.calculators import base, views, export
 from openquake.commonlib import logs
 
 TERMINATE = valid.boolean(
-    config.get('celery', 'terminate_workers_on_revoke') or 'false')
+    config.get('distribution', 'terminate_workers_on_revoke') or 'false')
 
 USE_CELERY = config.get('distribution', 'oq_distribute') == 'celery'
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -13,9 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-[celery]
+[distribution]
 # enable celery only if you have a cluster
-use_celery = false
+oq_distribute = futures
 
 # make sure workers are terminated when tasks are revoked
 terminate_workers_on_revoke = true


### PR DESCRIPTION
Just to be less celery-centered. The demos run: https://ci.openquake.org/job/zdevel_oq-engine/2442