### PR TITLE
Fixed ignore_covs for scenario_risk

### DIFF
--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -95,10 +95,12 @@ class ScenarioRiskCalculator(base.RiskCalculator):
         base.RiskCalculator.pre_execute(self)
 
         logging.info('Building the epsilons')
+        A = len(self.assetcol)
+        E = self.oqparam.number_of_ground_motion_fields
         if self.oqparam.ignore_covs:
-            eps = None
+            eps = numpy.zeros((A, E), numpy.float32)
         else:
-            eps = self.make_eps(self.oqparam.number_of_ground_motion_fields)
+            eps = self.make_eps(E)
         self.datastore['etags'], gmfs = calc.get_gmfs(
             self.datastore, self.precalc)
         hazard_by_rlz = {rlz: gmfs[rlz.ordinal]

--- a/openquake/qa_tests_data/scenario_risk/case_2/expected/agg.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_2/expected/agg.csv
@@ -1,2 +1,2 @@
 structural-unit,structural-mean,structural-stddev
-USD,5.161157E+02,3.691620E+02
+USD,4.738466E+02,2.286447E+02

--- a/openquake/qa_tests_data/scenario_risk/case_2/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_2/job_risk.ini
@@ -7,7 +7,7 @@ number_of_ground_motion_fields = 1000
 gmfs_csv = gmfs.txt
 structural_vulnerability_file = vulnerability.xml
 exposure_file = exposure_model.xml
-
+ignore_covs = true
 region_constraint =  15.48 38.30, 15.63 38.30,  15.63 38.01,  15.48 38.01
 
 export_dir = /tmp/


### PR DESCRIPTION
During debugging, it is useful to se `ignore_covs=true` in the `job.ini` file. This feature was broken for scenario_risk.