### PR TITLE
Relaxed two arbitrary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,8 +4,8 @@
   * Now the ucerf_risk calculators transfer only the events, not the ruptures,
     thus reducing the data transfer of several orders of magnitude
   * Added a view `get_available_gsims` to the WebUI and fixed the API docs
-  * Introduced a configuration parameter `max_site_model_distance` with default of
-    5 km
+  * Introduced a configuration parameter `max_site_model_distance` with default
+    of 5 km
   * Implemented sampling in the UCERF event based hazard calculator
 
   [Daniele Viganò]

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -195,12 +195,14 @@ class OqParam(valid.ParamSet):
             raise ValueError('asset_correlation != {0, 1} is no longer'
                              ' supported')
 
-        if self.ses_per_logic_tree_path >= TWO16:
-            raise ValueError('ses_per_logic_tree_path too big: %d' %
-                             self.ses_per_logic_tree_path)
-        if self.number_of_logic_tree_samples >= TWO16:
-            raise ValueError('number_of_logic_tree_samples too big: %d' %
-                             self.number_of_logic_tree_samples)
+        # checks for ucerf
+        if 'ucerf' in self.calculation_mode:
+            if self.ses_per_logic_tree_path >= TWO16:
+                raise ValueError('ses_per_logic_tree_path too big: %d' %
+                                 self.ses_per_logic_tree_path)
+            if self.number_of_logic_tree_samples >= TWO16:
+                raise ValueError('number_of_logic_tree_samples too big: %d' %
+                                 self.number_of_logic_tree_samples)
 
     def check_gsims(self, gsims):
         """


### PR DESCRIPTION
The constraints on `ses_per_logic_tree_path` and `number_of_logic_tree_samples` are only needed for UCERF. One of Anirudh's tests for regular `event_based_risk` actually uses  `ses_per_logic_tree_path=100,000` to compare with Julia's results, so this should be a valid value.

This fixes https://travis-ci.org/gem/oq-risk-tests/builds/210598804 and is needed for https://github.com/gem/oq-engine/issues/2624.