### PR TITLE
Removed `check_platform` because we have /opt now

### DIFF
--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -38,14 +38,6 @@ def strip_calc_id(fname):
     return re.sub('_\d+\.', '.', name)
 
 
-def check_platform(*supported):
-    """
-    Skip the test if the platform is not the reference one
-    """
-    if platform.dist()[-1] not in supported:
-        raise unittest.SkipTest
-
-
 def columns(line):
     data = []
     if ',' in line:  # csv file

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -21,7 +21,7 @@ from openquake.baselib import parallel
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import InvalidFile
 from openquake.calculators.export import export
-from openquake.calculators.tests import CalculatorTestCase, check_platform
+from openquake.calculators.tests import CalculatorTestCase
 from openquake.qa_tests_data.classical import (
     case_1, case_2, case_3, case_4, case_5, case_6, case_7, case_8, case_9,
     case_10, case_11, case_12, case_13, case_14, case_15, case_16, case_17,
@@ -194,9 +194,6 @@ hazard_uhs-smltp_SM2_a3b1-gsimltp_CB2008_@.csv
 hazard_uhs-smltp_SM2_a3pt2b0pt8-gsimltp_BA2008_@.csv
 hazard_uhs-smltp_SM2_a3pt2b0pt8-gsimltp_CB2008_@.csv'''.split(),
                               case_15.__file__, delta=1E-6)
-
-        # now some tests on the exact numbers
-        check_platform('xenial', 'trusty')
 
         # test UHS XML export
         fnames = [f for f in export(('uhs', 'xml'), self.calc.datastore)

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -23,7 +23,6 @@ from openquake.commonlib.writers import OLD_NUMPY
 from openquake.calculators.views import view
 from openquake.calculators.tests import CalculatorTestCase, strip_calc_id
 from openquake.calculators.export import export
-from openquake.calculators.tests import check_platform
 from openquake.qa_tests_data.event_based_risk import (
     case_1, case_2, case_3, case_4, case_4a, case_master, case_miriam,
     occupants, case_1g)

--- a/openquake/calculators/tests/scenario_damage_test.py
+++ b/openquake/calculators/tests/scenario_damage_test.py
@@ -26,13 +26,6 @@ from openquake.qa_tests_data.scenario_damage import (
 
 from openquake.calculators.tests import CalculatorTestCase
 
-try:
-    from shapely.geos import geos_version
-except:
-    old_geos = True
-else:
-    old_geos = geos_version < (3, 4, 2)
-
 
 class ScenarioDamageTestCase(CalculatorTestCase):
     def assert_ok(self, pkg, job_ini, exports='xml', kind='dmg'):
@@ -71,10 +64,6 @@ class ScenarioDamageTestCase(CalculatorTestCase):
 
     @attr('qa', 'risk', 'scenario_damage')
     def test_case_3(self):
-        if old_geos:
-            # in Ubuntu 12.04 avoid a mysterious finalization segfault
-            # due to HDF5 that only happens in this test
-            raise unittest.SkipTest
         self.assert_ok(case_3, 'job_risk.ini')
 
     @attr('qa', 'risk', 'scenario_damage')

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -69,21 +69,8 @@ class ScenarioTestCase(CalculatorTestCase):
 
     @attr('qa', 'hazard', 'scenario')
     def test_case_1(self):
-        # ROUNDING ERROR WARNING (MS): numbers such as 2.5 and 2.4999999999
-        # are extremely close (up to 4E-11) however they must be rounded to
-        # a single digit to compare equal in their string representation; for
-        # this reason the precision here has to be reduced a lot, even it the
-        # numbers are very close. It comes down to the known fact that
-        # comparing the XMLs is not a good idea; suboptimal choises
-        # sometimes have to be made, since we want this test to
-        # to run both on Ubuntu 12.04 and Ubuntu 14.04.
-        # Incidentally, when the approach of comparing the XML was taken,
-        # the idea of supporting at the same time different versions of the
-        # libraries was out of question, so it made a lot of sense to check
-        # the XMLs, since the numbers had to be exactly identical.
         with floatformat('%5.1E'):
             out = self.run_calc(case_1.__file__, 'job.ini', exports='xml')
-        raise unittest.SkipTest  # because of the rounding errors
         self.assertEqualFiles('expected.xml', out['gmf_data', 'xml'][0])
 
     @attr('qa', 'hazard', 'scenario')

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -288,9 +288,6 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
     - more tests will follow
     """
     def setUp(self):
-        if not hasattr(shapefile, '__version__'):
-            # for versions < 1.2.3
-            raise unittest.SkipTest('shapefile library too old')
         self.OUTDIR = tempfile.mkdtemp()
 
     def test_roundtrip_invalid(self):

--- a/openquake/qa_tests_data/scenario/case_1/expected.xml
+++ b/openquake/qa_tests_data/scenario/case_1/expected.xml
@@ -4,827 +4,827 @@ xmlns="http://openquake.org/xmlns/nrml/0.5"
 xmlns:gml="http://www.opengis.net/gml"
 >
     <gmfCollection
-    gsimTreePath="@"
-    sourceModelTreePath=""
+    gsimTreePath="b1"
+    sourceModelTreePath="b_1"
     >
         <gmfSet
         stochasticEventSetId="1"
         >
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000000"
+            ruptureId="scenario-0000000000~ses=1"
             >
-                <node gmv="6.8250E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.2709E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.6031E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.1608956E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7974805E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.1158248E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000001"
+            ruptureId="scenario-0000000001~ses=1"
             >
-                <node gmv="3.6566E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5618E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1069E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.8985063E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="4.0083918E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6362470E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000002"
+            ruptureId="scenario-0000000002~ses=1"
             >
-                <node gmv="8.7008E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.1064E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.2322E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.9229318E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.8540877E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4151289E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000003"
+            ruptureId="scenario-0000000003~ses=1"
             >
-                <node gmv="3.2793E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.3576E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.7811E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.9368364E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.2274002E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5807261E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000004"
+            ruptureId="scenario-0000000004~ses=1"
             >
-                <node gmv="6.9687E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5814E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3516E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="7.5868744E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5629855E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.7529629E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000005"
+            ruptureId="scenario-0000000005~ses=1"
             >
-                <node gmv="5.4388E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6277E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4147E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.7125604E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.7112659E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0611729E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000006"
+            ruptureId="scenario-0000000006~ses=1"
             >
-                <node gmv="2.5336E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.1942E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.6583E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.3002126E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.0832943E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5571481E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000007"
+            ruptureId="scenario-0000000007~ses=1"
             >
-                <node gmv="5.1935E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.9278E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.7214E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.0505222E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.2530617E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="8.7222360E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000008"
+            ruptureId="scenario-0000000008~ses=1"
             >
-                <node gmv="4.4369E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7973E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3117E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.6247472E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.7538950E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.9951185E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000009"
+            ruptureId="scenario-0000000009~ses=1"
             >
-                <node gmv="5.4464E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5337E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1593E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.5341477E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5696926E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4637445E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000010"
+            ruptureId="scenario-0000000010~ses=1"
             >
-                <node gmv="4.8803E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.3416E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1573E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.6525876E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.4337221E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.2075892E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000011"
+            ruptureId="scenario-0000000011~ses=1"
             >
-                <node gmv="4.5518E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.2313E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4269E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.0684697E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.3815181E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.9173501E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000012"
+            ruptureId="scenario-0000000012~ses=1"
             >
-                <node gmv="3.6969E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.3442E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="9.9874E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.5213684E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.4166519E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.1610097E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000013"
+            ruptureId="scenario-0000000013~ses=1"
             >
-                <node gmv="3.5190E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.4535E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.5050E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.0880722E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.1471667E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4684473E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000014"
+            ruptureId="scenario-0000000014~ses=1"
             >
-                <node gmv="6.3966E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.1378E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4038E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.5408975E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7782363E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0222384E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000015"
+            ruptureId="scenario-0000000015~ses=1"
             >
-                <node gmv="3.2966E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.1622E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3448E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.1774442E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5120740E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.0830632E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000016"
+            ruptureId="scenario-0000000016~ses=1"
             >
-                <node gmv="8.5454E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.6617E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.2813E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.6418360E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.3714222E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6941668E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000017"
+            ruptureId="scenario-0000000017~ses=1"
             >
-                <node gmv="4.5257E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.2289E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.5982E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.8334104E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.3023280E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0154448E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000018"
+            ruptureId="scenario-0000000018~ses=1"
             >
-                <node gmv="5.3248E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.4492E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3572E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.3537429E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.8203886E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.8954046E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000019"
+            ruptureId="scenario-0000000019~ses=1"
             >
-                <node gmv="5.9594E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.4615E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.2364E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.5821413E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.6509652E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.9337682E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000020"
+            ruptureId="scenario-0000000020~ses=1"
             >
-                <node gmv="3.6568E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6347E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.0707E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.2077631E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.5461823E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6378094E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000021"
+            ruptureId="scenario-0000000021~ses=1"
             >
-                <node gmv="5.5381E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.7392E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3843E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.1344317E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.8678318E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5466599E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000022"
+            ruptureId="scenario-0000000022~ses=1"
             >
-                <node gmv="2.8325E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.6489E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="8.1645E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.6874675E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.1530919E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6387486E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000023"
+            ruptureId="scenario-0000000023~ses=1"
             >
-                <node gmv="5.2097E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.6382E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.5140E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.9841381E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7309388E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0563961E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000024"
+            ruptureId="scenario-0000000024~ses=1"
             >
-                <node gmv="3.2596E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.5792E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8795E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.2266521E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7805296E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.1612912E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000025"
+            ruptureId="scenario-0000000025~ses=1"
             >
-                <node gmv="3.6019E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.0301E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.9281E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.2926614E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.0318426E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3182402E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000026"
+            ruptureId="scenario-0000000026~ses=1"
             >
-                <node gmv="6.5146E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6539E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="8.3188E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.2554697E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.8108870E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.0363203E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000027"
+            ruptureId="scenario-0000000027~ses=1"
             >
-                <node gmv="2.8997E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.3677E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="7.7491E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.9951423E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.1003266E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="8.2378276E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000028"
+            ruptureId="scenario-0000000028~ses=1"
             >
-                <node gmv="5.5686E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.8938E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.7032E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.9970315E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.3002241E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0386832E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000029"
+            ruptureId="scenario-0000000029~ses=1"
             >
-                <node gmv="9.4951E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.9449E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1323E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="8.1742501E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.6913717E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.1508937E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000030"
+            ruptureId="scenario-0000000030~ses=1"
             >
-                <node gmv="6.3762E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.3315E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="9.6193E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.1004460E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.7336924E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.3206786E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000031"
+            ruptureId="scenario-0000000031~ses=1"
             >
-                <node gmv="7.5817E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.8099E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4073E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.2675339E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.2194868E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5013821E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000032"
+            ruptureId="scenario-0000000032~ses=1"
             >
-                <node gmv="4.0906E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.9474E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.0960E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="7.2706193E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.6161706E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.2739525E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000033"
+            ruptureId="scenario-0000000033~ses=1"
             >
-                <node gmv="4.3166E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.4207E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4667E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="7.3497015E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.8997456E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3213313E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000034"
+            ruptureId="scenario-0000000034~ses=1"
             >
-                <node gmv="7.1555E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.6810E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.0939E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.4322845E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.5559577E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0691257E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000035"
+            ruptureId="scenario-0000000035~ses=1"
             >
-                <node gmv="6.1040E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7199E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3393E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.0785259E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.8097587E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.1521211E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000036"
+            ruptureId="scenario-0000000036~ses=1"
             >
-                <node gmv="2.7971E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.0445E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1419E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.1348180E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.7160702E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4320323E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000037"
+            ruptureId="scenario-0000000037~ses=1"
             >
-                <node gmv="6.1045E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.2842E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8725E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.2322680E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.4383861E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6490155E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000038"
+            ruptureId="scenario-0000000038~ses=1"
             >
-                <node gmv="4.7215E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.3070E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.6993E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.4099853E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.3609123E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="7.4065886E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000039"
+            ruptureId="scenario-0000000039~ses=1"
             >
-                <node gmv="7.1987E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.7931E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.5094E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.8574487E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.8002395E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3812606E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000040"
+            ruptureId="scenario-0000000040~ses=1"
             >
-                <node gmv="3.1350E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.3475E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.7021E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.2854434E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.5222597E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="8.5089087E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000041"
+            ruptureId="scenario-0000000041~ses=1"
             >
-                <node gmv="3.2666E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.8619E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8346E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.0079640E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.9794339E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4819725E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000042"
+            ruptureId="scenario-0000000042~ses=1"
             >
-                <node gmv="5.0145E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.9434E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.2337E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.9082544E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.1306940E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.1686548E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000043"
+            ruptureId="scenario-0000000043~ses=1"
             >
-                <node gmv="4.8281E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.9213E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.9400E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.3741921E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.4284013E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="7.9957895E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000044"
+            ruptureId="scenario-0000000044~ses=1"
             >
-                <node gmv="3.9380E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.3861E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="8.6697E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.6854511E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.0483378E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.6007951E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000045"
+            ruptureId="scenario-0000000045~ses=1"
             >
-                <node gmv="6.9436E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.0155E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1646E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.5934179E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5570278E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.9604354E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000046"
+            ruptureId="scenario-0000000046~ses=1"
             >
-                <node gmv="3.9686E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7938E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1156E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.4930053E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.2344160E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.9928709E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000047"
+            ruptureId="scenario-0000000047~ses=1"
             >
-                <node gmv="5.0416E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.8455E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="8.3637E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.4134906E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.6795947E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5811999E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000048"
+            ruptureId="scenario-0000000048~ses=1"
             >
-                <node gmv="4.7992E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5692E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.7924E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.0385011E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.8305580E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.8191756E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000049"
+            ruptureId="scenario-0000000049~ses=1"
             >
-                <node gmv="6.6105E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.4365E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="9.1547E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.7038406E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.0017597E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6503762E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000050"
+            ruptureId="scenario-0000000050~ses=1"
             >
-                <node gmv="5.1044E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.2040E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.2406E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.6371708E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.9522279E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3843410E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000051"
+            ruptureId="scenario-0000000051~ses=1"
             >
-                <node gmv="6.8014E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5743E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.5411E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.8515717E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.1915512E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5592027E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000052"
+            ruptureId="scenario-0000000052~ses=1"
             >
-                <node gmv="3.2033E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.7718E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1281E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.6450159E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.8674793E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0247625E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000053"
+            ruptureId="scenario-0000000053~ses=1"
             >
-                <node gmv="3.8113E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7981E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.2140E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.2223185E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.5829601E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.5310174E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000054"
+            ruptureId="scenario-0000000054~ses=1"
             >
-                <node gmv="5.1066E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5050E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3252E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.5193156E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.9023751E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0783429E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000055"
+            ruptureId="scenario-0000000055~ses=1"
             >
-                <node gmv="3.0737E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.2996E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8277E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.4142473E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.9457430E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.1009949E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000056"
+            ruptureId="scenario-0000000056~ses=1"
             >
-                <node gmv="5.5490E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.1569E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4382E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.0149417E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.4059077E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4656174E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000057"
+            ruptureId="scenario-0000000057~ses=1"
             >
-                <node gmv="5.5586E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.3845E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.0893E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="7.3710662E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.0627986E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.7006163E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000058"
+            ruptureId="scenario-0000000058~ses=1"
             >
-                <node gmv="6.1964E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.4951E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.5589E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.5025196E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7517876E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6261692E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000059"
+            ruptureId="scenario-0000000059~ses=1"
             >
-                <node gmv="4.6803E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.8197E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.9541E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.9941304E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.5120466E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4768259E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000060"
+            ruptureId="scenario-0000000060~ses=1"
             >
-                <node gmv="7.1274E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.0021E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.3581E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.7586182E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.1894403E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6204539E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000061"
+            ruptureId="scenario-0000000061~ses=1"
             >
-                <node gmv="7.0084E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.3205E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3079E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.1588005E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.9253458E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.3424007E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000062"
+            ruptureId="scenario-0000000062~ses=1"
             >
-                <node gmv="3.2388E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6536E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.9286E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.9066941E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.6335952E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3602851E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000063"
+            ruptureId="scenario-0000000063~ses=1"
             >
-                <node gmv="5.8913E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.3159E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="7.3588E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.8913306E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7319154E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.9498235E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000064"
+            ruptureId="scenario-0000000064~ses=1"
             >
-                <node gmv="3.8947E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.2324E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8286E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.2405767E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.3365584E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.7064518E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000065"
+            ruptureId="scenario-0000000065~ses=1"
             >
-                <node gmv="4.4357E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7083E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.1290E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.9378082E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5450060E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.2123138E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000066"
+            ruptureId="scenario-0000000066~ses=1"
             >
-                <node gmv="6.9577E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6673E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.0147E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.7044377E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.4016148E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.9492423E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000067"
+            ruptureId="scenario-0000000067~ses=1"
             >
-                <node gmv="6.4495E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.6403E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="7.8207E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.0121508E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.9930794E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.2195120E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000068"
+            ruptureId="scenario-0000000068~ses=1"
             >
-                <node gmv="4.3609E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.7532E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.5810E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="8.0744553E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.0676061E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3361456E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000069"
+            ruptureId="scenario-0000000069~ses=1"
             >
-                <node gmv="7.0022E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5023E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.3365E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.1426960E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.9652064E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0338406E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000070"
+            ruptureId="scenario-0000000070~ses=1"
             >
-                <node gmv="5.5726E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5891E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.2004E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.1798528E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5821955E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5917671E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000071"
+            ruptureId="scenario-0000000071~ses=1"
             >
-                <node gmv="4.2014E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.5387E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.2248E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.9928474E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.8105529E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.2240224E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000072"
+            ruptureId="scenario-0000000072~ses=1"
             >
-                <node gmv="6.9059E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.8785E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8277E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.5980375E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.4578111E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.0057769E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000073"
+            ruptureId="scenario-0000000073~ses=1"
             >
-                <node gmv="7.8415E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.5504E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.6975E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.4835109E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.3725564E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3509081E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000074"
+            ruptureId="scenario-0000000074~ses=1"
             >
-                <node gmv="3.5004E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.6739E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.1335E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.4379556E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.4359639E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.2286391E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000075"
+            ruptureId="scenario-0000000075~ses=1"
             >
-                <node gmv="5.0739E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7869E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.4374E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.8768002E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.6524803E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6442832E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000076"
+            ruptureId="scenario-0000000076~ses=1"
             >
-                <node gmv="3.9231E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.4143E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.0308E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="2.4925308E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.1019815E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.3791455E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000077"
+            ruptureId="scenario-0000000077~ses=1"
             >
-                <node gmv="5.1072E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7258E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8515E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.4259804E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.0028727E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.5451425E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000078"
+            ruptureId="scenario-0000000078~ses=1"
             >
-                <node gmv="2.8260E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.5796E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.1326E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.1836262E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.0293536E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5266961E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000079"
+            ruptureId="scenario-0000000079~ses=1"
             >
-                <node gmv="3.9479E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.4732E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="8.1125E-02" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.1362340E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.5032240E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.7802398E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000080"
+            ruptureId="scenario-0000000080~ses=1"
             >
-                <node gmv="4.6468E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.4318E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.4318E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.3622804E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.3535912E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.6812738E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000081"
+            ruptureId="scenario-0000000081~ses=1"
             >
-                <node gmv="4.0477E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.5710E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.9808E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.9010709E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.1685570E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.1282646E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000082"
+            ruptureId="scenario-0000000082~ses=1"
             >
-                <node gmv="4.1302E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.7231E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.8640E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.0060449E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7784762E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.3816387E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000083"
+            ruptureId="scenario-0000000083~ses=1"
             >
-                <node gmv="3.1824E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.0568E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3751E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="7.1773052E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.7734232E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.9466276E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000084"
+            ruptureId="scenario-0000000084~ses=1"
             >
-                <node gmv="4.8725E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.1528E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4053E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.9121146E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.6642267E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.7834304E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000085"
+            ruptureId="scenario-0000000085~ses=1"
             >
-                <node gmv="3.7152E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.4499E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.0775E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.5134606E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5209061E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.6972974E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000086"
+            ruptureId="scenario-0000000086~ses=1"
             >
-                <node gmv="7.6202E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5952E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.5858E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.7267010E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.5963289E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0026791E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000087"
+            ruptureId="scenario-0000000087~ses=1"
             >
-                <node gmv="5.3194E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5218E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.6629E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.1867298E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.4514722E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4912842E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000088"
+            ruptureId="scenario-0000000088~ses=1"
             >
-                <node gmv="7.3101E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.5800E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.2655E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.8056071E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.0156997E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0121388E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000089"
+            ruptureId="scenario-0000000089~ses=1"
             >
-                <node gmv="3.9759E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.1269E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.4135E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.5383309E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5354955E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4849840E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000090"
+            ruptureId="scenario-0000000090~ses=1"
             >
-                <node gmv="7.2863E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="3.0366E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.2299E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.3277868E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.0679193E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.2816435E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000091"
+            ruptureId="scenario-0000000091~ses=1"
             >
-                <node gmv="9.1110E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7895E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.0484E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.8080683E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.1502082E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="9.7859882E-02" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000092"
+            ruptureId="scenario-0000000092~ses=1"
             >
-                <node gmv="7.8749E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.7594E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.2763E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.7539046E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.4899156E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.3905464E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000093"
+            ruptureId="scenario-0000000093~ses=1"
             >
-                <node gmv="5.0379E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.1042E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3465E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.9663689E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.4035976E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4339320E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000094"
+            ruptureId="scenario-0000000094~ses=1"
             >
-                <node gmv="6.2226E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.0778E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.2867E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.6058985E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.1004012E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.7082134E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000095"
+            ruptureId="scenario-0000000095~ses=1"
             >
-                <node gmv="4.5065E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.5498E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.0990E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="7.7078861E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.5003297E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.0339440E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000096"
+            ruptureId="scenario-0000000096~ses=1"
             >
-                <node gmv="2.3686E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.7404E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3569E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="6.0513932E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="3.3827457E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="2.6146829E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000097"
+            ruptureId="scenario-0000000097~ses=1"
             >
-                <node gmv="2.4958E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.5138E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.2734E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.7625113E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.2395548E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.0846464E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000098"
+            ruptureId="scenario-0000000098~ses=1"
             >
-                <node gmv="3.5515E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.7900E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.9837E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.8717433E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.3513823E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5688202E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000099"
+            ruptureId="scenario-0000000099~ses=1"
             >
-                <node gmv="3.7528E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.6427E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.2815E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="3.5909608E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.3838483E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.5177082E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000100"
+            ruptureId="scenario-0000000100~ses=1"
             >
-                <node gmv="4.7613E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="1.2368E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="1.3411E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="4.3631884E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="2.6132658E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.9755529E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
             <gmf
             IMT="PGA"
-            ruptureId="scenario-0000000101"
+            ruptureId="scenario-0000000101~ses=1"
             >
-                <node gmv="4.4383E-01" lat="0.0000E+00" lon="0.0000E+00"/>
-                <node gmv="2.1748E-01" lat="1.0000E-01" lon="0.0000E+00"/>
-                <node gmv="2.5041E-01" lat="2.0000E-01" lon="0.0000E+00"/>
+                <node gmv="5.5244249E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+                <node gmv="1.3254601E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>
+                <node gmv="1.4134116E-01" lat="2.0000000E-01" lon="0.0000000E+00"/>
             </gmf>
         </gmfSet>
     </gmfCollection>


### PR DESCRIPTION
Unskipped the tests that very passing only on Ubuntu 16.04: now they pass on most platforms, thanks to the opt project. See https://ci.openquake.org/job/zdevel_oq-engine/2445/
https://ci.openquake.org/job/windows/job/zdevel_oq-engine/6/
https://ci.openquake.org/job/macos/job/zdevel_mac_oq-engine/90/