### PR TITLE
Differentiate listening interface and connect interface in dbserver

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Introduced an optional argument for 'oq dbserver' command line 
+    to be able to override its default interface binding behaviour
+
   [Michele Simionato]
   * Added a check on missing vulnerability functions for some loss type
     for some taxonomy

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -12,6 +12,6 @@ Index: oq-engine/openquake/engine/openquake.cfg
 +multi_user = true
 +file = /var/lib/openquake/db.sqlite3
 +log = /var/lib/openquake/dbserver.log
+ # dbserver master node ip address
  host = localhost
  # port 1908 has a good reputation:
- # https://isc.sans.edu/port.html?port=1908

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -29,7 +29,7 @@ $ oq dbserver start
 A custom binging address and port can be specified at startup time as a custom db path too:
 
 ```bash
-$ python -m openquake.server.dbserver 0.0.0.0:1985 /tmp/customdb.sqlite3
+$ oq dbserver start 0.0.0.0:1985 /tmp/customdb.sqlite3
 ```
 
 ### Celery

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -26,6 +26,12 @@ Sometimes it's useful to run the DbServer in foreground for debug purposes. It c
 $ oq dbserver start
 ```
 
+A custom binging address and port can be specified at startup time as a custom db path too:
+
+```bash
+$ python -m openquake.server.dbserver 0.0.0.0:1985 /tmp/customdb.sqlite3
+```
+
 ### Celery
 
 Celery can be manually started via this command:

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -24,7 +24,7 @@ from openquake.server import dbserver as dbs
 
 
 @sap.Script
-def dbserver(cmd):
+def dbserver(cmd, dbhostport=None, dbpath=None):
     """
     start/stop/restart the database server, or return its status
     """
@@ -42,14 +42,16 @@ def dbserver(cmd):
             print('dbserver already stopped')
     elif cmd == 'start':
         if status == 'not-running':
-            dbs.run_server()
+            dbs.run_server(dbhostport, dbpath)
         else:
             print('dbserver already running')
     elif cmd == 'restart':
         if status == 'running':
             logs.dbcmd('stop')
             print('dbserver stopped')
-        dbs.run_server()
+        dbs.run_server(dbhostport, dbpath)
 
 dbserver.arg('cmd', 'dbserver command',
              choices='start stop status restart'.split())
+dbserver.arg('dbhostport', 'dbhost:port')
+dbserver.arg('dbpath', 'dbpath')

--- a/openquake/commonlib/config.py
+++ b/openquake/commonlib/config.py
@@ -147,7 +147,6 @@ def flag_set(section, setting):
 
 
 port = int(get('dbserver', 'port'))
-DBS_LISTEN = (get('dbserver', 'listen'), port)
 DBS_ADDRESS = (get('dbserver', 'host'), port)
 DBS_AUTHKEY = encode(get('dbserver', 'authkey'))
 SHARED_DIR_ON = bool(get('directory', 'shared_dir'))

--- a/openquake/commonlib/config.py
+++ b/openquake/commonlib/config.py
@@ -147,6 +147,7 @@ def flag_set(section, setting):
 
 
 port = int(get('dbserver', 'port'))
+DBS_LISTEN = (get('dbserver', 'listen'), port)
 DBS_ADDRESS = (get('dbserver', 'host'), port)
 DBS_AUTHKEY = encode(get('dbserver', 'authkey'))
 SHARED_DIR_ON = bool(get('directory', 'shared_dir'))

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -43,8 +43,6 @@ celery_queue = celery
 multi_user = false
 file = ~/oqdata/db.sqlite3
 log = ~/oqdata/dbserver.log
-# binding interface: put 0.0.0.0 for any
-listen = localhost
 # dbserver master node ip address
 host = localhost
 # port 1908 has a good reputation:

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -43,6 +43,9 @@ celery_queue = celery
 multi_user = false
 file = ~/oqdata/db.sqlite3
 log = ~/oqdata/dbserver.log
+# binding interface: put 0.0.0.0 for any
+listen = localhost
+# dbserver master node ip address
 host = localhost
 # port 1908 has a good reputation:
 # https://isc.sans.edu/port.html?port=1908

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -133,7 +133,7 @@ def run_server(dbhostport=None, dbpath=None, logfile=DATABASE['LOG'],
         addr = (dbhost, int(port))
         DATABASE['PORT'] = int(port)
     else:
-        addr = config.DBS_LISTEN
+        addr = config.DBS_ADDRESS
 
     if dbpath:
         DATABASE['NAME'] = dbpath

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -122,18 +122,21 @@ def ensure_on():
 
 
 @sap.Script
-def run_server(dbpathport=None, logfile=DATABASE['LOG'], loglevel='WARN'):
+def run_server(dbhostport=None, dbpath=None, logfile=DATABASE['LOG'],
+               loglevel='WARN'):
     """
     Run the DbServer on the given database file and port. If not given,
     use the settings in openquake.cfg.
     """
-    if dbpathport:  # assume a string of the form "dbpath:port"
-        dbpath, port = dbpathport.split(':')
-        addr = (DATABASE['HOST'], int(port))
-        DATABASE['NAME'] = dbpath
+    if dbhostport:  # assume a string of the form "dbhost:port"
+        dbhost, port = dbhostport.split(':')
+        addr = (dbhost, int(port))
         DATABASE['PORT'] = int(port)
     else:
-        addr = config.DBS_ADDRESS
+        addr = config.DBS_LISTEN
+
+    if dbpath:
+        DATABASE['NAME'] = dbpath
 
     # create the db directory if needed
     dirname = os.path.dirname(DATABASE['NAME'])
@@ -151,7 +154,8 @@ def run_server(dbpathport=None, logfile=DATABASE['LOG'], loglevel='WARN'):
     logging.basicConfig(level=getattr(logging, loglevel), filename=logfile)
     DbServer(db, addr, config.DBS_AUTHKEY).loop()
 
-run_server.arg('dbpathport', 'dbpath:port')
+run_server.arg('dbhostport', 'dbhost:port')
+run_server.arg('dbpath', 'dbpath')
 run_server.arg('logfile', 'log file')
 run_server.opt('loglevel', 'WARN or INFO')
 


### PR DESCRIPTION
~~This PR differentiate the setting used to connect at a dbserver to the one which describes the interface where dbserver is attached to (i.e. 0.0.0.0, lo, a specific ip...)~~

After some more thought I decided to keep everything simple as it is, which works for most users, changing only the `dbserver` command line: This change allows smart user to differentiate the binding interface from the client host settings.

the `openquake.server.dbserver` command is changed from
```python
python openquake.server.dbserver /path/to/file:port
```
to
```python
python openquake.server.dbserver listeningip:port /path/to/file
```

This arguments can be now also passed via `oq dbserver`
```bash
$ oq dbserver start 0.0.0.0:1985 /tmp/dbfoo.sqlite3
```

https://ci.openquake.org/job/zdevel_oq-engine/2447/

Closes https://github.com/gem/oq-engine/issues/2529