### PR TITLE
Small fixes for local_settings template to be able to append settings

### DIFF
--- a/openquake/server/local_settings.py.standalone
+++ b/openquake/server/local_settings.py.standalone
@@ -1,3 +1,7 @@
+import os
+from openquake.server.settings import (INSTALLED_APPS, STANDALONE_APPS,
+                                       TEMPLATES)
+
 STANDALONE = True
 
 INSTALLED_APPS += (


### PR DESCRIPTION
The `local_settings.py` template was actually broken. This file isn't currently used, but it will be soon by the standalone apps.