### PR TITLE
Bump to h5py 2.7.0

### DIFF
--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -10,7 +10,7 @@ http://ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py27/pkgconfig-1.1.0-cp27-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/h5py-2.6.0-1-cp27-cp27mu-manylinux1_x86_64.whl
+http://ftp.openquake.org/wheelhouse/linux/py27/h5py-2.7.0-cp27-cp27mu-manylinux1_x86_64.whl
 http://ftp.openquake.org/wheelhouse/linux/py27/nose-1.3.7-py2-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py27/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl
 http://ftp.openquake.org/wheelhouse/linux/py27/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl

--- a/requirements-py27-macos.txt
+++ b/requirements-py27-macos.txt
@@ -8,7 +8,7 @@
 http://ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py27/pkgconfig-1.1.0-cp27-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/h5py-2.6.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://ftp.openquake.org/wheelhouse/macos/py27/h5py-2.7.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://ftp.openquake.org/wheelhouse/macos/py27/nose-1.3.7-py2-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py27/numpy-1.11.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://ftp.openquake.org/wheelhouse/macos/py27/scipy-0.17.1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -10,7 +10,7 @@ http://ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py35/pkgconfig-1.1.0-py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/h5py-2.6.0-1-cp35-cp35m-manylinux1_x86_64.whl
+http://ftp.openquake.org/wheelhouse/linux/py35/h5py-2.7.0-cp35-cp35m-manylinux1_x86_64.whl
 http://ftp.openquake.org/wheelhouse/linux/py35/nose-1.3.7-py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/linux/py35/numpy-1.11.1-cp35-cp35m-manylinux1_x86_64.whl
 http://ftp.openquake.org/wheelhouse/linux/py35/scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl

--- a/requirements-py35-macos.txt
+++ b/requirements-py35-macos.txt
@@ -8,7 +8,7 @@
 http://ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py35/pkgconfig-1.1.0-py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/h5py-2.6.0-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://ftp.openquake.org/wheelhouse/macos/py35/h5py-2.7.0-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://ftp.openquake.org/wheelhouse/macos/py35/nose-1.3.7-py3-none-any.whl
 http://ftp.openquake.org/wheelhouse/macos/py35/numpy-1.11.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://ftp.openquake.org/wheelhouse/macos/py35/scipy-0.17.1-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ PY_MODULES = ['openquake.commands.__main__']
 
 install_requires = [
     'mock >=1.0, <1.4',
-    'h5py >=2.2, <2.7',
+    'h5py >=2.2, <2.8',
     'nose >=1.3, <1.4',
     'numpy >=1.8, <1.12',
     'scipy >=0.13, <0.18',


### PR DESCRIPTION
See https://github.com/h5py/h5py/releases/tag/2.7.0

This affects https://github.com/gem/oq-libs too
Companion https://github.com/gem/oq-hazardlib/pull/614

MacOS: https://ci.openquake.org/job/macos/job/zdevel_mac_oq-engine/92/
Windows: https://ci.openquake.org/view/Windows/job/windows/job/zdevel_oq-engine/7/