### PR TITLE
Made the full report exportable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made the `fullreport` exportable
   * Fixed the `rup_data` export, since the boundary field was broken
   * Restored the output `losses_by_taxon` in the event_based_risk calculator
   * Fixed the calculator event based UCERF so that average losses can

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -28,6 +28,7 @@ from openquake.baselib.general import (
     groupby, humansize, get_array, group_array, DictArray)
 from openquake.hazardlib.imt import from_string
 from openquake.hazardlib.calc import disagg, gmf
+from openquake.calculators.views import view
 from openquake.calculators.export import export
 from openquake.commonlib import writers, hazard_writers, calc, util, source
 
@@ -1035,3 +1036,12 @@ def export_sourcegroups(ekey, dstore):
     path = dstore.export_path('sourcegroups.csv')
     writers.write_csv(path, data, fmt='%s')
     return [path]
+
+
+# because of the code in server.views.calc_results we are not visualizing
+# .txt outputs, so we use .rst here
+@export.add(('fullreport', 'rst'))
+def export_fullreport(ekey, dstore):
+    with open(dstore.export_path('report.rst'), 'w') as f:
+        f.write(view('fullreport', dstore))
+    return [f.name]

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -83,6 +83,7 @@ def expose_outputs(dstore):
     exportable = set(ekey[0] for ekey in export.export)
     calcmode = oq.calculation_mode
     dskeys = set(dstore) & exportable  # exportable datastore keys
+    dskeys.add('fullreport')
     if 'scenario' not in calcmode:  # export sourcegroups.csv
         dskeys.add('sourcegroups')
     if oq.uniform_hazard_spectra:

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -178,7 +178,7 @@ class EngineServerTestCase(unittest.TestCase):
                           'sourcegroups', 'uhs'], [r['name'] for r in results])
 
         # check the filename of the hmaps
-        hmaps_id = results[1]['id']
+        hmaps_id = results[2]['id']
         resp = requests.head('http://%s/v1/calc/result/%s?export_type=csv' %
                              (self.hostport, hmaps_id))
         # remove output ID digits from the filename

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -174,8 +174,8 @@ class EngineServerTestCase(unittest.TestCase):
 
         # check that we get the expected outputs
         results = self.get('%s/results' % job_id)
-        self.assertEqual(['hcurves', 'hmaps', 'realizations', 'sourcegroups',
-                          'uhs'], [r['name'] for r in results])
+        self.assertEqual(['fullreport', 'hcurves', 'hmaps', 'realizations',
+                          'sourcegroups', 'uhs'], [r['name'] for r in results])
 
         # check the filename of the hmaps
         hmaps_id = results[1]['id']


### PR DESCRIPTION
This closes https://github.com/gem/oq-engine/issues/2648 in another way, arguably better. Just run a calculation through the WebUI. In the outputs, you will also see a `fullreport` one. Just download it.