### PR TITLE
Simplified the serialization of ruptures

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -283,9 +283,7 @@ class PSHACalculator(base.HazardCalculator):
             truncation_level=oq.truncation_level,
             imtls=oq.imtls,
             maximum_distance=oq.maximum_distance,
-            disagg=oq.poes_disagg or oq.iml_disagg,
-            ses_per_logic_tree_path=oq.ses_per_logic_tree_path,
-            seed=oq.ses_seed)
+            disagg=oq.poes_disagg or oq.iml_disagg)
         with self.monitor('managing sources', autoflush=True):
             allargs = self.gen_args(self.csm, monitor)
             iterargs = saving_sources_by_task(allargs, self.datastore)
@@ -324,7 +322,9 @@ class PSHACalculator(base.HazardCalculator):
                 gsims = self.rlzs_assoc.gsims_by_grp_id[sg.id]
                 if oq.poes_disagg or oq.iml_disagg:  # only for disaggregation
                     monitor.sm_id = self.rlzs_assoc.sm_ids[sg.id]
-                param = dict(samples=sm.samples)
+                param = dict(
+                    samples=sm.samples, seed=oq.ses_seed,
+                    ses_per_logic_tree_path=oq.ses_per_logic_tree_path)
                 for block in self.csm.split_sources(
                         sg.sources, self.src_filter, maxweight):
                     yield block, self.src_filter, gsims, param, monitor

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -110,14 +110,14 @@ def compute_ruptures(sources, src_filter, gsims, param, monitor):
         if s_sites is None:
             continue
         num_occ_by_rup = sample_ruptures(
-            src, monitor.ses_per_logic_tree_path, param['samples'],
-            monitor.seed)
+            src, param['ses_per_logic_tree_path'], param['samples'],
+            param['seed'])
         # NB: the number of occurrences is very low, << 1, so it is
         # more efficient to filter only the ruptures that occur, i.e.
         # to call sample_ruptures *before* the filtering
         for ebr in _build_eb_ruptures(
                 src, num_occ_by_rup, src_filter.integration_distance,
-                s_sites, monitor.seed, rup_mon):
+                s_sites, param['seed'], rup_mon):
             eb_ruptures.append(ebr)
         dt = time.time() - t0
         calc_times.append((src.id, dt))

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -565,7 +565,7 @@ class EBRupture(object):
         if hasattr(surface, 'surfaces'):
             attrs['mesh_spacing'] = surface.surfaces[0].mesh_spacing
         else:
-            attrs['mesh_spacing'] = surface.mesh_spacing
+            attrs['mesh_spacing'] = getattr(surface, 'mesh_spacing', numpy.nan)
         arr = surface_to_mesh(surface)
         attrs['nbytes'] = self.sids.nbytes + self.events.nbytes + arr.nbytes
         return dict(sids=self.sids, events=self.events, mesh=arr), attrs

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -24,6 +24,7 @@ from openquake.baselib import hdf5
 from openquake.baselib.python3compat import encode, decode
 from openquake.baselib.general import get_array, group_array
 from openquake.hazardlib.geo.mesh import RectangularMesh, surface_to_mesh
+from openquake.hazardlib.source.rupture import Rupture
 from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.hazardlib.imt import from_string
 from openquake.hazardlib import geo, tom, calc
@@ -48,6 +49,8 @@ event_dt = numpy.dtype([('eid', U64), ('ses', U32), ('occ', U32),
 stored_event_dt = numpy.dtype([
     ('eid', U64), ('rupserial', U32), ('year', U32),
     ('ses', U32), ('occ', U32), ('sample', U32), ('grp_id', U16)])
+
+Rupture.init()  # initialize rupture codes
 
 # ############## utilities for the classical calculator ############### #
 
@@ -558,9 +561,7 @@ class EBRupture(object):
             attrs['pmf'] = rup.pmf
         attrs['seed'] = rup.seed
         attrs['hypo'] = rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z
-        attrs['source_class'] = hdf5.cls2dotname(rup.source_typology)
-        attrs['rupture_class'] = hdf5.cls2dotname(rup.__class__)
-        attrs['surface_class'] = hdf5.cls2dotname(rup.surface.__class__)
+        attrs['code'] = rup.code
         surface = self.rupture.surface
         if hasattr(surface, 'surfaces'):
             attrs['mesh_spacing'] = surface.surfaces[0].mesh_spacing
@@ -574,16 +575,15 @@ class EBRupture(object):
         attrs = dict(attrs)
         self.sids = dic['sids'].value
         self.events = dic['events'].value
-        surface_class = attrs['surface_class']
-        surface_cls = hdf5.dotname2cls(surface_class)
-        self.rupture = object.__new__(hdf5.dotname2cls(attrs['rupture_class']))
+        rupture_cls, surface_cls, source_cls = Rupture.types[attrs['code']]
+        self.rupture = object.__new__(rupture_cls)
         self.rupture.surface = surface = object.__new__(surface_cls)
         m = dic['mesh'].value
-        if surface_class.endswith('PlanarSurface'):
+        if surface_cls.__name__.endswith('PlanarSurface'):
             mesh_spacing = attrs.pop('mesh_spacing')
             self.rupture.surface = geo.PlanarSurface.from_array(
                 mesh_spacing, m.flatten())
-        elif surface_class.endswith('MultiSurface'):
+        elif surface_cls.__name__.endswith('MultiSurface'):
             mesh_spacing = attrs.pop('mesh_spacing')
             self.rupture.surface.__init__([
                 geo.PlanarSurface.from_array(mesh_spacing, m1.flatten())
@@ -600,13 +600,11 @@ class EBRupture(object):
             logging.error('rupture_slip_direction not implemented yet')
         self.rupture.rupture_slip_direction = None
         self.rupture.hypocenter = Point(*attrs.pop('hypo'))
-        self.rupture.source_typology = hdf5.dotname2cls(
-            attrs.pop('source_class'))
+        self.rupture.source_typology = source_cls
         self.source_id = attrs.pop('source_id')
         self.grp_id = attrs.pop('grp_id')
         self.serial = attrs.pop('serial')
-        del attrs['rupture_class']
-        del attrs['surface_class']
+        del attrs['code']
         vars(self.rupture).update(attrs)
 
     def __lt__(self, other):

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -566,9 +566,9 @@ class EBRupture(object):
             attrs['mesh_spacing'] = surface.surfaces[0].mesh_spacing
         else:
             attrs['mesh_spacing'] = getattr(surface, 'mesh_spacing', numpy.nan)
-        arr = surface_to_mesh(surface)
-        attrs['nbytes'] = self.sids.nbytes + self.events.nbytes + arr.nbytes
-        return dict(sids=self.sids, events=self.events, mesh=arr), attrs
+        mesh = surface_to_mesh(surface)
+        attrs['nbytes'] = self.sids.nbytes + self.events.nbytes + mesh.nbytes
+        return dict(sids=self.sids, events=self.events, mesh=mesh), attrs
 
     def __fromh5__(self, dic, attrs):
         attrs = dict(attrs)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -24,7 +24,7 @@ from openquake.baselib import hdf5
 from openquake.baselib.python3compat import encode, decode
 from openquake.baselib.general import get_array, group_array
 from openquake.hazardlib.geo.mesh import RectangularMesh, surface_to_mesh
-from openquake.hazardlib.source.rupture import Rupture
+from openquake.hazardlib.source.rupture import BaseRupture
 from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.hazardlib.imt import from_string
 from openquake.hazardlib import geo, tom, calc
@@ -50,7 +50,7 @@ stored_event_dt = numpy.dtype([
     ('eid', U64), ('rupserial', U32), ('year', U32),
     ('ses', U32), ('occ', U32), ('sample', U32), ('grp_id', U16)])
 
-Rupture.init()  # initialize rupture codes
+BaseRupture.init()  # initialize rupture codes
 
 # ############## utilities for the classical calculator ############### #
 
@@ -575,7 +575,7 @@ class EBRupture(object):
         attrs = dict(attrs)
         self.sids = dic['sids'].value
         self.events = dic['events'].value
-        rupture_cls, surface_cls, source_cls = Rupture.types[attrs['code']]
+        rupture_cls, surface_cls, source_cls = BaseRupture.types[attrs['code']]
         self.rupture = object.__new__(rupture_cls)
         self.rupture.surface = surface = object.__new__(surface_cls)
         m = dic['mesh'].value

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -555,7 +555,7 @@ class EBRupture(object):
         if hasattr(rup, 'temporal_occurrence_model'):
             attrs['time_span'] = rup.temporal_occurrence_model.time_span
         if hasattr(rup, 'pmf'):
-            attrs['pmf'] = rup.pmf_array()
+            attrs['pmf'] = rup.pmf
         attrs['seed'] = rup.seed
         attrs['hypo'] = rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z
         attrs['source_class'] = hdf5.cls2dotname(rup.source_typology)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -547,7 +547,7 @@ class CompositeSourceModel(collections.Sequence):
         source_models = []
         weight = 0
         for sm in self.source_models:
-            src_groups = [copy.copy(src) for src in sm.src_groups]
+            src_groups = [copy.copy(sg) for sg in sm.src_groups]
             for src_group in src_groups:
                 sources = []
                 for src, sites in src_filter(src_group.sources):


### PR DESCRIPTION
A small step towards https://github.com/gem/oq-engine/issues/2645. I have also moved the parameters `ses_per_logic_tree_path` and `seed` from the monitor to the dictionary `params`. Requires https://github.com/gem/oq-hazardlib/pull/619.