### PR TITLE
Changed the storage of the events

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Avoided storing twice the rupture events
   * Optimized the serialization of ruptures on HDF5 by using a `sids` output
   * Changed the Web UI button from "Run Risk" to "Continue"
   * The `avg` field in the loss curves is computed as the integral of the curve

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -203,7 +203,7 @@ def get_events(ebruptures):
     for ebr in ebruptures:
         for event in ebr.events:
             rec = (event['eid'], ebr.serial, year, event['ses'], event['occ'],
-                   event['sample'], ebr.grp_id)
+                   event['sample'])
             events.append(rec)
     return numpy.array(events, calc.stored_event_dt)
 

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -117,10 +117,11 @@ def export_ruptures_xml(ekey, dstore):
     sm_by_grp = dstore['csm_info'].get_sm_by_grp()
     mesh = get_mesh(dstore['sitecol'])
     ruptures = []
-    for grp_id in dstore['ruptures']:
-        for serial in dstore['ruptures/%s' % grp_id]:
-            ebr = dstore['ruptures/%s/%s' % (grp_id, serial)]
+    for grp in dstore['ruptures']:
+        for serial in dstore['ruptures/%s' % grp]:
+            ebr = dstore['ruptures/%s/%s' % (grp, serial)]
             ebr.sids = dstore['sids'][ebr.sidx]
+            ebr.events = dstore['events/' + grp][ebr.eidx1:ebr.eidx2]
             ruptures.extend(ebr.export(mesh, sm_by_grp))
     ses_coll = SESCollection(
         groupby(ruptures, operator.attrgetter('ses_idx')),

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -63,21 +63,6 @@ def get_mesh(sitecol, complete=True):
     return mesh
 
 
-def build_etags(events, grp_id):
-    """
-    An array of tags for the underlying seismic events
-    """
-    tags = []
-    for ev in events:
-        tag = 'grp=%02d~ses=%04d~rup=%d-%02d' % (
-            grp_id, ev['ses'], ev['rupserial'], ev['occ'])
-        sampleid = ev['sample']
-        if sampleid > 0:
-            tag += '~sample=%d' % sampleid
-        tags.append(tag)
-    return numpy.array(tags)
-
-
 class SES(object):
     """
     Stochastic Event Set: A container for 1 or more ruptures associated with a
@@ -150,7 +135,7 @@ def export_ses_csv(ekey, dstore):
     rows = []
     for grp_id, trt in sorted(grp_trt.items()):
         grp = 'grp-%02d' % grp_id
-        etags = build_etags(dstore['events/' + grp], grp_id)
+        etags = calc.build_etags(dstore['events/' + grp], grp_id)
         dic = groupby(etags, util.get_serial)
         for r in dstore['rup_data/grp-%02d' % grp_id]:
             for etag in dic[r['rupserial']]:
@@ -673,7 +658,8 @@ def export_gmf(ekey, dstore):
             if key not in events:  # source model producing zero ruptures
                 continue
             sm_events = events[key]
-            etags = dict(zip(sm_events['eid'], build_etags(sm_events, grp_id)))
+            etags = dict(zip(sm_events['eid'],
+                             calc.build_etags(sm_events, grp_id)))
         for rlz in rlzs:
             try:
                 gmf_arr = gmf_data['%s/%04d' % (key, rlz.ordinal)].value
@@ -807,7 +793,7 @@ class GmfExporter(object):
         imts = list(self.oq.imtls)
         events = self.dstore['events/grp-%02d' % grp_id]
         ok_events = events[events['eid'] == eid]
-        [etag] = build_etags(ok_events, grp_id)
+        [etag] = calc.build_etags(ok_events, grp_id)
         with self.dstore.ext5() as ext5:
             for rlzno in ext5['gmf_data/grp-%02d' % grp_id]:
                 rlz = rlzs[int(rlzno)]
@@ -831,7 +817,7 @@ class GmfExporter(object):
                 grp_id = int(grp[4:])  # strip grp-
                 events = self.dstore['events/' + grp]
                 etag = dict(zip(range(len(events)),
-                                build_etags(events, grp_id)))
+                                calc.build_etags(events, grp_id)))
                 for rlzno in ext5['gmf_data/' + grp]:
                     rlz = rlzs[int(rlzno)]
                     gmf = ext5['gmf_data/%s/%s' % (grp, rlzno)].value

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -68,8 +68,10 @@ def build_etags(events, grp_id):
     An array of tags for the underlying seismic events
     """
     tags = []
-    for eid, serial, year, ses, occ, sampleid in events:
-        tag = 'grp=%02d~ses=%04d~rup=%d-%02d' % (grp_id, ses, serial, occ)
+    for ev in events:
+        tag = 'grp=%02d~ses=%04d~rup=%d-%02d' % (
+            grp_id, ev['ses'], ev['rupserial'], ev['occ'])
+        sampleid = ev['sample']
         if sampleid > 0:
             tag += '~sample=%d' % sampleid
         tags.append(tag)
@@ -138,7 +140,7 @@ def export_ses_csv(ekey, dstore):
     :param ekey: export key, i.e. a pair (datastore key, fmt)
     :param dstore: datastore object
     """
-    if 'events' not in dstore:  # scenario
+    if 'rup_data' not in dstore:  # scenario
         return []
     dest = dstore.export_path('ruptures.csv')
     header = ('id mag centroid_lon centroid_lat centroid_depth trt '

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -156,7 +156,7 @@ def export_agg_losses(ekey, dstore):
     """
     agg_losses = dstore[ekey[0]].value
     rlzs = dstore['csm_info'].get_rlzs_assoc().realizations
-    etags = build_etags(dstore['events'])
+    etags = build_etags(dstore['events'], 0)
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     for rlz in rlzs:
         losses = agg_losses[:, rlz.ordinal]
@@ -207,7 +207,7 @@ def export_agg_losses_ebr(ekey, dstore):
             losses = data['loss']
             rlz_events = numpy.array([event_by_eid[eid] for eid in eids])
             elt = numpy.zeros(len(eids), elt_dt)
-            elt['event_tag'] = build_etags(rlz_events)
+            elt['event_tag'] = build_etags(rlz_events, grp_id)
             elt['year'] = rlz_events['year']
             if rup_data:
                 copy_to(elt, rup_data, rlz_events['rupserial'])
@@ -246,7 +246,7 @@ def export_all_loss_ratios(ekey, dstore):
     ok_events = events[events['eid'] == eid]
     if len(ok_events) == 0:
         return []
-    [event_tag] = build_etags(ok_events)
+    [event_tag] = build_etags(ok_events, grp_id)
     for rlz in rlzs:
         exportname = 'losses-grp=%02d-eid=%d' % (grp_id, eid)
         dest = dstore.build_fname(exportname, rlz, 'csv')

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -26,9 +26,8 @@ from openquake.baselib.general import AccumDict, get_array, group_array
 from openquake.hazardlib.stats import compute_stats2
 from openquake.risklib import scientific, riskinput
 from openquake.calculators.export import export
-from openquake.calculators.export.hazard import (
-    build_etags, get_grp_id_eid, savez)
-from openquake.commonlib import writers, risk_writers
+from openquake.calculators.export.hazard import get_grp_id_eid, savez
+from openquake.commonlib import writers, risk_writers, calc
 from openquake.commonlib.util import get_assets, compose_arrays
 from openquake.commonlib.risk_writers import (
     DmgState, DmgDistPerTaxonomy, DmgDistPerAsset, DmgDistTotal,
@@ -156,7 +155,7 @@ def export_agg_losses(ekey, dstore):
     """
     agg_losses = dstore[ekey[0]].value
     rlzs = dstore['csm_info'].get_rlzs_assoc().realizations
-    etags = build_etags(dstore['events'], 0)
+    etags = calc.build_etags(dstore['events'], 0)
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     for rlz in rlzs:
         losses = agg_losses[:, rlz.ordinal]
@@ -207,7 +206,7 @@ def export_agg_losses_ebr(ekey, dstore):
             losses = data['loss']
             rlz_events = numpy.array([event_by_eid[eid] for eid in eids])
             elt = numpy.zeros(len(eids), elt_dt)
-            elt['event_tag'] = build_etags(rlz_events, grp_id)
+            elt['event_tag'] = calc.build_etags(rlz_events, grp_id)
             elt['year'] = rlz_events['year']
             if rup_data:
                 copy_to(elt, rup_data, rlz_events['rupserial'])
@@ -246,7 +245,7 @@ def export_all_loss_ratios(ekey, dstore):
     ok_events = events[events['eid'] == eid]
     if len(ok_events) == 0:
         return []
-    [event_tag] = build_etags(ok_events, grp_id)
+    [event_tag] = calc.build_etags(ok_events, grp_id)
     for rlz in rlzs:
         exportname = 'losses-grp=%02d-eid=%d' % (grp_id, eid)
         dest = dstore.build_fname(exportname, rlz, 'csv')

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -52,14 +52,15 @@ class ScenarioCalculator(base.HazardCalculator):
                 'All sites were filtered out! maximum_distance=%s km' %
                 maxdist)
         # eid, ses, occ, sample
-        events = numpy.array(
-            [(eid, 1, 1, 0)
-             for eid in range(oq.number_of_ground_motion_fields)],
-            calc.event_dt)
-        rupture = calc.EBRupture(
-            rup, self.sitecol.sids, events, 0, 0)
+        events = numpy.zeros(oq.number_of_ground_motion_fields,
+                             calc.stored_event_dt)
+        events['eid'] = numpy.arange(oq.number_of_ground_motion_fields)
+        rupture = calc.EBRupture(rup, self.sitecol.sids, events, 0, 0)
         rupture.sidx = 0
+        rupture.eidx1 = 0
+        rupture.eidx2 = len(events)
         self.datastore['sids'] = self.sitecol.sids
+        self.datastore['events/grp-00'] = events
         self.datastore['ruptures/grp-00/0'] = rupture
         self.computer = GmfComputer(
             rupture, self.sitecol, oq.imtls, self.gsims,

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -636,7 +636,7 @@ class RuptureSerializer(object):
         Populate a dictionary of site IDs tuples and save the ruptures.
 
         :param ebruptures: a list of EBRupture objects to save
-        :param offset: the last event index saved
+        :param eidx: the last event index saved
         """
         for ebr in ebruptures:
             mul = ebr.multiplicity

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -571,15 +571,14 @@ class EBRupture(object):
         else:
             attrs['mesh_spacing'] = getattr(surface, 'mesh_spacing', numpy.nan)
         mesh = surface_to_mesh(surface)
-        attrs['nbytes'] = self.events.nbytes + mesh.nbytes
+        attrs['nbytes'] = mesh.nbytes
         attrs['sidx'] = self.sidx
         attrs['eidx1'] = self.eidx1
         attrs['eidx2'] = self.eidx2
-        return dict(events=self.events, mesh=mesh), attrs
+        return dict(mesh=mesh), attrs
 
     def __fromh5__(self, dic, attrs):
         attrs = dict(attrs)
-        self.events = dic['events'].value
         rupture_cls, surface_cls, source_cls = BaseRupture.types[attrs['code']]
         self.rupture = object.__new__(rupture_cls)
         self.rupture.surface = surface = object.__new__(surface_cls)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -488,21 +488,6 @@ class EBRupture(object):
         return len(self.sids) * len(self.events)
 
     @property
-    def etags(self):
-        """
-        An array of tags for the underlying seismic events
-        """
-        tags = []
-        for ev in self.events:
-            tag = 'grp=%02d~ses=%04d~rup=%d-%02d' % (
-                self.grp_id, ev['ses'], self.serial, ev['occ'])
-            sampleid = ev['sample']
-            if sampleid > 0:
-                tag += '~sample=%d' % sampleid
-            tags.append(encode(tag))
-        return numpy.array(tags)
-
-    @property
     def eids(self):
         """
         An array with the underlying event IDs
@@ -522,7 +507,7 @@ class EBRupture(object):
         attributes set, suitable for export in XML format.
         """
         rupture = self.rupture
-        for eid, etag in zip(self.eids, self.etags):
+        for eid, etag in zip(self.eids, build_etags(self.events, self.grp_id)):
             new = util.Rupture(sm_by_grp[self.grp_id], eid, etag, self.sids)
             new.mesh = mesh[self.sids]
             new.etag = etag
@@ -619,6 +604,21 @@ class EBRupture(object):
     def __repr__(self):
         return '<%s #%d, grp_id=%d>' % (self.__class__.__name__,
                                         self.serial, self.grp_id)
+
+
+def build_etags(events, grp_id):
+    """
+    An array of tags for the underlying seismic events
+    """
+    tags = []
+    for ev in events:
+        tag = 'grp=%02d~ses=%04d~rup=%d-%02d' % (
+            grp_id, ev['ses'], ev['rupserial'], ev['occ'])
+        sampleid = ev['sample']
+        if sampleid > 0:
+            tag += '~sample=%d' % sampleid
+        tags.append(tag)
+    return numpy.array(tags)
 
 
 class RuptureSerializer(object):

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -49,7 +49,7 @@ event_dt = numpy.dtype([('eid', U64), ('ses', U32), ('occ', U32),
                         ('sample', U32)])
 stored_event_dt = numpy.dtype([
     ('eid', U64), ('rupserial', U32), ('year', U32),
-    ('ses', U32), ('occ', U32), ('sample', U32), ('grp_id', U16)])
+    ('ses', U32), ('occ', U32), ('sample', U32)])
 
 sids_dt = h5py.special_dtype(vlen=U32)
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -116,7 +116,7 @@ class OqParam(valid.ParamSet):
     ruptures_per_block = valid.Param(valid.positiveint, 1000)
     complex_fault_mesh_spacing = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
-    save_ruptures = valid.Param(valid.boolean, False)
+    save_ruptures = valid.Param(valid.boolean, True)
     ses_per_logic_tree_path = valid.Param(valid.positiveint, 1)
     ses_seed = valid.Param(valid.positiveint, 42)
     max_site_model_distance = valid.Param(valid.positivefloat, 5)  # by Graeme

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -116,7 +116,7 @@ class OqParam(valid.ParamSet):
     ruptures_per_block = valid.Param(valid.positiveint, 1000)
     complex_fault_mesh_spacing = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
-    save_ruptures = valid.Param(valid.boolean, True)
+    save_ruptures = valid.Param(valid.boolean, False)
     ses_per_logic_tree_path = valid.Param(valid.positiveint, 1)
     ses_seed = valid.Param(valid.positiveint, 42)
     max_site_model_distance = valid.Param(valid.positivefloat, 5)  # by Graeme

--- a/openquake/commonlib/tests/calc_test.py
+++ b/openquake/commonlib/tests/calc_test.py
@@ -60,6 +60,8 @@ class SerializeRuptureTestCase(unittest.TestCase):
                 rup.seed = 0
                 ebr = calc.EBRupture(rup, self.sids, self.events, 0, self.i)
                 ebr.sidx = 0
+                ebr.eidx1 = 0
+                ebr.eidx2 = 1
                 f[str(self.i)] = ebr
                 self.i += 1
         with hdf5.File(self.path, 'r') as f:
@@ -77,6 +79,8 @@ class SerializeRuptureTestCase(unittest.TestCase):
         rup.seed = 0
         ebr1 = calc.EBRupture(rup, sids, events, 0, 0)
         ebr1.sidx = 0
+        ebr1.eidx1 = 0
+        ebr1.eidx2 = 1
         with hdf5.File(self.path, 'w') as f:
             f['ebr'] = ebr1
         with hdf5.File(self.path, 'r') as f:


### PR DESCRIPTION
Fourth step towards #2645.
Currently the events are store twice, in the `events` tables and in the ruptures. With this pull request the events are stored only once; the ruptures do not contain copies of the events, only indices to the their location in the events table.

Here is the saving in space for the Chile computation seen in https://github.com/gem/oq-engine/pull/2660:

```
master: 641.52 MB
this branch: 586.17 MB
```

The time is more or less the same.