### PR TITLE
Fix output encoding in lhc and lrc

### DIFF
--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -20,6 +20,7 @@ import os
 import sys
 import getpass
 import logging
+import codecs
 from openquake.baselib import sap
 from openquake.commonlib import datastore, config, logs
 from openquake.engine import engine as eng
@@ -27,6 +28,10 @@ from openquake.engine.export import core
 from openquake.engine.utils import confirm
 from openquake.engine.tools.make_html_report import make_report
 from openquake.server import dbserver
+
+# Hack: force utf-8 output on Windows
+if sys.platform == 'win32':
+    sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 HAZARD_CALCULATION_ARG = "--hazard-calculation-id"
 MISSING_HAZARD_MSG = "Please specify '%s=<id>'" % HAZARD_CALCULATION_ARG

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -187,7 +187,7 @@ def list_calculations(db, job_type, user_name):
                     status = 'failed'
             start_time = job.start_time
             yield ('%6d | %10s | %s| %s' % (
-                job.id, status, start_time, descr)).encode('utf-8')
+                job.id, status, start_time, descr))
 
 
 def list_outputs(db, job_id, full=True):


### PR DESCRIPTION
Closes #2662 

The output on windows still isn't valid UTF-8 (as before), just because the terminal does not support for it.

Could be improved more, but at least now it works.