### PR TITLE
Removed an offending encode

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
 python -m openquake.commands engine --run $TRAVIS_BUILD_DIR/demos/hazard/AreaSourceClassicalPSHA/job.ini
+python -m openquake.commands engine --lhc
 MPLBACKEND=Template python -m openquake.commands plot_uhs -1
 # MPLBACKEND=Template python -m openquake.commands plot -1

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -187,7 +187,7 @@ def list_calculations(db, job_type, user_name):
                     status = 'failed'
             start_time = job.start_time
             yield ('%6d | %10s | %s| %s' % (
-                job.id, status, start_time, descr)).encode('utf-8')
+                job.id, status, start_time, descr))
 
 
 def list_outputs(db, job_id, full=True):


### PR DESCRIPTION
This works on Python 2.7 (https://ci.openquake.org/job/zdevel_oq-engine/2449/console) and Python 3.5 (https://travis-ci.org/gem/oq-engine/builds/216617326) on Linux. This is Windows with Python 2.7:  https://ci.openquake.org/job/windows/job/zdevel_oq-engine/8/console.