### PR TITLE
Improve the WebUI command

### DIFF
--- a/bin/oq
+++ b/bin/oq
@@ -26,6 +26,7 @@ if os.path.realpath(__file__) == '/opt/openquake/bin/oq':
     # https://docs.python.org/2/library/sys.html#sys.path
     sys.path.insert(1, '/opt/openquake/lib/python' + str(sys.version_info[0]) +
                     '.' + str(sys.version_info[1]) + '/site-packages')
+    os.environ['PYTHONPATH'] = ":".join(sys.path)
 
 import openquake.commands.__main__ as main
 

--- a/bin/oq
+++ b/bin/oq
@@ -20,12 +20,13 @@
 import sys
 import os
 
+# this is only executed when openquake is installed via linux binary packages
 if os.path.realpath(__file__) == '/opt/openquake/bin/oq':
     # custom pythonpath is pushed in position 1 instead of 0 because
     # sys.path[0] is populated at runtime by python itself. See:
     # https://docs.python.org/2/library/sys.html#sys.path
-    sys.path.insert(1, '/opt/openquake/lib/python' + str(sys.version_info[0]) +
-                    '.' + str(sys.version_info[1]) + '/site-packages')
+    sys.path.insert(1, '/opt/openquake/lib/python%d.%d/site-packages' %
+                    sys.version_info[:2])
     os.environ['PYTHONPATH'] = ":".join(sys.path)
 
 import openquake.commands.__main__ as main

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+  [Daniele Viganò]
+  * The 'oq webui' command now works on a multi-user installation
+  * Subprocess calls can be now safely used when Linux binary packages
+    are used
+
   [Paolo Tormene]
   * The 'Continue' button in the Web UI is now available also for risk
     calculations

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -15,9 +15,12 @@
 
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
 import sys
 import subprocess
 from openquake.baselib import sap
+from openquake.commonlib import config
 from openquake.server import dbserver
 
 
@@ -34,8 +37,13 @@ def webui(cmd, hostport='127.0.0.1:8800'):
     start the webui server in foreground or perform other operation on the
     django application
     """
-    dbserver.ensure_on()  # start the dbserver in a subproces
+
+    db_owner = os.path.expanduser(config.get('dbserver', 'file'))
+    if not os.access(db_owner, os.W_OK):
+        sys.exit('This command must be run by the proper user: '
+                 'see the documentation for details')
     if cmd == 'start':
+        dbserver.ensure_on()  # start the dbserver in a subproces
         rundjango('runserver', hostport)
     elif cmd == 'migrate':
         rundjango('migrate')

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -38,8 +38,8 @@ def webui(cmd, hostport='127.0.0.1:8800'):
     django application
     """
 
-    db_owner = os.path.expanduser(config.get('dbserver', 'file'))
-    if not os.access(db_owner, os.W_OK):
+    db_path = os.path.expanduser(config.get('dbserver', 'file'))
+    if not os.access(db_path, os.W_OK):
         sys.exit('This command must be run by the proper user: '
                  'see the documentation for details')
     if cmd == 'start':

--- a/packager.sh
+++ b/packager.sh
@@ -664,6 +664,15 @@ celery_wait $GEM_MAXLOOP"
         oq engine --dc 1 --yes
         oq purge -1; oq reset --yes"
         scp "${lxc_ip}:jobs-*.html" "out_${BUILD_UBUVER}/"
+
+        # WebUI command check
+        webui_fail_msg="This command must be run by the proper user: see the documentation for details"
+        webui_fail=$(oq webui migrate 2>&1 || true)
+        if [ "$webui_fail" != "$webui_fail_msg" ]; then
+            echo "The 'oq webui' command is broken: it reports\n\t$webui_fail\ninstead of\n\t$webui_fail_msg"
+            exit 1
+        fi
+        sudo -u openquake oq webui migrate
     fi
 
     scp -r "${lxc_ip}:/usr/share/doc/${GEM_DEB_PACKAGE}/changelog*" "out_${BUILD_UBUVER}/"

--- a/packager.sh
+++ b/packager.sh
@@ -666,13 +666,13 @@ celery_wait $GEM_MAXLOOP"
         scp "${lxc_ip}:jobs-*.html" "out_${BUILD_UBUVER}/"
 
         # WebUI command check
-        webui_fail_msg="This command must be run by the proper user: see the documentation for details"
-        webui_fail=$(oq webui migrate 2>&1 || true)
-        if [ "$webui_fail" != "$webui_fail_msg" ]; then
-            echo "The 'oq webui' command is broken: it reports\n\t$webui_fail\ninstead of\n\t$webui_fail_msg"
+        ssh $lxc_ip "webui_fail_msg=\"This command must be run by the proper user: see the documentation for details\"
+        webui_fail=\$(oq webui migrate 2>&1 || true)
+        if [ \"\$webui_fail\" != \"\$webui_fail_msg\" ]; then
+            echo \"The 'oq webui' command is broken: it reports\n\t\$webui_fail\ninstead of\n\t\$webui_fail_msg\"
             exit 1
         fi
-        sudo -u openquake oq webui migrate
+        sudo -u openquake oq webui migrate"
     fi
 
     scp -r "${lxc_ip}:/usr/share/doc/${GEM_DEB_PACKAGE}/changelog*" "out_${BUILD_UBUVER}/"


### PR DESCRIPTION
This PR improves the behavior of the `oq webui` command.

Now it can be used in both single and multi user environment; in a multi-user environment it does tasks only if the command is run by the same user that is the database owner.

The `oq` entry point has been improved too. Now, when OQ is installed in `/opt` (packages), the `sys.path` is saved inside `os.environ['PYTHONPATH']` to pass the proper configuration to any subproccess call.

Tests (change affects only linux + packages): https://ci.openquake.org/job/zdevel_oq-engine/2450/

Fixes #2676. Thanks to @3rdcycle for the feedback.