### PR TITLE
Enable the 'Continue' button also for risk calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Paolo Tormene]
+  * The 'Continue' button in the Web UI is now available also for risk
+    calculations
+
   [Michele Simionato]
   * Avoided storing twice the rupture events
   * Optimized the serialization of ruptures on HDF5 by using a `sids` output

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -62,17 +62,15 @@
                 <a href="#" data-calc-id="<%= calc.get('id') %>" class="btn btn-sm btn-danger" style="margin: 2px 0 2px 0;">Remove</a>
                 <% if (calc.get('status') == 'complete') { %>
                   <a href="{% url "index" %}/<%= calc.get('id') %>/outputs" class="btn btn-sm" style="margin: 2px 0 2px 0">Outputs</a>
-                  <% if(calc.get('job_type') == 'hazard') { %>
-                    <form class="calc-form" enctype="multipart/form-data"
-                      style="margin: 0; display: inline-block"
-                      method="post" action="{{ oq_engine_server_url }}/v1/calc/run">
-                    <input type="hidden" name="calculation_type" value="risk"/>
-                    <div class="fileinput-new" data-provides="fileinput" style="margin: 2px 0 2px 0">
-                      <span class="btn btn-default btn-sm btn-file"><span class="fileinput-new">Continue</span><input type="file" name="archive"/></span>
-                    </div>
-                    <input type="hidden" name="hazard_job_id" value="<%= calc.get('id') %>"/>
-                    </form>
-                  <% } %>
+                  <form class="calc-form" enctype="multipart/form-data"
+                    style="margin: 0; display: inline-block"
+                    method="post" action="{{ oq_engine_server_url }}/v1/calc/run">
+                  <input type="hidden" name="calculation_type" value="risk"/>
+                  <div class="fileinput-new" data-provides="fileinput" style="margin: 2px 0 2px 0">
+                    <span class="btn btn-default btn-sm btn-file"><span class="fileinput-new">Continue</span><input type="file" name="archive"/></span>
+                  </div>
+                  <input type="hidden" name="hazard_job_id" value="<%= calc.get('id') %>"/>
+                  </form>
                 <% } else { %>
                   <a href="#" data-calc-id="<%= calc.get('id') %>" class="btn btn-sm btn-traceback" style="margin: 2px 0 2px 0;">Traceback</a>
                 <% } %>


### PR DESCRIPTION
This change follows what done in https://github.com/gem/oq-engine/pull/2661.
It enables to run a post-processing calculation also on top of an existing risk calculation.