### PR TITLE
Force hazard_calculation_id from POST to be an int

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -436,7 +436,7 @@ class HazardCalculator(BaseCalculator):
             # there is a precalculator
             precalc_id = self.oqparam.hazard_calculation_id
             self.precalc = (self.compute_previous() if precalc_id is None
-                            else self.read_previous(precalc_id))
+                            else self.read_previous(int(precalc_id)))
             self.init()
         else:  # we are in a basic calculator
             self.precalc = None

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -205,7 +205,7 @@ def get_mesh(oqparam):
     elif 'gmfs' in oqparam.inputs:
         return get_gmfs(oqparam)[0].mesh
     elif oqparam.hazard_calculation_id:
-        sitecol = datastore.read(oqparam.hazard_calculation_id)['sitecol']
+        sitecol = datastore.read(int(oqparam.hazard_calculation_id))['sitecol']
         return geo.Mesh(sitecol.lons, sitecol.lats, sitecol.depths)
     elif 'exposure' in oqparam.inputs:
         # the mesh is extracted from get_sitecol_assetcol

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -204,7 +204,6 @@ class EngineServerTestCase(unittest.TestCase):
         # make sure job_id is no more in the list of relevant jobs
         job_ids = [job['id'] for job in self.get('list', relevant=True)]
         self.assertFalse(job_id in job_ids)
-        # NB: the job is invisible but still there
 
     def test_err_2(self):
         # the file logic-tree-source-model.xml is missing


### PR DESCRIPTION
This fixes #2682 

The casting isn't done directly after the POST is read (or in any other step on top of `precalc`) because `hazard_job_id` can be `None`.
We need to test this functionality, but I would add it when we change this functionality (see #2680) 