### PR TITLE
Add a safeprint function to support UTF-8 everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 
 script:
   - bin/run-demos.sh
+  - python -m openquake.commands engine --lhc
   - nosetests --with-doctest -vsx -a'!slow'
   - cat /tmp/webui*
   - bin/oq reset --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 
 script:
   - bin/run-demos.sh
-  - python -m openquake.commands engine --lhc
   - nosetests --with-doctest -vsx -a'!slow'
   - cat /tmp/webui*
   - bin/oq reset --yes

--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
 python -m openquake.commands engine --run $TRAVIS_BUILD_DIR/demos/hazard/AreaSourceClassicalPSHA/job.ini
+python -m openquake.commands engine --lhc
 MPLBACKEND=Template python -m openquake.commands plot_uhs -1
 # MPLBACKEND=Template python -m openquake.commands plot -1

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -21,7 +21,7 @@ import sys
 import getpass
 import logging
 from openquake.baselib import sap
-from openquake.baselib.utf8 import print
+from openquake.baselib.safeprint import print
 from openquake.commonlib import datastore, config, logs
 from openquake.engine import engine as eng
 from openquake.engine.export import core

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -21,7 +21,7 @@ import sys
 import getpass
 import logging
 from openquake.baselib import sap
-from openquake.baselib.safeprint import print
+from openquake.baselib.general import safeprint
 from openquake.commonlib import datastore, config, logs
 from openquake.engine import engine as eng
 from openquake.engine.export import core
@@ -65,7 +65,7 @@ def run_job(cfg_file, log_level='info', log_file=None, exports='',
                         hazard_calculation_id=hazard_calculation_id, **kw)
     calc.monitor.flush()
     for line in logs.dbcmd('list_outputs', job_id, False):
-        print(line)
+        safeprint(line)
     return job_id
 
 
@@ -86,7 +86,7 @@ def del_calculation(job_id, confirmed=False):
         try:
             logs.dbcmd('del_calc', job_id, getpass.getuser())
         except RuntimeError as err:
-            print(err)
+            safeprint(err)
 
 
 @sap.Script
@@ -138,11 +138,11 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
         sys.exit(0)
 
     if version_db:
-        print(logs.dbcmd('version_db'))
+        safeprint(logs.dbcmd('version_db'))
         sys.exit(0)
 
     if what_if_I_upgrade:
-        print(logs.dbcmd('what_if_I_upgrade', 'extract_upgrade_scripts'))
+        safeprint(logs.dbcmd('what_if_I_upgrade', 'extract_upgrade_scripts'))
         sys.exit(0)
 
     # check if the db is outdated
@@ -180,9 +180,9 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
     elif list_hazard_calculations:
         for line in logs.dbcmd(
                 'list_calculations', 'hazard', getpass.getuser()):
-            print(line)
+            safeprint(line)
     elif run_hazard is not None:
-        print('WARN: --rh/--run-hazard are deprecated, use --run instead',
+        safeprint('WARN: --rh/--run-hazard are deprecated, use --run instead',
               file=sys.stderr)
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
@@ -193,9 +193,9 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
     # risk
     elif list_risk_calculations:
         for line in logs.dbcmd('list_calculations', 'risk', getpass.getuser()):
-            print(line)
+            safeprint(line)
     elif run_risk is not None:
-        print('WARN: --rr/--run-risk are deprecated, use --run instead',
+        safeprint('WARN: --rr/--run-risk are deprecated, use --run instead',
               file=sys.stderr)
         if hazard_calculation_id is None:
             sys.exit(MISSING_HAZARD_MSG)
@@ -208,17 +208,17 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
 
     # export
     elif make_html_report:
-        print('Written %s' % make_report(make_html_report))
+        safeprint('Written %s' % make_report(make_html_report))
         sys.exit(0)
 
     elif list_outputs is not None:
         hc_id = get_job_id(list_outputs)
         for line in logs.dbcmd('list_outputs', hc_id):
-            print(line)
+            safeprint(line)
     elif show_log is not None:
         hc_id = get_job_id(show_log)
         for line in logs.dbcmd('get_log', hc_id):
-            print(line)
+            safeprint(line)
 
     elif export_output is not None:
         output_id, target_dir = export_output
@@ -226,14 +226,14 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
         for line in core.export_output(
                 dskey, calc_id, datadir, os.path.expanduser(target_dir),
                 exports or 'csv,xml'):
-            print(line)
+            safeprint(line)
 
     elif export_outputs is not None:
         job_id, target_dir = export_outputs
         hc_id = get_job_id(job_id)
         for line in core.export_outputs(
                 hc_id, os.path.expanduser(target_dir), exports or 'csv,xml'):
-            print(line)
+            safeprint(line)
 
     elif delete_uncompleted_calculations:
         logs.dbcmd('delete_uncompleted_calculations', getpass.getuser())

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -21,6 +21,7 @@ import sys
 import getpass
 import logging
 from openquake.baselib import sap
+from openquake.baselib.utf8 import print
 from openquake.commonlib import datastore, config, logs
 from openquake.engine import engine as eng
 from openquake.engine.export import core

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -187,7 +187,7 @@ def list_calculations(db, job_type, user_name):
                     status = 'failed'
             start_time = job.start_time
             yield ('%6d | %10s | %s| %s' % (
-                job.id, status, start_time, descr)).encode('utf-8')
+                job.id, status, start_time, descr))
 
 
 def list_outputs(db, job_id, full=True):

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -186,7 +186,7 @@ def list_calculations(db, job_type, user_name):
                 else:
                     status = 'failed'
             start_time = job.start_time
-            yield ('%6d | %10s | %s| %s' % (
+            yield ('%6d | %10s | %s | %s' % (
                 job.id, status, start_time, descr))
 
 


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2662. Requires https://github.com/gem/oq-hazardlib/pull/622.

**Linux**
Python 2.7
```bash
LC_ALL=C oq engine --lhc
job_id |     status |          start_time |         description
     1 | successful | 2017-03-31 07:52:56| Scenario Hazard Demo (Nepal)
     3 | successful | 2017-03-31 13:13:57| Classical PSHA  Area Source

LC_ALL=en_US.iso-8859-1 oq engine --lhc
job_id |     status |          start_time |         description
     1 | successful | 2017-03-31 07:52:56| Scenario Hazard Demo (Nepal)
     3 | successful | 2017-03-31 13:13:57| Classical PSHA — Area Source

LC_ALL=en_US.utf8 oq engine --lhc
job_id |     status |          start_time |         description
     1 | successful | 2017-03-31 07:52:56| Scenario Hazard Demo (Nepal)
     3 | successful | 2017-03-31 13:13:57| Classical PSHA — Area Source

oq engine --lhc > file
WARNING:root:DB server started with /home/daniele/py27/bin/python2, listening on localhost:1908...
Traceback (most recent call last):
  File "/home/daniele/py27/bin/oq", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/daniele/GIT/gem/openquake/oq-engine/bin/oq", line 35, in <module>
    main.oq()
  File "/home/daniele/GIT/gem/openquake/oq-engine/openquake/commands/__main__.py", line 49, in oq
    parser.callfunc()
  File "/home/daniele/GIT/gem/openquake/oq-hazardlib/openquake/baselib/sap.py", line 186, in callfunc
    return self.func(**vars(namespace))
  File "/home/daniele/GIT/gem/openquake/oq-hazardlib/openquake/baselib/sap.py", line 245, in main
    return func(**kw)
  File "/home/daniele/GIT/gem/openquake/oq-engine/openquake/commands/engine.py", line 183, in engine
    print(line)
  File "/home/daniele/GIT/gem/openquake/oq-hazardlib/openquake/baselib/utf8.py", line 32, in print
    conv_str = s.encode('utf-8').decode(sys.stdout.encoding, 'ignore')
TypeError: decode() argument 1 must be string, not None

```

Python 3.5
```bash
LC_ALL=C oq engine --lhc
job_id |     status |          start_time |         description
     1 | successful | 2017-03-31 07:52:56| Scenario Hazard Demo (Nepal)
     3 | successful | 2017-03-31 13:13:57| Classical PSHA  Area Source


LC_ALL=en_US.iso-8859-1 oq engine --lhc
job_id |     status |          start_time |         description
     1 | successful | 2017-03-31 07:52:56| Scenario Hazard Demo (Nepal)
     3 | successful | 2017-03-31 13:13:57| Classical PSHA — Area Source


LC_ALL=en_US.utf8 oq engine --lhc
job_id |     status |          start_time |         description
     1 | successful | 2017-03-31 07:52:56| Scenario Hazard Demo (Nepal)
     3 | successful | 2017-03-31 13:13:57| Classical PSHA — Area Source

oq engine --lhc > file
cat file 
job_id |     status |          start_time |         description
     1 | successful | 2017-03-31 07:52:56| Scenario Hazard Demo (Nepal)
     3 | successful | 2017-03-31 13:13:57| Classical PSHA — Area Source

```

**Windows 10**
Python 2.7
```bash
C:\Program Files\OpenQuake Engine>oq engine --lhc
WARNING:root:DB server started with C:\Program Files\OpenQuake Engine\python2.7\python.exe, listening on localhost:1908...
job_id |     status |          start_time |         description
     1 | successful | 2017-03-31 13:40:31| Classical PSHA ΓÇö Area Source
```
The output in Windows isn't perfect, but that's an issue with its `cmd` terminal. Anyway, it isn't worst than now.

Linux: https://ci.openquake.org/job/zdevel_oq-engine/2458/
Windows: https://ci.openquake.org/job/windows/job/zdevel_oq-engine/11/
