### PR TITLE
Fixed a performance bug in `calc.get_gmfs`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a performance bug in `get_gmfs`: now the scenario risk and damage
+    calculators are orders of magnitude faster for big arrays
   * Added an .npz export for the output `losses_by_asset`
   * Exported the scenario_risk aggregate losses in a nicer format
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -616,8 +616,7 @@ class RiskCalculator(HazardCalculator):
             haz = ', '.join(imtls)
             raise ValueError('The IMTs in the risk models (%s) are disjoint '
                              "from the IMTs in the hazard (%s)" % (rsk, haz))
-        num_tasks = math.ceil((self.oqparam.concurrent_tasks or 1) /
-                              len(imtls))
+        num_tasks = self.oqparam.concurrent_tasks or 1
         rlzs = sorted(hazards_by_rlz)
         assets_by_site = self.assetcol.assets_by_site()
         with self.monitor('building riskinputs', autoflush=True):


### PR DESCRIPTION
The issue was discovered in a scenario_risk computation of one of our sponsors. All the time was spent reordering arrays in `get_gmfs` before even starting the real computation. After the fix the total runtime passed from 5 hours to 45 seconds.

PS: I have also fixed a small bug with `num_tasks`: we we producing too few tasks when there was a large number of IMTs.