### PR TITLE
Fixed the save_ruptures procedure when there are more than 256 surfaces

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed the save_ruptures procedure when there are more than 256
+    surfaces in the MultiSurface;
   * Renamed the `csq_` outputs of the scenario_damage to `losses_`
   * Changed the way scenario_damage are stored internally to be more
     consistent with the other calculators

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -142,9 +142,9 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         grp00 = self.calc.datastore.get_attr('ruptures/grp-00', 'nbytes')
         grp02 = self.calc.datastore.get_attr('ruptures/grp-02', 'nbytes')
         grp03 = self.calc.datastore.get_attr('ruptures/grp-03', 'nbytes')
-        self.assertEqual(grp00, 540)
-        self.assertEqual(grp02, 540)
-        self.assertEqual(grp03, 216)
+        self.assertEqual(grp00, 545)
+        self.assertEqual(grp02, 545)
+        self.assertEqual(grp03, 218)
 
         [fname] = export(('agg_curve-stats', 'xml'), self.calc.datastore)
         self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname)


### PR DESCRIPTION
This happened to Anirudh when running an UCERF calculation. He got the error

```python
File "/usr/local/openquake/oq-engine/openquake/commonlib/calc.py", line 667, in get_ruptures

    mesh = rec['points'].reshape(rec['sx'], rec['sy'], rec['sz'])

ValueError: total size of new array must be unchanged
```
The reason is that only one byte was reserved for the `sx` parameter of the rupture (i.e. the number of surfaces in the MultiSurface). Now we are reserving two bytes, i.e. up to 65,536 surfaces. Also, an error is raised if the limit is surpassed, whereas before we were silently truncating the parameter.