### PR TITLE
Split RPM packages in standard, master, worker

### DIFF
--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -7,9 +7,15 @@ Both services run on a single "master" node. It is not necessary and not recomme
 Running OpenQuake on an *MPI cluster* is currently not supported. See the [FAQ](../faq.md#mpi-support) for more information.
 
 ## Initial install
-On all nodes, install the `python-oq-engine` package as described in OpenQuake Engine installation for [Ubuntu](ubuntu.md) or [RedHat](rhel.md).
 
 Note: you have to **restart every celery node** after a configuration change.
+
+### Ubuntu
+On all nodes, install the `python-oq-engine` package as described in OpenQuake Engine installation for [Ubuntu](ubuntu.md).
+
+### RedHat
+For **RedHat** and derivates, install `python-oq-engine-master` package on the **master** node. It provides extra functionalities like _RabbitMQ_.
+On the workers install `python-oq-engine-worker`; it adds _celery_ support on top of the standard `python-oq-engine` package.
 
 ## OpenQuake Engine 'master' node configuration File
 

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -40,20 +40,31 @@ Obsoletes: python-oq-risklib
 Provides: python-oq-risklib
 
 %description
+OpenQuake is an open source application that allows users to
+compute seismic hazard and seismic risk of earthquakes on a global scale.
+
+Copyright (C) 2010-2017 GEM Foundation
+
+%package master
+Summary: OpenQuake Engine multi-node cluster support (master node)
+Group: Applications/Engineering
+Requires: %{name}%{?_isa} = %{version}-%{release} rabbitmq-server
+
+%description master
+OpenQuake Engine multi-node cluster support (master node)
 
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
 
 Copyright (C) 2010-2017 GEM Foundation
 
-%package cluster
-Summary: OpenQuake Engine multi-node cluster support
+%package worker
+Summary: OpenQuake Engine multi-node cluster support (worker node)
 Group: Applications/Engineering
-Requires: %{name}%{?_isa} = %{version}-%{release} rabbitmq-server
+Requires: %{name}%{?_isa} = %{version}-%{release}
 
-%description cluster
-
-OpenQuake Engine multi-node cluster support
+%description worker
+OpenQuake Engine multi-node cluster support (worker node)
 
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
@@ -125,7 +136,7 @@ rm -rf %{buildroot}
 %{_unitdir}/openquake-dbserver.service
 %{_unitdir}/openquake-webui.service
 
-%post cluster
+%post master
 (if ! rabbitmqctl status &>/dev/null; then
     systemctl start rabbitmq-server.service
     rabbit_started=true
@@ -141,15 +152,17 @@ if $rabbit_started; then
     systemctl stop rabbitmq-server.service
 fi
 ) >/dev/null || true
+
+%post worker
 %systemd_post openquake-celery.service
 
-%preun cluster
+%preun worker
 %systemd_preun openquake-celery.service
 
-%postun cluster
+%postun worker
 %systemd_postun_with_restart openquake-celery.service
 
-%files cluster
+%files worker
 %{_unitdir}/openquake-celery.service
 
 %changelog

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -95,24 +95,8 @@ cp -R demos %{buildroot}/%{_datadir}/openquake/engine
 cp -R utils %{buildroot}/%{_datadir}/openquake/engine
 
 %post
-(if ! rabbitmqctl status &>/dev/null; then
-    systemctl start rabbitmq-server.service
-    rabbit_started=true
-fi
-if ! rabbitmqctl list_users | grep %{oquser}; then
-    rabbitmqctl add_user %{oquser} %{oquser}
-fi
-if ! rabbitmqctl list_vhosts | grep %{oquser}; then
-    rabbitmqctl add_vhost %{oquser}
-    rabbitmqctl set_permissions -p %{oquser} %{oquser} ".*" ".*" ".*"
-fi
-if $rabbit_started; then
-    systemctl stop rabbitmq-server.service
-fi
-) >/dev/null || true
 %systemd_post openquake-dbserver.service
 %systemd_post openquake-webui.service
-%systemd_post openquake-celery.service
 
 %clean
 rm -rf %{buildroot}
@@ -120,12 +104,10 @@ rm -rf %{buildroot}
 %preun
 %systemd_preun openquake-dbserver.service
 %systemd_preun openquake-webui.service
-%systemd_preun openquake-celery.service
 
 %postun
 %systemd_postun_with_restart openquake-dbserver.service
 %systemd_postun_with_restart openquake-webui.service
-%systemd_postun_with_restart openquake-celery.service
 
 %files
 %defattr(-,root,root)
@@ -142,6 +124,24 @@ rm -rf %{buildroot}
 %{_sysconfdir}/openquake/openquake.cfg
 %{_unitdir}/openquake-dbserver.service
 %{_unitdir}/openquake-webui.service
+
+%post cluster
+(if ! rabbitmqctl status &>/dev/null; then
+    systemctl start rabbitmq-server.service
+    rabbit_started=true
+fi
+if ! rabbitmqctl list_users | grep %{oquser}; then
+    rabbitmqctl add_user %{oquser} %{oquser}
+fi
+if ! rabbitmqctl list_vhosts | grep %{oquser}; then
+    rabbitmqctl add_vhost %{oquser}
+    rabbitmqctl set_permissions -p %{oquser} %{oquser} ".*" ".*" ".*"
+fi
+if $rabbit_started; then
+    systemctl stop rabbitmq-server.service
+fi
+) >/dev/null || true
+%systemd_post openquake-celery.service
 
 %preun cluster
 %systemd_preun openquake-celery.service

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -32,7 +32,7 @@ Patch1: openquake.cfg.patch
 Requires(pre): shadow-utils
 
 Requires: python-oq-libs >= 1.0.0 python-oq-hazardlib >= 0.24.0
-Requires: sudo systemd python rabbitmq-server
+Requires: sudo systemd python
 
 BuildRequires: systemd python-setuptools
 
@@ -40,6 +40,20 @@ Obsoletes: python-oq-risklib
 Provides: python-oq-risklib
 
 %description
+
+OpenQuake is an open source application that allows users to
+compute seismic hazard and seismic risk of earthquakes on a global scale.
+
+Copyright (C) 2010-2017 GEM Foundation
+
+%package cluster
+Summary: OpenQuake Engine multi-node cluster support
+Group: Applications/Engineering
+Requires: %{name}%{?_isa} = %{version}-%{release} rabbitmq-server
+
+%description cluster
+
+OpenQuake Engine multi-node cluster support
 
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
@@ -128,6 +142,14 @@ rm -rf %{buildroot}
 %{_sysconfdir}/openquake/openquake.cfg
 %{_unitdir}/openquake-dbserver.service
 %{_unitdir}/openquake-webui.service
+
+%preun cluster
+%systemd_preun openquake-celery.service
+
+%postun cluster
+%systemd_postun_with_restart openquake-celery.service
+
+%files cluster
 %{_unitdir}/openquake-celery.service
 
 %changelog

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -153,6 +153,8 @@ if $rabbit_started; then
 fi
 ) >/dev/null || true
 
+%files master
+
 %post worker
 %systemd_post openquake-celery.service
 


### PR DESCRIPTION
`python-oq-engine` provides everything, but does not setup RabbitMQ nor Celery.

`python-oq-engine-master` adds support for RabbitMQ: the package downloads and configures it

`python-oq-engine-worker` adds support for Celery: the package setup the Celery daemon.

This configuration avoids the download of RabbitMQ and its ton of deps when not needed (i.e. single machine)

If the feedback is positive we can use the same approach with ubuntu packages. Let's start with RHEL which requires less changes and has more cluster users.

https://ci.openquake.org/job/builders/job/rpm-builder/73/