### PR TITLE
Allow the WebUI to bootstrap the DB

### DIFF
--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -39,7 +39,7 @@ def webui(cmd, hostport='127.0.0.1:8800'):
     """
 
     db_path = os.path.expanduser(config.get('dbserver', 'file'))
-    if not os.access(db_path, os.W_OK):
+    if os.path.isfile(db_path) and not os.access(db_path, os.W_OK):
         sys.exit('This command must be run by the proper user: '
                  'see the documentation for details')
     if cmd == 'start':


### PR DESCRIPTION
With this small fix the webui can be started via `oq webui start` even if the database does not exist yet; it will try to create it.

Without the fix, if `~/oqdata/db.sqlite3` does not exist yet, the `oq  webui start` command always says
```
This command must be run by the proper user: see the documentation for details
```
as soon as `oq engine` or `oq dbserver` are executed first. Instead the message should be printed only if the database _exists_ but is _not owned_ by who is executing the command.

This regression was introduced in https://github.com/gem/oq-engine/pull/2679