### PR TITLE
Loss maps npz exporter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added an .npz exporter for the loss maps
   * Raised an error early when using a complex logic tree in scenario
     calculations
   * Changed the CSV exporter for the loss curves: now it exports all the

--- a/openquake/calculators/tests/classical_risk_test.py
+++ b/openquake/calculators/tests/classical_risk_test.py
@@ -112,3 +112,8 @@ class ClassicalRiskTestCase(CalculatorTestCase):
         assert fnames  # sanity check
         for fname in fnames:
             self.assertEqualFiles('expected/' + strip_calc_id(fname), fname)
+
+        # exported the npz, not checking the content
+        for kind in ('rlzs', 'stats'):
+            [fname] = export(('loss_maps-' + kind, 'npz'), self.calc.datastore)
+            print('Generated ' + fname)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -105,8 +105,7 @@ def expose_outputs(dstore):
         dskeys.add('avg_losses-stats')
     if oq.conditional_loss_poes:  # expose loss_maps outputs
         if 'rcurves-rlzs' in dstore or 'loss_curves-rlzs' in dstore:
-            if len(rlzs) > 1:
-                dskeys.add('loss_maps-rlzs')
+            dskeys.add('loss_maps-rlzs')
         if 'rcurves-stats' in dstore or 'loss_curves-stats' in dstore:
             if len(rlzs) > 1:
                 dskeys.add('loss_maps-stats')


### PR DESCRIPTION
Another step needed for https://github.com/gem/oq-engine/issues/2650.
Here is an example of usage. Run a classical_risk (or event based risk) demo, then:

```bash
$ oq export loss_maps-rlzs -e npz
Exported 5.41 KB in ['./loss_maps-rlzs_2783.npz']
$ ipython
```

```python
In [1]: import numpy
In [3]: npz = numpy.load('./loss_maps-rlzs_2783.npz')
In [4]: npz.keys()
Out[4]: 
['rlz-002',
 'rlz-000',
 'rlz-001',
 'rlz-007',
 'rlz-004',
 'rlz-005',
 'rlz-006',
 'rlz-003']
In [7]: npz['rlz-002']['occupants']['poe-0.1']
Out[7]: 
array([ 0.0014482 ,  0.00602731,  0.00371133,  0.00965165,  0.01636052,
        0.00795973,  0.00605686], dtype=float32)
```

One should group the losses on the same point and plot the sum.
The demos are green: https://ci.openquake.org/job/zdevel_oq-engine/2465