### PR TITLE
The engine outputs are now streamed by the WebUI

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * The engine outputs are now streamed by the WebUI
   * Used a temporary export directory in the tests, to avoid conflicts
     in multiuser situations
   * Added an .npz exporter for the loss maps

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -554,9 +554,8 @@ def get_result(request, result_id):
             bname = bname[1:]
         fname = 'output-%s-%s' % (result_id, bname)
         # 'b' is needed when running the WebUI on Windows
-        data = open(exported, 'rb').read()
-        response = HttpResponse(data, content_type=content_type)
-        response['Content-Length'] = len(data)
+        stream = FileWrapper(open(exported, 'rb'))
+        response = FileResponse(stream, content_type=content_type)
         response['Content-Disposition'] = (
             'attachment; filename=%s' % os.path.basename(fname))
         return response


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2265.