### PR TITLE
Build the loss maps in a new datastore

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -385,7 +385,7 @@ class HazardCalculator(BaseCalculator):
         self.datastore.new = True
         self.datastore.parent = parent
         self.datastore.open()
-        self.datastore['oqparam'] = oq
+        self.save_params()
         self.set_log_format()
 
     def compute_previous(self):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -365,6 +365,15 @@ class HazardCalculator(BaseCalculator):
         """
         return len(self.assetcol)
 
+    def new_calculation(self):
+        parent = self.datastore
+        self.oqparam.hazard_calculation_id = parent.calc_id
+        self.__init__(self.oqparam)  # build a new datastore
+        self.datastore.parent = parent
+        self.datastore.open()
+        self.datastore['oqparam'] = self.oqparam
+        self.set_log_format()
+
     def compute_previous(self):
         precalc = calculators[self.pre_calculator](
             self.oqparam, self.monitor('precalculator'),

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -21,6 +21,7 @@ import sys
 import abc
 import pdb
 import socket
+import getpass
 import logging
 import operator
 import traceback
@@ -34,7 +35,7 @@ from openquake.baselib import general, hdf5
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.risklib import riskinput, __version__ as engine_version
-from openquake.commonlib import readinput, datastore, source, calc
+from openquake.commonlib import readinput, datastore, source, calc, logs
 from openquake.commonlib.oqvalidation import OqParam
 from openquake.baselib.parallel import Starmap, executor, wakeup_pool
 from openquake.baselib.python3compat import with_metaclass
@@ -132,6 +133,7 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
     :param monitor: monitor object
     :param calc_id: numeric calculation ID
     """
+    from_engine = False  # set by engine.run_calc
     sitecol = datastore.persistent_attribute('sitecol')
     assetcol = datastore.persistent_attribute('assetcol')
     performance = datastore.persistent_attribute('performance')
@@ -366,12 +368,24 @@ class HazardCalculator(BaseCalculator):
         return len(self.assetcol)
 
     def new_calculation(self):
+        """
+        Build a child of the current calculation and change the datastore
+        to the child's one.
+        """
+        oq = self.oqparam
         parent = self.datastore
-        self.oqparam.hazard_calculation_id = parent.calc_id
-        self.__init__(self.oqparam)  # build a new datastore
+        oq.hazard_calculation_id = parent.calc_id
+        if self.from_engine:  # build a new job_id
+            new_id = logs.dbcmd(
+                'create_job', oq.calculation_mode, oq.description,
+                getpass.getuser(), datastore.DATADIR, oq.hazard_calculation_id)
+        else:
+            new_id = None
+        self.__init__(self.oqparam, calc_id=new_id)  # build a new datastore
+        self.datastore.new = True
         self.datastore.parent = parent
         self.datastore.open()
-        self.datastore['oqparam'] = self.oqparam
+        self.datastore['oqparam'] = oq
         self.set_log_format()
 
     def compute_previous(self):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -235,12 +235,14 @@ class EbrPostCalculator(base.RiskCalculator):
             rlzs = self.rlzs_assoc.realizations
             quantiles = self.oqparam.quantile_loss_curves
             builder = self.riskmodel.curve_builder
-            lrgetter = riskinput.LossRatiosGetter(self.datastore)
             A = len(assetcol)
             R = len(self.datastore['realizations'])
 
             if self.oqparam.hazard_calculation_id is None:
+                lrgetter = riskinput.LossRatiosGetter(self.datastore)
                 self.new_calculation()  # increase calc_id
+            else:
+                lrgetter = riskinput.LossRatiosGetter(self.datastore.parent)
 
             # create loss_maps datasets
             self.datastore.create_dset(

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -239,7 +239,9 @@ class EbrPostCalculator(base.RiskCalculator):
             A = len(assetcol)
             R = len(self.datastore['realizations'])
 
-            self.new_calculation()  # increase calc_id
+            if self.oqparam.hazard_calculation_id is None:
+                self.new_calculation()  # increase calc_id
+
             # create loss_maps datasets
             self.datastore.create_dset(
                 'loss_maps-rlzs', builder.loss_maps_dt, (A, R), fillvalue=None)

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -66,6 +66,10 @@ def run_job(cfg_file, log_level='info', log_file=None, exports='',
     calc.monitor.flush()
     for line in logs.dbcmd('list_outputs', job_id, False):
         safeprint(line)
+    if hasattr(calc.datastore, 'new'):  # generated in .new_calculation
+        safeprint('Outputs of calculation %d' % calc.datastore.calc_id)
+        for line in logs.dbcmd('list_outputs', calc.datastore.calc_id, False):
+            safeprint(line)
     return job_id
 
 
@@ -183,7 +187,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             safeprint(line)
     elif run_hazard is not None:
         safeprint('WARN: --rh/--run-hazard are deprecated, use --run instead',
-              file=sys.stderr)
+                  file=sys.stderr)
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
         run_job(os.path.expanduser(run_hazard), log_level,
@@ -196,7 +200,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             safeprint(line)
     elif run_risk is not None:
         safeprint('WARN: --rr/--run-risk are deprecated, use --run instead',
-              file=sys.stderr)
+                  file=sys.stderr)
         if hazard_calculation_id is None:
             sys.exit(MISSING_HAZARD_MSG)
         log_file = os.path.expanduser(log_file) \

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -191,10 +191,14 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
         if USE_CELERY and os.environ.get('OQ_DISTRIBUTE') == 'celery':
             set_concurrent_tasks_default()
         calc = base.calculators(oqparam, monitor, calc_id=job_id)
+        calc.from_engine = True
         tb = 'None\n'
         try:
             logs.dbcmd('set_status', job_id, 'executing')
             _do_run_calc(calc, exports, hazard_calculation_id, **kw)
+            if hasattr(calc.datastore, 'new'):  # build in new_calculation
+                expose_outputs(calc.datastore.parent)
+                logs.dbcmd('finish', calc.datastore.parent.calc_id, 'complete')
             expose_outputs(calc.datastore)
             records = views.performance_view(calc.datastore)
             logs.dbcmd('save_performance', job_id, records)


### PR DESCRIPTION
This fixes a subtle bug introduced in https://github.com/gem/oq-engine/pull/2715: since the same datastore was used both for reading a writing (even if the writing was sequential), we could randomly get read errors like

```python
OSError: Unable to open file (Truncated file: eof = 2006887795, sblock->base_addr = 0, stored_eoa = 2006897267)
```
or
```python
  File "h5py/_proxy.pyx", line 84, in h5py._proxy.H5PY_H5Dread (/tmp/pip-nCYoKW-build/h5py/_proxy.c:1650)
IOError: Can't read data (Wrong b-tree signature)
```

Jenkins is happy: https://ci.openquake.org/job/zdevel_oq-engine/2473.

With this, the idea of replacing the .ext5 file with a parent .hdf5 (see the comment to https://github.com/gem/oq-engine/issues/2718) becomes more and more attractive. We must make it work in a cluster, though.

NB: I have also fixed `DataStore.__getitem__` and `DataStore.get_attrs` so that they are properly recursive and look on all the ancestors of a datastore, not only on the parent.