### PR TITLE
Added two tests and some refactoring

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -20,6 +20,7 @@ import os
 import sys
 import abc
 import pdb
+import getpass
 import logging
 import operator
 import traceback
@@ -33,7 +34,7 @@ from openquake.baselib import general, hdf5
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.risklib import riskinput, __version__ as engine_version
-from openquake.commonlib import readinput, datastore, source, calc
+from openquake.commonlib import readinput, datastore, source, calc, logs
 from openquake.commonlib.oqvalidation import OqParam
 from openquake.baselib.parallel import Starmap, executor, wakeup_pool
 from openquake.baselib.python3compat import with_metaclass
@@ -131,6 +132,7 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
     :param monitor: monitor object
     :param calc_id: numeric calculation ID
     """
+    from_engine = False  # set by engine.run_calc
     sitecol = datastore.persistent_attribute('sitecol')
     assetcol = datastore.persistent_attribute('assetcol')
     performance = datastore.persistent_attribute('performance')
@@ -372,12 +374,24 @@ class HazardCalculator(BaseCalculator):
         return len(self.assetcol)
 
     def new_calculation(self):
+        """
+        Build a child of the current calculation and change the datastore
+        to the child's one.
+        """
+        oq = self.oqparam
         parent = self.datastore
-        self.oqparam.hazard_calculation_id = parent.calc_id
-        self.__init__(self.oqparam)  # build a new datastore
+        oq.hazard_calculation_id = parent.calc_id
+        if self.from_engine:  # build a new job_id
+            new_id = logs.dbcmd(
+                'create_job', oq.calculation_mode, oq.description,
+                getpass.getuser(), datastore.DATADIR, oq.hazard_calculation_id)
+        else:
+            new_id = None
+        self.__init__(self.oqparam, calc_id=new_id)  # build a new datastore
+        self.datastore.new = True
         self.datastore.parent = parent
         self.datastore.open()
-        self.datastore['oqparam'] = self.oqparam
+        self.save_params()
         self.set_log_format()
 
     def compute_previous(self):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -20,7 +20,6 @@ import os
 import sys
 import abc
 import pdb
-import socket
 import logging
 import operator
 import traceback
@@ -153,7 +152,7 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         Return a new Monitor instance
         """
         mon = self._monitor(operation, hdf5path=self.datastore.hdf5path)
-        mon.calc_id = self.datastore.calc_id
+        self._monitor.calc_id = mon.calc_id = self.datastore.calc_id
         vars(mon).update(kw)
         return mon
 
@@ -458,7 +457,6 @@ class HazardCalculator(BaseCalculator):
             if 'source' in self.oqparam.inputs:
                 job_info.update(readinput.get_job_info(
                     self.oqparam, self.csm, self.sitecol))
-        job_info['hostname'] = socket.gethostname()
         if hasattr(self, 'riskmodel'):
             job_info['require_epsilons'] = bool(self.riskmodel.covs)
         self._monitor.save_info(job_info)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -278,7 +278,7 @@ class PSHACalculator(base.HazardCalculator):
         tectonic region type.
         """
         oq = self.oqparam
-        monitor = self.monitor.new(
+        monitor = self.monitor(
             self.core_task.__name__,
             truncation_level=oq.truncation_level,
             imtls=oq.imtls,
@@ -293,9 +293,8 @@ class PSHACalculator(base.HazardCalculator):
                 # then the Starmap will understand the case of a single
                 # argument tuple and it will run in core the task
                 iterargs = list(iterargs)
-            res = parallel.Starmap(
-                self.core_task.__func__, iterargs).submit_all()
-        acc = reduce(self.agg_dicts, res, self.zerodict())
+            smap = parallel.Starmap(self.core_task.__func__, iterargs)
+        acc = smap.reduce(self.agg_dicts, self.zerodict())
         with self.monitor('store source_info', autoflush=True):
             self.store_source_info(self.csm.infos)
         self.rlzs_assoc = self.csm.info.get_rlzs_assoc(
@@ -436,10 +435,9 @@ class ClassicalCalculator(PSHACalculator):
 
         logging.info('Building hazard curves')
         with self.monitor('submitting poes', autoflush=True):
-            res = parallel.Starmap(
-                build_hcurves_and_stats,
-                list(self.gen_args())).submit_all()
-        nbytes = reduce(self.save_hcurves, res, AccumDict())
+            nbytes = parallel.Starmap(
+                build_hcurves_and_stats, list(self.gen_args())
+            ).reduce(self.save_hcurves)
         return nbytes
 
     def gen_args(self):
@@ -447,7 +445,7 @@ class ClassicalCalculator(PSHACalculator):
         :param pmap_by_grp: dictionary of ProbabilityMaps keyed by src_grp_id
         :yields: arguments for the function build_hcurves_and_stats
         """
-        monitor = self.monitor.new(
+        monitor = self.monitor(
             'build_hcurves_and_stats',
             individual_curves=self.oqparam.individual_curves)
         weights = (None if self.oqparam.number_of_logic_tree_samples

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -224,10 +224,11 @@ class DisaggregationCalculator(classical.ClassicalCalculator):
                     for split, _sites in src_filter(
                             sourceconverter.split_source(src), sitecol):
                         split_sources.append(split)
+                mon = self.monitor('disaggregation')
                 for srcs in split_in_blocks(split_sources, nblocks):
                     all_args.append(
                         (src_filter, srcs, src_group.id, self.rlzs_assoc,
-                         trt_names, curves_dict, bin_edges, oq, self.monitor))
+                         trt_names, curves_dict, bin_edges, oq, mon))
 
         results = parallel.Starmap(compute_disagg, all_args).reduce(
             self.agg_result)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -551,7 +551,7 @@ class EventBasedCalculator(ClassicalCalculator):
                 os.makedirs(export_dir)
             oq.export_dir = export_dir
             # one could also set oq.number_of_logic_tree_samples = 0
-            self.cl = ClassicalCalculator(oq, self.monitor)
+            self.cl = ClassicalCalculator(oq, self.monitor('classical'))
             # TODO: perhaps it is possible to avoid reprocessing the source
             # model, however usually this is quite fast and do not dominate
             # the computation

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -259,9 +259,10 @@ class EbrPostCalculator(base.RiskCalculator):
             # to use a shared directory; the calculation is fast enough
             # (minutes) even for the largest event based I ever saw
             lrgetter.dstore.close()  # this is essential on the cluster
+            mon = self.monitor('loss maps')
             parallel.Processmap.apply(
                 build_loss_maps,
-                (assetcol, builder, lrgetter, rlzs, quantiles, self.monitor)
+                (assetcol, builder, lrgetter, rlzs, quantiles, mon)
             ).reduce(self.save_loss_maps)
             lrgetter.dstore.open()
 
@@ -455,6 +456,7 @@ class EbriskCalculator(base.RiskCalculator):
         ela_dt, elt_dt = build_el_dtypes(
             self.riskmodel.loss_types, oq.insured_losses)
         csm_info = self.datastore['csm_info']
+        mon = self.monitor('risk')
         for sm in csm_info.source_models:
             param = dict(
                 assetcol=self.assetcol,
@@ -469,7 +471,7 @@ class EbriskCalculator(base.RiskCalculator):
                 seed=self.oqparam.random_seed)
             yield (sm.ordinal, ruptures_by_grp, self.sitecol.complete,
                    param, self.riskmodel, imts, oq.truncation_level,
-                   correl_model, min_iml, self.monitor)
+                   correl_model, min_iml, mon)
 
     def execute(self):
         """

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -260,8 +260,12 @@ class EbrPostCalculator(base.RiskCalculator):
             # to use a shared directory; the calculation is fast enough
             # (minutes) even for the largest event based I ever saw
             lrgetter.dstore.close()  # this is essential on the cluster
-            time.sleep(.1)  # it seems to help against IOError:
+
+            # we sleep a bit to fight against IOError:
             # Can't read data (Wrong b-tree signature)
+            # that seems to happen only with Python 2
+            time.sleep(.1)
+
             mon = self.monitor('loss maps')
             parallel.Processmap.apply(
                 build_loss_maps,

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -20,6 +20,7 @@ import logging
 import operator
 import itertools
 import collections
+import time
 import numpy
 
 from openquake.baselib.python3compat import zip
@@ -259,6 +260,8 @@ class EbrPostCalculator(base.RiskCalculator):
             # to use a shared directory; the calculation is fast enough
             # (minutes) even for the largest event based I ever saw
             lrgetter.dstore.close()  # this is essential on the cluster
+            time.sleep(.1)  # it seems to help against IOError:
+            # Can't read data (Wrong b-tree signature)
             mon = self.monitor('loss maps')
             parallel.Processmap.apply(
                 build_loss_maps,

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -93,8 +93,11 @@ class ReportWriter(object):
         self.dstore = dstore
         self.oq = oq = dstore['oqparam']
         self.text = (decode(oq.description) + '\n' + '=' * len(oq.description))
-        info = {decode(k): decode(v)
-                for k, v in dict(dstore['job_info']).items()}
+        try:
+            info = {decode(k): decode(v)
+                    for k, v in dict(dstore['job_info']).items()}
+        except KeyError:  # job_info not in the datastore (scenario hazard)
+            info = dict(hostname='localhost')
         dpath = dstore.hdf5path
         mtime = os.path.getmtime(dpath)
         host = '%s:%s' % (info['hostname'], decode(dpath))

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -93,13 +93,13 @@ class CalculatorTestCase(unittest.TestCase):
         assert len(inis) in (1, 2), inis
         self.calc = self.get_calc(testfile, inis[0], **kw)
         self.edir = tempfile.mkdtemp()
-        with self.calc.monitor:
+        with self.calc._monitor:
             result = self.calc.run(export_dir=self.edir)
         if len(inis) == 2:
             hc_id = self.calc.datastore.calc_id
             self.calc = self.get_calc(
                 testfile, inis[1], hazard_calculation_id=str(hc_id), **kw)
-            with self.calc.monitor:
+            with self.calc._monitor:
                 result.update(self.calc.run(export_dir=self.edir))
         # reopen datastore, since some tests need to export from it
         dstore = datastore.read(self.calc.datastore.calc_id)

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -216,6 +216,11 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/ruptures_events.txt', fname)
         os.remove(fname)
 
+        # check job_info is stored
+        job_info = dict(self.calc.datastore['job_info'])
+        self.assertIn('build_loss_maps.sent', job_info)
+        self.assertIn('build_loss_maps.received', job_info)
+
     @attr('qa', 'risk', 'event_based_risk')
     def test_case_miriam(self):
         # this is a case with a grid and asset-hazard association

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -218,8 +218,8 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # check job_info is stored
         job_info = dict(self.calc.datastore['job_info'])
-        self.assertIn('build_loss_maps.sent', job_info)
-        self.assertIn('build_loss_maps.received', job_info)
+        self.assertIn(b'build_loss_maps.sent', job_info)
+        self.assertIn(b'build_loss_maps.received', job_info)
 
     @attr('qa', 'risk', 'event_based_risk')
     def test_case_miriam(self):

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import os
-import copy
 import time
+import socket
 import logging
 import functools
 from datetime import datetime
@@ -160,6 +160,7 @@ class UcerfPSHACalculator(classical.PSHACalculator):
         tectonic region type.
         """
         monitor = self.monitor(self.core_task.__name__)
+        monitor.save_info(dict(hostname=socket.gethostname()))
         monitor.oqparam = oq = self.oqparam
         self.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
         acc = AccumDict({

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -160,7 +160,6 @@ class UcerfPSHACalculator(classical.PSHACalculator):
         tectonic region type.
         """
         monitor = self.monitor(self.core_task.__name__)
-        monitor.save_info(dict(hostname=socket.gethostname()))
         monitor.oqparam = oq = self.oqparam
         self.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
         acc = AccumDict({

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -159,7 +159,7 @@ class UcerfPSHACalculator(classical.PSHACalculator):
         parallelizing on the sources according to their weight and
         tectonic region type.
         """
-        monitor = self.monitor.new(self.core_task.__name__)
+        monitor = self.monitor(self.core_task.__name__)
         monitor.oqparam = oq = self.oqparam
         self.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
         acc = AccumDict({

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -762,7 +762,7 @@ class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
         oq = self.oqparam
         self.read_risk_data()  # read the site collection
         self.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
-        self.monitor.save_info(dict(hostname=socket.gethostname()))
+        self._monitor.save_info(dict(hostname=socket.gethostname()))
         self.csm = get_composite_source_model(oq)
         logging.info('Found %d source model logic tree branches',
                      len(self.csm.source_models))

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -22,7 +22,6 @@ import time
 import math
 import os.path
 import logging
-import socket
 import collections
 import h5py
 import numpy
@@ -762,7 +761,6 @@ class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
         oq = self.oqparam
         self.read_risk_data()  # read the site collection
         self.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
-        self._monitor.save_info(dict(hostname=socket.gethostname()))
         self.csm = get_composite_source_model(oq)
         logging.info('Found %d source model logic tree branches',
                      len(self.csm.source_models))
@@ -865,6 +863,7 @@ class UCERFRiskCalculator(EbriskCalculator):
         imts = list(oq.imtls)
         ela_dt, elt_dt = build_el_dtypes(
             self.riskmodel.loss_types, oq.insured_losses)
+        monitor = self.monitor('compute_losses')
         for sm in self.csm.source_models:
             ssm = self.csm.get_model(sm.ordinal)
             for ses_idx in range(1, oq.ses_per_logic_tree_path + 1):
@@ -878,7 +877,7 @@ class UCERFRiskCalculator(EbriskCalculator):
                              insured_losses=oq.insured_losses)
                 yield (ssm, self.src_filter, param,
                        self.riskmodel, imts, oq.truncation_level,
-                       correl_model, min_iml, self.monitor)
+                       correl_model, min_iml, monitor)
 
     def execute(self):
         num_rlzs = len(self.rlzs_assoc.realizations)

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -63,7 +63,7 @@ def run_job(cfg_file, log_level='info', log_file=None, exports='',
         job_ini, getpass.getuser(), hazard_calculation_id)
     calc = eng.run_calc(job_id, oqparam, log_level, log_file, exports,
                         hazard_calculation_id=hazard_calculation_id, **kw)
-    calc.monitor.flush()
+    calc._monitor.flush()
     for line in logs.dbcmd('list_outputs', job_id, False):
         safeprint(line)
     return job_id

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -66,6 +66,10 @@ def run_job(cfg_file, log_level='info', log_file=None, exports='',
     calc._monitor.flush()
     for line in logs.dbcmd('list_outputs', job_id, False):
         safeprint(line)
+    if hasattr(calc.datastore, 'new'):  # generated in .new_calculation
+        safeprint('Outputs of calculation %d' % calc.datastore.calc_id)
+        for line in logs.dbcmd('list_outputs', calc.datastore.calc_id, False):
+            safeprint(line)
     return job_id
 
 
@@ -183,7 +187,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             safeprint(line)
     elif run_hazard is not None:
         safeprint('WARN: --rh/--run-hazard are deprecated, use --run instead',
-              file=sys.stderr)
+                  file=sys.stderr)
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
         run_job(os.path.expanduser(run_hazard), log_level,
@@ -196,7 +200,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             safeprint(line)
     elif run_risk is not None:
         safeprint('WARN: --rr/--run-risk are deprecated, use --run instead',
-              file=sys.stderr)
+                  file=sys.stderr)
         if hazard_calculation_id is None:
             sys.exit(MISSING_HAZARD_MSG)
         log_file = os.path.expanduser(log_file) \

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -75,13 +75,13 @@ def run2(job_haz, job_risk, concurrent_tasks, pdb, exports, params, monitor):
     Run both hazard and risk, one after the other
     """
     hcalc = base.calculators(readinput.get_oqparam(job_haz), monitor)
-    with hcalc.monitor:
+    with monitor:
         hcalc.run(concurrent_tasks=concurrent_tasks, pdb=pdb,
                   exports=exports, **params)
         hc_id = hcalc.datastore.calc_id
         oq = readinput.get_oqparam(job_risk, hc_id=hc_id)
     rcalc = base.calculators(oq, monitor)
-    with rcalc.monitor:
+    with monitor:
         rcalc.run(concurrent_tasks=concurrent_tasks, pdb=pdb, exports=exports,
                   hazard_calculation_id=hc_id, **params)
     return rcalc
@@ -110,7 +110,7 @@ def _run(job_ini, concurrent_tasks, pdb, loglevel, hc, exports, params):
                     'There are %d old calculations, cannot '
                     'retrieve the %s' % (len(calc_ids), hc_id))
         calc = base.calculators(oqparam, monitor)
-        with calc.monitor:
+        with calc._monitor:
             calc.run(concurrent_tasks=concurrent_tasks, pdb=pdb,
                      exports=exports, hazard_calculation_id=hc_id,
                      rlz_ids=rlz_ids, **params)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -32,6 +32,7 @@ from openquake.commands.show import show
 from openquake.commands.show_attrs import show_attrs
 from openquake.commands.export import export
 from openquake.commands.reduce import reduce
+from openquake.commands.engine import run_job
 from openquake.commands.db import db
 from openquake.commands.to_shapefile import to_shapefile
 from openquake.commands.from_shapefile import from_shapefile
@@ -41,6 +42,7 @@ from openquake.qa_tests_data.classical import case_1
 from openquake.qa_tests_data.classical_risk import case_3
 from openquake.qa_tests_data.scenario import case_4
 from openquake.qa_tests_data.event_based import case_5
+from openquake.qa_tests_data.event_based_risk import case_master
 from openquake.server import manage, dbapi
 
 DATADIR = os.path.join(commonlib.__path__[0], 'tests', 'data')
@@ -324,3 +326,16 @@ class DbTestCase(unittest.TestCase):
                 db('calc_info 1')
             except dbapi.NotFound:  # happens on an empty db
                 pass
+
+
+class EngineRunJobTestCase(unittest.TestCase):
+    """
+    Test a single case of `run_job`, but it is the most complex one,
+    event based risk with post processing
+    """
+    def test_ebr(self):
+        job_ini = os.path.join(
+            os.path.dirname(case_master.__file__), 'job.ini')
+        with Print.patch() as p:
+            run_job(job_ini, log_level='error')
+        self.assertIn('Outputs of calculation', str(p))

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -191,10 +191,14 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
         if USE_CELERY and os.environ.get('OQ_DISTRIBUTE') == 'celery':
             set_concurrent_tasks_default()
         calc = base.calculators(oqparam, monitor, calc_id=job_id)
+        calc.from_engine = True
         tb = 'None\n'
         try:
             logs.dbcmd('set_status', job_id, 'executing')
             _do_run_calc(calc, exports, hazard_calculation_id, **kw)
+            if hasattr(calc.datastore, 'new'):  # build in new_calculation
+                expose_outputs(calc.datastore.parent)
+                logs.dbcmd('finish', calc.datastore.parent.calc_id, 'complete')
             expose_outputs(calc.datastore)
             records = views.performance_view(calc.datastore)
             logs.dbcmd('save_performance', job_id, records)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -200,7 +200,7 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
             logs.dbcmd('save_performance', job_id, records)
             calc.datastore.close()
             logs.LOG.info('Calculation %d finished correctly in %d seconds',
-                          job_id, calc.monitor.duration)
+                          job_id, calc._monitor.duration)
             logs.dbcmd('finish', job_id, 'complete')
         except:
             tb = traceback.format_exc()
@@ -225,6 +225,6 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
 
 
 def _do_run_calc(calc, exports, hazard_calculation_id, **kw):
-    with calc.monitor:
+    with calc._monitor:
         calc.run(exports=exports, hazard_calculation_id=hazard_calculation_id,
                  close=False, **kw)  # don't close the datastore too soon


### PR DESCRIPTION
There is now a `.monitor` and a `._monitor` instance in the calculators. This is made so that the monitor gets the right calculation ID even in the case of datastores generated by the method `.new_calculation` (see https://github.com/gem/oq-engine/pull/2737). Also, there is a new test checking that `job_info` is always stored correctly. All this is in order to make sure that the `report.rst` is generated correctly.

The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2477