### PR TITLE
Added the ability to compute the upper limit of the hazard curves amongst the realizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ The **OpenQuake Engine** is an open source application that allows users to comp
 |       :---:        |         :---:        |
 | [![Build Status](https://ci.openquake.org/job/master_oq-engine/badge/icon)](https://ci.openquake.org/job/master_oq-engine/) | [![Build Status](https://travis-ci.org/gem/oq-engine.svg?branch=master)](https://travis-ci.org/gem/oq-engine) |
 
-Jenkins (Python 2): 
-
-Travis CI (Python 3): 
-
 ### Current stable
 
 Current stable version is the **OpenQuake Engine 2.3** 'Degenkolb'. The documentation is available at https://github.com/gem/oq-engine/tree/engine-2.3#openquake-engine.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ The **OpenQuake Engine** is an open source application that allows users to comp
 +## Documentation
 -## Documentation (master tree)
 -->
-Jenkins (Python 2): [![Build Status](https://ci.openquake.org/job/master_oq-engine/badge/icon)](https://ci.openquake.org/job/master_oq-engine/)
 
-Travis CI (Python 3): [![Build Status](https://travis-ci.org/gem/oq-engine.svg?branch=master)](https://travis-ci.org/gem/oq-engine)
+| Jenkins (Python 2) | Travis CI (Python 3) |
+|       :---:        |         :---:        |
+| [![Build Status](https://ci.openquake.org/job/master_oq-engine/badge/icon)](https://ci.openquake.org/job/master_oq-engine/) | [![Build Status](https://travis-ci.org/gem/oq-engine.svg?branch=master)](https://travis-ci.org/gem/oq-engine) |
+
+Jenkins (Python 2): 
+
+Travis CI (Python 3): 
 
 ### Current stable
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Added a `max_curve` functionality to compute the upper limit of the
+    hazard curves amongst realizations
   * Raised an error if the user specifies `quantile_loss_curves`
     or `conditional_loss_poes` in a classical_damage calculation
   * Added a CSV exporter for the benefit-cost-ratio calculator

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -387,6 +387,7 @@ class HazardCalculator(BaseCalculator):
                 getpass.getuser(), datastore.DATADIR, oq.hazard_calculation_id)
         else:
             new_id = None
+        self.datastore.close()
         self.__init__(self.oqparam, calc_id=new_id)  # build a new datastore
         self.datastore.new = True
         self.datastore.parent = parent

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -192,14 +192,14 @@ def event_based_risk(riskinput, riskmodel, param, monitor):
     return result
 
 
-def build_loss_maps(assets, builder, getter, rlzs, quantiles, monitor):
+def build_loss_maps(assets, builder, getter, rlzs, stats, monitor):
     """
     Thin wrapper over :meth:
     `openquake.risklib.scientific.CurveBuilder.build_maps`.
     :returns: assets IDs and loss maps for the given chunk of assets
     """
     aids, loss_maps, loss_maps_stats = builder.build_maps(
-        assets, getter, rlzs, quantiles, monitor)
+        assets, getter, rlzs, stats, monitor)
     res = {'aids': aids, 'loss_maps-rlzs': loss_maps}
     if loss_maps_stats is not None:
         res['loss_maps-stats'] = loss_maps_stats
@@ -236,7 +236,7 @@ class EbrPostCalculator(base.RiskCalculator):
                  and self.oqparam.conditional_loss_poes):
             assetcol = self.assetcol
             rlzs = self.rlzs_assoc.realizations
-            quantiles = self.oqparam.quantile_loss_curves
+            stats = self.oqparam.risk_stats()
             builder = self.riskmodel.curve_builder
             A = len(assetcol)
             R = len(self.datastore['realizations'])
@@ -251,9 +251,8 @@ class EbrPostCalculator(base.RiskCalculator):
             self.datastore.create_dset(
                 'loss_maps-rlzs', builder.loss_maps_dt, (A, R), fillvalue=None)
             if R > 1:
-                S = len(quantiles) + 1
                 self.datastore.create_dset(
-                    'loss_maps-stats', builder.loss_maps_dt, (A, S),
+                    'loss_maps-stats', builder.loss_maps_dt, (A, len(stats)),
                     fillvalue=None)
             mon = self.monitor('loss maps')
             # NB: a regular Starmap does not work on a single machine since
@@ -270,15 +269,14 @@ class EbrPostCalculator(base.RiskCalculator):
             self.datastore.close()  # this is essential
             Starmap.apply(
                 build_loss_maps,
-                (assetcol, builder, lrgetter, rlzs, quantiles, mon),
+                (assetcol, builder, lrgetter, rlzs, stats, mon),
                 self.oqparam.concurrent_tasks
             ).reduce(self.save_loss_maps)
             self.datastore.open()
 
         # build an aggregate loss curve per realization
         if 'agg_loss_table' in self.datastore:
-            with self.monitor('building agg_curve'):
-                self.build_agg_curve()
+            self.build_agg_curve()
 
     def post_execute(self):
         # override the base class method to avoid doing bad stuff
@@ -310,20 +308,19 @@ class EbrPostCalculator(base.RiskCalculator):
         self.datastore['agg_curve-rlzs'] = agg_curve
 
         if R > 1:  # save stats too
+            statnames, stats = zip(*oq.risk_stats())
             weights = self.datastore['realizations']['weight']
-            Q1 = len(oq.quantile_loss_curves) + 1
-            agg_curve_stats = numpy.zeros((I, Q1), agg_curve.dtype)
+            agg_curve_stats = numpy.zeros((I, len(stats)), agg_curve.dtype)
             for l, loss_type in enumerate(agg_curve.dtype.names):
                 acs = agg_curve_stats[loss_type]
                 data = agg_curve[loss_type]
                 for i in range(I):
+                    avg = data['avg'][i]
                     losses, all_poes = scientific.normalize_curves_eb(
                         [(c['losses'], c['poes']) for c in data[i]])
                     acs['losses'][i] = losses
-                    acs['poes'][i] = compute_stats(
-                        all_poes, oq.quantile_loss_curves, weights)
-                    acs['avg'][i] = compute_stats(
-                        data['avg'][i], oq.quantile_loss_curves, weights)
+                    acs['poes'][i] = compute_stats(all_poes, stats, weights)
+                    acs['avg'][i] = compute_stats(avg, stats, weights)
 
             self.datastore['agg_curve-stats'] = agg_curve_stats
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -258,9 +258,14 @@ class EbrPostCalculator(base.RiskCalculator):
             mon = self.monitor('loss maps')
             # NB: a regular Starmap does not work on a single machine since
             # the 'all_loss_ratios' dataset is not seen by the
-            # children (looks like a bug in hdf5); we use a Processmap instead
-            Starmap = (parallel.Processmap
-                       if parallel.oq_distribute() == 'futures'
+            # children (looks like a bug in hdf5); we may use a Processmap
+            # instead, but sometimes it breaks on Jenkins; so we use
+            # the safest choice, Sequential
+            # an alternative would be to force
+            # self.oqparam.hazard_calculation_id not None
+            Starmap = (parallel.Sequential
+                       if hasattr(self.datastore, 'new') and
+                       parallel.oq_distribute() == 'futures'
                        else parallel.Starmap)
             self.datastore.close()  # this is essential
             Starmap.apply(

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -20,12 +20,12 @@ import logging
 import operator
 import itertools
 import collections
-import time
 import numpy
 
 from openquake.baselib.python3compat import zip
 from openquake.baselib.general import AccumDict, block_splitter
 from openquake.hazardlib.stats import compute_stats
+from openquake.commonlib import config
 from openquake.calculators import base, event_based
 from openquake.baselib import parallel
 from openquake.risklib import riskinput, scientific
@@ -204,6 +204,7 @@ def build_loss_maps(assets, builder, getter, rlzs, quantiles, monitor):
     if loss_maps_stats is not None:
         res['loss_maps-stats'] = loss_maps_stats
     return res
+build_loss_maps.shared_dir_on = config.SHARED_DIR_ON
 
 
 @base.calculators.add('event_based_risk')
@@ -221,11 +222,12 @@ class EbrPostCalculator(base.RiskCalculator):
         Save the loss maps by opening and closing the datastore and
         return the total number of stored bytes.
         """
-        for key in res:
-            if key.startswith('loss_maps'):
-                acc += {key: res[key].nbytes}
-                self.datastore[key][res['aids']] = res[key]
-                self.datastore.set_attrs(key, nbytes=acc[key])
+        with self.datastore:
+            for key in res:
+                if key.startswith('loss_maps'):
+                    acc += {key: res[key].nbytes}
+                    self.datastore[key][res['aids']] = res[key]
+                    self.datastore.set_attrs(key, nbytes=acc[key])
         return acc
 
     def execute(self):
@@ -253,25 +255,20 @@ class EbrPostCalculator(base.RiskCalculator):
                 self.datastore.create_dset(
                     'loss_maps-stats', builder.loss_maps_dt, (A, S),
                     fillvalue=None)
-            # NB: we must fork here and not before,
-            # otherwise the 'all_loss_ratios' dataset is not seen by the
-            # children; this is why the regular Starmap would not work here;
-            # also, in this way everything is local and there is no need
-            # to use a shared directory; the calculation is fast enough
-            # (minutes) even for the largest event based I ever saw
-            lrgetter.dstore.close()  # this is essential on the cluster
-
-            # we sleep a bit to fight against IOError:
-            # Can't read data (Wrong b-tree signature)
-            # that seems to happen only with Python 2
-            time.sleep(.1)
-
             mon = self.monitor('loss maps')
-            parallel.Processmap.apply(
+            # NB: a regular Starmap does not work on a single machine since
+            # the 'all_loss_ratios' dataset is not seen by the
+            # children (looks like a bug in hdf5); we use a Processmap instead
+            Starmap = (parallel.Processmap
+                       if parallel.oq_distribute() == 'futures'
+                       else parallel.Starmap)
+            self.datastore.close()  # this is essential
+            Starmap.apply(
                 build_loss_maps,
-                (assetcol, builder, lrgetter, rlzs, quantiles, mon)
+                (assetcol, builder, lrgetter, rlzs, quantiles, mon),
+                self.oqparam.concurrent_tasks
             ).reduce(self.save_loss_maps)
-            lrgetter.dstore.open()
+            self.datastore.open()
 
         # build an aggregate loss curve per realization
         if 'agg_loss_table' in self.datastore:

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -81,9 +81,9 @@ def export_avg_losses(ekey, dstore):
     name, kind = ekey[0].split('-')
     value = dstore[name + '-rlzs'].value  # shape (A, R, L')
     if kind == 'stats':
-        tags = ['mean'] + ['quantile-%s' % q for q in oq.quantile_loss_curves]
         weights = dstore['realizations']['weight']
-        value = compute_stats2(value, oq.quantile_loss_curves, weights)
+        tags, stats = zip(*oq.risk_stats())
+        value = compute_stats2(value, stats, weights)
     else:  # rlzs
         tags = ['rlz-%03d' % r for r in range(len(dstore['realizations']))]
     for tag, values in zip(tags, value.transpose(1, 0, 2)):
@@ -869,9 +869,9 @@ def export_losses_by_taxon_csv(ekey, dstore):
     key, kind = ekey[0].split('-')
     value = dstore[key + '-rlzs'].value
     if kind == 'stats':
-        tags = ['mean'] + ['quantile-%s' % q for q in oq.quantile_loss_curves]
         weights = dstore['realizations']['weight']
-        value = compute_stats2(value, oq.quantile_loss_curves, weights)
+        tags, stats = zip(*oq.risk_stats())
+        value = compute_stats2(value, stats, weights)
     else:  # rlzs
         tags = rlzs
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1010,7 +1010,7 @@ class CurveBuilder(object):
                     arr['avg'] = average_loss([losses, poes])
         return curves
 
-    def build_maps(self, assets, getter, rlzs, quantiles, mon):
+    def build_maps(self, assets, getter, rlzs, stats, mon):
         """"
         :param assets:
             a list of assets
@@ -1018,8 +1018,8 @@ class CurveBuilder(object):
             a :class:`openquake.risklib.riskinput.LossRatiosGetter` instance
         :param rlzs:
             a list of realizations
-        :param quantiles:
-            a list of quantiles
+        :param stats:
+            a record of statistic functions
         :param mon:
             a :class:`openquake.baselib.performance.Monitor` instance
         :returns:
@@ -1040,9 +1040,10 @@ class CurveBuilder(object):
                 losses[cb.loss_type + '_ins'] = losses[cb.loss_type]
         all_poes = self.build_all_poes(aids, loss_ratios, rlzs)
         loss_maps = self._build_maps(losses, all_poes)
-        if len(rlzs) > 1:
+        if len(rlzs) > 1 and stats:
+            statnames, statfuncs = zip(*stats)
             weights = [rlz.weight for rlz in rlzs]
-            stat_poes = compute_stats2(all_poes, quantiles, weights)
+            stat_poes = compute_stats2(all_poes, statfuncs, weights)
             loss_maps_stats = self._build_maps(losses, stat_poes)
         else:
             loss_maps_stats = None

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -85,6 +85,11 @@ class DbServer(object):
             listener.close()
 
 
+def different_paths(path1, path2):
+    # don't care about the extension (it may be .py or .pyc)
+    return os.path.splitext(path1)[0] != os.path.splitext(path2)[0]
+
+
 def get_status(address=None):
     """
     Check if the DbServer is up.
@@ -106,7 +111,7 @@ def check_foreign():
     """
     if not config.flag_set('dbserver', 'multi_user'):
         remote_server_path = logs.dbcmd('get_path')
-        if server_path != remote_server_path:
+        if different_paths(server_path, remote_server_path):
             return('You are trying to contact a DbServer from another'
                    + ' instance (%s)\n' % remote_server_path
                    + 'Check the configuration or stop the foreign'

--- a/packager.sh
+++ b/packager.sh
@@ -959,7 +959,7 @@ builddoc_run () {
     for dep_item in $GEM_DEPENDS; do
         dep="$(echo "$dep_item" | cut -d '|' -f 1)"
         dep_type="$(echo "$dep_item" | cut -d '|' -f 2)"
-        if [ "$dep_type" = "deb" ]; then
+        if [ "$dep_type" != "src" ]; then
             continue
         fi
         found=0

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -6,54 +6,54 @@
 # We also provide pre-compiled manylinux1 wheels for
 # h5py, Shapely, psutil, Rtree, PyYAML, Basemap
 
-http://ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/pkgconfig-1.1.0-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/h5py-2.7.0-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/nose-1.3.7-py2-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/psutil-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/Shapely-1.5.13-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/docutils-0.12-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/futures-3.0.5-py2-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/Django-1.8.17-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/requests-2.9.1-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/pyshp-1.2.3-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/PyYAML-3.12-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/pkgconfig-1.1.0-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/h5py-2.7.0-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/nose-1.3.7-py2-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/psutil-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/Shapely-1.5.13-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/docutils-0.12-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/futures-3.0.5-py2-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/Django-1.8.17-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/requests-2.9.1-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/pyshp-1.2.3-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/PyYAML-3.12-cp27-cp27mu-manylinux1_x86_64.whl
 
 ## Extra ##
 
 ### pythn-prctl ###
 # comment the following lines to skip installation
 # of python-prctl (optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py27/python_prctl-1.6.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/python_prctl-1.6.1-cp27-cp27mu-manylinux1_x86_64.whl
 
 ### Rtree ###
 # comment the following lines to skip installation
 # of Rtree (experimental wheel, optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py27/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl
 
 ### Celery ###
 # comment the following lines to skip installation
 # of celery (optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py27/anyjson-0.3.3-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/amqp-1.4.9-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/kombu-3.0.33-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/billiard-3.3.0.22-cp27-cp27mu-linux_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py/celery-3.1.20-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/anyjson-0.3.3-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/amqp-1.4.9-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/kombu-3.0.33-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/billiard-3.3.0.22-cp27-cp27mu-linux_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/celery-3.1.20-py2.py3-none-any.whl
 
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py27/matplotlib-1.5.3-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/pyproj-1.9.5.1-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/basemap-1.1.0-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/matplotlib-1.5.3-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/pyproj-1.9.5.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/basemap-1.1.0-cp27-cp27mu-manylinux1_x86_64.whl

--- a/requirements-py27-macos.txt
+++ b/requirements-py27-macos.txt
@@ -5,25 +5,25 @@
 
 # GEM Mirror
 
-http://ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/pkgconfig-1.1.0-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/h5py-2.7.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/nose-1.3.7-py2-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/numpy-1.11.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/scipy-0.17.1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/psutil-4.4.2-cp27-cp27m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/Shapely-1.5.17.post1-cp27-cp27m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/docutils-0.12-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/futures-3.0.5-py2-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/Django-1.8.17-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/requests-2.9.1-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/pyshp-1.2.3-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/PyYAML-3.12-cp27-cp27m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/pkgconfig-1.1.0-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/h5py-2.7.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/nose-1.3.7-py2-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/numpy-1.11.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/scipy-0.17.1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/psutil-4.4.2-cp27-cp27m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/Shapely-1.5.17.post1-cp27-cp27m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/docutils-0.12-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/futures-3.0.5-py2-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/Django-1.8.17-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/requests-2.9.1-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/pyshp-1.2.3-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/PyYAML-3.12-cp27-cp27m-macosx_10_6_intel.whl
 
 ## Extra ##
 
@@ -32,9 +32,9 @@ http://ftp.openquake.org/wheelhouse/macos/py27/PyYAML-3.12-cp27-cp27m-macosx_10_
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-http://ftp.openquake.org/wheelhouse/macos/py27/matplotlib-1.5.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py/pyparsing-2.1.10-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/python_dateutil-2.6.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/pyproj-1.9.5.1-cp27-cp27m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/basemap-1.1.0-cp27-cp27m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/matplotlib-1.5.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/cycler-0.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/pyproj-1.9.5.1-cp27-cp27m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/basemap-1.1.0-cp27-cp27m-macosx_10_6_intel.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -6,53 +6,53 @@
 # We also provide pre-compiled manylinux1 wheels for
 # h5py, Shapely, psutil, Rtree, PyYAML, Basemap
 
-http://ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/pkgconfig-1.1.0-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/h5py-2.7.0-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/nose-1.3.7-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/numpy-1.11.1-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/psutil-3.4.2-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/Shapely-1.5.13-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/docutils-0.12-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/Django-1.8.17-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/requests-2.9.1-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/pyshp-1.2.3-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/PyYAML-3.12-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/pkgconfig-1.1.0-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/h5py-2.7.0-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/nose-1.3.7-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/numpy-1.11.1-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/psutil-3.4.2-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/Shapely-1.5.13-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/docutils-0.12-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/Django-1.8.17-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/requests-2.9.1-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/pyshp-1.2.3-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/PyYAML-3.12-cp35-cp35m-manylinux1_x86_64.whl
 
 ## Extra ##
 
 ### pythn-prctl ###
 # comment the following lines to skip installation
 # of python-prctl (optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py35/python_prctl-1.6.1-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/python_prctl-1.6.1-cp35-cp35m-manylinux1_x86_64.whl
 
 ### Rtree ###
 # comment the following lines to skip installation
 # of Rtree (experimental wheel, optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py35/Rtree-0.8.2-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/Rtree-0.8.2-cp35-cp35m-manylinux1_x86_64.whl
 
 ### Celery ###
 # comment the following lines to skip installation
 # of celery (optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py35/anyjson-0.3.3-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/amqp-1.4.9-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/kombu-3.0.33-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/billiard-3.3.0.22-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/celery-3.1.20-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/anyjson-0.3.3-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/amqp-1.4.9-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/kombu-3.0.33-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/billiard-3.3.0.22-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/celery-3.1.20-py2.py3-none-any.whl
 
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py35/matplotlib-1.5.3-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/pyproj-1.9.5.1-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/basemap-1.1.0-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/matplotlib-1.5.3-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/pyproj-1.9.5.1-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/basemap-1.1.0-cp35-cp35m-manylinux1_x86_64.whl

--- a/requirements-py35-macos.txt
+++ b/requirements-py35-macos.txt
@@ -5,24 +5,24 @@
 
 # GEM Mirror
 
-http://ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/pkgconfig-1.1.0-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/h5py-2.7.0-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/nose-1.3.7-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/numpy-1.11.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/scipy-0.17.1-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/psutil-4.4.2-cp35-cp35m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/Shapely-1.5.17.post1-cp35-cp35m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/docutils-0.12-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/Django-1.8.17-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/requests-2.9.1-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/pyshp-1.2.3-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/PyYAML-3.12-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/pkgconfig-1.1.0-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/h5py-2.7.0-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/nose-1.3.7-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/numpy-1.11.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/scipy-0.17.1-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/psutil-4.4.2-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/Shapely-1.5.17.post1-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/docutils-0.12-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/Django-1.8.17-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/requests-2.9.1-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/pyshp-1.2.3-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/PyYAML-3.12-cp35-cp35m-macosx_10_6_intel.whl
 
 ## Extra ##
 
@@ -31,9 +31,9 @@ http://ftp.openquake.org/wheelhouse/macos/py35/PyYAML-3.12-cp35-cp35m-macosx_10_
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-http://ftp.openquake.org/wheelhouse/macos/py35/matplotlib-1.5.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/pyproj-1.9.5.1-cp35-cp35m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/basemap-1.1.0-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/matplotlib-1.5.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/pyproj-1.9.5.1-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/basemap-1.1.0-cp35-cp35m-macosx_10_6_intel.whl


### PR DESCRIPTION
This uses the `max_curve` functionality in hazardlib.stats. Requires https://github.com/gem/oq-hazardlib/pull/627. Notice that it is now trivial to add any kind of statistical post-processing function with signature `statfunc(rlz_poes, rlz_weights)`.