### PR TITLE
Restored Starmap in build_loss_maps

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -20,12 +20,12 @@ import logging
 import operator
 import itertools
 import collections
-import time
 import numpy
 
 from openquake.baselib.python3compat import zip
 from openquake.baselib.general import AccumDict, block_splitter
 from openquake.hazardlib.stats import compute_stats
+from openquake.commonlib import config
 from openquake.calculators import base, event_based
 from openquake.baselib import parallel
 from openquake.risklib import riskinput, scientific
@@ -204,6 +204,7 @@ def build_loss_maps(assets, builder, getter, rlzs, quantiles, monitor):
     if loss_maps_stats is not None:
         res['loss_maps-stats'] = loss_maps_stats
     return res
+build_loss_maps.shared_dir_on = config.SHARED_DIR_ON
 
 
 @base.calculators.add('event_based_risk')
@@ -221,11 +222,12 @@ class EbrPostCalculator(base.RiskCalculator):
         Save the loss maps by opening and closing the datastore and
         return the total number of stored bytes.
         """
-        for key in res:
-            if key.startswith('loss_maps'):
-                acc += {key: res[key].nbytes}
-                self.datastore[key][res['aids']] = res[key]
-                self.datastore.set_attrs(key, nbytes=acc[key])
+        with self.datastore:
+            for key in res:
+                if key.startswith('loss_maps'):
+                    acc += {key: res[key].nbytes}
+                    self.datastore[key][res['aids']] = res[key]
+                    self.datastore.set_attrs(key, nbytes=acc[key])
         return acc
 
     def execute(self):
@@ -253,25 +255,19 @@ class EbrPostCalculator(base.RiskCalculator):
                 self.datastore.create_dset(
                     'loss_maps-stats', builder.loss_maps_dt, (A, S),
                     fillvalue=None)
-            # NB: we must fork here and not before,
-            # otherwise the 'all_loss_ratios' dataset is not seen by the
-            # children; this is why the regular Starmap would not work here;
-            # also, in this way everything is local and there is no need
-            # to use a shared directory; the calculation is fast enough
-            # (minutes) even for the largest event based I ever saw
-            lrgetter.dstore.close()  # this is essential on the cluster
-
-            # we sleep a bit to fight against IOError:
-            # Can't read data (Wrong b-tree signature)
-            # that seems to happen only with Python 2
-            time.sleep(.1)
-
             mon = self.monitor('loss maps')
-            parallel.Processmap.apply(
+            # NB: a regular Starmap does not work on a single machine since
+            # the 'all_loss_ratios' dataset is not seen by the
+            # children (looks like a bug in hdf5); we use a Processmap instead
+            Starmap = (parallel.Processmap
+                       if parallel.oq_distribute() == 'futures'
+                       else parallel.Starmap)
+            self.datastore.close()  # this is essential
+            Starmap.apply(
                 build_loss_maps,
                 (assetcol, builder, lrgetter, rlzs, quantiles, mon)
             ).reduce(self.save_loss_maps)
-            lrgetter.dstore.open()
+            self.datastore.open()
 
         # build an aggregate loss curve per realization
         if 'agg_loss_table' in self.datastore:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -265,7 +265,8 @@ class EbrPostCalculator(base.RiskCalculator):
             self.datastore.close()  # this is essential
             Starmap.apply(
                 build_loss_maps,
-                (assetcol, builder, lrgetter, rlzs, quantiles, mon)
+                (assetcol, builder, lrgetter, rlzs, quantiles, mon),
+                self.oqparam.concurrent_tasks
             ).reduce(self.save_loss_maps)
             self.datastore.open()
 


### PR DESCRIPTION
It seems that by closing the child datastore the full `Starmap` can be used in a cluster (i.e. there are no more reading errors in the workers). Without this change the `IOError: Can't read data (Wrong b-tree signature)` was still present, even with Python 3 and even with a `time.sleep`.
Jenkins is happy too: https://ci.openquake.org/job/zdevel_oq-engine/2479
Hopefully this solves also the random error on Jenkins: https://ci.openquake.org/job/master_oq-engine/3419/console