### PR TITLE
Renamed the parameter `all_losses` to `asset_loss_table`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Renamed the parameter `all_losses` to `asset_loss_table`
   * Added an experimental version of the event based risk calculator which
     is able to use GMFs imported from an external file
   * Added a `max_curve` functionality to compute the upper limit of the

--- a/doc/manual/oqum/risk/02_config_scenario_risk.tex
+++ b/doc/manual/oqum/risk/02_config_scenario_risk.tex
@@ -86,8 +86,8 @@ The remaining new parameters introduced in this example are the following:
     insurance limits and deductibles must be listed for each asset in the 
     exposure model, as described in Example~5 in Section~\ref{sec:exposure}.
 
-  \item \Verb+all_losses+: this parameter was introduced in \glsdesc{acr:oqe22}
-    and specifies whether the individual asset and portfolio losses should be
+  \item \Verb+asset_loss_table+: this parameter
+    specifies whether the individual asset and portfolio losses should be
     stored for each realization; the default value of this parameter is
     \Verb+false+ and only mean and standard deviation of the portfolio losses
     across all realizations are stored. If this flag is set to \Verb+true+, a

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -57,7 +57,7 @@ def scenario_risk(riskinput, riskmodel, param, monitor):
     L = len(riskmodel.loss_types)
     R = len(riskinput.rlzs)
     I = param['insured_losses'] + 1
-    all_losses = param['all_losses']
+    asset_loss_table = param['asset_loss_table']
     lbt = AccumDict(accum=numpy.zeros((R, L * I), F32))
     result = dict(agg=numpy.zeros((E, R, L * I), F32), avg=[],
                   losses_by_taxon=lbt, all_losses=AccumDict(accum={}))
@@ -77,7 +77,7 @@ def scenario_risk(riskinput, riskmodel, param, monitor):
             agglosses = losses.sum(axis=0)  # shape E, I
             for i in range(I):
                 result['agg'][:, r, l + L * i] += agglosses[:, i]
-            if all_losses:
+            if asset_loss_table:
                 aids = [asset.ordinal for asset in outputs.assets]
                 result['all_losses'][l, r] += AccumDict(zip(aids, losses))
     return result
@@ -115,7 +115,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
         self.riskinputs = self.build_riskinputs('gmf', hazard_by_rlz, eps)
         self.param['number_of_ground_motion_fields'] = E
         self.param['insured_losses'] = self.oqparam.insured_losses
-        self.param['all_losses'] = self.oqparam.all_losses
+        self.param['asset_loss_table'] = self.oqparam.asset_loss_table
 
     def post_execute(self, result):
         """
@@ -156,7 +156,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
             # losses by event
             self.datastore['losses_by_event'] = res  # shape (E, R, LI)
 
-            if self.oqparam.all_losses:
+            if self.oqparam.asset_loss_table:
                 array = numpy.zeros((A, E, R), loss_dt)
                 for (l, r), losses_by_aid in result['all_losses'].items():
                     for aid in losses_by_aid:

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -24,7 +24,7 @@ import numpy
 from openquake.baselib import parallel
 from openquake.baselib.general import DictArray
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib import correlation, stats, probability_map
+from openquake.hazardlib import correlation, stats
 from openquake.hazardlib import valid, InvalidFile
 from openquake.commonlib import logictree
 from openquake.commonlib.riskmodels import get_risk_files
@@ -41,7 +41,7 @@ class OqParam(valid.ParamSet):
         z2pt5='reference_depth_to_2pt5km_per_sec',
         backarc='reference_backarc',
     )
-    all_losses = valid.Param(valid.boolean, False)
+    asset_loss_table = valid.Param(valid.boolean, False)
     area_source_discretization = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
     asset_correlation = valid.Param(valid.NoneOr(valid.FloatRange(0, 1)), 0)

--- a/openquake/qa_tests_data/scenario_risk/case_1/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_1/job_risk.ini
@@ -12,4 +12,4 @@ region_constraint =  15.48 38.30, 15.63 38.30,  15.63 38.01,  15.48 38.01
 export_dir = /tmp/
 
 insured_losses = true
-all_losses = true
+asset_loss_table = true

--- a/openquake/qa_tests_data/scenario_risk/case_6a/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_6a/job_risk.ini
@@ -17,5 +17,5 @@ structural_vulnerability_file = structural_vulnerability_model.xml
 
 [calculation]
 insured_losses = False
-all_losses = True
+asset_loss_table = True
 export_dir = /tmp

--- a/openquake/qa_tests_data/scenario_risk/case_7/job.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_7/job.ini
@@ -13,7 +13,7 @@ number_of_ground_motion_fields = 11
 gmfs_csv = GMF_results_smallTest.txt
 
 [outputs]
-all_losses = true
+asset_loss_table = true
 
 [export]
 export_dir = /tmp

--- a/openquake/qa_tests_data/scenario_risk/case_master/job.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_master/job.ini
@@ -48,7 +48,7 @@ asset_correlation = 0.0
 
 [risk_outputs]
 insured_losses = true
-all_losses = true
+asset_loss_table = true
 
 [export]
 export_dir = ./


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2658. This is preliminary to https://github.com/gem/oq-engine/issues/2720. I want to have the same name for the parameter, both for the scenario_risk and event_based_risk calculators. The data are stored differently in the two calculators but the meaning is the same: if the user sets this parameter to true there will be enough information in the datastore to get the losses for all assets and all events.