### PR TITLE
Remove an old, wrong check about Django

### DIFF
--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -106,10 +106,6 @@ class EngineServerTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if django.get_version() < '1.5':
-            # Django too old
-            raise unittest.SkipTest('webui tests do not run with Diango < 1.5')
-
         cls.job_ids = []
         env = os.environ.copy()
         env['OQ_DISTRIBUTE'] = 'no'


### PR DESCRIPTION
While investigatin issues with the DbServer on macOS, I discovered that the WebUI related tests are skipped by CI on macOS due a wrong check, so I propose to remove it.

Django < 1.5 isn't supported at all now, and the dependency filter is made by `setup.py`. At the same time this check was preventing the WebUI tests to run against Django >= 1.10 (see https://ci.openquake.org/job/macos/job/master_mac_oq-engine/349/console) cause:

```python
In [1]: '1.10' < '1.5'
Out[1]: True
```

https://ci.openquake.org/job/macos/job/zdevel_mac_oq-engine/95/