### PR TITLE
Fix an issue with Travis branches when submitting PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ addons:
 
 install:
   - pip install -r requirements-py35-linux64.txt
-  - if [ "$(git ls-remote --heads https://github.com/gem/oq-hazardlib.git ${TRAVIS_BRANCH})" != "" ]; then BRANCH=$TRAVIS_BRANCH; else BRANCH='master'; fi; git clone -b ${BRANCH} --depth=1 https://github.com/gem/oq-hazardlib.git && echo "Running on oq-hazardlib/${BRANCH}"
+  - if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else BRANCH=$TRAVIS_BRANCH; fi
+  - if [ "$(git ls-remote --heads https://github.com/gem/oq-hazardlib.git ${BRANCH})" == "" ]; then BRANCH='master'; fi; git clone -b ${BRANCH} --depth=1 https://github.com/gem/oq-hazardlib.git && echo "Running on oq-hazardlib/${BRANCH}"
   - pip install -e oq-hazardlib/
   - pip install -e .
 


### PR DESCRIPTION
Travis uses different env vars to identify a branch when a PR is opened or when a build is made upon a push on a branch:

> `TRAVIS_BRANCH`:
>     for push builds, or builds not triggered by a pull request, this is the name of the branch.
>     for **builds triggered by a pull request this is the name of the branch targeted by the pull request**.

> `TRAVIS_PULL_REQUEST_BRANCH:`
>     if the current job is a pull request, the name of the branch from which the PR originated.
>     if the current job is a push build, this variable is empty ("").

from https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables

This means that in certain cases the PR is built against hazardlib/master: see for example https://travis-ci.org/gem/oq-engine/builds/229872417 (from https://github.com/gem/oq-engine/pull/2774 which has a companion on hazardlib) that says:

```
Running on oq-hazardlib/master
```

This PR makes use of the proper variable. This was discovered testing RMTK on Docker on Travis.


