### PR TITLE
Keep the association between rupture and events consistent

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -311,8 +311,7 @@ def set_random_years(dstore, events_sm, investigation_time):
     SES ordinal and the investigation time.
     """
     events = dstore[events_sm].value
-    events.sort(order='eid')
-    eids = events['eid']
+    eids = numpy.sort(events['eid'])
     years = numpy.random.choice(investigation_time, len(events)) + 1
     year_of = dict(zip(eids, years))
     for event in events:

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -632,6 +632,10 @@ class EBRupture(object):
                 new.lons[3], new.lats[3], new.depths[3])
             yield new
 
+    def __repr__(self):
+        return '<%s %d%s>' % (
+            self.__class__.__name__, self.serial, self.events['eid'])
+
 
 class RuptureSerializer(object):
     """


### PR DESCRIPTION
Very recently we introduced a test (case_7a) for event based risk with two configuration files `job_h.ini`
and `job_r.ini`. In such a case the `--hc` option is exercised. Therefore a previously unsolicited bug appeared, causing Jenkins to fail (see https://ci.openquake.org/job/master_oq-engine/3468/console).
The issue was extremely subtle. The ordering in which the ruptures and events are stored is random, since it depends on the ordering of the tasks. We had a call `events.sort(order='eid')` reordering the stored events without reordering the stored ruptures so we could randomly break the association rupture <-> events. The solution was to remove the sort which was not needed, since it is done in the exporter, anyway.

Jenkins is green now: https://ci.openquake.org/job/zdevel_oq-engine/2507/