### PR TITLE
Setting the years in the events dataset only once

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -283,14 +283,13 @@ class EventBasedRuptureCalculator(PSHACalculator):
         """
         Save the SES collection
         """
-        if hasattr(self, 'rupser'):
-            self.rupser.close()
-            with self.monitor('setting event years', measuremem=True,
-                              autoflush=True):
-                inv_time = int(self.oqparam.investigation_time)
-                numpy.random.seed(self.oqparam.ses_seed)
-                for sm in sorted(self.datastore['events']):
-                    set_random_years(self.datastore, 'events/' + sm, inv_time)
+        self.rupser.close()
+        with self.monitor('setting event years', measuremem=True,
+                          autoflush=True):
+            inv_time = int(self.oqparam.investigation_time)
+            numpy.random.seed(self.oqparam.ses_seed)
+            for sm in sorted(self.datastore['events']):
+                set_random_years(self.datastore, 'events/' + sm, inv_time)
         num_events = sum(_count(ruptures) for ruptures in result.values())
         if num_events == 0:
             raise RuntimeError(

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -284,18 +284,18 @@ class EventBasedRuptureCalculator(PSHACalculator):
         Save the SES collection
         """
         self.rupser.close()
-        with self.monitor('setting event years', measuremem=True,
-                          autoflush=True):
-            inv_time = int(self.oqparam.investigation_time)
-            numpy.random.seed(self.oqparam.ses_seed)
-            for sm in sorted(self.datastore['events']):
-                set_random_years(self.datastore, 'events/' + sm, inv_time)
         num_events = sum(_count(ruptures) for ruptures in result.values())
         if num_events == 0:
             raise RuntimeError(
                 'No seismic events! Perhaps the investigation time is too '
                 'small or the maximum_distance is too small')
         logging.info('Setting %d event years', num_events)
+        with self.monitor('setting event years', measuremem=True,
+                          autoflush=True):
+            inv_time = int(self.oqparam.investigation_time)
+            numpy.random.seed(self.oqparam.ses_seed)
+            for sm in sorted(self.datastore['events']):
+                set_random_years(self.datastore, 'events/' + sm, inv_time)
         h5 = self.datastore.hdf5
         if 'ruptures' in h5:
             self.datastore.set_nbytes('ruptures')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -285,18 +285,18 @@ class EventBasedRuptureCalculator(PSHACalculator):
         """
         if hasattr(self, 'rupser'):
             self.rupser.close()
+            with self.monitor('setting event years', measuremem=True,
+                              autoflush=True):
+                inv_time = int(self.oqparam.investigation_time)
+                numpy.random.seed(self.oqparam.ses_seed)
+                for sm in sorted(self.datastore['events']):
+                    set_random_years(self.datastore, 'events/' + sm, inv_time)
         num_events = sum(_count(ruptures) for ruptures in result.values())
         if num_events == 0:
             raise RuntimeError(
                 'No seismic events! Perhaps the investigation time is too '
                 'small or the maximum_distance is too small')
         logging.info('Setting %d event years', num_events)
-        with self.monitor('setting event years', measuremem=True,
-                          autoflush=True):
-            inv_time = int(self.oqparam.investigation_time)
-            numpy.random.seed(self.oqparam.ses_seed)
-            for sm in sorted(self.datastore['events']):
-                set_random_years(self.datastore, 'events/' + sm, inv_time)
         h5 = self.datastore.hdf5
         if 'ruptures' in h5:
             self.datastore.set_nbytes('ruptures')

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -604,8 +604,6 @@ class EbriskCalculator(base.RiskCalculator):
         """
         Save risk data and possibly execute the EbrPostCalculator
         """
-        event_based.EventBasedRuptureCalculator.__dict__['post_execute'](
-            self, num_events)
         # gmv[:-2] are the total gmv per each IMT
         gmv = sum(gm[:-2].sum() for gm in self.gmdata.values())
         if not gmv:


### PR DESCRIPTION
The same operation was done twice in event based calculations (both in hazard and risk, while it is enough to do it in the hazard part).