### PR TITLE
Using rtree to get the site model parameters

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -28,7 +28,7 @@ import collections
 import numpy
 
 from openquake.hazardlib import __version__ as hazardlib_version
-from openquake.hazardlib.geo import geodetic
+from openquake.hazardlib import geo
 from openquake.baselib import general, hdf5
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib.calc.filters import SourceFilter
@@ -341,7 +341,7 @@ class HazardCalculator(BaseCalculator):
         for some sites.
         """
         maximum_distance = self.oqparam.asset_hazard_distance
-        siteobjects = geodetic.GeographicObjects(
+        siteobjects = geo.utils.GeographicObjects(
             Site(sid, lon, lat) for sid, lon, lat in
             zip(sitecol.sids, sitecol.lons, sitecol.lats))
         assets_by_sid = general.AccumDict()

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -230,7 +230,7 @@ def get_site_model(oqparam):
         yield valid.site_param(**node.attrib)
 
 
-def get_site_collection(oqparam, mesh=None, site_model_params=None):
+def get_site_collection(oqparam, mesh=None):
     """
     Returns a SiteCollection instance by looking at the points and the
     site model defined by the configuration parameters.
@@ -240,9 +240,6 @@ def get_site_collection(oqparam, mesh=None, site_model_params=None):
     :param mesh:
         a mesh of hazardlib points; if None the mesh is
         determined by invoking get_mesh
-    :param site_model_params:
-        object with a method .get_closest returning the closest site
-        model parameters
     """
     if mesh is None:
         mesh = get_mesh(oqparam)
@@ -257,10 +254,9 @@ def get_site_collection(oqparam, mesh=None, site_model_params=None):
                     pt, param.vs30, param.measured,
                     param.z1pt0, param.z2pt5, param.backarc))
             return site.SiteCollection(sitecol)
-        if site_model_params is None:
-            # read the parameters directly from their file
-            site_model_params = geo.geodetic.GeographicObjects(
-                get_site_model(oqparam))
+        # read the parameters directly from their file
+        site_model_params = geo.geodetic.GeographicObjects(
+            get_site_model(oqparam))
         for pt in mesh:
             # attach the closest site model params to each site
             param, dist = site_model_params.get_closest(

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -255,7 +255,7 @@ def get_site_collection(oqparam, mesh=None):
                     param.z1pt0, param.z2pt5, param.backarc))
             return site.SiteCollection(sitecol)
         # read the parameters directly from their file
-        site_model_params = geo.geodetic.GeographicObjects(
+        site_model_params = geo.utils.GeographicObjects(
             get_site_model(oqparam))
         for pt in mesh:
             # attach the closest site model params to each site


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2586. The performance improvement is of over 20 times in the example of the cas_model_HAZUS100/VS_USGS. Requires https://github.com/gem/oq-hazardlib/pull/640.