### PR TITLE
oq webui start tries to open the browser

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Now the command `oq webui start` tries to open a browser tab
+    with the WebUI loaded
+
 python-oq-engine (2.4.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]

--- a/doc/installing/linux-generic.md
+++ b/doc/installing/linux-generic.md
@@ -89,6 +89,7 @@ to start the [WebUI](../running/server.md) use instead
 ```bash
 oq webui start
 ```
+The WebUI will be started and a new browser window will be opened.
 
 More information are available on [How to run the OpenQuake Engine](../running/unix.md) and [The OpenQuake Engine server and WebUI](../running/server.md).
 

--- a/doc/installing/macos.md
+++ b/doc/installing/macos.md
@@ -78,6 +78,7 @@ to start the [WebUI](../running/server.md) use instead
 ```bash
 oq webui start
 ```
+The WebUI will be started and a new browser window will be opened.
 
 More information are available on [How to run the OpenQuake Engine](../running/unix.md) and [The OpenQuake Engine server and WebUI](../running/server.md).
 


### PR DESCRIPTION
`oq webui start` now tries to open a browser tab pointing to the WebUI.

The browser starts only when the WebUI is up and running and responding to the requests. On headless servers this does not change normal behavior; the open browser feature can be also turned off passing the `--skip-browser` flag to the command:

`oq webui start --skip-browser`