### PR TITLE
Add more commands to webui plus some fixes to doc

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md LICENSE CONTRIBUTORS.txt
 include openquake/engine/openquake.cfg
+include openquake/server/local_settings.py.pam
 include openquake/server/local_settings.py.standalone
 
 recursive-include openquake/server/db *.sql

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,8 @@
   [Daniele Viganò]
+  * Added `collectstatic` and `createsuperuser` subcommands to the
+    `oq webui` command
+  * Added a `local_settings.py.pam` template to use PAM as the authentication
+    provider for API and WebUI
   * Now the command `oq webui start` tries to open a browser tab
     with the WebUI loaded
 

--- a/debian/supervisord/openquake-webui.conf
+++ b/debian/supervisord/openquake-webui.conf
@@ -5,7 +5,7 @@ directory=/usr/share/openquake/engine
 ; Using embedded django server
 command=/usr/bin/env python -m openquake.server.manage runserver 127.0.0.1:8800 --noreload
 ; Using gunicorn (Nginx or another webserver is needed for static content)
-; command=/usr/bin/env gunicorn -w 2 openquake.server.wsgi:application
+; command=/opt/openquake/bin/gunicorn -w 2 openquake.server.wsgi:application
 user=openquake
 group=openquake
 stdout_logfile=/var/log/openquake/webui.log

--- a/doc/installing/server.md
+++ b/doc/installing/server.md
@@ -45,6 +45,8 @@ This feature is available on _Linux only_ and the WebUI process owner must be me
 
 On a production system [nginx](http://nginx.org/en/) + [gunicorn](http://gunicorn.org/) is the recommended software stack to run the WebUI.
 
+When packages are used, the custom `local_settings.py` file should be placed in `/usr/share/openquake/engine` to avoid conflicts when packages are upgraded.
+
 #### gunicorn
 
 *gunicorn* can be installed either via `pip` or via the system packager (`apt`, `yum`, ...). When using `python-oq-libs` for RedHat or Debian *gunicorn* is already provided.

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -26,6 +26,9 @@ from openquake.commonlib import config
 from openquake.server import dbserver
 from openquake.server.utils import check_webserver_running
 
+# syncdb is left for backward compatibility with Django 1.6
+commands = ['start', 'migrate', 'syncdb', 'createsuperuser', 'collectstatic']
+
 
 def rundjango(subcmd, hostport=None, skip_browser=False):
     args = [sys.executable, '-m', 'openquake.server.manage', subcmd]
@@ -53,12 +56,9 @@ def webui(cmd, hostport='127.0.0.1:8800', skip_browser=False):
     if cmd == 'start':
         dbserver.ensure_on()  # start the dbserver in a subproces
         rundjango('runserver', hostport, skip_browser)
-    elif cmd == 'migrate':
-        rundjango('migrate')
-    # For backward compatibility with Django 1.6
-    elif cmd == 'syncdb':
-        rundjango('syncdb')
+    elif cmd in commands:
+        rundjango(cmd)
 
-webui.arg('cmd', 'webui command', choices='start migrate syncdb'.split())
+webui.arg('cmd', 'webui command', choices=commands)
 webui.arg('hostport', 'a string of the form <hostname:port>')
 webui.flg('skip_browser', 'do not automatically open the browser')

--- a/openquake/server/local_settings.py.pam
+++ b/openquake/server/local_settings.py.pam
@@ -10,6 +10,6 @@ INSTALLED_APPS += (
     'django_pam',
 )
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS += (
     'django_pam.auth.backends.PAMBackend',
 )

--- a/rpm/systemd/openquake-webui.service
+++ b/rpm/systemd/openquake-webui.service
@@ -10,7 +10,7 @@ Environment=PYTHONPATH=/opt/openquake/lib/python2.7/site-packages
 WorkingDirectory=/usr/share/openquake/engine
 ExecStart=/usr/bin/env python -m openquake.server.manage runserver 127.0.0.1:8800 --noreload
 # Using gunicorn (Nginx or another webserver is needed for static content)
-# ExecStart=/usr/bin/env gunicorn -w 2 openquake.server.wsgi:application
+# ExecStart=/opt/openquake/bin/gunicorn -w 2 openquake.server.wsgi:application
 Restart=always
 RestartSec=30
 KillMode=control-group


### PR DESCRIPTION
This PR adds more commands to the WebUI command because those commands are useful when packages are used and the `python -m` way is hard to use (because of `/opt` and the `PYTHONPATH`).

Improves also the documentation

Closes #2827 