### PR TITLE
Do not skip writing the `ruptureId` for the first event

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a bug when exporting a GMF with `ruptureId=0`
   * Added a parameter `disagg_outputs` to specify the kind of disaggregation
     outputs to export
   * Raised an early error if the consequence model is missing some taxonomies

--- a/openquake/commonlib/hazard_writers.py
+++ b/openquake/commonlib/hazard_writers.py
@@ -285,7 +285,7 @@ def gen_gmfs(gmf_set):
             gmf_node['saPeriod'] = str(gmf.sa_period)
             gmf_node['saDamping'] = str(gmf.sa_damping)
         eid = gmf.rupture_id
-        if eid:
+        if eid is not None:
             gmf_node['ruptureId'] = eid
         sorted_nodes = sorted(gmf)
         gmf_node.nodes = (

--- a/openquake/commonlib/hazard_writers.py
+++ b/openquake/commonlib/hazard_writers.py
@@ -284,9 +284,7 @@ def gen_gmfs(gmf_set):
         if gmf.imt == 'SA':
             gmf_node['saPeriod'] = str(gmf.sa_period)
             gmf_node['saDamping'] = str(gmf.sa_damping)
-        eid = gmf.rupture_id
-        if eid is not None:
-            gmf_node['ruptureId'] = eid
+        gmf_node['ruptureId'] = gmf.rupture_id
         sorted_nodes = sorted(gmf)
         gmf_node.nodes = (
             Node('node', dict(gmv=n.gmv, lon=n.location.x, lat=n.location.y))

--- a/openquake/qa_tests_data/scenario/case_1/expected.xml
+++ b/openquake/qa_tests_data/scenario/case_1/expected.xml
@@ -12,6 +12,7 @@ xmlns:gml="http://www.opengis.net/gml"
         >
             <gmf
             IMT="PGA"
+            ruptureId="0"
             >
                 <node gmv="5.1608956E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
                 <node gmv="2.7974805E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>

--- a/openquake/qa_tests_data/scenario/case_9/LinLee2008SSlab_gmf.xml
+++ b/openquake/qa_tests_data/scenario/case_9/LinLee2008SSlab_gmf.xml
@@ -12,6 +12,7 @@ xmlns:gml="http://www.opengis.net/gml"
         >
             <gmf
             IMT="PGA"
+            ruptureId="0"
             >
                 <node gmv="2.9987338E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
                 <node gmv="1.2938629E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>

--- a/openquake/qa_tests_data/scenario/case_9/YoungsEtAl1997SSlab_gmf.xml
+++ b/openquake/qa_tests_data/scenario/case_9/YoungsEtAl1997SSlab_gmf.xml
@@ -12,6 +12,7 @@ xmlns:gml="http://www.opengis.net/gml"
         >
             <gmf
             IMT="PGA"
+            ruptureId="0"
             >
                 <node gmv="4.4088796E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
                 <node gmv="1.5812968E-01" lat="1.0000000E-01" lon="0.0000000E+00"/>


### PR DESCRIPTION
Fixes #2836 