### PR TITLE
Improve `oq db` and remove the non-existing status `successful`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved the command `oq db`
   * Fixed an encoding bug when logging a filename with a non-ASCII character
   * Fixed a bug when exporting a GMF with `ruptureId=0`
   * Added a parameter `disagg_outputs` to specify the kind of disaggregation

--- a/openquake/commands/db.py
+++ b/openquake/commands/db.py
@@ -59,7 +59,7 @@ def db(cmd, args=()):
     else:
         dbserver.ensure_on()
         res = logs.dbcmd(cmd, *convert(args))
-        if hasattr(res, '_fields'):
+        if hasattr(res, '_fields') and res.__class__.__name__ != 'Row':
             print(rst_table(res))
         else:
             print(res)

--- a/openquake/commands/db.py
+++ b/openquake/commands/db.py
@@ -44,7 +44,7 @@ def convert(strings):
 
 
 @sap.Script
-def db(cmd, args):
+def db(cmd, args=()):
     """
     Run a database command
     """

--- a/openquake/commands/db.py
+++ b/openquake/commands/db.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import ast
-import shlex
 import inspect
 from decorator import getfullargspec
 from openquake.baselib import sap
@@ -45,11 +44,10 @@ def convert(strings):
 
 
 @sap.Script
-def db(cmd, args=''):
+def db(cmd, args):
     """
     Run a database command
     """
-    args = shlex.split(args)
     if cmd not in commands:
         okcmds = '\n'.join(
             '%s %s' % (name, repr(' '.join(args)) if args else '')
@@ -67,4 +65,4 @@ def db(cmd, args=''):
             print(res)
 
 db.arg('cmd', 'db command')
-db.arg('args', 'a string of arguments')
+db.arg('args', 'db command arguments', nargs='*')

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -322,7 +322,7 @@ class DbTestCase(unittest.TestCase):
                 'openquake.commonlib.logs.dbcmd', manage.dbcmd):
             db('version_db')
             try:
-                db('calc_info 1')
+                db('calc_info', (1,))
             except dbapi.NotFound:  # happens on an empty db
                 pass
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -60,20 +60,21 @@ def reset_is_running(db):
 
 def set_status(db, job_id, status):
     """
-    Set the status 'created', 'executing', 'successful', 'failed'
+    Set the status 'created', 'executing', 'complete', 'failed'
     consistently with `is_running`.
 
     :param db: a :class:`openquake.server.dbapi.Db` instance
     :param job_id: ID of the current job
     :param status: status string
     """
-    assert status in ('created', 'executing', 'successful', 'failed'), status
-    if status in ('created', 'successful', 'failed'):
+    assert status in ('created', 'executing', 'complete', 'failed'), status
+    if status in ('created', 'complete', 'failed'):
         is_running = 0
     else:  # 'executing'
         is_running = 1
-    db('UPDATE job SET status=?x, is_running=?x WHERE id=?x',
-       status, is_running, job_id)
+    cursor = db('UPDATE job SET status=?x, is_running=?x WHERE id=?x',
+                status, is_running, job_id)
+    return cursor.rowcount
 
 
 def create_job(db, calc_mode, description, user_name, datadir, hc_id=None):
@@ -178,16 +179,9 @@ def list_calculations(db, job_type, user_name):
                '        description')
         for job in jobs:
             descr = job.description
-            if job.is_running:
-                status = 'pending'
-            else:
-                if job.status == 'complete':
-                    status = 'successful'
-                else:
-                    status = 'failed'
             start_time = job.start_time
             yield ('%6d | %10s | %s | %s' % (
-                job.id, status, start_time, descr))
+                job.id, job.status, start_time, descr))
 
 
 def list_outputs(db, job_id, full=True):


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2839. Also, fixes a possible confusion: the name of the job status is `complete`, not `successful`, which is only the printed name.