### PR TITLE
Fixed v1/calc/XXX/oqparam

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made it is possible to pass the hdf5 full path to the DataStore class
   * Made it possible to use CELERY_RESULT_BACKEND != 'rpc://'
 
   [Michele Simionato, Daniele Viganò]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Made it possible to use CELERY_RESULT_BACKEND != 'rpc://'
+
   [Michele Simionato, Daniele Viganò]
   * Merged the `oq-hazardlib` repository into `oq-engine`.
     The `python-oq-hazardlib` package is now provided by `python-oq-engine`

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -571,8 +571,9 @@ class Starmap(object):
                 idx = self.task_ids.index(task_id)
                 self.task_ids.pop(idx)
                 fut = mkfuture(result_dict['result'])
-                # work around a celery bug
-                del app.backend._cache[task_id]
+                # work around a celery/rabbitmq bug
+                if CELERY_RESULT_BACKEND.startswith('rpc:'):
+                    del app.backend._cache[task_id]
                 yield fut
 
         else:  # future interface

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -75,19 +75,33 @@ def hdf5new(datadir=DATADIR):
     return new
 
 
+def extract_calc_id_datadir(hdf5path, datadir=DATADIR):
+    """
+    Extract the calculation ID from the given hdf5path or integer
+    """
+    if hdf5path is None:  # use a new datastore
+        return get_last_calc_id(datadir) + 1, datadir
+    try:
+        calc_id = int(hdf5path)
+    except TypeError:
+        datadir = os.path.dirname(hdf5path)
+        mo = re.match('calc_(\d+)\.hdf5', os.path.basename(hdf5path))
+        if mo is None:
+            raise ValueError('Cannot extract calc_id from %s' % hdf5path)
+        calc_id = int(mo.group(1))
+    else:
+        return calc_id, datadir
+
+
 def read(calc_id, mode='r', datadir=DATADIR):
     """
-    :param calc_id: calculation ID
+    :param calc_id: calculation ID or hdf5path
     :param mode: 'r' or 'w'
     :param datadir: the directory where to look
     :returns: the corresponding DataStore instance
 
     Read the datastore, if it exists and it is accessible.
     """
-    if calc_id < 0:  # retrieve an old datastore
-        calc_id = get_calc_ids(datadir)[calc_id]
-    fname = os.path.join(datadir, 'calc_%s.hdf5' % calc_id)
-    open(fname).close()  # check if the file exists and is accessible
     dstore = DataStore(calc_id, datadir, mode=mode)
     try:
         hc_id = dstore['oqparam'].hazard_calculation_id
@@ -126,11 +140,10 @@ class DataStore(collections.MutableMapping):
     """
     def __init__(self, calc_id=None, datadir=DATADIR,
                  params=(), mode=None):
+        calc_id, datadir = extract_calc_id_datadir(calc_id, datadir)
         if not os.path.exists(datadir):
             os.makedirs(datadir)
-        if calc_id is None:  # use a new datastore
-            self.calc_id = get_last_calc_id(datadir) + 1
-        elif calc_id < 0:  # use an old datastore
+        if calc_id < 0:  # use an old datastore
             calc_ids = get_calc_ids(datadir)
             try:
                 self.calc_id = calc_ids[calc_id]

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -77,20 +77,22 @@ def hdf5new(datadir=DATADIR):
 
 def extract_calc_id_datadir(hdf5path, datadir=DATADIR):
     """
-    Extract the calculation ID from the given hdf5path or integer
+    Extract the calculation ID from the given hdf5path or integer:
+
+    >>> extract_calc_id_datadir('/mnt/ssd/oqdata/calc_25.hdf5')
+    (25, '/mnt/ssd/oqdata')
     """
     if hdf5path is None:  # use a new datastore
         return get_last_calc_id(datadir) + 1, datadir
     try:
         calc_id = int(hdf5path)
-    except TypeError:
+    except:
         datadir = os.path.dirname(hdf5path)
         mo = re.match('calc_(\d+)\.hdf5', os.path.basename(hdf5path))
         if mo is None:
             raise ValueError('Cannot extract calc_id from %s' % hdf5path)
         calc_id = int(mo.group(1))
-    else:
-        return calc_id, datadir
+    return calc_id, datadir
 
 
 def read(calc_id, mode='r', datadir=DATADIR):

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -81,6 +81,10 @@ def extract_calc_id_datadir(hdf5path, datadir=DATADIR):
 
     >>> extract_calc_id_datadir('/mnt/ssd/oqdata/calc_25.hdf5')
     (25, '/mnt/ssd/oqdata')
+    >>> extract_calc_id_datadir('/mnt/ssd/oqdata/wrong_name.hdf5')
+    Traceback (most recent call last):
+       ...
+    ValueError: Cannot extract calc_id from /mnt/ssd/oqdata/wrong_name.hdf5
     """
     if hdf5path is None:  # use a new datastore
         return get_last_calc_id(datadir) + 1, datadir

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -164,6 +164,8 @@ class DataStore(collections.MutableMapping):
         self.datadir = datadir
         self.calc_dir = os.path.join(datadir, 'calc_%s' % self.calc_id)
         self.hdf5path = self.calc_dir + '.hdf5'
+        if mode == 'r' and not os.path.exists(self.hdf5path):
+            raise IOError('File not found: %s' % self.hdf5path)
         self.hdf5 = None
         self.open()
 

--- a/openquake/commonlib/tests/datastore_test.py
+++ b/openquake/commonlib/tests/datastore_test.py
@@ -76,7 +76,7 @@ class DataStoreTestCase(unittest.TestCase):
 
     def test_read(self):
         # cas of a non-existing directory
-        with self.assertRaises(IOError):
+        with self.assertRaises(OSError):
             read(42, datadir='/fake/directory')
         # case of a non-existing file
         with self.assertRaises(IOError):
@@ -88,4 +88,4 @@ class DataStoreTestCase(unittest.TestCase):
         os.chmod(fname, 0)
         with self.assertRaises(IOError) as ctx:
             read(42, datadir=tmp)
-        self.assertIn('Permission denied:', str(ctx.exception))
+        self.assertIn('permission denied', str(ctx.exception).lower())

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -600,7 +600,7 @@ def get_oqparam(request, job_id):
         job = logs.dbcmd('get_job', int(job_id), getpass.getuser())
     except dbapi.NotFound:
         return HttpResponseNotFound()
-    with datastore.read(job.id) as ds:
+    with datastore.read(job.ds_calc_dir + '.hdf5') as ds:
         oq = ds['oqparam']
     return HttpResponse(content=json.dumps(vars(oq)), content_type=JSON)
 


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2805: it was not working on Wilson since the wrong `datadir` was inferred. Now we pass to the DataStore class the full path of the datastore.