### PR TITLE
Fixed parallel.Starmap for non-rpc backends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Made it possible to use CELERY_RESULT_BACKEND != 'rpc://'
+
   [Michele Simionato, Daniele Viganò]
   * Merged the `oq-hazardlib` repository into `oq-engine`.
     The `python-oq-hazardlib` package is now provided by `python-oq-engine`

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -571,8 +571,9 @@ class Starmap(object):
                 idx = self.task_ids.index(task_id)
                 self.task_ids.pop(idx)
                 fut = mkfuture(result_dict['result'])
-                # work around a celery bug
-                del app.backend._cache[task_id]
+                # work around a celery/rabbitmq bug
+                if CELERY_RESULT_BACKEND.startswith('rpc:'):
+                    del app.backend._cache[task_id]
                 yield fut
 
         else:  # future interface


### PR DESCRIPTION
This is useful when using Redis as Celery backend.