### PR TITLE
Removed the composite_source_model from the datastore

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the pickled CompositeSourceModel from the datastore
   * Improved the error message when the rupture mesh spacing is too small
   * Unified the versions of baselib, hazardlib and engine
   * Raised a clear error if the user does not set the `calculation_mode`

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -134,7 +134,6 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
     sitecol = datastore.persistent_attribute('sitecol')
     assetcol = datastore.persistent_attribute('assetcol')
     performance = datastore.persistent_attribute('performance')
-    csm = datastore.persistent_attribute('composite_source_model')
     pre_calculator = None  # to be overridden
     is_stochastic = False  # True for scenario and event based calculators
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -231,6 +231,7 @@ class EventBasedRuptureCalculator(PSHACalculator):
         self.min_iml = calc.fix_minimum_intensity(
             oq.minimum_intensity, oq.imtls)
         self.rupser = calc.RuptureSerializer(self.datastore)
+        self.csm_info = self.datastore['csm_info']
 
     def zerodict(self):
         """
@@ -239,7 +240,7 @@ class EventBasedRuptureCalculator(PSHACalculator):
         zd = AccumDict()
         zd.calc_times = []
         zd.eff_ruptures = AccumDict()
-        self.grp_trt = self.csm.info.grp_trt()
+        self.grp_trt = self.csm_info.grp_trt()
         return zd
 
     def agg_dicts(self, acc, ruptures_by_grp_id):
@@ -482,8 +483,9 @@ class EventBasedCalculator(ClassicalCalculator):
             ruptures_by_grp = (self.precalc.result if self.precalc
                                else get_ruptures_by_grp(self.datastore.parent))
 
+        self.csm_info = self.datastore['csm_info']
         self.sm_id = {tuple(sm.path): sm.ordinal
-                      for sm in self.csm.info.source_models}
+                      for sm in self.csm_info.source_models}
         L = len(oq.imtls.array)
         rlzs = self.rlzs_assoc.realizations
         res = parallel.Starmap(

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -390,7 +390,7 @@ class EbriskCalculator(base.RiskCalculator):
         :param monitor: a Monitor instance
         :returns: an IterResult instance
         """
-        csm_info = self.csm.info.get_info(sm_id)
+        csm_info = self.csm_info.get_info(sm_id)
         grp_ids = sorted(csm_info.get_sm_by_grp())
         rlzs_assoc = csm_info.get_rlzs_assoc()
         num_events = sum(ebr.multiplicity for grp in ruptures_by_grp
@@ -480,6 +480,7 @@ class EbriskCalculator(base.RiskCalculator):
             EbrPostCalculator(self).run(close=False)
             return
 
+        self.csm_info = self.datastore['csm_info']
         with self.monitor('reading ruptures', autoflush=True):
             ruptures_by_grp = (
                 self.precalc.result if self.precalc
@@ -489,8 +490,8 @@ class EbriskCalculator(base.RiskCalculator):
                 ruptures_by_grp[grp].sort(key=operator.attrgetter('serial'))
         num_rlzs = 0
         allres = []
-        source_models = self.csm.info.source_models
-        self.sm_by_grp = self.csm.info.get_sm_by_grp()
+        source_models = self.csm_info.source_models
+        self.sm_by_grp = self.csm_info.get_sm_by_grp()
         for i, args in enumerate(self.gen_args(ruptures_by_grp)):
             ires = self.start_tasks(*args)
             allres.append(ires)

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -767,11 +767,11 @@ class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
         self.csm = get_composite_source_model(oq)
         logging.info('Found %d source model logic tree branches',
                      len(self.csm.source_models))
-        self.datastore['csm_info'] = self.csm.info
-        self.rlzs_assoc = self.csm.info.get_rlzs_assoc()
+        self.datastore['csm_info'] = self.csm_info = self.csm.info
+        self.rlzs_assoc = self.csm_info.get_rlzs_assoc()
         self.infos = []
         self.eid = collections.Counter()  # sm_id -> event_id
-        self.sm_by_grp = self.csm.info.get_sm_by_grp()
+        self.sm_by_grp = self.csm_info.get_sm_by_grp()
         if not self.oqparam.imtls:
             raise ValueError('Missing intensity_measure_types!')
         self.rupser = calc.RuptureSerializer(self.datastore)
@@ -886,7 +886,7 @@ class UCERFRiskCalculator(EbriskCalculator):
 
     def execute(self):
         num_rlzs = len(self.rlzs_assoc.realizations)
-        self.grp_trt = self.csm.info.grp_trt()
+        self.grp_trt = self.csm_info.grp_trt()
         res = parallel.Starmap(compute_losses, self.gen_args()).submit_all()
         self.vals = self.assetcol.values()
         num_events = self.save_results(res, num_rlzs)

--- a/openquake/commands/to_hdf5.py
+++ b/openquake/commands/to_hdf5.py
@@ -3,7 +3,7 @@ import os
 import logging
 import numpy
 from openquake.baselib import sap, hdf5, node, performance
-from openquake.hazardlib import nrml, sourceconverter
+from openquake.hazardlib import nrml
 
 
 def convert_npz_hdf5(input_file, output_file):
@@ -24,7 +24,6 @@ def convert_xml_hdf5(input_file, output_file):
             sm = inp.sourceModel
         else:  # not a NRML
             raise ValueError('Unknown NRML:' % inp['xmlns'])
-        sourceconverter.update_source_model(sm)
         out.save(node.node_to_dict(sm))
     return output_file
 


### PR DESCRIPTION
It was the last pickled object in the datastore. Since it was not really used, it was easy to remove it. We could in the future store it in the datastore again, since now sources can be converted into HDF5, however a performance analysis is needed first.