### PR TITLE
Moved the __version__ from risklib to baselib

### DIFF
--- a/helpers/makerpm.sh
+++ b/helpers/makerpm.sh
@@ -68,7 +68,7 @@ mkdir -p build-rpm/{RPMS,SOURCES,SPECS,SRPMS}
 
 LIB=$(cut -d "-" -f 2 <<< $REPO)
 SHA=$(git rev-parse --short $BRANCH)
-VER=$(cat openquake/risklib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")
+VER=$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")
 TIME=$(date +"%s")
 echo "$LIB - $BRANCH - $SHA - $VER"
 

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+from openquake.baselib.general import git_suffix
+
+# the version is managed by packager.sh with a sed
+__version__ = '2.5.0'
+__version__ += git_suffix(__file__)

--- a/openquake/commonlib/__init__.py
+++ b/openquake/commonlib/__init__.py
@@ -17,4 +17,4 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 # keep the following line to have a __version__
-from openquake.risklib import __version__
+from openquake.baselib import __version__

--- a/openquake/engine/__init__.py
+++ b/openquake/engine/__init__.py
@@ -51,8 +51,7 @@ along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
-from openquake.risklib import __version__
-# we want engine.__version__ == risklib.__version__ == commonlib.__version__
+from openquake.baselib import __version__
 
 # The path to the OpenQuake root directory
 OPENQUAKE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/openquake/hazardlib/__init__.py
+++ b/openquake/hazardlib/__init__.py
@@ -20,7 +20,7 @@
 hazardlib stands for Hazard Library.
 """
 
-from openquake.baselib.general import git_suffix
+from openquake.baselib import __version__
 from openquake.hazardlib import (
     calc, geo, gsim, mfd, scalerel, source, const, correlation, imt, pmf, site,
     tom, near_fault)
@@ -28,7 +28,3 @@ from openquake.hazardlib import (
 
 class InvalidFile(Exception):
     pass
-
-# the version is managed by packager.sh with a sed
-__version__ = '0.25.0'
-__version__ += git_suffix(__file__)

--- a/openquake/risklib/__init__.py
+++ b/openquake/risklib/__init__.py
@@ -16,16 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-from openquake.baselib.general import search_module, git_suffix
-
-# the version is managed by packager.sh with a sed
-__version__ = '2.5.0'
-__version__ += git_suffix(__file__)
-
-path = search_module('openquake.commonlib.general')
-if path:
-    sys.exit('Found an obsolete version of commonlib; '
-             'please remove %s and/or fix your PYTHONPATH'
-             % os.path.dirname(path))
+from openquake.baselib import __version__

--- a/packager.sh
+++ b/packager.sh
@@ -1256,7 +1256,7 @@ fi
 cd "$GEM_BUILD_SRC"
 
 # version info from openquake/risklib/__init__.py
-ini_vers="$(cat openquake/risklib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
+ini_vers="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
 ini_maj="$(echo "$ini_vers" | sed -n 's/^\([0-9]\+\).*/\1/gp')"
 ini_min="$(echo "$ini_vers" | sed -n 's/^[0-9]\+\.\([0-9]\+\).*/\1/gp')"
 ini_bfx="$(echo "$ini_vers" | sed -n 's/^[0-9]\+\.[0-9]\+\.\([0-9]\+\).*/\1/gp')"
@@ -1325,7 +1325,7 @@ if [ $BUILD_DEVEL -eq 1 ]; then
     cat debian/changelog.orig | sed -n "/^$GEM_DEB_PACKAGE/,\$ p" >> debian/changelog
     rm debian/changelog.orig
 
-    sed -i "s/^__version__[  ]*=.*/__version__ = '${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~dev${dt}-${hash}'/g" openquake/risklib/__init__.py
+    sed -i "s/^__version__[  ]*=.*/__version__ = '${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~dev${dt}-${hash}'/g" openquake/baselib/__init__.py
 else
     cp debian/changelog debian/changelog.orig
     cat debian/changelog.orig | sed "1 s/${BUILD_UBUVER_REFERENCE}/${BUILD_UBUVER}/g" > debian/changelog

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -89,7 +89,7 @@ getent passwd %{oquser} >/dev/null || \
     -c "The OpenQuake user" %{oquser}
 
 %install
-sed -i "s/^__version__[  ]*=.*/__version__ = '%{oqversion}-%{oqrelease}'/g" openquake/risklib/__init__.py
+sed -i "s/^__version__[  ]*=.*/__version__ = '%{oqversion}-%{oqrelease}'/g" openquake/baselib/__init__.py
 install -p -m 755 -d %{buildroot}%{_bindir}
 install -p -m 755 -d %{buildroot}%{oqprefix}/bin
 python setup.py install --single-version-externally-managed -O1 --root=%{buildroot} --prefix=%{oqprefix} --install-scripts=%{oqprefix}/bin

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_version():
     version_re = r"^__version__\s+=\s+['\"]([^'\"]*)['\"]"
     version = None
 
-    package_init = 'openquake/risklib/__init__.py'
+    package_init = 'openquake/baselib/__init__.py'
     for line in open(package_init, 'r'):
         version_match = re.search(version_re, line, re.M)
         if version_match:


### PR DESCRIPTION
Since it looks better. The packager is happy: https://ci.openquake.org/job/zdevel_oq-engine/2517
