### PR TITLE
Improved the error message when the rupture mesh is too small

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved the error message when the rupture mesh spacing is too small
   * Unified the versions of baselib, hazardlib and engine
   * Raised a clear error if the user does not set the `calculation_mode`
   * Made it is possible to pass the hdf5 full path to the DataStore class

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -539,9 +539,9 @@ class RuptureSerializer(object):
             sx, sy, sz = mesh.shape
             points = mesh.flatten()
             # sanity checks
-            assert sx < TWO16, sx
-            assert sy < 256, sy
-            assert sz < 256, sz
+            assert sx < TWO16, 'Too many multisurfaces: %d' % sx
+            assert sy < 256, 'The rupture mesh spacing is too small'
+            assert sz < 256, 'The rupture mesh spacing is too small'
             hypo = rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z
             rate = getattr(rup, 'occurrence_rate', numpy.nan)
             tup = (ebrupture.serial, rup.code, ebrupture.sidx,


### PR DESCRIPTION
This happened to an user setting 2 km of mesh spacing for the Cascadia complex fault rupture.