### PR TITLE
Exposed hmaps also in event based

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Hazard maps were not exposed to the engine in event based calculations
   * Optimized MultiMFD objects for the case of homogeneous parameters
   * Added an .npz exporter for the scenario_damage output `dmg_by_asset`
   * Removed the pickled CompositeSourceModel from the datastore

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -178,8 +178,8 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         global logversion
         self.close = close
         self.set_log_format()
-        logging.info('Running %s', self.oqparam.inputs['job_ini'])
         if logversion:  # make sure this is logged only once
+            logging.info('Running %s', self.oqparam.inputs['job_ini'])
             logging.info('Using engine version %s', engine_version)
             logversion = False
         if concurrent_tasks is None:  # use the default

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -178,6 +178,7 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         global logversion
         self.close = close
         self.set_log_format()
+        logging.info('Running %s', self.oqparam.inputs['job_ini'])
         if logversion:  # make sure this is logged only once
             logging.info('Using engine version %s', engine_version)
             logversion = False

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -95,7 +95,7 @@ def expose_outputs(dstore):
             dskeys.add('gmf_data')
     if 'scenario' not in calcmode:  # export sourcegroups.csv
         dskeys.add('sourcegroups')
-    if 'poes' in dstore:
+    if 'poes' in dstore or 'hcurves' in dstore:
         dskeys.add('hcurves')
         if oq.uniform_hazard_spectra:
             dskeys.add('uhs')  # export them

--- a/packager.sh
+++ b/packager.sh
@@ -612,7 +612,6 @@ celery_wait $GEM_MAXLOOP"
         cd /usr/share/openquake/engine/demos
 
         for ini in \$(find . -name job.ini | sort); do
-            echo \"Running \$ini\"
             for loop in \$(seq 1 $GEM_MAXLOOP); do
                 set +e
                 oq engine --run \$ini --exports xml,hdf5
@@ -643,9 +642,7 @@ celery_wait $GEM_MAXLOOP"
         for demo_dir in \$(find . -type d | sort); do
             if [ -f \$demo_dir/job_hazard.ini ]; then
             cd \$demo_dir
-            echo \"Running \$demo_dir/job_hazard.ini using celery\"
             OQ_DISTRIBUTE=celery oq engine --run job_hazard.ini
-            echo \"Running \$demo_dir/job_risk.ini\"
             oq engine --run job_risk.ini --exports csv,xml --hazard-calculation-id -1
             cd -
             fi


### PR DESCRIPTION
This was discovered by the users: the hazard event based demo was not exporting the hazard maps. We should make sure that Paolo has an integration test for this case.

The demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2522/console