### PR TITLE
Don't force the isa in sub packages

### DIFF
--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -48,7 +48,7 @@ Copyright (C) 2010-2017 GEM Foundation
 %package master
 Summary: OpenQuake Engine multi-node cluster support (master node)
 Group: Applications/Engineering
-Requires: %{name}%{?_isa} = %{version}-%{release} rabbitmq-server
+Requires: %{name} = %{version}-%{release} rabbitmq-server
 
 %description master
 OpenQuake Engine multi-node cluster support (master node)
@@ -61,7 +61,7 @@ Copyright (C) 2010-2017 GEM Foundation
 %package worker
 Summary: OpenQuake Engine multi-node cluster support (worker node)
 Group: Applications/Engineering
-Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: %{name} = %{version}-%{release}
 
 %description worker
 OpenQuake Engine multi-node cluster support (worker node)


### PR DESCRIPTION
There is a slight different between packages build on COPR and locally by mock. This was causing an error when a subpackage, from the official stable repo, was installed. This was not caught by tests using locally built packages.

Fixes #2871 