### PR TITLE
Fixed bug in dbserver.different_paths in presence of symlinks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed the check on the DbServer instance: it was failing in presence
+    symbolic links
   * Optimized MultiMFD objects for the case of homogeneous parameters
   * Added an .npz exporter for the scenario_damage output `dmg_by_asset`
   * Removed the pickled CompositeSourceModel from the datastore

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
   * Fixed the check on the DbServer instance: it was failing in presence
-    symbolic links
+    of symbolic links
   * Optimized MultiMFD objects for the case of homogeneous parameters
   * Added an .npz exporter for the scenario_damage output `dmg_by_asset`
   * Removed the pickled CompositeSourceModel from the datastore

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -86,6 +86,8 @@ class DbServer(object):
 
 
 def different_paths(path1, path2):
+    path1 = os.path.realpath(path1)  # expand symlinks
+    path2 = os.path.realpath(path2)  # expand symlinks
     # don't care about the extension (it may be .py or .pyc)
     return os.path.splitext(path1)[0] != os.path.splitext(path2)[0]
 
@@ -113,9 +115,9 @@ def check_foreign():
         remote_server_path = logs.dbcmd('get_path')
         if different_paths(server_path, remote_server_path):
             return('You are trying to contact a DbServer from another'
-                   + ' instance (%s)\n' % remote_server_path
-                   + 'Check the configuration or stop the foreign'
-                   + ' DbServer instance')
+                   ' instance (got %s, expected %s)\n'
+                   'Check the configuration or stop the foreign'
+                   ' DbServer instance') % (remote_server_path, server_path)
 
 
 def ensure_on():


### PR DESCRIPTION
This happened to me because for me oq-engine is a symlink to the directory oqcode/oq-engine.
