### PR TITLE
Add a zipped copy of demos in the packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: python-oq-engine
 Section: python
 Priority: extra
 Maintainer: Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>
-Build-Depends: debhelper (>= 7.0.50~), lsb-release, quilt, python (>=2.7), python-setuptools, python-coverage, python-sphinx
+Build-Depends: debhelper (>= 7.0.50~), lsb-release, quilt, python (>=2.7), python-setuptools, python-coverage, python-sphinx, zip
 Standards-Version: 3.9.3
 Homepage: http://github.com/gem/oq-engine
 

--- a/debian/rules
+++ b/debian/rules
@@ -43,8 +43,8 @@ override_dh_auto_install:
 
 override_dh_install:
 	python2 -m compileall $(PWD)/debian/python-oq-engine$(PREFIX) || true
-	# Make a zipped copy of each demo
 	dh_install
+	# Make a zipped copy of each demo
 	helpers/zipdemos.sh $(PWD)/debian/python-oq-engine/usr/share/openquake/engine/demos
 	mkdir -p $(PWD)/debian/python-oq-engine/usr/bin
 	ln -s $(PREFIX)/bin/oq $(PWD)/debian/python-oq-engine/usr/bin/oq

--- a/debian/rules
+++ b/debian/rules
@@ -43,6 +43,14 @@ override_dh_auto_install:
 
 override_dh_install:
 	python2 -m compileall $(PWD)/debian/python-oq-engine$(PREFIX) || true
+	# Make a zipped copy of each demo
+	for d in hazard risk; do
+	    cd $(PWD)/debian/python-oq-engine/usr/share/openquake/engine/demos/${d}
+	    for z in *; do
+	        zip -q -r ${z}.zip $z
+	    done
+	    cd -
+	done
 	dh_install
 	mkdir -p $(PWD)/debian/python-oq-engine/usr/bin
 	ln -s $(PREFIX)/bin/oq $(PWD)/debian/python-oq-engine/usr/bin/oq

--- a/debian/rules
+++ b/debian/rules
@@ -44,14 +44,8 @@ override_dh_auto_install:
 override_dh_install:
 	python2 -m compileall $(PWD)/debian/python-oq-engine$(PREFIX) || true
 	# Make a zipped copy of each demo
-	for d in hazard risk; do
-	    cd $(PWD)/debian/python-oq-engine/usr/share/openquake/engine/demos/${d}
-	    for z in *; do
-	        zip -q -r ${z}.zip $z
-	    done
-	    cd -
-	done
 	dh_install
+	helpers/zipdemos.sh $(PWD)/debian/python-oq-engine/usr/share/openquake/engine/demos
 	mkdir -p $(PWD)/debian/python-oq-engine/usr/bin
 	ln -s $(PREFIX)/bin/oq $(PWD)/debian/python-oq-engine/usr/bin/oq
 

--- a/helpers/testrpm.sh
+++ b/helpers/testrpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# makerpm.sh  Copyright (C) 2015-2017 GEM Foundation
+# testrpm.sh  Copyright (C) 2017 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published

--- a/helpers/zipdemos.sh
+++ b/helpers/zipdemos.sh
@@ -16,7 +16,6 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>
 
 set -e
-set -x
 
 checkcmd() {
     command -v $1 >/dev/null 2>&1 || { echo >&2 "This script requires '$1' but it isn't available. Aborting."; exit 1; }

--- a/helpers/zipdemos.sh
+++ b/helpers/zipdemos.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# zipdemos.sh  Copyright (C) 2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>
+
+set -e
+set -x
+
+checkcmd() {
+    command -v $1 >/dev/null 2>&1 || { echo >&2 "This script requires '$1' but it isn't available. Aborting."; exit 1; }
+}
+
+if [ -z $1 ]; then echo "Please provide the path where demos are located. Aborting."; exit 1; fi
+
+OQ_DEMOS=$1
+checkcmd zip
+
+# Make a zipped copy of each demo
+for d in hazard risk; do
+    cd ${OQ_DEMOS}/${d}
+    for z in *; do
+        zip -q -r ${z}.zip $z
+    done
+done

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -108,13 +108,7 @@ install -m 644 rpm/systemd/openquake-webui.service %{buildroot}%{_unitdir}/openq
 install -m 644 rpm/systemd/openquake-celery.service %{buildroot}%{_unitdir}/openquake-celery.service
 cp -R demos %{buildroot}/%{_datadir}/openquake/engine
 # Make a zipped copy of each demo
-for d in hazard risk; do
-    cd %{buildroot}/%{_datadir}/openquake/engine/demos/${d}
-    for z in *; do
-        zip -q -r ${z}.zip $z
-    done
-    cd -
-done
+helpers/zipdemos.sh %{buildroot}%{_datadir}/openquake/engine/demos
 cp -R utils %{buildroot}/%{_datadir}/openquake/engine
 
 %post

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -34,7 +34,7 @@ Requires(pre): shadow-utils
 Requires: python-oq-libs >= 1.3.0
 Requires: sudo systemd python
 
-BuildRequires: systemd python-setuptools
+BuildRequires: systemd python-setuptools zip
 
 Obsoletes: python-oq-risklib python-oq-hazardlib
 Provides: python-oq-risklib python-oq-hazardlib
@@ -107,6 +107,14 @@ install -m 644 rpm/systemd/openquake-dbserver.service %{buildroot}%{_unitdir}/op
 install -m 644 rpm/systemd/openquake-webui.service %{buildroot}%{_unitdir}/openquake-webui.service
 install -m 644 rpm/systemd/openquake-celery.service %{buildroot}%{_unitdir}/openquake-celery.service
 cp -R demos %{buildroot}/%{_datadir}/openquake/engine
+# Make a zipped copy of each demo
+for d in hazard risk; do
+    cd %{buildroot}/%{_datadir}/openquake/engine/demos/${d}
+    for z in *; do
+        zip -q -r ${z}.zip $z
+    done
+    cd -
+done
 cp -R utils %{buildroot}/%{_datadir}/openquake/engine
 
 %post


### PR DESCRIPTION
As we do in standalone installers. This has been asked by the users to make use of the WebUI more easy.

Zips are made at build time since all the zipped demos add less than 2MB to the final size. If the size will increase we can move this process into `post_install`.

https://ci.openquake.org/job/zdevel_oq-engine/2527/

Closes #2822 