### PR TITLE
Improve the zipdemos.sh script and add a test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ jobs:
     env: DEMOS
     script: 
         - bin/run-demos.sh
+  - stage: tests
+    env: SCRIPTS
+    script:
+        - helpers/zipdemos.sh $(pwd)/demos
 
 install:
   - pip -q install -r requirements-py35-linux64.txt

--- a/helpers/zipdemos.sh
+++ b/helpers/zipdemos.sh
@@ -30,6 +30,6 @@ checkcmd zip
 for d in hazard risk; do
     cd ${OQ_DEMOS}/${d}
     for z in *; do
-        zip -q -r ${z}.zip $z
+        if [ -d $z ]; then zip -q -r ${z}.zip $z; fi
     done
 done


### PR DESCRIPTION
Quick fix do avoid zipping twice already existing zip files. This never happens when packages are built, but it make the script useful on a installation from git too, where it can happen (with this PR if a zip already exists it's simply overwritten).

I also added a new section in travis.yml where to test scripts and helpers when needed.