### PR TITLE
Added commands `oq dump` and `oq restore`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ jobs:
         - bin/run-demos.sh
         - oq dump /tmp/oqdata.zip
         - oq restore /tmp/oqdata.zip /tmp/oqdata
-  - stage: tests
-    env: SCRIPTS
-    script:
         - helpers/zipdemos.sh $(pwd)/demos
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ jobs:
     env: DEMOS
     script: 
         - bin/run-demos.sh
+        - oq dump /tmp/oqdata.zip
+        - oq restore /tmp/oqdata.zip /tmp/oqdata
   - stage: tests
     env: SCRIPTS
     script:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added two commands `oq dump` and `oq restore`
   * Added a check that on the number of intensity measure types when
     generating uniform hazard spectra (must be > 1)
 

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -17,6 +17,7 @@
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+import time
 import os.path
 from openquake.baselib import sap
 from openquake.server.manage import db
@@ -29,11 +30,14 @@ def dump(archive):
     Dump the openquake database and all the complete calculations into a zip
     file. In a multiuser installation must be run as administrator.
     """
+    t0 = time.time()
     assert archive.endswith('.zip'), archive
     query = 'select ds_calc_dir || ".hdf5" from job where status="complete"'
     fnames = [fname for fname, in db(query) if os.path.exists(fname)]
     fnames.append(db.path)
     zipfiles(fnames, archive, print)
-    print('Archived %d files into %s' % (len(fnames), archive))
+    dt = time.time() - t0
+    print('Archived %d files into %s in %d seconds'
+          % (len(fnames), archive, dt))
 
 dump.arg('archive', 'path to a zip file')

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -1,0 +1,38 @@
+#  -*- coding: utf-8 -*-
+#  vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#  Copyright (c) 2017, GEM Foundation
+
+#  OpenQuake is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+#  OpenQuake is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import os.path
+from openquake.baselib import sap
+from openquake.server.manage import db
+from openquake.engine.export.core import zipfiles
+
+
+@sap.Script
+def dump(archive):
+    """
+    Dump the openquake database and all datastores into a archive zip file.
+    In a multiuser installation must be run as administrator.
+    """
+    assert archive.endswith('.zip'), archive
+    fnames = [fname for fname, in db('select ds_calc_dir || ".hdf5" from job')
+              if os.path.exists(fname)]
+    fnames.append(db.path)
+    zipfiles(fnames, archive)
+    print('Saved %d calculations into %s' % (len(fnames) - 1, archive))
+
+dump.arg('archive', 'path to a zip file')

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -32,7 +32,7 @@ def dump(archive):
     fnames = [fname for fname, in db('select ds_calc_dir || ".hdf5" from job')
               if os.path.exists(fname)]
     fnames.append(db.path)
+    print('Zipping %d files into %s' % (len(fnames), archive))
     zipfiles(fnames, archive)
-    print('Saved %d calculations into %s' % (len(fnames) - 1, archive))
 
 dump.arg('archive', 'path to a zip file')

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -15,8 +15,6 @@
 
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
-
-from __future__ import print_function
 import time
 import os.path
 from openquake.baselib import sap

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -26,14 +26,14 @@ from openquake.engine.export.core import zipfiles
 @sap.Script
 def dump(archive):
     """
-    Dump the openquake database and all datastores into a archive zip file.
-    In a multiuser installation must be run as administrator.
+    Dump the openquake database and all the complete calculations into a zip
+    file. In a multiuser installation must be run as administrator.
     """
     assert archive.endswith('.zip'), archive
-    fnames = [fname for fname, in db('select ds_calc_dir || ".hdf5" from job')
-              if os.path.exists(fname)]
+    query = 'select ds_calc_dir || ".hdf5" from job where status="complete"'
+    fnames = [fname for fname, in db(query) if os.path.exists(fname)]
     fnames.append(db.path)
     zipfiles(fnames, archive, print)
-    print('Zipped %d files into %s' % (len(fnames), archive))
+    print('Archived %d files into %s' % (len(fnames), archive))
 
 dump.arg('archive', 'path to a zip file')

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -38,16 +38,17 @@ def dump(archive, user=None):
     fnames = [f for f, in db(getfnames, param) if os.path.exists(f)]
     fnames.append(db.path)
     zipfiles(fnames, archive, safeprint)
-    executing = db('select id, description from job where status="executing"')
+    pending_jobs = db('select id, status, description from job '
+                      'where status!="complete"')
     dt = time.time() - t0
     safeprint('Archived %d files into %s in %d seconds'
               % (len(fnames), archive, dt))
-    if executing:
+    if pending_jobs:
         safeprint('WARNING: there were calculations executing during the dump')
         safeprint('They have been not copied; please check the correctness of'
                   ' the db.sqlite3 file')
-        for job_id, descr in executing:
-            safeprint('%d executing %s' % (job_id, descr))
+        for job_id, status, descr in pending_jobs:
+            safeprint('%d %s %s' % (job_id, status, descr))
 
 dump.arg('archive', 'path to the zip file where to dump the calculations')
 dump.arg('user', 'if missing, dump all calculations')

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -39,7 +39,7 @@ def dump(archive, user=None):
     fnames.append(db.path)
     zipfiles(fnames, archive, safeprint)
     pending_jobs = db('select id, status, description from job '
-                      'where status!="complete"')
+                      'where status="executing"')
     dt = time.time() - t0
     safeprint('Archived %d files into %s in %d seconds'
               % (len(fnames), archive, dt))

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -47,9 +47,9 @@ def dump(archive, user=None):
     if executing:
         safeprint('WARNING: there were calculations executing during the dump')
         safeprint('They have been not copied; please check the correctness of'
-                  ' the db.sqlite3 file.')
+                  ' the db.sqlite3 file')
         for job_id, descr in executing:
-            safeprint('%d %s' % (job_id, descr))
+            safeprint('%d executing %s' % (job_id, descr))
 
 dump.arg('archive', 'path to the zip file where to dump the calculations')
 dump.arg('user', 'if missing, dump all calculations')

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
 import os.path
 from openquake.baselib import sap
 from openquake.server.manage import db
@@ -32,7 +33,7 @@ def dump(archive):
     fnames = [fname for fname, in db('select ds_calc_dir || ".hdf5" from job')
               if os.path.exists(fname)]
     fnames.append(db.path)
-    print('Zipping %d files into %s' % (len(fnames), archive))
-    zipfiles(fnames, archive)
+    zipfiles(fnames, archive, print)
+    print('Zipped %d files into %s' % (len(fnames), archive))
 
 dump.arg('archive', 'path to a zip file')

--- a/openquake/commands/restore.py
+++ b/openquake/commands/restore.py
@@ -28,8 +28,7 @@ from openquake.server.dbapi import Db
 @sap.Script
 def restore(archive, oqdata):
     """
-    Dump the openquake database and all datastores into a archive zip file.
-    In a multiuser installation must be run as administrator.
+    Build a new oqdata directory from the data contained in the zip archive
     """
     oqdata = os.path.abspath(oqdata)
     assert archive.endswith('.zip'), archive

--- a/openquake/commands/restore.py
+++ b/openquake/commands/restore.py
@@ -18,6 +18,7 @@
 
 import re
 import sys
+import time
 import os.path
 import zipfile
 import sqlite3
@@ -30,6 +31,7 @@ def restore(archive, oqdata):
     """
     Build a new oqdata directory from the data contained in the zip archive
     """
+    t0 = time.time()
     oqdata = os.path.abspath(oqdata)
     assert archive.endswith('.zip'), archive
     if os.path.exists(oqdata):
@@ -48,7 +50,8 @@ def restore(archive, oqdata):
             db("UPDATE job SET ds_calc_dir=?x WHERE id=?x", fullname, job_id)
             print('Restoring ' + fname)
             n += 1
-    print('Extracted %d calculations into %s' % (n, oqdata))
+    dt = time.time() - t0
+    print('Extracted %d calculations into %s in %d seconds' % (n, oqdata, dt))
 
 
 restore.arg('archive', 'path to a zip file')

--- a/openquake/commands/restore.py
+++ b/openquake/commands/restore.py
@@ -1,0 +1,56 @@
+#  -*- coding: utf-8 -*-
+#  vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#  Copyright (c) 2017, GEM Foundation
+
+#  OpenQuake is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+#  OpenQuake is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import sys
+import os.path
+import zipfile
+import sqlite3
+from openquake.baselib import sap
+from openquake.server.dbapi import Db
+
+
+@sap.Script
+def restore(archive, oqdata):
+    """
+    Dump the openquake database and all datastores into a archive zip file.
+    In a multiuser installation must be run as administrator.
+    """
+    oqdata = os.path.abspath(oqdata)
+    assert archive.endswith('.zip'), archive
+    if os.path.exists(oqdata):
+        sys.exit('%s exists already' % oqdata)
+    os.mkdir(oqdata)
+    zipfile.ZipFile(archive).extractall(oqdata)
+    dbpath = os.path.join(oqdata, 'db.sqlite3')
+    db = Db(sqlite3.connect, dbpath, isolation_level=None,
+            detect_types=sqlite3.PARSE_DECLTYPES)
+    n = 0
+    for fname in os.listdir(oqdata):
+        mo = re.match('calc_(\d+)\.hdf5', fname)
+        if mo:
+            job_id = int(mo.group(1))
+            fullname = os.path.join(oqdata, fname)[:-5]  # strip .hdf5
+            db("UPDATE job SET ds_calc_dir=?x WHERE id=?x", fullname, job_id)
+            print('Restoring ' + fname)
+            n += 1
+    print('Extracted %d calculations into %s' % (n, oqdata))
+
+
+restore.arg('archive', 'path to a zip file')
+restore.arg('oqdata', 'path to an oqdata directory')

--- a/openquake/commands/restore.py
+++ b/openquake/commands/restore.py
@@ -23,6 +23,7 @@ import os.path
 import zipfile
 import sqlite3
 from openquake.baselib import sap
+from openquake.baselib.general import safeprint
 from openquake.server.dbapi import Db
 
 
@@ -48,10 +49,11 @@ def restore(archive, oqdata):
             job_id = int(mo.group(1))
             fullname = os.path.join(oqdata, fname)[:-5]  # strip .hdf5
             db("UPDATE job SET ds_calc_dir=?x WHERE id=?x", fullname, job_id)
-            print('Restoring ' + fname)
+            safeprint('Restoring ' + fname)
             n += 1
     dt = time.time() - t0
-    print('Extracted %d calculations into %s in %d seconds' % (n, oqdata, dt))
+    safeprint('Extracted %d calculations into %s in %d seconds'
+              % (n, oqdata, dt))
 
 
 restore.arg('archive', 'path to a zip file')

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -34,7 +34,7 @@ class DataStoreExportError(Exception):
     pass
 
 
-def zipfiles(fnames, archive):
+def zipfiles(fnames, archive, log=lambda msg: None):
     """
     Build a zip archive from the given file names.
 
@@ -43,6 +43,7 @@ def zipfiles(fnames, archive):
     """
     z = zipfile.ZipFile(archive, 'w', zipfile.ZIP_DEFLATED, allowZip64=True)
     for f in fnames:
+        log('Zipping %s' % f)
         z.write(f, os.path.basename(f))
     z.close()
 

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -43,7 +43,7 @@ def zipfiles(fnames, archive, log=lambda msg: None):
     """
     z = zipfile.ZipFile(archive, 'w', zipfile.ZIP_DEFLATED, allowZip64=True)
     for f in fnames:
-        log('Zipping %s' % f)
+        log('Archiving %s' % f)
         z.write(f, os.path.basename(f))
     z.close()
 

--- a/openquake/server/dbapi.py
+++ b/openquake/server/dbapi.py
@@ -303,6 +303,11 @@ class Db(object):
             self.local.conn = self.connect(*self.args, **self.kw)
             return self.local.conn
 
+    @property
+    def path(self):
+        """Path to the underlying sqlite file"""
+        return self.args[0]
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
Here is an example of use:

```bash
$ oq dump /tmp/oqdata.zip
...
Archiving /mnt/ssd/oqdata/calc_29304.hdf5
Archiving /mnt/ssd/oqdata/calc_29305.hdf5
Archiving /home/michele/oqdata/db.sqlite3
Archived 193 files into /tmp/x.zip in 212 seconds
WARNING: there were calculations executing during the dump
They have been not copied; please check the correctness of the db.sqlite3 file
3423 executing Virtual Island Seismic Risk - City C, ses=1
21895 executing LEONARD BACKGROUND RUN - NATIONAL MAPS
$ oq restore /tmp/oqdata.zip /tmp/oqdata
$ OQ_DATADIR=/tmp/oqdata oq webui start
```
