### PR TITLE
Allow installation of Django 1.11 LTS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Daniele Viganò]
+  * Updated requirements to allow installation of Django 1.11 (LTS)
+
   [Michele Simionato]
   * Added a check that on the number of intensity measure types when
     generating uniform hazard spectra (must be > 1)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_requires = [
     'shapely >=1.3, <1.6',
     'docutils >=0.11, <0.14',
     'decorator >=3.4, <4.1',
-    'django >=1.6, <1.11',
+    'django >=1.6, <1.12',
     'matplotlib >=1.5, <2.0',
     'requests >=2.2, <2.13',
     # pyshp is fragile, we want only versions we have tested


### PR DESCRIPTION
Django 1.11 it's an LTS (see https://www.djangoproject.com/weblog/2015/jun/25/roadmap/) so it's the best version to be used as our ref. We are already 100% compatible with it.