### PR TITLE
Do not propagate Django logs into the DbServer

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,7 @@
   [Daniele Viganò]
+  * Fixed a bug introduced by a change in Django 1.10 that was causing
+    the HTTP requests log to be caught by our logging system and
+    then saved in the DbServer
   * Updated requirements to allow installation of Django 1.11 (LTS)
 
   [Michele Simionato]

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -145,12 +145,12 @@ LOGGING = {
         'django': {
             'handlers': ['console'],
             'level': 'INFO',
-            'propagate': True,
+            'propagate': False,
         },
         'django.request': {
             'handlers': ['console'],
             'level': 'DEBUG',
-            'propagate': True,
+            'propagate': False,
         },
         'openquake.server': {
             'handlers': ['console'],


### PR DESCRIPTION
Fixes #2889 

This feature has been introduced in Django 1.10: https://docs.djangoproject.com/en/1.11/topics/logging/#django-server