### PR TITLE
The upgrade_manager is transactional again

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made the upgrade_manager transactional again
   * Changed the storage of the GMFs; as a consequence the exported .csv
     has a different format
 

--- a/openquake/server/db/upgrade_manager.py
+++ b/openquake/server/db/upgrade_manager.py
@@ -114,7 +114,9 @@ def apply_sql_script(conn, fname):
     """
     sql = open(fname).read()
     try:
-        conn.executescript(sql)
+        # we cannot use conn.executescript which is non transactional
+        for query in sql.split('\n\n'):
+            conn.execute(query)
     except:
         logging.error('Error executing %s' % fname)
         raise

--- a/openquake/server/tests/db/upgrade_manager_test.py
+++ b/openquake/server/tests/db/upgrade_manager_test.py
@@ -114,7 +114,6 @@ class UpgradeManagerTestCase(unittest.TestCase):
         # check that the rollback works: the version
         # table contains only the base script and the
         # tables are not populated, i.e. '0001' has to be rolled back
-        raise unittest.SkipTest
         self.assertEqual(count(conn, 'test_version'), 1)
         self.assertEqual(count(conn, 'test_hazard_calculation'), 0)
         self.assertEqual(count(conn, 'test_lt_source_model'), 0)

--- a/openquake/server/tests/db/upgrades/0001-populate.sql
+++ b/openquake/server/tests/db/upgrades/0001-populate.sql
@@ -1,14 +1,17 @@
 INSERT INTO test_hazard_calculation (id, description)
 VALUES (1, 'First calculation');
+
 INSERT INTO test_hazard_calculation (id, description)
 VALUES (2, 'Second calculation');
 
 INSERT INTO test_lt_source_model 
 VALUES (1, 1, 0, '{b1}', 'source_model.xml');
+
 INSERT INTO test_lt_source_model
 VALUES (2, 1, 1, '{b2}', 'source_model.xml');
 
 INSERT INTO test_lt_source_model
 VALUES (3, 2, 0, '{b11,b12}', 'other_model.xml');
+
 INSERT INTO test_lt_source_model
 VALUES (4, 2, 1, '{b21,b22}', 'other_model.xml');


### PR DESCRIPTION
I discovered that `conn.executescript` is issuing an implicit COMMIT, so it is non-transactional and the rollback does not work. The solution is to use `conn.execute` instead.
Closes https://github.com/gem/oq-engine/issues/2011, opened 14 months ago.