### PR TITLE
Changed the message printed by `oq dump`

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -26,4 +26,4 @@ MPLBACKEND=Agg python -m openquake.commands plot_uhs -3
 # fake a wrong calculation still in executing status
 python -m openquake.commands db set_status 1 executing
 # repeat the failed/executing calculation, which is useful for QGIS
-python -m openquake.commands run $1/hazard/AreaSourceClassicalPSHA/job.ini
+python -m openquake.commands engine --run $1/hazard/AreaSourceClassicalPSHA/job.ini

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -70,8 +70,8 @@ def dump(archive, user=None):
     smart_save(db.path, archive)
 
     dt = time.time() - t0
-    safeprint('Archived %d files into %s in %d seconds'
-              % (len(fnames) + 1, archive, dt))
+    safeprint('Archived %d calculations into %s in %d seconds'
+              % (len(fnames), archive, dt))
 
 
 dump.arg('archive', 'path to the zip file where to dump the calculations')


### PR DESCRIPTION
Before it was "Archived 16 files" (correct, 15 calculations + the db.sqlite3 file), now it is "Archived 15 calculations" which is more consistent with the message printed by `oq restore` that only mention calculations.

PS: I am also fixing run-demos to run the 17th demo with the engine, not with oq-lite.