### PR TITLE
Use a 403 response if calculation cannot be deleted

### DIFF
--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -189,23 +189,8 @@
                                     type: "POST",
                                     error: function (jqXHR, textStatus, errorThrown) {
                                         if (jqXHR.status == 403) {
-                                            console.log(jqXHR.status),
-                                            diaerror.show(false, "Error:", JSON.parse(jqXHR.responseText).error),
-                                            function(data, textStatus, jqXHR) {
-                                                console.log(data.error);
-                                                err = data.error;
-                                                if(!err) {
-                                                    err = "removed.";
-                                                }
-                                                var hide_or_back = (function(e) {
-                                                    closeTimer();
-                                                    this.conf_hide = $('#confirmDialog' + calc_id).hide();
-                                                    this.back_conf_hide = $('.back_confirmDialog' + calc_id).hide();
-                                                    setTimer();
-                                                })();
-                                                diaerror.show(false, "Calculation removed", "Calculation:<br><b>(" + calc_id + ") " + calc_desc + "</b> " + err );
-                                            }  
-                                         }
+                                            diaerror.show(false, "Error:", JSON.parse(jqXHR.responseText).error);
+                                        }
                                     },
                                     success: function(data, textStatus, jqXHR) {
                                         err = data.error;

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -189,6 +189,12 @@
                                     type: "POST",
                                     error: function (jqXHR, textStatus, errorThrown) {
                                         if (jqXHR.status == 403) {
+                                            var hide_or_back = (function(e) {
+                                                closeTimer();
+                                                this.conf_hide = $('#confirmDialog' + calc_id).hide();
+                                                this.back_conf_hide = $('.back_confirmDialog' + calc_id).hide();
+                                                setTimer();
+                                            })();
                                             diaerror.show(false, "Error:", JSON.parse(jqXHR.responseText).error);
                                         }
                                     },

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -326,15 +326,14 @@ def calc_remove(request, calc_id):
         message = logs.dbcmd('del_calc', calc_id, user)
     except dbapi.NotFound:
         return HttpResponseNotFound()
-    #return HttpResponse(content=json.dumps(message),
-    #                    content_type=JSON, status=200)
     if isinstance(message, list):  # list of removed files
         return HttpResponse(content=json.dumps(message),
                             content_type=JSON, status=200)
-    else:  # FIXME: the error is not passed properly to the javascript
+    else:
         logging.error(message)
-        return HttpResponse(content=message,
-                            content_type='text/plain', status=500)
+        return HttpResponse(content=json.dumps(message),
+                            content_type=JSON, status=403)
+
 
 def log_to_json(log):
     """Convert a log record into a list of strings"""

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -331,7 +331,7 @@ def calc_remove(request, calc_id):
         return HttpResponse(content=json.dumps(message),
                             content_type=JSON, status=200)
     elif 'error' in message:
-        logging.error(message)
+        logging.error(message['error'])
         return HttpResponse(content=json.dumps(message),
                             content_type=JSON, status=403)
     else:

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -338,7 +338,7 @@ def calc_remove(request, calc_id):
         # This is an untrapped server error
         logging.error(message)
         return HttpResponse(content=message,
-                            content_type='plain/text', status=500)
+                            content_type='text/plain', status=500)
      
 
 def log_to_json(log):

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -330,11 +330,16 @@ def calc_remove(request, calc_id):
     if 'success' in message:
         return HttpResponse(content=json.dumps(message),
                             content_type=JSON, status=200)
-    else:
+    elif 'error' in message:
         logging.error(message)
         return HttpResponse(content=json.dumps(message),
                             content_type=JSON, status=403)
-
+    else:
+        # This is an untrapped server error
+        logging.error(message)
+        return HttpResponse(content=message,
+                            content_type='plain/text', status=500)
+     
 
 def log_to_json(log):
     """Convert a log record into a list of strings"""

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -326,7 +326,8 @@ def calc_remove(request, calc_id):
         message = logs.dbcmd('del_calc', calc_id, user)
     except dbapi.NotFound:
         return HttpResponseNotFound()
-    if isinstance(message, list):  # list of removed files
+
+    if 'success' in message:
         return HttpResponse(content=json.dumps(message),
                             content_type=JSON, status=200)
     else:


### PR DESCRIPTION
This allows to send a `403` if the user cannot delete a calculation.

The code can be refactored and cleaned a bit, but I left it as it is for readability.