### PR TITLE
Parallelized `build_loss_maps` in all cases

### DIFF
--- a/demos/risk/EventBasedRisk/job.ini
+++ b/demos/risk/EventBasedRisk/job.ini
@@ -44,6 +44,7 @@ loss_curve_resolution = 20
 conditional_loss_poes = 0.01, 0.02
 insured_losses = true
 loss_ratios = {'structural': [0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], 'nonstructural': [0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}
+ruptures_per_block = 500
 
 [outputs]
 avg_losses = true

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -239,15 +239,14 @@ class EbrPostCalculator(base.RiskCalculator):
                     'loss_maps-stats', builder.loss_maps_dt, (A, len(stats)),
                     fillvalue=None)
             mon = self.monitor('loss maps')
+            Starmap = parallel.Starmap
             if self.oqparam.hazard_calculation_id and (
                     'asset_loss_table' in self.datastore.parent):
-                Starmap = parallel.Starmap  # we can parallelize fully
                 lrgetter = riskinput.LossRatiosGetter(self.datastore.parent)
                 # avoid OSError: Can't read data (Wrong b-tree signature)
                 self.datastore.parent.close()
             else:  # there is a single datastore
-                # we cannot read from it in parallel while writing
-                Starmap = parallel.Sequential
+                Starmap.restart()  # needed to avoid the HDF5 heisenbug
                 lrgetter = riskinput.LossRatiosGetter(self.datastore)
             Starmap.apply(
                 build_loss_maps,


### PR DESCRIPTION
Currently the function `build_loss_maps` in event_based_risk is not parallelized when the option `--hc` is not given, to avoid an heisenbug. The problem seems to go away with a `.restart` of the process pool. The new processes start with a file that was closed before their coming into existence; the old processes instead were started before closing the file. Let's merge this change experimentally for a while. Currently
travis, Jenkins (https://ci.openquake.org/job/zdevel_oq-engine/2536) and the cluster are happy.

This PR has an huge impact on large calculations. There is one on the cluster that went down from 9,901s to  2,565s, nearly 4 times, since it was dominated by the sequential computation of the loss maps.