### PR TITLE
Restored sequential calculations of the loss maps

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -239,15 +239,17 @@ class EbrPostCalculator(base.RiskCalculator):
                     'loss_maps-stats', builder.loss_maps_dt, (A, len(stats)),
                     fillvalue=None)
             mon = self.monitor('loss maps')
-            Starmap = parallel.Starmap
             if self.oqparam.hazard_calculation_id and (
                     'asset_loss_table' in self.datastore.parent):
                 lrgetter = riskinput.LossRatiosGetter(self.datastore.parent)
                 # avoid OSError: Can't read data (Wrong b-tree signature)
                 self.datastore.parent.close()
+                Starmap = parallel.Starmap
             else:  # there is a single datastore
-                Starmap.restart()  # needed to avoid the HDF5 heisenbug
                 lrgetter = riskinput.LossRatiosGetter(self.datastore)
+                Starmap = parallel.Sequential
+                # needed to avoid the HDF5 heisenbug; doing a .restart()
+                # is not enough :-(
             Starmap.apply(
                 build_loss_maps,
                 (assetcol, builder, lrgetter, rlzs, stats, mon),


### PR DESCRIPTION
Reverting the change in https://github.com/gem/oq-engine/pull/2915, since the heisenbug is back: https://ci.openquake.org/job/master_oq-engine/3621