### PR TITLE
Optimized the storage of gmf_data/indices

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -502,13 +502,18 @@ class EventBasedCalculator(ClassicalCalculator):
         self.indices = collections.defaultdict(list)  # sid -> indices
         acc = res.reduce(self.combine_pmaps_and_save_gmfs, {
             rlz.ordinal: ProbabilityMap(L) for rlz in rlzs})
-        if self.indices:
-            sids = numpy.array(sorted(self.indices))
-            self.datastore['gmf_data/sids'] = sids
-            self.datastore.save_vlen(
-                'gmf_data/indices', [numpy.array(self.indices[sid], indices_dt)
-                                     for sid in sids])
         save_gmdata(self, len(rlzs))
+        if self.indices:
+            logging.info('Saving gmf_data/indices')
+            with self.monitor('saving gmf_data/indices', measuremem=True,
+                              autoflush=True):
+                sids = numpy.array(self.indices)
+                sids.sort()
+                self.datastore['gmf_data/sids'] = sids
+                self.datastore.save_vlen(
+                    'gmf_data/indices',
+                    [numpy.array(self.indices[sid], indices_dt)
+                     for sid in sids])
         return acc
 
     def save_gmf_bytes(self):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -23,7 +23,6 @@ import itertools
 import logging
 import collections
 import mock
-import h5py
 import numpy
 
 from openquake.baselib import hdf5

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -503,8 +503,8 @@ class EventBasedCalculator(ClassicalCalculator):
         acc = res.reduce(self.combine_pmaps_and_save_gmfs, {
             rlz.ordinal: ProbabilityMap(L) for rlz in rlzs})
         if self.indices:
-            sids = sorted(self.indices)
-            self.datastore['gmf_data/sids'] = numpy.array(sids, U32)
+            sids = numpy.array(sorted(self.indices))
+            self.datastore['gmf_data/sids'] = sids
             self.datastore.save_vlen(
                 'gmf_data/indices', [numpy.array(self.indices[sid], indices_dt)
                                      for sid in sids])

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -507,8 +507,7 @@ class EventBasedCalculator(ClassicalCalculator):
             logging.info('Saving gmf_data/indices')
             with self.monitor('saving gmf_data/indices', measuremem=True,
                               autoflush=True):
-                sids = numpy.array(self.indices)
-                sids.sort()
+                sids = numpy.array(sorted(self.indices))
                 self.datastore['gmf_data/sids'] = sids
                 self.datastore.save_vlen(
                     'gmf_data/indices',

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -625,8 +625,9 @@ class RuptureSerializer(object):
         Flush the ruptures and the site IDs on the datastore
         """
         self.sids.clear()
-        self.datastore.save_vlen('sids', self.data)
-        del self.data[:]
+        if self.data:
+            self.datastore.save_vlen('sids', self.data)
+            del self.data[:]
 
 
 def get_ruptures(dstore, grp_id):

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -625,14 +625,7 @@ class RuptureSerializer(object):
         Flush the ruptures and the site IDs on the datastore
         """
         self.sids.clear()
-        dset = self.datastore.create_dset(
-            'sids', sids_dt, (len(self.data),), fillvalue=None)
-        nbytes = 0
-        for i, val in enumerate(self.data):
-            dset[i] = val
-            nbytes += val.nbytes
-        self.datastore.set_attrs('sids', nbytes=nbytes)
-        self.datastore.flush()
+        self.datastore.save_vlen('sids', self.data)
         del self.data[:]
 
 

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -278,10 +278,12 @@ class DataStore(collections.MutableMapping):
         dset = self.create_dset(
             key, h5py.special_dtype(vlen=dt), (len(data),), fillvalue=None)
         nbytes = 0
+        totlen = 0
         for i, val in enumerate(data):
             dset[i] = val
             nbytes += val.nbytes
-        self.set_attrs(key, nbytes=nbytes)
+            totlen += len(val)
+        self.set_attrs(key, nbytes=nbytes, avg_len=totlen / len(data))
         self.flush()
 
     def extend(self, key, array, **attrs):

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -267,6 +267,23 @@ class DataStore(collections.MutableMapping):
         return hdf5.create(
             self.hdf5, key, dtype, shape, compression, fillvalue, attrs)
 
+    def save_vlen(self, key, data):
+        """
+        Save a sequence of variable-length arrays
+
+        :param key: name of the dataset
+        :param data: data to store as vlen arrays
+        """
+        dt = data[0].dtype
+        dset = self.create_dset(
+            key, h5py.special_dtype(vlen=dt), (len(data),), fillvalue=None)
+        nbytes = 0
+        for i, val in enumerate(data):
+            dset[i] = val
+            nbytes += val.nbytes
+        self.set_attrs(key, nbytes=nbytes)
+        self.flush()
+
     def extend(self, key, array, **attrs):
         """
         Extend the dataset associated to the given key; create it if needed


### PR DESCRIPTION
Due to an ordering issue, the storage of the indices was ultra-slow. So I fixed the ordering and changed the data structure, so that now we are using less space (in an example calculation for Chile the space spent in the indices went down from 10.2 MB to 2.72 MB)