### PR TITLE
Upload artifacts only if a [dump] tag is provided or branch is master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,14 @@ jobs:
         - oq restore /tmp/oqdata.zip /tmp/oqdata
         - helpers/zipdemos.sh $(pwd)/demos
     after_success:
-        # Upload oqdata.zip to http://artifacts.openquake.org/travis/
-        - openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in .deploy_rsa.enc -out .deploy_rsa -d;
+        # Upload oqdata.zip to http://artifacts.openquake.org/travis/ only if
+        # the commit message includes a [dump] tag at the end or branch is master
+        - if [[ $(echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[dump\]$') || "$BRANCH" == "master" ]]; then
+            openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in .deploy_rsa.enc -out .deploy_rsa -d;
             chmod 600 .deploy_rsa;
             eval $(ssh-agent -s) && ssh-add .deploy_rsa;
             scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/oqdata.zip travis@ci.openquake.org:/var/www/artifacts.openquake.org/travis/oqdata-${BRANCH}.zip;
+          fi
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else BRANCH=$TRAVIS_BRANCH; fi


### PR DESCRIPTION
To avoid uploading artifacts after every build, for every branch (~30MB per run) we can make travis upload `oqdata.zip` only if a `[dump]` tag is provided at the end of the commit message, or if `$branch` is master.

The same approach may be used in the future to turn on/off specific steps in Travis at commit time (i.e. instead of `[skip ci]` just `[skip demos]`)