### PR TITLE
Smart resolution of the asset_loss_table heisenbug

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -246,9 +246,10 @@ class EbrPostCalculator(base.RiskCalculator):
                 Starmap = parallel.Starmap
             else:  # there is a single datastore
                 lrgetter = riskinput.LossRatiosGetter(self.datastore)
-                Starmap = parallel.Sequential
-                # needed to avoid the HDF5 heisenbug; doing a .restart()
-                # is not enough :-(
+                if parallel.oq_distribute() == 'futures':
+                    Starmap = parallel.Sequential
+                    # needed to avoid the HDF5 heisenbug; doing a .restart()
+                    # of the ProcessPool is not enough :-(
             Starmap.apply(
                 build_loss_maps,
                 (assetcol, builder, lrgetter, rlzs, stats, mon),

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -238,12 +238,12 @@ class EbrPostCalculator(base.RiskCalculator):
                     'loss_maps-stats', builder.loss_maps_dt, (A, len(stats)),
                     fillvalue=None)
             mon = self.monitor('loss maps')
+            Starmap = parallel.Starmap
             if self.oqparam.hazard_calculation_id and (
                     'asset_loss_table' in self.datastore.parent):
                 lrgetter = riskinput.LossRatiosGetter(self.datastore.parent)
                 # avoid OSError: Can't read data (Wrong b-tree signature)
                 self.datastore.parent.close()
-                Starmap = parallel.Starmap
             else:  # there is a single datastore
                 lrgetter = riskinput.LossRatiosGetter(self.datastore)
                 if parallel.oq_distribute() == 'futures':

--- a/packager.sh
+++ b/packager.sh
@@ -615,8 +615,8 @@ celery_wait $GEM_MAXLOOP"
         for demo_dir in \$(find . -type d | sort); do
             if [ -f \$demo_dir/job_hazard.ini ]; then
             cd \$demo_dir
-            OQ_DISTRIBUTE=celery oq engine --run job_hazard.ini
-            oq engine --run job_risk.ini --exports csv,npz --hazard-calculation-id -1
+            oq engine --run job_hazard.ini
+            OQ_DISTRIBUTE=celery oq engine --run job_risk.ini --exports csv,npz --hazard-calculation-id -1
             cd -
             fi
         done


### PR DESCRIPTION
It is impossible to compute the asset loss table reliably with multiprocessing and a single job.ini, so we must work sequentially in that case. However, celery has no problems, so we can keep parallelizing the calculation in that case. That means that asset_loss_table calculations on the cluster can still be fast.
Demos with celery are running here: https://ci.openquake.org/job/zdevel_oq-engine/2540