### PR TITLE
Run hazardlib and the demos on Travis on-demand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,14 @@ jobs:
   - stage: tests
     env: DEMOS
     script:
-        - bin/run-demos.sh $TRAVIS_BUILD_DIR/demos
-        - bin/check_demos
-        - oq dump /tmp/oqdata.zip
-        - oq restore /tmp/oqdata.zip /tmp/oqdata
-        - helpers/zipdemos.sh $(pwd)/demos
-    after_success:
         # Upload oqdata.zip to http://artifacts.openquake.org/travis/ only if
-        # the commit message includes a [dump] tag at the end or branch is master
-        - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[dump\]' || test "$BRANCH" == "master"; then
+        # the commit message includes a [demos] tag at the end or branch is master
+        - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[demos\]' || test "$BRANCH" == "master"; then
+            bin/run-demos.sh $TRAVIS_BUILD_DIR/demos;
+            bin/check_demos;
+            oq dump /tmp/oqdata.zip;
+            oq restore /tmp/oqdata.zip /tmp/oqdata;
+            helpers/zipdemos.sh $(pwd)/demos;
             openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in .deploy_rsa.enc -out .deploy_rsa -d;
             chmod 600 .deploy_rsa;
             eval $(ssh-agent -s) && ssh-add .deploy_rsa;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,15 @@ jobs:
         # Upload oqdata.zip to http://artifacts.openquake.org/travis/ only if
         # the commit message includes a [demos] tag at the end or branch is master
         - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[demos\]' || test "$BRANCH" == "master"; then
-            bin/run-demos.sh $TRAVIS_BUILD_DIR/demos;
-            bin/check_demos;
-            oq dump /tmp/oqdata.zip;
-            oq restore /tmp/oqdata.zip /tmp/oqdata;
-            helpers/zipdemos.sh $(pwd)/demos;
-            openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in .deploy_rsa.enc -out .deploy_rsa -d;
-            chmod 600 .deploy_rsa;
-            eval $(ssh-agent -s) && ssh-add .deploy_rsa;
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/oqdata.zip travis@ci.openquake.org:/var/www/artifacts.openquake.org/travis/oqdata-${BRANCH}.zip;
+            bin/run-demos.sh $TRAVIS_BUILD_DIR/demos &&
+            bin/check_demos &&
+            oq dump /tmp/oqdata.zip &&
+            oq restore /tmp/oqdata.zip /tmp/oqdata &&
+            helpers/zipdemos.sh $(pwd)/demos &&
+            openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in .deploy_rsa.enc -out .deploy_rsa -d &&
+            chmod 600 .deploy_rsa &&
+            eval $(ssh-agent -s) && ssh-add .deploy_rsa &&
+            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/oqdata.zip travis@ci.openquake.org:/var/www/artifacts.openquake.org/travis/oqdata-${BRANCH}.zip &&
             bin/oq reset --yes;
           fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ jobs:
             chmod 600 .deploy_rsa;
             eval $(ssh-agent -s) && ssh-add .deploy_rsa;
             scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/oqdata.zip travis@ci.openquake.org:/var/www/artifacts.openquake.org/travis/oqdata-${BRANCH}.zip;
+            bin/oq reset --yes;
           fi
 
 before_install:
@@ -55,5 +56,3 @@ install:
 before_script:
   - python -c'import platform; print(platform.platform()); import multiprocessing; print("#CPUs=%d" % multiprocessing.cpu_count())'
 
-after_script:
-  - bin/oq reset --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
     env: HAZARDLIB
     script:
         - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[hazardlib\]' || test "$BRANCH" == "master"; then
-          nosetests --with-doctest -xvs -a'!slow' openquake.baselib openquake.hazardlib
+          nosetests --with-doctest -xvs -a'!slow' openquake.baselib openquake.hazardlib;
           fi
   - stage: tests
     env: ENGINE

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ jobs:
   - stage: tests
     env: HAZARDLIB
     script:
-        - nosetests --with-doctest -xvs -a'!slow' openquake.baselib
-        - nosetests --with-doctest -xvs -a'!slow' openquake.hazardlib
-        - nosetests --with-doctest -xvs -a'!slow' openquake.hmtk
+        - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[hazardlib\]' || test "$BRANCH" == "master"; then
+          nosetests --with-doctest -xvs -a'!slow' openquake.baselib openquake.hazardlib
+          fi
   - stage: tests
     env: ENGINE
     before_script:

--- a/packager.sh
+++ b/packager.sh
@@ -610,11 +610,13 @@ celery_wait $GEM_MAXLOOP"
         fi
 
         /usr/share/openquake/engine/utils/celery-status 
-
-        cd /usr/share/openquake/engine/demos/risk/EventBasedRisk
-        OQ_DISTRIBUTE=celery oq engine --run job_hazard.ini
-        oq engine --run job_risk.ini --exports csv,npz --hazard-calculation-id -1
-        cd -
+        cd /usr/share/openquake/engine/demos
+        for demo_dir in $(find . -type d | sort); do
+           if [ -f $demo_dir/job_hazard.ini ]; then
+               OQ_DISTRIBUTE=celery python -m openquake.commands engine --run $demo_dir/job_hazard.ini && python -m openquake.commands engine --run $demo_dir/job_risk.ini --hc -1
+           fi
+        done
+        
         # Try to export a set of results AFTER the calculation
         # automatically creates a directory called out
         echo \"Exporting output #1\"

--- a/packager.sh
+++ b/packager.sh
@@ -611,9 +611,9 @@ celery_wait $GEM_MAXLOOP"
 
         /usr/share/openquake/engine/utils/celery-status 
         cd /usr/share/openquake/engine/demos
-        for demo_dir in $(find . -type d | sort); do
-           if [ -f $demo_dir/job_hazard.ini ]; then
-               OQ_DISTRIBUTE=celery python -m openquake.commands engine --run $demo_dir/job_hazard.ini && python -m openquake.commands engine --run $demo_dir/job_risk.ini --hc -1
+        for demo_dir in \$(find . -type d | sort); do
+           if [ -f \$demo_dir/job_hazard.ini ]; then
+               OQ_DISTRIBUTE=celery python -m openquake.commands engine --run \$demo_dir/job_hazard.ini && python -m openquake.commands engine --run \$demo_dir/job_risk.ini --hc -1
            fi
         done
         

--- a/packager.sh
+++ b/packager.sh
@@ -613,7 +613,7 @@ celery_wait $GEM_MAXLOOP"
         cd /usr/share/openquake/engine/demos
         for demo_dir in \$(find . -type d | sort); do
            if [ -f \$demo_dir/job_hazard.ini ]; then
-               OQ_DISTRIBUTE=celery oq engine --run \$demo_dir/job_hazard.ini && oq --run \$demo_dir/job_risk.ini --hc -1
+               OQ_DISTRIBUTE=celery oq engine --run \$demo_dir/job_hazard.ini && oq engine --run \$demo_dir/job_risk.ini --hc -1
            fi
         done
         

--- a/packager.sh
+++ b/packager.sh
@@ -613,7 +613,7 @@ celery_wait $GEM_MAXLOOP"
         cd /usr/share/openquake/engine/demos
         for demo_dir in \$(find . -type d | sort); do
            if [ -f \$demo_dir/job_hazard.ini ]; then
-               OQ_DISTRIBUTE=celery python -m openquake.commands engine --run \$demo_dir/job_hazard.ini && python -m openquake.commands engine --run \$demo_dir/job_risk.ini --hc -1
+               OQ_DISTRIBUTE=celery oq engine --run \$demo_dir/job_hazard.ini && oq --run \$demo_dir/job_risk.ini --hc -1
            fi
         done
         


### PR DESCRIPTION
They are run always in the master branch; however, in development branches, they are run only if the tag [hazardlib] and/or [demos] are in the commit message.

I have restored the risk demos on Jenkins: in this way Python 2 is tested for all demos, not only for one. After the time to run all demos is nearly the same than the time to run only one (the time is dominated by the installation/reinstallation/etc).

Jenkins is happy: https://ci.openquake.org/job/zdevel_oq-engine/2551.