### PR TITLE
Use Travis cache for wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ language: python
 python:
  - "3.5"
 
+
+cache:
+  pip: true
+  directories:
+  - wheels  
+
 jobs:
   include:
   - stage: tests
@@ -50,7 +56,11 @@ before_install:
   - if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else BRANCH=$TRAVIS_BRANCH; fi
 
 install:
-  - pip -q install -r requirements-py35-linux64.txt
+  # pip do not cache data when requirements includes full http URLs, so we need to download
+  # the wheels first, put the folder in cache and then install the wheels from there.
+  # A second run of 'pip download' will download only the missing wheels. 
+  - mkdir wheels && cd wheels && pip -q download -r requirements-py35-linux64.txt
+  - pip -q install wheels/*
   - pip -q install -e .
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   # pip do not cache data when requirements includes full http URLs, so we need to download
   # the wheels first, put the folder in cache and then install the wheels from there.
   # A second run of 'pip download' will download only the missing wheels. 
-  - pip -q download -r requirements-py35-linux64.txt -d wheels
+  - pip download -r requirements-py35-linux64.txt -d wheels
   - pip -q install wheels/*
   - pip -q install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   # pip do not cache data when requirements includes full http URLs, so we need to download
   # the wheels first, put the folder in cache and then install the wheels from there.
   # A second run of 'pip download' will download only the missing wheels. 
-  - pip download -r requirements-py35-linux64.txt -d wheels
+  - pip -q download -r requirements-py35-linux64.txt -d wheels
   - pip -q install wheels/*
   - pip -q install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   # pip do not cache data when requirements includes full http URLs, so we need to download
   # the wheels first, put the folder in cache and then install the wheels from there.
   # A second run of 'pip download' will download only the missing wheels. 
-  - mkdir wheels && cd wheels && pip -q download -r requirements-py35-linux64.txt
+  - pip -q download -r requirements-py35-linux64.txt -d wheels
   - pip -q install wheels/*
   - pip -q install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python:
  - "3.5"
 
-
 cache:
   pip: true
   directories:


### PR DESCRIPTION
This requires some "custom" work because `requirements` with full HTTP URLs are not cached in `.cache/pip`. We use the `download` feature of pip instead.

You can see in https://travis-ci.org/gem/oq-engine/jobs/249913955 that `pip` says

```bash
$ pip download -r requirements-py35-linux64.txt -d wheels
Collecting pytz==2016.7 from http://cdn.ftp.openquake.org/wheelhouse/linux/py/pytz-2016.7-py2.py3-none-any.whl (from -r requirements-py35-linux64.txt (line 9))
  File was already downloaded /home/travis/build/gem/oq-engine/wheels/pytz-2016.7-py2.py3-none-any.whl
Collecting setuptools==28.8.0 from http://cdn.ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl (from -r requirements-py35-linux64.txt (line 10))
  File was already downloaded /home/travis/build/gem/oq-engine/wheels/setuptools-28.8.0-py2.py3-none-any.whl
Collecting pkgconfig==1.1.0 from http://cdn.ftp.openquake.org/wheelhouse/linux/py35/pkgconfig-1.1.0-py3-none-any.whl (from -r requirements-py35-linux64.txt (line 11))
  File was already downloaded /home/travis/build/gem/oq-engine/wheels/pkgconfig-1.1.0-py3-none-any.whl
Collecting mock==1.3.0 from http://cdn.ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl (from -r requirements-py35-linux64.txt (line 12))
  File was already downloaded /home/travis/build/gem/oq-engine/wheels/mock-1.3.0-py2.py3-none-any.whl
Collecting h5py==2.7.0 from http://cdn.ftp.openquake.org/wheelhouse/linux/py35/h5py-2.7.0-cp35-cp35m-manylinux1_x86_64.whl (from -r requirements-py35-linux64.txt (line 13))
  File was already downloaded /home/travis/build/gem/oq-engine/wheels/h5py-2.7.0-cp35-cp35m-manylinux1_x86_64.whl
```

This is very useful in our case where we are using build stages.