### PR TITLE
Made the demo LogicTreeCase2ClassicalPSHA faster

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made the demo LogicTreeCase2ClassicalPSHA faster
   * Fixed the export by realization of the hazard outputs
   * Changed the generation of loss_maps in event based risk, without the option
     `--hc`: now it is done in parallel, except when reading the loss ratios

--- a/demos/hazard/LogicTreeCase2ClassicalPSHA/job.ini
+++ b/demos/hazard/LogicTreeCase2ClassicalPSHA/job.ini
@@ -15,9 +15,9 @@ number_of_logic_tree_samples = 0
 
 [erf]
 
-rupture_mesh_spacing = 2
+rupture_mesh_spacing = 4
 width_of_mfd_bin = 0.1
-area_source_discretization = 5.0
+area_source_discretization = 10.0
 
 [site_params]
 


### PR DESCRIPTION
By increasing the mesh spacing and the area discretization it is now 4 times faster. This was the slowest demo we had before. @mmpagani please confirm that the parameters are still reasonable.