### PR TITLE
Solved the heisenbug (hopefully)

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -183,8 +183,6 @@ def build_loss_maps(avalues, builder, lrgetter, weights, stats, monitor):
     `openquake.risklib.scientific.CurveBuilder.build_maps`.
     :returns: assets IDs and loss maps for the given chunk of assets
     """
-    if lrgetter.dstore.hdf5 is None:  # not open yet
-        lrgetter.dstore.open()
     loss_maps, loss_maps_stats = builder.build_maps(
         avalues, lrgetter, weights, stats, monitor)
     res = {'aids': lrgetter.aids, 'loss_maps-rlzs': loss_maps}

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -836,6 +836,7 @@ class LossRatiosGetter(object):
         """
         if getattr(self, 'data', None) is not None:
             return self.data
+        self.dstore.open()  # if closed
         data = self.dstore['all_loss_ratios/data']
         loss_ratio_data = []
         for aid, idxs in zip(self.aids, self.indices):


### PR DESCRIPTION
In the case of no `-hc` the data are read in the controller node and there is no need to call `lrgetter.dstore.open()` in the workers. This will avoid the random error

```
RuntimeError: 
  File "/home/travis/build/gem/oq-engine/openquake/baselib/parallel.py", line 241, in safely_call
    got = func(*args)
  File "/home/travis/build/gem/oq-engine/openquake/calculators/event_based_risk.py", line 187, in build_loss_maps
    lrgetter.dstore.open()
  File "/home/travis/build/gem/oq-engine/openquake/commonlib/datastore.py", line 178, in open
    self.hdf5 = hdf5.File(self.hdf5path, mode, libver='latest')
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/h5py/_hl/files.py", line 271, in __init__
    fid = make_fid(name, mode, userblock_size, fapl, swmr=swmr)
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/h5py/_hl/files.py", line 101, in make_fid
    fid = h5f.open(name, flags, fapl=fapl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/tmp/pip-huypgcah-build/h5py/_objects.c:2840)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/tmp/pip-huypgcah-build/h5py/_objects.c:2798)
  File "h5py/h5f.pyx", line 78, in h5py.h5f.open (/tmp/pip-huypgcah-build/h5py/h5f.c:2117)
OSError: Unable to open file (Truncated file: eof = 145581, sblock->base_addr = 0, stored_eoa = 153821
```