### PR TITLE
Changed the agg_loss_table storage

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -283,11 +283,10 @@ class EbrPostCalculator(base.RiskCalculator):
         loss_curve_dt = scientific.build_loss_curve_dt(
             cr, oq.conditional_loss_poes, oq.insured_losses)
         cb_inputs = self.cb_inputs('agg_loss_table')
-        I = oq.insured_losses + 1
         R = len(weights)
         # NB: using the Processmap since celery is hanging; the computation
         # is fast anyway and this part will likely be removed in the future
-        result = parallel.Sequential.apply(
+        result = parallel.Processmap.apply(
             build_agg_curve, (cb_inputs, self.monitor('')),
             concurrent_tasks=self.oqparam.concurrent_tasks).reduce()
         agg_curve = numpy.zeros(R, loss_curve_dt)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -53,7 +53,7 @@ def build_agg_curve(cb_inputs, monitor):
     :param monitor:
         a Monitor instance
     :returns:
-        a dictionary (r, li) -> (losses, poes, avg)
+        a dictionary (li, r) -> (losses, poes, avg)
     """
     result = {}
     for cbs, rlzname, data in cb_inputs:

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -80,12 +80,12 @@ def export_agg_curve_rlzs(ekey, dstore):
     if ekey[0].endswith('stats'):
         tags = ['mean'] + ['quantile-%s' % q for q in oq.quantile_loss_curves]
     else:
-        tags = ['rlz-%03d' % r for r in range(agg_curve.shape[1])]
+        tags = ['rlz-%03d' % r for r in range(len(agg_curve))]
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     for r, tag in enumerate(tags):
         data = [['loss_type', 'loss', 'poe']]
         for loss_type in agg_curve.dtype.names:
-            array = agg_curve[0, r][loss_type]
+            array = agg_curve[r][loss_type]
             for loss, poe in zip(array['losses'], array['poes']):
                 data.append((loss_type, loss, poe))
         dest = dstore.build_fname('agg_curve', tag, 'csv')

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -233,6 +233,7 @@ def export_agg_losses_ebr(ekey, dstore):
     :param dstore: datastore object
     """
     loss_types = dstore.get_attr('composite_risk_model', 'loss_types')
+    L = len(loss_types)
     name, ext = export.keyfunc(ekey)
     agg_losses = dstore[name]
     has_rup_data = 'ruptures' in dstore
@@ -279,7 +280,7 @@ def export_agg_losses_ebr(ekey, dstore):
             for i, ins in enumerate(
                     ['', '_ins'] if oq.insured_losses else ['']):
                 for l, loss_type in enumerate(loss_types):
-                    elt[loss_type + ins][:] = losses[:, l, i]
+                    elt[loss_type + ins][:] = losses[:, l + L * i]
             elt.sort(order=['year', 'event_id'])
             dest = dstore.build_fname('agg_losses', rlz, 'csv')
             writer.save(elt, dest)

--- a/openquake/calculators/gmf_ebrisk.py
+++ b/openquake/calculators/gmf_ebrisk.py
@@ -60,7 +60,7 @@ class GmfEbRiskCalculator(base.RiskCalculator):
         self.param['avg_losses'] = oq.avg_losses
         self.param['asset_loss_table'] = oq.asset_loss_table or oq.loss_ratios
         self.param['elt_dt'] = numpy.dtype(
-            [('eid', U64), ('loss', (F32, (self.L, self.I)))])
+            [('eid', U64), ('loss', (F32, (self.L * self.I,)))])
         self.taskno = 0
         self.start = 0
         self.datastore.create_dset('losses_by_taxon-rlzs', F32,

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -38,19 +38,17 @@ from openquake.qa_tests_data.event_based_risk import (
 def check_total_losses(calc):
     dstore = calc.datastore
     loss_dt = calc.oqparam.loss_dt()
-    L1 = len(loss_dt.names)
-    L = L1 // 2
-    data1 = numpy.zeros(L1, numpy.float32)
+    LI = len(loss_dt.names)
+    data1 = numpy.zeros(LI, numpy.float32)
     for dset in dstore['agg_loss_table'].values():
-        for l, lt in enumerate(loss_dt.names):
-            i = int(lt.endswith('_ins'))  # the cast avoids a numpy warning
-            data1[l] += dset['loss'][:, l - L * i, i].sum()
+        for li, lt in enumerate(loss_dt.names):
+            data1[li] += dset['loss'][:, li].sum()
 
     # check the sums are consistent with the ones coming from losses_by_taxon
-    data2 = numpy.zeros(L1, numpy.float32)
+    data2 = numpy.zeros(LI, numpy.float32)
     lbt = dstore['losses_by_taxon-rlzs']
-    for l in range(L1):
-        data2[l] += lbt[:, :, l].sum()
+    for li in range(LI):
+        data2[li] += lbt[:, :, li].sum()
     numpy.testing.assert_allclose(data1, data2, 1E-6)
 
     # test the asset_loss_table exporter; notice that I need to disable

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -974,6 +974,10 @@ class CurveBuilder(object):
                 dtlist.append((lt, (F32, len(cb.ratios))))
         self.dt = numpy.dtype(dtlist)
 
+    def __getitem__(self, li):
+        L = len(self.cbs)
+        return self.cbs[li % L]
+
     def __iter__(self):
         return iter(self.cbs)
 


### PR DESCRIPTION
To make is more consistent with the asset_loss_table storage. Instead of arrays of shape (E, L, I) we are using arrays of shape (E, L * I) were E is the number of events, L the number of loss types and I is 2 or 1 depending if there are insured losses or not. The exports are unchanged.

This is preliminary to https://github.com/gem/oq-engine/issues/2845.