### PR TITLE
Added experimental support for SCOOP

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -174,38 +174,7 @@ if OQ_DISTRIBUTE == 'celery':
     from openquake.engine.celeryconfig import BROKER_URL, CELERY_RESULT_BACKEND
     app = Celery('openquake', backend=CELERY_RESULT_BACKEND, broker=BROKER_URL)
 elif OQ_DISTRIBUTE == 'scoop':
-    from threading import Thread
-    from scoop import launcher, utils, futures as scoop_futures
-
-    def scoop_run(hostfile=None, hosts=None, n=None):
-        # Get a list of resources to launch worker(s) on
-        hosts = utils.getHosts(hostfile)
-        if n is None:
-            n = utils.getWorkerQte(hosts)
-        external_hostname = [utils.externalHostname(hosts)]
-
-        # Launch SCOOP
-        thisScoopApp = launcher.ScoopApp(
-            hosts, n, args.b, 0, sys.executable, external_hostname[0],
-            'oq', args.args, args.tunnel, args.path, args.debug, args.nice,
-            utils.getEnv(), args.profile, args.pythonpath[0],
-            args.prolog[0], args.backend)
-
-        rootTaskExitCode = False
-        interruptPreventer = Thread(target=thisScoopApp.close)
-        try:
-            rootTaskExitCode = thisScoopApp.run()
-        except Exception as e:
-            logging.error('Error while launching SCOOP subprocesses:%s', e)
-            logging.error(traceback.format_exc())
-            rootTaskExitCode = -1
-        finally:
-            interruptPreventer.start()
-            interruptPreventer.join()
-
-        # Exit with the proper exit code
-        if rootTaskExitCode:
-            sys.exit(rootTaskExitCode)
+    from scoop import futures as scoop_futures
 
 elif OQ_DISTRIBUTE == 'ipython':
     import ipyparallel as ipp

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -173,6 +173,39 @@ if OQ_DISTRIBUTE == 'celery':
     from celery.task import task
     from openquake.engine.celeryconfig import BROKER_URL, CELERY_RESULT_BACKEND
     app = Celery('openquake', backend=CELERY_RESULT_BACKEND, broker=BROKER_URL)
+elif OQ_DISTRIBUTE == 'scoop':
+    from threading import Thread
+    from scoop import launcher, utils, futures as scoop_futures
+
+    def scoop_run(hostfile=None, hosts=None, n=None):
+        # Get a list of resources to launch worker(s) on
+        hosts = utils.getHosts(hostfile)
+        if n is None:
+            n = utils.getWorkerQte(hosts)
+        external_hostname = [utils.externalHostname(hosts)]
+
+        # Launch SCOOP
+        thisScoopApp = launcher.ScoopApp(
+            hosts, n, args.b, 0, sys.executable, external_hostname[0],
+            'oq', args.args, args.tunnel, args.path, args.debug, args.nice,
+            utils.getEnv(), args.profile, args.pythonpath[0],
+            args.prolog[0], args.backend)
+
+        rootTaskExitCode = False
+        interruptPreventer = Thread(target=thisScoopApp.close)
+        try:
+            rootTaskExitCode = thisScoopApp.run()
+        except Exception as e:
+            logging.error('Error while launching SCOOP subprocesses:%s', e)
+            logging.error(traceback.format_exc())
+            rootTaskExitCode = -1
+        finally:
+            interruptPreventer.start()
+            interruptPreventer.join()
+
+        # Exit with the proper exit code
+        if rootTaskExitCode:
+            sys.exit(rootTaskExitCode)
 
 elif OQ_DISTRIBUTE == 'ipython':
     import ipyparallel as ipp
@@ -561,6 +594,9 @@ class Starmap(object):
             res = safe_task.delay(self.task_func, piks, True)
             self.task_ids.append(res.task_id)
             return res
+        elif self.distribute == 'scoop':
+            return scoop_futures.submit(
+                safely_call, self.task_func, piks, True)
         else:  # submit tasks by using the ProcessPoolExecutor or ipyparallel
             return self.executor.submit(
                 safely_call, self.task_func, piks, True)
@@ -581,6 +617,10 @@ class Starmap(object):
                 # work around a celery/rabbitmq bug
                 if CELERY_RESULT_BACKEND.startswith('rpc:'):
                     del app.backend._cache[task_id]
+                yield fut
+
+        elif self.distribute == 'scoop':
+            for fut in scoop_futures.as_completed(self.results):
                 yield fut
 
         else:  # future interface


### PR DESCRIPTION
We tried it on our cluster and it works. Here is an example

```
$ OQ_DISTRIBUTE=scoop /opt/python35/bin/python -m scoop --hostfile hosts /usr/local/openquake/oq-engine/bin/oq engine --run /home/michele/Tanzania/job.ini
```

where the file `hosts` has the following content:
```
wilson 1
mercury 64
marley 64
dylan 64
cobain 64
```