### PR TITLE
Refactor the reset command and make it work for multi_user

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Daniele Viganò]
+  * Extended the 'oq reset' command to work on multi user installations
+
   [Michele Simionato]
   * Fixed a bug: if there are multiple realizations and no hazard stats,
     it is an error to set hazard_maps=true or uniform_hazard_spectra=true

--- a/doc/installing/rhel.md
+++ b/doc/installing/rhel.md
@@ -87,6 +87,22 @@ sudo yum install yum-plugin-remove-with-leaves
 sudo yum erase --remove-leaves python-oq-*
 ```
 
+## Data cleanup
+
+To reset the database `oq reset` command can be used:
+
+```bash
+sudo systemctl stop openquake-dbserver.service
+sudo -u openquake oq reset
+sudo systemctl start openquake-dbserver.service
+```
+
+To remove **all** the data produced by the OpenQuake Engine (including datastores) you must also remove `~/oqdata` in each users' home. The `reset-db` bash script is provided, as a reference, in `/usr/share/openquake/engine/utils`.
+
+
+
+If the packages have been already uninstalled, it's safe to remove `/var/lib/openquake`.
+
 ***
 
 ## Getting help

--- a/doc/installing/ubuntu.md
+++ b/doc/installing/ubuntu.md
@@ -82,6 +82,20 @@ If you want to remove all the dependencies installed by the OpenQuake Engine you
 sudo apt-get autoremove
 ```
 
+## Data cleanup
+
+To reset the database `oq reset` command can be used:
+
+```bash
+sudo supervisorctl stop openquake-dbserver
+sudo -u openquake oq reset
+sudo supervisorctl start openquake-dbserver
+```
+
+To remove **all** the data produced by the OpenQuake Engine (including datastores) you must also remove `~/oqdata` in each users' home. The `reset-db` bash script is provided, as a reference, in `/usr/share/openquake/engine/utils`.
+
+If the packages have been already uninstalled, it's safe to remove `/var/lib/openquake`.
+
 ***
 
 ## Getting help

--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import os
 import re
 import getpass
+import shutil
 from openquake.baselib import sap
 from openquake.commonlib import datastore
 from openquake.commonlib.logs import dbcmd
@@ -39,16 +40,22 @@ def purge_one(calc_id, user):
 
 
 # used in the reset command
-def purge_all(user=None):
+def purge_all(user=None, fast=False):
     """
     Remove all calculations of the given user
     """
     user = user or getpass.getuser()
-    for fname in os.listdir(datastore.DATADIR):
-        mo = re.match('calc_(\d+)\.hdf5', fname)
-        if mo is not None:
-            calc_id = int(mo.group(1))
-            purge_one(calc_id, user)
+    datadir = datastore.DATADIR
+    if os.path.exists(datadir):
+        if fast:
+            shutil.rmtree(datadir)
+            print('Removed %s' % datadir)
+        else:
+            for fname in os.listdir(datadir):
+                mo = re.match('calc_(\d+)\.hdf5', fname)
+                if mo is not None:
+                    calc_id = int(mo.group(1))
+                    purge_one(calc_id, user)
 
 
 @sap.Script

--- a/openquake/commands/reset.py
+++ b/openquake/commands/reset.py
@@ -19,9 +19,8 @@
 from __future__ import print_function
 import os
 import sys
-import shutil
 from openquake.baselib import sap
-from openquake.commonlib import datastore, config
+from openquake.commonlib import config
 from openquake.commonlib import logs
 from openquake.engine.utils import confirm
 from openquake.server import dbserver
@@ -37,26 +36,27 @@ def reset(yes):
     if not ok:
         return
 
-    if config.flag_set('dbserver', 'multi_user'):
-        purge_all()  # remove data of the current user only
-        return
-
-    # else: fast way of removing everything
-
-    if dbserver.get_status() == 'running':
-        logs.dbcmd('stop')
-        print('dbserver stopped')
-
     dbpath = os.path.realpath(
         os.path.expanduser(config.get('dbserver', 'file')))
-    try:
-        os.remove(dbpath)  # database of the current user
-        print('Removed %s' % dbpath)
-    except OSError as exc:
-        print(exc, file=sys.stderr)
-    datadir = os.path.realpath(datastore.DATADIR)
-    if os.path.exists(datadir):
-        shutil.rmtree(datadir)  # datastore of the current user
-    print('Removed %s' % datadir)
+
+    # user must be able to access and write the databse file to remove it
+    if os.path.isfile(dbpath) and os.access(dbpath, os.W_OK):
+        if dbserver.get_status() == 'running':
+            if config.flag_set('dbserver', 'multi_user'):
+                sys.exit('The oq dbserver must be stopped '
+                         'before proceeding')
+            else:
+                logs.dbcmd('stop')
+                print('dbserver stopped')
+
+        try:
+            os.remove(dbpath)
+            print('Removed %s. You must re-apply any existing migration.'
+                  % dbpath)
+        except OSError as exc:
+            print(exc, file=sys.stderr)
+
+    # fast way of removing everything
+    purge_all(fast=True)  # datastore of the current user
 
 reset.flg('yes', 'confirmation')

--- a/openquake/commands/reset.py
+++ b/openquake/commands/reset.py
@@ -51,7 +51,7 @@ def reset(yes):
 
         try:
             os.remove(dbpath)
-            print('Removed %s. You must re-apply any existing migration.'
+            print('Removed %s'
                   % dbpath)
         except OSError as exc:
             print(exc, file=sys.stderr)

--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -52,8 +52,9 @@ def webui(cmd, hostport='127.0.0.1:8800', skip_browser=False):
     django application
     """
 
-    db_path = os.path.expanduser(config.get('dbserver', 'file'))
-    if os.path.isfile(db_path) and not os.access(db_path, os.W_OK):
+    dbpath = os.path.realpath(
+        os.path.expanduser(config.get('dbserver', 'file')))
+    if os.path.isfile(dbpath) and not os.access(dbpath, os.W_OK):
         sys.exit('This command must be run by the proper user: '
                  'see the documentation for details')
     if cmd == 'start':

--- a/utils/reset-db
+++ b/utils/reset-db
@@ -95,6 +95,9 @@ if [[ "$answer" == "y" ]]; then
     find /home -maxdepth 2 -type d -name "oqdata" -exec rm -Rf '{}' \; || true
     if [ -z $skipnew ]; then
         startstop start
+        echo " * Migrating schema"
+        cd /usr/share/openquake/engine || true
+        oq webui migrate
         echo " * Database created"
     fi
     echo ''


### PR DESCRIPTION
With this PR `oq reset` now deletes the DB and the WebUI datastore even if `multi_user = true`. To be able to use it in `multi_user` the command must be executed by the `openquake` user. If not, only `oqdata` for the user running the command will be deleted:

```bash
[daniele@centos7-oq ~]$ sudo -u openquake oq reset
Do you really want to destroy all your data? (y/n) y
Removed /var/lib/openquake/db.sqlite3. You must re-apply any existing migration.
Removed /var/lib/openquake/oqdata
```

```bash
[daniele@centos7-oq ~]$ oq reset
Do you really want to destroy all your data? (y/n) y
Removed /home/daniele/oqdata
```