### PR TITLE
Modified the Coefficients Table to be instantiated with dictionaries as well as strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist
 *.egg-info
 local_settings.py
 demos/*/*.zip
+*.swp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Graeme Weatherill]
+  * Adapts CoeffsTable to be instantiated with dictionarys as well as strings
+  
   [Daniele Viganò]
   * Extended the 'oq reset' command to work on multi user installations
 

--- a/debian/changelog_hazardlib
+++ b/debian/changelog_hazardlib
@@ -1,6 +1,3 @@
-  [Graeme Weatherill]
-  * Adapts CoeffsTable to be instantiated with dictionarys as well as strings
-  
   [Michele Simionato, Daniele Viganò]
   * Merged the `oq-hazardlib` repository into `oq-engine`.
     The `python-oq-hazardlib` package is now provided by `python-oq-engine`

--- a/debian/changelog_hazardlib
+++ b/debian/changelog_hazardlib
@@ -1,3 +1,6 @@
+  [Graeme Weatherill]
+  * Adapts CoeffsTable to be instantiated with dictionarys as well as strings
+  
   [Michele Simionato, Daniele Viganò]
   * Merged the `oq-hazardlib` repository into `oq-engine`.
     The `python-oq-hazardlib` package is now provided by `python-oq-engine`

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -940,8 +940,8 @@ class CoeffsTable(object):
                 else:
                     self.non_sa_coeffs[key] = table[key]
         else:
-            raise ValueError('CoeffsTable cannot be constructed with inputs '
-                             'of the form %s' % type(table))
+            raise TypeError("CoeffsTable cannot be constructed with inputs "
+                            "of the form '%s'" % table.__class__.__name__)
 
     def _setup_table_from_str(self, table, sa_damping):
         """

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -916,15 +916,11 @@ class CoeffsTable(object):
     It is also possible to instantiate a table from a tuple of dictionaries,
     corresponding to the SA coefficients and non-SA coefficients:
 
-    >>> sa_coeffs = {SA(0.1): {"a": 1.0, "b": 2.0},
-    ...              SA(1.0): {"a": 3.0, "b": 4.0}}
-    >>> non_sa_coeffs = {PGA(): {"a": 0.1, "b": 1.0},
-    ...                  PGV(): {"a": 0.5, "b": 10.0}}
-    >>> ct = CoeffsTable(sa_damping=5, table=(sa_coeffs, non_sa_coeffs))
-
-    Even if one of those is missing:
-
-    >>> ct = CoeffsTable(sa_damping=5, table=(None, non_sa_coeffs))
+    >>> coeffs = {SA(0.1): {"a": 1.0, "b": 2.0},
+    ...           SA(1.0): {"a": 3.0, "b": 4.0},
+    ...           PGA(): {"a": 0.1, "b": 1.0},
+    ...           PGV(): {"a": 0.5, "b": 10.0}}
+    >>> ct = CoeffsTable(sa_damping=5, table=coeffs)
     """
     def __init__(self, **kwargs):
         if 'table' not in kwargs:
@@ -937,12 +933,12 @@ class CoeffsTable(object):
             raise TypeError('CoeffsTable got unexpected kwargs: %r' % kwargs)
         if isinstance(table, str):
             self._setup_table_from_str(table, sa_damping)
-        elif isinstance(table, tuple):
-            sa_coeffs, non_sa_coeffs = table
-            if sa_coeffs:
-                self.sa_coeffs = sa_coeffs
-            if non_sa_coeffs:
-                self.non_sa_coeffs = non_sa_coeffs
+        elif isinstance(table, dict):
+            for key in table:
+                if isinstance(key, imt_module.SA):
+                    self.sa_coeffs[key] = table[key]
+                else:
+                    self.non_sa_coeffs[key] = table[key]
         else:
             raise ValueError('CoeffsTable cannot be constructed with inputs '
                              'of the form %s' % type(table))

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -912,20 +912,50 @@ class CoeffsTable(object):
     Traceback (most recent call last):
         ...
     KeyError: SA(period=0.01, damping=5)
+
+    It is also possible to instantiate a table from a tuple of dictionaries,
+    corresponding to the SA coefficients and non-SA coefficients:
+
+    >>> sa_coeffs = {SA(0.1): {"a": 1.0, "b": 2.0},
+    ...              SA(1.0): {"a": 3.0, "b": 4.0}}
+    >>> non_sa_coeffs = {PGA(): {"a": 0.1, "b": 1.0},
+    ...                  PGV(): {"a": 0.5, "b": 10.0}}
+    >>> ct = CoeffsTable(sa_damping=5, table=(sa_coeffs, non_sa_coeffs))
+
+    Even if one of those is missing:
+
+    >>> ct = CoeffsTable(sa_damping=5, table=(None, non_sa_coeffs))
     """
     def __init__(self, **kwargs):
         if 'table' not in kwargs:
             raise TypeError('CoeffsTable requires "table" kwarg')
-        table = kwargs.pop('table').strip().splitlines()
+        table = kwargs.pop('table')
+        self.sa_coeffs = {}
+        self.non_sa_coeffs = {}
         sa_damping = kwargs.pop('sa_damping', None)
         if kwargs:
             raise TypeError('CoeffsTable got unexpected kwargs: %r' % kwargs)
+        if isinstance(table, str):
+            self._setup_table_from_str(table, sa_damping)
+        elif isinstance(table, tuple):
+            sa_coeffs, non_sa_coeffs = table
+            if sa_coeffs:
+                self.sa_coeffs = sa_coeffs
+            if non_sa_coeffs:
+                self.non_sa_coeffs = non_sa_coeffs
+        else:
+            raise ValueError('CoeffsTable cannot be constructed with inputs '
+                             'of the form %s' % type(table))
+
+    def _setup_table_from_str(self, table, sa_damping):
+        """
+        Builds the input tables from a string definition
+        """
+        table = table.strip().splitlines()
         header = table.pop(0).split()
         if not header[0].upper() == "IMT":
             raise ValueError('first column in a table must be IMT')
         coeff_names = header[1:]
-        self.sa_coeffs = {}
-        self.non_sa_coeffs = {}
         for row in table:
             row = row.split()
             imt_name = row[0].upper()

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -21,6 +21,7 @@ import collections
 import mock
 
 import numpy
+from copy import deepcopy
 
 from openquake.hazardlib import const
 from openquake.hazardlib.gsim.base import (
@@ -652,8 +653,8 @@ class CoeffsTableTestCase(unittest.TestCase):
         table1 = CoeffsTable(sa_damping=5, table=self.coefficient_string)
         self.assertDictEqual(
             table1.non_sa_coeffs,
-            {PGV(): {"a": 0.1, "b": 0.2}, PGA(): {"a": 0.05, "b": 0.1}}
-            )
+            {PGV(): {"a": 0.1, "b": 0.2},
+             PGA(): {"a": 0.05, "b": 0.1}})
         self.assertDictEqual(
             table1.sa_coeffs,
             {SA(period=0.1, damping=5): {"a": 1.0, "b": 2.0},
@@ -661,17 +662,16 @@ class CoeffsTableTestCase(unittest.TestCase):
              SA(period=10.0, damping=5): {"a": 10.0, "b": 20.0}}
             )
 
-    def test_table_tuple_instantiation(self):
+    def test_table_dict_instantiation(self):
         # Check that the table instantiates with pre-defined dictionaries
         table1 = CoeffsTable(sa_damping=5, table=self.coefficient_string)
+        # Create target dictionatu
+        coeffs = deepcopy(table1.non_sa_coeffs)
+        coeffs.update(table1.sa_coeffs)
         table2 = CoeffsTable(sa_damping=5,
-                             table=(table1.sa_coeffs, table1.non_sa_coeffs))
+                             table=coeffs)
         self.assertDictEqual(table1.sa_coeffs, table2.sa_coeffs)
         self.assertDictEqual(table1.non_sa_coeffs, table2.non_sa_coeffs)
-
-        # Additional case when sa_coeffs is missing
-        table3 = CoeffsTable(sa_damping=5, table=(None, table1.non_sa_coeffs))
-        self.assertDictEqual(table3.sa_coeffs, {})
 
     def test_table_bad_instantiation(self):
         # If instantiated with anything other than string or tuple should

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -665,7 +665,7 @@ class CoeffsTableTestCase(unittest.TestCase):
     def test_table_dict_instantiation(self):
         # Check that the table instantiates with pre-defined dictionaries
         table1 = CoeffsTable(sa_damping=5, table=self.coefficient_string)
-        # Create target dictionatu
+        # Create target dictionary
         coeffs = deepcopy(table1.non_sa_coeffs)
         coeffs.update(table1.sa_coeffs)
         table2 = CoeffsTable(sa_damping=5,
@@ -675,9 +675,9 @@ class CoeffsTableTestCase(unittest.TestCase):
 
     def test_table_bad_instantiation(self):
         # If instantiated with anything other than string or tuple should
-        # raise an error
-        with self.assertRaises(ValueError) as ve:
+        # raise a TypeError
+        with self.assertRaises(TypeError) as te:
             CoeffsTable(sa_damping=5, table=5)
-        self.assertEqual(str(ve.exception),
+        self.assertEqual(str(te.exception),
                          "CoeffsTable cannot be constructed with "
-                         "inputs of the form <type 'int'>")
+                         "inputs of the form 'int'")


### PR DESCRIPTION
It is increasingly common to modify coefficients of published GMPEs depending on the application. This adapts the Coefficients Table object to support input of the coefficients in terms of a tuple of dictionaries (one for SA coefficients the other for Non-SA coefficients), in addition to the current means of definition using a string. This can allow for the coefficients table to be modified dynamically without the need for multiple tables to be hard coded. This is needed for https://github.com/gem/oq-engine/issues/2954