### PR TITLE
Python 3.6 fix

### DIFF
--- a/openquake/commands/upgrade_nrml.py
+++ b/openquake/commands/upgrade_nrml.py
@@ -146,7 +146,6 @@ def upgrade_nrml(directory, dry_run):
                             print(exc)
                     else:
                         print('Not upgrading', path)
-                ip._file.close()
 
 
 upgrade_nrml.arg('directory', 'directory to consider')


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/2962. The garbage collector will close the file anyway. Also, notice that this code is not used by the engine, it is just an utility to upgrade from NRML 0.4 to NRML 0.5.