### PR TITLE
Minor fixes for floating precision in gsim tables and tests

### DIFF
--- a/openquake/hazardlib/gsim/gsim_table.py
+++ b/openquake/hazardlib/gsim/gsim_table.py
@@ -524,8 +524,8 @@ class GMPETable(GMPE):
 
             low_period = round(periods[0], 7)
             high_period = round(periods[-1], 7)
-
-            if imt.period < low_period or imt.period > high_period:
+            if (round(imt.period, 7) < low_period) or\
+                (round(imt.period, 7) > high_period):
                 raise ValueError("Spectral period %.3f outside of valid range "
                                  "(%.3f to %.3f)" % (imt.period, periods[0],
                                                      periods[-1]))

--- a/openquake/hazardlib/tests/gsim/chiou_youngs_2014_test.py
+++ b/openquake/hazardlib/tests/gsim/chiou_youngs_2014_test.py
@@ -163,7 +163,7 @@ class ChiouYoungs2014NearFaultDistanceTaperTestCase(BaseGSIMTestCase):
             imts=[PGV()],
             gsim=ChiouYoungs2014NearFaultEffect(),
             truncation_level=0,
-            realizations=1.
+            realizations=1
         )
         gmf = fields[PGV()]
         self.assertAlmostEquals(2.27328758, gmf[0], delta=1e-4)

--- a/openquake/hazardlib/tests/gsim/gsim_table_test.py
+++ b/openquake/hazardlib/tests/gsim/gsim_table_test.py
@@ -181,7 +181,7 @@ class AmplificationTableSiteTestCase(unittest.TestCase):
                                 np.log10(np.array([1.5, 2.0, 0.5])))
         period = 0.3
         expected_table[:, self.IDX] = (
-            10.0 ** interpolator(np.log10(period))) * np.ones(10.)
+            10.0 ** interpolator(np.log10(period))) * np.ones(10)
         np.testing.assert_array_almost_equal(
             self.amp_table.get_mean_table(imt_module.SA(period), rctx),
             expected_table)


### PR DESCRIPTION
Some minor errors were turning up when running the OQ-engine test suite on my machine, which seem to relate to the erroneous use of floating point values when specifying numpy array dimensions (I'm using numpy 1.13.1). This PR fixes these errors.

Also, resolves the gsim_table period precision issue contained within https://github.com/gem/oq-engine/pull/2913 (recommend to close that PR as the other issue may be resolved in due course)