### PR TITLE
Add a deprecation warning to changelog_hazardlib and risklib

### DIFF
--- a/debian/changelog_hazardlib
+++ b/debian/changelog_hazardlib
@@ -1,3 +1,5 @@
+## DO NOT ADD NEW ITEMS: use `debian/changelog` instead ##
+
   [Michele Simionato, Daniele Viganò]
   * Merged the `oq-hazardlib` repository into `oq-engine`.
     The `python-oq-hazardlib` package is now provided by `python-oq-engine`

--- a/debian/changelog_risklib
+++ b/debian/changelog_risklib
@@ -1,3 +1,5 @@
+## DO NOT ADD NEW ITEMS: use `debian/changelog` instead ##
+
 python-oq-risklib (0.12.1-0~precise01) precise; urgency=low
 
   [Michele Simionato]


### PR DESCRIPTION
I'm using an invalid syntax to check that those files are *not* processed by dpkg/CI.

https://ci.openquake.org/job/zdevel_oq-engine/2566/