### PR TITLE
Fix export hcurves-rlzs in hdf5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed `oq export hcurves-rlzs -e hdf5`
   * Changed the source weighting algorithm: now it is proportional to the
     the number of affected sites
   * Added a command `oq show dupl_sources` and enhances `oq info job.ini`

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -391,7 +391,7 @@ def export_hcurves_rlzs(ekey, dstore):
         dset = f.create_dataset('hcurves-rlzs', (N, R), imtls.dt)
         dset.attrs['investigation_time'] = oq.investigation_time
         logging.info('Building the hazard curves for %d sites, %d rlzs', N, R)
-        for sids, allcurves in parallel.Processmap(build_hcurves, allargs):
+        for sids, allcurves in parallel.Starmap(build_hcurves, allargs):
             for sid, curves in zip(sids, allcurves):
                 dset[sid] = curves
     return [fname]


### PR DESCRIPTION
Despite the fact that the exporter was tested and working on the test, the Armenia calculation failed, as reported by Marco and Robin. I am fixing the bug by using the regular Starmap instead of the Processmap.
Why the Armenia is special is not clear at the moment.