### PR TITLE
Removed the support for pickled object in the datastore

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -317,8 +317,8 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
             self.datastore['realizations'] = numpy.array(
                 [(r.uid, sm_by_rlz[r], gsim_names(r), r.weight)
                  for r in self.rlzs_assoc.realizations], rlz_dt)
-        if 'hcurves' in set(self.datastore):
-            self.datastore.set_nbytes('hcurves')
+        for key in self.datastore:
+            self.datastore.set_nbytes(key)
         self.datastore.flush()
 
 

--- a/openquake/calculators/tests/base_test.py
+++ b/openquake/calculators/tests/base_test.py
@@ -19,10 +19,11 @@
 import unittest
 import mock
 from openquake.baselib.general import writetmp
+from openquake.baselib import hdf5
 from openquake.calculators import base
 
 
-class FakeParams(object):
+class FakeParams(hdf5.LiteralAttrs):
     export_dir = '/tmp'
     hazard_calculation_id = None
     inputs = {'job_ini': writetmp('fake_job.ini')}

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -231,9 +231,9 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         os.remove(fname)
 
         # check job_info is stored
-        job_info = dict(self.calc.datastore['job_info'])
-        self.assertIn(b'build_loss_maps.sent', job_info)
-        self.assertIn(b'build_loss_maps.received', job_info)
+        job_info = [str(k) for k in dict(self.calc.datastore['job_info'])]
+        self.assertIn('build_loss_maps.sent', job_info)
+        self.assertIn('build_loss_maps.received', job_info)
 
         check_total_losses(self.calc)
 

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -231,7 +231,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         os.remove(fname)
 
         # check job_info is stored
-        job_info = [str(k) for k in dict(self.calc.datastore['job_info'])]
+        job_info = {str(k) for k in dict(self.calc.datastore['job_info'])}
         self.assertIn('build_loss_maps.sent', job_info)
         self.assertIn('build_loss_maps.received', job_info)
 

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -20,10 +20,10 @@ import os
 import re
 import getpass
 import collections
-import numpy
+#import numpy
 import h5py
 
-from openquake.baselib.python3compat import pickle
+#from openquake.baselib.python3compat import pickle
 from openquake.baselib import hdf5
 from openquake.commonlib import config
 from openquake.commonlib.writers import write_csv
@@ -411,16 +411,16 @@ class DataStore(collections.MutableMapping):
             shape = val.shape
         except AttributeError:  # val is a group
             return val
-        if not shape:
-            val = pickle.loads(val.value)
+        #if not shape:
+        #    val = pickle.loads(val.value)
         return val
 
     def __setitem__(self, key, value):
         if isinstance(value, dict) or hasattr(value, '__toh5__'):
             val = value
-        elif (not isinstance(value, numpy.ndarray) or
-                value.dtype is numpy.dtype(object)):
-            val = numpy.array(pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
+        #elif (not isinstance(value, numpy.ndarray) or
+        #        value.dtype is numpy.dtype(object)):
+        #    val = numpy.array(pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
         else:
             val = value
         if key in self.hdf5:

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -407,10 +407,10 @@ class DataStore(collections.MutableMapping):
                         'No %r found in %s and ancestors' % (key, self))
             else:
                 raise KeyError('No %r found in %s' % (key, self))
-        try:
-            shape = val.shape
-        except AttributeError:  # val is a group
-            return val
+        #try:
+        #    shape = val.shape
+        #except AttributeError:  # val is a group
+        #    return val
         #if not shape:
         #    val = pickle.loads(val.value)
         return val

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -128,9 +128,9 @@ class DataStore(collections.MutableMapping):
     Here is a minimal example of usage:
 
     >>> ds = DataStore()
-    >>> ds['example'] = 'hello world'
-    >>> print(ds['example'])
-    hello world
+    >>> ds['example'] = 42
+    >>> print(ds['example'].value)
+    42
     >>> ds.clear()
 
     When reading the items, the DataStore will return a generator. The

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -20,10 +20,8 @@ import os
 import re
 import getpass
 import collections
-#import numpy
 import h5py
 
-#from openquake.baselib.python3compat import pickle
 from openquake.baselib import hdf5
 from openquake.commonlib import config
 from openquake.commonlib.writers import write_csv
@@ -407,20 +405,11 @@ class DataStore(collections.MutableMapping):
                         'No %r found in %s and ancestors' % (key, self))
             else:
                 raise KeyError('No %r found in %s' % (key, self))
-        #try:
-        #    shape = val.shape
-        #except AttributeError:  # val is a group
-        #    return val
-        #if not shape:
-        #    val = pickle.loads(val.value)
         return val
 
     def __setitem__(self, key, value):
         if isinstance(value, dict) or hasattr(value, '__toh5__'):
             val = value
-        #elif (not isinstance(value, numpy.ndarray) or
-        #        value.dtype is numpy.dtype(object)):
-        #    val = numpy.array(pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
         else:
             val = value
         if key in self.hdf5:

--- a/openquake/commonlib/tests/datastore_test.py
+++ b/openquake/commonlib/tests/datastore_test.py
@@ -31,16 +31,6 @@ class DataStoreTestCase(unittest.TestCase):
     def tearDown(self):
         self.dstore.clear()
 
-    def test_pik(self):
-        # store pickleable Python objects
-        self.dstore['key1'] = 'value1'
-        self.assertEqual(len(self.dstore), 1)
-        self.dstore['key2'] = 'value2'
-        self.assertEqual(list(self.dstore), ['key1', 'key2'])
-        del self.dstore['key2']
-        self.assertEqual(list(self.dstore), ['key1'])
-        self.assertEqual(self.dstore['key1'], 'value1')
-
     def test_hdf5(self):
         # store numpy arrays as hdf5 files
         self.assertEqual(len(self.dstore), 0)

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -327,6 +327,10 @@ class CompositeRiskModel(collections.Mapping):
             if oqparam.calculation_mode in ('classical', 'scenario'):
                 # case when the risk files are in the job_hazard.ini file
                 oqparam.calculation_mode += '_damage'
+                if 'exposure' not in oqparam.inputs:
+                    raise RuntimeError(
+                        'There are risk files in %r but not '
+                        'an exposure' % oqparam.inputs['job_ini'])
             self.damage_states = ['no_damage'] + oqparam.limit_states
             delattr(oqparam, 'limit_states')
             for taxonomy, ffs_by_lt in rmdict.items():


### PR DESCRIPTION
They are not used anymore. Removing the support makes it sure that they will never be reintroduced by mistake in the future. I am also adding some unrelated improvements:

1. now every dataset in the datastore has an attribute `nbytes` listing its size in bytes
2. there is a sanity check in scenario and classical calculations with a risk model but no exposure model