### PR TITLE
Using zmq in the dbserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ install:
   - pip -q install wheels/*
   - pip -q install -e .
 
-
 before_script:
   - python -c'import platform; print(platform.platform()); import multiprocessing; print("#CPUs=%d" % multiprocessing.cpu_count())'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ install:
   # A second run of 'pip download' will download only the missing wheels. 
   - pip -q download -r requirements-py35-linux64.txt -d wheels
   - pip -q install wheels/*
-  - pip -q install pyzmq
   - pip -q install -e .
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,9 @@ install:
   # A second run of 'pip download' will download only the missing wheels. 
   - pip -q download -r requirements-py35-linux64.txt -d wheels
   - pip -q install wheels/*
+  - pip -q install pyzmq
   - pip -q install -e .
+
 
 before_script:
   - python -c'import platform; print(platform.platform()); import multiprocessing; print("#CPUs=%d" % multiprocessing.cpu_count())'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Used zmq in the DbServer
   * Fixed correct_complex_sources.py
   * Fixed `oq export hcurves-rlzs -e hdf5`
   * Changed the source weighting algorithm: now it is proportional to the

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://github.com/gem/oq-engine
 
 Package: python-oq-engine
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-oq-libs (>=1.3.0~), rabbitmq-server (>=2.8.0-2~gem02), supervisor (>=3.0b2-1~)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-oq-libs (>=1.3.1~), rabbitmq-server (>=2.8.0-2~gem02), supervisor (>=3.0b2-1~)
 Conflicts: python-noq, python-oq, python-nhlib
 Replaces: python-oq-risklib, python-oq-hazardlib
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-breaks

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -1,7 +1,7 @@
 Index: oq-engine/openquake/engine/openquake.cfg
 ===================================================================
---- oq-engine.orig/openquake/engine/openquake.cfg	2016-05-06 14:06:06.000000000 +0000
-+++ oq-engine/openquake/engine/openquake.cfg	2016-05-06 16:23:04.006138759 +0000
+--- oq-engine.orig/openquake/engine/openquake.cfg	2017-09-04 14:36:12.000000000 +0000
++++ oq-engine/openquake/engine/openquake.cfg	2017-09-04 14:36:18.006138759 +0000
 @@ -40,9 +40,9 @@
  
  [dbserver]
@@ -13,5 +13,5 @@ Index: oq-engine/openquake/engine/openquake.cfg
 +file = /var/lib/openquake/db.sqlite3
 +log = /var/lib/openquake/dbserver.log
  # dbserver master node ip address
- host = localhost
+ host = 127.0.0.1
  # port 1908 has a good reputation:

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -7,6 +7,7 @@
 * Django - Used by the API server and the WebUI
 * HDF5 - Used for storing and managing data
 * numpy and scipy - Fundamental packages for scientific computing with Python
+* pyzmq - Used for internal inter-process communications
 
 ### Optional dependencies
 

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -19,7 +19,6 @@ import os
 import time
 import socket
 from datetime import datetime
-from multiprocessing.connection import Client
 
 import numpy
 
@@ -165,17 +164,6 @@ class Monitor(object):
         "To be overridden in subclasses"
         if self.autoflush:
             self.flush()
-
-    def send(self, *args):
-        """
-        Send a command to the listener. Add the .calc_id as last argument.
-        """
-        if self.address:
-            client = Client(self.address, authkey=self.authkey)
-            try:
-                client.send(args + (self.calc_id,))
-            finally:
-                client.close()
 
     def save_info(self, dic):
         """

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -19,7 +19,12 @@ class ReplySocket(object):
         self.zsocket.bind(self.end_point)
         with self.zsocket:
             while True:
-                yield self.zsocket.recv_pyobj()
+                args = self.zsocket.recv_pyobj()
+                if args[0] == 'stop':
+                    self.reply((None, None, None))
+                    break
+                else:
+                    yield args
 
     def reply(self, obj):
         self.zsocket.send_pyobj(obj)

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -1,0 +1,37 @@
+import zmq
+
+context = zmq.Context()
+
+
+class ReplySocket(object):
+    """
+    A ReplySocket class to be used with code like the following:
+
+     sock = ReplySocket('tcp://127.0.0.1:8000')
+     for cmd, *args in sock:
+         sock.reply(cmd(*args))
+    """
+    def __init__(self, end_point):
+        self.end_point = end_point
+
+    def __iter__(self):
+        self.zsocket = context.socket(zmq.REP)
+        self.zsocket.bind(self.end_point)
+        with self.zsocket:
+            while True:
+                yield self.zsocket.recv_pyobj()
+
+    def reply(self, obj):
+        self.zsocket.send_pyobj(obj)
+
+
+def request(end_point, *args):
+    """
+    Make a request to a remote server with the given arguments and
+    returns the reply.
+    """
+    zsocket = context.socket(zmq.REQ)
+    zsocket.connect(end_point)
+    with zsocket:
+        zsocket.send_pyobj(args)
+        return zsocket.recv_pyobj()

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -44,7 +44,7 @@ multi_user = false
 file = ~/oqdata/db.sqlite3
 log = ~/oqdata/dbserver.log
 # dbserver master node ip address
-host = localhost
+host = 127.0.0.1
 # port 1908 has a good reputation:
 # https://isc.sans.edu/port.html?port=1908
 port = 1908

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -23,10 +23,8 @@ import sqlite3
 import os.path
 import logging
 import subprocess
-from multiprocessing.connection import Listener
-from concurrent.futures import ThreadPoolExecutor
 
-from openquake.baselib import sap
+from openquake.baselib import sap, zeromq
 from openquake.baselib.parallel import safely_call
 from openquake.hazardlib import valid
 from openquake.commonlib import config, logs
@@ -35,10 +33,6 @@ from openquake.server import dbapi
 from openquake.server import __file__ as server_path
 from openquake.server.settings import DATABASE
 
-# using a ThreadPool because SQLite3 isn't fork-safe on macOS Sierra
-# ref: https://bugs.python.org/issue27126
-executor = ThreadPoolExecutor(1)
-
 
 class DbServer(object):
     """
@@ -46,43 +40,22 @@ class DbServer(object):
     """
     def __init__(self, db, address, authkey):
         self.db = db
-        self.address = address
+        self.address = 'tcp://%s:%s' % address
         self.authkey = authkey
 
     def loop(self):
-        listener = Listener(self.address, backlog=5, authkey=self.authkey)
-        logging.warn('DB server started with %s, listening on %s:%d...',
-                     sys.executable, *self.address)
-        try:
-            while True:
-                try:
-                    conn = listener.accept()
-                except KeyboardInterrupt:
-                    break
-                except:
-                    # unauthenticated connection, for instance by a port
-                    # scanner such as the one in manage.py
-                    continue
-                cmd_ = conn.recv()  # a tuple (name, arg1, ... argN)
-                cmd, args = cmd_[0], cmd_[1:]
-                logging.debug('Got ' + str(cmd_))
-                if cmd == 'stop':
-                    conn.send((None, None))
-                    conn.close()
-                    break
-                func = getattr(actions, cmd)
-                fut = executor.submit(safely_call, func, (self.db,) + args)
-
-                def sendback(fut, conn=conn):
-                    res, etype, _mon = fut.result()
-                    if etype:
-                        logging.error(res)
-                    # send back the result and the exception class
-                    conn.send((res, etype))
-                    conn.close()
-                fut.add_done_callback(sendback)
-        finally:
-            listener.close()
+        logging.warn('DB server started with %s, listening on %s...',
+                     sys.executable, self.address)
+        sock = zeromq.ReplySocket(self.address)
+        for cmd_ in sock:
+            cmd, args = cmd_[0], cmd_[1:]
+            logging.debug('Got ' + str(cmd_))
+            if cmd == 'stop':
+                sock.reply((None, None, None))
+                break
+            func = getattr(actions, cmd)
+            res = safely_call(func, (self.db,) + args)
+            sock.reply(res)
 
 
 def different_paths(path1, path2):
@@ -169,7 +142,6 @@ def run_server(dbhostport=None, dbpath=None, logfile=DATABASE['LOG'],
                   detect_types=sqlite3.PARSE_DECLTYPES)
     db('PRAGMA foreign_keys = ON')  # honor ON DELETE CASCADE
     actions.upgrade_db(db)
-    db.conn.close()
 
     # configure logging and start the server
     logging.basicConfig(level=getattr(logging, loglevel), filename=logfile)

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -50,12 +50,10 @@ class DbServer(object):
         for cmd_ in sock:
             cmd, args = cmd_[0], cmd_[1:]
             logging.debug('Got ' + str(cmd_))
-            if cmd == 'stop':
-                sock.reply((None, None, None))
-                break
             func = getattr(actions, cmd)
             res = safely_call(func, (self.db,) + args)
             sock.reply(res)
+        logging.warn('DB server stopped')
 
 
 def different_paths(path1, path2):

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -14,6 +14,7 @@ http://cdn.ftp.openquake.org/wheelhouse/linux/py27/h5py-2.7.0-cp27-cp27mu-manyli
 http://cdn.ftp.openquake.org/wheelhouse/linux/py27/nose-1.3.7-py2-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py27/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py27/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/pyzmq-16.0.2-cp27-cp27mu-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py27/psutil-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py27/Shapely-1.5.13-cp27-cp27mu-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py27/docutils-0.12-cp27-none-any.whl

--- a/requirements-py27-macos.txt
+++ b/requirements-py27-macos.txt
@@ -12,6 +12,7 @@ http://cdn.ftp.openquake.org/wheelhouse/macos/py27/h5py-2.7.0-cp27-cp27m-macosx_
 http://cdn.ftp.openquake.org/wheelhouse/macos/py27/nose-1.3.7-py2-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py27/numpy-1.11.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py27/scipy-0.17.1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/pyzmq-16.0.2-cp27-cp27m-macosx_10_6_intel.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py27/psutil-4.4.2-cp27-cp27m-macosx_10_6_intel.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py27/Shapely-1.5.17.post1-cp27-cp27m-macosx_10_6_intel.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py27/docutils-0.12-cp27-none-any.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -14,6 +14,7 @@ http://cdn.ftp.openquake.org/wheelhouse/linux/py35/h5py-2.7.0-cp35-cp35m-manylin
 http://cdn.ftp.openquake.org/wheelhouse/linux/py35/nose-1.3.7-py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py35/numpy-1.11.1-cp35-cp35m-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py35/scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/pyzmq-16.0.2-cp35-cp35m-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py35/psutil-3.4.2-cp35-cp35m-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py35/Shapely-1.5.13-cp35-cp35m-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py35/docutils-0.12-py3-none-any.whl

--- a/requirements-py35-macos.txt
+++ b/requirements-py35-macos.txt
@@ -12,6 +12,7 @@ http://cdn.ftp.openquake.org/wheelhouse/macos/py35/h5py-2.7.0-cp35-cp35m-macosx_
 http://cdn.ftp.openquake.org/wheelhouse/macos/py35/nose-1.3.7-py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py35/numpy-1.11.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py35/scipy-0.17.1-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/pyzmq-16.0.2-cp35-cp35m-macosx_10_6_intel.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py35/psutil-4.4.2-cp35-cp35m-macosx_10_6_intel.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py35/Shapely-1.5.17.post1-cp35-cp35m-macosx_10_6_intel.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py35/docutils-0.12-py3-none-any.whl

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -31,7 +31,7 @@ Patch1: openquake.cfg.patch
 
 Requires(pre): shadow-utils
 
-Requires: python-oq-libs >= 1.3.0
+Requires: python-oq-libs >= 1.3.1
 Requires: sudo systemd python
 
 BuildRequires: systemd python-setuptools zip

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ install_requires = [
     'nose >=1.3, <1.4',
     'numpy >=1.8, <1.12',
     'scipy >=0.13, <0.18',
-    'zeromq <17.0',
+    'pyzmq <17.0',
     'psutil >=1.2, <4.5',
     'shapely >=1.3, <1.6',
     'docutils >=0.11, <0.14',

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ install_requires = [
     'nose >=1.3, <1.4',
     'numpy >=1.8, <1.12',
     'scipy >=0.13, <0.18',
+    'zeromq <17.0',
     'psutil >=1.2, <4.5',
     'shapely >=1.3, <1.6',
     'docutils >=0.11, <0.14',


### PR DESCRIPTION
Two reasons:

1) the DbServer is simplified
2) we can gain experience with zmq in a simple case.

I am removing some unused code in performance.py too.