### PR TITLE
Fixed master

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -605,12 +605,14 @@ class Starmap(object):
     @property
     def num_tasks(self):
         """
-        The number of tasks, if known, or -1 otherwise.
+        The number of tasks, if known, or the empty string otherwise.
         """
         try:
             return len(self.task_args)
         except TypeError:  # generators have no len
-            return
+            return ''
+        # NB: returning -1 breaks openquake.hazardlib.tests.calc.
+        # hazard_curve_new_test.HazardCurvesTestCase02 :-(
 
     def submit_all(self):
         """
@@ -657,8 +659,8 @@ class Starmap(object):
                 args = pickle_sequence(args)
                 self.sent += {a: len(p) for a, p in zip(self.argnames, args)}
             if task_no == 1:  # first time
-                n = '' if self.num_tasks is None else self.num_tasks
-                self.progress('Submitting %s "%s" tasks', n, self.name)
+                self.progress('Submitting %s "%s" tasks', self.num_tasks,
+                              self.name)
             yield args
 
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -610,7 +610,7 @@ class Starmap(object):
         try:
             return len(self.task_args)
         except TypeError:  # generators have no len
-            return -1
+            return
 
     def submit_all(self):
         """
@@ -657,7 +657,7 @@ class Starmap(object):
                 args = pickle_sequence(args)
                 self.sent += {a: len(p) for a, p in zip(self.argnames, args)}
             if task_no == 1:  # first time
-                n = '' if self.num_tasks == -1 else self.num_tasks
+                n = '' if self.num_tasks is None else self.num_tasks
                 self.progress('Submitting %s "%s" tasks', n, self.name)
             yield args
 


### PR DESCRIPTION
This apparently innocuous change was breaking the tests on hazardlib relying on `parallel.Sequential`:
https://ci.openquake.org/job/master_oq-engine/3762/console
I am reverting the code as it was.
