### PR TITLE
Set relevant default to 1 instead of true

### DIFF
--- a/openquake/server/db/schema/upgrades/0000-base_schema.sql
+++ b/openquake/server/db/schema/upgrades/0000-base_schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE job(
      is_running BOOL NOT NULL DEFAULT false,
      start_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
      stop_time TIMESTAMP,
-     relevant BOOL DEFAULT true,
+     relevant BOOL DEFAULT 1,
      ds_calc_dir TEXT NOT NULL);
 
 CREATE TABLE log(


### PR DESCRIPTION
Otherwise, some calculations were not found by the filter in the web api, and the integration tests with the QGIS plugin were broken.