### PR TITLE
Trying to close and reopen conn after migration

### DIFF
--- a/bin/check_demos
+++ b/bin/check_demos
@@ -18,7 +18,7 @@
 #  along with OpenQuake.  If not, see <http://www.gnu.o']rg/licenses/>.
 import os.path
 import getpass
-from openquake.server.manage import db
+from openquake.server.dbserver import db
 
 expected_outputs = {
     'AreaSourceClassicalPSHA': ['hcurves', 'hmaps', 'uhs'],

--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -22,7 +22,7 @@ import os.path
 import tempfile
 from openquake.baselib import sap
 from openquake.baselib.general import safeprint
-from openquake.server.manage import db
+from openquake.server.dbserver import db
 from openquake.engine.export.core import zipfiles
 
 

--- a/openquake/server/db/schema/upgrades/0000-base_schema.sql
+++ b/openquake/server/db/schema/upgrades/0000-base_schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE job(
      is_running BOOL NOT NULL DEFAULT false,
      start_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
      stop_time TIMESTAMP,
-     relevant BOOL DEFAULT 1,
+     relevant BOOL DEFAULT true,
      ds_calc_dir TEXT NOT NULL);
 
 CREATE TABLE log(

--- a/openquake/server/dbapi.py
+++ b/openquake/server/dbapi.py
@@ -366,6 +366,13 @@ class Db(object):
             cursor.executemany(templ, rows)
         return cursor
 
+    def close(self):
+        """
+        Close the main thread connection and refresh the threadlocal object
+        """
+        self.conn.close()
+        self.local = threading.local()
+
 
 class Table(list):
     """Just a list of Rows with an attribute _fields"""

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -144,6 +144,10 @@ def run_server(dbhostport=None, dbpath=None, logfile=DATABASE['LOG'],
     with db:
         db('PRAGMA foreign_keys = ON')  # honor ON DELETE CASCADE
         actions.upgrade_db(db)
+    db.conn.close()
+
+    db = dbapi.Db(sqlite3.connect, DATABASE['NAME'], isolation_level=None,
+                  detect_types=sqlite3.PARSE_DECLTYPES)
 
     # configure logging and start the server
     logging.basicConfig(level=getattr(logging, loglevel), filename=logfile)

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -146,8 +146,8 @@ def run_server(dbhostport=None, dbpath=None, logfile=DATABASE['LOG'],
 
     # create and upgrade the db if needed
     db('PRAGMA foreign_keys = ON')  # honor ON DELETE CASCADE
-    actions.upgrade_db(db)  # the commit is inside upgrade_db
-    # the line below is needed to work around a very subtle of sqlite;
+    actions.upgrade_db(db)
+    # the line below is needed to work around a very subtle bug of sqlite;
     # we need new connections, see https://github.com/gem/oq-engine/pull/3002
     db.close()
 
@@ -156,7 +156,7 @@ def run_server(dbhostport=None, dbpath=None, logfile=DATABASE['LOG'],
     try:
         DbServer(db, addr, config.DBS_AUTHKEY).loop()
     finally:
-        db.conn.close()
+        db.close()
 
 run_server.arg('dbhostport', 'dbhost:port')
 run_server.arg('dbpath', 'dbpath')

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -19,18 +19,10 @@
 from __future__ import print_function
 import os
 import sys
-import sqlite3
 from django.core.management import execute_from_command_line
-from openquake.server.settings import DATABASE
 from openquake.server import executor, dbserver
 from openquake.server.db import actions
-from openquake.server.dbapi import Db
 from openquake.commonlib import logs
-
-db = Db(sqlite3.connect, DATABASE['NAME'], isolation_level=None,
-        detect_types=sqlite3.PARSE_DECLTYPES, timeout=20)
-# NB: I am increasing the timeout from 5 to 20 seconds to see if the random
-# OperationalError: "database is locked" disappear in the WebUI tests
 
 
 # bypass the DbServer and run the action directly
@@ -41,7 +33,7 @@ def dbcmd(action, *args):
     :param action: database action to perform
     :param args: arguments
     """
-    return getattr(actions, action)(db, *args)
+    return getattr(actions, action)(dbserver.db, *args)
 
 
 # the code here is run in development mode; for instance

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -33,7 +33,7 @@ import requests
 from openquake.baselib.general import writetmp
 from openquake.engine.export import core
 from openquake.server.db import actions
-from openquake.server.manage import db
+from openquake.server.dbserver import db
 from openquake.server.settings import DATABASE
 
 if requests.__version__ < '1.0.0':


### PR DESCRIPTION
It seems that the only way to see a change (ALTER TABLE) in a column default is to close and re-open the connection to the DB (commit isn't enough).

I'm also reverting the change in the original migration for consistency.

https://travis-ci.org/gem/oq-irmt-qgis/builds/272813819

The problem can be reproduced with
```
$ oq reset -y
$ oq dbserver start
$ oq engine --run job.ini
```
looking inside the job table in the db the field `relevant` must be `1` and not `true`, since the upgrade script 0001 must have changed the default from `true` to 1.
