### PR TITLE
Saved memory in event_based_risk

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -334,7 +334,7 @@ def compute_gmfs_and_curves(getter, oq, monitor):
         duration = oq.investigation_time * oq.ses_per_logic_tree_path
         with monitor('building hazard', measuremem=True):
             gmfdata = numpy.fromiter(getter.gen_gmv(), getter.gmf_data_dt)
-            hazard = sorted(getter.get_hazard(gmfdata).items())
+            hazard = sorted(getter.get_hazard(data=gmfdata).items())
         for rlzi, hazardr in hazard:
             for sid in getter.sids:
                 array = hazardr[sid]


### PR DESCRIPTION
Some simplification done 3 months ago when implementing the new gmf_ebrisk calculator caused the engine to use more memory than before. I was aware of the fact, but the impact was minor on the calculations I studied at the time, so I was not worried. However Mabe' calculation is particularly bad since the hazard part is extremely heavy (mostly due to a large maximum_distance and lots of sites), has a big logic tree and the memory effect is particularly severe. With the change implemented in this PR we are back computing the hazard for each GSIM and not for several GSIMs at once. In the case of Mabe' this reduces by 3 the amount of needed memory. Still the computation does not run on the cluster since it requires way more than 2 GB per core.
A serious change of strategy is needed to perform such calculations, but this fix is good enough for the moment. The release of engine 2.6 is not blocked anymore.

The demos with Python 2.7 are running here: https://ci.openquake.org/job/zdevel_oq-engine/2578