### PR TITLE
Remove check_mem_usage from the safety_call cause is giving troubles

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -234,7 +234,11 @@ def safely_call(func, args):
             child.hdf5path = mon.hdf5path
         else:
             mon = child
-        check_mem_usage(mon)  # check if too much memory is used
+        # FIXME check_mem_usage is disabled here because it's causing
+        # dead locks in threads when log messages are raised.
+        # check is done anyway in other parts of the code (submit and iter).
+        # Further investigation is needed
+        # check_mem_usage(mon)  # check if too much memory is used
         # FIXME: this approach does not work with the Threadmap
         mon._flush = False
         try:

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -236,8 +236,8 @@ def safely_call(func, args):
             mon = child
         # FIXME check_mem_usage is disabled here because it's causing
         # dead locks in threads when log messages are raised.
-        # check is done anyway in other parts of the code (submit and iter).
-        # Further investigation is needed
+        # Check is done anyway in other parts of the code (submit and iter);
+        # further investigation is needed
         # check_mem_usage(mon)  # check if too much memory is used
         # FIXME: this approach does not work with the Threadmap
         mon._flush = False


### PR DESCRIPTION
Warn logs are working with both futures and celery. Check is done in `submit` and `iter`.