### PR TITLE
Manage ctrl-c in a better way, killing children

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Changed the 'CTRL-C' behaviour to make sure that all children
+    processes are killed when a calculation in interrupted
+
   [Michele Simionato]
   * Replaced the agg_curve outputs with losses by return period outputs
   * Turned the DbServer into a multi-threaded server

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -131,10 +131,17 @@ def raiseMasterKilled(signum, _stack):
     :param int signum: the number of the received signal
     :param _stack: the current frame object, ignored
     """
-    if signum == signal.SIGTERM:
+    if signum in (signal.SIGTERM, signal.SIGINT):
         msg = 'The openquake master process was killed manually'
     else:
         msg = 'Received a signal %d' % signum
+
+    for pid in parallel.executor.pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except:
+            pass
+
     raise MasterKilled(msg)
 
 
@@ -144,6 +151,7 @@ def raiseMasterKilled(signum, _stack):
 # can be safely ignored
 try:
     signal.signal(signal.SIGTERM, raiseMasterKilled)
+    signal.signal(signal.SIGINT, raiseMasterKilled)
 except ValueError:
     pass
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -139,7 +139,7 @@ def raiseMasterKilled(signum, _stack):
     for pid in parallel.executor.pids:
         try:
             os.kill(pid, signal.SIGKILL)
-        except:
+        except OSError: # pid not found
             pass
 
     raise MasterKilled(msg)


### PR DESCRIPTION
Currently `CTRL-C` isn't working very well. It needs to be pressed several times and does not always kill the children (on Linux this is mitigated by `prctl`[1]) leaving orphans.

This simple change makes `CTRL-C` working at the first shot [2] and concurrent.futures child process will be brought down.

This doesn't change the behavior (revoke) when celery is used.

Currently it produces a stacktrace from every thread. ~process. I've been unable to change this behavior even registering the signal after the fork. This may be an issue on single nodes with lot of cores.~

[1] prctl has a different goal, which is to bring down children processes when master is killed by `SIGKILL`.
[2] more hits are still required when the dbserver is started by oq. I still need to manage this case.