### PR TITLE
Fixed a bug in the calculation of distances

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a bug when computing the rjb distances with multidimensional meshes
   * Changed the GMF CSV exporter to export the sites too; unified it with the
     event based one
 

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -210,7 +210,7 @@ def pure_distances(mlons, mlats, slons, slats):
     """
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
-    result = numpy.zeros((len(mlons), len(slons)))
+    result = numpy.zeros(mlons.shape + slons.shape)
     if len(mlons) < len(slons):  # lots of sites
         for i in range(len(mlons)):
             a = numpy.sin((mlats[i] - slats) / 2.0)

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -454,8 +454,7 @@ class RectangularMesh(Mesh):
         # out by the threshold and have positive distance instead of 0.
         # so for threshold of 40 km mesh spacing should not be more
         # than 56 km (typical values are 5 to 10 km).
-
-        [idxs] = (distances < 40).nonzero()
+        idxs = (distances < 40).nonzero()[0]  # indices on the first dimension
         if not len(idxs):
             # no point is close enough, return distances as they are
             return distances

--- a/openquake/hazardlib/tests/geo/geodetic_test.py
+++ b/openquake/hazardlib/tests/geo/geodetic_test.py
@@ -46,7 +46,7 @@ class TestGeodeticDistance(unittest.TestCase):
 
     def test_along_meridian(self):
         coords = list(map(numpy.array, [(77.5, -150.), (-10., 15.),
-                                   (77.5, -150.), (-20., 25.)]))
+                                        (77.5, -150.), (-20., 25.)]))
         dist = geodetic.geodetic_distance(*coords)
         assert_aeq(dist, [1111.949, 1111.949], decimal=3)
 
@@ -143,6 +143,15 @@ class TestDistance(unittest.TestCase):
         p2 = (0.5, -0.3, -2)
         distance = geodetic.distance(*(p1 + p2))
         self.assertAlmostEqual(distance, 65.0295143)
+
+    def test_pure_distances(self):
+        # distances between a 1D mesh and a 2D mesh are a 3D mesh
+        mlons = numpy.array([.1, .2])
+        mlats = numpy.array([.11, .22])
+        slons = numpy.ones((3, 3))
+        slats = numpy.zeros((3, 3))
+        res = geodetic.pure_distances(mlons, mlats, slons, slats)
+        self.assertEqual(res.shape, (2, 3, 3))
 
 
 class MinDistanceTest(unittest.TestCase):


### PR DESCRIPTION
This was discovered by Julio when calculating distances between a 1D mesh and a 2D mesh. `geodetic.pure_distances` was working only for 1D meshes. now it works also for multidimensional meshes.