### PR TITLE
Added a check for the SourceGroup tag into nrmlSourceModelParser

### DIFF
--- a/openquake/hmtk/parsers/source_model/nrml04_parser.py
+++ b/openquake/hmtk/parsers/source_model/nrml04_parser.py
@@ -461,7 +461,9 @@ class nrmlSourceModelParser(BaseSourceModelParser):
         source_model = mtkSourceModel(identifier,
                                       name=node_set.attrib["name"])
         for node in node_set:
-            if "pointSource" in node.tag:
+            if "sourceGroup" in node.tag:
+                print 'Source group not yet implemented... proceeding without'
+            elif "pointSource" in node.tag:
                 source_model.sources.append(
                     parse_point_source_node(node, mfd_spacing))
             elif "areaSource" in node.tag:


### PR DESCRIPTION
The xml source parser of htmk works only with nrml4. With this modification the parser can also be used with nrml5 files, but a proper parser (including the SourceGroup information) should be better implemented for that.

We would suggest also to create a generic parser which is version independent, working also with old nrml3 files.