### PR TITLE
Small cleanup

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -473,7 +473,7 @@ class EventBasedCalculator(ClassicalCalculator):
             rlzs_by_gsim = self.rlzs_assoc.rlzs_by_gsim[grp_id]
             for block in block_splitter(ruptures, oq.ruptures_per_block):
                 samples = samples_by_grp[grp_id]
-                getter = GmfGetter(grp_id, rlzs_by_gsim, block, self.sitecol,
+                getter = GmfGetter(rlzs_by_gsim, block, self.sitecol,
                                    imts, min_iml, oq.truncation_level,
                                    correl_model, samples)
                 yield getter, oq, monitor

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -261,7 +261,7 @@ class EbriskCalculator(base.RiskCalculator):
                         len(self.assetcol), seeds[start: start + n_events])
                     start += n_events
                 getter = riskinput.GmfGetter(
-                    grp_id, rlzs_by_gsim, rupts, sitecol, imts, min_iml,
+                    rlzs_by_gsim, rupts, sitecol, imts, min_iml,
                     trunc_level, correl_model, samples)
                 ri = riskinput.RiskInputFromRuptures(getter, eps)
                 allargs.append((ri, riskmodel, assetcol, monitor))

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -828,7 +828,7 @@ def export_gmf_scenario_csv(ekey, dstore):
     correl_model = oq.get_correl_model()
     sitecol = dstore['sitecol'].complete
     getter = GmfGetter(
-        ebr.grp_id, rlzs_by_gsim, ruptures, sitecol, imts,
+        rlzs_by_gsim, ruptures, sitecol, imts,
         min_iml, oq.truncation_level, correl_model, samples)
     getter.init()
     hazardr = getter.get_hazard()

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -831,7 +831,7 @@ def compute_losses(ssm, src_filter, param, riskmodel,
     num_rlzs = len(rlzs_assoc.realizations)
     rlzs_by_gsim = rlzs_assoc.rlzs_by_gsim[grp_id]
     getter = riskinput.GmfGetter(
-        grp_id, rlzs_by_gsim, ebruptures, src_filter.sitecol, imts, min_iml,
+        rlzs_by_gsim, ebruptures, src_filter.sitecol, imts, min_iml,
         trunc_level, correl_model, samples[grp_id])
     ri = riskinput.RiskInputFromRuptures(getter)
     res.append(event_based_risk(ri, riskmodel, param, monitor))

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -597,10 +597,10 @@ class GmfGetter(object):
     """
     kind = 'gmf'
 
-    def __init__(self, grp_id, rlzs_by_gsim, ebruptures, sitecol, imts,
+    def __init__(self, rlzs_by_gsim, ebruptures, sitecol, imts,
                  min_iml, truncation_level, correlation_model, samples):
         assert sitecol is sitecol.complete, sitecol
-        self.grp_id = grp_id
+        self.grp_id = ebruptures[0].grp_id
         self.rlzs_by_gsim = rlzs_by_gsim
         self.num_rlzs = sum(len(rlzs) for gsim, rlzs in rlzs_by_gsim.items())
         self.ebruptures = ebruptures


### PR DESCRIPTION
`grp_id` is redundant in the GMFGetter since it can be extracted from the underlying ruptures.