### PR TITLE
Fixing the length check for arbitrary mfd

### DIFF
--- a/openquake/hazardlib/mfd/arbitrary_mfd.py
+++ b/openquake/hazardlib/mfd/arbitrary_mfd.py
@@ -52,7 +52,7 @@ class ArbitraryMFD(BaseMFD):
         * Each number in occurrence rates list is non-negative.
         * Minimum magnitude is positive.
         """
-        if not self.occurrence_rates:
+        if not len(self.occurrence_rates):
             raise ValueError('at least one bin must be specified')
 
         if not all(value >= 0 for value in self.occurrence_rates):

--- a/openquake/hazardlib/mfd/multi_mfd.py
+++ b/openquake/hazardlib/mfd/multi_mfd.py
@@ -137,8 +137,7 @@ class MultiMFD(BaseMFD):
         Yields the occurrence rates of the underlying MFDs in order
         """
         for mfd in self:
-            for rates in mfd.get_annual_occurrence_rates():
-                yield rates
+            yield mfd.get_annual_occurrence_rates()
 
     def modify(self, modification, parameters):
         """

--- a/openquake/hazardlib/mfd/multi_mfd.py
+++ b/openquake/hazardlib/mfd/multi_mfd.py
@@ -137,7 +137,8 @@ class MultiMFD(BaseMFD):
         Yields the occurrence rates of the underlying MFDs in order
         """
         for mfd in self:
-            yield mfd.get_annual_occurrence_rates()
+            for rates in mfd.get_annual_occurrence_rates():
+                yield rates
 
     def modify(self, modification, parameters):
         """


### PR DESCRIPTION
Using the iterator of MultiMFD, the method mfd_class fails with arbitrary mfd type. This is due to the check_constraints method of the ArbitraryMFD class, not working when self.occurrence_rates is a list.