### PR TITLE
Added a check on number_of_ground_motion_fields

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Added a check on `number_of_ground_motion_fields` when the GMFs are
+    extracted from a NRML file
   * Added a command `oq extract` able to extract hazard outputs into HDF5 files
   * Fixed a bug when reading GMFs from a NRML file: the hazard sites were
     read from the exposure (incorrectly) and not from the GMFs

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -749,6 +749,9 @@ def get_gmfs(calc):
     elif 'gmfs' in oq.inputs:  # from file
         logging.info('Reading gmfs from file')
         eids, gmfs = readinput.get_gmfs(oq)
+        if len(eids) != E:
+            raise RuntimeError('Expected %d ground motion fields, found %d' %
+                               (E, len(eids)))
         # NB: get_gmfs redefine oq.sites in case of GMFs from XML
         haz_sitecol = readinput.get_site_collection(oq) or haz_sitecol
         calc.assoc_assets(haz_sitecol)

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -112,7 +112,7 @@ def scenario_damage(riskinput, riskmodel, param, monitor):
             for a, fraction in enumerate(damages):
                 asset = outputs.assets[a]
                 t = riskinput.tagmask[a]
-                damages = fraction * asset.number
+                damages = fraction * asset.number  # shape (E, D)
                 if c_model:  # compute consequences
                     means = [par[0] for par in c_model[asset.taxonomy].params]
                     # NB: we add a 0 in front for nodamage state

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -515,7 +515,7 @@ class CompositeRiskModel(collections.Mapping):
                         data = {i: (gmvs[:, i], eids) for i in rangeI}
                     elif eids is not None:  # gmf_ebrisk
                         data = {i: (haz[i], eids) for i in rangeI}
-                    else:  # classical
+                    else:  # classical or scenario from gmfs
                         data = haz
                     out = [None] * len(self.lti)
                     for lti, i in enumerate(rangeI):

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -541,7 +541,7 @@ class Damage(RiskModel):
         :param assets: a list of N assets of the same taxonomy
         :param gmvs: an array of E elements
         :param _eps: dummy parameter, unused
-        :returns: an array of N assets and an array of N x E x D elements
+        :returns: N arrays of E x D elements
 
         where N is the number of points, E the number of events
         and D the number of damage states.


### PR DESCRIPTION
Catalina had a calculation with `number_of_ground_motion_fields = 3000` but only 1000 events in the GMF file. With this change an helpful error message is raise before starting the risk calculation, so that an user can easily solve the problem by setting  `number_of_ground_motion_fields = 1000`.
