### PR TITLE
Made the ArrayWrapper serializable

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -89,6 +89,13 @@ class ArrayWrapper(object):
     def __getitem__(self, idx):
         return self.array[idx]
 
+    def __toh5__(self):
+        return (self.array, {k: v for k, v in vars(self).items()
+                             if k != 'array' and not k.startswith('_')})
+
+    def __fromh5__(self, array, attrs):
+        self.__init__(array, attrs)
+
     @property
     def dtype(self):
         return self.array.dtype

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -156,6 +156,7 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         Compute stats for the aggregated distributions and save
         the results on the datastore.
         """
+        tags = [t.encode('utf-8') for t in self.param['tags']]
         dstates = self.riskmodel.damage_states
         ltypes = self.riskmodel.loss_types
         L = len(ltypes)
@@ -176,6 +177,7 @@ class ScenarioDamageCalculator(base.RiskCalculator):
             d_asset, multi_stat_dt)
         self.datastore['dmg_by_tag'] = dist_by_tag(
             result['d_tag'], multi_stat_dt)
+        self.datastore.set_attrs('dmg_by_tag', tags=tags)
         by_tag = result['d_tag'][self.assetcol.get_tax_idx()]
         self.datastore['dmg_total'] = dist_total(by_tag, multi_stat_dt)
 
@@ -189,9 +191,7 @@ class ScenarioDamageCalculator(base.RiskCalculator):
             self.datastore['losses_by_asset'] = c_asset
             self.datastore['losses_by_tag'] = dist_by_tag(
                 result['c_tag'], multi_stat_dt)
-            self.datastore.set_attrs(
-                'losses_by_tag',
-                tags=[t.encode('utf-8') for t in self.param['tags']])
+            self.datastore.set_attrs('losses_by_tag', tags=tags)
             by_tag = result['c_tag'][self.assetcol.get_tax_idx()]
             self.datastore['losses_total'] = dist_total(by_tag, multi_stat_dt)
 


### PR DESCRIPTION
This is needed when storing the ArrayWrapper in .hdf5 format in `oq extract`. Moreover, I am adding the tags to the `dmg_by_tag` output: this will be useful for the plots in the QGIS side.