### PR TITLE
Fixed a Python 3 bug

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1295,7 +1295,7 @@ class GsimLogicTree(object):
         :returns: sorted list of available GSIMs for that trt
         """
         if rlzs is None:
-            if trt == '*':  # fake logictree
+            if trt == '*' or trt == b'*':  # fake logictree
                 [trt] = self.values
             gsims = self.values[trt]
         else:


### PR DESCRIPTION
```bash
$ oq export gmf_data -e npz
```
was giving a "No GSIM" error after running a scenario calculation.
The really hard thing is to understand why the current test (`scenario/case_9`) passes :-(
It is left for the next release.