### PR TITLE
Fixed gmf_data export when the GMFs are read from a file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the GMF .npz export when the GMFs are extracted from a file
   * Added a check on `number_of_ground_motion_fields` when the GMFs are
     extracted from a NRML file
   * Added a command `oq extract` able to extract hazard outputs into HDF5 files

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -702,12 +702,12 @@ def get_gmv_data(sids, gmfs):
     return numpy.fromiter(it, gmv_data_dt)
 
 
-def get_gmfs(self):
+def get_gmfs(calculator):
     """
-    :param self: a scenario_risk, scenario_damage or gmf_ebrisk calculator
+    :param calculator: a scenario_risk, scenario_damage or gmf_ebrisk calculator
     :returns: a pair (eids, gmfs) where gmfs is a matrix of shape (G, N, E, I)
     """
-    dstore = self.datastore
+    dstore = calculator.datastore
     oq = dstore['oqparam']
     num_assocs = dstore['csm_info'].get_num_rlzs()
     sitecol = dstore['sitecol']
@@ -720,9 +720,9 @@ def get_gmfs(self):
     E = oq.number_of_ground_motion_fields
     eids = numpy.arange(E)
     gmfs = numpy.zeros((num_assocs, N, E, I))
-    if self.precalc:
-        for g, gsim in enumerate(self.precalc.gsims):
-            gmfs[g, sitecol.sids] = self.precalc.gmfa[gsim]
+    if calculator.precalc:
+        for g, gsim in enumerate(calculator.precalc.gsims):
+            gmfs[g, sitecol.sids] = calculator.precalc.gmfa[gsim]
         return eids, gmfs
 
     if 'gmf_data/data' in dstore:
@@ -746,7 +746,7 @@ def get_gmfs(self):
                                (E, len(eids)))
         # NB: get_gmfs redefine oq.sites in case of GMFs from XML
         haz_sitecol = readinput.get_site_collection(oq) or haz_sitecol
-        self.assoc_assets(haz_sitecol)
+        calculator.assoc_assets(haz_sitecol)
         dstore['gmf_data/data'] = get_gmv_data(
             haz_sitecol.sids, gmfs[:, haz_sitecol.indices])
 

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -825,7 +825,8 @@ def export_gmf_scenario_csv(ekey, dstore):
 
 def _gmf_scenario(data, num_sites, imts):
     # convert data into the composite array expected by QGIS
-    eid2idx = {eid: idx for idx, eid in enumerate(numpy.unique(data['eid']))}
+    eids = sorted(numpy.unique(data['eid']))
+    eid2idx = {eid: idx for idx, eid in enumerate(eids)}
     E = len(eid2idx)
     gmf_dt = numpy.dtype([(imt, (F32, (E,))) for imt in imts])
     gmfa = numpy.zeros(num_sites, gmf_dt)

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -825,37 +825,9 @@ def export_gmf_scenario_csv(ekey, dstore):
 
 @export.add(('gmf_data', 'npz'))
 def export_gmf_scenario_npz(ekey, dstore):
-    oq = dstore['oqparam']
     dic = {}
     fname = dstore.export_path('%s.%s' % ekey)
-    if 'scenario' in oq.calculation_mode:
-        # compute the GMFs on the fly from the stored rupture
-        # NB: for visualization purposes we want to export the full mesh
-        # of points, including the ones outside the maximum distance
-        # NB2: in the future, I want to add a sitecol output, then the
-        # visualization of the mesh will be possibile even without the GMFs;
-        # in the future, here we will change
-        # sitemesh = get_mesh(dstore['sitecol'], complete=False)
-        sitecol = dstore['sitecol'].complete
-        sitemesh = get_mesh(sitecol)
-        rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
-        gsims = rlzs_assoc.gsims_by_grp_id[0]  # there is a single grp_id
-        E = oq.number_of_ground_motion_fields
-        correl_model = oq.get_correl_model()
-        [ebrupture] = calc.get_ruptures(dstore, 0)
-        computer = gmf.GmfComputer(
-            ebrupture, sitecol, oq.imtls,
-            gsims, oq.truncation_level, correl_model)
-        gmf_dt = numpy.dtype([(imt, (F32, (E,))) for imt in oq.imtls])
-        imts = list(oq.imtls)
-        for gsim in gsims:
-            arr = computer.compute(gsim, E, oq.random_seed)
-            I, S, E = arr.shape  # #IMTs, #sites, #events
-            gmfa = numpy.zeros(S, gmf_dt)
-            for imti, imt in enumerate(imts):
-                gmfa[imt] = arr[imti]
-            dic[str(gsim)] = util.compose_arrays(sitemesh, gmfa)
-    elif 'event_based' in oq.calculation_mode:
+    if 'gmf_data' in dstore:
         dic['sitemesh'] = get_mesh(dstore['sitecol'])
         data_by_rlzi = group_array(dstore['gmf_data/data'].value, 'rlzi')
         for rlzi in data_by_rlzi:

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -823,28 +823,32 @@ def export_gmf_scenario_csv(ekey, dstore):
     return writer.getsaved()
 
 
-def _gmf_scenario(data, num_sites, num_events, imts):
+def _gmf_scenario(data, num_sites, imts):
     # convert data into the composite array expected by QGIS
-    gmf_dt = numpy.dtype([(imt, (F32, (num_events,))) for imt in imts])
+    eid2idx = {eid: idx for idx, eid in enumerate(numpy.unique(data['eid']))}
+    E = len(eid2idx)
+    gmf_dt = numpy.dtype([(imt, (F32, (E,))) for imt in imts])
     gmfa = numpy.zeros(num_sites, gmf_dt)
     for rec in data:
         arr = gmfa[rec['sid']]
         for imt, gmv in zip(imts, rec['gmv']):
-            arr[imt][rec['eid']] = gmv
-    return gmfa
+            arr[imt][eid2idx[rec['eid']]] = gmv
+    return gmfa, E
 
 
 @export.add(('gmf_data', 'npz'))
 def export_gmf_scenario_npz(ekey, dstore):
     dic = {}
     oq = dstore['oqparam']
-    E = oq.number_of_ground_motion_fields
     mesh = get_mesh(dstore['sitecol'])
+    n = len(mesh)
     fname = dstore.export_path('%s.%s' % ekey)
     if 'gmf_data' in dstore:
         data_by_rlzi = group_array(dstore['gmf_data/data'].value, 'rlzi')
         for rlzi in data_by_rlzi:
-            gmfa = _gmf_scenario(data_by_rlzi[rlzi], len(mesh), E, oq.imtls)
+            gmfa, e = _gmf_scenario(data_by_rlzi[rlzi], n, oq.imtls)
+            logging.info('Exporting array of shape %s for rlz %d',
+                         (n, e), rlzi)
             dic['rlz-%03d' % rlzi] = util.compose_arrays(mesh, gmfa)
     else:  # nothing to export
         return []

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -137,9 +137,9 @@ class ScenarioTestCase(CalculatorTestCase):
         # test the .npz export
         [fname] = out['gmf_data', 'npz']
         with numpy.load(fname) as f:
-            self.assertEqual(len(f.keys()), 3)  # rlz-000 rlz-001 sitemesh
-            data1 = f['LinLee2008SSlab()']
-            data2 = f['YoungsEtAl1997SSlab()']
+            self.assertEqual(len(f.keys()), 2)  # rlz-000 rlz-001
+            data1 = f['rlz-000']
+            data2 = f['rlz-001']
             self.assertEqual(data1.dtype.names, ('lon', 'lat', 'PGA'))
             self.assertEqual(data1.shape, (3,))
             self.assertEqual(data1['PGA'].shape, (3, 10))

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -137,7 +137,7 @@ class ScenarioTestCase(CalculatorTestCase):
         # test the .npz export
         [fname] = out['gmf_data', 'npz']
         with numpy.load(fname) as f:
-            self.assertEqual(len(f.keys()), 2)  # there are only two datasets
+            self.assertEqual(len(f.keys()), 3)  # rlz-000 rlz-001 sitemesh
             data1 = f['LinLee2008SSlab()']
             data2 = f['YoungsEtAl1997SSlab()']
             self.assertEqual(data1.dtype.names, ('lon', 'lat', 'PGA'))


### PR DESCRIPTION
Discovered by Catalina. This only affects the .npz export. We need to add a demo for this situation, otherwise it will be untested in the QGIS side.