### PR TITLE
Do not silently replace openquake.cfg in RPM

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+  [Daniele Viganò]
+  * Changed the behaviour during RPM upgrades:
+    old openquake.cfg configuration is left untuched and the new one
+    installed as openquake.cfg.rpmnew
+
   [Michele Simionato]
   * Added a check on `number_of_ground_motion_fields` when the GMFs are
     extracted from a NRML file

--- a/doc/upgrading/rhel.md
+++ b/doc/upgrading/rhel.md
@@ -6,6 +6,8 @@ To upgrade the OpenQuake Engine and its libraries run
 sudo yum upgrade python-oq-*
 ```
 
+If a custom configuration is installed in `/etc/openquake/openquake.cfg` this configuration will be left untouched and the new configuration file, provided by the upgrade, will be installed as `/etc/openquake/openquake.cfg.rpmnew`. Before starting using OpenQuake you must check for new configuration parameters or changes in the `openquake.cfg.rpmnew` file and merge those into your `openquake.cfg`. This can be done manually with `diff` or using `rpmconf` (see `man rpmconf`).
+
 ### Coming from OpenQuake Engine 1.x
 
 The following dependencies are not used anymore by the OpenQuake Engine 2:

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -140,9 +140,11 @@ rm -rf %{buildroot}
 %{_datadir}/openquake/engine
 %{_datadir}/applications/oq-engine-webui.desktop
 %{_datadir}/pixmaps/openquake.png
-%{_sysconfdir}/openquake/openquake.cfg
 %{_unitdir}/openquake-dbserver.service
 %{_unitdir}/openquake-webui.service
+
+%config(noreplace)
+%{_sysconfdir}/openquake/openquake.cfg
 
 %post master
 (if ! rabbitmqctl status &>/dev/null; then


### PR DESCRIPTION
If a custom configuration is installed in `/etc/openquake/openquake.cfg` this configuration will be left untouched and the new configuration file, provided by the upgrade, will be installed as `/etc/openquake/openquake.cfg.rpmnew`. Before starting using OpenQuake you must check for new configuration parameters or changes in the `openquake.cfg.rpmnew` file and merge those into your `openquake.cfg`. This can be done manually with `diff` or using `rpmconf` (see `man rpmconf`).

https://ci.openquake.org/job/builders/job/rpm-builder/98/