### PR TITLE
Temporarily disable process kill during ctrl-c

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -138,11 +138,13 @@ def raiseMasterKilled(signum, _stack):
     else:
         msg = 'Received a signal %d' % signum
 
-    for pid in parallel.executor.pids:
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except OSError: # pid not found
-            pass
+    # FIXME this code has been temporary disabled due issues with large
+    # computations and further investigation is need code is left as reference
+    # for pid in parallel.executor.pids:
+    #     try:
+    #         os.kill(pid, signal.SIGKILL)
+    #     except OSError: # pid not found
+    #         pass
 
     raise MasterKilled(msg)
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -139,7 +139,7 @@ def raiseMasterKilled(signum, _stack):
         msg = 'Received a signal %d' % signum
 
     # FIXME this code has been temporary disabled due issues with large
-    # computations and further investigation is need code is left as reference
+    # computations and further investigation is need; code is left as reference
     # for pid in parallel.executor.pids:
     #     try:
     #         os.kill(pid, signal.SIGKILL)


### PR DESCRIPTION
Running heavy computations (with futures, this does not happens with celery) and firing a `ctrl-c` it may be locked itself because master is unable to kill processes due futex(es), probably caused by the threads created by the logging module.

Without this part of the code children will only die when they exhaust the running task, but at least it is possible to `ctrl-c` and get back to the terminal.

Further work is needed, but at least we are not blocking the release.