### PR TITLE
Used `setproctitle` in the multiprocessing workers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,13 +8,13 @@ Homepage: http://github.com/gem/oq-engine
 
 Package: python-oq-engine
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-oq-libs (>=1.4.0~), rabbitmq-server (>=2.8.0-2~gem02), supervisor (>=3.0b2-1~)
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-oq-libs (>=1.5.0~), rabbitmq-server (>=2.8.0-2~gem02), supervisor (>=3.0b2-1~)
 Conflicts: python-noq, python-oq, python-nhlib
 Replaces: python-oq-risklib, python-oq-hazardlib
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-breaks
 Breaks: python-oq-risklib, python-oq-hazardlib
 Recommends: ${dist:Recommends}
-Suggests: python-oq-libs-extra (>= 1.4.0~)
+Suggests: python-oq-libs-extra (>= 1.5.0~)
 Description: computes seismic hazard and physical risk
  based on the hazard and risk libraries developed by the GEM foundation
  (http://www.globalquakemodel.org/)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -688,7 +688,7 @@ if OQ_DISTRIBUTE == 'celery':
 
 def _wakeup(sec):
     """Waiting functions, used to wake up the process pool"""
-    setproctitle('oq worker')
+    setproctitle('oq-worker')
     try:
         import prctl
     except ImportError:

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -687,7 +687,7 @@ if OQ_DISTRIBUTE == 'celery':
 
 
 def _wakeup(sec):
-    """Waiting functions, used to wake up the process pool"""
+    """Waiting function, used to wake up the process pool"""
     setproctitle('oq-worker')
     try:
         import prctl

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -151,7 +151,14 @@ import multiprocessing.dummy
 from multiprocessing.connection import Client, Listener
 from concurrent.futures import (
     as_completed, ThreadPoolExecutor, ProcessPoolExecutor, Future)
+
 import numpy
+try:
+    from setproctitle import setproctitle
+except ImportError:
+    def setproctitle(title):
+        "Do nothing"
+
 from openquake.baselib import hdf5
 from openquake.baselib.python3compat import pickle
 from openquake.baselib.performance import Monitor, virtual_memory
@@ -681,6 +688,7 @@ if OQ_DISTRIBUTE == 'celery':
 
 def _wakeup(sec):
     """Waiting functions, used to wake up the process pool"""
+    setproctitle('oq worker')
     try:
         import prctl
     except ImportError:

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -30,7 +30,12 @@ http://cdn.ftp.openquake.org/wheelhouse/linux/py27/PyYAML-3.12-cp27-cp27mu-manyl
 
 ## Extra ##
 
-### pythn-prctl ###
+### setproctitle ###
+# comment the following lines to skip installation
+# of setproctitle (optional feature)
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/setproctitle-1.1.10-cp27-cp27mu-manylinux1_x86_64.whl
+
+### python-prctl ###
 # comment the following lines to skip installation
 # of python-prctl (optional feature)
 http://cdn.ftp.openquake.org/wheelhouse/linux/py27/python_prctl-1.6.1-cp27-cp27mu-manylinux1_x86_64.whl

--- a/requirements-py27-macos.txt
+++ b/requirements-py27-macos.txt
@@ -28,6 +28,11 @@ http://cdn.ftp.openquake.org/wheelhouse/macos/py27/PyYAML-3.12-cp27-cp27m-macosx
 
 ## Extra ##
 
+### setproctitle ###
+# comment the following lines to skip installation
+# of setproctitle (optional feature)
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/setproctitle-1.1.10-cp27-cp27m-macosx_10_6_intel.whl
+
 ### Rtree wheel is not currently available for macOS ###
 
 ### Plotting ###

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -29,7 +29,12 @@ http://cdn.ftp.openquake.org/wheelhouse/linux/py35/PyYAML-3.12-cp35-cp35m-manyli
 
 ## Extra ##
 
-### pythn-prctl ###
+### setproctitle ###
+# comment the following lines to skip installation
+# of setproctitle (optional feature)
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/setproctitle-1.1.10-cp35-cp35m-manylinux1_x86_64.whl
+
+### python-prctl ###
 # comment the following lines to skip installation
 # of python-prctl (optional feature)
 http://cdn.ftp.openquake.org/wheelhouse/linux/py35/python_prctl-1.6.1-cp35-cp35m-manylinux1_x86_64.whl

--- a/requirements-py35-macos.txt
+++ b/requirements-py35-macos.txt
@@ -27,6 +27,11 @@ http://cdn.ftp.openquake.org/wheelhouse/macos/py35/PyYAML-3.12-cp35-cp35m-macosx
 
 ## Extra ##
 
+### setproctitle ###
+# comment the following lines to skip installation
+# of setproctitle (optional feature)
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/setproctitle-1.1.10-cp35-cp35m-macosx_10_6_intel.whl
+
 ### Rtree wheel is not currently available for macOS ###
 
 ### Plotting ###

--- a/rpm/python-oq-engine.spec.inc
+++ b/rpm/python-oq-engine.spec.inc
@@ -31,7 +31,7 @@ Patch1: openquake.cfg.patch
 
 Requires(pre): shadow-utils
 
-Requires: python-oq-libs >= 1.4.0
+Requires: python-oq-libs >= 1.5.0
 Requires: sudo systemd python
 
 BuildRequires: systemd python-setuptools zip

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ if sys.version < '3':
     )
 
 extras_require = {
+    'setproctitle': ["setproctitle"],
     'prctl': ["python-prctl ==1.6.1"],
     'rtree':  ["Rtree >=0.8.2, <0.8.4"],
     'celery':  ["celery >=3.1, <4.0"],


### PR DESCRIPTION
In this way one can use `killall oq-worker` to kill all workers at once. It is up to Daniele to decide if we want to include setproctitle in our distribution. It is an optional dependency. It is installed already in our cluster ~~via apt-get~~. It is a workaround for https://github.com/gem/oq-engine/issues/3007.