### PR TITLE
Extracting arrays as npz files, not as pickle files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the /extract wen API to return an .npz file
   * Fixed a bug with multi-realization disaggregation, celery and no
     shared_dir: now the calculation does not hang anymore
 

--- a/doc/web-api.md
+++ b/doc/web-api.md
@@ -115,11 +115,11 @@ successfull, the list is empty.
 
 #### GET /v1/calc/:calc_id/extract/:spec
 
-Get a pickled file for the given output specification
+Get an .npz file for the given output specification
 
 Response:
 
-A single .pik file of Content-Type: application/octet-stream
+A single .npz file of Content-Type: application/octet-stream
 
 
 #### GET /v1/calc/:calc_id/results

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -21,6 +21,7 @@ Here there are some real functional tests starting an engine server and
 running computations.
 """
 from __future__ import print_function
+import io
 import os
 import re
 import sys
@@ -160,8 +161,8 @@ class EngineServerTestCase(unittest.TestCase):
         url = 'http://%s/v1/calc/%s/extract/asset_values/0' % (
             self.hostport, job_id)
         resp = requests.get(url)
-        got = numpy.loads(resp.content)
-        self.assertEqual(len(got), 0)  # there are 0 assets on site 0
+        got = numpy.load(io.BytesIO(resp.content))  # load npz file
+        self.assertEqual(len(got['array']), 0)  # there are 0 assets on site 0
         self.assertEqual(resp.status_code, 200)
 
         # there is some logic in `core.export_from_db` that it is only


### PR DESCRIPTION
This should solve a lot of issues Paolo has. The QGIS plugin should make calls like the following:

```python
        npz = numpy.load(io.BytesIO(requests.get(url).content))
```

`npz` is a dictionary-like object with a key "array" and possibly other keys which are the attributes of the array.