### PR TITLE
Removed a wrong @util.reader

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -18,7 +18,7 @@ for ini in $(find $1 -name job.ini | sort); do
 done
 
 # do something with the generated data; -2 is LogicTreeCase3ClassicalPSHA
-python -m openquake.commands export hcurves-rlzs -2 --exports hdf5 -d /tmp
+python -m openquake.commands extract hazard/rlzs -2
 python -m openquake.commands engine --lhc
 MPLBACKEND=Agg python -m openquake.commands plot -2
 MPLBACKEND=Agg python -m openquake.commands plot_uhs -2

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -25,7 +25,7 @@ import numpy
 from openquake.baselib.python3compat import zip, encode
 from openquake.baselib.general import (
     AccumDict, block_splitter, split_in_blocks)
-from openquake.commonlib import util
+from openquake.commonlib import util, config
 from openquake.calculators import base, event_based
 from openquake.calculators.export.loss_curves import get_loss_builder
 from openquake.baselib import parallel
@@ -512,7 +512,6 @@ class EbriskCalculator(base.RiskCalculator):
 
 # ######################### EbrPostCalculator ############################## #
 
-@util.reader
 def build_curves_maps(avalues, builder, lrgetter, stats, clp, monitor):
     """
     Build loss curves and optionally maps if conditional_loss_poes are set.
@@ -590,7 +589,7 @@ class EbrPostCalculator(base.RiskCalculator):
                     stats=[encode(name) for (name, func) in stats])
             mon = self.monitor('loss maps')
             lazy = (oq.hazard_calculation_id and 'all_loss_ratios'
-                    in self.datastore.parent)
+                    in self.datastore.parent) and config.READ_ACCESS
             logging.info('Instantiating LossRatiosGetters')
             with self.monitor('building lrgetters', measuremem=True,
                               autoflush=True):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -589,7 +589,7 @@ class EbrPostCalculator(base.RiskCalculator):
                     stats=[encode(name) for (name, func) in stats])
             mon = self.monitor('loss maps')
             lazy = (oq.hazard_calculation_id and 'all_loss_ratios'
-                    in self.datastore.parent) and config.READ_ACCESS
+                    in self.datastore.parent and config.READ_ACCESS)
             logging.info('Instantiating LossRatiosGetters')
             with self.monitor('building lrgetters', measuremem=True,
                               autoflush=True):

--- a/openquake/commonlib/config.py
+++ b/openquake/commonlib/config.py
@@ -150,3 +150,5 @@ port = int(get('dbserver', 'port'))
 DBS_ADDRESS = (get('dbserver', 'host'), port)
 DBS_AUTHKEY = encode(get('dbserver', 'authkey'))
 SHARED_DIR_ON = bool(get('directory', 'shared_dir'))
+READ_ACCESS = (SHARED_DIR_ON
+               if get('distribution', 'oq_distribute') == 'celery' else True)


### PR DESCRIPTION
`@util.reader` is used to mark tasks that require read access to the datastore from the workers. `build_curves_maps` is not in this class: if the shared_dir is off, the loss ratios are read in the controller node and transferred. The only calculators that require `@util.reader` are the UCERF ones, so the demos in the repository oq-engine-celery must run. See https://travis-ci.org/gem/oq-engine-celery/jobs/280010853