### PR TITLE
Fixed `openquake.engine.USE_CELERY` flag

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -35,7 +35,7 @@ from openquake.commonlib import logs
 TERMINATE = valid.boolean(
     config.get('distribution', 'terminate_workers_on_revoke') or 'false')
 
-USE_CELERY = config.get('distribution', 'oq_distribute') == 'celery'
+USE_CELERY = os.environ.get('OQ_DISTRIBUTE') == 'celery'
 
 if USE_CELERY:
     import celery.task.control


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/3050. The flag was read from the configuration file and the environment variable OQ_DISTRIBUTE was ignored.