### PR TITLE
Added the ability to extract attributes from the datastore

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a web API to extract the attributes of a datastore object
   * Fixed `oq to_shapefile` and `oq from_shapefile` to work with NRML 0.5
     (except MultiPointSources)
   * Added information about the loss units to the `agg_curve` outputs

--- a/doc/web-api.md
+++ b/doc/web-api.md
@@ -115,7 +115,7 @@ successfull, the list is empty.
 
 #### GET /v1/calc/:calc_id/extract/:spec
 
-Get an .npz file for the given output specification. If `spec` ends with
+Get an .npz file for the given object specification. If `spec` ends with
 the extension `.attrs` the attributes of the underlying object (usually
 coming from an HDF5 dataset) are used to build the .npz file, while the
 object itself is not retrieved.

--- a/doc/web-api.md
+++ b/doc/web-api.md
@@ -115,7 +115,10 @@ successfull, the list is empty.
 
 #### GET /v1/calc/:calc_id/extract/:spec
 
-Get an .npz file for the given output specification
+Get an .npz file for the given output specification. If `spec` ends with
+the extension `.attrs` the attributes of the underlying object (usually
+coming from an HDF5 dataset) are used to build the .npz file, while the
+object itself is not retrieved.
 
 Response:
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -518,11 +518,8 @@ class HazardCalculator(BaseCalculator):
         attrs = self.datastore.getitem('composite_risk_model').attrs
         attrs['min_iml'] = hdf5.array_of_vstr(sorted(rm.get_min_iml().items()))
         if rm.damage_states:
-            # saving it twice in the datastore: as an attribute of the
-            # composite risk model and also at top level, for easy
-            # extraction by the QGIS plugin
-            attrs['damage_states'] = ds = hdf5.array_of_vstr(rm.damage_states)
-            self.datastore['damage_states'] = ds
+            # best not to save them as bytes, they are used as headers
+            attrs['damage_states'] = hdf5.array_of_vstr(rm.damage_states)
         self.datastore['loss_ratios'] = rm.get_loss_ratios()
         self.datastore.set_nbytes('composite_risk_model')
         self.datastore.set_nbytes('loss_ratios')

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -250,6 +250,13 @@ class DataStore(collections.MutableMapping):
                 raise
             return default
 
+    def get_attrs(self, key):
+        """
+        :param key: dataset path
+        :returns: dictionary of attributes for that path
+        """
+        return dict(h5py.File.__getitem__(self.hdf5, key).attrs)
+
     def create_dset(self, key, dtype, shape=(None,), compression=None,
                     fillvalue=0, attrs=None):
         """

--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -157,6 +157,11 @@ class EngineServerTestCase(unittest.TestCase):
         all_jobs = self.get('list')
         self.assertGreater(len(all_jobs), 0)
 
+        # check extract/composite_risk_model.attrs
+        url = 'http://%s/v1/calc/%s/extract/composite_risk_model.attrs' % (
+            self.hostport, job_id)
+        self.assertEqual(requests.get(url).status_code, 200)
+
         # check asset_values
         url = 'http://%s/v1/calc/%s/extract/asset_values/0' % (
             self.hostport, job_id)

--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     url(r'^list$', views.calc),
     url(r'^(\d+)$', views.calc_info),
     url(r'^(\d+)/datastore$', views.get_datastore),
-    url(r'^(\d+)/extract/([-/_\w]+)$', views.extract),
+    url(r'^(\d+)/extract/([-/_\w]+)(\.attrs)?$', views.extract),
     url(r'^(\d+)/oqparam$', views.get_oqparam),
     url(r'^(\d+)/status$', views.calc),
     url(r'^(\d+)/results$', views.calc_results),


### PR DESCRIPTION
This is useful for Paolo. Now he can extracts the damage_states with `/extract/composite_risk_model.attrs` which returns the attributes of the composite_risk_model object as an .npz file, without building the full object. The dictionary contains the damage_states among other things.