### PR TITLE
Added a node <tagNames> in the exposure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a node `<tagNames>` in the exposure
   * Added a web API to extract the attributes of a datastore object
   * Fixed `oq to_shapefile` and `oq from_shapefile` to work with NRML 0.5
     (except MultiPointSources)

--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -39,7 +39,9 @@ def encode(val):
     :param: a unicode or bytes object
     :returns: bytes
     """
-    if isinstance(val, unicode):
+    if isinstance(val, list):  # encode a list of strings
+        return [encode(v) for v in val]
+    elif isinstance(val, unicode):
         return val.encode('utf-8')
     else:
         # assume it was an already encoded object

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -359,7 +359,7 @@ class EbriskCalculator(base.RiskCalculator):
         oq = self.oqparam
         self.R = num_rlzs
         self.A = len(self.assetcol)
-        tags = [tag.encode('ascii') for tag in self.assetcol.tags()]
+        tags = encode(self.assetcol.tags())
         T = len(tags)
         self.datastore.create_dset('losses_by_tag-rlzs', F32,
                                    (T, self.R, self.L * self.I))

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -19,6 +19,7 @@
 import itertools
 import numpy
 
+from openquake.baselib.python3compat import encode
 from openquake.commonlib import riskmodels
 from openquake.risklib import scientific
 from openquake.calculators import base, event_based
@@ -156,7 +157,7 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         Compute stats for the aggregated distributions and save
         the results on the datastore.
         """
-        tags = [t.encode('utf-8') for t in self.param['tags']]
+        tags = encode(self.param['tags'])
         dstates = self.riskmodel.damage_states
         ltypes = self.riskmodel.loss_types
         L = len(ltypes)

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -20,7 +20,7 @@ import logging
 
 import numpy
 
-from openquake.baselib.python3compat import zip
+from openquake.baselib.python3compat import zip, encode
 from openquake.baselib.general import AccumDict
 from openquake.risklib import scientific
 from openquake.calculators import base
@@ -137,7 +137,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
 
             # losses by tag
             self.datastore['losses_by_tag-rlzs'] = result['losses_by_tag']
-            tags = [tag.encode('ascii') for tag in self.assetcol.tags()]
+            tags = encode(self.assetcol.tags())
             self.datastore.set_attrs('losses_by_tag-rlzs', tags=tags,
                                      nbytes=result['losses_by_tag'].nbytes)
 

--- a/openquake/qa_tests_data/event_based_risk/case_master/exposure_model.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_master/exposure_model.xml
@@ -13,7 +13,7 @@
       <costType name="business_interruption" type="per_asset" unit="USD/month" />
     </costTypes>
   </conversions>
-  
+  <tagNames>state cresta</tagNames>
   <assets>
     <asset id="a1" number="1" area="100" taxonomy="tax1">
       <location lon="-122.000" lat="38.113" />

--- a/openquake/qa_tests_data/scenario_damage/case_1/exposure_model.xml
+++ b/openquake/qa_tests_data/scenario_damage/case_1/exposure_model.xml
@@ -8,6 +8,7 @@
         <costType name="structural" unit="USD" type="aggregated"/>
       </costTypes>
     </conversions>
+    <tagNames>CRESTA</tagNames>
     <assets>
       <asset id="a1" taxonomy="RM" number="3000">
         <location lon="15.48" lat="38.09"/>

--- a/openquake/qa_tests_data/scenario_risk/case_1/exposure_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_1/exposure_model.xml
@@ -8,6 +8,7 @@
         <costType name="structural" unit="USD" type="aggregated"/>
       </costTypes>
     </conversions>
+    <tagNames> OCC </tagNames>
     <assets>
       <asset id="a1" taxonomy="RM" number="3000">
         <location lon="15.48" lat="38.09"/>

--- a/openquake/qa_tests_data/scenario_risk/case_master/exposure_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_master/exposure_model.xml
@@ -13,7 +13,7 @@
       <costType name="business_interruption" type="per_asset" unit="USD/month" />
     </costTypes>
   </conversions>
-  
+  <tagNames>state cresta</tagNames>
   <assets>
     <asset id="a1" number="1" area="100" taxonomy="tax1">
       <location lon="-122.000" lat="38.113" />

--- a/openquake/risklib/read_nrml.py
+++ b/openquake/risklib/read_nrml.py
@@ -423,4 +423,5 @@ def update_validators():
         'damage': damage_triple,
         'damageStates': valid.namelist,
         'taxonomy': taxonomy,
+        'tagNames': valid.namelist,
     })

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -85,6 +85,7 @@ class AssetCollection(object):
         self.tot_sites = len(assets_by_site)
         self.array = self.build_asset_collection(assets_by_site, time_event)
         dic = dict(zip(self.array['idx'], range(len(self.array))))
+        self.tagnames = assets_by_tag.tagnames
         self.aids_by_tag = {}
         for tag, idxs in assets_by_tag.items():
             aids = []
@@ -214,6 +215,7 @@ class AssetCollection(object):
                  'i_lim': ' '.join(self.i_lim),
                  'retro': ' '.join(self.retro),
                  'tot_sites': self.tot_sites,
+                 'tagnames': encode(self.tagnames),
                  'nbytes': self.array.nbytes}
         return dict(array=self.array, aids_by_tag=self.aids_by_tag,
                     cost_calculator=self.cc), attrs
@@ -221,6 +223,7 @@ class AssetCollection(object):
     def __fromh5__(self, dic, attrs):
         for name in ('time_events', 'loss_types', 'deduc', 'i_lim', 'retro'):
             setattr(self, name, attrs[name].split())
+        self.tagnames = attrs['tagnames']
         self.time_event = attrs['time_event']
         self.tot_sites = attrs['tot_sites']
         self.nbytes = attrs['nbytes']


### PR DESCRIPTION
The Input Preparation Toolkit will require the user to specify the tag names for the current exposure. Since they are available upfront, it is a good idea to write them inside the exposure, before the `<assets>` section. In this way the importer can check that all the provided tags are consistent with the one declared at the beginning, thus avoid misspelling and case errors.
In order to keep compatibility with the past, the node `<tagNames>` is optional. Of course, if you do not add it, it becomes an error to add tags to the `<asset>` nodes.

@raoanirudh will have to change the exposures in his tests by adding the <tagNames> node as I did in this PR for the engine tests.
