### PR TITLE
Fixed logging when missing rtree

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a bug with logging configured a WARN level instead of INFO level
+    if rtree was missing (affecting only `oq run`)
   * Added a node `<tagNames>` in the exposure
   * Added a web API to extract the attributes of a datastore object
   * Fixed `oq to_shapefile` and `oq from_shapefile` to work with NRML 0.5

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -281,7 +281,7 @@ class SourceFilter(object):
             self.index = rtree.index.Index()
             for sid, lon, lat in zip(sitecol.sids, fixed_lons, sitecol.lats):
                 self.index.insert(sid, (lon, lat, lon, lat))
-        if rtree is None:
+        if sitecol is not None and rtree is None:
             logging.info('Using distance filtering [no rtree]')
 
     def get_affected_box(self, src):


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/3000.

The problem was rather subtle: since `openquake.hazardlib.calc.filters` has a toplevel definition
`source_site_noop_filter = SourceFilter(None, {})`, in absence of rtree the `logging.info` was triggered at import time, BEFORE calling `logging.basicConfig`. As a consequence, the logger was configured at the WARN level (the default) and messages at INFO level were not printed anymore for missing rtree.

It looks like a "feature" of the logging module, `logging.basicConfig` if called too late is not honored. Did I ever mention that I hate the logging module?