### PR TITLE
Changed the configuration paths search logic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the search logic for the configuration file openquake.cfg
   * Implemented an API `/extract/agglosses/loss_type?tagname1=tagvalue1`
   * Fixed several bugs in the gmf_ebrisk calculator, in particular in presence
     of asset correlation

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -59,7 +59,7 @@ def read(*paths, **validators):
     In the absence of this environment variable the following paths will be
     used:
        - $VIRTUAL_ENV/openquake.cfg when in a virtualenv
-       - /etc/openquake/openquake.cfg outside a virtualenv
+       - /etc/openquake/openquake.cfg outside of a virtualenv
 
     If those files are missing, the fallback is the source code:
        - openquake/engine/openquake.cfg

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -28,16 +28,18 @@ __version__ += git_suffix(__file__)
 
 venv = 'VIRTUAL_ENV' in os.environ or hasattr(sys, 'real_prefix')
 if venv:
-    PATHS = ['~/openquake.cfg']
-else:  # installation from packages, search also in /etc
-    PATHS = ['~/openquake.cfg', '/etc/openquake/openquake.cfg']
+    PATHS = [os.path.join(os.environ('VIRTUAL_ENV', '~'), 'openquake.cfg')]
+else:  # installation from packages, search in /etc
+    PATHS = ['/etc/openquake/openquake.cfg']
 cfg = os.environ.get('OQ_CONFIG_FILE')
 if cfg:  # has the precedence
     PATHS.insert(0, cfg)
 
 
 class DotDict(collections.OrderedDict):
-    """A string-valued dictionary that can be accessed with the "." notation"""
+    """
+    A string-valued dictionary that can be accessed with the "." notation
+    """
     def __getattr__(self, key):
         try:
             return self[key]
@@ -55,9 +57,11 @@ def read(*paths, **validators):
        - OQ_CONFIG_FILE
 
     In the absence of this environment variable the following paths will be
-    used in order:
-       - ~/openquake.cfg
-       - /etc/openquake/openquake.cfg (only when running outside a venv)
+    used:
+       - $VIRTUAL_ENV/openquake.cfg when in a virtualenv
+       - /etc/openquake/openquake.cfg outside a virtualenv
+
+    If those files are missing, the fallback is the source code:
        - openquake/engine/openquake.cfg
 
     Please note: settings in the site configuration file are overridden

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -28,7 +28,7 @@ __version__ += git_suffix(__file__)
 
 venv = 'VIRTUAL_ENV' in os.environ or hasattr(sys, 'real_prefix')
 if venv:
-    PATHS = [os.path.join(os.environ('VIRTUAL_ENV', '~'), 'openquake.cfg')]
+    PATHS = [os.path.join(os.environ.get('VIRTUAL_ENV', '~'), 'openquake.cfg')]
 else:  # installation from packages, search in /etc
     PATHS = ['/etc/openquake/openquake.cfg']
 cfg = os.environ.get('OQ_CONFIG_FILE')

--- a/openquake/baselib/tests/config_test.py
+++ b/openquake/baselib/tests/config_test.py
@@ -1,0 +1,37 @@
+#  -*- coding: utf-8 -*-
+#  vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#  Copyright (c) 2017, GEM Foundation
+
+#  OpenQuake is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+#  OpenQuake is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from openquake.baselib import config
+
+
+class ConfigPathsTestCase(unittest.TestCase):
+    """Make sure that the config path search logic is tested"""
+
+    def test_venv(self):
+        venv = os.environ.get('VIRTUAL_ENV')
+        if venv:
+            self.assertIn(os.path.join(venv, 'openquake.cfg'), config.paths)
+        else:
+            self.assertIn('/etc/openquake/openquake.cfg', config.paths)
+
+    def test_config_file(self):
+        cfgfile = os.environ.get('OQ_CONFIG_FILE')
+        if cfgfile:
+            self.assertEqual(config.paths[0], cfgfile)


### PR DESCRIPTION
Instead of the user's home, let's search `$VIRTUAL_ENV/openquake.cfg`: then an user can have several virtualenvs with different configurations. Tests and demos are running here: https://ci.openquake.org/job/zdevel_oq-engine/2591