### PR TITLE
Refactoring: get_hazard now returns the data by sid, not by rlzi

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -316,9 +316,8 @@ def compute_gmfs_and_curves(getter, oq, monitor):
         with monitor('building hazard', measuremem=True):
             gmfdata = numpy.fromiter(getter.gen_gmv(), getter.gmf_data_dt)
             hazard = sorted(getter.get_hazard(data=gmfdata).items())
-        for rlzi, hazardr in hazard:
-            for sid in getter.sids:
-                array = hazardr[sid]
+        for sid, hazardr in hazard:
+            for rlzi, array in hazardr.items():
                 if len(array) == 0:  # no data
                     continue
                 with hc_mon:

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -573,9 +573,9 @@ class HazardGetter(object):
         self.eids = eids
         self.data = collections.OrderedDict()
         self.num_rlzs, num_sids = hazards_by_rlz.shape[:2]
-        if len(hazards_by_rlz.shape) == 2:  # hcurves
+        if len(hazards_by_rlz.shape) == 2:  # hcurves, shape (R, N)
             hazards_by_sid = hazards_by_rlz.transpose(1, 0)
-        else:  # gmfs
+        else:  # gmfs, shape (R, N, E, I)
             hazards_by_sid = hazards_by_rlz.transpose(1, 0, 2, 3)
         for sid, hazard_by_rlz in enumerate(hazards_by_sid):
             self.data[sid] = datadict = {}

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -601,16 +601,16 @@ class HazardGetter(object):
         :param gsim: a GSIM instance
         :returns: an OrderedDict rlzi -> datadict
         """
-        #if self.kind == 'gmf':
-        #    # save info useful for debugging into gmdata
-        #    I = len(self.imts)
-        #    for rlzi, datadict in self.data.items():
-        #        arr = numpy.zeros(I + 2, F32)  # imt, events, bytes
-        #        arr[-1] = 4 * I * len(datadict)  # nbytes
-        #        for lst in datadict.values():
-        #            for i, gmvs in enumerate(lst):
-        #                arr[i] += gmvs.sum()
-        #        self.gmdata[rlzi] += arr
+        if self.kind == 'gmf':
+            # save info useful for debugging into gmdata
+            I = len(self.imts)
+            for sid, datadict in self.data.items():
+                arr = numpy.zeros(I + 2, F32)  # imt, events, bytes
+                for rlzi, lst in datadict.items():
+                    arr[-1] += 4 * I  # nbytes
+                    for i, gmvs in enumerate(lst):
+                        arr[i] += gmvs.sum()
+                self.gmdata[rlzi] += arr
         return self.data
 
 

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -601,16 +601,6 @@ class HazardGetter(object):
         :param gsim: a GSIM instance
         :returns: an OrderedDict rlzi -> datadict
         """
-        if self.kind == 'gmf':
-            # save info useful for debugging into gmdata
-            I = len(self.imts)
-            for sid, datadict in self.data.items():
-                arr = numpy.zeros(I + 2, F32)  # imt, events, bytes
-                for rlzi, lst in datadict.items():
-                    arr[-1] += 4 * I  # nbytes
-                    for i, gmvs in enumerate(lst):
-                        arr[i] += gmvs.sum()
-                self.gmdata[rlzi] += arr
         return self.data
 
 

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -559,7 +559,7 @@ class HazardGetter(object):
         source group ID
     :param rlzs_by_gsim:
         a dictionary gsim -> realizations for that GSIM
-    :param hazards_by_sid:
+    :param hazards_by_rlz:
         an array of curves of shape (R, N) or a GMF array of shape (R, N, E, I)
     :param imts:
         a list of IMT strings


### PR DESCRIPTION
This is simple refactoring, akin to transposing a matrix (R, N) into a matrix (N, R), being N the number of sites and R the number of realizations. It is another crucial step towards a full event based calculator reading the GMFs site by site (https://github.com/gem/oq-engine/issues/2017).