### PR TITLE
Stored the events into a single array

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -752,5 +752,5 @@ def get_gmfs(calculator):
         # store the events, useful when read the GMFs from a file
         events = numpy.zeros(E, calc.stored_event_dt)
         events['eid'] = eids
-        dstore['events/grp-00'] = events
+        dstore['events'] = events
         return eids, gmfs

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -348,6 +348,7 @@ def get_ruptures_by_grp(dstore):
     """
     Extracts the dictionary `ruptures_by_grp` from the given calculator
     """
+    events = dstore['events']
     n = 0
     for grp in dstore['ruptures']:
         n += len(dstore['ruptures/' + grp])
@@ -359,7 +360,8 @@ def get_ruptures_by_grp(dstore):
         ruptures_by_grp = AccumDict(accum=[])
         for grp in dstore['ruptures']:
             grp_id = int(grp[4:])  # strip 'grp-'
-            ruptures_by_grp[grp_id] = list(calc.get_ruptures(dstore, grp_id))
+            ruptures = list(calc.get_ruptures(dstore, events, grp_id))
+            ruptures_by_grp[grp_id] = ruptures
     return ruptures_by_grp
 
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -263,9 +263,9 @@ class EventBasedRuptureCalculator(PSHACalculator):
                      num_events, num_ruptures)
         with self.monitor('setting event years', measuremem=True,
                           autoflush=True):
-            inv_time = int(self.oqparam.investigation_time)
             numpy.random.seed(self.oqparam.ses_seed)
-            set_random_years(self.datastore, inv_time)
+            set_random_years(self.datastore,
+                             int(self.oqparam.investigation_time))
         h5 = self.datastore.hdf5
         if 'ruptures' in h5:
             self.datastore.set_nbytes('ruptures')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -238,15 +238,19 @@ class EventBasedRuptureCalculator(PSHACalculator):
         return acc
 
     def save_ruptures(self, ruptures_by_grp_id):
-        """Extend the 'events' dataset with the given ruptures"""
+        """
+        Extend the 'events' dataset with the events from the given ruptures;
+        also, save the ruptures if the flag `save_ruptures` is on.
+
+        :param ruptures_by_grp_id: a dictionary grp_id -> list of EBRuptures
+        """
         with self.monitor('saving ruptures', autoflush=True):
             for grp_id, ebrs in ruptures_by_grp_id.items():
                 if len(ebrs):
                     events = get_events(ebrs)
                     dset = self.datastore.extend('events', events)
                     if self.oqparam.save_ruptures:
-                        initial_eidx = len(dset) - len(events)
-                        self.rupser.save(ebrs, initial_eidx)
+                        self.rupser.save(ebrs, eidx=len(dset)-len(events))
 
     def post_execute(self, result):
         """
@@ -266,12 +270,6 @@ class EventBasedRuptureCalculator(PSHACalculator):
             numpy.random.seed(self.oqparam.ses_seed)
             set_random_years(self.datastore,
                              int(self.oqparam.investigation_time))
-        h5 = self.datastore.hdf5
-        if 'ruptures' in h5:
-            self.datastore.set_nbytes('ruptures')
-        if 'events' in h5:
-            self.datastore.set_attrs('events', num_events=num_events)
-            self.datastore.set_nbytes('events')
 
 
 def set_random_years(dstore, investigation_time):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -393,12 +393,12 @@ class EbriskCalculator(base.RiskCalculator):
             logging.debug(
                 'Saving results for source model #%d, realizations %d:%d',
                 res.sm_id + 1, start, stop)
-            if hasattr(res, 'ruptures_by_grp'):
+            if hasattr(res, 'ruptures_by_grp'):  # for UCERF
                 save_ruptures(self, res.ruptures_by_grp)
-            elif hasattr(res, 'events_by_grp'):
+            elif hasattr(res, 'events_by_grp'):  # for UCERF
                 for grp_id in res.events_by_grp:
                     events = res.events_by_grp[grp_id]
-                    self.datastore.extend('events/grp-%02d' % grp_id, events)
+                    self.datastore.extend('events', events)
             num_events[res.sm_id] += res.num_events
         if 'all_loss_ratios' in self.datastore:
             self.datastore['all_loss_ratios/num_losses'] = self.num_losses

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -28,7 +28,7 @@ from openquake.baselib import hdf5, parallel, performance
 from openquake.baselib.general import humansize, group_array, DictArray
 from openquake.hazardlib import valid
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib.calc import disagg, gmf
+from openquake.hazardlib.calc import disagg
 from openquake.calculators.views import view
 from openquake.calculators.export import export
 from openquake.calculators.extract import convert_to_array
@@ -89,7 +89,7 @@ def export_ruptures_xml(ekey, dstore):
 
 
 @export.add(('ruptures', 'csv'))
-def export_ses_csv(ekey, dstore):
+def export_ruptures_csv(ekey, dstore):
     """
     :param ekey: export key, i.e. a pair (datastore key, fmt)
     :param dstore: datastore object
@@ -658,13 +658,8 @@ def export_gmf(ekey, dstore):
     fnames = []
     ruptures_by_rlz = collections.defaultdict(list)
     data = gmf_data['data'].value
-    eventdict = {}
-    for grp in sorted(dstore['events']):
-        try:
-            events = dstore['events/' + grp]
-        except KeyError:  # source model producing zero ruptures
-            continue
-        eventdict.update((zip(events['eid'], events)))
+    events = dstore['events'].value
+    eventdict = dict(zip(events['eid'], events))
     for rlzi, gmf_arr in group_array(data, 'rlzi').items():
         ruptures = ruptures_by_rlz[rlzi]
         for eid, gmfa in group_array(gmf_arr, 'eid').items():

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -230,6 +230,7 @@ def export_agg_losses_ebr(ekey, dstore):
     csm_info = dstore['csm_info']
     rlzs_assoc = csm_info.get_rlzs_assoc()
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
+    all_events = group_array(dstore['events'], 'grp_id')
     for sm_id, rlzs in rlzs_assoc.rlzs_by_smodel.items():
         # populate rup_data and event_by_eid
         rup_data = {}
@@ -237,7 +238,7 @@ def export_agg_losses_ebr(ekey, dstore):
         for grp_id in csm_info.get_grp_ids(sm_id):
             event_by_grp[grp_id] = event_by_eid = {}
             try:
-                events = dstore['events/grp-%02d' % grp_id]
+                events = all_events[grp_id]
             except KeyError:
                 continue
             for event in events:

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -237,13 +237,8 @@ def export_agg_losses_ebr(ekey, dstore):
         rup_data = {}
         event_by_grp = {}  # grp_id -> eid -> event
         for grp_id in csm_info.get_grp_ids(sm_id):
-            event_by_grp[grp_id] = event_by_eid = {}
-            try:
-                events = all_events[grp_id]
-            except KeyError:
-                continue
-            for event in events:
-                event_by_eid[event['eid']] = event
+            event_by_grp[grp_id] = {
+                event['eid']: event for event in all_events.get(grp_id, [])}
             if has_rup_data:
                 ruptures = calc.get_ruptures(dstore, the_events, grp_id)
                 rup_data.update(get_rup_data(ruptures))

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -230,7 +230,8 @@ def export_agg_losses_ebr(ekey, dstore):
     csm_info = dstore['csm_info']
     rlzs_assoc = csm_info.get_rlzs_assoc()
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
-    all_events = group_array(dstore['events'], 'grp_id')
+    the_events = dstore['events'].value
+    all_events = group_array(the_events, 'grp_id')
     for sm_id, rlzs in rlzs_assoc.rlzs_by_smodel.items():
         # populate rup_data and event_by_eid
         rup_data = {}
@@ -244,8 +245,8 @@ def export_agg_losses_ebr(ekey, dstore):
             for event in events:
                 event_by_eid[event['eid']] = event
             if has_rup_data:
-                rup_data.update(
-                    get_rup_data(calc.get_ruptures(dstore, grp_id)))
+                ruptures = calc.get_ruptures(dstore, the_events, grp_id)
+                rup_data.update(get_rup_data(ruptures))
 
         for rlz in rlzs:
             rlzi = rlz.ordinal

--- a/openquake/calculators/gmf_ebrisk.py
+++ b/openquake/calculators/gmf_ebrisk.py
@@ -75,7 +75,7 @@ class GmfEbRiskCalculator(base.RiskCalculator):
         events = numpy.zeros(oq.number_of_ground_motion_fields,
                              calc.stored_event_dt)
         events['eid'] = eids
-        self.datastore['events/grp-00'] = events
+        self.datastore['events'] = events
 
     def post_execute(self, result):
         pass

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -54,7 +54,7 @@ class ScenarioCalculator(base.HazardCalculator):
         events = numpy.zeros(oq.number_of_ground_motion_fields,
                              calc.stored_event_dt)
         events['eid'] = numpy.arange(oq.number_of_ground_motion_fields)
-        self.datastore['events/grp-00'] = events
+        self.datastore['events'] = events
         rupture = calc.EBRupture(rup, self.sitecol.sids, events, 0, 0)
         rupture.sidx = 0
         rupture.eidx1 = 0

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -130,6 +130,9 @@ class UcerfTestCase(CalculatorTestCase):
         self.run_calc(ucerf.__file__, 'job_ebr.ini',
                       number_of_logic_tree_samples='2')
 
+        # check the right number of events was stored
+        self.assertEqual(len(self.calc.datastore['events']), 90)
+
         fname = writetmp(view('portfolio_loss', self.calc.datastore))
         self.assertEqualFiles('expected/portfolio_loss.txt', fname)
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -497,7 +497,7 @@ def view_assetcol(token, dstore):
 @view.add('ruptures_events')
 def view_ruptures_events(token, dstore):
     num_ruptures = sum(len(v) for v in dstore['ruptures'].values())
-    num_events = sum(len(v) for v in dstore['events'].values())
+    num_events = len(dstore['events'])
     mult = round(num_events / num_ruptures, 3)
     lst = [('Total number of ruptures', num_ruptures),
            ('Total number of events', num_events),

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -21,7 +21,7 @@ import warnings
 import numpy
 import h5py
 
-from openquake.baselib import hdf5
+from openquake.baselib import hdf5, general
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib.geo.mesh import (
     surface_to_mesh, point3d, RectangularMesh)
@@ -45,8 +45,8 @@ F64 = numpy.float64
 
 event_dt = numpy.dtype([('eid', U64), ('ses', U32), ('sample', U32)])
 stored_event_dt = numpy.dtype([
-    ('eid', U64), ('rup_id', U32), ('year', U32), ('ses', U32),
-    ('sample', U32)])
+    ('eid', U64), ('rup_id', U32), ('grp_id', U16), ('year', U32),
+    ('ses', U32), ('sample', U32)])
 
 sids_dt = h5py.special_dtype(vlen=U32)
 
@@ -570,13 +570,15 @@ def get_ruptures(dstore, grp_id):
 def _get_ruptures(dstore, grp_ids, rup_id):
     oq = dstore['oqparam']
     grp_trt = dstore['csm_info'].grp_trt()
+    all_events = dstore['events']
     for grp_id in grp_ids:
         trt = grp_trt[grp_id]
         grp = 'grp-%02d' % grp_id
-        if grp not in dstore['events']:
+        try:
+            recs = dstore['ruptures/' + grp]
+        except KeyError:  # no ruptures in grp
             continue
-        events = dstore['events/' + grp]
-        for rec in dstore['ruptures/' + grp]:
+        for rec in recs:
             if rup_id is not None and rup_id != rec['serial']:
                 continue
             mesh = rec['points'].reshape(rec['sx'], rec['sy'], rec['sz'])
@@ -612,7 +614,7 @@ def _get_ruptures(dstore, grp_ids, rup_id):
                 rupture.surface.mesh = RectangularMesh(
                     m['lon'], m['lat'], m['depth'])
             sids = dstore['sids'][rec['sidx']]
-            evs = events[rec['eidx1']:rec['eidx2']]
+            evs = all_events[rec['eidx1']:rec['eidx2']]
             ebr = EBRupture(rupture, sids, evs, grp_id, rec['serial'])
             ebr.eidx1 = rec['eidx1']
             ebr.eidx2 = rec['eidx2']

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -560,17 +560,16 @@ class RuptureSerializer(object):
             del self.data[:]
 
 
-def get_ruptures(dstore, grp_id):
+def get_ruptures(dstore, events, grp_id):
     """
     Extracts the ruptures of the given grp_id
     """
-    return _get_ruptures(dstore, [grp_id], None)
+    return _get_ruptures(dstore, events, [grp_id], None)
 
 
-def _get_ruptures(dstore, grp_ids, rup_id):
+def _get_ruptures(dstore, events, grp_ids, rup_id):
     oq = dstore['oqparam']
     grp_trt = dstore['csm_info'].grp_trt()
-    all_events = dstore['events']
     for grp_id in grp_ids:
         trt = grp_trt[grp_id]
         grp = 'grp-%02d' % grp_id
@@ -614,7 +613,7 @@ def _get_ruptures(dstore, grp_ids, rup_id):
                 rupture.surface.mesh = RectangularMesh(
                     m['lon'], m['lat'], m['depth'])
             sids = dstore['sids'][rec['sidx']]
-            evs = all_events[rec['eidx1']:rec['eidx2']]
+            evs = events[rec['eidx1']:rec['eidx2']]
             ebr = EBRupture(rupture, sids, evs, grp_id, rec['serial'])
             ebr.eidx1 = rec['eidx1']
             ebr.eidx2 = rec['eidx2']


### PR DESCRIPTION
Before they were stored in a different array for each source group. This refactoring will allow a simplification of the exporter of the aggregate loss table, to be done in a future pull request.