### PR TITLE
Deprecated get_hcurves_from_csv

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
   [Michele Simionato]
+  * Deprecated reading hazard curves from CSV, since it was an experimental
+    features and nobody is using it
   * Changed the exporter of the event loss table to export all realizations
-    into a single file
+   into a single file
 
   [Graeme Weatherill]
   * Adds the Bindi et al. (2017) GMPEs for Joyner-Boore and Hypocentral

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -28,14 +28,14 @@ import collections
 import numpy
 from shapely import wkt, geometry
 
-from openquake.baselib.general import groupby, AccumDict
+from openquake.baselib.general import groupby, AccumDict, deprecated
 from openquake.baselib.python3compat import configparser, decode
 from openquake.baselib.node import Node, context
 from openquake.baselib import hdf5
 from openquake.hazardlib import (
     geo, site, imt, valid, sourceconverter, nrml, InvalidFile)
 from openquake.hazardlib.calc.hazard_curve import zero_curves
-from openquake.risklib import asset, riskmodels, riskinput, read_nrml
+from openquake.risklib import asset, riskinput, read_nrml
 from openquake.baselib import datastore
 from openquake.commonlib.oqvalidation import OqParam
 from openquake.commonlib import logictree, source, writers
@@ -889,6 +889,7 @@ def get_hcurves(oqparam):
         raise NotImplementedError('Reading from %s' % fname)
 
 
+@deprecated('Reading hazard curves from CSV may change in the future')
 def get_hcurves_from_csv(oqparam, fname):
     """
     :param oqparam:


### PR DESCRIPTION
Currently this feature is only used in one of the classical_damage tests, so it may disappear easily. Probably we want to replace the CSV importer with an import from HDF5. However this is not urgent and will not be done until required.