### PR TITLE
Fix an error on windows when using random with numpy.uint32

### DIFF
--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -66,8 +66,14 @@ class DataStoreTestCase(unittest.TestCase):
 
     def test_read(self):
         # cas of a non-existing directory
-        with self.assertRaises(OSError):
-            read(42, datadir='/fake/directory')
+        if sys.platform == 'win32':
+            # On Windows an IOError exception is raised instead of
+            # an OSError one
+            with self.assertRaises(IOError):
+                read(42, datadir='/fake/directory')
+        else:
+            with self.assertRaises(OSError):
+                read(42, datadir='/fake/directory')
         # case of a non-existing file
         with self.assertRaises(IOError):
             read(42, datadir='/tmp')

--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -18,6 +18,7 @@
 
 import re
 import os
+import sys
 import unittest
 import tempfile
 import numpy

--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -66,15 +66,13 @@ class DataStoreTestCase(unittest.TestCase):
         self.assertIsNotNone(mo)
 
     def test_read(self):
-        # cas of a non-existing directory
+        # windows does not manage permissions properly. Skip the test
         if sys.platform == 'win32':
-            # On Windows an IOError exception is raised instead of
-            # an OSError one
-            with self.assertRaises(IOError):
-                read(42, datadir='/fake/directory')
-        else:
-            with self.assertRaises(OSError):
-                read(42, datadir='/fake/directory')
+            raise unittest.SkipTest('Windows')
+
+        # case of a non-existing directory
+        with self.assertRaises(OSError):
+            read(42, datadir='/fake/directory')
         # case of a non-existing file
         with self.assertRaises(IOError):
             read(42, datadir='/tmp')

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -501,7 +501,8 @@ class CompositionInfo(object):
     def _get_rlzs_gsims(self, smodel, gsim_lt, seed):
         if self.num_samples:  # sampling
             rlzs = logictree.sample(
-                gsim_lt, smodel.samples, random.Random(seed))
+                # the int is needed on Windows to convert numpy.uint32 objects
+                gsim_lt, smodel.samples, random.Random(int(seed)))
         else:  # full enumeration
             rlzs = logictree.get_effective_rlzs(gsim_lt)
         if len(rlzs) > TWO16:


### PR DESCRIPTION
This was fixed by https://github.com/gem/oq-engine/pull/2125/files but probably got lost.

```
test_classical (openquake.server.tests.functional_test.EngineServerTestCase) ... [11/Oct/2017 16:08:09] "GET /v1/calc/0
HTTP/1.1" 404 0
[11/Oct/2017 16:08:10] "GET /v1/available_gsims HTTP/1.1" 200 8776
[11/Oct/2017 16:08:11] "POST /v1/calc/run HTTP/1.1" 200 35
[2017-10-11 16:08:13,091 #99 INFO] Running c:\users\openqu~1\appdata\local\temp\tmptvcfw6\classical\job.ini
[2017-10-11 16:08:13,095 #99 INFO] Using engine version 2.7.0
[2017-10-11 16:08:13,118 #99 INFO] Read 30 hazard site(s)
[2017-10-11 16:08:13,130 #99 INFO] Parsing c:\users\openqu~1\appdata\local\temp\tmptvcfw6\classical\source_model.xml
[2017-10-11 16:08:13,142 #99 INFO] Processed source model 1 with 2 potential gsim path(s) and 1 sources
[2017-10-11 16:08:13,150 #99 INFO] Prefiltering the CompositeSourceModel
[2017-10-11 16:08:13,170 #99 CRITICAL]
Traceback (most recent call last):
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 2
04, in run
    self.pre_execute()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
47, in pre_execute
    self.basic_pre_execute()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
19, in basic_pre_execute
    self.init()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
65, in init
    self.rlzs_assoc = self.datastore['csm_info'].get_rlzs_assoc()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 4
12, in get_rlzs_assoc
    assoc = RlzsAssoc(self)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 1
44, in __init__
    self.gsims_by_grp_id = csm_info.get_gsims_by_grp()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 3
13, in get_gsims_by_grp
    sm, self.gsim_lt, self.seed + idx)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 5
04, in _get_rlzs_gsims
    gsim_lt, smodel.samples, random.Random(seed))
SystemError: ..\Objects\longobject.c:426: bad argument to internal function
[2017-10-11 16:08:13,177 #99 CRITICAL]
Traceback (most recent call last):
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 2
04, in run
    self.pre_execute()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
42, in pre_execute
    self.precalc = (self.compute_previous() if precalc_id is None
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 3
77, in compute_previous
    precalc.run(close=False)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 2
04, in run
    self.pre_execute()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
47, in pre_execute
    self.basic_pre_execute()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
19, in basic_pre_execute
    self.init()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
65, in init
    self.rlzs_assoc = self.datastore['csm_info'].get_rlzs_assoc()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 4
12, in get_rlzs_assoc
    assoc = RlzsAssoc(self)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 1
44, in __init__
    self.gsims_by_grp_id = csm_info.get_gsims_by_grp()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 3
13, in get_gsims_by_grp
    sm, self.gsim_lt, self.seed + idx)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 5
04, in _get_rlzs_gsims
    gsim_lt, smodel.samples, random.Random(seed))
SystemError: ..\Objects\longobject.c:426: bad argument to internal function
[2017-10-11 16:08:13,183 #99 CRITICAL] Traceback (most recent call last):
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\engine\engine.py", line 218,
 in run_calc
    _do_run_calc(calc, exports, hazard_calculation_id, **kw)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\engine\engine.py", line 253,
 in _do_run_calc
    close=False, **kw)  # don't close the datastore too soon
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 2
04, in run
    self.pre_execute()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
42, in pre_execute
    self.precalc = (self.compute_previous() if precalc_id is None
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 3
77, in compute_previous
    precalc.run(close=False)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 2
04, in run
    self.pre_execute()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
47, in pre_execute
    self.basic_pre_execute()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
19, in basic_pre_execute
    self.init()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\calculators\base.py", line 4
65, in init
    self.rlzs_assoc = self.datastore['csm_info'].get_rlzs_assoc()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 4
12, in get_rlzs_assoc
    assoc = RlzsAssoc(self)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 1
44, in __init__
    self.gsims_by_grp_id = csm_info.get_gsims_by_grp()
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 3
13, in get_gsims_by_grp
    sm, self.gsim_lt, self.seed + idx)
  File "C:\Users\openquake\Desktop\OpenQuake_Engine_win64_dev1709271456\oq-engine\openquake\commonlib\source.py", line 5
04, in _get_rlzs_gsims
    gsim_lt, smodel.samples, random.Random(seed))
SystemError: ..\Objects\longobject.c:426: bad argument to internal function
```

https://ci.openquake.org/job/windows/job/zdevel_oq-engine/19/