### PR TITLE
Add support for groups in the WebUI

### DIFF
--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -478,14 +478,13 @@ def get_calcs(db, request_get_dict, allowed_users, user_acl_on=False, id=None):
     # user_acl_on is true if settings.ACL_ON = True or when the user is a
     # Django super user
     if user_acl_on:
-        users_filter = ("user_name IN ('%s')" %
-                        "', '".join([str(item) for item in allowed_users]))
+        users_filter = "user_name IN (?X)"
     else:
         users_filter = 1
 
-    jobs = db('SELECT * FROM job WHERE ?A AND %s AND %s ORDER BY id DESC'
-              ' LIMIT %d'
-              % (time_filter, users_filter, limit), filterdict)
+    jobs = db('SELECT * FROM job WHERE ?A AND %s AND %s'
+              ' ORDER BY id DESC LIMIT %d'
+              % (users_filter, time_filter, limit), filterdict, allowed_users)
     return [(job.id, job.user_name, job.status, job.calculation_mode,
              job.is_running, job.description) for job in jobs]
 

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -128,6 +128,10 @@ nav.main-nav ul li.calc{
    border-bottom: solid #ffdc00 5px;
 }
 
+nav.main-nav ul li.admin{
+   border-bottom: solid #ff0000 5px;
+}
+
 nav.main-nav ul li:hover{
     border-bottom: solid #fff 5px;
 }

--- a/openquake/server/templates/engine/base.html
+++ b/openquake/server/templates/engine/base.html
@@ -32,6 +32,9 @@
                 {# Take the first app in STANDALONE_APPS as landing page for tools #}
                 <li class="tools"><a href="{{ app_list.0.url }}">Tools</a></li>
                 {% endif %}
+                {% if user.is_superuser %}
+                <li class="admin"><a href="{% url 'admin:index' %}">Admin</a></li>
+                {% endif %}
               </ul>
             </nav>
           </div> <!-- ./span10 -->

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -19,10 +19,15 @@
 import getpass
 import requests
 import logging
+import django
 
 from time import sleep
 from django.conf import settings
 from openquake.engine import __version__ as oqversion
+
+if settings.LOCKDOWN:
+    django.setup()
+    from django.contrib.auth.models import User
 
 
 def get_user_data(request):
@@ -34,16 +39,24 @@ def get_user_data(request):
     """
 
     acl_on = settings.ACL_ON
+    group_memebers = []
     if settings.LOCKDOWN and hasattr(request, 'user'):
         if request.user.is_authenticated():
             name = request.user.username
+            groups = request.user.groups.values_list('name', flat=True)
+            if groups:
+                group_memebers = list(User.objects.filter(groups__name=groups)
+                                      .values_list('username', flat=True))
         if request.user.is_superuser:
             acl_on = False
     else:
         name = (settings.DEFAULT_USER if
                 hasattr(settings, 'DEFAULT_USER') else getpass.getuser())
 
-    return {'name': name, 'acl_on': acl_on}
+    if not group_memebers:
+        group_memebers.append(name)
+
+    return {'name': name, 'group_memebers': group_memebers, 'acl_on': acl_on}
 
 
 def oq_server_context_processor(request):

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -39,13 +39,13 @@ def get_user_data(request):
     """
 
     acl_on = settings.ACL_ON
-    group_memebers = []
+    group_members = []
     if settings.LOCKDOWN and hasattr(request, 'user'):
         if request.user.is_authenticated():
             name = request.user.username
             groups = request.user.groups.values_list('name', flat=True)
             if groups:
-                group_memebers = list(User.objects.filter(groups__name=groups)
+                group_members = list(User.objects.filter(groups__name=groups)
                                       .values_list('username', flat=True))
         if request.user.is_superuser:
             acl_on = False
@@ -53,7 +53,7 @@ def get_user_data(request):
         name = (settings.DEFAULT_USER if
                 hasattr(settings, 'DEFAULT_USER') else getpass.getuser())
 
-    return {'name': name, 'group_memebers': group_memebers, 'acl_on': acl_on}
+    return {'name': name, 'group_members': group_members, 'acl_on': acl_on}
 
 
 def oq_server_context_processor(request):

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -53,9 +53,6 @@ def get_user_data(request):
         name = (settings.DEFAULT_USER if
                 hasattr(settings, 'DEFAULT_USER') else getpass.getuser())
 
-    if not group_memebers:
-        group_memebers.append(name)
-
     return {'name': name, 'group_memebers': group_memebers, 'acl_on': acl_on}
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -65,6 +65,7 @@ try:
 except ImportError:
     from django.core.servers.basehttp import FileWrapper
 
+
 read_nrml.update_validators()  # update risk validators
 
 METHOD_NOT_ALLOWED = 405
@@ -308,9 +309,9 @@ def calc(request, id=None):
     base_url = _get_base_url(request)
 
     user = utils.get_user_data(request)
-
+    allowed_users = user['group_memebers'] or user['user']
     calc_data = logs.dbcmd('get_calcs', request.GET,
-                           user['name'], user['acl_on'], id)
+                           allowed_users, user['acl_on'], id)
 
     response_data = []
     for hc_id, owner, status, calculation_mode, is_running, desc in calc_data:
@@ -470,7 +471,8 @@ def calc_results(request, calc_id):
     # throw back a 404.
     try:
         info = logs.dbcmd('calc_info', calc_id)
-        if user['acl_on'] and info['user_name'] != user['name']:
+        allowed_users = user['group_memebers'] or user['user']
+        if user['acl_on'] and info['user_name'] not in allowed_users:
             return HttpResponseNotFound()
     except dbapi.NotFound:
         return HttpResponseNotFound()

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -309,7 +309,7 @@ def calc(request, id=None):
     base_url = _get_base_url(request)
 
     user = utils.get_user_data(request)
-    allowed_users = user['group_memebers'] or user['user']
+    allowed_users = user['group_memebers'] or [user['name']]
     calc_data = logs.dbcmd('get_calcs', request.GET,
                            allowed_users, user['acl_on'], id)
 
@@ -471,7 +471,7 @@ def calc_results(request, calc_id):
     # throw back a 404.
     try:
         info = logs.dbcmd('calc_info', calc_id)
-        allowed_users = user['group_memebers'] or user['user']
+        allowed_users = user['group_memebers'] or [user['name']]
         if user['acl_on'] and info['user_name'] not in allowed_users:
             return HttpResponseNotFound()
     except dbapi.NotFound:

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -309,7 +309,7 @@ def calc(request, id=None):
     base_url = _get_base_url(request)
 
     user = utils.get_user_data(request)
-    allowed_users = user['group_memebers'] or [user['name']]
+    allowed_users = user['group_members'] or [user['name']]
     calc_data = logs.dbcmd('get_calcs', request.GET,
                            allowed_users, user['acl_on'], id)
 
@@ -471,7 +471,7 @@ def calc_results(request, calc_id):
     # throw back a 404.
     try:
         info = logs.dbcmd('calc_info', calc_id)
-        allowed_users = user['group_memebers'] or [user['name']]
+        allowed_users = user['group_members'] or [user['name']]
         if user['acl_on'] and info['user_name'] not in allowed_users:
             return HttpResponseNotFound()
     except dbapi.NotFound:


### PR DESCRIPTION
Very simple group management for the WebUI. Users in the same group can see all the calculations, logs and outputs from all the members. Computations can be deleted only by the owner (the delete button returns an error, I'll see to hide totally the button  in the future).

If you like the idea I will update the documentation and the changelog (I don't want to spend time on it if this does not get merged).

I also added a link to the admin area (only when logged in as super).