### PR TITLE
More refactoring of the risk calculators

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -401,3 +401,38 @@ def save(path, items, **extra):
             f[key] = val
         for k, v in extra.items():
             f.attrs[k] = v
+
+
+class ArrayWrapper(object):
+    """
+    A pickleable and serializable wrapper over an array, HDF5 dataset or group
+    """
+    def __init__(self, array, attrs):
+        vars(self).update(attrs)
+        self.array = array
+
+    def __iter__(self):
+        return iter(self.array)
+
+    def __len__(self):
+        return len(self.array)
+
+    def __getitem__(self, idx):
+        return self.array[idx]
+
+    def __toh5__(self):
+        return (self.array, {k: v for k, v in vars(self).items()
+                             if k != 'array' and not k.startswith('_')})
+
+    def __fromh5__(self, array, attrs):
+        self.__init__(array, attrs)
+
+    @property
+    def dtype(self):
+        """dtype of the underlying array"""
+        return self.array.dtype
+
+    @property
+    def shape(self):
+        """shape of the underlying array"""
+        return self.array.shape

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -750,7 +750,7 @@ def get_gmfs(calculator):
             haz_sitecol.sids, gmfs[:, haz_sitecol.indices])
 
         # store the events, useful when read the GMFs from a file
-        events = numpy.zeros(E, calc.stored_event_dt)
+        events = numpy.zeros(E, readinput.stored_event_dt)
         events['eid'] = eids
         dstore['events'] = events
         return eids, gmfs

--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -47,7 +47,7 @@ def classical_bcr(riskinput, riskmodel, param, monitor):
             loss_type = riskmodel.loss_types[l]
             for asset, (eal_orig, eal_retro, bcr) in zip(assets, out):
                 aval = asset.value(loss_type)
-                result[asset.ordinal, loss_type, outputs.r] = numpy.array([
+                result[asset.ordinal, loss_type, outputs.rlzi] = numpy.array([
                     (eal_orig * aval, eal_retro * aval, bcr)], bcr_dt)
     return result
 

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -44,7 +44,7 @@ def classical_damage(riskinput, riskmodel, param, monitor):
         for outputs in riskmodel.gen_outputs(riskinput, monitor):
             for l, out in enumerate(outputs):
                 ordinals = [a.ordinal for a in outputs.assets]
-                result[outputs.r] += dict(zip(ordinals, out))
+                result[outputs.rlzi] += dict(zip(ordinals, out))
     return result
 
 

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -24,7 +24,7 @@ from openquake.baselib.general import groupby, AccumDict
 from openquake.baselib.python3compat import encode
 from openquake.hazardlib.stats import compute_stats
 from openquake.risklib import scientific
-from openquake.commonlib import readinput, source, calc
+from openquake.commonlib import readinput, source
 from openquake.calculators import base
 
 
@@ -48,7 +48,7 @@ def classical_risk(riskinput, riskmodel, param, monitor):
     result = dict(loss_curves=[], stat_curves=[])
     all_outputs = list(riskmodel.gen_outputs(riskinput, monitor))
     for outputs in all_outputs:
-        r = outputs.r
+        r = outputs.rlzi
         outputs.average_losses = AccumDict(accum=[])  # l -> array
         for l, (loss_curves, insured_curves) in enumerate(outputs):
             for i, asset in enumerate(outputs.assets):
@@ -72,7 +72,7 @@ def classical_risk(riskinput, riskmodel, param, monitor):
         l_idxs = range(len(riskmodel.lti))
         for assets, rows in groupby(
                 all_outputs, lambda o: tuple(o.assets)).items():
-            weights = [w[row.r] for row in rows]
+            weights = [w[row.rlzi] for row in rows]
             row = rows[0]
             for l in l_idxs:
                 for i, asset in enumerate(assets):

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -70,21 +70,21 @@ def classical_risk(riskinput, riskmodel, param, monitor):
         w = param['weights']
         statnames, stats = zip(*param['stats'])
         l_idxs = range(len(riskmodel.lti))
-        for assets, rows in groupby(
+        for assets, outs in groupby(
                 all_outputs, lambda o: tuple(o.assets)).items():
-            weights = [w[row.rlzi] for row in rows]
-            row = rows[0]
+            weights = [w[out.rlzi] for out in outs]
+            out = outs[0]
             for l in l_idxs:
                 for i, asset in enumerate(assets):
-                    avgs = numpy.array([r.average_losses[l][i] for r in rows])
+                    avgs = numpy.array([r.average_losses[l][i] for r in outs])
                     avg_stats = compute_stats(avgs, stats, weights)
-                    # row is index by the loss type index l and row[l]
+                    # out is index by the loss type index l and out[l]
                     # is a pair loss_curves, insured_loss_curves
                     # loss_curves[i, 0] are the i-th losses,
                     # loss_curves[i, 1] are the i-th poes
-                    losses = row[l][0][i, 0]
+                    losses = out[l][0][i, 0]
                     poes_stats = compute_stats(
-                        numpy.array([row[l][0][i, 1] for row in rows]),
+                        numpy.array([out[l][0][i, 1] for out in outs]),
                         stats, weights)
                     result['stat_curves'].append(
                         (l, asset.ordinal, losses, poes_stats, avg_stats))

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -50,13 +50,12 @@ def _aggregate(outputs, compositemodel, tagmask, agg, all_eids, result, param):
     ass = result['assratios']
     idx = dict(zip(all_eids, range(E)))
     for outs in outputs:
-        r = outs.r
-        for l, out in enumerate(outs):
-            if out is None:  # for GMFs below the minimum_intensity
+        r = outs.rlzi
+        for l, loss_ratios in enumerate(outs):
+            if loss_ratios is None:  # for GMFs below the minimum_intensity
                 continue
-            loss_ratios, eids = out
             loss_type = compositemodel.loss_types[l]
-            indices = numpy.array([idx[eid] for eid in eids])
+            indices = numpy.array([idx[eid] for eid in outs.eids])
 
             for aid, asset in enumerate(outs.assets):
                 ratios = loss_ratios[aid]
@@ -83,7 +82,7 @@ def _aggregate(outputs, compositemodel, tagmask, agg, all_eids, result, param):
                 if param['asset_loss_table']:
                     for i in range(I):
                         li = l + L * i
-                        for eid, ratio in zip(eids, ratios[:, i]):
+                        for eid, ratio in zip(outs.eids, ratios[:, i]):
                             if ratio > 0:
                                 ass.append((aid, r, eid, li, ratio))
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -49,15 +49,15 @@ def _aggregate(outputs, compositemodel, tagmask, agg, all_eids, result, param):
     losses_by_tag = result['losses_by_tag']
     ass = result['assratios']
     idx = dict(zip(all_eids, range(E)))
-    for outs in outputs:
-        r = outs.rlzi
-        for l, loss_ratios in enumerate(outs):
+    for out in outputs:
+        r = out.rlzi
+        for l, loss_ratios in enumerate(out):
             if loss_ratios is None:  # for GMFs below the minimum_intensity
                 continue
             loss_type = compositemodel.loss_types[l]
-            indices = numpy.array([idx[eid] for eid in outs.eids])
+            indices = numpy.array([idx[eid] for eid in out.eids])
 
-            for aid, asset in enumerate(outs.assets):
+            for aid, asset in enumerate(out.assets):
                 ratios = loss_ratios[aid]
                 aid = asset.ordinal
                 losses = ratios * asset.value(loss_type)  # shape (E, I)
@@ -82,7 +82,7 @@ def _aggregate(outputs, compositemodel, tagmask, agg, all_eids, result, param):
                 if param['asset_loss_table']:
                     for i in range(I):
                         li = l + L * i
-                        for eid, ratio in zip(outs.eids, ratios[:, i]):
+                        for eid, ratio in zip(out.eids, ratios[:, i]):
                             if ratio > 0:
                                 ass.append((aid, r, eid, li, ratio))
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -27,6 +27,7 @@ except ImportError:
 else:
     memoized = lru_cache(100)
 from openquake.baselib.general import DictArray
+from openquake.baselib.hdf5 import ArrayWrapper
 from openquake.commonlib import calc
 
 
@@ -71,35 +72,6 @@ class Extract(collections.OrderedDict):
             return extract_(dstore, key)
 
 extract = Extract()
-
-
-class ArrayWrapper(object):
-    """
-    A pickleable wrapper over an HDF5 dataset or group
-    """
-    def __init__(self, array, attrs):
-        vars(self).update(attrs)
-        self.array = array
-
-    def __iter__(self):
-        return iter(self.array)
-
-    def __len__(self):
-        return len(self.array)
-
-    def __getitem__(self, idx):
-        return self.array[idx]
-
-    def __toh5__(self):
-        return (self.array, {k: v for k, v in vars(self).items()
-                             if k != 'array' and not k.startswith('_')})
-
-    def __fromh5__(self, array, attrs):
-        self.__init__(array, attrs)
-
-    @property
-    def dtype(self):
-        return self.array.dtype
 
 
 @extract.add('asset_values', cache=True)

--- a/openquake/calculators/gmf_ebrisk.py
+++ b/openquake/calculators/gmf_ebrisk.py
@@ -19,7 +19,7 @@
 import logging
 import numpy
 
-from openquake.commonlib import calc
+from openquake.commonlib import readinput
 from openquake.calculators import base, event_based_risk as ebr
 
 U16 = numpy.uint16
@@ -73,7 +73,7 @@ class GmfEbRiskCalculator(base.RiskCalculator):
                 'avg_losses-rlzs', F32, (self.A, self.R, self.L * self.I))
 
         events = numpy.zeros(oq.number_of_ground_motion_fields,
-                             calc.stored_event_dt)
+                             readinput.stored_event_dt)
         events['eid'] = eids
         self.datastore['events'] = events
 

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -39,7 +39,7 @@ class ScenarioCalculator(base.HazardCalculator):
         oq = self.oqparam
         trunc_level = oq.truncation_level
         correl_model = oq.get_correl_model()
-        ebr, self.sitecol = readinput.get_rupture(oq, self.sitecol)
+        ebr, self.sitecol = readinput.get_rupture_sitecol(oq, self.sitecol)
         self.gsims = readinput.get_gsims(oq)
         self.datastore['events'] = ebr.events
         rupser = calc.RuptureSerializer(self.datastore)

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -52,7 +52,7 @@ class ScenarioCalculator(base.HazardCalculator):
                 maxdist)
         # eid, ses, occ, sample
         events = numpy.zeros(oq.number_of_ground_motion_fields,
-                             calc.event_dt)
+                             calc.stored_event_dt)
         events['eid'] = numpy.arange(oq.number_of_ground_motion_fields)
         self.datastore['events'] = events
         rupture = calc.EBRupture(rup, self.sitecol.sids, events)

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -18,7 +18,7 @@
 import collections
 import numpy
 
-from openquake.hazardlib.calc import filters
+from openquake.hazardlib.site import FilteredSiteCollection
 from openquake.hazardlib.calc.gmf import GmfComputer
 from openquake.commonlib import readinput, source, calc
 from openquake.calculators import base
@@ -39,28 +39,14 @@ class ScenarioCalculator(base.HazardCalculator):
         oq = self.oqparam
         trunc_level = oq.truncation_level
         correl_model = oq.get_correl_model()
-        rup = readinput.get_rupture(oq)
-        rup.seed = self.oqparam.random_seed
+        ebr, self.sitecol = readinput.get_rupture(oq, self.sitecol)
         self.gsims = readinput.get_gsims(oq)
-        maxdist = oq.maximum_distance['default']
-        with self.monitor('filtering sites', autoflush=True):
-            self.sitecol = filters.filter_sites_by_distance_to_rupture(
-                rup, maxdist, self.sitecol)
-        if self.sitecol is None:
-            raise RuntimeError(
-                'All sites were filtered out! maximum_distance=%s km' %
-                maxdist)
-        # eid, ses, occ, sample
-        events = numpy.zeros(oq.number_of_ground_motion_fields,
-                             calc.stored_event_dt)
-        events['eid'] = numpy.arange(oq.number_of_ground_motion_fields)
-        self.datastore['events'] = events
-        rupture = calc.EBRupture(rup, self.sitecol.sids, events)
+        self.datastore['events'] = ebr.events
         rupser = calc.RuptureSerializer(self.datastore)
-        rupser.save([rupture])
+        rupser.save([ebr])
         rupser.close()
         self.computer = GmfComputer(
-            rupture, self.sitecol, oq.imtls, self.gsims,
+            ebr, self.sitecol, oq.imtls, self.gsims,
             trunc_level, correl_model)
         gsim_lt = readinput.get_gsim_lt(oq)
         cinfo = source.CompositionInfo.fake(gsim_lt)

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -56,11 +56,8 @@ class ScenarioCalculator(base.HazardCalculator):
         events['eid'] = numpy.arange(oq.number_of_ground_motion_fields)
         self.datastore['events'] = events
         rupture = calc.EBRupture(rup, self.sitecol.sids, events)
-        rupture.sidx = 0
-        rupture.eidx1 = 0
-        rupture.eidx2 = len(events)
         rupser = calc.RuptureSerializer(self.datastore)
-        rupser.save([rupture], 0)
+        rupser.save([rupture])
         rupser.close()
         self.computer = GmfComputer(
             rupture, self.sitecol, oq.imtls, self.gsims,

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -52,10 +52,10 @@ class ScenarioCalculator(base.HazardCalculator):
                 maxdist)
         # eid, ses, occ, sample
         events = numpy.zeros(oq.number_of_ground_motion_fields,
-                             calc.stored_event_dt)
+                             calc.event_dt)
         events['eid'] = numpy.arange(oq.number_of_ground_motion_fields)
         self.datastore['events'] = events
-        rupture = calc.EBRupture(rup, self.sitecol.sids, events, 0, 0)
+        rupture = calc.EBRupture(rup, self.sitecol.sids, events)
         rupture.sidx = 0
         rupture.eidx1 = 0
         rupture.eidx2 = len(events)

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -18,7 +18,6 @@
 import collections
 import numpy
 
-from openquake.hazardlib.site import FilteredSiteCollection
 from openquake.hazardlib.calc.gmf import GmfComputer
 from openquake.commonlib import readinput, source, calc
 from openquake.calculators import base

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -106,7 +106,7 @@ def scenario_damage(riskinput, riskmodel, param, monitor):
     result = dict(d_asset=[], d_tag=numpy.zeros((T, R, L, E, D), F64),
                   c_asset=[], c_tag=numpy.zeros((T, R, L, E), F64))
     for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        r = outputs.r
+        r = outputs.rlzi
         for l, damages in enumerate(outputs):
             loss_type = riskmodel.loss_types[l]
             c_model = c_models.get(loss_type)

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -62,7 +62,7 @@ def scenario_risk(riskinput, riskmodel, param, monitor):
     result = dict(agg=numpy.zeros((E, R, L * I), F32), avg=[],
                   losses_by_tag=lbt, all_losses=AccumDict(accum={}))
     for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        r = outputs.r
+        r = outputs.rlzi
         assets = outputs.assets
         for l, losses in enumerate(outputs):
             if losses is None:  # this may happen

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -44,9 +44,6 @@ U64 = numpy.uint64
 F64 = numpy.float64
 
 event_dt = numpy.dtype([('eid', U64), ('ses', U32), ('sample', U32)])
-stored_event_dt = numpy.dtype([
-    ('eid', U64), ('rup_id', U32), ('grp_id', U16), ('year', U32),
-    ('ses', U32), ('sample', U32)])
 
 sids_dt = h5py.special_dtype(vlen=U32)
 

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -502,7 +502,7 @@ class RuptureSerializer(object):
         self.data = []
         self.nbytes = 0
 
-    def save(self, ebruptures, eidx):
+    def save(self, ebruptures, eidx=0):
         """
         Populate a dictionary of site IDs tuples and save the ruptures.
 

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -21,7 +21,7 @@ import warnings
 import numpy
 import h5py
 
-from openquake.baselib import hdf5, general
+from openquake.baselib import hdf5
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib.geo.mesh import (
     surface_to_mesh, point3d, RectangularMesh)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -451,7 +451,7 @@ class OqParam(valid.ParamSet):
             sites=bool(self.sites),
             sites_csv=self.inputs.get('sites', 0),
             hazard_curves_csv=self.inputs.get('hazard_curves', 0),
-            gmfs_csv=self.inputs.get('gmvs', 0),
+            gmfs_csv=self.inputs.get('gmfs', 0),
             region=bool(self.region),
             exposure=self.inputs.get('exposure', 0))
         # NB: below we check that all the flags

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -331,6 +331,15 @@ def get_gsims(oqparam):
     return [valid.gsim(str(rlz)) for rlz in get_gsim_lt(oqparam)]
 
 
+def get_rlzs_by_gsim(oqparam):
+    """
+    Return an ordered dictionary gsim -> [realization]. Work for
+    gsim logic trees with a single tectonic region type.
+    """
+    cinfo = source.CompositionInfo.fake(get_gsim_lt(oqparam))
+    return cinfo.get_rlzs_assoc().rlzs_by_gsim[0]
+
+
 def get_rupture_sitecol(oqparam, sitecol):
     """
     Read the `rupture_model` file and by filter the site collection

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -331,13 +331,16 @@ def get_gsims(oqparam):
     return [valid.gsim(str(rlz)) for rlz in get_gsim_lt(oqparam)]
 
 
-def get_rupture(oqparam, sitecol):
+def get_rupture_sitecol(oqparam, sitecol):
     """
-    Returns an EBRupture by reading the `rupture_model` file and by filtering
-    the site collection.
+    Read the `rupture_model` file and by filter the site collection
 
     :param oqparam:
         an :class:`openquake.commonlib.oqvalidation.OqParam` instance
+    :param sitecol:
+        a :class:`openquake.hazardlib.site.SiteCollection` instance
+    :returns:
+        a pair (EBRupture, FilteredSiteCollection)
     """
     rup_model = oqparam.inputs['rupture_model']
     [rup_node] = nrml.read(rup_model)

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -569,7 +569,9 @@ class EBRupture(object):
         self.events = events
         self.grp_id = grp_id
         self.serial = serial
-        self.sidx = self.eidx1 = self.eidx2 = 0  # to be set when needed
+        self.sidx = 0
+        self.eidx1 = 0
+        self.eidx2 = len(events)
 
     @property
     def weight(self):

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -563,13 +563,13 @@ class EBRupture(object):
     object, containing an array of site indices affected by the rupture,
     as well as the IDs of the corresponding seismic events.
     """
-    def __init__(self, rupture, sids, events, grp_id, serial):
+    def __init__(self, rupture, sids, events, grp_id=0, serial=0):
         self.rupture = rupture
         self.sids = sids
         self.events = events
         self.grp_id = grp_id
         self.serial = serial
-        self.sidx = self.eidx1 = self.eidx2 = None  # to be set when needed
+        self.sidx = self.eidx1 = self.eidx2 = 0  # to be set when needed
 
     @property
     def weight(self):

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -289,7 +289,7 @@ class CompositeRiskModel(collections.Mapping):
     def _gen_outputs(self, hazard, imti, dic, eids):
         for taxonomy in sorted(dic):
             riskmodel = self[taxonomy]
-            rangeI = [imti[riskmodel.risk_functions[lt].imt]
+            rangeM = [imti[riskmodel.risk_functions[lt].imt]
                       for lt in self.loss_types]
             for sid, assets, epsgetter in dic[taxonomy]:
                 try:
@@ -300,15 +300,15 @@ class CompositeRiskModel(collections.Mapping):
                     if isinstance(haz, numpy.ndarray):
                         # event based and scenario
                         data = {i: (haz['gmv'][:, i], haz['eid'])
-                                for i in rangeI}
+                                for i in rangeM}
                     elif eids is not None:  # gmf_ebrisk
-                        data = {i: (haz[i], eids) for i in rangeI}
+                        data = {i: (haz[i], eids) for i in rangeM}
                     else:  # classical
                         data = haz
                     out = [None] * len(self.lti)
-                    for lti, i in enumerate(rangeI):
+                    for lti, m in enumerate(rangeM):
                         lt = self.loss_types[lti]
-                        out[lti] = riskmodel(lt, assets, data[i], epsgetter)
+                        out[lti] = riskmodel(lt, assets, data[m], epsgetter)
                     yield Output(self.loss_types, assets, out, sid, rlzi)
 
     def __toh5__(self):

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -22,6 +22,7 @@ import functools
 import numpy
 
 from openquake.baselib.general import CallableDict
+from openquake.baselib.hdf5 import ArrayWrapper
 from openquake.hazardlib import valid
 from openquake.risklib import utils, scientific
 
@@ -47,9 +48,10 @@ class RiskModel(object):
     compositemodel = None  # set by get_risk_model
     kind = None  # must be set in subclasses
 
-    def __init__(self, taxonomy, risk_functions):
+    def __init__(self, taxonomy, risk_functions, insured_losses):
         self.taxonomy = taxonomy
         self.risk_functions = risk_functions
+        self.insured_losses = insured_losses
 
     @property
     def loss_types(self):
@@ -66,6 +68,14 @@ class RiskModel(object):
         """
         return [lt for lt in self.loss_types
                 if self.risk_functions[lt].imt == imt]
+
+    def get_output(self, assets, data_by_lt, epsgetter):
+        """
+        returns an ArrayWrapper of shape (L, ...)
+        """
+        out = [self(lt, assets, data, epsgetter)
+               for lt, data in zip(self.loss_types, data_by_lt)]
+        return ArrayWrapper(numpy.array(out), {})
 
     def __toh5__(self):
         risk_functions = {lt: func for lt, func in self.risk_functions.items()}
@@ -222,7 +232,7 @@ class ProbabilisticEventBased(RiskModel):
                 loss_ratios[i, idxs, 1] = scientific.insured_losses(
                     ratios,  asset.deductible(loss_type),
                     asset.insurance_limit(loss_type))
-        return loss_ratios, eids
+        return loss_ratios
 
 
 @registry.add('classical_bcr')
@@ -238,6 +248,7 @@ class ClassicalBCR(RiskModel):
                  interest_rate, asset_life_expectancy):
         self.taxonomy = taxonomy
         self.risk_functions = vulnerability_functions_orig
+        self.insured_losses = False  # not implemented
         self.retro_functions = vulnerability_functions_retro
         self.assets = []  # set a __call__ time
         self.interest_rate = interest_rate
@@ -345,6 +356,7 @@ class Damage(RiskModel):
     def __init__(self, taxonomy, fragility_functions):
         self.taxonomy = taxonomy
         self.risk_functions = fragility_functions
+        self.insured_losses = False  # not implemented
 
     def __call__(self, loss_type, assets, gmvs_eids, _eps=None):
         """
@@ -376,6 +388,7 @@ class ClassicalDamage(Damage):
                  risk_investigation_time):
         self.taxonomy = taxonomy
         self.risk_functions = fragility_functions
+        self.insured_losses = False  # not implemented
         self.hazard_imtls = hazard_imtls
         self.investigation_time = investigation_time
         self.risk_investigation_time = risk_investigation_time


### PR DESCRIPTION
The final goal is to make it easier to use the engine as a library for risk calculations. There is still a long
way to go, but with this refactoring the scenario_risk calculator (simplified) can be written in around 40 lines of code:

```python
import numpy
from openquake.commonlib import readinput
from openquake.risklib import riskinput

def main(job_ini):
    oq = readinput.get_oqparam(job_ini)
    # first thing, read the exposure
    exposure = readinput.get_exposure(oq)
    # extract the sites and the assets from the exposure
    sitecol, assetcol = readinput.get_sitecol_assetcol(oq, exposure)
    # filter the sites with the rupture
    rupture, sitecol = readinput.get_rupture_sitecol(oq, sitecol)
    # build the dictionary rlzs_by_gsim
    rlzs_by_gsim = readinput.get_rlzs_by_gsim(oq)
    # read the full risk model
    riskmodel = readinput.get_risk_model(oq)
    # extract the minimum intensity dictionary
    min_iml = riskmodel.get_min_iml()
    # build the gmfgetter
    gmfgetter = riskinput.GmfGetter(
        rlzs_by_gsim, [rupture], sitecol.complete, oq.imtls,
        [min_iml[imt] for imt in oq.imtls], oq.truncation_level,
        oq.get_correl_model())
    gmfgetter.init()
    # build the epsilons
    eps = riskinput.make_eps(
        assetcol, oq.number_of_ground_motion_fields,
        oq.master_seed, oq.asset_correlation)
    # build the riskinput object
    rinput = riskinput.RiskInputFromRuptures(gmfgetter, eps)
    R = len(rlzs_by_gsim)  # number of GSIMs
    L = len(oq.lti)  # number of loss types
    A = len(assetcol)  # number of assets
    I = oq.insured_losses + 1  # insured losses
    # compute average losses for each asset, averaging on the events
    avglosses = numpy.zeros((A, L, I, R))
    for out in riskmodel.gen_outputs(rinput, assetcol=assetcol):
        # out has shape (L, A, E, I)
        for a, asset in enumerate(out.assets):
            mean = out.array[:, a, :, :].mean(axis=1)  # on the events
            avglosses[asset.ordinal, :, :, out.rlzi] += mean
    # compute total by summing on all assets
    print(avglosses.sum(axis=0))  # shape (L, I, R)
```
The API will likely change in the future, but this is an example of what can be done right now, useful for the risk scientists. Warning: I have not tested this example much, but at least it gives the right aggregated losses for the ScenarioRisk demo.