### PR TITLE
Make server functional tests more robust

### DIFF
--- a/openquake/server/tests/functional_test.py
+++ b/openquake/server/tests/functional_test.py
@@ -32,7 +32,6 @@ import subprocess
 import tempfile
 import requests
 import numpy
-import socket
 from openquake.baselib.general import writetmp
 from openquake.engine.export import core
 from openquake.server.db import actions
@@ -45,18 +44,10 @@ if requests.__version__ < '1.0.0':
 
 
 class EngineServerTestCase(unittest.TestCase):
-    hostport = ''
+    hostport = 'localhost:8761'
     datadir = os.path.join(os.path.dirname(__file__), 'data')
 
     # general utilities
-
-    @classmethod
-    def getsocket(cls):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(('', 0))
-        cls.hostport = 'localhost:%s' % s.getsockname()[1]
-        s.close()
-        return cls.hostport
 
     @classmethod
     def post(cls, path, data=None, **params):
@@ -132,7 +123,7 @@ class EngineServerTestCase(unittest.TestCase):
 
         cls.proc = subprocess.Popen(
             [sys.executable, '-m', 'openquake.server.manage', 'runserver',
-             cls.getsocket(), '--noreload', '--nothreading'],
+             cls.hostport, '--noreload', '--nothreading'],
             env=env, stderr=cls.fd)  # redirect the server logs
         check_webserver_running('http://%s' % cls.hostport)
 


### PR DESCRIPTION
This PR should mitigate two issues:

1. Warmup of the Django server can take some more time on macOS and (even more) on Windows compared to Linux. We have already an utils function (used by `oq webui start`) that waits, with a max timeout, for the webserver to be ready. This makes the test actually faster on linux ( < 5 secs) and more robust on other OSes and slower servers

2. Remove (or at least mitigate) issues when more tests are run at the same time on OSes with no process/network isolation (again macOS and Windows). Currently all the runs are using the same port for the functional tests, causing one job to run tests across the wrong webserver with unexpected behaviors.

Should fix https://github.com/gem/oq-engine/pull/3131
https://ci.openquake.org/job/macos/job/zdevel_macos_engine/3/ [![Build Status](https://ci.openquake.org/buildStatus/icon?job=macos/zdevel_macos_engine&build=3)](https://ci.openquake.org/job/macos/job/zdevel_macos_engine/3/)