### PR TITLE
Fix hazardlib test runner

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -393,7 +393,7 @@ _devtest_innervm_run () {
                  /opt/openquake/bin/nosetests -v --with-doctest --with-coverage --cover-package=openquake.commonlib openquake/commonlib
                  /opt/openquake/bin/nosetests -v --with-doctest --with-coverage --cover-package=openquake.commands openquake/commands
 
-		 export MPLBACKEND=Agg; /opt/openquake/bin/nosetests -a '${skip_tests}' -v  --with-xunit --with-doctest --with-coverage --cover-package=openquake.hazardlib
+                 export MPLBACKEND=Agg; /opt/openquake/bin/nosetests -a '${skip_tests}' -v  --with-xunit --with-doctest --with-coverage --cover-package=openquake.hazardlib openquake/hazardlib
 
 
 


### PR DESCRIPTION
Having a look at #3133 I discovered that we were running some tests twice. See for example `risklib` or `server` here https://ci.openquake.org/job/master_oq-engine/3917/consoleText.

Test are running here: https://ci.openquake.org/job/zdevel_oq-engine/2606/
