### PR TITLE
Reduced the number of demos running on Jenkins

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -590,7 +590,7 @@ celery_wait() {
 
 celery_wait $GEM_MAXLOOP"
 
-        # run all of the hazard and risk demos
+        # run one risk demo (event based risk)
         ssh $lxc_ip "export GEM_SET_DEBUG=$GEM_SET_DEBUG
         set -e
 
@@ -611,12 +611,7 @@ celery_wait $GEM_MAXLOOP"
 
         /usr/share/openquake/engine/utils/celery-status 
         cd /usr/share/openquake/engine/demos
-        # run demos
-        for demo_dir in \$(find . -type d | sort); do
-           if [ -f \$demo_dir/job_hazard.ini ]; then
-               OQ_DISTRIBUTE=celery oq engine --run \$demo_dir/job_hazard.ini && oq engine --run \$demo_dir/job_risk.ini --hc -1
-           fi
-        done
+        OQ_DISTRIBUTE=celery oq engine --run risk/EventBasedRisk/job_hazard.ini && oq engine --run risk/EventBasedRisk/job_risk.ini --hc -1
         
         # Try to export a set of results AFTER the calculation
         # automatically creates a directory called out


### PR DESCRIPTION
Since now Travis runs all the demos both with Python 2 and Python 3, there is no point in running all of them again on Jenkins. Instead on Jenkins we run only the event based risk demo, to check that the installation from packages went well. See https://ci.openquake.org/job/zdevel_oq-engine/2608/consoleFull.