### PR TITLE
Removed getpass from openquake.server.views

### DIFF
--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -32,12 +32,10 @@ if settings.LOCKDOWN:
 
 def get_user_data(request):
     """
-    Returns the real username if authentication support is enabled and user is
-    authenticated, otherwise it returns "platform" as user for backward
-    compatibility.
-    Returns also if the user is 'superuser' or not.
+    Returns a dictionary with `name`, `group_members` and `acl_on` keys.
+    `name` is the real username if authentication support is enabled and user
+    is authenticated, otherwise it is None.
     """
-
     acl_on = settings.ACL_ON
     group_members = []
     if settings.LOCKDOWN and hasattr(request, 'user'):
@@ -46,7 +44,7 @@ def get_user_data(request):
             groups = request.user.groups.values_list('name', flat=True)
             if groups:
                 group_members = list(User.objects.filter(groups__name=groups)
-                                      .values_list('username', flat=True))
+                                     .values_list('username', flat=True))
         if request.user.is_superuser:
             acl_on = False
     else:

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -21,7 +21,6 @@ import json
 import logging
 import os
 import inspect
-import getpass
 import tempfile
 try:
     import urllib.parse as urlparse
@@ -641,7 +640,9 @@ def get_datastore(request, job_id):
         A `django.http.HttpResponse` containing the content
         of the requested artifact, if present, else throws a 404
     """
-    job = logs.dbcmd('get_job', int(job_id), getpass.getuser())
+    user = utils.get_user_data(request)
+    username = user['name'] if user['acl_on'] else None
+    job = logs.dbcmd('get_job', int(job_id), username)
     if job is None:
         return HttpResponseNotFound()
 
@@ -659,7 +660,9 @@ def get_oqparam(request, job_id):
     """
     Return the calculation parameters as a JSON
     """
-    job = logs.dbcmd('get_job', int(job_id), getpass.getuser())
+    user = utils.get_user_data(request)
+    username = user['name'] if user['acl_on'] else None
+    job = logs.dbcmd('get_job', int(job_id), username)
     if job is None:
         return HttpResponseNotFound()
     with datastore.read(job.ds_calc_dir + '.hdf5') as ds:


### PR DESCRIPTION
Now the risk of extracting the username with the wrong call has disappeared, since the module contains only the right way of doing it, via get_user_data. This solves two issue discovered by Paolo, i.e. getting oqparam and the datastore.