### PR TITLE
Update download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Current stable version is the **OpenQuake Engine 2.6** 'Gutenberg'. The document
 
 #### VirtualBox
 
-* [Download OVA appliance](https://storage.globalquakemodel.org/ova/stable/)
+* [Download OVA appliance](https://downloads.openquake.org/ova/stable/)
 
 #### Docker
 

--- a/doc/installing/linux-generic.md
+++ b/doc/installing/linux-generic.md
@@ -30,7 +30,7 @@ Requirements are:
 
 ## Install packages from the OpenQuake website
 
-Download the installer from http://storage.globalquakemodel.org/pkgs/linux/oq-engine/openquake-setup-linux64-2.6.0-1.run using any browser
+Download the installer from https://downloads.openquake.org/pkgs/linux/oq-engine/openquake-setup-linux64-2.6.0-1.run using any browser
 
 From a terminal run
 

--- a/doc/installing/macos.md
+++ b/doc/installing/macos.md
@@ -20,7 +20,7 @@ Requirements are:
 
 ## Install packages from the OpenQuake website
 
-Download the installer from http://storage.globalquakemodel.org/pkgs/macos/oq-engine/openquake-setup-macos-2.6.0-1.run using any browser
+Download the installer from https://downloads.openquake.org/pkgs/macos/oq-engine/openquake-setup-macos-2.6.0-1.run using any browser
 
 From the Terminal app (or using iTerm) run
 

--- a/doc/installing/overview.md
+++ b/doc/installing/overview.md
@@ -6,7 +6,7 @@ The OpenQuake Engine can be installed in several different ways. This page will 
 
 See the **[Installing the OpenQuake Engine for development](development.md)** guide.
 
-A pre-configured VirtualBox appliance may be also [downloaded](https://storage.globalquakemodel.org/ova/stable/). It contains all the OpenQuake software pre-installed and pre-configured.
+A pre-configured VirtualBox appliance may be also [downloaded](https://downloads.openquake.org/ova/stable/). It contains all the OpenQuake software pre-installed and pre-configured.
 
 ## Single user
 

--- a/doc/installing/windows.md
+++ b/doc/installing/windows.md
@@ -21,7 +21,7 @@ Requirements are:
 
 ## Install or upgrade packages from the OpenQuake website
 
-Download the installer from http://storage.globalquakemodel.org/pkgs/windows/oq-engine/OpenQuake_Engine_2.6.0-1.exe using any browser and run the installer, then follow the wizard on screen.
+Download the installer from https://downloads.openquake.org/pkgs/windows/oq-engine/OpenQuake_Engine_2.6.0-1.exe using any browser and run the installer, then follow the wizard on screen.
 
 ![installer-screenshot-1](../img/win-installer-1.png)
 ![installer-screenshot-2](../img/win-installer-2.png)


### PR DESCRIPTION
https://downloads.openquake.org/

A step toward the decommissioning of Linode.

Old branches will still point to `storage`. Then `storage` will become an alias of `downloads`, but new documentation will be already up-to-date.

We still need to understand where we want to publish manuals.