### PR TITLE
Removed requests.get from check_obsolete_version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,4 @@
   [Michele Simionato]
-  * Fixed a tricky segfault on macOS caused by a call to requests.get
   * Fixed the risk exporters for tags containing non-ASCII characters
 
   [Valerio Poggi]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a tricky segfault on macOS caused by a call to requests.get
   * Fixed the risk exporters for tags containing non-ASCII characters
 
   [Valerio Poggi]

--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -27,6 +27,13 @@ import sys
 import math
 import importlib
 import subprocess
+try:
+    # Python 3
+    from urllib.request import urlopen, Request
+except ImportError:
+    # Python 2
+    from urllib2 import urlopen, Request
+
 
 PY3 = sys.version_info[0] >= 3
 PY2 = sys.version_info[0] == 2

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -300,8 +300,6 @@ def check_obsolete_version(calculation_mode='WebUI'):
     headers = {'User-Agent': 'OpenQuake Engine %s;%s;%s' %
                (__version__, calculation_mode, platform.platform())}
     try:
-        # we are not using requests.get here because it causes a segfault
-        # on macOS: https://github.com/gem/oq-engine/issues/3161
         req = Request(OQ_API + '/engine/latest', headers=headers)
         # NB: a timeout < 1 does not work
         data = urlopen(req, timeout=1).read()  # bytes

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -22,13 +22,13 @@ calculations."""
 import os
 import re
 import sys
+import json
 import signal
-import logging
 import traceback
-import requests
 import platform
 
 from openquake.baselib.performance import Monitor
+from openquake.baselib.python3compat import urlopen, Request, decode
 from openquake.baselib import (
     parallel, general, config, datastore, __version__, zeromq as z)
 from openquake.commonlib.oqvalidation import OqParam
@@ -300,19 +300,14 @@ def check_obsolete_version(calculation_mode='WebUI'):
     headers = {'User-Agent': 'OpenQuake Engine %s;%s;%s' %
                (__version__, calculation_mode, platform.platform())}
     try:
-        logger = logging.getLogger()  # root logger
-        level = logger.level
-        # requests.get logs at level INFO: raising the level so that
-        # the log is hidden
-        logger.setLevel(logging.WARN)
-        try:
-            json = requests.get(OQ_API + '/engine/latest', timeout=0.5,
-                                headers=headers).json()
-        finally:
-            logger.setLevel(level)  # back as it was
-        tag_name = json['tag_name']
+        # we are not using requests.get here because it causes a segfault
+        # on macOS: https://github.com/gem/oq-engine/issues/3161
+        req = Request(OQ_API + '/engine/latest', headers=headers)
+        # NB: a timeout < 1 does not work
+        data = urlopen(req, timeout=1).read()  # bytes
+        tag_name = json.loads(decode(data))['tag_name']
         current = version_triple(__version__)
-        latest = version_triple(json['tag_name'])
+        latest = version_triple(tag_name)
     except:  # page not available or wrong version tag
         return
     if current < latest:


### PR DESCRIPTION
This was done while investigating https://github.com/gem/oq-engine/issues/3161. It does not solve the issue, but it avoids the workaround with the logging levels, so probably it is worth the effort.