### PR TITLE
Fixed reading order in config.read

### DIFF
--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -39,11 +39,14 @@ class DotDict(collections.OrderedDict):
 
 
 config = DotDict()  # global configuration
+d = os.path.dirname
+fallback = os.path.join(d(d(__file__)), 'engine', 'openquake.cfg')
 if 'VIRTUAL_ENV' in os.environ or hasattr(sys, 'real_prefix'):
     config.paths = [
-        os.path.join(os.environ.get('VIRTUAL_ENV', '~'), 'openquake.cfg')]
+        os.path.join(os.environ.get('VIRTUAL_ENV', '~'), 'openquake.cfg'),
+        fallback]
 else:  # installation from packages, search in /etc
-    config.paths = ['/etc/openquake/openquake.cfg']
+    config.paths = ['/etc/openquake/openquake.cfg', fallback]
 cfgfile = os.environ.get('OQ_CONFIG_FILE')
 if cfgfile:  # has the precedence
     config.paths.insert(0, cfgfile)
@@ -93,8 +96,5 @@ def boolean(flag):
         return False
     raise ValueError('Unknown flag %r' % s)
 
-
-d = os.path.dirname
-config.read(os.path.join(d(d(__file__)), 'engine', 'openquake.cfg'),
-            soft_mem_limit=int, hard_mem_limit=int, port=int,
+config.read(soft_mem_limit=int, hard_mem_limit=int, port=int,
             multi_user=boolean)

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -39,14 +39,12 @@ class DotDict(collections.OrderedDict):
 
 
 config = DotDict()  # global configuration
-d = os.path.dirname
-fallback = os.path.join(d(d(__file__)), 'engine', 'openquake.cfg')
-if 'VIRTUAL_ENV' in os.environ or hasattr(sys, 'real_prefix'):
-    config.paths = [
-        os.path.join(os.environ.get('VIRTUAL_ENV', '~'), 'openquake.cfg'),
-        fallback]
-else:  # installation from packages, search in /etc
-    config.paths = ['/etc/openquake/openquake.cfg', fallback]
+if 'VIRTUAL_ENV' in os.environ:
+    config.paths = [os.path.join(os.environ['VIRTUAL_ENV'], 'openquake.cfg')]
+else:  # installation from sources or packages, search in $HOME or /etc
+    d = os.path.dirname
+    home_cfg = os.path.join(d(d(__file__)), 'engine', 'openquake.cfg')
+    config.paths = [home_cfg, '/etc/openquake/openquake.cfg']
 cfgfile = os.environ.get('OQ_CONFIG_FILE')
 if cfgfile:  # has the precedence
     config.paths.insert(0, cfgfile)
@@ -75,6 +73,7 @@ def read(*paths, **validators):
     found = parser.read(os.path.normpath(os.path.expanduser(p)) for p in paths)
     if not found:
         raise IOError('No configuration file found in %s' % str(paths))
+    config.found = found
     config.clear()
     for section in parser.sections():
         config[section] = sec = DotDict(parser.items(section))

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -39,12 +39,15 @@ class DotDict(collections.OrderedDict):
 
 
 config = DotDict()  # global configuration
+d = os.path.dirname
+fallback = os.path.join(d(d(__file__)), 'engine', 'openquake.cfg')
 if 'VIRTUAL_ENV' in os.environ:
-    config.paths = [os.path.join(os.environ['VIRTUAL_ENV'], 'openquake.cfg')]
+    config.paths = [
+        os.path.join(os.environ['VIRTUAL_ENV'], 'openquake.cfg'),
+        fallback]
 else:  # installation from sources or packages, search in $HOME or /etc
-    d = os.path.dirname
-    home_cfg = os.path.join(d(d(__file__)), 'engine', 'openquake.cfg')
-    config.paths = [home_cfg, '/etc/openquake/openquake.cfg']
+    config.paths = ['~/openquake.cfg', '/etc/openquake/openquake.cfg',
+                    fallback]
 cfgfile = os.environ.get('OQ_CONFIG_FILE')
 if cfgfile:  # has the precedence
     config.paths.insert(0, cfgfile)


### PR DESCRIPTION
The ConfigParser manages the .ini files in such a way that the last one wins, i.e. in the opposite order with respect to how it is implemented now (I simply forgot how it worked). Now it works correctly and in absence of virtualenv it is also able to read $HOME/openquake.cfg (if present) which takes the precedence over /etc/openquake,cfg but not with respect to OQ_CONFIG_FILE.

NB: currently things work well enough because `engine/openquake.cfg` is read first so it has the least precedence and `/etc/openquake.cfg` or the one in the virtualenv are read later and win.
OQ_CONFIG_FILE does not work in engine 2.7 since it is added first in the list, so with the least precedence while it should have the highest precedence.