### PR TITLE
`oq dbserver stop` now also stops the zworkers if zmq is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         # Upload oqdata.zip to http://artifacts.openquake.org/travis/ only if
         # the commit message includes a [demos] tag at the end or branch is master
         - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[demos\]' || test "$BRANCH" == "master"; then
-            time bin/run-demos.sh $TRAVIS_BUILD_DIR/demos &&
+            OQ_DISTRIBUTE=zmq time bin/run-demos.sh $TRAVIS_BUILD_DIR/demos &&
             bin/check_demos &&
             oq dump /tmp/oqdata.zip &&
             oq restore /tmp/oqdata.zip /tmp/oqdata &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         # the commit message includes a [demos] tag at the end or branch is master
         - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[demos\]' || test "$BRANCH" == "master"; then
             OQ_DISTRIBUTE=zmq time bin/run-demos.sh $TRAVIS_BUILD_DIR/demos &&
-            bin/check_demos &&
+            bin/check_demos && oq dbserver stop &&
             oq dump /tmp/oqdata.zip &&
             oq restore /tmp/oqdata.zip /tmp/oqdata &&
             helpers/zipdemos.sh $(pwd)/demos &&

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -39,7 +39,6 @@ def dbserver(cmd, dbhostport=None, dbpath=None):
         if status == 'running':
             pid = logs.dbcmd('getpid')
             os.kill(pid, signal.SIGTERM)
-            print('dbserver stopped')
         else:
             print('dbserver already stopped')
     elif cmd == 'start':
@@ -51,7 +50,6 @@ def dbserver(cmd, dbhostport=None, dbpath=None):
         if status == 'running':
             pid = logs.dbcmd('getpid')
             os.kill(pid, signal.SIGTERM)
-            print('dbserver stopped')
         dbs.run_server(dbhostport, dbpath)
 
 dbserver.arg('cmd', 'dbserver command',

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -73,7 +73,7 @@ class DbServer(object):
                 sock.send(safely_call(func, (self.db,) + args))
 
     def start(self):
-        # start database worker threads
+        """Start database worker threads"""
         dworkers = []
         for _ in range(self.num_workers):
             sock = z.Socket(self.backend, z.zmq.REP, 'connect')
@@ -104,6 +104,12 @@ class DbServer(object):
             for sock in dworkers:
                 sock.running = False
             logging.warn('DB server stopped')
+
+    def stop(self):
+        """Stop the DbServer and the zworkers if any"""
+        if ZMQ:
+            logging.warn(self.master.stop())
+        self.db.close()
 
 
 def different_paths(path1, path2):
@@ -194,9 +200,7 @@ def run_server(dbhostport=None, dbpath=None, logfile=DATABASE['LOG'],
     try:
         dbs.start()
     finally:
-        if ZMQ:
-            logging.warn(dbs.master.stop())
-        db.close()
+        dbs.stop()
 
 
 run_server.arg('dbhostport', 'dbhost:port')

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -190,9 +190,12 @@ def run_server(dbhostport=None, dbpath=None, logfile=DATABASE['LOG'],
 
     # configure logging and start the server
     logging.basicConfig(level=getattr(logging, loglevel), filename=logfile)
+    dbs = DbServer(db, addr)
     try:
-        DbServer(db, addr).start()
+        dbs.start()
     finally:
+        if ZMQ:
+            logging.warn(dbs.master.stop())
         db.close()
 
 


### PR DESCRIPTION
I am also enabling zmq in the demos so that it is tested too (celery is tested in the repository oq-engine-celery, futures is tested in the regular tests). Closes https://github.com/gem/oq-engine/issues/3168.