### PR TITLE
Building the `rlzs_assoc` object only once

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -512,12 +512,14 @@ class ClassicalCalculator(PSHACalculator):
             if self.datastore.parent != ():
                 # workers read from the parent datastore
                 pgetter = calc.PmapGetter(
-                    self.datastore.parent, lazy=config.directory.shared_dir)
+                    self.datastore.parent, lazy=config.directory.shared_dir,
+                    rlzs_assoc=self.rlzs_assoc)
                 allargs = list(self.gen_args(pgetter))
                 self.datastore.parent.close()
             else:
                 # workers read from the cache
-                pgetter = calc.PmapGetter(self.datastore)
+                pgetter = calc.PmapGetter(
+                    self.datastore, rlzs_assoc=self.rlzs_assoc)
                 allargs = self.gen_args(pgetter)
             ires = parallel.Starmap(
                 self.core_task.__func__, allargs).submit_all()

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -113,7 +113,7 @@ class PmapGetter(object):
         :returns: a new instance of the getter, with the cache populated
         """
         assert sids is not None
-        return self.__class__(self.dstore, sids, self.lazy)
+        return self.__class__(self.dstore, sids, self.lazy, self.rlzs_assoc)
 
     def get(self, sids, rlzi):
         """


### PR DESCRIPTION
Building the `rlzs_assoc` object can be extremely time consuming in computations with extra-large logic trees, like the India model. In particular, in the classical calculator the object is build three times when it could be built only once. This PR uses the `.rlzs_assoc` attribute to avoid rebuilding the object.
