### PR TITLE
Randomize the port selection in _get_free_port

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -874,7 +874,7 @@ def socket_ready(hostport):
         sock.close()
     return False if exc else True
 
-port_candidates = range(1920, 2000)
+port_candidates = list(range(1920, 2000))
 
 
 def _get_free_port():

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -27,6 +27,7 @@ import imp
 import copy
 import math
 import socket
+import random
 import operator
 import warnings
 import tempfile
@@ -873,7 +874,7 @@ def socket_ready(hostport):
         sock.close()
     return False if exc else True
 
-port_candidates = set(range(1920, 2000))
+port_candidates = range(1920, 2000)
 
 
 def _get_free_port():
@@ -884,7 +885,8 @@ def _get_free_port():
     # never considered free again, even if it is. These restrictions as
     # acceptable for usage in the tests, but only in that case.
     while port_candidates:
-        port = port_candidates.pop()
+        port = random.choice(port_candidates)
+        port_candidates.remove(port)
         if not socket_ready(('127.0.0.1', port)):  # no server listening
             return port  # the port is free
     raise RuntimeError('No free ports in the range 1920:2000')


### PR DESCRIPTION
Let's hope that this will solve the issues with the concurrent tests in macOS.