### PR TITLE
number_of_ground_motion_fields back to being optional if there is a file with the GMFs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * The parameter `number_of_ground_motion_fields` is back to be optional in
+    scenario calculators reading the GMFs from a file, since it can be inferred
   * Removed the deprecated risk outputs dmg_by_tag, dmg_total,
     losses_by_tag, losses_total
   * Deprecated the .geojson exporters for hazard curves and maps

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -113,11 +113,11 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         if 'gmfs' in self.oqparam.inputs:
             self.pre_calculator = None
         base.RiskCalculator.pre_execute(self)
+        base.get_gmfs(self)
         self.param['number_of_ground_motion_fields'] = (
             self.oqparam.number_of_ground_motion_fields)
         self.param['consequence_models'] = riskmodels.get_risk_models(
             self.oqparam, 'consequence')
-        base.get_gmfs(self)
         self.riskinputs = self.build_riskinputs('gmf')
         self.param['tags'] = self.assetcol.tags()
 
@@ -126,7 +126,6 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         Compute stats for the aggregated distributions and save
         the results on the datastore.
         """
-        tags = encode(self.param['tags'])
         dstates = self.riskmodel.damage_states
         ltypes = self.riskmodel.loss_types
         L = len(ltypes)

--- a/openquake/qa_tests_data/scenario_damage/case_1h/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_1h/job_risk.ini
@@ -1,7 +1,7 @@
 [general]
 description = scenario damage
 calculation_mode = scenario_damage
-number_of_ground_motion_fields = 6
+#number_of_ground_motion_fields = 6
 
 [boundaries]
 region_constraint = -122.6 38.3, -121.5 38.3, -121.5 37.9, -122.6 37.9


### PR DESCRIPTION
As requested by Mabe'. It is inferred from the GMF file. The user can still add it to the job.ini file, in this case there is a check that the parameter is consistent with the number of GMFs found in the file. It is a good practice to set the parameter, since in this way truncated GMFs files will raise a clear error (i.e. the file contains less lines than expected).