### PR TITLE
Give to the DbServer time to stop

### DIFF
--- a/openquake/commands/reset.py
+++ b/openquake/commands/reset.py
@@ -49,6 +49,7 @@ def reset(yes):
                 pid = logs.dbcmd('getpid')
                 os.kill(pid, signal.SIGTERM)
                 time.sleep(.5)  # give time to stop
+                assert dbserver.get_status() == 'not-running'
                 print('dbserver stopped')
         try:
             os.remove(dbpath)

--- a/openquake/commands/reset.py
+++ b/openquake/commands/reset.py
@@ -19,6 +19,7 @@
 from __future__ import print_function
 import os
 import sys
+import time
 import signal
 from openquake.baselib import sap, config
 from openquake.commonlib import logs
@@ -47,12 +48,11 @@ def reset(yes):
             else:
                 pid = logs.dbcmd('getpid')
                 os.kill(pid, signal.SIGTERM)
+                time.sleep(.5)  # give time to stop
                 print('dbserver stopped')
-
         try:
             os.remove(dbpath)
-            print('Removed %s'
-                  % dbpath)
+            print('Removed %s' % dbpath)
         except OSError as exc:
             print(exc, file=sys.stderr)
 


### PR DESCRIPTION
Should address https://github.com/gem/oq-engine/issues/3207.
NB: it seems to me that the configuration in zdevel_macos_engine is not starting/stopping the DbServer.