### PR TITLE
Exposing `loss_curves-stats` and `loss_maps-stats` as engine outputs

### DIFF
--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -262,7 +262,7 @@ def export_loss_curves(ekey, dstore):
 
 
 # this is used by classical_risk and event_based_risk
-@export.add(('loss_curves-rlzs', 'csv'))
+@export.add(('loss_curves-stats', 'csv'))
 def export_loss_curves_stats(ekey, dstore):
     num_rlzs = len(dstore['realizations'])
     kind = 'stats' if num_rlzs > 1 else 'rlzs'

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -128,16 +128,13 @@ def expose_outputs(dstore):
             dskeys.add('uhs')  # export them
         if oq.hazard_maps:
             dskeys.add('hmaps')  # export them
-    if 'avg_losses-rlzs' in dstore and rlzs:
+    if 'avg_losses-stats' in dstore or ('avg_losses-rlzs' in dstore and rlzs):
         dskeys.add('avg_losses-stats')
     if 'curves-stats' in dstore:
         logs.LOG.warn('loss curves are exportable with oq export')
     if oq.conditional_loss_poes:  # expose loss_maps outputs
-        if 'loss_curves-rlzs' in dstore:
-            dskeys.add('loss_maps-rlzs')
         if 'loss_curves-stats' in dstore:
-            if len(rlzs) > 1:
-                dskeys.add('loss_maps-stats')
+            dskeys.add('loss_maps-stats')
     if 'all_loss_ratios' in dskeys:
         dskeys.remove('all_loss_ratios')  # export only specific IDs
     if 'realizations' in dskeys and len(rlzs) <= 1:


### PR DESCRIPTION
https://github.com/gem/oq-engine/pull/3208 caused a regression when exposing the statistical outputs.