### PR TITLE
Fixed an unicode error while opening a calculation as a zip archive

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a Python 3 unicode error with `oq engine --run job.zip`
   * Added a command `oq abort <calc_id>`
   * Stored the avg_losses in classical risk in the same way as in
     event_based_risk and made them exportable with the same format

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -158,7 +158,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             sys.exit('%s should be a .ini filename or a pair of filenames '
                      'separated by a comma' % run)
         for job_ini in job_inis:
-            open(job_ini).read()  # raise an IOError if the file does not exist
+            open(job_ini, 'rb').read()  # IOError if the file does not exist
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
 


### PR DESCRIPTION
Catalina has a zip archive causing this error with Python 3:

```bash
$ oq engine --run job.ini
```
```python
  File "/home/michele/oq-engine/openquake/commands/engine.py", line 161, in engine
    open(job_ini).read()  # raise an IOError if the file does not exist
  File "/usr/lib/python3.5/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb6 in position 76: invalid start byte
```
The solution is trivial: open the job.ini in binary mode, not in text mode. Here is the archive: [psha.zip](https://github.com/gem/oq-engine/files/1449238/psha.zip)
