### PR TITLE
Python 2 unicode fix

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -117,7 +117,7 @@ class DisaggregationCalculator(classical.ClassicalCalculator):
     """
     POE_TOO_BIG = '''\
 You are trying to disaggregate for poe=%s.
-However the source model #%d, %r,
+However the source model #%d, '%s',
 produces at most probabilities of %s for rlz=#%d, IMT=%s.
 The disaggregation PoE is too big or your model is wrong,
 producing too small PoEs.'''


### PR DESCRIPTION
Fixes the error in https://ci.openquake.org/job/master_oq-engine/4024/