### PR TITLE
Optimized disaggregation with `iml_disagg`

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -142,7 +142,7 @@ producing too small PoEs.'''
     def get_curves(self, sid):
         """
         Get all the relevant hazard curves for the given site ordinal.
-        Returns a dictionary {(rlz_id, imt) -> curve}.
+        Returns a dictionary rlz_id -> curve_by_imt.
         """
         dic = {}
         imtls = self.oqparam.imtls
@@ -165,7 +165,7 @@ producing too small PoEs.'''
                         'skipping site %d, rlz=%d, IMT=%s',
                         sid, rlz.ordinal, imt_str)
                     continue
-                dic[rlz.ordinal, imt_str] = poes[imt_str]
+                dic[rlz.ordinal] = poes
         return dic
 
     def full_disaggregation(self):
@@ -205,8 +205,10 @@ producing too small PoEs.'''
                 sid = sitecol.sids[i]
                 curve = curves[i]
                 # populate max_poe array
-                for (rlzi, imt), poes in curve.items():
-                    max_poe[rlzi][imt] = max(max_poe[rlzi][imt], poes.max())
+                for rlzi, poes in curve.items():
+                    for imt in oq.imtls:
+                        max_poe[rlzi][imt] = max(
+                            max_poe[rlzi][imt], poes[imt].max())
                 if not curve:
                     continue  # skip zero-valued hazard curves
                 bb = bb_dict[sid]

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -52,7 +52,7 @@ def _disagg(poes, curves, rlzs_by_gsim, imtls, iml_disagg, rupture,
                     truncation_level, n_epsilons)
             for rlzi in rlzs_by_gsim[gsim]:
                 for imt in pne:
-                    yield rlzi, None, str(imt), iml_dict[imt], pne[imt]
+                    yield rlzi, None, str(imt), iml_disagg[imt], pne[imt]
         return
     for poe in poes:
         for gsim in rlzs_by_gsim:
@@ -60,9 +60,8 @@ def _disagg(poes, curves, rlzs_by_gsim, imtls, iml_disagg, rupture,
                 dic = {}
                 for imt_str, imls in imtls.items():
                     imt = from_string(imt_str)
-                    imls = numpy.array(imls[::-1])
                     dic[imt] = numpy.interp(
-                        poe, curves[rlzi][imt_str][::-1], imls)
+                        poe, curves[rlzi][imt_str][::-1], imls[::-1])
                 with disagg_pne:
                     pne = gsim.disaggregate_pne(
                         rupture, sctx, rctx, dctx, dic,

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -99,16 +99,14 @@ def _collect_bins_data(trt_num, sources, site, curves, rlzs_by_gsim, cmaker,
                                         rupture, rlzi, imt, sctx,
                                         rctx, dctx, truncation_level,
                                         n_epsilons, disagg_poe)
-                                    k, v = (rlzi, poe, imt_str), (iml, pne)
-                                    pnes[k].append(v)
+                                    pnes[rlzi, poe, imt_str].append((iml, pne))
                             else:
                                 pne = _disagg(
                                     iml, imls, gsim,
                                     rupture, rlzi, imt, sctx,
                                     rctx, dctx, truncation_level,
                                     n_epsilons, disagg_poe)
-                                k, v = (rlzi, poe, imt_str), (iml, pne)
-                                pnes[k].append(v)
+                                pnes[rlzi, None, imt_str].append((iml, pne))
         except Exception as err:
             etype, err, tb = sys.exc_info()
             msg = 'An error occurred with source id=%s. Error: %s'

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -42,24 +42,31 @@ BinData = collections.namedtuple(
     'BinData', 'mags, dists, lons, lats, trts, pnes')
 
 
-def _disagg(poes, curves, imtls, iml_disagg, gsim, rupture,
+def _disagg(poes, curves, rlzis, imtls, iml_disagg, gsim, rupture,
             sctx, rctx, dctx, truncation_level, n_epsilons, disagg_poe):
     for imt_str, imls in imtls.items():
         imt = from_string(imt_str)
         imls = numpy.array(imls[::-1])
         iml = iml_disagg.get(imt_str)
         if iml is None:
-            the_imls = [numpy.interp(poe, curves[imt_str][::-1], imls)
-                        for poe in poes]
+            for rlzi in rlzis:
+                for poe in poes:
+                    iml = numpy.interp(poe, curves[rlzi][imt_str][::-1], imls)
+                    with disagg_poe:
+                        [poes_given_rup_eps] = gsim.disaggregate_poe(
+                            sctx, rctx, dctx, imt, iml, truncation_level,
+                            n_epsilons)
+                    pne = rupture.get_probability_no_exceedance(
+                        poes_given_rup_eps)
+                    yield rlzi, poe, imt_str, iml, pne
         else:
-            poes = [None]
-            the_imls = [iml]
-        for poe, iml in zip(poes, the_imls):
             with disagg_poe:
                 [poes_given_rup_eps] = gsim.disaggregate_poe(
-                    sctx, rctx, dctx, imt, iml, truncation_level, n_epsilons)
+                    sctx, rctx, dctx, imt, iml, truncation_level,
+                    n_epsilons)
             pne = rupture.get_probability_no_exceedance(poes_given_rup_eps)
-            yield poe, imt_str, iml, pne
+            for rlzi in rlzis:
+                yield rlzi, None, imt_str, iml, pne
 
 
 def _collect_bins_data(trt_num, sources, site, curves, rlzs_by_gsim, cmaker,
@@ -95,12 +102,12 @@ def _collect_bins_data(trt_num, sources, site, curves, rlzs_by_gsim, cmaker,
                 trts.append(tect_reg)
                 # pnes: (rlz.id, poe, imt_str) -> [(iml, probs), ...]
                 for gsim in cmaker.gsims:
-                    for rlzi in rlzs_by_gsim[str(gsim)]:
-                        for poe, imt, iml, pne in _disagg(
-                                poes, curves[rlzi], imtls, iml_disagg, gsim,
-                                rupture, sctx, rctx, dctx, truncation_level,
-                                n_epsilons, disagg_poe):
-                            pnes[rlzi, poe, imt].append((iml, pne))
+                    for rlzi, poe, imt, iml, pne in _disagg(
+                            poes, curves, rlzs_by_gsim[str(gsim)], imtls,
+                            iml_disagg, gsim,
+                            rupture, sctx, rctx, dctx, truncation_level,
+                            n_epsilons, disagg_poe):
+                        pnes[rlzi, poe, imt].append((iml, pne))
 
         except Exception as err:
             etype, err, tb = sys.exc_info()

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -42,14 +42,14 @@ BinData = collections.namedtuple(
     'BinData', 'mags, dists, lons, lats, trts, pnes')
 
 
-def _disagg(poes, curves, imtls, iml_disagg, gsim, rupture, rlzi,
+def _disagg(poes, curves, imtls, iml_disagg, gsim, rupture,
             sctx, rctx, dctx, truncation_level, n_epsilons, disagg_poe):
     for imt_str, imls in imtls.items():
         imt = from_string(imt_str)
         imls = numpy.array(imls[::-1])
         iml = iml_disagg.get(imt_str)
         if iml is None:
-            the_imls = [numpy.interp(poe, curves[rlzi, imt_str][::-1], imls)
+            the_imls = [numpy.interp(poe, curves[imt_str][::-1], imls)
                         for poe in poes]
         else:
             poes = [None]
@@ -97,8 +97,8 @@ def _collect_bins_data(trt_num, sources, site, curves, rlzs_by_gsim, cmaker,
                 for gsim in cmaker.gsims:
                     for rlzi in rlzs_by_gsim[str(gsim)]:
                         for poe, imt, iml, pne in _disagg(
-                                poes, curves, imtls, iml_disagg, gsim, rupture,
-                                rlzi, sctx, rctx, dctx, truncation_level,
+                                poes, curves[rlzi], imtls, iml_disagg, gsim,
+                                rupture, sctx, rctx, dctx, truncation_level,
                                 n_epsilons, disagg_poe):
                             pnes[rlzi, poe, imt].append((iml, pne))
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -45,12 +45,10 @@ BinData = collections.namedtuple(
 def _disagg(poes, curves, rlzs_by_gsim, imtls, iml_disagg, rupture,
             sctx, rctx, dctx, truncation_level, n_epsilons, disagg_pne):
     if iml_disagg:
-        iml_dict = {from_string(imt): iml_disagg[imt]
-                    for imt, iml in iml_disagg.items()}
         for gsim in rlzs_by_gsim:
             with disagg_pne:
                 pne = gsim.disaggregate_pne(
-                    rupture, sctx, rctx, dctx, iml_dict,
+                    rupture, sctx, rctx, dctx, iml_disagg,
                     truncation_level, n_epsilons)
             for rlzi in rlzs_by_gsim[gsim]:
                 for imt in pne:
@@ -87,6 +85,8 @@ def _collect_bins_data(trt_num, sources, site, curves, rlzs_by_gsim, cmaker,
     sitemesh = sitecol.mesh
     make_ctxt = mon('making contexts', measuremem=False)
     disagg_pne = mon('disaggregate_pne', measuremem=False)
+    iml_disagg = {from_string(imt): iml_disagg[imt]
+                  for imt, iml in iml_disagg.items()}
     for source in sources:
         try:
             tect_reg = trt_num[source.tectonic_region_type]

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -554,14 +554,21 @@ class GroundShakingIntensityModel(with_metaclass(MetaGSIM)):
         poes = numpy.array(poe_by_site)
         return poes  # shape (n_sites, n_epsilons)
 
-    def disaggregate_pne(self, rupture, sctx, rctx, dctx, iml_dict,
+    def disaggregate_pne(self, rupture, sctx, rctx, dctx, imt, iml_by_key,
                          truncation_level, n_epsilons):
-        pne = {}
-        for imt, iml in iml_dict.items():
-            [poes] = self.disaggregate_poe(sctx, rctx, dctx, imt, iml,
-                                           truncation_level, n_epsilons)
-            pne[imt] = rupture.get_probability_no_exceedance(poes)
-        return pne
+        """
+        Disaggregate a dictionary of values iml_by_key and returns a dictionary
+        of probabilities of no exceedence pne_by_key.
+        """
+        pne_by_key = {}
+        cache = {}
+        for iml in set(iml_by_key.values()):  # unique values
+            [poes] = self.disaggregate_poe(
+                sctx, rctx, dctx, imt, iml, truncation_level, n_epsilons)
+            cache[iml] = rupture.get_probability_no_exceedance(poes)
+        for key in iml_by_key:
+            pne_by_key[key] = cache[iml_by_key[key]]
+        return pne_by_key
 
     @abc.abstractmethod
     def to_distribution_values(self, values):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -554,6 +554,13 @@ class GroundShakingIntensityModel(with_metaclass(MetaGSIM)):
         poes = numpy.array(poe_by_site)
         return poes  # shape (n_sites, n_epsilons)
 
+    def disaggregate_pne(self, rupture, sctx, rctx, dctx, imt, iml,
+                         truncation_level, n_epsilons):
+        [poes] = self.disaggregate_poe(sctx, rctx, dctx, imt, iml,
+                                       truncation_level, n_epsilons)
+        pne = rupture.get_probability_no_exceedance(poes)
+        return pne
+
     @abc.abstractmethod
     def to_distribution_values(self, values):
         """

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -554,11 +554,13 @@ class GroundShakingIntensityModel(with_metaclass(MetaGSIM)):
         poes = numpy.array(poe_by_site)
         return poes  # shape (n_sites, n_epsilons)
 
-    def disaggregate_pne(self, rupture, sctx, rctx, dctx, imt, iml,
+    def disaggregate_pne(self, rupture, sctx, rctx, dctx, iml_dict,
                          truncation_level, n_epsilons):
-        [poes] = self.disaggregate_poe(sctx, rctx, dctx, imt, iml,
-                                       truncation_level, n_epsilons)
-        pne = rupture.get_probability_no_exceedance(poes)
+        pne = {}
+        for imt, iml in iml_dict.items():
+            [poes] = self.disaggregate_poe(sctx, rctx, dctx, imt, iml,
+                                           truncation_level, n_epsilons)
+            pne[imt] = rupture.get_probability_no_exceedance(poes)
         return pne
 
     @abc.abstractmethod


### PR DESCRIPTION
When a disaggregation calculation is performed and the key `iml_disagg` is used in the `job.ini` file, an optimization is possible that avoids performing the same calculation multiple times. This is implemented as a cache in the method `gsim.disaggregate_pne` in hazardlib. Here are the results for the Armenia calculation, that went down from 78 minutes to 61 minutes in our cluster:

```
   wilson:~$ oq show performance 16424  -- master
   ================================== ========= ========= ===========
   operation                          time_sec  memory_mb counts     
   ================================== ========= ========= ===========
   total compute_disagg               1,302,379 92        2,187      
   arranging bins                     761,060   62        13,920     
   collecting bins                    540,845   101       2,187      
   disaggregate_poe                   462,545   0.0       161,704,928
   total pmap_from_grp                92,801    7.555     2,307      
   making contexts                    60,437    0.0       58,612,435
   
   wilson:~$ oq show performance 16452  -- this branch
   ================================== ========= ========= ==========
   operation                          time_sec  memory_mb counts    
   ================================== ========= ========= ==========
   total compute_disagg               1,095,420 59        2,187     
   arranging bins                     758,908   62        13,920    
   collecting bins                    336,121   63        2,187     
   disaggregate_pne                   265,327   0.0       95,850,776
   total pmap_from_grp                88,953    7.434     2,307     
   making contexts                    58,919    0.0       58,612,435
```

Notice that in master the operation  disaggregate_poe was called 161,704,928 times while in this branch, thanks to the cache the similar operation disaggregate_pne is called only  95,850,776 times, hence the speedup.