### PR TITLE
Deprecated `gsim.disaggregate_poe`

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -88,17 +88,13 @@ def compute_disagg(src_filter, sources, rlzs_by_gsim,
                 oqparam.poes_disagg, oqparam.truncation_level,
                 oqparam.num_epsilon_bins, oqparam.iml_disagg,
                 monitor('disaggregate_pne', measuremem=False))
-
-        for (rlzi, poe, imt), iml_pne_pairs in bdata.pnes.items():
+        for (poe, imt, iml, rlzi), pnes in bdata.pnes.items():
             # extract the probabilities of non-exceedance for the
             # given realization, disaggregation PoE, and IMT
-            iml = iml_pne_pairs[0][0]
-            probs = numpy.array([p for (i, p) in iml_pne_pairs], float)
-
             # bins in a format handy for hazardlib
             bins = [bdata.mags, bdata.dists,
                     bdata.lons, bdata.lats,
-                    bdata.trts, None, probs]
+                    bdata.trts, None, pnes]
 
             # call disagg._arrange_data_in_bins
             with arranging_mon:

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -37,6 +37,7 @@ from openquake.hazardlib import const, calc
 from openquake.hazardlib import imt as imt_module
 from openquake.hazardlib.calc.filters import IntegrationDistance, get_distances
 from openquake.baselib.general import DeprecationWarning
+from openquake.baselib.performance import Monitor
 from openquake.baselib.python3compat import with_metaclass
 
 
@@ -299,7 +300,7 @@ class ContextMaker(object):
         return rupture.get_probability_no_exceedance(poes)
 
     def disaggregate(self, sitecol, ruptures, imldict,
-                     truncnorm, n_epsilons, disagg_pne):
+                     truncnorm, n_epsilons, disagg_pne=Monitor()):
         """
         Disaggregate (separate) PoE of `imldict` in different contributions
         each coming from `n_epsilons` distribution bins.
@@ -308,9 +309,12 @@ class ContextMaker(object):
         :param ruptures: an iterator over ruptures
         :param imldict: a dictionary poe, gsim, imt, rlzi -> iml
         :param truncnorm: an instance of scipy.stats.truncnorm
-        :param n_epsilons: the number of epsilons
+        :param n_epsilons: the number of bins
         :param disagg_pne: a monitor of the disaggregation time
-        :yields: triples (rupture, site_dist, iml_pne)
+        :yields:
+            triples (rupture, site_dist, iml_pne) where iml_pne is a
+            dictionary poe, gsim, imt, iml, rlzi -> pne where pne is
+            an array of length n_epsilons of probabilities of no exceedence
         """
         assert len(sitecol) == 1, sitecol
         epsilons = numpy.linspace(truncnorm.a, truncnorm.b, n_epsilons + 1)
@@ -320,7 +324,7 @@ class ContextMaker(object):
             except calc.filters.FarAwayRupture:
                 continue
 
-            iml_pne = {}  # poe, gsim, imt, rlzi -> iml, pne
+            pnedict = {}  # poe, imt, iml, rlzi -> pne
             cache = {}  # gsim, imt, iml -> pne
             for (poe, gsim, imt, rlzi), iml in imldict.items():
                 try:
@@ -331,9 +335,9 @@ class ContextMaker(object):
                             gsim, rupture, sctx, rctx, dctx, imt, iml,
                             truncnorm, epsilons)
                     cache[gsim, imt, iml] = pne
-                iml_pne[poe, gsim, imt, rlzi] = (iml, pne)
+                pnedict[poe, str(imt), iml, rlzi] = pne
             [rjb_dist] = dctx.rjb  # 1 site => 1 distance
-            yield rupture, rjb_dist, iml_pne
+            yield rupture, rjb_dist, pnedict
 
 
 @functools.total_ordering

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -33,10 +33,11 @@ import scipy.stats
 from scipy.special import ndtr
 import numpy
 
-from openquake.hazardlib import const, calc
+from openquake.hazardlib import const
 from openquake.hazardlib import imt as imt_module
-from openquake.hazardlib.calc.filters import IntegrationDistance, get_distances
-from openquake.baselib.general import DeprecationWarning
+from openquake.hazardlib.calc.filters import (
+    IntegrationDistance, get_distances, FarAwayRupture)
+from openquake.baselib.general import DeprecationWarning, deprecated
 from openquake.baselib.performance import Monitor
 from openquake.baselib.python3compat import with_metaclass
 
@@ -321,7 +322,7 @@ class ContextMaker(object):
         for rupture in ruptures:
             try:
                 sctx, rctx, dctx = self.make_contexts(sitecol, rupture)
-            except calc.filters.FarAwayRupture:
+            except FarAwayRupture:
                 continue
 
             pnedict = {}  # poe, imt, iml, rlzi -> pne
@@ -567,8 +568,9 @@ class GroundShakingIntensityModel(with_metaclass(MetaGSIM)):
             else:
                 return _truncnorm_sf(truncation_level, values)
 
-    # TODO: deprecate this since it is slow and not used by the engine
+    # deprecated since it is slow and not used by the engine
     # alternatively, it should take truncnorm in input, not truncation_level
+    @deprecated('This method will disappear soon')
     def disaggregate_poe(self, sctx, rctx, dctx, imt, iml,
                          truncation_level, n_epsilons):
         """


### PR DESCRIPTION
Plus some cleanup, including fixing a circular import breaking Python 2.
