### PR TITLE
Removed `disagg._collect_bins_data_old`

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -94,7 +94,7 @@ def compute_disagg(src_filter, sources, rlzs_by_gsim,
             # bins in a format handy for hazardlib
             bins = [bdata.mags, bdata.dists,
                     bdata.lons, bdata.lats,
-                    bdata.trts, None, pnes]
+                    pnes, bdata.trts]
 
             # call disagg._arrange_data_in_bins
             with arranging_mon:

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -104,100 +104,6 @@ def _collect_bins_data(trt_num, sources, site, curves, rlzs_by_gsim, cmaker,
                    {k: numpy.array(pnes[k]) for k in pnes})
 
 
-def disaggregation(
-        sources, site, imt, iml, gsim_by_trt, truncation_level,
-        n_epsilons, mag_bin_width, dist_bin_width, coord_bin_width,
-        source_filter=filters.source_site_noop_filter):
-    """
-    Compute "Disaggregation" matrix representing conditional probability of an
-    intensity mesaure type ``imt`` exceeding, at least once, an intensity
-    measure level ``iml`` at a geographical location ``site``, given rupture
-    scenarios classified in terms of:
-
-    - rupture magnitude
-    - Joyner-Boore distance from rupture surface to site
-    - longitude and latitude of the surface projection of a rupture's point
-      closest to ``site``
-    - epsilon: number of standard deviations by which an intensity measure
-      level deviates from the median value predicted by a GSIM, given the
-      rupture parameters
-    - rupture tectonic region type
-
-    In other words, the disaggregation matrix allows to compute the probability
-    of each scenario with the specified properties (e.g., magnitude, or the
-    magnitude and distance) to cause one or more exceedences of a given hazard
-    level.
-
-    For more detailed information about the disaggregation, see for instance
-    "Disaggregation of Seismic Hazard", Paolo Bazzurro, C. Allin Cornell,
-    Bulletin of the Seismological Society of America, Vol. 89, pp. 501-520,
-    April 1999.
-
-    :param sources:
-        Seismic source model, as for
-        :mod:`PSHA <openquake.hazardlib.calc.hazard_curve>` calculator it
-        should be an iterator of seismic sources.
-    :param site:
-        :class:`~openquake.hazardlib.site.Site` of interest to calculate
-        disaggregation matrix for.
-    :param imt:
-        Instance of :mod:`intensity measure type <openquake.hazardlib.imt>`
-        class.
-    :param iml:
-        Intensity measure level. A float value in units of ``imt``.
-    :param gsim_by_trt:
-        Tectonic region type to GSIM objects mapping.
-    :param truncation_level:
-        Float, number of standard deviations for truncation of the intensity
-        distribution.
-    :param n_epsilons:
-        Integer number of epsilon histogram bins in the result matrix.
-    :param mag_bin_width:
-        Magnitude discretization step, width of one magnitude histogram bin.
-    :param dist_bin_width:
-        Distance histogram discretization step, in km.
-    :param coord_bin_width:
-        Longitude and latitude histograms discretization step,
-        in decimal degrees.
-    :param source_filter:
-        Optional source-site filter function. See
-        :mod:`openquake.hazardlib.calc.filters`.
-
-    :returns:
-        A tuple of two items. First is itself a tuple of bin edges information
-        for (in specified order) magnitude, distance, longitude, latitude,
-        epsilon and tectonic region types.
-
-        Second item is 6d-array representing the full disaggregation matrix.
-        Dimensions are in the same order as bin edges in the first item
-        of the result tuple. The matrix can be used directly by pmf-extractor
-        functions.
-    """
-    trts = sorted(set(src.tectonic_region_type for src in sources))
-    trt_num = dict((trt, i) for i, trt in enumerate(trts))
-    rlzs_by_gsim = {gsim_by_trt[trt]: [0] for trt in trts}
-    cmaker = ContextMaker(rlzs_by_gsim, source_filter.integration_distance)
-    bdata = _collect_bins_data(
-        trt_num, sources, site, None, rlzs_by_gsim, cmaker, {str(imt): [iml]},
-        None, truncation_level, n_epsilons, {str(imt): iml})
-    if all(len(x) == 0 for x in bdata):
-        # No ruptures have contributed to the hazard level at this site.
-        warnings.warn(
-            'No ruptures have contributed to the hazard at site %s'
-            % site, RuntimeWarning)
-        return None, None
-    [(key, pnes)] = bdata.pnes.items()
-    bins = [bdata.mags, bdata.dists, bdata.lons, bdata.lats, pnes, bdata.trts]
-    trt_bins = [trt for (num, trt) in sorted((num, trt)
-                for (trt, num) in trt_num.items())]
-    bin_edges = _define_bins(
-        bins, mag_bin_width, dist_bin_width, coord_bin_width,
-        truncation_level, n_epsilons) + (trt_bins,)
-    # mag_edges, dist_edges, lon_edges, lat_edges, eps_edges, trt_edges
-    diss_matrix = _arrange_data_in_bins(bins, bin_edges)
-    return bin_edges, diss_matrix
-
-
 def _define_bins(bins_data, mag_bin_width, dist_bin_width,
                  coord_bin_width, truncation_level, n_epsilons):
     """
@@ -304,6 +210,100 @@ def _digitize_lons(lons, lon_bins):
         return numpy.digitize(lons, lon_bins) - 1
 
 
+def disaggregation(
+        sources, site, imt, iml, gsim_by_trt, truncation_level,
+        n_epsilons, mag_bin_width, dist_bin_width, coord_bin_width,
+        source_filter=filters.source_site_noop_filter):
+    """
+    Compute "Disaggregation" matrix representing conditional probability of an
+    intensity mesaure type ``imt`` exceeding, at least once, an intensity
+    measure level ``iml`` at a geographical location ``site``, given rupture
+    scenarios classified in terms of:
+
+    - rupture magnitude
+    - Joyner-Boore distance from rupture surface to site
+    - longitude and latitude of the surface projection of a rupture's point
+      closest to ``site``
+    - epsilon: number of standard deviations by which an intensity measure
+      level deviates from the median value predicted by a GSIM, given the
+      rupture parameters
+    - rupture tectonic region type
+
+    In other words, the disaggregation matrix allows to compute the probability
+    of each scenario with the specified properties (e.g., magnitude, or the
+    magnitude and distance) to cause one or more exceedences of a given hazard
+    level.
+
+    For more detailed information about the disaggregation, see for instance
+    "Disaggregation of Seismic Hazard", Paolo Bazzurro, C. Allin Cornell,
+    Bulletin of the Seismological Society of America, Vol. 89, pp. 501-520,
+    April 1999.
+
+    :param sources:
+        Seismic source model, as for
+        :mod:`PSHA <openquake.hazardlib.calc.hazard_curve>` calculator it
+        should be an iterator of seismic sources.
+    :param site:
+        :class:`~openquake.hazardlib.site.Site` of interest to calculate
+        disaggregation matrix for.
+    :param imt:
+        Instance of :mod:`intensity measure type <openquake.hazardlib.imt>`
+        class.
+    :param iml:
+        Intensity measure level. A float value in units of ``imt``.
+    :param gsim_by_trt:
+        Tectonic region type to GSIM objects mapping.
+    :param truncation_level:
+        Float, number of standard deviations for truncation of the intensity
+        distribution.
+    :param n_epsilons:
+        Integer number of epsilon histogram bins in the result matrix.
+    :param mag_bin_width:
+        Magnitude discretization step, width of one magnitude histogram bin.
+    :param dist_bin_width:
+        Distance histogram discretization step, in km.
+    :param coord_bin_width:
+        Longitude and latitude histograms discretization step,
+        in decimal degrees.
+    :param source_filter:
+        Optional source-site filter function. See
+        :mod:`openquake.hazardlib.calc.filters`.
+
+    :returns:
+        A tuple of two items. First is itself a tuple of bin edges information
+        for (in specified order) magnitude, distance, longitude, latitude,
+        epsilon and tectonic region types.
+
+        Second item is 6d-array representing the full disaggregation matrix.
+        Dimensions are in the same order as bin edges in the first item
+        of the result tuple. The matrix can be used directly by pmf-extractor
+        functions.
+    """
+    trts = sorted(set(src.tectonic_region_type for src in sources))
+    trt_num = dict((trt, i) for i, trt in enumerate(trts))
+    rlzs_by_gsim = {gsim_by_trt[trt]: [0] for trt in trts}
+    cmaker = ContextMaker(rlzs_by_gsim, source_filter.integration_distance)
+    bdata = _collect_bins_data(
+        trt_num, sources, site, None, rlzs_by_gsim, cmaker, {str(imt): [iml]},
+        None, truncation_level, n_epsilons, {str(imt): iml})
+    if all(len(x) == 0 for x in bdata):
+        # No ruptures have contributed to the hazard level at this site.
+        warnings.warn(
+            'No ruptures have contributed to the hazard at site %s'
+            % site, RuntimeWarning)
+        return None, None
+    [pnes] = bdata.pnes.values()
+    bins = [bdata.mags, bdata.dists, bdata.lons, bdata.lats, pnes, bdata.trts]
+    trt_bins = [trt for (num, trt) in sorted((num, trt)
+                for (trt, num) in trt_num.items())]
+    bin_edges = _define_bins(
+        bins, mag_bin_width, dist_bin_width, coord_bin_width,
+        truncation_level, n_epsilons) + (trt_bins,)
+    # mag_edges, dist_edges, lon_edges, lat_edges, eps_edges, trt_edges
+    diss_matrix = _arrange_data_in_bins(bins, bin_edges)
+    return bin_edges, diss_matrix
+
+
 def mag_pmf(matrix):
     """
     Fold full disaggregation matrix to magnitude PMF.
@@ -320,8 +320,7 @@ def mag_pmf(matrix):
              for k in range(nlons)
              for l in range(nlats)
              for m in range(neps)
-             for n in range(ntrts)]
-        )
+             for n in range(ntrts)])
     return 1 - mag_pmf
 
 
@@ -341,8 +340,7 @@ def dist_pmf(matrix):
              for k in range(nlons)
              for l in range(nlats)
              for m in range(neps)
-             for n in range(ntrts)]
-        )
+             for n in range(ntrts)])
     return 1 - dist_pmf
 
 
@@ -362,8 +360,7 @@ def trt_pmf(matrix):
              for j in range(ndists)
              for k in range(nlons)
              for l in range(nlats)
-             for m in range(neps)]
-        )
+             for m in range(neps)])
     return 1 - trt_pmf
 
 
@@ -384,8 +381,7 @@ def mag_dist_pmf(matrix):
                  for k in range(nlons)
                  for l in range(nlats)
                  for m in range(neps)
-                 for n in range(ntrts)]
-            )
+                 for n in range(ntrts)])
     return 1 - mag_dist_pmf
 
 
@@ -429,8 +425,7 @@ def lon_lat_pmf(matrix):
                  for i in range(nmags)
                  for j in range(ndists)
                  for m in range(neps)
-                 for n in range(ntrts)]
-            )
+                 for n in range(ntrts)])
     return 1 - lon_lat_pmf
 
 
@@ -452,8 +447,7 @@ def mag_lon_lat_pmf(matrix):
                     [1 - matrix[i][j][k][l][m][n]
                      for j in range(ndists)
                      for m in range(neps)
-                     for n in range(ntrts)]
-                )
+                     for n in range(ntrts)])
     return 1 - mag_lon_lat_pmf
 
 
@@ -475,8 +469,7 @@ def lon_lat_trt_pmf(matrix):
                     [1 - matrix[i][j][k][l][m][n]
                      for i in range(nmags)
                      for j in range(ndists)
-                     for m in range(neps)]
-                )
+                     for m in range(neps)])
     return 1 - lon_lat_trt_pmf
 
 

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -77,7 +77,8 @@ class DisaggregateTestCase(unittest.TestCase):
         aaae(lon_bins, [0, 2.4])
         aaae(lat_bins, [0, 2.4])
         aaae(eps_bins, [-1, -0.3333333, 0.3333333, 1])
-        aaae(matrix.shape, (2, 28, 1, 1, 3, 60))
+        self.assertEqual(trt_bins, [self.trt])
+        aaae(matrix.shape, (2, 28, 1, 1, 3, 1))
         aaae(matrix.sum(), 6.14179818e-11)
 
 

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -16,169 +16,17 @@
 import mock
 import unittest
 import warnings
+import os.path
 
 import numpy
 
 from openquake.hazardlib.calc import disagg
-from openquake.hazardlib.calc import filters
-from openquake.hazardlib.tom import PoissonTOM
-from openquake.hazardlib.geo import Point, Mesh
+from openquake.hazardlib import nrml
+from openquake.hazardlib.sourceconverter import SourceConverter
+from openquake.hazardlib.gsim.campbell_2003 import Campbell2003
+from openquake.hazardlib.geo import Point
+from openquake.hazardlib.imt import PGA
 from openquake.hazardlib.site import Site
-from openquake.hazardlib.gsim.base import ContextMaker
-
-
-class _BaseDisaggTestCase(unittest.TestCase):
-    class FakeSurface(object):
-        def __init__(self, distance, lon, lat):
-            self.distance = distance
-            self.lon = lon
-            self.lat = lat
-
-        def get_joyner_boore_distance(self, sites):
-            assert len(sites) == 1
-            return numpy.array([self.distance], float)
-
-        def get_closest_points(self, sites):
-            assert len(sites) == 1
-            return Mesh(numpy.array([self.lon], float),
-                        numpy.array([self.lat], float),
-                        depths=None)
-
-    class FakeRupture(object):
-        def __init__(self, mag, probability, distance, lon, lat):
-            self.mag = mag
-            self.probability = probability
-            self.surface = _BaseDisaggTestCase.FakeSurface(distance, lon, lat)
-
-        def get_probability_no_exceedance(self, poe):
-            return (1 - self.probability) ** poe
-
-    class FakeSource(object):
-        def __init__(self, source_id, ruptures, tom, tectonic_region_type):
-            self.source_id = source_id
-            self.ruptures = ruptures
-            self.tom = tom
-            self.tectonic_region_type = tectonic_region_type
-
-        def iter_ruptures(self):
-            return iter(self.ruptures)
-
-    class FailSource(FakeSource):
-        def iter_ruptures(self):
-            raise ValueError('Something bad happened')
-
-    class FakeGSIM(object):
-        REQUIRES_DISTANCES = set()
-        REQUIRES_RUPTURE_PARAMETERS = set()
-        REQUIRES_SITES_PARAMETERS = set()
-
-        def __init__(self, iml, imt, truncation_level, n_epsilons,
-                     disaggregated_poes):
-            self.disaggregated_poes = disaggregated_poes
-            self.n_epsilons = n_epsilons
-            self.iml = iml
-            self.imt = imt
-            self.truncation_level = truncation_level
-            self.dists = object()
-
-        def disaggregate_poe(self, sctx, rctx, dctx, imt, iml,
-                             truncation_level, n_epsilons):
-            assert truncation_level is self.truncation_level
-            assert imt is self.imt
-            assert iml is self.iml
-            assert n_epsilons is self.n_epsilons
-            assert len(sctx) == 1
-            return numpy.array([self.disaggregated_poes[rctx]])
-
-    def setUp(self):
-        self.ruptures_and_poes1 = [
-            ([0, 0, 0], self.FakeRupture(5, 0.1, 3, 22, 44)),
-            ([0.1, 0.2, 0.1], self.FakeRupture(5, 0.2, 11, 22, 44)),
-            ([0, 0, 0.3], self.FakeRupture(5, 0.01, 12, 22, 45)),
-            ([0, 0.05, 0.001], self.FakeRupture(5, 0.33, 13, 22, 45)),
-            ([0, 0, 0], self.FakeRupture(9, 0.4, 14, 21, 44)),
-            ([0, 0, 0.02], self.FakeRupture(5, 0.05, 11, 21, 44)),
-            ([0.04, 0.1, 0.04], self.FakeRupture(5, 0.53, 11, 21, 45)),
-            ([0.2, 0.3, 0.2], self.FakeRupture(5, 0.066, 10, 21, 45)),
-            ([0.3, 0.4, 0.3], self.FakeRupture(6, 0.1, 12, 22, 44)),
-            ([0, 0, 0.1], self.FakeRupture(6, 0.1, 12, 21, 44)),
-            ([0, 0, 0], self.FakeRupture(6, 0.1, 11, 22, 45)),
-        ]
-        self.ruptures_and_poes2 = [
-            ([0, 0.1, 0.04], self.FakeRupture(8, 0.04, 5, 11, 45)),
-            ([0.1, 0.5, 0.1], self.FakeRupture(7, 0.03, 5, 11, 46))
-        ]
-        self.time_span = 10
-        self.tom = PoissonTOM(time_span=10)
-        self.source1 = self.FakeSource(
-            1, [rupture for poes, rupture in self.ruptures_and_poes1],
-            self.tom, 'trt1'
-        )
-        self.source2 = self.FakeSource(
-            2, [rupture for poes, rupture in self.ruptures_and_poes2],
-            self.tom, 'trt2'
-        )
-        self.disagreggated_poes = dict(
-            (rupture, poes) for (poes, rupture) in self.ruptures_and_poes1 +
-            self.ruptures_and_poes2
-        )
-        self.site = Site(Point(0, 0), 2, False, 4, 5)
-
-        self.iml, self.imt, self.truncation_level = (
-            object(), object(), object())
-        gsim = self.FakeGSIM(self.iml, self.imt, self.truncation_level,
-                             n_epsilons=3,
-                             disaggregated_poes=self.disagreggated_poes)
-        self.gsim = gsim
-        self.gsims = {'trt1': gsim, 'trt2': gsim}
-        self.sources = [self.source1, self.source2]
-
-        self.orig_make_contexts = ContextMaker.make_contexts
-        ContextMaker.make_contexts = lambda self, sites, rupture: (
-            sites, rupture, None)
-
-    def tearDown(self):
-        ContextMaker.make_contexts = self.orig_make_contexts
-
-
-class CollectBinsDataTestCase(_BaseDisaggTestCase):
-    def test_no_filters(self):
-        (mags, dists, lons, lats, trts, trt_bins, probs_no_exceed) = \
-            disagg._collect_bins_data_old(
-                self.sources, self.site, self.imt, self.iml, self.gsims,
-                self.truncation_level, n_epsilons=3,
-                source_site_filter=filters.source_site_noop_filter)
-
-        aae = numpy.testing.assert_array_equal
-
-        aae(mags, [5, 5, 5, 5, 9, 5, 5, 5, 6, 6, 6, 8, 7])
-        aae(dists, [3, 11, 12, 13, 14, 11, 11, 10, 12, 12, 11, 5, 5])
-        aae(lons, [22, 22, 22, 22, 21, 21, 21, 21, 22, 21, 22, 11, 11])
-        aae(lats, [44, 44, 45, 45, 44, 44, 45, 45, 44, 44, 45, 45, 46])
-        aae(trts, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1])
-
-        poe = numpy.array([
-            [0, 0, 0],
-            [0.1, 0.2, 0.1],
-            [0, 0, 0.3],
-            [0, 0.05, 0.001],
-            [0, 0, 0],
-            [0, 0, 0.02],
-            [0.04, 0.1, 0.04],
-            [0.2, 0.3, 0.2],
-            [0.3, 0.4, 0.3],
-            [0, 0, 0.1],
-            [0, 0, 0],
-            [0, 0.1, 0.04],
-            [0.1, 0.5, 0.1],
-        ])
-        p_one_more = numpy.array(
-            [0.1, 0.2, 0.01, 0.33, 0.4, 0.05, 0.53, 0.066,
-             0.1, 0.1, 0.1, 0.04, 0.03]
-        ).reshape(13, 1)
-        exp_p_ne = (1 - p_one_more) ** poe
-        aae(probs_no_exceed, exp_p_ne)
-        self.assertEqual(trt_bins, ['trt1', 'trt2'])
 
 
 class DigitizeLonsTestCase(unittest.TestCase):
@@ -202,217 +50,35 @@ class DigitizeLonsTestCase(unittest.TestCase):
         numpy.testing.assert_equal(idx, expected)
 
 
-class DefineBinsTestCase(unittest.TestCase):
+class DisaggregateTestCase(unittest.TestCase):
+    def setUp(self):
+        d = os.path.dirname(os.path.dirname(__file__))
+        source_model = os.path.join(d, 'source_model/multi-point-source.xml')
+        [self.sources] = nrml.parse(source_model, SourceConverter(
+            investigation_time=50., rupture_mesh_spacing=2.))
+        self.site = Site(Point(0.1, 0.1), 800, True, z1pt0=100., z2pt5=1.)
+        self.imt = PGA()
+        self.iml = 0.1
+        self.truncation_level = 1
+        self.trt = 'Stable Continental Crust'
+        self.gsims = {self.trt: Campbell2003()}
+
     def test(self):
-        mags = numpy.array([4.4, 5, 3.2, 7, 5.9])
-        dists = numpy.array([4, 1.2, 3.5, 52.1, 17])
-        lats = numpy.array([-25, -10, 0.6, -20, -15])
-        lons = numpy.array([179, -179, 176.4, -179.55, 180])
-        trts = [0, 1, 2, 2, 1]
-        trt_bins = ['foo', 'bar', 'baz']
-
-        # This is ignored by _define_bins, but it is returned by
-        # _collect_bins_data so we need to maintain that contract
-        probs_no_exceed = None
-
-        bins_data = (mags, dists, lons, lats, trts, trt_bins,
-                     probs_no_exceed)
-
-        (mag_bins, dist_bins, lon_bins, lat_bins,  eps_bins, trt_bins_
-         ) = disagg._define_bins(
-            bins_data, mag_bin_width=1, dist_bin_width=4.2,
-            coord_bin_width=1.2, truncation_level=1, n_epsilons=4
-        )
-
-        aae = numpy.testing.assert_array_equal
-        aaae = numpy.testing.assert_array_almost_equal
-        aae(mag_bins, [3, 4, 5, 6, 7])
-        aaae(dist_bins, [0., 4.2, 8.4, 12.6, 16.8, 21., 25.2, 29.4, 33.6,
-                         37.8, 42., 46.2, 50.4, 54.6])
-        aaae(lon_bins, [176.4, 177.6, 178.8, -180., -178.8])
-        aaae(lat_bins, [-25.2, -24., -22.8, -21.6, -20.4, -19.2, -18., -16.8,
-                        -15.6, -14.4, -13.2, -12., -10.8, -9.6, -8.4, -7.2,
-                        -6., -4.8, -3.6, -2.4, -1.2, 0., 1.2])
-        aae(eps_bins, [-1., -0.5, 0., 0.5, 1.])
-        self.assertIs(trt_bins, trt_bins_)
-
-
-class ArangeDataInBinsTestCase(unittest.TestCase):
-    def test(self):
-        mags = numpy.array([5, 5], float)
-        dists = numpy.array([6, 6], float)
-        lons = numpy.array([19, 19], float)
-        lats = numpy.array([41.5, 41.5], float)
-        trts = numpy.array([0, 0], int)
-        trt_bins = ['trt1', 'trt2']
-
-        probs_one_or_more = numpy.array([0.1] * len(mags)).reshape(2, 1)
-        probs_exceed_given_rup = numpy.ones((len(mags), 2)) * 0.1
-        probs_no_exceed = (1 - probs_one_or_more) ** probs_exceed_given_rup
-
-        bins_data = (mags, dists, lons, lats, trts, trt_bins,
-                     probs_no_exceed)
-
-        mag_bins = numpy.array([4, 6, 7], float)
-        dist_bins = numpy.array([0, 4, 8], float)
-        lon_bins = numpy.array([18, 20, 21], float)
-        lat_bins = numpy.array([40, 41, 42], float)
-        eps_bins = numpy.array([-2, 0, 2], float)
-
-        bin_edges = mag_bins, dist_bins, lon_bins, lat_bins, eps_bins, trt_bins
-
-        diss_matrix = disagg._arrange_data_in_bins(bins_data, bin_edges)
-
-        self.assertEqual(diss_matrix.shape, (2, 2, 2, 2, 2, 2))
-
-        for idx, value in [((0, 1, 0, 1, 0, 0), 0.02085163763902309),
-                           ((0, 1, 0, 1, 1, 0), 0.02085163763902309)]:
-            self.assertAlmostEqual(diss_matrix[idx], value)
-            diss_matrix[idx] = 0
-
-        self.assertEqual(diss_matrix.sum(), 0)
-
-
-class DisaggregateTestCase(_BaseDisaggTestCase):
-    def test(self):
-        self.gsim.truncation_level = self.truncation_level = 1
         bin_edges, matrix = disagg.disaggregation(
             self.sources, self.site, self.imt, self.iml, self.gsims,
             self.truncation_level, n_epsilons=3,
-            mag_bin_width=3, dist_bin_width=4, coord_bin_width=2.4
-        )
+            mag_bin_width=3, dist_bin_width=4, coord_bin_width=2.4)
         mag_bins, dist_bins, lon_bins, lat_bins, eps_bins, trt_bins = bin_edges
         aaae = numpy.testing.assert_array_almost_equal
         aaae(mag_bins, [3, 6, 9])
-        aaae(dist_bins, [0, 4, 8, 12, 16])
-        aaae(lon_bins, [9.6, 12., 14.4, 16.8, 19.2, 21.6, 24.])
-        aaae(lat_bins, [43.2, 45.6, 48.])
+        aaae(dist_bins, [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48,
+                         52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 96, 100,
+                         104, 108, 112])
+        aaae(lon_bins, [0, 2.4])
+        aaae(lat_bins, [0, 2.4])
         aaae(eps_bins, [-1, -0.3333333, 0.3333333, 1])
-        self.assertEqual(trt_bins, ['trt1', 'trt2'])
-        for idx, value in [((0, 2, 5, 0, 0, 0), 0.022067231457071457),
-                           ((0, 2, 5, 0, 1, 0), 0.043647500209963),
-                           ((0, 2, 5, 0, 2, 0), 0.022067231457071457),
-                           ((0, 3, 5, 0, 1, 0), 0.01982473192105061),
-                           ((0, 3, 5, 0, 2, 0), 0.003409751870464106),
-                           ((0, 2, 4, 0, 0, 0), 0.04290887394265486),
-                           ((0, 2, 4, 0, 1, 0), 0.09152318417708383),
-                           ((0, 2, 4, 0, 2, 0), 0.0438902176307755),
-                           ((1, 3, 5, 0, 0, 0), 0.03111383880273666),
-                           ((1, 3, 5, 0, 1, 0), 0.041268484485817325),
-                           ((1, 3, 5, 0, 2, 0), 0.03111383880273666),
-                           ((1, 3, 4, 0, 2, 0), 0.010480741793785553),
-                           ((1, 1, 0, 0, 1, 1), 0.004073878602149361),
-                           ((1, 1, 0, 0, 2, 1), 0.0016315473579483486),
-                           ((1, 1, 0, 1, 0, 1), 0.003041286638106211),
-                           ((1, 1, 0, 1, 1, 1), 0.015114219820389518),
-                           ((1, 1, 0, 1, 2, 1), 0.003041286638106211)]:
-            self.assertAlmostEqual(matrix[idx], value)
-            matrix[idx] = 0
-
-        self.assertEqual(matrix.sum(), 0)
-
-    def test_cross_idl(self):
-        # test disaggregation with source generating ruptures crossing
-        # internation date line
-        ruptures_and_poes = [
-            ([0, 0.2, 0.3], self.FakeRupture(5.5, 0.04, 55, -179.5, 45.5)),
-            ([0.4, 0.5, 0.6], self.FakeRupture(7.5, 0.03, 75, 179.5, 46.5))
-        ]
-        source = self.FakeSource(
-            1, [rupture for poes, rupture in ruptures_and_poes],
-            self.tom, 'trt1'
-        )
-
-        disagreggated_poes = dict(
-            (rupture, poes) for (poes, rupture) in ruptures_and_poes
-        )
-        gsim = self.FakeGSIM(self.iml, self.imt, truncation_level=1,
-                             n_epsilons=3,
-                             disaggregated_poes=disagreggated_poes)
-
-        bin_edges, matrix = disagg.disaggregation(
-            [source], self.site, self.imt, self.iml, {'trt1': gsim},
-            truncation_level=1, n_epsilons=3,
-            mag_bin_width=1, dist_bin_width=10, coord_bin_width=1.0
-        )
-        mag_bins, dist_bins, lon_bins, lat_bins, eps_bins, trt_bins = bin_edges
-        aaae = numpy.testing.assert_array_almost_equal
-        aaae(mag_bins, [5, 6, 7, 8])
-        aaae(dist_bins, [50, 60, 70, 80])
-        aaae(lon_bins, [179., -180, -179.])
-        aaae(lat_bins, [45., 46., 47.])
-        aaae(eps_bins, [-1, -0.3333333, 0.3333333, 1])
-        self.assertEqual(trt_bins, ['trt1'])
-        for idx, value in [((0, 0, 1, 0, 0, 0), 0),
-                           ((0, 0, 1, 0, 1, 0), 0.008131160717433694),
-                           ((0, 0, 1, 0, 2, 0), 0.012171913957925717),
-                           ((2, 2, 0, 1, 0, 0), 0.012109762440985716),
-                           ((2, 2, 0, 1, 1, 0), 0.015114219820389518),
-                           ((2, 2, 0, 1, 2, 0), 0.01810953978371055)]:
-            self.assertAlmostEqual(matrix[idx], value)
-            matrix[idx] = 0
-
-        self.assertEqual(matrix.sum(), 0)
-
-    def test_source_errors(self):
-        # exercise the case where an error occurs while computing on a given
-        # seismic source; in this case, we expect an error to be raised which
-        # signals the id of the source in question
-        fail_source = self.FailSource(self.source2.source_id,
-                                      self.source2.ruptures,
-                                      self.source2.tom,
-                                      self.source2.tectonic_region_type)
-        sources = iter([self.source1, fail_source])
-
-        with self.assertRaises(ValueError) as ae:
-            bin_edges, matrix = disagg.disaggregation(
-                sources, self.site, self.imt, self.iml, self.gsims,
-                self.truncation_level, n_epsilons=3,
-                mag_bin_width=3, dist_bin_width=4, coord_bin_width=2.4
-            )
-        expected_error = (
-            'An error occurred with source id=2. Error: Something bad happened'
-        )
-        self.assertEqual(expected_error, str(ae.exception))
-
-    def test_no_contributions_from_ruptures(self):
-        # Test that the `disaggregation` function returns `None, None` if no
-        # ruptures contribute to the hazard level.
-        array = numpy.array
-        float64 = numpy.float64
-        int64 = numpy.int64
-        # This is the result we get if the sources produce no ruptures:
-        fake_bins_data = (array([], dtype=float64), array([], dtype=float64),
-                          array([], dtype=float64), array([], dtype=float64),
-                          array([], dtype=float64), array([], dtype=int64), [])
-
-        with mock.patch(
-            'openquake.hazardlib.calc.disagg._collect_bins_data_old'
-        ) as cbd:
-            with warnings.catch_warnings(record=True) as w:
-                cbd.return_value = fake_bins_data
-
-                self.gsim.truncation_level = self.truncation_level = 1
-                bin_edges, matrix = disagg.disaggregation(
-                    self.sources, self.site, self.imt, self.iml, self.gsims,
-                    self.truncation_level, n_epsilons=3,
-                    mag_bin_width=3, dist_bin_width=4, coord_bin_width=2.4,
-                )
-
-                # We expect to get back 2 `None` values:
-                self.assertIsNone(bin_edges)
-                self.assertIsNone(matrix)
-
-                # Also check for the warning that should be raised:
-                expected_warning_msg = (
-                    'No ruptures have contributed to the hazard at site '
-                    '<Location=<Latitude=0.000000, Longitude=0.000000, '
-                    'Depth=0.0000>, Vs30=2.0000, Vs30Measured=False, '
-                    'Depth1.0km=4.0000, Depth2.5km=5.0000, Backarc=False>'
-                )
-                self.assertEqual(1, len(w))
-                [warning] = list(w)
-                self.assertEqual(expected_warning_msg, str(warning.message))
+        aaae(matrix.shape, (2, 28, 1, 1, 3, 60))
+        aaae(matrix.sum(), 6.14179818e-11)
 
 
 class PMFExtractorsTestCase(unittest.TestCase):
@@ -545,3 +211,4 @@ class PMFExtractorsTestCase(unittest.TestCase):
                         [0.999998665328, 0.999969082487, 0.999980380612]],
                        [[0.999447922645, 0.999996344798, 0.999999678475],
                         [0.999981572755, 0.999464007617, 0.999983196102]]])
+


### PR DESCRIPTION
After more than one year, finally closes https://github.com/gem/oq-engine/issues/2296. Now the hazardlib calculator `calc.disagg.disaggregation` uses the same functions used by the engine. Also, I am replacing the old tests, based on mocks, with new tests based on real sources and GSIMs.