### PR TITLE
Improved the error message if the user specifies a non-existing file in the job.ini

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Improved the error message if the user specifies a non-existing file in
+    the job.ini
   * Change the ordering of the TRT bins in disaggregation: now they are
     ordered lexicographically
   * Added more validity checks on the job.ini file for disaggregation

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1132,5 +1132,5 @@ def get_checksum32(oqparam):
             data = open(fname, 'rb').read()
             checksum = zlib.adler32(data, checksum) & 0xffffffff
         else:
-            raise ValueError('%s is not a file' % fname)
+            raise ValueError('%s does not exist or is not a file' % fname)
     return checksum


### PR DESCRIPTION
This happened to Anirudh and Cata.