### PR TITLE
Release of 2.7.0-3 standalone installers with an updated IPT

### DIFF
--- a/doc/installing/linux-generic.md
+++ b/doc/installing/linux-generic.md
@@ -30,14 +30,14 @@ Requirements are:
 
 ## Install packages from the OpenQuake website
 
-Download the installer from https://downloads.openquake.org/pkgs/linux/oq-engine/openquake-setup-linux64-2.7.0-2.run using any browser
+Download the installer from https://downloads.openquake.org/pkgs/linux/oq-engine/openquake-setup-linux64-2.7.0-3.run using any browser
 
 From a terminal run
 
 ```bash
 cd Downloads
-chmod +x openquake-setup-linux64-2.7.0-2.run
-./openquake-setup-linux64-2.7.0-2.run
+chmod +x openquake-setup-linux64-2.7.0-3.run
+./openquake-setup-linux64-2.7.0-3.run
 ```
 then follow the wizard on screen. By default the code is installed in `~/openquake`.
 

--- a/doc/installing/macos.md
+++ b/doc/installing/macos.md
@@ -20,14 +20,14 @@ Requirements are:
 
 ## Install packages from the OpenQuake website
 
-Download the installer from https://downloads.openquake.org/pkgs/macos/oq-engine/openquake-setup-macos-2.7.0-2.run using any browser
+Download the installer from https://downloads.openquake.org/pkgs/macos/oq-engine/openquake-setup-macos-2.7.0-3.run using any browser
 
 From the Terminal app (or using iTerm) run
 
 ```bash
 cd Downloads
-chmod +x openquake-setup-macos-2.7.0-2.run
-./openquake-setup-macos-2.7.0-2.run
+chmod +x openquake-setup-macos-2.7.0-3.run
+./openquake-setup-macos-2.7.0-3.run
 ```
 then follow the wizard on screen. By default the code is installed in `~/openquake`.
 

--- a/doc/installing/windows.md
+++ b/doc/installing/windows.md
@@ -21,7 +21,7 @@ Requirements are:
 
 ## Install or upgrade packages from the OpenQuake website
 
-Download the installer from https://downloads.openquake.org/pkgs/windows/oq-engine/OpenQuake_Engine_2.7.0-2.exe using any browser and run the installer, then follow the wizard on screen.
+Download the installer from https://downloads.openquake.org/pkgs/windows/oq-engine/OpenQuake_Engine_2.7.0-3.exe using any browser and run the installer, then follow the wizard on screen.
 
 ![installer-screenshot-1](../img/win-installer-1.png)
 ![installer-screenshot-2](../img/win-installer-2.png)


### PR DESCRIPTION
We released installers `2.7.0-3`

Blocked by https://ci.openquake.org/job/builders/job/installers-builder/54/