### PR TITLE
Fixed a missing magnitude bug, breaking Jenkins in systems without rtree

### DIFF
--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -413,7 +413,7 @@ class SourceFilter(object):
                     src.nsites = len(sids)
                     yield src, FilteredSiteCollection(sids, sites.complete)
             else:  # normal filtering, used in the workers
-                _, maxmag = src.mfd.get_min_max_mag()
+                _, maxmag = src.get_min_max_mag()
                 maxdist = self.integration_distance(
                     src.tectonic_region_type, maxmag)
                 with context(src):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -413,7 +413,9 @@ class SourceFilter(object):
                     src.nsites = len(sids)
                     yield src, FilteredSiteCollection(sids, sites.complete)
             else:  # normal filtering, used in the workers
-                maxdist = self.integration_distance(src.tectonic_region_type)
+                _, maxmag = src.mfd.get_min_max_mag()
+                maxdist = self.integration_distance(
+                    src.tectonic_region_type, maxmag)
                 with context(src):
                     s_sites = src.filter_sites_by_distance_to_source(
                         maxdist, sites)


### PR DESCRIPTION
Fixes https://ci.openquake.org/job/macos/job/master_macos_engine/label=macos,python=python3.5/182/testReport/openquake.calculators.tests.classical_test/ClassicalTestCase/test_case_19/

Since the maximum magnitude was not specified the retrieved `maxdist` was of 2000 km, too large, and causing the error in `src.get_rupture_enclosing_polygon(integration_distance)`.  This was introduced by the recent changes in https://github.com/gem/oq-engine/pull/3251.