### PR TITLE
Optimized the sending of the sources in the classical calculator

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -556,7 +556,8 @@ class Starmap(object):
         :param acc: the initial value of the accumulator
         :returns: the final value of the accumulator
         """
-        acc = self.submit_all().reduce(agg, acc or AccumDict())
+        acc = AccumDict() if acc is None else acc
+        acc = self.submit_all().reduce(agg, acc)
         self.results = []
         return acc
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -200,7 +200,7 @@ class PSHACalculator(base.HazardCalculator):
         for trt, sources in csm.get_sources_by_trt(opt).items():
             gsims = csm.info.gsim_lt.get_gsims(trt)
             self.csm.add_infos(sources)  # update self.csm.infos
-            for block in csm.split_sources(maxweight, sources):
+            for block in csm.split_in_blocks(maxweight, sources):
                 yield block, csm.src_filter, gsims, param
 
     def post_execute(self, pmap_by_grp_id):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -205,9 +205,6 @@ class PSHACalculator(base.HazardCalculator):
             if sg.src_interdep == 'mutex':
                 gsims = csm.info.gsim_lt.get_gsims(sg.trt)
                 self.csm.add_infos(sg.sources)  # update self.csm.infos
-                # sg.samples = sg.sources[0].samples
-                # FIXME: case_27 raise an error 'NonParametricSeismicSource'
-                # object has no attribute 'samples'
                 yield sg, csm.src_filter, gsims, param
 
     def _args_by_trt(self, csm, param, num_tiles, maxweight):
@@ -216,7 +213,6 @@ class PSHACalculator(base.HazardCalculator):
             gsims = csm.info.gsim_lt.get_gsims(trt)
             self.csm.add_infos(sources)  # update self.csm.infos
             for block in csm.split_sources(maxweight, sources):
-                block.samples = sources[0].samples
                 yield block, csm.src_filter, gsims, param
 
     def store_source_info(self, infos, acc):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -78,7 +78,7 @@ class PSHACalculator(base.HazardCalculator):
             # TODO: think about how to store source information for the case
             # of multiple grp_ids
             try:
-                [grp_id] = pmap.eff_ruptures
+                [grp_id] = pmap
             except ValueError:
                 pass
             else:
@@ -90,7 +90,8 @@ class PSHACalculator(base.HazardCalculator):
                     info.num_split += 1
             acc.eff_ruptures += pmap.eff_ruptures
             for grp_id in pmap:
-                acc[grp_id] |= pmap[grp_id]
+                if pmap[grp_id]:
+                    acc[grp_id] |= pmap[grp_id]
         return acc
 
     def count_eff_ruptures(self, result_dict, src_group_id):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -212,7 +212,7 @@ class PSHACalculator(base.HazardCalculator):
         for sg in csm.src_groups:
             if sg.src_interdep == 'mutex':
                 gsims = csm.info.gsim_lt.get_gsims(sg.trt)
-                csm.add_infos(sg.sources)
+                self.csm.add_infos(sg.sources)  # update self.csm.infos
                 # sg.samples = sg.sources[0].samples
                 # FIXME: case_27 raise an error 'NonParametricSeismicSource'
                 # object has no attribute 'samples'
@@ -221,7 +221,7 @@ class PSHACalculator(base.HazardCalculator):
     def _args_by_trt(self, csm, src_filter, param, num_tiles, maxweight):
         for trt, sources in self.sources_by_trt.items():
             gsims = csm.info.gsim_lt.get_gsims(trt)
-            csm.add_infos(sources)
+            self.csm.add_infos(sources)  # update self.csm.infos
             for block in csm.split_sources(
                     sources, src_filter, maxweight):
                 block.samples = sources[0].samples

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -143,10 +143,10 @@ class PSHACalculator(base.HazardCalculator):
                 # then the Starmap will understand the case of a single
                 # argument tuple and it will run in core the task
                 iterargs = list(iterargs)
-            acc = parallel.Starmap(pmap_from_trt, iterargs).reduce(
-                self.agg_dicts, self.zerodict())
-            if mutex_groups:  # collect them too
-                acc = ires.reduce(self.agg_dicts, acc)
+            ires2 = parallel.Starmap(pmap_from_trt, iterargs).submit_all()
+        acc = ires2.reduce(self.agg_dicts, self.zerodict())
+        if mutex_groups:  # collect them too
+            acc = ires.reduce(self.agg_dicts, acc)
         with self.monitor('store source_info', autoflush=True):
             self.store_source_info(self.csm.infos, acc)
         return acc

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -89,11 +89,8 @@ class PSHACalculator(base.HazardCalculator):
                     info.num_sites = max(info.num_sites, nsites)
                     info.num_split += 1
             acc.eff_ruptures += pmap.eff_ruptures
-            if isinstance(pmap, ProbabilityMap):
-                acc[grp_id] |= pmap
-            else:  # dictionary of pmaps
-                for grp_id in pmap:
-                    acc[grp_id] |= pmap[grp_id]
+            for grp_id in pmap:
+                acc[grp_id] |= pmap[grp_id]
         return acc
 
     def count_eff_ruptures(self, result_dict, src_group_id):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -63,7 +63,7 @@ class PSHACalculator(base.HazardCalculator):
     """
     Classical PSHA calculator
     """
-    core_task = pmap_from_grp
+    core_task = pmap_from_trt
     source_info = datastore.persistent_attribute('source_info')
 
     def agg_dicts(self, acc, pmap):
@@ -132,7 +132,8 @@ class PSHACalculator(base.HazardCalculator):
                 # then the Starmap will understand the case of a single
                 # argument tuple and it will run in core the task
                 iterargs = list(iterargs)
-            ires2 = parallel.Starmap(pmap_from_trt, iterargs).submit_all()
+            ires2 = parallel.Starmap(
+                self.core_task.__func__, iterargs).submit_all()
         acc = ires2.reduce(self.agg_dicts, self.zerodict())
         if mutex_groups:  # collect them too
             acc = ires.reduce(self.agg_dicts, acc)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -161,10 +161,7 @@ class PSHACalculator(base.HazardCalculator):
         :yields: (sources, sites, gsims, monitor) tuples
         """
         oq = self.oqparam
-        if self.is_stochastic:  # disable tiling
-            num_tiles = 1
-        else:
-            num_tiles = math.ceil(len(self.sitecol) / oq.sites_per_tile)
+        num_tiles = math.ceil(len(self.sitecol) / oq.sites_per_tile)
         if num_tiles > 1:
             tiles = self.sitecol.split_in_tiles(num_tiles)
         else:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -280,12 +280,12 @@ class EventBasedRuptureCalculator(PSHACalculator):
         csm = self.csm
         num_tasks = 0
         num_sources = 0
-        for sg in csm.src_groups:
-            gsims = csm.info.gsim_lt.get_gsims(sg.trt)
-            csm.add_infos(sg.sources)
+        for trt, sources in csm.get_sources_by_trt().items():
+            gsims = csm.info.gsim_lt.get_gsims(trt)
+            csm.add_infos(sources)
             for block in csm.split_sources(
-                    sg.sources, self.src_filter, maxweight):
-                block.samples = sg.sources[0].samples
+                    sources, self.src_filter, maxweight):
+                block.samples = sources[0].samples
                 yield block, self.src_filter, gsims, param, monitor
                 num_tasks += 1
                 num_sources += len(block)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -281,7 +281,7 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
             for sg in sm.src_groups:
                 gsims = csm.info.gsim_lt.get_gsims(sg.trt)
                 csm.add_infos(sg.sources)
-                for block in csm.split_sources(maxweight, sg.sources):
+                for block in csm.split_in_blocks(maxweight, sg.sources):
                     block.samples = sm.samples
                     yield block, self.src_filter, gsims, param, monitor
                     num_tasks += 1

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -273,7 +273,6 @@ class EventBasedRuptureCalculator(PSHACalculator):
             truncation_level=oq.truncation_level,
             imtls=oq.imtls, seed=oq.ses_seed,
             maximum_distance=oq.maximum_distance,
-            disagg=oq.poes_disagg or oq.iml_disagg,
             ses_per_logic_tree_path=oq.ses_per_logic_tree_path)
 
         num_tasks = 0

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -253,11 +253,12 @@ class EventBasedRuptureCalculator(PSHACalculator):
                     if self.oqparam.save_ruptures:
                         self.rupser.save(ebrs, eidx=len(dset)-len(events))
 
-    def gen_args(self, monitor):
+    def gen_args(self, csm, monitor):
         """
         Used in the case of large source model logic trees.
 
         :param monitor: a :class:`openquake.baselib.performance.Monitor`
+        :param csm: a reduced CompositeSourceModel
         :yields: (sources, sites, gsims, monitor) tuples
         """
         oq = self.oqparam
@@ -275,7 +276,6 @@ class EventBasedRuptureCalculator(PSHACalculator):
             disagg=oq.poes_disagg or oq.iml_disagg,
             ses_per_logic_tree_path=oq.ses_per_logic_tree_path)
 
-        csm = self.csm
         num_tasks = 0
         num_sources = 0
         for sm in csm.source_models:
@@ -293,7 +293,7 @@ class EventBasedRuptureCalculator(PSHACalculator):
         mutex_groups = list(self.csm.gen_mutex_groups())
         assert not mutex_groups, 'Mutex sources are not implemented!'
         with self.monitor('managing sources', autoflush=True):
-            allargs = self.gen_args(self.monitor('pmap_from_trt'))
+            allargs = self.gen_args(self.csm, self.monitor('pmap_from_trt'))
             iterargs = saving_sources_by_task(allargs, self.datastore)
             if isinstance(allargs, list):
                 # there is a trick here: if the arguments are known

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -36,7 +36,7 @@ from openquake.baselib import parallel
 from openquake.commonlib import calc, util, readinput
 from openquake.calculators import base
 from openquake.calculators.classical import (
-    ClassicalCalculator, PSHACalculator, saving_sources_by_task)
+    ClassicalCalculator, saving_sources_by_task)
 
 U8 = numpy.uint8
 U16 = numpy.uint16
@@ -194,7 +194,7 @@ def get_events(ebruptures):
 
 
 @base.calculators.add('event_based_rupture')
-class EventBasedRuptureCalculator(PSHACalculator):
+class EventBasedRuptureCalculator(base.HazardCalculator):
     """
     Event based PSHA calculator generating the ruptures only
     """

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -442,7 +442,7 @@ def update_nbytes(dstore, key, array):
 
 
 @base.calculators.add('event_based')
-class EventBasedCalculator(ClassicalCalculator):
+class EventBasedCalculator(base.HazardCalculator):
     """
     Event based PSHA calculator generating the ground motion fields and
     the hazard curves from the ruptures, depending on the configuration

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -56,8 +56,8 @@ class ClassicalTestCase(CalculatorTestCase):
             # make sure we saved the data transfer information in job_info
             keys = {decode(key) for key in dict(
                 self.calc.datastore['job_info'])}
-            self.assertIn('pmap_from_grp.received', keys)
-            self.assertIn('pmap_from_grp.sent', keys)
+            self.assertIn('pmap_from_trt.received', keys)
+            self.assertIn('pmap_from_trt.sent', keys)
 
         # there is a single source
         self.assertEqual(len(self.calc.datastore['source_info']), 1)

--- a/openquake/calculators/tests/classical_tiling_test.py
+++ b/openquake/calculators/tests/classical_tiling_test.py
@@ -23,7 +23,7 @@ from openquake.qa_tests_data.classical_tiling import case_1, case_2
 
 
 class ClassicalTilingTestCase(CalculatorTestCase):
-    @attr('qa', 'hazard', 'classical_tiling')
+    @attr('qa', 'hazard', 'classical')
     def test_case_1(self):
         out = self.run_calc(case_1.__file__, 'job.ini', exports='csv')
         expected = [
@@ -38,7 +38,7 @@ class ClassicalTilingTestCase(CalculatorTestCase):
         for fname, actual in zip(expected, got):
             self.assertEqualFiles('expected/%s' % fname, actual, delta=1E-6)
 
-    @attr('qa', 'hazard', 'classical_tiling')
+    @attr('qa', 'hazard', 'classical')
     def test_case_2(self):
         self.run_calc(case_2.__file__, 'job.ini', exports='csv,geojson')
         [fname] = export(('hmaps', 'csv'), self.calc.datastore)

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -93,6 +93,7 @@ def ucerf_classical(rupset_idx, ucerf_source, src_filter, gsims, monitor):
     truncation_level = monitor.oqparam.truncation_level
     imtls = monitor.oqparam.imtls
     ucerf_source.src_filter = src_filter  # so that .iter_ruptures() work
+    grp_id = ucerf_source.src_group_id
 
     # prefilter the sites close to the rupture set
     with h5py.File(ucerf_source.control.source_file, "r") as hdf5:
@@ -108,10 +109,10 @@ def ucerf_classical(rupset_idx, ucerf_source, src_filter, gsims, monitor):
         s_sites = ucerf_source.get_rupture_sites(hdf5, ridx, src_filter, mag)
         if s_sites is None:  # return an empty probability map
             pm = ProbabilityMap(len(imtls.array), len(gsims))
-            pm.calc_times = []  # TODO: fix .calc_times
-            pm.eff_ruptures = {ucerf_source.src_group_id: 0}
-            pm.grp_id = ucerf_source.src_group_id
-            return pm
+            acc = AccumDict({grp_id: pm})
+            acc.calc_times = []  # TODO: fix .calc_times
+            acc.eff_ruptures = {grp_id: 0}
+            return acc
 
     # compute the ProbabilityMap by using hazardlib.calc.hazard_curve.poe_map
     ucerf_source.rupset_idx = rupset_idx
@@ -124,11 +125,11 @@ def ucerf_classical(rupset_idx, ucerf_source, src_filter, gsims, monitor):
     pmap = poe_map(ucerf_source, s_sites, imtls, cmaker,
                    truncation_level, ctx_mon, pne_mons)
     nsites = len(s_sites)
-    pmap.calc_times = [
+    acc = AccumDict({grp_id: pmap})
+    acc.calc_times = [
         (ucerf_source.source_id, nruptures * nsites, nsites, time.time() - t0)]
-    pmap.grp_id = ucerf_source.src_group_id
-    pmap.eff_ruptures = {pmap.grp_id: ucerf_source.num_ruptures}
-    return pmap
+    acc.eff_ruptures = {grp_id: ucerf_source.num_ruptures}
+    return acc
 
 
 @base.calculators.add('ucerf_psha')

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -25,7 +25,7 @@ import h5py
 from openquake.baselib.general import DictArray, AccumDict
 from openquake.baselib import parallel
 from openquake.hazardlib.probability_map import ProbabilityMap
-from openquake.hazardlib.calc.hazard_curve import pmap_from_grp, poe_map
+from openquake.hazardlib.calc.hazard_curve import pmap_from_trt, poe_map
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.hazardlib import valid
@@ -74,8 +74,7 @@ SourceConverter.convert_UCERFSource = convert_UCERFSource
 
 
 @util.reader
-def ucerf_classical(
-        rupset_idx, ucerf_source, src_filter, gsims, monitor):
+def ucerf_classical(rupset_idx, ucerf_source, src_filter, gsims, monitor):
     """
     :param rupset_idx:
         indices of the rupture sets
@@ -188,7 +187,7 @@ class UcerfPSHACalculator(classical.PSHACalculator):
             # parallelize on the background sources, small tasks
             args = (bckgnd_sources, self.src_filter, gsims, param, monitor)
             bg_res = parallel.Starmap.apply(
-                pmap_from_grp, args, name='background_sources_%d' % grp_id,
+                pmap_from_trt, args, name='background_sources_%d' % grp_id,
                 concurrent_tasks=ct2).submit_all()
 
             # parallelize by rupture subsets
@@ -202,7 +201,7 @@ class UcerfPSHACalculator(classical.PSHACalculator):
 
             # compose probabilities from background sources
             for pmap in bg_res:
-                acc[grp_id] |= pmap
+                acc[grp_id] |= pmap[grp_id]
 
         with self.monitor('store source_info', autoflush=True):
             self.store_source_info(self.csm.infos, acc)

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -642,6 +642,7 @@ class UcerfSource(object):
                     ctl.mesh_spacing, ctl.msr, ctl.aspect, ctl.tom, ctl.usd,
                     ctl.lsd, Point(locations[i, 0], locations[i, 1]),
                     ctl.npd, ctl.hdd)
+                ps.src_group_id = self.src_group_id
                 sources.append(ps)
         return sources
 
@@ -762,8 +763,8 @@ class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
         logging.warn('%s is still experimental', self.__class__.__name__)
         oq = self.oqparam
         self.read_risk_data()  # read the site collection
-        self.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
         self.csm = get_composite_source_model(oq)
+        self.csm.src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
         logging.info('Found %d source model logic tree branches',
                      len(self.csm.source_models))
         self.datastore['csm_info'] = self.csm_info = self.csm.info
@@ -793,7 +794,8 @@ class UCERFRuptureCalculator(event_based.EventBasedRuptureCalculator):
                 ses_seeds = [(ses_idx, oq.ses_seed + ses_idx)]
                 param = dict(ses_seeds=ses_seeds, samples=sm.samples,
                              save_ruptures=oq.save_ruptures)
-                allargs.append((srcs, self.src_filter, gsims, param, monitor))
+                allargs.append(
+                    (srcs, self.csm.src_filter, gsims, param, monitor))
         return allargs
 
 
@@ -882,7 +884,7 @@ class UCERFRiskCalculator(EbriskCalculator):
                              elt_dt=elt_dt,
                              asset_loss_table=False,
                              insured_losses=oq.insured_losses)
-                yield (ssm, self.src_filter, param,
+                yield (ssm, self.csm.src_filter, param,
                        self.riskmodel, imts, oq.truncation_level,
                        correl_model, min_iml, monitor)
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -632,7 +632,7 @@ def view_task(token, dstore):
      $ oq show task:0  # the fastest task
      $ oq show task:-1  # the slowest task
     """
-    data = dstore['task_info/classical'].value
+    data = dstore['task_info/pmap_from_trt'].value
     data.sort(order='duration')
     i = int(token.split(':')[1])
     taskno, weight, duration = data[i]

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -811,30 +811,23 @@ class CompositeSourceModel(collections.Sequence):
             for grp_id in src.src_group_ids:
                 self.infos[grp_id, src.source_id] = SourceInfo(src)
 
-    def split_sources(self, sources=None, src_filter=None, maxweight=None,
-                      concurrent_tasks=None):
+    def split_sources(self, maxweight, sources=None):
         """
         Split a set of sources of the same source group; light sources
         (i.e. with weight <= maxweight) are not split.
 
         :param sources: sources of the same source group
-        :param src_filter: SourceFilter instance
-        :param maxweight: weight used to decide if a source is light
         :yields: blocks of sources of weight around maxweight
         """
         if sources is None:
             sources = self.get_sources()
-        if src_filter is None:
-            src_filter = self.src_filter
-        if maxweight is None:
-            maxweight = self.get_maxweight(concurrent_tasks)
         light = [src for src in sources if src.weight <= maxweight]
         for block in block_splitter(
                 light, maxweight, weight=operator.attrgetter('weight')):
             yield block
         heavy = [src for src in sources if src.weight > maxweight]
         for src in heavy:
-            srcs = split_filter_source(src, src_filter)
+            srcs = split_filter_source(src, self.src_filter)
             for block in block_splitter(
                     srcs, maxweight, weight=operator.attrgetter('weight')):
                 yield block

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -752,12 +752,10 @@ class CompositeSourceModel(collections.Sequence):
         for sm in self.source_models:
             for grp in sm.src_groups:
                 if grp.src_interdep != 'mutex':
-                    for src in grp:
-                        src.sm_id = sm.ordinal
-                        src.samples = sm.samples
                     acc[grp.trt].extend(grp)
         if optimize_same_id_sources is False:
             return acc
+        # extract a single source from multiple sources with the same ID
         dic = {}
         weight = 0
         for trt in acc:

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -764,7 +764,9 @@ class CompositeSourceModel(collections.Sequence):
             for grp in groupby(acc[trt], lambda x: x.source_id).values():
                 src = grp[0]
                 weight += src.weight
-                if len(grp) > 1:
+                if len(grp) > 1 and not isinstance(src.src_group_id, list):
+                    # src.src_group_id could be a list because grouped in a
+                    # previous step (this may happen in presence of tiles)
                     src.src_group_id = [s.src_group_id for s in grp]
                 dic[trt].append(src)
         self.weight = weight

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -829,7 +829,8 @@ class CompositeSourceModel(collections.Sequence):
             yield block
         heavy = [src for src in sources if src.weight > maxweight]
         for src in heavy:
-            srcs = split_filter_source(src, self.src_filter)
+            srcs = [src for src in split_source(src)
+                    if self.src_filter.get_close_sites(src) is not None]
             for block in block_splitter(srcs, maxweight, weight):
                 yield block
 
@@ -858,14 +859,12 @@ class CompositeSourceModel(collections.Sequence):
 split_map = {}  # src -> split sources
 
 
-def split_filter_source(src, src_filter):
+def split_source(src):
     """
     :param src: a source to split
-    :param src_filter: a SourceFilter instance
     :returns: a list of split sources
     """
     has_serial = hasattr(src, 'serial')
-    split_sources = []
     start = 0
     try:
         splits = split_map[src]  # read from the cache
@@ -880,9 +879,7 @@ def split_filter_source(src, src_filter):
             nr = split.num_ruptures
             split.serial = src.serial[start:start + nr]
             start += nr
-        if src_filter.get_close_sites(split) is not None:
-            split_sources.append(split)
-    return split_sources
+        yield split
 
 
 def collect_source_model_paths(smlt):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -814,7 +814,7 @@ class CompositeSourceModel(collections.Sequence):
 
     def split_in_blocks(self, maxweight, sources=None):
         """
-        Split a set of sources in blocks up weight up to maxweight; heavy
+        Split a set of sources in blocks of weight up to maxweight; heavy
         sources (i.e. with weight > maxweight) are split.
 
         :param maxweight: maximum weight of a block

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -633,7 +633,7 @@ class CompositeSourceModel(collections.Sequence):
             [sm.get_skeleton() for sm in self.source_models],
             self.weight)
         # dictionary src_group_id, source_id -> SourceInfo,
-        # populated by the split_sources method
+        # populated by the split_in_blocks method
         self.infos = {}
         try:
             dupl_sources = self.check_dupl_sources()
@@ -809,7 +809,7 @@ class CompositeSourceModel(collections.Sequence):
             for grp_id in src.src_group_ids:
                 self.infos[grp_id, src.source_id] = SourceInfo(src)
 
-    def split_sources(self, maxweight, sources=None):
+    def split_in_blocks(self, maxweight, sources=None):
         """
         Split a set of sources of the same source group; light sources
         (i.e. with weight <= maxweight) are not split.

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -747,7 +747,8 @@ class CompositeSourceModel(collections.Sequence):
 
     def get_sources_by_trt(self, optimize_same_id_sources=False):
         """
-        Build a dictionary TRT string -> sources
+        Build a dictionary TRT string -> sources. Sources of kind "mutex"
+        (if any) are silently discarded.
         """
         acc = AccumDict(accum=[])
         for sm in self.source_models:

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -754,6 +754,13 @@ class CompositeSourceModelTestCase(unittest.TestCase):
         # the example has number_of_logic_tree_samples = 1
         sitecol = readinput.get_site_collection(oqparam)
         csm = readinput.get_composite_source_model(oqparam, sitecol)
+
+        # check the attributes of the groups are set
+        [grp0, grp1] = csm.src_groups
+        for grp in csm.src_groups:
+            self.assertEqual(grp.src_interdep, 'indep')
+            self.assertEqual(grp.rup_interdep, 'indep')
+
         self.assertEqual(repr(csm.gsim_lt), '''\
 <GsimLogicTree
 Active Shallow Crust,b1,SadighEtAl1997(),w=0.5

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -187,7 +187,9 @@ def pmap_from_grp(group, src_filter, gsims, param, monitor=Monitor()):
                 pcurve += poemap[sid] * weight
             calc_times.append(
                 (src.source_id, src.weight, len(s_sites), time.time() - t0))
-        acc = AccumDict({group.id: pmap * (group.grp_probability or 1)})
+        if group.grp_probability is not None:
+            pmap *= group.grp_probability
+        acc = AccumDict({group.id: pmap})
         # adding the number of contributing ruptures too
         acc.eff_ruptures = {group.id: pne_mons[0].counts}
         acc.calc_times = calc_times

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -156,7 +156,6 @@ def pmap_from_grp(group, src_filter, gsims, param, monitor=Monitor()):
     :returns: a dictionary {grp_id: ProbabilityMap instance}
     """
     sources = group.sources
-    trt = sources[0].tectonic_region_type
     mutex_weight = {src.source_id: weight for src, weight in
                     zip(group.sources, group.srcs_weights)}
     maxdist = src_filter.integration_distance

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -116,7 +116,7 @@ class SourceGroup(collections.Sequence):
             for src in sorted(sources, key=operator.attrgetter('source_id')):
                 self.update(src)
         self.source_model = None  # to be set later, in CompositionInfo
-        self.eff_ruptures = eff_ruptures  # set later nby get_rlzs_assoc
+        self.eff_ruptures = eff_ruptures  # set later by get_rlzs_assoc
 
     def _check_init_variables(self, src_list, name, src_interdep, rup_interdep,
                               srcs_weights):
@@ -897,8 +897,8 @@ class SourceConverter(RuptureConverter):
                 raise ValueError('There are %d srcs_weights but %d source(s)'
                                  % (len(srcs_weights), len(node)))
         sg.name = node.attrib.get('name')
-        sg.src_interdep = node.attrib.get('src_interdep')
-        sg.rup_interdep = node.attrib.get('rup_interdep')
+        sg.src_interdep = node.attrib.get('src_interdep', 'indep')
+        sg.rup_interdep = node.attrib.get('rup_interdep', 'indep')
         sg._srcs_weights = srcs_weights
         sg.grp_probability = grp_probability
         return sg

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -150,7 +150,7 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
         param = dict(imtls=self.imtls)
         crv = pmap_from_grp(group, self.sites, gsim_by_trt, param)[0]
         npt.assert_almost_equal(numpy.array([0.35000, 0.32497, 0.10398]),
-                                crv.array[:, 0], decimal=4)
+                                crv[0].array[:, 0], decimal=4)
 
     def test_raise_error_non_uniform_group(self):
         # Test that the uniformity of a group (in terms of tectonic region)


### PR DESCRIPTION
Instead of sending the sources by SourceGroup, we can send them by tectonic region type, except for mutex sources. This makes the operation `managing sources` a lot faster. In the case of SHARE we went down from 3,159s to 1,229s. Also, the tasks become more homogeneous.

PS: while at it, I have also decouple the EventBasedCalculator from the ClassicalCalculator: there is no more an inheritance relationship. This is a lot cleaner conceptually and makes changing the calculators easier, at the cost of adding a few lines of code.