### PR TITLE
Made `oq show` show the calculations of other users

### DIFF
--- a/openquake/commands/show.py
+++ b/openquake/commands/show.py
@@ -19,7 +19,6 @@
 from __future__ import print_function
 import io
 import os
-import getpass
 import logging
 import numpy
 
@@ -33,11 +32,11 @@ from openquake.calculators.views import view
 from openquake.calculators.extract import extract
 
 if config.dbserver.multi_user:
-    # get the datastore of the user who ran the job
     def read(calc_id):
-        job = logs.dbcmd('get_job', calc_id, getpass.getuser())
-        datadir = os.path.dirname(job.ds_calc_dir)
-        return datastore.read(job.id, datadir=datadir)
+        job = logs.dbcmd('get_job', calc_id)
+        if job:
+            return datastore.read(job.ds_calc_dir + '.hdf5')
+        return datastore.read(calc_id)
 else:  # get the datastore of the current user
     read = datastore.read
 

--- a/openquake/commands/show.py
+++ b/openquake/commands/show.py
@@ -36,6 +36,8 @@ if config.dbserver.multi_user:
         job = logs.dbcmd('get_job', calc_id)
         if job:
             return datastore.read(job.ds_calc_dir + '.hdf5')
+        # calc_id can be present in the datastore and not in the database:
+        # this happens if the calculation was run with `oq run`
         return datastore.read(calc_id)
 else:  # get the datastore of the current user
     read = datastore.read


### PR DESCRIPTION
This was the behavior of the past. Recently I have "fixed" it so that only the calculations of the current user could be shown. This is really inconvenient, since all the time I want to do `oq show performance calc_id` for the calculations of the scientists. I think it is fine if the `oq show` command bypasses the Django authentication, since it can be used only by trusted users with ssh access.