### PR TITLE
Fixed the filtering of MultiPointSources

### DIFF
--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -674,16 +674,16 @@ class CompositeSourceModel(collections.Sequence):
             src_groups = []
             for src_group in sm.src_groups:
                 sources = []
-                for src, sites in src_filter(src_group.sources):
+                for src in src_group.sources:
                     if hasattr(src, '__iter__'):  # MultiPointSource
-                        for s, _sites in src_filter(src, sites):
-                            sources.append(s)
-                            weight += s.weight
+                        sources.extend(src)
                     else:
                         sources.append(src)
-                        weight += src.weight
                 sg = copy.copy(src_group)
-                sg.sources = sources
+                sg.sources = []
+                for src, sites in src_filter(sources):
+                    sg.sources.append(src)
+                    weight += src.weight
                 src_groups.append(sg)
             newsm = logictree.SourceModel(
                 sm.name, sm.weight, sm.path, src_groups,


### PR DESCRIPTION
The right order is

1) split the MultiPointSource
2) filter it

Instead we were using the opposite order and a MultiPointSource was incorrectly discarded in absence
of rtree. It means that `MultiPointSource.filter_sites_by_distance_to_source` does not work too well in some cases (it particular for test case_22, crossing the international date line). 

Fixes https://ci.openquake.org/job/macos/job/master_macos_engine/label=macos,python=python3.5/192/