### PR TITLE
Raise an error if both `iml_disagg` and `poes_disagg` are given

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * `iml_disagg` and `poes_disagg` cannot coexists in the job.ini file
   * Added a check on `conditional_loss_poes` in the event_based_risk calculator:
     now it requires `asset_loss_table` to be set
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * `iml_disagg` and `poes_disagg` cannot coexists in the job.ini file
+  * `iml_disagg` and `poes_disagg` cannot coexist in the job.ini file
   * Added a check on `conditional_loss_poes` in the event_based_risk calculator:
     now it requires `asset_loss_table` to be set
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -210,9 +210,9 @@ class OqParam(valid.ParamSet):
                 raise InvalidFile('poes_disagg or iml_disagg must be set '
                                   'in %(job_ini)s' % self.inputs)
             elif self.poes_disagg and self.iml_disagg:
-                raise ValueError(
-                    'iml_disagg and poes_disagg cannot be set '
-                    'at the same time in %(job_ini)s' % self.inputs)
+                raise InvalidFile(
+                    '%s: iml_disagg and poes_disagg cannot be set '
+                    'at the same time' % job_ini)
             for k in ('mag_bin_width', 'distance_bin_width',
                       'coordinate_bin_width', 'num_epsilon_bins'):
                 if k not in vars(self):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -155,8 +155,9 @@ class OqParam(valid.ParamSet):
 
     def __init__(self, **names_vals):
         super(OqParam, self).__init__(**names_vals)
+        job_ini = self.inputs['job_ini']
         if 'calculation_mode' not in names_vals:
-            raise ValueError('Missing calculation_mode in the .ini file!')
+            raise InvalidFile('Missing calculation_mode in %s' % job_ini)
         self.risk_investigation_time = (
             self.risk_investigation_time or self.investigation_time)
         if ('intensity_measure_types_and_levels' in names_vals and
@@ -166,9 +167,10 @@ class OqParam(valid.ParamSet):
         if 'iml_disagg' in names_vals:
             self.hazard_imtls = self.iml_disagg
             if 'intensity_measure_types_and_levels' in names_vals:
-                raise ValueError(
-                    'Please remove the intensity_measure_types_and_levels: '
-                    'they will be inferred from the iml_disagg dictionary')
+                raise InvalidFile(
+                    'Please remove the intensity_measure_types_and_levels '
+                    'from %s: they will be inferred from the iml_disagg '
+                    'dictionary' % job_ini)
         elif 'intensity_measure_types_and_levels' in names_vals:
             self.hazard_imtls = self.intensity_measure_types_and_levels
             delattr(self, 'intensity_measure_types_and_levels')
@@ -180,8 +182,8 @@ class OqParam(valid.ParamSet):
         # check the gsim_logic_tree
         if 'gsim_logic_tree' in self.inputs:
             if self.gsim:
-                raise ValueError('If `gsim_logic_tree_file` is set, there '
-                                 'must be no `gsim` key')
+                raise InvalidFile('%s: if `gsim_logic_tree_file` is set, there'
+                                  ' must be no `gsim` key' % job_ini)
             path = os.path.join(
                 self.base_path, self.inputs['gsim_logic_tree'])
             gsim_lt = logictree.GsimLogicTree(path, ['*'])
@@ -190,8 +192,8 @@ class OqParam(valid.ParamSet):
             branchsets = len(gsim_lt._ltnode)
             if 'scenario' in self.calculation_mode and branchsets > 1:
                 raise InvalidFile(
-                    '%s for a scenario calculation must contain a single '
-                    'branchset, found %d!' % (path, branchsets))
+                    '%s: %s for a scenario calculation must contain a single '
+                    'branchset, found %d!' % (job_ini, path, branchsets))
 
             # check the IMTs vs the GSIMs
             self._gsims_by_trt = gsim_lt.values
@@ -205,23 +207,23 @@ class OqParam(valid.ParamSet):
         # checks for disaggregation
         if self.calculation_mode == 'disaggregation':
             if not self.poes_disagg and not self.iml_disagg:
-                raise ValueError('poes_disagg or iml_disagg must be set '
-                                 'in the job.ini file')
+                raise InvalidFile('poes_disagg or iml_disagg must be set '
+                                  'in %(job_ini)s' % self.inputs)
             elif self.poes_disagg and self.iml_disagg:
-                logging.warn(
-                    'iml_disagg=%s will not be computed from poes_disagg=%s',
-                    str(self.iml_disagg), self.poes_disagg)
+                raise ValueError(
+                    'iml_disagg and poes_disagg cannot be set '
+                    'at the same time in %(job_ini)s' % self.inputs)
             for k in ('mag_bin_width', 'distance_bin_width',
                       'coordinate_bin_width', 'num_epsilon_bins'):
                 if k not in vars(self):
-                    raise ValueError('%s must be set in the job.ini file' % k)
+                    raise InvalidFile('%s must be set in %s' % (k, job_ini))
 
         # checks for classical_damage
         if self.calculation_mode == 'classical_damage':
             if self.conditional_loss_poes:
-                raise ValueError('conditional_loss_poes are not defined '
-                                 'for classical_damage calculations: '
-                                 'remove them for the .ini file')
+                raise InvalidFile(
+                    '%s: conditional_loss_poes are not defined '
+                    'for classical_damage calculations' % job_ini)
 
         # checks for event_based_risk
         if (self.calculation_mode == 'event_based_risk'
@@ -230,14 +232,14 @@ class OqParam(valid.ParamSet):
                              ' supported')
         elif (self.calculation_mode == 'event_based_risk'
               and self.conditional_loss_poes and not self.asset_loss_table):
-            raise ValueError(
-                'conditional_loss_poes is set, but the loss maps cannot '
-                'be generated unless you set asset_loss_table=true')
+            raise InvalidFile(
+                '%s: conditional_loss_poes is set, but the loss maps cannot '
+                'be generated unless you set asset_loss_table=true' % job_ini)
 
         # check for GMFs from file
         if (self.inputs.get('gmfs', '').endswith('.csv') and not self.sites and
                 'sites' not in self.inputs):
-            raise ValueError('You forgot sites|sites_csv in the job .ini file!')
+            raise InvalidFile('%s: You forgot sites|sites_csv' % job_ini)
 
         # checks for ucerf
         if 'ucerf' in self.calculation_mode:

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -21,6 +21,7 @@ import mock
 import unittest
 import tempfile
 from openquake.baselib.general import writetmp
+from openquake.hazardlib import InvalidFile
 from openquake.commonlib.oqvalidation import OqParam
 
 TMP = tempfile.gettempdir()
@@ -39,14 +40,14 @@ GST = {'gsim_logic_tree': writetmp('''\
         </logicTreeBranchingLevel>
     </logicTree>
 </nrml>'''),
-       'source': 'fake'}
+       'source': 'fake', "job_ini": "job.ini"}
 
 # hard-coded to avoid a dependency from openquake.calculators
 OqParam.calculation_mode.validator.choices = (
     'classical', 'disaggregation', 'scenario', 'scenario_damage',
     'event_based', 'event_based_risk', 'classical_risk')
 
-fakeinputs = {"source": "fake"}
+fakeinputs = {"source": "fake", "job_ini": "job.ini"}
 
 
 class OqParamTestCase(unittest.TestCase):
@@ -68,10 +69,10 @@ class OqParamTestCase(unittest.TestCase):
 
     def test_truncation_level_disaggregation(self):
         # for disaggregation, the truncation level cannot be None
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InvalidFile):
             OqParam(calculation_mode='disaggregation',
                     hazard_calculation_id=None, hazard_output_id=None,
-                    inputs=dict(site_model=''), maximum_distance='10',
+                    inputs=fakeinputs, maximum_distance='10',
                     sites='',
                     intensity_measure_types_and_levels="{'PGA': [0.1, 0.2]}",
                     truncation_level=None).validate()
@@ -94,8 +95,9 @@ class OqParamTestCase(unittest.TestCase):
                 calculation_mode='classical_risk',
                 hazard_calculation_id=None, hazard_output_id=None,
                 maximum_distance='10',
+                inputs=fakeinputs,
                 region='-78.182 15.615, -78.152 15.615, -78.152 15.565, '
-                '-78.182 15.565', sites='0.1 0.2', inputs=dict(site_model='')
+                '-78.182 15.565', sites='0.1 0.2',
             ).validate()
 
     def test_poes(self):
@@ -105,13 +107,13 @@ class OqParamTestCase(unittest.TestCase):
             OqParam(
                 calculation_mode='classical_risk',
                 hazard_calculation_id=None, hazard_output_id=None,
-                inputs=dict(site_model=''), maximum_distance='10', sites='',
+                inputs=fakeinputs, maximum_distance='10', sites='',
                 hazard_maps='true',  poes='').validate()
         with self.assertRaises(ValueError):
             OqParam(
                 calculation_mode='classical_risk',
                 hazard_calculation_id=None, hazard_output_id=None,
-                inputs=dict(site_model=''), maximum_distance='10', sites='',
+                inputs=fakeinputs, maximum_distance='10', sites='',
                 uniform_hazard_spectra='true',  poes='').validate()
 
     def test_site_model(self):
@@ -127,13 +129,13 @@ class OqParamTestCase(unittest.TestCase):
     def test_missing_maximum_distance(self):
         with self.assertRaises(ValueError):
             OqParam(
-                calculation_mode='classical_risk', inputs=dict(site_model=''),
+                calculation_mode='classical_risk', inputs=fakeinputs,
                 hazard_calculation_id=None, hazard_output_id=None,
                 sites='0.1 0.2').validate()
 
         with self.assertRaises(ValueError):
             OqParam(
-                calculation_mode='classical_risk', inputs=dict(site_model=''),
+                calculation_mode='classical_risk', inputs=fakeinputs,
                 hazard_calculation_id=None, hazard_output_id=None,
                 sites='0.1 0.2', maximum_distance='0').validate()
 
@@ -260,7 +262,7 @@ class OqParamTestCase(unittest.TestCase):
                       str(ctx.exception))
 
     def test_ambiguous_gsim(self):
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(InvalidFile) as ctx:
             OqParam(
                 calculation_mode='scenario', inputs=GST,
                 gsim='AbrahamsonEtAl2014',
@@ -278,6 +280,7 @@ class OqParamTestCase(unittest.TestCase):
                 sites='0.1 0.2',
                 maximum_distance='400',
                 intensity_measure_types='PGV',
+                inputs=fakeinputs,
             ).validate()
         self.assertIn('The IMT PGV is not accepted by the GSIM ToroEtAl2002',
                       str(ctx.exception))
@@ -290,6 +293,7 @@ class OqParamTestCase(unittest.TestCase):
                 sites='0.1 0.2',
                 maximum_distance='400',
                 intensity_measure_types='PGA',
+                inputs=fakeinputs,
             ).validate()
         self.assertIn("Please set a value for 'reference_vs30_value', this is"
                       " required by the GSIM AbrahamsonSilva1997",
@@ -340,16 +344,15 @@ class OqParamTestCase(unittest.TestCase):
     def test_gmfs_but_no_sites(self):
         inputs = fakeinputs.copy()
         inputs['gmfs'] = 'fake.csv'
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(InvalidFile) as ctx:
             OqParam(
                 calculation_mode='scenario_damage',
                 inputs=inputs,
                 maximum_distance='400')
-        self.assertIn('You forgot sites|sites_csv in the job .ini file!',
-                      str(ctx.exception))
+        self.assertIn('You forgot sites|sites_csv', str(ctx.exception))
 
     def test_disaggregation(self):
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(InvalidFile) as ctx:
             OqParam(
                 calculation_mode='disaggregation',
                 inputs=fakeinputs,
@@ -364,7 +367,7 @@ class OqParamTestCase(unittest.TestCase):
                       str(ctx.exception))
 
     def test_event_based_risk(self):
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(InvalidFile) as ctx:
             OqParam(
                 calculation_mode='event_based_risk',
                 inputs=fakeinputs,

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -366,6 +366,21 @@ class OqParamTestCase(unittest.TestCase):
         self.assertIn("poes_disagg or iml_disagg must be set",
                       str(ctx.exception))
 
+        with self.assertRaises(InvalidFile) as ctx:
+            OqParam(
+                calculation_mode='disaggregation',
+                inputs=fakeinputs,
+                gsim='BooreAtkinson2008',
+                reference_vs30_value='200',
+                sites='0.1 0.2',
+                poes='0.2',
+                maximum_distance='400',
+                iml_disagg="{'PGV': [0.1, 0.2, 0.3]}",
+                poes_disagg="0.1",
+                uniform_hazard_spectra='1')
+        self.assertIn("iml_disagg and poes_disagg cannot be set at the "
+                      "same time", str(ctx.exception))
+
     def test_event_based_risk(self):
         with self.assertRaises(InvalidFile) as ctx:
             OqParam(


### PR DESCRIPTION
Those are exclusive modalities of the disaggregation calculator. Before `poes_disagg` was accepted but ignored in the presence of `iml_disagg`. Now there is less room for confusion.

PS: while at it, I have also replaced several ValueError with InvalidFile errors.