### PR TITLE
Add a title to the Manual PDF

### DIFF
--- a/doc/manual/configuration/configuration.tex
+++ b/doc/manual/configuration/configuration.tex
@@ -138,7 +138,17 @@
 \usepackage[cache=true]{minted} % Syntax highlighting for xml
 
 \usepackage{hyperref}
-\hypersetup{hidelinks,colorlinks=true,breaklinks=true,citecolor=oqblue,linkcolor=gembrown,urlcolor=oqblue,bookmarksopen=false,pdftitle={Title},pdfauthor={Author}}
+\hypersetup{
+hidelinks,
+colorlinks=true,
+breaklinks=true,
+citecolor=oqblue,
+linkcolor=gembrown,
+urlcolor=oqblue,
+bookmarksopen=false,
+pdftitle={The OpenQuake Engine Manual},
+pdfauthor={GEM Foundation}
+}
 
 % Package to create a glossary - must be loaded after hyperref
 \usepackage[acronym,nonumberlist,style=altlist,section=section,toc]{glossaries}

--- a/doc/manual/oq-manual.tex
+++ b/doc/manual/oq-manual.tex
@@ -30,6 +30,12 @@
 \input{configuration/configuration} % ------------- Load packages and template -
 \graphicspath{{figures/}} % -------------- Directory where pictures are stored -
 
+\usepackage{hyperref}
+\hypersetup{
+pdftitle={The OpenQuake Engine Manual},
+pdfauthor={GEM Foundation},
+}
+
 \begin{document}
 \input{oqum/glossary} % ---------------------------------------- Load glossary -
 

--- a/doc/manual/oq-manual.tex
+++ b/doc/manual/oq-manual.tex
@@ -30,12 +30,6 @@
 \input{configuration/configuration} % ------------- Load packages and template -
 \graphicspath{{figures/}} % -------------- Directory where pictures are stored -
 
-\usepackage{hyperref}
-\hypersetup{
-pdftitle={The OpenQuake Engine Manual},
-pdfauthor={GEM Foundation},
-}
-
 \begin{document}
 \input{oqum/glossary} % ---------------------------------------- Load glossary -
 


### PR DESCRIPTION
Could be improved better (subject, keywords, real authors) but for now I hope it's enough.

```
Title:          The OpenQuake Engine Manual
Subject:        
Keywords:       
Author:         GEM Foundation
Creator:        LaTeX with hyperref package
Producer:       pdfTeX-1.40.16
CreationDate:   Thu Nov 30 17:31:20 2017
ModDate:        Thu Nov 30 17:31:20 2017
Tagged:         no
UserProperties: no
Suspects:       no
Form:           none
JavaScript:     no
Pages:          194
Encrypted:      no
Page size:      595.28 x 841.89 pts (A4)
Page rot:       0
File size:      3106076 bytes
Optimized:      no
PDF version:    1.4
```

https://ci.openquake.org/job/builders/job/pdf-builder/73/