### PR TITLE
Do not change the global REQUIRES_RUPTURE_PARAMETERS in GMPETable._setup_amplification

### DIFF
--- a/openquake/hazardlib/gsim/gsim_table.py
+++ b/openquake/hazardlib/gsim/gsim_table.py
@@ -393,10 +393,11 @@ class GMPETable(GMPE):
             self.REQUIRES_SITES_PARAMETERS = set(
                 [self.amplification.parameter])
         elif self.amplification.element == "Rupture":
-            # Re-set the site parameters
+            # set the site and rupture parameters on the instance
             self.REQUIRES_SITES_PARAMETERS = set()
-            self.REQUIRES_RUPTURE_PARAMETERS.add(
-                self.amplification.parameter)
+            self.REQUIRES_RUPTURE_PARAMETERS = (
+                self.REQUIRES_RUPTURE_PARAMETERS | set(
+                    [self.amplification.parameter]))
 
     def _supported_imts(self):
         """

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -598,7 +598,8 @@ class NGAEastGMPE(NGAEastBaseGMPE):
         if not self.NGA_EAST_TABLE:
             raise NotImplementedError("NGA East Fixed-Table GMPE requires "
                                       "input table")
-        super(NGAEastGMPE, self).__init__(gmpe_table=self.NGA_EAST_TABLE,
+        super(NGAEastGMPE, self).__init__(
+            gmpe_table=self.NGA_EAST_TABLE,
             tau_model=tau_model, phi_model=phi_model,
             phi_s2ss_model=phi_s2ss_model, tau_quantile=tau_quantile,
             phi_ss_quantile=phi_ss_quantile,

--- a/openquake/hazardlib/tests/gsim/nga_east_full_uncertainty_test.py
+++ b/openquake/hazardlib/tests/gsim/nga_east_full_uncertainty_test.py
@@ -556,10 +556,8 @@ class NGAEastUncertaintyTestCase(unittest.TestCase):
 
     def get_context_attributes(self, ctx):
         att = inspect.getmembers(ctx, lambda a: not inspect.isroutine(a))
-        att = [
-            k for k, v in att if not ('_abc' in k)
-            and not ((k.startswith('_') and k.endswith('_')))
-        ]
+        att = [k for k, v in att if '_abc' not in k
+               and not (k.startswith('_') and k.endswith('_'))]
         return set(att)
 
     def check(self, gsim, filename, max_discrep_percentage):


### PR DESCRIPTION
The test GSIMTableTestCaseRupture was changing the global variable GMPETable.REQUIRES_RUPTURE_PARAMETERS so other unrelated tests broke. The change here should solve the error in https://ci.openquake.org/job/master_oq-engine/4117/console