### PR TITLE
Made the weight proportional to the number of GSIMs

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -167,10 +167,10 @@ from openquake.baselib.general import (
 
 executor = ProcessPoolExecutor()
 executor.pids = ()  # set by wakeup_pool
-# the num_tasks_hint is chosen to be 5 times bigger than the name of
+# the num_tasks_hint is chosen to be 2 times bigger than the name of
 # cores; it is a heuristic number to get a good distribution;
 # it has no more significance than that
-executor.num_tasks_hint = executor._max_workers * 5
+executor.num_tasks_hint = executor._max_workers * 2
 
 OQ_DISTRIBUTE = os.environ.get('OQ_DISTRIBUTE', 'futures').lower()
 
@@ -690,7 +690,7 @@ class BaseStarmap(object):
     num_tasks = Starmap.__dict__['num_tasks']
 
     @classmethod
-    def apply(cls, func, args, concurrent_tasks=executor._max_workers * 5,
+    def apply(cls, func, args, concurrent_tasks=executor._max_workers * 2,
               weight=lambda item: 1, key=lambda item: 'Unspecified'):
         chunks = split_in_blocks(args[0], concurrent_tasks or 1, weight, key)
         if concurrent_tasks == 0:

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -36,7 +36,7 @@ from openquake.commonlib import logictree
 
 
 MINWEIGHT = source.MINWEIGHT
-MAXWEIGHT = 4E6  # heuristic, set by M. Simionato
+MAXWEIGHT = 1E7  # heuristic, set by M. Simionato
 MAX_INT = 2 ** 31 - 1
 TWO16 = 2 ** 16
 U16 = numpy.uint16

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -655,6 +655,7 @@ class CompositeSourceModel(collections.Sequence):
         :param sitecol: a SiteCollection instance
         :para src_filter: a SourceFilter instance
         """
+        ngsims = {trt: len(gs) for trt, gs in self.gsim_lt.values.items()}
         source_models = []
         weight = 0
         for sm in self.source_models:
@@ -670,6 +671,7 @@ class CompositeSourceModel(collections.Sequence):
                 sg.sources = []
                 for src, _sites in src_filter(sources):
                     sg.sources.append(src)
+                    src.ngsims = ngsims[src.tectonic_region_type]
                     weight += src.weight
                 src_groups.append(sg)
             newsm = logictree.SourceModel(

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -60,7 +60,7 @@ if parallel.oq_distribute() == 'zmq':
                     logs.LOG.warn('%s is not running', host)
                     continue
                 num_workers += sock.send('get_num_workers')
-        OqParam.concurrent_tasks.default = num_workers * 5
+        OqParam.concurrent_tasks.default = num_workers * 2
         logs.LOG.info('Using %d zmq workers', num_workers)
 
 elif USE_CELERY:
@@ -75,7 +75,7 @@ elif USE_CELERY:
         if not stats:
             sys.exit("No live compute nodes, aborting calculation")
         num_cores = sum(stats[k]['pool']['max-concurrency'] for k in stats)
-        OqParam.concurrent_tasks.default = num_cores * 5
+        OqParam.concurrent_tasks.default = num_cores * 2
         logs.LOG.info(
             'Using %s, %d cores', ', '.join(sorted(stats)), num_cores)
 

--- a/openquake/hazardlib/source/__init__.py
+++ b/openquake/hazardlib/source/__init__.py
@@ -123,7 +123,6 @@ def split_fault_source(src):
             new_src = copy.copy(src)
             new_src.source_id = '%s:%s' % (src.source_id, i)
             new_src.mfd = mfd.ArbitraryMFD([mag], [rate])
-            new_src.num_ruptures = new_src.count_ruptures()
             i += 1
             splitlist.append(new_src)
     elif hasattr(src, 'start'):  # split by slice of ruptures
@@ -144,19 +143,13 @@ def _split_source(src):
     # helper for split_source
     if hasattr(src, '__iter__'):  # multipoint source
         for s in src:
-            s.src_group_id = src.src_group_id
-            s.num_ruptures = s.count_ruptures()
             yield s
     elif isinstance(src, AreaSource):
         for s in area_to_point_sources(src):
-            s.src_group_id = src.src_group_id
-            s.num_ruptures = s.count_ruptures()
             yield s
     elif isinstance(
             src, (SimpleFaultSource, ComplexFaultSource)):
         for s in split_fault_source(src):
-            s.src_group_id = src.src_group_id
-            s.num_ruptures = s.count_ruptures()
             yield s
     else:
         # characteristic and nonparametric sources are not split
@@ -179,6 +172,9 @@ def split_source(src):
             has_serial = hasattr(src, 'serial')
             start = 0
             for split in splits:
+                split.src_group_id = src.src_group_id
+                split.num_ruptures = split.count_ruptures()
+                split.ngsims = src.ngsims
                 if has_serial:
                     nr = split.num_ruptures
                     split.serial = src.serial[start:start + nr]

--- a/openquake/hazardlib/source/__init__.py
+++ b/openquake/hazardlib/source/__init__.py
@@ -126,6 +126,7 @@ def split_fault_source(src):
             i += 1
             splitlist.append(new_src)
     elif hasattr(src, 'start'):  # split by slice of ruptures
+        # for instance ClassicalTestCase.test_case_20
         for start, stop in _split_start_stop(src.num_ruptures, MINWEIGHT):
             new_src = copy.copy(src)
             new_src.start = start

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -41,6 +41,7 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
                'src_group_id', 'num_ruptures', 'seed', 'id']
     RUPTURE_WEIGHT = 1.  # overridden in (Multi)PointSource, AreaSource
     nsites = 1  # FIXME: remove this and fix all hazardlib tests
+    ngsims = 1
 
     @abc.abstractproperty
     def MODIFICATIONS(self):
@@ -54,7 +55,8 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
         """
         if not self.num_ruptures:
             self.num_ruptures = self.count_ruptures()
-        return self.num_ruptures * self.RUPTURE_WEIGHT * self.nsites
+        return (self.num_ruptures * self.RUPTURE_WEIGHT *
+                self.nsites * self.ngsims)
 
     @property
     def src_group_ids(self):

--- a/openquake/qa_tests_data/classical/case_18/expected/uhs-rlz-1.xml
+++ b/openquake/qa_tests_data/classical/case_18/expected/uhs-rlz-1.xml
@@ -39,7 +39,7 @@ xmlns:gml="http://www.opengis.net/gml"
                 </gml:pos>
             </gml:Point>
             <IMLs>
-                0.0582346418992 0.129590859011 0.0432801822219
+                0.0582346418991 0.129590859011 0.0432801822219
             </IMLs>
         </uhs>
     </uniformHazardSpectra>


### PR DESCRIPTION
This improves the task distribution for calculations dominated by `get_poes` (i.e. most calculations). Since the task distribution is better, I am going back to the old recipe of having concurrent_tasks = 2 * num_cores (it was changed to 5 * num_cores a few months ago since the task distribution was not so good).

Here is the change in full SHARE:
```
   michele@wilson:~$ oq2 show performance 16957  -- master
   ============================== ========= ========= =======
   operation                      time_sec  memory_mb counts
   ============================== ========= ========= =======
   total classical                1,151,195 418       1,361
   get_poes                       995,456   0.0       468,349
   make_contexts                  136,947   0.0       483,395
   total runtime                  8,066     6,649     1
   managing sources               901       379       1
   prefiltering                   397       170       7
   ================== ==== ====== ===== ===== =========
   operation-duration mean stddev min   max   num_tasks
   classical          845  645    0.007 4,254 1,361    
   ================== ==== ====== ===== ===== =========
   michele@wilson:~$ oq2 show performance 16961  -- this branch
   ============================== ========= ========= =======
   operation                      time_sec  memory_mb counts 
   ============================== ========= ========= =======
   total classical                1,156,084 361       2,001  
   get_poes                       999,567   0.0       468,349
   make_contexts                  137,949   0.0       483,393
   total runtime                  7,823     6,705     1      
   managing sources               910       394       1      
   prefiltering                   393       169       7      
   ================== ==== ====== ===== ===== =========
   operation-duration mean stddev min   max   num_tasks
   classical          577  419    0.007 2,982 2,001    
```

The relative stddev goes down from 76% from 72%. This is a very minor improvement, but better than nothing.