### PR TITLE
Changed gmf_ebrisk to use the same epsilon_getter as event_based_risk

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -683,7 +683,7 @@ class RiskCalculator(HazardCalculator):
                 for assets in reduced_assets:
                     for ass in assets:
                         ass.tagmask = self.tagmask[ass.ordinal]
-                        if len(eps):
+                        if eps is not None and len(eps):
                             reduced_eps[ass.ordinal] = eps[ass.ordinal]
                 # build the riskinputs
                 if kind == 'poe':  # hcurves, shape (R, N)

--- a/openquake/calculators/gmf_ebrisk.py
+++ b/openquake/calculators/gmf_ebrisk.py
@@ -21,6 +21,7 @@ import numpy
 
 from openquake.baselib import general
 from openquake.commonlib import readinput
+from openquake.risklib import riskinput
 from openquake.calculators import base, event_based_risk as ebr
 
 U16 = numpy.uint16
@@ -49,11 +50,11 @@ class GmfEbRiskCalculator(base.RiskCalculator):
         self.I = oq.insured_losses + 1
         eids, gmfs = base.get_gmfs(self)  # shape (R, N, E, I)
         self.E = len(eids)
-        if oq.ignore_covs:
-            eps = numpy.zeros((self.A, self.E), numpy.float32)
-        else:
-            logging.info('Building the epsilons')
-            eps = self.make_eps(self.E)
+        eps = riskinput.epsilon_getter(
+            len(self.assetcol), self.E, oq.asset_correlation,
+            oq.random_seed, oq.master_seed,
+            oq.ignore_covs or not self.riskmodel.covs)()
+
         self.R = len(gmfs)
         self.riskinputs = self.build_riskinputs('gmf', eps, eids)
         self.param['assetcol'] = self.assetcol

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -608,6 +608,9 @@ class EpsilonMatrix0(object):
             self.eps = self.make_eps()
         return self.eps[item]
 
+    def __len__(self):
+        return self.num_assets
+
 
 class EpsilonMatrix1(object):
     """
@@ -641,7 +644,7 @@ def epsilon_getter(n_assets, n_events, correlation, seed, master_seed, no_eps):
     assert no_eps in (True, False), no_eps
     seeds = seed + numpy.arange(n_events)
 
-    def get_eps(start, stop):
+    def get_eps(start=0, stop=n_events):
         if no_eps:
             eps = None
         elif correlation:


### PR DESCRIPTION
This is essential since we want the gmf_ebrisk calculator to give the same number as the event_based_risk calculator if the GMFs are the same. Needed for https://github.com/gem/oq-engine/issues/2017.