### PR TITLE
Given a better advice to the users that do not want to compute the loss maps

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -233,8 +233,8 @@ class OqParam(valid.ParamSet):
         elif (self.calculation_mode == 'event_based_risk'
               and self.conditional_loss_poes and not self.asset_loss_table):
             raise InvalidFile(
-                '%s: conditional_loss_poes is set, but the loss maps cannot '
-                'be generated unless you set asset_loss_table=true' % job_ini)
+                '%s: asset_loss_table is not set, probably you want to remove'
+                ' conditional_loss_poes' % job_ini)
 
         # check for GMFs from file
         if (self.inputs.get('gmfs', '').endswith('.csv') and not self.sites and

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -393,5 +393,5 @@ class OqParamTestCase(unittest.TestCase):
                 maximum_distance='400',
                 intensity_measure_types_and_levels="{'PGV': [0.1, 0.2, 0.3]}",
                 conditional_loss_poes='0.02')
-        self.assertIn("the loss maps cannot be generated unless you set "
-                      "asset_loss_table=true", str(ctx.exception))
+        self.assertIn("asset_loss_table is not set, probably you want to "
+                      "remove conditional_loss_poes", str(ctx.exception))


### PR DESCRIPTION
99% of the time the users do not want to compute the loss_maps (which is a very heavy operation consuming a lot of memory) but they have `conditional_loss_poes` set because they copied the job.ini from some old example. Now the error message gives the right suggestion (remove `conditional_loss_poes`) while before some users might have set `asset_loss_table=true`.