### PR TITLE
Fixes ASK14 GMPE behaviour to remove ValueError

### DIFF
--- a/openquake/hazardlib/gsim/abrahamson_2014.py
+++ b/openquake/hazardlib/gsim/abrahamson_2014.py
@@ -361,10 +361,15 @@ class AbrahamsonEtAl2014(GMPE):
         phi_al = self._get_phi_al_regional(C, mag, vs30measured, rrup)
         derAmp = self._get_derivative(C, sa1180, vs30)
         phi_amp = 0.4
-        if any(phi_al**2 < phi_amp**2):
-            print('phi_al:' % (phi_al))
-            print('magnitude: %.2f' % (mag))
-            raise ValueError('sqrt argument < 0')
+        idx = phi_al < phi_amp
+        if np.any(idx):
+            # In the case of small magnitudes and long periods it is possible
+            # for phi_al to take a value less than phi_amp, which would return
+            # a complex value. According to the GMPE authors in this case
+            # phi_amp should be reduced such that it is fractionally smaller
+            # than phi_al
+            phi_amp = 0.4 * np.ones_like(phi_al)
+            phi_amp[idx] = 0.99 * phi_al[idx]
         phi_b = np.sqrt(phi_al**2 - phi_amp**2)
         phi = np.sqrt(phi_b**2 * (1 + derAmp)**2 + phi_amp**2)
         return phi


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/3270

When presented with small magnitudes at long periods the Abrahamson et al. (2014) GMPE provides erroneous (i.e. complex) values for intra-event standard deviation. Currently this is caught by raising a ValueError, breaking the calculation. However, as noted in https://github.com/gem/oq-engine/issues/3270 the GMPE authors themselves catch this case by reducing the `phi_amp` term so that it is fractionally smaller than `phi_al`, preventing this from happening. The PR implements this adjustment.
