### PR TITLE
Fixed a bug of oq zip for gmf_ebrisk calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed oq zip to work with gmf_ebrisk calculations
   * Fixed a serious bug in the gmf_ebrisk calculator: the results were in most
     cases wrong and dependent on the number of spawned tasks
   * Now the `master_seed` controls the generation of the epsilons in all

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -45,6 +45,7 @@ from openquake.qa_tests_data.classical_risk import case_3
 from openquake.qa_tests_data.scenario import case_4
 from openquake.qa_tests_data.event_based import case_5
 from openquake.qa_tests_data.event_based_risk import case_master
+from openquake.qa_tests_data.gmf_ebrisk import case_1 as ebrisk
 from openquake.server import manage, dbapi
 
 DATADIR = os.path.join(commonlib.__path__[0], 'tests', 'data')
@@ -308,6 +309,18 @@ class ZipTestCase(unittest.TestCase):
                           'source_model_logic_tree.xml',
                           'vancouver_area_source.xml',
                           'vancouver_school_sites.csv'], names)
+        shutil.rmtree(dtemp)
+
+    def test_zip_gmf_ebrisk(self):
+        # this is a case without gsims and with a gmf file
+        ini = os.path.join(os.path.dirname(ebrisk.__file__), 'job_risk.ini')
+        dtemp = tempfile.mkdtemp()
+        xzip = os.path.join(dtemp, 'x.zip')
+        zip_cmd(ini, xzip)
+        names = sorted(zipfile.ZipFile(xzip).namelist())
+        self.assertEqual(['exposure_model.xml', 'gmf_scenario.csv',
+                          'job_risk.ini', 'sites.csv', 'vulnerability.xml'],
+                         names)
         shutil.rmtree(dtemp)
 
 

--- a/openquake/commands/zip.py
+++ b/openquake/commands/zip.py
@@ -38,25 +38,25 @@ def zip(job_ini, archive_zip):
         sys.exit('%s exists already' % archive_zip)
     logging.basicConfig(level=logging.INFO)
     oq = readinput.get_oqparam(job_ini)
+    files = set()
 
     # collect .hdf5 tables for the GSIMs, if any
-    gsim_lt = readinput.get_gsim_lt(oq)
-    gmpetables = set()
-    for gsims in gsim_lt.values.values():
-        for gsim in gsims:
-            table = getattr(gsim, 'GMPE_TABLE', None)
-            if table:
-                gmpetables.add(table)
+    if 'gsim_logic_tree' in oq.inputs or oq.gsim:
+        gsim_lt = readinput.get_gsim_lt(oq)
+        for gsims in gsim_lt.values.values():
+            for gsim in gsims:
+                table = getattr(gsim, 'GMPE_TABLE', None)
+                if table:
+                    files.add(table)
 
     # collect all other files
-    files = list(gmpetables)
     for key in oq.inputs:
         fname = oq.inputs[key]
         if isinstance(fname, list):
             for f in fname:
-                files.append(os.path.normpath(f))
+                files.add(os.path.normpath(f))
         else:
-            files.append(os.path.normpath(fname))
+            files.add(os.path.normpath(fname))
     general.zipfiles(files, archive_zip, log=logging.info)
 
 


### PR DESCRIPTION
It was trying to find the tables associated to the GSIMs, but there are no GSIMs in this case. Solved with an `if 'gsim_logic_tree' in oq.inputs or oq.gsim`.