### PR TITLE
Use a recent version of Sphinx in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ jobs:
         - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commands
         - oq webui migrate
-    after_success:  # sphinx is not working anymore on travis!
-        - pip install sphinx==1.3.6 && cd doc/sphinx # && make html
+    after_success:  # old sphinx does not work well with Python 3.5.4
+        - pip install sphinx==1.6.5 && cd doc/sphinx && make html
     after_script:
         - oq dbserver stop
   - stage: tests


### PR DESCRIPTION
to avoid errors with Python 3.5.4, which is now the version provided by Travis.

See https://github.com/sphinx-doc/sphinx/issues/4006

