### PR TITLE
Changed the rupture storage

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -25,11 +25,11 @@ import numpy
 from openquake.baselib.python3compat import zip, encode
 from openquake.baselib.general import (
     AccumDict, block_splitter, split_in_blocks)
-from openquake.baselib import config
-from openquake.calculators import base, event_based
-from openquake.calculators.export.loss_curves import get_loss_builder
 from openquake.baselib import parallel
 from openquake.risklib import riskinput
+from openquake.commonlib import calc
+from openquake.calculators import base, event_based
+from openquake.calculators.export.loss_curves import get_loss_builder
 
 U8 = numpy.uint8
 U16 = numpy.uint16
@@ -263,7 +263,7 @@ class EbriskCalculator(base.RiskCalculator):
         with self.monitor('reading ruptures', autoflush=True):
             ruptures_by_grp = (
                 self.precalc.result if self.precalc
-                else event_based.get_ruptures_by_grp(self.datastore.parent))
+                else calc.get_ruptures_by_grp(self.datastore.parent))
             # the ordering of the ruptures is essential for repeatibility
             for grp in ruptures_by_grp:
                 ruptures_by_grp[grp].sort(key=operator.attrgetter('serial'))

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -72,18 +72,15 @@ def export_ruptures_xml(ekey, dstore):
     """
     fmt = ekey[-1]
     oq = dstore['oqparam']
-    events = dstore['events']
     sm_by_grp = dstore['csm_info'].get_sm_by_grp()
     mesh = get_mesh(dstore['sitecol'])
-    ruptures = {}
-    for grp in dstore['ruptures']:
-        grp_id = int(grp[4:])  # strip grp-
-        ruptures[grp_id] = []
-        for ebr in calc.get_ruptures(dstore, events, grp_id):
-            ruptures[grp_id].append(ebr.export(mesh, sm_by_grp))
+    ruptures_by_grp = {}
+    for grp_id, ruptures in calc.get_ruptures_by_grp(dstore).items():
+        ruptures_by_grp[grp_id] = [ebr.export(mesh, sm_by_grp)
+                                   for ebr in ruptures]
     dest = dstore.export_path('ses.' + fmt)
     writer = hazard_writers.SESXMLWriter(dest)
-    writer.serialize(ruptures, oq.investigation_time)
+    writer.serialize(ruptures_by_grp, oq.investigation_time)
     return [dest]
 
 
@@ -96,16 +93,16 @@ def export_ruptures_csv(ekey, dstore):
     oq = dstore['oqparam']
     if 'scenario' in oq.calculation_mode:
         return []
-    events = dstore['events']
     dest = dstore.export_path('ruptures.csv')
     header = ('rupid multiplicity mag centroid_lon centroid_lat centroid_depth'
               ' trt strike dip rake boundary').split()
     csm_info = dstore['csm_info']
     grp_trt = csm_info.grp_trt()
     rows = []
+    ruptures_by_grp = calc.get_ruptures_by_grp(dstore)
     for grp_id, trt in sorted(grp_trt.items()):
         rup_data = calc.RuptureData(trt, csm_info.get_gsims(grp_id))
-        for r in rup_data.to_array(calc.get_ruptures(dstore, events, grp_id)):
+        for r in rup_data.to_array(ruptures_by_grp.get(grp_id, [])):
             rows.append(
                 (r['rup_id'], r['multiplicity'], r['mag'],
                  r['lon'], r['lat'], r['depth'],
@@ -741,9 +738,8 @@ def export_gmf_scenario_csv(ekey, dstore):
         raise ValueError(
             "Invalid format: %r does not match 'rup-(\d+)$'" % what[1])
     rup_id = int(mo.group(1))
-    grp_ids = sorted(int(grp[4:]) for grp in dstore['ruptures'])
     events = dstore['events']
-    ruptures = list(calc.get_all_ruptures(dstore, events, grp_ids, rup_id))
+    ruptures = list(calc.get_all_ruptures(dstore, events, rup_id=rup_id))
     if not ruptures:
         logging.warn('There is no rupture %d', rup_id)
         return []

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -208,6 +208,9 @@ def export_agg_losses_ebr(ekey, dstore):
     :param ekey: export key, i.e. a pair (datastore key, fmt)
     :param dstore: datastore object
     """
+    if 'ruptures' not in dstore:
+        logging.warn('There are no ruptures in the datastore')
+        return []
     name, ext = export.keyfunc(ekey)
     agg_losses = dstore[name]
     has_rup_data = 'ruptures' in dstore

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -227,11 +227,13 @@ def export_agg_losses_ebr(ekey, dstore):
     rup_data = {}
     event_by_eid = {}  # eid -> event
     # populate rup_data and event_by_eid
+    ruptures_by_grp = calc.get_ruptures_by_grp(dstore)
+    # TODO: avoid reading the events twice
     for grp_id, events in all_events.items():
         for event in events:
             event_by_eid[event['eid']] = event
         if has_rup_data:
-            ruptures = calc.get_ruptures(dstore, the_events, grp_id)
+            ruptures = ruptures_by_grp.get(grp_id, [])
             rup_data.update(get_rup_data(ruptures))
     for r, row in enumerate(agg_losses):
         rec = elt[r]

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -164,12 +164,8 @@ class EventBasedRiskTestCase(CalculatorTestCase):
                       exports='csv', concurrent_tasks='4')
 
         # test the number of bytes saved in the rupture records
-        grp00 = self.calc.datastore.get_attr('ruptures/grp-00', 'nbytes')
-        grp02 = self.calc.datastore.get_attr('ruptures/grp-02', 'nbytes')
-        grp03 = self.calc.datastore.get_attr('ruptures/grp-03', 'nbytes')
-        self.assertEqual(grp00, 530)
-        self.assertEqual(grp02, 530)
-        self.assertEqual(grp03, 212)
+        nbytes = self.calc.datastore.get_attr('ruptures', 'nbytes')
+        self.assertEqual(nbytes, 1272)
 
         hc_id = self.calc.datastore.calc_id
         self.run_calc(case_3.__file__, 'job.ini',

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -715,12 +715,11 @@ def compute_ruptures(sources, src_filter, gsims, param, monitor):
                     indices = r_sites.indices
                     events = []
                     for _ in range(n_occ):
-                        events.append((0, ses_idx, sample))
+                        events.append((0, src.src_group_id, ses_idx, sample))
                     if events:
                         evs = numpy.array(events, calc.event_dt)
                         ebruptures.append(
-                            calc.EBRupture(rup, indices, evs,
-                                           src.src_group_id, serial))
+                            calc.EBRupture(rup, indices, evs, serial))
                         serial += 1
     res.num_events = event_based.set_eids(ebruptures)
     res[src.src_group_id] = ebruptures

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -464,7 +464,7 @@ def view_assetcol(token, dstore):
 
 @view.add('ruptures_events')
 def view_ruptures_events(token, dstore):
-    num_ruptures = sum(len(v) for v in dstore['ruptures'].values())
+    num_ruptures = len(dstore['ruptures'])
     num_events = len(dstore['events'])
     mult = round(num_events / num_ruptures, 3)
     lst = [('Total number of ruptures', num_ruptures),

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -18,11 +18,14 @@
 
 from __future__ import division
 import collections
+import operator
 import warnings
+import logging
 import numpy
 import h5py
+import mock
 
-from openquake.baselib import hdf5
+from openquake.baselib import hdf5, general
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib.geo.mesh import (
     surface_to_mesh, point3d, RectangularMesh)
@@ -44,7 +47,8 @@ F32 = numpy.float32
 U64 = numpy.uint64
 F64 = numpy.float64
 
-event_dt = numpy.dtype([('eid', U64), ('ses', U32), ('sample', U32)])
+event_dt = numpy.dtype([('eid', U64), ('grp_id', U16), ('ses', U32),
+                        ('sample', U32)])
 
 BaseRupture.init()  # initialize rupture codes
 
@@ -557,14 +561,13 @@ class RuptureSerializer(object):
             rup = ebr.rupture
             if hasattr(rup, 'pmf'):
                 pmfs = numpy.array([(ebr.serial, rup.pmf)], self.pmfs_dt)
-                dset = self.datastore.extend(
-                    'pmfs/grp-%02d' % ebr.grp_id, pmfs)
+                dset = self.datastore.extend('pmfs', pmfs)
                 ebr.pmfx = len(dset) - 1
                 pmfbytes += self.pmfs_dt.itemsize + rup.pmf.nbytes
 
         # store the ruptures in a compact format
         array, nbytes = self.get_array_nbytes(ebruptures)
-        key = 'ruptures/grp-%02d' % ebr.grp_id
+        key = 'ruptures'
         try:
             dset = self.datastore.getitem(key)
         except KeyError:  # not created yet
@@ -585,65 +588,64 @@ class RuptureSerializer(object):
         pass
 
 
-def get_ruptures(dstore, events, grp_id):
+def get_ruptures_by_grp(dstore, start=0, stop=None, rup_id=None):
     """
     Extracts the ruptures of the given grp_id
     """
-    return get_all_ruptures(dstore, events, [grp_id], None)
+    events = dstore['events'].value
+    n = len(dstore['ruptures'])
+    logging.info('Reading %d ruptures from the datastore', n)
+    # disable check on PlaceSurface to support UCERF ruptures
+    with mock.patch(
+            'openquake.hazardlib.geo.surface.PlanarSurface.'
+            'IMPERFECT_RECTANGLE_TOLERANCE', numpy.inf):
+        return general.groupby(
+            get_all_ruptures(dstore, events, start, stop),
+            operator.attrgetter('grp_id'))
 
 
-def get_all_ruptures(dstore, events=None, grp_ids=None, rup_id=None):
+def get_all_ruptures(dstore, events, start=0, stop=None, rup_id=None):
     oq = dstore['oqparam']
     grp_trt = dstore['csm_info'].grp_trt()
-    if events is None:
-        events = dstore['events'].value
-    if grp_ids is None:
-        grp_ids = grp_trt
-    for grp_id in grp_ids:
-        trt = grp_trt[grp_id]
-        grp = 'grp-%02d' % grp_id
-        try:
-            recs = dstore['ruptures/' + grp]
-        except KeyError:  # no ruptures in grp
+    recs = dstore['ruptures'][start:stop]
+    for rec in recs:
+        if rup_id is not None and rup_id != rec['serial']:
             continue
-        for rec in recs:
-            if rup_id is not None and rup_id != rec['serial']:
-                continue
-            mesh = rec['points'].reshape(rec['sx'], rec['sy'], rec['sz'])
-            rupture_cls, surface_cls, source_cls = BaseRupture.types[
-                rec['code']]
-            rupture = object.__new__(rupture_cls)
-            rupture.surface = object.__new__(surface_cls)
-            # MISSING: case complex_fault_mesh_spacing != rupture_mesh_spacing
-            if 'Complex' in surface_cls.__name__:
-                mesh_spacing = oq.complex_fault_mesh_spacing
-            else:
-                mesh_spacing = oq.rupture_mesh_spacing
-            rupture.source_typology = source_cls
-            rupture.mag = rec['mag']
-            rupture.rake = rec['rake']
-            rupture.seed = rec['seed']
-            rupture.hypocenter = geo.Point(*rec['hypo'])
-            rupture.occurrence_rate = rec['occurrence_rate']
-            rupture.tectonic_region_type = trt
-            pmfx = rec['pmfx']
-            if pmfx != -1:
-                rupture.pmf = dstore['pmfs/' + grp][pmfx]
-            if surface_cls is geo.PlanarSurface:
-                rupture.surface = geo.PlanarSurface.from_array(
-                    mesh_spacing, rec['points'])
-            elif surface_cls.__name__.endswith('MultiSurface'):
-                rupture.surface.__init__([
-                    geo.PlanarSurface.from_array(mesh_spacing, m1.flatten())
-                    for m1 in mesh])
-            else:  # fault surface, strike and dip will be computed
-                rupture.surface.strike = rupture.surface.dip = None
-                m = mesh[0]
-                rupture.surface.mesh = RectangularMesh(
-                    m['lon'], m['lat'], m['depth'])
-            evs = events[rec['eidx1']:rec['eidx2']]
-            ebr = EBRupture(rupture, (), evs, grp_id, rec['serial'])
-            ebr.eidx1 = rec['eidx1']
-            ebr.eidx2 = rec['eidx2']
-            # not implemented: rupture_slip_direction
-            yield ebr
+        mesh = rec['points'].reshape(rec['sx'], rec['sy'], rec['sz'])
+        rupture_cls, surface_cls, source_cls = BaseRupture.types[
+            rec['code']]
+        rupture = object.__new__(rupture_cls)
+        rupture.surface = object.__new__(surface_cls)
+        # MISSING: case complex_fault_mesh_spacing != rupture_mesh_spacing
+        if 'Complex' in surface_cls.__name__:
+            mesh_spacing = oq.complex_fault_mesh_spacing
+        else:
+            mesh_spacing = oq.rupture_mesh_spacing
+        rupture.source_typology = source_cls
+        rupture.mag = rec['mag']
+        rupture.rake = rec['rake']
+        rupture.seed = rec['seed']
+        rupture.hypocenter = geo.Point(*rec['hypo'])
+        rupture.occurrence_rate = rec['occurrence_rate']
+        pmfx = rec['pmfx']
+        if pmfx != -1:
+            rupture.pmf = dstore['pmfs'][pmfx]
+        if surface_cls is geo.PlanarSurface:
+            rupture.surface = geo.PlanarSurface.from_array(
+                mesh_spacing, rec['points'])
+        elif surface_cls.__name__.endswith('MultiSurface'):
+            rupture.surface.__init__([
+                geo.PlanarSurface.from_array(mesh_spacing, m1.flatten())
+                for m1 in mesh])
+        else:  # fault surface, strike and dip will be computed
+            rupture.surface.strike = rupture.surface.dip = None
+            m = mesh[0]
+            rupture.surface.mesh = RectangularMesh(
+                m['lon'], m['lat'], m['depth'])
+        evs = events[rec['eidx1']:rec['eidx2']]
+        ebr = EBRupture(rupture, (), evs, rec['serial'])
+        ebr.eidx1 = rec['eidx1']
+        ebr.eidx2 = rec['eidx2']
+        # not implemented: rupture_slip_direction
+        rupture.tectonic_region_type = grp_trt[ebr.grp_id]
+        yield ebr

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -563,15 +563,20 @@ class EBRupture(object):
     object, containing an array of site indices affected by the rupture,
     as well as the IDs of the corresponding seismic events.
     """
-    def __init__(self, rupture, sids, events, grp_id=0, serial=0):
+    def __init__(self, rupture, sids, events, serial=0):
         self.rupture = rupture
         self.sids = sids
         self.events = events
-        self.grp_id = grp_id
         self.serial = serial
-        self.sidx = 0
         self.eidx1 = 0
         self.eidx2 = len(events)
+
+    @property
+    def grp_id(self):
+        """
+        Group ID of the rupture
+        """
+        return int(self.events[0]['grp_id'])  # need Python int, not uint16
 
     @property
     def weight(self):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -440,7 +440,7 @@ class RuptureConverter(object):
                         for eid in (~sesnode).split():
                             events.append((eid, ses, 0))
                 ebr = source.rupture.EBRupture(
-                    rup, None, numpy.array(events, event_dt), grp_id, rupid)
+                    rup, (), numpy.array(events, event_dt), rupid)
                 ebrs.append(ebr)
         return coll
 


### PR DESCRIPTION
Before there was a dataset per each source group ID of the form `ruptures/grp-XX`; now there is a single dataset called `ruptures`. The final goal is to make it possible to read bunch of ruptures from the workers and it will be accomplished in future pull requests.