### PR TITLE
Allow more control over figures in HMTK

### DIFF
--- a/openquake/hmtk/plotting/mapping.py
+++ b/openquake/hmtk/plotting/mapping.py
@@ -4,53 +4,52 @@
 #
 # LICENSE
 #
-# Copyright (c) 2010-2017, GEM Foundation, G. Weatherill, M. Pagani, 
+# Copyright (c) 2010-2017, GEM Foundation, G. Weatherill, M. Pagani,
 # D. Monelli., L. E. Rodriguez-Abreu
 #
-# The Hazard Modeller's Toolkit is free software: you can redistribute 
-# it and/or modify it under the terms of the GNU Affero General Public 
-# License as published by the Free Software Foundation, either version 
+# The Hazard Modeller's Toolkit is free software: you can redistribute
+# it and/or modify it under the terms of the GNU Affero General Public
+# License as published by the Free Software Foundation, either version
 # 3 of the License, or (at your option) any later version.
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>
 #
 # DISCLAIMER
-# 
-# The software Hazard Modeller's Toolkit (openquake.hmtk) provided herein 
-# is released as a prototype implementation on behalf of 
-# scientists and engineers working within the GEM Foundation (Global 
-# Earthquake Model). 
 #
-# It is distributed for the purpose of open collaboration and in the 
+# The software Hazard Modeller's Toolkit (openquake.hmtk) provided herein
+# is released as a prototype implementation on behalf of
+# scientists and engineers working within the GEM Foundation (Global
+# Earthquake Model).
+#
+# It is distributed for the purpose of open collaboration and in the
 # hope that it will be useful to the scientific, engineering, disaster
-# risk and software design communities. 
-# 
-# The software is NOT distributed as part of GEM's OpenQuake suite 
-# (https://www.globalquakemodel.org/tools-products) and must be considered as a 
-# separate entity. The software provided herein is designed and implemented 
-# by scientific staff. It is not developed to the design standards, nor 
-# subject to same level of critical review by professional software 
-# developers, as GEM's OpenQuake software suite.  
-# 
-# Feedback and contribution to the software is welcome, and can be 
-# directed to the hazard scientific staff of the GEM Model Facility 
-# (hazard@globalquakemodel.org). 
-# 
-# The Hazard Modeller's Toolkit (openquake.hmtk) is therefore distributed WITHOUT 
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
-# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+# risk and software design communities.
+#
+# The software is NOT distributed as part of GEM's OpenQuake suite
+# (https://www.globalquakemodel.org/tools-products) and must be considered as a
+# separate entity. The software provided herein is designed and implemented
+# by scientific staff. It is not developed to the design standards, nor
+# subject to same level of critical review by professional software
+# developers, as GEM's OpenQuake software suite.
+#
+# Feedback and contribution to the software is welcome, and can be
+# directed to the hazard scientific staff of the GEM Model Facility
+# (hazard@globalquakemodel.org).
+#
+# The Hazard Modeller's Toolkit (openquake.hmtk) is therefore distributed
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
-# 
-# The GEM Foundation, and the authors of the software, assume no 
-# liability for use of the software. 
-
-#!/usr/bin/env python
+#
+# The GEM Foundation, and the authors of the software, assume no
+# liability for use of the software.
 
 '''
 Module openquake.hmtk.plotting.catalogue.map is a graphical
 function for plotting the spatial distribution of events
 '''
+from builtins import range
 import collections
 import numpy as np
 import matplotlib.pyplot as plt
@@ -64,26 +63,24 @@ from openquake.hmtk.sources.simple_fault_source import mtkSimpleFaultSource
 from openquake.hmtk.sources.complex_fault_source import mtkComplexFaultSource
 
 
-DEFAULT_SYMBOLOGY = [(-np.inf, 1., 'k.'), # M < 1
-                     (1., 2., 'g*'), # 1 < M < 2
-                     (2., 3.,'cx'), # 2 < M < 3
-                     (3., 4.,'yd'), # 3 < M < 4
-                     (4., 5.,'m^'), # 4 < M < 5
-                     (5., 6.,'go'), # 5 < M < 6
-                     (6., 7.,'yh'), # 6 < M < 7
-                     (7., 8.,'bs'), # 7 < M < 8
-                     (8., 9.,'k^'), # 8 < M < 9
-                     (9., np.inf,'ro')] # 9 < M < 10
+DEFAULT_SYMBOLOGY = [(-np.inf, 1., 'k.'),  # M < 1
+                     (1., 2., 'g*'),  # 1 < M < 2
+                     (2., 3., 'cx'),  # 2 < M < 3
+                     (3., 4., 'yd'),  # 3 < M < 4
+                     (4., 5., 'm^'),  # 4 < M < 5
+                     (5., 6., 'go'),  # 5 < M < 6
+                     (6., 7., 'yh'),  # 6 < M < 7
+                     (7., 8., 'bs'),  # 7 < M < 8
+                     (8., 9., 'k^'),  # 8 < M < 9
+                     (9., np.inf, 'ro')]  # 9 < M < 10
 
-LEGEND_OFFSET=(1.3, 1.0)
+LEGEND_OFFSET = (1.3, 1.0)
 PORTRAIT_ASPECT = (6, 8)
 LANDSCAPE_ASPECT = (8, 6)
 NCOLS = len(DISSIMILAR_COLOURLIST)
 
-def _fault_polygon_from_mesh(source):
-    """
 
-    """
+def _fault_polygon_from_mesh(source):
     # Mesh
     upper_edge = np.column_stack([source.geometry.mesh.lons[1],
                                   source.geometry.mesh.lats[1],
@@ -93,12 +90,13 @@ def _fault_polygon_from_mesh(source):
                                   source.geometry.mesh.depths[-1]])
     return np.vstack([upper_edge, np.flipud(lower_edge), upper_edge[0, :]])
 
+
 class HMTKBaseMap(object):
     '''
     Class to plot the spatial distribution of events based in the Catalogue
     imported from openquake.hmtk.
     '''
-    def __init__(self, config, title, dpi=300):
+    def __init__(self, config, title, dpi=300, lat_lon_spacing=2.):
         """
         :param dict config:
             Configuration parameters of the algorithm, containing the
@@ -116,6 +114,7 @@ class HMTKBaseMap(object):
         self.config = config
         self.title = title
         self.dpi = dpi
+        self.lat_lon_spacing = lat_lon_spacing
         self.fig = None
         self.m = None
         self._build_basemap()
@@ -134,7 +133,7 @@ class HMTKBaseMap(object):
         lowcrnrlon = self.config['min_lon']
         uppcrnrlat = self.config['max_lat']
         uppcrnrlon = self.config['max_lon']
-        if not 'resolution' in self.config.keys():
+        if 'resolution' not in self.config.keys():
             self.config['resolution'] = 'l'
 
         lat0 = lowcrnrlat + ((uppcrnrlat - lowcrnrlat) / 2)
@@ -150,8 +149,8 @@ class HMTKBaseMap(object):
                               edgecolor='k')
         if self.title:
             plt.title(self.title, fontsize=16)
-        parallels = np.arange(-90., 90., 2.)
-        meridians = np.arange(0., 360., 2.)
+        parallels = np.arange(-90., 90., self.lat_lon_spacing)
+        meridians = np.arange(0., 360., self.lat_lon_spacing)
 
         # Build Map
         self.m = Basemap(
@@ -198,25 +197,23 @@ class HMTKBaseMap(object):
         # Magnitudes bins and minimum marrker size
         # min_mag = np.min(catalogue.data['magnitude'])
         # max_mag = np.max(catalogue.data['magnitude'])
-        con_min = np.where(np.array([symb[0] for symb in DEFAULT_SYMBOLOGY]) < 
+        con_min = np.where(np.array([symb[0] for symb in DEFAULT_SYMBOLOGY]) <
                            np.min(catalogue.data['magnitude']))[0]
         con_max = np.where(np.array([symb[1] for symb in DEFAULT_SYMBOLOGY]) >
                            np.max(catalogue.data['magnitude']))[0]
         if len(con_min) == 1:
             min_loc = con_min[0]
         else:
-            min_loc = con_min[-1] 
+            min_loc = con_min[-1]
         if len(con_max) == 1:
             max_loc = con_max[0]
         else:
             max_loc = con_max[1]
-        #min_loc = np.where(np.array([symb[0] for symb in DEFAULT_SYMBOLOGY]) <
-        #                   np.min(catalogue.data['magnitude']))[0][-1]
-        #max_loc = np.where(np.array([symb[1] for symb in DEFAULT_SYMBOLOGY]) >
-        #                   np.max(catalogue.data['magnitude']))[0][1]
+        # min_loc = np.where(np.array([symb[0] for symb in DEFAULT_SYMBOLOGY])
+        #                   < np.min(catalogue.data['magnitude']))[0][-1]
+        # max_loc = np.where(np.array([symb[1] for symb in DEFAULT_SYMBOLOGY])
+        #                   > np.max(catalogue.data['magnitude']))[0][1]
         symbology = DEFAULT_SYMBOLOGY[min_loc:max_loc]
-        legend_list = []
-        leg_handles = []
         for sym in symbology:
             # Create legend string
             if np.isinf(sym[0]):
@@ -224,7 +221,7 @@ class HMTKBaseMap(object):
             elif np.isinf(sym[1]):
                 leg_str = 'M >= %5.2f' % sym[0]
             else:
-                leg_str = '%5.2f <= M < %5.2f' %(sym[0], sym[1])
+                leg_str = '%5.2f <= M < %5.2f' % (sym[0], sym[1])
             idx = np.logical_and(catalogue.data['magnitude'] >= sym[0],
                                  catalogue.data['magnitude'] < sym[1])
             mag_size = 1.2 * np.min([sym[0] + 0.5, sym[1] - 0.5])
@@ -291,7 +288,7 @@ class HMTKBaseMap(object):
         self.m.plot(x, y, border, linewidth=1.3 * border_width)
 
     def _plot_complex_fault(self, source, border='k-', border_width=1.0,
-            min_depth=0., max_depth=None, alpha=1.0):
+                            min_depth=0., max_depth=None, alpha=1.0):
         """
         Plots the simple fault source as a composite of the fault trace
         and the surface projection of the fault.
@@ -310,7 +307,7 @@ class HMTKBaseMap(object):
 
         bottom_edge = np.column_stack([source.geometry.mesh.lons[-1][::-1],
                                        source.geometry.mesh.lats[-1][::-1]])
-        outline = np.vstack([top_edge, bottom_edge, top_edge[0,:]])
+        outline = np.vstack([top_edge, bottom_edge, top_edge[0, :]])
         lons = source.geometry.mesh.lons.flatten()
         lats = source.geometry.mesh.lats.flatten()
         depths = source.geometry.mesh.depths.flatten()
@@ -421,19 +418,19 @@ class HMTKBaseMap(object):
     def _select_color_mag(self, mag):
         if (mag > 8.0):
             color = 'k'
-            #color.append('k')
+            # color.append('k')
         elif (mag < 8.0) and (mag >= 7.0):
             color = 'b'
-            #color.append('b')
+            # color.append('b')
         elif (mag < 7.0) and (mag >= 6.0):
             color = 'y'
-            #color.append('y')
+            # color.append('y')
         elif (mag < 6.0) and (mag >= 5.0):
             color = 'g'
-            #color.append('g')
+            # color.append('g')
         elif (mag < 5.0):
             color = 'm'
-            #color.append('m')
+            # color.append('m')
         return color
 
     def add_focal_mechanism(self, catalogue, magnitude=None, overlay=True):
@@ -461,7 +458,7 @@ class HMTKBaseMap(object):
                 if not overlay:
                     plt.show()
         else:
-            for i in xrange(0, catalogue.get_number_tensors()):
+            for i in range(0, catalogue.get_number_tensors()):
                 x, y = self.m(longitude[i], latitude[i])
                 self.m.plot(x, y)
                 focal_mechanism = [strike[i], dip[i], rake[i]]
@@ -473,7 +470,7 @@ class HMTKBaseMap(object):
                     plt.show()
 
     def add_catalogue_cluster(self, catalogue, vcl, flagvector,
-            cluster_id=None, overlay=True):
+                              cluster_id=None, overlay=True):
         """
         Creates a plot of a catalogue showing where particular clusters exist
         """

--- a/openquake/hmtk/seismicity/completeness/comp_stepp_1971.py
+++ b/openquake/hmtk/seismicity/completeness/comp_stepp_1971.py
@@ -37,25 +37,24 @@
 # directed to the hazard scientific staff of the GEM Model Facility
 # (hazard@globalquakemodel.org).
 #
-# The Hazard Modeller's Toolkit (openquake.hmtk) is therefore distributed WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# The Hazard Modeller's Toolkit (openquake.hmtk) is therefore distributed
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 #
 # The GEM Foundation, and the authors of the software, assume no
 # liability for use of the software.
 
-#/usr/bin/env/python
-
 """
-Module :mod: 'openquake.hmtk.seismicity.completeness.comp_stepp_1972' defines the
-openquake.hmtk implementation of the Stepp (1972) algorithm for analysing the
-completeness of an earthquake catalogue
+Module :mod: 'openquake.hmtk.seismicity.completeness.comp_stepp_1972' defines
+the openquake.hmtk implementation of the Stepp (1972) algorithm for analysing
+the completeness of an earthquake catalogue
 """
 
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
-from openquake.hmtk.seismicity.utils import decimal_time, piecewise_linear_scalar
+from openquake.hmtk.seismicity.utils import (
+    decimal_time, piecewise_linear_scalar)
 from openquake.hmtk.seismicity.completeness.base import (
     BaseCatalogueCompleteness, COMPLETENESS_METHODS)
 
@@ -146,9 +145,11 @@ class Stepp1971(BaseCatalogueCompleteness):
         :param dict config:
             Configuration parameters of the algorithm, containing the
             following information:
-            'magnitude_bin' Size of magnitude bin (non-negative float)
-            'time_bin' Size (in dec. years) of the time window (non-negative float)         'increment_lock' Boolean to indicate whether to ensure
-            completeness magnitudes always decrease with more recent bins
+                'magnitude_bin' Size of magnitude bin (non-negative float)
+                'time_bin' Size (in dec. years) of the time window
+                (non-negative float)
+                'increment_lock' Boolean to indicate whether to ensure
+                completeness magnitudes always decrease with more recent bins
 
         :returns:
             2-column table indicating year of completeness and corresponding
@@ -196,6 +197,43 @@ class Stepp1971(BaseCatalogueCompleteness):
             np.floor(self.end_year - comp_time),
             self.magnitude_bin[:-1]])
         return self.completeness_table
+
+    def simplify(self, deduplicate=True, mag_range=None, year_range=None):
+        """
+        Simplify a completeness table result. Intended to work with
+        'increment_lock' enabled.
+        """
+
+        if self.completeness_table is None:
+            return
+
+        years = self.completeness_table[:, 0]
+        mags = self.completeness_table[:, 1]
+        keep = np.array([True]*years.shape[0])
+
+        if deduplicate:
+            keep[1:] = years[1:] != years[:-1]
+
+        if year_range is not None:
+            year_min, year_max = year_range
+            if year_min is not None:
+                too_early = years < year_min
+                keep &= years >= years[too_early].max()
+                self.completeness_table[too_early, 0] = year_min
+            if year_max is not None:
+                keep &= years <= year_max
+
+        if mag_range is not None:
+            mag_min, mag_max = mag_range
+            if mag_min is not None:
+                keep &= mags >= mag_min
+            if mag_max is not None:
+                keep &= mags <= mag_max
+
+        self.completeness_table = self.completeness_table[keep, :]
+        self.model_line = self.model_line[:, keep]
+        self.sigma = self.sigma[:, keep]
+        self.magnitude_bin = self.magnitude_bin[np.hstack((keep, True))]
 
     def _get_time_limits_from_config(self, config, dec_year):
         '''
@@ -370,7 +408,7 @@ class Stepp1971(BaseCatalogueCompleteness):
                                                           np.ndarray):
             x_0 = initial_values
         else:
-            x_0 = [-1.0, xdata[len(xdata) / 2], xdata[0]]
+            x_0 = [-1.0, xdata[int(len(xdata) / 2)], xdata[0]]
 
         bnds = ((None, fixed_slope), (0.0, None), (None, None))
         result, _, convergence_info = \


### PR DESCRIPTION
I have made some of the HMTK plotting routines more flexible, primarily by allowing the user to pass a Axes object into which the data is to be plotted, allowing multiple similar plots to be plotted into the same Figure, for example. 

A few other minor improvements:
- Made colouring of lines in create_stepp_plot() predictable instead of random (@g-weatherill)
- Made filename optional in create_stepp_plot()
- Removed some problematic hardcoding of fontsize
- Made latitude/longitude grid spacing configurable in HMTKBasemap.
- Added simplify() method to Stepp1971 which removes redundant entries from automatically-generated completeness tables, making Stepp plots more readable

It is tricky to test plotting routines - there are no HMTK plot tests to update - so I haven't added any. I have informally tested everything I am pushing, at least. I could add a test for the simplification of completeness tables, if the maintainer thinks that would be helpful.