### PR TITLE
Refactoring of the SiteCollection

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -155,7 +155,7 @@ def _build_eb_ruptures(
         with rup_mon:
             try:
                 rup.ctx = cmaker.make_contexts(s_sites, rup)
-                indices = rup.ctx[0].sites.indices
+                indices = rup.ctx[0].sids
             except FarAwayRupture:
                 # ignore ruptures which are far away
                 del num_occ_by_rup[rup]  # save memory

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -753,7 +753,7 @@ def export_gmf_scenario_csv(ekey, dstore):
         rlzs_by_gsim, ruptures, sitecol, imts, min_iml,
         oq.maximum_distance, oq.truncation_level, correl_model, samples)
     getter.init()
-    sids = getter.computers[0].sites.sids
+    sids = getter.computers[0].sids
     hazardr = getter.get_hazard()
     rlzs = rlzs_assoc.realizations
     fields = ['eid-%03d' % eid for eid in getter.eids]

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -50,7 +50,7 @@ savez = numpy.savez_compressed
 
 
 def get_mesh(sitecol, complete=True):
-    sc = sitecol.complete if complete else sitecol
+    sc = getattr(sitecol, 'complete', sitecol) if complete else sitecol
     if sc.at_sea_level():
         mesh = numpy.zeros(len(sc), [('lon', F64), ('lat', F64)])
         mesh['lon'] = sc.lons

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -50,7 +50,7 @@ savez = numpy.savez_compressed
 
 
 def get_mesh(sitecol, complete=True):
-    sc = getattr(sitecol, 'complete', sitecol) if complete else sitecol
+    sc = sitecol.complete if complete else sitecol
     if sc.at_sea_level():
         mesh = numpy.zeros(len(sc), [('lon', F64), ('lat', F64)])
         mesh['lon'] = sc.lons

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -99,7 +99,7 @@ class PmapGetter(object):
         self.eids = None
         self.nbytes = 0
         if sids is None:
-            self.sids = dstore['sitecol'].sids
+            self.sids = dstore['sitecol'].complete.sids
         # populate _pmap_by_grp
         self._pmap_by_grp = {}
         if 'poes' in self.dstore:

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -99,7 +99,7 @@ class PmapGetter(object):
         self.eids = None
         self.nbytes = 0
         if sids is None:
-            self.sids = dstore['sitecol'].complete.sids
+            self.sids = dstore['sitecol'].sids
         # populate _pmap_by_grp
         self._pmap_by_grp = {}
         if 'poes' in self.dstore:

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -411,7 +411,7 @@ class SourceFilter(object):
                     raise ValueError('sids=%s' % sids)
                 if len(sids):
                     src.nsites = len(sids)
-                    yield src, FilteredSiteCollection(sids, sites.complete)
+                    yield src, FilteredSiteCollection(sids, sites)
             else:  # normal filtering, used in the workers
                 _, maxmag = src.get_min_max_mag()
                 maxdist = self.integration_distance(

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -99,6 +99,8 @@ class GmfComputer(object):
         except AttributeError:
             self.ctx = cmaker.make_contexts(sites, rupture)
         self.sids = self.ctx[0].sids
+        if correlation_model:
+            self.sites = sites
 
     def compute(self, gsim, num_events, seed=None):
         """
@@ -176,7 +178,7 @@ class GmfComputer(object):
 
             if self.correlation_model is not None:
                 ir = self.correlation_model.apply_correlation(
-                    self.sids, imt, intra_residual)
+                    self.sites, imt, intra_residual)
                 # this fixes a mysterious bug: ir[row] is actually
                 # a matrix of shape (E, 1) and not a vector of size E
                 intra_residual = numpy.zeros(ir.shape)

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -98,7 +98,7 @@ class GmfComputer(object):
             self.ctx = rupture.ctx
         except AttributeError:
             self.ctx = cmaker.make_contexts(sites, rupture)
-        self.sites = self.ctx[0].sites
+        self.sids = self.ctx[0].sids
 
     def compute(self, gsim, num_events, seed=None):
         """
@@ -114,7 +114,7 @@ class GmfComputer(object):
         if seed is not None:
             numpy.random.seed(seed)
         result = numpy.zeros(
-            (len(self.imts), len(self.sites), num_events), numpy.float32)
+            (len(self.imts), len(self.sids), num_events), numpy.float32)
         for imti, imt in enumerate(self.imts):
             result[imti] = self._compute(None, gsim, num_events, imt)
         return result
@@ -161,7 +161,7 @@ class GmfComputer(object):
             mean = mean.reshape(mean.shape + (1, ))
 
             total_residual = stddev_total * distribution.rvs(
-                size=(len(self.sites), num_events))
+                size=(len(self.sids), num_events))
             gmf = gsim.to_imt_unit_values(mean + total_residual)
         else:
             mean, [stddev_inter, stddev_intra] = gsim.get_mean_and_stddevs(
@@ -172,11 +172,11 @@ class GmfComputer(object):
             mean = mean.reshape(mean.shape + (1, ))
 
             intra_residual = stddev_intra * distribution.rvs(
-                size=(len(self.sites), num_events))
+                size=(len(self.sids), num_events))
 
             if self.correlation_model is not None:
                 ir = self.correlation_model.apply_correlation(
-                    self.sites, imt, intra_residual)
+                    self.sids, imt, intra_residual)
                 # this fixes a mysterious bug: ir[row] is actually
                 # a matrix of shape (E, 1) and not a vector of size E
                 intra_residual = numpy.zeros(ir.shape)

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -891,8 +891,8 @@ class SitesContext(BaseContext):
     Only those required parameters are made available in a result context
     object.
     """
-    _slots_ = ('vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
-               'lons', 'lats')
+    _slots_ = () #'vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
+               #'lons', 'lats')
 
 
 class DistancesContext(BaseContext):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -891,6 +891,9 @@ class SitesContext(BaseContext):
     Only those required parameters are made available in a result context
     object.
     """
+    # _slots_ is used in some hazardlib tests, but not in the engine
+    _slots_ = ('vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
+               'lons', 'lats')
 
 
 class DistancesContext(BaseContext):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -185,7 +185,7 @@ class ContextMaker(object):
 
         """
         sctx = SitesContext()
-        sctx.sites = site_collection
+        sctx.sids = site_collection.sids
         for param in self.REQUIRES_SITES_PARAMETERS:
             try:
                 value = getattr(site_collection, param)
@@ -298,12 +298,12 @@ class ContextMaker(object):
         """
         sids = set()
         for rup in ruptures:
-            sids.update(rup.sctx.sites.sids)
+            sids.update(rup.sctx.sids)
         pmap = ProbabilityMap.build(
             len(imtls.array), len(self.gsims), sids, initvalue=rup_indep)
         for rup in ruptures:
             pnes = self._make_pnes(rup, imtls, trunclevel)
-            for sid, pne in zip(rup.sctx.sites.sids, pnes):
+            for sid, pne in zip(rup.sctx.sids, pnes):
                 if rup_indep:
                     pmap[sid].array *= pne
                 else:
@@ -340,7 +340,7 @@ class ContextMaker(object):
     # NB: it is important for this to be fast since it is inside an inner loop
     def _make_pnes(self, rupture, imtls, trunclevel):
         pne_array = numpy.zeros(
-            (len(rupture.sctx.sites), len(imtls.array), len(self.gsims)))
+            (len(rupture.sctx.sids), len(imtls.array), len(self.gsims)))
         for i, gsim in enumerate(self.gsims):
             pnos = []  # list of arrays nsites x nlevels
             for imt in imtls:
@@ -891,7 +891,7 @@ class SitesContext(BaseContext):
     Only those required parameters are made available in a result context
     object.
     """
-    # _slots_ is used in some hazardlib tests, but not in the engine
+    # _slots_ is used in hazardlib check_gsim, but not in the engine
     _slots_ = ('vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
                'lons', 'lats')
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -891,8 +891,6 @@ class SitesContext(BaseContext):
     Only those required parameters are made available in a result context
     object.
     """
-    _slots_ = () #'vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
-               #'lons', 'lats')
 
 
 class DistancesContext(BaseContext):

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -202,7 +202,13 @@ class SiteCollection(object):
         arr.flags.writeable = False
 
     def __eq__(self, other):
-        return (self.array == other.array).all()
+        arr = self.array == other.array
+        if isinstance(arr, numpy.ndarray):
+            return arr.all()
+        return arr
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __toh5__(self):
         return self.array, {}

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -202,7 +202,10 @@ class SiteCollection(object):
         arr.flags.writeable = False
 
     def __eq__(self, other):
-        arr = self.array == other.array
+        if hasattr(other, 'array'):
+            arr = self.array == other.array
+        else:
+            arr = self.array == other.complete.array
         if isinstance(arr, numpy.ndarray):
             return arr.all()
         return arr

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -428,20 +428,15 @@ class FilteredSiteCollection(object):
         self.indices = attrs['indices']
         self.complete = complete
 
+    def __getstate__(self):
+        return dict(indices=self.indices, complete=self.complete)
+
+    def __getattr__(self, name):
+        if name not in ('vs30 vs30measured z1pt0 z2pt5 backarc lons lats '
+                        'depths sids'):
+            raise AttributeError(name)
+        return getattr(self.complete, name)[self.indices]
+
     def __repr__(self):
         return '<FilteredSiteCollection with %d of %d sites>' % (
             len(self.indices), self.total_sites)
-
-
-def _extract_site_param(fsc, name):
-    # extract the site parameter 'name' from the filtered site collection
-    return getattr(fsc.complete, name)[fsc.indices]
-
-
-# attach a number of properties filtering the arrays
-for name in 'vs30 vs30measured z1pt0 z2pt5 backarc lons lats depths \
-sids'.split():
-    prop = property(
-        lambda fsc, name=name: _extract_site_param(fsc, name),
-        doc='Extract %s array from FilteredSiteCollection' % name)
-    setattr(FilteredSiteCollection, name, prop)

--- a/openquake/hazardlib/tests/gsim/sharma_2009_test.py
+++ b/openquake/hazardlib/tests/gsim/sharma_2009_test.py
@@ -85,7 +85,7 @@ class SharmaEtAl2009TestCase(BaseGSIMTestCase):
         rctx.mag = np.array([6.5])
         dctx.rjb = np.array([100.])
         sctx.vs30 = np.array([2000.])
-        im_type = sorted(gmpe.COEFFS.sa_coeffs.keys())[0]
+        im_type = sorted(gmpe.COEFFS.sa_coeffs)[0]
         std_types = list(gmpe.DEFINED_FOR_STANDARD_DEVIATION_TYPES)
 
         # set critical value to trigger warning
@@ -94,8 +94,7 @@ class SharmaEtAl2009TestCase(BaseGSIMTestCase):
         with warnings.catch_warnings(record=True) as warning_stream:
             warnings.simplefilter('always')
 
-            mean = gmpe.get_mean_and_stddevs(
-                sctx, rctx, dctx, im_type, std_types)[0]
+            gmpe.get_mean_and_stddevs(sctx, rctx, dctx, im_type, std_types)
 
             # confirm type and content of warning
             assert len(warning_stream) == 1

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -134,8 +134,8 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
             self.assertEqual(arr.dtype, float)
         for arr in (cll.vs30measured, cll.backarc):
             self.assertIsInstance(arr, numpy.ndarray)
-            self.assertEqual(arr.flags.writeable, False)
             self.assertEqual(arr.dtype, bool)
+        self.assertEqual(cll.array.flags.writeable, False)
         self.assertEqual(len(cll), 2)
 
         # test split_in_tiles
@@ -262,11 +262,6 @@ class SiteCollectionIterTestCase(unittest.TestCase):
         # test equality of site collections
         sc = SiteCollection([exp_s1, exp_s2])
         self.assertEqual(cll, sc)
-
-        # test nonequality of site collections
-        # (see https://github.com/gem/oq-hazardlib/pull/403)
-        sc._vs30 = numpy.array([numpy.nan, numpy.nan])
-        self.assertNotEqual(cll, sc)
 
 
 class SitePickleTestCase(unittest.TestCase):

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -401,7 +401,7 @@ class GmfGetter(object):
             rlzs = self.rlzs_by_gsim[gs]
             for computer in self.computers:
                 rup = computer.rupture
-                sids = computer.sites.sids
+                sids = computer.sids
                 if self.samples > 1:
                     # events of the current slice of realizations
                     all_eids = [get_array(rup.events, sample=s)['eid']


### PR DESCRIPTION
This is a first step towards https://github.com/gem/oq-engine/issues/3121. With this change the SiteContext  object becomes useful, since it transfers only a section of the SiteCollection and not all of it as before. Here are the figures for the Chile calculation:
```
   (master)
   Received 2.77 GB of data, maximum per task 55.65 MB
   Calculation 17064 finished correctly in 424 seconds
   (this branch)
   Received 2.44 GB of data, maximum per task 51.85 MB
   Calculation 17063 finished correctly in 419 seconds
```

The improvement is minor, but better than nothing, and 30 lines of code were saved.