### PR TITLE
Reduced the data transfer when computing the hazard curves in postprocessing

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -18,8 +18,8 @@ for ini in $(find $1 -name job.ini | sort); do
 done
 
 # test generation of statistical hazard curves from previous calculation;
-# -2 is LogicTreeCase3ClassicalPSHA
-oq engine --run $1/hazard/LogicTreeCase3ClassicalPSHA/job.ini --hc -2
+# 20 is LogicTreeCase3ClassicalPSHA
+oq engine --run $1/hazard/LogicTreeCase3ClassicalPSHA/job.ini --hc 20
 
 # do something with the generated data
 oq extract -1 hazard/rlzs

--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -19,7 +19,7 @@ done
 
 # test generation of statistical hazard curves from previous calculation;
 # -2 is LogicTreeCase3ClassicalPSHA
-oq engine --run hazard/LogicTreeCase3ClassicalPSHA/job.ini --hc -2
+oq engine --run $1/hazard/LogicTreeCase3ClassicalPSHA/job.ini --hc -2
 
 # do something with the generated data
 oq extract -1 hazard/rlzs

--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -17,12 +17,16 @@ for ini in $(find $1 -name job.ini | sort); do
     oq engine --run $ini
 done
 
-# do something with the generated data; -2 is LogicTreeCase3ClassicalPSHA
-oq extract -2 hazard/rlzs
+# test generation of statistical hazard curves from previous calculation;
+# -2 is LogicTreeCase3ClassicalPSHA
+oq engine --run hazard/LogicTreeCase3ClassicalPSHA/job.ini --hc -2
+
+# do something with the generated data
+oq extract -1 hazard/rlzs
 oq engine --lhc
-MPLBACKEND=Agg oq plot -2
-MPLBACKEND=Agg oq plot_uhs -2
-MPLBACKEND=Agg oq plot_sites -2
+MPLBACKEND=Agg oq plot -1
+MPLBACKEND=Agg oq plot_uhs -1
+MPLBACKEND=Agg oq plot_sites -1
 
 # fake a wrong calculation still in executing status (AreaSource)
 oq db set_status 26 executing

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Fixed some bugs when generating the hazard curves with the `--hc` option
+  * Reduced the data transfer when computing the hazard curves in postprocessing
 
   [Nick Ackerley]
   * Some improvements to the plotting routines of the HMTK

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed some bugs when generating the hazard curves with the `--hc` option
+
   [Nick Ackerley]
   * Some improvements to the plotting routines of the HMTK
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,8 +2,6 @@
   * Some improvements to the plotting routines of the HMTK
 
   [Michele Simionato]
-  * Changed `oq run job_h.ini,job_r.ini` to disable concurrency in the second
-    run, as a workaround on reading the parent datastore from workers
   * Removed the ability to run `oq engine --run job_h.ini,job_r.ini`
   * Forbidden the site model in gmf_ebrisk calculations
   * When the option `--hc` is given the ruptures can now be read directly

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -705,7 +705,7 @@ class RiskCalculator(HazardCalculator):
                         dstore, sids, self.R, eids)
                 if dstore is self.datastore:
                     # read the hazard data in the controller node
-                    logging.info('Reading GMFs')
+                    logging.info('Reading hazard')
                     getter.init()
                 ri = riskinput.RiskInput(getter, reduced_assets, reduced_eps)
                 if ri.weight > 0:

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -492,7 +492,7 @@ class HazardCalculator(BaseCalculator):
             self.sitecol, self.assetcol = (
                 readinput.get_sitecol_assetcol(self.oqparam, self.exposure))
             logging.info('Read %d assets on %d sites',
-                         len(self.sitecol), len(self.assetcol))
+                         len(self.assetcol), len(self.sitecol))
             # NB: using hdf5.vstr would fail for large exposures;
             # the datastore could become corrupt, and also ultra-strange things
             # may happen (i.e. having the sitecol saved inside asset_refs!!)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -705,6 +705,7 @@ class RiskCalculator(HazardCalculator):
                         dstore, sids, self.R, eids)
                 if dstore is self.datastore:
                     # read the hazard data in the controller node
+                    logging.info('Reading GMFs')
                     getter.init()
                 ri = riskinput.RiskInput(getter, reduced_assets, reduced_eps)
                 if ri.weight > 0:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -244,6 +244,8 @@ def build_hcurves_and_stats(pgetter, hstats, monitor):
             pmaps = pgetter.get_pmaps(pgetter.sids)
         except IndexError:  # no data
             return {}
+        if sum(len(pmap) for pmap in pmaps) == 0:  # no data
+            return {}
     pmap_by_kind = {}
     for kind, stat in hstats:
         with monitor('compute ' + kind):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -314,7 +314,7 @@ class ClassicalCalculator(PSHACalculator):
         for t in self.sitecol.split_in_tiles(self.oqparam.concurrent_tasks):
             pgetter = calc.PmapGetter(parent, t.sids, self.rlzs_assoc)
             if parent is self.datastore:  # read now, not in the workers
-                logging.info('Reading PoEs')
+                logging.info('Reading PoEs on %d sites', len(t))
                 pgetter.init()
             yield pgetter, hstats, monitor
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -304,9 +304,12 @@ class ClassicalCalculator(PSHACalculator):
         """
         monitor = self.monitor('build_hcurves_and_stats')
         hstats = self.oqparam.hazard_stats()
+        parent = self.can_read_parent()
+        if parent is None:
+            parent = self.datastore
         for t in self.sitecol.split_in_tiles(self.oqparam.concurrent_tasks):
-            pgetter = calc.PmapGetter(self.datastore, t.sids, self.rlzs_assoc)
-            if not self.can_read_parent():  # read now, not in the workers
+            pgetter = calc.PmapGetter(parent, t.sids, self.rlzs_assoc)
+            if parent is None:  # read now, not in the workers
                 pgetter.init()
             yield pgetter, hstats, monitor
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -311,7 +311,7 @@ class ClassicalCalculator(PSHACalculator):
             parent = self.datastore
         for t in self.sitecol.split_in_tiles(self.oqparam.concurrent_tasks):
             pgetter = calc.PmapGetter(parent, t.sids, self.rlzs_assoc)
-            if parent is None:  # read now, not in the workers
+            if parent is self.datastore:  # read now, not in the workers
                 logging.info('Reading PoEs')
                 pgetter.init()
             yield pgetter, hstats, monitor

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -310,6 +310,7 @@ class ClassicalCalculator(PSHACalculator):
         for t in self.sitecol.split_in_tiles(self.oqparam.concurrent_tasks):
             pgetter = calc.PmapGetter(parent, t.sids, self.rlzs_assoc)
             if parent is None:  # read now, not in the workers
+                logging.info('Reading PoEs')
                 pgetter.init()
             yield pgetter, hstats, monitor
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -239,9 +239,11 @@ def build_hcurves_and_stats(pgetter, hstats, monitor):
     used to specify the kind of output.
     """
     with monitor('combine pmaps'):
-        pmaps = pgetter.get_pmaps(pgetter.sids)
-    if sum(len(pmap) for pmap in pmaps) == 0:  # no data
-        return {}
+        pgetter.init()  # if not already initialized
+        try:
+            pmaps = pgetter.get_pmaps(pgetter.sids)
+        except IndexError:  # no data
+            return {}
     pmap_by_kind = {}
     for kind, stat in hstats:
         with monitor('compute ' + kind):

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -140,6 +140,7 @@ producing too small PoEs.'''
         dic = {}
         imtls = self.oqparam.imtls
         pgetter = calc.PmapGetter(self.datastore, sids=numpy.array([sid]))
+        pgetter.init()
         for rlz in self.rlzs_assoc.realizations:
             try:
                 pmap = pgetter.get(rlz.ordinal)

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -63,6 +63,7 @@ class DisaggregationTestCase(CalculatorTestCase):
 
         # disaggregation by source group
         pgetter = calc.PmapGetter(self.calc.datastore)
+        pgetter.init()
         pmaps = []
         for grp in sorted(pgetter.dstore['poes']):
             pmaps.append(pgetter.get_mean(grp))

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -58,6 +58,7 @@ def make_figure(indices, n, imtls, spec_curves, curves=(), label=''):
 
 def get_pmaps(dstore, indices):
     getter = calc.PmapGetter(dstore)
+    getter.init()
     pmaps = getter.get_pmaps(indices)
     weights = dstore['realizations']['weight']
     mean = compute_pmap_stats(pmaps, [mean_curve], weights)

--- a/openquake/commands/plot_uhs.py
+++ b/openquake/commands/plot_uhs.py
@@ -61,6 +61,7 @@ def plot_uhs(calc_id, sites='0'):
     # read the hazard data
     dstore = datastore.read(calc_id)
     getter = calc.PmapGetter(dstore)
+    getter.init()
     oq = dstore['oqparam']
     indices = list(map(int, sites.split(',')))
     n_sites = len(dstore['sitecol'])

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -101,8 +101,12 @@ class PmapGetter(object):
         self.nbytes = 0
         if sids is None:
             self.sids = dstore['sitecol'].complete.sids
+
+    def init(self):
+        if hasattr(self, 'data'):  # already initialized
+            return
+        self.dstore.open()  # if not
         # populate _pmap_by_grp
-        # this cannot be done on the workers, it would take too much memory
         self._pmap_by_grp = {}
         if 'poes' in self.dstore:
             # build probability maps restricted to the given sids
@@ -120,10 +124,6 @@ class PmapGetter(object):
                 self._pmap_by_grp[grp] = pmap
                 self.nbytes += pmap.nbytes
 
-    def init(self):
-        if hasattr(self, 'data'):  # already initialized
-            return
-        self.dstore.open()  # if not
         self.imtls = self.dstore['oqparam'].imtls
         self.data = collections.OrderedDict()
         hcurves = self.get_hcurves(self.imtls)  # shape (R, N)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -123,6 +123,7 @@ class PmapGetter(object):
     def init(self):
         if hasattr(self, 'data'):  # already initialized
             return
+        self.dstore.open()  # if not
         self.imtls = self.dstore['oqparam'].imtls
         self.data = collections.OrderedDict()
         hcurves = self.get_hcurves(self.imtls)  # shape (R, N)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -126,7 +126,10 @@ class PmapGetter(object):
 
         self.imtls = self.dstore['oqparam'].imtls
         self.data = collections.OrderedDict()
-        hcurves = self.get_hcurves(self.imtls)  # shape (R, N)
+        try:
+            hcurves = self.get_hcurves(self.imtls)  # shape (R, N)
+        except IndexError:  # no data
+            return
         for sid, hcurve_by_rlz in zip(self.sids, hcurves.T):
             self.data[sid] = datadict = {}
             for rlzi, hcurve in enumerate(hcurve_by_rlz):

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -103,6 +103,11 @@ class PmapGetter(object):
             self.sids = dstore['sitecol'].complete.sids
         # populate _pmap_by_grp
         self._pmap_by_grp = {}
+
+    def init(self):
+        if hasattr(self, 'data'):  # already initialized
+            return
+        self.dstore.open()  # if not
         if 'poes' in self.dstore:
             # build probability maps restricted to the given sids
             for grp, dset in self.dstore['poes'].items():
@@ -118,11 +123,6 @@ class PmapGetter(object):
                         pmap[sid] = probability_map.ProbabilityCurve(dset[idx])
                 self._pmap_by_grp[grp] = pmap
                 self.nbytes += pmap.nbytes
-
-    def init(self):
-        if hasattr(self, 'data'):  # already initialized
-            return
-        self.dstore.open()  # if not
         self.imtls = self.dstore['oqparam'].imtls
         self.data = collections.OrderedDict()
         hcurves = self.get_hcurves(self.imtls)  # shape (R, N)
@@ -185,6 +185,7 @@ class PmapGetter(object):
             the kind of PoEs to extract; if not given, returns the realization
             if there is only one or the statistics otherwise.
         """
+        self.init()  # if not already initialized
         num_rlzs = len(self.weights)
         if not kind:  # use default
             if 'hcurves' in self.dstore:

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -91,6 +91,7 @@ class PmapGetter(object):
     :param rlzs_assoc: a RlzsAssoc instance (if None, infers it)
     """
     def __init__(self, dstore, sids=None, rlzs_assoc=None):
+        dstore.open()  # if not
         self.rlzs_assoc = rlzs_assoc or dstore['csm_info'].get_rlzs_assoc()
         self.dstore = dstore
         self.weights = [rlz.weight for rlz in self.rlzs_assoc.realizations]

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -102,12 +102,8 @@ class PmapGetter(object):
         if sids is None:
             self.sids = dstore['sitecol'].complete.sids
         # populate _pmap_by_grp
+        # this cannot be done on the workers, it would take too much memory
         self._pmap_by_grp = {}
-
-    def init(self):
-        if hasattr(self, 'data'):  # already initialized
-            return
-        self.dstore.open()  # if not
         if 'poes' in self.dstore:
             # build probability maps restricted to the given sids
             for grp, dset in self.dstore['poes'].items():
@@ -123,6 +119,10 @@ class PmapGetter(object):
                         pmap[sid] = probability_map.ProbabilityCurve(dset[idx])
                 self._pmap_by_grp[grp] = pmap
                 self.nbytes += pmap.nbytes
+
+    def init(self):
+        if hasattr(self, 'data'):  # already initialized
+            return
         self.imtls = self.dstore['oqparam'].imtls
         self.data = collections.OrderedDict()
         hcurves = self.get_hcurves(self.imtls)  # shape (R, N)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/3334. The data transfer is reduced because the initialization of the PmapGetter has been moved to the workers. The change is very substantial. For instance in a toy SHARE computation on my workstation the data transfer in the pgetter object goes down from 138.67 MB to 838.25 KB(170x improvement with respect to engine-2.8).