### PR TITLE
Removed the 'realizations' output

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Turned the 'realizations' output into a dynamic output
+
   [Matteo Nastasi]
   * Implemented an API `/v1/on_same_fs` to check filesystem accessibility
     between engine and a client application.

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -294,11 +294,8 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
 
     def before_export(self):
         """
-        Collect the realizations and set the attributes nbytes
+        Set the attributes nbytes
         """
-        if 'csm_info' in self.datastore and hasattr(self, 'rlzs_assoc'):
-            self.datastore['realizations'] = self.datastore['csm_info'].rlzs
-        # do not save the 'realizations' dataset when not possible
         for key in self.datastore:
             self.datastore.set_nbytes(key)
         self.datastore.flush()
@@ -792,7 +789,7 @@ def get_gmfs(calculator):
 
     else:  # with --hc option
         return (calculator.datastore['events']['eid'],
-                len(calculator.datastore['realizations']))
+                len(calculator.datastore['csm_info'].rlzs))
 
 
 def save_gmf_data(dstore, sitecol, gmfs):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -789,7 +789,7 @@ def get_gmfs(calculator):
 
     else:  # with --hc option
         return (calculator.datastore['events']['eid'],
-                len(calculator.datastore['csm_info'].rlzs))
+                calculator.datastore['csm_info'].get_num_rlzs())
 
 
 def save_gmf_data(dstore, sitecol, gmfs):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -62,8 +62,6 @@ class AssetSiteAssociationError(Exception):
     """Raised when there are no hazard sites close enough to any asset"""
 
 
-rlz_dt = numpy.dtype([('uid', 'S200'), ('model', 'S200'),
-                      ('gsims', 'S100'), ('weight', F32)])
 logversion = True
 
 
@@ -95,13 +93,6 @@ def set_array(longarray, shortarray):
     """
     longarray[:len(shortarray)] = shortarray
     longarray[len(shortarray):] = numpy.nan
-
-
-def gsim_names(rlz):
-    """
-    Names of the underlying GSIMs separated by spaces
-    """
-    return ' '.join(str(v) for v in rlz.gsim_rlz.value)
 
 
 def check_precalc_consistency(calc_mode, precalc_mode):
@@ -306,12 +297,7 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
         Collect the realizations and set the attributes nbytes
         """
         if 'csm_info' in self.datastore and hasattr(self, 'rlzs_assoc'):
-            sm_by_rlz = self.datastore['csm_info'].get_sm_by_rlz(
-                self.rlzs_assoc.realizations) or collections.defaultdict(
-                    lambda: 'NA')
-            self.datastore['realizations'] = numpy.array(
-                [(r.uid, sm_by_rlz[r], gsim_names(r), r.weight)
-                 for r in self.rlzs_assoc.realizations], rlz_dt)
+            self.datastore['realizations'] = self.datastore['csm_info'].rlzs
         # do not save the 'realizations' dataset when not possible
         for key in self.datastore:
             self.datastore.set_nbytes(key)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -269,7 +269,7 @@ class ClassicalCalculator(PSHACalculator):
         if 'poes' not in self.datastore:  # for short report
             return
         oq = self.oqparam
-        num_rlzs = len(self.datastore['realizations'])
+        num_rlzs = len(self.datastore['csm_info'].rlzs)
         if num_rlzs == 1:  # no stats to compute
             return {}
         elif not oq.hazard_stats():

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -269,7 +269,7 @@ class ClassicalCalculator(PSHACalculator):
         if 'poes' not in self.datastore:  # for short report
             return
         oq = self.oqparam
-        num_rlzs = len(self.datastore['csm_info'].rlzs)
+        num_rlzs = self.datastore['csm_info'].get_num_rlzs()
         if num_rlzs == 1:  # no stats to compute
             return {}
         elif not oq.hazard_stats():

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -111,7 +111,7 @@ class ClassicalRiskCalculator(base.RiskCalculator):
             super(ClassicalRiskCalculator, self).pre_execute()
             if 'poes' not in self.datastore:  # when building short report
                 return
-        weights = self.datastore['realizations']['weight']
+        weights = self.datastore['csm_info'].rlzs['weight']
         self.R = len(weights)
         with self.monitor('build riskinputs', measuremem=True, autoflush=True):
             self.riskinputs = self.build_riskinputs('poe')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -534,7 +534,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.sm_id = {tuple(sm.path): sm.ordinal
                       for sm in self.csm_info.source_models}
         L = len(oq.imtls.array)
-        R = len(self.datastore['realizations'])
+        R = len(self.datastore['csm_info'].rlzs)
         self.gmdata = {}
         self.offset = 0
         self.indices = collections.defaultdict(list)  # sid -> indices

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -534,7 +534,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.sm_id = {tuple(sm.path): sm.ordinal
                       for sm in self.csm_info.source_models}
         L = len(oq.imtls.array)
-        R = len(self.datastore['csm_info'].rlzs)
+        R = self.datastore['csm_info'].get_num_rlzs()
         self.gmdata = {}
         self.offset = 0
         self.indices = collections.defaultdict(list)  # sid -> indices

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -376,6 +376,7 @@ def export_hcurves_csv(ekey, dstore):
                     ekey, kind, rlzs_assoc, fname, sitecol, hcurves, oq))
     return sorted(fnames)
 
+
 UHS = collections.namedtuple('UHS', 'imls location')
 
 
@@ -933,7 +934,7 @@ def export_disagg_csv(ekey, dstore):
 
 @export.add(('realizations', 'csv'))
 def export_realizations(ekey, dstore):
-    rlzs = dstore[ekey[0]]
+    rlzs = dstore['csm_info'].realizations
     data = [['ordinal', 'uid', 'model', 'gsim', 'weight']]
     for i, rlz in enumerate(rlzs):
         data.append([i, rlz['uid'], rlz['model'], rlz['gsims'], rlz['weight']])

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -934,9 +934,8 @@ def export_disagg_csv(ekey, dstore):
 
 @export.add(('realizations', 'csv'))
 def export_realizations(ekey, dstore):
-    rlzs = dstore['csm_info'].realizations
     data = [['ordinal', 'uid', 'model', 'gsim', 'weight']]
-    for i, rlz in enumerate(rlzs):
+    for i, rlz in enumerate(dstore['csm_info'].rlzs):
         data.append([i, rlz['uid'], rlz['model'], rlz['gsims'], rlz['weight']])
     path = dstore.export_path('realizations.csv')
     writers.write_csv(path, data, fmt='%s')

--- a/openquake/calculators/export/loss_curves.py
+++ b/openquake/calculators/export/loss_curves.py
@@ -67,7 +67,7 @@ class LossCurveExporter(object):
         self.str2asset = {arefs[asset.idx]: asset for asset in self.assetcol}
         self.asset_refs = self.dstore['asset_refs'].value
         self.loss_types = dstore.get_attr('composite_risk_model', 'loss_types')
-        self.R = len(dstore['csm_info'].rlzs)
+        self.R = dstore['csm_info'].get_num_rlzs()
 
     def parse(self, what):
         """

--- a/openquake/calculators/export/loss_curves.py
+++ b/openquake/calculators/export/loss_curves.py
@@ -27,7 +27,7 @@ def get_loss_builder(dstore):
     :returns: a LossesByPeriodBuilder instance
     """
     oq = dstore['oqparam']
-    weights = dstore['realizations']['weight']
+    weights = dstore['csm_info'].rlzs['weight']
     eff_time = oq.investigation_time * oq.ses_per_logic_tree_path
     num_events = dstore['gmdata']['events']
     periods = oq.return_periods or scientific.return_periods(
@@ -67,7 +67,7 @@ class LossCurveExporter(object):
         self.str2asset = {arefs[asset.idx]: asset for asset in self.assetcol}
         self.asset_refs = self.dstore['asset_refs'].value
         self.loss_types = dstore.get_attr('composite_risk_model', 'loss_types')
-        self.R = len(dstore['realizations'])
+        self.R = len(dstore['csm_info'].rlzs)
 
     def parse(self, what):
         """

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -95,7 +95,7 @@ def export_avg_losses(ekey, dstore):
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     name, kind = dskey.split('-')
     if kind == 'stats':
-        weights = dstore['realizations']['weight']
+        weights = dstore['csm_info'].rlzs['weight']
         tags, stats = zip(*oq.risk_stats())
         if dskey in dstore:  # precomputed
             value = dstore[dskey].value
@@ -270,7 +270,7 @@ def export_loss_curves(ekey, dstore):
 # this is used by classical_risk and event_based_risk
 @export.add(('loss_curves-stats', 'csv'))
 def export_loss_curves_stats(ekey, dstore):
-    num_rlzs = len(dstore['realizations'])
+    num_rlzs = len(dstore['csm_info'].rlzs)
     kind = 'stats' if num_rlzs > 1 else 'rlzs'
     return export_loss_curves(('loss_curves/' + kind, 'csv'), dstore)
 
@@ -299,7 +299,7 @@ def export_loss_maps_npz(ekey, dstore):
     kind = ekey[0].split('-')[1]  # rlzs or stats
     assets = get_assets(dstore)
     value = get_loss_maps(dstore, kind)
-    R = len(dstore['realizations'])
+    R = len(dstore['csm_info'].rlzs)
     if kind == 'rlzs':
         tags = ['rlz-%03d' % r for r in range(R)]
     else:

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -299,7 +299,7 @@ def export_loss_maps_npz(ekey, dstore):
     kind = ekey[0].split('-')[1]  # rlzs or stats
     assets = get_assets(dstore)
     value = get_loss_maps(dstore, kind)
-    R = len(dstore['csm_info'].rlzs)
+    R = dstore['csm_info'].get_num_rlzs()
     if kind == 'rlzs':
         tags = ['rlz-%03d' % r for r in range(R)]
     else:

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -270,7 +270,7 @@ def export_loss_curves(ekey, dstore):
 # this is used by classical_risk and event_based_risk
 @export.add(('loss_curves-stats', 'csv'))
 def export_loss_curves_stats(ekey, dstore):
-    num_rlzs = len(dstore['csm_info'].rlzs)
+    num_rlzs = dstore['csm_info'].get_num_rlzs()
     kind = 'stats' if num_rlzs > 1 else 'rlzs'
     return export_loss_curves(('loss_curves/' + kind, 'csv'), dstore)
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -118,7 +118,7 @@ def extract_hazard(dstore, what):
     yield 'sitecol', sitecol
     yield 'oqparam', oq
     yield 'imtls', oq.imtls
-    yield 'realizations', dstore['realizations'].value
+    yield 'realizations', dstore['csm_info'].rlzs
     yield 'checksum32', dstore['/'].attrs['checksum32']
     nsites = len(sitecol)
     M = len(oq.imtls)
@@ -153,7 +153,7 @@ def extract_hazard_for_qgis(dstore, what):
     sitecol = dstore['sitecol']
     yield 'sitecol', sitecol
     yield 'oqparam', oq
-    yield 'realizations', dstore['realizations'].value
+    yield 'realizations', dstore['csm_info'].rlzs
     yield 'checksum32', dstore['/'].attrs['checksum32']
     N = len(sitecol)
     if oq.poes:

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -215,7 +215,7 @@ class EventBasedTestCase(CalculatorTestCase):
         for exp, got in zip(expected, fnames):
             self.assertEqualFiles('expected/%s' % exp, got)
 
-        [fname] = out['realizations', 'csv']
+        [fname] = export(('realizations', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/realizations.csv', fname)
 
         # test for the mean gmv

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -334,7 +334,7 @@ def avglosses_data_transfer(token, dstore):
     """
     oq = dstore['oqparam']
     N = len(dstore['assetcol'])
-    R = len(dstore['realizations'])
+    R = len(dstore['csm_info'].rlzs)
     L = len(dstore.get_attr('composite_risk_model', 'loss_types'))
     I = oq.insured_losses + 1
     ct = oq.concurrent_tasks
@@ -378,7 +378,7 @@ def view_portfolio_loss(token, dstore):
     """
     oq = dstore['oqparam']
     loss_dt = oq.loss_dt()
-    R = len(dstore['realizations'])
+    R = len(dstore['csm_info'].rlzs)
     by_rlzi = group_array(dstore['agg_loss_table'].value, 'rlzi')
     data = numpy.zeros(R, loss_dt)
     rlzids = [str(r) for r in range(R)]
@@ -415,7 +415,7 @@ def sum_table(records):
 @view.add('mean_avg_losses')
 def view_mean_avg_losses(token, dstore):
     dt = dstore['oqparam'].loss_dt()
-    weights = dstore['realizations']['weight']
+    weights = dstore['csm_info'].rlzs['weight']
     array = dstore['avg_losses-rlzs'].value  # shape (N, R)
     if len(weights) == 1:  # one realization
         mean = array[:, 0]
@@ -760,7 +760,7 @@ def view_elt(token, dstore):
     Display the event loss table averaged by event
     """
     oq = dstore['oqparam']
-    R = len(dstore['realizations'])
+    R = len(dstore['csm_info'].rlzs)
     dic = group_array(dstore['agg_loss_table'].value, 'rlzi')
     header = oq.loss_dt().names
     tbl = []

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -334,7 +334,7 @@ def avglosses_data_transfer(token, dstore):
     """
     oq = dstore['oqparam']
     N = len(dstore['assetcol'])
-    R = len(dstore['csm_info'].rlzs)
+    R = dstore['csm_info'].get_num_rlzs()
     L = len(dstore.get_attr('composite_risk_model', 'loss_types'))
     I = oq.insured_losses + 1
     ct = oq.concurrent_tasks
@@ -378,7 +378,7 @@ def view_portfolio_loss(token, dstore):
     """
     oq = dstore['oqparam']
     loss_dt = oq.loss_dt()
-    R = len(dstore['csm_info'].rlzs)
+    R = dstore['csm_info'].get_num_rlzs()
     by_rlzi = group_array(dstore['agg_loss_table'].value, 'rlzi')
     data = numpy.zeros(R, loss_dt)
     rlzids = [str(r) for r in range(R)]

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -60,7 +60,7 @@ def get_pmaps(dstore, indices):
     getter = calc.PmapGetter(dstore)
     getter.init()
     pmaps = getter.get_pmaps(indices)
-    weights = dstore['realizations']['weight']
+    weights = dstore['csm_info'].rlzs['weight']
     mean = compute_pmap_stats(pmaps, [mean_curve], weights)
     return mean, pmaps
 

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -44,6 +44,15 @@ U32 = numpy.uint32
 I32 = numpy.int32
 F32 = numpy.float32
 weight = operator.attrgetter('weight')
+rlz_dt = numpy.dtype([('uid', 'S200'), ('model', 'S200'),
+                      ('gsims', 'S100'), ('weight', F32)])
+
+
+def gsim_names(rlz):
+    """
+    Names of the underlying GSIMs separated by spaces
+    """
+    return ' '.join(str(v) for v in rlz.gsim_rlz.value)
 
 
 class LtRealization(object):
@@ -483,6 +492,18 @@ class CompositionInfo(object):
             return source_model.samples
         trts = set(sg.trt for sg in source_model.src_groups)
         return self.gsim_lt.reduce(trts).get_num_paths()
+
+    @property
+    def rlzs(self):
+        """
+        :returns: an array of realizations
+        """
+        realizations = self.get_rlzs_assoc().realizations
+        sm_by_rlz = self.get_sm_by_rlz(
+            realizations) or collections.defaultdict(lambda: 'NA')
+        return numpy.array(
+            [(r.uid, sm_by_rlz[r], gsim_names(r), r.weight)
+             for r in realizations], rlz_dt)
 
     def get_rlzs_assoc(self, count_ruptures=None,
                        sm_lt_path=None, trts=None):

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -111,7 +111,7 @@ def expose_outputs(dstore):
     dskeys = set(dstore) & exportable  # exportable datastore keys
     dskeys.add('fullreport')
     try:
-        rlzs = list(dstore['realizations'])
+        rlzs = dstore['csm_info'].rlzs
     except KeyError:
         rlzs = []
     # expose gmf_data only if < 10 MB
@@ -137,8 +137,6 @@ def expose_outputs(dstore):
             dskeys.add('loss_maps-stats')
     if 'all_loss_ratios' in dskeys:
         dskeys.remove('all_loss_ratios')  # export only specific IDs
-    if 'realizations' in dskeys and len(rlzs) <= 1:
-        dskeys.remove('realizations')  # do not export a single realization
     if 'ruptures' in dskeys and 'scenario' in calcmode:
         exportable.remove('ruptures')  # do not export, as requested by Vitor
     logs.dbcmd('create_outputs', dstore.calc_id, sorted(dskeys & exportable))

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -126,7 +126,8 @@ def expose_outputs(dstore):
             dskeys.add('uhs')  # export them
         if oq.hazard_maps:
             dskeys.add('hmaps')  # export them
-    if 'avg_losses-stats' in dstore or ('avg_losses-rlzs' in dstore and rlzs):
+    if 'avg_losses-stats' in dstore or (
+            'avg_losses-rlzs' in dstore and len(rlzs)):
         dskeys.add('avg_losses-stats')
     if 'curves-stats' in dstore:
         logs.LOG.warn('loss curves are exportable with oq export')

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -110,10 +110,8 @@ def expose_outputs(dstore):
     calcmode = oq.calculation_mode
     dskeys = set(dstore) & exportable  # exportable datastore keys
     dskeys.add('fullreport')
-    try:
-        rlzs = dstore['csm_info'].rlzs
-    except KeyError:
-        rlzs = []
+    rlzs = dstore['csm_info'].rlzs
+    dskeys.add('realizations')
     # expose gmf_data only if < 10 MB
     if oq.ground_motion_fields and calcmode == 'event_based':
         nbytes = dstore['gmf_data'].attrs['nbytes']

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -111,7 +111,8 @@ def expose_outputs(dstore):
     dskeys = set(dstore) & exportable  # exportable datastore keys
     dskeys.add('fullreport')
     rlzs = dstore['csm_info'].rlzs
-    dskeys.add('realizations')
+    if len(rlzs) > 1:
+        dskeys.add('realizations')
     # expose gmf_data only if < 10 MB
     if oq.ground_motion_fields and calcmode == 'event_based':
         nbytes = dstore['gmf_data'].attrs['nbytes']


### PR DESCRIPTION
The 'realizations' output is a derived output that can be extracted from the 'csm_info' output. It is best to remove it from the datastore, but to keep it in the engine for backward compatibility.