### PR TITLE
Kill all oq processes if the webui is killed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Killing the WebUI kills all the `oq-` jobs spawned by the WebUI user
   * Turned the 'realizations' output into a dynamic output
 
   [Matteo Nastasi]

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -66,6 +66,6 @@ if __name__ == "__main__":
         for p in psutil.process_iter():
             pname = p.name()
             if pname == 'oq-worker':
-                os.kill(p.pid, signal.SIGTERM)
+                os.kill(p.pid, signal.SIGKILL)
             elif pname.startswith('oq-job-'):
-                os.kill(p.pid, signal.SIGTERM)
+                os.kill(p.pid, signal.SIGKILL)

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -64,5 +64,8 @@ if __name__ == "__main__":
         execute_from_command_line(sys.argv)
     finally:
         for p in psutil.process_iter():
-            if p.name().startswith('oq-'):
-                os.kill(p.pid, signal.SIGKILL)
+            pname = p.name()
+            if pname == 'oq-worker':
+                os.kill(p.pid, signal.SIGTERM)
+            elif pname.startswith('oq-job-'):
+                os.kill(p.pid, signal.SIGTERM)

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import sys
+import signal
+import psutil
 try:
     from setproctitle import setproctitle
 except ImportError:
@@ -58,4 +60,9 @@ if __name__ == "__main__":
         logs.dbcmd('reset_is_running')  # reset the flag is_running
 
     setproctitle('oq-webui')
-    execute_from_command_line(sys.argv)
+    try:
+        execute_from_command_line(sys.argv)
+    finally:
+        for p in psutil.process_iter():
+            if p.name().startswith('oq-'):
+                os.kill(p.pid, signal.SIGKILL)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/3211. Notice that I had to use SIGKILL, SIGTERM is not enough. In our cluster the WebUI is run by the user openquake, so if it is killed only the processes of openquake are killed, which is good.