### PR TITLE
Added command `oq shell`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a command `oq python` embedding IPython if available
   * Turned the 'realizations' output into a dynamic output
 
   [Matteo Nastasi]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Added a command `oq python` embedding IPython if available
+  * Added a command `oq python` embedding (I)Python
   * Turned the 'realizations' output into a dynamic output
 
   [Matteo Nastasi]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Added a command `oq python` embedding (I)Python
+  * Added a command `oq shell` to open an embedded (I)Python shell
   * Turned the 'realizations' output into a dynamic output
 
   [Matteo Nastasi]

--- a/openquake/commands/python.py
+++ b/openquake/commands/python.py
@@ -20,14 +20,17 @@ from openquake.baselib import sap
 
 class OQ(object):
     """
-    Singleton object with convenience methods which are aliases over common
-    engine functions useful for work in the interactive interpreter.
+    Singleton object with convenience functions which are aliases over
+    engine utilities for work in the interactive interpreter.
     """
     def __init__(self):
         from openquake.baselib.datastore import read
         from openquake.commonlib import readinput
         self.read = read
         self.get_oqparam = readinput.get_oqparam
+        self.get_site_collection = readinput.get_site_collection
+        self.get_exposure = readinput.get_exposure
+        # TODO: more utilities when be added when deemed useful
 
 
 @sap.Script

--- a/openquake/commands/python.py
+++ b/openquake/commands/python.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2018 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import sys
+from openquake.baselib import sap
+
+
+class _OQ(object):
+    def __init__(self):
+        from openquake.baselib.datastore import read
+        from openquake.commonlib import readinput
+        self.read = read
+        self.get_oqparam = readinput.get_oqparam
+
+
+@sap.Script
+def python():
+    """
+    Start an embedded ipython instance if possible
+    """
+    try:
+        import IPython
+    except ImportError:
+        sys.exit('IPython is not available')
+    oq = _OQ()  # noqa
+    IPython.embed(banner1='IPython shell with a global oq object')

--- a/openquake/commands/python.py
+++ b/openquake/commands/python.py
@@ -15,11 +15,14 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-import sys
 from openquake.baselib import sap
 
 
-class _OQ(object):
+class OQ(object):
+    """
+    Singleton object with convenience methods which are aliases over common
+    engine functions useful for work in the interactive interpreter.
+    """
     def __init__(self):
         from openquake.baselib.datastore import read
         from openquake.commonlib import readinput
@@ -30,11 +33,13 @@ class _OQ(object):
 @sap.Script
 def python():
     """
-    Start an embedded ipython instance if possible
+    Start an embedded (i)python instance with a global oq object
     """
+    oq = OQ()  # noqa
     try:
         import IPython
+        IPython.embed(banner1='IPython shell with a global oq object')
     except ImportError:
-        sys.exit('IPython is not available')
-    oq = _OQ()  # noqa
-    IPython.embed(banner1='IPython shell with a global oq object')
+        import code
+        code.interact(banner='Python shell with a global oq object',
+                      local=dict(oq=oq))

--- a/openquake/commands/shell.py
+++ b/openquake/commands/shell.py
@@ -34,7 +34,7 @@ class OQ(object):
 
 
 @sap.Script
-def python():
+def shell():
     """
     Start an embedded (i)python instance with a global oq object
     """


### PR DESCRIPTION
This is an easy way to drop into an (I)Python console, as suggest by Matteo. Here is an example of usage:

$ oq ~~~python~~~ shell
```python
IPython shell with a global oq object
In [1]: oq.read(-1)
Out[1]: <DataStore 19464, open>
In [2]: oq.  # press TAB here
            get_exposure()        get_site_collection() 
            get_oqparam()         read()               
```