### PR TITLE
Rectify loss ratio sampling function for the Beta distribution

### DIFF
--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -815,8 +815,8 @@ class LogNormalDistribution(Distribution):
 @DISTRIBUTIONS.add('BT')
 class BetaDistribution(Distribution):
     def sample(self, means, _covs, stddevs, _idxs=None):
-        alpha = self._alpha(means, stddevs)
-        beta = self._beta(means, stddevs)
+        alpha = self._alpha(means, means * _covs)
+        beta = self._beta(means, means * _covs)
         return numpy.random.beta(alpha, beta, size=None)
 
     def survival(self, loss_ratio, mean, stddev):


### PR DESCRIPTION
Currently, scenario_risk calculations with vulnerability functions using the Beta distribution fail with the following error:

```sh
RuntimeError:
  File "/Users/GEM/oq-engine/openquake/baselib/workerpool.py", line 47, in safely_call
    got = func(*args)
  File "/Users/GEM/oq-engine/openquake/calculators/scenario_risk.py", line 61, in scenario_risk
    for outputs in riskmodel.gen_outputs(riskinput, monitor):
  File "/Users/GEM/oq-engine/openquake/risklib/riskinput.py", line 245, in gen_outputs
    for out in self._gen_outputs(hazard_getter, dic, None):
  File "/Users/GEM/oq-engine/openquake/risklib/riskinput.py", line 270, in _gen_outputs
    out = riskmodel.get_output(assets, data, epsgetter)
  File "/Users/GEM/oq-engine/openquake/risklib/riskmodels.py", line 80, in get_output
    for lt, data in zip(self.loss_types, data_by_lt)]
  File "/Users/GEM/oq-engine/openquake/risklib/riskmodels.py", line 80, in <listcomp>
    for lt, data in zip(self.loss_types, data_by_lt)]
  File "/Users/GEM/oq-engine/openquake/risklib/riskmodels.py", line 337, in __call__
    loss_ratio_matrix[i, idxs] = vf.sample(means, covs, idxs, eps)
  File "/Users/GEM/oq-engine/openquake/risklib/scientific.py", line 173, in sample
    return self.distribution.sample(means, covs, None, idxs)
  File "/Users/GEM/oq-engine/openquake/risklib/scientific.py", line 818, in sample
    alpha = self._alpha(means, stddevs)
  File "/Users/GEM/oq-engine/openquake/risklib/scientific.py", line 829, in _alpha
    return ((1 - mean) / stddev ** 2 - 1 / mean) * mean ** 2
TypeError: unsupported operand type(s) for ** or pow(): 'NoneType' and 'int'
```

This patch fixes the above issue. A test case is available here: [oq-risk-tests/scenario_risk/case_1g](https://github.com/gem/oq-risk-tests/tree/master/test/scenario_risk/inputs/case_1g)