### PR TITLE
Improve abort button

### DIFF
--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -234,7 +234,7 @@
                                             err = "has been aborted.";
                                         }
                                         diaerror.show(false, "Calculation aborted", "The calculation:<br><b>(" + calc_id + ") " + calc_desc + "</b> " + err );
-                                        view.calculations.remove([view.calculations.get(calc_id)]);
+                                        calculations.fetch({reset: true})
                                     }});
             },
 

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -199,12 +199,12 @@
                                         }
                                     },
                                     success: function(data, textStatus, jqXHR) {
-                                        err = data.error;
-                                        if(!err) {
-                                            err = "has been removed.";
+                                        if(data.error) {
+                                            diaerror.show(false, "Error", data.error);
+                                        } else {
+                                            diaerror.show(false, "Calculation removed", "Calculation <b>(" + calc_id + ") " + calc_desc + "</b> has been removed." );
+                                            view.calculations.remove([view.calculations.get(calc_id)]);
                                         }
-                                        diaerror.show(false, "Calculation removed", "The calculation:<br><b>(" + calc_id + ") " + calc_desc + "</b> " + err );
-                                        view.calculations.remove([view.calculations.get(calc_id)]);
                                     }});
             },
 
@@ -229,12 +229,12 @@
                                         }
                                     },
                                     success: function(data, textStatus, jqXHR) {
-                                        err = data.error;
-                                        if(!err) {
-                                            err = "has been aborted.";
+                                        if(data.error) {
+                                            diaerror.show(false, "Error", data.error );
+                                        } else {
+                                            diaerror.show(false, "Calculation aborted", "Calculation <b>(" + calc_id + ") " + calc_desc + "</b> has been aborted." );
+                                            calculations.fetch({reset: true})
                                         }
-                                        diaerror.show(false, "Calculation aborted", "The calculation:<br><b>(" + calc_id + ") " + calc_desc + "</b> " + err );
-                                        calculations.fetch({reset: true})
                                     }});
             },
 

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -56,3 +56,8 @@ if settings.LOCKDOWN:
         url(r'^accounts/ajax_login/$', views.ajax_login),
         url(r'^accounts/ajax_logout/$', views.ajax_logout),
     ]
+
+# To enable gunicorn debug without Nginx (to serve static files)
+# uncomment the following lines
+# from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+# urlpatterns += staticfiles_urlpatterns()

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -346,7 +346,7 @@ def calc_abort(request, calc_id):
     Abort the given calculation, it is it running
     """
     job = logs.dbcmd('get_job', calc_id)
-    message = 'Job %s is not running' % job.id
+    message = {'error': 'Job %s is not running' % job.id}
     if job is None or job.status not in ('executing', 'running'):
         return HttpResponse(content=json.dumps(message), content_type=JSON)
 
@@ -354,8 +354,8 @@ def calc_abort(request, calc_id):
     info = logs.dbcmd('calc_info', calc_id)
     allowed_users = user['group_members'] or [user['name']]
     if user['acl_on'] and info['user_name'] not in allowed_users:
-        message = ('User %s has No permission to abort job %s' %
-                   (info['user_name'], job.id))
+        message = {'error': ('User %s has no permission to abort job %s' %
+                             (info['user_name'], job.id))}
         return HttpResponse(content=json.dumps(message), content_type=JSON,
                             status=403)
 
@@ -363,10 +363,10 @@ def calc_abort(request, calc_id):
         name = 'oq-job-%d' % job.id
         os.kill(job2pid[job.id], signal.SIGTERM)
         logs.dbcmd('set_status', job.id, 'aborted')
-        message = 'Killing job %s' % name
+        message = {'success': 'Job %s killed' % name}
         return HttpResponse(content=json.dumps(name), content_type=JSON)
 
-    message = 'PIDs for job %s not found' % job.id
+    message = {'error': 'PIDs for job %s not found' % job.id}
     return HttpResponse(content=json.dumps(message), content_type=JSON)
 
 


### PR DESCRIPTION
This PR improves #3355 and fixes some bugs in the error messages management, in particular we are not hiding anymore error messages sent by the backend; this change has been backported to `remove` too.
Adds also a (commented out) snippet to help debugging guinicorn locally (without a reverse proxy).