### PR TITLE
Added an URL /v1/calc/ID/list

### DIFF
--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -23,6 +23,7 @@ from openquake.server import views
 # each url is prefixed with /v1/calc/
 urlpatterns = [
     url(r'^list$', views.calc),
+    url(r'^(\d+)/list$', views.calc),
     url(r'^(\d+)$', views.calc_info),
     url(r'^(\d+)/abort$', views.calc_abort),
     url(r'^(\d+)/datastore$', views.get_datastore),

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -324,6 +324,8 @@ def calc(request, id=None):
             dict(id=hc_id, owner=owner,
                  calculation_mode=calculation_mode, status=status,
                  is_running=bool(is_running), description=desc, url=url))
+    if not response_data:
+        return HttpResponseNotFound()
 
     # if id is specified the related dictionary is returned instead the list
     if id is not None:


### PR DESCRIPTION
Returns info in the same format as /v1/calc/list, but only for the specified calc_id:
```
url	"http://127.0.0.1:8800/v1/calc/21953"
is_running	false
calculation_mode	"event_based_risk"
id	21953
description	"Virtual Island Seismic Risk - City C, ses=1"
status	"failed"
owner	"michele"
```