### PR TITLE
Warning for no output

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -274,10 +274,11 @@ class ClassicalCalculator(PSHACalculator):
             return {}
         elif not oq.hazard_stats():
             if oq.hazard_maps or oq.uniform_hazard_spectra:
-                raise ValueError('The job.ini says that no statistics should '
-                                 'be computed, but then there is no output!')
-            else:
-                return {}
+                logging.warn('mean_hazard_curves was false in the job.ini, '
+                             'so no outputs were generated.\nYou can compute '
+                             'the statistics without repeating the calculation'
+                             ' with the --hc option')
+            return {}
         # initialize datasets
         N = len(self.sitecol)
         L = len(oq.imtls.array)

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -34,9 +34,9 @@ from openquake.qa_tests_data.classical import (
 class ClassicalTestCase(CalculatorTestCase):
 
     def assert_curves_ok(self, expected, test_dir, delta=None, **kw):
+        kind = kw.pop('kind', '')  # 'all' or ''
         self.run_calc(test_dir, 'job.ini', **kw)
         ds = self.calc.datastore
-        kind = kw.get('kind', '')  # 'all' or ''
         got = (export(('hcurves/' + kind, 'csv'), ds) +
                export(('hmaps/' + kind, 'csv'), ds) +
                export(('uhs/' + kind, 'csv'), ds))
@@ -123,13 +123,10 @@ class ClassicalTestCase(CalculatorTestCase):
              'hazard_curve-smltp_b2-gsimltp_b1.csv'],
             case_7.__file__, kind='all')
 
-        with self.assertRaises(ValueError) as ctx:
-            self.run_calc(
-                case_7.__file__, 'job.ini', mean_hazard_curves='false',
-                hazard_maps='true', poes='0.1')
-        self.assertEqual(
-            'The job.ini says that no statistics should be computed, but then '
-            'there is no output!', str(ctx.exception))
+        # exercise the warning for no output when mean_hazard_curves='false'
+        self.run_calc(
+            case_7.__file__, 'job.ini', mean_hazard_curves='false',
+            hazard_maps='true', poes='0.1')
 
     @attr('qa', 'hazard', 'classical')
     def test_case_8(self):


### PR DESCRIPTION
Certain calculations (i.e. the Canada model) are so big that the mean hazard curves cannot be computed directly: you will get an error
```python
       return dumper(obj, protocol=pickle_protocol)
   kombu.exceptions.EncodeError: cannot serialize a string larger than 4GiB
```
because the data transfer is just too large. For such calculations it is correct to set `mean_hazard_curves=false` in the job.ini file and to disable the computation of all quantiles. The statistics can still be computed in postprocessing, with the command `oq engine --run job.ini --hc <previous_calculation_id>`. The postprocessing bypasses kombu and Python pickling limitations (if there is a shared file system) since it is able to read directly the probability maps without using rabbitmq.

Unfortunately at the moment disabling all the statistics raises an error. This pull request turns the error into a warning, since it is a legitimate situation.