### PR TITLE
Worked around the usual fork issue

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -218,17 +218,16 @@ class EbriskCalculator(base.RiskCalculator):
             samples = samples_by_grp[grp_id]
             ruptures = self.ruptures_by_grp.get(grp_id, [])
             num_ruptures[grp_id] = len(ruptures)
-            if hasattr(ruptures, 'split'):  # RuptureGetter
+            from_parent = hasattr(ruptures, 'split')
+            if from_parent:  # read the ruptures from the parent datastore
                 logging.info('Reading ruptures group #%d', grp_id)
                 with self.monitor('reading ruptures', measuremem=True):
                     blocks = ruptures.split(ruptures_per_block)
-            else:  # a simple list of ruptures
+            else:  # the ruptures are already in memory
                 blocks = block_splitter(ruptures, ruptures_per_block)
             for rupts in blocks:
-                if hasattr(rupts, 'n_events'):
-                    n_events = rupts.n_events
-                else:
-                    n_events = sum(ebr.multiplicity for ebr in rupts)
+                n_events = (rupts.n_events if from_parent
+                            else sum(ebr.multiplicity for ebr in rupts))
                 eps = self.get_eps(self.start, self.start + n_events)
                 num_events += n_events
                 self.start += n_events

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -82,7 +82,8 @@ def run2(job_haz, job_risk, concurrent_tasks, pdb, exports, params, monitor):
         oq = readinput.get_oqparam(job_risk, hc_id=hc_id)
     rcalc = base.calculators(oq)
     with rcalc._monitor:
-        rcalc.run(concurrent_tasks=concurrent_tasks, pdb=pdb, exports=exports,
+        # disable concurrency in the second calculation to avoid fork issues
+        rcalc.run(concurrent_tasks=0, pdb=pdb, exports=exports,
                   hazard_calculation_id=hc_id, **params)
     return rcalc
 

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -670,7 +670,8 @@ class RuptureGetter(object):
             idxs = list(block)  # not numpy.int_(block)!
             rgetter = self.__class__(self.dstore, idxs, self.grp_id)
             rup = self.dstore['ruptures'][idxs]
-            rgetter.n_events = (rup['eidx2'] - rup['eidx1']).sum()
+            # use int below, otherwise n_events would be a numpy.uint64
+            rgetter.n_events = int((rup['eidx2'] - rup['eidx1']).sum())
             getters.append(rgetter)
         return getters
 


### PR DESCRIPTION
Fixes https://travis-ci.org/gem/oq-risk-tests/builds/332691751 and avoids a numpy warning
```python
/home/travis/build/gem/oq-risk-tests/oq-engine/openquake/risklib/riskinput.py:581: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  eps = EpsilonMatrix0(n_assets, seeds[start:stop])
```