### PR TITLE
Detach dbserver only in single user mode

### DIFF
--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -213,7 +213,9 @@ run_server.arg('logfile', 'log file')
 run_server.opt('loglevel', 'WARN or INFO')
 
 if __name__ == '__main__':
-    if hasattr(os, 'fork'):
+    if hasattr(os, 'fork') and not config.dbserver.multi_user:
         # needed for https://github.com/gem/oq-engine/issues/3211
+        # but only if multi_user = False, otherwise init/supervisor
+        # will loose control of the process
         detach_process()
     run_server.callfunc()


### PR DESCRIPTION
#3384 introduced a regression when running in multi_user mode. In such case we must not detach the process otherwise init/supervisor will loose control on it.