### PR TITLE
Fixed several annoying issues affecting the California calculation with HAZUS exposure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed several small issues with the UCERF calculators; now ucerf_hazard
+    can be used as a precalculator of gmf_ebrisk
   * Initial support for disaggregation by source
   * Added the ability to import large exposures as CSV (experimental)
   * Changed the source weights to be proportional to the number of GSIMs

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -317,7 +317,8 @@ def check_time_event(oqparam, occupancy_periods):
     if time_event and time_event not in occupancy_periods:
         raise ValueError(
             'time_event is %s in %s, but the exposure contains %s' %
-            (time_event, oqparam.inputs['job_ini'], ', '.join(occupancy_periods)))
+            (time_event, oqparam.inputs['job_ini'],
+             ', '.join(occupancy_periods)))
 
 
 class HazardCalculator(BaseCalculator):
@@ -369,7 +370,8 @@ class HazardCalculator(BaseCalculator):
             self.exposure.tagnames,
             self.exposure.cost_calculator,
             self.oqparam.time_event,
-            occupancy_periods=hdf5.array_of_vstr(sorted(self.exposure.occupancy_periods)))
+            occupancy_periods=hdf5.array_of_vstr(
+                sorted(self.exposure.occupancy_periods)))
 
     def count_assets(self):
         """

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -511,6 +511,7 @@ class HazardCalculator(BaseCalculator):
         The riskmodel can be empty for hazard calculations.
         Save the loss ratios (if any) in the datastore.
         """
+        logging.info('Reading the risk model')
         self.riskmodel = rm = readinput.get_risk_model(self.oqparam)
         if not self.riskmodel:  # can happen only in a hazard calculation
             return

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -125,7 +125,6 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
     """
     from_engine = False  # set by engine.run_calc
     sitecol = datastore.persistent_attribute('sitecol')
-    assetcol = datastore.persistent_attribute('assetcol')
     performance = datastore.persistent_attribute('performance')
     pre_calculator = None  # to be overridden
     is_stochastic = False  # True for scenario and event based calculators
@@ -559,6 +558,7 @@ class HazardCalculator(BaseCalculator):
             if self.datastore.parent:
                 haz_sitecol = self.datastore.parent['sitecol']
             self.assoc_assets(haz_sitecol)
+            self.datastore['assetcol'] = self.assetcol
         elif oq.job_type == 'risk':
             raise RuntimeError(
                 'Missing exposure_file in %(job_ini)s' % oq.inputs)
@@ -671,6 +671,8 @@ class RiskCalculator(HazardCalculator):
             raise ValueError('The IMTs in the risk models (%s) are disjoint '
                              "from the IMTs in the hazard (%s)" % (rsk, haz))
         num_tasks = self.oqparam.concurrent_tasks or 1
+        if not hasattr(self, 'assetcol'):
+            self.assetcol = self.datastore['assetcol']
         assets_by_site = self.assetcol.assets_by_site()
         with self.monitor('building riskinputs', autoflush=True):
             riskinputs = []

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -414,7 +414,7 @@ class HazardCalculator(BaseCalculator):
         oq = self.oqparam
         wakeup_pool()  # fork before reading the data
         self.read_risk_data()
-        if 'source' in oq.inputs:
+        if 'source' in oq.inputs and oq.hazard_calculation_id is None:
             with self.monitor('reading composite source model', autoflush=1):
                 self.csm = readinput.get_composite_source_model(oq)
             if self.is_stochastic:
@@ -447,7 +447,7 @@ class HazardCalculator(BaseCalculator):
         else:  # we are in a basic calculator
             self.precalc = None
             self.read_inputs()
-            if 'source' in self.oqparam.inputs:
+            if 'source' in self.oqparam.inputs and precalc_id is None:
                 job_info.update(readinput.get_job_info(
                     self.oqparam, self.csm, self.sitecol))
         if hasattr(self, 'riskmodel'):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -78,7 +78,7 @@ PRECALC_MAP = dict(
                  'event_based_risk', 'ucerf_rupture'],
     event_based_risk=['event_based', 'event_based_rupture', 'ucerf_rupture',
                       'event_based_risk'],
-    gmf_ebrisk=['event_based'],
+    gmf_ebrisk=['event_based', 'ucerf_hazard'],
     ucerf_classical=['ucerf_psha'],
     ucerf_hazard=['ucerf_rupture'])
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -102,7 +102,7 @@ class PSHACalculator(base.HazardCalculator):
                 srcid = src_id.split(':', 1)[0]
                 info = self.csm.infos[srcid]
                 info.calc_time += calc_time
-                info.num_sites = max(info.num_sites, nsites)
+                info.num_sites = max(info.num_sites, nsites or 0)
                 info.num_split += 1
         return acc
 

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -104,6 +104,7 @@ class ClassicalRiskCalculator(base.RiskCalculator):
             self.read_exposure()  # define .assets_by_site
             self.load_riskmodel()
             self.sitecol, self.assetcol = self.assoc_assets_sites(haz_sitecol)
+            self.datastore['assetcol'] = self.assetcol
             self.datastore['csm_info'] = fake = source.CompositionInfo.fake()
             self.rlzs_assoc = fake.get_rlzs_assoc()
             self.before_export()  # save 'realizations' dataset

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -314,6 +314,8 @@ class EbriskCalculator(base.RiskCalculator):
         source_models = self.csm_info.source_models
         self.sm_by_grp = self.csm_info.get_sm_by_grp()
         num_events = len(self.datastore['events'])
+        if not hasattr(self, 'assetcol'):
+            self.assetcol = self.datastore['assetcol']
         self.get_eps = riskinput.make_epsilon_getter(
             len(self.assetcol), num_events,
             self.oqparam.asset_correlation,
@@ -555,7 +557,7 @@ class EbrPostCalculator(base.RiskCalculator):
         R = len(self.loss_builder.weights)
         # build loss maps
         if 'all_loss_ratios' in self.datastore and oq.conditional_loss_poes:
-            assetcol = self.assetcol
+            assetcol = self.datastore['assetcol']
             stats = oq.risk_stats()
             builder = self.loss_builder
             A = len(assetcol)

--- a/openquake/calculators/gmf_ebrisk.py
+++ b/openquake/calculators/gmf_ebrisk.py
@@ -52,10 +52,6 @@ class GmfEbRiskCalculator(base.RiskCalculator):
             assert 'gmfs' not in oq.inputs, 'no gmfs_file when using --hc!'
             parent = self.read_previous(oq.hazard_calculation_id)
             oqp = parent['oqparam']
-            if oqp.ses_per_logic_tree_path != 1:
-                logging.warn(
-                    'The parent calculation was using ses_per_logic_tree_path'
-                    '=%d != 1', oqp.ses_per_logic_tree_path)
             if oqp.investigation_time != oq.investigation_time:
                 raise ValueError(
                     'The parent calculation was using investigation_time=%s'

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -96,6 +96,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
             self.pre_calculator = None
         base.RiskCalculator.pre_execute(self)
         eids, self.R = base.get_gmfs(self)
+        self.assetcol = self.datastore['assetcol']
         A = len(self.assetcol)
         E = self.oqparam.number_of_ground_motion_fields
         logging.info('Building the epsilons')

--- a/openquake/commands/extract.py
+++ b/openquake/commands/extract.py
@@ -54,15 +54,16 @@ def extract(what, calc_id=-1):
     logging.basicConfig(level=logging.INFO)
     if calc_id < 0:
         calc_id = datastore.get_calc_ids()[calc_id]
+    hdf5path = None
     if dbserver.get_status() == 'running':
         job = dbcmd('get_job', calc_id)
         if job is not None:
-            calc_id = job.ds_calc_dir + '.hdf5'
-    dstore = datastore.read(calc_id)
+            hdf5path = job.ds_calc_dir + '.hdf5'
+    dstore = datastore.read(hdf5path or calc_id)
     parent_id = dstore['oqparam'].hazard_calculation_id
     if parent_id:
         dstore.parent = datastore.read(parent_id)
-    print('Emulating call to /v1/calc/%s/extract/%s' % (calc_id, quote(what)))
+    print('Emulating call to /v1/calc/%s/extract/%d' % (calc_id, quote(what)))
     with performance.Monitor('extract', measuremem=True) as mon, dstore:
         items = extract_(dstore, what)
         if not inspect.isgenerator(items):

--- a/openquake/commands/extract.py
+++ b/openquake/commands/extract.py
@@ -63,7 +63,7 @@ def extract(what, calc_id=-1):
     parent_id = dstore['oqparam'].hazard_calculation_id
     if parent_id:
         dstore.parent = datastore.read(parent_id)
-    print('Emulating call to /v1/calc/%s/extract/%d' % (calc_id, quote(what)))
+    print('Emulating call to /v1/calc/%d/extract/%s' % (calc_id, quote(what)))
     with performance.Monitor('extract', measuremem=True) as mon, dstore:
         items = extract_(dstore, what)
         if not inspect.isgenerator(items):

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -265,7 +265,7 @@ class ReduceTestCase(unittest.TestCase):
         shutil.copy(os.path.join(testdir, 'sites.csv'), tempdir)
         with Print.patch() as p:
             reduce(dest, 0.5)
-        self.assertIn('Extracted 50 lines out of 100', str(p))
+        self.assertIn('Extracted 50 lines out of 99', str(p))
         shutil.rmtree(tempdir)
 
 

--- a/openquake/commands/zip.py
+++ b/openquake/commands/zip.py
@@ -38,6 +38,7 @@ def zip(job_ini, archive_zip):
         sys.exit('%s exists already' % archive_zip)
     logging.basicConfig(level=logging.INFO)
     oq = readinput.get_oqparam(job_ini)
+    import pdb; pdb.set_trace()
     files = set()
 
     # collect .hdf5 tables for the GSIMs, if any

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -184,7 +184,7 @@ class Classical(RiskModel):
 
 
 @registry.add('event_based_risk', 'event_based', 'event_based_rupture',
-              'ucerf_rupture', 'ucerf_risk', 'gmf_ebrisk')
+              'ucerf_rupture', 'ucerf_hazard', 'ucerf_risk', 'gmf_ebrisk')
 class ProbabilisticEventBased(RiskModel):
     """
     Implements the Probabilistic Event Based riskmodel.


### PR DESCRIPTION
While supporting Anirudh I discovered and fixed the following issues:

1. the IMPERFECT_RECTANGLE_TOLERANCE bug
2. oq zip not saving properly the exposure in CSV and the UCERF .hdf5 model
3. an h5py bug visible only with extra-large exposures
4. a bug with num_sites = None
5. ucerf_hazard not registered as a precalculator of gmf_ebrisk
6. the engine trying to read the composite source model even in a post calculator, when unneeded
7. oq reduce being not able to reduce properly CSV files with an header
8. oq extract confusing calc_id with the associated hdf5path
9. removed a warning on the number of SESs now useless