### PR TITLE
Added initial support for disaggregation by source

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -324,6 +324,8 @@ class HazardCalculator(BaseCalculator):
     """
     Base class for hazard calculators based on source models
     """
+    grp_by_src = False  # set True in disaggregation
+
     def can_read_parent(self):
         """
         :returns:
@@ -416,6 +418,8 @@ class HazardCalculator(BaseCalculator):
         if 'source' in oq.inputs:
             with self.monitor('reading composite source model', autoflush=1):
                 self.csm = readinput.get_composite_source_model(oq)
+                if self.grp_by_src:  # set in disaggregation
+                    self.csm = self.csm.grp_by_src()
             if self.is_stochastic:
                 # initialize the rupture serial numbers before the
                 # filtering; in this way the serials are independent

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -102,7 +102,7 @@ class PSHACalculator(base.HazardCalculator):
                 srcid = src_id.split(':', 1)[0]
                 info = self.csm.infos[srcid]
                 info.calc_time += calc_time
-                info.num_sites = max(info.num_sites, nsites)
+                info.num_sites = max(info.num_sites, nsites or 0)
                 info.num_split += 1
         return acc
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -200,14 +200,16 @@ class PSHACalculator(base.HazardCalculator):
         :param pmap_by_grp_id:
             a dictionary grp_id -> hazard curves
         """
-        grp_trt = self.csm.info.grp_trt()
+        grp_trt = self.csm.info.grp_by("trt")
+        grp_name = self.csm.info.grp_by("name")
         with self.monitor('saving probability maps', autoflush=True):
             for grp_id, pmap in pmap_by_grp_id.items():
                 if pmap:  # pmap can be missing if the group is filtered away
                     fix_ones(pmap)  # avoid saving PoEs == 1
                     key = 'poes/grp-%02d' % grp_id
                     self.datastore[key] = pmap
-                    self.datastore.set_attrs(key, trt=grp_trt[grp_id])
+                    self.datastore.set_attrs(key, trt=grp_trt[grp_id],
+                                             name=str(grp_name[grp_id]))
             if 'poes' in self.datastore:
                 self.datastore.set_nbytes('poes')
 

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -109,6 +109,7 @@ producing too small PoEs.'''
             # the hazard curves, hence the need to run a PSHACalculator here
             cl = classical.PSHACalculator(oq, self.monitor('classical'),
                                           calc_id=self.datastore.calc_id)
+            cl.grp_by_src = True
             cl.run()
             self.csm = cl.csm
             self.rlzs_assoc = cl.rlzs_assoc  # often reduced logic tree

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -214,7 +214,7 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
         zd = AccumDict()
         zd.calc_times = []
         zd.eff_ruptures = AccumDict()
-        self.grp_trt = self.csm.info.grp_trt()
+        self.grp_trt = self.csm.info.grp_by("trt")
         return zd
 
     def agg_dicts(self, acc, ruptures_by_grp_id):

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -95,7 +95,7 @@ def export_ruptures_csv(ekey, dstore):
     header = ('rupid multiplicity mag centroid_lon centroid_lat centroid_depth'
               ' trt strike dip rake boundary').split()
     csm_info = dstore['csm_info']
-    grp_trt = csm_info.grp_trt()
+    grp_trt = csm_info.grp_by("trt")
     rows = []
     ruptures_by_grp = calc.get_ruptures_by_grp(dstore)
     for grp_id, trt in sorted(grp_trt.items()):

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -898,7 +898,7 @@ class UCERFRiskCalculator(EbriskCalculator):
 
     def execute(self):
         num_rlzs = len(self.rlzs_assoc.realizations)
-        self.grp_trt = self.csm_info.grp_trt()
+        self.grp_trt = self.csm_info.grp_by("trt")
         res = parallel.Starmap(compute_losses, self.gen_args()).submit_all()
         self.vals = self.assetcol.values()
         self.eff_ruptures = AccumDict(accum=0)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -783,12 +783,14 @@ def view_elt(token, dstore):
 @view.add('pmap')
 def view_pmap(token, dstore):
     """
-    Display the ProbabilityMap associated to a given source group name
+    Display the mean ProbabilityMap associated to a given source group name
     """
     name = token.split(':')[1]  # called as pmap:name
     pmap = {}
+    pgetter = getters.PmapGetter(dstore)
+    pgetter.init()
     for grp, dset in dstore['poes'].items():
         if dset.attrs['name'] == name:
-            pmap = dstore['poes/' + grp]
+            pmap = pgetter.get_mean(grp)
             break
     return str(pmap)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -569,7 +569,7 @@ def view_required_params_per_trt(token, dstore):
     """
     csm_info = dstore['csm_info']
     tbl = []
-    for grp_id, trt in sorted(csm_info.grp_trt().items()):
+    for grp_id, trt in sorted(csm_info.grp_by("trt").items()):
         gsims = csm_info.gsim_lt.get_gsims(trt)
         maker = ContextMaker(gsims)
         distances = sorted(maker.REQUIRES_DISTANCES)
@@ -778,3 +778,17 @@ def view_elt(token, dstore):
         else:
             tbl.append([0.] * len(header))
     return rst_table(tbl, header)
+
+
+@view.add('pmap')
+def view_pmap(token, dstore):
+    """
+    Display the ProbabilityMap associated to a given source group name
+    """
+    name = token.split(':')[1]  # called as pmap:name
+    pmap = {}
+    for grp, dset in dstore['poes'].items():
+        if dset.attrs['name'] == name:
+            pmap = dstore['poes/' + grp]
+            break
+    return str(pmap)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -533,7 +533,7 @@ class RuptureGetter(object):
     def __iter__(self):
         self.dstore.open()  # if needed
         oq = self.dstore['oqparam']
-        grp_trt = self.dstore['csm_info'].grp_trt()
+        grp_trt = self.dstore['csm_info'].grp_by("trt")
         ruptures = self.dstore['ruptures'][self.mask]
         # NB: ruptures.sort(order='serial') causes sometimes a SystemError:
         # <ufunc 'greater'> returned a result with an error set

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -331,7 +331,7 @@ class SourceFilter(object):
     :param use_rtree:
         by default True, i.e. try to use the rtree module if available
     """
-    def __init__(self, sitecol, integration_distance, use_rtree=False):
+    def __init__(self, sitecol, integration_distance, use_rtree=True):
         self.integration_distance = (
             IntegrationDistance(integration_distance)
             if isinstance(integration_distance, dict)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -331,7 +331,7 @@ class SourceFilter(object):
     :param use_rtree:
         by default True, i.e. try to use the rtree module if available
     """
-    def __init__(self, sitecol, integration_distance, use_rtree=True):
+    def __init__(self, sitecol, integration_distance, use_rtree=False):
         self.integration_distance = (
             IntegrationDistance(integration_distance)
             if isinstance(integration_distance, dict)

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -166,7 +166,8 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
         if integration_distance is None:  # no filtering
             return sites
         rup_enc_poly = self.get_rupture_enclosing_polygon(integration_distance)
-        return sites.filter(rup_enc_poly.intersects(sites.mesh))
+        mask = rup_enc_poly.intersects(sites.mesh)
+        return sites.filter(mask)
 
     def modify(self, modification, parameters):
         """

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -94,8 +94,8 @@ class CharacteristicFaultSource(ParametricSeismicSource):
                                numpy.array([[north, north], [south, south]]),
                                None)
         poly = mesh.get_convex_hull()
-
-        return poly.dilate(dilation)
+        dpoly = poly.dilate(dilation)
+        return dpoly
 
     def iter_ruptures(self):
         """


### PR DESCRIPTION
In the case of disaggregation calculations without `poes_disagg` I am changing the CompositeSourceModel to use a SourceGroup per each source, effectively implementing disaggregation by source. The change is completely internal with no effects on the disaggregation outputs.
This is useful when debugging issues like the one reported in https://groups.google.com/d/msg/openquake-users/P03SxJsfW_s/nCdcxj8WAAAJ, i.e. https://github.com/gem/oq-engine/issues/3394.