### PR TITLE
Fixed a performance regression in the hazard exporters

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -452,7 +452,7 @@ class DataStore(collections.MutableMapping):
         return self.calc_id
 
     def __repr__(self):
-        status = 'open' if self.hdf5 else 'close'
+        status = 'open' if self.hdf5 else 'closed'
         return '<%s %d, %s>' % (self.__class__.__name__, self.calc_id, status)
 
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -241,6 +241,7 @@ def build_hcurves_and_stats(pgetter, hstats, monitor):
     used to specify the kind of output.
     """
     with monitor('combine pmaps'):
+        pgetter.init()  # if not already initialized
         try:
             pmaps = pgetter.get_pmaps(pgetter.sids)
         except IndexError:  # no data

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -317,7 +317,7 @@ class ClassicalCalculator(PSHACalculator):
             pgetter = getters.PmapGetter(parent, t.sids, self.rlzs_assoc)
             if parent is self.datastore:  # read now, not in the workers
                 logging.info('Reading PoEs on %d sites', len(t))
-                pgetter.pmap_by_grp
+                pgetter.init()
             yield pgetter, hstats, monitor
 
     def save_hcurves(self, acc, pmap_by_kind):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -241,7 +241,6 @@ def build_hcurves_and_stats(pgetter, hstats, monitor):
     used to specify the kind of output.
     """
     with monitor('combine pmaps'):
-        pgetter.init()  # if not already initialized
         try:
             pmaps = pgetter.get_pmaps(pgetter.sids)
         except IndexError:  # no data
@@ -318,7 +317,7 @@ class ClassicalCalculator(PSHACalculator):
             pgetter = getters.PmapGetter(parent, t.sids, self.rlzs_assoc)
             if parent is self.datastore:  # read now, not in the workers
                 logging.info('Reading PoEs on %d sites', len(t))
-                pgetter.init()
+                pgetter.pmap_by_grp
             yield pgetter, hstats, monitor
 
     def save_hcurves(self, acc, pmap_by_kind):

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -142,7 +142,6 @@ producing too small PoEs.'''
         dic = {}
         imtls = self.oqparam.imtls
         pgetter = getters.PmapGetter(self.datastore, sids=numpy.array([sid]))
-        pgetter.init()
         for rlz in self.rlzs_assoc.realizations:
             try:
                 pmap = pgetter.get(rlz.ordinal)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -201,36 +201,48 @@ def hazard_items(dic, mesh, *extras, **kw):
 
 @extract.add('hcurves')
 def extract_hcurves(dstore, what):
+    """
+    Extracts hazard curves. Use it as /extract/hcurves/mean or
+    /extract/hcurves/rlz-0, /extract/hcurves/stats, /extract/hcurves/rlzs etc
+    """
     oq = dstore['oqparam']
     mesh = get_mesh(dstore['sitecol'])
     dic = {}
-    for kind, hcurves in getters.PmapGetter(dstore).items():
+    for kind, hcurves in getters.PmapGetter(dstore).items(what):
         dic[kind] = hcurves.convert_npy(oq.imtls, len(mesh))
-    return hazard_items(dic, mesh, investigation_time=oq.investigation_time)
-
-
-@extract.add('uhs')
-def extract_uhs(dstore, what):
-    oq = dstore['oqparam']
-    mesh = get_mesh(dstore['sitecol'])
-    dic = {}
-    for kind, hcurves in getters.PmapGetter(dstore).items():
-        dic[kind] = calc.make_uhs(hcurves, oq.imtls, oq.poes, len(mesh))
     return hazard_items(dic, mesh, investigation_time=oq.investigation_time)
 
 
 @extract.add('hmaps')
 def extract_hmaps(dstore, what):
+    """
+    Extracts hazard maps. Use it as /extract/hmaps/mean or
+    /extract/hmaps/rlz-0, etc
+    """
     oq = dstore['oqparam']
     sitecol = dstore['sitecol']
     mesh = get_mesh(sitecol)
     pdic = DictArray({imt: oq.poes for imt in oq.imtls})
     dic = {}
-    for kind, hcurves in getters.PmapGetter(dstore).items():
+    for kind, hcurves in getters.PmapGetter(dstore).items(what):
         hmap = calc.make_hmap(hcurves, oq.imtls, oq.poes)
         dic[kind] = calc.convert_to_array(hmap, len(mesh), pdic)
     return hazard_items(dic, mesh, ('vs30', F32, sitecol.vs30),
                         investigation_time=oq.investigation_time)
+
+
+@extract.add('uhs')
+def extract_uhs(dstore, what):
+    """
+    Extracts uniform hazard spectra. Use it as /extract/uhs/mean or
+    /extract/uhs/rlz-0, etc
+    """
+    oq = dstore['oqparam']
+    mesh = get_mesh(dstore['sitecol'])
+    dic = {}
+    for kind, hcurves in getters.PmapGetter(dstore).items(what):
+        dic[kind] = calc.make_uhs(hcurves, oq.imtls, oq.poes, len(mesh))
+    return hazard_items(dic, mesh, investigation_time=oq.investigation_time)
 
 
 def _agg(losses, idxs):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -56,6 +56,7 @@ class PmapGetter(object):
         """
         if hasattr(self, 'data'):  # already initialized
             return
+        self.dstore.open()  # if not
         self.imtls = self.dstore['oqparam'].imtls
         self.data = collections.OrderedDict()
         try:
@@ -76,7 +77,6 @@ class PmapGetter(object):
         """
         if hasattr(self, '_pmap_by_grp'):  # already called
             return self._pmap_by_grp
-        self.dstore.open()  # if not
         # populate _pmap_by_grp
         self._pmap_by_grp = {}
         if 'poes' in self.dstore:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -50,6 +50,12 @@ class PmapGetter(object):
         if sids is None:
             self.sids = dstore['sitecol'].complete.sids
 
+    def init(self):
+        """
+        Read the poes and set the .data attribute with the hazard curves
+        """
+        self.pmap_by_grp
+
     @property
     def pmap_by_grp(self):
         if hasattr(self, '_pmap_by_grp'):  # already initialized

--- a/openquake/calculators/tests/classical_damage_test.py
+++ b/openquake/calculators/tests/classical_damage_test.py
@@ -22,10 +22,8 @@ from openquake.qa_tests_data.classical_damage import (
     case_1, case_2, case_1a, case_1b, case_1c, case_2a, case_2b, case_3a,
     case_4a, case_4b, case_4c, case_5a, case_6a, case_6b, case_7a, case_7b,
     case_7c, case_8a)
-from openquake.commonlib.oqvalidation import OqParam
 from openquake.calculators.export import export
 from openquake.calculators.tests import CalculatorTestCase
-from openquake.calculators.classical_damage import ClassicalDamageCalculator
 
 import numpy
 
@@ -85,7 +83,8 @@ class ClassicalDamageTestCase(CalculatorTestCase):
 
     def check(self, case):
         out = self.run_calc(
-            case.__file__, 'job_haz.ini,job_risk.ini', exports='csv')
+            case.__file__, 'job_haz.ini,job_risk.ini', exports='csv',
+            concurrent_tasks='0')  # avoid the usual fork issue
         [fname] = out['damages-rlzs', 'csv']
         self.assertEqualFiles('expected/damages.csv', fname)
 

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -201,7 +201,7 @@ class ClassicalTestCase(CalculatorTestCase):
                                  'hmaps/poe-0.2/rlz-003'])
 
         # test extract/hcurves/rlz-0 also works, used by the npz exports
-        haz = dict(extract(self.calc.datastore, 'hcurves/rlz-0'))
+        haz = dict(extract(self.calc.datastore, 'hcurves'))
         self.assertEqual(sorted(haz), ['all', 'investigation_time'])
         self.assertEqual(
             haz['all'].dtype.names, ('lon', 'lat', 'depth', 'mean'))

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -63,7 +63,6 @@ class DisaggregationTestCase(CalculatorTestCase):
 
         # disaggregation by source group
         pgetter = getters.PmapGetter(self.calc.datastore)
-        pgetter.init()
         pmaps = []
         for grp in sorted(pgetter.dstore['poes']):
             pmaps.append(pgetter.get_mean(grp))

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -789,7 +789,6 @@ def view_pmap(token, dstore):
     name = token.split(':')[1]  # called as pmap:name
     pmap = {}
     pgetter = getters.PmapGetter(dstore)
-    pgetter.init()
     for grp, dset in dstore['poes'].items():
         if dset.attrs['name'] == name:
             pmap = pgetter.get_mean(grp)


### PR DESCRIPTION
Due to the call to `pgetter.init()` when not needed, the full set of hazard curves was built at export time, consuming terabytes of memory for the Canada model.
I put this branch on cluster2 and now the outputs https://oq2.wilson.openquake.org/engine/17219/outputs can be downloaded in a few minutes:
```bash
   $ oq2 export hcurves 17219 -e npz
   Exported 160.83 MB in ['./hcurves_17219.npz']
   <Monitor export, duration=82.89593696594238s, memory=66.62 MB>
   $ oq2 export hmaps 17219 -e npz
   Exported 39.33 MB in ['./hmaps_17219.npz']
   <Monitor export, duration=256.3020009994507s, memory=194.46 MB>
   $ oq2 export uhs 17219 -e npz
   Exported 38.96 MB in ['./uhs_17219.npz']
   <Monitor export, duration=222.33143281936646s, memory=138.8 MB>
```
