### PR TITLE
Upgrade max dependency limits in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,11 @@ install:
   # the wheels first, put the folder in cache and then install the wheels from there.
   # A second run of 'pip download' will download only the missing wheels. 
   - pip -q download -r requirements-py35-linux64.txt -d wheels
-  - pip -q install wheels/*
+  # use '[skip wheels]' to get dependencies from upstream pypi without using cached wheels
+  # this is needed to test that (max) requirements in setup.py are still valid
+  - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip wheels\]'; then
+        pip -q install wheels/*;
+    fi
   - pip -q install -e .
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,12 @@ before_install:
   - if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else BRANCH=$TRAVIS_BRANCH; fi
 
 install:
-  # use '[skip wheels]' to get dependencies from upstream pypi without using cached wheels
-  # this is needed to test that (max) requirements in setup.py are still valid
+  # Use '[skip wheels]' to get dependencies from upstream pypi without using cached wheels;
+  # this is needed to test that (max) requirements in setup.py are still valid.
+  # Also pip do not cache data when requirements includes full http URLs, so we need
+  # to download the wheels first, put the folder in cache and then install the wheels from there.
+  # A second run of 'pip download' will download only the missing wheels.
   - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip wheels\]'; then
-      # pip do not cache data when requirements includes full http URLs, so we need to download
-      # the wheels first, put the folder in cache and then install the wheels from there.
-      # A second run of 'pip download' will download only the missing wheels.
       pip -q download -r requirements-py35-linux64.txt -d wheels &&
       pip -q install wheels/* ;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,14 +58,14 @@ before_install:
   - if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else BRANCH=$TRAVIS_BRANCH; fi
 
 install:
-  # pip do not cache data when requirements includes full http URLs, so we need to download
-  # the wheels first, put the folder in cache and then install the wheels from there.
-  # A second run of 'pip download' will download only the missing wheels. 
-  - pip -q download -r requirements-py35-linux64.txt -d wheels
   # use '[skip wheels]' to get dependencies from upstream pypi without using cached wheels
   # this is needed to test that (max) requirements in setup.py are still valid
   - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip wheels\]'; then
-        pip -q install wheels/*;
+      # pip do not cache data when requirements includes full http URLs, so we need to download
+      # the wheels first, put the folder in cache and then install the wheels from there.
+      # A second run of 'pip download' will download only the missing wheels.
+      pip -q download -r requirements-py35-linux64.txt -d wheels &&
+      pip -q install wheels/* ;
     fi
   - pip -q install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
 install:
   # Use '[skip wheels]' to get dependencies from upstream pypi without using cached wheels;
   # this is needed to test that (max) requirements in setup.py are still valid.
-  # Also pip do not cache data when requirements includes full http URLs, so we need
+  # Also pip does not cache data when requirements includes full http URLs, so we need
   # to download the wheels first, put the folder in cache and then install the wheels from there.
   # A second run of 'pip download' will download only the missing wheels.
   - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip wheels\]'; then

--- a/openquake/hmtk/plotting/mapping.py
+++ b/openquake/hmtk/plotting/mapping.py
@@ -53,7 +53,6 @@ from builtins import range
 import collections
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.basemap import Basemap
 from matplotlib.colors import Normalize
 from openquake.hmtk.sources.area_source import mtkAreaSource
 from openquake.hmtk.sources.point_source import mtkPointSource
@@ -159,6 +158,9 @@ class HMTKBaseMap(object):
         meridians = np.arange(0., 360., self.lat_lon_spacing)
 
         # Build Map
+        # Do not import Basemap at top level since it's an optional feature
+        # and it would break doctests
+        from mpl_toolkits.basemap import Basemap
         self.m = Basemap(
             llcrnrlon=lowcrnrlon, llcrnrlat=lowcrnrlat,
             urcrnrlon=uppcrnrlon, urcrnrlat=uppcrnrlat,

--- a/setup.py
+++ b/setup.py
@@ -51,19 +51,19 @@ Copyright (C) 2010-2017 GEM Foundation
 PY_MODULES = ['openquake.commands.__main__']
 
 install_requires = [
-    'mock >=1.0, <1.4',
+    'mock >=1.0, <2.0',
     'h5py >=2.2, <2.8',
     'nose >=1.3, <1.4',
     'numpy >=1.8, <1.12',
     'scipy >=0.13, <0.18',
     'pyzmq <17.0',
-    'psutil >=1.2, <4.5',
-    'shapely >=1.3, <1.6',
-    'docutils >=0.11, <0.14',
-    'decorator >=3.4, <4.2',
+    'psutil >=1.2, <5.5',
+    'shapely >=1.3, <1.7',
+    'docutils >=0.11, <0.15',
+    'decorator >=3.4',
     'django >=1.6, <1.12',
-    'matplotlib >=1.5, <2.0',
-    'requests >=2.2, <2.13',
+    'matplotlib >=1.5, <2.2',
+    'requests >=2.2, <2.19',
     # pyshp is fragile, we want only versions we have tested
     'pyshp >=1.2.3, <1.2.11',
     'PyYAML',

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ install_requires = [
     'shapely >=1.3, <1.7',
     'docutils >=0.11, <0.15',
     'decorator >=3.4',
-    'django >=1.6, <1.12',
+    'django >=1.6, <2.1',
     'matplotlib >=1.5, <2.2',
     'requests >=2.2, <2.19',
     # pyshp is fragile, we want only versions we have tested


### PR DESCRIPTION
For just a bunch of 'safe' libraries (not numpy, scipy...).

I added also an option to Travis to run tests against packages from upstream instead of our wheels, so in such case latest possible versions will be used.