### PR TITLE
Several small improvements

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Deprecated `nrml.parse`, it is now called `nrml.to_python`
   * Improved the task distribution by splitting the AreaSources upfront
     and by improving the weighting algorithm
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -208,7 +208,7 @@ class PSHACalculator(base.HazardCalculator):
             for trt, sources in csm.get_sources_by_trt(opt).items():
                 gsims = self.csm.info.gsim_lt.get_gsims(trt)
                 for block in csm.split_in_blocks(maxweight, sources):
-                    yield block, csm.src_filter, gsims, param, monitor
+                    yield block, src_filter, gsims, param, monitor
                     num_tasks += 1
                     num_sources += len(block)
             logging.info('Sent %d sources in %d tasks', num_sources, num_tasks)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -186,7 +186,7 @@ producing too small PoEs.'''
                         min_poe = max_poe[rlzi][imt]
                         if poe > min_poe:
                             raise ValueError(self.POE_TOO_BIG % (
-                                poe, sm_id, smodel.name, min_poe, rlzi, imt))
+                                poe, sm_id, smodel.names, min_poe, rlzi, imt))
 
     def full_disaggregation(self, curves):
         """

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -27,7 +27,7 @@ import sys
 import mock
 import time
 import operator
-
+import numpy
 from openquake.baselib.general import AccumDict, groupby
 from openquake.baselib.python3compat import encode
 from openquake.commonlib import readinput
@@ -49,16 +49,17 @@ def count_ruptures(sources, srcfilter, gsims, param, monitor):
     dic = groupby(sources, operator.attrgetter('src_group_id'))
     acc = AccumDict({grp_id: {} for grp_id in dic})
     acc.eff_ruptures = {grp_id: 0 for grp_id in dic}
-    acc.calc_times = []
+    acc.calc_times = AccumDict(accum=numpy.zeros(4))
     for grp_id in dic:
         for src in sources:
             t0 = time.time()
+            src_id = src.source_id.split(':')[0]
             sites = srcfilter.get_close_sites(src)
             if sites is not None:
                 acc.eff_ruptures[grp_id] += src.num_ruptures
                 dt = time.time() - t0
-                acc.calc_times.append(
-                    (src.source_id, len(sites), src.weight, dt))
+                acc.calc_times[src_id] += numpy.array(
+                    [src.weight, len(sites), dt, 1])
     return acc
 
 

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -26,7 +26,6 @@ import os
 import sys
 import mock
 import time
-import operator
 import numpy
 from openquake.baselib.general import AccumDict, groupby
 from openquake.baselib.python3compat import encode
@@ -46,7 +45,7 @@ def count_ruptures(sources, srcfilter, gsims, param, monitor):
     src_group_id -> {}.
     All sources must belong to the same tectonic region type.
     """
-    dic = groupby(sources, operator.attrgetter('src_group_id'))
+    dic = groupby(sources, lambda src: src.src_group_ids[0])
     acc = AccumDict({grp_id: {} for grp_id in dic})
     acc.eff_ruptures = {grp_id: 0 for grp_id in dic}
     acc.calc_times = AccumDict(accum=numpy.zeros(4))

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -293,7 +293,7 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/ses.xml', fname)
 
         # check that the exported file is parseable
-        rupcoll = nrml.parse(fname, RuptureConverter(1))
+        rupcoll = nrml.convert(fname, RuptureConverter(1))
         self.assertEqual(list(rupcoll), [1])  # one group
         self.assertEqual(len(rupcoll[1]), 3)  # three EBRuptures
 

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -293,7 +293,7 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/ses.xml', fname)
 
         # check that the exported file is parseable
-        rupcoll = nrml.convert(fname, RuptureConverter(1))
+        rupcoll = nrml.to_python(fname, RuptureConverter(1))
         self.assertEqual(list(rupcoll), [1])  # one group
         self.assertEqual(len(rupcoll[1]), 3)  # three EBRuptures
 

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -739,7 +739,7 @@ def get_composite_source_model(oq):
     :param oq: :class:`openquake.commonlib.oqvalidation.OqParam` instance
     :returns: a `class:`openquake.commonlib.source.CompositeSourceModel`
     """
-    [src_group] = nrml.parse(
+    [src_group] = nrml.convert(
         oq.inputs["source_model"],
         SourceConverter(oq.investigation_time, oq.rupture_mesh_spacing))
     source_models = []

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -749,7 +749,7 @@ def get_composite_source_model(oq):
         sg = copy.copy(src_group)
         sg.id = sm.ordinal
         sm.src_groups = [sg]
-        sg.sources = [sg[0].new(sm.ordinal, sm.name)]
+        sg.sources = [sg[0].new(sm.ordinal, sm.names)]
         source_models.append(sm)
     return source.CompositeSourceModel(gsim_lt, smlt, source_models)
 

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -739,7 +739,7 @@ def get_composite_source_model(oq):
     :param oq: :class:`openquake.commonlib.oqvalidation.OqParam` instance
     :returns: a `class:`openquake.commonlib.source.CompositeSourceModel`
     """
-    [src_group] = nrml.convert(
+    [src_group] = nrml.to_python(
         oq.inputs["source_model"],
         SourceConverter(oq.investigation_time, oq.rupture_mesh_spacing))
     source_models = []

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -255,7 +255,7 @@ def view_ruptures_per_trt(token, dstore):
                 num_trts += 1
                 eff_ruptures += er
                 tbl.append(
-                    (sm.name, src_group.id, trt, er, src_group.tot_ruptures))
+                    (sm.names, src_group.id, trt, er, src_group.tot_ruptures))
             tot_ruptures += src_group.tot_ruptures
     rows = [('#TRT models', num_trts),
             ('#eff_ruptures', eff_ruptures),

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -115,7 +115,12 @@ See http://docs.openquake.org/oq-engine/stable/effective-realizations.html for a
         # this is a test with multiple same ID sources
         self.assertIn('multiplicity', str(p))
 
-    # NB: info --report is tested in the packager
+    def test_report(self):
+        path = os.path.join(os.path.dirname(case_9.__file__), 'job.ini')
+        save = 'openquake.calculators.reportwriter.ReportWriter.save'
+        with Print.patch() as p, mock.patch(save, lambda self, fname: None):
+            info(None, None, None, None, None, True, path)
+        self.assertIn('report.rst', str(p))
 
 
 class TidyTestCase(unittest.TestCase):

--- a/openquake/commands/upgrade_nrml.py
+++ b/openquake/commands/upgrade_nrml.py
@@ -97,7 +97,7 @@ def upgrade_file(path, multipoint):
             nodes=[obj_to_node(val) for val in vf_dict.values()])
         gml = False
     elif tag == 'fragilityModel':
-        node0 = read_nrml.convert_fragility_model_04(
+        node0 = read_nrml.to_python_fragility_model_04(
             nrml.read(path)[0], path)
         gml = False
     elif tag == 'sourceModel':

--- a/openquake/commands/upgrade_nrml.py
+++ b/openquake/commands/upgrade_nrml.py
@@ -97,7 +97,7 @@ def upgrade_file(path, multipoint):
             nodes=[obj_to_node(val) for val in vf_dict.values()])
         gml = False
     elif tag == 'fragilityModel':
-        node0 = read_nrml.to_python_fragility_model_04(
+        node0 = read_nrml.convert_fragility_model_04(
             nrml.read(path)[0], path)
         gml = False
     elif tag == 'sourceModel':

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -58,15 +58,28 @@ class SourceModel(object):
     A container of SourceGroup instances with some additional attributes
     describing the source model in the logic tree.
     """
-    def __init__(self, name, weight, path, src_groups, num_gsim_paths, ordinal,
-                 samples):
-        self.name = name
+    def __init__(self, names, weight, path, src_groups, num_gsim_paths,
+                 ordinal, samples):
+        self.names = names
         self.weight = weight
         self.path = path
         self.src_groups = src_groups
         self.num_gsim_paths = num_gsim_paths
         self.ordinal = ordinal
         self.samples = samples
+
+    @property
+    def name(self):
+        """
+	Compact representation for the names
+	"""
+        names = self.names.split()
+        if len(names) == 1:
+            return names[0]
+        elif len(names) == 2:
+            return ' '.join(names)
+        else:
+            return ' '.join([names[0], '...', names[-1]])
 
     @property
     def num_sources(self):
@@ -82,13 +95,13 @@ class SourceModel(object):
             sg = copy.copy(grp)
             sg.sources = []
             src_groups.append(sg)
-        return self.__class__(self.name, self.weight, self.path, src_groups,
+        return self.__class__(self.names, self.weight, self.path, src_groups,
                               self.num_gsim_paths, self.ordinal, self.samples)
 
     def __repr__(self):
         samples = ', samples=%d' % self.samples if self.samples > 1 else ''
         return '<%s #%d %s, path=%s, weight=%s%s>' % (
-            self.__class__.__name__, self.ordinal, self.name,
+            self.__class__.__name__, self.ordinal, self.names,
             '_'.join(self.path), self.weight, samples)
 
 Realization = namedtuple('Realization', 'value weight lt_path ordinal lt_uid')

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1168,7 +1168,7 @@ class GsimLogicTree(object):
         """
         :returns: an XML string representing the logic tree
         """
-        return nrml.convert(self._ltnode)
+        return nrml.to_nrml(self._ltnode)
 
     def reduce(self, trts):
         """

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1168,7 +1168,7 @@ class GsimLogicTree(object):
         """
         :returns: an XML string representing the logic tree
         """
-        return nrml.to_nrml(self._ltnode)
+        return nrml.to_string(self._ltnode)
 
     def reduce(self, trts):
         """

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -431,7 +431,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
     # consider only the effective realizations
     for sm in source_model_lt.gen_source_models(gsim_lt):
         src_groups = []
-        for name in sm.name.split():
+        for name in sm.names.split():
             fname = os.path.abspath(os.path.join(oqparam.base_path, name))
             if in_memory:
                 apply_unc = source_model_lt.make_apply_uncertainties(sm.path)

--- a/openquake/commonlib/riskmodels.py
+++ b/openquake/commonlib/riskmodels.py
@@ -100,7 +100,7 @@ def get_risk_models(oqparam, kind=None):
         if mo:
             key_type = mo.group(1)  # the cost_type in the key
             # can be occupants, structural, nonstructural, ...
-            rmodel = nrml.convert(oqparam.inputs[key])
+            rmodel = nrml.to_python(oqparam.inputs[key])
             rmodels[key_type] = rmodel
             if rmodel.lossCategory is None:  # NRML 0.4
                 continue

--- a/openquake/commonlib/riskmodels.py
+++ b/openquake/commonlib/riskmodels.py
@@ -100,7 +100,7 @@ def get_risk_models(oqparam, kind=None):
         if mo:
             key_type = mo.group(1)  # the cost_type in the key
             # can be occupants, structural, nonstructural, ...
-            rmodel = nrml.parse(oqparam.inputs[key])
+            rmodel = nrml.convert(oqparam.inputs[key])
             rmodels[key_type] = rmodel
             if rmodel.lossCategory is None:  # NRML 0.4
                 continue

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -432,7 +432,7 @@ class CompositionInfo(object):
                 data.append((src_group.id, trti[src_group.trt],
                              src_group.eff_ruptures, src_group.tot_ruptures,
                              sm.ordinal))
-        lst = [(sm.name, sm.weight, '_'.join(sm.path),
+        lst = [(sm.names, sm.weight, '_'.join(sm.path),
                 sm.num_gsim_paths, sm.samples)
                for i, sm in enumerate(self.source_models)]
         return (dict(
@@ -578,7 +578,7 @@ class CompositionInfo(object):
         for sm in self.source_models:
             for rlz in realizations:
                 if rlz.sm_lt_path == sm.path:
-                    dic[rlz] = sm.name
+                    dic[rlz] = sm.names
         return dic
 
     def get_sm_by_grp(self):
@@ -611,7 +611,7 @@ class CompositionInfo(object):
         if len(rlzs) > TWO16:
             raise ValueError(
                 'The source model %s has %d realizations, the maximum '
-                'is %d' % (smodel.name, len(rlzs), TWO16))
+                'is %d' % (smodel.names, len(rlzs), TWO16))
         return rlzs
 
     def __repr__(self):
@@ -619,7 +619,7 @@ class CompositionInfo(object):
         for sm in self.source_models:
             info_by_model[sm.path] = (
                 '_'.join(map(decode, sm.path)),
-                decode(sm.name),
+                decode(sm.names),
                 [sg.id for sg in sm.src_groups],
                 sm.weight,
                 self.get_num_rlzs(sm))
@@ -668,7 +668,7 @@ class CompositeSourceModel(collections.Sequence):
         grp_id = 0
         for sm in self.source_models:
             src_groups = []
-            smodel = sm.__class__(sm.name, sm.weight, sm.path, src_groups,
+            smodel = sm.__class__(sm.names, sm.weight, sm.path, src_groups,
                                   sm.num_gsim_paths, sm.ordinal, sm.samples)
             for sg in sm.src_groups:
                 for src in sg.sources:
@@ -724,7 +724,7 @@ class CompositeSourceModel(collections.Sequence):
                     weight += src.weight
                 src_groups.append(sg)
             newsm = logictree.SourceModel(
-                sm.name, sm.weight, sm.path, src_groups,
+                sm.names, sm.weight, sm.path, src_groups,
                 sm.num_gsim_paths, sm.ordinal, sm.samples)
             source_models.append(newsm)
         new = self.__class__(self.gsim_lt, self.source_model_lt, source_models)

--- a/openquake/commonlib/tests/riskmodels_test.py
+++ b/openquake/commonlib/tests/riskmodels_test.py
@@ -66,7 +66,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
     </vulnerabilityModel>
 </nrml>
 """)
-        vfs = nrml.convert(vuln_content)
+        vfs = nrml.to_python(vuln_content)
         assert_almost_equal(vfs['PGA', 'RC/A'].imls,
                             numpy.array([0.005, 0.007, 0.0098, 0.0137]))
         assert_almost_equal(vfs['PGA', 'RC/B'].imls,
@@ -108,7 +108,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
 </nrml>
 """)
         with self.assertRaises(InvalidFile) as ar:
-            nrml.convert(vuln_content)
+            nrml.to_python(vuln_content)
         self.assertIn('Duplicated vulnerabilityFunctionID: A',
                       str(ar.exception))
 
@@ -135,7 +135,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
 </nrml>
 """)
         with self.assertRaises(ValueError) as ar:
-            nrml.convert(vuln_content)
+            nrml.to_python(vuln_content)
         self.assertIn('It is not valid to define a loss ratio = 0.0 with a '
                       'corresponding coeff. of variation > 0.0',
                       str(ar.exception))
@@ -161,7 +161,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
     </fragilityModel>
 </nrml>""")
         with self.assertRaises(KeyError) as ar:
-            nrml.convert(vuln_content)
+            nrml.to_python(vuln_content)
         self.assertIn("node IML: 'minIML', line 9", str(ar.exception))
 
     def test_missing_maxIML(self):
@@ -185,7 +185,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
     </fragilityModel>
 </nrml>""")
         with self.assertRaises(KeyError) as ar:
-            nrml.convert(vuln_content)
+            nrml.to_python(vuln_content)
         self.assertIn("node IML: 'maxIML', line 9", str(ar.exception))
 
 
@@ -245,7 +245,7 @@ lossCategory="contents">
 
     def test_ok(self):
         fname = os.path.join(EXAMPLES_DIR, 'consequence-model.xml')
-        cmodel = nrml.convert(fname)
+        cmodel = nrml.to_python(fname)
         self.assertEqual(
             repr(cmodel),
             "<ConsequenceModel structural ds1, ds2, ds3, ds4 tax1>")
@@ -278,18 +278,18 @@ lossCategory="contents">
     def test_wrong_files(self):
         # missing lossCategory
         with self.assertRaises(KeyError) as ctx:
-            nrml.convert(self.wrong_csq_model_1)
+            nrml.to_python(self.wrong_csq_model_1)
         self.assertIn("node consequenceModel: 'lossCategory', line 3",
                       str(ctx.exception))
 
         # missing loss state
         with self.assertRaises(ValueError) as ctx:
-            nrml.convert(self.wrong_csq_model_2)
+            nrml.to_python(self.wrong_csq_model_2)
         self.assertIn("node consequenceFunction: Expected 4 limit"
                       " states, got 3, line 9", str(ctx.exception))
 
         # inverted loss states
         with self.assertRaises(ValueError) as ctx:
-            nrml.convert(self.wrong_csq_model_3)
+            nrml.to_python(self.wrong_csq_model_3)
         self.assertIn("node params: Expected 'ds3', got 'ds4', line 12",
                       str(ctx.exception))

--- a/openquake/commonlib/tests/riskmodels_test.py
+++ b/openquake/commonlib/tests/riskmodels_test.py
@@ -66,7 +66,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
     </vulnerabilityModel>
 </nrml>
 """)
-        vfs = nrml.parse(vuln_content)
+        vfs = nrml.convert(vuln_content)
         assert_almost_equal(vfs['PGA', 'RC/A'].imls,
                             numpy.array([0.005, 0.007, 0.0098, 0.0137]))
         assert_almost_equal(vfs['PGA', 'RC/B'].imls,
@@ -108,7 +108,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
 </nrml>
 """)
         with self.assertRaises(InvalidFile) as ar:
-            nrml.parse(vuln_content)
+            nrml.convert(vuln_content)
         self.assertIn('Duplicated vulnerabilityFunctionID: A',
                       str(ar.exception))
 
@@ -135,7 +135,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
 </nrml>
 """)
         with self.assertRaises(ValueError) as ar:
-            nrml.parse(vuln_content)
+            nrml.convert(vuln_content)
         self.assertIn('It is not valid to define a loss ratio = 0.0 with a '
                       'corresponding coeff. of variation > 0.0',
                       str(ar.exception))
@@ -161,7 +161,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
     </fragilityModel>
 </nrml>""")
         with self.assertRaises(KeyError) as ar:
-            nrml.parse(vuln_content)
+            nrml.convert(vuln_content)
         self.assertIn("node IML: 'minIML', line 9", str(ar.exception))
 
     def test_missing_maxIML(self):
@@ -185,7 +185,7 @@ class ParseCompositeRiskModelTestCase(unittest.TestCase):
     </fragilityModel>
 </nrml>""")
         with self.assertRaises(KeyError) as ar:
-            nrml.parse(vuln_content)
+            nrml.convert(vuln_content)
         self.assertIn("node IML: 'maxIML', line 9", str(ar.exception))
 
 
@@ -245,7 +245,7 @@ lossCategory="contents">
 
     def test_ok(self):
         fname = os.path.join(EXAMPLES_DIR, 'consequence-model.xml')
-        cmodel = nrml.parse(fname)
+        cmodel = nrml.convert(fname)
         self.assertEqual(
             repr(cmodel),
             "<ConsequenceModel structural ds1, ds2, ds3, ds4 tax1>")
@@ -278,18 +278,18 @@ lossCategory="contents">
     def test_wrong_files(self):
         # missing lossCategory
         with self.assertRaises(KeyError) as ctx:
-            nrml.parse(self.wrong_csq_model_1)
+            nrml.convert(self.wrong_csq_model_1)
         self.assertIn("node consequenceModel: 'lossCategory', line 3",
                       str(ctx.exception))
 
         # missing loss state
         with self.assertRaises(ValueError) as ctx:
-            nrml.parse(self.wrong_csq_model_2)
+            nrml.convert(self.wrong_csq_model_2)
         self.assertIn("node consequenceFunction: Expected 4 limit"
                       " states, got 3, line 9", str(ctx.exception))
 
         # inverted loss states
         with self.assertRaises(ValueError) as ctx:
-            nrml.parse(self.wrong_csq_model_3)
+            nrml.convert(self.wrong_csq_model_3)
         self.assertIn("node params: Expected 'ds3', got 'ds4', line 12",
                       str(ctx.exception))

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -128,9 +128,11 @@ node_to_obj = CallableDict(keyfunc=get_tag_version, keymissing=lambda n, f: n)
 def get_rupture_collection(node, fname, converter):
     return converter.convert_node(node)
 
+default = sourceconverter.SourceConverter()
+
 
 @node_to_obj.add(('sourceModel', 'nrml/0.4'))
-def get_source_model_04(node, fname, converter):
+def get_source_model_04(node, fname, converter=default):
     sources = []
     source_ids = set()
     converter.fname = fname
@@ -150,7 +152,7 @@ def get_source_model_04(node, fname, converter):
 
 
 @node_to_obj.add(('sourceModel', 'nrml/0.5'))
-def get_source_model_05(node, fname, converter):
+def get_source_model_05(node, fname, converter=default):
     converter.fname = fname
     groups = []  # expect a sequence of sourceGroup nodes
     for src_group in node:

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -110,7 +110,7 @@ def get_tag_version(nrml_node):
     return tag, version
 
 
-def convert(fname, *args):
+def to_python(fname, *args):
     """
     Parse a NRML file and return an associated Python object. It works by
     calling nrml.read() and node_to_obj() in sequence.
@@ -118,7 +118,7 @@ def convert(fname, *args):
     [node] = read(fname)
     return node_to_obj(node, fname, *args)
 
-parse = deprecated('Use nrml.convert instead')(convert)
+parse = deprecated('Use nrml.to_python instead')(to_python)
 
 node_to_obj = CallableDict(keyfunc=get_tag_version, keymissing=lambda n, f: n)
 # dictionary of functions with at least two arguments, node and fname
@@ -299,7 +299,7 @@ class SourceModelParser(object):
             the full pathname of the source model file
         """
         try:
-            return convert(fname, self.converter)
+            return to_python(fname, self.converter)
         except ValueError as e:
             err = str(e)
             e1 = 'Surface does not conform with Aki & Richards convention'
@@ -361,7 +361,7 @@ def write(nodes, output=sys.stdout, fmt='%.7E', gml=True, xmlns=None):
         read(output)  # validate the written file
 
 
-def to_nrml(node):
+def to_string(node):
     """
     Convert a node into a string in NRML format
     """

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -83,7 +83,7 @@ import collections
 
 import numpy
 
-from openquake.baselib.general import CallableDict, groupby
+from openquake.baselib.general import CallableDict, groupby, deprecated
 from openquake.baselib.node import (
     node_to_xml, Node, striptag, ValidatingXmlParser, floatformat)
 from openquake.hazardlib import valid, sourceconverter, InvalidFile
@@ -110,13 +110,15 @@ def get_tag_version(nrml_node):
     return tag, version
 
 
-def parse(fname, *args):
+def convert(fname, *args):
     """
     Parse a NRML file and return an associated Python object. It works by
     calling nrml.read() and node_to_obj() in sequence.
     """
     [node] = read(fname)
     return node_to_obj(node, fname, *args)
+
+parse = deprecated('Use nrml.convert instead')(convert)
 
 node_to_obj = CallableDict(keyfunc=get_tag_version, keymissing=lambda n, f: n)
 # dictionary of functions with at least two arguments, node and fname
@@ -295,7 +297,7 @@ class SourceModelParser(object):
             the full pathname of the source model file
         """
         try:
-            return parse(fname, self.converter)
+            return convert(fname, self.converter)
         except ValueError as e:
             err = str(e)
             e1 = 'Surface does not conform with Aki & Richards convention'
@@ -357,7 +359,7 @@ def write(nodes, output=sys.stdout, fmt='%.7E', gml=True, xmlns=None):
         read(output)  # validate the written file
 
 
-def convert(node):
+def to_nrml(node):
     """
     Convert a node into a string in NRML format
     """

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -52,7 +52,7 @@ class DisaggregateTestCase(unittest.TestCase):
     def setUp(self):
         d = os.path.dirname(os.path.dirname(__file__))
         source_model = os.path.join(d, 'source_model/multi-point-source.xml')
-        [self.sources] = nrml.parse(source_model, SourceConverter(
+        [self.sources] = nrml.convert(source_model, SourceConverter(
             investigation_time=50., rupture_mesh_spacing=2.))
         self.site = Site(Point(0.1, 0.1), 800, True, z1pt0=100., z2pt5=1.)
         self.imt = PGA()

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -52,7 +52,7 @@ class DisaggregateTestCase(unittest.TestCase):
     def setUp(self):
         d = os.path.dirname(os.path.dirname(__file__))
         source_model = os.path.join(d, 'source_model/multi-point-source.xml')
-        [self.sources] = nrml.convert(source_model, SourceConverter(
+        [self.sources] = nrml.to_python(source_model, SourceConverter(
             investigation_time=50., rupture_mesh_spacing=2.))
         self.site = Site(Point(0.1, 0.1), 800, True, z1pt0=100., z2pt5=1.)
         self.imt = PGA()

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -191,7 +191,7 @@ class NankaiTestCase(unittest.TestCase):
     # use a source model for the Nankai region provided by M. Pagani
     def test(self):
         source_model = os.path.join(os.path.dirname(__file__), 'nankai.xml')
-        groups = nrml.parse(source_model, SourceConverter(
+        groups = nrml.convert(source_model, SourceConverter(
             investigation_time=50., rupture_mesh_spacing=2.))
         site = Site(Point(135.68, 35.68), 800, True, z1pt0=100., z2pt5=1.)
         s_filter = SourceFilter(SiteCollection([site]), {})
@@ -207,7 +207,7 @@ class MultiPointTestCase(unittest.TestCase):
     def test(self):
         d = os.path.dirname(os.path.dirname(__file__))
         source_model = os.path.join(d, 'source_model/multi-point-source.xml')
-        groups = nrml.parse(source_model, SourceConverter(
+        groups = nrml.convert(source_model, SourceConverter(
             investigation_time=50., rupture_mesh_spacing=2.))
         site = Site(Point(0.1, 0.1), 800, True, z1pt0=100., z2pt5=1.)
         sitecol = SiteCollection([site])

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -191,7 +191,7 @@ class NankaiTestCase(unittest.TestCase):
     # use a source model for the Nankai region provided by M. Pagani
     def test(self):
         source_model = os.path.join(os.path.dirname(__file__), 'nankai.xml')
-        groups = nrml.convert(source_model, SourceConverter(
+        groups = nrml.to_python(source_model, SourceConverter(
             investigation_time=50., rupture_mesh_spacing=2.))
         site = Site(Point(135.68, 35.68), 800, True, z1pt0=100., z2pt5=1.)
         s_filter = SourceFilter(SiteCollection([site]), {})
@@ -207,7 +207,7 @@ class MultiPointTestCase(unittest.TestCase):
     def test(self):
         d = os.path.dirname(os.path.dirname(__file__))
         source_model = os.path.join(d, 'source_model/multi-point-source.xml')
-        groups = nrml.convert(source_model, SourceConverter(
+        groups = nrml.to_python(source_model, SourceConverter(
             investigation_time=50., rupture_mesh_spacing=2.))
         site = Site(Point(0.1, 0.1), 800, True, z1pt0=100., z2pt5=1.)
         sitecol = SiteCollection([site])

--- a/openquake/hmtk/parsers/source_model/nrml04_parser.py
+++ b/openquake/hmtk/parsers/source_model/nrml04_parser.py
@@ -452,7 +452,7 @@ class nrmlSourceModelParser(BaseSourceModelParser):
     Parser for a source model in NRML format, permitting partial validation
     such that not all fields need to be specified for the file to be parsed
     """
-    @deprecated('Use openquake.hazardlib.nrml.convert instead')
+    @deprecated('Use openquake.hazardlib.nrml.to_python instead')
     def read_file(self, identifier, mfd_spacing=0.1, simple_mesh_spacing=1.0,
                   complex_mesh_spacing=4.0, area_discretization=10.):
         """

--- a/openquake/hmtk/parsers/source_model/nrml04_parser.py
+++ b/openquake/hmtk/parsers/source_model/nrml04_parser.py
@@ -452,7 +452,7 @@ class nrmlSourceModelParser(BaseSourceModelParser):
     Parser for a source model in NRML format, permitting partial validation
     such that not all fields need to be specified for the file to be parsed
     """
-    @deprecated('Use openquake.hazardlib.nrml.parse instead')
+    @deprecated('Use openquake.hazardlib.nrml.convert instead')
     def read_file(self, identifier, mfd_spacing=0.1, simple_mesh_spacing=1.0,
                   complex_mesh_spacing=4.0, area_discretization=10.):
         """

--- a/openquake/risklib/tests/read_nrml_test.py
+++ b/openquake/risklib/tests/read_nrml_test.py
@@ -70,6 +70,6 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
 	</vulnerabilityModel> 
 </nrml>''')
         with self.assertRaises(ValueError) as ctx:
-            nrml.parse(fname)
+            nrml.convert(fname)
         self.assertIn('Wrong number of probabilities (expected 14, got 17)',
                       str(ctx.exception))

--- a/openquake/risklib/tests/read_nrml_test.py
+++ b/openquake/risklib/tests/read_nrml_test.py
@@ -70,6 +70,6 @@ class VulnerabilityFunctionTestCase(unittest.TestCase):
 	</vulnerabilityModel> 
 </nrml>''')
         with self.assertRaises(ValueError) as ctx:
-            nrml.convert(fname)
+            nrml.to_python(fname)
         self.assertIn('Wrong number of probabilities (expected 14, got 17)',
                       str(ctx.exception))

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -255,7 +255,7 @@ def validate_nrml(request):
             'Please provide the "xml_text" parameter')
     xml_file = writetmp(xml_text, suffix='.xml')
     try:
-        nrml.convert(xml_file)
+        nrml.to_python(xml_file)
     except ExpatError as exc:
         return _make_response(error_msg=str(exc),
                               error_line=exc.lineno,

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -255,7 +255,7 @@ def validate_nrml(request):
             'Please provide the "xml_text" parameter')
     xml_file = writetmp(xml_text, suffix='.xml')
     try:
-        nrml.parse(xml_file)
+        nrml.convert(xml_file)
     except ExpatError as exc:
         return _make_response(error_msg=str(exc),
                               error_line=exc.lineno,


### PR DESCRIPTION
- fixed the reportwriter which was broken by the change in `.calc_times` introduced yesterday
- fixed a bug in the reportwriter for calculations with the same source in multiple groups
- added a test for the reportwriter
- renamed `nrml.parse` -> `nrml.to_python`, `nrml.convert` -> `nrml.to_string`
- kept the old `nrml.parse`, but it is now deprecated
- now `nrml.to_python('source_model.xml')` works by using a default SourceConverter
- renamed `SourceModel.name` -> `SourceModel.names` 