### PR TITLE
Automatically update version number on manual cover page

### DIFF
--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -5,6 +5,9 @@ if [ $GEM_SET_DEBUG ]; then
 fi
 set -e
 
+version="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
+sed -i "s/Version [0-9]\.[0-9]\.[0-9]/Version $version/" oq_manual_cover.svg
+
 inkscape -A figures/oq_manual_cover.pdf figures/oq_manual_cover.svg
 
 (pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex

--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -5,8 +5,9 @@ if [ $GEM_SET_DEBUG ]; then
 fi
 set -e
 
-version="$(cat openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
-sed -i "s/Version [0-9]\.[0-9]\.[0-9]/Version $version/" oq_manual_cover.svg
+CURPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+VERSION="$(cat $CURPATH/../../openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
+sed -i "s/Version [0-9]\.[0-9]\.[0-9]/Version $VERSION/" oq_manual_cover.svg
 
 inkscape -A figures/oq_manual_cover.pdf figures/oq_manual_cover.svg
 


### PR DESCRIPTION
Addresses the easy part of #2887

The citation and DOI require far more regex wizardry. eg: https://github.com/gem/oq-engine/pull/3422/files#diff-5bc4e11693b47d7e445cc1f5754a4074