### PR TITLE
Fixed the MINWEIGHT

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -164,6 +164,7 @@ class PSHACalculator(base.HazardCalculator):
         else:
             tiles = [self.sitecol]
         param = dict(truncation_level=oq.truncation_level, imtls=oq.imtls)
+        maxweight = None
         for tile_i, tile in enumerate(tiles, 1):
             num_tasks = 0
             num_sources = 0
@@ -171,7 +172,9 @@ class PSHACalculator(base.HazardCalculator):
                 logging.info('Prefiltering tile %d of %d', tile_i, len(tiles))
                 src_filter = SourceFilter(tile, oq.maximum_distance)
                 csm = self.csm.filter(src_filter)
-            if tile_i == 1:  # set it only on the first tile
+                if csm.weight == 0:  # the tile was completely filtered out
+                    continue
+            if maxweight is None:  # set maxweight only once
                 maxweight = csm.get_maxweight(tasks_per_tile)
                 logging.info('Using maxweight=%d', maxweight)
             if csm.has_dupl_sources and not opt:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -164,7 +164,6 @@ class PSHACalculator(base.HazardCalculator):
         else:
             tiles = [self.sitecol]
         param = dict(truncation_level=oq.truncation_level, imtls=oq.imtls)
-        maxweight = None
         minweight = source.MINWEIGHT * math.sqrt(len(self.sitecol))
         for tile_i, tile in enumerate(tiles, 1):
             num_tasks = 0
@@ -173,9 +172,7 @@ class PSHACalculator(base.HazardCalculator):
                 logging.info('Prefiltering tile %d of %d', tile_i, len(tiles))
                 src_filter = SourceFilter(tile, oq.maximum_distance)
                 csm = self.csm.filter(src_filter)
-                if csm.weight == 0:  # the tile was completely filtered out
-                    continue
-            if maxweight is None:  # set maxweight only once
+            if tile_i == 1:  # set it only on the first tile
                 maxweight = csm.get_maxweight(tasks_per_tile, minweight)
                 logging.info('Using maxweight=%d', maxweight)
             if csm.has_dupl_sources and not opt:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -175,7 +175,8 @@ class PSHACalculator(base.HazardCalculator):
                 if csm.weight == 0:  # the tile was completely filtered out
                     continue
             if maxweight is None:  # set maxweight only once
-                maxweight = csm.get_maxweight(tasks_per_tile)
+                maxweight = csm.get_maxweight(
+                    tasks_per_tile, source.MINWEIGHT * num_tasks)
                 logging.info('Using maxweight=%d', maxweight)
             if csm.has_dupl_sources and not opt:
                 logging.warn('Found %d duplicated sources, use oq info',

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -165,7 +165,7 @@ class PSHACalculator(base.HazardCalculator):
             tiles = [self.sitecol]
         param = dict(truncation_level=oq.truncation_level, imtls=oq.imtls)
         maxweight = None
-        minweight = source.MINWEIGHT * math.sqrt(oq.sites_per_tile)
+        minweight = source.MINWEIGHT * math.sqrt(len(self.sitecol))
         for tile_i, tile in enumerate(tiles, 1):
             num_tasks = 0
             num_sources = 0

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -165,6 +165,7 @@ class PSHACalculator(base.HazardCalculator):
             tiles = [self.sitecol]
         param = dict(truncation_level=oq.truncation_level, imtls=oq.imtls)
         maxweight = None
+        minweight = source.MINWEIGHT * math.sqrt(oq.sites_per_tile)
         for tile_i, tile in enumerate(tiles, 1):
             num_tasks = 0
             num_sources = 0
@@ -175,8 +176,7 @@ class PSHACalculator(base.HazardCalculator):
                 if csm.weight == 0:  # the tile was completely filtered out
                     continue
             if maxweight is None:  # set maxweight only once
-                maxweight = csm.get_maxweight(
-                    tasks_per_tile, source.MINWEIGHT * num_tasks)
+                maxweight = csm.get_maxweight(tasks_per_tile, minweight)
                 logging.info('Using maxweight=%d', maxweight)
             if csm.has_dupl_sources and not opt:
                 logging.warn('Found %d duplicated sources, use oq info',

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -17,6 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import time
+import math
 import os.path
 import operator
 import itertools
@@ -34,7 +35,7 @@ from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.stats import compute_pmap_stats
 from openquake.risklib.riskinput import str2rsi, rsi2str, indices_dt
 from openquake.baselib import parallel
-from openquake.commonlib import calc, util, readinput
+from openquake.commonlib import calc, util, readinput, source
 from openquake.calculators import base
 from openquake.calculators.getters import GmfGetter
 from openquake.calculators.classical import (
@@ -259,9 +260,9 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
         oq = self.oqparam
         src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
         csm = self.csm.filter(src_filter)
-        maxweight = csm.get_maxweight(oq.concurrent_tasks)
-        numheavy = len(csm.get_sources('heavy', maxweight))
-        logging.info('Using maxweight=%d, numheavy=%d', maxweight, numheavy)
+        minweight = source.MINWEIGHT * math.sqrt(len(self.sitecol))
+        maxweight = csm.get_maxweight(oq.concurrent_tasks, minweight)
+        logging.info('Using maxweight=%d', maxweight)
         param = dict(
             truncation_level=oq.truncation_level,
             imtls=oq.imtls, seed=oq.ses_seed,

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -836,17 +836,13 @@ class CompositeSourceModel(collections.Sequence):
                 src.serial = rup_serial[start:start + nr]
                 start += nr
 
-    def get_maxweight(self, concurrent_tasks):
+    def get_maxweight(self, concurrent_tasks,
+                      minweight=MINWEIGHT, maxweight=MAXWEIGHT):
         """
         Return an appropriate maxweight for use in the block_splitter
         """
         ct = concurrent_tasks or 1
-        mw = math.ceil(self.weight / ct)
-        if mw < MINWEIGHT:
-            mw = MINWEIGHT
-        elif mw > MAXWEIGHT:
-            mw = MAXWEIGHT
-        return mw
+        return numpy.clip(math.ceil(self.weight / ct), minweight, maxweight)
 
     def add_infos(self, sources):
         """

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -37,7 +37,6 @@ from openquake.commonlib import logictree
 
 
 MINWEIGHT = source.MINWEIGHT
-MAXWEIGHT = 1E7  # heuristic, set by M. Simionato
 MAX_INT = 2 ** 31 - 1
 TWO16 = 2 ** 16
 U16 = numpy.uint16
@@ -836,13 +835,13 @@ class CompositeSourceModel(collections.Sequence):
                 src.serial = rup_serial[start:start + nr]
                 start += nr
 
-    def get_maxweight(self, concurrent_tasks,
-                      minweight=MINWEIGHT, maxweight=MAXWEIGHT):
+    def get_maxweight(self, concurrent_tasks, minweight=MINWEIGHT):
         """
         Return an appropriate maxweight for use in the block_splitter
         """
         ct = concurrent_tasks or 1
-        return numpy.clip(math.ceil(self.weight / ct), minweight, maxweight)
+        mw = math.ceil(self.weight / ct)
+        return max(mw, minweight)
 
     def add_infos(self, sources):
         """

--- a/openquake/hazardlib/source/__init__.py
+++ b/openquake/hazardlib/source/__init__.py
@@ -30,7 +30,7 @@ from openquake.hazardlib.source.non_parametric import NonParametricSeismicSource
 from openquake.hazardlib.source.multi import MultiPointSource
 
 
-MINWEIGHT = 200  # tuned by M. Simionato
+MINWEIGHT = 2000  # tuned by M. Simionato
 
 
 def _split_start_stop(n, chunksize):

--- a/openquake/hazardlib/source/__init__.py
+++ b/openquake/hazardlib/source/__init__.py
@@ -30,7 +30,7 @@ from openquake.hazardlib.source.non_parametric import NonParametricSeismicSource
 from openquake.hazardlib.source.multi import MultiPointSource
 
 
-MINWEIGHT = 2000  # tuned by M. Simionato
+MINWEIGHT = 200  # tuned by M. Simionato
 
 
 def _split_start_stop(n, chunksize):


### PR DESCRIPTION
Due to a recent change the weight of the sources is now proportional to the square root of the number of affected sites, but I forgot to apply the change to the MINWEIGHT constant. The effect is that in rare circumstances, i.e. when the sources of the first tile are nearly completely filtered out, the task weight is equal to MINWEIGHT and it is very small, thus generating a lot of tasks. This happened to Julio:
```
2018-02-10T06:36:59.08,INFO,MainProcess/30874,Sent 145.3 GB of data in 145627 task(s)
```
The solution is to multiply `MINWEIGHT* sqrt(num_sites)`. With this change Julio's calculation would
generate only 3040 tasks, which is a manageable number.