### PR TITLE
Mutex sources cannot be split

### DIFF
--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -707,13 +707,16 @@ class CompositeSourceModel(collections.Sequence):
         for sm in self.source_models:
             src_groups = []
             for src_group in sm.src_groups:
+                mutex = getattr(src_group, 'src_interdep', None) == 'mutex'
                 self.add_infos(src_group.sources)  # unsplit sources
                 sources = []
                 for src in src_group.sources:
-                    if hasattr(src, '__iter__'):  # MultiPoint, AreaSource
+                    if hasattr(src, '__iter__') and not mutex:
+                        # MultiPoint, AreaSource, NonParametric
                         # NB: source.split_source is cached
                         sources.extend(source.split_source(src))
                     else:
+                        # mutex sources cannot be split
                         sources.append(src)
                 sg = copy.copy(src_group)
                 sg.sources = []

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -83,13 +83,14 @@ def classical(group, src_filter, gsims, param, monitor=Monitor()):
     if getattr(group, 'src_interdep', None) == 'mutex':
         mutex_weight = {src.source_id: weight for src, weight in
                         zip(group.sources, group.srcs_weights)}
+        srcs = group.sources
     else:
         mutex_weight = None
+        srcs = sum([split_source(src) for src in group], [])
     grp_ids = set()
     for src in group:
         grp_ids.update(src.src_group_ids)
     maxdist = src_filter.integration_distance
-    srcs = sum([split_source(src) for src in group], [])  # split first
     with GroundShakingIntensityModel.forbid_instantiation():
         imtls = param['imtls']
         trunclevel = param.get('truncation_level')


### PR DESCRIPTION
Otherwise they will end up in separate tasks. We can split only if the sources are independent.