### PR TITLE
Fixed HDF5 fork bug (again)

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -700,6 +700,9 @@ class RiskCalculator(HazardCalculator):
                     # read the hazard data in the controller node
                     logging.info('Reading hazard')
                     getter.init()
+                else:
+                    # the datastore must be closed to avoid the HDF5 fork bug
+                    assert dstore.hdf5 == (), '%s is not closed!' % dstore
                 ri = riskinput.RiskInput(getter, reduced_assets, reduced_eps)
                 if ri.weight > 0:
                     riskinputs.append(ri)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -692,7 +692,7 @@ class RiskCalculator(HazardCalculator):
                             reduced_eps[ass.ordinal] = eps[ass.ordinal]
                 # build the riskinputs
                 if kind == 'poe':  # hcurves, shape (R, N)
-                    getter = PmapGetter(dstore, sids)
+                    getter = PmapGetter(dstore, sids, self.rlzs_assoc)
                     getter.num_rlzs = self.R
                 else:  # gmf
                     getter = GmfDataGetter(dstore, sids, self.R, eids)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -39,11 +39,9 @@ class PmapGetter(object):
     :param rlzs_assoc: a RlzsAssoc instance (if None, infers it)
     """
     def __init__(self, dstore, sids=None, rlzs_assoc=None):
-        dstore.open()  # if not
         self.rlzs_assoc = rlzs_assoc or dstore['csm_info'].get_rlzs_assoc()
         self.dstore = dstore
         self.weights = [rlz.weight for rlz in self.rlzs_assoc.realizations]
-        self.num_levels = len(self.dstore['oqparam'].imtls.array)
         self.sids = sids
         self.eids = None
         self.nbytes = 0
@@ -109,8 +107,9 @@ class PmapGetter(object):
         :param grp: None (all groups) or a string of the form "grp-XX"
         :returns: the hazard curves for the given realization
         """
+        self.init()
         assert self.sids is not None
-        pmap = probability_map.ProbabilityMap(self.num_levels, 1)
+        pmap = probability_map.ProbabilityMap(len(self.imtls.array), 1)
         grps = [grp] if grp is not None else sorted(self.pmap_by_grp)
         array = self.rlzs_assoc.by_grp()
         for grp in grps:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -731,13 +731,11 @@ class Exposure(object):
         nodes = assets if assets else exposure._read_csv(
             ~assets, os.path.dirname(param['fname']))
         exposure._populate_from(nodes, param)
-        if param['region']:
-            logging.info('Read %d assets within the region_constraint '
-                         'and discarded %d assets outside the region',
-                         len(exposure.assets), param['out_of_region'])
-            if len(exposure.assets) == 0:
-                raise RuntimeError(
-                    'Could not find any asset within the region!')
+        if param['region'] and param['out_of_region']:
+            logging.info('Discarded %d assets outside the region',
+                         param['out_of_region'])
+        if len(exposure.assets) == 0:
+            raise RuntimeError('Could not find any asset within the region!')
         # sanity checks
         values = any(len(ass.values) + ass.number for ass in exposure.assets)
         assert values, 'Could not find any value??'


### PR DESCRIPTION
The situation is bad. HDF5 files can be read reliably only if they are opened after the fork, not before. However, the engine must read the datastore before the fork, so we must

1) make sure that the datastore have been closed before the fork
2) make sure that nobody have opened the datastore again after we closed it!

I cannot think of a robust solution, so at each refactoring the bug can resurface and the tests cannot cover it, since it is random. Only the tests macOS can give some hint sometimes.

Depression :-(

NB: my ideal solution for this issue would be to remove the fork, i.e. to abandon multiprocessing and to do the concurrency with zmq. That would have the additional benefit of a much better performance on Windows.