### PR TITLE
Fix hazard outputs in the case of no outputs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a bug in the hazard outputs: they were displayed in the WebUI even
+    missing
   * Implemented splitting of nonparametric sources
 
   [Marco Pagani]

--- a/demos/hazard/AreaSourceClassicalPSHA/job.ini
+++ b/demos/hazard/AreaSourceClassicalPSHA/job.ini
@@ -48,8 +48,6 @@ maximum_distance = 200.0
 [output]
 
 export_dir = /tmp
-mean_hazard_curves = false
-quantile_hazard_curves =
 hazard_maps = true
 uniform_hazard_spectra = true
 poes = 0.1 0.02

--- a/demos/hazard/CharacteristicFaultSourceCase1ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase1ClassicalPSHA/job.ini
@@ -48,7 +48,6 @@ maximum_distance = [(5, 100), (6, 200)]
 [output]
 
 export_dir = /tmp
-mean_hazard_curves = false
 quantile_hazard_curves =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/CharacteristicFaultSourceCase2ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase2ClassicalPSHA/job.ini
@@ -38,7 +38,6 @@ maximum_distance = 200.0
 [output]
 
 export_dir = /tmp
-mean_hazard_curves = false
 quantile_hazard_curves =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/CharacteristicFaultSourceCase3ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase3ClassicalPSHA/job.ini
@@ -38,7 +38,6 @@ maximum_distance = 200.0
 [output]
 
 export_dir = /tmp
-mean_hazard_curves = false
 quantile_hazard_curves =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/ComplexFaultSourceClassicalPSHA/job.ini
+++ b/demos/hazard/ComplexFaultSourceClassicalPSHA/job.ini
@@ -38,7 +38,6 @@ maximum_distance = 200.0
 [output]
 
 export_dir = /tmp
-mean_hazard_curves = false
 quantile_hazard_curves =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/EventBasedPSHA/job.ini
+++ b/demos/hazard/EventBasedPSHA/job.ini
@@ -48,7 +48,5 @@ export_dir = /tmp
 save_ruptures = true
 ground_motion_fields = true
 hazard_curves_from_gmfs = true
-mean_hazard_curves = false
-quantile_hazard_curves =
 hazard_maps = true
 poes = 0.1

--- a/demos/hazard/PointSourceClassicalPSHA/job.ini
+++ b/demos/hazard/PointSourceClassicalPSHA/job.ini
@@ -38,7 +38,6 @@ maximum_distance = 200.0
 [output]
 
 export_dir = /tmp
-mean_hazard_curves = false
 quantile_hazard_curves =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/SimpleFaultSourceClassicalPSHA/job.ini
+++ b/demos/hazard/SimpleFaultSourceClassicalPSHA/job.ini
@@ -38,7 +38,6 @@ maximum_distance = 200.0
 [output]
 
 export_dir = /tmp
-mean_hazard_curves = false
 quantile_hazard_curves =
 uniform_hazard_spectra = true
 poes = 0.1 0.02

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -126,7 +126,7 @@ class ClassicalTestCase(CalculatorTestCase):
         # exercise the warning for no output when mean_hazard_curves='false'
         self.run_calc(
             case_7.__file__, 'job.ini', mean_hazard_curves='false',
-            hazard_maps='true', poes='0.1')
+            poes='0.1')
 
     @attr('qa', 'hazard', 'classical')
     def test_case_8(self):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -208,6 +208,17 @@ class OqParam(valid.ParamSet):
         elif self.gsim is not None:
             self.check_gsims([self.gsim])
 
+        # checks for hazard outputs
+        if not self.hazard_stats():
+            if self.uniform_hazard_spectra:
+                raise InvalidFile(
+                    '%(job_ini)s: uniform_hazard_spectra=true is inconsistent '
+                    'with mean_hazard_curves=false' % self.inputs)
+            elif self.hazard_maps:
+                raise InvalidFile(
+                    '%(job_ini)s: hazard_maps=true is inconsistent '
+                    'with mean_hazard_curves=false' % self.inputs)
+
         # checks for disaggregation
         if self.calculation_mode == 'disaggregation':
             if not self.poes_disagg and not self.iml_disagg:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -121,7 +121,7 @@ def expose_outputs(dstore):
     if 'scenario' not in calcmode:  # export sourcegroups.csv
         dskeys.add('sourcegroups')
     hdf5 = dstore.hdf5
-    if 'poes' in hdf5 or 'hcurves' in hdf5:
+    if (len(rlzs) == 1 and 'poes' in hdf5) or 'hcurves' in hdf5:
         dskeys.add('hcurves')
         if oq.uniform_hazard_spectra:
             dskeys.add('uhs')  # export them


### PR DESCRIPTION
The issue, discovered by Paolo, is that the WebUI incorrectly exposes hazard curves/maps/uhs even in the case when there are no outputs, so that the QGIS plugin gets empty outputs and fails.
To test it:

1. take a calculation like LogicTreeCase1ClassicalPSHA and change in the job.ini
```
mean_hazard_curves = false
quantile_hazard_curves = 
```
2. run the calculation with QGIS.

There will be no outputs shown.
