### PR TITLE
Honored concurrent_tasks in event based GMF

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -498,10 +498,12 @@ class EventBasedCalculator(base.HazardCalculator):
         rlzs_by_gsim = {grp_id: self.rlzs_assoc.get_rlzs_by_gsim(grp_id)
                         for grp_id in samples_by_grp}
         if self.precalc:
+            num_ruptures = sum(len(rs) for rs in self.precalc.result.values())
+            block_size = math.ceil(num_ruptures, oq.concurrent_tasks or 1)
             for grp_id, ruptures in self.precalc.result.items():
                 if not ruptures:
                     continue
-                for block in block_splitter(ruptures, oq.ruptures_per_block):
+                for block in block_splitter(ruptures, block_size):
                     getter = GmfGetter(
                         rlzs_by_gsim[grp_id], block, self.sitecol,
                         imts, min_iml, oq.maximum_distance,

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-
+from __future__ import division
 import time
 import math
 import os.path
@@ -499,7 +499,7 @@ class EventBasedCalculator(base.HazardCalculator):
                         for grp_id in samples_by_grp}
         if self.precalc:
             num_ruptures = sum(len(rs) for rs in self.precalc.result.values())
-            block_size = math.ceil(num_ruptures, oq.concurrent_tasks or 1)
+            block_size = math.ceil(num_ruptures / (oq.concurrent_tasks or 1))
             for grp_id, ruptures in self.precalc.result.items():
                 if not ruptures:
                     continue


### PR DESCRIPTION
When computing the GMFs from ruptures in memory the parameter `concurrent_tasks` was not honored, inconsistently with the case of ruptures read from the disk, and also inconsistently with most calculators.