### PR TITLE
Improved error message for source model files with the wrong NRML version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Improved error message for source model files declared as nrml/0.5 when
+    they actually are nrml/0.4
   * Optimized the classical_bcr calculator for the case of many realizations
   * Extended the exposure CSV importer to manage the `retrofitted` field
 

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -157,7 +157,10 @@ def get_source_model_05(node, fname, converter=default):
     groups = []  # expect a sequence of sourceGroup nodes
     for src_group in node:
         if 'sourceGroup' not in src_group.tag:
-            raise ValueError('expected sourceGroup')
+            raise InvalidFile(
+                '%s: you have an incorrect declaration '
+                'xmlns="http://openquake.org/xmlns/nrml/0.5"; it should be '
+                'xmlns="http://openquake.org/xmlns/nrml/0.4"' % fname)
         groups.append(converter.convert_node(src_group))
     return sorted(groups)
 


### PR DESCRIPTION
As requested by @raoanirudh, closes https://github.com/gem/oq-engine/issues/3444.
