### PR TITLE
Avoid transferring the event IDs in event based risk from GMFs

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -650,14 +650,14 @@ class RiskCalculator(HazardCalculator):
                 self.assetcol, num_ruptures,
                 oq.master_seed, oq.asset_correlation)
 
-    def build_riskinputs(self, kind, eps=None, eids=None):
+    def build_riskinputs(self, kind, eps=None, num_events=0):
         """
         :param kind:
             kind of hazard getter, can be 'poe' or 'gmf'
         :param eps:
             a matrix of epsilons (or None)
-        :param eids:
-            an array of event IDs (or None)
+        :param num_events:
+            how many events there are
         :returns:
             a list of RiskInputs objects, sorted by IMT.
         """
@@ -695,7 +695,7 @@ class RiskCalculator(HazardCalculator):
                     getter = PmapGetter(dstore, sids, self.rlzs_assoc)
                     getter.num_rlzs = self.R
                 else:  # gmf
-                    getter = GmfDataGetter(dstore, sids, self.R, eids)
+                    getter = GmfDataGetter(dstore, sids, self.R, num_events)
                 if dstore is self.datastore:
                     # read the hazard data in the controller node
                     logging.info('Reading hazard')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -276,8 +276,8 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
             for sg in sm.src_groups:
                 gsims = csm.info.gsim_lt.get_gsims(sg.trt)
                 csm.add_infos(sg.sources)
-                for block in block_splitter(
-                        sg.sources, maxweight,
+                for block in csm.split_in_blocks(
+                        maxweight, sg.sources,
                         operator.attrgetter('num_ruptures')):
                     block.samples = sm.samples
                     yield block, src_filter, gsims, param, monitor

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -260,8 +260,11 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
         oq = self.oqparam
         src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
         csm = self.csm.filter(src_filter)
+
+        def weight(src):
+            return src.num_ruptures * src.RUPTURE_WEIGHT
         maxweight = math.ceil(
-            sum(src.num_ruptures for src in self.csm.get_sources()) /
+            sum(weight(src) for src in self.csm.get_sources()) /
             (oq.concurrent_tasks or 1))
         logging.info('Using maxweight=%d', maxweight)
         param = dict(
@@ -272,9 +275,6 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
 
         num_tasks = 0
         num_sources = 0
-
-        def weight(src):
-            return src.num_ruptures * src.RUPTURE_WEIGHT
         for sm in csm.source_models:
             for sg in sm.src_groups:
                 gsims = csm.info.gsim_lt.get_gsims(sg.trt)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -272,13 +272,15 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
 
         num_tasks = 0
         num_sources = 0
+
+        def weight(src):
+            return src.num_ruptures * src.RUPTURE_WEIGHT
         for sm in csm.source_models:
             for sg in sm.src_groups:
                 gsims = csm.info.gsim_lt.get_gsims(sg.trt)
                 csm.add_infos(sg.sources)
                 for block in csm.split_in_blocks(
-                        maxweight, sg.sources,
-                        operator.attrgetter('num_ruptures')):
+                        maxweight, sg.sources, weight):
                     block.samples = sm.samples
                     yield block, src_filter, gsims, param, monitor
                     num_tasks += 1

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -260,7 +260,9 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
         oq = self.oqparam
         src_filter = SourceFilter(self.sitecol, oq.maximum_distance)
         csm = self.csm.filter(src_filter)
-        maxweight = sum(src.num_ruptures for src in self.csm.get_sources())
+        maxweight = math.ceil(
+            sum(src.num_ruptures for src in self.csm.get_sources()) /
+            (oq.concurrent_tasks or 1))
         logging.info('Using maxweight=%d', maxweight)
         param = dict(
             truncation_level=oq.truncation_level,

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -229,7 +229,7 @@ class EbriskCalculator(base.RiskCalculator):
                     event_based.save_gmdata(self, self.R)
         self.E = len(self.eids)
         eps = self.epsilon_getter()()
-        self.riskinputs = self.build_riskinputs('gmf', eps, self.eids)
+        self.riskinputs = self.build_riskinputs('gmf', eps, self.E)
         self.param['gmf_ebrisk'] = True
         self.param['insured_losses'] = oq.insured_losses
         self.param['avg_losses'] = oq.avg_losses

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -187,17 +187,18 @@ class GmfDataGetter(collections.Mapping):
     """
     A dictionary-like object {sid: dictionary by realization index}
     """
-    def __init__(self, dstore, sids, num_rlzs, eids=None):
+    def __init__(self, dstore, sids, num_rlzs, num_events=0):
         self.dstore = dstore
         self.sids = sids
         self.num_rlzs = num_rlzs
-        self.eids = eids
-        self.E = 0 if eids is None else len(eids)
+        self.E = num_events
 
     def init(self):
         if hasattr(self, 'data'):  # already initialized
             return
         self.dstore.open()  # if not already open
+        self.eids = self.dstore['events']['eid']
+        self.eids.sort()
         self.data = collections.OrderedDict()
         for sid in self.sids:
             self.data[sid] = data = self[sid]

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -118,7 +118,7 @@ class ScenarioDamageCalculator(base.RiskCalculator):
             self.oqparam.number_of_ground_motion_fields)
         self.param['consequence_models'] = riskmodels.get_risk_models(
             self.oqparam, 'consequence')
-        self.riskinputs = self.build_riskinputs('gmf', eids=eids)
+        self.riskinputs = self.build_riskinputs('gmf', num_events=len(eids))
         self.param['tags'] = list(self.assetcol.tagcol)
 
     def post_execute(self, result):

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -104,7 +104,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
             eps = numpy.zeros((A, E), numpy.float32)
         else:
             eps = self.make_eps(E)
-        self.riskinputs = self.build_riskinputs('gmf', eps, eids)
+        self.riskinputs = self.build_riskinputs('gmf', eps, E)
         self.param['number_of_ground_motion_fields'] = E
         self.param['insured_losses'] = self.oqparam.insured_losses
         self.param['asset_loss_table'] = self.oqparam.asset_loss_table

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -864,13 +864,14 @@ class CompositeSourceModel(collections.Sequence):
         for src in sources:
             self.infos[src.source_id] = SourceInfo(src)
 
-    def split_in_blocks(self, maxweight, sources):
+    def split_in_blocks(self, maxweight, sources, weight=weight):
         """
         Split a set of sources in blocks of weight up to maxweight; heavy
         sources (i.e. with weight > maxweight) are split.
 
         :param maxweight: maximum weight of a block
         :param sources: sources of the same source group
+        :param weight: source weight function
         :yields: blocks of sources of weight around maxweight
         """
         sources.sort(key=weight)


### PR DESCRIPTION
Transferring the event IDs arrays can be a big issue in calculations with many events. It is best to read them directly from the workers. With this small change the improvement in the Guatemala computation with 25,000 years is of 23 times:

```
master:       total runtime           1,398 s
this branch:  total runtime           60 s
```

Doing 250,000 years is still impossible, due to the limitations of celery/rabbitmq :-(