### PR TITLE
Renamed oq -> o

### DIFF
--- a/openquake/commands/shell.py
+++ b/openquake/commands/shell.py
@@ -18,7 +18,7 @@
 from openquake.baselib import sap
 
 
-class OQ(object):
+class OpenQuake(object):
     """
     Singleton object with convenience functions which are aliases over
     engine utilities for work in the interactive interpreter.
@@ -41,13 +41,13 @@ class OQ(object):
 @sap.Script
 def shell():
     """
-    Start an embedded (i)python instance with a global oq object
+    Start an embedded (i)python instance with a global object "o"
     """
-    oq = OQ()  # noqa
+    o = OpenQuake()  # noqa
     try:
         import IPython
-        IPython.embed(banner1='IPython shell with a global oq object')
+        IPython.embed(banner1='IPython shell with a global object "o"')
     except ImportError:
         import code
-        code.interact(banner='Python shell with a global oq object',
-                      local=dict(oq=oq))
+        code.interact(banner='Python shell with a global object "o"',
+                      local=dict(o=o))


### PR DESCRIPTION
Short is better. This also avoids confusion with the name `oq` which is used in a million places as an abbreviation for the oqparam object.