### PR TITLE
asset_refs and assets now have the same ordering

### DIFF
--- a/openquake/calculators/export/loss_curves.py
+++ b/openquake/calculators/export/loss_curves.py
@@ -86,7 +86,7 @@ class LossCurveExporter(object):
             arefs = []
             for aid, rec in enumerate(self.assetcol.array):
                 aids.append(aid)
-                arefs.append(self.asset_refs[rec['idx']])
+                arefs.append(self.asset_refs[aid])
         elif spec.startswith('sid-'):  # passed the site ID
             sid = int(spec[4:])
             aids = []
@@ -94,7 +94,7 @@ class LossCurveExporter(object):
             for aid, rec in enumerate(self.assetcol.array):
                 if rec['site_id'] == sid:
                     aids.append(aid)
-                    arefs.append(self.asset_refs[rec['idx']])
+                    arefs.append(self.asset_refs[aid])
         elif spec.startswith('ref-'):  # passed the asset name
             arefs = [spec[4:]]
             aids = [self.str2asset[arefs[0]].ordinal]

--- a/openquake/calculators/export/loss_curves.py
+++ b/openquake/calculators/export/loss_curves.py
@@ -51,7 +51,7 @@ class LossCurveExporter(object):
     mean/sid-42   # export mean loss curves of site #42
     quantile-0.1/sid-42   # export quantile loss curves of site #42
 
-    rlzs/ref-a1          # export loss curves of asset a1 for all realizations
+    rlzs/ref-a1         # export loss curves of asset a1 for all realizations
     rlz-003/ref-a1      # export loss curves of asset a1, realization 3
     stats/ref-a1        # export statistical loss curves of asset a1
     mean/ref-a1         # export mean loss curves of asset a1
@@ -65,7 +65,7 @@ class LossCurveExporter(object):
             pass
         self.assetcol = dstore['assetcol']
         arefs = [decode(aref) for aref in self.assetcol.asset_refs]
-        self.str2asset = {arefs[asset.idx]: asset for asset in self.assetcol}
+        self.str2asset = dict(zip(arefs, self.assetcol))
         self.asset_refs = arefs
         self.loss_types = dstore.get_attr('composite_risk_model', 'loss_types')
         self.R = dstore['csm_info'].get_num_rlzs()

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -540,7 +540,7 @@ def get_paths(rlz):
 def export_bcr_map(ekey, dstore):
     oq = dstore['oqparam']
     assetcol = dstore['assetcol/array'].value
-    aref = dstore['assetcol/asset_refs'].value
+    arefs = dstore['assetcol/asset_refs'].value
     bcr_data = dstore[ekey[0]]
     N, R = bcr_data.shape
     if ekey[0].endswith('stats'):
@@ -554,9 +554,8 @@ def export_bcr_map(ekey, dstore):
         path = dstore.build_fname('bcr', tag, 'csv')
         data = [['lon', 'lat', 'asset_ref', 'average_annual_loss_original',
                  'average_annual_loss_retrofitted', 'bcr']]
-        for ass, value in zip(assetcol, rlz_data):
-            data.append((ass['lon'], ass['lat'],
-                         decode(aref[ass['idx']]),
+        for aref, ass, value in zip(arefs, assetcol, rlz_data):
+            data.append((ass['lon'], ass['lat'], aref,
                          value['annual_loss_orig'],
                          value['annual_loss_retro'],
                          value['bcr']))

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -122,7 +122,7 @@ def extract_asset_values(dstore, sid):
     for assets in assets_by_site:
         vals = numpy.zeros(len(assets), dt)
         for a, asset in enumerate(assets):
-            vals[a]['aref'] = asset_refs[asset.idx]
+            vals[a]['aref'] = asset_refs[a]
             vals[a]['aid'] = asset.ordinal
             for lt in lts:
                 vals[a][lt] = asset.value(lt, time_event)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -713,7 +713,7 @@ def _get_exposure(fname, ok_cost_types, stop=None):
     asset_refs = []
     exp = Exposure(
         exposure['id'], exposure['category'],
-        ~description, cost_types, occupancy_periods.split(),
+        description.text, cost_types, occupancy_periods.split(),
         insurance_limit_is_absolute, deductible_is_absolute, retrofitted,
         area.attrib, assets, asset_refs, cc, asset.TagCollection(tagnames))
     return exp, exposure.assets

--- a/openquake/commonlib/util.py
+++ b/openquake/commonlib/util.py
@@ -125,11 +125,11 @@ def get_assets(dstore):
     :returns: an ordered array of records (asset_ref, taxonomy, lon, lat)
     """
     assetcol = dstore['assetcol']
-    arefs = assetcol.asset_refs
     taxo = dstore['assetcol/tagcol/taxonomy'].value
     asset_data = []
-    for a, t in zip(assetcol.array, assetcol.taxonomies):
-        data = (arefs[a['idx']], '"%s"' % taxo[t], a['lon'], a['lat'])
+    for aref, a, t in zip(
+            assetcol.asset_refs, assetcol.array, assetcol.taxonomies):
+        data = (aref, '"%s"' % taxo[t], a['lon'], a['lat'])
         asset_data.append(data)
     return numpy.array(asset_data, asset_dt)
 

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -420,6 +420,7 @@ class AssetCollection(object):
         new = object.__new__(self.__class__)
         vars(new).update(vars(self))
         new.array = self.array[ok_indices]
+        new.asset_refs = self.asset_refs[ok_indices]
         return new
 
     def values(self, aids=None):

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -355,7 +355,6 @@ class AssetCollection(object):
         self.array = self.build_asset_array(
             assets_by_site, tagcol.tagnames, time_event)
         self.asset_refs = [asset_refs[rec['idx']] for rec in self.array]
-        import pdb; pdb.set_trace()
         fields = self.array.dtype.names
         self.loss_types = [f[6:] for f in fields if f.startswith('value-')]
         if 'occupants' in fields:

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -355,6 +355,7 @@ class AssetCollection(object):
         self.array = self.build_asset_array(
             assets_by_site, tagcol.tagnames, time_event)
         self.asset_refs = [asset_refs[rec['idx']] for rec in self.array]
+        import pdb; pdb.set_trace()
         fields = self.array.dtype.names
         self.loss_types = [f[6:] for f in fields if f.startswith('value-')]
         if 'occupants' in fields:
@@ -366,6 +367,9 @@ class AssetCollection(object):
 
     @property
     def tagnames(self):
+        """
+        :returns: the tagnames
+        """
         return self.tagcol.tagnames
 
     def get_aids_by_tag(self):

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -373,14 +373,13 @@ class AssetCollection(object):
 
     def get_aids_by_tag(self):
         """
-        :returns: dict tag -> asset ordinals
+        :returns: dict idx -> aid
         """
-        ordinal = dict(zip(self.array['idx'], range(len(self.array))))
         aids_by_tag = general.AccumDict(accum=set())
-        for ass in self:
+        for aid, ass in enumerate(self):
             for tagname, tagidx in zip(self.tagnames, ass.tagidxs):
                 tag = self.tagcol.get_tag(tagname, tagidx)
-                aids_by_tag[tag].add(ordinal[ass.idx])
+                aids_by_tag[tag].add(aid)
         return aids_by_tag
 
     @property

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -373,7 +373,7 @@ class AssetCollection(object):
 
     def get_aids_by_tag(self):
         """
-        :returns: dict idx -> aid
+        :returns: dict tag -> asset ordinals
         """
         aids_by_tag = general.AccumDict(accum=set())
         for aid, ass in enumerate(self):

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -347,7 +347,6 @@ class AssetCollection(object):
 
     def __init__(self, asset_refs, assets_by_site, tagcol, cost_calculator,
                  time_event, occupancy_periods=''):
-        self.asset_refs = asset_refs
         self.tagcol = tagcol
         self.cost_calculator = cost_calculator
         self.time_event = time_event
@@ -355,6 +354,7 @@ class AssetCollection(object):
         self.tot_sites = len(assets_by_site)
         self.array = self.build_asset_array(
             assets_by_site, tagcol.tagnames, time_event)
+        self.asset_refs = [asset_refs[rec['idx']] for rec in self.array]
         fields = self.array.dtype.names
         self.loss_types = [f[6:] for f in fields if f.startswith('value-')]
         if 'occupants' in fields:

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -32,16 +32,7 @@ class ValidationError(Exception):
 U32 = numpy.uint32
 F32 = numpy.float32
 by_taxonomy = operator.attrgetter('taxonomy')
-aids_dt = numpy.dtype([('aids', hdf5.vuint32)])
 indices_dt = numpy.dtype([('start', U32), ('stop', U32)])
-
-
-def get_refs(assets, hdf5path):
-    """
-    Debugging method returning the string IDs of the assets from the datastore
-    """
-    with hdf5.File(hdf5path, 'r') as f:
-        return f['asset_refs'][[a.idx for a in assets]]
 
 
 def read_composite_risk_model(dstore):


### PR DESCRIPTION
Before one had to use the `idx` field to extract the right `asset_ref` from the asset in a dozen different places. Thanks to this refactoring it is possible to reduce the number of asset_refs in the reduced asset collection with one line: `reduced_assetcol.asset_refs = assetcol.asset_refs[ok_indices]`.
Closes https://github.com/gem/oq-engine/issues/3466.