### PR TITLE
Import deductible and insuranceLimit even if insured_losses is false

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -740,8 +740,8 @@ def get_exposure(oqparam):
     """
     return Exposure.read(
         oqparam.inputs['exposure'], oqparam.calculation_mode,
-        oqparam.insured_losses, oqparam.region_constraint,
-        oqparam.all_cost_types, oqparam.ignore_missing_costs)
+        oqparam.region_constraint, oqparam.all_cost_types,
+        oqparam.ignore_missing_costs)
 
 
 class Exposure(object):
@@ -755,9 +755,8 @@ class Exposure(object):
               'cost_calculator', 'tagcol']
 
     @classmethod
-    def read(cls, fname, calculation_mode='', insured_losses=False,
-             region_constraint='', all_cost_types=(), ignore_missing_costs=(),
-             asset_nodes=False):
+    def read(cls, fname, calculation_mode='', region_constraint='',
+             all_cost_types=(), ignore_missing_costs=(), asset_nodes=False):
         """
         Call `Exposure.read(fname)` to get an :class:`Exposure` instance
         keeping all the assets in memory or
@@ -766,7 +765,6 @@ class Exposure(object):
         """
         param = {'calculation_mode': calculation_mode}
         param['out_of_region'] = 0
-        param['insured_losses'] = insured_losses
         if region_constraint:
             param['region'] = wkt.loads(region_constraint)
         else:
@@ -915,9 +913,14 @@ class Exposure(object):
                     retrofitted = cost.get('retrofitted')
                 if cost_type in param['relevant_cost_types']:
                     values[cost_type] = cost['value']
-                    if param['insured_losses']:
+                    try:
                         deductibles[cost_type] = cost['deductible']
+                    except KeyError:
+                        pass
+                    try:
                         insurance_limits[cost_type] = cost['insuranceLimit']
+                    except KeyError:
+                        pass
 
         # check we are not missing a cost type
         missing = param['relevant_cost_types'] - set(values)

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -452,22 +452,6 @@ POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         self.assertIn("Invalid ID 'a 1': the only accepted chars are "
                       "a-zA-Z0-9_-, line 11", str(ctx.exception))
 
-    def test_no_insured_data(self):
-        oqparam = mock.Mock()
-        oqparam.base_path = '/'
-        oqparam.calculation_mode = 'scenario_risk'
-        oqparam.all_cost_types = ['structural']
-        oqparam.insured_losses = True
-        oqparam.inputs = {'exposure': self.exposure,
-                          'structural_vulnerability': None}
-        oqparam.region_constraint = '''\
-POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
-        oqparam.time_event = None
-        oqparam.ignore_missing_costs = []
-        with self.assertRaises(KeyError) as ctx:
-            readinput.get_exposure(oqparam)
-        self.assertIn("node cost: 'deductible', line 14", str(ctx.exception))
-
     def test_no_assets(self):
         oqparam = mock.Mock()
         oqparam.base_path = '/'


### PR DESCRIPTION
Because they can be useful later, in the context of pre-imported exposures.
Closes https://github.com/gem/oq-engine/issues/3474