### PR TITLE
Remove old stuff from debian inits and solve celery issue in packager.sh

### DIFF
--- a/debian/supervisord/openquake-celery.conf
+++ b/debian/supervisord/openquake-celery.conf
@@ -1,6 +1,6 @@
 [program:openquake-celery]
 priority=998
-environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake,PYTHONPATH=/opt/openquake/lib/python2.7/site-packages
+environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake
 directory=/usr/share/openquake/engine
 ## With Celery 3 (Ubuntu >= 14.04)
 command=/opt/openquake/bin/python3 -m celery worker --config openquake.engine.celeryconfig --purge -Ofair

--- a/debian/supervisord/openquake-dbserver.conf
+++ b/debian/supervisord/openquake-dbserver.conf
@@ -1,6 +1,6 @@
 [program:openquake-dbserver]
 priority=997
-environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake,PYTHONPATH=/opt/openquake/lib/python2.7/site-packages
+environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake
 directory=/usr/share/openquake/engine
 command=/opt/openquake/bin/python3 -m openquake.server.dbserver
 user=openquake

--- a/debian/supervisord/openquake-webui.conf
+++ b/debian/supervisord/openquake-webui.conf
@@ -1,6 +1,6 @@
 [program:openquake-webui]
 priority=999
-environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake,PYTHONPATH=/opt/openquake/lib/python2.7/site-packages
+environment=LANG=en_US.UTF-8,LC_ALL=en_US.UTF-8,LOGNAME=openquake
 directory=/usr/share/openquake/engine
 ; Using embedded django server
 command=/opt/openquake/bin/python3 -m openquake.server.manage runserver 127.0.0.1:8800 --noreload

--- a/packager.sh
+++ b/packager.sh
@@ -585,9 +585,11 @@ _pkgtest_innervm_run () {
         fi
 
         cd /usr/share/openquake/engine/demos
-        OQ_DISTRIBUTE=celery oq engine --run risk/EventBasedRisk/job_hazard.ini && oq engine --run risk/EventBasedRisk/job_risk.ini --hc -1 || echo \"distribution with celery not supported without master and/or worker packages\"
+        oq engine --run risk/EventBasedRisk/job_hazard.ini && oq engine --run risk/EventBasedRisk/job_risk.ini --hc -1 || echo \"distribution with celery not supported without master and/or worker packages\"
 
         sudo apt-get install -y python3-oq-engine-master python3-oq-engine-worker
+        # Switch to celery mode
+        sudo sed -i 's/oq_distribute = futures/oq_distribute = celery/g' /etc/openquake/openquake.cfg
 
 export PYTHONPATH=\"$OPT_LIBS_PATH\"
 # FIXME: the big sleep below is a temporary workaround to avoid races.
@@ -622,7 +624,7 @@ sudo supervisorctl start openquake-celery
 celery_wait $GEM_MAXLOOP
 
         /usr/share/openquake/engine/utils/celery-status
-        OQ_DISTRIBUTE=celery oq engine --run risk/EventBasedRisk/job_hazard.ini && oq engine --run risk/EventBasedRisk/job_risk.ini --hc -1
+        oq engine --run risk/EventBasedRisk/job_hazard.ini && oq engine --run risk/EventBasedRisk/job_risk.ini --hc -1
 
         # Try to export a set of results AFTER the calculation
         # automatically creates a directory called out


### PR DESCRIPTION
Removes old stuff in Debian inits and solve an issue with celery when running the packager.sh demos: https://ci.openquake.org/job/master_oq-engine/4363/

Demos running here: https://ci.openquake.org/job/zdevel_oq-engine/2710/