### PR TITLE
Removed get_job_info

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -387,7 +387,6 @@ class HazardCalculator(BaseCalculator):
         the previous calculation; if not, read the inputs directly.
         """
         precalc_id = self.oqparam.hazard_calculation_id
-        job_info = {}
         if self.pre_calculator is not None:
             # the parameter hazard_calculation_id is only meaningful if
             # there is a precalculator
@@ -399,12 +398,6 @@ class HazardCalculator(BaseCalculator):
             self.init()
         else:  # we are in a basic calculator
             self.read_inputs()
-            if 'source' in self.oqparam.inputs and precalc_id is None:
-                job_info.update(readinput.get_job_info(
-                    self.oqparam, self.csm, self.sitecol))
-        if hasattr(self, 'riskmodel'):
-            job_info['require_epsilons'] = bool(self.riskmodel.covs)
-        self._monitor.save_info(job_info)
         self.param = {}  # used in the risk calculators
 
     def init(self):

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -69,12 +69,3 @@ shared_dir =
 # drive containing the root fs is usually quite small
 # path must exists otherwise default $TMPDIR will be used as fallback
 custom_tmp =
-
-[hazard]
-# maximum weight of the sources; 0 means no limit
-# for a laptop, a good number is 200,000
-max_input_weight = 0
-
-# maximum size of the output in some units; 0 means no limit
-# for a laptop, a good number is 4,000,000
-max_output_weight = 0


### PR DESCRIPTION
It is a really old an obsolete feature. The information is in the .rst reports now. I am also removed the unused parameter `max_input_weight` and `max_output_weight` from `openquake.cfg`. 