### PR TITLE
Bug fix: we were reading the source model twice in disaggregation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a small bug: we were reading the source model twice in disaggregation
   * Added a check to discard results coming from the wrong calculation
     for the distribution mode `celery_zmq`
   * Removed the long time deprecated commands

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -109,9 +109,9 @@ producing too small PoEs.'''
             # the hazard curves, hence the need to run a PSHACalculator here
             cl = classical.PSHACalculator(oq, self.monitor('classical'),
                                           calc_id=self.datastore.calc_id)
+            cl.csm = self.csm
             cl.grp_by_src = oq.disagg_by_src
-            cl.run()
-            self.csm = cl.csm
+            cl.run(pre_execute=False)
             self.rlzs_assoc = cl.rlzs_assoc  # often reduced logic tree
             curves = [self.get_curves(sid) for sid in self.sitecol.sids]
             self.check_poes_disagg(curves)


### PR DESCRIPTION
I discovered this by looking at the logs of Julio's computations, that were taking a long time parsing the source models. @mmpagani, we need to merge the pull requests on disaggregation, that have been open for two months. If you have no time to tests the new features, let's not document them and keep them in experimental status, but having pull requests open two months is no good, then errors like this one that I thought I had fixed a long time ago will stay in master and will affect the official release (engine 2.9 has this bug).