### PR TITLE
Renumber source IDs

### DIFF
--- a/openquake/commands/renumber_sources.py
+++ b/openquake/commands/renumber_sources.py
@@ -33,14 +33,15 @@ def renumber_sources(smlt_file):
     logging.basicConfig(level=logging.INFO)
     number = 1
     for path in readinput.get_paths(smlt_file):
-        smodel = nrml.read(path)
-        if smodel['xmlns'] == 'http://openquake.org/xmlns/nrml/0.4':
+        root = nrml.read(path)
+        if root['xmlns'] == 'http://openquake.org/xmlns/nrml/0.4':
             raise ObsoleteFormat('Please use oq upgrade_nrml .')
+        [smodel] = root
         for sgroup in smodel:
             for src in sgroup:
                 src['id'] = str(number)
                 number += 1
         with open(path, 'wb') as f:
-            nrml.write(smodel, f)
+            nrml.write(root, f)
 
 renumber_sources.arg('smlt_file', 'source model logic tree file')

--- a/openquake/commands/renumber_sources.py
+++ b/openquake/commands/renumber_sources.py
@@ -33,6 +33,7 @@ def renumber_sources(smlt_file):
     logging.basicConfig(level=logging.INFO)
     number = 1
     for path in readinput.get_paths(smlt_file):
+        logging.info('Renumbering %s', path)
         root = nrml.read(path)
         if root['xmlns'] == 'http://openquake.org/xmlns/nrml/0.4':
             raise ObsoleteFormat('Please use oq upgrade_nrml .')

--- a/openquake/commands/renumber_sources.py
+++ b/openquake/commands/renumber_sources.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import shutil
 import logging
 from openquake.baselib import sap
 from openquake.commonlib import readinput
@@ -28,21 +29,25 @@ class ObsoleteFormat(Exception):
 @sap.Script
 def renumber_sources(smlt_file):
     """
-    Renumber all the sources in all XML files.
+    Renumber the sources belowing to the same source model, even if split
+    in multiple files, to avoid duplicated source IDs.
     """
     logging.basicConfig(level=logging.INFO)
-    number = 1
-    for path in readinput.get_paths(smlt_file):
-        logging.info('Renumbering %s', path)
-        root = nrml.read(path)
-        if root['xmlns'] == 'http://openquake.org/xmlns/nrml/0.4':
-            raise ObsoleteFormat('Please use oq upgrade_nrml .')
-        [smodel] = root
-        for sgroup in smodel:
-            for src in sgroup:
-                src['id'] = str(number)
-                number += 1
-        with open(path, 'wb') as f:
-            nrml.write(root, f)
+    for paths in readinput.gen_sm_paths(smlt_file):
+        number = 1
+        for path in paths:
+            # make a backup of the original file
+            shutil.copy(path, path + '~')
+            logging.info('Renumbering %s', path)
+            root = nrml.read(path)
+            if root['xmlns'] == 'http://openquake.org/xmlns/nrml/0.4':
+                raise ObsoleteFormat('Please use oq upgrade_nrml .')
+            [smodel] = root
+            for sgroup in smodel:
+                for src in sgroup:
+                    src['id'] = str(number)
+                    number += 1
+            with open(path, 'wb') as f:
+                nrml.write(root, f)
 
 renumber_sources.arg('smlt_file', 'source model logic tree file')

--- a/openquake/commands/renumber_sources.py
+++ b/openquake/commands/renumber_sources.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2018 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import logging
+from openquake.baselib import sap
+from openquake.commonlib import readinput
+from openquake.hazardlib import nrml
+
+
+class ObsoleteFormat(Exception):
+    pass
+
+
+@sap.Script
+def renumber_sources(smlt_file):
+    """
+    Renumber all the sources in all XML files.
+    """
+    logging.basicConfig(level=logging.INFO)
+    number = 1
+    for path in readinput.get_paths(smlt_file):
+        smodel = nrml.read(path)
+        if smodel['xmlns'] == 'http://openquake.org/xmlns/nrml/0.4':
+            raise ObsoleteFormat('Please use oq upgrade_nrml .')
+        for sgroup in smodel:
+            for src in sgroup:
+                src['id'] = str(number)
+                number += 1
+        with open(path, 'wb') as f:
+            nrml.write(smodel, f)
+
+renumber_sources.arg('smlt_file', 'source model logic tree file')

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -147,25 +147,30 @@ def get_params(job_inis, **kw):
     inputs = params['inputs']
     smlt = inputs.get('source_model_logic_tree')
     if smlt:
-        inputs['source'] = sorted(get_paths(smlt))
+        inputs['source'] = []
+        for paths in gen_sm_paths(smlt):
+            inputs['source'].extend(paths)
     elif 'source_model' in inputs:
         inputs['source'] = [inputs['source_model']]
     return params
 
 
-def get_paths(smlt):
+def gen_sm_paths(smlt):
     """
-    Extract the path names for the source models listed in the smlt file
+    Yields the path names for the source models listed in the smlt file,
+    a block at the time.
     """
     base_path = os.path.dirname(smlt)
     for model in source.collect_source_model_paths(smlt):
+        paths = []
         for name in model.split():
             if os.path.isabs(name):
                 raise InvalidFile('%s: %s must be a relative path' %
                                   (smlt, name))
             fname = os.path.abspath(os.path.join(base_path, name))
             if os.path.exists(fname):  # consider only real paths
-                yield fname
+                paths.append(fname)
+        yield paths
 
 
 def get_oqparam(job_ini, pkg=None, calculators=None, hc_id=None):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -147,14 +147,16 @@ def get_params(job_inis, **kw):
     inputs = params['inputs']
     smlt = inputs.get('source_model_logic_tree')
     if smlt:
-        inputs['source'] = sorted(_get_paths(smlt))
+        inputs['source'] = sorted(get_paths(smlt))
     elif 'source_model' in inputs:
         inputs['source'] = [inputs['source_model']]
     return params
 
 
-def _get_paths(smlt):
-    # extract the path names for the source models listed in the smlt file
+def get_paths(smlt):
+    """
+    Extract the path names for the source models listed in the smlt file
+    """
     base_path = os.path.dirname(smlt)
     for model in source.collect_source_model_paths(smlt):
         for name in model.split():

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -193,7 +193,6 @@ validators = {
     'bin_width': valid.positivefloats,
     'probability': valid.probability,
     'occurRates': valid.positivefloats,  # they can be > 1
-    'probs_occur': valid.pmf,
     'weight': valid.probability,
     'uncertaintyWeight': decimal.Decimal,
     'alongStrike': valid.probability,

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -717,7 +717,7 @@ class SourceConverter(RuptureConverter):
         trt = node.attrib.get('tectonicRegion')
         rup_pmf_data = []
         for rupnode in node:
-            probs = pmf.PMF(rupnode['probs_occur'])
+            probs = pmf.PMF(valid.pmf(rupnode['probs_occur']))
             rup = RuptureConverter.convert_node(self, rupnode)
             rup.tectonic_region_type = trt
             rup_pmf_data.append((rup, probs))

--- a/openquake/qa_tests_data/classical/case_2/source_model.xml
+++ b/openquake/qa_tests_data/classical/case_2/source_model.xml
@@ -1,29 +1,47 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
-      xmlns:gml="http://www.opengis.net/gml">
-    <sourceModel name="Classical Hazard QA Test, Case 2 source model">
-        <pointSource id="1" name="point source" tectonicRegion="active shallow crust">
-            <pointGeometry>
-                <gml:Point>
-                    <gml:pos>0.0 0.0</gml:pos>
-                </gml:Point>
-
-                <upperSeismoDepth>0.0</upperSeismoDepth>
-                <lowerSeismoDepth>10.0</lowerSeismoDepth>
-            </pointGeometry>
-
-            <magScaleRel>PeerMSR</magScaleRel>
-            <ruptAspectRatio>1.0</ruptAspectRatio>
-
-            <truncGutenbergRichterMFD aValue="2.0" bValue="1.0" minMag="4.0" maxMag="7.0" />
-
-            <nodalPlaneDist>
-                <nodalPlane probability="1.0" strike="0.0" dip="90.0" rake="0.0" />
-            </nodalPlaneDist>
-
-            <hypoDepthDist>
-                <hypoDepth probability="1.0" depth="0.5" />
-            </hypoDepthDist>
-        </pointSource>
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    name="Classical Hazard QA Test, Case 2 source model"
+    >
+        <sourceGroup
+        name="group 1"
+        tectonicRegion="active shallow crust"
+        >
+            <pointSource
+            id="1"
+            name="point source"
+            tectonicRegion="active shallow crust"
+            >
+                <pointGeometry>
+                    <gml:Point>
+                        <gml:pos>
+                            0.0000000E+00 0.0000000E+00
+                        </gml:pos>
+                    </gml:Point>
+                    <upperSeismoDepth>
+                        0.0000000E+00
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        1.0000000E+01
+                    </lowerSeismoDepth>
+                </pointGeometry>
+                <magScaleRel>
+                    PeerMSR
+                </magScaleRel>
+                <ruptAspectRatio>
+                    1.0000000E+00
+                </ruptAspectRatio>
+                <truncGutenbergRichterMFD aValue="2.0000000E+00" bValue="1.0000000E+00" maxMag="7.0000000E+00" minMag="4.0000000E+00"/>
+                <nodalPlaneDist>
+                    <nodalPlane dip="9.0000000E+01" probability="1.0000000E+00" rake="0.0000000E+00" strike="0.0000000E+00"/>
+                </nodalPlaneDist>
+                <hypoDepthDist>
+                    <hypoDepth depth="5.0000000E-01" probability="1.0000000E+00"/>
+                </hypoDepthDist>
+            </pointSource>
+        </sourceGroup>
     </sourceModel>
 </nrml>


### PR DESCRIPTION
This script allows to renumber all the sources in a composite source model. It is useful in models (i.e. CCARA) containing duplicated source IDs. In another PR I am adding a warning on duplicated source IDs, so that it is possible to recognize this situation.