### PR TITLE
Fixed bug with duplicated GMPE tables

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1191,7 +1191,7 @@ class GsimLogicTree(object):
                 ','.join(self.tectonic_region_types))
         self.values = collections.defaultdict(list)  # {trt: gsims}
         self._ltnode = ltnode or node_from_xml(fname).logicTree
-        self.gmpe_tables = []  # populated right below
+        self.gmpe_tables = set() # populated right below
         self.all_trts, self.branches = self._build_trts_branches()
         if tectonic_region_types and not self.branches:
             raise InvalidLogicTree(
@@ -1224,7 +1224,7 @@ class GsimLogicTree(object):
         """
         dest = dstore.hdf5
         dirname = os.path.dirname(self.fname)
-        for gmpe_table in self.gmpe_tables:
+        for gmpe_table in sorted(self.gmpe_tables):
             hdf5path = os.path.join(dirname, gmpe_table)
             with hdf5.File(hdf5path, 'r') as f:
                 for group in f:
@@ -1318,7 +1318,7 @@ class GsimLogicTree(object):
                             # a bit hackish: set the GMPE_DIR equal to the
                             # directory where the gsim_logic_tree file is
                             GMPETable.GMPE_DIR = os.path.dirname(self.fname)
-                            self.gmpe_tables.append(uncertainty['gmpe_table'])
+                            self.gmpe_tables.add(uncertainty['gmpe_table'])
                         try:
                             gsim = valid.gsim(gsim_name, **uncertainty.attrib)
                         except:

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1228,13 +1228,13 @@ class GsimLogicTree(object):
             hdf5path = os.path.join(dirname, gmpe_table)
             with hdf5.File(hdf5path, 'r') as f:
                 for group in f:
-                    name = 'gmpe_table/%s/%s' % (gmpe_table, group)
+                    name = '%s/%s' % (gmpe_table, group)
                     if hasattr(f[group], 'value'):  # dataset, not group
                         dstore[name] = f[group].value
                         for k, v in f[group].attrs.items():
                             dstore[name].attrs[k] = v
                     else:
-                        grp = dest.require_group('gmpe_table/%s' % gmpe_table)
+                        grp = dest.require_group(gmpe_table)
                         f.copy(group, grp)
 
     def __str__(self):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -463,7 +463,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
             fname = os.path.abspath(os.path.join(smlt_dir, name))
             if in_memory:
                 apply_unc = source_model_lt.make_apply_uncertainties(sm.path)
-                logging.info('Parsing %s', fname)
+                logging.info('Reading %s', fname)
                 src_groups.extend(psr.parse_src_groups(fname, apply_unc))
             else:  # just collect the TRT models
                 smodel = nrml.read(fname).sourceModel


### PR DESCRIPTION
This should fix a problem affecting a CCARA calculation by Julio (ID=17716) with error:

```python
  File "/usr/local/openquake/oq-engine/openquake/commonlib/logictree.py", line 1238, in store_gmpe_tables
    f.copy(group, grp)
  File "/opt/python35/lib/python3.5/site-packages/h5py/_hl/group.py", line 393, in copy
    copypl, base.dlcpl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/tmp/pip-huypgcah-build/h5py/_objects.c:2840)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/tmp/pip-huypgcah-build/h5py/_objects.c:2798)
  File "h5py/h5o.pyx", line 217, in h5py.h5o.copy (/tmp/pip-huypgcah-build/h5py/h5o.c:4061)
ValueError: Destination object already exists (Destination object already exists)
```