### PR TITLE
Cast occupants from string to float before attempting to add them

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a TypeError when reading CSV exposures with occupancy periods
   * Extended the check on duplicated source IDs to models in format NRML 0.5
   * Added a warning when reading the sources if .count_ruptures() is
     suspiciously slow

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -897,7 +897,7 @@ class Exposure(object):
             with context(param['fname'], occupancy):
                 occupants = 'occupants_%s' % occupancy['period']
                 values[occupants] = occupancy['occupants']
-                tot_occupants += values[occupants]
+                tot_occupants += float(values[occupants])
         if occupancies:  # store average occupants
             values['occupants_None'] = tot_occupants / len(occupancies)
         area = float(asset_node.get('area', 1))

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -786,7 +786,7 @@ class Exposure(object):
                     asset = Node('asset', lineno=i)
                     with context(fname, asset):
                         asset['id'] = dic['id']
-                        asset['number'] = float(dic['number'])
+                        asset['number'] = valid.positivefloat(dic['number'])
                         asset['taxonomy'] = dic['taxonomy']
                         if 'area' in dic:  # optional attribute
                             asset['area'] = dic['area']
@@ -896,8 +896,8 @@ class Exposure(object):
         for occupancy in occupancies:
             with context(param['fname'], occupancy):
                 occupants = 'occupants_%s' % occupancy['period']
-                values[occupants] = occupancy['occupants']
-                tot_occupants += float(values[occupants])
+                values[occupants] = float(occupancy['occupants'])
+                tot_occupants += values[occupants]
         if occupancies:  # store average occupants
             values['occupants_None'] = tot_occupants / len(occupancies)
         area = float(asset_node.get('area', 1))

--- a/openquake/qa_tests_data/scenario_risk/case_2d/exposure_model.xml
+++ b/openquake/qa_tests_data/scenario_risk/case_2d/exposure_model.xml
@@ -13,6 +13,9 @@
       <costType name="business_interruption" type="per_asset" unit="USD/month" />
     </costTypes>
   </conversions>
+  <occupancyPeriods>
+    day night transit
+  </occupancyPeriods>
   <assets>
     <asset id="a1" number="1" area="100" taxonomy="tax1" >
       <location lon="-122.000" lat="38.113" />


### PR DESCRIPTION
The csv DictReader reads all values as strings by default. Thus, when adding the number of occupants during different periods, the attempt to add strings to an int fails, eg:
```sh
File "/opt/python36/src/oq-engine/openquake/commonlib/readinput.py", line 941, in _add_asset
  tot_occupants += values[occupants]
File "/opt/python36/lib/python3.6/contextlib.py", line 99, in __exit__
  self.gen.throw(type, value, traceback)
File "/opt/python36/src/oq-engine/openquake/baselib/node.py", line 768, in context
  raise_(etype, msg, tb)
File "/opt/python36/src/oq-engine/openquake/baselib/python3compat.py", line 134, in raise_
  raise exc.with_traceback(tb)
File "/opt/python36/src/oq-engine/openquake/baselib/node.py", line 763, in context
  yield node
File "/opt/python36/src/oq-engine/openquake/commonlib/readinput.py", line 941, in _add_asset
  tot_occupants += values[occupants]
TypeError: node occupancy: unsupported operand type(s) for +=: 'int' and 'str', line None of exposure_model-col.xml
```
This PR resolves the above issue.