### PR TITLE
Fix version number in the manual

### DIFF
--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -7,7 +7,8 @@ set -e
 
 CURPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VERSION="$(cat $CURPATH/../../openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
-cd $CURPATH sed -i "s/Version [0-9]\.[0-9]\.[0-9]/Version $VERSION/" figures/oq_manual_cover.svg
+cd $CURPATH
+sed -i "s/Version [0-9]\.[0-9]\.[0-9]/Version $VERSION/" figures/oq_manual_cover.svg
 
 inkscape -A figures/oq_manual_cover.pdf figures/oq_manual_cover.svg
 


### PR DESCRIPTION
Build are green here: https://ci.openquake.org/job/builders/job/pdf-builder/82/
You can the manual here: https://ci.openquake.org/job/builders/job/pdf-builder/82/artifact/oq-engine/doc/manual/oq-manual.pdf