### PR TITLE
Fixed zmq server stop

### DIFF
--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -136,12 +136,7 @@ class Socket(object):
             except zmq.ZMQError:
                 # sending SIGTERM raises ZMQError
                 break
-            if args == 'stop':
-                if self.socket_type == zmq.REP:
-                    self.send((None, None, None))
-                break
-            else:
-                yield args
+            yield args
 
     def send(self, obj):
         """


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/3520. The `stop` command was intercepted by the socket loop instead of being transmitted and managed by the server.