### PR TITLE
Reading all available cost types in the exposure

### DIFF
--- a/openquake/commands/shell.py
+++ b/openquake/commands/shell.py
@@ -29,7 +29,7 @@ class OpenQuake(object):
         from openquake.calculators.extract import extract
         self.extract = extract
         self.read = read
-        self.read_exposure = readinput.Exposure.read
+        self.get__exposure = readinput.get_exposure
         self.get_oqparam = readinput.get_oqparam
         self.get_site_collection = readinput.get_site_collection
         self.get_composite_source_model = readinput.get_composite_source_model

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -587,9 +587,8 @@ def get_cost_calculator(oqparam):
     """
     Read the first lines of the exposure file and infers the cost calculator
     """
-    return asset._get_exposure(oqparam.inputs['exposure'],
-                               set(oqparam.all_cost_types),
-                               stop='assets')[0].cost_calculator
+    exposure = asset._get_exposure(oqparam.inputs['exposure'], stop='assets')
+    return exposure[0].cost_calculator
 
 
 def get_exposure(oqparam):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -603,8 +603,7 @@ def get_exposure(oqparam):
     """
     return asset.Exposure.read(
         oqparam.inputs['exposure'], oqparam.calculation_mode,
-        oqparam.region_constraint, oqparam.all_cost_types,
-        oqparam.ignore_missing_costs)
+        oqparam.region_constraint, oqparam.ignore_missing_costs)
 
 
 def _get_mesh_assets_by_site(oqparam, exposure):

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -397,8 +397,7 @@ class ExposureTestCase(unittest.TestCase):
 </nrml>''')
 
     def test_get_metadata(self):
-        exp, _assets = asset._get_exposure(
-            self.exposure, ['structural'], stop='assets')
+        exp, _assets = asset._get_exposure(self.exposure, stop='assets')
         self.assertEqual(exp.description, 'Exposure model for buildings')
         self.assertIsNone(exp.insurance_limit_is_absolute)
         self.assertIsNone(exp.deductible_is_absolute)

--- a/openquake/qa_tests_data/event_based_risk/case_1/exposure.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_1/exposure.xml
@@ -13,7 +13,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <conversions>
             <area type="per_asset" unit="square meters"/>
             <costTypes>
-                <costType name="contents" type="per_asset" unit="EUR"/>
                 <costType name="structural" type="per_area" unit="EUR"/>
                 <costType name="nonstructural" type="aggregated" unit="EUR"/>
             </costTypes>

--- a/openquake/qa_tests_data/scenario_damage/case_4/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_4/job_risk.ini
@@ -2,10 +2,6 @@
 
 description = QA Scenario Risk
 calculation_mode = scenario_damage
-
-exposure_file = exposure_model.xml
 fragility_file = fragility_model.xml
-
 region_constraint = 78.0 31.5,89.5 31.5,89.5 25.5,78 25.5
-
 export_dir = /tmp

--- a/openquake/qa_tests_data/scenario_damage/case_4b/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_4b/job_risk.ini
@@ -5,9 +5,6 @@ calculation_mode = scenario_damage
 [boundaries]
 region_constraint = -122.6 38.3, -121.5 38.3, -121.5 37.9, -122.6 37.9
 
-[exposure]
-exposure_file = exposure_model.xml
-
 [hazard]
 asset_hazard_distance = 20.0
 

--- a/openquake/qa_tests_data/scenario_damage/case_5/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_5/job_risk.ini
@@ -2,8 +2,6 @@
 
 description = Scenario Damage Nepal
 calculation_mode = scenario_damage
-
-exposure_file = exposure_model.xml
 fragility_file = structural_fragility_model.xml
 
 region_constraint =  78.0 31.5,89.5 31.5,89.5 25.5,78 25.5

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -581,12 +581,10 @@ cost_type_dt = numpy.dtype([('name', hdf5.vstr),
                             ('unit', hdf5.vstr)])
 
 
-def _get_exposure(fname, ok_cost_types, stop=None):
+def _get_exposure(fname, stop=None):
     """
     :param fname:
         path of the XML file containing the exposure
-    :param ok_cost_types:
-        a set of cost types (as strings)
     :param stop:
         node at which to stop parsing (or None)
     :returns:
@@ -632,22 +630,21 @@ def _get_exposure(fname, ok_cost_types, stop=None):
     cost_types = []
     retrofitted = False
     for ct in conversions.costTypes:
-        if not ok_cost_types or ct['name'] in ok_cost_types:
-            with context(fname, ct):
-                ctname = ct['name']
-                if ctname == 'structural' and 'retrofittedType' in ct.attrib:
-                    if ct['retrofittedType'] != ct['type']:
-                        raise ValueError(
-                            'The retrofittedType %s is different from the type'
-                            '%s' % (ct['retrofittedType'], ct['type']))
-                    if ct['retrofittedUnit'] != ct['unit']:
-                        raise ValueError(
-                            'The retrofittedUnit %s is different from the unit'
-                            '%s' % (ct['retrofittedUnit'], ct['unit']))
-                    retrofitted = True
-                cost_types.append(
-                    (ctname, valid.cost_type_type(ct['type']), ct['unit']))
-    if 'occupants' in ok_cost_types:
+        with context(fname, ct):
+            ctname = ct['name']
+            if ctname == 'structural' and 'retrofittedType' in ct.attrib:
+                if ct['retrofittedType'] != ct['type']:
+                    raise ValueError(
+                        'The retrofittedType %s is different from the type'
+                        '%s' % (ct['retrofittedType'], ct['type']))
+                if ct['retrofittedUnit'] != ct['unit']:
+                    raise ValueError(
+                        'The retrofittedUnit %s is different from the unit'
+                        '%s' % (ct['retrofittedUnit'], ct['unit']))
+                retrofitted = True
+            cost_types.append(
+                (ctname, valid.cost_type_type(ct['type']), ct['unit']))
+    if 'occupants' in cost_types:
         cost_types.append(('occupants', 'per_area', 'people'))
     cost_types.sort(key=operator.itemgetter(0))
     cost_types = numpy.array(cost_types, cost_type_dt)
@@ -686,7 +683,7 @@ class Exposure(object):
 
     @classmethod
     def read(cls, fname, calculation_mode='', region_constraint='',
-             all_cost_types=(), ignore_missing_costs=(), asset_nodes=False):
+             ignore_missing_costs=(), asset_nodes=False):
         """
         Call `Exposure.read(fname)` to get an :class:`Exposure` instance
         keeping all the assets in memory or
@@ -699,13 +696,11 @@ class Exposure(object):
             param['region'] = wkt.loads(region_constraint)
         else:
             param['region'] = None
-        param['all_cost_types'] = set(all_cost_types)
         param['fname'] = fname
-        param['relevant_cost_types'] = param['all_cost_types'] - set(
-            ['occupants'])
         param['ignore_missing_costs'] = set(ignore_missing_costs)
-        exposure, assets = _get_exposure(
-            param['fname'], param['all_cost_types'])
+        exposure, assets = _get_exposure(param['fname'])
+        param['relevant_cost_types'] = set(exposure.cost_types['name']) - set(
+            ['occupants'])
         nodes = assets if assets else exposure._read_csv(
             assets.text, os.path.dirname(param['fname']))
         if asset_nodes:  # this is useful for the GED4ALL import script
@@ -753,7 +748,7 @@ class Exposure(object):
                 if expected_header - header:
                     raise InvalidFile(
                         'Unexpected header in %s\nExpected: %s\nGot: %s' %
-                        (fname, expected_header, header))
+                        (fname, sorted(expected_header), sorted(header)))
         for fname in fnames:
             with open(fname) as f:
                 for i, dic in enumerate(csv.DictReader(f), 1):
@@ -815,7 +810,7 @@ class Exposure(object):
                 except KeyError:
                     number = 1
                 else:
-                    if 'occupants' in param['all_cost_types']:
+                    if 'occupants' in self.cost_types['name']:
                         values['occupants_None'] = number
             location = asset_node.location['lon'], asset_node.location['lat']
             if param['region'] and not geometry.Point(*location).within(

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -402,7 +402,11 @@ class AssetCollection(object):
         for lt in loss_types:
             if lt.endswith('_ins'):
                 lt = lt[:-4]
-            lst.append(encode(units[lt]))
+            if lt == 'occupants':
+                unit = 'people'
+            else:
+                unit = units[lt]
+            lst.append(encode(unit))
         return numpy.array(lst)
 
     def assets_by_site(self):


### PR DESCRIPTION
Currently the engine reads only the cost types needed by the risk functions. This is an issue in the case of pre-imported exposures: in that case we want to import all available costs, even in absence of risk functions in the hazard part, since the risk functions will be provided later in the risk part. Related to https://github.com/gem/oq-engine/issues/3466, closes https://github.com/gem/oq-engine/issues/3525.