### PR TITLE
Improved error message for invalid IMTs in GMF.csv

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Added a check on IMTs for GMFs read from CSV
+
   [Daniele Viganò]
   * Changed the default DbServer port in Linux packages from 1908 to 1907
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -733,9 +733,12 @@ def get_gmfs(oqparam):
                               'realization is supported' % (fname, R))
         # the array has the structure rlzi, sid, eid, gmv_PGA, gmv_...
         dtlist = [(name, array.dtype[name]) for name in array.dtype.names[:3]]
-        num_gmv = len(array.dtype.names[3:])
-        assert num_gmv == M, (num_gmv, M)
-        dtlist.append(('gmv', (F32, num_gmv)))
+        required_imts = list(oqparam.imtls)
+        imts = [name[4:] for name in array.dtype.names[3:]]
+        if imts != required_imts:
+            raise ValueError('Required %s, but %s contains %s' % (
+                required_imts, fname, imts))
+        dtlist.append(('gmv', (F32, M)))
         eids = numpy.unique(array['eid'])
         E = len(eids)
         found_eids = set(eids)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/3517.