### PR TITLE
Use port 1907 for the DbServer in packages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Daniele Viganò]
+  * Changed the default DbServer port in Linux packages from 1908 to 1907
+
   [Michele Simionato]
   * Logged rupture floating factor and rupture spinning factor
   * Added an extract API for losses_by_asset

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -1,11 +1,12 @@
-diff --git a/openquake/engine/openquake.cfg b/openquake/engine/openquake.cfg
-index 818f6882e9..a6329a3905 100644
---- a/openquake/engine/openquake.cfg
-+++ b/openquake/engine/openquake.cfg
-@@ -40,13 +40,15 @@ celery_queue = celery
+Index: oq-engine/openquake/engine/openquake.cfg
+===================================================================
+--- oq-engine.orig/openquake/engine/openquake.cfg	2018-03-15 08:47:12.245368066 +0200
++++ oq-engine/openquake/engine/openquake.cfg	2018-03-15 08:47:12.245368066 +0200
+@@ -39,15 +39,14 @@
+ celery_queue = celery
  
  [dbserver]
- # enable multi_user if you have a multiple user installation
+-# enable multi_user if you have a multiple user installation
 -multi_user = false
 -file = ~/oqdata/db.sqlite3
 -log = ~/oqdata/dbserver.log
@@ -16,10 +17,12 @@ index 818f6882e9..a6329a3905 100644
 -# port 1908 has a good reputation:
 -# https://isc.sans.edu/port.html?port=1908
 -port = 1908
+-authkey = changeme
 +# for packages we use port 1907 to avoid conflicts
 +# with local development installations
 +# https://isc.sans.edu/port.html?port=1907
 +port = 1907
- authkey = changeme
  
  [zworkers]
+ master_host = 127.0.0.1
+

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -1,8 +1,8 @@
-Index: oq-engine/openquake/engine/openquake.cfg
-===================================================================
---- oq-engine.orig/openquake/engine/openquake.cfg	2017-10-13 07:49:34.110383342 +0200
-+++ oq-engine/openquake/engine/openquake.cfg	2017-10-13 08:24:07.242368866 +0200
-@@ -40,9 +40,9 @@
+diff --git a/openquake/engine/openquake.cfg b/openquake/engine/openquake.cfg
+index 818f6882e9..a6329a3905 100644
+--- a/openquake/engine/openquake.cfg
++++ b/openquake/engine/openquake.cfg
+@@ -40,13 +40,15 @@ celery_queue = celery
  
  [dbserver]
  # enable multi_user if you have a multiple user installation
@@ -13,5 +13,13 @@ Index: oq-engine/openquake/engine/openquake.cfg
 +file = /var/lib/openquake/db.sqlite3
 +log = /var/lib/openquake/dbserver.log
  host = 127.0.0.1
- # port 1908 has a good reputation:
- # https://isc.sans.edu/port.html?port=1908
+-# port 1908 has a good reputation:
+-# https://isc.sans.edu/port.html?port=1908
+-port = 1908
++# for packages we use port 1907 to avoid conflicts
++# with local development installations
++# https://isc.sans.edu/port.html?port=1907
++port = 1907
+ authkey = changeme
+ 
+ [zworkers]

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -89,7 +89,7 @@ On Ubuntu make sure to run `apt dist-upgrade` instead on `apt upgrade` to make a
 
 ### DbServer ports
 
-The default port for the DbServer (configured via the `openquake.cfg` configuration file) is `1908` for single-user installations and it's `1907` for multi-user deployments made via Linux packages (both Ubuntu and RHEL/CentOS).
+The default port for the DbServer (configured via the `openquake.cfg` configuration file) is `1908` and `1907`.
 
 ***
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -87,6 +87,12 @@ On Ubuntu make sure to run `apt dist-upgrade` instead on `apt upgrade` to make a
 
 ***
 
+### DbServer ports
+
+The default port for the DbServer (configured via the `openquake.cfg` configuration file) is `1908` for single-user installations and it's `1907` for multi-user deployments made via Linux packages (both Ubuntu and RHEL/CentOS).
+
+***
+
 ### error: [Errno 111] Connection refused
 
 A more detailed stack trace:

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -51,7 +51,7 @@ multi_user = true
 file = /var/lib/openquake/db.sqlite3
 log = /var/lib/openquake/dbserver.log
 host = w.x.y.z
-port = 1908
+port = 1907
 authkey = changeme
 ```
 
@@ -181,10 +181,10 @@ Additionally, access to the RabbitMQ, and DbServer ports should be limited (agai
 The following ports must be open on the **master node**:
 
 * 5672 for RabbitMQ
-* 1908 for DbServer
+* 1907 for DbServer (or any other port allocated for the DbServer in the `openquake.cfg`)
 * 8800 for the API/WebUI (optional)
 
-The **worker nodes** must be able to connect to the master on port 5672, and port 1908.
+The **worker nodes** must be able to connect to the master on port 5672, and port 1907.
 
 
 ## Storage requirements


### PR DESCRIPTION
As suggested by @micheles we are changing the default DbServer port for installation made with packages to reduce the risk of having a local development installation conflicting with the system-wide DbServer provided by (Linux) packages.

We should warn users about the change in the next 'What's new'.

https://ci.openquake.org/job/zdevel_oq-engine/2726/