### PR TITLE
Extended sample_rupture to manage mutex sources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Implemented event based with mutex sources
   * Add an utility to read XML shakemap files in hazardlib
   * Added a check on IMTs for GMFs read from CSV
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Implemented event based with mutex sources
+  * Implemented event based with mutex sources (experimental)
   * Add an utility to read XML shakemap files in hazardlib
   * Added a check on IMTs for GMFs read from CSV
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -45,9 +45,6 @@ U32 = numpy.uint32
 U64 = numpy.uint64
 F32 = numpy.float32
 F64 = numpy.float64
-TWO16 = 2 ** 16  # 65,536
-TWO32 = 2 ** 32  # 4,294,967,296
-TWO48 = 2 ** 48  # 281,474,976,710,656
 
 
 def compute_ruptures(sources, src_filter, gsims, param, monitor):

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -721,7 +721,7 @@ def compute_ruptures(sources, src_filter, gsims, param, monitor):
                     for _ in range(n_occ):
                         events.append((0, src.src_group_id, ses_idx, sample))
                     if events:
-                        evs = numpy.array(events, calc.event_dt)
+                        evs = numpy.array(events, stochastic.event_dt)
                         ebruptures.append(
                             EBRupture(rup, indices, evs, serial))
                         serial += 1

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -59,6 +59,7 @@ U16 = numpy.uint16
 U32 = numpy.uint32
 U64 = numpy.uint64
 F32 = numpy.float32
+TWO16 = 2 ** 16
 
 # DEFAULT VALUES FOR UCERF BACKGROUND MODELS
 DEFAULT_MESH_SPACING = 1.0
@@ -703,7 +704,7 @@ def compute_ruptures(sources, src_filter, gsims, param, monitor):
     idist = src_filter.integration_distance
     for sample in range(param['samples']):
         for ses_idx, ses_seed in param['ses_seeds']:
-            seed = sample * event_based.TWO16 + ses_seed
+            seed = sample * TWO16 + ses_seed
             with sampl_mon:
                 rups, n_occs = src.generate_event_set(
                     background_sids, src_filter, seed)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -43,8 +43,6 @@ F64 = numpy.float64
 
 EVENTS = -2
 NBYTES = -1
-event_dt = numpy.dtype([('eid', U64), ('grp_id', U16), ('ses', U32),
-                        ('sample', U32)])
 
 # ############## utilities for the classical calculator ############### #
 

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -184,10 +184,12 @@ def _sample_ruptures(src, prob, num_ses, num_samples, seed):
         numpy.random.seed(rup.seed)
         for sam_idx in range(num_samples):
             for ses_idx in range(1, num_ses + 1):
-                num_occ = rup.sample_number_of_occurrences()
-                ok_occ = numpy.random.random() < prob if prob < 1 else True
-                if num_occ and ok_occ:
-                    num_occ_by_rup[rup] += {(sam_idx, ses_idx): num_occ}
+                # sampling of mutex sources if prob < 1
+                ok = numpy.random.random() < prob if prob < 1 else True
+                if ok:
+                    num_occ = rup.sample_number_of_occurrences()
+                    if num_occ:
+                        num_occ_by_rup[rup] += {(sam_idx, ses_idx): num_occ}
         rup.rup_no = rup_no + 1
     return num_occ_by_rup
 

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -26,6 +26,7 @@ import operator
 import collections
 import numpy
 from openquake.baselib.general import AccumDict
+from openquake.baselib.performance import Monitor
 from openquake.baselib.python3compat import range, raise_
 from openquake.hazardlib.calc.filters import FarAwayRupture
 from openquake.hazardlib.source.rupture import EBRupture
@@ -101,20 +102,6 @@ def stochastic_event_set(
 
 # ######################## rupture calculator ############################ #
 
-def sample(elements, prob, seed=None):
-    """
-    Sample elements with a given probability.
-
-    >>> sample(numpy.array(list('ABCDEFGHIJKLMNOPQRSTUVWXYZ')), 0.1, seed=42)
-    array(['G', 'T', 'O'], 
-          dtype='<U1')
-    """
-    numpy.random.seed(seed)
-    if prob in (1, None):
-        return elements
-    return numpy.random.choice(elements, round(prob * len(elements)))
-
-
 def set_eids(ebruptures):
     """
     Set event IDs on the given list of ebruptures.
@@ -133,7 +120,7 @@ def set_eids(ebruptures):
     return num_events
 
 
-def sample_ruptures(group, src_filter, gsims, param, monitor):
+def sample_ruptures(group, src_filter, gsims, param, monitor=Monitor()):
     """
     :param group:
         a SourceGroup or a sequence of sources of the same group
@@ -149,8 +136,7 @@ def sample_ruptures(group, src_filter, gsims, param, monitor):
         a dictionary with eb_ruptures, num_events, num_ruptures, calc_times
     """
     if getattr(group, 'src_interdep', None) == 'mutex':
-        weight = {src: weight for src, weight in
-                  zip(group.sources, group.srcs_weights)}
+        weight = {src: w for src, w in zip(group, group.srcs_weights)}
     else:
         weight = {src: 1 for src in group}
     eb_ruptures = []

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -13,9 +13,17 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
 import unittest
+import numpy
+from openquake.hazardlib import nrml, geo
+from openquake.hazardlib.calc.filters import SourceFilter
+from openquake.hazardlib.calc.stochastic import (
+    stochastic_event_set, sample_ruptures)
+from openquake.hazardlib.site import Site, SiteCollection
+from openquake.hazardlib.gsim.si_midorikawa_1999 import SiMidorikawa1999SInter
 
-from openquake.hazardlib.calc.stochastic import stochastic_event_set
+aae = numpy.testing.assert_almost_equal
 
 
 class StochasticEventSetTestCase(unittest.TestCase):
@@ -88,3 +96,29 @@ class StochasticEventSetTestCase(unittest.TestCase):
             'An error occurred with source id=2. Error: Something bad happened'
         )
         self.assertEqual(expected_error, str(ae.exception))
+
+    def test_nankai(self):
+        # source model for the Nankai region provided by M. Pagani
+        source_model = os.path.join(os.path.dirname(__file__), 'nankai.xml')
+        # it has a single group containing 15 mutex sources
+        [group] = nrml.to_python(source_model)
+        aae(group.srcs_weights,
+            [0.0125, 0.0125, 0.0125, 0.0125, 0.1625, 0.1625, 0.0125, 0.0125,
+             0.025, 0.025, 0.05, 0.05, 0.325, 0.025, 0.1])
+        rup_serial = numpy.arange(group.tot_ruptures, dtype=numpy.uint32)
+        start = 0
+        for i, src in enumerate(group):
+            src.id = i
+            nr = src.num_ruptures
+            src.serial = rup_serial[start:start + nr]
+            start += nr
+        group.samples = 1
+        site = Site(geo.Point(135.68, 35.68), 800, True, z1pt0=100., z2pt5=1.)
+        s_filter = SourceFilter(SiteCollection([site]), {})
+        param = dict(ses_per_logic_tree_path=10, seed=42)
+        gsims = [SiMidorikawa1999SInter()]
+        dic = sample_ruptures(group, s_filter, gsims, param)
+        self.assertEqual(dic['num_ruptures'], 19)  # total ruptures
+        self.assertEqual(dic['num_events'], 13)
+        self.assertEqual(len(dic['eb_ruptures']), 8)
+        self.assertEqual(len(dic['calc_times']), 15)  # mutex sources


### PR DESCRIPTION
The mutex logic is cleanly implemented in the single line `ok_occ = numpy.random.random() < weight`