### PR TITLE
Replaced celery with celery_zmq

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Replaced celery with celery_zmq as distribution mechanism
   * Added a check against duplicated fields in the exposure CSV
   * Implemented event based with mutex sources (experimental)
   * Add an utility to read XML shakemap files in hazardlib


### PR DESCRIPTION
After several weeks of testing on our clusters we discovered exactly zero issues and a lot of benefits, so it makes sense to use celery_zmq always.