### PR TITLE
Fix authentication on API

### DIFF
--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -547,7 +547,10 @@ def get_calcs(db, request_get_dict, allowed_users, user_acl_on=False, id=None):
     else:
         time_filter = 1
 
-    users_filter = "user_name IN (?X)"
+    if user_acl_on:
+        users_filter = "user_name IN (?X)"
+    else:
+        users_filter = 1
 
     jobs = db('SELECT * FROM job WHERE ?A AND %s AND %s'
               ' ORDER BY id DESC LIMIT %d'

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -547,12 +547,7 @@ def get_calcs(db, request_get_dict, allowed_users, user_acl_on=False, id=None):
     else:
         time_filter = 1
 
-    # user_acl_on is true if settings.ACL_ON = True or when the user is a
-    # Django super user
-    if user_acl_on:
-        users_filter = "user_name IN (?X)"
-    else:
-        users_filter = 1
+    users_filter = "user_name IN (?X)"
 
     jobs = db('SELECT * FROM job WHERE ?A AND %s AND %s'
               ' ORDER BY id DESC LIMIT %d'

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -508,10 +508,10 @@ def get_calcs(db, request_get_dict, allowed_users, user_acl_on=False, id=None):
         a :class:`openquake.server.dbapi.Db` instance
     :param request_get_dict:
         a dictionary
-    :param user_name:
-        user name
+    :param allowed_users:
+        a list of users
     :param user_acl_on:
-        if True, returns only the calculations owned by the user
+        if True, returns only the calculations owned by the user or the group
     :param id:
         if given, extract only the specified calculation
     :returns:

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -649,7 +649,8 @@ def get_result(db, result_id):
     """
     job = db('SELECT job.*, ds_key FROM job, output WHERE '
              'oq_job_id=job.id AND output.id=?x', result_id, one=True)
-    return job.id, job.status, os.path.dirname(job.ds_calc_dir), job.ds_key
+    return (job.id, job.status, job.user_name,
+            os.path.dirname(job.ds_calc_dir), job.ds_key)
 
 
 def get_results(db, job_id):

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -39,7 +39,7 @@ def get_user(request):
         if request.user.is_authenticated():
             user = request.user.username
         else:
-            # This may happens with crafted requests
+            # This may happen with crafted requests
             user = ''
     else:
         user = (settings.DEFAULT_USER if
@@ -61,7 +61,7 @@ def get_valid_users(request):
                 users = list(User.objects.filter(groups__name=groups)
                              .values_list('username', flat=True))
         else:
-            # This may happens with crafted requests
+            # This may happen with crafted requests
             users = []
     return users
 

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -36,7 +36,11 @@ def get_user(request):
     returns the default user (from settings, or as reported by the OS).
     """
     if settings.LOCKDOWN and hasattr(request, 'user'):
-        user = request.user.username
+        if request.user.is_authenticated():
+            user = request.user.username
+        else:
+            # Should never happens
+            user = ''
     else:
         user = (settings.DEFAULT_USER if
                 hasattr(settings, 'DEFAULT_USER') else getpass.getuser())
@@ -57,6 +61,9 @@ def get_valid_users(request):
             if groups:
                 users = list(User.objects.filter(groups__name=groups)
                              .values_list('username', flat=True))
+        else:
+            # Should never happens
+            users = []
     return users
 
 

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -64,8 +64,12 @@ def get_acl_on(request):
     """
     Returns `true` if ACL should be honorated, returns otherwise `false`.
     """
-    return (False if request.user.is_superuser or not settings.ACL_ON
-            else True)
+    if settings.LOCKDOWN and hasattr(request, 'user'):
+        if not request.user.is_superuser and settings.ACL_ON:
+            acl_on = True
+    else:
+        acl_on = False
+    return acl_on
 
 
 def user_has_permission(request, owner):

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -39,7 +39,7 @@ def get_user(request):
         if request.user.is_authenticated():
             user = request.user.username
         else:
-            # Should never happens
+            # This may happens with crafted requests
             user = ''
     else:
         user = (settings.DEFAULT_USER if
@@ -53,8 +53,7 @@ def get_valid_users(request):
     Returns a list of `users` based on groups membership.
     Returns a list made of a single user when it is not member of any group.
     """
-    users = []
-    users.append(get_user(request))
+    users = [get_user(request)]
     if settings.LOCKDOWN and hasattr(request, 'user'):
         if request.user.is_authenticated():
             groups = request.user.groups.values_list('name', flat=True)
@@ -62,7 +61,7 @@ def get_valid_users(request):
                 users = list(User.objects.filter(groups__name=groups)
                              .values_list('username', flat=True))
         else:
-            # Should never happens
+            # This may happens with crafted requests
             users = []
     return users
 
@@ -84,8 +83,7 @@ def user_has_permission(request, owner):
     Returns `true` if user coming from the request has the permission
     to view a resource, returns `false` otherwise.
     """
-    return (True if owner in get_valid_users(request)
-            or not get_acl_on(request) else False)
+    return owner in get_valid_users(request) or not get_acl_on(request)
 
 
 def oq_server_context_processor(request):

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -64,11 +64,11 @@ def get_acl_on(request):
     """
     Returns `true` if ACL should be honorated, returns otherwise `false`.
     """
+    acl_on = settings.ACL_ON
     if settings.LOCKDOWN and hasattr(request, 'user'):
-        if not request.user.is_superuser and settings.ACL_ON:
-            acl_on = True
-    else:
-        acl_on = False
+        # ACL is always disabled for superusers
+        if request.user.is_superuser:
+            acl_on = False
     return acl_on
 
 

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -42,8 +42,7 @@ def get_user(request):
             # This may happen with crafted requests
             user = ''
     else:
-        user = (settings.DEFAULT_USER if
-                hasattr(settings, 'DEFAULT_USER') else getpass.getuser())
+        user = getattr(settings, 'DEFAULT_USER', getpass.getuser())
 
     return user
 
@@ -68,7 +67,7 @@ def get_valid_users(request):
 
 def get_acl_on(request):
     """
-    Returns `true` if ACL should be honorated, returns otherwise `false`.
+    Returns `True` if ACL should be honorated, returns otherwise `False`.
     """
     acl_on = settings.ACL_ON
     if settings.LOCKDOWN and hasattr(request, 'user'):
@@ -80,7 +79,7 @@ def get_acl_on(request):
 
 def user_has_permission(request, owner):
     """
-    Returns `true` if user coming from the request has the permission
+    Returns `True` if user coming from the request has the permission
     to view a resource, returns `false` otherwise.
     """
     return owner in get_valid_users(request) or not get_acl_on(request)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -296,9 +296,10 @@ def calc_info(request, calc_id):
     (specified by ``calc_id``). Also includes the current job status (
     executing, complete, etc.).
     """
-    # FIXME no auth
     try:
         info = logs.dbcmd('calc_info', calc_id)
+        if not utils.user_has_permission(request, info['user_name']):
+            return HttpResponseNotFound()
     except dbapi.NotFound:
         return HttpResponseNotFound()
     return HttpResponse(content=json.dumps(info), content_type=JSON)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -615,10 +615,11 @@ def get_result(request, result_id):
     # If the result for the requested ID doesn't exist, OR
     # the job which it is related too is not complete,
     # throw back a 404.
-    # FIXME no auth
     try:
-        job_id, job_status, datadir, ds_key = logs.dbcmd(
+        job_id, job_status, job_user, datadir, ds_key = logs.dbcmd(
             'get_result', result_id)
+        if not utils.user_has_permission(request, job_user):
+            return HttpResponseNotFound()
     except dbapi.NotFound:
         return HttpResponseNotFound()
 


### PR DESCRIPTION
This PR addresses the following issues:

- The logic behind users access validation was repeated many times in the code, it has been now moved entirely in `utils.py`
- Some endpoints were not honoring groups ACLs
- Some endpoints were not protected by ACLs at all

Now, ACLs can be validated against a resource (like a `job`) with the function

```python
utils.user_has_permission(request, res_owner)
```
which returns `True` if the current logged user has permission to see a resource owned by `res_owner`

Another two helpers are provided:

- `utils.get_user(request)` returns a username following a logic based on the fact that the authentication mechanism is on or off
- `utils.get_valid_users(request)` returns a list of usernames based on groups membership

Closes https://github.com/gem/oq-engine/issues/3485