### PR TITLE
Supported the case of no region_constraint with pre-imported exposure

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -481,13 +481,16 @@ class HazardCalculator(BaseCalculator):
             self.load_riskmodel()  # must be called *after* read_exposure
             self.datastore['assetcol'] = self.assetcol
         elif 'assetcol' in self.datastore.parent:
-            region = wkt.loads(self.oqparam.region_constraint)
-            self.sitecol = haz_sitecol.within(region)
-            assetcol = self.datastore.parent['assetcol']
-            self.assetcol = assetcol.reduce(self.sitecol.sids)
-            self.datastore['assetcol'] = self.assetcol
-            logging.info('There are %d/%d assets in the region',
-                         len(self.assetcol), len(assetcol))
+            if self.oqparam.region_constraint:
+                region = wkt.loads(self.oqparam.region_constraint)
+                self.sitecol = haz_sitecol.within(region)
+                assetcol = self.datastore.parent['assetcol']
+                self.assetcol = assetcol.reduce(self.sitecol.sids)
+                self.datastore['assetcol'] = self.assetcol
+                logging.info('There are %d/%d assets in the region',
+                             len(self.assetcol), len(assetcol))
+            else:
+                self.assetcol = self.datastore.parent['assetcol']
             self.load_riskmodel()
         else:  # no exposure
             self.load_riskmodel()

--- a/openquake/qa_tests_data/scenario_risk/case_2d/job_r.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_2d/job_r.ini
@@ -2,9 +2,6 @@
 description = scenario risk
 calculation_mode = scenario_risk
 
-[boundaries]
-region_constraint = -122.6 38.3, -121.5 38.3, -121.5 37.9, -122.6 37.9
-
 [exposure]
 exposure_file = exposure_model.xml
 


### PR DESCRIPTION
Avoids the error
```python
  File "/home/michele/oq-engine/openquake/calculators/base.py", line 484, in read_risk_data
    region = wkt.loads(self.oqparam.region_constraint)
  File "/usr/lib/python3/dist-packages/shapely/wkt.py", line 10, in loads
    return geos.WKTReader(geos.lgeos).read(data)
  File "/usr/lib/python3/dist-packages/shapely/geos.py", line 284, in read
    text = text.encode('ascii')
AttributeError: 'NoneType' object has no attribute 'encode'
```