### PR TITLE
Call `Starmap.init/Starmap.shutdown` in the proper places

### DIFF
--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -3,7 +3,6 @@
 ### Main dependencies
  
 * Python - Implementation language
-* concurrent.futures - Standard package for concurrence in Python
 * Django - Used by the API server and the WebUI
 * HDF5 - Used for storing and managing data
 * numpy and scipy - Fundamental packages for scientific computing with Python

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -175,6 +175,7 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
             # save the used concurrent_tasks
             self.oqparam.concurrent_tasks = ct
         self.save_params(**kw)
+        Starmap.init()
         try:
             if pre_execute:
                 self.pre_execute()
@@ -197,6 +198,7 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
                     del os.environ['OQ_DISTRIBUTE']
                 else:
                     os.environ['OQ_DISTRIBUTE'] = oq_distribute
+            Starmap.shutdown()
         return getattr(self, 'exported', {})
 
     def core_task(*args):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -316,7 +316,7 @@ class HazardCalculator(BaseCalculator):
             workers, None otherwise
         """
         read_access = (
-            config.distribution.oq_distribute in ('no', 'futures') or
+            config.distribution.oq_distribute in ('no', 'processpool') or
             config.directory.shared_dir)
         if self.oqparam.hazard_calculation_id and read_access:
             self.datastore.parent.close()  # make sure it is closed

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -87,28 +87,24 @@ class CalculatorTestCase(unittest.TestCase):
         """
         Return the outputs of the calculation as a dictionary
         """
-        parallel.Starmap.init()
-        try:
-            inis = job_ini.split(',')
-            assert len(inis) in (1, 2), inis
-            self.calc = self.get_calc(testfile, inis[0], **kw)
-            self.edir = tempfile.mkdtemp()
+        inis = job_ini.split(',')
+        assert len(inis) in (1, 2), inis
+        self.calc = self.get_calc(testfile, inis[0], **kw)
+        self.edir = tempfile.mkdtemp()
+        with self.calc._monitor:
+            result = self.calc.run(export_dir=self.edir)
+        if len(inis) == 2:
+            hc_id = self.calc.datastore.calc_id
+            self.calc = self.get_calc(
+                testfile, inis[1], hazard_calculation_id=str(hc_id), **kw)
+            # run the second job.ini with zero tasks to avoid fork issues
             with self.calc._monitor:
-                result = self.calc.run(export_dir=self.edir)
-            if len(inis) == 2:
-                hc_id = self.calc.datastore.calc_id
-                self.calc = self.get_calc(
-                    testfile, inis[1], hazard_calculation_id=str(hc_id), **kw)
-                # run the second job.ini with zero tasks to avoid fork issues
-                with self.calc._monitor:
-                    exported = self.calc.run(export_dir=self.edir,
-                                             concurrent_tasks=0)
-                    result.update(exported)
-            # reopen datastore, since some tests need to export from it
-            dstore = datastore.read(self.calc.datastore.calc_id)
-            self.calc.datastore = dstore
-        finally:
-            parallel.Starmap.shutdown()
+                exported = self.calc.run(export_dir=self.edir,
+                                         concurrent_tasks=0)
+                result.update(exported)
+        # reopen datastore, since some tests need to export from it
+        dstore = datastore.read(self.calc.datastore.calc_id)
+        self.calc.datastore = dstore
         return result
 
     def execute(self, testfile, job_ini):

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -34,7 +34,7 @@ NO_SHARED_DIR = celery and not config.directory.shared_dir
 def manage_shared_dir_error(func, self):
     """
     When the shared_dir is not configured, expect an error, unless
-    the distribution mechanism is set to futures.
+    the distribution mechanism is set to processpool.
     """
     if NO_SHARED_DIR:
         with self.assertRaises(ValueError) as ctx:

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -15,7 +15,7 @@
 
 [distribution]
 # enable celery only if you have a cluster
-oq_distribute = futures
+oq_distribute = processpool
 
 # make sure workers are terminated when tasks are revoked
 terminate_workers_on_revoke = true

--- a/packager.sh
+++ b/packager.sh
@@ -589,7 +589,7 @@ _pkgtest_innervm_run () {
 
         sudo apt-get install -y python3-oq-engine-master python3-oq-engine-worker
         # Switch to celery mode
-        sudo sed -i 's/oq_distribute = futures/oq_distribute = celery/g' /etc/openquake/openquake.cfg
+        sudo sed -i 's/oq_distribute = processpool/oq_distribute = celery/g' /etc/openquake/openquake.cfg
 
 export PYTHONPATH=\"$OPT_LIBS_PATH\"
 # FIXME: the big sleep below is a temporary workaround to avoid races.

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -22,7 +22,6 @@ http://cdn.ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-a
 http://cdn.ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
-http://cdn.ftp.openquake.org/wheelhouse/linux/py27/futures-3.0.5-py2-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py/Django-1.8.17-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py/requests-2.9.1-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py27/pyshp-1.2.3-cp27-none-any.whl

--- a/requirements-py27-macos.txt
+++ b/requirements-py27-macos.txt
@@ -20,7 +20,6 @@ http://cdn.ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-a
 http://cdn.ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
-http://cdn.ftp.openquake.org/wheelhouse/macos/py27/futures-3.0.5-py2-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py/Django-1.8.17-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py/requests-2.9.1-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py27/pyshp-1.2.3-cp27-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -69,11 +69,6 @@ install_requires = [
     'PyYAML',
 ]
 
-if sys.version < '3':
-    install_requires.append(
-        'futures >=2.1, <3.1'
-    )
-
 extras_require = {
     'setproctitle': ["setproctitle"],
     'prctl': ["python-prctl ==1.6.1"],


### PR DESCRIPTION
When using a process pool it is imperative to fork before reading the source model, to avoid using a lot of memory.  This is done by calling `Starmap.init` in the `.run()` method of a calculator before reading the inputs. With this fix, on a calculation by Kendra, on my workstation the memory occupations went down from 50 GB to 5 GB.

While at it, I changed the name of distribution mechanism: what was called `futures` is now called `processpool`. We are not using futures anymore, so I am also changing the requirements (actually the requirements file for Python 2.7 should be remove, but I leave that task to Daniele).