### PR TITLE
Some debhelper functions were still using Python 2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: extra
 Maintainer: Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>
 Build-Depends: debhelper (>= 7.0.50~), lsb-release, quilt, python-setuptools, oq-python3.5, zip
 Standards-Version: 3.9.3
+X-Python3-Version: >= 3.5
 Homepage: http://github.com/gem/oq-engine
 
 Package: python3-oq-engine

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://github.com/gem/oq-engine
 
 Package: python3-oq-engine
 Architecture: all
-X-Python-Version: >= 3.2
+X-Python-Version: >= 3.5
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, python3-oq-libs (>=1.6.0~), supervisor (>=3.0b2-1~)
 Conflicts: python-noq, python-oq, python-nhlib
 Replaces: python-oq-risklib, python-oq-hazardlib, python-oq-engine (<< ${binary:Version})
@@ -23,7 +23,7 @@ Description: computes seismic hazard and physical risk
 
 Package: python3-oq-engine-master
 Architecture: all
-X-Python-Version: >= 3.2
+X-Python-Version: >= 3.5
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, rabbitmq-server (>=2.8.0-2~gem02), python3-oq-engine (= ${binary:Version})
 Replaces: python-oq-risklib, python-oq-hazardlib, python-oq-engine-master (<< ${binary:Version})
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-breaks
@@ -35,7 +35,7 @@ Description: computes seismic hazard and physical risk
 
 Package: python3-oq-engine-worker
 Architecture: all
-X-Python-Version: >= 3.2
+X-Python-Version: >= 3.5
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, supervisor (>=3.0b2-1~), python3-oq-engine (= ${binary:Version})
 Replaces: python-oq-risklib, python-oq-hazardlib, python-oq-engine-worker (<< ${binary:Version})
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-breaks

--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,6 @@ else
 	RECOMMENDS = -Vdist:Recommends="$(DEFAULT_REC)"
 endif
 
-
 override_dh_auto_install:
 	/opt/openquake/bin/python3 setup.py install --force --install-layout=deb --root=$(PWD)/debian/python3-oq-engine --prefix=$(PREFIX) --no-compile -O0
 

--- a/debian/rules
+++ b/debian/rules
@@ -66,4 +66,4 @@ override_dh_gencontrol:
 	dh_gencontrol -- $(DEPENDS) $(RECOMMENDS)
 
 %:
-	dh --with python3 --with quilt --buildsystem=python_distutils $@
+	dh --with python3 --with quilt --buildsystem=pybuild $@

--- a/debian/rules
+++ b/debian/rules
@@ -38,6 +38,9 @@ else
 	RECOMMENDS = -Vdist:Recommends="$(DEFAULT_REC)"
 endif
 
+override_dh_auto_clean:
+	/opt/openquake/bin/python3 setup.py clean -a
+
 override_dh_auto_install:
 	/opt/openquake/bin/python3 setup.py install --force --install-layout=deb --root=$(PWD)/debian/python3-oq-engine --prefix=$(PREFIX) --no-compile -O0
 

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,7 @@ export DISTUTILS_DEBUG=1
 export DH_VERBOSE=1
 export DH_OPTIONS=-v
 export PREFIX=/opt/openquake
+export PATH:=/opt/openquake/bin:$(PATH)
 
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
@@ -38,8 +39,6 @@ else
 	RECOMMENDS = -Vdist:Recommends="$(DEFAULT_REC)"
 endif
 
-override_dh_auto_clean:
-	/opt/openquake/bin/python3 setup.py clean -a
 
 override_dh_auto_install:
 	/opt/openquake/bin/python3 setup.py install --force --install-layout=deb --root=$(PWD)/debian/python3-oq-engine --prefix=$(PREFIX) --no-compile -O0


### PR DESCRIPTION
Fixes master https://ci.openquake.org/job/master_oq-engine/4388/

The issue was raised by #3555 

Tests + Demos: https://ci.openquake.org/job/zdevel_oq-engine/2733/