### PR TITLE
Continuous data transfer information

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * `oq show job_info` now shows the received data while the calculation is
+    progressing
+
   [Daniele Viganò]
   * Removed support for Python 2 in `setup.py`
   * Removed files containing Python 2 dependencies

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -31,7 +31,7 @@ except ImportError:  # with Python 2
 import collections
 import numpy
 import h5py
-from openquake.baselib.python3compat import pickle, decode
+from openquake.baselib.python3compat import decode
 
 vbytes = h5py.special_dtype(vlen=bytes)
 vstr = h5py.special_dtype(vlen=str)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -380,7 +380,7 @@ class IterResult(object):
     """
     task_data_dt = numpy.dtype(
         [('taskno', numpy.uint32), ('weight', numpy.float32),
-         ('duration', numpy.float32)])
+         ('duration', numpy.float32), ('received', numpy.float32)])
 
     def __init__(self, iresults, taskname, num_tasks,
                  progress=logging.info, sent=0):
@@ -445,7 +445,7 @@ class IterResult(object):
     def save_task_data(self, mon):
         if mon.hdf5path:
             duration = mon.children[0].duration  # the task is the first child
-            tup = (mon.task_no, mon.weight, duration)
+            tup = (mon.task_no, mon.weight, duration, self.received[-1])
             data = numpy.array([tup], self.task_data_dt)
             hdf5.extend3(mon.hdf5path, 'task_info/' + self.name, data)
         mon.flush()

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -378,28 +378,27 @@ class IterResult(object):
     :param sent:
         the number of bytes sent (0 if OQ_DISTRIBUTE=no)
     """
-    task_data_dt = numpy.dtype(
-        [('taskno', numpy.uint32), ('weight', numpy.float32),
-         ('duration', numpy.float32),
-         ('sent', numpy.float32), ('received', numpy.float32)])
-
-    def __init__(self, iresults, taskname, num_tasks,
-                 progress=logging.info, sent=()):
+    def __init__(self, iresults, taskname, num_tasks, sent,
+                 progress=logging.info):
         self.iresults = iresults
         self.name = taskname
         self.num_tasks = num_tasks
-        self.progress = progress
         self.sent = sent
+        self.progress = progress
         self.received = []
         if self.num_tasks:
             self.log_percent = self._log_percent()
             next(self.log_percent)
         else:
             self.progress('No %s tasks were submitted', self.name)
-        if sent:
-            totsent = sum(sent, AccumDict())
-            self.progress('Sent %s of data in %s task(s)',
-                          humansize(sum(totsent.values())), num_tasks)
+        nargs = len(sent[0])
+        self.task_data_dt = numpy.dtype(
+            [('taskno', numpy.uint32), ('weight', numpy.float32),
+             ('duration', numpy.float32),
+             ('sent', (numpy.int64, nargs)), ('received', numpy.int64)])
+        totsent = sum(s.sum() for s in sent)
+        self.progress('Sent %s of data in %s task(s)',
+                      humansize(totsent), num_tasks)
 
     def _log_percent(self):
         yield 0
@@ -447,9 +446,8 @@ class IterResult(object):
     def save_task_data(self, mon):
         if mon.hdf5path:
             duration = mon.children[0].duration  # the task is the first child
-            sent = sum(self.sent[-1], AccumDict()) if self.sent else {}
-            tup = (mon.task_no, mon.weight, duration,
-                   sum(sent.values()), self.received[-1])
+            sent = self.sent[mon.task_no - 1]
+            tup = (mon.task_no, mon.weight, duration, sent, self.received[-1])
             data = numpy.array([tup], self.task_data_dt)
             hdf5.extend3(mon.hdf5path, 'task_info/' + self.name, data)
         mon.flush()
@@ -498,7 +496,7 @@ def init_workers():
     return os.getpid()
 
 
-def _wakeup(sec):
+def _wakeup(sec, mon):
     """Waiting function, used to wake up the process pool"""
     time.sleep(sec)
     return os.getpid()
@@ -513,7 +511,8 @@ class Starmap(object):
     def init(cls, poolsize=None):
         if OQ_DISTRIBUTE == 'processpool' and not hasattr(cls, 'pool'):
             cls.pool = multiprocessing.Pool(poolsize, init_workers)
-            self = cls(_wakeup, [(.2,) for _ in range(cls.pool._processes)])
+            m = Monitor('wakeup')
+            self = cls(_wakeup, [(.2, m) for _ in range(cls.pool._processes)])
             cls.pids = list(self)
 
     @classmethod
@@ -601,8 +600,9 @@ class Starmap(object):
                 self.calc_id = getattr(mon, 'calc_id', None)
             if pickle:
                 args = pickle_sequence(args)
-                self.sent.append(
-                    {a: len(p) for a, p in zip(self.argnames, args)})
+                self.sent.append(numpy.array([len(p) for p in args]))
+            else:
+                self.sent.append(numpy.zeros(len(args)))
             if task_no == 1:  # first time
                 self.progress('Submitting %s "%s" tasks', self.num_tasks,
                               self.name)
@@ -621,7 +621,7 @@ class Starmap(object):
         elif self.distribute == 'zmq':
             it = self._iter_zmq()
         num_tasks = next(it)
-        return IterResult(it, self.name, num_tasks, self.progress, self.sent)
+        return IterResult(it, self.name, num_tasks, self.sent, self.progress)
 
     def reduce(self, agg=operator.add, acc=None):
         """

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -438,10 +438,6 @@ class IterResult(object):
             max_per_task = max(self.received)
             self.progress('Received %s of data, maximum per task %s',
                           humansize(tot), humansize(max_per_task))
-            received = {'max_per_task': max_per_task, 'tot': tot}
-            tname = self.name
-            dic = {tname: {'sent': self.sent, 'received': received}}
-            result.mon.save_info(dic)
 
     def save_task_data(self, mon):
         if mon.hdf5path:

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -165,18 +165,6 @@ class Monitor(object):
         if self.autoflush:
             self.flush()
 
-    def save_info(self, dic):
-        """
-        Save (name, value) information in the associated hdf5path
-        """
-        if self.hdf5path:
-            if 'hostname' not in dic:
-                dic['hostname'] = socket.gethostname()
-            data = numpy.array(
-                _pairs(dic.items()),
-                [('par_name', hdf5.vstr), ('par_value', hdf5.vstr)])
-            hdf5.extend3(self.hdf5path, 'job_info', data)
-
     def flush(self):
         """
         Save the measurements on the performance file (or on stdout)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -282,9 +282,9 @@ class EbriskCalculator(base.RiskCalculator):
         taskname = '%s#%d' % (event_based_risk.__name__, sm_id + 1)
         monitor = self.monitor(taskname)
         for grp_id in grp_ids:
+            ruptures = self.ruptures_by_grp.get(grp_id, [])
             rlzs_by_gsim = rlzs_assoc.get_rlzs_by_gsim(grp_id)
             samples = samples_by_grp[grp_id]
-            ruptures = self.ruptures_by_grp.get(grp_id, [])
             num_ruptures[grp_id] = len(ruptures)
             from_parent = hasattr(ruptures, 'split')
             if from_parent:  # read the ruptures from the parent datastore

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -53,6 +53,7 @@ class ClassicalTestCase(CalculatorTestCase):
             case_1.__file__)
 
         if parallel.oq_distribute() != 'no':
+            import pdb; pdb.set_trace()
             # make sure we saved the data transfer information in job_info
             keys = {decode(key) for key in dict(
                 self.calc.datastore['job_info'])}

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -21,6 +21,7 @@ from nose.plugins.attrib import attr
 from openquake.baselib import parallel
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import InvalidFile
+from openquake.calculators.views import view
 from openquake.calculators.export import export
 from openquake.calculators.extract import extract
 from openquake.calculators.tests import CalculatorTestCase, REFERENCE_OS
@@ -53,12 +54,10 @@ class ClassicalTestCase(CalculatorTestCase):
             case_1.__file__)
 
         if parallel.oq_distribute() != 'no':
-            import pdb; pdb.set_trace()
-            # make sure we saved the data transfer information in job_info
-            keys = {decode(key) for key in dict(
-                self.calc.datastore['job_info'])}
-            self.assertIn('classical.received', keys)
-            self.assertIn('classical.sent', keys)
+            info = view('job_info', self.calc.datastore)
+            self.assertIn('task', info)
+            self.assertIn('sent', info)
+            self.assertIn('received', info)
 
         # there is a single source
         self.assertEqual(len(self.calc.datastore['source_info']), 1)

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -246,10 +246,6 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/ruptures_events.txt', fname)
         os.remove(fname)
 
-        # check job_info is stored
-        job_info = {decode(k) for k in dict(self.calc.datastore['job_info'])}
-        self.assertIn('build_curves_maps.sent', job_info)
-        self.assertIn('build_curves_maps.received', job_info)
         check_total_losses(self.calc)
 
     @attr('qa', 'risk', 'event_based_risk')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -328,9 +328,13 @@ def view_job_info(token, dstore):
     Determine the amount of data transferred from the controller node
     to the workers and back in a classical calculation.
     """
-    job_info = dict(dstore.hdf5['job_info'])
-    rows = [(k, _humansize(v)) for k, v in sorted(job_info.items())]
-    return rst_table(rows)
+    data = [['task', 'sent', 'received']]
+    for task in dstore['task_info']:
+        if task not in ('task_sources', 'source_data'):
+            sent = dstore['task_info/' + task]['sent'].sum()
+            recv = dstore['task_info/' + task]['received'].sum()
+            data.append((task, humansize(sent), humansize(recv)))
+    return rst_table(data)
 
 
 @view.add('avglosses_data_transfer')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -331,9 +331,13 @@ def view_job_info(token, dstore):
     data = [['task', 'sent', 'received']]
     for task in dstore['task_info']:
         if task not in ('task_sources', 'source_data'):
-            sent = dstore['task_info/' + task]['sent'].sum()
-            recv = dstore['task_info/' + task]['received'].sum()
-            data.append((task, humansize(sent), humansize(recv)))
+            dset = dstore['task_info/' + task]
+            argnames = dset.attrs['argnames'].split()
+            totsent = dset['sent'].sum(axis=0)
+            sent = ['%s=%s' % (a, humansize(s))
+                    for s, a in sorted(zip(totsent, argnames), reverse=True)]
+            recv = dset['received'].sum()
+            data.append((task, ' '.join(sent), humansize(recv)))
     return rst_table(data)
 
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -619,14 +619,14 @@ def view_task_classical(token, dstore):
     """
     data = dstore['task_info/classical'].value
     data.sort(order='duration')
-    i = int(token.split(':')[1])
-    taskno, weight, duration = data[i]
+    rec = data[int(token.split(':')[1])]
+    taskno = rec['taskno']
     arr = get_array(dstore['task_info/source_data'].value, taskno=taskno)
     st = [stats('nsites', arr['nsites']), stats('weight', arr['weight'])]
     sources = dstore['task_info/task_sources'][taskno - 1].split()
     srcs = set(decode(s).split(':', 1)[0] for s in sources)
     res = 'taskno=%d, weight=%d, duration=%d s, sources="%s"\n\n' % (
-        taskno, weight, duration, ' '.join(sorted(srcs)))
+        taskno, rec['weight'], rec['duration'], ' '.join(sorted(srcs)))
     return res + rst_table(st, header='variable mean stddev min max n'.split())
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ import re
 import sys
 from setuptools import setup, find_packages
 
-if sys.version_info < (3,5):
+if sys.version_info < (3, 5):
     sys.exit('Sorry, Python < 3.5 is not supported')
+
 
 def get_version():
     version_re = r"^__version__\s+=\s+['\"]([^'\"]*)['\"]"


### PR DESCRIPTION
Currently, one can get information about the data transfer by calling `oq show job_info`. Unfortunately, the underlying data structure is populated only at the end of the calculation. With this PR, the information is stored continuously every time a task ends, so that one can see how things are progressing. This is important for the received data.