### PR TITLE
20180226 decimal

### DIFF
--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -838,7 +838,7 @@ def pmf(value):
     [(0.157, 0), (0.843, 1)]
     """
     probs = probabilities(value)
-    if sum(map(Decimal, value.split())) != 1:
+    if abs(1.-sum(map(float, value.split()))) > 1e-12:
         raise ValueError('The probabilities %s do not sum up to 1!' % value)
     return [(p, i) for i, p in enumerate(probs)]
 


### PR DESCRIPTION
This removes the use of decimal in testing that probabilities sum to 1. The test now uses a precision of 1e-12.