### PR TITLE
Change the API to return a proper error code with auth on

### DIFF
--- a/doc/web-api.md
+++ b/doc/web-api.md
@@ -264,12 +264,12 @@ Attempt to login, given the parameters `username` and `password`
 Logout
 
 
-#### GET /engine_version
+#### GET /v1/engine_version
 
 Return a string with the OpenQuake engine version
 
 
-#### GET /engine_latest_version
+#### GET /v1/engine_latest_version
 
 Return a string with if new versions have been released.
 Return 'None' if the version is not available

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -24,8 +24,8 @@ from openquake.server import views
 
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url='/engine/', permanent=True)),
-    url(r'^engine_version$', views.get_engine_version),
-    url(r'^engine_latest_version$', views.get_engine_latest_version),
+    url(r'^v1/engine_version$', views.get_engine_version),
+    url(r'^v1/engine_latest_version$', views.get_engine_latest_version),
     url(r'^v1/calc/', include('openquake.server.v1.calc_urls')),
     url(r'^v1/valid/', views.validate_nrml),
     url(r'^v1/available_gsims$', views.get_available_gsims),


### PR DESCRIPTION
With the following PR we

- return a proper HTTP code if an API endpoint under `/v1/` is called without being authenticated (when `LOCKDOWN = True`). This helps API consumers to properly validate the response
- moved `engine_version` and `engine_latest_version` under `/v1/` for the above reason