### PR TITLE
Extract the site mesh from the exposure before looking at the site model

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -430,6 +430,7 @@ class HazardCalculator(BaseCalculator):
         with self.monitor('reading exposure', autoflush=True):
             self.sitecol, self.assetcol = readinput.get_sitecol_assetcol(
                 self.oqparam, haz_sitecol)
+            readinput.exposure = None  # reset the global
 
     def get_min_iml(self, oq):
         # set the minimum_intensity

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -193,11 +193,14 @@ class BaseCalculator(with_metaclass(abc.ABCMeta)):
                 logging.critical('', exc_info=True)
                 raise
         finally:
+            # cleanup globals
             if ct == 0:  # restore OQ_DISTRIBUTE
                 if oq_distribute is None:  # was not set
                     del os.environ['OQ_DISTRIBUTE']
                 else:
                     os.environ['OQ_DISTRIBUTE'] = oq_distribute
+            readinput.pmap = None
+            readinput.exposure = None
             Starmap.shutdown()
         return getattr(self, 'exported', {})
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -27,7 +27,7 @@ import tempfile
 import collections
 import numpy
 
-from openquake.baselib.general import groupby, AccumDict, DictArray, deprecated
+from openquake.baselib.general import AccumDict, DictArray, deprecated
 from openquake.baselib.python3compat import configparser, decode
 from openquake.baselib.node import Node
 from openquake.baselib import hdf5
@@ -209,6 +209,9 @@ pmap = None  # set as side effect when the user reads hazard_curves from a file
 # unhappy legacy design choice that I fixed in the GMFs CSV format only) thus
 # this hack is necessary, otherwise we would have to parse the file twice
 
+exposure = None  # set as side effect when the user reads the site mesh
+# this hack is necessary, otherwise we would have to parse the exposure twice
+
 
 def get_mesh(oqparam):
     """
@@ -218,7 +221,9 @@ def get_mesh(oqparam):
     :param oqparam:
         an :class:`openquake.commonlib.oqvalidation.OqParam` instance
     """
-    global pmap
+    global pmap, exposure
+    if 'exposure' in oqparam.inputs:
+        exposure = get_exposure(oqparam)
     if oqparam.sites:
         return geo.Mesh.from_coords(sorted(oqparam.sites))
     elif 'sites' in oqparam.inputs:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -615,6 +615,7 @@ def get_sitecol_assetcol(oqparam, haz_sitecol):
     """
     global exposure
     if exposure is None:
+        # haz_sitecol not extracted from the exposure
         exposure = get_exposure(oqparam)
     tot_assets = sum(len(assets) for assets in exposure.assets_by_site)
     all_sids = haz_sitecol.complete.sids

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -269,8 +269,6 @@ def get_mesh(oqparam):
                 'Could not discretize region %(region)s with grid spacing '
                 '%(region_grid_spacing)s' % vars(oqparam))
     elif 'exposure' in oqparam.inputs:
-        exposure.mesh, exposure.assets_by_site = (
-            exposure.get_mesh_assets_by_site())
         return exposure.mesh
     elif 'site_model' in oqparam.inputs:
         coords = [(param['lon'], param['lat'], 0)
@@ -606,9 +604,11 @@ def get_exposure(oqparam):
     :returns:
         an :class:`Exposure` instance or a compatible AssetCollection
     """
-    return asset.Exposure.read(
+    exposure = asset.Exposure.read(
         oqparam.inputs['exposure'], oqparam.calculation_mode,
         oqparam.region_constraint, oqparam.ignore_missing_costs)
+    exposure.mesh, exposure.assets_by_site = exposure.get_mesh_assets_by_site()
+    return exposure
 
 
 def get_sitecol_assetcol(oqparam, haz_sitecol=None):
@@ -617,9 +617,6 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None):
     :param haz_sitecol: a pre-existing site collection, if any
     :returns: (site collection, asset collection) instances
     """
-    if not hasattr(exposure, 'mesh'):  # not read already
-        exposure.mesh, exposure.assets_by_site = (
-            exposure.get_mesh_assets_by_site())
     if haz_sitecol:
         tot_assets = sum(len(assets) for assets in exposure.assets_by_site)
         all_sids = haz_sitecol.complete.sids

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -618,7 +618,6 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None):
     :param haz_sitecol: a pre-existing site collection, if any
     :returns: (site collection, asset collection) instances
     """
-    exposure = get_exposure(oqparam)
     mesh, assets_by_site = exposure.get_mesh_assets_by_site()
     if haz_sitecol:
         tot_assets = sum(len(assets) for assets in assets_by_site)

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -208,8 +208,9 @@ reference_depth_to_2pt5km_per_sec = 5.0
 reference_depth_to_1pt0km_per_sec = 100.0
 intensity_measure_types = PGA
 investigation_time = 50.
+source_model_file = fake.xml
 """)
-        oqparam = readinput.get_oqparam(source, hc_id=1)
+        oqparam = readinput.get_oqparam(source)
         with self.assertRaises(ValueError) as ctx:
             readinput.get_site_collection(oqparam)
         self.assertIn('Could not discretize region', str(ctx.exception))
@@ -249,6 +250,7 @@ class ClosestSiteModelTestCase(unittest.TestCase):
 
     def test_get_far_away_parameter(self):
         oqparam = mock.Mock()
+        oqparam.hazard_calculation_id = None
         oqparam.base_path = '/'
         oqparam.maximum_distance = 100
         oqparam.max_site_model_distance = 5

--- a/openquake/qa_tests_data/classical_damage/case_6a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_6a/job_risk.ini
@@ -1,7 +1,6 @@
 [general]
 description = Classical PSHA-Based Damage
 calculation_mode = classical_damage
-exposure_file = exposure_model.xml
 
 [boundaries]
 region_constraint = -122.6 38.2, -121.5 38.2, -121.5 37.1, -122.6 37.1

--- a/openquake/qa_tests_data/classical_damage/case_6b/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_6b/job_risk.ini
@@ -1,7 +1,6 @@
 [general]
 description = Classical PSHA-Based Damage
 calculation_mode = classical_damage
-exposure_file = exposure_model.xml
 
 [boundaries]
 region_constraint = -122.6 38.2, -121.5 38.2, -121.5 37.1, -122.6 37.1

--- a/openquake/qa_tests_data/classical_damage/case_7a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_7a/job_risk.ini
@@ -1,7 +1,6 @@
 [general]
 description = Classical PSHA-Based Damage
 calculation_mode = classical_damage
-exposure_file = exposure_model.xml
 
 [boundaries]
 region_constraint = -122.6 38.2, -121.5 38.2, -121.5 37.1, -122.6 37.1

--- a/openquake/qa_tests_data/classical_damage/case_7b/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_7b/job_risk.ini
@@ -1,7 +1,6 @@
 [general]
 description = Classical PSHA-Based Damage
 calculation_mode = classical_damage
-exposure_file = exposure_model.xml
 
 [boundaries]
 region_constraint = -122.6 38.2, -121.5 38.2, -121.5 37.1, -122.6 37.1

--- a/openquake/qa_tests_data/classical_damage/case_7c/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_7c/job_risk.ini
@@ -1,7 +1,6 @@
 [general]
 description = Classical PSHA-Based Damage
 calculation_mode = classical_damage
-exposure_file = exposure_model.xml
 
 [boundaries]
 region_constraint = -122.6 38.2, -121.5 38.2, -121.5 37.1, -122.6 37.1

--- a/openquake/qa_tests_data/classical_damage/case_8a/job_risk.ini
+++ b/openquake/qa_tests_data/classical_damage/case_8a/job_risk.ini
@@ -1,7 +1,6 @@
 [general]
 description = Classical PSHA-Based Damage
 calculation_mode = classical_damage
-exposure_file = exposure_model.xml
 
 [boundaries]
 region_constraint = -122.6 38.2, -121.5 38.2, -121.5 37.1, -122.6 37.1


### PR DESCRIPTION
This is needed for https://github.com/gem/oq-engine/issues/3499. Currently the site model is used in precedence over the exposure to extract the site mesh and we need to change that.