### PR TITLE
Add backward compatibility with current QGIS master

### DIFF
--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -35,6 +35,10 @@ urlpatterns = [
         views.web_engine_get_outputs, name="outputs"),
     url(r'^engine/license$', views.license,
         name="license"),
+    # FIXME this two rules are kept for backward compatibility QGIS plugin
+    # while a compatible version is released
+    url(r'^engine_version$', views.get_engine_version),
+    url(r'^engine_latest_version$', views.get_engine_latest_version),
 ]
 
 for app in settings.STANDALONE_APPS:

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -35,8 +35,8 @@ urlpatterns = [
         views.web_engine_get_outputs, name="outputs"),
     url(r'^engine/license$', views.license,
         name="license"),
-    # FIXME this two rules are kept for backward compatibility QGIS plugin
-    # while a compatible version is released
+    # FIXME this two rules are kept for backward compatibility with the
+    # QGIS plugin while a compatible version is released
     url(r'^engine_version$', views.get_engine_version),
     url(r'^engine_latest_version$', views.get_engine_latest_version),
 ]


### PR DESCRIPTION
We need these while the work on https://github.com/gem/oq-irmt-qgis/pull/411 is merged and a new experimental version of the plugin released.

We cannot update cluster unless this is merged.