### PR TITLE
Minor improvements to openquake.hmtk.plotting

### DIFF
--- a/openquake/hmtk/plotting/faults/geology_mfd_plot.py
+++ b/openquake/hmtk/plotting/faults/geology_mfd_plot.py
@@ -5,16 +5,10 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-from openquake.hmtk.faults.mfd import get_available_mfds
 from openquake.hmtk.faults.fault_models import RecurrenceBranch
 from openquake.hmtk.plotting.seismicity.catalogue_plots import _save_image
-#from openquake.hmtk.faults.mfd.anderson_luco_arbitrary import AndersonLucoArbitrary
-#from openquake.hmtk.faults.mfd.anderson_luco_area_mmax import AndersonLucoAreaMmax
-#from openquake.hmtk.faults.mfd.characteristic import Characteristic
-# from openquake.hmtk.faults.mfd.youngs_coppersmith import (YoungsCoppersmithExponential,
-#    YoungsCoppersmithCharacteristic)
-#
-#
+
+
 #
 # def _get_occurence_array(mmin, bin_width, occurrence):
 #    """
@@ -26,21 +20,21 @@ from openquake.hmtk.plotting.seismicity.catalogue_plots import _save_image
 #    return np.column_stack([mags, occurrence, cumulative])
 #
 
-DEFAULT_SIZE = (8., 6.)
-MFD_MAP = get_available_mfds()
-
-
 def plot_recurrence_models(
         configs, area, slip, msr, rake,
         shear_modulus=30.0, disp_length_ratio=1.25E-5, msr_sigma=0.,
-        filename=None, filetype='png', dpi=300):
+        figure_size=(8, 6), filename=None, filetype='png', dpi=300, ax=None):
     """
     Plots a set of recurrence models
 
     :param list configs:
         List of configuration dictionaries
     """
-    plt.figure(figsize=DEFAULT_SIZE)
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figure_size)
+    else:
+        fig = ax.get_figure()
+
     for config in configs:
         model = RecurrenceBranch(area, slip, msr, rake, shear_modulus,
                                  disp_length_ratio, msr_sigma, weight=1.0)
@@ -54,11 +48,12 @@ def plot_recurrence_models(
         else:
             flt_label = config['Model_Name']
         flt_color = np.random.uniform(0.1, 1.0, 3)
-        plt.semilogy(model.magnitudes, cumulative, '-', label=flt_label,
-                     color=flt_color, linewidth=2.)
-        plt.semilogy(model.magnitudes, model.recurrence.occur_rates, '--',
-                     color=flt_color, linewidth=2.)
-    plt.xlabel('Magnitude', fontsize=14)
-    plt.ylabel('Annual Rate', fontsize=14)
-    plt.legend(bbox_to_anchor=(1.1, 1.0))
-    _save_image(filename, filetype, dpi)
+        ax.semilogy(model.magnitudes, cumulative, '-', label=flt_label,
+                    color=flt_color, linewidth=2.)
+        ax.semilogy(model.magnitudes, model.recurrence.occur_rates, '--',
+                    color=flt_color, linewidth=2.)
+
+    ax.set_xlabel('Magnitude')
+    ax.set_ylabel('Annual Rate')
+    ax.legend(bbox_to_anchor=(1.1, 1.0))
+    _save_image(fig, filename, filetype, dpi)

--- a/openquake/hmtk/plotting/seismicity/catalogue_plots.py
+++ b/openquake/hmtk/plotting/seismicity/catalogue_plots.py
@@ -12,9 +12,6 @@ from matplotlib.colors import LogNorm, Normalize
 
 from openquake.hmtk.seismicity.occurrence.utils import get_completeness_counts
 
-# Default the figure size
-DEFAULT_SIZE = (8., 6.)
-
 
 def build_filename(filename, filetype='png', resolution=300):
     """
@@ -76,7 +73,7 @@ def _get_catalogue_bin_limits(catalogue, dmag):
 def plot_depth_histogram(
         catalogue, bin_width,
         normalisation=False, bootstrap=None, filename=None,
-        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
+        figure_size=(8, 6), filetype='png', dpi=300, ax=None):
     """
     Creates a histogram of the depths in the catalogue
 
@@ -107,12 +104,12 @@ def plot_depth_histogram(
            depth_hist,
            width=0.95 * bin_width,
            edgecolor='k')
-    ax.set_xlabel('Depth (km)', fontsize='large')
+    ax.set_xlabel('Depth (km)')
     if normalisation:
-        ax.set_ylabel('Probability Mass Function', fontsize='large')
+        ax.set_ylabel('Probability Mass Function')
     else:
         ax.set_ylabel('Count')
-    ax.set_title('Depth Histogram', fontsize='large')
+    ax.set_title('Depth Histogram')
 
     _save_image(fig, filename, filetype, dpi)
 
@@ -122,7 +119,7 @@ def plot_depth_histogram(
 def plot_magnitude_depth_density(
         catalogue, mag_int, depth_int,
         logscale=False, normalisation=False, bootstrap=None, filename=None,
-        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
+        figure_size=(8, 6), filetype='png', dpi=300, ax=None):
     """
     Creates a density plot of the magnitude and depth distribution
 
@@ -151,29 +148,30 @@ def plot_magnitude_depth_density(
                                                                 normalisation,
                                                                 bootstrap)
     vmin_val = np.min(mag_depth_dist[mag_depth_dist > 0.])
-    # Create plot
-    if logscale:
-        normaliser = LogNorm(vmin=vmin_val, vmax=np.max(mag_depth_dist))
-    else:
-        normaliser = Normalize(vmin=0, vmax=np.max(mag_depth_dist))
+
     if ax is None:
         fig, ax = plt.subplots(figsize=figure_size)
     else:
         fig = ax.get_figure()
 
+    if logscale:
+        normaliser = LogNorm(vmin=vmin_val, vmax=np.max(mag_depth_dist))
+    else:
+        normaliser = Normalize(vmin=0, vmax=np.max(mag_depth_dist))
+
     im = ax.pcolor(mag_bins[:-1],
                    depth_bins[:-1],
                    mag_depth_dist.T,
                    norm=normaliser)
-    ax.set_xlabel('Magnitude', fontsize='large')
-    ax.set_ylabel('Depth (km)', fontsize='large')
+    ax.set_xlabel('Magnitude')
+    ax.set_ylabel('Depth (km)')
     ax.set_xlim(mag_bins[0], mag_bins[-1])
     ax.set_ylim(depth_bins[0], depth_bins[-1])
     fig.colorbar(im, ax=ax)
     if normalisation:
-        ax.set_title('Magnitude-Depth Density', fontsize='large')
+        ax.set_title('Magnitude-Depth Density')
     else:
-        ax.set_title('Magnitude-Depth Count', fontsize='large')
+        ax.set_title('Magnitude-Depth Count')
 
     _save_image(fig, filename, filetype, dpi)
 
@@ -182,7 +180,7 @@ def plot_magnitude_depth_density(
 
 def plot_magnitude_time_scatter(
         catalogue, plot_error=False, fmt_string='o', filename=None,
-        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
+        figure_size=(8, 6), filetype='png', dpi=300, ax=None):
     """
     Creates a simple scatter plot of magnitude with time
 
@@ -200,7 +198,7 @@ def plot_magnitude_time_scatter(
         fig = ax.get_figure()
 
     dtime = catalogue.get_decimal_time()
-    if len(catalogue.data['sigmaMagnitude']) == 0:
+    if not catalogue.data['sigmaMagnitude']:
         print('Magnitude Error is missing - neglecting error bars!')
         plot_error = False
 
@@ -212,9 +210,9 @@ def plot_magnitude_time_scatter(
                     fmt=fmt_string)
     else:
         ax.plot(dtime, catalogue.data['magnitude'], fmt_string)
-    ax.set_xlabel('Year', fontsize='large')
-    ax.set_ylabel('Magnitude', fontsize='large')
-    ax.set_title('Magnitude-Time Plot', fontsize='large')
+    ax.set_xlabel('Year')
+    ax.set_ylabel('Magnitude')
+    ax.set_title('Magnitude-Time Plot')
 
     _save_image(fig, filename, filetype, dpi)
 
@@ -224,7 +222,7 @@ def plot_magnitude_time_scatter(
 def plot_magnitude_time_density(
         catalogue, mag_int, time_int, completeness=None,
         normalisation=False, logscale=True, bootstrap=None, filename=None,
-        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
+        figure_size=(8, 6), filetype='png', dpi=300, ax=None):
     """
     Creates a plot of magnitude-time density
 
@@ -282,8 +280,8 @@ def plot_magnitude_time_density(
                    mag_bins[:-1],
                    mag_time_dist.T,
                    norm=norm_data)
-    ax.set_xlabel('Time (year)', fontsize='large')
-    ax.set_ylabel('Magnitude', fontsize='large')
+    ax.set_xlabel('Time (year)')
+    ax.set_ylabel('Magnitude')
     ax.set_xlim(time_bins[0], time_bins[-1])
     # Fix the title
     if normalisation:
@@ -301,6 +299,9 @@ def plot_magnitude_time_density(
 
 
 def _plot_completeness(ax, comw, start_time, end_time):
+    '''
+    Adds completeness intervals to a plot
+    '''
     comw = np.array(comw)
     comp = np.column_stack([np.hstack([end_time, comw[:, 0], start_time]),
                             np.hstack([comw[0, 1], comw[:, 1], comw[-1, 1]])])
@@ -361,7 +362,7 @@ def get_completeness_adjusted_table(catalogue, completeness, dmag, end_year):
 
 def plot_observed_recurrence(
         catalogue, completeness, dmag, end_year=None, filename=None,
-        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
+        figure_size=(8, 6), filetype='png', dpi=300, ax=None):
     """
     Plots the observed recurrence taking into account the completeness
     """
@@ -388,8 +389,7 @@ def plot_observed_recurrence(
     ax.semilogy(cent_mag, obs_rates, 'bo', label="Incremental")
     ax.semilogy(cent_mag, cum_obs_rates, 'rs', label="Cumulative")
     ax.set_xlim([cent_mag[0] - 0.1, cent_mag[-1] + 0.1])
-    ax.set_xlabel('Magnitude', fontsize=16)
-    ax.set_ylabel('Annual Rate', fontsize=16)
-    ax.legend(fontsize=14)
-    ax.tick_params(labelsize=12)
+    ax.set_xlabel('Magnitude')
+    ax.set_ylabel('Annual Rate')
+    ax.legend()
     _save_image(fig, filename, filetype, dpi)

--- a/openquake/hmtk/plotting/seismicity/catalogue_plots.py
+++ b/openquake/hmtk/plotting/seismicity/catalogue_plots.py
@@ -74,8 +74,9 @@ def _get_catalogue_bin_limits(catalogue, dmag):
 
 
 def plot_depth_histogram(
-        catalogue, bin_width, normalisation=False,
-        bootstrap=None, filename=None, filetype='png', dpi=300, ax=None):
+        catalogue, bin_width,
+        normalisation=False, bootstrap=None, filename=None,
+        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
     """
     Creates a histogram of the depths in the catalogue
 
@@ -90,11 +91,11 @@ def plot_depth_histogram(
         To sample depth uncertainty choose number of samples
     """
     if ax is None:
-        fig, ax = plt.subplots(figsize=DEFAULT_SIZE)
+        fig, ax = plt.subplots(figsize=figure_size)
     else:
         fig = ax.get_figure()
     # Create depth range
-    if len(catalogue.data['depth']) == 0:
+    if not catalogue.data['depth']:
         raise ValueError('No depths reported in catalogue!')
     depth_bins = np.arange(0.,
                            np.max(catalogue.data['depth']) + bin_width,
@@ -119,9 +120,9 @@ def plot_depth_histogram(
 
 
 def plot_magnitude_depth_density(
-        catalogue, mag_int, depth_int, logscale=False,
-        normalisation=False, bootstrap=None, filename=None, filetype='png',
-        dpi=300, ax=None):
+        catalogue, mag_int, depth_int,
+        logscale=False, normalisation=False, bootstrap=None, filename=None,
+        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
     """
     Creates a density plot of the magnitude and depth distribution
 
@@ -139,7 +140,7 @@ def plot_magnitude_depth_density(
     :param int bootstrap:
         To sample magnitude and depth uncertainties choose number of samples
     """
-    if len(catalogue.data['depth']) == 0:
+    if not catalogue.data['depth']:
         raise ValueError('No depths reported in catalogue!')
     depth_bins = np.arange(0.,
                            np.max(catalogue.data['depth']) + depth_int,
@@ -156,7 +157,7 @@ def plot_magnitude_depth_density(
     else:
         normaliser = Normalize(vmin=0, vmax=np.max(mag_depth_dist))
     if ax is None:
-        fig, ax = plt.subplots(figsize=DEFAULT_SIZE)
+        fig, ax = plt.subplots(figsize=figure_size)
     else:
         fig = ax.get_figure()
 
@@ -180,8 +181,8 @@ def plot_magnitude_depth_density(
 
 
 def plot_magnitude_time_scatter(
-        catalogue, plot_error=False, filename=None,
-        filetype='png', dpi=300, fmt_string='o', ax=None):
+        catalogue, plot_error=False, fmt_string='o', filename=None,
+        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
     """
     Creates a simple scatter plot of magnitude with time
 
@@ -194,7 +195,7 @@ def plot_magnitude_time_scatter(
         Symbology of plot
     """
     if ax is None:
-        fig, ax = plt.subplots(figsize=DEFAULT_SIZE)
+        fig, ax = plt.subplots(figsize=figure_size)
     else:
         fig = ax.get_figure()
 
@@ -221,9 +222,9 @@ def plot_magnitude_time_scatter(
 
 
 def plot_magnitude_time_density(
-        catalogue, mag_int, time_int,
+        catalogue, mag_int, time_int, completeness=None,
         normalisation=False, logscale=True, bootstrap=None, filename=None,
-        filetype='png', dpi=300, completeness=None, ax=None):
+        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
     """
     Creates a plot of magnitude-time density
 
@@ -240,12 +241,12 @@ def plot_magnitude_time_density(
         To sample magnitude and depth uncertainties choose number of samples
     """
     if ax is None:
-        fig, ax = plt.subplots(figsize=DEFAULT_SIZE)
+        fig, ax = plt.subplots(figsize=figure_size)
     else:
         fig = ax.get_figure()
 
     # Create the magnitude bins
-    if isinstance(mag_int, np.ndarray) or isinstance(mag_int, list):
+    if isinstance(mag_int, (np.ndarray, list)):
         mag_bins = mag_int
     else:
         mag_bins = np.arange(
@@ -253,7 +254,7 @@ def plot_magnitude_time_density(
             np.max(catalogue.data['magnitude']) + mag_int / 2.,
             mag_int)
     # Creates the time bins
-    if isinstance(time_int, np.ndarray) or isinstance(time_int, list):
+    if isinstance(time_int, (np.ndarray, list)):
         time_bins = time_int
     else:
         time_bins = np.arange(
@@ -359,8 +360,8 @@ def get_completeness_adjusted_table(catalogue, completeness, dmag, end_year):
 
 
 def plot_observed_recurrence(
-        catalogue, completeness, dmag, end_year=None, figure_size=DEFAULT_SIZE,
-        filename=None, filetype='png', dpi=300, ax=None):
+        catalogue, completeness, dmag, end_year=None, filename=None,
+        figure_size=DEFAULT_SIZE, filetype='png', dpi=300, ax=None):
     """
     Plots the observed recurrence taking into account the completeness
     """
@@ -380,7 +381,7 @@ def plot_observed_recurrence(
                               for i in range(len(obs_rates))])
 
     if ax is None:
-        fig, ax = plt.subplots(figsize=DEFAULT_SIZE)
+        fig, ax = plt.subplots(figsize=figure_size)
     else:
         fig = ax.get_figure()
 

--- a/openquake/hmtk/plotting/seismicity/catalogue_plots.py
+++ b/openquake/hmtk/plotting/seismicity/catalogue_plots.py
@@ -92,7 +92,7 @@ def plot_depth_histogram(
     else:
         fig = ax.get_figure()
     # Create depth range
-    if not catalogue.data['depth']:
+    if len(catalogue.data['depth']) == 0:  # pylint: disable=len-as-condition
         raise ValueError('No depths reported in catalogue!')
     depth_bins = np.arange(0.,
                            np.max(catalogue.data['depth']) + bin_width,
@@ -137,7 +137,7 @@ def plot_magnitude_depth_density(
     :param int bootstrap:
         To sample magnitude and depth uncertainties choose number of samples
     """
-    if not catalogue.data['depth']:
+    if len(catalogue.data['depth']) == 0:  # pylint: disable=len-as-condition
         raise ValueError('No depths reported in catalogue!')
     depth_bins = np.arange(0.,
                            np.max(catalogue.data['depth']) + depth_int,
@@ -198,7 +198,8 @@ def plot_magnitude_time_scatter(
         fig = ax.get_figure()
 
     dtime = catalogue.get_decimal_time()
-    if not catalogue.data['sigmaMagnitude']:
+    # pylint: disable=len-as-condition
+    if len(catalogue.data['sigmaMagnitude']) == 0:
         print('Magnitude Error is missing - neglecting error bars!')
         plot_error = False
 
@@ -305,7 +306,7 @@ def _plot_completeness(ax, comw, start_time, end_time):
     comw = np.array(comw)
     comp = np.column_stack([np.hstack([end_time, comw[:, 0], start_time]),
                             np.hstack([comw[0, 1], comw[:, 1], comw[-1, 1]])])
-    ax.step(comp[:-1, 0], comp[1:, 1], ls='--',
+    ax.step(comp[:-1, 0], comp[1:, 1], linestyle='-',
             where="post", linewidth=3, color='brown')
 
 

--- a/openquake/hmtk/plotting/seismicity/completeness/plot_stepp_1972.py
+++ b/openquake/hmtk/plotting/seismicity/completeness/plot_stepp_1972.py
@@ -61,7 +61,8 @@ VALID_MARKERS = ['s', 'o', '^', 'D', 'p', 'h', '8',
                  '*', 'd', 'v', '<', '>', 'H']
 
 
-def create_stepp_plot(model, filename=None, filetype='png', dpi=300, ax=None):
+def create_stepp_plot(model, figure_size=(8, 6),
+                      filename=None, filetype='png', dpi=300, ax=None):
     '''
     Creates the classic Stepp (1972) plots for a completed Stepp analysis,
     and exports the figure to a file.
@@ -77,7 +78,7 @@ def create_stepp_plot(model, filename=None, filetype='png', dpi=300, ax=None):
         Resolution (dots per inch) of output file
     '''
     if ax is None:
-        fig, ax = plt.subplots()
+        fig, ax = plt.subplots(figsize=figure_size)
     else:
         fig = ax.get_figure()
 

--- a/openquake/hmtk/plotting/seismicity/max_magnitude/cumulative_moment.py
+++ b/openquake/hmtk/plotting/seismicity/max_magnitude/cumulative_moment.py
@@ -47,9 +47,11 @@ Module to produce cumulative moment plot
 
 import numpy as np
 import matplotlib.pyplot as plt
+from openquake.hmtk.plotting.seismicity.catalogue_plots import _save_image
 
 
-def plot_cumulative_moment(year, mag):
+def plot_cumulative_moment(year, mag, figure_size=(8, 6),
+                           filename=None, filetype='png', dpi=300, ax=None):
     '''Calculation of Mmax using aCumulative Moment approach, adapted from
     the cumulative strain energy method of Makropoulos & Burton (1983)
     :param year: Year of Earthquake
@@ -77,11 +79,17 @@ def plot_cumulative_moment(year, mag):
     # Average moment rate vector
     exp_morate = np.cumsum(ave_morate * np.ones(nyr))
 
-    plt.step(year_range, np.cumsum(morate), 'b-', linewidth=2)
-    plt.plot(year_range, exp_morate, 'r-', linewidth=2)
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figure_size)
+    else:
+        fig = ax.get_figure()
+
+    ax.step(year_range, np.cumsum(morate), 'b-', linewidth=2)
+    ax.plot(year_range, exp_morate, 'r-', linewidth=2)
     # Get offsets
     upper_morate = exp_morate + (np.max(np.cumsum(morate) - exp_morate))
     lower_morate = exp_morate + (np.min(np.cumsum(morate) - exp_morate))
-    plt.plot(year_range, upper_morate, 'r--', linewidth=1)
-    plt.plot(year_range, lower_morate, 'r--', linewidth=1)
-    plt.axis([np.min(year), np.max(year), 0.0, np.sum(morate)])
+    ax.plot(year_range, upper_morate, 'r--', linewidth=1)
+    ax.plot(year_range, lower_morate, 'r--', linewidth=1)
+    ax.axis([np.min(year), np.max(year), 0.0, np.sum(morate)])
+    _save_image(fig, filename, filetype, dpi)

--- a/openquake/hmtk/plotting/seismicity/occurrence/recurrence_plot.py
+++ b/openquake/hmtk/plotting/seismicity/occurrence/recurrence_plot.py
@@ -49,16 +49,12 @@ def _check_completeness_table(completeness, catalogue):
 
 
 def plot_recurrence_model(
-        input_model, catalogue, completeness, dmag, filename=None,
-        figure_size=None, filetype='png', dpi=300, ax=None):
+        input_model, catalogue, completeness, dmag=0.1, filename=None,
+        figure_size=(8, 6), filetype='png', dpi=300, ax=None):
     """
     Plot a calculated recurrence model over an observed catalogue, adjusted for
     time-varying completeness
     """
-    if figure_size is None:
-        figure_size = (8, 6)
-    if dmag is None:
-        dmag = 0.1
     annual_rates, cumulative_rates = _get_recurrence_model(input_model)
 
     # Get observed annual recurrence
@@ -72,7 +68,7 @@ def plot_recurrence_model(
                               for i in range(len(obs_rates))])
 
     if ax is None:
-        fig, ax = plt.subplots(figsize=(8, 6))
+        fig, ax = plt.subplots(figsize=figure_size)
     else:
         fig = ax.get_figure()
 

--- a/openquake/hmtk/plotting/seismicity/occurrence/recurrence_plot.py
+++ b/openquake/hmtk/plotting/seismicity/occurrence/recurrence_plot.py
@@ -14,26 +14,15 @@ from openquake.hazardlib.mfd.youngs_coppersmith_1985 import\
     YoungsCoppersmith1985MFD
 
 
-def _check_recurrence_model_type(input_model):
-    """
-    Ensure model is a known type
-    """
-    valid_model = False
-    for model in [TruncatedGRMFD, EvenlyDiscretizedMFD,
-                  YoungsCoppersmith1985MFD]:
-        valid_model = isinstance(input_model, model)
-        if valid_model:
-            break
-    if not valid_model:
-        raise ValueError('Recurrence model not recognised')
-
-
 def _get_recurrence_model(input_model):
     """
     Returns the annual and cumulative recurrence rates predicted by the
     recurrence model
     """
-    _check_recurrence_model_type(input_model)
+    if not isinstance(input_model, (TruncatedGRMFD,
+                                    EvenlyDiscretizedMFD,
+                                    YoungsCoppersmith1985MFD)):
+        raise ValueError('Recurrence model not recognised')
     # Get model annual occurrence rates
     annual_rates = input_model.get_annual_occurrence_rates()
     annual_rates = np.array([[val[0], val[1]] for val in annual_rates])

--- a/openquake/hmtk/plotting/seismicity/occurrence/recurrence_plot.py
+++ b/openquake/hmtk/plotting/seismicity/occurrence/recurrence_plot.py
@@ -6,8 +6,7 @@ Simple plots for the recurrence model
 
 import numpy as np
 import matplotlib.pyplot as plt
-from openquake.hmtk.plotting.seismicity.catalogue_plots import \
-    (get_completeness_adjusted_table, _save_image, DEFAULT_SIZE)
+from openquake.hmtk.plotting.seismicity.catalogue_plots import _save_image
 from openquake.hmtk.seismicity.occurrence.utils import get_completeness_counts
 from openquake.hazardlib.mfd.truncated_gr import TruncatedGRMFD
 from openquake.hazardlib.mfd.evenly_discretized import EvenlyDiscretizedMFD
@@ -17,7 +16,7 @@ from openquake.hazardlib.mfd.youngs_coppersmith_1985 import\
 
 def _check_recurrence_model_type(input_model):
     """
-
+    Ensure model is a known type
     """
     valid_model = False
     for model in [TruncatedGRMFD, EvenlyDiscretizedMFD,
@@ -60,18 +59,19 @@ def _check_completeness_table(completeness, catalogue):
         raise ValueError('Completeness representation not recognised')
 
 
-def plot_recurrence_model(input_model, catalogue, completeness, dmag,
-                          figure_size=DEFAULT_SIZE, filename=None,
-                          filetype='png',  dpi=300, ax=None):
+def plot_recurrence_model(
+        input_model, catalogue, completeness, dmag, filename=None,
+        figure_size=None, filetype='png', dpi=300, ax=None):
     """
     Plot a calculated recurrence model over an observed catalogue, adjusted for
     time-varying completeness
     """
     if figure_size is None:
-        figure_size = (10, 8)
+        figure_size = (8, 6)
     if dmag is None:
         dmag = 0.1
     annual_rates, cumulative_rates = _get_recurrence_model(input_model)
+
     # Get observed annual recurrence
     if not catalogue.end_year:
         catalogue.update_end_year()
@@ -81,31 +81,31 @@ def plot_recurrence_model(input_model, catalogue, completeness, dmag,
     obs_rates = n_obs / t_per
     cum_obs_rates = np.array([np.sum(obs_rates[i:])
                               for i in range(len(obs_rates))])
-    # Create plot
+
     if ax is None:
-        fig, ax = plt.subplots(figsize=DEFAULT_SIZE)
+        fig, ax = plt.subplots(figsize=(8, 6))
     else:
         fig = ax.get_figure()
 
-    plt.figure(figsize=figure_size)
-    plt.semilogy(cent_mag, obs_rates, 'bo')
-    plt.semilogy(annual_rates[:, 0], annual_rates[:, 1], 'b-')
-    plt.semilogy(cent_mag, cum_obs_rates, 'rs')
-    plt.semilogy(annual_rates[:, 0], cumulative_rates, 'r-')
-    plt.grid(which='both')
-    plt.xlabel('Magnitude', fontsize='16')
-    plt.ylabel('Annual Rate', fontsize='16')
-    plt.legend(['Observed Incremental Rate',
-                'Model Incremental Rate',
-                'Observed Cumulative Rate',
-                'Model Cumulative Rate'], fontsize=14)
-    plt.tick_params(labelsize=12)
+    ax.semilogy(cent_mag, obs_rates, 'bo')
+    ax.semilogy(annual_rates[:, 0], annual_rates[:, 1], 'b-')
+    ax.semilogy(cent_mag, cum_obs_rates, 'rs')
+    ax.semilogy(annual_rates[:, 0], cumulative_rates, 'r-')
+    ax.grid(which='both')
+    ax.set_xlabel('Magnitude')
+    ax.set_ylabel('Annual Rate')
+    ax.legend(['Observed Incremental Rate',
+               'Model Incremental Rate',
+               'Observed Cumulative Rate',
+               'Model Cumulative Rate'])
+    ax.tick_params(labelsize=12)
     _save_image(fig, filename, filetype, dpi)
 
 
-def plot_trunc_gr_model(aval, bval, min_mag, max_mag, dmag, catalogue=None,
-                        completeness=None, figure_size=None, filename=None, filetype='png',
-                        dpi=300):
+def plot_trunc_gr_model(
+        aval, bval, min_mag, max_mag, dmag,
+        catalogue=None, completeness=None, filename=None,
+        figure_size=(8, 6), filetype='png', dpi=300, ax=None):
     """
     Plots a Gutenberg-Richter model
     """
@@ -113,19 +113,21 @@ def plot_trunc_gr_model(aval, bval, min_mag, max_mag, dmag, catalogue=None,
     if not catalogue:
         # Plot only the modelled recurrence
         annual_rates, cumulative_rates = _get_recurrence_model(input_model)
-        plt.semilogy(annual_rates[:, 0], annual_rates[:, 1], 'b-')
-        plt.semilogy(annual_rates[:, 0], cumulative_rates, 'r-')
-        plt.xlabel('Magnitude', fontsize='large')
-        plt.ylabel('Annual Rate', fontsize='large')
-        plt.legend(['Incremental Rate', 'Cumulative Rate'])
-        _save_image(filename, filetype, dpi)
+
+        if ax is None:
+            fig, ax = plt.subplots(figsize=figure_size)
+        else:
+            fig = ax.get_figure()
+
+        ax.semilogy(annual_rates[:, 0], annual_rates[:, 1], 'b-')
+        ax.semilogy(annual_rates[:, 0], cumulative_rates, 'r-')
+        ax.xlabel('Magnitude')
+        ax.set_ylabel('Annual Rate')
+        ax.set_legend(['Incremental Rate', 'Cumulative Rate'])
+        _save_image(fig, filename, filetype, dpi)
+
     else:
         completeness = _check_completeness_table(completeness, catalogue)
-        plot_recurrence_model(input_model,
-                              catalogue,
-                              completeness,
-                              input_model.bin_width,
-                              figure_size,
-                              filename,
-                              filetype,
-                              dpi)
+        plot_recurrence_model(
+            input_model, catalogue, completeness, dmag, filename=filename,
+            figure_size=figure_size, filetype=filetype, dpi=dpi, ax=ax)

--- a/openquake/hmtk/plotting/seismicity/occurrence/recurrence_plot.py
+++ b/openquake/hmtk/plotting/seismicity/occurrence/recurrence_plot.py
@@ -7,7 +7,7 @@ Simple plots for the recurrence model
 import numpy as np
 import matplotlib.pyplot as plt
 from openquake.hmtk.plotting.seismicity.catalogue_plots import \
-    (get_completeness_adjusted_table, _save_image)
+    (get_completeness_adjusted_table, _save_image, DEFAULT_SIZE)
 from openquake.hmtk.seismicity.occurrence.utils import get_completeness_counts
 from openquake.hazardlib.mfd.truncated_gr import TruncatedGRMFD
 from openquake.hazardlib.mfd.evenly_discretized import EvenlyDiscretizedMFD
@@ -61,7 +61,8 @@ def _check_completeness_table(completeness, catalogue):
 
 
 def plot_recurrence_model(input_model, catalogue, completeness, dmag,
-                          figure_size=(10, 8), filename=None, filetype='png', dpi=300):
+                          figure_size=DEFAULT_SIZE, filename=None,
+                          filetype='png',  dpi=300, ax=None):
     """
     Plot a calculated recurrence model over an observed catalogue, adjusted for
     time-varying completeness
@@ -81,6 +82,11 @@ def plot_recurrence_model(input_model, catalogue, completeness, dmag,
     cum_obs_rates = np.array([np.sum(obs_rates[i:])
                               for i in range(len(obs_rates))])
     # Create plot
+    if ax is None:
+        fig, ax = plt.subplots(figsize=DEFAULT_SIZE)
+    else:
+        fig = ax.get_figure()
+
     plt.figure(figsize=figure_size)
     plt.semilogy(cent_mag, obs_rates, 'bo')
     plt.semilogy(annual_rates[:, 0], annual_rates[:, 1], 'b-')
@@ -94,7 +100,7 @@ def plot_recurrence_model(input_model, catalogue, completeness, dmag,
                 'Observed Cumulative Rate',
                 'Model Cumulative Rate'], fontsize=14)
     plt.tick_params(labelsize=12)
-    _save_image(filename, filetype, dpi)
+    _save_image(fig, filename, filetype, dpi)
 
 
 def plot_trunc_gr_model(aval, bval, min_mag, max_mag, dmag, catalogue=None,

--- a/openquake/hmtk/seismicity/occurrence/utils.py
+++ b/openquake/hmtk/seismicity/occurrence/utils.py
@@ -229,6 +229,7 @@ def get_completeness_counts(catalogue, completeness, d_m):
         * n_obs - number of events in completeness period
     """
     mmax_obs = np.max(catalogue.data["magnitude"])
+    catalogue.data["dtime"] = catalogue.get_decimal_time()
     if mmax_obs > np.max(completeness[:, 1]):
         cmag = np.hstack([completeness[:, 1], mmax_obs])
     else:

--- a/pylintrc
+++ b/pylintrc
@@ -13,7 +13,7 @@ profile=no
 
 # Add <file or directory> to the black list. It should be a base name, not a
 # path. You may set this option multiple times.
-ignore=CVS
+ignore=CVS,tests
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -21,10 +21,6 @@ persistent=yes
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 load-plugins=
-
-# Add <file or directory> to the black list. It should be a base name, not a
-# path. You may set this option multiple times.
-ignore=tests
 
 [MESSAGES CONTROL]
 


### PR DESCRIPTION
The impetus here was a bug introduced by my last pull request whereby the call to _save_image() in plot_recurrence_models() was not getting the wrong arguments and failing. The usage is now consistent wherever it is called; it would be better implemented as a decorator, however.

The commit messages summarize the changes in some detail. The main goal is flexibility, for example if you want to do these plots for a number of zones, sending the results to different axes of plt.subplots().