### PR TITLE
Deprecated stochastic_event_set

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Deprecated `openquake.hazardlib.calc.stochastic.stochastic_event_set`
   * Fixed the export of ruptures with a GriddedSurface geometry
   * Added a check for wrong or missing `<occupancyPeriods>` in the exposure
   * Fixed the issue of slow tasks in event_based_risk from precomputed GMFs

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -25,7 +25,7 @@ import time
 import operator
 import collections
 import numpy
-from openquake.baselib.general import AccumDict
+from openquake.baselib.general import AccumDict, deprecated
 from openquake.baselib.performance import Monitor
 from openquake.baselib.python3compat import range, raise_
 from openquake.hazardlib.calc.filters import FarAwayRupture
@@ -42,6 +42,7 @@ event_dt = numpy.dtype([('eid', U64), ('grp_id', U16), ('ses', U32),
                         ('sample', U32)])
 
 
+@deprecated('Use sample_ruptures instead')
 def stochastic_event_set(
         sources,
         sites=None,


### PR DESCRIPTION
We could even remove it, to my knowledge it is only used in some notebook. Waiting from @mmpagani to decide.