### PR TITLE
Changed `DataStore.get_attrs` to look at the parent

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed bug in the datastore: now we automatically look for the attributes
+    in the parent dataset, if the dataset is missing in the child datastore
   * Extended extract_losses_by_asset to the event based risk calculator
   * Stored in source_info the number of events generated per source
   * Added a script utils/reduce_sm to reduce the source model of a calculation

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -242,7 +242,14 @@ class DataStore(collections.MutableMapping):
         :param key: dataset path
         :returns: dictionary of attributes for that path
         """
-        return dict(h5py.File.__getitem__(self.hdf5, key).attrs)
+        try:
+            dset = h5py.File.__getitem__(self.hdf5, key)
+        except KeyError:
+            if self.parent != ():
+                dset = h5py.File.__getitem__(self.parent.hdf5, key)
+            else:
+                raise
+        return dict(dset.attrs)
 
     def create_dset(self, key, dtype, shape=(None,), compression=None,
                     fillvalue=0, attrs=None):


### PR DESCRIPTION
With this change the QGIS integration tests will work, notably the event based risk one, looking for composite_risk_model.attrs.