### PR TITLE
Removed output disagg_by_src if there are multiple realizations

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -212,9 +212,10 @@ class PSHACalculator(base.HazardCalculator):
         :param pmap_by_grp_id:
             a dictionary grp_id -> hazard curves
         """
+        oq = self.oqparam
         grp_trt = self.csm.info.grp_by("trt")
         grp_source = self.csm.info.grp_by("name")
-        if self.oqparam.disagg_by_src:
+        if oq.disagg_by_src:
             src_name = {src.src_group_id: src.name
                         for src in self.csm.get_sources()}
         data = []
@@ -225,12 +226,14 @@ class PSHACalculator(base.HazardCalculator):
                     key = 'poes/grp-%02d' % grp_id
                     self.datastore[key] = pmap
                     self.datastore.set_attrs(key, trt=grp_trt[grp_id])
-                    if self.oqparam.disagg_by_src:
+                    if oq.disagg_by_src:
                         data.append(
                             (grp_id, grp_source[grp_id], src_name[grp_id]))
             if 'poes' in self.datastore:
                 self.datastore.set_nbytes('poes')
-                if self.oqparam.disagg_by_src:
+                if oq.disagg_by_src and self.csm.info.get_num_rlzs() == 1:
+                    # this is useful for disaggregation, which is implemented
+                    # only for the case of a single realization
                     self.datastore['disagg_by_src/source_id'] = numpy.array(
                         sorted(data), grp_source_dt)
 


### PR DESCRIPTION
This solves an uglyness discovered by Robin: for disagg_by_src=true and multiple realizations the output "Disaggregation by Source" appears but it is empty. Now it does not appear.

