### PR TITLE
Fix DOI and citation

### DIFF
--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -12,7 +12,7 @@ sed -i "s/Version X\.Y\.Z/Version $VERSION/" figures/oq_manual_cover.svg
 
 inkscape -A figures/oq_manual_cover.pdf figures/oq_manual_cover.svg
 
-sed -i "s/GEM (YEAR)/GEM ($(date +%Y))/" oq-manual.tex
+sed -i "s/#PUBYEAR#/$(date +%Y)/g; s/#PUBMONTH#/$(date +%B)/g" oq-manual.tex
 sed -i "s/version X\.Y\.Z/version $VERSION/" oq-manual.tex
 sed -i "s/ENGINE\.X\.Y\.Z/ENGINE\.$VERSION/" oq-manual.tex
 

--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -8,9 +8,13 @@ set -e
 CURPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VERSION="$(cat $CURPATH/../../openquake/baselib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")"
 cd $CURPATH
-sed -i "s/Version [0-9]\.[0-9]\.[0-9]/Version $VERSION/" figures/oq_manual_cover.svg
+sed -i "s/Version X\.Y\.Z/Version $VERSION/" figures/oq_manual_cover.svg
 
 inkscape -A figures/oq_manual_cover.pdf figures/oq_manual_cover.svg
+
+sed -i "s/GEM (YEAR)/GEM ($(date +%Y))/" oq-manual.tex
+sed -i "s/version X\.Y\.Z/version $VERSION/" oq-manual.tex
+sed -i "s/ENGINE\.X\.Y\.Z/ENGINE\.$VERSION/" oq-manual.tex
 
 (pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex
 bibtex oq-manual

--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -13,8 +13,7 @@ sed -i "s/Version X\.Y\.Z/Version $VERSION/" figures/oq_manual_cover.svg
 inkscape -A figures/oq_manual_cover.pdf figures/oq_manual_cover.svg
 
 sed -i "s/#PUBYEAR#/$(date +%Y)/g; s/#PUBMONTH#/$(date +%B)/g" oq-manual.tex
-sed -i "s/version X\.Y\.Z/version $VERSION/" oq-manual.tex
-sed -i "s/ENGINE\.X\.Y\.Z/ENGINE\.$VERSION/" oq-manual.tex
+sed -i "s/version X\.Y\.Z/version $VERSION/; s/ENGINE\.X\.Y\.Z/ENGINE\.$VERSION/" oq-manual.tex
 
 (pdflatex -shell-escape -interaction=nonstopmode oq-manual.tex
 bibtex oq-manual

--- a/doc/manual/configuration/configuration.tex
+++ b/doc/manual/configuration/configuration.tex
@@ -48,6 +48,9 @@
 \usepackage[top=3cm,bottom=3cm,left=3.2cm,right=3.2cm,headsep=10pt,a4paper]{geometry}
 \linespread{1.25}
 
+% Page count
+\usepackage{lastpage}
+
 % Font settings
 \usepackage[condensed]{roboto} % Use the Roboto font for headings
 \usepackage[bitstream-charter]{mathdesign} % Use the Bitstream Charter font for text

--- a/doc/manual/figures/oq_manual_cover.svg
+++ b/doc/manual/figures/oq_manual_cover.svg
@@ -424,7 +424,7 @@
          x="60.236198 69.501198 77.695198 83.679199 91.482201 95.154198 103.7392"
          y="-377.51379"
          sodipodi:role="line"
-         id="tspan324">Version 2.9.0</tspan></text>
+         id="tspan324">Version X.Y.Z</tspan></text>
 <path
        d="m 40.895,384.4629 -14.042,14.042 0,-28.084 14.042,14.042 z"
        style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"

--- a/doc/manual/oq-manual.tex
+++ b/doc/manual/oq-manual.tex
@@ -98,9 +98,9 @@
 \noindent
    {\textbf{Citation}} \hfill \\
    Please cite this document as: \hfill \\
-   GEM (2018). The OpenQuake-engine User Manual.
-   \textit{Global Earthquake Model (GEM) Technical Report 2018-02.\\
-   doi: 10.13117/GEM.OPENQUAKE.MAN.ENGINE.2.9/01, 194 pages.} \hfill \\
+   GEM (YEAR). The OpenQuake-engine User Manual.
+   \textit{Global Earthquake Model (GEM) OpenQuake Manual for Engine version X.Y.Z.\\
+   doi: 10.13117/GEM.OPENQUAKE.MAN.ENGINE.X.Y.Z, 194 pages.} \hfill \\
 \noindent \hfill\\
 \noindent
    {\bf{Disclaimer}} \hfill \\

--- a/doc/manual/oq-manual.tex
+++ b/doc/manual/oq-manual.tex
@@ -98,7 +98,7 @@
 \noindent
    {\textbf{Citation}} \hfill \\
    Please cite this document as: \hfill \\
-   GEM (YEAR). The OpenQuake-engine User Manual.
+   GEM (#PUBYEAR#). The OpenQuake-engine User Manual.
    \textit{Global Earthquake Model (GEM) OpenQuake Manual for Engine version X.Y.Z.\\
    doi: 10.13117/GEM.OPENQUAKE.MAN.ENGINE.X.Y.Z, \pageref{LastPage} pages.} \hfill \\
 \noindent \hfill\\
@@ -126,8 +126,8 @@
    provide proper credit, but you cannot change it in any way or use it
    commercially.\hfill \\
 
-\noindent \copyright\ \textsc{2013--2018 GEM Foundation}\\
-\noindent \textit{Seventeenth printing, February 2018} % Printing/edition date
+\noindent \copyright\ \textsc{2013--#PUBYEAR# GEM Foundation}\\
+\noindent \textit{Seventeenth printing, #PUBMONTH# #PUBYEAR#} % Printing/edition date
 
 %-------------------------------------------------------------------------------
 %  TABLE OF CONTENTS

--- a/doc/manual/oq-manual.tex
+++ b/doc/manual/oq-manual.tex
@@ -127,7 +127,7 @@
    commercially.\hfill \\
 
 \noindent \copyright\ \textsc{2013--#PUBYEAR# GEM Foundation}\\
-\noindent \textit{Seventeenth printing, #PUBMONTH# #PUBYEAR#} % Printing/edition date
+\noindent \textit{#PUBMONTH# #PUBYEAR#} % Printing/edition date
 
 %-------------------------------------------------------------------------------
 %  TABLE OF CONTENTS

--- a/doc/manual/oq-manual.tex
+++ b/doc/manual/oq-manual.tex
@@ -100,7 +100,7 @@
    Please cite this document as: \hfill \\
    GEM (YEAR). The OpenQuake-engine User Manual.
    \textit{Global Earthquake Model (GEM) OpenQuake Manual for Engine version X.Y.Z.\\
-   doi: 10.13117/GEM.OPENQUAKE.MAN.ENGINE.X.Y.Z, 194 pages.} \hfill \\
+   doi: 10.13117/GEM.OPENQUAKE.MAN.ENGINE.X.Y.Z, \pageref{LastPage} pages.} \hfill \\
 \noindent \hfill\\
 \noindent
    {\bf{Disclaimer}} \hfill \\


### PR DESCRIPTION
This PR makes the DOI generation (and the citation) fully automatic. I changed a bit the citation because previously it was using an index that is not exposed to the builder (progress number of technical reports).

Artifact: https://ci.openquake.org/job/builders/job/pdf-builder/108/artifact/oq-engine/doc/manual/oq-manual.pdf

