### PR TITLE
Added information about the distribution mechanism used in the User-Agent

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -291,8 +291,9 @@ def check_obsolete_version(calculation_mode='WebUI'):
         # avoid flooding our API server with requests from CI systems
         return
 
-    headers = {'User-Agent': 'OpenQuake Engine %s;%s;%s' %
-               (__version__, calculation_mode, platform.platform())}
+    headers = {'User-Agent': 'OpenQuake Engine %s;%s;%s;%s' %
+               (__version__, calculation_mode, platform.platform(),
+                config.distribution.oq_distribute)}
     try:
         req = Request(OQ_API + '/engine/latest', headers=headers)
         # NB: a timeout < 1 does not work


### PR DESCRIPTION
This is interesting to see if people are using a cluster (i.e. oq_distribute=celery) or not.


