### PR TITLE
Refactored the association mechanism

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -648,14 +648,16 @@ def get_sitecol_assetcol(oqparam, haz_sitecol):
             if obj.sid in sids and distance <= haz_distance:
                 # keep the assets, otherwise discard them
                 assets_by_sid[obj.sid].extend(assets)
-                assets.sort(key=operator.attrgetter('ordinal'))
         if not assets_by_sid:
             raise geo.utils.SiteAssociationError(
                 'Could not associate any site to any assets within the '
                 'asset_hazard_distance of %s km' % haz_distance)
         mask = numpy.array(
             [sid in assets_by_sid for sid in all_sids])
-        exposure.assets_by_site = [assets_by_sid[sid] for sid in all_sids]
+        exposure.assets_by_site = [
+            sorted(assets_by_sid.get(sid, []),
+                   key=operator.attrgetter('ordinal'))
+            for sid in all_sids]
         num_assets = sum(len(assets) for assets in exposure.assets_by_site)
         sitecol = haz_sitecol.complete.filter(mask)
         logging.info('Associated %d assets to %d sites',

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -647,8 +647,8 @@ def get_sitecol_assetcol(oqparam, haz_sitecol):
             obj, distance = siteobjects.get_closest(lon, lat)
             if obj.sid in sids and distance <= haz_distance:
                 # keep the assets, otherwise discard them
-                #assets.sort(key=operator.attrgetter('ordinal'))
                 assets_by_sid[obj.sid].extend(assets)
+                assets.sort(key=operator.attrgetter('ordinal'))
         if not assets_by_sid:
             raise geo.utils.SiteAssociationError(
                 'Could not associate any site to any assets within the '

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -647,6 +647,7 @@ def get_sitecol_assetcol(oqparam, haz_sitecol):
             obj, distance = siteobjects.get_closest(lon, lat)
             if obj.sid in sids and distance <= haz_distance:
                 # keep the assets, otherwise discard them
+                #assets.sort(key=operator.attrgetter('ordinal'))
                 assets_by_sid[obj.sid].extend(assets)
         if not assets_by_sid:
             raise geo.utils.SiteAssociationError(
@@ -654,9 +655,7 @@ def get_sitecol_assetcol(oqparam, haz_sitecol):
                 'asset_hazard_distance of %s km' % haz_distance)
         mask = numpy.array(
             [sid in assets_by_sid for sid in all_sids])
-        exposure.assets_by_site = [
-            sorted(assets_by_sid[sid], key=operator.attrgetter('ordinal'))
-            for sid in all_sids]
+        exposure.assets_by_site = [assets_by_sid[sid] for sid in all_sids]
         num_assets = sum(len(assets) for assets in exposure.assets_by_site)
         sitecol = haz_sitecol.complete.filter(mask)
         logging.info('Associated %d assets to %d sites',

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -652,11 +652,13 @@ def get_sitecol_assetcol(oqparam, haz_sitecol):
             raise geo.utils.SiteAssociationError(
                 'Could not associate any site to any assets within the '
                 'asset_hazard_distance of %s km' % haz_distance)
+        mask = numpy.array(
+            [sid in assets_by_sid for sid in all_sids])
         exposure.assets_by_site = [
             sorted(assets_by_sid[sid], key=operator.attrgetter('ordinal'))
             for sid in all_sids]
         num_assets = sum(len(assets) for assets in exposure.assets_by_site)
-        sitecol = haz_sitecol.filtered(assets_by_sid)
+        sitecol = haz_sitecol.complete.filter(mask)
         logging.info('Associated %d assets to %d sites',
                      num_assets, len(sitecol))
         if num_assets < tot_assets:

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -121,6 +121,7 @@ class _GeographicObjects(object):
 
         :param assets_by_sites: a list of lists of assets
         :param assoc_dist: the maximum distance for association
+        :param mode: 'strict' or 'error'
         :returns: (filtered site collection, filtered assets by site)
         """
         self.objects.filtered  # self.objects must be a SiteCollection
@@ -146,10 +147,17 @@ class _GeographicObjects(object):
         return self.objects.filtered(sids), assets_by_site
 
 
-def assoc(objects, sitecol, assoc_dist, mode='error'):
+def assoc(objects, sitecol, assoc_dist, mode):
     """
     Associate geographic objects to a site collection.
 
+    :param objects:
+        an array with fields lon, lat or a list of geographic objects
+    :param assoc_dist:
+        the maximum distance for association
+    :param mode:
+        if 'strict' fail if at least one site is not associated
+        if 'error' fail if all sites are not associated
     :returns: (filtered site collection, filtered objects)
     """
     if isinstance(objects, numpy.ndarray):

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -39,9 +39,6 @@ UNCERTAINTY_RX = URL_RX + "uncertainty\.xml(\.zip)?"
 F32 = numpy.float32
 PCTG = 100  # percent of g, the gravity acceleration
 
-LON = operator.itemgetter('lon')
-LAT = operator.itemgetter('lat')
-
 
 class DownloadFailed(Exception):
     """Raised by shakemap.download"""
@@ -112,8 +109,7 @@ def get_sitecol_shakemap(array_or_id, sitecol=None, assoc_dist=None):
     sitecol_within = sitecol.within_bbox(bbox)
     logging.info('Associating %d GMVs to %d sites',
                  len(array), len(sitecol_within))
-    data = geo.utils.GeographicObjects(array, LON, LAT)
-    return data.assoc(sitecol_within, assoc_dist)
+    return geo.utils.assoc(array, sitecol_within, assoc_dist)
 
 
 # Here is the explanation of USGS for the units they are using:

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -60,18 +60,20 @@ class Site(object):
 
     def __init__(self, location, vs30, vs30measured, z1pt0, z2pt5,
                  backarc=False):
-        if not vs30 > 0:
-            raise ValueError('vs30 must be positive')
-        if not z1pt0 > 0:
-            raise ValueError('z1pt0 must be positive')
-        if not z2pt5 > 0:
-            raise ValueError('z2pt5 must be positive')
         self.location = location
         self.vs30 = vs30
         self.vs30measured = vs30measured
         self.z1pt0 = z1pt0
         self.z2pt5 = z2pt5
         self.backarc = backarc
+
+    @property
+    def lon(self):
+        return self.location.x
+
+    @property
+    def lat(self):
+        return self.location.y
 
     def __str__(self):
         """
@@ -295,8 +297,10 @@ class SiteCollection(object):
         one at a time.
         """
         for i, location in enumerate(self.mesh):
-            yield Site(location, self.vs30[i], self.vs30measured[i],
-                       self.z1pt0[i], self.z2pt5[i], self.backarc[i])
+            site = Site(location, self.vs30[i], self.vs30measured[i],
+                        self.z1pt0[i], self.z2pt5[i], self.backarc[i])
+            site.sid = i
+            yield site
 
     def filter(self, mask):
         """

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -376,9 +376,15 @@ class SiteCollection(object):
             idx = self.indices
         return self.array[idx][name]
 
+    def __getitem__(self, site_id):
+        """
+        :returns: a site record
+        """
+        return self.array[site_id]
+
     def __len__(self):
         """
-        Return the number of sites in the collection.
+        :returns: the number of sites in the collection
         """
         return (len(self.indices) if self.indices is not None
                 else len(self.array))

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -207,8 +207,12 @@ class SiteCollection(object):
 
     def filtered(self, indices):
         """
-        :returns: a filtered SiteCollection instance
+        :returns:
+           a filtered SiteCollection instance if indices is a proper subset
+           of the available indices, otherwise returns the full SiteCollection
         """
+        if len(indices) == len(self.complete):
+            return self.complete
         new = object.__new__(self.__class__)
         new.indices = numpy.uint32(sorted(indices))
         new.array = self.array

--- a/openquake/hazardlib/tests/geo/utils_test.py
+++ b/openquake/hazardlib/tests/geo/utils_test.py
@@ -423,19 +423,4 @@ class PlaneFit(unittest.TestCase):
         self.assertAlmostEqual(self.c[-1], -sum(par*pnt), 2)
 
 
-class GeographicObjectsTest(unittest.TestCase):
-    def setUp(self):
-        p1 = Point(0.0, 0.1)
-        p2 = Point(0.0, 0.2)
-        p3 = Point(0.0, 0.3)
-        self.points = utils.GeographicObjects([p1, p2, p3])
-
-    def test_closest(self):
-        point, dist = self.points.get_closest(0.0, 0.21)
-        self.assertEqual(point, Point(0.0, 0.2))
-        point, dist = self.points.get_closest(0.0, 0.29)
-        self.assertEqual(point, Point(0.0, 0.3))
-
-    def test_exact_point(self):
-        point, dist = self.points.get_closest(0.0, 0.2)
-        self.assertEqual(point, Point(0.0, 0.2))
+# NB: utils.assoc is tested in the engine

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -37,6 +37,46 @@ class SiteModelParam(object):
         self.reference_backarc = False
 
 
+class SiteTestCase(unittest.TestCase):
+    def _assert_creation(self, error=None, **kwargs):
+        default_kwargs = {
+            'location': Point(10, 20),
+            'vs30': 10,
+            'vs30measured': False,
+            'z1pt0': 20,
+            'z2pt5': 30,
+            'backarc': True
+        }
+        default_kwargs.update(kwargs)
+        kwargs = default_kwargs
+        if error is not None:
+            with self.assertRaises(ValueError) as ar:
+                Site(**kwargs)
+            self.assertEqual(str(ar.exception), error)
+        else:
+            site = Site(**kwargs)
+            for attr in kwargs:
+                self.assertEqual(getattr(site, attr), kwargs[attr])
+
+    def test_wrong_vs30(self):
+        error = 'vs30 must be positive'
+        self._assert_creation(error=error, vs30=0)
+        self._assert_creation(error=error, vs30=-1)
+
+    def test_wrong_z1pt0(self):
+        error = 'z1pt0 must be positive'
+        self._assert_creation(error=error, z1pt0=0)
+        self._assert_creation(error=error, z1pt0=-1)
+
+    def test_wrong_z2pt5(self):
+        error = 'z2pt5 must be positive'
+        self._assert_creation(error=error, z2pt5=0)
+        self._assert_creation(error=error, z2pt5=-1)
+
+    def test_successful_creation(self):
+        self._assert_creation()
+
+
 class SiteCollectionCreationTestCase(unittest.TestCase):
     def test_from_sites(self):
         s1 = Site(location=Point(10, 20, 30),

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -37,46 +37,6 @@ class SiteModelParam(object):
         self.reference_backarc = False
 
 
-class SiteTestCase(unittest.TestCase):
-    def _assert_creation(self, error=None, **kwargs):
-        default_kwargs = {
-            'location': Point(10, 20),
-            'vs30': 10,
-            'vs30measured': False,
-            'z1pt0': 20,
-            'z2pt5': 30,
-            'backarc': True
-        }
-        default_kwargs.update(kwargs)
-        kwargs = default_kwargs
-        if error is not None:
-            with self.assertRaises(ValueError) as ar:
-                Site(**kwargs)
-            self.assertEqual(str(ar.exception), error)
-        else:
-            site = Site(**kwargs)
-            for attr in kwargs:
-                self.assertEqual(getattr(site, attr), kwargs[attr])
-
-    def test_wrong_vs30(self):
-        error = 'vs30 must be positive'
-        self._assert_creation(error=error, vs30=0)
-        self._assert_creation(error=error, vs30=-1)
-
-    def test_wrong_z1pt0(self):
-        error = 'z1pt0 must be positive'
-        self._assert_creation(error=error, z1pt0=0)
-        self._assert_creation(error=error, z1pt0=-1)
-
-    def test_wrong_z2pt5(self):
-        error = 'z2pt5 must be positive'
-        self._assert_creation(error=error, z2pt5=0)
-        self._assert_creation(error=error, z2pt5=-1)
-
-    def test_successful_creation(self):
-        self._assert_creation()
-
-
 class SiteCollectionCreationTestCase(unittest.TestCase):
     def test_from_sites(self):
         s1 = Site(location=Point(10, 20, 30),


### PR DESCRIPTION
I have introduced an unified utility `hazardlib.geo.utils.assoc(objects, sitecol, assoc_dist)` which is able to associate with a common interface:

1. site parameters to hazard sites
2. assets to hazard sites
3. shakemap to hazard sites