### PR TITLE
Convert celery-status in an oq command

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
   [Daniele Viganò]
-  * Move to Celery 4. Celery support is removed from Windows.
+  * `celery-status` script converted into `oq celery status` command
+  * Removed Django < 1.10 backward compatibility
+  * Updated Python dependices (numpy 1.14, scipy 1.0.1,
+    Django 1.10+, Celery 4+)
 
   [Michele Simionato]
   * Implemented scenario_risk/scenario_damage from shakemap calculators

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -111,7 +111,7 @@ The *Celery* daemon is not started at boot by default on the workers node and th
 
 ### Monitoring Celery
 
-The `celery-status` script is provided under `/usr/share/openquake/engine/utils` to check the status of the worker nodes, the task distribution and the cluster occupation. An output like this is produced:
+`oq celery status` can be used to check the status of the worker nodes, the task distribution and the cluster occupation. An output like this is produced:
 
 ```
 ==========

--- a/openquake/commands/celery.py
+++ b/openquake/commands/celery.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
-# Copyright (C) 2017-2018 GEM Foundation
+# Copyright (C) 2018 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published
@@ -17,18 +17,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import sys
-
-if os.path.isfile('/opt/openquake/bin/oq'):
-    # custom pythonpath is pushed in position 1 instead of 0 because
-    # sys.path[0] is populated at runtime by python itself. See:
-    # https://docs.python.org/2/library/sys.html#sys.path
-    sys.path.insert(1, '/opt/openquake/lib/python%d.%d/site-packages' %
-                    sys.version_info[:2])
-    os.environ['PYTHONPATH'] = ":".join(sys.path)
-
 from celery import Celery
+
+from openquake.baselib import sap
 from openquake.engine.celeryconfig import broker_url, result_backend
 
 
@@ -76,5 +68,11 @@ def status():
         (float(num_active_tasks) / total_workers) * 100))
 
 
-if __name__ == "__main__":
-    status()
+@sap.Script
+def celery(cmd):
+    if cmd == 'status':
+        status()
+
+
+celery.arg('cmd', 'celery command',
+           choices='status'.split())

--- a/openquake/commands/celery.py
+++ b/openquake/commands/celery.py
@@ -35,8 +35,7 @@ else:
 
         all_stats = ins.stats()
         if all_stats is None:
-            print("No active workers")
-            sys.exit(0)
+            sys.exit("No active workers")
 
         hostnames = []
 

--- a/packager.sh
+++ b/packager.sh
@@ -623,7 +623,7 @@ sudo supervisorctl start openquake-celery
 
 celery_wait $GEM_MAXLOOP
 
-        /usr/share/openquake/engine/utils/celery-status
+        oq celery status
         oq engine --run risk/EventBasedRisk/job_hazard.ini && oq engine --run risk/EventBasedRisk/job_risk.ini --hc -1
 
         # Try to export a set of results AFTER the calculation

--- a/rpm/python3-oq-engine.spec.inc
+++ b/rpm/python3-oq-engine.spec.inc
@@ -139,8 +139,6 @@ cp -R demos %{buildroot}/%{_datadir}/openquake/engine
 # Make a zipped copy of each demo
 helpers/zipdemos.sh %{buildroot}%{_datadir}/openquake/engine/demos
 cp -R utils %{buildroot}/%{_datadir}/openquake/engine
-# FIXME To be removed after python3 switch is completed
-sed -i "s|/usr/bin/env python|%{__python3}|" %{buildroot}/%{_datadir}/openquake/engine/utils/celery-status
 
 %post
 %systemd_post openquake-dbserver.service


### PR DESCRIPTION
This PR converts `celery-status` script into an `oq` command. In this way we can avoid ugly hacks to make the script working when packages are used (common case on multi-node setups).

Will reduce also maintenance costs on our clusters.

```bash
$ oq celery status
==========
Host: celery@gemlatitude5450
Status: Online
Worker processes: 4
Active tasks: 0
==========

Total workers:       4
Active tasks:        0
Cluster utilization: 0.00%
```

Part of #3614