### PR TITLE
Warn the user about optimize_same_id_sources when it looks like he should do that

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Added a warning about the option `optimize_same_id_sources` when the user
+    should take advantage of it
+
   [Daniele Viganò]
   * `celery-status` script converted into `oq celery status` command
   * Removed Django < 1.10 backward compatibility

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1130,9 +1130,11 @@ class SourceModelLogicTree(object):
             branchset = branch.child_branchset
 
         def apply_uncertainties(source):
+            if not branchsets_and_uncertainties:
+                return False  # nothing changed
             for branchset, value in branchsets_and_uncertainties:
                 branchset.apply_uncertainty(value, source)
-            return True  # sentinel that the source was changed
+            return True  # the source was changed
         return apply_uncertainties
 
     def samples_by_lt_path(self):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -274,7 +274,6 @@ def get_mesh(oqparam):
         return exposure.mesh
 
 
-
 site_model_dt = numpy.dtype([
     ('lon', numpy.float64),
     ('lat', numpy.float64),
@@ -504,6 +503,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
     for fname, hits in psr.fname_hits.items():
         if hits > 1:
             logging.info('%s has been considered %d times', fname, hits)
+            oqparam.optimize_same_id_sources = True
 
 
 def getid(src):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -504,6 +504,8 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
         if hits > 1:
             logging.info('%s has been considered %d times', fname, hits)
             if not psr.changed_sources:
+                # we can safely enable the optimization, since exactly the
+                # same sources have been read multiple times
                 oqparam.optimize_same_id_sources = True
 
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -500,13 +500,15 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
     psr.check_nonparametric_sources(oqparam.investigation_time)
 
     # log if some source file is being used more than once
+    all_hits = 0
     for fname, hits in psr.fname_hits.items():
         if hits > 1:
             logging.info('%s has been considered %d times', fname, hits)
-            if not psr.changed_sources:
-                # we can safely enable the optimization, since exactly the
-                # same sources have been read multiple times
-                oqparam.optimize_same_id_sources = True
+            all_hits += hits
+    if all_hits and not psr.changed_sources:
+        logging.warn('You are doing redundant calculations: please make sure '
+                     'that different sources have different IDs and set '
+                     'optimize_same_id_sources=true in your .ini file')
 
 
 def getid(src):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -503,7 +503,8 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
     for fname, hits in psr.fname_hits.items():
         if hits > 1:
             logging.info('%s has been considered %d times', fname, hits)
-            oqparam.optimize_same_id_sources = True
+            if not psr.changed_sources:
+                oqparam.optimize_same_id_sources = True
 
 
 def getid(src):

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -279,6 +279,7 @@ class SourceModelParser(object):
         self.converter = converter
         self.sm = {}  # cache fname -> source model
         self.fname_hits = collections.Counter()  # fname -> number of calls
+        self.changed_sources = 0
 
     def parse_src_groups(self, fname, apply_uncertainties):
         """
@@ -299,6 +300,7 @@ class SourceModelParser(object):
                 if changed:
                     # redo count_ruptures which can be slow
                     src.num_ruptures = src.count_ruptures()
+                    self.changed_sources += 1
         self.fname_hits[fname] += 1
         return groups
 


### PR DESCRIPTION
The source model for Russia has three branches in which the same sources are repeated (there are submodels like 6.15.nrml, 6.25.nrml, ... 8.45.nrml) and there are no uncertainties applied. This means that `optimize_same_id_sources` can be set and the calculation will become 3 times faster, at least for the sources which are repeated (the GridMultiSources are different in the three branches). It is up to the hazard modeler to make sure that different sources have different IDs and equal sources have equal IDs.
