### PR TITLE
Refined the check on too many realizations

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -50,6 +50,7 @@ U16 = numpy.uint16
 U32 = numpy.uint32
 U64 = numpy.uint64
 F32 = numpy.float32
+TWO16 = 2 ** 16
 
 
 class InvalidCalculationID(Exception):
@@ -572,7 +573,18 @@ class HazardCalculator(BaseCalculator):
         self.rlzs_assoc = self.csm.info.get_rlzs_assoc(self.oqparam.sm_lt_path)
         if not self.rlzs_assoc:
             raise RuntimeError('Empty logic tree: too much filtering?')
+
         self.datastore['csm_info'] = self.csm.info
+        R = len(self.rlzs_assoc.realizations)
+        if R > TWO16:
+            if self.is_stochastic:
+                raise ValueError(
+                    'The logic tree has %d realizations, the maximum '
+                    'is %d' % (R, TWO16))
+            else:
+                logging.warn(
+                    'The logic tree has %d realizations(!), please consider '
+                    'sampling it', R)
         if 'source_info' in self.datastore:
             # the table is missing for UCERF, we should fix that
             self.datastore.set_attrs(

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -576,15 +576,15 @@ class HazardCalculator(BaseCalculator):
 
         self.datastore['csm_info'] = self.csm.info
         R = len(self.rlzs_assoc.realizations)
-        if R > TWO16:
-            if self.is_stochastic:
-                raise ValueError(
-                    'The logic tree has %d realizations, the maximum '
-                    'is %d' % (R, TWO16))
-            else:
-                logging.warn(
-                    'The logic tree has %d realizations(!), please consider '
-                    'sampling it', R)
+        if self.is_stochastic and R >= TWO16:
+            # rlzi is 16 bit integer in the GMFs, so there is hard limit or R
+            raise ValueError(
+                'The logic tree has %d realizations, the maximum '
+                'is %d' % (R, TWO16))
+        elif R > 10000:
+            logging.warn(
+                'The logic tree has %d realizations(!), please consider '
+                'sampling it', R)
         if 'source_info' in self.datastore:
             # the table is missing for UCERF, we should fix that
             self.datastore.set_attrs(

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -38,7 +38,6 @@ from openquake.commonlib import logictree
 
 MINWEIGHT = source.MINWEIGHT
 MAX_INT = 2 ** 31 - 1
-TWO16 = 2 ** 16
 U16 = numpy.uint16
 U32 = numpy.uint32
 I32 = numpy.int32
@@ -644,10 +643,6 @@ class CompositionInfo(object):
             rlzs = [all_rlzs[idx] for idx in idxs]
         else:  # full enumeration
             rlzs = logictree.get_effective_rlzs(all_rlzs)
-        if len(rlzs) > TWO16:
-            raise ValueError(
-                'The source model %s has %d realizations, the maximum '
-                'is %d' % (smodel.names, len(rlzs), TWO16))
         return rlzs
 
     def __repr__(self):


### PR DESCRIPTION
The check has been demoted to a warning except for event based and scenario, where it is necessary because the GMF arrays use a 16 bit field `rlzi`.