### PR TITLE
Turned rtree into a required library

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Optimize the rtree index generation
   * Introduced a `preclassical` calculator
   * Extended the scenario_damage calculator to export `dmg_by_event`
     outputs as well as `losses_by_event` outputs if there is a consequence

--- a/doc/installing/development.md
+++ b/doc/installing/development.md
@@ -190,15 +190,15 @@ To uninstall the OpenQuake development make sure that its environment is not loa
 
 ### Notes ###
 
-*<a name="note1">[1]</a>: extra features, like celery and rtree support can be installed running:*
+*<a name="note1">[1]</a>: extra features, like celery and pam support can be installed running:*
 
 ```bash
-# oq-engine with Rtree support
-pip install -e oq-engine/[Rtree]
 # oq-engine with celery support
 pip install -e oq-engine/[celery]
+# oq-engine with pam support
+pip install -e oq-engine/[pam]
 # oq-engine with support for both
-pip install -e oq-engine/[rtree,celery]
+pip install -e oq-engine/[celery,pam]
 ```
 
 *<a name="note2">[2]</a>: unsupported systems:*

--- a/doc/installing/macos.md
+++ b/doc/installing/macos.md
@@ -3,7 +3,7 @@
 The OpenQuake Engine is available for macOS in the form of **self-installable binary distribution**.
 
 - this distribution uses Python 3.5 official installer provided by the Python Foundation (https://www.python.org/downloads/release/python-354/) and includes its own distribution of the dependencies needed by the OpenQuake Engine
-    - pip, numpy, scipy, h5py, django, shapely, and few more
+    - pip, numpy, scipy, h5py, django, shapely, rtree and few more
 - can be installed without `root` permission (i.e. in the user home)
 - multiple versions can be installed alongside
 - currently does not support Celery (and will never do)

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -9,10 +9,10 @@ A 64bit operating system and 64bit capable hardware are required.
 * HDF5 - Used for storing and managing data
 * numpy and scipy - Fundamental packages for scientific computing with Python
 * pyzmq - Used for internal inter-process communications
+* Rtree - a wrapper of libspatialindex that provides a number of advanced spatial indexing features
 
 ### Optional dependencies
 
-* Rtree - a wrapper of libspatialindex that provides a number of advanced spatial indexing features 
 * Celery - Distributed task queue library, using the `iterator_native()`
 * RabbitMQ - Message broker for Celery tasks, logging channels, and other signalling
 

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -340,9 +340,10 @@ class SourceFilter(object):
             integration_distance and sitecol is not None and
             sitecol.at_sea_level())
         if self.use_rtree:
-            self.index = rtree.index.Index()
-            for sid, lon, lat in zip(sitecol.sids, sitecol.lons, sitecol.lats):
-                self.index.insert(sid, (lon, lat, lon, lat))
+            self.index = rtree.index.Index(
+                (sid, (lon, lat, lon, lat), (lon, lat, lon, lat))
+                for sid, lon, lat in zip(
+                        sitecol.sids, sitecol.lons, sitecol.lats))
         if sitecol is not None and rtree is None:
             logging.info('Using distance filtering [no rtree]')
 

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -65,12 +65,8 @@ import collections
 from contextlib import contextmanager
 import numpy
 from scipy.interpolate import interp1d
-try:
-    import rtree
-except ImportError:
-    rtree = None
+import rtree
 from openquake.baselib.python3compat import raise_
-from openquake.hazardlib.site import SiteCollection
 
 KM_TO_DEGREES = 0.0089932  # 1 degree == 111 km
 DEGREES_TO_RAD = 0.01745329252  # 1 radians = 57.295779513 degrees
@@ -306,8 +302,8 @@ class IntegrationDistance(collections.Mapping):
 
 class SourceFilter(object):
     """
-    The SourceFilter uses the rtree library if available. The index is
-    generated at instantiation time and kept in memory. The filter should be
+    The SourceFilter uses the rtree library. The index is generated at
+    instantiation time and kept in memory. The filter should be
     instantiated only once per calculation, after the site collection is
     known. It should be used as follows::
 
@@ -336,7 +332,7 @@ class SourceFilter(object):
             if isinstance(integration_distance, dict)
             else integration_distance)
         self.sitecol = sitecol
-        self.use_rtree = use_rtree and rtree and (
+        self.use_rtree = use_rtree and (
             integration_distance and sitecol is not None and
             sitecol.at_sea_level())
         if self.use_rtree:
@@ -405,7 +401,7 @@ class SourceFilter(object):
                     # MS: sanity check against rtree bugs; what happened to me
                     # is that by following the advice in http://toblerity.org/rtree/performance.html#use-stream-loading
                     # self.index.intersection(box) started reporting duplicate
-                    # and wrong sids!
+                    # and wrong sids! the current rtree version is fine though
                     raise ValueError('sids=%s' % sids)
                 if len(sids):
                     src.nsites = len(sids)

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -22,11 +22,6 @@ transformations, optimized for massive calculations.
 """
 from __future__ import division
 import numpy
-try:
-    import rtree
-except ImportError:
-    rtree = None
-
 from openquake.baselib.python3compat import round
 
 #: Earth radius in km.

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -23,10 +23,7 @@ to several geographical primitives and some other low-level spatial operations.
 import logging
 import operator
 import collections
-try:
-    import rtree
-except:
-    rtree = None
+import rtree
 import numpy
 import shapely.geometry
 
@@ -57,13 +54,13 @@ class _GeographicObjects(object):
         elif isinstance(objects, numpy.ndarray):
             self.lons = objects['lon']
             self.lats = objects['lat']
-        if rtree:
-            self.index = rtree.index.Index()
-            self.proj = OrthographicProjection.from_lons_lats(
-                self.lons, self.lats)
-            xs, ys = self.proj(self.lons, self.lats)
-            for i, (x, y) in enumerate(zip(xs, ys)):
-                self.index.insert(i, (x, y, x, y))
+
+        self.proj = OrthographicProjection.from_lons_lats(
+            self.lons, self.lats)
+        xs, ys = self.proj(self.lons, self.lats)
+        self.index = rtree.index.Index(
+            (i, (x, y, x, y), (x, y, x, y))
+            for i, (x, y) in enumerate(zip(xs, ys)))
 
     def get_closest(self, lon, lat):
         """

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ install_requires = [
     'scipy >=1.0.1, <1.1',
     'pyzmq <18.0',
     'psutil >=1.2, <5.5',
-    'rtree == 0.8.3',
+    'rtree ==0.8.3',
     'shapely >=1.3, <1.7',
     'docutils >=0.11, <0.15',
     'decorator >=3.4',

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ install_requires = [
     'scipy >=1.0.1, <1.1',
     'pyzmq <18.0',
     'psutil >=1.2, <5.5',
+    'rtree == 0.8.3',
     'shapely >=1.3, <1.7',
     'docutils >=0.11, <0.15',
     'decorator >=3.4',
@@ -74,7 +75,6 @@ install_requires = [
 extras_require = {
     'setproctitle': ["setproctitle"],
     'prctl': ["python-prctl ==1.6.1"],
-    'rtree':  ["Rtree >=0.8.2, <0.8.4"],
     'celery':  ["celery >=4.0, <4.2"],
     'pam': ["python-pam", "django-pam"],
     'plotting':  [


### PR DESCRIPTION
Two reasons:

1. now we have the wheels on all platforms, there is no reason to keep it optional
2. now rtree is used intensively, more than before.

I have also changed the way the index is generated: now it is faster, but it only works in version 0.8.3
(the old version was bugged).