### PR TITLE
Removed rtree index optimization

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,5 @@
   [Michele Simionato]
   * Now sites and exposure can be set at the same time in the job.ini
-  * Optimized the rtree index generation
   * Introduced a `preclassical` calculator
   * Extended the scenario_damage calculator to export `dmg_by_event`
     outputs as well as `losses_by_event` outputs if there is a consequence

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -340,7 +340,7 @@ class SourceFilter(object):
             for sid, lon, lat in zip(sitecol.sids, sitecol.lons, sitecol.lats):
                 self.index.insert(sid, (lon, lat, lon, lat))
             # http://toblerity.org/rtree/performance.html#use-stream-loading
-            # causes all kind of indefined behavior!
+            # causes undefined behavior, with wrong associations being made
 
     def get_affected_box(self, src):
         """

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -93,7 +93,7 @@ def context(src):
     """
     try:
         yield
-    except:
+    except Exception:
         etype, err, tb = sys.exc_info()
         msg = 'An error occurred with source id=%s. Error: %s'
         msg %= (src.source_id, err)
@@ -324,7 +324,7 @@ class SourceFilter(object):
         :meth:`openquake.hazardlib.source.base.BaseSeismicSource.filter_sites_by_distance_to_source`
         which is what is actually used for filtering.
     :param use_rtree:
-        by default True, i.e. try to use the rtree module if available
+        by default True, i.e. use the rtree module
     """
     def __init__(self, sitecol, integration_distance, use_rtree=True):
         self.integration_distance = (
@@ -336,12 +336,11 @@ class SourceFilter(object):
             integration_distance and sitecol is not None and
             sitecol.at_sea_level())
         if self.use_rtree:
-            self.index = rtree.index.Index(
-                (sid, (lon, lat, lon, lat), (lon, lat, lon, lat))
-                for sid, lon, lat in zip(
-                        sitecol.sids, sitecol.lons, sitecol.lats))
-        if sitecol is not None and rtree is None:
-            logging.info('Using distance filtering [no rtree]')
+            self.index = rtree.index.Index()
+            for sid, lon, lat in zip(sitecol.sids, sitecol.lons, sitecol.lats):
+                self.index.insert(sid, (lon, lat, lon, lat))
+            # http://toblerity.org/rtree/performance.html#use-stream-loading
+            # causes all kind of indefined behavior!
 
     def get_affected_box(self, src):
         """
@@ -398,12 +397,9 @@ class SourceFilter(object):
                 box = self.get_affected_box(src)
                 sids = numpy.array(sorted(self.index.intersection(box)))
                 if len(set(sids)) < len(sids):
-                    # MS: sanity check against rtree bugs; what happened to me
-                    # is that by following the advice in http://toblerity.org/rtree/performance.html#use-stream-loading
-                    # self.index.intersection(box) started reporting duplicate
-                    # and wrong sids! the current rtree version is fine though
+                    # MS: sanity check against rtree bugs
                     raise ValueError('sids=%s' % sids)
-                if len(sids):
+                elif len(sids):
                     src.nsites = len(sids)
                     yield src, sites.filtered(sids)
             else:  # normal filtering, used in the workers

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -57,9 +57,10 @@ class _GeographicObjects(object):
         self.proj = OrthographicProjection.from_lons_lats(
             self.lons, self.lats)
         xs, ys = self.proj(self.lons, self.lats)
-        self.index = rtree.index.Index(
-            (i, (x, y, x, y), (x, y, x, y))
-            for i, (x, y) in enumerate(zip(xs, ys)))
+        self.index = rtree.index.Index()
+        # no http://toblerity.org/rtree/performance.html#use-stream-loading!
+        for i, (x, y) in enumerate(zip(xs, ys)):
+            self.index.insert(i, (x, y, x, y))
 
     def get_closest(self, lon, lat):
         """


### PR DESCRIPTION
By following @mmpagani suggestion, I recently (https://github.com/gem/oq-engine/pull/3634) introduced the rtree index optimization discussed in http://toblerity.org/rtree/performance.html#use-stream-loading on the ground that the tests were green with the latest version of rtree.
Unfortunately, the change broke the code for the Aristotle project (not the tests, the true calculation) and it could be responsible for strange things seen by Valerio in the Russia calculation. So I am reverting the
optimization until some clarity is done.

Marked as CRITICAL since potentially all calculations are giving wrong results.