### PR TITLE
Fixed shakemap units

### DIFF
--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -22,7 +22,6 @@ import re
 import math
 import zipfile
 import logging
-import operator
 import numpy
 from scipy.stats import truncnorm
 from scipy import interpolate
@@ -251,7 +250,7 @@ def to_gmfs(shakemap, site_effects, trunclevel, num_gmfs, seed):
     """
     std = shakemap['std']
     imts = [imt.from_string(name) for name in std.dtype.names]
-    val = {imt: numpy.log(shakemap['val'][imt] / PCTG) - std[imt] ** 2 / 2.
+    val = {imt: numpy.log(shakemap['val'][imt]) - std[imt] ** 2 / 2.
            for imt in std.dtype.names}
     dmatrix = geo.geodetic.distance_matrix(shakemap['lon'], shakemap['lat'])
     spatial_corr = spatial_correlation_array(dmatrix, imts)
@@ -269,7 +268,7 @@ def to_gmfs(shakemap, site_effects, trunclevel, num_gmfs, seed):
     gmfs = numpy.exp(numpy.dot(L, Z) + mu)
     if site_effects:
         gmfs = amplify_gmfs(imts, shakemap['vs30'], gmfs) * 0.8
-    return gmfs.reshape((1, M, N, num_gmfs)).transpose(0, 2, 3, 1)
+    return gmfs.reshape((1, M, N, num_gmfs)).transpose(0, 2, 3, 1) / PCTG
 
 """
 here is an example for Tanzania:

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -32,7 +32,7 @@ class ShakemapTestCase(unittest.TestCase):
         n = 4  # number of sites
         self.assertEqual(len(sitecol), n)
         gmf_by_imt = mean_gmf(shakemap)
-        aae(gmf_by_imt, [0.0047045, 0.0184625, 0.0346171, 0.0175625])
+        aae(gmf_by_imt, [0.0035974, 0.0135442, 0.0296358, 0.0150663])
 
     def test_amplify(self):
         res = amplify_ground_shaking(T=3.0, vs30=780, gmvs=[0.1, 0.2, 0.3])
@@ -84,5 +84,5 @@ class ShakemapTestCase(unittest.TestCase):
 
         gmfs = to_gmfs(
             shakemap, site_effects=True, trunclevel=3, num_gmfs=2, seed=42)
-        aae(gmfs[..., 0].sum(axis=1), [[0.4101717, 0.6240185]])  # PGA
-        aae(gmfs[..., 2].sum(axis=1), [[0.3946015, 0.5385107]])  # SA(1.0)
+        aae(gmfs[..., 0].sum(axis=1), [[0.2832467, 0.433162]])  # PGA
+        aae(gmfs[..., 2].sum(axis=1), [[0.3279128, 0.4475009]])  # SA(1.0)


### PR DESCRIPTION
The shakemap units are PCTG (percent of g) so we must divide by 100 the generated ground motion fields. Before we were dividing by 100 the intensity value but not the standard deviation, which is inconsistent. Needed for https://github.com/gem/oq-engine/issues/3637.