### PR TITLE
Added a `cross_correlation` parameter used when working with shakemaps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a `cross_correlation` parameter used when working with shakemaps
   * Now sites and exposure can be set at the same time in the job.ini
   * Introduced a `preclassical` calculator
   * Extended the scenario_damage calculator to export `dmg_by_event`

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -629,8 +629,8 @@ class RiskCalculator(HazardCalculator):
 
         logging.info('Building GMFs')
         with self.monitor('building/saving GMFs'):
-            gmfs = to_gmfs(shakemap, oq.site_effects, oq.truncation_level, E,
-                           oq.random_seed)
+            gmfs = to_gmfs(shakemap, oq.cross_correlation, oq.site_effects,
+                           oq.truncation_level, E, oq.random_seed)
             save_gmf_data(self.datastore, self.sitecol, gmfs)
             events = numpy.zeros(E, readinput.stored_event_dt)
             events['eid'] = numpy.arange(E, dtype=U64)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -57,6 +57,8 @@ class OqParam(valid.ParamSet):
         valid.positiveint, multiprocessing.cpu_count() * 3)  # by M. Simionato
     conditional_loss_poes = valid.Param(valid.probabilities, [])
     continuous_fragility_discretization = valid.Param(valid.positiveint, 20)
+    cross_correlation = valid.Param(valid.Choice('cross', 'no correlation'),
+                                    'cross')
     description = valid.Param(valid.utf8_not_empty)
     disagg_by_src = valid.Param(valid.boolean, False)
     disagg_outputs = valid.Param(valid.disagg_outputs, None)

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -243,7 +243,7 @@ def cholesky(spatial_cov, cross_corr):
     return numpy.linalg.cholesky(numpy.array(LLT))
 
 
-def to_gmfs(shakemap, site_effects, trunclevel, num_gmfs, seed):
+def to_gmfs(shakemap, crosscorr, site_effects, trunclevel, num_gmfs, seed):
     """
     :returns: an array of GMFs of shape (R, N, E, M)
     """
@@ -255,7 +255,7 @@ def to_gmfs(shakemap, site_effects, trunclevel, num_gmfs, seed):
     spatial_corr = spatial_correlation_array(dmatrix, imts)
     stddev = [std[imt] for imt in std.dtype.names]
     spatial_cov = spatial_covariance_array(stddev, spatial_corr)
-    cross_corr = cross_correlation_matrix(imts)
+    cross_corr = cross_correlation_matrix(imts, crosscorr)
     M, N = spatial_corr.shape[:2]
     mu = numpy.array([numpy.ones(num_gmfs) * val[imt][j]
                       for imt in std.dtype.names for j in range(N)])
@@ -268,8 +268,3 @@ def to_gmfs(shakemap, site_effects, trunclevel, num_gmfs, seed):
     if site_effects:
         gmfs = amplify_gmfs(imts, shakemap['vs30'], gmfs) * 0.8
     return gmfs.reshape((1, M, N, num_gmfs)).transpose(0, 2, 3, 1)
-
-"""
-here is an example for Tanzania:
-https://earthquake.usgs.gov/archive/product/shakemap/us10006nkx/us/1480920466172/download/grid.xml
-"""

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -18,7 +18,8 @@ CDIR = os.path.dirname(__file__)
 
 def mean_gmf(shakemap):
     gmfs = to_gmfs(
-        shakemap, site_effects=True, trunclevel=3, num_gmfs=10, seed=42)
+        shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
+        num_gmfs=10, seed=42)
     return [gmfs[..., i].mean() for i in range(len(imts))]
 
 
@@ -83,6 +84,7 @@ class ShakemapTestCase(unittest.TestCase):
         aae(gmfs[..., 0].sum(axis=1), [[0.3708301, 0.5671011]])  # PGA
 
         gmfs = to_gmfs(
-            shakemap, site_effects=True, trunclevel=3, num_gmfs=2, seed=42)
+            shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
+            num_gmfs=2, seed=42)
         aae(gmfs[..., 0].sum(axis=1), [[0.4101717, 0.6240185]])  # PGA
         aae(gmfs[..., 2].sum(axis=1), [[0.3946015, 0.5385107]])  # SA(1.0)

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -79,13 +79,13 @@ class ShakemapTestCase(unittest.TestCase):
         shakemap['val'] = val
         shakemap['std'] = std
         gmfs = to_gmfs(
-            shakemap, crosscorr=True, site_effects=False, trunclevel=3,
+            shakemap, crosscorr='corr', site_effects=False, trunclevel=3,
             num_gmfs=2, seed=42)
         # shape (R, N, E, M)
         aae(gmfs[..., 0].sum(axis=1), [[0.3708301, 0.5671011]])  # PGA
 
         gmfs = to_gmfs(
-            shakemap, crosscorr=True, site_effects=True, trunclevel=3,
+            shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
             num_gmfs=2, seed=42)
         aae(gmfs[..., 0].sum(axis=1), [[0.2832467, 0.433162]])  # PGA
-        aae(gmfs[..., 2].sum(axis=1), [[0.3972117, 0.401503]])  # SA(1.0)
+        aae(gmfs[..., 2].sum(axis=1), [[0.3279128, 0.4475009]])  # SA(1.0)


### PR DESCRIPTION
By default it is enabled, but it is possible to disable it to compare the results.