### PR TITLE
Added a .serial attribute to the hazardlib ruptures

### DIFF
--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -512,6 +512,7 @@ class RuptureGetter(object):
             rupture_cls, surface_cls, source_cls = BaseRupture.types[
                 rec['code']]
             rupture = object.__new__(rupture_cls)
+            rupture.serial = serial
             rupture.surface = object.__new__(surface_cls)
             # MISSING: case complex_fault_mesh_spacing != rupture_mesh_spacing
             if 'Complex' in surface_cls.__name__:
@@ -545,7 +546,7 @@ class RuptureGetter(object):
                     m = mesh[0]
                     rupture.surface.mesh = RectangularMesh(
                         m['lon'], m['lat'], m['depth'])
-            ebr = EBRupture(rupture, (), evs, serial)
+            ebr = EBRupture(rupture, (), evs)
             ebr.eidx1 = rec['eidx1']
             ebr.eidx2 = rec['eidx2']
             # not implemented: rupture_slip_direction

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -265,7 +265,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         os.remove(fname)
 
         # this is a case with exposure and region_grid_spacing
-        out = self.run_calc(case_miriam.__file__, 'job2.ini')
+        self.run_calc(case_miriam.__file__, 'job2.ini')
         hcurves = dict(extract(self.calc.datastore, 'hcurves'))['all']
         sitecol = self.calc.datastore['sitecol']  # filtered sitecol
         self.assertEqual(len(hcurves), len(sitecol))

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -709,6 +709,7 @@ def compute_ruptures(sources, src_filter, gsims, param, monitor):
                     background_sids, src_filter, seed)
             with filt_mon:
                 for rup, n_occ in zip(rups, n_occs):
+                    rup.serial = serial
                     rup.seed = seed
                     try:
                         r_sites, rrup = idist.get_closest(sitecol, rup)
@@ -721,8 +722,7 @@ def compute_ruptures(sources, src_filter, gsims, param, monitor):
                         events.append((0, src.src_group_id, ses_idx, sample))
                     if events:
                         evs = numpy.array(events, stochastic.event_dt)
-                        ebruptures.append(
-                            EBRupture(rup, indices, evs, serial))
+                        ebruptures.append(EBRupture(rup, indices, evs))
                         serial += 1
     res.num_events = len(stochastic.set_eids(ebruptures))
     res[src.src_group_id] = ebruptures

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -206,6 +206,7 @@ def _build_eb_ruptures(
     yield pairs (rupture, <list of associated EBRuptures>)
     """
     for rup in sorted(num_occ_by_rup, key=operator.attrgetter('rup_no')):
+        rup.serial = rup.seed - random_seed + 1
         with rup_mon:
             try:
                 rup.ctx = cmaker.make_contexts(s_sites, rup)
@@ -216,7 +217,6 @@ def _build_eb_ruptures(
                 continue
 
         # creating EBRuptures
-        serial = rup.seed - random_seed + 1
         events = []
         for (sam_idx, ses_idx), num_occ in sorted(
                 num_occ_by_rup[rup].items()):
@@ -225,5 +225,4 @@ def _build_eb_ruptures(
                 # set a bit later, in set_eids
                 events.append((0, src.src_group_id, ses_idx, sam_idx))
         if events:
-            yield EBRupture(rup, indices, numpy.array(events, event_dt),
-                            serial)
+            yield EBRupture(rup, indices, numpy.array(events, event_dt))

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -75,6 +75,7 @@ class BaseRupture(with_metaclass(abc.ABCMeta)):
     """
     _slots_ = '''mag rake tectonic_region_type hypocenter surface
     source_typology rupture_slip_direction'''.split()
+    serial = 0
 
     @classmethod
     def init(cls):
@@ -583,7 +584,7 @@ class EBRupture(object):
         """
         Serial number of the rupture
         """
-        return getattr(self.rupture, 'serial', 0)
+        return self.rupture.serial
 
     @property
     def grp_id(self):

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -571,13 +571,19 @@ class EBRupture(object):
     object, containing an array of site indices affected by the rupture,
     as well as the IDs of the corresponding seismic events.
     """
-    def __init__(self, rupture, sids, events, serial=0):
+    def __init__(self, rupture, sids, events):
         self.rupture = rupture
         self.sids = sids
         self.events = events
-        self.serial = serial
         self.eidx1 = 0
         self.eidx2 = len(events)
+
+    @property
+    def serial(self):
+        """
+        Serial number of the rupture
+        """
+        return getattr(self.rupture, 'serial', 0)
 
     @property
     def grp_id(self):

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -75,7 +75,7 @@ class BaseRupture(with_metaclass(abc.ABCMeta)):
     """
     _slots_ = '''mag rake tectonic_region_type hypocenter surface
     source_typology rupture_slip_direction'''.split()
-    serial = 0
+    serial = 0  # set to a value > 0 by the engine
 
     @classmethod
     def init(cls):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -449,7 +449,7 @@ class RuptureConverter(object):
             coll[grp_id] = ebrs = []
             for node in grpnode:
                 rup = self.convert_node(node)
-                rupid = int(node['id'])
+                rup.serial = int(node['id'])
                 sesnodes = node.stochasticEventSets
                 events = []
                 for sesnode in sesnodes:
@@ -458,7 +458,7 @@ class RuptureConverter(object):
                         for eid in sesnode.text.split():
                             events.append((eid, ses, 0))
                 ebr = source.rupture.EBRupture(
-                    rup, (), numpy.array(events, event_dt), rupid)
+                    rup, (), numpy.array(events, event_dt))
                 ebrs.append(ebr)
         return coll
 


### PR DESCRIPTION
This is for debuggability. One wants to be able to see which one is the rupture causing issues when debugging the internals of hazardlib. Before the serial was an attribute of the EBRupture wrapper, but
this is not enough.