### PR TITLE
Fixed the GMF rescaling

### DIFF
--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -203,10 +203,10 @@ def amplify_ground_shaking(T, vs30, gmvs):
     """
     :param T: period
     :param vs30: velocity
-    :param gmvs: ground motion values for the current site
+    :param gmvs: ground motion values for the current site in units of g
     """
     interpolator = interpolate.interp1d(
-        [-1, 0.1, 0.2, 0.3, 0.4, 100],
+        [0, 0.1, 0.2, 0.3, 0.4, 10],
         [(760 / vs30)**0.35,
          (760 / vs30)**0.35,
          (760 / vs30)**0.25,
@@ -214,7 +214,7 @@ def amplify_ground_shaking(T, vs30, gmvs):
          (760 / vs30)**-0.05,
          (760 / vs30)**-0.05],
     ) if T <= 0.3 else interpolate.interp1d(
-        [-1, 0.1, 0.2, 0.3, 0.4, 100],
+        [0, 0.1, 0.2, 0.3, 0.4, 10],
         [(760 / vs30)**0.65,
          (760 / vs30)**0.65,
          (760 / vs30)**0.60,
@@ -263,7 +263,7 @@ def to_gmfs(shakemap, crosscorr, site_effects, trunclevel, num_gmfs, seed):
     Z = truncnorm.rvs(-trunclevel, trunclevel, loc=0, scale=1,
                       size=(M * N, num_gmfs), random_state=seed)
     # Z has shape (M * N, E)
-    gmfs = numpy.exp(numpy.dot(L, Z) + mu)
+    gmfs = numpy.exp(numpy.dot(L, Z) + mu) / PCTG
     if site_effects:
         gmfs = amplify_gmfs(imts, shakemap['vs30'], gmfs) * 0.8
-    return gmfs.reshape((1, M, N, num_gmfs)).transpose(0, 2, 3, 1) / PCTG
+    return gmfs.reshape((1, M, N, num_gmfs)).transpose(0, 2, 3, 1)

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -33,7 +33,7 @@ class ShakemapTestCase(unittest.TestCase):
         n = 4  # number of sites
         self.assertEqual(len(sitecol), n)
         gmf_by_imt = mean_gmf(shakemap)
-        aae(gmf_by_imt, [0.0035974, 0.0135442, 0.0296358, 0.0150663])
+        aae(gmf_by_imt, [0.0047045, 0.0184625, 0.0346171, 0.0175625])
 
     def test_amplify(self):
         res = amplify_ground_shaking(T=3.0, vs30=780, gmvs=[0.1, 0.2, 0.3])
@@ -87,5 +87,5 @@ class ShakemapTestCase(unittest.TestCase):
         gmfs = to_gmfs(
             shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
             num_gmfs=2, seed=42)
-        aae(gmfs[..., 0].sum(axis=1), [[0.2832467, 0.433162]])  # PGA
-        aae(gmfs[..., 2].sum(axis=1), [[0.3279128, 0.4475009]])  # SA(1.0)
+        aae(gmfs[..., 0].sum(axis=1), [[0.4101717, 0.6240185]])  # PGA
+        aae(gmfs[..., 2].sum(axis=1), [[0.3946015, 0.5385107]])  # SA(1.0)


### PR DESCRIPTION
In https://github.com/gem/oq-engine/pull/3644 I introduced a bug: the rescaling of the GMFs by a factor of 100 (because the shakemap unit of measure is PCTG) should be made *before* calling `amplify_gmfs`, not after, because  `amplify_gmfs` expects the GMFs to be in units of `g`. I am also reducing the interpolation range to [0, 10] so that negative GMVs or too large GMFs are flagged as errors.