### PR TITLE
Added a parameter `use_rtree`

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -170,7 +170,7 @@ class PSHACalculator(base.HazardCalculator):
         for tile_i, tile in enumerate(tiles, 1):
             num_tasks = 0
             num_sources = 0
-            src_filter = SourceFilter(tile, oq.maximum_distance)
+            src_filter = SourceFilter(tile, oq.maximum_distance, oq.use_rtree)
             if num_tiles > 1:
                 logging.info('Processing tile %d of %d', tile_i, len(tiles))
             with self.monitor('prefiltering'):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -158,7 +158,8 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
         :yields: (sources, sites, gsims, monitor) tuples
         """
         oq = self.oqparam
-        src_filter = SourceFilter(self.sitecol.complete, oq.maximum_distance)
+        src_filter = SourceFilter(self.sitecol.complete, oq.maximum_distance,
+                                  oq.use_rtree)
 
         def weight(src):
             return src.num_ruptures * src.RUPTURE_WEIGHT

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -119,6 +119,7 @@ class OqParam(valid.ParamSet):
     optimize_same_id_sources = valid.Param(valid.boolean, False)
     risk_imtls = valid.Param(valid.intensity_measure_types_and_levels, {})
     risk_investigation_time = valid.Param(valid.positivefloat, None)
+    use_rtree = valid.Param(valid.boolean, True)
     rupture_mesh_spacing = valid.Param(valid.positivefloat)
     ruptures_per_block = valid.Param(valid.positiveint, 1000)
     complex_fault_mesh_spacing = valid.Param(


### PR DESCRIPTION
By default `use_rtree` is True and the user should never touch it. However the parameter is useful to debug rtree bugs. It is always good to have an option to disable the rtree filtering.