### PR TITLE
Replaced the old hazardlib filtering mechanism with the `sitecol.within_bbox` filtering

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -83,6 +83,7 @@ class PSHACalculator(base.HazardCalculator):
     Classical PSHA calculator
     """
     core_task = classical
+    prefilter = True
 
     def agg_dicts(self, acc, pmap_by_grp):
         """
@@ -175,8 +176,11 @@ class PSHACalculator(base.HazardCalculator):
             if num_tiles > 1:
                 logging.info('Processing tile %d of %d', tile_i, len(tiles))
             with self.monitor('prefiltering'):
-                logging.info('Prefiltering sources')
-                csm = self.csm.filter(src_filter)
+                if self.prefilter:
+                    logging.info('Prefiltering sources')
+                    csm = self.csm.filter(src_filter)
+                else:
+                    csm = self.csm
 
             if tile_i == 1:  # set it only on the first tile
                 maxweight = csm.get_maxweight(
@@ -207,7 +211,8 @@ class PSHACalculator(base.HazardCalculator):
             logging.info('Sent %d sources in %d tasks', num_sources, num_tasks)
             # cleanup filtering information for the next tile
             for src in csm.get_sources():
-                del src.indices
+                if hasattr(src, 'indices'):
+                    del src.indices
         self.csm.info.tot_weight = totweight
 
     def post_execute(self, pmap_by_grp_id):
@@ -275,6 +280,7 @@ class PreCalculator(PSHACalculator):
     ruptures
     """
     core_task = count_ruptures
+    prefilter = False
 
 
 def fix_ones(pmap):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -419,7 +419,7 @@ class SourceFilter(object):
                 if set_:
                     src.indices = numpy.array(sorted(set_))
                     yield src, sites.filtered(src.indices)
-            else:  # slow filtering
+            else:  # numpy filtering
                 s_sites = sites.within_bbox(self.get_affected_box(src))
                 if s_sites is not None:
                     src.indices = get_indices(s_sites)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -420,12 +420,7 @@ class SourceFilter(object):
                     src.indices = numpy.array(sorted(set_))
                     yield src, sites.filtered(src.indices)
             else:  # slow filtering
-                _, maxmag = src.get_min_max_mag()
-                maxdist = self.integration_distance(
-                    src.tectonic_region_type, maxmag)
-                with context(src):
-                    s_sites = src.filter_sites_by_distance_to_source(
-                        maxdist, sites)
+                s_sites = sites.within_bbox(self.get_affected_box(src))
                 if s_sites is not None:
                     src.indices = get_indices(s_sites)
                     yield src, s_sites

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -105,10 +105,12 @@ def get_sitecol_shakemap(array_or_id, sitecol=None, assoc_dist=None):
     # associate the shakemap to the (filtered) site collection
     bbox = (array['lon'].min(), array['lat'].min(),
             array['lon'].max(), array['lat'].max())
-    sitecol_within = sitecol.within_bbox(bbox)
-    logging.info('Associating %d GMVs to %d sites',
-                 len(array), len(sitecol_within))
-    return geo.utils.assoc(array, sitecol_within, assoc_dist, 'warn')
+    sites = sitecol.within_bbox(bbox)
+    if sites is None:
+        raise RuntimeError('There are no sites within the boundind box %s'
+                           % str(bbox))
+    logging.info('Associating %d GMVs to %d sites', len(array), len(sites))
+    return geo.utils.assoc(array, sites, assoc_dist, 'warn')
 
 
 # Here is the explanation of USGS for the units they are using:

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -350,8 +350,10 @@ class SiteCollection(object):
 
     def within_bbox(self, bbox):
         """
-        :param bbox: a quartet (min_lon, min_lat, max_lon, max_lat)
-        :returns: a filtered SiteCollection strictly within the bounding box
+        :param bbox:
+            a quartet (min_lon, min_lat, max_lon, max_lat)
+        :returns:
+            a filtered SiteCollection within the bounding box or None
         """
         min_lon, min_lat, max_lon, max_lat = bbox
         arr = self.array if self.indices is None else self.array[self.indices]
@@ -361,9 +363,6 @@ class SiteCollection(object):
             min_lon, max_lon = min_lon % 360, max_lon % 360
         mask = (min_lon < lons) * (lons < max_lon) * \
                (min_lat < lats) * (lats < max_lat)
-        if not mask.any():
-            raise Exception('There are no sites within the boundind box %s'
-                            % str(bbox))
         return self.filter(mask)
 
     def __getstate__(self):


### PR DESCRIPTION
Normally the rtree filtering is used. However, it can be disabled and in that case the `sitecol.within_bbox` filtering should be used instead. That is the one used in the `preclassical` calculator. In a separate pull request I will remove the obsolete filtering code.