### PR TITLE
Changed filter_sources_with_rtree->prefilter_sources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
   [Michele Simionato]
   * Fixed another tricky bug with rtree filtering across the international
     date line
-  * Added a parameter `filter_sources_with_rtree`
+  * Added a parameter `prefilter_sources`
   * Removed the prefiltering on the workers, resulting in a huge speedup
     for gridded ruptures at the cost of a larger data transfer
   * Changed the `losses_by_event` output to export a single .csv file with

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -172,7 +172,7 @@ class PSHACalculator(base.HazardCalculator):
             num_tasks = 0
             num_sources = 0
             src_filter = SourceFilter(tile, oq.maximum_distance,
-                                      oq.filter_sources_with_rtree)
+                                      oq.prefilter_sources)
             if num_tiles > 1:
                 logging.info('Processing tile %d of %d', tile_i, len(tiles))
             with self.monitor('prefiltering'):

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -213,7 +213,7 @@ producing too small PoEs.'''
         oq = self.oqparam
         tl = oq.truncation_level
         src_filter = SourceFilter(self.sitecol, oq.maximum_distance,
-                                  use_rtree=False)
+                                  prefilter='no')
         csm = self.csm.filter(src_filter)  # fine filtering
         if not csm.get_sources():
             raise RuntimeError('All sources were filtered away!')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -159,7 +159,7 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
         """
         oq = self.oqparam
         src_filter = SourceFilter(self.sitecol.complete, oq.maximum_distance,
-                                  oq.filter_sources_with_rtree)
+                                  oq.prefilter_sources)
 
         def weight(src):
             return src.num_ruptures * src.RUPTURE_WEIGHT

--- a/openquake/commands/plot_sites.py
+++ b/openquake/commands/plot_sites.py
@@ -43,7 +43,7 @@ def plot_sites(calc_id=-1):
     sitecol = dstore['sitecol']
     lons, lats = sitecol.lons, sitecol.lats
     srcfilter = SourceFilter(sitecol, oq.maximum_distance,
-                             oq.filter_sources_with_rtree)
+                             oq.prefilter_sources)
     csm = readinput.get_composite_source_model(oq).filter(srcfilter)
     fig, ax = p.subplots()
     ax.grid(True)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -67,7 +67,7 @@ class OqParam(valid.ParamSet):
     export_dir = valid.Param(valid.utf8, '.')
     export_multi_curves = valid.Param(valid.boolean, False)
     exports = valid.Param(valid.export_formats, ())
-    filter_sources_with_rtree = valid.Param(valid.boolean, True)
+    prefilter_sources = valid.Param(valid.Choice('rtree', 'numpy', 'no'), 'rtree')
     ground_motion_correlation_model = valid.Param(
         valid.NoneOr(valid.Choice(*GROUND_MOTION_CORRELATION_MODELS)), None)
     ground_motion_correlation_params = valid.Param(valid.dictionary)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -329,9 +329,9 @@ class SourceFilter(object):
 
     As a side effect, sets the `.nsites` attribute of the source, i.e. the
     number of sites within the integration distance. Notice that SourceFilter
-    instances can be pickled, but when unpickled `prefilter` is set to
-    'no' and the index is lost: the reason is that libspatialindex indices
-    cannot be properly pickled (https://github.com/Toblerity/rtree/issues/65).
+    instances can be pickled, but when unpickled the index is lost: the reason
+    is that libspatialindex indices cannot be properly pickled
+    (https://github.com/Toblerity/rtree/issues/65).
 
     :param sitecol:
         :class:`openquake.hazardlib.site.SiteCollection` instance (or None)
@@ -340,7 +340,7 @@ class SourceFilter(object):
         :meth:`openquake.hazardlib.source.base.BaseSeismicSource.filter_sites_by_distance_to_source`
         which is what is actually used for filtering.
     :param prefilter:
-        by default True, i.e. use the rtree module
+        by default "rtree", i.e. use the rtree module
     """
     def __init__(self, sitecol, integration_distance, prefilter='rtree'):
         if sitecol is not None and len(sitecol) < len(sitecol.complete):
@@ -427,7 +427,7 @@ class SourceFilter(object):
 
     def __getstate__(self):
         return dict(integration_distance=self.integration_distance,
-                    sitecol=self.sitecol, prefilter='no')
+                    sitecol=self.sitecol, prefilter=self.prefilter)
 
 
 source_site_noop_filter = SourceFilter(None, {})


### PR DESCRIPTION
The parameter `prefilter_sources` now accepts three values:

"rtree": prefilter with rtree
"numpy": prefilter with numpy
"no": do not prefilter at all

 `prefilter_sources=no` is useful when debugging issues with the prefiltering mechanism.