### PR TITLE
Removed the .source_typology attribute from the ruptures

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Removed the source typology from the rupture classes
+  * Removed the source typology from the ruptures and reduced the rupture
+    hierarchy
   * Removed the mesh spacing from PlanarSurfaces
   * Optimized the instantiation of the rtree index
   * Replaced the old prefiltering mechanism with the new one

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the source typology from the rupture classes
   * Removed the mesh spacing from PlanarSurfaces
   * Optimized the instantiation of the rtree index
   * Replaced the old prefiltering mechanism with the new one

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -509,11 +509,10 @@ class RuptureGetter(object):
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
             mesh = rec['points'].reshape(rec['sx'], rec['sy'], rec['sz'])
-            rup_cls, surf_cls, src_cls = code2cls[rec['code']]
+            rup_cls, surf_cls = code2cls[rec['code']]
             rupture = object.__new__(rup_cls)
             rupture.serial = serial
             rupture.surface = object.__new__(surf_cls)
-            rupture.source_typology = src_cls
             rupture.mag = rec['mag']
             rupture.rake = rec['rake']
             rupture.seed = rec['seed']

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -493,7 +493,7 @@ class RuptureGetter(object):
     def __iter__(self):
         self.dstore.open()  # if needed
         attrs = self.dstore.get_attrs('ruptures')
-        code2cls = {}  # code -> rup_cls, surf_cls, src_cls
+        code2cls = {}  # code -> rupture_cls, surface_cls
         for key, val in attrs.items():
             if key.startswith('code_'):
                 code2cls[int(key[5:])] = [classes[v] for v in val.split()]
@@ -509,10 +509,10 @@ class RuptureGetter(object):
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
             mesh = rec['points'].reshape(rec['sx'], rec['sy'], rec['sz'])
-            rup_cls, surf_cls = code2cls[rec['code']]
-            rupture = object.__new__(rup_cls)
+            rupture_cls, surface_cls = code2cls[rec['code']]
+            rupture = object.__new__(rupture_cls)
             rupture.serial = serial
-            rupture.surface = object.__new__(surf_cls)
+            rupture.surface = object.__new__(surface_cls)
             rupture.mag = rec['mag']
             rupture.rake = rec['rake']
             rupture.seed = rec['seed']
@@ -522,12 +522,12 @@ class RuptureGetter(object):
             pmfx = rec['pmfx']
             if pmfx != -1:
                 rupture.pmf = self.dstore['pmfs'][pmfx]
-            if surf_cls is geo.PlanarSurface:
+            if surface_cls is geo.PlanarSurface:
                 rupture.surface = geo.PlanarSurface.from_array(rec['points'])
-            elif surf_cls is geo.MultiSurface:
+            elif surface_cls is geo.MultiSurface:
                 rupture.surface.__init__([
                     geo.PlanarSurface.from_array(m1.flatten()) for m1 in mesh])
-            elif surf_cls is geo.GriddedSurface:
+            elif surface_cls is geo.GriddedSurface:
                 # fault surface, strike and dip will be computed
                 rupture.surface.strike = rupture.surface.dip = None
                 m = mesh[0]

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -46,7 +46,6 @@ from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.source.rupture import (
     ParametricProbabilisticRupture, EBRupture)
-from openquake.hazardlib.source.characteristic import CharacteristicFaultSource
 from openquake.hazardlib.source.point import PointSource
 from openquake.hazardlib.scalerel.wc1994 import WC1994
 from openquake.hazardlib.calc.filters import SourceFilter, FarAwayRupture
@@ -288,7 +287,7 @@ def generate_background_ruptures(tom, locations, occurrence, mag, npd,
                                depths[i][0])
         ruptures.append(ParametricProbabilisticRupture(
             mag, nodal_planes[i][1].rake, trt, hypocentre, surface,
-            PointSource, rupture_probability, tom))
+            rupture_probability, tom))
     return ruptures
 
 
@@ -535,7 +534,6 @@ class UCERFSource(object):
         :param src_filter:
             Sites for consideration and maximum distance
         """
-        mesh_spacing = self.mesh_spacing
         trt = self.tectonic_region_type
         ridx = self.get_ridx(iloc)
         mag = self.mags[iloc]
@@ -565,8 +563,7 @@ class UCERFSource(object):
         rupture = ParametricProbabilisticRupture(
             mag, self.rake[iloc], trt,
             surface_set[len(surface_set) // 2].get_middle_point(),
-            MultiSurface(surface_set), CharacteristicFaultSource,
-            self.rate[iloc], self.tom)
+            MultiSurface(surface_set), self.rate[iloc], self.tom)
 
         return rupture
 

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -126,8 +126,7 @@ class AreaSource(ParametricSeismicSource):
                 hypocenter.depth = hc_depth
                 rupture = ParametricProbabilisticRupture(
                     mag, rake, self.tectonic_region_type, hypocenter,
-                    surface, type(self), occ_rate,
-                    self.temporal_occurrence_model)
+                    surface, occ_rate, self.temporal_occurrence_model)
                 yield rupture
 
     def count_ruptures(self):

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -89,8 +89,7 @@ class CharacteristicFaultSource(ParametricSeismicSource):
         for mag, occurrence_rate in self.get_annual_occurrence_rates():
             yield ParametricProbabilisticRupture(
                 mag, self.rake, self.tectonic_region_type, hypocenter,
-                self.surface, type(self), occurrence_rate,
-                self.temporal_occurrence_model)
+                self.surface, occurrence_rate, self.temporal_occurrence_model)
 
     def count_ruptures(self):
         """

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -194,14 +194,12 @@ class ComplexFaultSource(ParametricSeismicSource):
         on the whole fault surface.
         """
         whole_fault_surface = ComplexFaultSurface.from_fault_data(
-            self.edges, self.rupture_mesh_spacing
-        )
+            self.edges, self.rupture_mesh_spacing)
         whole_fault_mesh = whole_fault_surface.mesh
         cell_center, cell_length, cell_width, cell_area = (
-            whole_fault_mesh.get_cell_dimensions()
-        )
+            whole_fault_mesh.get_cell_dimensions())
 
-        for (mag, mag_occ_rate) in self.get_annual_occurrence_rates():
+        for mag, mag_occ_rate in self.get_annual_occurrence_rates():
             rupture_area = self.magnitude_scaling_relationship.get_median_area(
                 mag, self.rake)
             rupture_length = numpy.sqrt(
@@ -214,7 +212,6 @@ class ComplexFaultSource(ParametricSeismicSource):
                 # XXX: use surface centroid as rupture's hypocenter
                 # XXX: instead of point with middle index
                 hypocenter = mesh.get_middle_point()
-
                 try:
                     surface = ComplexFaultSurface(mesh)
                 except ValueError as e:

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -222,8 +222,7 @@ class ComplexFaultSource(ParametricSeismicSource):
                         self.source_id, str(e)))
                 yield ParametricProbabilisticRupture(
                     mag, self.rake, self.tectonic_region_type, hypocenter,
-                    surface, type(self),
-                    occurrence_rate, self.temporal_occurrence_model)
+                    surface, occurrence_rate, self.temporal_occurrence_model)
 
     def count_ruptures(self):
         """

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -17,10 +17,8 @@
 Module :mod:`openquake.hazardlib.source.non_parametric` defines
 :class:`NonParametricSeismicSource`
 """
-import numpy
 from openquake.hazardlib.source.base import BaseSeismicSource
 from openquake.hazardlib.geo.surface.multi import MultiSurface
-from openquake.hazardlib.geo.mesh import RectangularMesh
 from openquake.hazardlib.source.rupture import \
     NonParametricProbabilisticRupture
 from openquake.hazardlib.geo.utils import angular_distance, KM_TO_DEGREES
@@ -50,8 +48,7 @@ class NonParametricSeismicSource(BaseSeismicSource):
     MODIFICATIONS = set()
 
     def __init__(self, source_id, name, tectonic_region_type, data):
-        super(NonParametricSeismicSource, self). \
-            __init__(source_id, name, tectonic_region_type)
+        super().__init__(source_id, name, tectonic_region_type)
         self.data = data
 
     def iter_ruptures(self):
@@ -66,7 +63,7 @@ class NonParametricSeismicSource(BaseSeismicSource):
         for rup, pmf in self.data:
             yield NonParametricProbabilisticRupture(
                 rup.mag, rup.rake, self.tectonic_region_type, rup.hypocenter,
-                rup.surface, rup.source_typology, pmf)
+                rup.surface, pmf)
 
     def __iter__(self):
         if len(self.data) == 1:  # there is nothing to split

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -210,8 +210,8 @@ class PointSource(ParametricSeismicSource):
                     surface = self._get_rupture_surface(mag, np, hypocenter)
                     yield ParametricProbabilisticRupture(
                         mag, np.rake, self.tectonic_region_type, hypocenter,
-                        surface, type(self),
-                        occurrence_rate, self.temporal_occurrence_model)
+                        surface, occurrence_rate,
+                        self.temporal_occurrence_model)
 
     def count_ruptures(self):
         """

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -32,10 +32,8 @@ from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib.geo.mesh import RectangularMesh
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo.geodetic import geodetic_distance
-from openquake.hazardlib.near_fault import (get_plane_equation, projection_pp,
-                                            directp, average_s_rad,
-                                            isochone_ratio)
-from openquake.hazardlib.source.base import BaseSeismicSource
+from openquake.hazardlib.near_fault import (
+    get_plane_equation, projection_pp, directp, average_s_rad, isochone_ratio)
 from openquake.hazardlib.geo.surface.base import BaseSurface
 
 pmf_dt = numpy.dtype([('prob', float), ('occ', numpy.uint32)])
@@ -61,10 +59,6 @@ class BaseRupture(with_metaclass(abc.ABCMeta)):
         An instance of subclass of
         :class:`~openquake.hazardlib.geo.surface.base.BaseSurface`.
         Object representing the rupture surface geometry.
-    :param source_typology:
-        Subclass of :class:`~openquake.hazardlib.source.base.BaseSeismicSource`
-        (class object, not an instance) referencing the typology
-        of the source that produced this rupture.
     :param rupture_slip_direction:
         Angle describing rupture propagation direction in decimal degrees.
 
@@ -75,7 +69,7 @@ class BaseRupture(with_metaclass(abc.ABCMeta)):
     attribute surface_nodes to an appropriate value.
     """
     _slots_ = '''mag rake tectonic_region_type hypocenter surface
-    source_typology rupture_slip_direction'''.split()
+    rupture_slip_direction'''.split()
     serial = 0  # set to a value > 0 by the engine
     _code = {}
     types = {}
@@ -89,22 +83,20 @@ class BaseRupture(with_metaclass(abc.ABCMeta)):
         source_class). This is useful when serializing the rupture to and
         from HDF5.
         """
-        source_classes = list(get_subclasses(BaseSeismicSource))
         rupture_classes = [BaseRupture] + list(get_subclasses(BaseRupture))
         surface_classes = list(get_subclasses(BaseSurface))
-        for cl in source_classes + rupture_classes + surface_classes:
+        for cl in rupture_classes + surface_classes:
             classes[cl.__name__] = cl
         n = 0
-        for src, rup, sur in itertools.product(
-                source_classes, rupture_classes, surface_classes):
-            cls._code[rup, sur, src] = n
-            cls.types[n] = rup, sur, src
+        for rup, sur in itertools.product(rupture_classes, surface_classes):
+            cls._code[rup, sur] = n
+            cls.types[n] = rup, sur
             n += 1
         if n >= 256:
             raise ValueError('Too many rupture codes: %d' % n)
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter,
-                 surface, source_typology, rupture_slip_direction=None):
+                 surface, rupture_slip_direction=None):
         if not mag > 0:
             raise ValueError('magnitude must be positive')
         NodalPlane.check_rake(rake)
@@ -113,14 +105,12 @@ class BaseRupture(with_metaclass(abc.ABCMeta)):
         self.mag = mag
         self.hypocenter = hypocenter
         self.surface = surface
-        self.source_typology = source_typology
         self.rupture_slip_direction = rupture_slip_direction
 
     @property
     def code(self):
         """Returns the code (integer in the range 0 .. 255) of the rupture"""
-        return self._code[self.__class__, self.surface.__class__,
-                          self.source_typology]
+        return self._code[self.__class__, self.surface.__class__]
 
     def get_probability_no_exceedance(self, poes):
         """
@@ -182,7 +172,7 @@ class NonParametricProbabilisticRupture(BaseRupture):
         in increasing order, and if they are not defined with unit step
     """
     def __init__(self, mag, rake, tectonic_region_type, hypocenter, surface,
-                 source_typology, pmf, rupture_slip_direction=None):
+                 pmf, rupture_slip_direction=None):
         occ = numpy.array([occ for (prob, occ) in pmf.data])
         if not occ[0] == 0:
             raise ValueError('minimum number of ruptures must be zero')
@@ -194,7 +184,7 @@ class NonParametricProbabilisticRupture(BaseRupture):
                 'numbers of ruptures must be defined with unit step')
         super().__init__(
             mag, rake, tectonic_region_type, hypocenter, surface,
-            source_typology, rupture_slip_direction)
+            rupture_slip_direction)
         # an array of probabilities with sum 1
         self.pmf = numpy.array(
             [prob for (prob, occ) in pmf.data], numpy.float32)
@@ -265,13 +255,13 @@ class ParametricProbabilisticRupture(BaseRupture):
         'occurrence_rate', 'temporal_occurrence_model']
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter, surface,
-                 source_typology, occurrence_rate, temporal_occurrence_model,
+                 occurrence_rate, temporal_occurrence_model,
                  rupture_slip_direction=None):
         if not occurrence_rate > 0:
             raise ValueError('occurrence rate must be positive')
         super().__init__(
             mag, rake, tectonic_region_type, hypocenter, surface,
-            source_typology, rupture_slip_direction)
+            rupture_slip_direction)
         self.temporal_occurrence_model = temporal_occurrence_model
         self.occurrence_rate = occurrence_rate
 

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -172,8 +172,7 @@ class SimpleFaultSource(ParametricSeismicSource):
 
                         yield ParametricProbabilisticRupture(
                             mag, self.rake, self.tectonic_region_type,
-                            hypocenter, surface, type(self),
-                            occurrence_rate_hypo,
+                            hypocenter, surface, occurrence_rate_hypo,
                             self.temporal_occurrence_model)
                     else:
                         for hypo in self.hypo_list:

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -143,14 +143,13 @@ class SimpleFaultSource(ParametricSeismicSource):
         """
         whole_fault_surface = SimpleFaultSurface.from_fault_data(
             self.fault_trace, self.upper_seismogenic_depth,
-            self.lower_seismogenic_depth, self.dip, self.rupture_mesh_spacing
-        )
+            self.lower_seismogenic_depth, self.dip, self.rupture_mesh_spacing)
         whole_fault_mesh = whole_fault_surface.mesh
         mesh_rows, mesh_cols = whole_fault_mesh.shape
         fault_length = float((mesh_cols - 1) * self.rupture_mesh_spacing)
         fault_width = float((mesh_rows - 1) * self.rupture_mesh_spacing)
 
-        for (mag, mag_occ_rate) in self.get_annual_occurrence_rates():
+        for mag, mag_occ_rate in self.get_annual_occurrence_rates():
             rup_cols, rup_rows = self._get_rupture_dimensions(
                 fault_length, fault_width, mag)
             num_rup_along_length = mesh_cols - rup_cols + 1
@@ -186,8 +185,7 @@ class SimpleFaultSource(ParametricSeismicSource):
 
                                 yield ParametricProbabilisticRupture(
                                     mag, self.rake, self.tectonic_region_type,
-                                    hypocenter, surface, type(self),
-                                    occurrence_rate_hypo,
+                                    hypocenter, surface, occurrence_rate_hypo,
                                     self.temporal_occurrence_model,
                                     rupture_slip_direction)
 

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -366,8 +366,7 @@ class RuptureConverter(object):
         rupt = source.rupture.BaseRupture(
             mag=mag, rake=rake, tectonic_region_type=None,
             hypocenter=hypocenter,
-            surface=self.convert_surfaces(surfaces),
-            source_typology=source.SimpleFaultSource)
+            surface=self.convert_surfaces(surfaces))
         return rupt
 
     def convert_complexFaultRupture(self, node):
@@ -382,8 +381,7 @@ class RuptureConverter(object):
         rupt = source.rupture.BaseRupture(
             mag=mag, rake=rake, tectonic_region_type=None,
             hypocenter=hypocenter,
-            surface=self.convert_surfaces(surfaces),
-            source_typology=source.ComplexFaultSource)
+            surface=self.convert_surfaces(surfaces))
         return rupt
 
     def convert_singlePlaneRupture(self, node):
@@ -399,8 +397,7 @@ class RuptureConverter(object):
             mag=mag, rake=rake,
             tectonic_region_type=None,
             hypocenter=hypocenter,
-            surface=self.convert_surfaces(surfaces),
-            source_typology=source.NonParametricSeismicSource)
+            surface=self.convert_surfaces(surfaces))
         return rupt
 
     def convert_multiPlanesRupture(self, node):
@@ -416,8 +413,7 @@ class RuptureConverter(object):
             mag=mag, rake=rake,
             tectonic_region_type=None,
             hypocenter=hypocenter,
-            surface=self.convert_surfaces(surfaces),
-            source_typology=source.NonParametricSeismicSource)
+            surface=self.convert_surfaces(surfaces))
         return rupt
 
     def convert_griddedRupture(self, node):
@@ -433,8 +429,7 @@ class RuptureConverter(object):
             mag=mag, rake=rake,
             tectonic_region_type=None,
             hypocenter=hypocenter,
-            surface=self.convert_surfaces(surfaces),
-            source_typology=source.NonParametricSeismicSource)
+            surface=self.convert_surfaces(surfaces))
         return rupt
 
     def convert_ruptureCollection(self, node):

--- a/openquake/hazardlib/tests/acceptance/_peer_test_data.py
+++ b/openquake/hazardlib/tests/acceptance/_peer_test_data.py
@@ -346,7 +346,6 @@ SET1_CASE2_SOURCE_DATA = {
     'mag': 6.,
     'rake': 0.,
     'tectonic_region_type': 'Active Shallow Crust',
-    'source_typology': SimpleFaultSource,
     'pmf': PMF([(0.9997772, 0), (0.0002228, 1)]),
     'lons': numpy.zeros((8, 15)) - 122.,
     'lats': [

--- a/openquake/hazardlib/tests/acceptance/peer_test.py
+++ b/openquake/hazardlib/tests/acceptance/peer_test.py
@@ -230,8 +230,7 @@ class Set1TestCase(unittest.TestCase):
                     data['hypo_depths'][i, j]
                 )
                 rup = BaseRupture(data['mag'], data['rake'],
-                                  data['tectonic_region_type'], hypo, surf,
-                                  data['source_typology'])
+                                  data['tectonic_region_type'], hypo, surf)
                 ruptures.append((rup, data['pmf']))
         npss = NonParametricSeismicSource(
             'id', 'name', data['tectonic_region_type'], ruptures

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -286,9 +286,7 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
         self.rupture = BaseRupture(
             mag=123.45, rake=123.56,
             tectonic_region_type=const.TRT.VOLCANIC,
-            hypocenter=self.rupture_hypocenter, surface=FakeSurface(),
-            source_typology=object()
-        )
+            hypocenter=self.rupture_hypocenter, surface=FakeSurface())
         self.gsim_class.DEFINED_FOR_TECTONIC_REGION_TYPE = const.TRT.VOLCANIC
         self.fake_surface = FakeSurface
 

--- a/openquake/hazardlib/tests/gsim/chiou_youngs_2014_test.py
+++ b/openquake/hazardlib/tests/gsim/chiou_youngs_2014_test.py
@@ -139,7 +139,6 @@ class ChiouYoungs2014NearFaultDistanceTaperTestCase(BaseGSIMTestCase):
             'surface': SimpleFaultSurface.from_fault_data(
                 fault_trace, upper_seismogenic_depth, lower_seismogenic_depth,
                 dip=dip, mesh_spacing=mesh_spacing),
-            'source_typology': object(),
             'rupture_slip_direction': 0.,
             'occurrence_rate': 0.01,
             'temporal_occurrence_model': PoissonTOM(50)

--- a/openquake/hazardlib/tests/source/area_test.py
+++ b/openquake/hazardlib/tests/source/area_test.py
@@ -83,7 +83,6 @@ class AreaSourceIterRupturesTestCase(unittest.TestCase):
                                            lat, delta=1e-3)
                     self.assertAlmostEqual(rupture.hypocenter.depth,
                                            depths[iloc], delta=1e-3)
-                    self.assertIs(rupture.source_typology, AreaSource)
                 self.assertEqual(r1.mag, 5.5)
                 self.assertEqual(r2.mag, 5.5)
                 self.assertEqual(r3.mag, 6.5)

--- a/openquake/hazardlib/tests/source/characteristic_test.py
+++ b/openquake/hazardlib/tests/source/characteristic_test.py
@@ -74,9 +74,6 @@ class CharacteristicFaultSourceIterRuptures(_BaseFaultSourceTestCase):
             self.assertTrue(ruptures[i].hypocenter == Point(0., 0., 5.))
             self.assertTrue(ruptures[i].surface.strike == self.STRIKE)
             self.assertTrue(ruptures[i].surface.dip == self.DIP)
-            self.assertTrue(
-                ruptures[i].source_typology == CharacteristicFaultSource
-            )
             numpy.testing.assert_equal(ruptures[i].surface.corner_lons,
                                        self.CORNER_LONS)
             numpy.testing.assert_equal(ruptures[i].surface.corner_lats,

--- a/openquake/hazardlib/tests/source/non_parametric_test.py
+++ b/openquake/hazardlib/tests/source/non_parametric_test.py
@@ -40,12 +40,10 @@ def make_non_parametric_source():
     )
     rup1 = BaseRupture(
         mag=5., rake=90., tectonic_region_type='ASC',
-        hypocenter=Point(0., 0., 5.), surface=surf1, source_typology=None
-    )
+        hypocenter=Point(0., 0., 5.), surface=surf1)
     rup2 = BaseRupture(
         mag=6, rake=0, tectonic_region_type='ASC',
-        hypocenter=Point(0., 0., 5.), surface=surf2, source_typology=None
-    )
+        hypocenter=Point(0., 0., 5.), surface=surf2)
     pmf1 = PMF([(0.7, 0), (0.3, 1)])
     pmf2 = PMF([(0.7, 0), (0.2, 1), (0.1, 2)])
     kwargs = {
@@ -86,9 +84,7 @@ class NonParametricSourceTestCase(unittest.TestCase):
             self.assertEqual(rup.surface.top_left, exp_rup.surface.top_left)
             self.assertEqual(rup.surface.top_right, exp_rup.surface.top_right)
             self.assertEqual(
-                rup.surface.bottom_right, exp_rup.surface.bottom_right
-            )
-            self.assertEqual(rup.source_typology, exp_rup.source_typology)
+                rup.surface.bottom_right, exp_rup.surface.bottom_right)
             numpy.testing.assert_allclose(
                 rup.pmf, [prob for prob, occ in exp_pmf.data])
 

--- a/openquake/hazardlib/tests/source/rupture_test.py
+++ b/openquake/hazardlib/tests/source/rupture_test.py
@@ -38,7 +38,6 @@ def make_rupture(rupture_class, **kwargs):
         'hypocenter': Point(5, 6, 7),
         'surface': PlanarSurface(11, 12, Point(0, 0, 1), Point(1, 0, 1),
                                  Point(1, 0, 2), Point(0, 0, 2)),
-        'source_typology': object()
     }
     default_arguments.update(kwargs)
     kwargs = default_arguments
@@ -151,7 +150,6 @@ class Cdppvalue(unittest.TestCase):
             'surface': SimpleFaultSurface.from_fault_data(
                 fault_trace, upper_seismogenic_depth, lower_seismogenic_depth,
                 dip=dip, mesh_spacing=mesh_spacing),
-            'source_typology': object(),
             'rupture_slip_direction': 0.
         }
         default_arguments.update(kwargs)


### PR DESCRIPTION
It is not used. ~50 lines have been removed.