### PR TITLE
Changed the signature of `stochastic_event_set`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Undeprecated `hazardlib.calc.stochastic.stochastic_event_set` and
+    made its signature right
   * Removed the source typology from the ruptures and reduced the rupture
     hierarchy
   * Removed the mesh spacing from PlanarSurfaces

--- a/openquake/hazardlib/calc/__init__.py
+++ b/openquake/hazardlib/calc/__init__.py
@@ -21,7 +21,6 @@ Package :mod:`openquake.hazardlib.calc` contains hazard calculator modules
 and utilities for them, such as :mod:`~openquake.hazardlib.calc.filters`.
 """
 from openquake.hazardlib.calc.gmf import ground_motion_fields
-from openquake.hazardlib.calc.stochastic import stochastic_event_set
 # from disagg we want to import main calc function
 # as well as all the pmf extractors
 from openquake.hazardlib.calc.disagg import *

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -27,6 +27,7 @@ import collections
 import numpy
 from openquake.baselib.general import AccumDict
 from openquake.baselib.performance import Monitor
+from openquake.baselib.python3compat import raise_
 from openquake.hazardlib.calc.filters import FarAwayRupture
 from openquake.hazardlib.source.rupture import EBRupture
 from openquake.hazardlib.gsim.base import ContextMaker
@@ -41,33 +42,63 @@ event_dt = numpy.dtype([('eid', U64), ('grp_id', U16), ('ses', U32),
                         ('sample', U32)])
 
 
-def stochastic_event_sets(sources, ss_filter, seed=42,
-                          ses_per_logic_tree_path=1):
+# this is used in acceptance/stochastic_test.py, not in the engine
+def stochastic_event_set(
+        sources,
+        sites=None,
+        source_site_filter=filters.source_site_noop_filter):
     """
-    Generates 'Stochastic Event Sets' (that is a collection of earthquake
-    ruptures) representing possible realizations of the seismicity as
+    Generates a 'Stochastic Event Set' (that is a collection of earthquake
+    ruptures) representing a possible *realization* of the seismicity as
     described by a source model.
 
     The calculator loops over sources. For each source, it loops over ruptures.
     For each rupture, the number of occurrence is randomly sampled by
-    calling :meth:`openquake.hazardlib.source.rupture.BaseProbabilisticRupture.sample_number_of_occurrences`
+    calling
+    :meth:`openquake.hazardlib.source.rupture.BaseProbabilisticRupture.sample_number_of_occurrences`
+
+    .. note::
+        This calculator is using random numbers. In order to reproduce the
+        same results numpy random numbers generator needs to be seeded, see
+        http://docs.scipy.org/doc/numpy/reference/generated/numpy.random.seed.html
 
     :param sources:
         An iterator of seismic sources objects (instances of subclasses
         of :class:`~openquake.hazardlib.source.base.BaseSeismicSource`).
-    :param ss_filter:
-        A source sites filter or a site collection
-    :param seed:
-        The seed to use in the random number generator
-    :param ses_per_logic_tree_path:
-        The number of stochastic event sets to generate (default 1)
+    :param sites:
+        A list of sites to consider (or None)
+    :param source_site_filter:
+        The source filter to use (only meaningful is sites is not None)
+    :param source_site_filter:
+        The rupture filter to use (only meaningful is sites is not None)
     :returns:
-        A list of EBRuptures
+        Generator of :class:`~openquake.hazardlib.source.rupture.Rupture`
+        objects that are contained in an event set. Some ruptures can be
+        missing from it, others can appear one or more times in a row.
     """
-    if not hasattr(ss_filter, 'sitecol'):  # assume a sitecol was passed
-        ss_filter = filters.SourceFilter(ss_filter, {})
-    param = dict(seed=seed, ses_per_logic_tree_path=ses_per_logic_tree_path)
-    return sample_ruptures(sources, ss_filter, [], param)['eb_ruptures']
+    if sites is None:  # no filtering
+        for source in sources:
+            try:
+                for rupture in source.iter_ruptures():
+                    for i in range(rupture.sample_number_of_occurrences()):
+                        yield rupture
+            except Exception as err:
+                etype, err, tb = sys.exc_info()
+                msg = 'An error occurred with source id=%s. Error: %s'
+                msg %= (source.source_id, str(err))
+                raise_(etype, msg, tb)
+        return
+    # else apply filtering
+    for source, s_sites in source_site_filter(sources, sites):
+        try:
+            for rupture in source.iter_ruptures():
+                for i in range(rupture.sample_number_of_occurrences()):
+                    yield rupture
+        except Exception as err:
+            etype, err, tb = sys.exc_info()
+            msg = 'An error occurred with source id=%s. Error: %s'
+            msg %= (source.source_id, str(err))
+            raise_(etype, msg, tb)
 
 
 # ######################## rupture calculator ############################ #
@@ -98,10 +129,9 @@ def sample_ruptures(group, src_filter, gsims, param, monitor=Monitor()):
     :param src_filter:
         a source site filter
     :param gsims:
-        a list of GSIMs for the current tectonic region model (possibly empty)
+        a list of GSIMs for the current tectonic region model
     :param param:
-        a dictionary of additional parameters, including seed and
-        ses_per_logic_tree_path
+        a dictionary of additional parameters
     :param monitor:
         monitor instance
     :returns:

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -44,9 +44,7 @@ event_dt = numpy.dtype([('eid', U64), ('grp_id', U16), ('ses', U32),
 
 # this is used in acceptance/stochastic_test.py, not in the engine
 def stochastic_event_set(
-        sources,
-        sites=None,
-        source_site_filter=filters.source_site_noop_filter):
+        sources, source_site_filter=filters.source_site_noop_filter):
     """
     Generates a 'Stochastic Event Set' (that is a collection of earthquake
     ruptures) representing a possible *realization* of the seismicity as
@@ -65,31 +63,14 @@ def stochastic_event_set(
     :param sources:
         An iterator of seismic sources objects (instances of subclasses
         of :class:`~openquake.hazardlib.source.base.BaseSeismicSource`).
-    :param sites:
-        A list of sites to consider (or None)
     :param source_site_filter:
-        The source filter to use (only meaningful is sites is not None)
-    :param source_site_filter:
-        The rupture filter to use (only meaningful is sites is not None)
+        The source filter to use (default noop filter)
     :returns:
         Generator of :class:`~openquake.hazardlib.source.rupture.Rupture`
         objects that are contained in an event set. Some ruptures can be
         missing from it, others can appear one or more times in a row.
     """
-    if sites is None:  # no filtering
-        for source in sources:
-            try:
-                for rupture in source.iter_ruptures():
-                    for i in range(rupture.sample_number_of_occurrences()):
-                        yield rupture
-            except Exception as err:
-                etype, err, tb = sys.exc_info()
-                msg = 'An error occurred with source id=%s. Error: %s'
-                msg %= (source.source_id, str(err))
-                raise_(etype, msg, tb)
-        return
-    # else apply filtering
-    for source, s_sites in source_site_filter(sources, sites):
+    for source, s_sites in source_site_filter(sources):
         try:
             for rupture in source.iter_ruptures():
                 for i in range(rupture.sample_number_of_occurrences()):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -28,7 +28,6 @@ import sys
 import math
 import warnings
 import functools
-import contextlib
 from scipy.special import ndtr
 import numpy
 
@@ -63,9 +62,8 @@ def gsim_imt_dt(sorted_gsims, sorted_imts):
 
 class MetaGSIM(abc.ABCMeta):
     """
-    Metaclass controlling the instantiation mechanism.  A subclass with
-    instantiable=False will raise a NonInstantiableError when directly
-    instantiated. A GroundShakingIntensityModel subclass with an
+    Metaclass controlling the instantiation mechanism.
+    A GroundShakingIntensityModel subclass with an
     attribute deprecated=True will print a deprecation warning when
     instantiated. A subclass with an attribute non_verified=True will
     print a UserWarning.

--- a/openquake/hazardlib/tests/acceptance/stochastic_test.py
+++ b/openquake/hazardlib/tests/acceptance/stochastic_test.py
@@ -57,8 +57,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
             polygon=Point(0., 0.).to_polygon(100.),
             area_discretization=9.0,
             rupture_mesh_spacing=1.0,
-            temporal_occurrence_model=PoissonTOM(self.time_span)
-        )
+            temporal_occurrence_model=PoissonTOM(self.time_span))
 
         # area source of circular shape with radius of 100 km
         # centered at 1., 1.
@@ -76,8 +75,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
             polygon=Point(5., 5.).to_polygon(100.),
             area_discretization=9.0,
             rupture_mesh_spacing=1.0,
-            temporal_occurrence_model=PoissonTOM(self.time_span)
-        )
+            temporal_occurrence_model=PoissonTOM(self.time_span))
 
         # non-parametric source
         self.np_src, _ = make_non_parametric_source()
@@ -86,14 +84,8 @@ class StochasticEventSetTestCase(unittest.TestCase):
         """
         Extract annual rates of occurence from stochastic event set
         """
-        mags = []
-        for r in ses:
-            mags.append(r.mag)
-
-        rates, _ = numpy.histogram(mags, bins=bins)
-        rates = rates / time_span
-
-        return rates
+        rates, _ = numpy.histogram([r.mag for r in ses], bins=bins)
+        return rates / time_span
 
     def test_ses_generation_from_parametric_source(self):
         # generate stochastic event set (SES) from area source with given
@@ -103,14 +95,10 @@ class StochasticEventSetTestCase(unittest.TestCase):
         # approximately equal to the original MFD.
         numpy.random.seed(123)
         ses = stochastic_event_set([self.area1])
-
         rates = self._extract_rates(ses, time_span=self.time_span,
                                     bins=numpy.arange(5., 6.6, 0.1))
-
         expect_rates = numpy.array(
-            [r for m, r in self.mfd.get_annual_occurrence_rates()]
-        )
-
+            [r for m, r in self.mfd.get_annual_occurrence_rates()])
         numpy.testing.assert_allclose(rates, expect_rates, rtol=0, atol=1e-4)
 
     def test_ses_generation_from_parametric_source_with_filtering(self):
@@ -123,23 +111,17 @@ class StochasticEventSetTestCase(unittest.TestCase):
         # to the one of area1 only.
         numpy.random.seed(123)
         sites = SiteCollection([
-            Site(
-                location=Point(0., 0.), vs30=760, vs30measured=True,
-                z1pt0=40., z2pt5=2.
-            )
-        ])
+            Site(location=Point(0., 0.), vs30=760, vs30measured=True,
+                 z1pt0=40., z2pt5=2.)])
         ses = stochastic_event_set(
             [self.area1, self.area2],
-            sites=sites,
-            source_site_filter=filters.SourceFilter(sites, {'default': 100.})
-        )
+            filters.SourceFilter(sites, {'default': 100.}))
 
         rates = self._extract_rates(ses, time_span=self.time_span,
                                     bins=numpy.arange(5., 6.6, 0.1))
 
         expect_rates = numpy.array(
-            [r for m, r in self.mfd.get_annual_occurrence_rates()]
-        )
+            [r for m, r in self.mfd.get_annual_occurrence_rates()])
 
         numpy.testing.assert_allclose(rates, expect_rates, rtol=0, atol=1e-4)
 

--- a/openquake/hazardlib/tests/acceptance/stochastic_test.py
+++ b/openquake/hazardlib/tests/acceptance/stochastic_test.py
@@ -23,7 +23,7 @@ from openquake.hazardlib.scalerel import WC1994
 from openquake.hazardlib.geo import Point, NodalPlane
 from openquake.hazardlib.mfd import TruncatedGRMFD
 from openquake.hazardlib.tom import PoissonTOM
-from openquake.hazardlib.calc.stochastic import stochastic_event_set
+from openquake.hazardlib.calc.stochastic import stochastic_event_sets
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.site import Site, SiteCollection
 
@@ -57,8 +57,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
             polygon=Point(0., 0.).to_polygon(100.),
             area_discretization=9.0,
             rupture_mesh_spacing=1.0,
-            temporal_occurrence_model=PoissonTOM(self.time_span)
-        )
+            temporal_occurrence_model=PoissonTOM(self.time_span))
 
         # area source of circular shape with radius of 100 km
         # centered at 1., 1.
@@ -76,8 +75,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
             polygon=Point(5., 5.).to_polygon(100.),
             area_discretization=9.0,
             rupture_mesh_spacing=1.0,
-            temporal_occurrence_model=PoissonTOM(self.time_span)
-        )
+            temporal_occurrence_model=PoissonTOM(self.time_span))
 
         # non-parametric source
         self.np_src, _ = make_non_parametric_source()
@@ -89,7 +87,6 @@ class StochasticEventSetTestCase(unittest.TestCase):
         mags = []
         for r in ses:
             mags.append(r.mag)
-
         rates, _ = numpy.histogram(mags, bins=bins)
         rates = rates / time_span
 
@@ -122,24 +119,18 @@ class StochasticEventSetTestCase(unittest.TestCase):
         # excluded. the MFD from the SES will be therefore approximately equal
         # to the one of area1 only.
         numpy.random.seed(123)
-        sites = SiteCollection([
-            Site(
-                location=Point(0., 0.), vs30=760, vs30measured=True,
-                z1pt0=40., z2pt5=2.
-            )
-        ])
-        ses = stochastic_event_set(
+        site = Site(location=Point(0., 0.), vs30=760, vs30measured=True,
+                    z1pt0=40., z2pt5=2.)
+        sites = SiteCollection([site])
+        ses = stochastic_event_sets(
             [self.area1, self.area2],
-            sites=sites,
-            source_site_filter=filters.SourceFilter(sites, {'default': 100.})
-        )
+            filters.SourceFilter(sites, {'default': 100.}))
 
         rates = self._extract_rates(ses, time_span=self.time_span,
                                     bins=numpy.arange(5., 6.6, 0.1))
 
         expect_rates = numpy.array(
-            [r for m, r in self.mfd.get_annual_occurrence_rates()]
-        )
+            [r for m, r in self.mfd.get_annual_occurrence_rates()])
 
         numpy.testing.assert_allclose(rates, expect_rates, rtol=0, atol=1e-4)
 
@@ -155,7 +146,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         # compared with the expected value
         numpy.random.seed(123)
         num_sess = 10000
-        sess = [stochastic_event_set([self.np_src]) for i in range(num_sess)]
+        sess = [stochastic_event_sets([self.np_src]) for i in range(num_sess)]
 
         # loop over ses. For each ses count number of rupture
         # occurrences (for each magnitude)
@@ -173,8 +164,8 @@ class StochasticEventSetTestCase(unittest.TestCase):
         # count how many SESs have 0,1 or 2 occurrences, and then normalize
         # by the total number of SESs generated. This gives the probability
         # of having 0, 1 or 2 occurrences
-        n_occs1 = numpy.array(list(n_rups1.values()))
-        n_occs2 = numpy.array(list(n_rups2.values()))
+        n_occs1 = numpy.fromiter(n_rups1.values())
+        n_occs2 = numpy.fromiter(n_rups2.values())
 
         p_occs1_0 = float(len(n_occs1[n_occs1 == 0])) / num_sess
         p_occs1_1 = float(len(n_occs1[n_occs1 == 1])) / num_sess

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -19,7 +19,7 @@ import numpy
 from openquake.hazardlib import nrml, geo
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.calc.stochastic import (
-    stochastic_event_sets, sample_ruptures)
+    stochastic_event_set, sample_ruptures)
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.gsim.si_midorikawa_1999 import SiMidorikawa1999SInter
 
@@ -61,5 +61,5 @@ class StochasticEventSetTestCase(unittest.TestCase):
         ebr.export(mesh)
 
         # test no filtering
-        ruptures = stochastic_event_sets(group, s_filter)
-        self.assertEqual(len(ruptures), 2)
+        ruptures = list(stochastic_event_set(group))
+        self.assertEqual(len(ruptures), 19)

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -19,7 +19,7 @@ import numpy
 from openquake.hazardlib import nrml, geo
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.calc.stochastic import (
-    stochastic_event_set, sample_ruptures)
+    stochastic_event_sets, sample_ruptures)
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.gsim.si_midorikawa_1999 import SiMidorikawa1999SInter
 
@@ -27,75 +27,6 @@ aae = numpy.testing.assert_almost_equal
 
 
 class StochasticEventSetTestCase(unittest.TestCase):
-    class FakeRupture(object):
-        def __init__(self, occurrences):
-            self.occurrences = occurrences
-
-        def sample_number_of_occurrences(self):
-            return self.occurrences
-
-    class FakeSource(object):
-        def __init__(self, source_id, ruptures):
-            self.source_id = source_id
-            self.ruptures = ruptures
-
-        def iter_ruptures(self):
-            return iter(self.ruptures)
-
-    class FailSource(FakeSource):
-        def iter_ruptures(self):
-            raise ValueError('Something bad happened')
-
-    def setUp(self):
-        self.time_span = 15
-        self.r1_1 = self.FakeRupture(1)
-        self.r1_0 = self.FakeRupture(0)
-        self.r1_2 = self.FakeRupture(2)
-        self.r2_1 = self.FakeRupture(1)
-        self.source1 = self.FakeSource(
-            1, [self.r1_1, self.r1_0, self.r1_2])
-        self.source2 = self.FakeSource(
-            2, [self.r2_1])
-
-    def test_no_filter(self):
-        ses = list(
-            stochastic_event_set(
-                [self.source1, self.source2]
-            ))
-        self.assertEqual(ses, [self.r1_1, self.r1_2, self.r1_2, self.r2_1])
-
-    def test(self):
-        ses = list(stochastic_event_set(
-            [self.source1, self.source2]))
-        self.assertEqual(ses, [self.r1_1, self.r1_2, self.r1_2, self.r2_1])
-
-    def test_source_errors(self):
-        # exercise the case where an error occurs while computing on a given
-        # seismic source; in this case, we expect an error to be raised which
-        # signals the id of the source in question
-        fail_source = self.FailSource(2, [self.r2_1])
-        with self.assertRaises(ValueError) as ae:
-            list(stochastic_event_set([self.source1, fail_source]))
-
-        expected_error = (
-            'An error occurred with source id=2. Error: Something bad happened'
-        )
-        self.assertEqual(expected_error, str(ae.exception))
-
-    def test_source_errors_with_sites(self):
-        # exercise the case where an error occurs while computing on a given
-        # seismic source; in this case, we expect an error to be raised which
-        # signals the id of the source in question
-        fail_source = self.FailSource(2, [self.r2_1])
-        fake_sites = SiteCollection.from_points([0], [0])
-        with self.assertRaises(ValueError) as ae:
-            list(stochastic_event_set([self.source1, fail_source],
-                                      sites=fake_sites))
-
-        expected_error = (
-            'An error occurred with source id=2. Error: Something bad happened'
-        )
-        self.assertEqual(expected_error, str(ae.exception))
 
     def test_nankai(self):
         # source model for the Nankai region provided by M. Pagani
@@ -128,3 +59,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         mesh = numpy.array([lonlat], [('lon', float), ('lat', float)])
         ebr = dic['eb_ruptures'][0]
         ebr.export(mesh)
+
+        # test no filtering
+        ruptures = stochastic_event_sets(group, s_filter)
+        self.assertEqual(len(ruptures), 2)

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -473,15 +473,6 @@ class GsimInstantiationTestCase(unittest.TestCase):
             warning_msg, 'MyGMPE is not independently verified - '
             'the user is liable for their application')
 
-    def test_non_instantiable(self):
-        # check that a NonInstantiableError is raised when a non-instantiable
-        # GSIM is instantiated
-        class MyGMPE(TGMPE):
-            pass
-        with self.assertRaises(NonInstantiableError):
-            with TGMPE.forbid_instantiation():
-                MyGMPE()
-
 
 class GsimOrderingTestCase(unittest.TestCase):
     def test_ordering_and_equality(self):

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -26,7 +26,7 @@ from copy import deepcopy
 from openquake.hazardlib import const
 from openquake.hazardlib.gsim.base import (
     GMPE, IPE, CoeffsTable, SitesContext, RuptureContext, DistancesContext,
-    NonInstantiableError, NotVerifiedWarning, DeprecationWarning)
+    NotVerifiedWarning, DeprecationWarning)
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.imt import PGA, PGV, SA


### PR DESCRIPTION
It was somewhat inconsistent. This is marked internal, since that function is not used by the engine or the SMTK, but only in a test. I am undeprecating the function because it is useful for analysis of the rupture distribution.

PS: while at it, I have removed the `forbid_instantiation` feature, which is not so important now.
