### PR TITLE
Turned rtree into an optional dependence again

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made rtree optional again and disabled it in macOS
   * Optimized the SiteCollection class and doubled the speed of distance
     calculations in most continental scale calculations
   * Fixed an ordering bug in event based risk from GMFs when using a

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -15,8 +15,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-
-from __future__ import division
 import math
 import time
 import logging
@@ -29,7 +27,6 @@ from openquake.baselib.general import AccumDict, block_splitter, groupby
 from openquake.hazardlib.calc.hazard_curve import classical, ProbabilityMap
 from openquake.hazardlib.stats import compute_pmap_stats
 from openquake.hazardlib import source
-from openquake.hazardlib.calc.filters import SourceFilter, RtreeFilter
 from openquake.calculators import getters
 from openquake.calculators import base
 
@@ -163,15 +160,7 @@ class PSHACalculator(base.HazardCalculator):
         totweight = 0
         num_tasks = 0
         num_sources = 0
-        src_filter = SourceFilter(self.sitecol.complete, oq.maximum_distance)
-        monitor = self.monitor('prefiltering')
-        if oq.prefilter_sources == 'rtree':
-            prefilter = RtreeFilter(self.sitecol.complete, oq.maximum_distance)
-            csm = self.csm.filter(prefilter, monitor)
-        elif oq.prefilter_sources == 'numpy':
-            csm = self.csm.filter(src_filter, monitor)
-        else:
-            csm = self.csm
+        csm, src_filter = self.filter_csm()
         maxweight = csm.get_maxweight(weight, oq.concurrent_tasks, minweight)
         if maxweight == minweight:
             logging.info('Using minweight=%d', minweight)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -358,6 +358,8 @@ class RtreeFilter(SourceFilter):
         Integration distance dictionary (TRT -> distance in km)
     """
     def __init__(self, sitecol, integration_distance):
+        if rtree is None:
+            raise ImportError('rtree')
         self.integration_distance = integration_distance
         self.distribute = 'processpool'
         self.indexpath = gettemp()

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -21,8 +21,11 @@ import operator
 import collections
 from contextlib import contextmanager
 import numpy
+try:
+    import rtree
+except ImportError:
+    rtree = None
 from scipy.interpolate import interp1d
-import rtree
 from openquake.baselib.parallel import Starmap
 from openquake.baselib.general import gettemp, groupby
 from openquake.baselib.python3compat import raise_

--- a/openquake/hazardlib/tests/geo/utils_test.py
+++ b/openquake/hazardlib/tests/geo/utils_test.py
@@ -17,7 +17,10 @@ import unittest
 import collections
 
 import numpy
-import rtree
+try:
+    import rtree
+except ImportError:
+    rtree = None
 import shapely.geometry
 
 from openquake.hazardlib import geo
@@ -374,7 +377,10 @@ class WithinTestCase(unittest.TestCase):
     """
     Test geo.utils.within(bbox, lonlat_index)
     """
-    def setUp(self):
+
+    def test(self):
+        if rtree is None:  # not installed
+            raise unittest.SkipTest
         self.lons = [
             -179.75, -179.5, -179.25, -179.0, -178.75, -178.5, -178.25, -178.0,
             -177.75, -177.5, -177.25, -177.0, -176.75, -176.5, -176.25, -176.0,
@@ -385,7 +391,6 @@ class WithinTestCase(unittest.TestCase):
             (i, (x, y, x, y), None)
             for i, (x, y) in enumerate(zip(self.lons, self.lats)))
 
-    def test(self):
         all_sites = numpy.arange(27, dtype=numpy.uint32)
         expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 19, 20, 21, 22, 23,
                     24, 25, 26]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ install_requires = [
     'scipy >=1.0.1, <1.1',
     'pyzmq <18.0',
     'psutil >=1.2, <5.5',
-    'rtree ==0.8.3',
     'shapely >=1.3, <1.7',
     'docutils >=0.11, <0.15',
     'decorator >=3.4',
@@ -73,6 +72,7 @@ install_requires = [
 ]
 
 extras_require = {
+    'rtree': ['rtree ==0.8.3'],
     'setproctitle': ["setproctitle"],
     'prctl': ["python-prctl ==1.6.1"],
     'celery':  ["celery >=4.0, <4.2"],


### PR DESCRIPTION
And disabled its usage on macOS. While at it, I have also removed some duplication by moving the filtering functionality in a method `.filter_csm`.