### PR TITLE
Inhibit multiple CTRL-C to give time Celery to revoke tasks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Made impossible to fire  multiple `CTRL-C` in sequence
+    to allow processes teardown and tasks revocation
+
   [Michele Simionato]
   * Made it possible to specify the `filter_distance` in the `job.ini`
   * Made rtree optional again and disabled it in macOS

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -151,6 +151,10 @@ class MasterKilled(KeyboardInterrupt):
     "Exception raised when a job is killed manually"
 
 
+def inhibitSigInt(signum, _stack):
+    logs.LOG.warn('Revoking tasks, please wait.')
+
+
 def raiseMasterKilled(signum, _stack):
     """
     When a SIGTERM is received, raise the MasterKilled
@@ -159,8 +163,10 @@ def raiseMasterKilled(signum, _stack):
     :param int signum: the number of the received signal
     :param _stack: the current frame object, ignored
     """
-    msg = 'Received a signal %d' % signum
+    # Disable further CTRL-C to allow tasks revocation
+    signal.signal(signal.SIGINT, inhibitSigInt)
 
+    msg = 'Received a signal %d' % signum
     if signum in (signal.SIGTERM, signal.SIGINT):
         msg = 'The openquake master process was killed manually'
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -152,7 +152,7 @@ class MasterKilled(KeyboardInterrupt):
 
 
 def inhibitSigInt(signum, _stack):
-    logs.LOG.warn('Revoking tasks, please wait.')
+    logs.LOG.warn('Revoking tasks, please wait')
 
 
 def raiseMasterKilled(signum, _stack):

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -152,7 +152,7 @@ class MasterKilled(KeyboardInterrupt):
 
 
 def inhibitSigInt(signum, _stack):
-    logs.LOG.warn('Revoking tasks, please wait')
+    logs.LOG.warn('Killing job, please wait')
 
 
 def raiseMasterKilled(signum, _stack):


### PR DESCRIPTION
If multiple `CTRl-C` are fired in sequence tasks aren't revoked properly. Our users are willing to this bad practice which has bad effects, especially on multi-many-nodes clusters, so here I'm inhibiting further `CTRL-C`s if `OQ` is in the cleanup phase; a warning is print instead.

```bash
openquake.engine.engine.MasterKilled: The openquake master process was killed manually

[2018-05-17 15:45:38,017 #33 WARNING] Revoking 38 tasks
^C[2018-05-17 15:45:38,374 #33 WARNING] Revoking tasks, please wait.
^C[2018-05-17 15:45:39,898 #33 WARNING] Revoking tasks, please wait.
^C[2018-05-17 15:45:40,247 #33 WARNING] Revoking tasks, please wait.
...
openquake.engine.engine.MasterKilled: The openquake master process was killed manually
```