### PR TITLE
Monitored the time spent in iter_ruptures

### DIFF
--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -115,12 +115,10 @@ def ucerf_classical(rupset_idx, ucerf_source, src_filter, gsims, monitor):
         return acc
 
     # compute the ProbabilityMap
-    cmaker = ContextMaker(gsims, src_filter.integration_distance)
+    cmaker = ContextMaker(gsims, src_filter.integration_distance,
+                          monitor=monitor)
     imtls = DictArray(imtls)
-    ctx_mon = monitor('make_contexts', measuremem=False)
-    poe_mon = monitor('get_poes', measuremem=False)
-    pmap = cmaker.poe_map(ucerf_source, s_sites, imtls,
-                          truncation_level, ctx_mon, poe_mon)
+    pmap = cmaker.poe_map(ucerf_source, s_sites, imtls, truncation_level)
     nsites = len(s_sites)
     acc = AccumDict({grp_id: pmap})
     acc.calc_times = {

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -86,9 +86,8 @@ def collect_bin_data(sources, sitecol, cmaker, iml4,
     truncnorm = scipy.stats.truncnorm(-truncation_level, truncation_level)
     epsilons = numpy.linspace(truncnorm.a, truncnorm.b, n_epsilons + 1)
     acc = AccumDict(accum=[])
-    mon = monitor('iter_ruptures', measuremem=False)
     for source in sources:
-        with mon:
+        with cmaker.ir_mon:
             ruptures = list(source.iter_ruptures())
         try:
             acc += cmaker.disaggregate(

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -89,9 +89,7 @@ def classical(group, src_filter, gsims, param, monitor=Monitor()):
     maxdist = src_filter.integration_distance
     imtls = param['imtls']
     trunclevel = param.get('truncation_level')
-    cmaker = ContextMaker(gsims, maxdist, param['filter_distance'])
-    ctx_mon = monitor('make_contexts', measuremem=False)
-    poe_mon = monitor('get_poes', measuremem=False)
+    cmaker = ContextMaker(gsims, maxdist, param['filter_distance'], monitor)
     pmap = AccumDict({grp_id: ProbabilityMap(len(imtls.array), len(gsims))
                       for grp_id in grp_ids})
     # AccumDict of arrays with 4 elements weight, nsites, calc_time, split
@@ -100,8 +98,7 @@ def classical(group, src_filter, gsims, param, monitor=Monitor()):
     for src, s_sites in src_filter(group):  # filter now
         t0 = time.time()
         indep = group.rup_interdep == 'indep' if mutex_weight else True
-        poemap = cmaker.poe_map(
-            src, s_sites, imtls, trunclevel, ctx_mon, poe_mon, indep)
+        poemap = cmaker.poe_map(src, s_sites, imtls, trunclevel, indep)
         if mutex_weight:  # mutex sources
             weight = mutex_weight[src.source_id]
             for sid in poemap:

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -128,7 +128,7 @@ def sample_ruptures(group, src_filter, gsims, param, monitor=Monitor()):
     num_ruptures = 0
     eids = numpy.zeros(0)
     cmaker = ContextMaker(gsims, src_filter.integration_distance,
-                          param['filter_distance'])
+                          param['filter_distance'], monitor)
     for src, s_sites in src_filter(group):
         t0 = time.time()
         num_ruptures += src.num_ruptures

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -174,7 +174,8 @@ class ContextMaker(object):
         """
         with self.ir_mon:
             all_ruptures = list(src.iter_ruptures())
-        weight = 1. / len(all_ruptures)
+        # all_ruptures can be empty only in UCERF
+        weight = 1. / (len(all_ruptures) or 1)
         ruptures = []
         with self.ctx_mon:
             for rup in all_ruptures:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -68,7 +68,8 @@ class ContextMaker(object):
     """
     REQUIRES = ['DISTANCES', 'SITES_PARAMETERS', 'RUPTURE_PARAMETERS']
 
-    def __init__(self, gsims, maximum_distance=None, filter_distance='rjb'):
+    def __init__(self, gsims, maximum_distance=None, filter_distance='rjb',
+                 monitor=Monitor()):
         self.gsims = gsims
         self.maximum_distance = maximum_distance or {}
         self.filter_distance = filter_distance
@@ -85,6 +86,9 @@ class ContextMaker(object):
             for gsim, rlzis in gsims.items():
                 for rlzi in rlzis:
                     self.gsim_by_rlzi[rlzi] = gsim
+        self.ir_mon = monitor('iter_ruptures', measuremem=False)
+        self.ctx_mon = monitor('make_contexts', measuremem=False)
+        self.poe_mon = monitor('get_poes', measuremem=False)
 
     def filter(self, sites, rupture):
         """
@@ -134,23 +138,6 @@ class ContextMaker(object):
         # access site parameters different from the ones declared
         return SitesContext(sites, self.REQUIRES_SITES_PARAMETERS), dctx
 
-    def filter_ruptures(self, src, sites):
-        """
-        :param src: a source object, already filtered and split
-        :param sites: a filtered SiteCollection
-        :return: a list of filtered ruptures with context attributes
-        """
-        ruptures = []
-        weight = 1. / (src.num_ruptures or src.count_ruptures())
-        for rup in src.iter_ruptures():
-            rup.weight = weight
-            try:
-                rup.sctx, rup.dctx = self.make_contexts(sites, rup)
-            except FarAwayRupture:
-                continue
-            ruptures.append(rup)
-        return ruptures
-
     def make_pmap(self, ruptures, imtls, trunclevel, rup_indep):
         """
         :param src: a source object
@@ -176,24 +163,31 @@ class ContextMaker(object):
         tildemap.eff_ruptures = len(ruptures)
         return tildemap
 
-    def poe_map(self, src, sites, imtls, trunclevel, ctx_mon, poe_mon,
-                rup_indep=True):
+    def poe_map(self, src, sites, imtls, trunclevel, rup_indep=True):
         """
         :param src: a source object
         :param sites: a filtered SiteCollection
         :param imtls: intensity measure and levels
         :param trunclevel: truncation level
-        :param ctx_mon: a Monitor instance for make_context
-        :param poe_mon: a Monitor instance for get_poes
         :param rup_indep: True if the ruptures are independent
         :returns: a ProbabilityMap instance
         """
-        with ctx_mon:
-            ruptures = self.filter_ruptures(src, sites)
+        with self.ir_mon:
+            all_ruptures = list(src.iter_ruptures())
+        weight = 1. / len(all_ruptures)
+        ruptures = []
+        with self.ctx_mon:
+            for rup in all_ruptures:
+                rup.weight = weight
+                try:
+                    rup.sctx, rup.dctx = self.make_contexts(sites, rup)
+                except FarAwayRupture:
+                    continue
+                ruptures.append(rup)
         if not ruptures:
             return {}
         try:
-            with poe_mon:
+            with self.poe_mon:
                 pmap = self.make_pmap(ruptures, imtls, trunclevel, rup_indep)
         except Exception as err:
             etype, err, tb = sys.exc_info()


### PR DESCRIPTION
Before the time spent in `iter_ruptures` was hidden inside `make_contexts` and it was not possible to distinguish between time spent in distance calculations and rupture instantiation. It turns out that for complex fault sources the time spent in `iter_ruptures` can be very significant, even more than the time spent in distance calculations. In particular the method `geo.Line.resample_to_num_points` is slow.