### PR TITLE
Closing process pool after prefiltering

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -513,6 +513,7 @@ class Starmap(object):
     @classmethod
     def shutdown(cls, poolsize=None):
         if hasattr(cls, 'pool'):
+            logging.info('Closing process pool')
             cls.pool.close()
             cls.pool.terminate()
             cls.pool.join()

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -291,7 +291,8 @@ class SourceFilter(BaseFilter):
             prefilter, (sources, self, monitor), distribute=self.distribute,
             name=self.__class__.__name__,
         ).reduce()
-        Starmap.shutdown()
+        Starmap.shutdown()  # close the processpool
+        Starmap.init()  # reopen it if necessary
         # avoid task ordering issues
         for sources in sources_by_grp.values():
             sources.sort(key=operator.attrgetter('source_id'))

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -291,6 +291,7 @@ class SourceFilter(BaseFilter):
             prefilter, (sources, self, monitor), distribute=self.distribute,
             name=self.__class__.__name__,
         ).reduce()
+        Starmap.shutdown()
         # avoid task ordering issues
         for sources in sources_by_grp.values():
             sources.sort(key=operator.attrgetter('source_id'))


### PR DESCRIPTION
The prefiltering phase takes few minutes but a lot of memory. Currently for a large calculation like EMME it can take on wilson 30 GB of RAM which are then released at the end of the complete calculation, i.e. after  40 hours. With the small fix here the RAM is released immediately at the end of the prefiltering phase.