### PR TITLE
Fixed the GmfGetter in a corner case with FarAwayRupture errors

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -116,7 +116,7 @@ class ContextMaker(object):
             if mask.any():
                 sites, distances = sites.filter(mask), distances[mask]
             else:
-                raise FarAwayRupture
+                raise FarAwayRupture(rupture.serial)
         return sites, DistancesContext([(self.filter_distance, distances)])
 
     def add_rup_params(self, rupture):


### PR DESCRIPTION
This happened when reading the ruptures coming from the Guatemala calculation.