### PR TITLE
Used the norm distribution when truncation_level=0 in shakemap.to_gmfs

### DIFF
--- a/openquake/calculators/tests/scenario_risk_test.py
+++ b/openquake/calculators/tests/scenario_risk_test.py
@@ -232,7 +232,7 @@ class ScenarioRiskTestCase(CalculatorTestCase):
         self.assertEqual(gmfa.dtype.names,
                          ('lon', 'lat', 'PGA', 'SA(0.3)', 'SA(1.0)'))
         agglosses = extract(self.calc.datastore, 'agglosses-rlzs')
-        aac(agglosses['mean'], numpy.array([[314017.34]], numpy.float32),
+        aac(agglosses['mean'], numpy.array([[1981390.9]], numpy.float32),
             atol=.1)
-        aac(agglosses['stddev'], numpy.array([[263641.7]], numpy.float32),
+        aac(agglosses['stddev'], numpy.array([[3204116.5]], numpy.float32),
             atol=.1)

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -23,7 +23,7 @@ import math
 import zipfile
 import logging
 import numpy
-from scipy.stats import truncnorm
+from scipy.stats import truncnorm, norm
 from scipy import interpolate
 
 from openquake.hazardlib import geo, site, imt, correlation
@@ -266,8 +266,11 @@ def to_gmfs(shakemap, crosscorr, site_effects, trunclevel, num_gmfs, seed,
                       for imt in imts for j in range(N)])
     # mu has shape (M * N, E)
     L = cholesky(spatial_cov, cross_corr)  # shape (M * N, M * N)
-    Z = truncnorm.rvs(-trunclevel, trunclevel, loc=0, scale=1,
-                      size=(M * N, num_gmfs), random_state=seed)
+    if trunclevel:
+        Z = truncnorm.rvs(-trunclevel, trunclevel, loc=0, scale=1,
+                          size=(M * N, num_gmfs), random_state=seed)
+    else:
+        Z = norm.rvs(loc=0, scale=1, size=(M * N, num_gmfs), random_state=seed)
     # Z has shape (M * N, E)
     gmfs = numpy.exp(numpy.dot(L, Z) + mu) / PCTG
     if site_effects:

--- a/openquake/qa_tests_data/scenario_risk/case_shakemap/job.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_shakemap/job.ini
@@ -3,5 +3,4 @@ calculation_mode = scenario_risk
 random_seed = 152
 number_of_ground_motion_fields = 3
 shakemap_file = usp000fjta.npy
-truncation_level = 3
 asset_hazard_distance = 20


### PR DESCRIPTION
This was requested by Vitor some week ago. See https://github.com/gem/oq-engine/issues/3637.