### PR TITLE
create shapefile for sources with different mfds

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Robin Gee]
+  * Extend `oq to_shapefile` method to also work with `YoungsCoppersmithMFD`
+    and `arbitraryMFD` MFD typologies.
+
   [Michele Simionato]
   * Now the hazard statistics can be computed efficiently even in a single
     calculation, i.e. without the `--hc` option

--- a/openquake/commands/tests/data/sample_source_model_05.xml
+++ b/openquake/commands/tests/data/sample_source_model_05.xml
@@ -45,6 +45,38 @@ xmlns:gml="http://www.opengis.net/gml"
                     </planarSurface>
                 </surface>
             </characteristicFaultSource>
+            <simpleFaultSource
+            id="2A"
+            name="Mount Diablo Thrust YC Characteristic Rate"
+            tectonicRegion="Active Shallow Crust"
+            >
+                <simpleFaultGeometry>
+                    <gml:LineString>
+                        <gml:posList>
+                            -1.2182290E+02 3.7730100E+01 -1.2203880E+02 3.7877100E+01
+                        </gml:posList>
+                    </gml:LineString>
+                    <dip>
+                        4.5000000E+01
+                    </dip>
+                    <upperSeismoDepth>
+                        1.0000000E+01
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        2.0000000E+01
+                    </lowerSeismoDepth>
+                </simpleFaultGeometry>
+                <magScaleRel>
+                    WC1994
+                </magScaleRel>
+                <ruptAspectRatio>
+                    1.5000000E+00
+                </ruptAspectRatio>
+                <YoungsCoppersmithMFD bValue="1.0000000E+00" binWidth="1.0000000E-01" characteristicMag="7.0000000E+00" characteristicRate="5.0000000E-03" minMag="5.0000000E+00"/>
+                <rake>
+                    3.0000000E+01
+                </rake>
+            </simpleFaultSource>
         </sourceGroup>
         <sourceGroup
         name="group 2"
@@ -443,6 +475,55 @@ xmlns:gml="http://www.opengis.net/gml"
                             <gml:LineString>
                                 <gml:posList>
                                     -1.2382900E+02 4.0347000E+01 2.4017550E+01 -1.2417259E+02 4.1217820E+01 1.4835820E+01 -1.2438969E+02 4.2111700E+01 1.2127140E+01 -1.2451445E+02 4.2979690E+01 1.3663320E+01 -1.2450873E+02 4.3700000E+01 1.5277110E+01 -1.2449237E+02 4.3862740E+01 1.5988220E+01 -1.2435632E+02 4.4742350E+01 1.9361950E+01 -1.2448830E+02 4.5000000E+01 1.7458620E+01 -1.2432961E+02 4.5489320E+01 2.0209830E+01 -1.2413677E+02 4.6300000E+01 2.2928260E+01 -1.2413849E+02 4.6364190E+01 2.2909400E+01 -1.2411635E+02 4.6778600E+01 2.3948630E+01 -1.2389909E+02 4.7237660E+01 2.7912690E+01 -1.2391646E+02 4.7708930E+01 2.9320020E+01 -1.2436144E+02 4.8151650E+01 2.7868880E+01 -1.2480386E+02 4.8553250E+01 2.7841440E+01 -1.2543884E+02 4.8860980E+01 2.5033540E+01 -1.2617539E+02 4.9214440E+01 2.2974710E+01 -1.2682846E+02 4.9736650E+01 2.3691290E+01
+                                </gml:posList>
+                            </gml:LineString>
+                        </faultBottomEdge>
+                    </complexFaultGeometry>
+                </surface>
+            </characteristicFaultSource>
+            <characteristicFaultSource
+            id="1"
+            name="characteristic source, complex fault arbitrary mfd"
+            tectonicRegion="Subduction Interface"
+            >
+                <arbitraryMFD>
+                    <occurRates>
+                        6.0000000E-04 8.0000000E-04 4.0000000E-04
+                    </occurRates>
+                    <magnitudes>
+                        8.6000000E+00 8.8000000E+00 9.0000000E+00
+                    </magnitudes>
+                </arbitraryMFD>
+                <rake>
+                    6.0000000E+01
+                </rake>
+                <surface>
+                    <complexFaultGeometry>
+                        <faultTopEdge>
+                            <gml:LineString>
+                                <gml:posList>
+                                    -1.2470400E+02 4.0363000E+01 5.4932600E+00 -1.2497700E+02 4.1214000E+01 4.9885600E+00 -1.2514000E+02 4.2096000E+01 4.8973400E+00
+                                </gml:posList>
+                            </gml:LineString>
+                        </faultTopEdge>
+                        <intermediateEdge>
+                            <gml:LineString>
+                                <gml:posList>
+                                    -1.2470400E+02 4.0363000E+01 5.5932600E+00 -1.2497700E+02 4.1214000E+01 5.0885600E+00 -1.2514000E+02 4.2096000E+01 4.9973400E+00
+                                </gml:posList>
+                            </gml:LineString>
+                        </intermediateEdge>
+                        <intermediateEdge>
+                            <gml:LineString>
+                                <gml:posList>
+                                    -1.2470400E+02 4.0363000E+01 5.6932600E+00 -1.2497700E+02 4.1214000E+01 5.1885600E+00 -1.2514000E+02 4.2096000E+01 5.0973400E+00
+                                </gml:posList>
+                            </gml:LineString>
+                        </intermediateEdge>
+                        <faultBottomEdge>
+                            <gml:LineString>
+                                <gml:posList>
+                                    -1.2382900E+02 4.0347000E+01 2.0384900E+01 -1.2413700E+02 4.1218000E+01 1.7413900E+01 -1.2425200E+02 4.2115000E+01 1.7527400E+01
                                 </gml:posList>
                             </gml:LineString>
                         </faultBottomEdge>

--- a/openquake/commonlib/shapefileparser.py
+++ b/openquake/commonlib/shapefileparser.py
@@ -60,6 +60,7 @@ MFD_PARAMS = [
     ('minMag', 'min_mag', 'f'), ('maxMag', 'max_mag', 'f'),
     ('aValue', 'a_val', 'f'), ('bValue', 'b_val', 'f'),
     ('binWidth', 'bin_width', 'f'),
+    ('characteristicMag', 'characteristic_mag','f')
 ]
 
 
@@ -333,9 +334,7 @@ def extract_mfd_params(src):
     elif "arbitraryMFD" in tags:
         mfd_node = src.nodes[tags.index("arbitraryMFD")]
     elif "YoungsCoppersmithMFD" in tags:
-        mfd_node = src.nodes[tags.index("arbitraryMFD")]
-    elif "multiMFD" in tags:
-        mfd_node = src.nodes[tags.index("arbitraryMFD")]
+        mfd_node = src.nodes[tags.index("YoungsCoppersmithMFD")]
     else:
         raise ValueError("Source %s contains no supported MFD type!" % src.tag)
     data = []
@@ -345,7 +344,7 @@ def extract_mfd_params(src):
             data.append((param, mfd_node.attrib[key]))
         else:
             data.append((param, None))
-    if "incrementalMFD" in mfd_node.tag:
+    if ("incrementalMFD" or "arbitraryMFD") in mfd_node.tag:
         # Extract Rates
         rates = ~mfd_node.occurRates
         n_r = len(rates)
@@ -353,6 +352,9 @@ def extract_mfd_params(src):
             raise ValueError("Number of rates in source %s too large "
                              "to be placed into shapefile" % src.tag)
         rate_dict = OrderedDict([(key, rates[i] if i < n_r else None)
+                                 for i, (key, _) in enumerate(RATE_PARAMS)])
+    elif "YoungsCoppersmithMFD" in mfd_node.tag:
+        rate_dict = OrderedDict([(key, mfd_node.attrib['characteristicRate'])
                                  for i, (key, _) in enumerate(RATE_PARAMS)])
     else:
         rate_dict = OrderedDict([(key, None)

--- a/openquake/commonlib/shapefileparser.py
+++ b/openquake/commonlib/shapefileparser.py
@@ -328,8 +328,14 @@ def extract_mfd_params(src):
     tags = get_taglist(src)
     if "incrementalMFD" in tags:
         mfd_node = src.nodes[tags.index("incrementalMFD")]
-    elif "truncGutenbergRichterMFD":
+    elif "truncGutenbergRichterMFD" in tags:
         mfd_node = src.nodes[tags.index("truncGutenbergRichterMFD")]
+    elif "arbitraryMFD" in tags:
+        mfd_node = src.nodes[tags.index("arbitraryMFD")]
+    elif "YoungsCoppersmithMFD" in tags:
+        mfd_node = src.nodes[tags.index("arbitraryMFD")]
+    elif "multiMFD" in tags:
+        mfd_node = src.nodes[tags.index("arbitraryMFD")]
     else:
         raise ValueError("Source %s contains no supported MFD type!" % src.tag)
     data = []


### PR DESCRIPTION
Previously, it was only possible to perform "oq to_shapefile" for sources with specific mfd typologies. Now it is also possible with the "YoungsCoppersmithMFD" and "arbitraryMFD" typologies.