### PR TITLE
Disable multiple CTRL-C only when celery is used

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,7 +7,7 @@
 
   [Daniele Viganò]
   * Made it impossible to fire  multiple `CTRL-C` in sequence
-    to allow processes teardown and tasks revocation
+    to allow processes teardown and tasks revocation when Celery is used
 
   [Michele Simionato]
   * Used `scipy.spatial.distance.cdist` in `Mesh.get_min_distance`

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -162,8 +162,9 @@ def raiseMasterKilled(signum, _stack):
     :param int signum: the number of the received signal
     :param _stack: the current frame object, ignored
     """
-    # Disable further CTRL-C to allow tasks revocation
-    signal.signal(signal.SIGINT, inhibitSigInt)
+    # Disable further CTRL-C to allow tasks revocation when Celery is used
+    if USE_CELERY:
+        signal.signal(signal.SIGINT, inhibitSigInt)
 
     msg = 'Received a signal %d' % signum
     if signum in (signal.SIGTERM, signal.SIGINT):


### PR DESCRIPTION
When using `processpool` multiple CTRL-C work as expected and are sometime useful in development.