### PR TITLE
get_executing_jobs now return only jobs with an existing pid

### DIFF
--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -690,7 +690,7 @@ SELECT %s FROM job WHERE status='executing' ORDER BY id desc''' % fields)
     for r in rows:
         # if r.pid is 0 it means that such information
         # is not available in the database
-        if psutil.pid_exists(r.pid) and r.pid != 0:
+        if r.pid and psutil.pid_exists(r.pid):
             running.append(r)
     return running
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import os
+import psutil
 import operator
 from datetime import datetime
 
@@ -668,17 +669,30 @@ def get_results(db, job_id):
 
 # ############################### db commands ########################### #
 
+class List(list):
+    _fields = ()
+
+
 def get_executing_jobs(db):
     """
     :param db:
         a :class:`openquake.server.dbapi.Db` instance
     :returns:
-        (id, user_name, start_time) tuples
+        (id, pid, user_name, start_time) tuples
     """
-    query = '''-- executing jobs
-SELECT id, user_name, start_time
-FROM job WHERE status='executing' ORDER BY id desc'''
-    return db(query)
+    fields = 'id,pid,user_name,start_time'
+    running = List()
+    running._fields = fields.split(',')
+
+    query = ('''-- executing jobs
+SELECT %s FROM job WHERE status='executing' ORDER BY id desc''' % fields)
+    rows = db(query)
+    for r in rows:
+        # if r.pid is 0 it means that such information
+        # is not available in the database
+        if psutil.pid_exists(r.pid) and r.pid != 0:
+            running.append(r)
+    return running
 
 
 def get_longest_jobs(db):


### PR DESCRIPTION
Closes https://github.com/gem/oq-infrastructure/issues/59

I would not update the changelog since this is an internal only feature 