### PR TITLE
Store ProbabilityMap.sids as an HDF5 dataset, not an attribute

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -272,14 +272,6 @@ class File(h5py.File):
         else:
             return h5obj
 
-    def set_attrs(self, key, **kw):
-        """
-        Set the HDF5 attributes of the given key
-        """
-        attrs = super().__getitem__(key).attrs
-        for k, v in kw.items():
-            attrs[k] = v
-
     def set_nbytes(self, key, nbytes=None):
         """
         Set the `nbytes` attribute on the HDF5 object identified by `key`.

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -272,6 +272,14 @@ class File(h5py.File):
         else:
             return h5obj
 
+    def set_attrs(self, key, **kw):
+        """
+        Set the HDF5 attributes of the given key
+        """
+        attrs = super().__getitem__(key).attrs
+        for k, v in kw.items():
+            attrs[k] = v
+
     def set_nbytes(self, key, nbytes=None):
         """
         Set the `nbytes` attribute on the HDF5 object identified by `key`.

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -548,9 +548,7 @@ class HazardCalculator(BaseCalculator):
                              len(self.assetcol), len(assetcol))
             else:
                 self.assetcol = assetcol
-            self.load_riskmodel()
         else:  # no exposure
-            self.load_riskmodel()
             self.sitecol = haz_sitecol
 
         if oq_hazard:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -210,9 +210,6 @@ class PSHACalculator(base.HazardCalculator):
                     key = 'poes/grp-%02d' % grp_id
                     self.datastore[key] = pmap
                     self.datastore.set_attrs(key, trt=grp_trt[grp_id])
-                    if hasattr(self, 'hdf5cache'):
-                        with hdf5.File(self.hdf5cache) as cache:
-                            cache[key] = pmap
                     if oq.disagg_by_src:
                         data.append(
                             (grp_id, grp_source[grp_id], src_name[grp_id]))
@@ -223,9 +220,12 @@ class PSHACalculator(base.HazardCalculator):
                 # only for the case of a single realization
                 self.datastore['disagg_by_src/source_id'] = numpy.array(
                     sorted(data), grp_source_dt)
+
+        # save a copy of the poes in hdf5cache
         if hasattr(self, 'hdf5cache'):
             with hdf5.File(self.hdf5cache) as cache:
                 cache['oqparam'] = oq
+                self.datastore.hdf5.copy('poes', cache)
 
 
 # used in PreClassicalCalculator

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -221,11 +221,11 @@ class PSHACalculator(base.HazardCalculator):
                 self.datastore['disagg_by_src/source_id'] = numpy.array(
                     sorted(data), grp_source_dt)
 
-        # save a copy of the poes in hdf5cache
-        if hasattr(self, 'hdf5cache'):
-            with hdf5.File(self.hdf5cache) as cache:
-                cache['oqparam'] = oq
-                self.datastore.hdf5.copy('poes', cache)
+            # save a copy of the poes in hdf5cache
+            if hasattr(self, 'hdf5cache'):
+                with hdf5.File(self.hdf5cache) as cache:
+                    cache['oqparam'] = oq
+                    self.datastore.hdf5.copy('poes', cache)
 
 
 # used in PreClassicalCalculator

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -210,21 +210,22 @@ class PSHACalculator(base.HazardCalculator):
                     key = 'poes/grp-%02d' % grp_id
                     self.datastore[key] = pmap
                     self.datastore.set_attrs(key, trt=grp_trt[grp_id])
+                    if hasattr(self, 'hdf5cache'):
+                        with hdf5.File(self.hdf5cache) as cache:
+                            cache[key] = pmap
                     if oq.disagg_by_src:
                         data.append(
                             (grp_id, grp_source[grp_id], src_name[grp_id]))
-        if 'poes' in self.datastore and hasattr(self, 'hdf5cache'):
+        if 'poes' in self.datastore:
             self.datastore.set_nbytes('poes')
             if oq.disagg_by_src and self.csm.info.get_num_rlzs() == 1:
                 # this is useful for disaggregation, which is implemented
                 # only for the case of a single realization
                 self.datastore['disagg_by_src/source_id'] = numpy.array(
                     sorted(data), grp_source_dt)
-
-            # save a copy of the poes in hdf5cache
+        if hasattr(self, 'hdf5cache'):
             with hdf5.File(self.hdf5cache) as cache:
                 cache['oqparam'] = oq
-                self.datastore.hdf5.copy('poes', cache)
 
 
 # used in PreClassicalCalculator
@@ -331,15 +332,17 @@ class ClassicalCalculator(PSHACalculator):
         # initialize datasets
         N = len(self.sitecol.complete)
         L = len(oq.imtls.array)
-        attrs = dict(
-            __pyclass__='openquake.hazardlib.probability_map.ProbabilityMap',
-            sids=numpy.arange(N, dtype=numpy.uint32))
+        pyclass = 'openquake.hazardlib.probability_map.ProbabilityMap'
+        all_sids = self.sitecol.complete.sids
         nbytes = N * L * 4  # bytes per realization (32 bit floats)
         totbytes = 0
         if num_rlzs > 1:
             for name, stat in oq.hazard_stats():
                 self.datastore.create_dset(
-                    'hcurves/' + name, F32, (N, L, 1), attrs=attrs)
+                    'hcurves/%s/array' % name, F32, (N, L, 1))
+                self.datastore['hcurves/%s/sids' % name] = all_sids
+                self.datastore.set_attrs(
+                    'hcurves/%s' % name, __pyclass__=pyclass)
                 totbytes += nbytes
         if 'hcurves' in self.datastore:
             self.datastore.set_attrs('hcurves', nbytes=totbytes)
@@ -378,7 +381,7 @@ class ClassicalCalculator(PSHACalculator):
             for kind in pmap_by_kind:
                 pmap = pmap_by_kind[kind]
                 if pmap:
-                    key = 'hcurves/' + kind
+                    key = 'hcurves/%s/array' % kind
                     dset = self.datastore.getitem(key)
                     for sid in pmap:
                         dset[sid] = pmap[sid].array

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -93,8 +93,10 @@ class PmapGetter(object):
         if 'poes' in self.dstore:
             # build probability maps restricted to the given sids
             for grp, dset in self.dstore['poes'].items():
-                sid2idx = {sid: i for i, sid in enumerate(dset.attrs['sids'])}
-                L, I = dset.shape[1:]
+                arr = dset['array'].value
+                sids = dset['sids'].value
+                sid2idx = {sid: i for i, sid in enumerate(sids)}
+                L, I = arr.shape[1:]
                 pmap = probability_map.ProbabilityMap(L, I)
                 for sid in self.sids:
                     try:
@@ -102,7 +104,7 @@ class PmapGetter(object):
                     except KeyError:
                         continue
                     else:
-                        pmap[sid] = probability_map.ProbabilityCurve(dset[idx])
+                        pmap[sid] = probability_map.ProbabilityCurve(arr[idx])
                 self._pmap_by_grp[grp] = pmap
                 self.nbytes += pmap.nbytes
         return self._pmap_by_grp

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -221,8 +221,10 @@ class RunShowExportTestCase(unittest.TestCase):
 
     def test_show_attrs(self):
         with Print.patch() as p:
-            show_attrs('poes', self.calc_id)
-        self.assertEqual('nbytes 48', str(p))
+            show_attrs('sitecol', self.calc_id)
+        self.assertEqual(
+            '__pyclass__ openquake.hazardlib.site.SiteCollection\nnbytes 54',
+            str(p))
 
     def test_export_calc(self):
         tempdir = tempfile.mkdtemp()

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -334,13 +334,15 @@ class ProbabilityMap(dict):
         array = numpy.zeros(shape, F64)
         for i, sid in numpy.ndenumerate(sids):
             array[i] = self[sid].array
-        return array, dict(sids=sids)
+        return dict(array=array, sids=sids), {}
 
-    def __fromh5__(self, array, attrs):
+    def __fromh5__(self, dic, attrs):
         # rebuild the map from sids and probs arrays
+        array = dic['array']
+        sids = dic['sids']
         self.shape_y = array.shape[1]
         self.shape_z = array.shape[2]
-        for sid, prob in zip(attrs['sids'], array):
+        for sid, prob in zip(sids, array):
             self[sid] = ProbabilityCurve(prob)
 
 


### PR DESCRIPTION
Solves the segmentation fault experienced by @mmpagani.
The problem lied with HDF5 and as always it is mysterious. According to the docs (https://support.hdfgroup.org/HDF5/doc1.6/UG/13_Attributes.html#SpecIssues) attributes larger than 64K are not supported. The docs lie because we used attributes larger than 64K for 3 years without any problem; even now they work for the datastore file but mysteriously do not work for the newly introduced cache file (see https://github.com/gem/oq-engine/pull/3720). The attribute causing problems is the `sids` attribute of ProbabilityMap datasets; since we have an easy way to convert it to into a dataset I did so and the segfault disappeared (in my tests). To be tried on the cluster.