### PR TITLE
Solved a memory regression in the PmapGetter

### DIFF
--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -67,7 +67,7 @@ class PmapGetter(object):
         else:
             self.dstore.open()  # if not
         if self.sids is None:
-            self.sids = self.dstore['sitecol'].complete.sids
+            self.sids = self.dstore['sitecol'].sids
         self.imtls = self.dstore['oqparam'].imtls
         self.data = collections.OrderedDict()
         try:
@@ -93,9 +93,8 @@ class PmapGetter(object):
         if 'poes' in self.dstore:
             # build probability maps restricted to the given sids
             for grp, dset in self.dstore['poes'].items():
-                arr = dset['array'].value
-                sids = dset['sids'].value
-                sid2idx = {sid: i for i, sid in enumerate(sids)}
+                arr = dset['array']
+                sid2idx = {sid: i for i, sid in enumerate(dset['sids'])}
                 L, I = arr.shape[1:]
                 pmap = probability_map.ProbabilityMap(L, I)
                 for sid in self.sids:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -93,7 +93,7 @@ class PmapGetter(object):
         if 'poes' in self.dstore:
             # build probability maps restricted to the given sids
             for grp, dset in self.dstore['poes'].items():
-                arr = dset['array']
+                ds = dset['array']  # do not call .value, save memory!
                 sid2idx = {sid: i for i, sid in enumerate(dset['sids'])}
                 L, I = arr.shape[1:]
                 pmap = probability_map.ProbabilityMap(L, I)
@@ -103,7 +103,7 @@ class PmapGetter(object):
                     except KeyError:
                         continue
                     else:
-                        pmap[sid] = probability_map.ProbabilityCurve(arr[idx])
+                        pmap[sid] = probability_map.ProbabilityCurve(ds[idx])
                 self._pmap_by_grp[grp] = pmap
                 self.nbytes += pmap.nbytes
         return self._pmap_by_grp

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -94,15 +94,12 @@ class PmapGetter(object):
             # build probability maps restricted to the given sids
             ok_sids = set(self.sids)
             for grp, dset in self.dstore['poes'].items():
-                sid_arr = []
                 ds = dset['array']
-                for idx, sid in enumerate(dset['sids'].value):
-                    if sid in ok_sids:
-                        sid_arr.append((sid, ds[idx]))
                 L, I = ds.shape[1:]
                 pmap = probability_map.ProbabilityMap(L, I)
-                for sid, arr in sid_arr:
-                    pmap[sid] = probability_map.ProbabilityCurve(arr)
+                for idx, sid in enumerate(dset['sids'].value):
+                    if sid in ok_sids:
+                        pmap[sid] = probability_map.ProbabilityCurve(ds[idx])
                 self._pmap_by_grp[grp] = pmap
                 self.nbytes += pmap.nbytes
         return self._pmap_by_grp

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -94,16 +94,15 @@ class PmapGetter(object):
             # build probability maps restricted to the given sids
             ok_sids = set(self.sids)
             for grp, dset in self.dstore['poes'].items():
-                idxsid = []
+                sid_arr = []
+                ds = dset['array']
                 for idx, sid in enumerate(dset['sids'].value):
                     if sid in ok_sids:
-                        idxsid.append((idx, sid))
-                idxsid = sorted(idxsid)  # shape (N, 2)
-                arr = dset['array'][[item[0] for item in idxsid]]
-                L, I = arr.shape[1:]
+                        sid_arr.append((sid, ds[idx]))
+                L, I = ds.shape[1:]
                 pmap = probability_map.ProbabilityMap(L, I)
-                for idx, sid in idxsid:
-                    pmap[sid] = probability_map.ProbabilityCurve(arr[idx])
+                for sid, arr in sid_arr:
+                    pmap[sid] = probability_map.ProbabilityCurve(arr)
                 self._pmap_by_grp[grp] = pmap
                 self.nbytes += pmap.nbytes
         return self._pmap_by_grp

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -90,20 +90,21 @@ class PmapGetter(object):
             return self._pmap_by_grp
         # populate _pmap_by_grp
         self._pmap_by_grp = {}
+        ok_set = set(self.sids)
         if 'poes' in self.dstore:
             # build probability maps restricted to the given sids
             for grp, dset in self.dstore['poes'].items():
-                ds = dset['array']  # do not call .value, save memory!
-                sid2idx = {sid: i for i, sid in enumerate(dset['sids'])}
+                sids = []
+                idxs = []
+                for idx, sid in enumerate(dset['sids'].value):
+                    if sid in ok_set:
+                        sids.append(sid)
+                        idxs.append(idx)
+                array = dset['array'][idxs]  # do not use .value, save memory
                 L, I = arr.shape[1:]
                 pmap = probability_map.ProbabilityMap(L, I)
-                for sid in self.sids:
-                    try:
-                        idx = sid2idx[sid]
-                    except KeyError:
-                        continue
-                    else:
-                        pmap[sid] = probability_map.ProbabilityCurve(ds[idx])
+                for idx, sid in zip(idxs, sids):
+                    pmap[sid] = probability_map.ProbabilityCurve(array[idx])
                 self._pmap_by_grp[grp] = pmap
                 self.nbytes += pmap.nbytes
         return self._pmap_by_grp


### PR DESCRIPTION
Discovered yesterday with the South Africa calculation by @mmpagani 
It was a minor regression introduced yesterday morning, so that the engine was reading all the PoEs in memory instead of only the PoEs for the current task sites. Here are the figures:

yesterday master on wilson:
```
operation                          time_sec memory_mb counts
================================== ======== ========= ======
total build_hcurves_and_stats      4,316    2,119     864   
combine pmaps                      4,288    2,119     864   
ClassicalCalculator.run            146      62        1     
compute mean                       12       0.21094   861   
```
this branch on the workers:
```
operation                          time_sec memory_mb counts
================================== ======== ========= ======
total build_hcurves_and_stats      2,500    22        864   
combine pmaps                      2,470    21        864   
ClassicalCalculator.run            26       34        1     
compute mean                       15       0.36328   861   
```

We use 100 times less memory and we are 4 times faster.