### PR TITLE
Stored the zipped input files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Stored the zipped input files in the datastore for reproducibility
   * Fixed a regression when reading GMFs from an XML in absence of a sites.csv
     file
 

--- a/openquake/calculators/export/__init__.py
+++ b/openquake/calculators/export/__init__.py
@@ -74,6 +74,6 @@ def export_job_zip(ekey, dstore):
     Export the bytes in the job_zip dataset in a job.zip file
     """
     dest = dstore.export_path('job.zip')
-    zbytes = dstore['job_zip'].value + b'\x00' * 4
+    zbytes = dstore['job_zip'].value + b'\x00' * 4  # magic trick!
     open(dest, 'wb').write(zbytes)
     return [dest]

--- a/openquake/calculators/export/__init__.py
+++ b/openquake/calculators/export/__init__.py
@@ -74,6 +74,10 @@ def export_job_zip(ekey, dstore):
     Export the bytes in the job_zip dataset in a job.zip file
     """
     dest = dstore.export_path('job.zip')
-    zbytes = dstore['job_zip'].value + b'\x00' * 4  # magic trick!
+    nbytes = dstore.get_attr('job_zip', 'nbytes')
+    zbytes = dstore['job_zip'].value
+    # when reading job_zip some terminating null bytes are truncated (for
+    # unknown reasons) therefore they must be restored
+    zbytes += b'\x00' * (nbytes - len(zbytes))
     open(dest, 'wb').write(zbytes)
     return [dest]

--- a/openquake/calculators/export/__init__.py
+++ b/openquake/calculators/export/__init__.py
@@ -15,7 +15,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-
+import zipfile
+import io
 from openquake.baselib.general import import_all, CallableDict
 from openquake.commonlib.writers import write_csv
 
@@ -59,8 +60,20 @@ def keyfunc(ekey):
     fullname, ext = ekey
     return (fullname.split('/', 1)[0], ext)
 
+
 export = CallableDict(keyfunc)
 
 export.from_db = False  # overridden when exporting from db
 
 import_all('openquake.calculators.export')
+
+
+@export.add(('job_zip', 'zip'))
+def export_job_zip(ekey, dstore):
+    """
+    Export the bytes in the job_zip dataset in a job.zip file
+    """
+    dest = dstore.export_path('job.zip')
+    zbytes = dstore['job_zip'].value + b'\x00' * 4
+    open(dest, 'wb').write(zbytes)
+    return [dest]

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -62,8 +62,8 @@ def run_job(cfg_file, log_level='info', log_file=None, exports='',
     job_ini = os.path.abspath(cfg_file)
     job_id, oqparam = eng.job_from_file(
         job_ini, getpass.getuser(), hazard_calculation_id)
-    calc = eng.run_calc(job_id, oqparam, log_level, log_file, exports,
-                        hazard_calculation_id=hazard_calculation_id, **kw)
+    eng.run_calc(job_id, oqparam, log_level, log_file, exports,
+                 hazard_calculation_id=hazard_calculation_id, **kw)
     for line in logs.dbcmd('list_outputs', job_id, False):
         safeprint(line)
     return job_id

--- a/openquake/commands/zip.py
+++ b/openquake/commands/zip.py
@@ -15,68 +15,9 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-import sys
-import os.path
-import logging
-from openquake.baselib import sap, general
-from openquake.hazardlib import nrml
-from openquake.commonlib import readinput
+from openquake.baselib import sap
+from openquake.engine.engine import zip
 
-
-@sap.Script
-def zip(job_ini, archive_zip):
-    """
-    Zip the given job.ini file into the given archive, together with all
-    related files.
-    """
-    if not os.path.exists(job_ini):
-        sys.exit('%s does not exist' % job_ini)
-    if not archive_zip.endswith('.zip'):
-        sys.exit('%s does not end with .zip' % archive_zip)
-    if os.path.exists(archive_zip):
-        sys.exit('%s exists already' % archive_zip)
-    logging.basicConfig(level=logging.INFO)
-    # do not validate to avoid permissions error on the export_dir
-    oq = readinput.get_oqparam(job_ini, validate=False)
-    files = set()
-
-    # collect .hdf5 tables for the GSIMs, if any
-    if 'gsim_logic_tree' in oq.inputs or oq.gsim:
-        gsim_lt = readinput.get_gsim_lt(oq)
-        for gsims in gsim_lt.values.values():
-            for gsim in gsims:
-                table = getattr(gsim, 'GMPE_TABLE', None)
-                if table:
-                    files.add(table)
-
-    # collect exposure.csv, if any
-    exposure_xml = oq.inputs.get('exposure')
-    if exposure_xml:
-        dname = os.path.dirname(exposure_xml)
-        expo = nrml.read(exposure_xml, stop='asset')[0]
-        if not expo.assets:
-            exposure_csv = (~expo.assets).strip()
-            for csv in exposure_csv.split():
-                if csv and os.path.exists(os.path.join(dname, csv)):
-                    files.add(os.path.join(dname, csv))
-
-    # collection .hdf5 UCERF file, if any
-    if oq.calculation_mode.startswith('ucerf_'):
-        sm = nrml.read(oq.inputs['source_model'])
-        fname = sm.sourceModel.UCERFSource['filename']
-        f = os.path.join(os.path.dirname(oq.inputs['source_model']), fname)
-        files.add(os.path.normpath(f))
-
-    # collect all other files
-    for key in oq.inputs:
-        fname = oq.inputs[key]
-        if isinstance(fname, list):
-            for f in fname:
-                files.add(os.path.normpath(f))
-        else:
-            files.add(os.path.normpath(fname))
-    general.zipfiles(files, archive_zip, log=logging.info)
-
-
+zip = sap.Script(zip)
 zip.arg('job_ini', 'path to a job.ini file')
 zip.arg('archive_zip', 'path to a non-existing .zip file')

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -116,7 +116,9 @@ def get_params(job_inis, **kw):
     :returns:
         A dictionary of parameters
     """
+    job_zip = None
     if len(job_inis) == 1 and job_inis[0].endswith('.zip'):
+        job_zip = job_inis[0]
         job_inis = extract_from_zip(
             job_inis[0], ['job_hazard.ini', 'job_haz.ini',
                           'job.ini', 'job_risk.ini'])
@@ -132,6 +134,8 @@ def get_params(job_inis, **kw):
     job_ini = os.path.abspath(job_inis[0])
     base_path = decode(os.path.dirname(job_ini))
     params = dict(base_path=base_path, inputs={'job_ini': job_ini})
+    if job_zip:
+        params['inputs']['job_zip'] = os.path.abspath(job_zip)
 
     for sect in cp.sections():
         _update(params, cp.items(sect), base_path)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -313,7 +313,7 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
             if job_zip:  # the input was zipped from the beginning
                 data = open(job_zip, 'rb').read()
             else:  # zip the input
-                logs.LOG.info('zipping and storing the input files')
+                logs.LOG.info('zipping the input files')
                 bio = io.BytesIO()
                 zip(oqparam.inputs['job_ini'], bio, oqparam, logging.debug)
                 data = bio.getvalue()

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -311,13 +311,15 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
         tb = 'None\n'
         try:
             if job_zip:  # the input was zipped from the beginning
-                calc.datastore['job_zip'] = numpy.array(
-                    open(job_zip, 'rb').read())
+                data = open(job_zip, 'rb').read()
             else:  # zip the input
                 logs.LOG.info('zipping and storing the input files')
                 bio = io.BytesIO()
                 zip(oqparam.inputs['job_ini'], bio, oqparam, logging.debug)
-                calc.datastore['job_zip'] = numpy.array(bio.getvalue())
+                data = bio.getvalue()
+            calc.datastore['job_zip'] = numpy.array(data)
+            calc.datastore.set_attrs('job_zip', nbytes=len(data))
+
             logs.dbcmd('update_job', job_id, {'status': 'executing',
                                               'pid': _PID})
             t0 = time.time()

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -311,6 +311,7 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
         if job_zip:  # the input was zipped from the beginning
             calc.datastore['job_zip'] = numpy.array(open(job_zip, 'rb').read())
         else:  # zip the input
+            logs.LOG.info('zipping and storing the input files')
             bio = io.BytesIO()
             zip(oqparam.inputs['job_ini'], bio, oqparam, logging.debug)
             calc.datastore['job_zip'] = numpy.array(bio.getvalue())

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -308,15 +308,16 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
         calc = base.calculators(oqparam, calc_id=job_id)
         calc.from_engine = True
         job_zip = oqparam.inputs.get('job_zip')
-        if job_zip:  # the input was zipped from the beginning
-            calc.datastore['job_zip'] = numpy.array(open(job_zip, 'rb').read())
-        else:  # zip the input
-            logs.LOG.info('zipping and storing the input files')
-            bio = io.BytesIO()
-            zip(oqparam.inputs['job_ini'], bio, oqparam, logging.debug)
-            calc.datastore['job_zip'] = numpy.array(bio.getvalue())
         tb = 'None\n'
         try:
+            if job_zip:  # the input was zipped from the beginning
+                calc.datastore['job_zip'] = numpy.array(
+                    open(job_zip, 'rb').read())
+            else:  # zip the input
+                logs.LOG.info('zipping and storing the input files')
+                bio = io.BytesIO()
+                zip(oqparam.inputs['job_ini'], bio, oqparam, logging.debug)
+                calc.datastore['job_zip'] = numpy.array(bio.getvalue())
             logs.dbcmd('update_job', job_id, {'status': 'executing',
                                               'pid': _PID})
             t0 = time.time()

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -203,7 +203,7 @@ except ValueError:
     pass
 
 
-def zip(job_ini, archive_zip):
+def zip(job_ini, archive_zip, oq=None, log=logging.info):
     """
     Zip the given job.ini file into the given archive, together with all
     related files.
@@ -217,7 +217,7 @@ def zip(job_ini, archive_zip):
             sys.exit('%s exists already' % archive_zip)
     logging.basicConfig(level=logging.INFO)
     # do not validate to avoid permissions error on the export_dir
-    oq = readinput.get_oqparam(job_ini, validate=False)
+    oq = oq or readinput.get_oqparam(job_ini, validate=False)
     files = set()
 
     # collect .hdf5 tables for the GSIMs, if any
@@ -255,7 +255,7 @@ def zip(job_ini, archive_zip):
                 files.add(os.path.normpath(f))
         else:
             files.add(os.path.normpath(fname))
-    general.zipfiles(files, archive_zip, log=logging.info)
+    general.zipfiles(files, archive_zip, log=log)
 
 
 def job_from_file(cfg_file, username, hazard_calculation_id=None):
@@ -312,7 +312,7 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
             calc.datastore['job_zip'] = numpy.array(open(job_zip, 'rb').read())
         else:  # zip the input
             bio = io.BytesIO()
-            zip(oqparam.inputs['job_ini'], bio)
+            zip(oqparam.inputs['job_ini'], bio, oqparam, logging.debug)
             calc.datastore['job_zip'] = numpy.array(bio.getvalue())
         tb = 'None\n'
         try:

--- a/openquake/server/tests/tests.py
+++ b/openquake/server/tests/tests.py
@@ -192,10 +192,11 @@ class EngineServerTestCase(unittest.TestCase):
         job_id = self.postzip('classical.zip')
         self.wait()
 
-        # check that we get the expected 5 outputs
+        # check that we get at least the following 5 outputs
         # fullreport, hcurves, hmaps, realizations, sourcegroups
+        # we can add more outputs in the future
         results = self.get('%s/results' % job_id)
-        self.assertEqual(len(results), 5)
+        self.assertGreaterEqual(len(results), 5)
 
         # check the filename of the hmaps
         hmaps_id = results[2]['id']

--- a/openquake/server/tests/tests.py
+++ b/openquake/server/tests/tests.py
@@ -56,10 +56,10 @@ class EngineServerTestCase(unittest.TestCase):
     def get(cls, path, **data):
         resp = cls.c.get('/v1/calc/%s' % path, data,
                          HTTP_HOST='127.0.0.1')
-        assert resp.content
+        assert resp.content, 'No content from /v1/calc/%s' % path
         try:
             return json.loads(resp.content.decode('utf8'))
-        except:
+        except Exception:
             print('Invalid JSON, see %s' % gettemp(resp.content),
                   file=sys.stderr)
             return {}
@@ -85,7 +85,7 @@ class EngineServerTestCase(unittest.TestCase):
             resp = self.post('run', dict(archive=a))
         try:
             js = json.loads(resp.content.decode('utf8'))
-        except:
+        except Exception:
             raise ValueError(b'Invalid JSON response: %r' % resp.content)
         if resp.status_code == 200:  # ok case
             job_id = js['job_id']

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -305,20 +305,19 @@ def calc_list(request, id=None):
     Responses are in JSON.
     """
     base_url = _get_base_url(request)
-
     calc_data = logs.dbcmd('get_calcs', request.GET,
                            utils.get_valid_users(request),
                            utils.get_acl_on(request), id)
 
     response_data = []
+    username = psutil.Process(os.getpid()).username()
     for (hc_id, owner, status, calculation_mode, is_running, desc, pid,
          parent_id) in calc_data:
         url = urlparse.urljoin(base_url, 'v1/calc/%d' % hc_id)
         abortable = False
         if is_running:
             try:
-                if (psutil.Process(pid).username() ==
-                        psutil.Process(os.getpid()).username()):
+                if psutil.Process(pid).username() == username:
                     abortable = True
             except psutil.NoSuchProcess:
                 pass


### PR DESCRIPTION
The scientists always try to make my life more difficult, for instance by hiding the input files they have been using. With the change here the input files are store (in zipped form) in the datastore, so that I can easily get them when I have to debug a calculation with `oq export job_zip`.