### PR TITLE
Reduced the data transfer in the UCERF calculators

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced the data transfer in the UCERF calculators
   * Stored the zipped input files in the datastore for reproducibility
   * Fixed a regression when reading GMFs from an XML in absence of a sites.csv
     file

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -410,16 +410,19 @@ class UCERFSource(object):
 
     @cached_property
     def mags(self):
+        # read from FM0_0/MEANFS/MEANMSR/Magnitude
         with h5py.File(self.source_file, "r") as hdf5:
             return hdf5[self.idx_set["mag"]].value
 
     @cached_property
     def rate(self):
+        # read from FM0_0/MEANFS/MEANMSR/Rates/MeanRates
         with h5py.File(self.source_file, "r") as hdf5:
             return hdf5[self.idx_set["rate"]].value
 
     @cached_property
     def rake(self):
+        # read from FM0_0/MEANFS/Rake
         with h5py.File(self.source_file, "r") as hdf5:
             return hdf5[self.idx_set["rake"]].value
 

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -25,7 +25,7 @@ import collections
 import h5py
 import numpy
 
-from openquake.baselib.general import AccumDict
+from openquake.baselib.general import AccumDict, cached_property
 from openquake.baselib.python3compat import zip
 from openquake.baselib import parallel
 from openquake.hazardlib import nrml
@@ -408,6 +408,21 @@ class UCERFSource(object):
         self.tectonic_region_type = trt
         self.num_ruptures = 0  # not set yet
 
+    @cached_property
+    def mags(self):
+        with h5py.File(self.source_file, "r") as hdf5:
+            return hdf5[self.idx_set["mag"]].value
+
+    @cached_property
+    def rate(self):
+        with h5py.File(self.source_file, "r") as hdf5:
+            return hdf5[self.idx_set["rate"]].value
+
+    @cached_property
+    def rake(self):
+        with h5py.File(self.source_file, "r") as hdf5:
+            return hdf5[self.idx_set["rake"]].value
+
     def count_ruptures(self):
         """
         The length of the rupture array if the branch_id is set, else 0
@@ -426,14 +441,7 @@ class UCERFSource(object):
         new.source_id = branch_id
         new.idx_set = build_idx_set(branch_id, self.start_date)
         with h5py.File(self.source_file, "r") as hdf5:
-            # read from datasets like
-            # FM0_0/MEANFS/MEANMSR/Magnitude
-            # FM0_0/MEANFS/MEANMSR/Rates/MeanRates
-            # FM0_0/MEANFS/Rake
-            new.mags = hdf5[new.idx_set["mag"]].value
-            new.rate = hdf5[new.idx_set["rate"]].value
-            new.rake = hdf5[new.idx_set["rake"]].value
-            new.num_ruptures = len(new.mags)
+            new.num_ruptures = len(hdf5[new.idx_set["mag"]])
         return new
 
     def get_min_max_mag(self):


### PR DESCRIPTION
Before:
```
[2018-05-29 13:15:44,230 #18178 INFO] Sent 4.43 GB of data in 240 task(s)
```
With this branch:
```
[2018-05-29 13:50:01,040 #18179 INFO] Sent 43.74 MB of data in 240 task(s)
```
The gain is 100x. I am also decoupling the background tasks from the fault source tasks: this solves the issue of the calculation hanging mysteriously. 

This is the first green calculation: https://oq2.wilson.openquake.org/engine/18180/outputs