### PR TITLE
Removed distribution by rupture in the event_based_risk calculator

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the event_based_risk calculator to distribute by GMFs always
   * Optimized the memory consumption in the UCERF classical calculator
   * Added a parameter `minimum_magnitude` in the job.ini
   * Added an utility `utils/combine_mean_curves.py`

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -759,7 +759,8 @@ class RiskCalculator(HazardCalculator):
                 getter = PmapGetter(dstore, self.rlzs_assoc, sids)
                 getter.num_rlzs = self.R
             else:  # gmf
-                getter = GmfDataGetter(dstore, sids, self.R, num_events)
+                getter = GmfDataGetter(dstore, sids, self.R, num_events,
+                                       self.oqparam.imtls)
             if dstore is self.datastore:
                 # read the hazard data in the controller node
                 logging.info('Reading hazard')

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -120,6 +120,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
     from_engine = False  # set by engine.run_calc
     pre_calculator = None  # to be overridden
     is_stochastic = False  # True for scenario and event based calculators
+    dynamic_parent = None
 
     def __init__(self, oqparam, calc_id=None):
         self.datastore = datastore.DataStore(calc_id)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -450,6 +450,9 @@ class EventBasedCalculator(base.HazardCalculator):
                     'gmf_data/indices',
                     [numpy.array(self.indices[sid], indices_dt)
                      for sid in self.sitecol.complete.sids])
+        else:
+            raise RuntimeError('No GMFs were generated, perhaps they were '
+                               'all below the minimum_intensity threshold')
         return acc
 
     def save_gmf_bytes(self):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -293,16 +293,13 @@ def compute_gmfs_and_curves(getters, oq, monitor):
             with monitor('building hazard', measuremem=True):
                 gmfdata = numpy.fromiter(getter.gen_gmv(), getter.gmf_data_dt)
         indices = []
-        if oq.ground_motion_fields:
-            gmfdata.sort(order=('sid', 'rlzi', 'eid'))
-            start = stop = 0
-            for sid, rows in itertools.groupby(gmfdata['sid']):
-                for row in rows:
-                    stop += 1
-                indices.append((sid, start, stop))
-                start = stop
-        else:
-            gmfdata = None
+        gmfdata.sort(order=('sid', 'rlzi', 'eid'))
+        start = stop = 0
+        for sid, rows in itertools.groupby(gmfdata['sid']):
+            for row in rows:
+                stop += 1
+            indices.append((sid, start, stop))
+            start = stop
         res = dict(gmfdata=gmfdata, hcurves=hcurves, gmdata=getter.gmdata,
                    indices=numpy.array(indices, (U32, 3)))
         if len(getter.gmdata):
@@ -342,16 +339,15 @@ class EventBasedCalculator(base.HazardCalculator):
         for res in results:
             self.gmdata += res['gmdata']
             data = res['gmfdata']
-            if data is not None:
-                with sav_mon:
-                    hdf5.extend3(hdf5path, 'gmf_data/data', data)
-                    # it is important to save the number of bytes while the
-                    # computation is going, to see the progress
-                    update_nbytes(self.datastore, 'gmf_data/data', data)
-                    for sid, start, stop in res['indices']:
-                        self.indices[sid].append(
-                            (start + self.offset, stop + self.offset))
-                    self.offset += len(data)
+            with sav_mon:
+                hdf5.extend3(hdf5path, 'gmf_data/data', data)
+                # it is important to save the number of bytes while the
+                # computation is going, to see the progress
+                update_nbytes(self.datastore, 'gmf_data/data', data)
+                for sid, start, stop in res['indices']:
+                    self.indices[sid].append(
+                        (start + self.offset, stop + self.offset))
+                self.offset += len(data)
             slicedic = self.oqparam.imtls.slicedic
             with agg_mon:
                 for key, poes in res['hcurves'].items():
@@ -421,10 +417,7 @@ class EventBasedCalculator(base.HazardCalculator):
         tectonic region type.
         """
         oq = self.oqparam
-        if not oq.hazard_curves_from_gmfs and not oq.ground_motion_fields:
-            return
-        if self.oqparam.ground_motion_fields:
-            calc.check_overflow(self)
+        calc.check_overflow(self)
 
         self.csm_info = self.datastore['csm_info']
         self.sm_id = {tuple(sm.path): sm.ordinal
@@ -469,9 +462,7 @@ class EventBasedCalculator(base.HazardCalculator):
             dictionary if hazard_curves_from_gmfs is false
         """
         oq = self.oqparam
-        if not oq.hazard_curves_from_gmfs and not oq.ground_motion_fields:
-            return
-        elif oq.hazard_curves_from_gmfs:
+        if oq.hazard_curves_from_gmfs:
             rlzs = self.rlzs_assoc.realizations
             # save individual curves
             for i in sorted(result):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -191,7 +191,8 @@ class EbrCalculator(base.RiskCalculator):
             ebcalc = base.calculators[self.pre_calculator](self.oqparam)
             ebcalc.run(close=False)
             self.set_log_format()
-            parent = self.datastore.parent = ebcalc.datastore
+            parent = self.dynamic_parent = self.datastore.parent = (
+                ebcalc.datastore)
             oq.hazard_calculation_id = parent.calc_id
             self.datastore['oqparam'] = oq
             self.param = ebcalc.param

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -210,9 +210,9 @@ class EbrCalculator(base.RiskCalculator):
                     ' != %s' % (oqp.investigation_time, oq.investigation_time))
             # sorting the eids is essential to get the epsilons in the right
             # order (i.e. consistent with the one used in ebr from ruptures)
-            self.eids = sorted(parent['events']['eid'])
             self.datastore['csm_info'] = parent['csm_info']
             self.rlzs_assoc = parent['csm_info'].get_rlzs_assoc()
+        self.eids = sorted(parent['events']['eid'])
         self.E = len(self.eids)
         eps = self.epsilon_getter()()
         self.riskinputs = self.build_riskinputs('gmf', eps, self.E)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -22,8 +22,7 @@ import collections
 import numpy
 
 from openquake.baselib.python3compat import zip, encode
-from openquake.baselib.general import (
-    AccumDict, block_splitter, split_in_blocks)
+from openquake.baselib.general import AccumDict, split_in_blocks
 from openquake.baselib import parallel
 from openquake.hazardlib.stats import set_rlzs_stats
 from openquake.risklib import riskinput
@@ -178,10 +177,9 @@ class EbrCalculator(base.RiskCalculator):
             super().pre_execute()
             parent = self.datastore.parent
         else:
-            ebcalc = event_based.EventBasedCalculator(self.oqparam)
-            ebcalc.run()
+            ebcalc = base.calculators[self.pre_calculator](self.oqparam)
+            ebcalc.run(close=False)
             parent = self.datastore.parent = ebcalc.datastore
-            parent.open()
             oq.hazard_calculation_id = parent.calc_id
             self.datastore['oqparam'] = oq
             self.param = ebcalc.param

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -179,6 +179,7 @@ class EbrCalculator(base.RiskCalculator):
         else:
             ebcalc = base.calculators[self.pre_calculator](self.oqparam)
             ebcalc.run(close=False)
+            self.set_log_format()
             parent = self.datastore.parent = ebcalc.datastore
             oq.hazard_calculation_id = parent.calc_id
             self.datastore['oqparam'] = oq
@@ -236,12 +237,6 @@ class EbrCalculator(base.RiskCalculator):
             self.oqparam.asset_correlation,
             self.oqparam.master_seed,
             self.oqparam.ignore_covs or not self.riskmodel.covs)
-
-    def execute(self):
-        """
-        Run the calculator and aggregate the results
-        """
-        return base.RiskCalculator.execute(self)
 
     def save_results(self, allres, num_rlzs):
         """

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -213,8 +213,6 @@ class EbrCalculator(base.RiskCalculator):
         self.param['avg_losses'] = oq.avg_losses
         self.param['ses_ratio'] = oq.ses_ratio
         self.param['asset_loss_table'] = oq.asset_loss_table
-        self.param['elt_dt'] = numpy.dtype(
-            [('eid', U64), ('rlzi', U16), ('loss', (F32, (self.L * self.I,)))])
         self.taskno = 0
         self.start = 0
         avg_losses = self.oqparam.avg_losses
@@ -339,13 +337,14 @@ class EbrCalculator(base.RiskCalculator):
         Save risk data and possibly execute the EbrPostCalculator
         """
         logging.info('Saving event loss table')
+        elt_dt = numpy.dtype(
+            [('eid', U64), ('rlzi', U16), ('loss', (F32, (self.L * self.I,)))])
         with self.monitor('saving event loss table', measuremem=True):
             # saving zeros is a lot faster than adding an `if loss.sum()`
             agglosses = numpy.fromiter(
                 ((e, r, loss)
                  for e, losses in zip(self.eids, self.agglosses)
-                 for r, loss in enumerate(losses) if loss.sum()),
-                self.param['elt_dt'])
+                 for r, loss in enumerate(losses) if loss.sum()), elt_dt)
             self.datastore['losses_by_event'] = agglosses
         self.postproc()
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -117,7 +117,7 @@ def event_based_risk(riskinput, riskmodel, param, monitor):
                 # agglosses, asset_loss_table
                 for i in range(I):
                     li = l + L * i
-                    # this is the critical loop: it is import to keep it
+                    # this is the critical loop: it is important to keep it
                     # vectorized in terms of the event indices
                     agg[indices, r, li] += losses[:, i]
                     if param['asset_loss_table']:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -197,11 +197,12 @@ class GmfDataGetter(collections.Mapping):
     """
     A dictionary-like object {sid: dictionary by realization index}
     """
-    def __init__(self, dstore, sids, num_rlzs, num_events=0):
+    def __init__(self, dstore, sids, num_rlzs, num_events, imtls):
         self.dstore = dstore
         self.sids = sids
         self.num_rlzs = num_rlzs
         self.E = num_events
+        self.imtls = imtls
 
     def init(self):
         if hasattr(self, 'data'):  # already initialized
@@ -220,7 +221,6 @@ class GmfDataGetter(collections.Mapping):
         # now some attributes set for API compatibility with the GmfGetter
         # number of ground motion fields
         # dictionary rlzi -> array(imts, events, nbytes)
-        self.imtls = self.dstore['oqparam'].imtls
         self.gmdata = AccumDict(accum=numpy.zeros(len(self.imtls) + 1, F32))
 
     def get_hazard(self, gsim=None):

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -286,8 +286,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         # Turkey with SHARE logic tree; TODO: add site model
         # it has 8 realizations but 4 of them have 0 ruptures
         out = self.run_calc(case_4.__file__, 'job.ini',
-                            calculation_mode='event_based',
-                            ground_motion_fields='false', exports='csv')
+                            calculation_mode='event_based', exports='csv')
         [f1, f2] = [f for f in out['hcurves', 'csv'] if 'mean' in f]
         self.assertEqualFiles('expected/hazard_curve-mean-PGA.csv', f1)
         self.assertEqualFiles('expected/hazard_curve-mean-SA(0.5).csv', f2)

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -134,7 +134,8 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         os.remove(fname)
 
         # test the composite_risk_model keys (i.e. slash escaping)
-        crm = sorted(self.calc.datastore.getitem('composite_risk_model'))
+        parent = self.calc.datastore.parent
+        crm = sorted(parent.getitem('composite_risk_model'))
         self.assertEqual(crm, ['RC%2B', 'RM', 'W%2F1'])
 
         # test the case when all GMFs are filtered out

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -415,15 +415,12 @@ class UCERFRiskCalculator(EbrCalculator):
         :param offset:
             realization offset
         """
-        agglosses = dic.pop('agglosses')
-        avglosses = dic.pop('avglosses')
         with self.monitor('saving event loss table', autoflush=True):
+            agglosses = dic.pop('agglosses')
             agglosses['rlzi'] += offset
             self.datastore.extend('losses_by_event', agglosses)
-
-        if not hasattr(self, 'vals'):
-            self.vals = self.assetcol.values()
         with self.monitor('saving avg_losses-rlzs'):
+            avglosses = dic.pop('avglosses')
             for (l, r), ratios in avglosses.items():
                 lt = self.riskmodel.loss_types[l]
                 self.dset[:, r + offset, l] += ratios * self.vals[lt]

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -32,13 +32,78 @@ from openquake.commonlib import calc, util, readinput
 from openquake.calculators import base, event_based, getters
 from openquake.calculators.ucerf_base import (
     DEFAULT_TRT, UcerfFilter, generate_background_ruptures)
-from openquake.calculators.event_based_risk import (
-    EbrCalculator, event_based_risk)
+from openquake.calculators.event_based_risk import EbrCalculator
 
 U16 = numpy.uint16
 U64 = numpy.uint64
 F32 = numpy.float32
+F64 = numpy.float64
 TWO16 = 2 ** 16
+
+
+def event_based_risk(riskinput, riskmodel, param, monitor):
+    """
+    :param riskinput:
+        a :class:`openquake.risklib.riskinput.RiskInput` object
+    :param riskmodel:
+        a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
+    :param param:
+        a dictionary of parameters
+    :param monitor:
+        :class:`openquake.baselib.performance.Monitor` instance
+    :returns:
+        a dictionary of numpy arrays of shape (L, R)
+    """
+    with monitor('%s.init' % riskinput.hazard_getter.__class__.__name__):
+        riskinput.hazard_getter.init()
+    eids = riskinput.hazard_getter.eids
+    A = len(riskinput.aids)
+    E = len(eids)
+    assert not param['insured_losses']
+    L = len(riskmodel.lti)
+    R = riskinput.hazard_getter.num_rlzs
+    param['lrs_dt'] = numpy.dtype([('rlzi', U16), ('ratios', (F32, L))])
+    agg = numpy.zeros((E, R, L), F32)
+    avg = AccumDict(accum={} if riskinput.by_site or not param['avg_losses']
+                    else numpy.zeros(A, F64))
+    result = dict(aids=riskinput.aids, avglosses=avg)
+
+    # update the result dictionary and the agg array with each output
+    for out in riskmodel.gen_outputs(riskinput, monitor):
+        if len(out.eids) == 0:  # this happens for sites with no events
+            continue
+        r = out.rlzi
+        idx = riskinput.hazard_getter.eid2idx
+        for l, loss_ratios in enumerate(out):
+            if loss_ratios is None:  # for GMFs below the minimum_intensity
+                continue
+            loss_type = riskmodel.loss_types[l]
+            indices = numpy.array([idx[eid] for eid in out.eids])
+            for a, asset in enumerate(out.assets):
+                ratios = loss_ratios[a]  # shape (E, I)
+                aid = asset.ordinal
+                losses = ratios * asset.value(loss_type)
+                # average losses
+                if param['avg_losses']:
+                    rat = ratios.sum(axis=0) * param['ses_ratio']
+                    lba = avg[l, r]
+                    try:
+                        lba[aid] += rat
+                    except KeyError:
+                        lba[aid] = rat
+
+                # agglosses
+                # this is the critical loop: it is import to keep it
+                # vectorized in terms of the event indices
+                agg[indices, r, l] += losses[:, 0]
+
+    it = ((eid, r, losses)
+          for eid, all_losses in zip(eids, agg)
+          for r, losses in enumerate(all_losses) if losses.sum())
+    result['agglosses'] = numpy.fromiter(it, param['elt_dt'])
+    # store info about the GMFs, must be done at the end
+    result['gmdata'] = riskinput.gmdata
+    return result
 
 
 def generate_event_set(ucerf, background_sids, src_filter, seed):
@@ -324,7 +389,6 @@ class UCERFRiskCalculator(EbrCalculator):
                              ses_ratio=oq.ses_ratio,
                              avg_losses=oq.avg_losses,
                              elt_dt=elt_dt,
-                             asset_loss_table=False,
                              insured_losses=oq.insured_losses)
                 yield (ssm, self.csm.src_filter, param,
                        self.riskmodel, imts, oq.truncation_level,
@@ -341,3 +405,50 @@ class UCERFRiskCalculator(EbrCalculator):
         self.csm.info.update_eff_ruptures(self.eff_ruptures)
         self.datastore['csm_info'] = self.csm.info
         return num_events
+
+    def save_losses(self, dic, offset=0):
+        """
+        Save the event loss tables incrementally.
+
+        :param dic:
+            dictionary with agglosses, assratios, avglosses, lrs_idx
+        :param offset:
+            realization offset
+        """
+        agglosses = dic.pop('agglosses')
+        avglosses = dic.pop('avglosses')
+        with self.monitor('saving event loss table', autoflush=True):
+            agglosses['rlzi'] += offset
+            self.datastore.extend('losses_by_event', agglosses)
+
+        if not hasattr(self, 'vals'):
+            self.vals = self.assetcol.values()
+        with self.monitor('saving avg_losses-rlzs'):
+            for (l, r), ratios in avglosses.items():
+                lt = self.riskmodel.loss_types[l]
+                self.dset[:, r + offset, l] += ratios * self.vals[lt]
+        self.taskno += 1
+
+    def post_execute(self, result):
+        """
+        Save risk data and possibly execute the EbrPostCalculator
+        """
+        num_events = result
+        # gmv[:-1] are the events per each IMT
+        gmv = sum(gm[:-1].sum() for gm in self.gmdata.values())
+        if not gmv:
+            raise RuntimeError('No GMFs were generated, perhaps they were '
+                               'all below the minimum_intensity threshold')
+
+        if 'losses_by_event' not in self.datastore:
+            logging.warning(
+                'No losses were generated: most likely there is an error '
+                'in y our input files or the GMFs were below the minimum '
+                'intensity')
+        else:
+            self.datastore.set_nbytes('losses_by_event')
+            E = sum(num_events.values())
+            agglt = self.datastore['losses_by_event']
+            agglt.attrs['nonzero_fraction'] = len(agglt) / E
+
+        self.postproc()

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -41,7 +41,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 
 
-def event_based_risk(riskinput, riskmodel, param, monitor):
+def ucerf_risk(riskinput, riskmodel, param, monitor):
     """
     :param riskinput:
         a :class:`openquake.risklib.riskinput.RiskInput` object
@@ -338,7 +338,7 @@ def compute_losses(ssm, src_filter, param, riskmodel,
         src_filter.integration_distance, trunc_level, correl_model,
         samples[grp_id])
     ri = riskinput.RiskInput(getter, param['assetcol'].assets_by_site())
-    res.append(event_based_risk(ri, riskmodel, param, monitor))
+    res.append(ucerf_risk(ri, riskmodel, param, monitor))
     res.sm_id = ssm.sm_id
     res.num_events = len(ri.hazard_getter.eids)
     start = res.sm_id * num_rlzs
@@ -427,7 +427,7 @@ class UCERFRiskCalculator(EbrCalculator):
 
     def post_execute(self, result):
         """
-        Call the EbrPostCalculator
+        Call the EbrPostCalculator to compute the aggregate loss curves
         """
         if 'losses_by_event' not in self.datastore:
             logging.warning(

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -427,23 +427,16 @@ class UCERFRiskCalculator(EbrCalculator):
 
     def post_execute(self, result):
         """
-        Save risk data and possibly execute the EbrPostCalculator
+        Call the EbrPostCalculator
         """
-        num_events = result
-        # gmv[:-1] are the events per each IMT
-        gmv = sum(gm[:-1].sum() for gm in self.gmdata.values())
-        if not gmv:
-            raise RuntimeError('No GMFs were generated, perhaps they were '
-                               'all below the minimum_intensity threshold')
-
         if 'losses_by_event' not in self.datastore:
             logging.warning(
                 'No losses were generated: most likely there is an error '
-                'in y our input files or the GMFs were below the minimum '
+                'in your input files or the GMFs were below the minimum '
                 'intensity')
         else:
             self.datastore.set_nbytes('losses_by_event')
-            E = sum(num_events.values())
+            E = sum(result.values())
             agglt = self.datastore['losses_by_event']
             agglt.attrs['nonzero_fraction'] = len(agglt) / E
 

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -92,10 +92,9 @@ def event_based_risk(riskinput, riskmodel, param, monitor):
                     except KeyError:
                         lba[aid] = rat
 
-                # agglosses
-                # this is the critical loop: it is import to keep it
+                # this is the critical loop: it is important to keep it
                 # vectorized in terms of the event indices
-                agg[indices, r, l] += losses[:, 0]
+                agg[indices, r, l] += losses[:, 0]  # 0 == no insured
 
     it = ((eid, r, losses)
           for eid, all_losses in zip(eids, agg)

--- a/openquake/commands/importcalc.py
+++ b/openquake/commands/importcalc.py
@@ -73,12 +73,10 @@ def importcalc(host, calc_id, username, password):
             down += len(chunk)
             general.println('Downloaded {:,} bytes'.format(down))
     print()
-    logs.dbcmd('import_job', calc_id, json['calculation_mode'],
-               json['description'], json['owner'], json['status'],
-               json['parent_id'], datadir)
     with datastore.read(calc_id) as dstore:
-        engine.expose_outputs(dstore)
+        engine.expose_outputs(dstore, json['owner'], json['status'])
     logging.info('Imported calculation %d successfully', calc_id)
+
 
 importcalc.arg('host', 'remote host (ex. https://oq1.wilson.openquake.org/)')
 importcalc.arg('calc_id', 'calculation ID', type=int)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -407,6 +407,5 @@ class EngineRunJobTestCase(unittest.TestCase):
         # to a wrong refactoring of the safely_call function)
         with read(job_id) as dstore:
             perf = view('performance', dstore)
-            self.assertIn('total compute_ruptures', perf)
             self.assertIn('total event_based_risk', perf)
             self.assertIn('total build_curves_maps', perf)

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -31,9 +31,6 @@ LEVELS = {'debug': logging.DEBUG,
           'error': logging.ERROR,
           'critical': logging.CRITICAL}
 
-LOG_FORMAT = ('[%(asctime)s #%(job_id)s %(hostname)s '
-              '%(levelname)s %(processName)s/%(process)s] %(message)s')
-
 LOG = logging.getLogger()
 
 DBSERVER_PORT = int(os.environ.get('OQ_DBSERVER_PORT') or config.dbserver.port)
@@ -88,7 +85,6 @@ class LogStreamHandler(logging.StreamHandler):
     """
     def __init__(self, job_id):
         super().__init__()
-        self.setFormatter(logging.Formatter(LOG_FORMAT))
         self.job_id = job_id
 
     def emit(self, record):  # pylint: disable=E0202
@@ -102,7 +98,6 @@ class LogFileHandler(logging.FileHandler):
     """
     def __init__(self, job_id, log_file):
         super().__init__(log_file)
-        self.setFormatter(logging.Formatter(LOG_FORMAT))
         self.job_id = job_id
         self.log_file = log_file
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -73,7 +73,7 @@ class OqParam(valid.ParamSet):
     ground_motion_correlation_model = valid.Param(
         valid.NoneOr(valid.Choice(*GROUND_MOTION_CORRELATION_MODELS)), None)
     ground_motion_correlation_params = valid.Param(valid.dictionary)
-    ground_motion_fields = valid.Param(valid.boolean, False)
+    ground_motion_fields = valid.Param(valid.boolean, True)
     gsim = valid.Param(valid.gsim, valid.FromFile())
     hazard_calculation_id = valid.Param(valid.NoneOr(valid.positiveint), None)
     hazard_curves_from_gmfs = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -73,7 +73,6 @@ class OqParam(valid.ParamSet):
     ground_motion_correlation_model = valid.Param(
         valid.NoneOr(valid.Choice(*GROUND_MOTION_CORRELATION_MODELS)), None)
     ground_motion_correlation_params = valid.Param(valid.dictionary)
-    ground_motion_fields = valid.Param(valid.boolean, True)
     gsim = valid.Param(valid.gsim, valid.FromFile())
     hazard_calculation_id = valid.Param(valid.NoneOr(valid.positiveint), None)
     hazard_curves_from_gmfs = valid.Param(valid.boolean, False)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -124,7 +124,7 @@ def expose_outputs(dstore):
     if len(rlzs) > 1:
         dskeys.add('realizations')
     # expose gmf_data only if < 10 MB
-    if oq.ground_motion_fields and calcmode == 'event_based':
+    if calcmode == 'event_based':
         nbytes = dstore['gmf_data'].attrs['nbytes']
         if nbytes < 10 * 1024 ** 2:
             dskeys.add('gmf_data')

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -305,9 +305,10 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
         if OQ_DISTRIBUTE.startswith(('celery', 'zmq')):
             set_concurrent_tasks_default(job_id)
         msg = check_obsolete_version(oqparam.calculation_mode)
+        calc = base.calculators(oqparam, calc_id=job_id)
+        calc.set_log_format()
         if msg:
             logs.LOG.warn(msg)
-        calc = base.calculators(oqparam, calc_id=job_id)
         calc.from_engine = True
         input_zip = oqparam.inputs.get('input_zip')
         tb = 'None\n'

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -155,8 +155,8 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
     if logs.dbcmd('get_job', dstore.calc_id) is None:
         # the calculation has not been imported in the db yet
         logs.dbcmd('import_job', dstore.calc_id, oq.calculation_mode,
-                   oq.description, owner, status, oq.hazard_calculation_id,
-                   dstore.datadir)
+                   oq.description + ' [parent]', owner, status,
+                   oq.hazard_calculation_id, dstore.datadir)
     logs.dbcmd('create_outputs', dstore.calc_id, sorted(dskeys & exportable))
 
 

--- a/openquake/qa_tests_data/event_based_risk/case_3/expected/agg_loss-mean.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_3/expected/agg_loss-mean.csv
@@ -1,3 +1,3 @@
 annual_frequency_of_exceedence,return_period,structural
-1.00000E+00,1,7.39919E+05
-5.00000E-01,2,4.83760E+06
+1.00000E+00,1,7.39922E+05
+5.00000E-01,2,4.83758E+06


### PR DESCRIPTION
Now the GMFs are always stored and used, except in the ucerf_risk calculator, where the distribution by rupture mechanism has been kept (it is efficient there). If there is  single job.ini file internally the engine will generate two calculations but the hazard one will not be stored in the database (we could store it if deemed necessary).