### PR TITLE
Make it possible to see the username in `oq celery inspect`

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -226,6 +226,7 @@ class Pickled(object):
     def __init__(self, obj):
         self.clsname = obj.__class__.__name__
         self.calc_id = str(getattr(obj, 'calc_id', ''))  # for monitors
+        self.username = '[%s]' % obj.username if hasattr(obj, 'user') else ''
         try:
             self.pik = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
         except TypeError as exc:  # can't pickle, show the obj in the message
@@ -233,8 +234,8 @@ class Pickled(object):
 
     def __repr__(self):
         """String representation of the pickled object"""
-        return '<Pickled %s #%s %s>' % (
-            self.clsname, self.calc_id, humansize(len(self)))
+        return '<Pickled %s%s #%s %s>' % (
+            self.clsname, self.username, self.calc_id, humansize(len(self)))
 
     def __len__(self):
         """Length of the pickled bytestring"""

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -167,6 +167,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
         """
         global logversion
         with self._monitor:
+            self._monitor.username = kw.get('username', '')
             self.close = close
             self.set_log_format()
             if logversion:  # make sure this is logged only once

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -43,7 +43,7 @@ def get_job_id(job_id, username=None):
 
 
 def run_job(cfg_file, log_level='info', log_file=None, exports='',
-            hazard_calculation_id=None, **kw):
+            hazard_calculation_id=None,  username=getpass.getuser(), **kw):
     """
     Run a job using the specified config file and other options.
 
@@ -57,11 +57,14 @@ def run_job(cfg_file, log_level='info', log_file=None, exports='',
         A comma-separated string of export types requested by the user.
     :param hazard_calculation_id:
         ID of the previous calculation or None
+    :param username:
+        Name of the user running the job
     """
     # if the master dies, automatically kill the workers
     job_ini = os.path.abspath(cfg_file)
     job_id, oqparam = eng.job_from_file(
-        job_ini, getpass.getuser(), hazard_calculation_id)
+        job_ini, username, hazard_calculation_id)
+    kw['username'] = username
     eng.run_calc(job_id, oqparam, log_level, log_file, exports,
                  hazard_calculation_id=hazard_calculation_id, **kw)
     for line in logs.dbcmd('list_outputs', job_id, False):

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -490,19 +490,21 @@ from openquake.engine import engine
 if __name__ == '__main__':
     oqparam = pickle.loads(%(pik)r)
     engine.run_calc(
-        %(job_id)s, oqparam, 'info', os.devnull, '', %(hazard_job_id)s)
+        %(job_id)s, oqparam, 'info', os.devnull, '', %(hazard_job_id)s,
+        username='%(username)s')
     os.remove(__file__)
 '''
 
 
-def submit_job(job_ini, user_name, hazard_job_id=None):
+def submit_job(job_ini, username, hazard_job_id=None):
     """
     Create a job object from the given job.ini file in the job directory
     and run it in a new process. Returns the job ID and PID.
     """
-    job_id, oq = engine.job_from_file(job_ini, user_name, hazard_job_id)
+    job_id, oq = engine.job_from_file(job_ini, username, hazard_job_id)
     pik = pickle.dumps(oq, protocol=0)  # human readable protocol
-    code = RUNCALC % dict(job_id=job_id, hazard_job_id=hazard_job_id, pik=pik)
+    code = RUNCALC % dict(job_id=job_id, hazard_job_id=hazard_job_id, pik=pik,
+                          username=username)
     tmp_py = gettemp(code, suffix='.py')
     # print(code, tmp_py)  # useful when debugging
     devnull = subprocess.DEVNULL


### PR DESCRIPTION
It is clearly useful to see who is the owner of the tasks currently running. The trick is to pass the username to the `Monitor` object and to change its `__repr__` as well as the `__repr__` of  the `Pickled` class.