### PR TITLE
Decouple zmq from zworkers and bind/connect IPs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Daniele Viganò]
+  * Changed the openquake.cfg file and added a dbserver.listen parameter
   * Added the hostname in the WebUI page. It can be customize by the user
     via the `local_settings.py` file
 

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -24,5 +24,5 @@ Index: oq-engine/openquake/engine/openquake.cfg
 +port = 1907
  
  [zworkers]
- master_host = 127.0.0.1
+ master_host = localhost
 

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -1,8 +1,8 @@
 Index: oq-engine/openquake/engine/openquake.cfg
 ===================================================================
---- oq-engine.orig/openquake/engine/openquake.cfg	2018-03-15 08:47:12.245368066 +0200
-+++ oq-engine/openquake/engine/openquake.cfg	2018-03-15 08:47:12.245368066 +0200
-@@ -39,15 +39,14 @@
+--- oq-engine.orig/openquake/engine/openquake.cfg	2018-06-14 15:52:40.006774324 +0200
++++ oq-engine/openquake/engine/openquake.cfg	2018-06-14 15:53:55.484502255 +0200
+@@ -39,19 +39,20 @@
  celery_queue = celery
  
  [dbserver]
@@ -10,19 +10,23 @@ Index: oq-engine/openquake/engine/openquake.cfg
 -multi_user = false
 -file = ~/oqdata/db.sqlite3
 -log = ~/oqdata/dbserver.log
++# run in multi_user mode
 +multi_user = true
 +file = /var/lib/openquake/db.sqlite3
 +log = /var/lib/openquake/dbserver.log
- host = 127.0.0.1
+ # daemon bind address; must be a valid IP address
+ # example: 0.0.0.0
+ listen = 127.0.0.1
+ # address of the dbserver; can be an hostname too
+ # example: master.hpc
+ host = localhost
 -# port 1908 has a good reputation:
 -# https://isc.sans.edu/port.html?port=1908
 -port = 1908
--authkey = changeme
 +# for packages we use port 1907 to avoid conflicts
 +# with local development installations
 +# https://isc.sans.edu/port.html?port=1907
 +port = 1907
- 
- [zmq]
- master_host = localhost
-
+ # port range used by workers to send back results
+ # to the master node; used only with a multi-node setup
+ receiver_ports = 1912-1920

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -23,6 +23,6 @@ Index: oq-engine/openquake/engine/openquake.cfg
 +# https://isc.sans.edu/port.html?port=1907
 +port = 1907
  
- [zworkers]
+ [zmq]
  master_host = localhost
 

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -35,26 +35,28 @@ oq_distribute = celery
 ## OpenQuake Engine 'worker' node configuration File
 On all worker nodes, the `/etc/openquake/openquake.cfg` file should be also modified to set the *DbServer* and *RabbitMQ* daemons IP address:
 
-```
+```ini
 [amqp]
+# RabbitMQ server address
 host = w.x.y.z
 port = 5672
 user = openquake
 password = openquake
 vhost = openquake
-# This is where tasks will be enqueued.
 celery_queue = celery
 
 [dbserver]
-# enable multi_user if you have a multiple user installation
 multi_user = true
 file = /var/lib/openquake/db.sqlite3
 log = /var/lib/openquake/dbserver.log
+# daemon bind address; must be a valid IP address
+listen = 0.0.0.0
+# address of the dbserver; can be an hostname too
 host = w.x.y.z
 port = 1907
-authkey = changeme
+receiver_ports = 1912-1920
+authkey = somethingstronger
 ```
-
 
 ### Configuring daemons
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -567,7 +567,7 @@ class Starmap(object):
         else:  # instance with a __call__ method
             self.argnames = inspect.getargspec(task_func.__call__).args[1:]
         self.receiver = 'tcp://%s:%s' % (
-            config.dbserver.host, config.zmq.receiver_ports)
+            config.dbserver.listen, config.dbserver.receiver_ports)
         self.sent = numpy.zeros(len(self.argnames))
 
     @property
@@ -649,7 +649,7 @@ class Starmap(object):
 
     def _iter_celery(self):
         with Socket(self.receiver, zmq.PULL, 'bind') as socket:
-            backurl = 'tcp://%s:%s' % (config.zmq.master_host, socket.port)
+            backurl = 'tcp://%s:%s' % (config.dbserver.host, socket.port)
             logging.info('Using receiver %s', backurl)
             results = []
             for piks in self._genargs(backurl):
@@ -675,10 +675,10 @@ class Starmap(object):
 
     def _iter_zmq(self):
         with Socket(self.receiver, zmq.PULL, 'bind') as socket:
-            task_in_url = 'tcp://%s:%s' % (config.zmq.master_host,
+            task_in_url = 'tcp://%s:%s' % (config.dbserver.host,
                                            config.zworkers.task_in_port)
             with Socket(task_in_url, zmq.PUSH, 'connect') as sender:
-                backurl = 'tcp://%s:%s' % (config.zmq.master_host, socket.port)
+                backurl = 'tcp://%s:%s' % (config.dbserver.host, socket.port)
                 num_results = 0
                 for args in self._genargs(backurl):
                     sender.send((self.task_func, args))

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -151,6 +151,5 @@ class Socket(object):
             return self.zsocket.recv_pyobj()
 
     def __repr__(self):
-        end_point = getattr(self, self.end_point)
-        return '<%s %s %s %s>' % (self.__class__.__name__, end_point,
-                                  SOCKTYPE[self.socket_type], self.mode)
+        return '<%s %s %s>' % (self.__class__.__name__,
+                               SOCKTYPE[self.socket_type], self.mode)

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -76,9 +76,10 @@ class Socket(object):
     :param timeout: default 5000 ms, used when polling the underlying socket
     """
     def __init__(self, end_point, socket_type, mode, timeout=5000):
-        assert 'localhost' not in end_point, 'Use 127.0.0.1 instead'
         assert socket_type in (zmq.REP, zmq.REQ, zmq.PULL, zmq.PUSH)
         assert mode in ('bind', 'connect'), mode
+        if mode == 'bind':
+            assert 'localhost' not in end_point, 'Use 127.0.0.1 instead'
         self.end_point = end_point
         self.socket_type = socket_type
         self.mode = mode

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -98,10 +98,8 @@ class Socket(object):
             port = self.zsocket.bind_to_random_port(end_point, p1, p2)
             # NB: will raise a ZMQBindError if no port is available
             self.port = port
-            self.backurl = '%s:%d' % (end_point, port)
         elif self.mode == 'bind':
             self.zsocket = bind(self.end_point, self.socket_type)
-            self.backurl = self.end_point
         else:  # connect
             self.zsocket = connect(self.end_point, self.socket_type)
         port = re.search(r':(\d+)$', self.end_point)
@@ -153,6 +151,6 @@ class Socket(object):
             return self.zsocket.recv_pyobj()
 
     def __repr__(self):
-        end_point = getattr(self, 'backurl', self.end_point)
+        end_point = getattr(self, self.end_point)
         return '<%s %s %s %s>' % (self.__class__.__name__, end_point,
                                   SOCKTYPE[self.socket_type], self.mode)

--- a/openquake/commands/workers.py
+++ b/openquake/commands/workers.py
@@ -28,7 +28,9 @@ def workers(cmd):
     if config.dbserver.multi_user and getpass.getuser() != 'openquake':
         sys.exit('oq workers only works in single user mode')
 
-    master = workerpool.WorkerMaster(**config.zworkers)
+    master = workerpool.WorkerMaster(config.zmq.master_host,
+                                     **config.zworkers)
     print(getattr(master, cmd)())
+
 
 workers.arg('cmd', 'command', choices='start stop status restart'.split())

--- a/openquake/commands/workers.py
+++ b/openquake/commands/workers.py
@@ -28,7 +28,7 @@ def workers(cmd):
     if config.dbserver.multi_user and getpass.getuser() != 'openquake':
         sys.exit('oq workers only works in single user mode')
 
-    master = workerpool.WorkerMaster(config.zmq.master_host,
+    master = workerpool.WorkerMaster(config.dbserver.host,
                                      **config.zworkers)
     print(getattr(master, cmd)())
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -30,12 +30,12 @@ soft_mem_limit = 80
 hard_mem_limit = 100
 
 [amqp]
+# RabbitMQ server address
 host = localhost
 port = 5672
 user = openquake
 password = openquake
 vhost = openquake
-# This is where tasks will be enqueued.
 celery_queue = celery
 
 [dbserver]
@@ -43,15 +43,19 @@ celery_queue = celery
 multi_user = false
 file = ~/oqdata/db.sqlite3
 log = ~/oqdata/dbserver.log
-host = 127.0.0.1
+# daemon bind address; must be a valid IP address
+# example: 0.0.0.0
+listen = 127.0.0.1
+# address of the dbserver; can be an hostname too
+# example: master.hpc
+host = localhost
 # port 1908 has a good reputation:
 # https://isc.sans.edu/port.html?port=1908
 port = 1908
-authkey = changeme
-
-[zmq]
-master_host = localhost
+# port range used by workers to send back results
+# to the master node; used only with a multi-node setup
 receiver_ports = 1912-1920
+authkey = changeme
 
 [zworkers]
 host_cores = 127.0.0.1 -1

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -49,13 +49,15 @@ host = 127.0.0.1
 port = 1908
 authkey = changeme
 
+[zmq]
+master_host = localhost
+receiver_ports = 1912-1920
+
 [zworkers]
-master_host = 127.0.0.1
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
 task_in_port = 1910
 task_out_port = 1911
-receiver_ports = 1912-1920
 remote_python =
 
 [directory]

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -57,7 +57,8 @@ class DbServer(object):
         self.backend = 'inproc://dbworkers'
         self.num_workers = num_workers
         self.pid = os.getpid()
-        self.master = w.WorkerMaster(**config.zworkers)
+        self.master = w.WorkerMaster(config.zmq.master_host,
+                                     **config.zworkers)
 
     def dworker(self, sock):
         # a database worker responding to commands

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -57,7 +57,7 @@ class DbServer(object):
         self.backend = 'inproc://dbworkers'
         self.num_workers = num_workers
         self.pid = os.getpid()
-        self.master = w.WorkerMaster(config.zmq.master_host,
+        self.master = w.WorkerMaster(config.dbserver.host,
                                      **config.zworkers)
 
     def dworker(self, sock):
@@ -191,7 +191,7 @@ def run_server(dbpath=os.path.expanduser(config.dbserver.file),
         dbhost, port = dbhostport.split(':')
         addr = (dbhost, int(port))
     else:
-        addr = (config.dbserver.host, DBSERVER_PORT)
+        addr = (config.dbserver.listen, DBSERVER_PORT)
 
     # create the db directory if needed
     dirname = os.path.dirname(dbpath)


### PR DESCRIPTION
Fixes #3780. See the ticket for an explanation and https://github.com/gem/oq-builders/pull/96 for a real-life example.

It also provides better explanation of `openquake.cfg` settings for hardcore deployments.

https://ci.openquake.org/job/zdevel_oq-engine/2775/