### PR TITLE
Various small refactorings

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -62,7 +62,7 @@ def create(hdf5, name, dtype, shape=(None,), compression=None,
     return dset
 
 
-def extend(dset, array):
+def extend(dset, array, **attrs):
     """
     Extend an extensible dataset with an array of a compatible dtype.
 
@@ -74,6 +74,8 @@ def extend(dset, array):
     newlength = length + len(array)
     dset.resize((newlength,) + array.shape[1:])
     dset[length:newlength] = array
+    for key, val in attrs.items():
+        dset.attrs[key] = val
     return newlength
 
 
@@ -271,6 +273,10 @@ class File(h5py.File):
             return obj
         else:
             return h5obj
+
+    def __getstate__(self):
+        # make the file pickleable
+        return {'_id': 0}
 
     def set_nbytes(self, key, nbytes=None):
         """

--- a/openquake/baselib/sap.py
+++ b/openquake/baselib/sap.py
@@ -111,9 +111,6 @@ class Script(object):
         if registry:
             self.registry['%s.%s' % (func.__module__, func.__name__)] = self
 
-    def __call__(self, *args):
-        return self.func(*args)
-
     def group(self, descr):
         """Added a new group of arguments with the given description"""
         self._group = self.parentparser.add_argument_group(descr)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -99,7 +99,6 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
         minimum_intensity dictionary.
         """
         oq = self.oqparam
-        self.min_iml = self.get_min_iml(oq)
         self.rupser = calc.RuptureSerializer(self.datastore)
 
     def zerodict(self):
@@ -226,7 +225,7 @@ class EventBasedRuptureCalculator(base.HazardCalculator):
             self.csm.info.get_samples_by_grp(),
             len(self.oqparam.imtls))
         self.datastore.set_attrs('events', max_gmf_size=gmf_size)
-        msg = 'less than ' if self.min_iml.sum() else ''
+        msg = 'less than ' if self.get_min_iml(self.oqparam).sum() else ''
         logging.info('Generating %s%s of GMFs', msg, humansize(gmf_size))
 
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -304,6 +304,7 @@ def compute_gmfs_and_curves(getters, oq, monitor):
         a list of dictionaries with keys gmfcoll and hcurves
     """
     results = []
+    dt = oq.gmf_data_dt()
     for getter in getters:
         with monitor('GmfGetter.init', measuremem=True):
             getter.init()
@@ -312,7 +313,7 @@ def compute_gmfs_and_curves(getters, oq, monitor):
             hc_mon = monitor('building hazard curves', measuremem=False)
             duration = oq.investigation_time * oq.ses_per_logic_tree_path
             with monitor('building hazard', measuremem=True):
-                gmfdata = numpy.fromiter(getter.gen_gmv(), getter.gmf_data_dt)
+                gmfdata = numpy.fromiter(getter.gen_gmv(), dt)
                 hazard = getter.get_hazard(data=gmfdata)
             for sid, hazardr in zip(getter.sids, hazard):
                 for rlzi, array in hazardr.items():
@@ -327,7 +328,7 @@ def compute_gmfs_and_curves(getters, oq, monitor):
                             hcurves[rsi2str(rlzi, sid, imt)] = poes
         else:  # fast lane
             with monitor('building hazard', measuremem=True):
-                gmfdata = numpy.fromiter(getter.gen_gmv(), getter.gmf_data_dt)
+                gmfdata = numpy.fromiter(getter.gen_gmv(), dt)
         indices = []
         gmfdata.sort(order=('sid', 'rlzi', 'eid'))
         start = stop = 0

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -270,9 +270,6 @@ class GmfGetter(object):
         self.correlation_model = oqparam.correl_model
         self.filter_distance = oqparam.filter_distance
         self.samples = samples
-        self.gmf_data_dt = numpy.dtype(
-            [('rlzi', U16), ('sid', U32),
-             ('eid', U64), ('gmv', (F32, (len(oqparam.imtls),)))])
 
     def init(self):
         """

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -44,14 +44,14 @@ def dbserver(cmd, dbhostport=None,
             print('dbserver already stopped')
     elif cmd == 'start':
         if status == 'not-running':
-            dbs.func.run_server(dbpath, dbhostport)
+            dbs.run_server.func(dbpath, dbhostport)
         else:
             print('dbserver already running')
     elif cmd == 'restart':
         if status == 'running':
             pid = logs.dbcmd('getpid')
             os.kill(pid, signal.SIGINT)
-        dbs.func.run_server(dbpath, dbhostport)
+        dbs.run_server.func(dbpath, dbhostport)
 
 
 dbserver.arg('cmd', 'dbserver command',

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -44,7 +44,7 @@ def dbserver(cmd, dbhostport=None,
             print('dbserver already stopped')
     elif cmd == 'start':
         if status == 'not-running':
-            dbs.run_server(dbpath, dbhostport)
+            dbs.func.run_server(dbpath, dbhostport)
         else:
             print('dbserver already running')
     elif cmd == 'restart':

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -51,7 +51,8 @@ def dbserver(cmd, dbhostport=None,
         if status == 'running':
             pid = logs.dbcmd('getpid')
             os.kill(pid, signal.SIGINT)
-        dbs.run_server(dbpath, dbhostport)
+        dbs.func.run_server(dbpath, dbhostport)
+
 
 dbserver.arg('cmd', 'dbserver command',
              choices='start stop status restart'.split())

--- a/openquake/commands/show.py
+++ b/openquake/commands/show.py
@@ -70,7 +70,7 @@ def show(what='contents', calc_id=-1, extra=()):
                 ds = read(calc_id)
                 oq = ds['oqparam']
                 cmode, descr = oq.calculation_mode, oq.description
-            except:
+            except Exception:
                 # invalid datastore file, or missing calculation_mode
                 # and description attributes, perhaps due to a manual kill
                 f = os.path.join(datadir, 'calc_%s.hdf5' % calc_id)
@@ -113,6 +113,7 @@ def show(what='contents', calc_id=-1, extra=()):
         print('%s not found' % what)
 
     ds.close()
+
 
 show.arg('what', 'key or view of the datastore')
 show.arg('calc_id', 'calculation ID', type=int)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -78,7 +78,7 @@ See http://docs.openquake.org/oq-engine/stable/effective-realizations.html for a
     def test_zip(self):
         path = os.path.join(DATADIR, 'frenchbug.zip')
         with Print.patch() as p:
-            info(None, None, None, None, None, None, path)
+            info.func(None, None, None, None, None, None, path)
         self.assertEqual(self.EXPECTED, str(p)[:len(self.EXPECTED)])
 
     # poor man tests: checking that the flags produce a few characters
@@ -86,33 +86,33 @@ See http://docs.openquake.org/oq-engine/stable/effective-realizations.html for a
 
     def test_calculators(self):
         with Print.patch() as p:
-            info(True, None, None, None, None, None, '')
+            info.func(True, None, None, None, None, None, '')
         self.assertGreater(len(str(p)), 10)
 
     def test_gsims(self):
         with Print.patch() as p:
-            info(None, True, None, None, None, None, '')
+            info.func(None, True, None, None, None, None, '')
         self.assertGreater(len(str(p)), 10)
 
     def test_views(self):
         with Print.patch() as p:
-            info(None, None, True, None, None, None, '')
+            info.func(None, None, True, None, None, None, '')
         self.assertGreater(len(str(p)), 10)
 
     def test_exports(self):
         with Print.patch() as p:
-            info(None, None, None, True, None, None, '')
+            info.func(None, None, None, True, None, None, '')
         self.assertGreater(len(str(p)), 10)
 
     def test_extracts(self):
         with Print.patch() as p:
-            info(None, None, None, None, True, None, '')
+            info.func(None, None, None, None, True, None, '')
         self.assertGreater(len(str(p)), 10)
 
     def test_job_ini(self):
         path = os.path.join(os.path.dirname(case_9.__file__), 'job.ini')
         with Print.patch() as p:
-            info(None, None, None, None, None, None, path)
+            info.func(None, None, None, None, None, None, path)
         # this is a test with multiple same ID sources
         self.assertIn('multiplicity', str(p))
 
@@ -120,7 +120,7 @@ See http://docs.openquake.org/oq-engine/stable/effective-realizations.html for a
         path = os.path.join(os.path.dirname(case_9.__file__), 'job.ini')
         save = 'openquake.calculators.reportwriter.ReportWriter.save'
         with Print.patch() as p, mock.patch(save, lambda self, fname: None):
-            info(None, None, None, None, None, True, path)
+            info.func(None, None, None, None, None, True, path)
         self.assertIn('report.rst', str(p))
 
 
@@ -140,7 +140,7 @@ class TidyTestCase(unittest.TestCase):
 </gmfCollection>
 </nrml>''', suffix='.xml')
         with Print.patch() as p:
-            tidy([fname])
+            tidy.func([fname])
         self.assertIn('Reformatted', str(p))
         self.assertEqual(open(fname).read(), '''\
 <?xml version="1.0" encoding="utf-8"?>
@@ -182,7 +182,7 @@ xmlns:gml="http://www.opengis.net/gml"
 </gmfCollection>
 </nrml>''', suffix='.xml')
         with Print.patch() as p:
-            tidy([fname])
+            tidy.func([fname])
         self.assertIn('Could not convert gmv->positivefloat: '
                       'float -0.012492 < 0, line 8', str(p))
 
@@ -207,21 +207,21 @@ class RunShowExportTestCase(unittest.TestCase):
 
     def test_show_calc(self):
         with Print.patch() as p:
-            show('contents', self.calc_id)
+            show.func('contents', self.calc_id)
         self.assertIn('sitecol', str(p))
 
         with Print.patch() as p:
-            show('sitecol', self.calc_id)
+            show.func('sitecol', self.calc_id)
         self.assertEqual(str(p), '<SiteCollection with 1/1 sites>')
 
         with Print.patch() as p:
-            show('slow_sources', self.calc_id)
+            show.func('slow_sources', self.calc_id)
         self.assertIn('source_id source_class num_ruptures calc_time '
                       'split_time num_sites num_split', str(p))
 
     def test_show_attrs(self):
         with Print.patch() as p:
-            show_attrs('sitecol', self.calc_id)
+            show_attrs.func('sitecol', self.calc_id)
         self.assertEqual(
             '__pyclass__ openquake.hazardlib.site.SiteCollection\nnbytes 54',
             str(p))
@@ -229,7 +229,7 @@ class RunShowExportTestCase(unittest.TestCase):
     def test_export_calc(self):
         tempdir = tempfile.mkdtemp()
         with Print.patch() as p:
-            export('hcurves', self.calc_id, 'csv', tempdir)
+            export.func('hcurves', self.calc_id, 'csv', tempdir)
         fnames = os.listdir(tempdir)
         self.assertIn(str(fnames[0]), str(p))
         shutil.rmtree(tempdir)
@@ -243,7 +243,7 @@ class ReduceTestCase(unittest.TestCase):
         dest = os.path.join(tempdir, 'exposure_model.xml')
         shutil.copy(os.path.join(self.TESTDIR, 'exposure_model.xml'), dest)
         with Print.patch() as p:
-            reduce(dest, 0.5)
+            reduce.func(dest, 0.5)
         self.assertIn('Extracted 8 nodes out of 13', str(p))
         shutil.rmtree(tempdir)
 
@@ -252,7 +252,7 @@ class ReduceTestCase(unittest.TestCase):
         dest = os.path.join(tempdir, 'source_model.xml')
         shutil.copy(os.path.join(self.TESTDIR, 'source_model.xml'), tempdir)
         with Print.patch() as p:
-            reduce(dest, 0.5)
+            reduce.func(dest, 0.5)
         self.assertIn('Extracted 9 nodes out of 15', str(p))
         shutil.rmtree(tempdir)
 
@@ -262,7 +262,7 @@ class ReduceTestCase(unittest.TestCase):
         dest = os.path.join(tempdir, 'site_model.xml')
         shutil.copy(os.path.join(testdir, 'site_model.xml'), tempdir)
         with Print.patch() as p:
-            reduce(dest, 0.5)
+            reduce.func(dest, 0.5)
         self.assertIn('Extracted 2 nodes out of 3', str(p))
         shutil.rmtree(tempdir)
 
@@ -272,7 +272,7 @@ class ReduceTestCase(unittest.TestCase):
         dest = os.path.join(tempdir, 'sites.csv')
         shutil.copy(os.path.join(testdir, 'sites.csv'), tempdir)
         with Print.patch() as p:
-            reduce(dest, 0.5)
+            reduce.func(dest, 0.5)
         self.assertIn('Extracted 50 lines out of 99', str(p))
         shutil.rmtree(tempdir)
 
@@ -295,7 +295,7 @@ class UpgradeNRMLTestCase(unittest.TestCase):
         </discreteVulnerabilitySet>
     </vulnerabilityModel>
 </nrml>''')
-        upgrade_nrml(tmpdir, False, False)
+        upgrade_nrml.func(tmpdir, False, False)
         shutil.rmtree(tmpdir)
 
 
@@ -307,7 +307,7 @@ class ZipTestCase(unittest.TestCase):
         ini = os.path.join(os.path.dirname(case_18.__file__), 'job.ini')
         dtemp = tempfile.mkdtemp()
         xzip = os.path.join(dtemp, 'x.zip')
-        zip_cmd(ini, xzip)
+        zip_cmd.func(ini, xzip)
         names = sorted(zipfile.ZipFile(xzip).namelist())
         self.assertEqual(['Wcrust_high_rhypo.hdf5',
                           'Wcrust_low_rhypo.hdf5',
@@ -324,7 +324,7 @@ class ZipTestCase(unittest.TestCase):
         ini = os.path.join(os.path.dirname(ebrisk.__file__), 'job_risk.ini')
         dtemp = tempfile.mkdtemp()
         xzip = os.path.join(dtemp, 'x.zip')
-        zip_cmd(ini, xzip)
+        zip_cmd.func(ini, xzip)
         names = sorted(zipfile.ZipFile(xzip).namelist())
         self.assertEqual(['exposure_model.xml', 'gmf_scenario.csv',
                           'job_risk.ini', 'sites.csv', 'vulnerability.xml'],
@@ -344,14 +344,14 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
         # test the conversion to shapefile and back for an invalid file
         smc = os.path.join(os.path.dirname(__file__),
                            "data", "source_model_complete.xml")
-        to_shapefile(os.path.join(self.OUTDIR, 'smc'), smc, False)
+        to_shapefile.func(os.path.join(self.OUTDIR, 'smc'), smc, False)
         shpfiles = [os.path.join(self.OUTDIR, f)
                     for f in os.listdir(self.OUTDIR)]
-        from_shapefile(os.path.join(self.OUTDIR, 'smc'), shpfiles, False)
+        from_shapefile.func(os.path.join(self.OUTDIR, 'smc'), shpfiles, False)
 
         # test invalid file
         with self.assertRaises(Exception) as ctx:
-            to_shapefile(os.path.join(self.OUTDIR, 'smc'), smc, True)
+            to_shapefile.func(os.path.join(self.OUTDIR, 'smc'), smc, True)
         self.assertIn('Edges points are not in the right order',
                       str(ctx.exception))
 
@@ -359,19 +359,19 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
         # test the conversion to shapefile and back for a valid file NRML 0.4
         ssm = os.path.join(os.path.dirname(__file__),
                            "data", "sample_source_model.xml")
-        to_shapefile(os.path.join(self.OUTDIR, 'smc'), ssm, True)
+        to_shapefile.func(os.path.join(self.OUTDIR, 'smc'), ssm, True)
         shpfiles = [os.path.join(self.OUTDIR, f)
                     for f in os.listdir(self.OUTDIR)]
-        from_shapefile(os.path.join(self.OUTDIR, 'smc'), shpfiles, True)
+        from_shapefile.func(os.path.join(self.OUTDIR, 'smc'), shpfiles, True)
 
     def test_roundtrip_valid_05(self):
         # test the conversion to shapefile and back for a valid file NRML 0.5
         ssm = os.path.join(os.path.dirname(__file__),
                            "data", "sample_source_model_05.xml")
-        to_shapefile(os.path.join(self.OUTDIR, 'smc'), ssm, True)
+        to_shapefile.func(os.path.join(self.OUTDIR, 'smc'), ssm, True)
         shpfiles = [os.path.join(self.OUTDIR, f)
                     for f in os.listdir(self.OUTDIR)]
-        from_shapefile(os.path.join(self.OUTDIR, 'smc'), shpfiles, True)
+        from_shapefile.func(os.path.join(self.OUTDIR, 'smc'), shpfiles, True)
 
     def tearDown(self):
         # comment out the line below if you need to debug the test
@@ -383,9 +383,9 @@ class DbTestCase(unittest.TestCase):
         # the some db commands bypassing the dbserver
         with Print.patch(), mock.patch(
                 'openquake.commonlib.logs.dbcmd', manage.fakedbcmd):
-            db('db_version')
+            db.func('db_version')
             try:
-                db('calc_info', (1,))
+                db.func('calc_info', (1,))
             except dbapi.NotFound:  # happens on an empty db
                 pass
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -32,6 +32,9 @@ from openquake.risklib.riskmodels import get_risk_files
 
 GROUND_MOTION_CORRELATION_MODELS = ['JB2009']
 TWO16 = 2 ** 16  # 65536
+U16 = numpy.uint16
+U32 = numpy.uint32
+U64 = numpy.uint64
 F32 = numpy.float32
 F64 = numpy.float64
 
@@ -416,6 +419,14 @@ class OqParam(valid.ParamSet):
         ltypes = self.loss_dt(dtype).names
         lst = [('poe-%s' % poe, dtype) for poe in self.conditional_loss_poes]
         return numpy.dtype([(lt, lst) for lt in ltypes])
+
+    def gmf_data_dt(self):
+        """
+        Return a composite data type for the GMFs
+        """
+        return numpy.dtype(
+            [('rlzi', U16), ('sid', U32),
+             ('eid', U64), ('gmv', (F32, (len(self.imtls),)))])
 
     def no_imls(self):
         """


### PR DESCRIPTION
They will be useful for future work. Moreover, the method `Script.__call__` has been removed. Script objects did  not preserve the signature of the underlying function and this was confusing to the users (i.e. Catalina). It is best to force the users to call `.func` directly.