### PR TITLE
Convert oq into an entry-point

### DIFF
--- a/rpm/python3-oq-engine.spec.inc
+++ b/rpm/python3-oq-engine.spec.inc
@@ -123,8 +123,6 @@ sed -i "s/^__version__[  ]*=.*/__version__ = '%{oqversion}-%{oqrelease}'/g" open
 install -p -m 755 -d %{buildroot}%{_bindir}
 install -p -m 755 -d %{buildroot}%{_oqbindir}
 %{__python3} setup.py install --single-version-externally-managed -O1 --root=%{buildroot} --prefix=%{_oqprefix} --install-scripts=%{_oqbindir}
-# FIXME To be removed after python3 switch is completed
-sed -i "s|/usr/bin/env python|%{__python3}|" %{buildroot}%{_oqbindir}/oq
 ln -sf %{_oqbindir}/oq %{buildroot}%{_bindir}/oq
 # create directories where the files will be located
 mkdir -p %{buildroot}%{_localstatedir}/lib/openquake

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,9 @@ setup(
     namespace_packages=['openquake'],
     install_requires=install_requires,
     extras_require=extras_require,
-    scripts=['bin/oq'],
+    entry_points={
+        'console_scripts': ['oq = openquake.commands.__main__:oq'],
+    },
     test_loader='openquake.baselib.runtests:TestLoader',
     test_suite='openquake.risklib,openquake.commonlib,openquake.calculators',
     zip_safe=False,


### PR DESCRIPTION
This makes life much easier and allows it to be used on Windows too.

The old script way isn't required anymore since https://github.com/gem/oq-engine/commit/6ebc8b28f8cdbd7313ba20b45b01d8b61e4d0d5d

I am anyway keeping the script in `bin/oq` for development purposes (even if the entrypoint will be created by `pip install -e` and `pip` must be always used!)

https://ci.openquake.org/job/zdevel_oq-engine/2778/