### PR TITLE
Made engine-visible and exportable the loss_curves output

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Made the loss curves and maps outputs from an event based risk calculation
+    visible to the engine and the WebUI (only the stats)
   * Added a check on duplicated branchIDs in GMPE logic trees
 
   [Daniele Viganò]

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -262,22 +262,10 @@ def export_agg_losses_ebr(ekey, dstore):
 
 
 # this is used by classical_risk and event_based_risk
-@export.add(('loss_curves', 'csv'))
+@export.add(('loss_curves-rlzs', 'csv'), ('loss_curves-stats', 'csv'))
 def export_loss_curves(ekey, dstore):
-    if '/' not in ekey[0]:  # full loss curves are not exportable
-        logging.error('Use the command oq export loss_curves/rlz-0 to export '
-                      'the first realization')
-        return []
-    what = ekey[0].split('/', 1)[1]
-    return loss_curves.LossCurveExporter(dstore).export('csv', what)
-
-
-# this is used by classical_risk and event_based_risk
-@export.add(('loss_curves-stats', 'csv'))
-def export_loss_curves_stats(ekey, dstore):
-    num_rlzs = dstore['csm_info'].get_num_rlzs()
-    kind = 'stats' if num_rlzs > 1 else 'rlzs'
-    return export_loss_curves(('loss_curves/' + kind, 'csv'), dstore)
+    kind = ekey[0].split('-')[1]  # rlzs or stats
+    return loss_curves.LossCurveExporter(dstore).export('csv', kind)
 
 
 # used by classical_risk and event_based_risk

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -262,9 +262,13 @@ def export_agg_losses_ebr(ekey, dstore):
 
 
 # this is used by classical_risk and event_based_risk
-@export.add(('loss_curves-rlzs', 'csv'), ('loss_curves-stats', 'csv'))
+@export.add(('loss_curves-rlzs', 'csv'), ('loss_curves-stats', 'csv'),
+            ('loss_curves', 'csv'))
 def export_loss_curves(ekey, dstore):
-    kind = ekey[0].split('-')[1]  # rlzs or stats
+    if '/' in ekey[0]:
+        kind = ekey[0].split('/', 1)[1]
+    else:
+        kind = ekey[0].split('-', 1)[1]  # rlzs or stats
     return loss_curves.LossCurveExporter(dstore).export('csv', kind)
 
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -141,9 +141,9 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
     if 'avg_losses-stats' in dstore or (
             'avg_losses-rlzs' in dstore and len(rlzs)):
         dskeys.add('avg_losses-stats')
-    if 'curves-rlzs' in dstore:
+    if 'curves-rlzs' in dstore and len(rlzs) == 1:
         dskeys.add('loss_curves-rlzs')
-    if 'curves-stats' in dstore:
+    if 'curves-stats' in dstore and len(rlzs) > 1:
         dskeys.add('loss_curves-stats')
     if oq.conditional_loss_poes:  # expose loss_maps outputs
         if 'loss_curves-stats' in dstore:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -141,8 +141,10 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
     if 'avg_losses-stats' in dstore or (
             'avg_losses-rlzs' in dstore and len(rlzs)):
         dskeys.add('avg_losses-stats')
+    if 'curves-rlzs' in dstore:
+        dskeys.add('loss_curves-rlzs')
     if 'curves-stats' in dstore:
-        logs.LOG.warn('loss curves are exportable with oq export')
+        dskeys.add('loss_curves-stats')
     if oq.conditional_loss_poes:  # expose loss_maps outputs
         if 'loss_curves-stats' in dstore:
             dskeys.add('loss_maps-stats')

--- a/openquake/engine/export/core.py
+++ b/openquake/engine/export/core.py
@@ -86,6 +86,7 @@ def export_from_db(output_key, calc_id, datadir, target):
         else:  # single file
             return exported[0]
 
+
 #: Used to separate node labels in a logic tree path
 LT_PATH_JOIN_TOKEN = '_'
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -268,7 +268,7 @@ DISPLAY_NAME = {
     'dmg_by_event': 'Aggregate Event Damages',
     'avg_losses-rlzs': 'Average Asset Losses',
     'avg_losses-stats': 'Average Asset Losses Statistics',
-    'loss_curves': 'Asset Loss Curves',
+    'loss_curves-rlzs': 'Asset Loss Curves',
     'loss_curves-stats': 'Asset Loss Curves Statistics',
     'loss_maps-rlzs': 'Asset Loss Maps',
     'loss_maps-stats': 'Asset Loss Maps Statistics',


### PR DESCRIPTION
This was requested by Catalina, see https://github.com/gem/oq-engine/issues/3024