### PR TITLE
Various refactoring

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -165,22 +165,21 @@ class DataStore(collections.MutableMapping):
         else:  # use the given datastore
             self.calc_id = calc_id
         self.params = params
-        self.mode = mode
         self.parent = ()  # can be set later
         self.datadir = datadir
         self.calc_dir = os.path.join(datadir, 'calc_%s' % self.calc_id)
         self.hdf5path = self.calc_dir + '.hdf5'
-        if mode == 'r' and not os.path.exists(self.hdf5path):
+        self.mode = mode or 'r+' if os.path.exists(self.hdf5path) else 'w'
+        if self.mode == 'r' and not os.path.exists(self.hdf5path):
             raise IOError('File not found: %s' % self.hdf5path)
         self.hdf5 = ()  # so that `key in self.hdf5` is valid
-        self.open()
+        self.open(self.mode)
 
-    def open(self):
+    def open(self, mode):
         """
         Open the underlying .hdf5 file and the parent, if any
         """
         if self.hdf5 == ():  # not already open
-            mode = self.mode or 'r+' if os.path.exists(self.hdf5path) else 'w'
             self.hdf5 = hdf5.File(self.hdf5path, mode, libver='latest')
 
     @property
@@ -402,7 +401,7 @@ class DataStore(collections.MutableMapping):
             val = self.hdf5[key]
         except KeyError:
             if self.parent != ():
-                self.parent.open()
+                self.parent.open('r')
                 try:
                     val = self.parent[key]
                 except KeyError:
@@ -430,7 +429,7 @@ class DataStore(collections.MutableMapping):
     def __enter__(self):
         self.was_close = self.hdf5 == ()
         if self.was_close:
-            self.open()
+            self.open(self.mode)
         return self
 
     def __exit__(self, etype, exc, tb):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -167,7 +167,6 @@ class BaseCalculator(metaclass=abc.ABCMeta):
         global logversion
         with self._monitor:
             self._monitor.username = kw.get('username', '')
-            self.close = close
             self.set_log_format()
             if logversion:  # make sure this is logged only once
                 logging.info('Running %s', self.oqparam.inputs['job_ini'])
@@ -184,7 +183,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                 # save the used concurrent_tasks
                 self.oqparam.concurrent_tasks = ct
             self.save_params(**kw)
-            Starmap.init()
+            Starmap.init(distribute=os.environ['OQ_DISTRIBUTE'])
             try:
                 if pre_execute:
                     self.pre_execute()
@@ -211,7 +210,17 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                 readinput.pmap = None
                 readinput.exposure = None
                 Starmap.shutdown()
-        self._monitor.flush()
+                self._monitor.flush()
+
+                if close:  # in the engine we close later
+                    self.result = None
+                    try:
+                        self.datastore.close()
+                    except (RuntimeError, ValueError):
+                        # sometimes produces errors but they are difficult to
+                        # reproduce
+                        logging.warn('', exc_info=True)
+
         return getattr(self, 'exported', {})
 
     def core_task(*args):
@@ -270,15 +279,6 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                 self._export(('hmaps', fmt))
             if has_hcurves and self.oqparam.uniform_hazard_spectra:
                 self._export(('uhs', fmt))
-
-        if self.close:  # in the engine we close later
-            self.result = None
-            try:
-                self.datastore.close()
-            except (RuntimeError, ValueError):
-                # sometimes produces errors but they are difficult to
-                # reproduce
-                logging.warn('', exc_info=True)
 
     def _export(self, ekey):
         if ekey not in exp or self.exported.get(ekey):  # already exported
@@ -357,6 +357,8 @@ class HazardCalculator(BaseCalculator):
                 'gmf_data' not in self.datastore.hdf5):
             self.datastore.parent.close()  # make sure it is closed
             return self.datastore.parent
+        logging.warn('With a parent calculation reading the hazard '
+                     'would be much faster')
 
     def compute_previous(self):
         precalc = calculators[self.pre_calculator](
@@ -706,7 +708,7 @@ class RiskCalculator(HazardCalculator):
         :returns:
             a list of RiskInputs objects, sorted by IMT.
         """
-        logging.info('Found %d realization(s)', self.R)
+        logging.info('Building risk inputs from %d realization(s)', self.R)
         imtls = self.oqparam.imtls
         if not set(self.oqparam.risk_imtls) & set(imtls):
             rsk = ', '.join(self.oqparam.risk_imtls)
@@ -759,7 +761,6 @@ class RiskCalculator(HazardCalculator):
                                        self.oqparam.imtls)
             if dstore is self.datastore:
                 # read the hazard data in the controller node
-                logging.info('Reading hazard')
                 getter.init()
             else:
                 # the datastore must be closed to avoid the HDF5 fork bug
@@ -816,6 +817,7 @@ def save_gmdata(calc, n_rlzs):
         gmv = data[:-1] / events / n_sites
         array[rlzi] = tuple(gmv) + (events,)
     calc.datastore['gmdata'] = array
+    calc.num_events = array['events']
 
 
 def save_gmfs(calculator):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -817,7 +817,6 @@ def save_gmdata(calc, n_rlzs):
         gmv = data[:-1] / events / n_sites
         array[rlzi] = tuple(gmv) + (events,)
     calc.datastore['gmdata'] = array
-    calc.num_events = array['events']
 
 
 def save_gmfs(calculator):

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -112,8 +112,8 @@ class ClassicalRiskCalculator(base.RiskCalculator):
             super().pre_execute()
             if 'poes' not in self.datastore:  # when building short report
                 return
-        rlzs = self.datastore['csm_info'].rlzs
-        self.param = dict(stats=oq.risk_stats(), weights=rlzs['weight'])
+        weights = [rlz.weight for rlz in self.rlzs_assoc.realizations]
+        self.param = dict(stats=oq.risk_stats(), weights=weights)
         self.riskinputs = self.build_riskinputs('poe')
         self.A = len(self.assetcol)
         self.L = len(self.riskmodel.loss_types)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -515,7 +515,7 @@ class EventBasedCalculator(base.HazardCalculator):
                     pmap = compute_pmap_stats(result.values(), [stat], weights)
                     self.datastore['hcurves/' + kind] = pmap
         if self.datastore.parent:
-            self.datastore.parent.open()
+            self.datastore.parent.open('r')
         if 'gmf_data' in self.datastore:
             self.save_gmf_bytes()
         if oq.compare_with_classical:  # compute classical curves

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -65,7 +65,7 @@ class PmapGetter(object):
         if isinstance(self.dstore, str):
             self.dstore = hdf5.File(self.dstore, 'r')
         else:
-            self.dstore.open()  # if not
+            self.dstore.open('r')  # if not
         if self.sids is None:
             self.sids = self.dstore['sitecol'].sids
         self.imtls = self.dstore['oqparam'].imtls
@@ -208,7 +208,7 @@ class GmfDataGetter(collections.Mapping):
     def init(self):
         if hasattr(self, 'data'):  # already initialized
             return
-        self.dstore.open()  # if not already open
+        self.dstore.open('r')  # if not already open
         self.eids = self.dstore['events']['eid']
         self.eids.sort()
         self.data = collections.OrderedDict()
@@ -447,7 +447,7 @@ class RuptureGetter(object):
         return getters
 
     def __iter__(self):
-        self.dstore.open()  # if needed
+        self.dstore.open('r')  # if needed
         attrs = self.dstore.get_attrs('ruptures')
         code2cls = {}  # code -> rupture_cls, surface_cls
         for key, val in attrs.items():

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -99,14 +99,14 @@ class CalculatorTestCase(unittest.TestCase):
         duration = {inis[0]: self.calc._monitor.duration}
         if len(inis) == 2:
             hc_id = self.calc.datastore.calc_id
-            self.calc = self.get_calc(
+            calc = self.get_calc(
                 testfile, inis[1], hazard_calculation_id=str(hc_id), **kw)
             # run the second job.ini with zero tasks to avoid fork issues
-            with self.calc._monitor:
-                exported = self.calc.run(export_dir=self.edir,
-                                         concurrent_tasks=0)
+            with calc._monitor:
+                exported = calc.run(export_dir=self.edir, concurrent_tasks=0)
                 result.update(exported)
-            duration[inis[1]] = self.calc._monitor.duration
+            duration[inis[1]] = calc._monitor.duration
+            self.calc = calc
         # reopen datastore, since some tests need to export from it
         dstore = datastore.read(self.calc.datastore.calc_id)
         self.calc.datastore = dstore

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -33,6 +33,7 @@ from openquake.calculators import base, event_based, getters
 from openquake.calculators.ucerf_base import (
     DEFAULT_TRT, UcerfFilter, generate_background_ruptures)
 from openquake.calculators.event_based_risk import EbrCalculator
+from openquake.calculators.export.loss_curves import get_loss_builder
 
 U16 = numpy.uint16
 U32 = numpy.uint32
@@ -474,4 +475,5 @@ class UCERFRiskCalculator(EbrCalculator):
             agglt = self.datastore['losses_by_event']
             agglt.attrs['nonzero_fraction'] = len(agglt) / E
 
+        self.param = dict(builder=get_loss_builder(self.datastore))
         self.postproc()

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -199,7 +199,7 @@ class RunShowExportTestCase(unittest.TestCase):
         job_ini = os.path.join(os.path.dirname(case_1.__file__), 'job.ini')
         with Print.patch() as cls.p:
             calc = run._run(job_ini, 0, False, 'info', None, '', {})
-            calc.datastore.open()  # if closed
+            calc.datastore.open('r')  # if closed
         cls.calc_id = calc.datastore.calc_id
 
     def test_run_calc(self):

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -228,8 +228,8 @@ class CompositeRiskModel(collections.Mapping):
         for sid, assets in zip(sids, riskinput.assets_by_site):
             group = groupby(assets, by_taxonomy)
             for taxonomy in group:
-                epsgetter = riskinput.epsilon_getter
-                dic[taxonomy].append((sid, group[taxonomy], epsgetter))
+                dic[taxonomy].append(
+                    (sid, group[taxonomy], riskinput.epsilon_getter))
         yield from self._gen_outputs(hazard_getter, dic)
 
         if hasattr(hazard_getter, 'gmdata'):  # for event based risk


### PR DESCRIPTION
While trying (unsuccessfully) to work around the HDF5 1.10 file locking, I made several refactorings that I am including here, since they are generally useful. In particolar now the DataStore.open method requires a `mode` parameter (explicit is better than implicit), the Calculator.close attribute has been removed by moving the close inside the run method, Starmap.init now closes a pre-existing process pool if needed, I avoid reading csm_info from the datastore when it is not necessary, I better manage the loss curves builder and I improved the logging.