### PR TITLE
Added a check on duplicated branch IDs in GsimLogicTree

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -108,6 +108,7 @@ class LtSourceModel(object):
             self.__class__.__name__, self.ordinal, self.names,
             '_'.join(self.path), self.weight, samples)
 
+
 Realization = namedtuple('Realization', 'value weight lt_path ordinal lt_uid')
 Realization.uid = property(lambda self: '_'.join(self.lt_uid))  # unique ID
 Realization.__str__ = lambda self: (
@@ -1306,10 +1307,12 @@ class GsimLogicTree(object):
                 effective = (self.tectonic_region_types == ['*'] or
                              trt in self.tectonic_region_types)
                 weights = []
+                branch_ids = []
                 for branch in branchset:
                     weight = Decimal(branch.uncertaintyWeight.text)
                     weights.append(weight)
                     branch_id = branch['branchID']
+                    branch_ids.append(branch_id)
                     uncertainty = branch.uncertaintyModel
                     if hasattr(uncertainty.text, 'strip'):  # a string
                         gsim_name = uncertainty.text.strip()
@@ -1335,6 +1338,9 @@ class GsimLogicTree(object):
                         branchset, branch_id, gsim, weight, effective)
                     branches.append(bt)
                 assert sum(weights) == 1, weights
+                if len(branch_ids) > len(set(branch_ids)):
+                    raise InvalidLogicTree(
+                        'There where duplicated branchIDs in %s' % self.fname)
         if len(trts) > len(set(trts)):
             raise InvalidLogicTree(
                 '%s: Found duplicated applyToTectonicRegionType=%s' %

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -2135,6 +2135,37 @@ class GsimLogicTreeTestCase(unittest.TestCase):
             xml, logictree.InvalidLogicTree,
             "<StringIO>: Duplicated branchSetID bs1")
 
+    def test_branch_id_not_unique(self):
+        xml = _make_nrml("""
+<logicTree logicTreeID="lt1">
+    <logicTreeBranchingLevel branchingLevelID="bl4">
+        <logicTreeBranchSet uncertaintyType="gmpeModel"
+                            branchSetID="GrpD"
+                            applyToTectonicRegionType="Subduction Interface">
+
+            <logicTreeBranch branchID="GrpD_Gmpe1">
+                <uncertaintyModel>AbrahamsonEtAl2015SInter</uncertaintyModel>
+                <uncertaintyWeight>0.334</uncertaintyWeight>
+            </logicTreeBranch>
+
+            <logicTreeBranch branchID="GrpD_Gmpe2">
+                <uncertaintyModel>McVerry2006SInter</uncertaintyModel>
+                <uncertaintyWeight>0.333</uncertaintyWeight>
+            </logicTreeBranch>
+
+            <logicTreeBranch branchID="GrpD_Gmpe2">
+                <uncertaintyModel>ZhaoEtAl2016SInter</uncertaintyModel>
+                <uncertaintyWeight>0.333</uncertaintyWeight>
+            </logicTreeBranch>
+
+        </logicTreeBranchSet>
+    </logicTreeBranchingLevel>
+</logicTree>
+        """)
+        self.parse_invalid(
+            xml, logictree.InvalidLogicTree,
+            "There where duplicated branchIDs in <StringIO>")
+
     def test_invalid_gsim(self):
         xml = _make_nrml("""\
         <logicTree logicTreeID="lt1">


### PR DESCRIPTION
We had a check on duplicated branchSetIDs but non on branchIDs.