### PR TITLE
Force the exposure to be read as UTF-8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Daniele Viganò]
+  * Fixed a bug when reading exposure with non-utf8 names on systems
+    with non-utf8 terminals (Windows)
   * Changed the openquake.cfg file and added a dbserver.listen parameter
   * Added the hostname in the WebUI page. It can be customize by the user
     via the `local_settings.py` file

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -775,7 +775,7 @@ class Exposure(object):
         expected_header = self._csv_header()
         fnames = [os.path.join(dirname, f) for f in csvnames.split()]
         for fname in fnames:
-            with open(fname) as f:
+            with open(fname, encoding='utf-8') as f:
                 fields = next(csv.reader(f))
                 header = set(fields)
                 if len(header) < len(fields):
@@ -788,7 +788,7 @@ class Exposure(object):
                         (fname, sorted(expected_header), sorted(header)))
         occupancy_periods = self.occupancy_periods.split()
         for fname in fnames:
-            with open(fname) as f:
+            with open(fname, encoding='utf-8') as f:
                 for i, dic in enumerate(csv.DictReader(f), 1):
                     asset = Node('asset', lineno=i)
                     with context(fname, asset):


### PR DESCRIPTION
Since we are working with `UTF-8` but we cannot expect all terminals (like Windows `cmd`) to use `UTF-8`. If a terminal is set to an encoding different from `UTF-8` all the open operations are then performed with the corresponding encoding.

Maybe we have to fix other `open()`s?

With this fix I'm able to run the 'Aristotle' demo on a Win 7 VM.

Fixes #3789 