### PR TITLE
Workaround race condition on temp cleanup

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -369,7 +369,10 @@ def removetmp():
     """
     for path in _tmp_paths:
         if os.path.exists(path):  # not removed yet
-            os.remove(path)
+            try:
+                os.remove(path)
+            except PermissionError:
+                pass
 
 
 def git_suffix(fname):


### PR DESCRIPTION
On Windows, when the machine is a bit loaded, a race condition could happen when trying to remove the temporary files:

<img width="674" alt="capture" src="https://user-images.githubusercontent.com/1818657/41599381-418fd76c-73d3-11e8-8f13-c20ff3ee9d52.PNG">

It's very easy to reproduce and can be found also on Jenkins: https://ci.openquake.org/job/windows/job/master_oq-engine/1613/console

This PR just skip deletion if the file is locked (it will be cleaned up by the OS).