### PR TITLE
Cleaned up /tmp in datastore test_read

### DIFF
--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -84,3 +84,4 @@ class DataStoreTestCase(unittest.TestCase):
         with self.assertRaises(IOError) as ctx:
             read(42, datadir=tmp)
         self.assertIn('permission denied', str(ctx.exception).lower())
+        os.remove(fname)


### PR DESCRIPTION
This should solve https://ci.openquake.org/job/macos/job/master_macos_engine/label=macos,python=python3.5/858/