### PR TITLE
Fixed --delete-calculation

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -33,6 +33,10 @@ oq db set_status 26 executing
 # repeat the failed/executing calculation, which is useful for QGIS
 oq engine --run $1/hazard/AreaSourceClassicalPSHA/job.ini
 
+# test deleting a calculation
+
+oq engine --dc 26
+
 # display the calculations
 oq db find %
 

--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -35,7 +35,7 @@ oq engine --run $1/hazard/AreaSourceClassicalPSHA/job.ini
 
 # test deleting a calculation
 
-oq engine --dc 26
+oq engine --dc 26 -y
 
 # display the calculations
 oq db find %

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -91,7 +91,7 @@ def del_calculation(job_id, confirmed=False):
             'Are you sure you want to (abort and) delete this calculation and '
             'all associated outputs?\nThis action cannot be undone. (y/n): '):
         try:
-            abort(job_id)
+            abort.func(job_id)
             resp = logs.dbcmd('del_calc', job_id, getpass.getuser())
         except RuntimeError as err:
             safeprint(err)


### PR DESCRIPTION
It was broken recently and we did not notice it since a test was missing. Now `oq engine --dc` is tested in the demos.