### PR TITLE
Removed the event based rupture calculators

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the event_based_rupture calculator and three others
   * Added a field `size_mb` to the `output` table in the database and made
     it visible in the WebUI as a tooltip
   * Added a command `oq check_input job.ini` to check the input files

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -68,7 +68,7 @@ PRECALC_MAP = dict(
     classical_risk=['classical'],
     classical_bcr=['classical'],
     classical_damage=['classical'],
-    event_based=['event_based', 'ebrisk', 'event_based_risk'],
+    event_based=['event_based', 'event_based_risk'],
     event_based_risk=['event_based', 'event_based_rupture',
                       'event_based_risk', 'ucerf_hazard'],
     ucerf_classical=['ucerf_psha'],

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -69,8 +69,7 @@ PRECALC_MAP = dict(
     classical_bcr=['classical'],
     classical_damage=['classical'],
     event_based=['event_based', 'event_based_risk'],
-    event_based_risk=['event_based', 'event_based_rupture',
-                      'event_based_risk', 'ucerf_hazard'],
+    event_based_risk=['event_based', 'event_based_risk', 'ucerf_hazard'],
     ucerf_classical=['ucerf_psha'],
     ucerf_hazard=['ucerf_hazard'])
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -68,12 +68,11 @@ PRECALC_MAP = dict(
     classical_risk=['classical'],
     classical_bcr=['classical'],
     classical_damage=['classical'],
-    event_based=['event_based', 'event_based_rupture', 'ebrisk',
-                 'event_based_risk', 'ucerf_rupture'],
-    event_based_risk=['event_based', 'event_based_rupture', 'ucerf_rupture',
+    event_based=['event_based', 'ebrisk', 'event_based_risk'],
+    event_based_risk=['event_based', 'event_based_rupture',
                       'event_based_risk', 'ucerf_hazard'],
     ucerf_classical=['ucerf_psha'],
-    ucerf_hazard=['ucerf_rupture'])
+    ucerf_hazard=['ucerf_hazard'])
 
 
 def set_array(longarray, shortarray):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -337,6 +337,7 @@ class HazardCalculator(BaseCalculator):
             csm = self.csm.filter(prefilter, mon)
         else:  # prefilter_sources='no'
             csm = self.csm.filter(SourceFilter(None, {}), mon)
+        logging.info('There are %d realizations', csm.info.get_num_rlzs())
         return csm, src_filter
 
     def can_read_parent(self):
@@ -619,7 +620,6 @@ class HazardCalculator(BaseCalculator):
             raise RuntimeError('Empty logic tree: too much filtering?')
         self.datastore['csm_info'] = self.csm.info
         R = len(self.rlzs_assoc.realizations)
-        logging.info('There are %d realizations', R)
         if self.is_stochastic and R >= TWO16:
             # rlzi is 16 bit integer in the GMFs, so there is hard limit or R
             raise ValueError(

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -163,10 +163,10 @@ def compute_hazard(sources_or_ruptures, src_filter,
             grp_id = sources_or_ruptures[0].src_group_id
             dic = sample_ruptures(
                 sources_or_ruptures, src_filter, rlzs_by_gsim, param, monitor)
+            ruptures = dic['eb_ruptures']
             res.num_events = dic['num_events']
             res.calc_times = dic['calc_times']
-            res.eff_ruptures = {grp_id: dic['num_ruptures']}
-            ruptures = dic['eb_ruptures']
+            res.eff_ruptures = {grp_id: len(ruptures)}
             res['ruptures'] = {grp_id: ruptures}
             sitecol = src_filter.sitecol
     getter = GmfGetter(

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -745,7 +745,8 @@ class EventBasedNewCalculator(base.HazardCalculator):
             raise RuntimeError(
                 'No seismic events! Perhaps the investigation time is too '
                 'small or the maximum_distance is too small')
-        num_ruptures = sum(len(ruptures) for ruptures in result.values())
+        num_ruptures = sum(
+            len(ruptures) for ruptures in result.ruptures.values())
         logging.info('Setting %d event years on %d ruptures',
                      num_events, num_ruptures)
         with self.monitor('setting event years', measuremem=True,

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -537,7 +537,7 @@ def compute_hazard(sources_or_ruptures, src_filter, gsims, param, monitor):
     getter = GmfGetter(
         param['rlzs_by_gsim'], res.ruptures[grp_id], src_filter.sitecol,
         param['oqparam'], param['min_iml'], sources_or_ruptures.samples)
-    res.gmfs_curves = compute_gmfs_and_curves([getter], monitor)
+    res.gmfs_curves = getter.compute_gmfs_curves(monitor)
     return res
 
 
@@ -619,7 +619,8 @@ class EventBasedNewCalculator(base.HazardCalculator):
         sav_mon = self.monitor('saving gmfs')
         agg_mon = self.monitor('aggregating hcurves')
         hdf5path = self.datastore.hdf5path
-        for res in result.gmfs_curves:
+        res = result.gmfs_curves
+        if res:
             self.gmdata += res['gmdata']
             data = res['gmfdata']
             with sav_mon:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -46,8 +46,8 @@ def weight(src):
     """
     :returns: source weight multiplied by the total occurrence rate
     """
-    # tot_rate = sum(rate for mag, rate in src.get_annual_occurrence_rates())
-    return src.weight
+    tot_rate = sum(rate for mag, rate in src.get_annual_occurrence_rates())
+    return tot_rate
 
 
 def get_events(ebruptures):
@@ -226,9 +226,8 @@ class EventBasedCalculator(base.HazardCalculator):
                     num_tasks += 1
                     num_sources += len(sg.sources)
                     continue
-                for src in sg:
-                    # or block_splitter(sg.sources, maxweight, weight)
-                    yield [src], self.src_filter, rlzs_by_gsim, param, monitor
+                for block in block_splitter(sg.sources, maxweight, weight):
+                    yield block, self.src_filter, rlzs_by_gsim, param, monitor
                     num_tasks += 1
                     num_sources += 1
         logging.info('Sent %d sources in %d tasks', num_sources, num_tasks)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -33,8 +33,7 @@ from openquake.baselib import parallel
 from openquake.commonlib import calc, util, readinput
 from openquake.calculators import base
 from openquake.calculators.getters import GmfGetter, RuptureGetter
-from openquake.calculators.classical import (
-    ClassicalCalculator, saving_sources_by_task, weight)
+from openquake.calculators.classical import ClassicalCalculator, weight
 
 U8 = numpy.uint8
 U16 = numpy.uint16
@@ -42,32 +41,6 @@ U32 = numpy.uint32
 U64 = numpy.uint64
 F32 = numpy.float32
 F64 = numpy.float64
-
-
-def compute_ruptures(sources, src_filter, gsims, param, monitor):
-    """
-    :param sources:
-        a sequence of sources of the same group
-    :param src_filter:
-        a source site filter
-    :param gsims:
-        a list of GSIMs for the current tectonic region model
-    :param param:
-        a dictionary of additional parameters
-    :param monitor:
-        monitor instance
-    :returns:
-        a dictionary src_group_id -> [Rupture instances]
-    """
-    # NB: by construction each block is a non-empty list with
-    # sources of the same src_group_id
-    grp_id = sources[0].src_group_id
-    dic = sample_ruptures(sources, src_filter, gsims, param, monitor)
-    res = AccumDict({grp_id: dic['eb_ruptures']})
-    res.num_events = dic['num_events']
-    res.calc_times = dic['calc_times']
-    res.eff_ruptures = {grp_id: dic['num_ruptures']}
-    return res
 
 
 def get_events(ebruptures):
@@ -82,148 +55,6 @@ def get_events(ebruptures):
                    event['sample'])
             events.append(rec)
     return numpy.array(events, readinput.stored_event_dt)
-
-
-@base.calculators.add('event_based_rupture')
-class EventBasedRuptureCalculator(base.HazardCalculator):
-    """
-    Event based PSHA calculator generating the ruptures only
-    """
-    core_task = compute_ruptures
-    is_stochastic = True
-
-    def init(self):
-        """
-        Set the random seed passed to the SourceManager and the
-        minimum_intensity dictionary.
-        """
-        self.rupser = calc.RuptureSerializer(self.datastore)
-
-    def zerodict(self):
-        """
-        Initial accumulator, a dictionary (grp_id, gsim) -> curves
-        """
-        zd = AccumDict()
-        zd.eff_ruptures = AccumDict()
-        self.grp_trt = self.csm.info.grp_by("trt")
-        return zd
-
-    def agg_dicts(self, acc, ruptures_by_grp_id):
-        """
-        Accumulate dictionaries of ruptures and populate the `events`
-        dataset in the datastore.
-
-        :param acc: accumulator dictionary
-        :param ruptures_by_grp_id: a nested dictionary grp_id -> ruptures
-        """
-        if hasattr(ruptures_by_grp_id, 'calc_times'):
-            for srcid, nsites, eids, dt in ruptures_by_grp_id.calc_times:
-                info = self.csm.infos[srcid]
-                info.num_sites += nsites
-                info.calc_time += dt
-                info.num_split += 1
-                info.events += len(eids)
-        if hasattr(ruptures_by_grp_id, 'eff_ruptures'):
-            acc.eff_ruptures += ruptures_by_grp_id.eff_ruptures
-        acc += ruptures_by_grp_id
-        self.save_ruptures(ruptures_by_grp_id)
-        return acc
-
-    def save_ruptures(self, ruptures_by_grp_id):
-        """
-        Extend the 'events' dataset with the events from the given ruptures;
-        also, save the ruptures if the flag `save_ruptures` is on.
-
-        :param ruptures_by_grp_id: a dictionary grp_id -> list of EBRuptures
-        """
-        with self.monitor('saving ruptures', autoflush=True):
-            for grp_id, ebrs in ruptures_by_grp_id.items():
-                if len(ebrs):
-                    events = get_events(ebrs)
-                    dset = self.datastore.extend('events', events)
-                    if self.oqparam.save_ruptures:
-                        self.rupser.save(ebrs, eidx=len(dset)-len(events))
-
-    def gen_args(self, monitor):
-        """
-        Used in the case of large source model logic trees.
-
-        :param monitor: a :class:`openquake.baselib.performance.Monitor`
-        :yields: (sources, sites, gsims, monitor) tuples
-        """
-        oq = self.oqparam
-
-        def weight(src):
-            return src.num_ruptures * src.RUPTURE_WEIGHT
-        csm, src_filter = self.filter_csm()
-        maxweight = csm.get_maxweight(weight, oq.concurrent_tasks or 1)
-        logging.info('Using maxweight=%d', maxweight)
-        param = dict(
-            truncation_level=oq.truncation_level,
-            imtls=oq.imtls, filter_distance=oq.filter_distance,
-            seed=oq.ses_seed, maximum_distance=oq.maximum_distance,
-            ses_per_logic_tree_path=oq.ses_per_logic_tree_path)
-
-        num_tasks = 0
-        num_sources = 0
-        for sm in csm.source_models:
-            for sg in sm.src_groups:
-                gsims = csm.info.gsim_lt.get_gsims(sg.trt)
-                csm.add_infos(sg.sources)
-                if sg.src_interdep == 'mutex':  # do not split
-                    sg.samples = sm.samples
-                    yield sg, src_filter, gsims, param, monitor
-                    num_tasks += 1
-                    num_sources += len(sg.sources)
-                    continue
-                for block in block_splitter(sg.sources, maxweight, weight):
-                    block.samples = sm.samples
-                    yield block, src_filter, gsims, param, monitor
-                    num_tasks += 1
-                    num_sources += len(block)
-        logging.info('Sent %d sources in %d tasks', num_sources, num_tasks)
-
-    def execute(self):
-        with self.monitor('managing sources', autoflush=True):
-            allargs = self.gen_args(self.monitor('classical'))
-            iterargs = saving_sources_by_task(allargs, self.datastore)
-            if isinstance(allargs, list):
-                # there is a trick here: if the arguments are known
-                # (a list, not an iterator), keep them as a list
-                # then the Starmap will understand the case of a single
-                # argument tuple and it will run in core the task
-                iterargs = list(iterargs)
-            acc = parallel.Starmap(self.core_task.__func__, iterargs).reduce(
-                self.agg_dicts, self.zerodict())
-        with self.monitor('store source_info', autoflush=True):
-            self.store_source_info(self.csm.infos, acc)
-        return acc
-
-    def post_execute(self, result):
-        """
-        Save the SES collection
-        """
-        self.rupser.close()
-        num_events = sum(set_counts(self.datastore, 'events').values())
-        if num_events == 0:
-            raise RuntimeError(
-                'No seismic events! Perhaps the investigation time is too '
-                'small or the maximum_distance is too small')
-        num_ruptures = sum(len(ruptures) for ruptures in result.values())
-        logging.info('Setting %d event years on %d ruptures',
-                     num_events, num_ruptures)
-        with self.monitor('setting event years', measuremem=True,
-                          autoflush=True):
-            numpy.random.seed(self.oqparam.ses_seed)
-            set_random_years(self.datastore, 'events',
-                             int(self.oqparam.investigation_time))
-        gmf_size = max_gmf_size(
-            result, self.rlzs_assoc.get_rlzs_by_gsim,
-            self.csm.info.get_samples_by_grp(),
-            len(self.oqparam.imtls))
-        self.datastore.set_attrs('events', max_gmf_size=gmf_size)
-        msg = 'less than ' if self.get_min_iml(self.oqparam).sum() else ''
-        logging.info('Generating %s%s of GMFs', msg, humansize(gmf_size))
 
 
 def max_gmf_size(ruptures_by_grp, get_rlzs_by_gsim,
@@ -289,215 +120,9 @@ def set_random_years(dstore, name, investigation_time):
 # ######################## GMF calculator ############################ #
 
 
-def compute_gmfs_and_curves(getters, monitor):
-    """
-    :param getters:
-        a list of GmfGetter instances
-    :param monitor:
-        a Monitor instance
-    :returns:
-        a list of dictionaries with keys gmfcoll and hcurves
-    """
-    results = []
-    for getter in getters:
-        res = getter.compute_gmfs_curves(monitor)
-        if len(getter.gmdata):
-            results.append(res)
-    return results
-
-
 def update_nbytes(dstore, key, array):
     nbytes = dstore.get_attr(key, 'nbytes', 0)
     dstore.set_attrs(key, nbytes=nbytes + array.nbytes)
-
-
-@base.calculators.add('event_based')
-class EventBasedCalculator(base.HazardCalculator):
-    """
-    Event based PSHA calculator generating the ground motion fields and
-    the hazard curves from the ruptures, depending on the configuration
-    parameters.
-    """
-    pre_calculator = 'event_based_rupture'
-    core_task = compute_gmfs_and_curves
-    is_stochastic = True
-
-    def combine_pmaps_and_save_gmfs(self, acc, results):
-        """
-        Combine the hazard curves (if any) and save the gmfs (if any)
-        sequentially; notice that the gmfs may come from
-        different tasks in any order.
-
-        :param acc: an accumulator for the hazard curves
-        :param results: dictionaries rlzi, imt -> [gmf_array, curves_by_imt]
-        :returns: a new accumulator
-        """
-        sav_mon = self.monitor('saving gmfs')
-        agg_mon = self.monitor('aggregating hcurves')
-        hdf5path = self.datastore.hdf5path
-        for res in results:
-            self.gmdata += res['gmdata']
-            data = res['gmfdata']
-            with sav_mon:
-                hdf5.extend3(hdf5path, 'gmf_data/data', data)
-                # it is important to save the number of bytes while the
-                # computation is going, to see the progress
-                update_nbytes(self.datastore, 'gmf_data/data', data)
-                for sid, start, stop in res['indices']:
-                    self.indices[sid].append(
-                        (start + self.offset, stop + self.offset))
-                self.offset += len(data)
-            slicedic = self.oqparam.imtls.slicedic
-            with agg_mon:
-                for key, poes in res['hcurves'].items():
-                    r, sid, imt = str2rsi(key)
-                    array = acc[r].setdefault(sid, 0).array[slicedic[imt], 0]
-                    array[:] = 1. - (1. - array) * (1. - poes)
-            sav_mon.flush()
-            agg_mon.flush()
-            self.datastore.flush()
-            if 'ruptures' in res:
-                vars(EventBasedRuptureCalculator)['save_ruptures'](
-                    self, res['ruptures'])
-        return acc
-
-    def gen_args(self):
-        """
-        :yields: the arguments for compute_gmfs_and_curves
-        """
-        oq = self.oqparam
-        sitecol = self.sitecol.complete
-        monitor = self.monitor(self.core_task.__name__)
-        min_iml = self.get_min_iml(oq)
-        try:
-            csm_info = self.csm.info
-        except AttributeError:  # no csm
-            csm_info = self.datastore['csm_info']
-        samples_by_grp = csm_info.get_samples_by_grp()
-        rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
-        if self.precalc:
-            num_ruptures = sum(len(rs) for rs in self.precalc.result.values())
-            block_size = math.ceil(num_ruptures / (oq.concurrent_tasks or 1))
-            for grp_id, ruptures in self.precalc.result.items():
-                if not ruptures:
-                    continue
-                for block in block_splitter(ruptures, block_size):
-                    getter = GmfGetter(
-                        rlzs_by_gsim[grp_id], block, sitecol,
-                        oq, min_iml, samples_by_grp[grp_id])
-                    yield [getter], monitor
-            return
-        U = len(self.datastore['ruptures'])
-        logging.info('Found %d ruptures', U)
-        parent = self.can_read_parent() or self.datastore
-        for slc in split_in_slices(U, oq.concurrent_tasks or 1):
-            getters = []
-            for grp_id in rlzs_by_gsim:
-                ruptures = RuptureGetter(parent, slc, grp_id)
-                if parent is self.datastore:  # not accessible parent
-                    ruptures = list(ruptures)
-                    if not ruptures:
-                        continue
-                getter = GmfGetter(
-                    rlzs_by_gsim[grp_id], ruptures, sitecol,
-                    oq, min_iml, samples_by_grp[grp_id])
-                getters.append(getter)
-            yield getters, monitor
-
-    def execute(self):
-        """
-        Run in parallel `core_task(sources, sitecol, monitor)`, by
-        parallelizing on the ruptures according to their weight and
-        tectonic region type.
-        """
-        oq = self.oqparam
-        calc.check_overflow(self)
-
-        self.csm_info = self.datastore['csm_info']
-        self.sm_id = {tuple(sm.path): sm.ordinal
-                      for sm in self.csm_info.source_models}
-        L = len(oq.imtls.array)
-        R = self.datastore['csm_info'].get_num_rlzs()
-        self.gmdata = {}
-        self.offset = 0
-        self.indices = collections.defaultdict(list)  # sid -> indices
-        ires = parallel.Starmap(
-            self.core_task.__func__, self.gen_args()).submit_all()
-        if self.precalc and self.precalc.result:
-            # remove the ruptures in memory to save memory
-            self.precalc.result.clear()
-        acc = ires.reduce(self.combine_pmaps_and_save_gmfs, {
-            r: ProbabilityMap(L) for r in range(R)})
-        base.save_gmdata(self, R)
-        if self.indices:
-            logging.info('Saving gmf_data/indices')
-            with self.monitor('saving gmf_data/indices', measuremem=True,
-                              autoflush=True):
-                self.datastore.save_vlen(
-                    'gmf_data/indices',
-                    [numpy.array(self.indices[sid], indices_dt)
-                     for sid in self.sitecol.complete.sids])
-        else:
-            raise RuntimeError('No GMFs were generated, perhaps they were '
-                               'all below the minimum_intensity threshold')
-        return acc
-
-    def save_gmf_bytes(self):
-        """Save the attribute nbytes in the gmf_data datasets"""
-        ds = self.datastore
-        for sm_id in ds['gmf_data']:
-            ds.set_nbytes('gmf_data/' + sm_id)
-        ds.set_nbytes('gmf_data')
-
-    def post_execute(self, result):
-        """
-        :param result:
-            a dictionary (src_group_id, gsim) -> haz_curves or an empty
-            dictionary if hazard_curves_from_gmfs is false
-        """
-        oq = self.oqparam
-        if oq.hazard_curves_from_gmfs:
-            rlzs = self.rlzs_assoc.realizations
-            # save individual curves
-            for i in sorted(result):
-                key = 'hcurves/rlz-%03d' % i
-                if result[i]:
-                    self.datastore[key] = result[i]
-                else:
-                    self.datastore[key] = ProbabilityMap(oq.imtls.array.size)
-                    logging.info('Zero curves for %s', key)
-            # compute and save statistics; this is done in process and can
-            # be very slow if there are thousands of realizations
-            weights = [rlz.weight for rlz in rlzs]
-            hstats = self.oqparam.hazard_stats()
-            if len(hstats) and len(rlzs) > 1:
-                logging.info('Computing statistical hazard curves')
-                for kind, stat in hstats:
-                    pmap = compute_pmap_stats(result.values(), [stat], weights)
-                    self.datastore['hcurves/' + kind] = pmap
-        if self.datastore.parent:
-            self.datastore.parent.open('r')
-        if 'gmf_data' in self.datastore:
-            self.save_gmf_bytes()
-        if oq.compare_with_classical:  # compute classical curves
-            export_dir = os.path.join(oq.export_dir, 'cl')
-            if not os.path.exists(export_dir):
-                os.makedirs(export_dir)
-            oq.export_dir = export_dir
-            # one could also set oq.number_of_logic_tree_samples = 0
-            self.cl = ClassicalCalculator(oq)
-            # TODO: perhaps it is possible to avoid reprocessing the source
-            # model, however usually this is quite fast and do not dominate
-            # the computation
-            self.cl.run(close=False)
-            cl_mean_curves = get_mean_curves(self.cl.datastore)
-            eb_mean_curves = get_mean_curves(self.datastore)
-            for imt in eb_mean_curves.dtype.names:
-                rdiff, index = util.max_rel_diff_index(
-                    cl_mean_curves[imt], eb_mean_curves[imt])
-                logging.warn('Relative difference with the classical '
-                             'mean curves for IMT=%s: %d%% at site index %d',
-                             imt, rdiff * 100, index)
 
 
 def get_mean_curves(dstore):
@@ -546,7 +171,7 @@ def compute_hazard(sources_or_ruptures, src_filter,
 
 
 @base.calculators.add('event_based')
-class EventBasedNewCalculator(base.HazardCalculator):
+class EventBasedCalculator(base.HazardCalculator):
     """
     Event based PSHA calculator generating the ground motion fields and
     the hazard curves from the ruptures, depending on the configuration
@@ -663,9 +288,23 @@ class EventBasedNewCalculator(base.HazardCalculator):
         agg_mon.flush()
         self.datastore.flush()
         if 'ruptures' in res:
-            vars(EventBasedRuptureCalculator)['save_ruptures'](
-                self, res['ruptures'])
+            self.save_ruptures(res['ruptures'])
         return acc
+
+    def save_ruptures(self, ruptures_by_grp_id):
+        """
+        Extend the 'events' dataset with the events from the given ruptures;
+        also, save the ruptures if the flag `save_ruptures` is on.
+
+        :param ruptures_by_grp_id: a dictionary grp_id -> list of EBRuptures
+        """
+        with self.monitor('saving ruptures', autoflush=True):
+            for grp_id, ebrs in ruptures_by_grp_id.items():
+                if len(ebrs):
+                    events = get_events(ebrs)
+                    dset = self.datastore.extend('events', events)
+                    if self.oqparam.save_ruptures:
+                        self.rupser.save(ebrs, eidx=len(dset)-len(events))
 
     def execute(self):
         if self.oqparam.hazard_calculation_id:
@@ -719,21 +358,6 @@ class EventBasedNewCalculator(base.HazardCalculator):
         minimum_intensity dictionary.
         """
         self.rupser = calc.RuptureSerializer(self.datastore)
-
-    def save_ruptures(self, ruptures_by_grp_id):
-        """
-        Extend the 'events' dataset with the events from the given ruptures;
-        also, save the ruptures if the flag `save_ruptures` is on.
-
-        :param ruptures_by_grp_id: a dictionary grp_id -> list of EBRuptures
-        """
-        with self.monitor('saving ruptures', autoflush=True):
-            for grp_id, ebrs in ruptures_by_grp_id.items():
-                if len(ebrs):
-                    events = get_events(ebrs)
-                    dset = self.datastore.extend('events', events)
-                    if self.oqparam.save_ruptures:
-                        self.rupser.save(ebrs, eidx=len(dset)-len(events))
 
     def post_execute(self, result):
         """

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -35,7 +35,7 @@ from openquake.commonlib import calc, util, readinput
 from openquake.calculators import base
 from openquake.calculators.getters import GmfGetter, RuptureGetter
 from openquake.calculators.classical import (
-    ClassicalCalculator, saving_sources_by_task)
+    ClassicalCalculator, saving_sources_by_task, weight)
 
 U8 = numpy.uint8
 U16 = numpy.uint16
@@ -548,3 +548,259 @@ def get_mean_curves(dstore):
     elif len(hcurves) == 1:  # there is a single realization
         mean = dstore['hcurves/rlz-0000']
     return mean.convert(imtls, nsites)
+
+# ########################################################################## #
+
+
+def compute_hazard(sources, src_filter, gsims, param, monitor):
+    grp_id = sources[0].src_group_id
+    dic = sample_ruptures(sources, src_filter, gsims, param, monitor)
+    res = AccumDict()
+    res.num_events = dic['num_events']
+    res.calc_times = dic['calc_times']
+    res.eff_ruptures = {grp_id: dic['num_ruptures']}
+    res.ruptures = {grp_id: dic['eb_ruptures']}
+    getter = GmfGetter(
+        param['rlzs_by_gsim'], dic['eb_ruptures'], src_filter.sitecol,
+        param['oqparam'], param['min_iml'], sources.samples)
+    res.gmfs_curves = compute_gmfs_and_curves([getter], monitor)
+    return res
+
+
+@base.calculators.add('event_based')
+class EventBasedNewCalculator(base.HazardCalculator):
+    """
+    Event based PSHA calculator generating the ground motion fields and
+    the hazard curves from the ruptures, depending on the configuration
+    parameters.
+    """
+    pre_calculator = None
+    core_task = compute_hazard
+    is_stochastic = True
+
+    def gen_args(self, monitor):
+        """
+        :yields: the arguments for compute_gmfs_and_curves
+        """
+        oq = self.oqparam
+        maxweight = self.csm.get_maxweight(weight, oq.concurrent_tasks or 1)
+        logging.info('Using maxweight=%d', maxweight)
+        param = dict(
+            oqparam=oq, min_iml=self.get_min_iml(oq),
+            truncation_level=oq.truncation_level,
+            imtls=oq.imtls, filter_distance=oq.filter_distance,
+            seed=oq.ses_seed, maximum_distance=oq.maximum_distance,
+            ses_per_logic_tree_path=oq.ses_per_logic_tree_path)
+
+        num_tasks = 0
+        num_sources = 0
+        for sm in self.csm.source_models:
+            for sg in sm.src_groups:
+                param['rlzs_by_gsim'] = self.rlzs_by_gsim_grp[sg.id]
+                gsims = self.csm.info.gsim_lt.get_gsims(sg.trt)
+                self.csm.add_infos(sg.sources)
+                if sg.src_interdep == 'mutex':  # do not split
+                    sg.samples = sm.samples
+                    yield sg, self.src_filter, gsims, param, monitor
+                    num_tasks += 1
+                    num_sources += len(sg.sources)
+                    continue
+                for block in block_splitter(sg.sources, maxweight, weight):
+                    block.samples = sm.samples
+                    yield block, self.src_filter, gsims, param, monitor
+                    num_tasks += 1
+                    num_sources += len(block)
+        logging.info('Sent %d sources in %d tasks', num_sources, num_tasks)
+
+    def zerodict(self):
+        """
+        Initial accumulator, a dictionary (grp_id, gsim) -> curves
+        """
+        self.csm, self.src_filter = self.filter_csm()  # must be called first
+        self.rlzs_by_gsim_grp = self.csm.info.get_rlzs_by_gsim_grp()
+        self.L = len(self.oqparam.imtls.array)
+        self.R = self.csm.info.get_num_rlzs()
+        zd = AccumDict({r: ProbabilityMap(self.L) for r in range(self.R)})
+        zd.eff_ruptures = AccumDict()
+        zd.ruptures = AccumDict()
+        self.grp_trt = self.csm.info.grp_by("trt")
+        return zd
+
+    def agg_dicts(self, acc, result):
+        """
+        :param acc: accumulator dictionary
+        :param result: an AccumDict with events, ruptures, gmfs and hcurves
+        """
+        acc.ruptures += result.ruptures
+        if hasattr(result, 'calc_times'):
+            for srcid, nsites, eids, dt in result.calc_times:
+                info = self.csm.infos[srcid]
+                info.num_sites += nsites
+                info.calc_time += dt
+                info.num_split += 1
+                info.events += len(eids)
+        if hasattr(result, 'eff_ruptures'):
+            acc.eff_ruptures += result.eff_ruptures
+        self.save_ruptures(result.ruptures)
+        sav_mon = self.monitor('saving gmfs')
+        agg_mon = self.monitor('aggregating hcurves')
+        hdf5path = self.datastore.hdf5path
+        for res in result.gmfs_curves:
+            self.gmdata += res['gmdata']
+            data = res['gmfdata']
+            with sav_mon:
+                hdf5.extend3(hdf5path, 'gmf_data/data', data)
+                # it is important to save the number of bytes while the
+                # computation is going, to see the progress
+                update_nbytes(self.datastore, 'gmf_data/data', data)
+                for sid, start, stop in res['indices']:
+                    self.indices[sid].append(
+                        (start + self.offset, stop + self.offset))
+                self.offset += len(data)
+            slicedic = self.oqparam.imtls.slicedic
+            with agg_mon:
+                for key, poes in res['hcurves'].items():
+                    r, sid, imt = str2rsi(key)
+                    array = acc[r].setdefault(sid, 0).array[slicedic[imt], 0]
+                    array[:] = 1. - (1. - array) * (1. - poes)
+            sav_mon.flush()
+            agg_mon.flush()
+            self.datastore.flush()
+            if 'ruptures' in res:
+                vars(EventBasedRuptureCalculator)['save_ruptures'](
+                    self, res['ruptures'])
+        return acc
+
+    def execute(self):
+        self.gmdata = {}
+        self.offset = 0
+        self.indices = collections.defaultdict(list)  # sid -> indices
+        acc = self.zerodict()
+        self.sm_id = {tuple(sm.path): sm.ordinal
+                      for sm in self.csm.info.source_models}
+        with self.monitor('managing sources', autoflush=True):
+            allargs = self.gen_args(self.monitor('classical'))
+            iterargs = saving_sources_by_task(allargs, self.datastore)
+            if isinstance(allargs, list):
+                # there is a trick here: if the arguments are known
+                # (a list, not an iterator), keep them as a list
+                # then the Starmap will understand the case of a single
+                # argument tuple and it will run in core the task
+                iterargs = list(iterargs)
+            acc = parallel.Starmap(self.core_task.__func__, iterargs).reduce(
+                self.agg_dicts, acc)
+        with self.monitor('store source_info', autoflush=True):
+            self.store_source_info(self.csm.infos, acc)
+        calc.check_overflow(self)
+        base.save_gmdata(self, self.R)
+        if self.indices:
+            logging.info('Saving gmf_data/indices')
+            with self.monitor('saving gmf_data/indices', measuremem=True,
+                              autoflush=True):
+                self.datastore.save_vlen(
+                    'gmf_data/indices',
+                    [numpy.array(self.indices[sid], indices_dt)
+                     for sid in self.sitecol.complete.sids])
+        else:
+            raise RuntimeError('No GMFs were generated, perhaps they were '
+                               'all below the minimum_intensity threshold')
+        return acc
+
+    def save_gmf_bytes(self):
+        """Save the attribute nbytes in the gmf_data datasets"""
+        ds = self.datastore
+        for sm_id in ds['gmf_data']:
+            ds.set_nbytes('gmf_data/' + sm_id)
+        ds.set_nbytes('gmf_data')
+
+    def init(self):
+        """
+        Set the random seed passed to the SourceManager and the
+        minimum_intensity dictionary.
+        """
+        self.rupser = calc.RuptureSerializer(self.datastore)
+
+    def save_ruptures(self, ruptures_by_grp_id):
+        """
+        Extend the 'events' dataset with the events from the given ruptures;
+        also, save the ruptures if the flag `save_ruptures` is on.
+
+        :param ruptures_by_grp_id: a dictionary grp_id -> list of EBRuptures
+        """
+        with self.monitor('saving ruptures', autoflush=True):
+            for grp_id, ebrs in ruptures_by_grp_id.items():
+                if len(ebrs):
+                    events = get_events(ebrs)
+                    dset = self.datastore.extend('events', events)
+                    if self.oqparam.save_ruptures:
+                        self.rupser.save(ebrs, eidx=len(dset)-len(events))
+
+    def post_execute(self, result):
+        """
+        Save the SES collection
+        """
+        self.rupser.close()
+        num_events = sum(set_counts(self.datastore, 'events').values())
+        if num_events == 0:
+            raise RuntimeError(
+                'No seismic events! Perhaps the investigation time is too '
+                'small or the maximum_distance is too small')
+        num_ruptures = sum(len(ruptures) for ruptures in result.values())
+        logging.info('Setting %d event years on %d ruptures',
+                     num_events, num_ruptures)
+        with self.monitor('setting event years', measuremem=True,
+                          autoflush=True):
+            numpy.random.seed(self.oqparam.ses_seed)
+            set_random_years(self.datastore, 'events',
+                             int(self.oqparam.investigation_time))
+        gmf_size = max_gmf_size(
+            result.ruptures, self.rlzs_assoc.get_rlzs_by_gsim,
+            self.csm.info.get_samples_by_grp(),
+            len(self.oqparam.imtls))
+        self.datastore.set_attrs('events', max_gmf_size=gmf_size)
+        msg = 'less than ' if self.get_min_iml(self.oqparam).sum() else ''
+        logging.info('Generating %s%s of GMFs', msg, humansize(gmf_size))
+
+        oq = self.oqparam
+        if oq.hazard_curves_from_gmfs:
+            rlzs = self.rlzs_assoc.realizations
+            # save individual curves
+            for i in sorted(result):
+                key = 'hcurves/rlz-%03d' % i
+                if result[i]:
+                    self.datastore[key] = result[i]
+                else:
+                    self.datastore[key] = ProbabilityMap(oq.imtls.array.size)
+                    logging.info('Zero curves for %s', key)
+            # compute and save statistics; this is done in process and can
+            # be very slow if there are thousands of realizations
+            weights = [rlz.weight for rlz in rlzs]
+            hstats = self.oqparam.hazard_stats()
+            if len(hstats) and len(rlzs) > 1:
+                logging.info('Computing statistical hazard curves')
+                for kind, stat in hstats:
+                    pmap = compute_pmap_stats(result.values(), [stat], weights)
+                    self.datastore['hcurves/' + kind] = pmap
+        if self.datastore.parent:
+            self.datastore.parent.open('r')
+        if 'gmf_data' in self.datastore:
+            self.save_gmf_bytes()
+        if oq.compare_with_classical:  # compute classical curves
+            export_dir = os.path.join(oq.export_dir, 'cl')
+            if not os.path.exists(export_dir):
+                os.makedirs(export_dir)
+            oq.export_dir = export_dir
+            # one could also set oq.number_of_logic_tree_samples = 0
+            self.cl = ClassicalCalculator(oq)
+            # TODO: perhaps it is possible to avoid reprocessing the source
+            # model, however usually this is quite fast and do not dominate
+            # the computation
+            self.cl.run(close=False)
+            cl_mean_curves = get_mean_curves(self.cl.datastore)
+            eb_mean_curves = get_mean_curves(self.datastore)
+            for imt in eb_mean_curves.dtype.names:
+                rdiff, index = util.max_rel_diff_index(
+                    cl_mean_curves[imt], eb_mean_curves[imt])
+                logging.warn('Relative difference with the classical '
+                             'mean curves for IMT=%s: %d%% at site index %d',
+                             imt, rdiff * 100, index)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -263,7 +263,8 @@ class EventBasedCalculator(base.HazardCalculator):
         :param acc: accumulator dictionary
         :param result: an AccumDict with events, ruptures, gmfs and hcurves
         """
-        if not self.oqparam.ground_motion_fields:
+        oq = self.oqparam
+        if oq.save_ruptures and not oq.ground_motion_fields:
             self.gmf_size += max_gmf_size(
                 result['ruptures'], self.csm_info.rlzs_assoc.get_rlzs_by_gsim,
                 self.csm_info.get_samples_by_grp(), len(self.oqparam.imtls))

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -252,7 +252,6 @@ class EventBasedCalculator(base.HazardCalculator):
         self.R = self.csm_info.get_num_rlzs()
         zd = AccumDict({r: ProbabilityMap(self.L) for r in range(self.R)})
         zd.eff_ruptures = AccumDict()
-        zd.num_ruptures = 0
         self.grp_trt = self.csm_info.grp_by("trt")
         return zd
 
@@ -275,7 +274,6 @@ class EventBasedCalculator(base.HazardCalculator):
                 info.events += len(eids)
         if hasattr(result, 'eff_ruptures'):
             acc.eff_ruptures += result.eff_ruptures
-            acc.num_ruptures += result.num_ruptures
         if hasattr(result, 'events'):
             self.datastore.extend('events', result.events)
         self.save_ruptures(result['ruptures'])
@@ -383,15 +381,14 @@ class EventBasedCalculator(base.HazardCalculator):
         Save the SES collection
         """
         oq = self.oqparam
-        if getattr(result, 'num_ruptures', 0):
+        if oq.hazard_calculation_id is None:
             self.rupser.close()
             num_events = sum(set_counts(self.datastore, 'events').values())
             if num_events == 0:
                 raise RuntimeError(
                     'No seismic events! Perhaps the investigation time is too '
                     'small or the maximum_distance is too small')
-            logging.info('Setting %d event years on %d ruptures',
-                         num_events, result.num_ruptures)
+            logging.info('Setting %d event years', num_events)
             with self.monitor('setting event years', measuremem=True,
                               autoflush=True):
                 numpy.random.seed(self.oqparam.ses_seed)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -226,10 +226,11 @@ class EventBasedCalculator(base.HazardCalculator):
                     num_tasks += 1
                     num_sources += len(sg.sources)
                     continue
-                for block in block_splitter(sg.sources, maxweight, weight):
-                    yield block, self.src_filter, rlzs_by_gsim, param, monitor
+                for src in sg:
+                    # or block_splitter(sg.sources, maxweight, weight)
+                    yield [src], self.src_filter, rlzs_by_gsim, param, monitor
                     num_tasks += 1
-                    num_sources += len(block)
+                    num_sources += 1
         logging.info('Sent %d sources in %d tasks', num_sources, num_tasks)
 
     def zerodict(self):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -156,21 +156,22 @@ def compute_hazard(sources_or_ruptures, src_filter,
     Compute events, ruptures, gmfs and hazard curves
     """
     res = AccumDict()
-    if isinstance(sources_or_ruptures, RuptureGetter):
-        grp_id = sources_or_ruptures.grp_id
-        res['ruptures'] = {}
-        ruptures = sources_or_ruptures
-        sitecol = src_filter
-    else:
-        grp_id = sources_or_ruptures[0].src_group_id
-        dic = sample_ruptures(
-            sources_or_ruptures, src_filter, rlzs_by_gsim, param, monitor)
-        res.num_events = dic['num_events']
-        res.calc_times = dic['calc_times']
-        res.eff_ruptures = {grp_id: dic['num_ruptures']}
-        ruptures = dic['eb_ruptures']
-        res['ruptures'] = {grp_id: ruptures}
-        sitecol = src_filter.sitecol
+    with monitor('building ruptures', measuremem=True):
+        if isinstance(sources_or_ruptures, RuptureGetter):
+            grp_id = sources_or_ruptures.grp_id
+            res['ruptures'] = {}
+            ruptures = list(sources_or_ruptures)
+            sitecol = src_filter
+        else:
+            grp_id = sources_or_ruptures[0].src_group_id
+            dic = sample_ruptures(
+                sources_or_ruptures, src_filter, rlzs_by_gsim, param, monitor)
+            res.num_events = dic['num_events']
+            res.calc_times = dic['calc_times']
+            res.eff_ruptures = {grp_id: dic['num_ruptures']}
+            ruptures = dic['eb_ruptures']
+            res['ruptures'] = {grp_id: ruptures}
+            sitecol = src_filter.sitecol
     getter = GmfGetter(
         rlzs_by_gsim, ruptures, sitecol,
         param['oqparam'], param['min_iml'], param['samples'])

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -40,6 +40,7 @@ U32 = numpy.uint32
 U64 = numpy.uint64
 F32 = numpy.float32
 F64 = numpy.float64
+TWO32 = 2 ** 32
 
 
 def weight(src):
@@ -293,6 +294,9 @@ class EventBasedCalculator(base.HazardCalculator):
                     self.indices[sid].append(
                         (start + self.offset, stop + self.offset))
                 self.offset += len(data)
+                if self.offset >= TWO32:
+                    raise RuntimeError(
+                        'The gmf_data table has more than %d rows' % TWO32)
         slicedic = self.oqparam.imtls.slicedic
         with agg_mon:
             for key, poes in result.get('hcurves', {}).items():

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -46,8 +46,9 @@ def weight(src):
     """
     :returns: source weight multiplied by the total occurrence rate
     """
-    tot_rate = sum(rate for mag, rate in src.get_annual_occurrence_rates())
-    return tot_rate
+    return src.num_ruptures
+    # tot_rate = sum(rate for mag, rate in src.get_annual_occurrence_rates())
+    # return src.weight * tot_rate
 
 
 def get_events(ebruptures):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -44,12 +44,8 @@ TWO32 = 2 ** 32
 
 
 def weight(src):
-    """
-    :returns: source weight multiplied by the total occurrence rate
-    """
+    # a poor man weight
     return src.num_ruptures
-    # tot_rate = sum(rate for mag, rate in src.get_annual_occurrence_rates())
-    # return src.weight * tot_rate
 
 
 def get_events(ebruptures):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -177,6 +177,8 @@ class EbrCalculator(base.RiskCalculator):
         else:
             ebcalc = base.calculators[self.pre_calculator](self.oqparam)
             ebcalc.run(close=False)
+            if not self.oqparam.ground_motion_fields:
+                return  # this happens in the reportwriter
             self.set_log_format()
             parent = self.dynamic_parent = self.datastore.parent = (
                 ebcalc.datastore)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -177,8 +177,6 @@ class EbrCalculator(base.RiskCalculator):
         else:
             ebcalc = base.calculators[self.pre_calculator](self.oqparam)
             ebcalc.run(close=False)
-            if not self.oqparam.ground_motion_fields:
-                return  # this happens in the reportwriter
             self.set_log_format()
             parent = self.dynamic_parent = self.datastore.parent = (
                 ebcalc.datastore)
@@ -188,6 +186,8 @@ class EbrCalculator(base.RiskCalculator):
             self.sitecol = ebcalc.sitecol
             self.assetcol = ebcalc.assetcol
             self.riskmodel = ebcalc.riskmodel
+            if not self.oqparam.ground_motion_fields:
+                return  # this happens in the reportwrite
 
         self.L = len(self.riskmodel.lti)
         self.T = len(self.assetcol.tagcol)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -184,7 +184,7 @@ class EbrCalculator(base.RiskCalculator):
             self.datastore['oqparam'] = oq
             self.param = ebcalc.param
             self.sitecol = ebcalc.sitecol
-            self.assetcol = ebcalc.precalc.assetcol
+            self.assetcol = ebcalc.assetcol
             self.riskmodel = ebcalc.riskmodel
 
         self.L = len(self.riskmodel.lti)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -399,9 +399,11 @@ class GmfGetter(object):
                                 gmvs[:, imti], oq.imtls[imt],
                                 oq.investigation_time, duration)
                             hcurves[rsi2str(rlzi, sid, imt)] = poes
-        else:  # fast lane
+        elif oq.ground_motion_fields:  # fast lane
             with monitor('building hazard', measuremem=True):
                 gmfdata = numpy.fromiter(self.gen_gmv(), dt)
+        else:
+            return {}
         indices = []
         gmfdata.sort(order=('sid', 'rlzi', 'eid'))
         start = stop = 0

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -139,10 +139,7 @@ def build_report(job_ini, output_dir=None):
     # the goal is to extract information about the source management only
     p = mock.patch.object
     with p(PSHACalculator, 'core_task', count_eff_ruptures):
-        calc.prefilter = False
-        if calc.pre_calculator == 'event_based_risk':
-            # compute the ruptures only, not the risk
-            calc.pre_calculator = 'event_based_rupture'
+        calc.oqparam.ground_motion_fields = False
         calc.pre_execute()
     if hasattr(calc, 'csm'):
         calc.datastore['csm_info'] = calc.csm.info

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -53,8 +53,8 @@ class ReportWriter(object):
         'avglosses_data_transfer': 'Estimated data transfer for the avglosses',
         'exposure_info': 'Exposure model',
         'short_source_info': 'Slowest sources',
-        'task_classical:0': 'Fastest task',
-        'task_classical:-1': 'Slowest task',
+        'task_hazard:0': 'Fastest task',
+        'task_hazard:-1': 'Slowest task',
         'task_info': 'Information about the tasks',
         'times_by_source_class': 'Computation times by source typology',
         'performance': 'Slowest operations',
@@ -106,8 +106,8 @@ class ReportWriter(object):
             self.add('task_info')
             tasks = set(ds['task_info'])
             if 'classical' in tasks or 'count_eff_ruptures' in tasks:
-                self.add('task_classical:0')
-                self.add('task_classical:-1')
+                self.add('task_hazard:0')
+                self.add('task_hazard:-1')
             self.add('job_info')
         if 'performance_data' in ds:
             self.add('performance')

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -223,9 +223,10 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         os.remove(fname)
 
         # check max_gmf_size
-        exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
-        got = self.calc.datastore['gmf_data/data'].value.nbytes
-        self.assertGreater(exp, got)  # there is minimum_intensity
+        # FIXME: do this only if ground_motion_fields = false
+        # exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
+        # got = self.calc.datastore['gmf_data/data'].value.nbytes
+        # self.assertGreater(exp, got)  # there is minimum_intensity
 
     @attr('qa', 'risk', 'event_based_risk')
     def test_case_miriam(self):

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -222,12 +222,6 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/ruptures_events.txt', fname)
         os.remove(fname)
 
-        # check max_gmf_size
-        # FIXME: do this only if ground_motion_fields = false
-        # exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
-        # got = self.calc.datastore['gmf_data/data'].value.nbytes
-        # self.assertGreater(exp, got)  # there is minimum_intensity
-
     @attr('qa', 'risk', 'event_based_risk')
     def test_case_miriam(self):
         # this is a case with a grid and asset-hazard association

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -169,11 +169,6 @@ class EventBasedTestCase(CalculatorTestCase):
         ltr0 = out['gmf_data', 'xml'][0]
         self.assertEqualFiles('expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml',
                               ltr0)
-
-        exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
-        got = self.calc.datastore['gmf_data/data'].value.nbytes
-        self.assertEqual(exp, got)
-
         ltr = out['hcurves', 'csv']
         self.assertEqualFiles(
             'expected/hc-smltp_b1-gsimltp_b1-ltr_0.csv', ltr[0])
@@ -240,6 +235,9 @@ class EventBasedTestCase(CalculatorTestCase):
             reldiff, _index = max_rel_diff_index(
                 mean_cl[imt], mean_eb[imt], min_value=0.1)
             self.assertLess(reldiff, 0.20)
+
+        exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
+        self.assertEqual(exp, 375496)
 
     @attr('qa', 'hazard', 'event_based')
     def test_case_8(self):

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -18,7 +18,6 @@
 import os
 import re
 import math
-import unittest
 from nose.plugins.attrib import attr
 
 import numpy.testing
@@ -284,7 +283,6 @@ class EventBasedTestCase(CalculatorTestCase):
 
     @attr('qa', 'hazard', 'event_based')
     def test_case_17(self):  # oversampling and save_ruptures
-        raise unittest.SkipTest
         expected = [
             'hazard_curve-mean.csv',
             'hazard_curve-rlz-001.csv',

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -170,9 +170,10 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml',
                               ltr0)
 
-        exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
-        got = self.calc.datastore['gmf_data/data'].value.nbytes
-        self.assertEqual(exp, got)
+        # FIXME: restore this only if ground_motion_fields is False
+        # exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
+        # got = self.calc.datastore['gmf_data/data'].value.nbytes
+        # self.assertEqual(exp, got)
 
         ltr = out['hcurves', 'csv']
         self.assertEqualFiles(

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -170,10 +170,9 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml',
                               ltr0)
 
-        # FIXME: restore this only if ground_motion_fields is False
-        # exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
-        # got = self.calc.datastore['gmf_data/data'].value.nbytes
-        # self.assertEqual(exp, got)
+        exp = self.calc.datastore.get_attr('events', 'max_gmf_size')
+        got = self.calc.datastore['gmf_data/data'].value.nbytes
+        self.assertEqual(exp, got)
 
         ltr = out['hcurves', 'csv']
         self.assertEqualFiles(

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -18,6 +18,7 @@
 import os
 import re
 import math
+import unittest
 from nose.plugins.attrib import attr
 
 import numpy.testing
@@ -283,6 +284,7 @@ class EventBasedTestCase(CalculatorTestCase):
 
     @attr('qa', 'hazard', 'event_based')
     def test_case_17(self):  # oversampling and save_ruptures
+        raise unittest.SkipTest
         expected = [
             'hazard_curve-mean.csv',
             'hazard_curve-rlz-001.csv',

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -79,8 +79,6 @@ class UcerfTestCase(CalculatorTestCase):
     @manage_shared_dir_error
     def test_event_based_sampling(self):
         self.run_calc(ucerf.__file__, 'job_ebh.ini')
-        import unittest
-        raise unittest.SkipTest
 
         # check the GMFs
         gmdata = self.calc.datastore['gmdata'].value

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -79,6 +79,8 @@ class UcerfTestCase(CalculatorTestCase):
     @manage_shared_dir_error
     def test_event_based_sampling(self):
         self.run_calc(ucerf.__file__, 'job_ebh.ini')
+        import unittest
+        raise unittest.SkipTest
 
         # check the GMFs
         gmdata = self.calc.datastore['gmdata'].value

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import os
-import unittest
 from decorator import decorator
 from nose.plugins.attrib import attr
 from openquake.baselib import config
@@ -61,7 +60,6 @@ class UcerfTestCase(CalculatorTestCase):
 
         # run a regular event based on top of the UCERF ruptures and
         # check the generated hazard maps
-        raise unittest.SkipTest
         self.run_calc(ucerf.__file__, 'job.ini',
                       calculation_mode='event_based',
                       concurrent_tasks='0',  # avoid usual fork bug

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import os
+import unittest
 from decorator import decorator
 from nose.plugins.attrib import attr
 from openquake.baselib import config
@@ -60,6 +61,7 @@ class UcerfTestCase(CalculatorTestCase):
 
         # run a regular event based on top of the UCERF ruptures and
         # check the generated hazard maps
+        raise unittest.SkipTest
         self.run_calc(ucerf.__file__, 'job.ini',
                       calculation_mode='event_based',
                       concurrent_tasks='0',  # avoid usual fork bug

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -272,7 +272,6 @@ class UCERFHazardCalculator(event_based.EventBasedCalculator):
         """
         logging.warn('%s is still experimental', self.__class__.__name__)
         oq = self.oqparam
-        #assert oq.hazard_calculation_id is None, 'Cannot use --hc option'
         self.read_risk_data()  # read the site collection
         self.csm = readinput.get_composite_source_model(oq)
         logging.info('Found %d source model logic tree branches',
@@ -392,7 +391,7 @@ class UCERFRiskCalculator(EbrCalculator):
                              min_iml=min_iml,
                              oqparam=oq,
                              insured_losses=oq.insured_losses)
-                yield (ssm, src_filter, param, self.riskmodel, monitor)
+                yield ssm, src_filter, param, self.riskmodel, monitor
 
     def execute(self):
         self.riskmodel.taxonomy = self.assetcol.tagcol.taxonomy

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -272,7 +272,7 @@ class UCERFHazardCalculator(event_based.EventBasedCalculator):
         """
         logging.warn('%s is still experimental', self.__class__.__name__)
         oq = self.oqparam
-        assert oq.hazard_calculation_id is None, 'Cannot use --hc option'
+        #assert oq.hazard_calculation_id is None, 'Cannot use --hc option'
         self.read_risk_data()  # read the site collection
         self.csm = readinput.get_composite_source_model(oq)
         logging.info('Found %d source model logic tree branches',
@@ -376,7 +376,7 @@ class UCERFRiskCalculator(EbrCalculator):
         elt_dt = numpy.dtype([('eid', U64), ('rlzi', U16),
                               ('loss', (F32, (self.L, self.I)))])
         monitor = self.monitor('compute_losses')
-        src_filter = UcerfFilter(self.sitecol, oq.maximum_distance)
+        src_filter = UcerfFilter(self.sitecol.complete, oq.maximum_distance)
 
         for sm in self.csm.source_models:
             if sm.samples > 1:

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -299,9 +299,9 @@ class UCERFHazardCalculator(event_based.EventBasedCalculator):
         oq = self.oqparam
         allargs = []  # it is better to return a list; if there is single
         # branch then `parallel.Starmap` will run the task in core
+        rlzs_by_gsim = self.csm.info.get_rlzs_by_gsim_grp()
         for sm_id in range(len(self.csm.source_models)):
             ssm = self.csm.get_model(sm_id)
-            rlzs_by_gsim = ssm.info.get_rlzs_by_gsim_grp()[sm_id]
             [sm] = ssm.source_models
             srcs = ssm.get_sources()
             for ses_idx in range(1, oq.ses_per_logic_tree_path + 1):
@@ -311,7 +311,7 @@ class UCERFHazardCalculator(event_based.EventBasedCalculator):
                              filter_distance=oq.filter_distance,
                              gmf=oq.ground_motion_fields,
                              min_iml=self.get_min_iml(oq))
-                allargs.append((srcs, self.src_filter, rlzs_by_gsim,
+                allargs.append((srcs, self.src_filter, rlzs_by_gsim[sm_id],
                                 param, monitor))
         return allargs
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -606,21 +606,23 @@ def view_task_durations(token, dstore):
     return '\n'.join(map(str, array))
 
 
-@view.add('task_classical')
-def view_task_classical(token, dstore):
+@view.add('task_hazard')
+def view_task_hazard(token, dstore):
     """
     Display info about a given task. Here are a few examples of usage::
 
-     $ oq show task_classical:0  # the fastest task
-     $ oq show task_classical:-1  # the slowest task
+     $ oq show task_hazard:0  # the fastest task
+     $ oq show task_hazard:-1  # the slowest task
     """
     tasks = set(dstore['task_info'])
     if 'task_info/source_data' not in dstore:
         return 'Missing source_data'
     if 'classical' in tasks:
         data = dstore['task_info/classical'].value
-    else:
+    elif 'count_eff_ruptures' in tasks:
         data = dstore['task_info/count_eff_ruptures'].value
+    else:
+        data = dstore['task_info/compute_hazard'].value
     data.sort(order='duration')
     rec = data[int(token.split(':')[1])]
     taskno = rec['taskno']

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -76,6 +76,7 @@ class OqParam(valid.ParamSet):
     ground_motion_correlation_model = valid.Param(
         valid.NoneOr(valid.Choice(*GROUND_MOTION_CORRELATION_MODELS)), None)
     ground_motion_correlation_params = valid.Param(valid.dictionary)
+    ground_motion_fields = valid.Param(valid.boolean, True)
     gsim = valid.Param(valid.gsim, valid.FromFile())
     hazard_calculation_id = valid.Param(valid.NoneOr(valid.positiveint), None)
     hazard_curves_from_gmfs = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -544,6 +544,8 @@ class CompositionInfo(object):
         if self.num_samples:
             return source_model.samples
         trts = set(sg.trt for sg in source_model.src_groups)
+        if sum(sg.eff_ruptures for sg in source_model.src_groups) == 0:
+            return 0
         return self.gsim_lt.reduce(trts).get_num_paths()
 
     @property

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -543,7 +543,7 @@ class CompositionInfo(object):
             return sum(self.get_num_rlzs(sm) for sm in self.source_models)
         if self.num_samples:
             return source_model.samples
-        trts = set(sg.trt for sg in source_model.src_groups)
+        trts = set(sg.trt for sg in source_model.src_groups if sg.eff_ruptures)
         if sum(sg.eff_ruptures for sg in source_model.src_groups) == 0:
             return 0
         return self.gsim_lt.reduce(trts).get_num_paths()

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -133,7 +133,7 @@ def sample_ruptures(group, src_filter, gsims, param, monitor=Monitor()):
         t0 = time.time()
         num_ruptures += src.num_ruptures
         num_occ_by_rup = _sample_ruptures(
-            src, prob[src], param['ses_per_logic_tree_path'], group.samples,
+            src, prob[src], param['ses_per_logic_tree_path'], param['samples'],
             param['seed'])
         # NB: the number of occurrences is very low, << 1, so it is
         # more efficient to filter only the ruptures that occur, i.e.

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -43,12 +43,11 @@ class StochasticEventSetTestCase(unittest.TestCase):
             nr = src.num_ruptures
             src.serial = rup_serial[start:start + nr]
             start += nr
-        group.samples = 1
         lonlat = 135.68, 35.68
         site = Site(geo.Point(*lonlat), 800, True, z1pt0=100., z2pt5=1.)
         s_filter = SourceFilter(SiteCollection([site]), {})
         param = dict(ses_per_logic_tree_path=10, seed=42,
-                     filter_distance='rjb')
+                     filter_distance='rjb', samples=1)
         gsims = [SiMidorikawa1999SInter()]
         dic = sample_ruptures(group, s_filter, gsims, param)
         self.assertEqual(dic['num_ruptures'], 19)  # total ruptures

--- a/openquake/qa_tests_data/event_based/case_17/job.ini
+++ b/openquake/qa_tests_data/event_based/case_17/job.ini
@@ -37,6 +37,5 @@ maximum_distance = 200.0
 
 [output]
 
-ground_motion_fields = false
 hazard_curves_from_gmfs = True
 export_dir = /tmp

--- a/openquake/qa_tests_data/event_based/case_8/job.ini
+++ b/openquake/qa_tests_data/event_based/case_8/job.ini
@@ -1,7 +1,7 @@
 [general]
 random_seed = 23
 description = Event Based from NonParametric source
-calculation_mode = event_based_rupture
+calculation_mode = event_based
 
 [geometry]
 sites = 143 41, 143 41.2, 143 41.4
@@ -31,3 +31,4 @@ ses_per_logic_tree_path = 2
 truncation_level = 3
 maximum_distance = 500.0
 save_ruptures = true
+ground_motion_fields = false

--- a/openquake/qa_tests_data/event_based/mutex/job.ini
+++ b/openquake/qa_tests_data/event_based/mutex/job.ini
@@ -1,7 +1,7 @@
 [general]
 
 description = Event Based QA Test, Case 1
-calculation_mode = event_based_rupture
+calculation_mode = event_based
 ses_seed = 1066
 
 [geometry]
@@ -48,6 +48,7 @@ ground_motion_correlation_params =
 
 [output]
 
+ground_motion_fields = false
 hazard_curves_from_gmfs = true
 mean_hazard_curves = false
 

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_1/job.ini
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_1/job.ini
@@ -44,3 +44,7 @@ maximum_distance = 200.0
 ses_per_logic_tree_path = 125
 ground_motion_correlation_model = JB2009
 ground_motion_correlation_params = {"vs30_clustering": False}
+
+[output]
+
+save_ruptures = false

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_2/job.ini
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_2/job.ini
@@ -44,3 +44,7 @@ maximum_distance = 200.0
 ses_per_logic_tree_path = 150
 ground_motion_correlation_model = JB2009
 ground_motion_correlation_params = {"vs30_clustering": True}
+
+[output]
+
+save_ruptures = false

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_3/job.ini
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_3/job.ini
@@ -42,3 +42,7 @@ maximum_distance = 200.0
 [event_based_params]
 
 ses_per_logic_tree_path = 300
+
+[output]
+
+save_ruptures = false

--- a/openquake/qa_tests_data/ucerf/job.ini
+++ b/openquake/qa_tests_data/ucerf/job.ini
@@ -1,6 +1,6 @@
 [general]
 description = Ucerf test
-calculation_mode = ucerf_rupture
+calculation_mode = ucerf_hazard
 random_seed = 1066
 ses_seed = 1066
 

--- a/openquake/qa_tests_data/ucerf/job.ini
+++ b/openquake/qa_tests_data/ucerf/job.ini
@@ -39,7 +39,6 @@ ground_motion_correlation_params =
 [output]
 export_dir = /tmp
 mean_hazard_curves = true
-ground_motion_fields = false
 hazard_curves_from_gmfs = true
 hazard_maps = true
 poes = 0.02 0.2


### PR DESCRIPTION
The change in the prefiltering mechanism introduced in engine 3.1 has far reaching consequences: in particular now the effective logic tree is available even *before* starting the real computation. It means that the event_based_rupture calculator (which was essential because it was determining the effective logic tree) can be removed and the ruptures can be computed as part of the hazard calculation producing GMFs and hazard curves. This saves a lot of memory and of data transfer, since there is no need to send back and forth the ruptures. Moreover the logic of the event based calculation can be substantially simplified (no need of precalculators) and we can reduced the total number of event based calculators from 6 to 4. A big improvement. Extra care has to be taken to avoid the issue of slow tasks.

With the change in this PR I was able, for the first time ever, to run the full Guatemala calculation producing 300+ GB of GMFs. Still, I am adding here a check to forbid calculations producing more
than 2**32 rows in the gmf_data/data table, thus making the Guatemala calculation impossible again ;-)
The reason is that given the technological limits (speed of reading the disks, speed of NFS, etc) such calculations are terribly inefficient even when barely possible. It is best to raise an error and make the scientists think.

This is a first step towards https://github.com/gem/oq-engine/issues/3806.