### PR TITLE
20180625 decimaltime

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Marco Pagani]
+  * Adding tests to the method computing decimal time
+
   [Michele Simionato]
   * Added a field `size_mb` to the `output` table in the database and made
     it visible in the WebUI as a tooltip

--- a/openquake/hmtk/seismicity/utils.py
+++ b/openquake/hmtk/seismicity/utils.py
@@ -157,7 +157,20 @@ def decimal_time(year, month, day, hour, minute, second):
     tho = np.zeros_like(year, dtype=int)
     tmi = np.zeros_like(year, dtype=int)
     tse = np.zeros_like(year, dtype=float)
-
+    #
+    # Checking inputs
+    if any(month < 1) or any(month > 12):
+        raise ValueError('Month must be in [1, 12]')
+    if any(day < 1) or any(day > 31):
+        raise ValueError('Day must be in [1, 31]')
+    if any(hour < 0) or any(hour > 24):
+        raise ValueError('Hour must be in [0, 24]')
+    if any(minute < 0) or any(minute > 60):
+        raise ValueError('Minute must be in [0, 60]')
+    if any(second < 0) or any(second > 60):
+        raise ValueError('Second must be in [0, 60]')
+    #
+    # Initialising values
     if any(month):
         tmo = month
     if any(day):
@@ -168,14 +181,15 @@ def decimal_time(year, month, day, hour, minute, second):
         tmi = minute
     if any(second):
         tse = second
-
+    #
+    # Computing decimal
     tmonth = tmo - 1
     day_count = MARKER_NORMAL[tmonth] + tda - 1
     id_leap = leap_check(year)
     leap_loc = np.where(id_leap)[0]
     day_count[leap_loc] = MARKER_LEAP[tmonth[leap_loc]] + tda[leap_loc] - 1
-    year_secs = (day_count.astype(float) * SECONDS_PER_DAY) + tse + \
-        (60. * tmi.astype(float)) + (3600. * tho.astype(float))
+    year_secs = ((day_count.astype(float) * SECONDS_PER_DAY) + tse +
+                 (60. * tmi.astype(float)) + (3600. * tho.astype(float)))
     dtime = year.astype(float) + (year_secs / (365. * 24. * 3600.))
     dtime[leap_loc] = year[leap_loc].astype(float) + \
         (year_secs[leap_loc] / (366. * 24. * 3600.))

--- a/openquake/hmtk/tests/seismicity/data/test_cat_01.csv
+++ b/openquake/hmtk/tests/seismicity/data/test_cat_01.csv
@@ -1,0 +1,2 @@
+eventID,Agency,year,month,day,hour,minute,second,timeError,longitude,latitude,depth,magnitude
+1,Test,2015,0,0,,,,,10.0000,10.0000,11,4.9

--- a/openquake/hmtk/tests/seismicity/data/test_cat_02.csv
+++ b/openquake/hmtk/tests/seismicity/data/test_cat_02.csv
@@ -1,0 +1,6 @@
+eventID,Identifier,year,month,day,hour,minute,second,latitude,longitude,depth,SemiMajor90,SemiMinor90,ErrorStrike,timeError,depthError,Agency,LocId,magnitude,sigmaMagnitude,magnitudeType,MagId
+AAA,BBB,2015,1,1,,,,-5.69,-36.24,0,,,,,,BSB_PI,BSB104,3.3,0,Mwp,BSB104
+BSB104,BSB_PI|BSB,1963,8,27,,,,-5.69,-36.24,0,,,,,,BSB_PI,BSB104,3.3,0,Mwp,BSB104
+BSB104,BSB_PI|BSB,1963,8,27,1,1,1.,-5.69,-36.24,0,,,,,,BSB_PI,BSB104,3.3,0,Mwp,BSB104
+BSB104,BSB_PI|BSB,1963,8,,,,,-5.69,-36.24,0,,,,,,BSB_PI,BSB104,3.3,0,Mwp,BSB104
+BSB740,BSB_I|BSB,1999,8,18,4,43,58,-13.3,-49.2,0,,,,,,BSB_I,BSB740,3.2,0,Mwp,BSB740

--- a/openquake/hmtk/tests/seismicity/test_utils.py
+++ b/openquake/hmtk/tests/seismicity/test_utils.py
@@ -1,0 +1,90 @@
+#
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#
+# LICENSE
+#
+# Copyright (C) 2010-2018 GEM Foundation, G. Weatherill, M. Pagani,
+# D. Monelli.
+#
+# The Hazard Modeller's Toolkit is free software: you can redistribute
+# it and/or modify it under the terms of the GNU Affero General Public
+# License as published by the Free Software Foundation, either version
+# 3 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>
+#
+# DISCLAIMER
+#
+# The software Hazard Modeller's Toolkit (hmtk) provided herein
+# is released as a prototype implementation on behalf of
+# scientists and engineers working within the GEM Foundation (Global
+# Earthquake Model).
+#
+# It is distributed for the purpose of open collaboration and in the
+# hope that it will be useful to the scientific, engineering, disaster
+# risk and software design communities.
+#
+# The software is NOT distributed as part of GEM’s OpenQuake suite
+# (https://www.globalquakemodel.org/tools-products) and must be considered as a
+# separate entity. The software provided herein is designed and implemented
+# by scientific staff. It is not developed to the design standards, nor
+# subject to same level of critical review by professional software
+# developers, as GEM’s OpenQuake software suite.
+#
+# Feedback and contribution to the software is welcome, and can be
+# directed to the hazard scientific staff of the GEM Model Facility
+# (hazard@globalquakemodel.org).
+#
+# The Hazard Modeller's Toolkit (hmtk) is therefore distributed WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# The GEM Foundation, and the authors of the software, assume no
+# liability for use of the software.
+
+"""
+Module :mod:`openquake.hmtk.tests.seismicity.test_utils`
+implements :class:`TestDecimaltime`.
+"""
+
+import os
+import numpy
+import unittest
+from openquake.hmtk.parsers.catalogue import CsvCatalogueParser
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
+
+class TestDecimaltime(unittest.TestCase):
+    '''
+    Tests calculation of decimal time
+    '''
+
+    def test_convert_to_decimal_1(self):
+        fname = os.path.join(DATA_DIR, 'test_cat_01.csv')
+        parser = CsvCatalogueParser(fname)
+        cat = parser.read_file()
+        with self.assertRaises(ValueError):
+            _ = cat.get_decimal_time()
+
+    def test_convert_to_decimal_2(self):
+        fname = os.path.join(DATA_DIR, 'test_cat_02.csv')
+        parser = CsvCatalogueParser(fname)
+        cat = parser.read_file()
+
+        for lab in ['day', 'hour', 'minute', 'second']:
+            idx = numpy.isnan(cat.data[lab])
+            if lab == 'day':
+                cat.data[lab][idx] = 1
+            elif lab == 'second':
+                cat.data[lab][idx] = 0.0
+            else:
+                cat.data[lab][idx] = 0
+        computed = cat.get_decimal_time()
+        expected = numpy.array([2015., 1963.65205479, 1963.65217088,
+                                1963.58082192, 1999.62793753])
+        numpy.testing.assert_almost_equal(computed, expected)


### PR DESCRIPTION
This PR adds some tests to the function computing decimal time. In case of earthquakes missing some of the timing parameters, these can be replaced with a default value using a bunch of lines like the ones included in one of the two tests. 