### PR TITLE
Do not delete calculations in the demos

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -33,10 +33,6 @@ oq db set_status 26 executing
 # repeat the failed/executing calculation, which is useful for QGIS
 oq engine --run $1/hazard/AreaSourceClassicalPSHA/job.ini
 
-# test deleting a calculation
-
-oq engine --dc 26 -y
-
 # display the calculations
 oq db find %
 

--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -70,4 +70,5 @@ def purge(calc_id):
             return
     purge_one(calc_id, getpass.getuser())
 
+
 purge.arg('calc_id', 'calculation ID', type=int)

--- a/openquake/server/tests/tests.py
+++ b/openquake/server/tests/tests.py
@@ -37,6 +37,7 @@ from openquake.baselib.general import gettemp
 from openquake.engine.export import core
 from openquake.server.db import actions
 from openquake.server.dbserver import db, get_status
+from openquake.commands import engine
 
 
 class EngineServerTestCase(unittest.TestCase):
@@ -237,6 +238,9 @@ class EngineServerTestCase(unittest.TestCase):
         job_ids = [job['id'] for job in self.get('list', relevant=True)]
         self.assertFalse(job_id in job_ids)
         # NB: the job is invisible but still there
+
+        # check deleting job
+        engine.del_calculation(job_id, True)
 
     def test_err_2(self):
         # the file logic-tree-source-model.xml is missing


### PR DESCRIPTION
There is the risk of removing a parent calculation; then exporting the full report may not work. It happened while running the QGIS tests.