### PR TITLE
Added an utility to extract mean and stddev of the hazard curves

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Added a flag `std_hazard_curves`; by setting it to `true` the user can
+    compute the standard deviation of the hazard curves across realizations
+
   [Marco Pagani]
   * Added Thingbaijam et al. (2017) magnitude-scaling relationship
 

--- a/demos/hazard/LogicTreeCase1ClassicalPSHA/job.ini
+++ b/demos/hazard/LogicTreeCase1ClassicalPSHA/job.ini
@@ -38,6 +38,7 @@ maximum_distance = 200.0
 
 export_dir = /tmp
 mean_hazard_curves = true
+std_hazard_curves = true
 quantile_hazard_curves = 0.05 0.5 0.95
 uniform_hazard_spectra = true
 hazard_maps = true

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -775,6 +775,12 @@ class DictArray(collections.Mapping):
         for imt in carray.dtype.names:
             self[imt] = carray[0][imt]
 
+    def __eq__(self, other):
+        return (self.array == other.array).all()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __repr__(self):
         data = ['%s: %s' % (imt, self[imt]) for imt in self]
         return '<%s\n%s>' % (self.__class__.__name__, '\n'.join(data))

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -30,7 +30,6 @@ else:
 from openquake.baselib.hdf5 import ArrayWrapper
 from openquake.baselib.general import DictArray, group_array
 from openquake.baselib.python3compat import encode
-from openquake.hazardlib import stats
 from openquake.calculators import getters
 from openquake.commonlib import calc, util
 
@@ -528,8 +527,12 @@ def extract_mfd(dstore, what):
 
 
 @extract.add('mean_std_curves')
-def extract_mean_std(dstore, what):
+def extract_mean_std_curves(dstore, what):
     """
     Yield mean and stddev for each IMT for each site
     """
-    return getters.PmapGetter(dstore).gen_mean_std()
+    getter = getters.PmapGetter(dstore)
+    arr = getter.get_mean().array
+    for imt in getter.imtls:
+        yield 'imls/' + imt, getter.imtls[imt]
+        yield 'poes/' + imt, arr[:, getter.imtls.slicedic[imt]]

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -529,4 +529,7 @@ def extract_mfd(dstore, what):
 
 @extract.add('mean_std_curves')
 def extract_mean_std(dstore, what):
+    """
+    Yield mean and stddev for each IMT for each site
+    """
     return getters.PmapGetter(dstore).gen_mean_std()

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -30,6 +30,7 @@ else:
 from openquake.baselib.hdf5 import ArrayWrapper
 from openquake.baselib.general import DictArray, group_array
 from openquake.baselib.python3compat import encode
+from openquake.hazardlib import stats
 from openquake.calculators import getters
 from openquake.commonlib import calc, util
 
@@ -524,3 +525,8 @@ def extract_mfd(dstore, what):
     dt = numpy.dtype([('mag', float), ('freq', int)])
     magfreq = numpy.array(sorted(dd.items(), key=operator.itemgetter(0)), dt)
     return magfreq
+
+
+@extract.add('mean_std_curves')
+def extract_mean_std(dstore, what):
+    return getters.PmapGetter(dstore).gen_mean_std()

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -529,7 +529,7 @@ def extract_mfd(dstore, what):
 @extract.add('mean_std_curves')
 def extract_mean_std_curves(dstore, what):
     """
-    Yield mean and stddev for each IMT for each site
+    Yield imls/IMT and poes/IMT containg mean and stddev for all sites
     """
     getter = getters.PmapGetter(dstore)
     arr = getter.get_mean().array

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -203,7 +203,8 @@ class PmapGetter(object):
         self.init()
         pmaps = self.get_pmaps(self.sids)
         for imt in self.imtls:
-            yield imt, stats.mean_std_curve(
+            yield 'imls/' + imt, self.imtls[imt]
+            yield 'poes/' + imt, stats.mean_std_curve(
                 [pmap.array[:, self.imtls.slicedic[imt], 0]
                  for pmap in pmaps], self.weights)
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -198,7 +198,7 @@ class PmapGetter(object):
 
     def gen_mean_std(self):
         """
-        :yields: mean and std for all curves and IMTs
+        :yields: mean and std for each IMT and all sites
         """
         self.init()
         pmaps = self.get_pmaps(self.sids)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -194,19 +194,8 @@ class PmapGetter(object):
         else:  # multiple realizations, assume hcurves/mean is there
             dic = ({g: self.dstore['poes/' + g] for g in self.dstore['poes']}
                    if grp is None else {grp: self.dstore['poes/' + grp]})
-            return self.rlzs_assoc.compute_pmap_stats(dic, [stats.mean_curve])
-
-    def gen_mean_std(self):
-        """
-        :yields: mean and std for each IMT and all sites
-        """
-        self.init()
-        pmaps = self.get_pmaps(self.sids)
-        for imt in self.imtls:
-            yield 'imls/' + imt, self.imtls[imt]
-            yield 'poes/' + imt, stats.mean_std_curve(
-                [pmap.array[:, self.imtls.slicedic[imt], 0]
-                 for pmap in pmaps], self.weights)
+            return self.rlzs_assoc.compute_pmap_stats(
+                dic, [stats.mean_curve, stats.std_curve])
 
 
 class GmfDataGetter(collections.Mapping):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -196,15 +196,16 @@ class PmapGetter(object):
                    if grp is None else {grp: self.dstore['poes/' + grp]})
             return self.rlzs_assoc.compute_pmap_stats(dic, [stats.mean_curve])
 
-    def get_mean_std(self):
+    def gen_mean_std(self):
         """
-        :returns: mean and std for all curves and IMTs
+        :yields: mean and std for all curves and IMTs
         """
         self.init()
-        res = stats.mean_std_curve(
-            [pmap.array[:, :, 0] for pmap in self.get_pmaps(self.sids)],
-            self.weights)
-        return res
+        pmaps = self.get_pmaps(self.sids)
+        for imt in self.imtls:
+            yield imt, stats.mean_std_curve(
+                [pmap.array[:, self.imtls.slicedic[imt], 0]
+                 for pmap in pmaps], self.weights)
 
 
 class GmfDataGetter(collections.Mapping):

--- a/openquake/calculators/tests/classical_risk_test.py
+++ b/openquake/calculators/tests/classical_risk_test.py
@@ -68,6 +68,7 @@ class ClassicalRiskTestCase(CalculatorTestCase):
     def test_case_4(self):
         self.run_calc(case_4.__file__, 'job_haz.ini,job_risk.ini',
                       exports='csv')
+
         fnames = export(('loss_maps-rlzs', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/loss_maps-b1,b1.csv', fnames[0])
         self.assertEqualFiles('expected/loss_maps-b1,b2.csv', fnames[1])

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -126,6 +126,9 @@ class ClassicalTestCase(CalculatorTestCase):
              'hazard_curve-smltp_b2-gsimltp_b1.csv'],
             case_7.__file__, kind='all')
 
+        # exercising extract/mean_std_curves
+        dict(extract(self.calc.datastore, 'mean_std_curves'))
+
         # exercise the warning for no output when mean_hazard_curves='false'
         self.run_calc(
             case_7.__file__, 'job.ini', mean_hazard_curves='false',

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -43,7 +43,7 @@ F64 = numpy.float64
 # ############## utilities for the classical calculator ############### #
 
 
-def convert_to_array(pmap, nsites, imtls):
+def convert_to_array(pmap, nsites, imtls, inner_idx=0):
     """
     Convert the probability map into a composite array with header
     of the form PGA-0.1, PGA-0.2 ...
@@ -64,7 +64,7 @@ def convert_to_array(pmap, nsites, imtls):
         idx = 0
         for imt, imls in imtls.items():
             for iml in imls:
-                curve['%s-%s' % (imt, iml)] = pcurve.array[idx]
+                curve['%s-%s' % (imt, iml)] = pcurve.array[idx, inner_idx]
                 idx += 1
     return curves
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -100,6 +100,7 @@ class OqParam(valid.ParamSet):
     asset_hazard_distance = valid.Param(valid.positivefloat, 5)  # km
     max_hazard_curves = valid.Param(valid.boolean, False)
     mean_hazard_curves = valid.Param(valid.boolean, True)
+    std_hazard_curves = valid.Param(valid.boolean, False)
     max_loss_curves = valid.Param(valid.boolean, False)
     mean_loss_curves = valid.Param(valid.boolean, True)
     minimum_intensity = valid.Param(valid.floatdict, {})  # IMT -> minIML
@@ -458,6 +459,9 @@ class OqParam(valid.ParamSet):
         if self.mean_hazard_curves:
             names.append('mean')
             funcs.append(stats.mean_curve)
+        if self.std_hazard_curves:
+            names.append('std')
+            funcs.append(stats.std_curve)
         for q in self.quantile_hazard_curves:
             names.append('quantile-%s' % q)
             funcs.append(functools.partial(stats.quantile_curve, q))

--- a/openquake/commonlib/util.py
+++ b/openquake/commonlib/util.py
@@ -60,7 +60,7 @@ def max_rel_diff_index(curve_ref, curve, min_value=0.01):
     return maxdiff, maxindex
 
 
-def rmsep(array_ref, array, min_value=0.01):
+def rmsep(array_ref, array, min_value=0):
     """
     Root Mean Square Error Percentage for two arrays.
 
@@ -73,7 +73,7 @@ def rmsep(array_ref, array, min_value=0.01):
     ... [0.01, 0.02, 0.04, 0.06]])
     >>> curve = numpy.array([[0.011, 0.021, 0.031, 0.051],
     ... [0.012, 0.022, 0.032, 0.051]])
-    >>> str(round(rmsep(curve_ref, curve), 5))
+    >>> str(round(rmsep(curve_ref, curve, .01), 5))
     '0.11292'
     """
     bigvalues = array_ref > min_value

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -20,34 +20,29 @@ Utilities to compute mean and quantile curves
 """
 import numpy
 
-mean_std_dt = numpy.dtype([('mean', float), ('std', float)])
+_mean = None  # set by mean_curve and std_curve
 
 
 def mean_curve(values, weights=None):
     """
     Compute the mean by using numpy.average on the first axis.
     """
+    global _mean
     if weights is None:
         weights = [1. / len(values)] * len(values)
     if isinstance(values[0], (numpy.ndarray, list, tuple)):  # fast lane
-        return numpy.average(values, axis=0, weights=weights)
-    return sum(value * weight for value, weight in zip(values, weights))
+        _mean = numpy.average(values, axis=0, weights=weights)
+    _mean = sum(value * weight for value, weight in zip(values, weights))
+    return _mean
 
 
-def mean_std_curve(values, weights=None):
-    """
-    :param values: an array of (R ...) values
-    :param weights: R weights
-    :returns: array with fields 'mean', 'std'
-    """
+def std_curve(values, weights=None):
+    global _mean
+    assert _mean is not None, 'You must call mean_curve before std_curve'
     if weights is None:
         weights = [1. / len(values)] * len(values)
-    if not isinstance(values, numpy.ndarray):
-        values = numpy.array(values)
-    res = numpy.zeros(values.shape[1:], mean_std_dt)
-    res['mean'] = numpy.average(values, axis=0, weights=weights)
-    res['std'] = numpy.sqrt(
-        numpy.einsum('i,i...', weights, (res['mean'] - values) ** 2))
+    res = numpy.sqrt(numpy.einsum('i,i...', weights, (_mean - values) ** 2))
+    _mean = None  # reset cache
     return res
 
 

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -30,9 +30,9 @@ def mean_curve(values, weights=None):
     global _mean
     if weights is None:
         weights = [1. / len(values)] * len(values)
-    if isinstance(values[0], (numpy.ndarray, list, tuple)):  # fast lane
-        _mean = numpy.average(values, axis=0, weights=weights)
-    _mean = sum(value * weight for value, weight in zip(values, weights))
+    if not isinstance(values, numpy.ndarray):
+        values = numpy.array(values)
+    _mean = numpy.average(values, axis=0, weights=weights)
     return _mean
 
 

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -20,6 +20,8 @@ Utilities to compute mean and quantile curves
 """
 import numpy
 
+mean_std_dt = numpy.dtype([('mean', float), ('std', float)])
+
 
 def mean_curve(values, weights=None):
     """
@@ -30,6 +32,23 @@ def mean_curve(values, weights=None):
     if isinstance(values[0], (numpy.ndarray, list, tuple)):  # fast lane
         return numpy.average(values, axis=0, weights=weights)
     return sum(value * weight for value, weight in zip(values, weights))
+
+
+def mean_std_curve(values, weights=None):
+    """
+    :param values: an array of (R ...) values
+    :param weights: R weights
+    :returns: array with fields 'mean', 'std'
+    """
+    if weights is None:
+        weights = [1. / len(values)] * len(values)
+    if not isinstance(values, numpy.ndarray):
+        values = numpy.array(values)
+    res = numpy.zeros(values.shape[1:], mean_std_dt)
+    res['mean'] = numpy.average(values, axis=0, weights=weights)
+    res['std'] = numpy.sqrt(
+        numpy.einsum('i,i...', weights, (res['mean'] - values) ** 2))
+    return res
 
 
 def quantile_curve(quantile, curves, weights=None):

--- a/openquake/hazardlib/tests/stats_test.py
+++ b/openquake/hazardlib/tests/stats_test.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy
 from openquake.hazardlib.stats import (
-    mean_curve, quantile_curve, mean_std_curve)
+    mean_curve, quantile_curve, std_curve)
 
 aaae = numpy.testing.assert_array_almost_equal
 
@@ -44,9 +44,12 @@ class MeanCurveTestCase(unittest.TestCase):
             expected_mean_curve, mean_curve(curves, weights=weights))
 
     def test_mean_std(self):
-        arr = mean_std_curve([[5, 4], [10, 9], [8, 7]], [.2, .3, .5])
-        aaae(arr['mean'], [8, 7])
-        aaae(arr['std'], [1.73205081, 1.73205081])
+        values = [[5, 4], [10, 9], [8, 7]]
+        weights = [.2, .3, .5]
+        mean = mean_curve(values, weights)
+        std = std_curve(values, weights)
+        aaae(mean, [8, 7])
+        aaae(std, [1.73205081, 1.73205081])
 
 
 class QuantileCurveTestCase(unittest.TestCase):

--- a/openquake/hazardlib/tests/stats_test.py
+++ b/openquake/hazardlib/tests/stats_test.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy
-from openquake.hazardlib.stats import mean_curve, quantile_curve
+from openquake.hazardlib.stats import (
+    mean_curve, quantile_curve, mean_std_curve)
 
 aaae = numpy.testing.assert_array_almost_equal
 
@@ -41,6 +42,11 @@ class MeanCurveTestCase(unittest.TestCase):
         expected_mean_curve = numpy.array([0.83, 0.67333333, 0.54333333, 0.17])
         numpy.testing.assert_allclose(
             expected_mean_curve, mean_curve(curves, weights=weights))
+
+    def test_mean_std(self):
+        arr = mean_std_curve([[5, 4], [10, 9], [8, 7]], [.2, .3, .5])
+        aaae(arr['mean'], [8, 7])
+        aaae(arr['std'], [1.73205081, 1.73205081])
 
 
 class QuantileCurveTestCase(unittest.TestCase):

--- a/utils/compare_mean_curves.py
+++ b/utils/compare_mean_curves.py
@@ -57,8 +57,8 @@ def compare_mean_curves(calc_ref, calc):
             if not ok:
                 md = (numpy.abs(mean[sl] - mean_ref[sl])).max()
                 plt.title('point=%s, imt=%s, maxdiff=%.2e' % (lonlat, imt, md))
-                plt.plot(imtls[imt], mean_ref[sl], label=str(calc_ref))
-                plt.plot(imtls[imt], mean[sl], label=str(calc))
+                plt.loglog(imtls[imt], mean_ref[sl], label=str(calc_ref))
+                plt.loglog(imtls[imt], mean[sl], label=str(calc))
                 plt.legend()
                 plt.show()
 

--- a/utils/compare_mean_curves.py
+++ b/utils/compare_mean_curves.py
@@ -23,7 +23,7 @@ from openquake.calculators.getters import PmapGetter
 
 
 @sap.Script
-def compare_mean_curves(calc_ref, calc):
+def compare_mean_curves(calc_ref, calc, nsigma=1):
     """
     Compare the hazard curves coming from two different calculations.
     """
@@ -53,7 +53,7 @@ def compare_mean_curves(calc_ref, calc):
         err = numpy.sqrt(std**2 + std_ref**2)
         for imt in imtls:
             sl = imtls.slicedic[imt]
-            ok = (numpy.abs(mean[sl] - mean_ref[sl]) < 3 * err[sl]).all()
+            ok = (numpy.abs(mean[sl] - mean_ref[sl]) < nsigma * err[sl]).all()
             if not ok:
                 md = (numpy.abs(mean[sl] - mean_ref[sl])).max()
                 plt.title('point=%s, imt=%s, maxdiff=%.2e' % (lonlat, imt, md))
@@ -65,7 +65,7 @@ def compare_mean_curves(calc_ref, calc):
 
 compare_mean_curves.arg('calc_ref', 'first calculation', type=int)
 compare_mean_curves.arg('calc', 'second calculation', type=int)
-
+compare_mean_curves.opt('nsigma', 'tolerance as number of sigma', type=float)
 
 if __name__ == '__main__':
     compare_mean_curves.callfunc()


### PR DESCRIPTION
The stddev is computed by taking into account the weights, see https://en.wikipedia.org/wiki/Weighted_arithmetic_mean, which in numpy parliance is

```python
std(values) = numpy.sqrt(numpy.einsum('i,i...', weights, (weighted_mean - values) ** 2))
```
where `i` is the realization index. To enable the feature just write

`std_hazard_curves = true`.

in the job.ini. An exporter is missing and left for the future.