### PR TITLE
Removed the error "corner points do not lie on the same plane"

### DIFF
--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -20,8 +20,8 @@
 Module :mod:`openquake.hazardlib.geo.surface.planar` contains
 :class:`PlanarSurface`.
 """
+import logging
 import numpy
-
 from openquake.baselib.node import Node
 from openquake.hazardlib.geo import Point
 from openquake.hazardlib.geo.surface.base import BaseSurface
@@ -137,7 +137,7 @@ class PlanarSurface(BaseSurface):
         tolerance = (self.width * self.length *
                      self.IMPERFECT_RECTANGLE_TOLERANCE)
         if numpy.max(numpy.abs(dists)) > tolerance:
-            raise ValueError("corner points do not lie on the same plane")
+            logging.warn("corner points do not lie on the same plane")
         if length2 < 0:
             raise ValueError("corners are in the wrong order")
         if abs(length1 - length2) > tolerance:

--- a/openquake/hazardlib/tests/geo/surface/planar_test.py
+++ b/openquake/hazardlib/tests/geo/surface/planar_test.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
-
+import mock
 import numpy
 
 from openquake.hazardlib.geo import Point
@@ -48,12 +48,6 @@ class PlanarSurfaceCreationTestCase(unittest.TestCase):
         corners = [Point(0, -1, 1), Point(0, 1, 1),
                    Point(0, -1, 2), Point(0, 1, 2)]
         msg = 'corners are in the wrong order'
-        self.assert_failed_creation(0, 90, corners, ValueError, msg)
-
-    def test_corners_not_on_the_same_plane(self):
-        corners = [Point(0, -1, 1), Point(0, 1, 1),
-                   Point(-0.3, 1, 2), Point(0.3, -1, 2)]
-        msg = 'corner points do not lie on the same plane'
         self.assert_failed_creation(0, 90, corners, ValueError, msg)
 
     def test_top_edge_shorter_than_bottom_edge(self):

--- a/openquake/hazardlib/tests/geo/surface/planar_test.py
+++ b/openquake/hazardlib/tests/geo/surface/planar_test.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
-import mock
 import numpy
 
 from openquake.hazardlib.geo import Point


### PR DESCRIPTION
Since there is no much that we can do (see the discussion in https://github.com/gem/oq-engine/issues/3392) the error has been declassed to a mere warning. In this way the rupture exporter can work also for Canada and California.