### PR TITLE
Added an extra check on the source model logic tree parser

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Added a check on source model logic tree files: the uncertaintyModel
+    values cannot be repeated in the same branchset
   * Added a flag `std_hazard_curves`; by setting it to `true` the user can
     compute the standard deviation of the hazard curves across realizations
 

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -622,10 +622,13 @@ class SourceModelLogicTree(object):
         """
         weight_sum = 0
         branches = branchset_node.nodes
+        values = []
         for branchnode in branches:
             weight = ~branchnode.uncertaintyWeight
             weight_sum += weight
             value_node = node_from_elem(branchnode.uncertaintyModel)
+            if value_node.text is not None:
+                values.append(value_node.text.strip())
             if validate:
                 self.validate_uncertainty_value(value_node, branchset)
             value = self.parse_uncertainty_value(value_node, branchset)
@@ -641,6 +644,11 @@ class SourceModelLogicTree(object):
             raise ValidationError(
                 branchset_node, self.filename,
                 "branchset weights don't sum up to 1.0")
+        if len(set(values)) < len(values):
+            raise ValidationError(
+                branchset_node, self.filename,
+                "there are duplicate values in uncertaintyModel: " +
+                ' '.join(values))
 
     def gen_source_models(self, gsim_lt):
         """

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -645,6 +645,19 @@ class SourceModelLogicTree(object):
                 branchset_node, self.filename,
                 "branchset weights don't sum up to 1.0")
         if len(set(values)) < len(values):
+            # TODO: add a test for this case
+            # <logicTreeBranch branchID="b71">
+            #     <uncertaintyModel> 7.7 </uncertaintyModel>
+            #     <uncertaintyWeight>0.333</uncertaintyWeight>
+            # </logicTreeBranch>
+            # <logicTreeBranch branchID="b72">
+            #     <uncertaintyModel> 7.695 </uncertaintyModel>
+            #     <uncertaintyWeight>0.333</uncertaintyWeight>
+            # </logicTreeBranch>
+            # <logicTreeBranch branchID="b73">
+            #     <uncertaintyModel> 7.7 </uncertaintyModel>
+            #     <uncertaintyWeight>0.334</uncertaintyWeight>
+            # </logicTreeBranch>
             raise ValidationError(
                 branchset_node, self.filename,
                 "there are duplicate values in uncertaintyModel: " +


### PR DESCRIPTION
A case like the following one will be rejected now:
```xml
                <logicTreeBranch branchID="b71">
                    <uncertaintyModel> 7.7 </uncertaintyModel>
                    <uncertaintyWeight>0.333</uncertaintyWeight>
                </logicTreeBranch>
                <logicTreeBranch branchID="b72">
                    <uncertaintyModel> 7.695 </uncertaintyModel>
                    <uncertaintyWeight>0.333</uncertaintyWeight>
                </logicTreeBranch>
                <logicTreeBranch branchID="b73">
                    <uncertaintyModel> 7.7 </uncertaintyModel>
                    <uncertaintyWeight>0.334</uncertaintyWeight>
                </logicTreeBranch>
```
It makes no sense to have the same value (7.7) repeated in two different branches. This come from a logic tree submitted by an user. I am not adding a test case because it is too much of an effort for the benefit and hopefully soon we will completely rewrite the SourceModelLogicTree class and its tests.