### PR TITLE
Made MultiPointSources serializable to HDF5

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -219,9 +219,7 @@ class DataStore(collections.MutableMapping):
         """
         Set the HDF5 attributes of the given key
         """
-        attrs = h5py.File.__getitem__(self.hdf5, key).attrs
-        for k, v in kw.items():
-            attrs[k] = v
+        self.hdf5.save_attrs(key, kw)
 
     def get_attr(self, key, name, default=None):
         """

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -272,25 +272,6 @@ class DataStore(collections.MutableMapping):
         return hdf5.create(
             self.hdf5, key, dtype, shape, compression, fillvalue, attrs)
 
-    def save_vlen(self, key, data):
-        """
-        Save a sequence of variable-length arrays
-
-        :param key: name of the dataset
-        :param data: data to store as vlen arrays
-        """
-        dt = data[0].dtype
-        dset = self.create_dset(
-            key, h5py.special_dtype(vlen=dt), (len(data),), fillvalue=None)
-        nbytes = 0
-        totlen = 0
-        for i, val in enumerate(data):
-            dset[i] = val
-            nbytes += val.nbytes
-            totlen += len(val)
-        self.set_attrs(key, nbytes=nbytes, avg_len=totlen / len(data))
-        self.flush()
-
     def extend(self, key, array, **attrs):
         """
         Extend the dataset associated to the given key; create it if needed

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -292,7 +292,7 @@ class File(h5py.File):
             pyclass = cls2dotname(cls)
         else:
             pyclass = ''
-        if isinstance(obj, (dict, Group)):
+        if isinstance(obj, (dict, Group)) and obj:
             for k, v in sorted(obj.items()):
                 key = '%s/%s' % (path, quote_plus(k))
                 self[key] = v

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -878,8 +878,8 @@ def save_gmf_data(dstore, sitecol, gmfs, eids=()):
         n = len(rows)
         lst.append(numpy.array([(offset, offset + n)], riskinput.indices_dt))
         offset += n
-    dstore.save_vlen('gmf_data/indices', lst)
-    dstore.set_attrs('gmf_data', num_gmfs=len(gmfs))
+    dstore.hdf5.save_vlen('gmf_data/indices', lst)
+    dstore.hdf5.set_attrs('gmf_data', num_gmfs=len(gmfs))
     if len(eids):  # store the events
         events = numpy.zeros(len(eids), readinput.stored_event_dt)
         events['eid'] = eids

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -879,7 +879,7 @@ def save_gmf_data(dstore, sitecol, gmfs, eids=()):
         lst.append(numpy.array([(offset, offset + n)], riskinput.indices_dt))
         offset += n
     dstore.hdf5.save_vlen('gmf_data/indices', lst)
-    dstore.hdf5.set_attrs('gmf_data', num_gmfs=len(gmfs))
+    dstore.set_attrs('gmf_data', num_gmfs=len(gmfs))
     if len(eids):  # store the events
         events = numpy.zeros(len(eids), readinput.stored_event_dt)
         events['eid'] = eids
@@ -915,7 +915,7 @@ def import_gmfs(dstore, fname, sids):
         if n:
             offset += n
             dstore.extend('gmf_data/data', dic[sid])
-    dstore.save_vlen('gmf_data/indices', lst)
+    dstore.hdf5.save_vlen('gmf_data/indices', lst)
 
     # FIXME: if there is no data for the maximum realization
     # the inferred number of realizations will be wrong

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -358,7 +358,7 @@ class EventBasedCalculator(base.HazardCalculator):
             logging.info('Saving gmf_data/indices')
             with self.monitor('saving gmf_data/indices', measuremem=True,
                               autoflush=True):
-                self.datastore.save_vlen(
+                self.datastore.hdf5.save_vlen(
                     'gmf_data/indices',
                     [numpy.array(self.indices[sid], indices_dt)
                      for sid in self.sitecol.complete.sids])

--- a/openquake/commands/upgrade_nrml.py
+++ b/openquake/commands/upgrade_nrml.py
@@ -129,7 +129,7 @@ def upgrade_nrml(directory, dry_run, multipoint):
                 try:
                     fulltag = next(ip)[1].tag  # tag of the first node
                     xmlns, tag = fulltag.split('}')
-                except:  # not a NRML file
+                except Exception:  # not a NRML file
                     xmlns, tag = '', ''
                 if xmlns[1:] == NRML05:  # already upgraded
                     if 'sourceModel' in tag and multipoint:

--- a/openquake/hazardlib/mfd/evenly_discretized.py
+++ b/openquake/hazardlib/mfd/evenly_discretized.py
@@ -58,7 +58,7 @@ class EvenlyDiscretizedMFD(BaseMFD):
         if not self.bin_width > 0:
             raise ValueError('bin width must be positive')
 
-        if not self.occurrence_rates:
+        if len(self.occurrence_rates) == 0:
             raise ValueError('at least one bin must be specified')
 
         if not all(value >= 0 for value in self.occurrence_rates):

--- a/openquake/hazardlib/mfd/multi_mfd.py
+++ b/openquake/hazardlib/mfd/multi_mfd.py
@@ -18,7 +18,6 @@ Module :mod:`openquake.hazardlib.mfd.multi_mfd` defines a composite
 MFD used for MultiPoint sources.
 """
 import numpy
-from openquake.baselib import hdf5
 from openquake.hazardlib.mfd.base import BaseMFD
 from openquake.hazardlib.mfd.evenly_discretized import EvenlyDiscretizedMFD
 from openquake.hazardlib.mfd.truncated_gr import TruncatedGRMFD

--- a/openquake/hazardlib/mfd/multi_mfd.py
+++ b/openquake/hazardlib/mfd/multi_mfd.py
@@ -18,6 +18,7 @@ Module :mod:`openquake.hazardlib.mfd.multi_mfd` defines a composite
 MFD used for MultiPoint sources.
 """
 import numpy
+from openquake.baselib import hdf5
 from openquake.hazardlib.mfd.base import BaseMFD
 from openquake.hazardlib.mfd.evenly_discretized import EvenlyDiscretizedMFD
 from openquake.hazardlib.mfd.truncated_gr import TruncatedGRMFD
@@ -147,13 +148,3 @@ class MultiMFD(BaseMFD):
         """
         for src in self:
             src.modify(modification, parameters)
-
-    def __toh5__(self):
-        return {k: numpy.array(v, float) for k, v in self.kwargs.items()}, {
-            'kind': self.kind, 'size': self.size,
-            'width_of_mfd_bin': self.width_of_mfd_bin}
-
-    def __fromh5__(self, kwargs, attrs):
-        vars(self).update(attrs)
-        self.kwargs = kwargs
-        self.mfd_class = ASSOC[self.kind][0]

--- a/openquake/hazardlib/mfd/multi_mfd.py
+++ b/openquake/hazardlib/mfd/multi_mfd.py
@@ -149,8 +149,9 @@ class MultiMFD(BaseMFD):
             src.modify(modification, parameters)
 
     def __toh5__(self):
-        return self.kwargs, {'kind': self.kind, 'size': self.size,
-                             'width_of_mfd_bin': self.width_of_mfd_bin}
+        return {k: numpy.array(v, float) for k, v in self.kwargs.items()}, {
+            'kind': self.kind, 'size': self.size,
+            'width_of_mfd_bin': self.width_of_mfd_bin}
 
     def __fromh5__(self, kwargs, attrs):
         vars(self).update(attrs)

--- a/openquake/hazardlib/mfd/multi_mfd.py
+++ b/openquake/hazardlib/mfd/multi_mfd.py
@@ -147,3 +147,12 @@ class MultiMFD(BaseMFD):
         """
         for src in self:
             src.modify(modification, parameters)
+
+    def __toh5__(self):
+        return self.kwargs, {'kind': self.kind, 'size': self.size,
+                             'width_of_mfd_bin': self.width_of_mfd_bin}
+
+    def __fromh5__(self, kwargs, attrs):
+        vars(self).update(attrs)
+        self.kwargs = kwargs
+        self.mfd_class = ASSOC[self.kind][0]

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -125,8 +125,8 @@ class SourceModel(collections.Sequence):
         dic = {}
         for i, grp in enumerate(self.src_groups):
             grpname = grp.name or 'group-%d' % i
-            srcs = {src.source_id: src for src in grp
-                    if hasattr(src, '__toh5__')}
+            srcs = [(src.source_id, src) for src in grp
+                    if hasattr(src, '__toh5__')]
             dic[grpname] = hdf5.Group(srcs, {'trt': grp.trt})
         attrs = dict(name=self.name,
                      investigation_time=self.investigation_time or 'NA',

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -127,10 +127,13 @@ class SourceModel(collections.Sequence):
             grpname = grp.name or 'group-%d' % i
             srcs = [(src.source_id, src) for src in grp
                     if hasattr(src, '__toh5__')]
-            dic[grpname] = hdf5.Group(srcs, {'trt': grp.trt})
+            if srcs:
+                dic[grpname] = hdf5.Group(srcs, {'trt': grp.trt})
         attrs = dict(name=self.name,
                      investigation_time=self.investigation_time or 'NA',
                      start_time=self.start_time or 'NA')
+        if not dic:
+            raise ValueError('There are no serializable sources in %s' % self)
         return dic, attrs
 
     def __fromh5__(self, dic, attrs):

--- a/openquake/hazardlib/source/multi.py
+++ b/openquake/hazardlib/source/multi.py
@@ -22,7 +22,6 @@ from openquake.hazardlib.source.point import PointSource
 
 npd_dt = numpy.dtype([('probability', float),
                       ('dip', float), ('rake', float), ('strike', float)])
-
 hdd_dt = numpy.dtype([('probability', float), ('depth', float)])
 mesh_dt = numpy.dtype([('lon', float), ('lat', float), ('depth', float)])
 

--- a/openquake/hazardlib/source/multi.py
+++ b/openquake/hazardlib/source/multi.py
@@ -18,7 +18,7 @@ Module :mod:`openquake.hazardlib.source.area` defines :class:`AreaSource`.
 """
 import numpy
 from openquake.hazardlib.source.base import ParametricSeismicSource
-from openquake.hazardlib.mfd.multi import MultiMFD
+from openquake.hazardlib.mfd.multi_mfd import MultiMFD
 from openquake.hazardlib.geo import NodalPlane
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.pmf import PMF
@@ -29,7 +29,7 @@ F32 = numpy.float32
 npd_dt = numpy.dtype([('probability', F32),
                       ('strike', F32), ('dip', F32), ('rake', F32)])
 hdd_dt = numpy.dtype([('probability', F32), ('depth', F32)])
-mesh_dt = numpy.dtype([('lon', F32), ('lat', F32), ('depth', F32)])
+mesh_dt = numpy.dtype([('lon', F32), ('lat', F32)])
 
 
 class MultiPointSource(ParametricSeismicSource):

--- a/openquake/hazardlib/source/multi.py
+++ b/openquake/hazardlib/source/multi.py
@@ -23,7 +23,7 @@ from openquake.hazardlib.source.point import PointSource
 npd_dt = numpy.dtype([('probability', float),
                       ('dip', float), ('rake', float), ('strike', float)])
 hdd_dt = numpy.dtype([('probability', float), ('depth', float)])
-mesh_dt = numpy.dtype([('lon', float), ('lat', float), ('depth', float)])
+mesh_dt = numpy.dtype([('lon', float), ('lat', float)])
 
 
 class MultiPointSource(ParametricSeismicSource):
@@ -37,23 +37,22 @@ class MultiPointSource(ParametricSeismicSource):
     RUPTURE_WEIGHT = 0.1
 
     def __init__(self, source_id, name, tectonic_region_type,
-                 mfd, rupture_mesh_spacing,
-                 magnitude_scaling_relationship,
-                 rupture_aspect_ratio, temporal_occurrence_model,
+                 mfd, magnitude_scaling_relationship, rupture_aspect_ratio,
                  # point-specific parameters (excluding location)
                  upper_seismogenic_depth, lower_seismogenic_depth,
-                 nodal_plane_distribution, hypocenter_distribution, mesh):
+                 nodal_plane_distribution, hypocenter_distribution,
+                 mesh, temporal_occurrence_model=None):
         assert len(mfd) == len(mesh), (len(mfd), len(mesh))
+        rupture_mesh_spacing = None
         super().__init__(
-            source_id, name, tectonic_region_type, mfd,
-            rupture_mesh_spacing, magnitude_scaling_relationship,
-            rupture_aspect_ratio, temporal_occurrence_model)
+            source_id, name, tectonic_region_type, mfd, rupture_mesh_spacing,
+            magnitude_scaling_relationship, rupture_aspect_ratio,
+            temporal_occurrence_model)
         self.upper_seismogenic_depth = upper_seismogenic_depth
         self.lower_seismogenic_depth = lower_seismogenic_depth
         self.nodal_plane_distribution = nodal_plane_distribution
         self.hypocenter_distribution = hypocenter_distribution
         self.mesh = mesh
-        self.max_radius = 0
 
     def __iter__(self):
         for i, (mfd, point) in enumerate(zip(self.mfd, self.mesh)):
@@ -106,7 +105,7 @@ class MultiPointSource(ParametricSeismicSource):
         npd = [(prob, np.dip, np.rake, np.strike)
                for prob, np in self.nodal_plane_distribution.data]
         hdd = self.hypocenter_distribution.data
-        points = [(p.x, p.y, p.z) for p in self.mesh]
+        points = [(p.x, p.y) for p in self.mesh]
         mfd = self.mfd.kwargs.copy()
         for k, vals in mfd.items():
             if k in ('occurRates', 'magnitudes'):

--- a/openquake/hazardlib/source/multi.py
+++ b/openquake/hazardlib/source/multi.py
@@ -108,11 +108,15 @@ class MultiPointSource(ParametricSeismicSource):
                for prob, np in self.nodal_plane_distribution.data]
         hdd = self.hypocenter_distribution.data
         points = [(p.x, p.y, p.z) for p in self.mesh]
-        mfd_data, mfd_attrs = self.mfd.__toh5__()
+        mfd = self.mfd.kwargs.copy()
+        for k, vals in mfd.items():
+            if k in ('occurRates', 'magnitudes'):
+                mfd[k] = [numpy.array(lst) for lst in vals]
+        mfd['kind'] = self.mfd.kind
+        mfd['size'] = self.mfd.size
         dic = {'nodal_plane_distribution': numpy.array(npd, npd_dt),
                'hypocenter_distribution': numpy.array(hdd, hdd_dt),
-               'mesh': numpy.array(points, mesh_dt),
-               'mfd_data': mfd_data}#, 'mfd_attrs': mfd_attrs}
+               'mesh': numpy.array(points, mesh_dt), 'mfd': mfd}
         attrs = {'upper_seismogenic_depth': self.upper_seismogenic_depth,
                  'lower_seismogenic_depth': self.lower_seismogenic_depth,
                  'magnitude_scaling_relationship':
@@ -121,6 +125,4 @@ class MultiPointSource(ParametricSeismicSource):
 
     def __fromh5__(self, dic, attrs):
         vars(self).update(attrs)
-        self.nodal_plane_distribution = dic['nodal_plane_distribution']
-        self.hypocenter_distribution = dic['hypocenter_distribution']
-        self.mesh = dic['mesh']
+        # TODO: the rest

--- a/openquake/hazardlib/source/multi.py
+++ b/openquake/hazardlib/source/multi.py
@@ -116,6 +116,8 @@ class MultiPointSource(ParametricSeismicSource):
         for k, vals in mfd.items():
             if k in ('occurRates', 'magnitudes'):
                 mfd[k] = [numpy.array(lst, F32) for lst in vals]
+            else:
+                mfd[k] = numpy.array(vals, F32)
         dic = {'nodal_plane_distribution': numpy.array(npd, npd_dt),
                'hypocenter_distribution': numpy.array(hdd, hdd_dt),
                'mesh': numpy.array(points, mesh_dt),

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -537,7 +537,7 @@ class SourceConverter(RuptureConverter):
                     np['probability'], np['strike'], np['dip'], np['rake'])
                 npdist.append((prob, geo.NodalPlane(strike, dip, rake)))
             if os.environ.get('OQ_SPINNING') == 'no':
-                npdist = [(1, npdist[0][1])]  # consider only the first nodal plane
+                npdist = [(1, npdist[0][1])]  # consider the first nodal plane
             return pmf.PMF(npdist)
 
     def convert_hpdist(self, node):
@@ -549,8 +549,11 @@ class SourceConverter(RuptureConverter):
         :returns: a :class:`openquake.hazardlib.pmf.PMF` instance
         """
         with context(self.fname, node):
-            return pmf.PMF([(hd['probability'], hd['depth'])
-                            for hd in node.hypoDepthDist])
+            hcdist = [(hd['probability'], hd['depth'])
+                      for hd in node.hypoDepthDist]
+            if os.environ.get('OQ_FLOATING') == 'no':
+                hcdist = [(1, hcdist[0][1])]
+            return pmf.PMF(hcdist)
 
     def convert_areaSource(self, node):
         """

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -629,15 +629,15 @@ class SourceConverter(RuptureConverter):
             name=node['name'],
             tectonic_region_type=node.attrib.get('tectonicRegion'),
             mfd=self.convert_mfdist(node),
-            rupture_mesh_spacing=self.rupture_mesh_spacing,
             magnitude_scaling_relationship=msr,
             rupture_aspect_ratio=~node.ruptAspectRatio,
             upper_seismogenic_depth=~geom.upperSeismoDepth,
             lower_seismogenic_depth=~geom.lowerSeismoDepth,
             nodal_plane_distribution=self.convert_npdist(node),
             hypocenter_distribution=self.convert_hpdist(node),
+            mesh=geo.Mesh(F32(lons), F32(lats)),
             temporal_occurrence_model=self.tom,
-            mesh=geo.Mesh(F32(lons), F32(lats)))
+        )
 
     def convert_simpleFaultSource(self, node):
         """

--- a/openquake/hazardlib/tests/source/multipoint_test.py
+++ b/openquake/hazardlib/tests/source/multipoint_test.py
@@ -70,7 +70,10 @@ multiPointSource{id='mp1', name='multi point source', tectonicRegion='Active Sha
     hypoDepth{depth=14, probability=1.0}
 ''')
 
-        # test serialization to hdf5
+        # test serialization to and from hdf5
         tmp = general.gettemp(suffix='.hdf5')
         with hdf5.File(tmp, 'w') as f:
             f[mps.source_id] = mps
+
+        with hdf5.File(tmp, 'r') as f:
+            f[mps.source_id]

--- a/openquake/hazardlib/tests/source/multipoint_test.py
+++ b/openquake/hazardlib/tests/source/multipoint_test.py
@@ -39,6 +39,8 @@ class MultiPointTestCase(unittest.TestCase):
                         min_mag=[4.5],
                         bin_width=[2.0],
                         occurRates=[[.3, .1], [.4, .2, .1]])
+        kwargs, attrs = mmfd.__toh5__()
+        mmfd.__fromh5__(kwargs, attrs)
         mps = MultiPointSource('mp1', 'multi point source',
                                'Active Shallow Crust',
                                mmfd, 2.0, PeerMSR(), 1.0,

--- a/openquake/hazardlib/tests/source/multipoint_test.py
+++ b/openquake/hazardlib/tests/source/multipoint_test.py
@@ -40,8 +40,6 @@ class MultiPointTestCase(unittest.TestCase):
                         min_mag=[4.5],
                         bin_width=[2.0],
                         occurRates=[[.3, .1], [.4, .2, .1]])
-        kwargs, attrs = mmfd.__toh5__()
-        mmfd.__fromh5__(kwargs, attrs)
         mps = MultiPointSource('mp1', 'multi point source',
                                'Active Shallow Crust',
                                mmfd, 2.0, PeerMSR(), 1.0,
@@ -78,4 +76,3 @@ multiPointSource{id='mp1', name='multi point source', tectonicRegion='Active Sha
         tmp = general.gettemp(suffix='.hdf5')
         with hdf5.File(tmp, 'w') as f:
             f[mps.source_id] = mps
-        import pdb; pdb.set_trace()

--- a/openquake/hazardlib/tests/source/multipoint_test.py
+++ b/openquake/hazardlib/tests/source/multipoint_test.py
@@ -17,6 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
 import numpy
+from openquake.baselib import hdf5, general
 from openquake.hazardlib.sourcewriter import obj_to_node
 from openquake.hazardlib.mfd.multi_mfd import MultiMFD
 from openquake.hazardlib.source.multi import MultiPointSource
@@ -72,3 +73,9 @@ multiPointSource{id='mp1', name='multi point source', tectonicRegion='Active Sha
   hypoDepthDist
     hypoDepth{depth=14, probability=1.0}
 ''')
+
+        # test serialization to hdf5
+        tmp = general.gettemp(suffix='.hdf5')
+        with hdf5.File(tmp, 'w') as f:
+            f[mps.source_id] = mps
+        import pdb; pdb.set_trace()

--- a/openquake/hazardlib/tests/source/multipoint_test.py
+++ b/openquake/hazardlib/tests/source/multipoint_test.py
@@ -23,7 +23,6 @@ from openquake.hazardlib.mfd.multi_mfd import MultiMFD
 from openquake.hazardlib.source.multi import MultiPointSource
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.scalerel.peer import PeerMSR
-from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.geo import NodalPlane
 from openquake.hazardlib.pmf import PMF
 
@@ -34,7 +33,6 @@ class MultiPointTestCase(unittest.TestCase):
                    (0.5, NodalPlane(2, 2, 4))])
         hd = PMF([(1, 14)])
         mesh = Mesh(numpy.array([0, 1]), numpy.array([0.5, 1]))
-        tom = PoissonTOM(50.)
         mmfd = MultiMFD('incrementalMFD',
                         size=2,
                         min_mag=[4.5],
@@ -42,8 +40,8 @@ class MultiPointTestCase(unittest.TestCase):
                         occurRates=[[.3, .1], [.4, .2, .1]])
         mps = MultiPointSource('mp1', 'multi point source',
                                'Active Shallow Crust',
-                               mmfd, 2.0, PeerMSR(), 1.0,
-                               tom, 10, 20, npd, hd, mesh)
+                               mmfd, PeerMSR(), 1.0,
+                               10, 20, npd, hd, mesh)
         # test the splitting
         splits = list(mps)
         self.assertEqual(len(splits), 2)

--- a/openquake/hazardlib/tests/sourcewriter_test.py
+++ b/openquake/hazardlib/tests/sourcewriter_test.py
@@ -78,7 +78,9 @@ class SourceWriterTestCase(unittest.TestCase):
         with hdf5.File(temp, 'w') as f:
             f['/'] = smodel
         with hdf5.File(temp, 'r') as f:
-            f['/']
+            sm = f['/']
+        self.assertEqual(smodel.name, sm.name)
+        self.assertEqual(len(smodel.src_groups), len(sm.src_groups))
 
 
 class DeepcopyTestCase(unittest.TestCase):

--- a/openquake/hazardlib/tests/sourcewriter_test.py
+++ b/openquake/hazardlib/tests/sourcewriter_test.py
@@ -20,7 +20,7 @@ import os
 import copy
 import unittest
 import tempfile
-from openquake.baselib import hdf5
+from openquake.baselib import hdf5, general
 from openquake.hazardlib.sourcewriter import write_source_model, hdf5write
 from openquake.hazardlib.sourceconverter import SourceConverter
 from openquake.hazardlib import nrml
@@ -56,6 +56,7 @@ class SourceWriterTestCase(unittest.TestCase):
         if open(name).read() != open(fname).read():
             raise Exception('Different files: %s %s' % (name, fname))
         os.remove(name)
+        return smodel
 
     def test_mixed(self):
         self.check_round_trip(MIXED)
@@ -70,8 +71,15 @@ class SourceWriterTestCase(unittest.TestCase):
         self.check_round_trip(COLLECTION)
 
     def test_multipoint(self):
-        self.check_round_trip(MULTIPOINT)
+        smodel = self.check_round_trip(MULTIPOINT)
 
+        # test hdf5 round trip
+        temp = general.gettemp(suffix='.hdf5')
+        with hdf5.File(temp, 'w') as f:
+            f['/'] = smodel
+        with hdf5.File(temp, 'r') as f:
+            f['/']
+        import pdb; pdb.set_trace()
 
 class DeepcopyTestCase(unittest.TestCase):
     def test_is_writeable(self):

--- a/openquake/hazardlib/tests/sourcewriter_test.py
+++ b/openquake/hazardlib/tests/sourcewriter_test.py
@@ -79,7 +79,7 @@ class SourceWriterTestCase(unittest.TestCase):
             f['/'] = smodel
         with hdf5.File(temp, 'r') as f:
             f['/']
-        import pdb; pdb.set_trace()
+
 
 class DeepcopyTestCase(unittest.TestCase):
     def test_is_writeable(self):

--- a/utils/mpoint2hdf5.py
+++ b/utils/mpoint2hdf5.py
@@ -10,7 +10,7 @@ def multipoint2hdf5(fname):
     with hdf5.File(fname.replace('.xml', '.hdf5'), 'w') as f:
         for grp in sm:
             for src in grp:
-                if src.__class__.__name__ == 'MultiPointSource':
+                if hasattr(src, '__toh5__'):
                     print('saving', src)
                     f[src.source_id] = src
 

--- a/utils/mpoint2hdf5.py
+++ b/utils/mpoint2hdf5.py
@@ -1,0 +1,18 @@
+from openquake.baselib import hdf5, sap
+from openquake.hazardlib import nrml
+
+
+@sap.Script
+def multipoint2hdf5(fname):
+    sm = nrml.to_python(fname)
+    with hdf5.File(fname.replace('.xml', '.hdf5', 'w')) as f:
+        for grp in sm:
+            for src in grp:
+                if src.__class__.__name__ == 'MultiPointSource':
+                    f[src.source_id] = src
+
+
+multipoint2hdf5.arg('fname', 'source model file in XML format')
+
+if __name__ == '__main__':
+    multipoint2hdf5.callfunc()

--- a/utils/mpoint2hdf5.py
+++ b/utils/mpoint2hdf5.py
@@ -8,11 +8,7 @@ def multipoint2hdf5(fname):
         area_source_discretization=10, width_of_mfd_bin=.1)
     sm = nrml.to_python(fname, sc)
     with hdf5.File(fname.replace('.xml', '.hdf5'), 'w') as f:
-        for grp in sm:
-            for src in grp:
-                if hasattr(src, '__toh5__'):
-                    print('saving', src)
-                    f[src.source_id] = src
+        f['/'] = sm
 
 
 multipoint2hdf5.arg('fname', 'source model file in XML format')


### PR DESCRIPTION
First step towards https://github.com/gem/oq-engine/issues/3829.
I have added a script `utils/mpoint2hdf5.py` to convert existing models in XML format. It is as
simple as this::

```python
def multipoint2hdf5(fname):
    sc = sourceconverter.SourceConverter(
        area_source_discretization=10, width_of_mfd_bin=.1)
    sm = nrml.to_python(fname, sc)
    with hdf5.File(fname.replace('.xml', '.hdf5'), 'w') as f:
        f['/'] = sm
```
There is not yet a way to read the source model in .hdf5 format from the engine. This is left for the future.
For instance, in the case of the source model SSA18 (SSHARA - Smoothed Seismicity) the space saving is 4x:

```
876K	./SSA18/in/ssm/source_model.hdf5
3,5M	./SSA18/in/ssm/source_model.xml
```

NB: the signature of MultiPointSource has changed, and this could break the scripts of @klunk386 .
