### PR TITLE
Increase region_grid_spacing in 2 demos

### DIFF
--- a/demos/hazard/CharacteristicFaultSourceCase2ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase2ClassicalPSHA/job.ini
@@ -7,7 +7,7 @@ random_seed = 23
 [geometry]
 
 region = 0.5 -1.0, 0.5 0.7, 2.2 0.7, 2.2 -1.0
-region_grid_spacing = 4.0
+region_grid_spacing = 4.
 
 [logic_tree]
 

--- a/demos/hazard/CharacteristicFaultSourceCase2ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase2ClassicalPSHA/job.ini
@@ -7,7 +7,7 @@ random_seed = 23
 [geometry]
 
 region = 0.5 -1.0, 0.5 0.7, 2.2 0.7, 2.2 -1.0
-region_grid_spacing = 2.0
+region_grid_spacing = 4.0
 
 [logic_tree]
 

--- a/demos/hazard/CharacteristicFaultSourceCase3ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase3ClassicalPSHA/job.ini
@@ -7,7 +7,7 @@ random_seed = 23
 [geometry]
 
 region = 0.0 -2.0, 0.0 -0.5, 2.0 -0.5, 2.0 -2.0
-region_grid_spacing = 2.0
+region_grid_spacing = 4.0
 
 [logic_tree]
 

--- a/demos/hazard/CharacteristicFaultSourceCase3ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase3ClassicalPSHA/job.ini
@@ -7,7 +7,7 @@ random_seed = 23
 [geometry]
 
 region = 0.0 -2.0, 0.0 -0.5, 2.0 -0.5, 2.0 -2.0
-region_grid_spacing = 4.0
+region_grid_spacing = 4.
 
 [logic_tree]
 


### PR DESCRIPTION
Loading those demos in the OQ-Engine/IRMT-QGIS-plugin integration tests was quite slow (see https://github.com/gem/oq-irmt-qgis/pull/476). With this minor change, the QGIS loaders for these demos become about 5 times faster (loading hcurves still requires almost 20 seconds, but it's much better than over 100).
I kindly ask @mmpagani, and the scientific team in general, if it's possible to make faster also any of the other demos listed in https://github.com/gem/oq-irmt-qgis/pull/476 