### PR TITLE
Extends site objects for geotechical properties

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Graeme Weatherill]
+  * Extends site object to include geotechnical (secondary hazards) parameters
+  
   [Michele Simionato]
   * Added a check on source model logic tree files: the uncertaintyModel
     values cannot be repeated in the same branchset

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -225,7 +225,7 @@ class RunShowExportTestCase(unittest.TestCase):
         with Print.patch() as p:
             show_attrs.func('sitecol', self.calc_id)
         self.assertEqual(
-            '__pyclass__ openquake.hazardlib.site.SiteCollection\nnbytes 54',
+            '__pyclass__ openquake.hazardlib.site.SiteCollection\nnbytes 134',
             str(p))
 
     def test_export_calc(self):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -310,6 +310,17 @@ site_model_dt = numpy.dtype([
     ('z1pt0', numpy.float64),
     ('z2pt5', numpy.float64),
     ('backarc', numpy.bool),
+    ('liquefaction_susceptibility', numpy.int16),
+    ('landsliding_susceptibility', numpy.int16),
+    ('dw', numpy.float64),
+    ('yield_acceleration', numpy.float64),
+    ('slope', numpy.float64),
+    ('cti', numpy.float64),
+    ('dc', numpy.float64),
+    ('dr', numpy.float64),
+    ('dwb', numpy.float64),
+    ('hwater', numpy.float64),
+    ('precip', numpy.float64)
 ])
 
 
@@ -392,6 +403,30 @@ def get_gsim_lt(oqparam, trts=['*']):
         oqparam.base_path, oqparam.inputs['gsim_logic_tree'])
     gsim_lt = logictree.GsimLogicTree(gsim_file, trts)
     gmfcorr = oqparam.correl_model
+    for trt, gsims in gsim_lt.values.items():
+        for gsim in gsims:
+            if gmfcorr and (gsim.DEFINED_FOR_STANDARD_DEVIATION_TYPES ==
+                            set([StdDev.TOTAL])):
+                raise CorrelationButNoInterIntraStdDevs(gmfcorr, gsim)
+    return gsim_lt
+
+def get_gdem_lt(oqparam, trts=["*"]):
+    """
+    :param oqparam:
+        an :class:`openquake.commonlib.oqvalidation.OqParam` instance
+    :param trts:
+        a sequence of tectonic region types as strings; trts=['*']
+        means that there is no filtering
+    :returns:
+        a GsimLogicTree instance obtained by filtering on the provided
+        tectonic region types.
+    """
+    if 'gsim_logic_tree' not in oqparam.inputs:
+        return logictree.GdemLogicTree.from_(oqparam.gsim)
+    gsim_file = os.path.join(
+        oqparam.base_path, oqparam.inputs['gsim_logic_tree'])
+    gsim_lt = logictree.GdemLogicTree(gsim_file, trts)
+    gmfcorr = oqparam.get_correl_model()
     for trt, gsims in gsim_lt.values.items():
         for gsim in gsims:
             if gmfcorr and (gsim.DEFINED_FOR_STANDARD_DEVIATION_TYPES ==

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -236,9 +236,9 @@ def sitemodel():
 <nrml xmlns:gml="http://www.opengis.net/gml"
       xmlns="http://openquake.org/xmlns/nrml/0.4">
     <siteModel>
-        <site lon="0.0" lat="0.0" vs30="1200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" />
-        <site lon="0.0" lat="0.1" vs30="600.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="True" />
-        <site lon="0.0" lat="0.2" vs30="200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" />
+        <site lon="0.0" lat="0.0" vs30="1200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" liquefaction_susceptibility="0" landsliding_susceptibility="3" cti="1.0" slope="5" dw="3" yield_acceleration="0.1" dc="1.0" dr="1.0" dwb="1.0" hwater="1.0" precip="1.0" />
+        <site lon="0.0" lat="0.1" vs30="600.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="True" liquefaction_susceptibility="0" landsliding_susceptibility="3" cti="1.0" slope="5" dw="3" yield_acceleration="0.1" dc="1.0" dr="1.0" dwb="1.0" hwater="1.0" precip="1.0" />
+        <site lon="0.0" lat="0.2" vs30="200.0" vs30Type="inferred" z1pt0="100.0" z2pt5="2.0" backarc="False" liquefaction_susceptibility="0" landsliding_susceptibility="3" cti="1.0" slope="5" dw="3" yield_acceleration="0.1" dc="1.0" dr="1.0" dwb="1.0" hwater="1.0" precip="1.0" />
     </siteModel>
 </nrml>''')
 

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -27,7 +27,8 @@ import functools
 # NB: (MS) the management of the IMTs implemented here is horrible and will
 # be thrown away when we will need to introduce a new IMT.
 
-__all__ = ('PGA', 'PGV', 'PGD', 'SA', 'IA', 'CAV', 'RSD', 'MMI')
+__all__ = ('PGA', 'PGV', 'PGD', 'SA', 'IA', 'CAV', 'RSD', 'MMI',
+           'PGDfLatSpread', 'PGDfSettle', 'PGDfSlope', 'PGDfRupture')
 
 DEFAULT_SA_DAMPING = 5.0
 
@@ -190,4 +191,24 @@ class MMI(_IMT):
     Modified Mercalli intensity, a Roman numeral describing the severity
     of an earthquake in terms of its effects on the earth's surface
     and on humans and their structures.
+    """
+
+class PGDfLatSpread(_IMT):
+    """
+    Permanent ground defomation (m) from lateral spread
+    """
+
+class PGDfSettle(_IMT):
+    """
+    Permanent ground defomation (m) from settlement
+    """
+
+class PGDfSlope(_IMT):
+    """
+    Permanent ground deformation (m) from slope failure
+    """
+
+class PGDfRupture(_IMT):
+    """
+    Permanent ground deformation (m) from co-seismic rupture
     """

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -48,7 +48,28 @@ class Site(object):
     :param backarc":
         Boolean value, ``True`` if the site is in the subduction backarc and
         ``False`` if it is in the subduction forearc or is unknown
-
+    :param liquefaction_susceptibility:
+        HAZUS Liquefaction susceptibility classes (as integer in range 0 - 5)
+    :param landsliding_susceptibility:
+        HAZUS Landsliding susceptibility class (as integer in range 0 - 10)
+    :param dw:
+        Depth to water table (m)
+    :param yield_acceleration:
+        Yield acceleration (g) for landsliding
+    :param slope:
+        Slope angle (degrees)
+    :param cti:
+        Compound Topographic Index (dimensionless)
+    :param dc:
+        Distance to coast (km)
+    :param dr:
+        Distance to river (km)
+    :param dwb:
+        Distance to nearest water body (km)
+    :param hwater:
+        Elevation above nearest water body (m)
+    :param precip:
+        Annual Precipitation (mm)
     :raises ValueError:
         If any of ``vs30``, ``z1pt0`` or ``z2pt5`` is zero or negative.
 
@@ -56,10 +77,16 @@ class Site(object):
 
         :class:`Sites <Site>` are pickleable
     """
-    _slots_ = 'location vs30 vs30measured z1pt0 z2pt5 backarc'.split()
+    _slots_ = ('location vs30 vs30measured z1pt0 z2pt5 backarc '
+               'liquefaction_susceptibility landsliding_susceptibility '
+               'dw yield_acceleration slope cti dc dr dwb hwater precip'
+               ).split()
 
     def __init__(self, location, vs30, vs30measured, z1pt0, z2pt5,
-                 backarc=False):
+                 backarc=False, liquefaction_susceptibility=0,
+                 landsliding_susceptibility=0, dw=10.,
+                 yield_acceleration=0.0, slope=0.0, cti=0.0, dc=0.0, dr=0.0,
+                 dwb=0.0, hwater=0.0, precip=0.0):
         if not vs30 > 0:
             raise ValueError('vs30 must be positive')
         if not z1pt0 > 0:
@@ -72,6 +99,30 @@ class Site(object):
         self.z1pt0 = z1pt0
         self.z2pt5 = z2pt5
         self.backarc = backarc
+        # Geotech parameters
+        # HAZUS classes must be integers between 0 and 5 (for liquefaction)
+        # or 0 and 10 (for landsliding)
+        if liquefaction_susceptibility < 0 or liquefaction_susceptibility > 5\
+            or not isinstance(liquefaction_susceptibility, int):
+            raise ValueError('liqufaction_susceptibility must be integer'
+                             ' between 0 and 5')
+        self.liquefaction_susceptibility = liquefaction_susceptibility
+        if landsliding_susceptibility < 0 or landsliding_susceptibility > 10\
+            or not isinstance(landsliding_susceptibility, int):
+            raise ValueError('landsliding_susceptibility must be integer'
+                             ' between 0 and 10')
+        self.landsliding_susceptibility = landsliding_susceptibility
+        self.dw = dw
+        self.yield_acceleration = yield_acceleration
+        self.slope = slope
+        self.cti = cti
+        # The rest of the parameters are from Zhu et al. (2017) - not used
+        # initially but placeholders subsequently
+        self.dc = dc
+        self.dr = dr
+        self.dwb = dwb
+        self.hwater = hwater
+        self.precip = precip
 
     def __str__(self):
         """
@@ -141,6 +192,17 @@ class SiteCollection(object):
         ('z1pt0', numpy.float64),
         ('z2pt5', numpy.float64),
         ('backarc', numpy.bool),
+        ('landsliding_susceptibility', numpy.uint32),
+        ('liquefaction_susceptibility', numpy.uint32),
+        ('dw', numpy.float64),
+        ('yield_acceleration', numpy.float64),
+        ('slope', numpy.float64),
+        ('cti', numpy.float64),
+        ('dc', numpy.float64),
+        ('dr', numpy.float64),
+        ('dwb', numpy.float64),
+        ('hwater', numpy.float64),
+        ('precip', numpy.float64)
     ])
 
     @classmethod
@@ -197,7 +259,11 @@ class SiteCollection(object):
             arr['vs30measured'] = sitemodel.reference_vs30_type == 'measured'
             arr['z1pt0'] = sitemodel.reference_depth_to_1pt0km_per_sec
             arr['z2pt5'] = sitemodel.reference_depth_to_2pt5km_per_sec
-            arr['backarc'] = sitemodel.reference_backarc
+            # Optional attributes
+            for name in self.dtype.names[8:]:
+                if hasattr(sitemodel, name):
+                    arr[name] = getattr(sitemodel, name)
+            arr.flags.writeable = False
         elif 'vs30' in sitemodel.dtype.names:  # site params
             for name in sitemodel.dtype.names[2:]:  # except lon, lat
                 arr[name] = sitemodel[name]
@@ -247,6 +313,19 @@ class SiteCollection(object):
             arr['z1pt0'][i] = sites[i].z1pt0
             arr['z2pt5'][i] = sites[i].z2pt5
             arr['backarc'][i] = sites[i].backarc
+            arr['landsliding_susceptibility'][i] =\
+                sites[i].landsliding_susceptibility
+            arr['liquefaction_susceptibility'][i] =\
+                sites[i].liquefaction_susceptibility
+            arr['dw'][i]= sites[i].dw
+            arr['yield_acceleration'][i] = sites[i].yield_acceleration
+            arr['slope'][i] = sites[i].slope
+            arr['cti'][i] = sites[i].cti
+            arr['dc'][i] = sites[i].dc
+            arr['dr'][i] = sites[i].dr
+            arr['dwb'][i] = sites[i].dwb
+            arr['hwater'][i] = sites[i].hwater
+            arr['precip'][i] = sites[i].precip
 
         # protect arrays from being accidentally changed. it is useful
         # because we pass these arrays directly to a GMPE through
@@ -365,7 +444,9 @@ class SiteCollection(object):
 
     def __getattr__(self, name):
         if name not in ('vs30 vs30measured z1pt0 z2pt5 backarc lons lats '
-                        'depths sids'):
+                        'depths sids liquefaction_susceptibility dw '
+                        'landsliding_susceptibility yield_acceleration cti '
+                        'dc dr dwb hwater precip'):
             raise AttributeError(name)
         return self.array[name]
 

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -1011,11 +1011,14 @@ def simple_slice(value):
 vs30_type = ChoiceCI('measured', 'inferred')
 
 SiteParam = collections.namedtuple(
-    'SiteParam', 'lon lat depth z1pt0 z2pt5 vs30measured vs30 backarc'.split())
+    'SiteParam', 'lon lat depth z1pt0 z2pt5 vs30measured vs30 backarc liquefaction_susceptibility landsliding_susceptibility dw yield_acceleration slope cti dc dr dwb hwater precip'.split())
 
 
 def site_param(z1pt0, z2pt5, vs30Type, vs30, lon, lat,
-               depth=0, backarc="false"):
+               depth=0, backarc="false", liquefaction_susceptibility=0,
+               landsliding_susceptibility=0, dw=10.,
+               yield_acceleration=0.0, slope=0.0, cti=0.0, dc=0.0, dr=0.0,
+               dwb=0.0, hwater=0.0, precip=0.0):
     """
     Used to convert a node like
 
@@ -1028,7 +1031,15 @@ def site_param(z1pt0, z2pt5, vs30Type, vs30, lon, lat,
                      vs30measured=vs30_type(vs30Type) == 'measured',
                      vs30=positivefloat(vs30), lon=longitude(lon),
                      lat=latitude(lat), depth=float_(depth),
-                     backarc=boolean(backarc))
+                     backarc=boolean(backarc),
+                     liquefaction_susceptibility=positiveint(liquefaction_susceptibility),
+                     landsliding_susceptibility=positiveint(landsliding_susceptibility),
+                     dw=float_(dw),
+                     yield_acceleration=float_(yield_acceleration),
+                     slope=float_(slope),
+                     cti=float_(cti), dc=float_(dc), dr=float_(dr),
+                     dwb=float_(dwb), hwater=float_(hwater),
+                     precip=float_(precip))
 
 # used for the exposure validation
 cost_type = Choice('structural', 'nonstructural', 'contents',


### PR DESCRIPTION
Addresses points 1 and 2 of https://github.com/gem/oq-engine/issues/3833

Adds the following optional attributes to the site object, including reading and validation from a site model: `yield acceleration`, `slope`, compound topographic index (`cti`), HAZUS liquefaction susceptibility category (`liquefaction_susceptibility`), HAZUS landsliding susceptibility category (`landsliding_susceptibility`), groundwater depth (`dw`), distance to coast (`dc`), distance to river (`dr`), distance to nearest water body (`dwb`), elevation above nearest water body (`hwater`), annual precipitation (`precip`)

Adds IMTs for permanent ground displacement phenomena:  Lateral Spread (`PGDfLatSpread`), Settlement (`PGDfSettle`), slope displacement (`PGDfSlope`) and co-seismic rupture (`PGDfRupture`)