### PR TITLE
Added site parameters for geotechnic hazard

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added 11 new site parameters for geotechnic hazard
   * Changed the SiteCollection to store only the parameters required by the
     GSIMs
 

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -123,6 +123,19 @@ site_param_dt = {
     'z1pt0': numpy.float64,
     'z2pt5': numpy.float64,
     'backarc': numpy.bool,
+
+    # parameters for geotechnic hazard
+    'liquefaction_susceptibility': numpy.int16,
+    'landsliding_susceptibility': numpy.int16,
+    'dw': numpy.float64,
+    'yield_acceleration': numpy.float64,
+    'slope': numpy.float64,
+    'cti': numpy.float64,
+    'dc': numpy.float64,
+    'dr': numpy.float64,
+    'dwb': numpy.float64,
+    'hwater': numpy.float64,
+    'precip': numpy.float64
 }
 
 


### PR DESCRIPTION
Adding new parameters is now trivial. I am closing https://github.com/gem/oq-engine/pull/3834.
I leave to  @g-weatherill to open another PR with the changes in the imt.py module and the tests.