### PR TITLE
Fixed heisenbug by sorting the dictionary of parameters

### DIFF
--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-import unittest
 import numpy
 from numpy.testing import assert_almost_equal as aae
 from nose.plugins.attrib import attr
@@ -95,11 +94,6 @@ class ScenarioTestCase(CalculatorTestCase):
     @attr('qa', 'hazard', 'scenario')
     def test_case_4(self):
         medians = self.medians(case_4)['PGA']
-        if numpy.isinf(medians[0]):
-            raise unittest.SkipTest('infinite GMF!?')
-        # FIXME: the medians should never by inf, however they are
-        # (only on CI); it is impossible to reproduce the problem
-        # locally; skipped until I am able to reproduce the issue
         aae(medians, [0.41615372, 0.22797466, 0.1936226], decimal=2)
 
         # this is a case with a site model

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -322,14 +322,13 @@ def get_site_model(oqparam, req_site_params):
     elif missing:
         raise InvalidFile('%s: missing parameter %s' %
                           (oqparam.inputs['site_model'], ', '.join(missing)))
+    # NB: the sorted in sorted(params[0]) is essential, otherwise there is
+    # an heisenbug in scenario/test_case_4
     site_model_dt = numpy.dtype([(p, site.site_param_dt[p])
-                                 for p in params[0]])
-    array = numpy.zeros(len(params), site_model_dt)
-    for i, param in enumerate(params):
-        rec = array[i]
-        for name in site_model_dt.names:
-            rec[name] = param[name]
-    return array
+                                 for p in sorted(params[0])])
+    tuples = [tuple(param[name] for name in site_model_dt.names)
+              for param in params]
+    return numpy.array(tuples, site_model_dt)
 
 
 def get_site_collection(oqparam, mesh=None):

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -219,8 +219,9 @@ class SiteCollection(object):
             self._set('z1pt0', sitemodel.reference_depth_to_1pt0km_per_sec)
             self._set('z2pt5', sitemodel.reference_depth_to_2pt5km_per_sec)
         else:
-            for name in sitemodel.dtype.names[2:]:  # except lon, lat
-                self._set(name, sitemodel[name])
+            for name in sitemodel.dtype.names:
+                if name not in ('lon', 'lat'):
+                    self._set(name, sitemodel[name])
         return self
 
     def _set(self, param, value):


### PR DESCRIPTION
Without the sort scenario/test_case_4 was breaking randomly on Jenkins, due to a vs30=0 causing an infinite GMF.
