### PR TITLE
Cleanup the namespace and add setuptools to deps

### DIFF
--- a/openquake/__init__.py
+++ b/openquake/__init__.py
@@ -16,9 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-# Make the namespace compatible with old setuptools, like the one
-# provided by QGIS 2.1x on Windows
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ url = "https://github.com/gem/oq-engine"
 PY_MODULES = ['openquake.commands.__main__']
 
 install_requires = [
+    'setuptools',
     'mock >=1.0, <2.1',
     'nose >=1.3, <1.4',
     'h5py >=2.8, <2.9',


### PR DESCRIPTION
As recommended by https://packaging.python.org/guides/packaging-namespace-packages/ I'm getting rid of the fallback method in the namespace since it can break other libs (i.e. `mbt`, `sub`):

> Note: Some older recommendations advise the following in the namespace package __init__.py:
>
>```python
>try:
>    __import__('pkg_resources').declare_namespace(__name__)
>except ImportError:
>    __path__ = __import__('pkgutil').extend_path(__path__, __name__)
>```
>
>The idea behind this was that in the rare case that setuptools isn’t available packages would fall-back to the pkgutil-style packages. This isn’t advisable because pkgutil and pkg_resources-style namespace packages are not cross-compatible. If the presence of setuptools is a concern then the package should just explicitly depend on setuptools via install_requires.


To make sure that namespace will work I'm adding `setuptools` to the requirements in `setup.py`. It was already part of our binary distribution (i.e. `requirements-py35-linux.txt`) but it might be missing when using `pip install openquake.engine` directly (even if this is an uncommon scenario).