### PR TITLE
Move some Jenkins customizations from Sphinx Makefile to packager

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -j 8 # -n -W
-SPHINXBUILD   = /opt/openquake/bin/python3 /opt/openquake/bin/sphinx-build
+SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
 

--- a/packager.sh
+++ b/packager.sh
@@ -466,7 +466,7 @@ _builddoc_innervm_run () {
     # install sources of this package
     git archive --prefix ${GEM_GIT_PACKAGE}/ HEAD | ssh "$lxc_ip" "tar xv"
 
-    ssh "$lxc_ip" "set -e ; export PATH=/opt/openquake/bin:\$PATH ; sudo -E pip install sphinx ; cd oq-engine; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
+    ssh "$lxc_ip" "set -e ; export PATH=/opt/openquake/bin:\$PATH ; sudo /opt/openquake/bin/pip install sphinx ; cd oq-engine; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
 
     scp -r "${lxc_ip}:oq-engine/doc/sphinx/build/html" "out_${BUILD_UBUVER}/" || true
 

--- a/packager.sh
+++ b/packager.sh
@@ -466,7 +466,7 @@ _builddoc_innervm_run () {
     # install sources of this package
     git archive --prefix ${GEM_GIT_PACKAGE}/ HEAD | ssh "$lxc_ip" "tar xv"
 
-    ssh "$lxc_ip" "set -e ; export PATH=/opt/openquake/bin:\$PATH ; sudo pip install sphinx ; cd oq-engine; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
+    ssh "$lxc_ip" "set -e ; export PATH=/opt/openquake/bin:\$PATH ; sudo -E pip install sphinx ; cd oq-engine; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
 
     scp -r "${lxc_ip}:oq-engine/doc/sphinx/build/html" "out_${BUILD_UBUVER}/" || true
 

--- a/packager.sh
+++ b/packager.sh
@@ -466,7 +466,7 @@ _builddoc_innervm_run () {
     # install sources of this package
     git archive --prefix ${GEM_GIT_PACKAGE}/ HEAD | ssh "$lxc_ip" "tar xv"
 
-    ssh "$lxc_ip" "set -e ; sudo /opt/openquake/bin/pip install sphinx ; cd oq-engine; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
+    ssh "$lxc_ip" "set -e ; export PATH=/opt/openquake/bin:\$PATH ; sudo pip install sphinx ; cd oq-engine; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
 
     scp -r "${lxc_ip}:oq-engine/doc/sphinx/build/html" "out_${BUILD_UBUVER}/" || true
 

--- a/packager.sh
+++ b/packager.sh
@@ -466,7 +466,7 @@ _builddoc_innervm_run () {
     # install sources of this package
     git archive --prefix ${GEM_GIT_PACKAGE}/ HEAD | ssh "$lxc_ip" "tar xv"
 
-    ssh "$lxc_ip" "set -e ; export PATH=/opt/openquake/bin:\$PATH ; sudo /opt/openquake/bin/pip install sphinx ; cd oq-engine; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
+    ssh "$lxc_ip" "set -e ; sudo /opt/openquake/bin/pip install sphinx ; cd oq-engine; export PATH=/opt/openquake/bin:\$PATH ; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
 
     scp -r "${lxc_ip}:oq-engine/doc/sphinx/build/html" "out_${BUILD_UBUVER}/" || true
 


### PR DESCRIPTION
In this way we'll have a standard makefile that can be used locally or on Travis but at the same time we are not breaking jenkins.

Fixes #3849 

https://ci.openquake.org/job/zdevel_oq-engine/2788/