### PR TITLE
Changed SitesContext._slots_

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -320,7 +320,8 @@ class SitesContext(BaseContext):
     object.
     """
     # _slots_ is used in hazardlib check_gsim and in the SMTK
-    def __init__(self, slots=None, sitecol=None):
+    def __init__(self, slots='vs30 vs30measured z1pt0 z2pt5'.split(),
+                 sitecol=None):
         self._slots_ = slots
         if sitecol is not None:
             self.sids = sitecol.sids

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -320,11 +320,12 @@ class SitesContext(BaseContext):
     object.
     """
     # _slots_ is used in hazardlib check_gsim and in the SMTK
-    _slots_ = ('vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
-               'lons', 'lats')
+    #_slots_ = ('vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
+    #           'lons', 'lats')
     # lons, lats are needed in si_midorikawa_1999_test.py
 
     def __init__(self, sitecol=None, slots=None):
+        self._slots_ = slots
         if sitecol is not None:
             self.sids = sitecol.sids
             for name in self._slots_ if slots is None else slots:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -180,7 +180,7 @@ class ContextMaker(object):
         self.add_rup_params(rupture)
         # NB: returning a SitesContext make sures that the GSIM cannot
         # access site parameters different from the ones declared
-        sctx = SitesContext(sites, self.REQUIRES_SITES_PARAMETERS)
+        sctx = SitesContext(self.REQUIRES_SITES_PARAMETERS, sites)
         return sctx, dctx
 
     def poe_map(self, src, sites, imtls, trunclevel, rup_indep=True):
@@ -320,11 +320,7 @@ class SitesContext(BaseContext):
     object.
     """
     # _slots_ is used in hazardlib check_gsim and in the SMTK
-    #_slots_ = ('vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
-    #           'lons', 'lats')
-    # lons, lats are needed in si_midorikawa_1999_test.py
-
-    def __init__(self, sitecol=None, slots=None):
+    def __init__(self, slots=None, sitecol=None):
         self._slots_ = slots
         if sitecol is not None:
             self.sids = sitecol.sids

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -325,8 +325,8 @@ class SitesContext(BaseContext):
         self._slots_ = slots
         if sitecol is not None:
             self.sids = sitecol.sids
-            for name in self._slots_ if slots is None else slots:
-                setattr(self, name, getattr(sitecol, name))
+            for slot in slots:
+                setattr(self, slot, getattr(sitecol, slot))
 
 
 class DistancesContext(BaseContext):

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -32,9 +32,9 @@ from scipy.interpolate import interp1d
 import numpy
 
 from openquake.baselib.python3compat import decode
-from openquake.hazardlib import const
+from openquake.hazardlib import const, site
 from openquake.hazardlib import imt as imt_module
-from openquake.hazardlib.gsim.base import GMPE, RuptureContext, SitesContext
+from openquake.hazardlib.gsim.base import GMPE, RuptureContext
 from openquake.baselib.python3compat import round
 
 
@@ -102,7 +102,7 @@ class AmplificationTable(object):
         self.values = self.values[self.argidx]
         if self.parameter in RuptureContext._slots_:
             self.element = "Rupture"
-        elif self.parameter in SitesContext._slots_:
+        elif self.parameter in site.site_param_dt:
             self.element = "Sites"
         else:
             raise ValueError("Amplification parameter %s not recognised!"

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -357,13 +357,14 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
 
 class ContextTestCase(unittest.TestCase):
     def test_equality(self):
-        sctx1 = SitesContext()
+        slots = 'vs30 vs30measured z1pt0 z2pt5'.split()
+        sctx1 = SitesContext(slots=slots)
         sctx1.vs30 = numpy.array([500., 600., 700.])
         sctx1.vs30measured = True
         sctx1.z1pt0 = numpy.array([40., 50., 60.])
         sctx1.z2pt5 = numpy.array([1, 2, 3])
 
-        sctx2 = SitesContext()
+        sctx2 = SitesContext(slots=slots)
         sctx2.vs30 = numpy.array([500., 600., 700.])
         sctx2.vs30measured = True
         sctx2.z1pt0 = numpy.array([40., 50., 60.])
@@ -371,7 +372,7 @@ class ContextTestCase(unittest.TestCase):
 
         self.assertTrue(sctx1 == sctx2)
 
-        sctx2 = SitesContext()
+        sctx2 = SitesContext(slots=slots)
         sctx2.vs30 = numpy.array([500., 600.])
         sctx2.vs30measured = True
         sctx2.z1pt0 = numpy.array([40., 50., 60.])
@@ -379,7 +380,7 @@ class ContextTestCase(unittest.TestCase):
 
         self.assertTrue(sctx1 != sctx2)
 
-        sctx2 = SitesContext()
+        sctx2 = SitesContext(slots=slots)
         sctx2.vs30 = numpy.array([500., 600., 700.])
         sctx2.vs30measured = False
         sctx2.z1pt0 = numpy.array([40., 50., 60.])

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -357,14 +357,13 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
 
 class ContextTestCase(unittest.TestCase):
     def test_equality(self):
-        slots = 'vs30 vs30measured z1pt0 z2pt5'.split()
-        sctx1 = SitesContext(slots=slots)
+        sctx1 = SitesContext()
         sctx1.vs30 = numpy.array([500., 600., 700.])
         sctx1.vs30measured = True
         sctx1.z1pt0 = numpy.array([40., 50., 60.])
         sctx1.z2pt5 = numpy.array([1, 2, 3])
 
-        sctx2 = SitesContext(slots=slots)
+        sctx2 = SitesContext()
         sctx2.vs30 = numpy.array([500., 600., 700.])
         sctx2.vs30measured = True
         sctx2.z1pt0 = numpy.array([40., 50., 60.])
@@ -372,7 +371,7 @@ class ContextTestCase(unittest.TestCase):
 
         self.assertTrue(sctx1 == sctx2)
 
-        sctx2 = SitesContext(slots=slots)
+        sctx2 = SitesContext()
         sctx2.vs30 = numpy.array([500., 600.])
         sctx2.vs30measured = True
         sctx2.z1pt0 = numpy.array([40., 50., 60.])
@@ -380,7 +379,7 @@ class ContextTestCase(unittest.TestCase):
 
         self.assertTrue(sctx1 != sctx2)
 
-        sctx2 = SitesContext(slots=slots)
+        sctx2 = SitesContext()
         sctx2.vs30 = numpy.array([500., 600., 700.])
         sctx2.vs30measured = False
         sctx2.z1pt0 = numpy.array([40., 50., 60.])

--- a/openquake/hazardlib/tests/gsim/check_gsim.py
+++ b/openquake/hazardlib/tests/gsim/check_gsim.py
@@ -193,7 +193,6 @@ def _parse_csv(datafile, debug, req_site_params):
     headers = [param_name.lower() for param_name in next(reader)]
     sctx, rctx, dctx, stddev_types, expected_results, result_type \
         = _parse_csv_line(headers, next(reader), req_site_params)
-    #sattrs = [slot for slot in SitesContext._slots_ if hasattr(sctx, slot)]
     sattrs = sctx._slots_
     dattrs = [slot for slot in DistancesContext._slots_
               if hasattr(dctx, slot)]

--- a/openquake/hazardlib/tests/gsim/check_gsim.py
+++ b/openquake/hazardlib/tests/gsim/check_gsim.py
@@ -69,7 +69,8 @@ def check_gsim(gsim_cls, datafile, max_discrep_percentage, debug=False):
     linenum = 1
     discrepancies = []
     started = time.time()
-    for testcase in _parse_csv(datafile, debug):
+    for testcase in _parse_csv(
+            datafile, debug, gsim.REQUIRES_SITES_PARAMETERS):
         linenum += 1
         (sctx, rctx, dctx, stddev_types, expected_results, result_type) \
             = testcase
@@ -175,7 +176,7 @@ context objects changed = %s'''
     return stats
 
 
-def _parse_csv(datafile, debug):
+def _parse_csv(datafile, debug, req_site_params):
     """
     Parse a data file in csv format and generate everything needed to exercise
     GSIM and check the result.
@@ -191,13 +192,14 @@ def _parse_csv(datafile, debug):
     reader = iter(csv.reader(datafile))
     headers = [param_name.lower() for param_name in next(reader)]
     sctx, rctx, dctx, stddev_types, expected_results, result_type \
-        = _parse_csv_line(headers, next(reader))
-    sattrs = [slot for slot in SitesContext._slots_ if hasattr(sctx, slot)]
+        = _parse_csv_line(headers, next(reader), req_site_params)
+    #sattrs = [slot for slot in SitesContext._slots_ if hasattr(sctx, slot)]
+    sattrs = sctx._slots_
     dattrs = [slot for slot in DistancesContext._slots_
               if hasattr(dctx, slot)]
     for line in reader:
         (sctx2, rctx2, dctx2, stddev_types2, expected_results2, result_type2) \
-            = _parse_csv_line(headers, line)
+            = _parse_csv_line(headers, line, req_site_params)
         if not debug \
                 and stddev_types2 == stddev_types \
                 and result_type2 == result_type \
@@ -220,7 +222,7 @@ def _parse_csv(datafile, debug):
     yield sctx, rctx, dctx, stddev_types, expected_results, result_type
 
 
-def _parse_csv_line(headers, values):
+def _parse_csv_line(headers, values, req_site_params):
     """
     Parse a single line from data file.
 
@@ -254,7 +256,7 @@ def _parse_csv_line(headers, values):
             is taken from column ``result_type``.
     """
     rctx = RuptureContext()
-    sctx = SitesContext()
+    sctx = SitesContext(slots=req_site_params)
     dctx = DistancesContext()
     expected_results = {}
     stddev_types = result_type = damping = None

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -27,7 +27,7 @@ class BaseGSIMTestCase(unittest.TestCase):
     GSIM_CLASS = None
 
     def get_context_attributes(self, ctx):
-        return set(vars(ctx))
+        return set(vars(ctx)) - set(['_slots_'])
 
     def check(self, filename, max_discrep_percentage):
         gsim = self.GSIM_CLASS()


### PR DESCRIPTION
After the change in https://github.com/gem/oq-engine/pull/3844 the site parameters are no more hard-coded. This means that they must be passed to the SitesContext.