### PR TITLE
Saving the rupture geometries in a format compatible with HDFView 3.0

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -71,7 +71,11 @@ def extend(dset, array, **attrs):
     """
     length = len(dset)
     newlength = length + len(array)
-    dset.resize((newlength,) + array.shape[1:])
+    if array.dtype.name == 'object':  # vlen array
+        shape = (newlength,)
+    else:
+        shape = (newlength,) + array.shape[1:]
+    dset.resize(shape)
     dset[length:newlength] = array
     for key, val in attrs.items():
         dset.attrs[key] = val
@@ -86,8 +90,11 @@ def extend3(hdf5path, key, array, **attrs):
         try:
             dset = h5[key]
         except KeyError:
-            dset = create(h5, key, array.dtype,
-                          shape=(None,) + array.shape[1:])
+            if array.dtype.name == 'object':  # vlen array
+                shape = (None,)
+            else:
+                shape = (None,) + array.shape[1:]
+            dset = create(h5, key, array.dtype, shape)
         length = extend(dset, array)
         for key, val in attrs.items():
             dset.attrs[key] = val

--- a/openquake/baselib/tests/hdf5_test.py
+++ b/openquake/baselib/tests/hdf5_test.py
@@ -36,5 +36,12 @@ class Hdf5TestCase(unittest.TestCase):
         with hdf5.File(self.tmp, 'r') as f:
             print(f['dset'].value)
 
+    def test_extend3_vlen_same_len(self):
+        data = numpy.array([[4, 1], [1, 2], [3, 1]], hdf5.vfloat32)
+        nrows = hdf5.extend3(self.tmp, 'dset', data)
+        self.assertEqual(nrows, 3)
+        with hdf5.File(self.tmp, 'r') as f:
+            print(f['dset'].value)
+
     def tearDown(self):
         os.remove(self.tmp)

--- a/openquake/baselib/tests/hdf5_test.py
+++ b/openquake/baselib/tests/hdf5_test.py
@@ -1,0 +1,40 @@
+#  -*- coding: utf-8 -*-
+#  vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#  Copyright (c) 2018, GEM Foundation
+
+#  OpenQuake is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+#  OpenQuake is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+import os
+import numpy
+import unittest
+from openquake.baselib import general, hdf5
+
+
+class Hdf5TestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = general.gettemp(suffix='.hdf5')
+
+    def test_extend3(self):
+        nrows = hdf5.extend3(self.tmp, 'dset', numpy.zeros(3))
+        self.assertEqual(nrows, 3)
+
+    def test_extend3_vlen(self):
+        data = numpy.array([[], [1, 2], [3]], hdf5.vfloat32)
+        nrows = hdf5.extend3(self.tmp, 'dset', data)
+        self.assertEqual(nrows, 3)
+        with hdf5.File(self.tmp, 'r') as f:
+            print(f['dset'].value)
+
+    def tearDown(self):
+        os.remove(self.tmp)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -525,8 +525,7 @@ class RuptureGetter(object):
             evs = events[rec['eidx1']:rec['eidx2']]
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
-            geom = rupgeoms[ridx]
-            mesh = geom['points'].reshape(3, rec['sy'], rec['sz'])
+            mesh = rupgeoms[ridx].reshape(3, rec['sy'], rec['sz'])
             rupture_cls, surface_cls = code2cls[rec['code']]
             rupture = object.__new__(rupture_cls)
             rupture.serial = serial

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -525,7 +525,7 @@ class RuptureGetter(object):
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
             geom = rupgeoms[ridx]
-            mesh = geom['points'].reshape(3, geom['sy'], geom['sz'])
+            mesh = geom['points'].reshape(3, rec['sy'], rec['sz'])
             rupture_cls, surface_cls = code2cls[rec['code']]
             rupture = object.__new__(rupture_cls)
             rupture.serial = serial

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -512,6 +512,7 @@ class RuptureGetter(object):
             if key.startswith('code_'):
                 code2cls[int(key[5:])] = [classes[v] for v in val.split()]
         grp_trt = self.dstore['csm_info'].grp_by("trt")
+        events = self.dstore['events']
         ruptures = self.dstore['ruptures'][self.mask]
         rupgeoms = self.dstore['rupgeoms'][self.mask]
         # NB: ruptures.sort(order='serial') causes sometimes a SystemError:
@@ -521,7 +522,7 @@ class RuptureGetter(object):
             ruptures['serial']))
         for serial, ridx in data:
             rec = ruptures[ridx]
-            evs = self.dstore['events'][rec['eidx1']:rec['eidx2']]
+            evs = events[rec['eidx1']:rec['eidx2']]
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
             geom = rupgeoms[ridx]

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -147,7 +147,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # test the number of bytes saved in the rupture records
         nbytes = self.calc.datastore.get_attr('ruptures', 'nbytes')
-        self.assertEqual(nbytes, 1859)
+        #self.assertEqual(nbytes, 1859)
 
         # test postprocessing
         self.calc.datastore.close()

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -147,7 +147,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # test the number of bytes saved in the rupture records
         nbytes = self.calc.datastore.get_attr('ruptures', 'nbytes')
-        #self.assertEqual(nbytes, 1859)
+        self.assertEqual(nbytes, 1911)
 
         # test postprocessing
         self.calc.datastore.close()

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -355,10 +355,9 @@ class RuptureSerializer(object):
         ('serial', U32), ('grp_id', U16), ('code', U8),
         ('eidx1', U32), ('eidx2', U32), ('pmfx', I32), ('seed', U32),
         ('mag', F32), ('rake', F32), ('occurrence_rate', F32),
-        ('hypo', (F32, 3))])
+        ('hypo', (F32, 3)), ('sy', U16), ('sz', U16)])
 
-    geom_dt = numpy.dtype([
-        ('points', hdf5.vfloat32), ('sy', U16), ('sz', U16)])
+    geom_dt = numpy.dtype([('points', hdf5.vfloat32)])
 
     pmfs_dt = numpy.dtype([('serial', U32), ('pmf', hdf5.vfloat32)])
 
@@ -383,9 +382,9 @@ class RuptureSerializer(object):
             tup = (ebrupture.serial, ebrupture.grp_id, rup.code,
                    ebrupture.eidx1, ebrupture.eidx2,
                    getattr(ebrupture, 'pmfx', -1),
-                   rup.seed, rup.mag, rup.rake, rate, hypo)
+                   rup.seed, rup.mag, rup.rake, rate, hypo, sy, sz)
             lst.append(tup)
-            geom.append((points, sy, sz))
+            geom.append((points,))
             nbytes += cls.rupture_dt.itemsize + mesh.nbytes
         return (numpy.array(lst, cls.rupture_dt),
                 numpy.array(geom, cls.geom_dt),

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -394,8 +394,7 @@ class RuptureSerializer(object):
         if datastore['oqparam'].save_ruptures:
             datastore.create_dset('ruptures', self.rupture_dt, fillvalue=None,
                                   attrs={'nbytes': 0})
-            datastore.create_dset('rupgeoms', hdf5.vfloat32, fillvalue=None,
-                                  attrs={'nbytes': 0})
+            datastore.create_dset('rupgeoms', hdf5.vfloat32, fillvalue=None)
 
     def save(self, ebruptures, eidx=0):
         """

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -431,7 +431,7 @@ class RuptureSerializer(object):
         # save nbytes occupied by the PMFs
         if pmfbytes:
             if 'nbytes' in dset.attrs:
-                 dset.attrs['nbytes'] += pmfbytes
+                dset.attrs['nbytes'] += pmfbytes
             else:
                 dset.attrs['nbytes'] = pmfbytes
         self.datastore.flush()


### PR DESCRIPTION
This required fixing a bug in `hdf5.extend` in the case of variable-length arrays.