### PR TITLE
Fixed `gmf_data/indices` to work with HDFView 3.0

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -274,7 +274,10 @@ class File(h5py.File):
         """
         dt = data[0].dtype
         vdt = h5py.special_dtype(vlen=dt)
-        dset = create(self, key, vdt, fillvalue=None)
+        try:
+            dset = self[key]
+        except KeyError:
+            dset = create(self, key, vdt, fillvalue=None)
         nbytes = 0
         totlen = 0
         for i, val in enumerate(data):

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -71,7 +71,11 @@ def extend(dset, array, **attrs):
     """
     length = len(dset)
     newlength = length + len(array)
-    dset.resize((newlength,) + array.shape[1:])
+    if array.dtype.name == 'object':  # vlen array
+        shape = (newlength,)
+    else:
+        shape = (newlength,) + array.shape[1:]
+    dset.resize(shape)
     dset[length:newlength] = array
     for key, val in attrs.items():
         dset.attrs[key] = val
@@ -86,8 +90,11 @@ def extend3(hdf5path, key, array, **attrs):
         try:
             dset = h5[key]
         except KeyError:
-            dset = create(h5, key, array.dtype,
-                          shape=(None,) + array.shape[1:])
+            if array.dtype.name == 'object':  # vlen array
+                shape = (None,)
+            else:
+                shape = (None,) + array.shape[1:]
+            dset = create(h5, key, array.dtype, shape)
         length = extend(dset, array)
         for key, val in attrs.items():
             dset.attrs[key] = val

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -273,19 +273,15 @@ class File(h5py.File):
         :param data: data to store as a list of arrays
         """
         dt = data[0].dtype
-        shape = (len(data),) + data[0].shape[:-1]
-        dset = create(self, key, h5py.special_dtype(vlen=dt), shape,
-                      fillvalue=None)
+        vdt = h5py.special_dtype(vlen=dt)
+        dset = create(self, key, vdt, fillvalue=None)
         nbytes = 0
         totlen = 0
         for i, val in enumerate(data):
-            dset[i] = val
             nbytes += val.nbytes
             totlen += len(val)
-        attrs = super().__getitem__(key).attrs
-        attrs['nbytes'] = nbytes
-        attrs['avg_len'] = totlen / len(data)
-        self.flush()
+        extend(dset, numpy.array(data, vdt),
+               nbytes=nbytes, avg_len=totlen / len(data))
 
     def save_attrs(self, path, attrs, **kw):
         items = list(attrs.items()) + list(kw.items())

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -273,18 +273,19 @@ class File(h5py.File):
         :param data: data to store as a list of arrays
         """
         dt = data[0].dtype
-        vdt = h5py.special_dtype(vlen=dt)
-        try:
-            dset = self[key]
-        except KeyError:
-            dset = create(self, key, vdt, fillvalue=None)
+        shape = (len(data),) + data[0].shape[:-1]
+        dset = create(self, key, h5py.special_dtype(vlen=dt), shape,
+                      fillvalue=None)
         nbytes = 0
         totlen = 0
         for i, val in enumerate(data):
+            dset[i] = val
             nbytes += val.nbytes
             totlen += len(val)
-        extend(dset, numpy.array(data, vdt),
-               nbytes=nbytes, avg_len=totlen / len(data))
+        attrs = super().__getitem__(key).attrs
+        attrs['nbytes'] = nbytes
+        attrs['avg_len'] = totlen / len(data)
+        self.flush()
 
     def save_attrs(self, path, attrs, **kw):
         items = list(attrs.items()) + list(kw.items())

--- a/openquake/baselib/tests/hdf5_test.py
+++ b/openquake/baselib/tests/hdf5_test.py
@@ -36,5 +36,12 @@ class Hdf5TestCase(unittest.TestCase):
         with hdf5.File(self.tmp, 'r') as f:
             print(f['dset'].value)
 
+    def test_extend3_vlen_same_len(self):
+        data = numpy.array([[4, 1], [1, 2], [3, 1]], hdf5.vfloat32)
+        nrows = hdf5.extend3(self.tmp, 'dset', data)
+        self.assertEqual(nrows, 3)
+        with hdf5.File(self.tmp, 'r') as f:
+            print(f['dset'].value)
+
     def tearDown(self):
         os.remove(self.tmp)

--- a/openquake/baselib/tests/hdf5_test.py
+++ b/openquake/baselib/tests/hdf5_test.py
@@ -1,0 +1,40 @@
+#  -*- coding: utf-8 -*-
+#  vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#  Copyright (c) 2018, GEM Foundation
+
+#  OpenQuake is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+#  OpenQuake is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+import os
+import numpy
+import unittest
+from openquake.baselib import general, hdf5
+
+
+class Hdf5TestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = general.gettemp(suffix='.hdf5')
+
+    def test_extend3(self):
+        nrows = hdf5.extend3(self.tmp, 'dset', numpy.zeros(3))
+        self.assertEqual(nrows, 3)
+
+    def test_extend3_vlen(self):
+        data = numpy.array([[], [1, 2], [3]], hdf5.vfloat32)
+        nrows = hdf5.extend3(self.tmp, 'dset', data)
+        self.assertEqual(nrows, 3)
+        with hdf5.File(self.tmp, 'r') as f:
+            print(f['dset'].value)
+
+    def tearDown(self):
+        os.remove(self.tmp)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -27,6 +27,7 @@ from functools import partial
 from datetime import datetime
 from shapely import wkt
 import numpy
+import h5py
 
 from openquake.baselib import (
     config, general, hdf5, datastore, __version__ as engine_version)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -739,7 +739,11 @@ class RiskCalculator(HazardCalculator):
             elif indices is None:
                 weight = len(assets)
             else:
-                num_gmfs = sum(stop - start for start, stop in indices[sid])
+                idx = indices[sid]
+                if indices.dtype.names:  # engine < 3.2
+                    num_gmfs = sum(stop - start for start, stop in idx)
+                else:  # engine >= 3.2
+                    num_gmfs = (idx[1] - idx[0]).sum()
                 weight = len(assets) * (num_gmfs or 1)
             sid_weight.append((sid, weight))
         for block in general.split_in_blocks(
@@ -867,9 +871,9 @@ def save_gmf_data(dstore, sitecol, gmfs, eids=()):
     for sid in all_sids:
         rows = dic.get(sid, ())
         n = len(rows)
-        lst.append(numpy.array([(offset, offset + n)], riskinput.indices_dt))
+        lst.append((offset, offset + n))
         offset += n
-    dstore.hdf5.save_vlen('gmf_data/indices', lst)
+    dstore['gmf_data/indices'] = numpy.array(lst, U32)
     dstore.set_attrs('gmf_data', num_gmfs=len(gmfs))
     if len(eids):  # store the events
         events = numpy.zeros(len(eids), readinput.stored_event_dt)
@@ -902,11 +906,11 @@ def import_gmfs(dstore, fname, sids):
     offset = 0
     for sid in sids:
         n = len(dic.get(sid, []))
-        lst.append(numpy.array([(offset, offset + n)], riskinput.indices_dt))
+        lst.append((offset, offset + n))
         if n:
             offset += n
             dstore.extend('gmf_data/data', dic[sid])
-    dstore.hdf5.save_vlen('gmf_data/indices', lst)
+    dstore['gmf_data/indices'] = numpy.array(lst, U32)
 
     # FIXME: if there is no data for the maximum realization
     # the inferred number of realizations will be wrong

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -28,7 +28,7 @@ from openquake.baselib.general import (
 from openquake.hazardlib.calc.stochastic import sample_ruptures
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.stats import compute_pmap_stats
-from openquake.risklib.riskinput import str2rsi, indices_dt
+from openquake.risklib.riskinput import str2rsi
 from openquake.baselib import parallel
 from openquake.commonlib import calc, util, readinput
 from openquake.calculators import base
@@ -294,8 +294,8 @@ class EventBasedCalculator(base.HazardCalculator):
                 # computation is going, to see the progress
                 update_nbytes(self.datastore, 'gmf_data/data', data)
                 for sid, start, stop in result['indices']:
-                    self.indices[sid].append(
-                        (start + self.offset, stop + self.offset))
+                    self.indices[sid, 0].append(start + self.offset)
+                    self.indices[sid, 1].append(stop + self.offset)
                 self.offset += len(data)
                 if self.offset >= TWO32:
                     raise RuntimeError(
@@ -335,7 +335,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.gmdata = {}
         self.offset = 0
         self.gmf_size = 0
-        self.indices = collections.defaultdict(list)  # sid -> indices
+        self.indices = collections.defaultdict(list)  # sid, idx -> indices
         acc = self.zerodict()
         with self.monitor('managing sources', autoflush=True):
             allargs = self.gen_args(self.monitor('classical'))
@@ -361,10 +361,11 @@ class EventBasedCalculator(base.HazardCalculator):
             with self.monitor('saving gmf_data/indices', measuremem=True,
                               autoflush=True):
                 dset = self.datastore.create_dset(
-                    'gmf_data/indices', h5py.special_dtype(vlen=indices_dt),
-                    shape=(N,), fillvalue=None)
+                    'gmf_data/indices', hdf5.vuint32,
+                    shape=(N, 2), fillvalue=None)
                 for sid in self.sitecol.complete.sids:
-                    dset[sid] = numpy.array(self.indices[sid], indices_dt)
+                    dset[sid, 0] = self.indices[sid, 0]
+                    dset[sid, 1] = self.indices[sid, 1]
         elif (self.oqparam.ground_motion_fields and
               'ucerf' not in self.oqparam.calculation_mode):
             raise RuntimeError('No GMFs were generated, perhaps they were '

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -525,8 +525,7 @@ class RuptureGetter(object):
             evs = events[rec['eidx1']:rec['eidx2']]
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
-            geom = rupgeoms[ridx]
-            mesh = geom['points'].reshape(3, rec['sy'], rec['sz'])
+            mesh = rupgeoms[ridx].reshape(3, rec['sy'], rec['sz'])
             rupture_cls, surface_cls = code2cls[rec['code']]
             rupture = object.__new__(rupture_cls)
             rupture.serial = serial

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -244,10 +244,14 @@ class GmfDataGetter(collections.Mapping):
     def __getitem__(self, sid):
         dset = self.dstore['gmf_data/data']
         idxs = self.dstore['gmf_data/indices'][sid]
-        if len(idxs) == 0:  # site ID with no data
+        if idxs.dtype.name == 'uint32':  # scenario
+            idxs = [idxs]
+        elif not idxs.dtype.names:  # engine >= 3.2
+            idxs = zip(*idxs)
+        data = [dset[start:stop] for start, stop in idxs]
+        if len(data) == 0:  # site ID with no data
             return {}
-        array = numpy.concatenate([dset[start:stop] for start, stop in idxs])
-        return group_array(array, 'rlzi')
+        return group_array(numpy.concatenate(data), 'rlzi')
 
     def __iter__(self):
         return iter(self.sids)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -525,7 +525,7 @@ class RuptureGetter(object):
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
             geom = rupgeoms[ridx]
-            mesh = geom['points'].reshape(3, geom['sy'], geom['sz'])
+            mesh = geom['points'].reshape(3, rec['sy'], rec['sz'])
             rupture_cls, surface_cls = code2cls[rec['code']]
             rupture = object.__new__(rupture_cls)
             rupture.serial = serial

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -512,6 +512,7 @@ class RuptureGetter(object):
             if key.startswith('code_'):
                 code2cls[int(key[5:])] = [classes[v] for v in val.split()]
         grp_trt = self.dstore['csm_info'].grp_by("trt")
+        events = self.dstore['events']
         ruptures = self.dstore['ruptures'][self.mask]
         rupgeoms = self.dstore['rupgeoms'][self.mask]
         # NB: ruptures.sort(order='serial') causes sometimes a SystemError:
@@ -521,7 +522,7 @@ class RuptureGetter(object):
             ruptures['serial']))
         for serial, ridx in data:
             rec = ruptures[ridx]
-            evs = self.dstore['events'][rec['eidx1']:rec['eidx2']]
+            evs = events[rec['eidx1']:rec['eidx2']]
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
             geom = rupgeoms[ridx]

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -147,7 +147,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # test the number of bytes saved in the rupture records
         nbytes = self.calc.datastore.get_attr('ruptures', 'nbytes')
-        self.assertEqual(nbytes, 1859)
+        #self.assertEqual(nbytes, 1859)
 
         # test postprocessing
         self.calc.datastore.close()

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -147,7 +147,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # test the number of bytes saved in the rupture records
         nbytes = self.calc.datastore.get_attr('ruptures', 'nbytes')
-        #self.assertEqual(nbytes, 1859)
+        self.assertEqual(nbytes, 1911)
 
         # test postprocessing
         self.calc.datastore.close()

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -355,10 +355,9 @@ class RuptureSerializer(object):
         ('serial', U32), ('grp_id', U16), ('code', U8),
         ('eidx1', U32), ('eidx2', U32), ('pmfx', I32), ('seed', U32),
         ('mag', F32), ('rake', F32), ('occurrence_rate', F32),
-        ('hypo', (F32, 3))])
+        ('hypo', (F32, 3)), ('sy', U16), ('sz', U16)])
 
-    geom_dt = numpy.dtype([
-        ('points', hdf5.vfloat32), ('sy', U16), ('sz', U16)])
+    geom_dt = numpy.dtype([('points', hdf5.vfloat32)])
 
     pmfs_dt = numpy.dtype([('serial', U32), ('pmf', hdf5.vfloat32)])
 
@@ -383,9 +382,9 @@ class RuptureSerializer(object):
             tup = (ebrupture.serial, ebrupture.grp_id, rup.code,
                    ebrupture.eidx1, ebrupture.eidx2,
                    getattr(ebrupture, 'pmfx', -1),
-                   rup.seed, rup.mag, rup.rake, rate, hypo)
+                   rup.seed, rup.mag, rup.rake, rate, hypo, sy, sz)
             lst.append(tup)
-            geom.append((points, sy, sz))
+            geom.append((points,))
             nbytes += cls.rupture_dt.itemsize + mesh.nbytes
         return (numpy.array(lst, cls.rupture_dt),
                 numpy.array(geom, cls.geom_dt),

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -394,8 +394,7 @@ class RuptureSerializer(object):
         if datastore['oqparam'].save_ruptures:
             datastore.create_dset('ruptures', self.rupture_dt, fillvalue=None,
                                   attrs={'nbytes': 0})
-            datastore.create_dset('rupgeoms', hdf5.vfloat32, fillvalue=None,
-                                  attrs={'nbytes': 0})
+            datastore.create_dset('rupgeoms', hdf5.vfloat32, fillvalue=None)
 
     def save(self, ebruptures, eidx=0):
         """

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -431,7 +431,7 @@ class RuptureSerializer(object):
         # save nbytes occupied by the PMFs
         if pmfbytes:
             if 'nbytes' in dset.attrs:
-                 dset.attrs['nbytes'] += pmfbytes
+                dset.attrs['nbytes'] += pmfbytes
             else:
                 dset.attrs['nbytes'] = pmfbytes
         self.datastore.flush()

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -34,7 +34,6 @@ class ValidationError(Exception):
 U32 = numpy.uint32
 F32 = numpy.float32
 by_taxonomy = operator.attrgetter('taxonomy')
-indices_dt = numpy.dtype((U32, 2))
 
 
 def read_composite_risk_model(dstore):

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -34,7 +34,7 @@ class ValidationError(Exception):
 U32 = numpy.uint32
 F32 = numpy.float32
 by_taxonomy = operator.attrgetter('taxonomy')
-indices_dt = numpy.dtype([('start', U32), ('stop', U32)])
+indices_dt = numpy.dtype((U32, 2))
 
 
 def read_composite_risk_model(dstore):


### PR DESCRIPTION
This is compatible with the past, i.e. we can still run the risk starting from GMFs generated/imported with old versions of the engine.