### PR TITLE
Added attributes units, return_periods and stats to extract/agg_curves

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Renamed /extract/agglosses -> /extract/agg_losses and same for aggdamages
   * Supported equivalent epicentral distance with a `reqv_hdf5` file
   * Fixed the risk from ShakeMap feature in the case of missing IMTs
   * Changed the way gmf_data/indices and ruptures are stored

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -341,7 +341,8 @@ class EbrCalculator(base.RiskCalculator):
         with self.monitor('building agg_curves', measuremem=True):
             array, arr_stats = b.build(dstore['losses_by_event'].value, stats)
         self.datastore['agg_curves-rlzs'] = array
-        units = self.assetcol.units(loss_types=array.dtype.names)
+        units = self.assetcol.cost_calculator.get_units(
+            loss_types=array.dtype.names)
         self.datastore.set_attrs(
             'agg_curves-rlzs', return_periods=b.return_periods, units=units)
         if arr_stats is not None:

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -328,12 +328,12 @@ def get_loss_type_tags(what):
     return loss_type, tags
 
 
-@extract.add('agglosses')
-def extract_agglosses(dstore, what):
+@extract.add('agg_losses')
+def extract_agg_losses(dstore, what):
     """
     Aggregate losses of the given loss type and tags. Use it as
-    /extract/agglosses/structural?taxonomy=RC&zipcode=20126
-    /extract/agglosses/structural?taxonomy=RC&zipcode=*
+    /extract/agg_losses/structural?taxonomy=RC&zipcode=20126
+    /extract/agg_losses/structural?taxonomy=RC&zipcode=*
 
     :returns:
         an array of shape (T, R) if one of the tag names has a `*` value
@@ -342,7 +342,7 @@ def extract_agglosses(dstore, what):
     """
     loss_type, tags = get_loss_type_tags(what)
     if not loss_type:
-        raise ValueError('loss_type not passed in agglosses/<loss_type>')
+        raise ValueError('loss_type not passed in agg_losses/<loss_type>')
     l = dstore['oqparam'].lti[loss_type]
     if 'losses_by_asset' in dstore:  # scenario_risk
         stats = None
@@ -358,11 +358,11 @@ def extract_agglosses(dstore, what):
     return _filter_agg(dstore['assetcol'], losses, tags, stats)
 
 
-@extract.add('aggdamages')
-def extract_aggdamages(dstore, what):
+@extract.add('agg_damages')
+def extract_agg_damages(dstore, what):
     """
     Aggregate damages of the given loss type and tags. Use it as
-    /extract/aggdamages/structural?taxonomy=RC&zipcode=20126
+    /extract/agg_damages/structural?taxonomy=RC&zipcode=20126
 
     :returns:
         array of shape (R, D), being R the number of realizations and D
@@ -382,7 +382,7 @@ def extract_agg_curves(dstore, what):
     """
     Aggregate loss curves of the given loss type and tags for
     event based risk calculations. Use it as
-    /extract/aggcurves/structural?taxonomy=RC&zipcode=20126
+    /extract/agg_curves/structural?taxonomy=RC&zipcode=20126
 
     :returns:
         array of shape (S, P), being P the number of return periods

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -376,8 +376,8 @@ def extract_aggdamages(dstore, what):
     return _filter_agg(dstore['assetcol'], losses, tags)
 
 
-@extract.add('aggcurves')
-def extract_aggcurves(dstore, what):
+@extract.add('agg_curves')
+def extract_agg_curves(dstore, what):
     """
     Aggregate loss curves of the given loss type and tags for
     event based risk calculations. Use it as

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -390,9 +390,13 @@ def extract_agg_curves(dstore, what):
     loss_type, tags = get_loss_type_tags(what)
     if 'curves-stats' in dstore:  # event_based_risk
         losses = dstore['curves-stats'][loss_type]
+        stats = dstore['curves-stats'].attrs['stats']
+    elif 'curves-rlzs' in dstore:  # event_based_risk, 1 rlz
+        losses = dstore['curves-rlzs'][loss_type]
+        assert losses.shape[1] == 1, 'There must be a single realization'
+        stats = ['mean']
     else:
         raise KeyError('No curves found in %s' % dstore)
-    stats = dstore['curves-stats'].attrs['stats']
     return _filter_agg(dstore['assetcol'], losses, tags, stats)
 
 

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -208,7 +208,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # extract curves by tag
         tags = 'taxonomy=tax1&state=01&cresta=0.11'
-        a = extract(self.calc.datastore, 'aggcurves/structural?' + tags)
+        a = extract(self.calc.datastore, 'agg_curves/structural?' + tags)
         self.assertEqual(a.array.shape, (4, 3))  # 4 stats, 3 return periods
 
         fname = gettemp(view('portfolio_loss', self.calc.datastore))

--- a/openquake/calculators/tests/scenario_damage_test.py
+++ b/openquake/calculators/tests/scenario_damage_test.py
@@ -58,13 +58,13 @@ RM       4,000
 *ALL*    6,000    
 ======== =========''', got)
 
-        # test aggdamages, 1 realization x 3 damage states
-        [dmg] = extract(self.calc.datastore, 'aggdamages/structural?'
+        # test agg_damages, 1 realization x 3 damage states
+        [dmg] = extract(self.calc.datastore, 'agg_damages/structural?'
                         'taxonomy=RC&CRESTA=01.1')
         numpy.testing.assert_almost_equal(
             [998.6327515, 720.0072021, 281.3600769], dmg)
         # test no intersection
-        dmg = extract(self.calc.datastore, 'aggdamages/structural?'
+        dmg = extract(self.calc.datastore, 'agg_damages/structural?'
                       'taxonomy=RM&CRESTA=01.1')
         self.assertEqual(len(dmg), 0)
 
@@ -73,7 +73,7 @@ RM       4,000
         # this is a case with more hazard sites than exposure sites
         test_dir = os.path.dirname(case_1c.__file__)
         self.run_calc(test_dir, 'job.ini', exports='csv')
-        total = extract(self.calc.datastore, 'aggdamages/structural')
+        total = extract(self.calc.datastore, 'agg_damages/structural')
         aae([[0.4799988, 0.3537988, 0.0655346, 0.018449, 0.0822188]],
             total)  # shape (R, D) = (1, 5)
 
@@ -133,7 +133,7 @@ RM       4,000
     def test_case_5a(self):
         # this is a case with two gsims and one asset
         self.assert_ok(case_5a, 'job_haz.ini,job_risk.ini')
-        dmg = extract(self.calc.datastore, 'aggdamages/structural?taxonomy=*')
+        dmg = extract(self.calc.datastore, 'agg_damages/structural?taxonomy=*')
         tmpname = write_csv(None, dmg)  # shape (T, R, D) == (1, 2, 5)
         self.assertEqualFiles('expected/dmg_by_taxon.csv', tmpname)
 
@@ -141,7 +141,7 @@ RM       4,000
     def test_case_6(self):
         # this is a case with 5 assets on the same point
         self.assert_ok(case_6, 'job_h.ini,job_r.ini')
-        dmg = extract(self.calc.datastore, 'aggdamages/structural?taxonomy=*')
+        dmg = extract(self.calc.datastore, 'agg_damages/structural?taxonomy=*')
         tmpname = write_csv(None, dmg)  # shape (T, R, D) == (5, 1, 5)
         self.assertEqualFiles('expected/dmg_by_taxon.csv', tmpname)
 

--- a/openquake/calculators/tests/scenario_risk_test.py
+++ b/openquake/calculators/tests/scenario_risk_test.py
@@ -87,11 +87,11 @@ class ScenarioRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/losses_by_asset.csv', fname)
 
         # test agglosses
-        tot = extract(self.calc.datastore, 'agglosses/occupants')
+        tot = extract(self.calc.datastore, 'agg_losses/occupants')
         aac(tot.array, [0.028281], atol=1E-5)
 
         # test agglosses with *
-        tbl = extract(self.calc.datastore, 'agglosses/occupants?taxonomy=*')
+        tbl = extract(self.calc.datastore, 'agg_losses/occupants?taxonomy=*')
         self.assertEqual(tbl.array.shape, (1, 1))  # 1 taxonomy, 1 rlz
 
     @attr('qa', 'risk', 'scenario_risk')
@@ -185,14 +185,14 @@ class ScenarioRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/realizations.csv', fname)
 
         # check losses by taxonomy
-        agglosses = extract(self.calc.datastore, 'agglosses/structural?'
+        agglosses = extract(self.calc.datastore, 'agg_losses/structural?'
                             'taxonomy=*').array  # shape (T, R) = (3, 2)
         aac(agglosses, [[1981.4681, 2363.5803],
                         [712.8535, 924.75616],
                         [986.7066, 1344.0371]])
 
         # extract agglosses with a * and a selection
-        obj = extract(self.calc.datastore, 'agglosses/structural?'
+        obj = extract(self.calc.datastore, 'agg_losses/structural?'
                       'state=*&cresta=0.11')
         self.assertEqual(obj.selected, [b'state=*', b'cresta=0.11'])
         self.assertEqual(obj.tags, [b'state=01'])
@@ -213,7 +213,7 @@ class ScenarioRiskTestCase(CalculatorTestCase):
         # a complex scenario_risk from GMFs where the hazard sites are
         # not in the asset locations
         self.run_calc(case_8.__file__, 'job.ini')
-        agglosses = extract(self.calc.datastore, 'agglosses/structural')
+        agglosses = extract(self.calc.datastore, 'agg_losses/structural')
         aac(agglosses.array, [984065.75])
 
         # make sure the fullreport can be extracted
@@ -223,7 +223,7 @@ class ScenarioRiskTestCase(CalculatorTestCase):
     def test_case_9(self):
         # using gmfs.xml
         self.run_calc(case_9.__file__, 'job.ini')
-        agglosses = extract(self.calc.datastore, 'agglosses/structural')
+        agglosses = extract(self.calc.datastore, 'agg_losses/structural')
         aac(agglosses.array, [7306.7124])
 
     @attr('qa', 'risk', 'scenario_risk')

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -78,6 +78,22 @@ class CostCalculator(object):
         # this should never happen
         raise RuntimeError('Unable to compute cost')
 
+    def get_units(self, loss_types):
+        """
+        :param: a list of loss types
+        :returns: an array of units as byte strings, suitable for HDF5
+        """
+        lst = []
+        for lt in loss_types:
+            if lt.endswith('_ins'):
+                lt = lt[:-4]
+            if lt == 'occupants':
+                unit = 'people'
+            else:
+                unit = self.units[lt]
+            lst.append(encode(unit))
+        return numpy.array(lst)
+
     def __toh5__(self):
         loss_types = sorted(self.cost_types)
         dt = numpy.dtype([('cost_type', hdf5.vstr),
@@ -99,6 +115,7 @@ class CostCalculator(object):
 
     def __repr__(self):
         return '<%s %s>' % (self.__class__.__name__, vars(self))
+
 
 costcalculator = CostCalculator(
     cost_types=dict(structural='per_area'),
@@ -398,17 +415,7 @@ class AssetCollection(object):
         :param: a list of loss types
         :returns: an array of units as byte strings, suitable for HDF5
         """
-        units = self.cost_calculator.units
-        lst = []
-        for lt in loss_types:
-            if lt.endswith('_ins'):
-                lt = lt[:-4]
-            if lt == 'occupants':
-                unit = 'people'
-            else:
-                unit = units[lt]
-            lst.append(encode(unit))
-        return numpy.array(lst)
+        return self.cost_calculator.get_units(loss_types)
 
     def assets_by_site(self):
         """

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -410,13 +410,6 @@ class AssetCollection(object):
         """
         return self.array['taxonomy']
 
-    def units(self, loss_types):
-        """
-        :param: a list of loss types
-        :returns: an array of units as byte strings, suitable for HDF5
-        """
-        return self.cost_calculator.get_units(loss_types)
-
     def assets_by_site(self):
         """
         :returns: numpy array of lists with the assets by each site

--- a/openquake/server/tests/tests.py
+++ b/openquake/server/tests/tests.py
@@ -164,7 +164,7 @@ class EngineServerTestCase(unittest.TestCase):
 
         # check avg_losses-rlzs
         resp = self.c.get(
-            extract_url + 'agglosses/structural?taxonomy=W-SLFB-1')
+            extract_url + 'agg_losses/structural?taxonomy=W-SLFB-1')
         data = b''.join(ln for ln in resp.streaming_content)
         got = numpy.load(io.BytesIO(data))  # load npz file
         self.assertEqual(len(got['array']), 1)  # expected 1 aggregate value
@@ -172,7 +172,7 @@ class EngineServerTestCase(unittest.TestCase):
 
         # check *-aggregation
         resp = self.c.get(
-            extract_url + 'agglosses/structural?taxonomy=*')
+            extract_url + 'agg_losses/structural?taxonomy=*')
         data = b''.join(ln for ln in resp.streaming_content)
         got = numpy.load(io.BytesIO(data))  # load npz file
         self.assertEqual(len(got['tags']), 6)  # expected 6 taxonomies

--- a/openquake/server/tests/tests.py
+++ b/openquake/server/tests/tests.py
@@ -179,12 +179,15 @@ class EngineServerTestCase(unittest.TestCase):
         self.assertEqual(len(got['array']), 6)  # expected 6 aggregates
         self.assertEqual(resp.status_code, 200)
 
-        # check agg_curves, there is a single realization
+        # check agg_curves with a single realization
+        # the case with multiple rlzs is tested in event_based_risk/case_master
         resp = self.c.get(
             extract_url + 'agg_curves/structural?taxonomy=*')
         data = b''.join(ln for ln in resp.streaming_content)
         got = numpy.load(io.BytesIO(data))  # load npz file
-        # import pdb; pdb.set_trace()
+        self.assertEqual(list(got['stats']), [b'mean'])
+        self.assertEqual(list(got['return_periods']), [2, 5, 10, 20, 50])
+        self.assertEqual(list(got['units']), [b'EUR'])
 
         # there is some logic in `core.export_from_db` that it is only
         # exercised when the export fails

--- a/openquake/server/tests/tests.py
+++ b/openquake/server/tests/tests.py
@@ -179,7 +179,12 @@ class EngineServerTestCase(unittest.TestCase):
         self.assertEqual(len(got['array']), 6)  # expected 6 aggregates
         self.assertEqual(resp.status_code, 200)
 
-        # TODO: check aggcurves
+        # check agg_curves, there is a single realization
+        resp = self.c.get(
+            extract_url + 'agg_curves/structural?taxonomy=*')
+        data = b''.join(ln for ln in resp.streaming_content)
+        got = numpy.load(io.BytesIO(data))  # load npz file
+        # import pdb; pdb.set_trace()
 
         # there is some logic in `core.export_from_db` that it is only
         # exercised when the export fails


### PR DESCRIPTION
This should help Paolo on the QGIS side, to visualize aggregate loss curves.Also, at Paolo's request, I am renaming the URLs agglosses->agg_losses and aggdamages->agg_damages for consistency with agg_curves.