### PR TITLE
Added a tooltip with the size of the datastore in the webUI

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
+  [Michele Simionato]
+  * Saved the size of the datastore in the database and used it in the WebUI
+
   [Graeme Weatherill]
   * Adds geotechnical related IMTs
-  
+
   [Michele Simionato]
   * Renamed /extract/agglosses -> /extract/agg_losses and same for aggdamages
   * Supported equivalent epicentral distance with a `reqv_hdf5` file

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -50,6 +50,7 @@ OQ_API = 'https://api.openquake.org'
 TERMINATE = config.distribution.terminate_workers_on_revoke
 OQ_DISTRIBUTE = parallel.oq_distribute()
 
+MB = 1024 ** 2
 _PID = os.getpid()  # the PID
 _PPID = os.getppid()  # the controlling terminal PID
 
@@ -123,11 +124,6 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
     rlzs = dstore['csm_info'].rlzs
     if len(rlzs) > 1:
         dskeys.add('realizations')
-    # expose gmf_data only if < 10 MB
-    if calcmode == 'event_based':
-        nbytes = dstore['gmf_data'].attrs['nbytes']
-        if nbytes < 10 * 1024 ** 2:  # expose only small GMFs
-            dskeys.add('gmf_data')
     if 'scenario' not in calcmode:  # export sourcegroups.csv
         dskeys.add('sourcegroups')
     hdf5 = dstore.hdf5
@@ -161,11 +157,12 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
     keysize = []
     for key in sorted(dskeys & exportable):
         try:
-            size_mb = dstore.get_attr(key, 'nbytes') / 1024 ** 2
+            size_mb = dstore.get_attr(key, 'nbytes') / MB
         except KeyError:
             size_mb = None
         keysize.append((key, size_mb))
-    logs.dbcmd('create_outputs', dstore.calc_id, keysize)
+    ds_size = os.path.getsize(dstore.hdf5path) / MB
+    logs.dbcmd('create_outputs', dstore.calc_id, keysize, ds_size)
 
 
 class MasterKilled(KeyboardInterrupt):

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -302,17 +302,19 @@ for key in DISPLAY_NAME:
     assert key in dic, key
 
 
-def create_outputs(db, job_id, keysize):
+def create_outputs(db, job_id, keysize, ds_size):
     """
     Build a correspondence between the outputs in the datastore and the
-    ones in the database.
+    ones in the database. Also, update the datastore size in the job table.
 
     :param db: a :class:`openquake.server.dbapi.Db` instance
     :param job_id: ID of the current job
-    :param dskeys: a list of datastore keys
+    :param keysize: a list of pairs (key, size_mb)
+    :param ds_size: total datastore size in MB
     """
     rows = [(job_id, DISPLAY_NAME.get(key, key), key, size)
             for key, size in keysize]
+    db('UPDATE job SET size_mb=?x WHERE id=?x', ds_size, job_id)
     db.insert('output', 'oq_job_id display_name ds_key size_mb'.split(), rows)
 
 

--- a/openquake/server/db/schema/upgrades/0004-job.py
+++ b/openquake/server/db/schema/upgrades/0004-job.py
@@ -1,0 +1,30 @@
+# due to a sqlite3.DatabaseError:
+# malformed database schema (job) - near "NU": syntax error
+# we need to do this instead of a simple
+# ALTER TABLE job ADD COLUMN size_mb FLOAT
+
+job_sql = '''CREATE TABLE job(
+     id INTEGER PRIMARY KEY AUTOINCREMENT,
+     description TEXT NOT NULL,
+     user_name TEXT NOT NULL,
+     calculation_mode TEXT NOT NULL,
+     hazard_calculation_id INTEGER REFERENCES job (id) ON DELETE CASCADE,
+     status TEXT NOT NULL DEFAULT 'created',
+     is_running BOOL NOT NULL DEFAULT 1,
+     start_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     stop_time TIMESTAMP,
+     relevant BOOL NOT NULL DEFAULT 1,
+     ds_calc_dir TEXT NOT NULL,
+     pid INTEGER NOT NULL DEFAULT 0,
+     size_mb FLOAT
+     )'''
+
+
+def upgrade(conn, job_sql=job_sql):
+    version, = conn.execute('PRAGMA schema_version').fetchone()
+    conn.execute('PRAGMA writable_schema=ON')
+    conn.execute("UPDATE sqlite_master SET sql=?"
+                 "WHERE type='table' AND name='job'", (job_sql,))
+    conn.execute('PRAGMA schema_version=%s' % (version + 1))
+    conn.execute('PRAGMA writable_schema=OFF')
+    conn.execute('PRAGMA integrity_check')

--- a/openquake/server/db/schema/upgrades/0004-job.sql
+++ b/openquake/server/db/schema/upgrades/0004-job.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job ADD COLUMN size_mb FLOAT;

--- a/openquake/server/db/schema/upgrades/0004-job.sql
+++ b/openquake/server/db/schema/upgrades/0004-job.sql
@@ -1,1 +1,0 @@
-ALTER TABLE job ADD COLUMN size_mb FLOAT;

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -11,7 +11,7 @@
               <div id="my-outputs" class="well"></div>
               <div id="my-datastore">
                 <a href="/v1/calc/{{ calc_id }}/datastore"
-                   title="Size: {{ ds_size }}" class="btn btn-sm">
+                   title="Size: {{ size_mb }} MB" class="btn btn-sm">
                   Download hdf5 datastore</a>
               </div>
           </div>

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -11,7 +11,7 @@
               <div id="my-outputs" class="well"></div>
               <div id="my-datastore">
                 <a href="/v1/calc/{{ calc_id }}/datastore"
-                   title="Size: {{ ds_size}}" class="btn btn-sm">
+                   title="Size: {{ ds_size }}" class="btn btn-sm">
                   Download hdf5 datastore</a>
               </div>
           </div>

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -10,7 +10,9 @@
               <h2>Outputs from calculation {{ calc_id }}</h2>
               <div id="my-outputs" class="well"></div>
               <div id="my-datastore">
-                  <a href="/v1/calc/{{ calc_id }}/datastore" class="btn btn-sm">Download hdf5 datastore</a>
+                <a href="/v1/calc/{{ calc_id }}/datastore"
+                   title="Size: {{ ds_size}}" class="btn btn-sm">
+                  Download hdf5 datastore</a>
               </div>
           </div>
         </div>

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -755,8 +755,9 @@ def web_engine(request, **kwargs):
 @require_http_methods(['GET'])
 def web_engine_get_outputs(request, calc_id, **kwargs):
     job = logs.dbcmd('get_job', calc_id)
+    size_mb = 'unknown' if job.size_mb is None else '%.2f' % job.size_mb
     return render(request, "engine/get_outputs.html",
-                  dict(calc_id=calc_id, size_mb='%.2f' % job.size_mb))
+                  dict(calc_id=calc_id, size_mb=size_mb))
 
 
 @csrf_exempt

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -755,7 +755,7 @@ def web_engine(request, **kwargs):
 @require_http_methods(['GET'])
 def web_engine_get_outputs(request, calc_id, **kwargs):
     job = logs.dbcmd('get_job', calc_id)
-    size_mb = 'unknown' if job.size_mb is None else '%.2f' % job.size_mb
+    size_mb = '?' if job.size_mb is None else '%.2f' % job.size_mb
     return render(request, "engine/get_outputs.html",
                   dict(calc_id=calc_id, size_mb=size_mb))
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -42,7 +42,7 @@ from django.views.decorators.http import require_http_methods
 from django.shortcuts import render
 
 from openquake.baselib import datastore
-from openquake.baselib.general import groupby, gettemp
+from openquake.baselib.general import groupby, gettemp, humansize
 from openquake.baselib.parallel import safely_call
 from openquake.hazardlib import nrml, gsim
 
@@ -754,8 +754,10 @@ def web_engine(request, **kwargs):
 @cross_domain_ajax
 @require_http_methods(['GET'])
 def web_engine_get_outputs(request, calc_id, **kwargs):
+    job = logs.dbcmd('get_job', calc_id)
+    ds_size = humansize(os.path.getsize(job.ds_calc_dir + '.hdf5'))
     return render(request, "engine/get_outputs.html",
-                  dict([('calc_id', calc_id)]))
+                  dict(calc_id=calc_id, ds_size=ds_size))
 
 
 @csrf_exempt

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -42,7 +42,7 @@ from django.views.decorators.http import require_http_methods
 from django.shortcuts import render
 
 from openquake.baselib import datastore
-from openquake.baselib.general import groupby, gettemp, humansize
+from openquake.baselib.general import groupby, gettemp
 from openquake.baselib.parallel import safely_call
 from openquake.hazardlib import nrml, gsim
 
@@ -755,9 +755,8 @@ def web_engine(request, **kwargs):
 @require_http_methods(['GET'])
 def web_engine_get_outputs(request, calc_id, **kwargs):
     job = logs.dbcmd('get_job', calc_id)
-    ds_size = humansize(os.path.getsize(job.ds_calc_dir + '.hdf5'))
     return render(request, "engine/get_outputs.html",
-                  dict(calc_id=calc_id, ds_size=ds_size))
+                  dict(calc_id=calc_id, size_mb='%.2f' % job.size_mb))
 
 
 @csrf_exempt


### PR DESCRIPTION
It is good to know the size before attempting to download the datastore. I am storing the size in the job table, so it becomes easy to make queries to see who are the users taking more disk space.

