### PR TITLE
Removed the dynamic parent concept

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -117,7 +117,6 @@ class BaseCalculator(metaclass=abc.ABCMeta):
     """
     from_engine = False  # set by engine.run_calc
     is_stochastic = False  # True for scenario and event based calculators
-    dynamic_parent = None
 
     def __init__(self, oqparam, calc_id=None):
         self.datastore = datastore.DataStore(calc_id)
@@ -438,12 +437,10 @@ class HazardCalculator(BaseCalculator):
                     'The parent calculation was using minimum_intensity=%s'
                     ' != %s' % (oqp.minimum_intensity, oq.minimum_intensity))
         elif pre_calculator:
-            calc = calculators[pre_calculator](self.oqparam)
+            calc = calculators[pre_calculator](self.oqparam,
+                                               self.datastore.calc_id)
             calc.run(close=False)
             self.set_log_format()
-            self.dynamic_parent = self.datastore.parent = calc.datastore
-            self.oqparam.hazard_calculation_id = self.dynamic_parent.calc_id
-            self.datastore['oqparam'] = self.oqparam
             self.param = calc.param
             self.sitecol = calc.sitecol
             self.assetcol = calc.assetcol

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -437,10 +437,9 @@ class HazardCalculator(BaseCalculator):
                     'The parent calculation was using minimum_intensity=%s'
                     ' != %s' % (oqp.minimum_intensity, oq.minimum_intensity))
         elif pre_calculator:
-            calc = calculators[pre_calculator](self.oqparam,
-                                               self.datastore.calc_id)
-            calc.run(close=False)
-            self.set_log_format()
+            calc = calculators[pre_calculator](
+                self.oqparam, self.datastore.calc_id)
+            calc.run()
             self.param = calc.param
             self.sitecol = calc.sitecol
             self.assetcol = calc.assetcol
@@ -765,7 +764,7 @@ class RiskCalculator(HazardCalculator):
                 getter = PmapGetter(dstore, self.rlzs_assoc, sids)
                 getter.num_rlzs = self.R
             else:  # gmf
-                getter = GmfDataGetter(dstore, sids, self.R, num_events,
+                getter = GmfDataGetter(dstore, sids, self.R,
                                        self.oqparam.imtls)
             if dstore is self.datastore:
                 # read the hazard data in the controller node

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -155,9 +155,9 @@ class EbrCalculator(base.RiskCalculator):
     def pre_execute(self):
         oq = self.oqparam
         super().pre_execute('event_based')
-        parent = self.dynamic_parent
+        parent = self.datastore.parent
         if not self.oqparam.ground_motion_fields:
-            return  # this happens in the reportwrite
+            return  # this happens in the reportwriter
 
         self.L = len(self.riskmodel.lti)
         self.T = len(self.assetcol.tagcol)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -208,11 +208,10 @@ class GmfDataGetter(collections.Mapping):
     """
     A dictionary-like object {sid: dictionary by realization index}
     """
-    def __init__(self, dstore, sids, num_rlzs, num_events, imtls):
+    def __init__(self, dstore, sids, num_rlzs, imtls):
         self.dstore = dstore
         self.sids = sids
         self.num_rlzs = num_rlzs
-        self.E = num_events
         self.imtls = imtls
 
     def init(self):

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -109,8 +109,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         os.remove(fname)
 
         # test the composite_risk_model keys (i.e. slash escaping)
-        parent = self.calc.datastore.parent
-        crm = sorted(parent.getitem('composite_risk_model'))
+        crm = sorted(self.calc.datastore.getitem('composite_risk_model'))
         self.assertEqual(crm, ['RC%2B', 'RM', 'W%2F1'])
 
         # test the case when all GMFs are filtered out

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -344,8 +344,6 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
                      hazard_calculation_id=hazard_calculation_id,
                      close=False, **kw)  # don't close the datastore too soon
             logs.LOG.info('Exposing the outputs to the database')
-            if calc.dynamic_parent:
-                expose_outputs(calc.dynamic_parent)
             expose_outputs(calc.datastore)
             duration = time.time() - t0
             calc._monitor.flush()

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -278,7 +278,7 @@ class CompositeRiskModel(collections.Mapping):
                                     for imt in imt_lt]
                         elif not haz:  # no hazard for this site
                             eids = []
-                            data = [(numpy.zeros(hazard_getter.E),
+                            data = [(numpy.zeros(len(hazard_getter.eids)),
                                      hazard_getter.eids) for imt in imt_lt]
                         else:  # classical
                             eids = hazard_getter.eids


### PR DESCRIPTION
Currently, an event based risk calculation without a parent dynamically generates a parent with an higher calculation ID. This is confusing to the user. We are already telling people to split calculations in hazard part + risk part, so it is acceptable if there is penalty for people not doing that (the penalty is the large data transfer). There is always the hope that the SWMR mode will make it possible to run efficiently a calculation with a single datastore.