### PR TITLE
Update the documentation for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: python
 
 python:
- - "3.5"
+ - "3.6"
 
 # FIXME temporarily disable cache
 # cache:
@@ -31,7 +31,7 @@ jobs:
         - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commands
         - oq webui migrate
-    after_success:  # old sphinx does not work well with Python 3.5.4
+    after_success:  # old sphinx does not work well with Python 3.5.4+
         - pip install sphinx==1.6.5 && cd doc/sphinx && make html
     after_script:
         - oq dbserver stop
@@ -65,7 +65,7 @@ install:
   # to download the wheels first, put the folder in cache and then install the wheels from there.
   # A second run of 'pip download' will download only the missing wheels.
   - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip wheels\]'; then
-      pip -q download -r requirements-py35-linux64.txt -d wheels &&
+      pip -q download -r requirements-py36-linux64.txt -d wheels &&
       pip -q install wheels/* ;
     fi
   - pip -q install -e .

--- a/debian/control
+++ b/debian/control
@@ -2,28 +2,28 @@ Source: python3-oq-engine
 Section: python
 Priority: extra
 Maintainer: Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>
-Build-Depends: debhelper (>= 7.0.50~), lsb-release, quilt, oq-python3.5, zip, dh-python
+Build-Depends: debhelper (>= 7.0.50~), lsb-release, quilt, oq-python3.6, zip, dh-python
 Standards-Version: 3.9.3
-X-Python3-Version: >= 3.5
+X-Python3-Version: >= 3.6
 Homepage: http://github.com/gem/oq-engine
 
 Package: python3-oq-engine
 Architecture: all
-X-Python-Version: >= 3.5
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, python3-oq-libs (>=2.0.0~), supervisor (>=3.0b2-1~)
+X-Python-Version: >= 3.6
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, python3-oq-libs (>=2.2.0~), supervisor (>=3.0b2-1~)
 Conflicts: python-noq, python-oq, python-nhlib
 Replaces: python-oq-risklib, python-oq-hazardlib, python-oq-engine (<< ${binary:Version})
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-breaks
 Breaks: python-oq-risklib, python-oq-hazardlib, python-oq-engine (<< ${binary:Version})
 Recommends: ${dist:Recommends}
-Suggests: python3-oq-libs-extra (>= 2.0.0~)
+Suggests: python3-oq-libs-extra (>= 2.2.0~)
 Description: computes seismic hazard and physical risk
  based on the hazard and risk libraries developed by the GEM foundation
  (http://www.globalquakemodel.org/)
 
 Package: python3-oq-engine-master
 Architecture: all
-X-Python-Version: >= 3.5
+X-Python-Version: >= 3.6
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, rabbitmq-server (>=2.8.0-2~gem02), python3-oq-engine (= ${binary:Version})
 Replaces: python-oq-risklib, python-oq-hazardlib, python-oq-engine-master (<< ${binary:Version})
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-breaks
@@ -35,7 +35,7 @@ Description: computes seismic hazard and physical risk
 
 Package: python3-oq-engine-worker
 Architecture: all
-X-Python-Version: >= 3.5
+X-Python-Version: >= 3.6
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, supervisor (>=3.0b2-1~), python3-oq-engine (= ${binary:Version})
 Replaces: python-oq-risklib, python-oq-hazardlib, python-oq-engine-worker (<< ${binary:Version})
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-breaks

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -127,21 +127,21 @@ A more detailed stack trace:
 
 ```python
 Traceback (most recent call last):
-  File "/opt/openquake/lib/python3.5/site-packages/kombu/utils/functional.py", line 333, in retry_over_time
+  File "/opt/openquake/lib/python3.6/site-packages/kombu/utils/functional.py", line 333, in retry_over_time
     return fun(*args, **kwargs)
-  File "/opt/openquake/lib/python3.5/site-packages/kombu/connection.py", line 261, in connect
+  File "/opt/openquake/lib/python3.6/site-packages/kombu/connection.py", line 261, in connect
     return self.connection
-  File "/opt/openquake/lib/python3.5/site-packages/kombu/connection.py", line 802, in connection
+  File "/opt/openquake/lib/python3.6/site-packages/kombu/connection.py", line 802, in connection
     self._connection = self._establish_connection()
-  File "/opt/openquake/lib/python3.5/site-packages/kombu/connection.py", line 757, in _establish_connection
+  File "/opt/openquake/lib/python3.6/site-packages/kombu/connection.py", line 757, in _establish_connection
     conn = self.transport.establish_connection()
-  File "/opt/openquake/lib/python3.5/site-packages/kombu/transport/pyamqp.py", line 130, in establish_connection
+  File "/opt/openquake/lib/python3.6/site-packages/kombu/transport/pyamqp.py", line 130, in establish_connection
     conn.connect()
-  File "/opt/openquake/lib/python3.5/site-packages/amqp/connection.py", line 282, in connect
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/connection.py", line 282, in connect
     self.transport.connect()
-  File "/opt/openquake/lib/python3.5/site-packages/amqp/transport.py", line 109, in connect
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/transport.py", line 109, in connect
     self._connect(self.host, self.port, self.connect_timeout)
-  File "/opt/openquake/lib/python3.5/site-packages/amqp/transport.py", line 150, in _connect
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/transport.py", line 150, in _connect
     self.sock.connect(sa)
 ConnectionRefusedError: [Errno 111] Connection refused
 ```
@@ -155,52 +155,48 @@ It may also mean that an incompatible version of Celery is used. Please check it
 
 ***
 
-### error: [Errno 104] Connection reset by peer
+### error: [Errno 104] Connection reset by peer _or_ (403) ACCESS_REFUSED
 
-A more detailed stack trace:
+More detailed stack traces:
+
 
 ```python
 Traceback (most recent call last):
-  File "/opt/openquake/lib/python3.5/dist-packages/celery/worker/__init__.py", line 206, in start
-    self.blueprint.start(self)
-  File "/opt/openquake/lib/python3.5/dist-packages/celery/bootsteps.py", line 119, in start
-    self.on_start()
-  File "/opt/openquake/lib/python3.5/dist-packages/celery/apps/worker.py", line 165, in on_start
-    self.purge_messages()
-  File "/opt/openquake/lib/python3.5/dist-packages/celery/apps/worker.py", line 189, in purge_messages
-    count = self.app.control.purge()
-  File "/opt/openquake/lib/python3.5/dist-packages/celery/app/control.py", line 145, in purge
-    return self.app.amqp.TaskConsumer(conn).purge()
-  File "/opt/openquake/lib/python3.5/dist-packages/celery/app/amqp.py", line 375, in __init__
-    **kw
-  File "/opt/openquake/lib/python3.5/dist-packages/kombu/messaging.py", line 364, in __init__
-    self.revive(self.channel)
-  File "/opt/openquake/lib/python3.5/dist-packages/kombu/messaging.py", line 369, in revive
-    channel = self.channel = maybe_channel(channel)
-  File "/opt/openquake/lib/python3.5/dist-packages/kombu/connection.py", line 1054, in maybe_channel
-    return channel.default_channel
-  File "/opt/openquake/lib/python3.5/dist-packages/kombu/connection.py", line 756, in default_channel
-    self.connection
-  File "/opt/openquake/lib/python3.5/dist-packages/kombu/connection.py", line 741, in connection
-    self._connection = self._establish_connection()
-  File "/opt/openquake/lib/python3.5/dist-packages/kombu/connection.py", line 696, in _establish_connection
-    conn = self.transport.establish_connection()
-  File "/opt/openquake/lib/python3.5/dist-packages/kombu/transport/pyamqp.py", line 116, in establish_connection
-    conn = self.Connection(**opts)
-  File "/opt/openquake/lib/python3.5/dist-packages/amqp/connection.py", line 180, in __init__
+  [...]
+  File "/opt/openquake/lib/python3.6/dist-packages/amqp/connection.py", line 180, in __init__
     (10, 30),  # tune
-  File "/opt/openquake/lib/python3.5/dist-packages/amqp/abstract_channel.py", line 67, in wait
+  File "/opt/openquake/lib/python3.6/dist-packages/amqp/abstract_channel.py", line 67, in wait
     self.channel_id, allowed_methods, timeout)
-  File "/opt/openquake/lib/python3.5/dist-packages/amqp/connection.py", line 241, in _wait_method
+  File "/opt/openquake/lib/python3.6/dist-packages/amqp/connection.py", line 241, in _wait_method
     channel, method_sig, args, content = read_timeout(timeout)
-  File "/opt/openquake/lib/python3.5/dist-packages/amqp/connection.py", line 330, in read_timeout
+  File "/opt/openquake/lib/python3.6/dist-packages/amqp/connection.py", line 330, in read_timeout
     return self.method_reader.read_method()
-  File "/opt/openquake/lib/python3.5/dist-packages/amqp/method_framing.py", line 189, in read_method
+  File "/opt/openquake/lib/python3.6/dist-packages/amqp/method_framing.py", line 189, in read_method
     raise m
 error: [Errno 104] Connection reset by peer
 ```
 
-This means that RabbiMQ _user_ and _vhost_ have not been created or set correctly. Please refer to [cluster documentation](installing/cluster.md#rabbitmq) to fix it.
+```python
+Traceback (most recent call last):
+  [...]
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/connection.py", line 288, in connect
+    self.drain_events(timeout=self.connect_timeout)
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/connection.py", line 471, in drain_events
+    while not self.blocking_read(timeout):
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/connection.py", line 477, in blocking_read
+    return self.on_inbound_frame(frame)
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/method_framing.py", line 55, in on_frame
+    callback(channel, method_sig, buf, None)
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/connection.py", line 481, in on_inbound_method
+    method_sig, payload, content,
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/abstract_channel.py", line 128, in dispatch_method
+    listener(*args)
+  File "/opt/openquake/lib/python3.6/site-packages/amqp/connection.py", line 603, in _on_close
+    (class_id, method_id), ConnectionError)
+amqp.exceptions.AccessRefused: (0, 0): (403) ACCESS_REFUSED - Login was refused using authentication mechanism AMQPLAIN. For details see the broker logfile.
+```
+
+These errors mean that RabbiMQ _user_ and _vhost_ have not been created or set correctly. Please refer to [cluster documentation](installing/cluster.md#rabbitmq) to fix it.
 
 ***
 

--- a/doc/installing/development.md
+++ b/doc/installing/development.md
@@ -1,4 +1,4 @@
-# Installing the OpenQuake Engine for development using Python 3.5
+# Installing the OpenQuake Engine for development using Python 3.6
 
 To develop with the OpenQuake Engine and Hazardlib an installation from sources must be performed.
 
@@ -6,10 +6,8 @@ The official supported distributions to develop the OpenQuake Engine and its lib
 
 ### Linux
 
-- Ubuntu 16.04 LTS (Xenial)
-- RedHat Enterprise Linux 7
-- CentOS 7
-- Scientific Linux 7
+- Ubuntu 18.04 LTS (Bionic)
+- RedHat Enterprise Linux 7 / CentOS 7 / Scientific Linux 7
 - Fedora 27/28
 
 This guide may work also on other Linux releases/distributions.
@@ -24,17 +22,17 @@ This guide may work also on other Linux releases/distributions.
 
 Knowledge of [Python](https://www.python.org/) (and its virtual environments), [git](https://git-scm.com/) and [software development](https://xkcd.com/844/) are required.
 
-Some software prerequisites are needed to build the development environment. Python 3.5 is used in this guide.
+Some software prerequisites are needed to build the development environment. Python 3.6 or greater is required.
 
 ### Ubuntu
 
 ```bash
-sudo apt install git python3.5 python3.5-venv python3-pip
+sudo apt install git python3.6 python3.6-venv python3-pip
 ```
 
 ### RedHat and clones
 
-On RedHat and its clones (CentOS/SL) Python 3.5 isn't available in the standard repositories, but it can be installed via [RedHat Software Collections](https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html-single/Software_Collections_Guide/).
+On RedHat and its clones (CentOS/SL) Python 3.6 isn't available in the standard repositories, but it can be installed via [RedHat Software Collections](https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html-single/Software_Collections_Guide/).
 
 ```bash
 ## RedHat
@@ -43,8 +41,8 @@ sudo yum install git scl-utils scl-utils-build
 ## CentOS/SL
 sudo yum install git centos-release-scl
 
-sudo yum install rh-python35
-scl enable rh-python35 bash
+sudo yum install rh-python36
+scl enable rh-python36 bash
 ```
 
 ### Fedora
@@ -90,7 +88,7 @@ mkdir $HOME/openquake && cd $HOME/openquake
 then build a development environment using python *virtualenv*
 
 ```bash
-python3.5 -m venv oqenv
+python3.6 -m venv oqenv
 source oqenv/bin/activate
 ```
 
@@ -115,12 +113,12 @@ It's strongly recommended to install Python dependencies using our Python wheels
 
 ```bash
 # For Linux
-pip install -r oq-engine/requirements-py35-linux64.txt
+pip install -r oq-engine/requirements-py36-linux64.txt
 ```
 
 ```bash
 # For macOS
-pip install -r oq-engine/requirements-py35-macos.txt
+pip install -r oq-engine/requirements-py36-macos.txt
 ```
 
 ```bash

--- a/doc/installing/development.md
+++ b/doc/installing/development.md
@@ -66,7 +66,7 @@ If Xcode is already installed on your machine, then there is no need to install 
 
 #### Python
 
-You need to download Python from [python.org](https://python.org): https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg
+You need to download Python from [python.org](https://python.org): https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.9.pkg
 
 #### Encoding
 

--- a/doc/installing/docker.md
+++ b/doc/installing/docker.md
@@ -11,7 +11,7 @@ For more information about operating system support (which includes Linux, macOS
 
 Each container includes:
 
-- Python 3.5
+- Python 3.6
 - Python dependencies (numpy, scipy, h5py...)
 - OpenQuake Engine and Hazardlib
 - The `oq` command line tool

--- a/doc/installing/linux-generic.md
+++ b/doc/installing/linux-generic.md
@@ -2,7 +2,7 @@
 
 The OpenQuake Engine is also available in the form of **self-installable binary distribution**.
 This way of installing OpenQuake is strongly suggested for old versions of Linux which
-do not ship with Python 3.5 (like RHEL/CentOS/SL 6), or for users that do not have
+do not ship with Python 3.6 (like RHEL/CentOS/SL 6), or for users that do not have
 administrator privileges (they cannot run `sudo` or `su`).
 
 ### Differences with packages for Ubuntu and RedHat
@@ -11,8 +11,7 @@ This distribution has some differences with the packages we provide for Ubuntu a
 
 - includes its own distribution of the dependencies needed by the OpenQuake Engine
     - OpenSSL 1.0
-    - HDF5 1.8
-    - Python 3.5
+    - Python 3.6
     - Python dependencies (pip, numpy, scipy, h5py, django, shapely, rtree and few more)
 - can be installed without `root` permission (i.e. in the user home)
 - multiple versions can be installed alongside

--- a/doc/installing/macos.md
+++ b/doc/installing/macos.md
@@ -17,9 +17,9 @@ Requirements are:
 - 4 GB of RAM (8 GB recommended)
 - 1.2 GB of free disk space
 - [Terminal](https://support.apple.com/guide/terminal/welcome) or [iTerm2](https://www.iterm2.com/) app
-- Python 3.6 (from https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.6.pkg)
+- Python 3.6 from [python.org](https://python.org)
 
-Before you can start you must have downloaded and installed [Python 3.6](https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.6.pkg).
+Before you can start you must have downloaded and installed [Python 3.6](https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.9.pkg).
 
 ## Install packages from the OpenQuake website
 

--- a/doc/installing/macos.md
+++ b/doc/installing/macos.md
@@ -2,7 +2,7 @@
 
 The OpenQuake Engine is available for macOS in the form of **self-installable binary distribution**.
 
-- this distribution uses Python 3.5 official installer provided by the Python Foundation (https://www.python.org/downloads/release/python-354/) and includes its own distribution of the dependencies needed by the OpenQuake Engine
+- this distribution uses Python 3.6 official installer provided by the Python Foundation (https://www.python.org/downloads/release/python-366/) and includes its own distribution of the dependencies needed by the OpenQuake Engine
     - pip, numpy, scipy, h5py, django, shapely, rtree and few more
 - can be installed without `root` permission (i.e. in the user home)
 - multiple versions can be installed alongside
@@ -17,9 +17,9 @@ Requirements are:
 - 4 GB of RAM (8 GB recommended)
 - 1.2 GB of free disk space
 - [Terminal](https://support.apple.com/guide/terminal/welcome) or [iTerm2](https://www.iterm2.com/) app
-- Python 3.5 (from https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg)
+- Python 3.6 (from https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.6.pkg)
 
-Before you can start you must have downloaded and installed [Python 3.5](https://www.python.org/ftp/python/3.5.4/python-3.5.4-macosx10.6.pkg).
+Before you can start you must have downloaded and installed [Python 3.6](https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.6.pkg).
 
 ## Install packages from the OpenQuake website
 

--- a/doc/installing/windows.md
+++ b/doc/installing/windows.md
@@ -3,7 +3,7 @@
 The OpenQuake Engine is available for Windows in the form of **self-installable binary distribution**.
 
 - this distribution includes its own distribution of the dependencies needed by the OpenQuake Engine
-    - Python 3.5
+    - Python 3.6
     - Python dependencies (pip, numpy, scipy, h5py, django, shapely, rtree and few more)
 - multiple versions can be installed alongside
 - currently does not support Celery (and will never do)

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -18,7 +18,7 @@ A 64bit operating system and 64bit capable hardware are required.
 
 ### Python dependencies
 
-Python 3.5 or Python 3.6.
+Python 3.6+
 
 See [setup.py](../setup.py) for a complete list of the Python dependencies.
 
@@ -28,7 +28,7 @@ Software  | Version(s)
 --------- | ----------
 RabbitMQ | 2.6 to 3.2
 libgeos | >= 3.2.2
-HDF5 | 1.8
+HDF5 | 1.10
 
 ***
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -523,6 +523,7 @@ class Starmap(object):
             cls(
                 _wakeup, [(.2, m) for _ in range(cls.pool._processes)]
             ).submit_all(logging.debug)
+            cls.task_ids = []
         elif distribute == 'threadpool' and not hasattr(cls, 'pool'):
             cls.pool = multiprocessing.dummy.Pool(poolsize)
         elif distribute == 'no' and hasattr(cls, 'pool'):

--- a/openquake/commands/__main__.py
+++ b/openquake/commands/__main__.py
@@ -31,7 +31,7 @@ PY_VER = sys.version_info[:3]
 if PY_VER < (3, 5):
     sys.exit('Python 3.5+ is required, you are using %s', sys.executable)
 elif PY_VER < (3, 6):
-    print('Warning: Python %s.%s.%s is deprecated. '
+    print('DeprecationWarning: Python %s.%s.%s is deprecated. '
           'Please upgrade to Python 3.6+' % PY_VER)
 
 # force cluster users to use `oq engine` so that we have centralized logs

--- a/openquake/commands/__main__.py
+++ b/openquake/commands/__main__.py
@@ -25,9 +25,14 @@ from openquake.baselib import sap
 from openquake.commonlib import __version__
 from openquake import commands
 
+PY_VER = sys.version_info[:3]
+
 # check for Python version
-if sys.version < '3.5':
+if PY_VER < (3, 5):
     sys.exit('Python 3.5+ is required, you are using %s', sys.executable)
+elif PY_VER < (3, 6):
+    print('Warning: Python %s.%s.%s is deprecated. '
+          'Please upgrade to Python 3.6+' % PY_VER)
 
 # force cluster users to use `oq engine` so that we have centralized logs
 if os.environ['OQ_DISTRIBUTE'] == 'celery' and 'run' in sys.argv:
@@ -44,6 +49,7 @@ def oq():
     parser = sap.compose(sap.Script.registry.values(),
                          prog='oq', version=__version__)
     parser.callfunc()
+
 
 if __name__ == '__main__':
     oq()

--- a/rpm/python3-oq-engine.spec.inc
+++ b/rpm/python3-oq-engine.spec.inc
@@ -57,7 +57,7 @@ Patch1: openquake.cfg.patch
 
 Requires(pre): shadow-utils
 
-Requires: oq-python3 python3-oq-libs >= 2.0.0
+Requires: oq-python3 python3-oq-libs >= 2.2.0
 Requires: sudo systemd
 
 BuildRequires: oq-python3 sed systemd zip


### PR DESCRIPTION
Also add a deprecation warning.

I would not add the deprecation warning to the `setup.py` since it is not propagated to the user (unless an hard fail is performed, see https://github.com/pypa/pip/issues/2933)

I would merge this just before the next release to avoid confusion between description and links to the installers. At least it should merged after everything else in #3864 has been completed.
Tests are green here: https://ci.openquake.org/job/zdevel_oq-engine/2794/