### PR TITLE
Cached sources_by_trt

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -180,7 +180,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 num_tasks += 1
                 num_sources += len(sg.sources)
         # NB: csm.get_sources_by_trt discards the mutex sources
-        for trt, sources in csm.get_sources_by_trt().items():
+        for trt, sources in csm.sources_by_trt.items():
             gsims = self.csm.info.gsim_lt.get_gsims(trt)
             for block in block_splitter(sources, maxweight, weight):
                 yield block, src_filter, gsims, param, monitor

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -28,7 +28,7 @@ import numpy
 from openquake.baselib import performance, hdf5
 from openquake.baselib.python3compat import decode
 from openquake.baselib.general import (
-    groupby, group_array, gettemp, AccumDict, random_filter)
+    groupby, group_array, gettemp, AccumDict, random_filter, cached_property)
 from openquake.hazardlib import (
     source, sourceconverter, probability_map, stats, contexts)
 from openquake.hazardlib.gsim.gmpe_table import GMPETable
@@ -805,7 +805,7 @@ class CompositeSourceModel(collections.Sequence):
         :returns: total weight of the source model
         """
         tot_weight = 0
-        for srcs in self.get_sources_by_trt().values():
+        for srcs in self.sources_by_trt.values():
             tot_weight += sum(map(weight, srcs))
         for grp in self.gen_mutex_groups():
             tot_weight += sum(map(weight, grp))
@@ -870,7 +870,8 @@ class CompositeSourceModel(collections.Sequence):
             raise RuntimeError('All sources were filtered away!')
         return sources
 
-    def get_sources_by_trt(self):
+    @cached_property
+    def sources_by_trt(self):
         """
         Build a dictionary TRT string -> sources. Sources of kind "mutex"
         (if any) are silently discarded.


### PR DESCRIPTION
This avoids calling the same method twice and getting a double log:
```
[#18613 INFO] Reduced 363531 sources to 332700 sources with unique IDs
[#18613 INFO] Using maxweight=160945
[#18613 INFO] Reduced 363531 sources to 332700 sources with unique IDs
```