### PR TITLE
Try to override a race condition during imports

### DIFF
--- a/openquake/calculators/export/__init__.py
+++ b/openquake/calculators/export/__init__.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-from openquake.baselib.general import import_all, CallableDict
+from openquake.baselib.general import CallableDict
 from openquake.commonlib.writers import write_csv
 
 
@@ -62,8 +62,6 @@ def keyfunc(ekey):
 export = CallableDict(keyfunc)
 
 export.from_db = False  # overridden when exporting from db
-
-import_all('openquake.calculators.export')
 
 
 @export.add(('input_zip', 'zip'))


### PR DESCRIPTION
This is very hard to reproduce because it happens only in certain machines (but always there) or conditions (artificially limited I/O, high load avg). It looks like a race conditions during modules bootstrap.

This PR apparently solves the issue; tests are passing but I don't know if there's any side effect or disadvantage in removing `import_all()` from here, I let @micheles decide.

Fixes #3879  
