### PR TITLE
Create indexes for tables with a FK to job.id

### DIFF
--- a/openquake/server/db/schema/upgrades/0005-index.sql
+++ b/openquake/server/db/schema/upgrades/0005-index.sql
@@ -1,0 +1,5 @@
+CREATE INDEX log_job_id on log (job_id);
+
+CREATE INDEX performance_job_id on performance (job_id);
+
+CREATE INDEX output_job_id on output (oq_job_id);


### PR DESCRIPTION
From:

```
287 rows returned in 1037ms from: select * from log where job_id = 18669
```

To:
```
287 rows returned in 1ms from: select * from log where job_id = 18669
```

Fixes #3877 