### PR TITLE
Force shebang to python3

### DIFF
--- a/bin/oq
+++ b/bin/oq
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/bin/slowtests
+++ b/bin/slowtests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from openquake.baselib import sap
 from openquake.baselib.node import node_from_xml
 

--- a/openquake/commands/__main__.py
+++ b/openquake/commands/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/openquake/commands/celery.py
+++ b/openquake/commands/celery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/openquake/commands/reduce.py
+++ b/openquake/commands/reduce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/utils/extract_sites
+++ b/utils/extract_sites
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/utils/extract_source
+++ b/utils/extract_source
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/utils/postzip
+++ b/utils/postzip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/utils/reduce_sm
+++ b/utils/reduce_sm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #  -*- coding: utf-8 -*-
 #  vim: tabstop=4 shiftwidth=4 softtabstop=4
 

--- a/utils/renumber_sources
+++ b/utils/renumber_sources
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #

--- a/utils/xml2hdf5
+++ b/utils/xml2hdf5
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from openquake.baselib import hdf5, sap
 from openquake.hazardlib import nrml, sourceconverter
 


### PR DESCRIPTION
Since we are only compatible with python3 and since packaging systems like `rpm` are too smart and then they want to install python2 too even if not required and not in the requirements.

After #3890 