### PR TITLE
Remove a check related to PY2 and VENVs

### DIFF
--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -41,10 +41,7 @@ class DotDict(collections.OrderedDict):
 config = DotDict()  # global configuration
 d = os.path.dirname
 base = os.path.join(d(d(__file__)), 'engine', 'openquake.cfg')
-# FIXME `hasattr(sys, 'real_prefix')` check can be removed
-# after the removal of Python 2 support
-if (hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix')
-                                    and sys.base_prefix != sys.prefix)):
+if hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix:
     config.paths = [base, os.path.join(sys.prefix, 'openquake.cfg')]
 else:  # installation from sources or packages, search in $HOME or /etc
     config.paths = [base, '/etc/openquake/openquake.cfg', '~/openquake.cfg']


### PR DESCRIPTION
We don't need it anymore:

```python
In [4]: hasattr(sys, 'base_prefix')
Out[4]: True

In [5]: sys.base_prefix != sys.prefix
Out[5]: True

In [6]: hasattr(sys, 'real_prefix')
Out[6]: False
```