### PR TITLE
[RPM] Fix shebangs also for scripts not in bin

### DIFF
--- a/rpm/python3-oq-engine.spec.inc
+++ b/rpm/python3-oq-engine.spec.inc
@@ -119,6 +119,11 @@ getent passwd %{oquser} >/dev/null || \
     -c "The OpenQuake user" %{oquser}
 
 %install
+# Fix shebangs before installation
+for f in $(find . -type f -executable | xargs --no-run-if-empty grep -rlE '^#!/usr/bin/env python3$'); do \
+    sed -i 's|#!/usr/bin/env python3|#!/opt/openquake/bin/python3|' $f; \
+done
+# Fix version in python init
 sed -i "s/^__version__[  ]*=.*/__version__ = '%{oqversion}-%{oqrelease}'/g" openquake/baselib/__init__.py
 install -p -m 755 -d %{buildroot}%{_bindir}
 install -p -m 755 -d %{buildroot}%{_oqbindir}


### PR DESCRIPTION
This PR forces all shebangs in the RPM package to point to the proper python installation. This was already done by the installation phase for `oq` but the scripts in `utils` were left with the wrong shebang.

That had 2 effects:

- a user had to execute them prepending the full path to the python executable
- the package manager was automatically adding `python3` to the dependencies (since it provides `/usr/bin/env python3`).

List of automatic deps:
```
/bin/bash
/bin/sh
/bin/sh
/bin/sh
/bin/sh
/opt/openquake/bin/python3
config(python3-oq-engine) = 3.2.0-1533041321_gita6ca003c97
oq-python3
python3-oq-libs >= 2.2.0
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
shadow-utils
sudo
systemd
rpmlib(PayloadIsXz) <= 5.2-1
```