### PR TITLE
Adapts hmtk source model parser for cases when name is missing in the source model

### DIFF
--- a/openquake/hmtk/parsers/source_model/nrml04_parser.py
+++ b/openquake/hmtk/parsers/source_model/nrml04_parser.py
@@ -461,9 +461,14 @@ class nrmlSourceModelParser(BaseSourceModelParser):
         sm_node = node_from_xml(self.input_file)[0]
         if sm_node[0].tag.startswith('{http://openquake.org/xmlns/nrml/0.4}'):
             node_sets = [sm_node]
+            if "name" in sm_node.attrib:
+                sm_name = sm_node["name"]
+            else:
+                sm_name = ""
         else:  # format NRML 0.5+
             node_sets = sm_node
-        source_model = mtkSourceModel(identifier, name=sm_node["name"])
+            sm_name = sm_node["name"]
+        source_model = mtkSourceModel(identifier, name=sm_name)
         for node_set in node_sets:
             for node in node_set:
                 if "pointSource" in node.tag:


### PR DESCRIPTION
Earlier usages of the hmtk could take into account source models for which the name is not present. This is causing an error in the current parser re-running previous files, and the name is not a critical feature of the workflow. This PR deals with this case. 