### PR TITLE
Speed-up the download of hazard maps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Speedup the download of the hazard maps
   * Honored `concurrent_tasks` in the prefiltering phase too
   * It is now legal to compute uniform hazard spectra for a single period
   * Added command `oq plot_memory`

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -647,6 +647,26 @@ class HazardCalculator(BaseCalculator):
                 has_dupl_sources=self.csm.has_dupl_sources)
         self.datastore.flush()
 
+    def save_hmaps(self):
+        """
+        Save hazard maps generated from the hazard curves
+        """
+        oq = self.oqparam
+        if oq.poes:
+            logging.info('Computing hazard maps for PoEs=%s', oq.poes)
+            with self.monitor('computing hazard maps',
+                              autoflush=True, measuremem=True):
+                if 'hcurves' in self.datastore:
+                    # TODO: we could parallelize this branch
+                    for kind in self.datastore['hcurves']:
+                        self.datastore['hmaps/' + kind] = calc.make_hmap(
+                            self.datastore['hcurves/' + kind],
+                            oq.imtls, oq.poes)
+                else:  # single realization
+                    pg = PmapGetter(self.datastore, self.rlzs_assoc)
+                    self.datastore['hmaps/mean'] = calc.make_hmap(
+                        pg.get_mean(), oq.imtls, oq.poes)
+
     def post_process(self):
         """For compatibility with the engine"""
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -656,17 +656,17 @@ class HazardCalculator(BaseCalculator):
             logging.info('Computing hazard maps for PoEs=%s', oq.poes)
             with self.monitor('computing hazard maps',
                               autoflush=True, measuremem=True):
-                n = len(self.sitecol)
+                N = len(self.sitecol.complete)
                 if 'hcurves' in self.datastore:
                     # TODO: we could parallelize this branch
                     for kind in self.datastore['hcurves']:
                         self.datastore['hmaps/' + kind] = calc.make_hmap_array(
                             self.datastore['hcurves/' + kind],
-                            oq.imtls, oq.poes, n)
+                            oq.imtls, oq.poes, N)
                 else:  # single realization
                     pg = PmapGetter(self.datastore, self.rlzs_assoc)
                     self.datastore['hmaps/mean'] = calc.make_hmap_array(
-                        pg.get_mean(), oq.imtls, oq.poes, n)
+                        pg.get_mean(), oq.imtls, oq.poes, N)
 
     def post_process(self):
         """For compatibility with the engine"""

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -656,16 +656,17 @@ class HazardCalculator(BaseCalculator):
             logging.info('Computing hazard maps for PoEs=%s', oq.poes)
             with self.monitor('computing hazard maps',
                               autoflush=True, measuremem=True):
+                n = len(self.sitecol)
                 if 'hcurves' in self.datastore:
                     # TODO: we could parallelize this branch
                     for kind in self.datastore['hcurves']:
-                        self.datastore['hmaps/' + kind] = calc.make_hmap(
+                        self.datastore['hmaps/' + kind] = calc.make_hmap_array(
                             self.datastore['hcurves/' + kind],
-                            oq.imtls, oq.poes)
+                            oq.imtls, oq.poes, n)
                 else:  # single realization
                     pg = PmapGetter(self.datastore, self.rlzs_assoc)
-                    self.datastore['hmaps/mean'] = calc.make_hmap(
-                        pg.get_mean(), oq.imtls, oq.poes)
+                    self.datastore['hmaps/mean'] = calc.make_hmap_array(
+                        pg.get_mean(), oq.imtls, oq.poes, n)
 
     def post_process(self):
         """For compatibility with the engine"""

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -27,7 +27,6 @@ from openquake.baselib.general import AccumDict, block_splitter, groupby
 from openquake.hazardlib.calc.hazard_curve import classical, ProbabilityMap
 from openquake.hazardlib.stats import compute_pmap_stats
 from openquake.hazardlib import source
-from openquake.commonlib import calc
 from openquake.calculators import getters
 from openquake.calculators import base
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -265,20 +265,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 self.calc_stats(self.hdf5cache)
             else:
                 self.calc_stats(self.datastore)
-        # save hmaps
-        if oq.poes:
-            logging.info('Computing hazard maps for PoEs=%s', oq.poes)
-            with self.monitor('computing hazard maps',
-                              autoflush=True, measuremem=True):
-                if 'hcurves' in self.datastore:
-                    for stat in self.datastore['hcurves']:
-                        self.datastore['hmaps/' + stat] = calc.make_hmap(
-                            self.datastore['hcurves/' + stat],
-                            oq.imtls, oq.poes)
-                else:  # single realization
-                    pg = getters.PmapGetter(self.datastore, self.rlzs_assoc)
-                    self.datastore['hmaps/mean'] = calc.make_hmap(
-                        pg.get_mean(), oq.imtls, oq.poes)
+        self.save_hmaps()
 
     def calc_stats(self, parent):
         oq = self.oqparam

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -276,8 +276,9 @@ class ClassicalCalculator(base.HazardCalculator):
                             self.datastore['hcurves/' + stat],
                             oq.imtls, oq.poes)
                 else:  # single realization
+                    pg = getters.PmapGetter(self.datastore, self.rlzs_assoc)
                     self.datastore['hmaps/mean'] = calc.make_hmap(
-                        self.datastore['poes'], oq.imtls, oq.poes)
+                        pg.get_mean(), oq.imtls, oq.poes)
 
     def calc_stats(self, parent):
         oq = self.oqparam

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -428,6 +428,7 @@ class EventBasedCalculator(base.HazardCalculator):
                 for kind, stat in hstats:
                     pmap = compute_pmap_stats(result.values(), [stat], weights)
                     self.datastore['hcurves/' + kind] = pmap
+            self.save_hmaps()
         if self.datastore.parent:
             self.datastore.parent.open('r')
         if 'gmf_data' in self.datastore:

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -258,8 +258,11 @@ def export_hazard_csv(key, dest, sitemesh, pmap, pdic, comment):
     :param pdic: intensity measure types and levels
     :param comment: comment to use as header of the exported CSV file
     """
-    curves = util.compose_arrays(
-        sitemesh, calc.convert_to_array(pmap, len(sitemesh), pdic))
+    if isinstance(pmap, dict):
+        array = calc.convert_to_array(pmap, len(sitemesh), pdic)
+    else:
+        array = pmap
+    curves = util.compose_arrays(sitemesh, array)
     writers.write_csv(dest, curves, comment=comment)
     return [dest]
 

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -258,9 +258,9 @@ def export_hazard_csv(key, dest, sitemesh, pmap, pdic, comment):
     :param pdic: intensity measure types and levels
     :param comment: comment to use as header of the exported CSV file
     """
-    if isinstance(pmap, dict):
+    if isinstance(pmap, dict):  # old format
         array = calc.convert_to_array(pmap, len(sitemesh), pdic)
-    else:
+    else:  # new format for engine >= 3.2
         array = pmap
     curves = util.compose_arrays(sitemesh, array)
     writers.write_csv(dest, curves, comment=comment)

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -385,7 +385,7 @@ def export_hcurves_csv(ekey, dstore):
                 comment=comment)
             fnames.append(fname)
         elif key == 'hmaps' and oq.poes and oq.hazard_maps:
-            hmap = calc.make_hmap(hcurves, oq.imtls, oq.poes)
+            hmap = dstore['hmaps/' + kind]
             fnames.extend(
                 export_hazard_csv(ekey, fname, sitemesh, hmap, pdic, comment))
         elif key == 'hcurves':

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -177,7 +177,7 @@ def extract_hazard(dstore, what):
             yield key, arr
         try:
             hmap = dstore['hmaps/' + kind]
-        except KeyError:
+        except KeyError:  # for kind=rlz-XXX
             hmap = calc.make_hmap(pmap, oq.imtls, oq.poes)
         for p, poe in enumerate(oq.poes):
             key = 'hmaps/poe-%s/%s' % (poe, kind)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -255,12 +255,11 @@ def extract_hmaps(dstore, what):
     """
     oq = dstore['oqparam']
     sitecol = dstore['sitecol']
-    rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
     mesh = get_mesh(sitecol)
     pdic = DictArray({imt: oq.poes for imt in oq.imtls})
     dic = {}
-    for kind, hcurves in getters.PmapGetter(dstore, rlzs_assoc).items(what):
-        hmap = calc.make_hmap(hcurves, oq.imtls, oq.poes)
+    for kind in dstore['hmaps']:
+        hmap = dstore['hmaps/' + kind]
         dic[kind] = calc.convert_to_array(hmap, len(mesh), pdic)
     return hazard_items(dic, mesh, investigation_time=oq.investigation_time)
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -28,7 +28,7 @@ except ImportError:
 else:
     memoized = lru_cache(100)
 from openquake.baselib.hdf5 import ArrayWrapper
-from openquake.baselib.general import DictArray, group_array
+from openquake.baselib.general import group_array
 from openquake.baselib.python3compat import encode
 from openquake.calculators import getters
 from openquake.calculators.export.loss_curves import get_loss_builder
@@ -256,11 +256,7 @@ def extract_hmaps(dstore, what):
     oq = dstore['oqparam']
     sitecol = dstore['sitecol']
     mesh = get_mesh(sitecol)
-    pdic = DictArray({imt: oq.poes for imt in oq.imtls})
-    dic = {}
-    for kind in dstore['hmaps']:
-        hmap = dstore['hmaps/' + kind]
-        dic[kind] = calc.convert_to_array(hmap, len(mesh), pdic)
+    dic = {kind: dstore['hmaps/' + kind] for kind in dstore['hmaps']}
     return hazard_items(dic, mesh, investigation_time=oq.investigation_time)
 
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -175,7 +175,9 @@ def extract_hazard(dstore, what):
                 arr[sid] = pmap[sid].array[oq.imtls.slicedic[imt], 0]
             logging.info('extracting %s', key)
             yield key, arr
-        if oq.poes:
+        try:
+            hmap = dstore['hmaps/' + kind]
+        except KeyError:
             hmap = calc.make_hmap(pmap, oq.imtls, oq.poes)
         for p, poe in enumerate(oq.poes):
             key = 'hmaps/poe-%s/%s' % (poe, kind)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -17,9 +17,8 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import warnings
 import numpy
-import h5py
 
-from openquake.baselib import hdf5
+from openquake.baselib import hdf5, general
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib.source.rupture import BaseRupture
 from openquake.hazardlib.geo.mesh import surface_to_array
@@ -220,6 +219,15 @@ def make_hmap(pmap, imtls, poes):
             for j, val in enumerate(value):
                 array[i * P + j] = val
     return hmap
+
+
+def make_hmap_array(pmap, imtls, poes, nsites):
+    """
+    :returns: a compound array of hazard maps of shape nsites
+    """
+    hmap = make_hmap(pmap, imtls, poes)
+    pdic = general.DictArray({imt: poes for imt in imtls})
+    return convert_to_array(hmap, nsites, pdic)
 
 
 def make_uhs(pmap, imtls, poes, nsites):


### PR DESCRIPTION
See the last comment in https://github.com/gem/oq-engine/issues/3899. Currently the download is slow because the call to `make_hmap` is done at download time. With this change the call is made at storage time, so the download is just a download without any processing of the hazard curves. This is akin to caching the hazard maps inside the datastore.

TODO: extend the same approach to the hazard curves.