### PR TITLE
Pickle the source models

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Parallelized the reading of the source models
   * Optimized `oq info --report` by not splitting the sources in that case
   * Speedup the download of the hazard maps
   * Honored `concurrent_tasks` in the prefiltering phase too

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -700,21 +700,6 @@ class SourceModelLogicTree(object):
                 "there are duplicate values in uncertaintyModel: " +
                 ' '.join(values))
 
-    def cache_source_models(self, gsim_lt, converter):
-        """
-        Convert the source model files listed in the logic tree
-        into picked files.
-
-        :returns: a dictionary file -> file.pik
-        """
-        smlt_dir = os.path.abspath(os.path.dirname(self.filename))
-        fnames = []
-        for sm in self.gen_source_models(gsim_lt):
-            for name in sm.names.split():
-                fnames.append(os.path.join(smlt_dir, name))
-        monitor = performance.Monitor('cache source models')
-        return nrml.cache_source_models(fnames, converter, monitor)
-
     def gen_source_models(self, gsim_lt):
         """
         Yield empty LtSourceModel instances (one per effective realization)
@@ -1485,3 +1470,18 @@ class GsimLogicTree(object):
                                     b.id, b.uncertainty, b.weight)
                  for b in self.branches if b.effective]
         return '<%s\n%s>' % (self.__class__.__name__, '\n'.join(lines))
+
+
+def pickle_source_models(gsim_lt, source_model_lt, converter):
+    """
+    Convert the source model files listed in the logic tree
+    into picked files.
+    :returns: a dictionary file -> file.pik
+    """
+    smlt_dir = os.path.abspath(os.path.dirname(source_model_lt.filename))
+    fnames = []
+    for sm in source_model_lt.gen_source_models(gsim_lt):
+        for name in sm.names.split():
+            fnames.append(os.path.join(smlt_dir, name))
+    monitor = performance.Monitor('cache source models')
+    return nrml.pickle_source_models(fnames, converter, monitor)

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1472,7 +1472,7 @@ class GsimLogicTree(object):
         return '<%s\n%s>' % (self.__class__.__name__, '\n'.join(lines))
 
 
-def pickle_source_models(gsim_lt, source_model_lt, converter):
+def parallel_pickle_source_models(gsim_lt, source_model_lt, converter):
     """
     Convert the source model files listed in the logic tree
     into picked files.

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1484,14 +1484,14 @@ def pickle_source_models(gsim_lt, source_model_lt, converter):
     :returns: a dictionary file -> file.pik
     """
     smlt_dir = os.path.dirname(source_model_lt.filename)
-    fnames = []
+    fnames = set()
     for sm in source_model_lt.gen_source_models(gsim_lt):
         for name in sm.names.split():
-            fnames.append(os.path.abspath(os.path.join(smlt_dir, name)))
+            fnames.add(os.path.abspath(os.path.join(smlt_dir, name)))
     monitor = performance.Monitor('cache source models')
     dist = 'no' if os.environ.get('OQ_DISTRIBUTE') == 'no' else 'processpool'
     dic = parallel.Starmap.apply(nrml.pickle_source_models,
-                                 (fnames, converter, monitor),
+                                 (sorted(fnames), converter, monitor),
                                  distribute=dist).reduce()
     parallel.Starmap.shutdown()  # close the processpool
     return dic

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1476,13 +1476,18 @@ def pickle_source_models(gsim_lt, source_model_lt, converter):
     """
     Convert the source model files listed in the logic tree
     into picked files.
+
+    :param gsim_lt: a :class:`GsimLogicTree` instance
+    :param source_model_lt: a :class:`SourceModelLogicTree` instance
+    :param converter:
+        a :class:`openquake.hazardlib.sourceconverter.SourceConverter` instance
     :returns: a dictionary file -> file.pik
     """
-    smlt_dir = os.path.abspath(os.path.dirname(source_model_lt.filename))
+    smlt_dir = os.path.dirname(source_model_lt.filename)
     fnames = []
     for sm in source_model_lt.gen_source_models(gsim_lt):
         for name in sm.names.split():
-            fnames.append(os.path.join(smlt_dir, name))
+            fnames.append(os.path.abspath(os.path.join(smlt_dir, name)))
     monitor = performance.Monitor('cache source models')
     dist = 'no' if os.environ.get('OQ_DISTRIBUTE') == 'no' else 'processpool'
     dic = parallel.Starmap.apply(nrml.pickle_source_models,

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -34,11 +34,11 @@ import operator
 from collections import namedtuple
 from decimal import Decimal
 import numpy
-from openquake.baselib import hdf5, node
+from openquake.baselib import hdf5, node, performance
 from openquake.baselib.general import groupby
 from openquake.baselib.python3compat import raise_
 import openquake.hazardlib.source as ohs
-from openquake.hazardlib.gsim.base import CoeffsTable, GMPE
+from openquake.hazardlib.gsim.base import CoeffsTable
 from openquake.hazardlib.gsim.multi import MultiGMPE
 from openquake.hazardlib.gsim.gmpe_table import GMPETable
 from openquake.hazardlib.imt import from_string
@@ -699,6 +699,21 @@ class SourceModelLogicTree(object):
                 branchset_node, self.filename,
                 "there are duplicate values in uncertaintyModel: " +
                 ' '.join(values))
+
+    def cache_source_models(self, gsim_lt, converter):
+        """
+        Convert the source model files listed in the logic tree
+        into picked files.
+
+        :returns: a dictionary file -> file.pik
+        """
+        smlt_dir = os.path.abspath(os.path.dirname(self.filename))
+        fnames = []
+        for sm in self.gen_source_models(gsim_lt):
+            for name in sm.names.split():
+                fnames.append(os.path.join(smlt_dir, name))
+        monitor = performance.Monitor('cache source models')
+        return nrml.cache_source_models(fnames, converter, monitor)
 
     def gen_source_models(self, gsim_lt):
         """

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -533,7 +533,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
         [grp] = nrml.to_python(oqparam.inputs["source_model"], converter)
     elif in_memory:
         logging.info('Pickling the source model(s)')
-        pik = logictree.pickle_source_models(
+        pik = logictree.parallel_pickle_source_models(
             gsim_lt, source_model_lt, converter)
 
     # consider only the effective realizations

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -532,6 +532,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
     if oqparam.calculation_mode.startswith('ucerf'):
         [grp] = nrml.to_python(oqparam.inputs["source_model"], converter)
     elif in_memory:
+        logging.info('Pickling the source model(s)')
         pik = logictree.pickle_source_models(
             gsim_lt, source_model_lt, converter)
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -544,8 +544,8 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
                 src_groups.append(sg)
             elif in_memory:
                 apply_unc = source_model_lt.make_apply_uncertainties(sm.path)
-                logging.info('Reading %s', fname)
-                src_groups.extend(psr.parse_src_groups(fname, apply_unc))
+                src_groups.extend(psr.parse_src_groups(
+                    fname, apply_unc, oqparam.investigation_time))
             else:  # just collect the TRT models
                 src_groups.extend(read_source_groups(fname))
         num_sources = sum(len(sg.sources) for sg in src_groups)
@@ -564,9 +564,6 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
                         "Found in %r a tectonic region type %r inconsistent "
                         "with the ones in %r" % (sm, src_group.trt, gsim_file))
         yield sm
-
-    # check investigation_time
-    psr.check_nonparametric_sources(oqparam.investigation_time)
 
     # log if some source file is being used more than once
     dupl = 0

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -528,11 +528,12 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
         oqparam.width_of_mfd_bin,
         oqparam.area_source_discretization)
 
-    pik = source_model_lt.cache_source_models(gsim_lt, converter)
-
     psr = nrml.SourceModelParser(converter)
     if oqparam.calculation_mode.startswith('ucerf'):
         [grp] = nrml.to_python(oqparam.inputs["source_model"], converter)
+    elif in_memory:
+        pik = logictree.pickle_source_models(
+            gsim_lt, source_model_lt, converter)
 
     # consider only the effective realizations
     smlt_dir = os.path.dirname(source_model_lt.filename)
@@ -547,7 +548,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
                 src_groups.append(sg)
             elif in_memory:
                 apply_unc = source_model_lt.make_apply_uncertainties(sm.path)
-                src_groups.extend(psr.parse_src_groups(
+                src_groups.extend(psr.parse(
                     fname, pik[fname], apply_unc, oqparam.investigation_time))
             else:  # just collect the TRT models
                 src_groups.extend(read_source_groups(fname))

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -527,6 +527,9 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
         oqparam.complex_fault_mesh_spacing,
         oqparam.width_of_mfd_bin,
         oqparam.area_source_discretization)
+
+    pik = source_model_lt.cache_source_models(gsim_lt, converter)
+
     psr = nrml.SourceModelParser(converter)
     if oqparam.calculation_mode.startswith('ucerf'):
         [grp] = nrml.to_python(oqparam.inputs["source_model"], converter)
@@ -545,7 +548,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, in_memory=True):
             elif in_memory:
                 apply_unc = source_model_lt.make_apply_uncertainties(sm.path)
                 src_groups.extend(psr.parse_src_groups(
-                    fname, apply_unc, oqparam.investigation_time))
+                    fname, pik[fname], apply_unc, oqparam.investigation_time))
             else:  # just collect the TRT models
                 src_groups.extend(read_source_groups(fname))
         num_sources = sum(len(sg.sources) for sg in src_groups)

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -305,6 +305,24 @@ validators = {
 }
 
 
+def parse_src_groups(fname, converter, monitor):
+    """
+    :param fname:
+        the full pathname of a source model file
+    :param converter:
+        a SourceConverter instance
+    :param monitor:
+        a :class:`openquake.performance.Monitor` instance
+    """
+    if fname.endswith(('.xml', '.nrml')):
+        sm = to_python(fname, converter)
+    elif fname.endswith('.hdf5'):
+        sm = sourceconverter.to_python(fname, converter)
+    else:
+        raise ValueError('Unrecognized extension in %s' % fname)
+    return sm.src_groups
+
+
 class SourceModelParser(object):
     """
     A source model parser featuring a cache.

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -72,7 +72,6 @@ this is a job for the Node class which can be subclassed and
 supplemented by a dictionary of validators.
 """
 import io
-import os
 import re
 import sys
 import pickle
@@ -190,15 +189,13 @@ def get_source_model_04(node, fname, converter=default):
     sources = []
     source_ids = set()
     converter.fname = fname
-    for no, src_node in enumerate(node, 1):
+    for src_node in node:
         src = converter.convert_node(src_node)
         if src.source_id in source_ids:
             raise DuplicatedID(
                 'The source ID %s is duplicated!' % src.source_id)
         sources.append(src)
         source_ids.add(src.source_id)
-        if no % 10000 == 0:  # log every 10,000 sources parsed
-            logging.info('Instantiated %d sources from %s', no, fname)
     groups = groupby(
         sources, operator.attrgetter('tectonic_region_type'))
     src_groups = sorted(sourceconverter.SourceGroup(trt, srcs)

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -307,7 +307,7 @@ validators = {
 }
 
 
-def cache_source_models(fnames, converter,  monitor):
+def pickle_source_models(fnames, converter,  monitor):
     """
     :param fnames:
         list of source model files
@@ -370,8 +370,7 @@ class SourceModelParser(object):
         self.fname_hits = collections.Counter()  # fname -> number of calls
         self.changed_sources = 0
 
-    def parse_src_groups(self, fname, pik, apply_uncertainties,
-                         investigation_time):
+    def parse(self, fname, pik, apply_uncertainties, investigation_time):
         """
         :param fname:
             the full pathname of a source model file
@@ -393,7 +392,7 @@ class SourceModelParser(object):
                     src.num_ruptures = src.count_ruptures()
                     self.changed_sources += 1
         self.fname_hits[fname] += 1
-        return sm.src_groups
+        return sm
 
 
 def read(source, chatty=True, stop=None):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -59,8 +59,8 @@ class SourceGroup(collections.Sequence):
     :param max_mag:
         the maximum magnitude among the given sources
     :param id:
-        an optional numeric ID (default None) useful to associate
-        the model to a database object
+        an optional numeric ID (default 0) set by the engine and used
+        when serializing SourceModels to HDF5
     :param eff_ruptures:
         the number of ruptures contained in the group; if -1,
         the number is unknown and has to be computed by using


### PR DESCRIPTION
This is an optimization for the case of multiple source models (example: Trevor Allen's computation with 20 source models). With the new approach the source models are read *in parallel* in the controller node and saved into temporary pickled files. The rest is as before. The speedup is substantial when the time to read the source models is the dominating factor (i.e. in `oq info --report`).

In the future one could think of re-using the `.pik` files (i.e. the second time you run a calculation you do not need to parse again the same source models, just use the `.pik` files produced the first time) but this is not implemented here (it could be implement with a flag `--use-pik`).

NB: this optimization helps also in the case of source models split in a large number of files (i.e. CCARA has 100+ files) since now they are read in parallel.