### PR TITLE
Removed evil `isinstance(imt, ...)` checks

### DIFF
--- a/openquake/hazardlib/gsim/abrahamson_2014.py
+++ b/openquake/hazardlib/gsim/abrahamson_2014.py
@@ -188,7 +188,7 @@ class AbrahamsonEtAl2014(GMPE):
         This computes equations 8 and 9 at page 1034
         """
         # compute the v1 value (see eq. 9, page 1034)
-        if isinstance(imt, SA):
+        if imt.prefix == "SA":
             t = imt.period
             if t <= 0.50:
                 v1 = 1500.0
@@ -196,7 +196,7 @@ class AbrahamsonEtAl2014(GMPE):
                 v1 = np.exp(-0.35 * np.log(t / 0.5) + np.log(1500.))
             else:
                 v1 = 800.0
-        elif isinstance(imt, PGA):
+        elif imt.prefix == "PGA":
             v1 = 1500.0
         else:
             # This covers the PGV case

--- a/openquake/hazardlib/gsim/abrahamson_2014.py
+++ b/openquake/hazardlib/gsim/abrahamson_2014.py
@@ -188,7 +188,7 @@ class AbrahamsonEtAl2014(GMPE):
         This computes equations 8 and 9 at page 1034
         """
         # compute the v1 value (see eq. 9, page 1034)
-        if imt.prefix == "SA":
+        if imt.name == "SA":
             t = imt.period
             if t <= 0.50:
                 v1 = 1500.0
@@ -196,7 +196,7 @@ class AbrahamsonEtAl2014(GMPE):
                 v1 = np.exp(-0.35 * np.log(t / 0.5) + np.log(1500.))
             else:
                 v1 = 800.0
-        elif imt.prefix == "PGA":
+        elif imt.name == "PGA":
             v1 = 1500.0
         else:
             # This covers the PGV case

--- a/openquake/hazardlib/gsim/abrahamson_silva_2008.py
+++ b/openquake/hazardlib/gsim/abrahamson_silva_2008.py
@@ -417,7 +417,7 @@ class AbrahamsonSilva2008(GMPE):
         """
         Compute and return v1 factor, equation 6, page 77.
         """
-        if imt.prefix == "SA":
+        if imt.name == "SA":
             t = imt.period
             if t <= 0.50:
                 v1 = 1500.0
@@ -427,7 +427,7 @@ class AbrahamsonSilva2008(GMPE):
                 v1 = np.exp(6.76 - 0.297 * np.log(t))
             else:
                 v1 = 700.0
-        elif imt.prefix == "PGA":
+        elif imt.name == "PGA":
             v1 = 1500.0
         else:
             # this is for PGV
@@ -441,9 +441,9 @@ class AbrahamsonSilva2008(GMPE):
         """
         e2 = np.zeros_like(vs30)
 
-        if imt.prefix == "PGV":
+        if imt.name == "PGV":
             period = 1
-        elif imt.prefix == "PGA":
+        elif imt.name == "PGA":
             period = 0
         else:
             period = imt.period
@@ -478,7 +478,7 @@ class AbrahamsonSilva2008(GMPE):
         """
         Compute and return the a22 factor, equation 20, page 80.
         """
-        if imt.prefix == 'PGV':
+        if imt.name == 'PGV':
             return 0.0
         period = imt.period
         if period < 2.0:

--- a/openquake/hazardlib/gsim/abrahamson_silva_2008.py
+++ b/openquake/hazardlib/gsim/abrahamson_silva_2008.py
@@ -478,6 +478,8 @@ class AbrahamsonSilva2008(GMPE):
         """
         Compute and return the a22 factor, equation 20, page 80.
         """
+        if imt.prefix == 'PGV':
+            return 0.0
         period = imt.period
         if period < 2.0:
             return 0.0

--- a/openquake/hazardlib/gsim/abrahamson_silva_2008.py
+++ b/openquake/hazardlib/gsim/abrahamson_silva_2008.py
@@ -417,7 +417,7 @@ class AbrahamsonSilva2008(GMPE):
         """
         Compute and return v1 factor, equation 6, page 77.
         """
-        if isinstance(imt, SA):
+        if imt.prefix == "SA":
             t = imt.period
             if t <= 0.50:
                 v1 = 1500.0
@@ -427,7 +427,7 @@ class AbrahamsonSilva2008(GMPE):
                 v1 = np.exp(6.76 - 0.297 * np.log(t))
             else:
                 v1 = 700.0
-        elif isinstance(imt, PGA):
+        elif imt.prefix == "PGA":
             v1 = 1500.0
         else:
             # this is for PGV
@@ -441,9 +441,9 @@ class AbrahamsonSilva2008(GMPE):
         """
         e2 = np.zeros_like(vs30)
 
-        if isinstance(imt, PGV):
+        if imt.prefix == "PGV":
             period = 1
-        elif isinstance(imt, PGA):
+        elif imt.prefix == "PGA":
             period = 0
         else:
             period = imt.period
@@ -478,14 +478,11 @@ class AbrahamsonSilva2008(GMPE):
         """
         Compute and return the a22 factor, equation 20, page 80.
         """
-        if isinstance(imt, PGA) or isinstance(imt, PGV):
-            return 0
-        elif isinstance(imt, SA):
-            period = imt.period
-            if period < 2.0:
-                return 0.0
-            else:
-                return 0.0625 * (period - 2.0)
+        period = imt.period
+        if period < 2.0:
+            return 0.0
+        else:
+            return 0.0625 * (period - 2.0)
 
     #: Coefficient tables obtained by joining table 5a page 84, and table 5b
     #: page 85.

--- a/openquake/hazardlib/gsim/akkar_bommer_2010.py
+++ b/openquake/hazardlib/gsim/akkar_bommer_2010.py
@@ -109,14 +109,14 @@ class AkkarBommer2010(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.prefix in 'PGA SA':
+        if imt.name in 'PGA SA':
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:
             mean = np.log(10.0 ** imean)
 
         # apply scaling factor for SA at 4 s
-        if imt.prefix == 'SA' and imt.period == 4.0:
+        if imt.name == 'SA' and imt.period == 4.0:
             mean /= 0.8
 
         istddevs = self._get_stddevs(

--- a/openquake/hazardlib/gsim/akkar_bommer_2010.py
+++ b/openquake/hazardlib/gsim/akkar_bommer_2010.py
@@ -109,14 +109,14 @@ class AkkarBommer2010(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in 'PGA SA':
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:
             mean = np.log(10.0 ** imean)
 
         # apply scaling factor for SA at 4 s
-        if isinstance(imt, SA) and imt.period == 4.0:
+        if imt.prefix == 'SA' and imt.period == 4.0:
             mean /= 0.8
 
         istddevs = self._get_stddevs(

--- a/openquake/hazardlib/gsim/akkar_cagnan_2010.py
+++ b/openquake/hazardlib/gsim/akkar_cagnan_2010.py
@@ -111,7 +111,7 @@ class AkkarCagnan2010(BooreAtkinson2008):
                                                             C_SR))
 
         # convert from cm/s**2 to g for SA (PGA is already computed in g)
-        if imt.prefix == "SA":
+        if imt.name == "SA":
             mean = np.log(np.exp(mean) * 1e-2 / g)
 
         stddevs = self._get_stddevs(C, stddev_types, num_sites=len(sites.vs30))

--- a/openquake/hazardlib/gsim/akkar_cagnan_2010.py
+++ b/openquake/hazardlib/gsim/akkar_cagnan_2010.py
@@ -111,7 +111,7 @@ class AkkarCagnan2010(BooreAtkinson2008):
                                                             C_SR))
 
         # convert from cm/s**2 to g for SA (PGA is already computed in g)
-        if isinstance(imt, SA):
+        if imt.prefix == "SA":
             mean = np.log(np.exp(mean) * 1e-2 / g)
 
         stddevs = self._get_stddevs(C, stddev_types, num_sites=len(sites.vs30))

--- a/openquake/hazardlib/gsim/atkinson_2015.py
+++ b/openquake/hazardlib/gsim/atkinson_2015.py
@@ -82,7 +82,7 @@ class Atkinson2015(GMPE):
         imean = (self._get_magnitude_term(C, rup.mag) +
                  self._get_distance_term(C, dists.rhypo, rup.mag))
         # Convert mean from cm/s and cm/s/s
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log(10.0 ** imean)

--- a/openquake/hazardlib/gsim/atkinson_2015.py
+++ b/openquake/hazardlib/gsim/atkinson_2015.py
@@ -82,7 +82,7 @@ class Atkinson2015(GMPE):
         imean = (self._get_magnitude_term(C, rup.mag) +
                  self._get_distance_term(C, dists.rhypo, rup.mag))
         # Convert mean from cm/s and cm/s/s
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log(10.0 ** imean)

--- a/openquake/hazardlib/gsim/atkinson_boore_2003.py
+++ b/openquake/hazardlib/gsim/atkinson_boore_2003.py
@@ -67,9 +67,9 @@ class AtkinsonBoore2003SInter(GMPE):
     ])
 
     #: Supported intensity measure component is the random horizontal
-    #component :
-    #attr:`~openquake.hazardlib.const.IMC.RANDOM_HORIZONTAL`, see
-    #paragraph 'Functional : Form', page 1706
+    #: component:
+    #: attr:`~openquake.hazardlib.const.IMC.RANDOM_HORIZONTAL`, see
+    #: paragraph 'Functional : Form', page 1706
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.RANDOM_HORIZONTAL
 
     #: Supported standard deviation types are inter-event, intra-event
@@ -120,7 +120,7 @@ class AtkinsonBoore2003SInter(GMPE):
         # periods 0.4 s (2.5 Hz) and 0.2 s (5 Hz) need a special case because
         # of the erratum. SA for 0.4s and 0.2s is computed and a weighted sum
         # is returned
-        if isinstance(imt, SA) and imt.period in (0.2, 0.4):
+        if imt.period in (0.2, 0.4):
             C04 = self.COEFFS_SINTER[SA(period=0.4, damping=5.0)]
             C02 = self.COEFFS_SINTER[SA(period=0.2, damping=5.0)]
             mean04 = self._compute_mean(C04, G, mag, rup.hypo_depth,
@@ -139,7 +139,7 @@ class AtkinsonBoore2003SInter(GMPE):
         # convert from log10 to ln and units from cm/s**2 to g
         mean = np.log((10 ** mean) * 1e-2 / g)
 
-        if isinstance(imt, SA) and imt.period == 4.0:
+        if imt.period == 4.0:
             mean /= 0.550
 
         stddevs = self._get_stddevs(C, stddev_types, sites.vs30.shape[0])
@@ -205,7 +205,7 @@ class AtkinsonBoore2003SInter(GMPE):
         Compute soil linear factor as explained in paragraph 'Functional
         Form', page 1706.
         """
-        if isinstance(imt, SA) and imt.period >= 1:
+        if imt.period >= 1:
             return np.ones_like(pga_rock)
         else:
             sl = np.zeros_like(pga_rock)
@@ -213,9 +213,9 @@ class AtkinsonBoore2003SInter(GMPE):
             pga_between_100_500 = (pga_rock > 100) & (pga_rock < 500)
             pga_greater_equal_500 = pga_rock >= 500
 
-            is_SA_between_05_1 = isinstance(imt, SA) and 0.5 < imt.period < 1
+            is_SA_between_05_1 = 0.5 < imt.period < 1
 
-            is_SA_less_equal_05 = isinstance(imt, SA) and (imt.period <= 0.5)
+            is_SA_less_equal_05 = imt.period <= 0.5
 
             if is_SA_between_05_1:
                 sl[pga_between_100_500] = (1 - (1. / imt.period - 1) *
@@ -223,7 +223,7 @@ class AtkinsonBoore2003SInter(GMPE):
                                            100) / 400)
                 sl[pga_greater_equal_500] = 1 - (1. / imt.period - 1)
 
-            if is_SA_less_equal_05 or isinstance(imt, PGA):
+            if is_SA_less_equal_05 or imt.period == 0:
                 sl[pga_between_100_500] = (1 - (pga_rock[pga_between_100_500] -
                                            100) / 400)
 
@@ -308,7 +308,7 @@ class AtkinsonBoore2003SSlab(AtkinsonBoore2003SInter):
                                   sites.vs30, pga_rock, imt)
         mean = np.log((10 ** mean) * 1e-2 / g)
 
-        if isinstance(imt, SA) and imt.period == 4.0:
+        if imt.period == 4.0:
             mean /= 0.550
 
         stddevs = self._get_stddevs(C, stddev_types, sites.vs30.shape[0])

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -388,9 +388,9 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
         """
         Make sure that ``imt`` is valid and is supported by this GSIM.
         """
-        prefixes = set(f.__name__
-                       for f in self.DEFINED_FOR_INTENSITY_MEASURE_TYPES)
-        if imt.name not in prefixes:
+        names = set(f.__name__
+                    for f in self.DEFINED_FOR_INTENSITY_MEASURE_TYPES)
+        if imt.name not in names:
             raise ValueError('imt %s is not supported by %s' %
                              (imt.name, type(self).__name__))
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -390,9 +390,9 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
         """
         prefixes = set(f.__name__
                        for f in self.DEFINED_FOR_INTENSITY_MEASURE_TYPES)
-        if imt.prefix not in prefixes:
+        if imt.name not in prefixes:
             raise ValueError('imt %s is not supported by %s' %
-                             (imt.prefix, type(self).__name__))
+                             (imt.name, type(self).__name__))
 
     def __lt__(self, other):
         """
@@ -667,7 +667,7 @@ class CoeffsTable(object):
             self._setup_table_from_str(table, sa_damping)
         elif isinstance(table, dict):
             for imt in table:
-                if imt.prefix == 'SA':
+                if imt.name == 'SA':
                     self.sa_coeffs[imt] = table[imt]
                 else:
                     self.non_sa_coeffs[imt] = table[imt]
@@ -717,7 +717,7 @@ class CoeffsTable(object):
             If ``imt`` is not available in the table and no interpolation
             can be done.
         """
-        if imt.prefix != 'SA':
+        if imt.name != 'SA':
             return self.non_sa_coeffs[imt]
 
         try:

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -388,11 +388,11 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
         """
         Make sure that ``imt`` is valid and is supported by this GSIM.
         """
-        if not issubclass(type(imt), imt_module._IMT):
-            raise ValueError('imt must be an instance of IMT subclass')
-        if not type(imt) in self.DEFINED_FOR_INTENSITY_MEASURE_TYPES:
+        prefixes = set(f.__name__
+                       for f in self.DEFINED_FOR_INTENSITY_MEASURE_TYPES)
+        if imt.prefix not in prefixes:
             raise ValueError('imt %s is not supported by %s' %
-                             (type(imt).__name__, type(self).__name__))
+                             (imt.prefix, type(self).__name__))
 
     def __lt__(self, other):
         """
@@ -614,11 +614,11 @@ class CoeffsTable(object):
     >>> ct[imt.PGV()]
     Traceback (most recent call last):
         ...
-    KeyError: PGV()
+    KeyError: PGV
     >>> ct[imt.SA(1.0, 4)]
     Traceback (most recent call last):
         ...
-    KeyError: SA(period=1.0, damping=4)
+    KeyError: SA(1.0, 4)
 
     Table of coefficients for spectral acceleration could be indexed
     by instances of :class:`openquake.hazardlib.imt.SA` with period
@@ -636,14 +636,14 @@ class CoeffsTable(object):
     >>> ct[imt.SA(period=0.9, damping=15)]
     Traceback (most recent call last):
         ...
-    KeyError: SA(period=0.9, damping=15)
+    KeyError: SA(0.9, 15)
 
     Extrapolation is not possible:
 
     >>> ct[imt.SA(period=0.01, damping=5)]
     Traceback (most recent call last):
         ...
-    KeyError: SA(period=0.01, damping=5)
+    KeyError: SA(0.01, 5)
 
     It is also possible to instantiate a table from a tuple of dictionaries,
     corresponding to the SA coefficients and non-SA coefficients:
@@ -666,11 +666,11 @@ class CoeffsTable(object):
         if isinstance(table, str):
             self._setup_table_from_str(table, sa_damping)
         elif isinstance(table, dict):
-            for key in table:
-                if isinstance(key, imt_module.SA):
-                    self.sa_coeffs[key] = table[key]
+            for imt in table:
+                if imt.prefix == 'SA':
+                    self.sa_coeffs[imt] = table[imt]
                 else:
-                    self.non_sa_coeffs[key] = table[key]
+                    self.non_sa_coeffs[imt] = table[imt]
         else:
             raise TypeError("CoeffsTable cannot be constructed with inputs "
                             "of the form '%s'" % table.__class__.__name__)
@@ -717,7 +717,7 @@ class CoeffsTable(object):
             If ``imt`` is not available in the table and no interpolation
             can be done.
         """
-        if not isinstance(imt, imt_module.SA):
+        if imt.prefix != 'SA':
             return self.non_sa_coeffs[imt]
 
         try:

--- a/openquake/hazardlib/gsim/bindi_2011.py
+++ b/openquake/hazardlib/gsim/bindi_2011.py
@@ -94,7 +94,7 @@ class BindiEtAl2011(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/bindi_2011.py
+++ b/openquake/hazardlib/gsim/bindi_2011.py
@@ -94,14 +94,14 @@ class BindiEtAl2011(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:
             mean = np.log(10.0 ** imean)
         # Return stddevs in terms of natural log scaling
         stddevs = np.log(10.0 ** np.array(istddevs))
-        #mean_LogNaturale = np.log((10 ** mean) * 1e-2 / g)
+        # mean_LogNaturale = np.log((10 ** mean) * 1e-2 / g)
         return mean, stddevs
 
     def _get_stddevs(self, C, stddev_types, num_sites):

--- a/openquake/hazardlib/gsim/bindi_2014.py
+++ b/openquake/hazardlib/gsim/bindi_2014.py
@@ -97,7 +97,7 @@ class BindiEtAl2014Rjb(GMPE):
 
         C = self.COEFFS[imt]
         imean = self._get_mean(C, rup, dists, sites)
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             # Convert units to g,
             # but only for PGA and SA (not PGV):
             mean = np.log((10.0 ** (imean - 2.0)) / g)

--- a/openquake/hazardlib/gsim/bindi_2014.py
+++ b/openquake/hazardlib/gsim/bindi_2014.py
@@ -97,7 +97,7 @@ class BindiEtAl2014Rjb(GMPE):
 
         C = self.COEFFS[imt]
         imean = self._get_mean(C, rup, dists, sites)
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             # Convert units to g,
             # but only for PGA and SA (not PGV):
             mean = np.log((10.0 ** (imean - 2.0)) / g)

--- a/openquake/hazardlib/gsim/boore_2014.py
+++ b/openquake/hazardlib/gsim/boore_2014.py
@@ -92,7 +92,7 @@ class BooreEtAl2014(GMPE):
         # intensity measure type.
         C = self.COEFFS[imt]
         C_PGA = self.COEFFS[PGA()]
-        imt_per = imt.period
+        imt_per = 0 if imt.prefix == 'PGV' else imt.period
         pga_rock = self._get_pga_on_rock(C_PGA, rup, dists)
         mean = (self._get_magnitude_scaling_term(C, rup) +
                 self._get_path_scaling(C, dists, rup.mag) +

--- a/openquake/hazardlib/gsim/boore_2014.py
+++ b/openquake/hazardlib/gsim/boore_2014.py
@@ -92,10 +92,7 @@ class BooreEtAl2014(GMPE):
         # intensity measure type.
         C = self.COEFFS[imt]
         C_PGA = self.COEFFS[PGA()]
-        if isinstance(imt, (PGA, PGV)):
-            imt_per = 0.0
-        else:
-            imt_per = imt.period
+        imt_per = imt.period
         pga_rock = self._get_pga_on_rock(C_PGA, rup, dists)
         mean = (self._get_magnitude_scaling_term(C, rup) +
                 self._get_path_scaling(C, dists, rup.mag) +

--- a/openquake/hazardlib/gsim/boore_2014.py
+++ b/openquake/hazardlib/gsim/boore_2014.py
@@ -92,7 +92,7 @@ class BooreEtAl2014(GMPE):
         # intensity measure type.
         C = self.COEFFS[imt]
         C_PGA = self.COEFFS[PGA()]
-        imt_per = 0 if imt.prefix == 'PGV' else imt.period
+        imt_per = 0 if imt.name == 'PGV' else imt.period
         pga_rock = self._get_pga_on_rock(C_PGA, rup, dists)
         mean = (self._get_magnitude_scaling_term(C, rup) +
                 self._get_path_scaling(C, dists, rup.mag) +

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
@@ -96,7 +96,7 @@ class CampbellBozorgnia2008(GMPE):
         # For spectral accelerations at periods between 0.0 and 0.25 s, Sa (T)
         # cannot be less than PGA on soil, therefore if the IMT is in this
         # period range it is necessary to calculate PGA on soil
-        if isinstance(imt, SA) and (imt.period > 0.0) and (imt.period < 0.25):
+        if imt.period > 0.0 and imt.period < 0.25:
             get_pga_site = True
         else:
             get_pga_site = False

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
@@ -96,7 +96,7 @@ class CampbellBozorgnia2008(GMPE):
         # For spectral accelerations at periods between 0.0 and 0.25 s, Sa (T)
         # cannot be less than PGA on soil, therefore if the IMT is in this
         # period range it is necessary to calculate PGA on soil
-        if imt.period > 0.0 and imt.period < 0.25:
+        if imt.name == 'SA' and imt.period > 0.0 and imt.period < 0.25:
             get_pga_site = True
         else:
             get_pga_site = False

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
@@ -103,7 +103,7 @@ class CampbellBozorgnia2014(GMPE):
         pga1100 = np.exp(self.get_mean_values(C_PGA, sites, rup, dists, None))
         # Get mean and standard deviations for IMT
         mean = self.get_mean_values(C, sites, rup, dists, pga1100)
-        if imt.prefix == "SA" and imt.period <= 0.25:
+        if imt.name == "SA" and imt.period <= 0.25:
             # According to Campbell & Bozorgnia (2013) [NGA West 2 Report]
             # If Sa (T) < PGA for T < 0.25 then set mean Sa(T) to mean PGA
             # Get PGA on soil

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
@@ -103,7 +103,7 @@ class CampbellBozorgnia2014(GMPE):
         pga1100 = np.exp(self.get_mean_values(C_PGA, sites, rup, dists, None))
         # Get mean and standard deviations for IMT
         mean = self.get_mean_values(C, sites, rup, dists, pga1100)
-        if isinstance(imt, SA) and (imt.period <= 0.25):
+        if imt.prefix == "SA" and imt.period <= 0.25:
             # According to Campbell & Bozorgnia (2013) [NGA West 2 Report]
             # If Sa (T) < PGA for T < 0.25 then set mean Sa(T) to mean PGA
             # Get PGA on soil

--- a/openquake/hazardlib/gsim/cauzzi_2014.py
+++ b/openquake/hazardlib/gsim/cauzzi_2014.py
@@ -112,10 +112,10 @@ class CauzziEtAl2014(GMPE):
                 self._get_site_amplification_term(C, sites.vs30))
         # convert from cm/s**2 to g for SA and from cm/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if isinstance(imt, PGA):
+        if imt.prefix == "PGA":
             mean = np.log((10 ** mean) * ((2 * np.pi / 0.01) ** 2) *
                           1e-2 / g)
-        elif isinstance(imt, SA):
+        elif imt.prefix == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
         else:
@@ -407,10 +407,10 @@ class CauzziEtAl2014NoSOF(CauzziEtAl2014):
                 self._get_site_amplification_term(C, sites.vs30))
         # convert from cm/s**2 to g for SA and from m/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if isinstance(imt, PGA):
+        if imt.prefix == "PGA":
             mean = np.log((10 ** mean) * ((2 * np.pi / 0.01) ** 2) *
                           1e-2 / g)
-        elif isinstance(imt, SA):
+        elif imt.prefix == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
         else:

--- a/openquake/hazardlib/gsim/cauzzi_2014.py
+++ b/openquake/hazardlib/gsim/cauzzi_2014.py
@@ -112,10 +112,10 @@ class CauzziEtAl2014(GMPE):
                 self._get_site_amplification_term(C, sites.vs30))
         # convert from cm/s**2 to g for SA and from cm/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if imt.prefix == "PGA":
+        if imt.name == "PGA":
             mean = np.log((10 ** mean) * ((2 * np.pi / 0.01) ** 2) *
                           1e-2 / g)
-        elif imt.prefix == "SA":
+        elif imt.name == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
         else:
@@ -407,10 +407,10 @@ class CauzziEtAl2014NoSOF(CauzziEtAl2014):
                 self._get_site_amplification_term(C, sites.vs30))
         # convert from cm/s**2 to g for SA and from m/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if imt.prefix == "PGA":
+        if imt.name == "PGA":
             mean = np.log((10 ** mean) * ((2 * np.pi / 0.01) ** 2) *
                           1e-2 / g)
-        elif imt.prefix == "SA":
+        elif imt.name == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
         else:

--- a/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
+++ b/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
@@ -164,9 +164,9 @@ class CauzziFaccioli2008(GMPE):
 
         # convert from cm/s**2 to g for SA and from m/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if imt.prefix == "PGA":
+        if imt.name == "PGA":
             mean = np.log((10 ** mean) / g)
-        elif imt.prefix == "SA":
+        elif imt.name == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
         else:

--- a/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
+++ b/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
@@ -164,9 +164,9 @@ class CauzziFaccioli2008(GMPE):
 
         # convert from cm/s**2 to g for SA and from m/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if isinstance(imt, PGA):
+        if imt.prefix == "PGA":
             mean = np.log((10 ** mean) / g)
-        elif isinstance(imt, SA):
+        elif imt.prefix == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
         else:

--- a/openquake/hazardlib/gsim/climent_1994.py
+++ b/openquake/hazardlib/gsim/climent_1994.py
@@ -164,7 +164,7 @@ class ClimentEtAl1994(GMPE):
 
         # convert from m/s**2 to g for PGA and from m/s to g for PSV
         # and divided this value for the ratio(SA_larger/SA_geo_mean)
-        if imt.prefix == "PGA":
+        if imt.name == "PGA":
             mean = (np.exp(mean) / g) / C['r_SA']
         else:
             W = (2. * np.pi)/imt.period

--- a/openquake/hazardlib/gsim/climent_1994.py
+++ b/openquake/hazardlib/gsim/climent_1994.py
@@ -164,11 +164,11 @@ class ClimentEtAl1994(GMPE):
 
         # convert from m/s**2 to g for PGA and from m/s to g for PSV
         # and divided this value for the ratio(SA_larger/SA_geo_mean)
-        if isinstance(imt, PGA):
-            mean = (np.exp(mean) /g) / C['r_SA']
+        if imt.prefix == "PGA":
+            mean = (np.exp(mean) / g) / C['r_SA']
         else:
             W = (2. * np.pi)/imt.period
-            mean = ((np.exp(mean) * W) /g) / C['r_SA']
+            mean = ((np.exp(mean) * W) / g) / C['r_SA']
         return np.log(mean)
 
     #: Equation coefficients, described in Table 4.1 on pp. 22

--- a/openquake/hazardlib/gsim/derras_2014.py
+++ b/openquake/hazardlib/gsim/derras_2014.py
@@ -81,7 +81,7 @@ class DerrasEtAl2014(GMPE):
         C = self.COEFFS[imt]
         # Get the mean
         mean = self.get_mean(C, rup, sites, dists)
-        if imt.prefix == "PGV":
+        if imt.name == "PGV":
             # Convert from log10 m/s to ln cm/s
             mean = np.log((10.0 ** mean) * 100.)
         else:

--- a/openquake/hazardlib/gsim/derras_2014.py
+++ b/openquake/hazardlib/gsim/derras_2014.py
@@ -81,7 +81,7 @@ class DerrasEtAl2014(GMPE):
         C = self.COEFFS[imt]
         # Get the mean
         mean = self.get_mean(C, rup, sites, dists)
-        if isinstance(imt, PGV):
+        if imt.prefix == "PGV":
             # Convert from log10 m/s to ln cm/s
             mean = np.log((10.0 ** mean) * 100.)
         else:

--- a/openquake/hazardlib/gsim/dost_2004.py
+++ b/openquake/hazardlib/gsim/dost_2004.py
@@ -78,7 +78,7 @@ class DostEtAl2004(GMPE):
         imean = (self._compute_magnitude_term(C, rup.mag) +
                  self._compute_distance_term(C, dists.rhypo))
         # Convert mean from cm/s and cm/s/s
-        if imt.prefix == "PGA":
+        if imt.name == "PGA":
             mean = np.log((10.0 ** (imean)) / g)
         else:
             mean = np.log(10.0 ** imean)

--- a/openquake/hazardlib/gsim/dost_2004.py
+++ b/openquake/hazardlib/gsim/dost_2004.py
@@ -78,7 +78,7 @@ class DostEtAl2004(GMPE):
         imean = (self._compute_magnitude_term(C, rup.mag) +
                  self._compute_distance_term(C, dists.rhypo))
         # Convert mean from cm/s and cm/s/s
-        if isinstance(imt, PGA):
+        if imt.prefix == "PGA":
             mean = np.log((10.0 ** (imean)) / g)
         else:
             mean = np.log(10.0 ** imean)

--- a/openquake/hazardlib/gsim/douglas_stochastic_2013.py
+++ b/openquake/hazardlib/gsim/douglas_stochastic_2013.py
@@ -157,7 +157,7 @@ class DouglasEtAl2013StochasticSD001Q200K005(GMPE):
 
         #: Mean ground motions initially returned in cm/s/s (for PGA, SA)
         #: and cm/s for PGV
-        if not imt.prefix == "PGV":
+        if not imt.name == "PGV":
             # Convert mean from log(cm/s/s) to g
             mean = np.log(np.exp(mean) / (100. * g))
 

--- a/openquake/hazardlib/gsim/douglas_stochastic_2013.py
+++ b/openquake/hazardlib/gsim/douglas_stochastic_2013.py
@@ -157,7 +157,7 @@ class DouglasEtAl2013StochasticSD001Q200K005(GMPE):
 
         #: Mean ground motions initially returned in cm/s/s (for PGA, SA)
         #: and cm/s for PGV
-        if not isinstance(imt, PGV):
+        if not imt.prefix == "PGV":
             # Convert mean from log(cm/s/s) to g
             mean = np.log(np.exp(mean) / (100. * g))
 

--- a/openquake/hazardlib/gsim/drouet_2015_brazil.py
+++ b/openquake/hazardlib/gsim/drouet_2015_brazil.py
@@ -77,14 +77,11 @@ class DrouetBrazil2015(GMPE):
         <.base.GroundShakingIntensityModel.get_mean_and_stddevs>`
         for spec of input and result values.
         """
-        #assert all(stddev_type in self.DEFINED_FOR_STANDARD_DEVIATION_TYPES
-        #           for stddev_type in stddev_types)
-
         C = self.COEFFS[imt]
         mean = self._compute_mean(C, rup, dists.rjb)
-        if isinstance(imt, (SA, PGA)): # Convert from m/s**2 to g
+        if imt.prefix in "SA PGA":  # Convert from m/s**2 to g
             mean -= np.log(g)
-        elif isinstance(imt, PGV): # Convert from m/s to cm/s
+        elif imt.prefix == "PGV":  # Convert from m/s to cm/s
             mean += np.log(100.0)
         stddevs = self._get_stddevs(C, stddev_types, rup.mag,
                                     dists.rjb.shape)

--- a/openquake/hazardlib/gsim/drouet_2015_brazil.py
+++ b/openquake/hazardlib/gsim/drouet_2015_brazil.py
@@ -79,9 +79,9 @@ class DrouetBrazil2015(GMPE):
         """
         C = self.COEFFS[imt]
         mean = self._compute_mean(C, rup, dists.rjb)
-        if imt.prefix in "SA PGA":  # Convert from m/s**2 to g
+        if imt.name in "SA PGA":  # Convert from m/s**2 to g
             mean -= np.log(g)
-        elif imt.prefix == "PGV":  # Convert from m/s to cm/s
+        elif imt.name == "PGV":  # Convert from m/s to cm/s
             mean += np.log(100.0)
         stddevs = self._get_stddevs(C, stddev_types, rup.mag,
                                     dists.rjb.shape)

--- a/openquake/hazardlib/gsim/edwards_fah_2013a.py
+++ b/openquake/hazardlib/gsim/edwards_fah_2013a.py
@@ -110,7 +110,7 @@ class EdwardsFah2013Alpine10Bars(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log(mean / (g*100.))
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/edwards_fah_2013a.py
+++ b/openquake/hazardlib/gsim/edwards_fah_2013a.py
@@ -110,7 +110,7 @@ class EdwardsFah2013Alpine10Bars(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log(mean / (g*100.))
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/edwards_fah_2013f.py
+++ b/openquake/hazardlib/gsim/edwards_fah_2013f.py
@@ -67,7 +67,7 @@ class EdwardsFah2013Foreland10Bars(EdwardsFah2013Alpine10Bars):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log(mean / (g*100.))
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/edwards_fah_2013f.py
+++ b/openquake/hazardlib/gsim/edwards_fah_2013f.py
@@ -67,7 +67,7 @@ class EdwardsFah2013Foreland10Bars(EdwardsFah2013Alpine10Bars):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log(mean / (g*100.))
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/faccioli_2010.py
+++ b/openquake/hazardlib/gsim/faccioli_2010.py
@@ -74,9 +74,9 @@ class FaccioliEtAl2010(CauzziFaccioli2008):
 
         # convert from cm/s**2 to g for SA and from m/s**2 to g for PGA,
         # and also convert from base 10 to base e.
-        if imt.prefix == "PGA":
+        if imt.name == "PGA":
             mean = np.log((10 ** mean) / g)
-        elif imt.prefix == "SA":
+        elif imt.name == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
 

--- a/openquake/hazardlib/gsim/faccioli_2010.py
+++ b/openquake/hazardlib/gsim/faccioli_2010.py
@@ -74,9 +74,9 @@ class FaccioliEtAl2010(CauzziFaccioli2008):
 
         # convert from cm/s**2 to g for SA and from m/s**2 to g for PGA,
         # and also convert from base 10 to base e.
-        if isinstance(imt, PGA):
+        if imt.prefix == "PGA":
             mean = np.log((10 ** mean) / g)
-        elif isinstance(imt, SA):
+        elif imt.prefix == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
 

--- a/openquake/hazardlib/gsim/ghofrani_atkinson_2014.py
+++ b/openquake/hazardlib/gsim/ghofrani_atkinson_2014.py
@@ -87,7 +87,7 @@ class GhofraniAtkinson2014(GMPE):
                  self._get_scaling_term(C, dists.rrup))
         # Convert mean from cm/s and cm/s/s and from common logarithm to
         # natural logarithm
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log((10.0 ** (imean)))

--- a/openquake/hazardlib/gsim/ghofrani_atkinson_2014.py
+++ b/openquake/hazardlib/gsim/ghofrani_atkinson_2014.py
@@ -87,7 +87,7 @@ class GhofraniAtkinson2014(GMPE):
                  self._get_scaling_term(C, dists.rrup))
         # Convert mean from cm/s and cm/s/s and from common logarithm to
         # natural logarithm
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log((10.0 ** (imean)))

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -211,9 +211,9 @@ class AmplificationTable(object):
             Number Levels]
         """
         # Levels by Distances
-        if imt.prefix in 'PGA PGV':
+        if imt.name in 'PGA PGV':
             interpolator = interp1d(self.magnitudes,
-                                    numpy.log10(self.mean[imt.prefix]), axis=2)
+                                    numpy.log10(self.mean[imt.name]), axis=2)
             output_table = 10.0 ** (
                 interpolator(rctx.mag).reshape(self.shape[0], self.shape[3]))
         else:
@@ -241,9 +241,9 @@ class AmplificationTable(object):
         output_tables = []
         for stddev_type in stddev_types:
             # For PGA and PGV only needs to apply magnitude interpolation
-            if imt.prefix in 'PGA PGV':
+            if imt.name in 'PGA PGV':
                 interpolator = interp1d(self.magnitudes,
-                                        self.sigma[stddev_type][imt.prefix],
+                                        self.sigma[stddev_type][imt.name],
                                         axis=2)
                 output_tables.append(
                     interpolator(rctx.mag).reshape(self.shape[0],
@@ -505,12 +505,12 @@ class GMPETable(GMPE):
         :param val_type:
             String indicating the type of data {"IMLs", "Total", "Inter" etc}
         """
-        if imt.prefix in 'PGA PGV':
+        if imt.name in 'PGA PGV':
             # Get scalar imt
             if val_type == "IMLs":
-                iml_table = self.imls[imt.prefix][:]
+                iml_table = self.imls[imt.name][:]
             else:
-                iml_table = self.stddevs[val_type][imt.prefix][:]
+                iml_table = self.stddevs[val_type][imt.name][:]
             n_d, n_s, n_m = iml_table.shape
             iml_table = iml_table.reshape([n_d, n_m])
         else:

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -211,12 +211,11 @@ class AmplificationTable(object):
             Number Levels]
         """
         # Levels by Distances
-        if isinstance(imt, (imt_module.PGA, imt_module.PGV)):
+        if imt.prefix in 'PGA PGV':
             interpolator = interp1d(self.magnitudes,
-                                    numpy.log10(self.mean[str(imt)]), axis=2)
+                                    numpy.log10(self.mean[imt.prefix]), axis=2)
             output_table = 10.0 ** (
-                interpolator(rctx.mag).reshape(self.shape[0], self.shape[3])
-                )
+                interpolator(rctx.mag).reshape(self.shape[0], self.shape[3]))
         else:
             # For spectral accelerations - need two step process
             # Interpolate period - log-log space
@@ -242,9 +241,9 @@ class AmplificationTable(object):
         output_tables = []
         for stddev_type in stddev_types:
             # For PGA and PGV only needs to apply magnitude interpolation
-            if isinstance(imt, (imt_module.PGA, imt_module.PGV)):
+            if imt.prefix in 'PGA PGV':
                 interpolator = interp1d(self.magnitudes,
-                                        self.sigma[stddev_type][str(imt)],
+                                        self.sigma[stddev_type][imt.prefix],
                                         axis=2)
                 output_tables.append(
                     interpolator(rctx.mag).reshape(self.shape[0],
@@ -355,7 +354,7 @@ class GMPETable(GMPE):
         # Load intensity measure types and levels
         self.imls = hdf_arrays_to_dict(fle["IMLs"])
         self.DEFINED_FOR_INTENSITY_MEASURE_TYPES = set(self._supported_imts())
-        if "SA" in self.imls.keys() and "T" not in self.imls:
+        if "SA" in self.imls and "T" not in self.imls:
             raise ValueError("Spectral Acceleration must be accompanied by "
                              "periods")
         # Get the standard deviations
@@ -410,10 +409,10 @@ class GMPETable(GMPE):
                 continue
             else:
                 try:
-                    imt_val = imt_module.from_string(key)
-                except:
+                    factory = getattr(imt_module.imt, key)
+                except Exception:
                     continue
-                imt_list.append(imt_val.__class__)
+                imt_list.append(factory)
         return imt_list
 
     def get_mean_and_stddevs(self, sctx, rctx, dctx, imt, stddev_types):
@@ -506,12 +505,12 @@ class GMPETable(GMPE):
         :param val_type:
             String indicating the type of data {"IMLs", "Total", "Inter" etc}
         """
-        if isinstance(imt, (imt_module.PGA, imt_module.PGV)):
+        if imt.prefix in 'PGA PGV':
             # Get scalar imt
             if val_type == "IMLs":
-                iml_table = self.imls[str(imt)][:]
+                iml_table = self.imls[imt.prefix][:]
             else:
-                iml_table = self.stddevs[val_type][str(imt)][:]
+                iml_table = self.stddevs[val_type][imt.prefix][:]
             n_d, n_s, n_m = iml_table.shape
             iml_table = iml_table.reshape([n_d, n_m])
         else:
@@ -524,8 +523,8 @@ class GMPETable(GMPE):
 
             low_period = round(periods[0], 7)
             high_period = round(periods[-1], 7)
-            if (round(imt.period, 7) < low_period) or\
-                (round(imt.period, 7) > high_period):
+            if (round(imt.period, 7) < low_period) or (
+                    round(imt.period, 7) > high_period):
                 raise ValueError("Spectral period %.3f outside of valid range "
                                  "(%.3f to %.3f)" % (imt.period, periods[0],
                                                      periods[-1]))

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -409,7 +409,7 @@ class GMPETable(GMPE):
                 continue
             else:
                 try:
-                    factory = getattr(imt_module.imt, key)
+                    factory = getattr(imt_module, key)
                 except Exception:
                     continue
                 imt_list.append(factory)

--- a/openquake/hazardlib/gsim/idriss_2014.py
+++ b/openquake/hazardlib/gsim/idriss_2014.py
@@ -144,7 +144,7 @@ class Idriss2014(GMPE):
         else:
             stddev_mag = mag
 
-        if isinstance(imt, PGA) or (imt.period < 0.05):
+        if imt.prefix == "PGA" or imt.period < 0.05:
             total_sigma = 1.18 + 0.035 * np.log(0.05) - 0.06 * stddev_mag
         elif imt.period > 3.0:
             total_sigma = 1.18 + 0.035 * np.log(3.0) - 0.06 * stddev_mag

--- a/openquake/hazardlib/gsim/idriss_2014.py
+++ b/openquake/hazardlib/gsim/idriss_2014.py
@@ -144,7 +144,7 @@ class Idriss2014(GMPE):
         else:
             stddev_mag = mag
 
-        if imt.prefix == "PGA" or imt.period < 0.05:
+        if imt.name == "PGA" or imt.period < 0.05:
             total_sigma = 1.18 + 0.035 * np.log(0.05) - 0.06 * stddev_mag
         elif imt.period > 3.0:
             total_sigma = 1.18 + 0.035 * np.log(3.0) - 0.06 * stddev_mag

--- a/openquake/hazardlib/gsim/kanno_2006.py
+++ b/openquake/hazardlib/gsim/kanno_2006.py
@@ -148,7 +148,7 @@ class Kanno2006Shallow(GMPE):
         ln_stddevs = np.array(log_stddevs)*LOG10
 
         # convert accelerations from cm/s^2 to g
-        if not isinstance(imt, PGV):
+        if not imt.prefix == "PGV":
             ln_mean -= np.log(100*g)
 
         return ln_mean, ln_stddevs

--- a/openquake/hazardlib/gsim/kanno_2006.py
+++ b/openquake/hazardlib/gsim/kanno_2006.py
@@ -148,7 +148,7 @@ class Kanno2006Shallow(GMPE):
         ln_stddevs = np.array(log_stddevs)*LOG10
 
         # convert accelerations from cm/s^2 to g
-        if not imt.prefix == "PGV":
+        if not imt.name == "PGV":
             ln_mean -= np.log(100*g)
 
         return ln_mean, ln_stddevs

--- a/openquake/hazardlib/gsim/kotha_2016.py
+++ b/openquake/hazardlib/gsim/kotha_2016.py
@@ -88,7 +88,7 @@ class KothaEtAl2016(GMPE):
 
         # Units of GMPE are in terms of m/s (corrected in an Erratum)
         # Convert to g
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log(np.exp(mean) / g)
         else:
             # For PGV convert from m/s to cm/s/s

--- a/openquake/hazardlib/gsim/kotha_2016.py
+++ b/openquake/hazardlib/gsim/kotha_2016.py
@@ -88,7 +88,7 @@ class KothaEtAl2016(GMPE):
 
         # Units of GMPE are in terms of m/s (corrected in an Erratum)
         # Convert to g
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log(np.exp(mean) / g)
         else:
             # For PGV convert from m/s to cm/s/s

--- a/openquake/hazardlib/gsim/megawati_2003.py
+++ b/openquake/hazardlib/gsim/megawati_2003.py
@@ -79,7 +79,7 @@ class MegawatiEtAl2003(GMPE):
                 self._get_distance_scaling(coe, dists.rhypo) +
                 self._get_azimuth_correction(coe, dists.azimuth))
         # Convert to g
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log(np.exp(mean) / (100.0 * g))
         # Compute std
         stddevs = self._compute_std(coe, stddev_types, dists.azimuth.shape)

--- a/openquake/hazardlib/gsim/megawati_2003.py
+++ b/openquake/hazardlib/gsim/megawati_2003.py
@@ -79,7 +79,7 @@ class MegawatiEtAl2003(GMPE):
                 self._get_distance_scaling(coe, dists.rhypo) +
                 self._get_azimuth_correction(coe, dists.azimuth))
         # Convert to g
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log(np.exp(mean) / (100.0 * g))
         # Compute std
         stddevs = self._compute_std(coe, stddev_types, dists.azimuth.shape)

--- a/openquake/hazardlib/gsim/megawati_pan_2010.py
+++ b/openquake/hazardlib/gsim/megawati_pan_2010.py
@@ -84,7 +84,7 @@ class MegawatiPan2010(GMPE):
         C = self.COEFFS[imt]
         mean = (self._get_magnitude_scaling(C, rup.mag) +
                 self._get_distance_scaling(C, rup.mag, dists.rhypo))
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log(np.exp(mean) / (100.0 * g))
         stddevs = self._compute_std(C, stddev_types, len(dists.rhypo))
         return mean, stddevs

--- a/openquake/hazardlib/gsim/megawati_pan_2010.py
+++ b/openquake/hazardlib/gsim/megawati_pan_2010.py
@@ -84,7 +84,7 @@ class MegawatiPan2010(GMPE):
         C = self.COEFFS[imt]
         mean = (self._get_magnitude_scaling(C, rup.mag) +
                 self._get_distance_scaling(C, rup.mag, dists.rhypo))
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log(np.exp(mean) / (100.0 * g))
         stddevs = self._compute_std(C, stddev_types, len(dists.rhypo))
         return mean, stddevs

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -147,7 +147,7 @@ def global_tau(imt, mag, params):
     'Global' model of inter-event variability, as presented in equation 5.6
     (p103)
     """
-    if isinstance(imt, PGV):
+    if imt.prefix == "PGV":
         C = params["PGV"]
     else:
         C = params["SA"]
@@ -167,7 +167,7 @@ def cena_constant_tau(imt, mag, params):
     """
     Returns the inter-event tau for the constant tau case
     """
-    if isinstance(imt, PGV):
+    if imt.prefix == "PGV":
         return params["PGV"]["tau"]
     else:
         return params["SA"]["tau"]
@@ -177,7 +177,7 @@ def cena_tau(imt, mag, params):
     """
     Returns the inter-event standard deviation, tau, for the CENA case
     """
-    if isinstance(imt, PGV):
+    if imt.prefix == "PGV":
         C = params["PGV"]
     else:
         C = params["SA"]

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -147,7 +147,7 @@ def global_tau(imt, mag, params):
     'Global' model of inter-event variability, as presented in equation 5.6
     (p103)
     """
-    if imt.prefix == "PGV":
+    if imt.name == "PGV":
         C = params["PGV"]
     else:
         C = params["SA"]
@@ -167,7 +167,7 @@ def cena_constant_tau(imt, mag, params):
     """
     Returns the inter-event tau for the constant tau case
     """
-    if imt.prefix == "PGV":
+    if imt.name == "PGV":
         return params["PGV"]["tau"]
     else:
         return params["SA"]["tau"]
@@ -177,7 +177,7 @@ def cena_tau(imt, mag, params):
     """
     Returns the inter-event standard deviation, tau, for the CENA case
     """
-    if imt.prefix == "PGV":
+    if imt.name == "PGV":
         C = params["PGV"]
     else:
         C = params["SA"]

--- a/openquake/hazardlib/gsim/rietbrock_2013.py
+++ b/openquake/hazardlib/gsim/rietbrock_2013.py
@@ -90,7 +90,7 @@ class RietbrockEtAl2013SelfSimilar(GMPE):
                  self._get_distance_scaling_term(C, dists.rjb, rup.mag))
         # convert from cm/s**2 to g for SA and from cm/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log(10 ** imean)

--- a/openquake/hazardlib/gsim/rietbrock_2013.py
+++ b/openquake/hazardlib/gsim/rietbrock_2013.py
@@ -90,7 +90,7 @@ class RietbrockEtAl2013SelfSimilar(GMPE):
                  self._get_distance_scaling_term(C, dists.rjb, rup.mag))
         # convert from cm/s**2 to g for SA and from cm/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log(10 ** imean)

--- a/openquake/hazardlib/gsim/shahjouei_pezeshk_2016.py
+++ b/openquake/hazardlib/gsim/shahjouei_pezeshk_2016.py
@@ -167,7 +167,7 @@ class ShahjoueiPezeshk2016(GMPE):
         described on page 744, eq. 4
         """
         sigma_mean = 0.
-        if imt.prefix in "SA PGA":
+        if imt.name in "SA PGA":
             psi = -6.898E-3
         else:
             psi = -3.054E-5

--- a/openquake/hazardlib/gsim/shahjouei_pezeshk_2016.py
+++ b/openquake/hazardlib/gsim/shahjouei_pezeshk_2016.py
@@ -167,7 +167,7 @@ class ShahjoueiPezeshk2016(GMPE):
         described on page 744, eq. 4
         """
         sigma_mean = 0.
-        if isinstance(imt, (PGA, SA)):
+        if imt.prefix in "SA PGA":
             psi = -6.898E-3
         else:
             psi = -3.054E-5

--- a/openquake/hazardlib/gsim/si_midorikawa_1999.py
+++ b/openquake/hazardlib/gsim/si_midorikawa_1999.py
@@ -207,8 +207,6 @@ class SiMidorikawa1999Asc(GMPE):
         """
         Return mean value as defined in equation 3.5.1-1 page 148
         """
-        assert imt.__class__ in self.DEFINED_FOR_INTENSITY_MEASURE_TYPES
-
         # clip magnitude at 8.3 as per note at page 3-36 in table Table 3.3.2-6
         # in "Technical Reports on National Seismic Hazard Maps for Japan"
         mag = min(mag, 8.3)

--- a/openquake/hazardlib/gsim/toro_2002.py
+++ b/openquake/hazardlib/gsim/toro_2002.py
@@ -55,8 +55,8 @@ class ToroEtAl2002(GMPE):
     ])
 
     #: Supported intensity measure component is the geometric mean of
-    #two : horizontal components
-    #:attr:`~openquake.hazardlib.const.IMC.AVERAGE_HORIZONTAL`,
+    #: two : horizontal components
+    #: :attr:`~openquake.hazardlib.const.IMC.AVERAGE_HORIZONTAL`,
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.AVERAGE_HORIZONTAL
 
     #: Supported standard deviation type is only total.
@@ -89,11 +89,10 @@ class ToroEtAl2002(GMPE):
 
         # apply decay factor for 3 and 4 seconds (not originally supported
         # by the equations)
-        if isinstance(imt, SA):
-            if imt.period == 3.0:
-                mean /= 0.612
-            if imt.period == 4.0:
-                mean /= 0.559
+        if imt.period == 3.0:
+            mean /= 0.612
+        if imt.period == 4.0:
+            mean /= 0.559
 
         return mean, stddevs
 
@@ -139,7 +138,7 @@ class ToroEtAl2002(GMPE):
         sigma_ale = np.sqrt(sigma_ale_m ** 2 + sigma_ale_rjb ** 2)
 
         # epistemic uncertainty
-        if isinstance(imt, PGA) or (isinstance(imt, SA) and imt.period < 1):
+        if imt.period < 1:
             sigma_epi = 0.36 + 0.07 * (mag - 6)
         else:
             sigma_epi = 0.34 + 0.06 * (mag - 6)

--- a/openquake/hazardlib/gsim/utils.py
+++ b/openquake/hazardlib/gsim/utils.py
@@ -41,15 +41,16 @@ def mblg_to_mw_atkinson_boore_87(mag):
     """
     return 2.715 - 0.277 * mag + 0.127 * mag * mag
 
+
 def clip_mean(imt, mean):
     """
     Clip GMPE mean value at 1.5 g for PGA and 3 g for short periods
     (0.02 < T < 0.55)
     """
-    if imt == PGA():
+    if imt.period == 0:
         mean[mean > 0.405] = 0.405
 
-    if isinstance(imt, SA) and (0.02 < imt.period < 0.55):
+    if 0.02 < imt.period < 0.55:
         mean[mean > 1.099] = 1.099
 
     return mean

--- a/openquake/hazardlib/gsim/yu_2013.py
+++ b/openquake/hazardlib/gsim/yu_2013.py
@@ -214,19 +214,19 @@ class YuEtAl2013Ms(GMPE):
         # 225 is hardcoded under the assumption that the hypocentral depth
         # corresponds to 15 km (i.e. 15**2)
         mean1 = (a1ca + a1cb * mag +
-                    a1cc * np.log((ras**2+225)**0.5 +
-                                a1cd * np.exp(a1ce * mag)))
+                 a1cc * np.log((ras**2+225)**0.5 +
+                               a1cd * np.exp(a1ce * mag)))
         mean2 = (a2ca + a2cb * mag +
-                    a2cc * np.log((rbs**2+225)**0.5 +
-                                a2cd * np.exp(a2ce * mag)))
+                 a2cc * np.log((rbs**2+225)**0.5 +
+                               a2cd * np.exp(a2ce * mag)))
         #
         # Get distances
         x = (mean1 * np.sin(np.radians(dists.azimuth)))**2
         y = (mean2 * np.cos(np.radians(dists.azimuth)))**2
         mean = mean1 * mean2 / np.sqrt(x+y)
-        if isinstance(imt, (PGA)):
+        if imt.prefix == "PGA":
             mean = np.exp(mean)/g/100
-        elif isinstance(imt, (PGV)):
+        elif imt.prefix == "PGV":
             mean = np.exp(mean)
         else:
             raise ValueError('Unsupported IMT')
@@ -338,9 +338,9 @@ class YuEtAl2013Mw(YuEtAl2013Ms):
         x = (mean1 * np.sin(np.radians(dists.azimuth)))**2
         y = (mean2 * np.cos(np.radians(dists.azimuth)))**2
         mean = mean1 * mean2 / np.sqrt(x+y)
-        if isinstance(imt, (PGA)):
+        if imt.prefix == "PGA":
             mean = np.exp(mean)/g/100
-        elif isinstance(imt, (PGV)):
+        elif imt.prefix == "PGV":
             mean = np.exp(mean)
         else:
             raise ValueError('Unsupported IMT')

--- a/openquake/hazardlib/gsim/yu_2013.py
+++ b/openquake/hazardlib/gsim/yu_2013.py
@@ -224,9 +224,9 @@ class YuEtAl2013Ms(GMPE):
         x = (mean1 * np.sin(np.radians(dists.azimuth)))**2
         y = (mean2 * np.cos(np.radians(dists.azimuth)))**2
         mean = mean1 * mean2 / np.sqrt(x+y)
-        if imt.prefix == "PGA":
+        if imt.name == "PGA":
             mean = np.exp(mean)/g/100
-        elif imt.prefix == "PGV":
+        elif imt.name == "PGV":
             mean = np.exp(mean)
         else:
             raise ValueError('Unsupported IMT')
@@ -338,9 +338,9 @@ class YuEtAl2013Mw(YuEtAl2013Ms):
         x = (mean1 * np.sin(np.radians(dists.azimuth)))**2
         y = (mean2 * np.cos(np.radians(dists.azimuth)))**2
         mean = mean1 * mean2 / np.sqrt(x+y)
-        if imt.prefix == "PGA":
+        if imt.name == "PGA":
             mean = np.exp(mean)/g/100
-        elif imt.prefix == "PGV":
+        elif imt.name == "PGV":
             mean = np.exp(mean)
         else:
             raise ValueError('Unsupported IMT')

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -81,7 +81,7 @@ class _IMT(tuple, metaclass=IMTMeta):
     _fields = ()
 
     @property
-    def prefix(self):
+    def name(self):
         return self[0]
 
     def __new__(cls, sa_period=None, sa_damping=None):
@@ -100,7 +100,7 @@ class _IMT(tuple, metaclass=IMTMeta):
             other[0], other[1] or 0, other[2] or 0)
 
     def __repr__(self):
-        if not self._fields:  # return the prefix
+        if not self._fields:  # return the name
             return self[0]
         return '%s(%s)' % (type(self).__name__,
                            ', '.join(str(getattr(self, field))

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -80,6 +80,10 @@ class _IMT(tuple, metaclass=IMTMeta):
     """
     _fields = ()
 
+    @property
+    def prefix(self):
+        return self[0]
+
     def __new__(cls, sa_period=None, sa_damping=None):
         return tuple.__new__(cls, (cls.__name__, sa_period, sa_damping))
 

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -100,9 +100,11 @@ class _IMT(tuple, metaclass=IMTMeta):
             other[0], other[1] or 0, other[2] or 0)
 
     def __repr__(self):
+        if not self._fields:  # return the prefix
+            return self[0]
         return '%s(%s)' % (type(self).__name__,
-                           ', '.join('%s=%s' % (field, getattr(self, field))
-                                     for field in type(self)._fields))
+                           ', '.join(str(getattr(self, field))
+                                     for field in self._fields))
 
 
 class PGA(_IMT):

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -82,6 +82,7 @@ class _IMT(tuple, metaclass=IMTMeta):
 
     @property
     def name(self):
+        """The name of the Intensity Measure Type (ex. "PGA", "SA", ...)"""
         return self[0]
 
     def __new__(cls, sa_period=None, sa_damping=None):


### PR DESCRIPTION
[isinstance checks are a bad practice in Python](http://www.voidspace.org.uk/python/articles/duck_typing.shtml) . In spite of that, there are plenty of `isinstance` checks in hazardlib. In particular the `isinstance(imt, ...)` checks are annoying right now because they forbid refactoring the IMT mechanism along the lines described in https://github.com/gem/oq-engine/issues/3919. So the first step is to replace all those checks with duck typing friendly checks. I am also (slightly) changing the string representation of IMT objects. This will be useful in the future.