### PR TITLE
Optimized the parsing of the source model tree

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Optimized the parsing of the logic tree when there is no "applyToSources"
   * Made the IMT classes extensible in client code
   * Reduced the hazard maps from 64 to 32 bit, to be consistent with the
     hazard curves and to reduce by half the download time

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -27,7 +27,7 @@ from openquake.baselib.general import groupby
 from openquake.baselib.performance import Monitor
 from openquake.baselib.parallel import get_pickled_sizes
 from openquake.hazardlib import gsim, nrml, InvalidFile
-from openquake.commonlib import readinput
+from openquake.commonlib import readinput, logictree
 from openquake.calculators.export import export
 from openquake.calculators.extract import extract
 from openquake.calculators import base, reportwriter
@@ -146,8 +146,7 @@ def info(calculators, gsims, views, exports, extracts, report, input_file=''):
             print(source_model_info([node[0]]))
         elif node[0].tag.endswith('logicTree'):
             nodes = [nrml.read(sm_path)[0]
-                     for sm_paths in readinput.gen_sm_paths(input_file)
-                     for sm_path in sm_paths]
+                     for sm_path in logictree.collect_info(input_file).smpaths]
             print(source_model_info(nodes))
         else:
             print(node.to_str())

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -602,8 +602,6 @@ class SourceModelLogicTree(object):
 
     def get_source_ids(self):
         """
-        :param oqparam:
-            an :class:`openquake.commonlib.oqvalidation.OqParam` instance
         :returns:
             the complete set of source IDs found in all the source models
         """

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -576,9 +576,6 @@ class SourceModelLogicTree(object):
                     'characteristicFault')
 
     def __init__(self, filename, validate=True, seed=0, num_samples=0):
-        self.info = collect_info(filename)
-        if self.info.applytosources:
-            self.source_ids = self.get_source_ids()
         self.filename = filename
         self.basepath = os.path.dirname(filename)
         self.seed = seed
@@ -630,6 +627,11 @@ class SourceModelLogicTree(object):
         Parse the whole tree and point ``root_branchset`` attribute
         to the tree's root.
         """
+        self.info = collect_info(self.filename)
+        if self.info.applytosources:
+            self.source_ids = self.get_source_ids()
+        else:
+            self.source_ids = set()
         for depth, branchinglevel_node in enumerate(tree_node.nodes):
             self.parse_branchinglevel(branchinglevel_node, depth, validate)
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -425,48 +425,6 @@ def get_rupture(oqparam):
     return rup
 
 
-def read_source_groups(fname):
-    """
-    :param fname: a path to a source model XML file
-    :return: a list of SourceGroup objects containing source nodes
-    """
-    smodel = nrml.read(fname).sourceModel
-    src_groups = []
-    if smodel[0].tag.endswith('sourceGroup'):  # NRML 0.5 format
-        for sg_node in smodel:
-            sg = sourceconverter.SourceGroup(
-                sg_node['tectonicRegion'])
-            sg.sources = sg_node.nodes
-            src_groups.append(sg)
-    else:  # NRML 0.4 format: smodel is a list of source nodes
-        src_groups.extend(
-            sourceconverter.SourceGroup.collect(smodel))
-    return src_groups
-
-
-def get_source_ids(oqparam):
-    """
-    :param oqparam:
-        an :class:`openquake.commonlib.oqvalidation.OqParam` instance
-    :returns:
-        the complete set of source IDs found in all the source models
-    """
-    fnames = oqparam.inputs['source']
-    source_ids = set()
-    logging.info('Reading source IDs from %d model file(s)', len(fnames))
-    for fname in fnames:
-        if fname.endswith('.hdf5'):
-            with hdf5.File(fname, 'r') as f:
-                for sg in f['/']:
-                    for src in sg:
-                        source_ids.add(src.source_id)
-        else:
-            for sg in read_source_groups(fname):
-                for src_node in sg:
-                    source_ids.add(src_node['id'])
-    return source_ids
-
-
 def get_source_model_lt(oqparam):
     """
     :param oqparam:
@@ -480,8 +438,7 @@ def get_source_model_lt(oqparam):
         # NB: converting the random_seed into an integer is needed on Windows
         return logictree.SourceModelLogicTree(
             fname, validate=False, seed=int(oqparam.random_seed),
-            num_samples=oqparam.number_of_logic_tree_samples,
-            source_ids=get_source_ids(oqparam))
+            num_samples=oqparam.number_of_logic_tree_samples)
     return logictree.FakeSmlt(oqparam.inputs['source_model'],
                               int(oqparam.random_seed),
                               oqparam.number_of_logic_tree_samples)
@@ -538,7 +495,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
                 src_groups.extend(psr.parse(
                     fname, pik[fname], apply_unc, oqparam.investigation_time))
             else:  # just collect the TRT models
-                src_groups.extend(read_source_groups(fname))
+                src_groups.extend(logictree.read_source_groups(fname))
         num_sources = sum(len(sg.sources) for sg in src_groups)
         sm.src_groups = src_groups
         trts = [mod.trt for mod in src_groups]

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -38,7 +38,7 @@ import openquake.hazardlib
 from openquake.hazardlib import geo
 from openquake.baselib.general import gettemp
 from openquake.hazardlib import valid
-from openquake.commonlib import logictree, readinput, tests, source
+from openquake.commonlib import logictree, readinput, tests
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.mfd import TruncatedGRMFD, EvenlyDiscretizedMFD
@@ -2465,8 +2465,7 @@ class LogicTreeProcessorParsePathTestCase(unittest.TestCase):
     def test_parse_invalid_smlt(self):
         smlt = os.path.join(DATADIR, 'source_model_logic_tree.xml')
         with self.assertRaises(Exception) as ctx:
-            for smpath in logictree.collect_source_model_paths(smlt):
-                pass
+            logictree.collect_info(smlt)
         exc = ctx.exception
         self.assertIn('not well-formed (invalid token)', str(exc))
         self.assertEqual(exc.lineno, 5)

--- a/utils/renumber_sources
+++ b/utils/renumber_sources
@@ -18,7 +18,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import logging
 from openquake.baselib import sap
-from openquake.commonlib import readinput
+from openquake.commonlib import readinput, logictree
 from openquake.hazardlib import nrml
 
 
@@ -57,8 +57,8 @@ def renumber_sources(smlt_file):
     XML files in place, without making a backup, so be careful.
     """
     logging.basicConfig(level=logging.INFO)
-    for paths in readinput.gen_sm_paths(smlt_file):
-        renumber(paths, number=1)
+    for info in logictree.collect_info(smlt_file):
+        renumber(info.smpaths, number=1)
 
 
 renumber_sources.arg('smlt_file', 'source model logic tree file')


### PR DESCRIPTION
When a source model logic tree has attributes "applyToSources" on the branchsets it is necessary to read all of the source models to check that the source IDs in the logic tree match the source IDs in the models.
Unfortunately, at the moment this operation is performed always, even when there is no "applyToSources" in the logic tree. This has a negative performance effect on extra large source models (i.e. Trevor's model which has no "applyToSources").  This PR fixes the issue. On Trevor's model we can save ~15 minutes.