### PR TITLE
Removed the ProcessPool and used subprocesses instead

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the multiprocessing.ProcessPool
   * Optimized the parsing of the logic tree when there is no "applyToSources"
   * Made the IMT classes extensible in client code
   * Reduced the hazard maps from 64 to 32 bit, to be consistent with the

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Removed the multiprocessing.ProcessPool
+  * Removed the multiprocessing ProcessPool
   * Optimized the parsing of the logic tree when there is no "applyToSources"
   * Made the IMT classes extensible in client code
   * Reduced the hazard maps from 64 to 32 bit, to be consistent with the

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -693,7 +693,8 @@ class Starmap(object):
             yield from self._loop(start(it), iter(socket), next(it))
 
     def _gen_popen_args(self):
-        allargs = list(self._genargs())
+        with self.monitor('getting %s arguments' % self.name):
+            allargs = list(self._genargs())
         yield len(allargs)
         for args in allargs:
             pik = pickle.dumps((self.task_func, args, self.monitor),

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -179,7 +179,7 @@ OQ_DISTRIBUTE = os.environ.get('OQ_DISTRIBUTE', 'processpool').lower()
 if OQ_DISTRIBUTE == 'futures':  # legacy name
     print('Warning: OQ_DISTRIBUTE=futures is deprecated', file=sys.stderr)
     OQ_DISTRIBUTE = os.environ['OQ_DISTRIBUTE'] = 'processpool'
-if OQ_DISTRIBUTE not in ('no', 'subprocess', 'processpool', 'threadpool',
+if OQ_DISTRIBUTE not in ('no', 'processpool', 'threadpool',
                          'celery', 'zmq', 'dask'):
     raise ValueError('Invalid oq_distribute=%s' % OQ_DISTRIBUTE)
 
@@ -519,30 +519,6 @@ class IterResult(object):
         return res
 
 
-def init_workers():
-    """Waiting function, used to wake up the process pool"""
-    setproctitle('oq-worker')
-    # unregister raiseMasterKilled in oq-workers to avoid deadlock
-    # since processes are terminated via pool.terminate()
-    signal.signal(signal.SIGTERM, signal.SIG_DFL)
-    # prctl is still useful (on Linux) to terminate all spawned processes
-    # when master is killed via SIGKILL
-    try:
-        import prctl
-    except ImportError:
-        pass
-    else:
-        # if the parent dies, the children die
-        prctl.set_pdeathsig(signal.SIGKILL)
-    return os.getpid()
-
-
-def _wakeup(sec, mon):
-    """Waiting function, used to wake up the process pool"""
-    time.sleep(sec)
-    return os.getpid()
-
-
 SAFELY_CALL = '''\
 import sys, pickle
 from openquake.baselib.parallel import safely_call
@@ -551,17 +527,26 @@ with open(sys.argv[1], 'rb') as f:
 safely_call(*func_args_mon)'''
 
 
-def completed(popen_args, free_cpus=cpu_count):
+def wait(popens, delta=.25):
+    while popens:
+        time.sleep(delta)
+        ready = [po for po in popens if po.poll() is not None]
+        if ready:
+            for po in ready:
+                popens.remove(po)
+            return ready
+
+
+def start(popen_args, free_cpus=cpu_count):
     to_send = collections.deque(popen_args)
-    to_recv = collections.deque()
+    to_recv = []  # popen objects
     while to_send or to_recv:
         for _ in range(min(len(to_send), free_cpus)):
             popen_args = to_send.popleft()
             to_recv.append(subprocess.Popen(popen_args))
-        popen = to_recv.popleft()
-        popen.wait()
-        yield popen
-        free_cpus = 1
+        ready = wait(to_recv)
+        yield from ready
+        free_cpus = len(ready)
 
 
 class Starmap(object):
@@ -571,30 +556,14 @@ class Starmap(object):
     hdf5 = None
 
     @classmethod
-    def init(cls, poolsize=None, distribute=OQ_DISTRIBUTE):
-        if distribute == 'processpool' and not hasattr(cls, 'pool'):
-            cls.pool = multiprocessing.Pool(poolsize, init_workers)
-            m = Monitor('wakeup')
-            ires = cls(
-                _wakeup, [(.2, m) for _ in range(cls.pool._processes)]
-            ).submit_all(logging.debug)
-            cls.pids = list(ires)
-            cls.task_ids = []
-        elif distribute == 'threadpool' and not hasattr(cls, 'pool'):
-            cls.pool = multiprocessing.dummy.Pool(poolsize)
-        elif distribute == 'no' and hasattr(cls, 'pool'):
-            cls.shutdown()
-        elif distribute == 'dask':
+    def init(cls, distribute=OQ_DISTRIBUTE):
+        cls.pids = []  # TODO: see if we can remove this
+        cls.task_ids = []  # TODO: see if we can remove this
+        if distribute == 'dask':
             cls.dask_client = Client()
 
     @classmethod
-    def shutdown(cls, poolsize=None):
-        if hasattr(cls, 'pool'):
-            cls.pool.close()
-            cls.pool.terminate()
-            cls.pool.join()
-            del cls.pool
-            cls.pids = []
+    def shutdown(cls):
         if hasattr(cls, 'dask_client'):
             del cls.dask_client
 
@@ -710,7 +679,7 @@ class Starmap(object):
         for args in allargs:
             yield safely_call(self.task_func, args, self.monitor)
 
-    def _iter_subprocess(self):
+    def _iter_processpool(self):
         with Socket(self.receiver, zmq.PULL, 'bind') as socket:
             self.monitor.backurl = 'tcp://%s:%s' % (
                 config.dbserver.host, socket.port)
@@ -720,26 +689,20 @@ class Starmap(object):
                                    pickle.HIGHEST_PROTOCOL)
                 pikfile = gettemp(pik, suffix='.pik')
                 popens.append([sys.executable, '-c', SAFELY_CALL, pikfile])
-            yield from self._loop(completed(popens), iter(socket), len(popens))
-
-    def _iter_processpool(self):
-        safefunc = functools.partial(safely_call, self.task_func,
-                                     monitor=self.monitor)
-        allargs = list(self._genargs())
-        yield len(allargs)
-        yield from self.pool.imap_unordered(safefunc, allargs)
-
-    _iter_threadpool = _iter_processpool
+            yield from self._loop(start(popens), iter(socket), len(popens))
 
     def _loop(self, ierr, isocket, num_results):
         yield num_results
-        for err, res in zip(ierr, isocket):
+        for err in ierr:
             if isinstance(err, Exception):  # TaskRevokedError
                 raise err
-            elif self.calc_id and self.calc_id != res.mon.calc_id:
-                logging.warn('Discarding a result from job %d, since this '
-                             'is job %d', res.mon.calc_id, self.calc_id)
-                continue
+            while True:
+                res = next(isocket)
+                if self.calc_id and self.calc_id != res.mon.calc_id:
+                    logging.warn('Discarding a result from job %d, since this '
+                                 'is job %d', res.mon.calc_id, self.calc_id)
+                else:
+                    break
             yield res
 
     def _iter_celery(self):

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -433,7 +433,7 @@ class IterResult(object):
             next(self.log_percent)
         else:
             self.progress('No %s tasks were submitted', self.name)
-        self.progress('Sent %s of data in %s task(s)',
+        self.progress('Pickled %s of data in %s task(s)',
                       humansize(sent.sum()), num_tasks)
 
     def _log_percent(self):
@@ -702,7 +702,7 @@ class Starmap(object):
             self.monitor.backurl = 'tcp://%s:%s' % (
                 config.dbserver.host, socket.port)
             popens = []
-            for args in self._genargs(pickle=False):
+            for args in self._genargs():
                 pik = pickle.dumps((self.task_func, args, self.monitor),
                                    pickle.HIGHEST_PROTOCOL)
                 pikfile = gettemp(pik, suffix='.pik')

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -518,8 +518,9 @@ class IterResult(object):
 
 
 SAFELY_CALL = '''\
-import sys, pickle
+import sys, pickle, setproctitle
 from openquake.baselib.parallel import safely_call
+setproctitle.setproctitle('oq-subprocess')
 with open(sys.argv[1], 'rb') as f:
     func_args_mon = pickle.load(f)
 safely_call(*func_args_mon)'''

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -23,7 +23,7 @@ There are several good libraries to manage parallel programming, both
 in the standard library and in third party packages. Since we are not
 interested in reinventing the wheel, OpenQuake does not offer any new
 parallel library; however, it does offer some glue code so that you
-can use your library of choice. Currently threading, multiprocessing,
+can use your library of choice. Currently threading, subprocess,
 zmq and celery are supported. Moreover,
 :mod:`openquake.baselib.parallel` offers some additional facilities
 that make it easier to parallelize scientific computations,
@@ -78,7 +78,7 @@ environment variable `OQ_DISTRIBUTE`. Here are the possibilities
 available at the moment:
 
 `OQ_DISTRIBUTE` not set or set to "processpool":
-  use multiprocessing
+  use subprocesses
 `OQ_DISTRIBUTE` set to "no":
   disable the parallelization, useful for debugging
 `OQ_DISTRIBUTE` set to "celery":
@@ -147,7 +147,6 @@ import os
 import sys
 import time
 import socket
-import signal
 import pickle
 import inspect
 import logging
@@ -157,7 +156,6 @@ import itertools
 import traceback
 import subprocess
 import collections
-import multiprocessing.dummy
 import psutil
 import numpy
 try:
@@ -173,7 +171,7 @@ from openquake.baselib.performance import Monitor, memory_rss, perf_dt
 from openquake.baselib.general import (
     split_in_blocks, block_splitter, AccumDict, humansize, gettemp)
 
-cpu_count = multiprocessing.cpu_count()
+cpu_count = os.cpu_count()
 GB = 1024 ** 3
 OQ_DISTRIBUTE = os.environ.get('OQ_DISTRIBUTE', 'processpool').lower()
 if OQ_DISTRIBUTE == 'futures':  # legacy name

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -82,6 +82,7 @@ class StarmapTestCase(unittest.TestCase):
 
 class ThreadPoolTestCase(unittest.TestCase):
     def test(self):
+        raise unittest.SkipTest('Not implemented')
         monitor = parallel.Monitor()
         with mock.patch.dict(os.environ, {'OQ_DISTRIBUTE': 'threadpool'}):
             parallel.Starmap.init()

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1547,7 +1547,7 @@ def parallel_pickle_source_models(gsim_lt, source_model_lt,
     for sm in source_model_lt.gen_source_models(gsim_lt):
         for name in sm.names.split():
             fnames.add(os.path.abspath(os.path.join(smlt_dir, name)))
-    dist = 'no' if os.environ.get('OQ_DISTRIBUTE') == 'no' else 'subprocess'
+    dist = 'no' if os.environ.get('OQ_DISTRIBUTE') == 'no' else 'processpool'
     dic = parallel.Starmap.apply(
         nrml.pickle_source_models,
         (sorted(fnames), converter, monitor),

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1490,10 +1490,9 @@ def parallel_pickle_source_models(gsim_lt, source_model_lt,
     for sm in source_model_lt.gen_source_models(gsim_lt):
         for name in sm.names.split():
             fnames.add(os.path.abspath(os.path.join(smlt_dir, name)))
-    dist = 'no' if os.environ.get('OQ_DISTRIBUTE') == 'no' else 'processpool'
+    dist = 'no' if os.environ.get('OQ_DISTRIBUTE') == 'no' else 'subprocess'
     dic = parallel.Starmap.apply(
         nrml.pickle_source_models,
         (sorted(fnames), converter, monitor),
         distribute=dist).reduce()
-    parallel.Starmap.shutdown()  # close the processpool
     return dic

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -212,8 +212,7 @@ class SourceFilter(object):
             raise ValueError('%s is not complete!' % sitecol)
         self.hdf5path = hdf5path
         if hdf5path and (
-                config.distribution.oq_distribute in
-                ('no', 'subprocess', 'processpool') or
+                config.distribution.oq_distribute in ('no', 'processpool') or
                 config.directory.shared_dir):  # store the sitecol
             with hdf5.File(hdf5path, 'w') as h5:
                 h5['sitecol'] = sitecol

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -212,7 +212,8 @@ class SourceFilter(object):
             raise ValueError('%s is not complete!' % sitecol)
         self.hdf5path = hdf5path
         if hdf5path and (
-                config.distribution.oq_distribute in ('no', 'processpool') or
+                config.distribution.oq_distribute in
+                ('no', 'subprocess', 'processpool') or
                 config.directory.shared_dir):  # store the sitecol
             with hdf5.File(hdf5path, 'w') as h5:
                 h5['sitecol'] = sitecol
@@ -225,7 +226,7 @@ class SourceFilter(object):
         if os.environ.get('OQ_DISTRIBUTE') == 'no':
             self.distribute = 'no'
         else:
-            self.distribute = 'processpool'
+            self.distribute = 'subprocess'
 
     @property
     def sitecol(self):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -226,7 +226,7 @@ class SourceFilter(object):
         if os.environ.get('OQ_DISTRIBUTE') == 'no':
             self.distribute = 'no'
         else:
-            self.distribute = 'subprocess'
+            self.distribute = 'processpool'
 
     @property
     def sitecol(self):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -19,10 +19,11 @@ import operator
 import collections
 import time
 import os
+import logging
 import numpy
 
 from openquake.baselib import hdf5
-from openquake.baselib.general import groupby, warn
+from openquake.baselib.general import groupby
 from openquake.baselib.node import context, striptag, Node
 from openquake.hazardlib import geo, mfd, pmf, source
 from openquake.hazardlib.tom import PoissonTOM
@@ -196,21 +197,22 @@ def get_set_num_ruptures(src):
         dt = time.time() - t0
         clsname = src.__class__.__name__
         if dt > 10:
-            # NB: I am not using logging.warn because it hangs when called
+            # NB: logging.warn hangs when called
             # from a worker with processpool distribution; see
             # https://github.com/gem/oq-engine/pull/3923
+            # pickle_source_model is called with the subprocess distribution
             if 'Area' in clsname:
-                warn('%s.count_ruptures took %d seconds, perhaps the '
-                     'area discretization is too small', src, dt)
+                logging.warn('%s.count_ruptures took %d seconds, perhaps the '
+                             'area discretization is too small', src, dt)
             elif 'ComplexFault' in clsname:
-                warn('%s.count_ruptures took %d seconds, perhaps the c'
-                     'omplex_fault_mesh_spacing is too small', src, dt)
+                logging.warn('%s.count_ruptures took %d seconds, perhaps the c'
+                             'omplex_fault_mesh_spacing is too small', src, dt)
             elif 'SimpleFault' in clsname:
-                warn('%s.count_ruptures took %d seconds, perhaps the '
-                     'rupture_mesh_spacing is too small', src, dt)
+                logging.warn('%s.count_ruptures took %d seconds, perhaps the '
+                             'rupture_mesh_spacing is too small', src, dt)
             else:
                 # multiPointSource
-                warn('count_ruptures %s took %d seconds', src, dt)
+                logging.warn('count_ruptures %s took %d seconds', src, dt)
     return src.num_ruptures
 
 


### PR DESCRIPTION
This really solves https://github.com/gem/oq-engine/pull/3923 and paves the way for https://github.com/gem/oq-engine/issues/3918. This proves times and again my old saying: *any problem can be solved by removing enough dependencies*. The threadpool distribution is not used by the engine, so it is not important right now and will be restored in the future.

NB: using subprocesses has a high startup time compared to multiprocessing that uses fork. This is not an issue in real calculations that take hours, but it is an issue in the tests that take seconds: they are getting a lot slower (spawning 100 subprocesses can take 2 seconds or more, forking 0.05 seconds or less) .