### PR TITLE
Generated one risk task per hazard site

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Improved the distribution of the risk tasks by changing the weight
+
   [Pablo Heresi]
   * Contributed the HM2018CorrelationModel
 

--- a/demos/risk/EventBasedRisk/job_risk.ini
+++ b/demos/risk/EventBasedRisk/job_risk.ini
@@ -1,7 +1,7 @@
 [general]
 description = Stochastic Event-Based Risk Demo (Nepal)
 calculation_mode = event_based_risk
-concurrent_tasks = 16
+concurrent_tasks = 24
 
 [boundaries]
 region = 78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -473,8 +473,8 @@ class IterResult(object):
             else:  # this should never happen
                 raise ValueError(result)
             if OQ_DISTRIBUTE == 'processpool':
-                mem_gb = memory_rss(os.getpid()) + sum(
-                    memory_rss(pid) for pid in Starmap.pids) / GB
+                mem_gb = (memory_rss(os.getpid()) + sum(
+                    memory_rss(pid) for pid in Starmap.pids)) / GB
             else:
                 mem_gb = numpy.nan
             next(self.log_percent)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -482,6 +482,7 @@ class IterResult(object):
                 self.save_task_info(result.mon, mem_gb)
             yield val
 
+        next(self.log_percent)
         if self.received:
             tot = sum(self.received)
             max_per_task = max(self.received)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -805,6 +805,7 @@ class RiskCalculator(HazardCalculator):
                 # the datastore must be closed to avoid the HDF5 fork bug
                 assert dstore.hdf5 == (), '%s is not closed!' % dstore
             ri = riskinput.RiskInput(getter, [assets], reduced_eps)
+            ri.weight = len(assets)
             yield ri
 
     def execute(self):

--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -28,12 +28,12 @@ bcr_dt = numpy.dtype([('annual_loss_orig', F32), ('annual_loss_retro', F32),
                       ('bcr', F32)])
 
 
-def classical_bcr(riskinput, riskmodel, param, monitor):
+def classical_bcr(riskinputs, riskmodel, param, monitor):
     """
     Compute and return the average losses for each asset.
 
-    :param riskinput:
-        a :class:`openquake.risklib.riskinput.RiskInput` object
+    :param riskinputs:
+        :class:`openquake.risklib.riskinput.RiskInput` objects
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
     :param param:
@@ -41,15 +41,16 @@ def classical_bcr(riskinput, riskmodel, param, monitor):
     :param monitor:
         :class:`openquake.baselib.performance.Monitor` instance
     """
-    R = riskinput.hazard_getter.num_rlzs
+    R = riskinputs[0].hazard_getter.num_rlzs
     result = AccumDict(accum=numpy.zeros((R, 3), F32))
-    for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        assets = outputs.assets
-        for out in outputs:
-            for asset, (eal_orig, eal_retro, bcr) in zip(assets, out):
-                aval = asset.value('structural')
-                result[asset.ordinal][outputs.rlzi] = numpy.array([
-                    eal_orig * aval, eal_retro * aval, bcr])
+    for ri in riskinputs:
+        for outputs in riskmodel.gen_outputs(ri, monitor):
+            assets = outputs.assets
+            for out in outputs:
+                for asset, (eal_orig, eal_retro, bcr) in zip(assets, out):
+                    aval = asset.value('structural')
+                    result[asset.ordinal][outputs.rlzi] = numpy.array([
+                        eal_orig * aval, eal_retro * aval, bcr])
     return result
 
 

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -23,12 +23,12 @@ from openquake.hazardlib import stats
 from openquake.calculators import base, classical_risk
 
 
-def classical_damage(riskinput, riskmodel, param, monitor):
+def classical_damage(riskinputs, riskmodel, param, monitor):
     """
     Core function for a classical damage computation.
 
-    :param riskinput:
-        a :class:`openquake.risklib.riskinput.RiskInput` object
+    :param riskinputs:
+        :class:`openquake.risklib.riskinput.RiskInput` objects
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
     :param param:
@@ -39,10 +39,11 @@ def classical_damage(riskinput, riskmodel, param, monitor):
         a nested dictionary rlz_idx -> asset -> <damage array>
     """
     result = AccumDict(accum=AccumDict())
-    for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        for l, out in enumerate(outputs):
-            ordinals = [a.ordinal for a in outputs.assets]
-            result[l, outputs.rlzi] += dict(zip(ordinals, out))
+    for ri in riskinputs:
+        for outputs in riskmodel.gen_outputs(ri, monitor):
+            for l, out in enumerate(outputs):
+                ordinals = [a.ordinal for a in outputs.assets]
+                result[l, outputs.rlzi] += dict(zip(ordinals, out))
     return result
 
 

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -26,12 +26,12 @@ from openquake.calculators import base
 F32 = numpy.float32
 
 
-def classical_risk(riskinput, riskmodel, param, monitor):
+def classical_risk(riskinputs, riskmodel, param, monitor):
     """
     Compute and return the average losses for each asset.
 
-    :param riskinput:
-        a :class:`openquake.risklib.riskinput.RiskInput` object
+    :param riskinputs:
+        :class:`openquake.risklib.riskinput.RiskInput` objects
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
     :param param:
@@ -40,41 +40,42 @@ def classical_risk(riskinput, riskmodel, param, monitor):
         :class:`openquake.baselib.performance.Monitor` instance
     """
     result = dict(loss_curves=[], stat_curves=[])
-    all_outputs = list(riskmodel.gen_outputs(riskinput, monitor))
-    for outputs in all_outputs:
-        r = outputs.rlzi
-        outputs.average_losses = AccumDict(accum=[])  # l -> array
-        for l, loss_curves in enumerate(outputs):
-            # loss_curves has shape (C, N, 2)
-            for i, asset in enumerate(outputs.assets):
-                aid = asset.ordinal
-                avg = scientific.average_loss(loss_curves[:, i].T)
-                outputs.average_losses[l].append(avg)
-                lcurve = (loss_curves[:, i, 0], loss_curves[:, i, 1], avg)
-                result['loss_curves'].append((l, r, aid, lcurve))
+    for ri in riskinputs:
+        all_outputs = list(riskmodel.gen_outputs(ri, monitor))
+        for outputs in all_outputs:
+            r = outputs.rlzi
+            outputs.average_losses = AccumDict(accum=[])  # l -> array
+            for l, loss_curves in enumerate(outputs):
+                # loss_curves has shape (C, N, 2)
+                for i, asset in enumerate(outputs.assets):
+                    aid = asset.ordinal
+                    avg = scientific.average_loss(loss_curves[:, i].T)
+                    outputs.average_losses[l].append(avg)
+                    lcurve = (loss_curves[:, i, 0], loss_curves[:, i, 1], avg)
+                    result['loss_curves'].append((l, r, aid, lcurve))
 
-    # compute statistics
-    R = riskinput.hazard_getter.num_rlzs
-    w = param['weights']
-    statnames, stats = zip(*param['stats'])
-    l_idxs = range(len(riskmodel.lti))
-    for assets, outs in groupby(
-            all_outputs, lambda o: tuple(o.assets)).items():
-        weights = [w[out.rlzi] for out in outs]
-        out = outs[0]
-        for l in l_idxs:
-            for i, asset in enumerate(assets):
-                avgs = numpy.array([r.average_losses[l][i] for r in outs])
-                avg_stats = compute_stats(avgs, stats, weights)
-                # is a pair loss_curves, insured_loss_curves
-                # out[l][:, i, 0] are the i-th losses
-                # out[l][:, i, 1] are the i-th poes
-                losses = out[l][:, i, 0]
-                poes_stats = compute_stats(
-                    numpy.array([out[l][:, i, 1] for out in outs]),
-                    stats, weights)
-                result['stat_curves'].append(
-                    (l, asset.ordinal, losses, poes_stats, avg_stats))
+        # compute statistics
+        R = ri.hazard_getter.num_rlzs
+        w = param['weights']
+        statnames, stats = zip(*param['stats'])
+        l_idxs = range(len(riskmodel.lti))
+        for assets, outs in groupby(
+                all_outputs, lambda o: tuple(o.assets)).items():
+            weights = [w[out.rlzi] for out in outs]
+            out = outs[0]
+            for l in l_idxs:
+                for i, asset in enumerate(assets):
+                    avgs = numpy.array([r.average_losses[l][i] for r in outs])
+                    avg_stats = compute_stats(avgs, stats, weights)
+                    # is a pair loss_curves, insured_loss_curves
+                    # out[l][:, i, 0] are the i-th losses
+                    # out[l][:, i, 1] are the i-th poes
+                    losses = out[l][:, i, 0]
+                    poes_stats = compute_stats(
+                        numpy.array([out[l][:, i, 1] for out in outs]),
+                        stats, weights)
+                    result['stat_curves'].append(
+                        (l, asset.ordinal, losses, poes_stats, avg_stats))
     if R == 1:  # the realization is the same as the mean
         del result['loss_curves']
     return result

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -55,10 +55,10 @@ def build_loss_tables(dstore):
     return tbl, lbr
 
 
-def event_based_risk(riskinput, riskmodel, param, monitor):
+def event_based_risk(riskinputs, riskmodel, param, monitor):
     """
-    :param riskinput:
-        a :class:`openquake.risklib.riskinput.RiskInput` object
+    :param riskinputs:
+        :class:`openquake.risklib.riskinput.RiskInput` objects
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
     :param param:
@@ -68,83 +68,88 @@ def event_based_risk(riskinput, riskmodel, param, monitor):
     :returns:
         a dictionary of numpy arrays of shape (L, R)
     """
-    with monitor('%s.init' % riskinput.hazard_getter.__class__.__name__):
-        riskinput.hazard_getter.init()
-    eids = riskinput.hazard_getter.eids
-    A = len(riskinput.aids)
+    aids = []
+    for ri in riskinputs:
+        with monitor('%s.init' % ri.hazard_getter.__class__.__name__):
+            # NB: ri.dstore['events']['eid'] will be called multiple times
+            ri.hazard_getter.init()
+            aids.extend(ri.aids)
+    eids = ri.hazard_getter.eids
+    A = len(aids)
     E = len(eids)
     I = param['insured_losses'] + 1
     L = len(riskmodel.lti)
-    R = riskinput.hazard_getter.num_rlzs
-    param['lrs_dt'] = numpy.dtype([('rlzi', U16), ('ratios', (F32, (L * I,)))])
+    R = ri.hazard_getter.num_rlzs
+    param['lrs_dt'] = numpy.dtype(
+        [('rlzi', U16), ('ratios', (F32, (L * I,)))])
     ass = []
     agg = numpy.zeros((E, R, L * I), F32)
-    avg = AccumDict(accum={} if riskinput.by_site or not param['avg_losses']
+    avg = AccumDict(accum={} if ri.by_site or not param['avg_losses']
                     else numpy.zeros(A, F64))
-    result = dict(assratios=ass, aids=riskinput.aids, avglosses=avg)
-    if 'builder' in param:
-        builder = param['builder']
-        A = len(riskinput.aids)
-        R = len(builder.weights)
-        P = len(builder.return_periods)
-        all_curves = numpy.zeros((A, R, P), builder.loss_dt)
-        aid2idx = {aid: idx for idx, aid in enumerate(riskinput.aids)}
-    # update the result dictionary and the agg array with each output
-    for out in riskmodel.gen_outputs(riskinput, monitor):
-        if len(out.eids) == 0:  # this happens for sites with no events
-            continue
-        r = out.rlzi
-        eid2idx = riskinput.hazard_getter.eid2idx
-        for l, loss_ratios in enumerate(out):
-            if loss_ratios is None:  # for GMFs below the minimum_intensity
+    result = dict(assratios=ass, aids=aids, avglosses=avg)
+    for ri in riskinputs:
+        if 'builder' in param:
+            builder = param['builder']
+            R = len(builder.weights)
+            P = len(builder.return_periods)
+            all_curves = numpy.zeros((A, R, P), builder.loss_dt)
+            aid2idx = {aid: idx for idx, aid in enumerate(ri.aids)}
+        # update the result dictionary and the agg array with each output
+        for out in riskmodel.gen_outputs(ri, monitor):
+            if len(out.eids) == 0:  # this happens for sites with no events
                 continue
-            loss_type = riskmodel.loss_types[l]
-            indices = numpy.array([eid2idx[eid] for eid in out.eids])
-            for a, asset in enumerate(out.assets):
-                ratios = loss_ratios[a]  # shape (E, I)
-                aid = asset.ordinal
-                aval = asset.value(loss_type)
-                losses = aval * ratios
-                if 'builder' in param:
-                    idx = aid2idx[aid]
+            r = out.rlzi
+            eid2idx = ri.hazard_getter.eid2idx
+            for l, loss_ratios in enumerate(out):
+                if loss_ratios is None:  # for GMFs below the minimum_intensity
+                    continue
+                loss_type = riskmodel.loss_types[l]
+                indices = numpy.array([eid2idx[eid] for eid in out.eids])
+                for a, asset in enumerate(out.assets):
+                    ratios = loss_ratios[a]  # shape (E, I)
+                    aid = asset.ordinal
+                    aval = asset.value(loss_type)
+                    losses = aval * ratios
+                    if 'builder' in param:
+                        idx = aid2idx[aid]
+                        for i in range(I):
+                            lt = loss_type + '_ins' * i
+                            all_curves[idx, r][lt] = builder.build_curve(
+                                aval, ratios[:, i], r)
+
+                    # average losses
+                    if param['avg_losses']:
+                        rat = ratios.sum(axis=0) * param['ses_ratio']
+                        for i in range(I):
+                            lba = avg[l + L * i, r]
+                            try:
+                                lba[aid] += rat[i]
+                            except KeyError:
+                                lba[aid] = rat[i]
+
+                    # agglosses
                     for i in range(I):
-                        lt = loss_type + '_ins' * i
-                        all_curves[idx, r][lt] = builder.build_curve(
-                            aval, ratios[:, i], r)
+                        li = l + L * i
+                        # this is the critical loop: it is important to keep it
+                        # vectorized in terms of the event indices
+                        agg[indices, r, li] += losses[:, i]
 
-                # average losses
-                if param['avg_losses']:
-                    rat = ratios.sum(axis=0) * param['ses_ratio']
-                    for i in range(I):
-                        lba = avg[l + L * i, r]
-                        try:
-                            lba[aid] += rat[i]
-                        except KeyError:
-                            lba[aid] = rat[i]
-
-                # agglosses
-                for i in range(I):
-                    li = l + L * i
-                    # this is the critical loop: it is important to keep it
-                    # vectorized in terms of the event indices
-                    agg[indices, r, li] += losses[:, i]
-
-    idx = agg.nonzero()  # return only the nonzero values
-    result['agglosses'] = (idx, agg[idx])
-    if 'builder' in param:
-        clp = param['conditional_loss_poes']
-        result['curves-rlzs'], result['curves-stats'] = builder.pair(
-            all_curves, param['stats'])
-        if R > 1 and param['individual_curves'] is False:
-            del result['curves-rlzs']
-        if clp:
-            result['loss_maps-rlzs'], result['loss_maps-stats'] = (
-                builder.build_maps(all_curves, clp, param['stats']))
+        idx = agg.nonzero()  # return only the nonzero values
+        result['agglosses'] = (idx, agg[idx])
+        if 'builder' in param:
+            clp = param['conditional_loss_poes']
+            result['curves-rlzs'], result['curves-stats'] = builder.pair(
+                all_curves, param['stats'])
             if R > 1 and param['individual_curves'] is False:
-                del result['loss_maps-rlzs']
+                del result['curves-rlzs']
+            if clp:
+                result['loss_maps-rlzs'], result['loss_maps-stats'] = (
+                    builder.build_maps(all_curves, clp, param['stats']))
+                if R > 1 and param['individual_curves'] is False:
+                    del result['loss_maps-rlzs']
 
     # store info about the GMFs, must be done at the end
-    result['gmdata'] = riskinput.gmdata
+    result['gmdata'] = ri.gmdata
     return result
 
 

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -51,12 +51,12 @@ def dist_by_asset(data, multi_stat_dt, number):
     return out
 
 
-def scenario_damage(riskinput, riskmodel, param, monitor):
+def scenario_damage(riskinputs, riskmodel, param, monitor):
     """
     Core function for a damage computation.
 
-    :param riskinput:
-        a :class:`openquake.risklib.riskinput.RiskInput` object
+    :param riskinputs:
+        :class:`openquake.risklib.riskinput.RiskInput` objects
     :param riskmodel:
         a :class:`openquake.risklib.riskinput.CompositeRiskModel` instance
     :param monitor:
@@ -76,34 +76,35 @@ def scenario_damage(riskinput, riskmodel, param, monitor):
     """
     c_models = param['consequence_models']
     L = len(riskmodel.loss_types)
-    R = riskinput.hazard_getter.num_rlzs
     D = len(riskmodel.damage_states)
     E = param['number_of_ground_motion_fields']
+    R = riskinputs[0].hazard_getter.num_rlzs
     result = dict(d_asset=[], d_event=numpy.zeros((E, R, L, D), F64),
                   c_asset=[], c_event=numpy.zeros((E, R, L), F64))
-    for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        r = outputs.rlzi
-        for l, damages in enumerate(outputs):
-            loss_type = riskmodel.loss_types[l]
-            c_model = c_models.get(loss_type)
-            for a, fraction in enumerate(damages):
-                asset = outputs.assets[a]
-                taxo = riskmodel.taxonomy[asset.taxonomy]
-                damages = fraction * asset.number
-                result['d_event'][:, r, l] += damages  # shape (E, D)
-                if c_model:  # compute consequences
-                    means = [par[0] for par in c_model[taxo].params]
-                    # NB: we add a 0 in front for nodamage state
-                    c_ratio = numpy.dot(fraction, [0] + means)
-                    consequences = c_ratio * asset.value(loss_type)
-                    result['c_asset'].append(
-                        (l, r, asset.ordinal,
-                         scientific.mean_std(consequences)))
-                    result['c_event'][:, r, l] += consequences
-                    # TODO: consequences for the occupants
-                result['d_asset'].append(
-                    (l, r, asset.ordinal, scientific.mean_std(damages)))
-    result['gmdata'] = riskinput.gmdata
+    for ri in riskinputs:
+        for outputs in riskmodel.gen_outputs(ri, monitor):
+            r = outputs.rlzi
+            for l, damages in enumerate(outputs):
+                loss_type = riskmodel.loss_types[l]
+                c_model = c_models.get(loss_type)
+                for a, fraction in enumerate(damages):
+                    asset = outputs.assets[a]
+                    taxo = riskmodel.taxonomy[asset.taxonomy]
+                    damages = fraction * asset.number
+                    result['d_event'][:, r, l] += damages  # shape (E, D)
+                    if c_model:  # compute consequences
+                        means = [par[0] for par in c_model[taxo].params]
+                        # NB: we add a 0 in front for nodamage state
+                        c_ratio = numpy.dot(fraction, [0] + means)
+                        consequences = c_ratio * asset.value(loss_type)
+                        result['c_asset'].append(
+                            (l, r, asset.ordinal,
+                             scientific.mean_std(consequences)))
+                        result['c_event'][:, r, l] += consequences
+                        # TODO: consequences for the occupants
+                    result['d_asset'].append(
+                        (l, r, asset.ordinal, scientific.mean_std(damages)))
+    result['gmdata'] = ri.gmdata
     return result
 
 

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -32,7 +32,7 @@ F64 = numpy.float64  # higher precision to avoid task order dependency
 stat_dt = numpy.dtype([('mean', F32), ('stddev', F32)])
 
 
-def scenario_risk(riskinput, riskmodel, param, monitor):
+def scenario_risk(riskinputs, riskmodel, param, monitor):
     """
     Core function for a scenario computation.
 
@@ -55,27 +55,28 @@ def scenario_risk(riskinput, riskmodel, param, monitor):
     """
     E = param['number_of_ground_motion_fields']
     L = len(riskmodel.loss_types)
-    R = riskinput.hazard_getter.num_rlzs
     I = param['insured_losses'] + 1
+    R = riskinputs[0].hazard_getter.num_rlzs
     result = dict(agg=numpy.zeros((E, R, L * I), F32), avg=[],
                   all_losses=AccumDict(accum={}))
-    for outputs in riskmodel.gen_outputs(riskinput, monitor):
-        r = outputs.rlzi
-        assets = outputs.assets
-        for l, losses in enumerate(outputs):
-            if losses is None:  # this may happen
-                continue
-            stats = numpy.zeros((len(assets), I), stat_dt)  # mean, stddev
-            for a, asset in enumerate(assets):
-                stats['mean'][a] = losses[a].mean()
-                stats['stddev'][a] = losses[a].std(ddof=1)
-                result['avg'].append((l, r, asset.ordinal, stats[a]))
-            agglosses = losses.sum(axis=0)  # shape E, I
-            for i in range(I):
-                result['agg'][:, r, l + L * i] += agglosses[:, i]
-            if param['asset_loss_table']:
-                aids = [asset.ordinal for asset in outputs.assets]
-                result['all_losses'][l, r] += AccumDict(zip(aids, losses))
+    for ri in riskinputs:
+        for outputs in riskmodel.gen_outputs(ri, monitor):
+            r = outputs.rlzi
+            assets = outputs.assets
+            for l, losses in enumerate(outputs):
+                if losses is None:  # this may happen
+                    continue
+                stats = numpy.zeros((len(assets), I), stat_dt)  # mean, stddev
+                for a, asset in enumerate(assets):
+                    stats['mean'][a] = losses[a].mean()
+                    stats['stddev'][a] = losses[a].std(ddof=1)
+                    result['avg'].append((l, r, asset.ordinal, stats[a]))
+                agglosses = losses.sum(axis=0)  # shape E, I
+                for i in range(I):
+                    result['agg'][:, r, l + L * i] += agglosses[:, i]
+                if param['asset_loss_table']:
+                    aids = [asset.ordinal for asset in outputs.assets]
+                    result['all_losses'][l, r] += AccumDict(zip(aids, losses))
     return result
 
 

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -318,6 +318,7 @@ class RiskInput(object):
         self.hazard_getter = hazard_getter
         self.assets_by_site = assets_by_site
         self.eps = eps_dict or {}
+        self.weight = sum(len(assets) for assets in assets_by_site)
         taxonomies_set = set()
         aids = []
         for assets in self.assets_by_site:


### PR DESCRIPTION
This is needed to solve the problem of slow tasks in risk calculations. In particular, the calculation for Chile that @CatalinaYepes is running has a slow task taking 19,693 seconds on a total runtime of 23,613 seconds. With this branch, there has been a few improvements.

1. by splitting per site only the longest task takes 18,832 seconds on a total runtime of 19,376 seconds.
2. by splitting per taxonomy the longest task takes only  2,071s.
3. by splitting per blocks of 1000 assets the longest tasks takes only 291s (cluster1, calc 18918).

Having set `ignore_covs=true` and `avg_losses=false` the full runtime goes down to 1962 seconds, i.e. I gained more than one order of magnitude.