### PR TITLE
Implemented tasks as generator functions

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -719,24 +719,23 @@ class Starmap(object):
     def _loop(self, ierr, isocket, num_tasks):
         self.total = self.todo = num_tasks
         yield num_tasks
-        for err in ierr:
-            while self.todo:
-                try:
-                    err = next(ierr)
-                except StopIteration:  # sent everything already
-                    pass
-                else:
-                    if isinstance(err, Exception):  # TaskRevokedError
-                        raise err
-                res = next(isocket)
-                if self.calc_id and self.calc_id != res.mon.calc_id:
-                    logging.warn('Discarding a result from job %d, since this '
-                                 'is job %d', res.mon.calc_id, self.calc_id)
-                    continue
-                elif res.tb_str == 'TASK_ENDED':
-                    self.todo -= 1
-                else:
-                    yield res
+        while self.todo:
+            try:
+                err = next(ierr)
+            except StopIteration:  # sent everything already
+                pass
+            else:
+                if isinstance(err, Exception):  # TaskRevokedError
+                    raise err
+            res = next(isocket)
+            if self.calc_id and self.calc_id != res.mon.calc_id:
+                logging.warn('Discarding a result from job %d, since this '
+                             'is job %d', res.mon.calc_id, self.calc_id)
+                continue
+            elif res.tb_str == 'TASK_ENDED':
+                self.todo -= 1
+            else:
+                yield res
 
     def _iter_celery(self):
         with Socket(self.receiver, zmq.PULL, 'bind') as socket:

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -379,9 +379,9 @@ def safely_call(func, args, monitor=dummy_mon):
         else:
             def gfunc(*args):
                 yield func(*args)
-        genobj = gfunc(*args)
+        gobj = gfunc(*args)
         while True:
-            res = Result.new(next, (genobj,), mon)
+            res = Result.new(next, (gobj,), mon)  # StopIteration -> TASK_ENDED
             try:
                 zsocket.send(res)
             except Exception:  # like OverflowError

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -316,7 +316,7 @@ class Result(object):
         Returns the underlying value or raise the underlying exception
         """
         val = self.pik.unpickle()
-        if self.tb_str:
+        if self.tb_str and self.tb_str != 'TASK_ENDED':
             etype = val.__class__
             msg = '\n%s%s: %s' % (self.tb_str, etype.__name__, val)
             if issubclass(etype, KeyError):
@@ -723,7 +723,8 @@ class Starmap(object):
                     continue
                 elif res.tb_str == 'TASK_ENDED':
                     break
-            yield res
+                else:
+                    yield res
 
     def _iter_celery(self):
         with Socket(self.receiver, zmq.PULL, 'bind') as socket:

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -84,7 +84,7 @@ class StarmapTestCase(unittest.TestCase):
         mon = self.monitor
         res = list(parallel.Starmap(gfunc, [('xy', mon), ('z', mon)],
                                     distribute='no'))
-        self.assertEqual(res, ['xxx', 'zzz', 'yyy'])
+        self.assertEqual(sorted(res), ['xxx', 'yyy', 'zzz'])
 
     @classmethod
     def tearDownClass(cls):

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -32,6 +32,11 @@ def get_length(data, monitor):
     return {'n': len(data)}
 
 
+def gfunc(text, monitor):
+    for char in text:
+        yield char * 3
+
+
 class StarmapTestCase(unittest.TestCase):
     monitor = parallel.Monitor()
 
@@ -74,6 +79,12 @@ class StarmapTestCase(unittest.TestCase):
         for key, val in res.items():
             res[key] = val.reduce()
         self.assertEqual(res, {'a': {'n': 10}, 'c': {'n': 15}, 'b': {'n': 20}})
+
+    def test_gfunc(self):
+        mon = self.monitor
+        res = list(parallel.Starmap(gfunc, [('xy', mon), ('z', mon)],
+                                    distribute='no'))
+        self.assertEqual(res, ['xxx', 'zzz', 'yyy'])
 
     @classmethod
     def tearDownClass(cls):

--- a/openquake/baselib/tests/workerpool_test.py
+++ b/openquake/baselib/tests/workerpool_test.py
@@ -18,7 +18,6 @@
 
 import time
 import unittest
-import multiprocessing
 from openquake.baselib import config
 from openquake.baselib.workerpool import WorkerMaster
 from openquake.baselib.parallel import Starmap
@@ -30,7 +29,9 @@ def double(x, mon):
     return 2 * x
 
 
-class WorkerPoolTestCase(unittest.TestCase):
+# this test is temporarily disabled, the workerpool is tested in the demos
+# in travis, since they are run with OQ_DISTRIBUTE=zmq
+class _WorkerPoolTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.z = config.zworkers.copy()

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -40,9 +40,6 @@ db.cmd = lambda action, *args: getattr(actions, action)(db, *args)
 # NB: I am increasing the timeout from 5 to 20 seconds to see if the random
 # OperationalError: "database is locked" disappear in the WebUI tests
 
-ZMQ = os.environ.get(
-    'OQ_DISTRIBUTE', config.distribution.oq_distribute) == 'zmq'
-
 DBSERVER_PORT = int(os.environ.get('OQ_DBSERVER_PORT') or config.dbserver.port)
 
 
@@ -89,20 +86,20 @@ class DbServer(object):
             dworkers.append(sock)
         logging.warn('DB server started with %s on %s, pid %d',
                      sys.executable, self.frontend, self.pid)
-        if ZMQ:
-            # start task_in->task_out streamer thread
-            c = config.zworkers
-            threading.Thread(
-                target=w._streamer,
-                args=(self.master_host, c.task_in_port, c.task_out_port)
-            ).start()
-            logging.warn('Task streamer started from %s -> %s',
-                         c.task_in_port, c.task_out_port)
 
-            # start zworkers and wait a bit for them
-            msg = self.master.start()
-            logging.warn(msg)
-            time.sleep(1)
+        # start task_in->task_out streamer thread
+        c = config.zworkers
+        threading.Thread(
+            target=w._streamer,
+            args=(self.master_host, c.task_in_port, c.task_out_port)
+        ).start()
+        logging.warn('Task streamer started from %s -> %s',
+                     c.task_in_port, c.task_out_port)
+
+        # start zworkers and wait a bit for them
+        msg = self.master.start()
+        logging.warn(msg)
+        time.sleep(1)
 
         # start frontend->backend proxy for the database workers
         try:
@@ -117,9 +114,8 @@ class DbServer(object):
 
     def stop(self):
         """Stop the DbServer and the zworkers if any"""
-        if ZMQ:
-            logging.warn(self.master.stop())
-            z.context.term()
+        logging.warn(self.master.stop())
+        z.context.term()
         self.db.close()
 
 
@@ -177,6 +173,11 @@ def ensure_on():
                          'Please check the configuration')
             time.sleep(1)
             waiting_seconds -= 1
+
+    # check if we are talking to the right server
+    err = check_foreign()
+    if err:
+        sys.exit(err)
 
 
 @sap.Script

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -40,6 +40,9 @@ db.cmd = lambda action, *args: getattr(actions, action)(db, *args)
 # NB: I am increasing the timeout from 5 to 20 seconds to see if the random
 # OperationalError: "database is locked" disappear in the WebUI tests
 
+ZMQ = os.environ.get(
+    'OQ_DISTRIBUTE', config.distribution.oq_distribute) == 'zmq'
+
 DBSERVER_PORT = int(os.environ.get('OQ_DBSERVER_PORT') or config.dbserver.port)
 
 
@@ -86,20 +89,20 @@ class DbServer(object):
             dworkers.append(sock)
         logging.warn('DB server started with %s on %s, pid %d',
                      sys.executable, self.frontend, self.pid)
+        if ZMQ:
+            # start task_in->task_out streamer thread
+            c = config.zworkers
+            threading.Thread(
+                target=w._streamer,
+                args=(self.master_host, c.task_in_port, c.task_out_port)
+            ).start()
+            logging.warn('Task streamer started from %s -> %s',
+                         c.task_in_port, c.task_out_port)
 
-        # start task_in->task_out streamer thread
-        c = config.zworkers
-        threading.Thread(
-            target=w._streamer,
-            args=(self.master_host, c.task_in_port, c.task_out_port)
-        ).start()
-        logging.warn('Task streamer started from %s -> %s',
-                     c.task_in_port, c.task_out_port)
-
-        # start zworkers and wait a bit for them
-        msg = self.master.start()
-        logging.warn(msg)
-        time.sleep(1)
+            # start zworkers and wait a bit for them
+            msg = self.master.start()
+            logging.warn(msg)
+            time.sleep(1)
 
         # start frontend->backend proxy for the database workers
         try:
@@ -114,8 +117,9 @@ class DbServer(object):
 
     def stop(self):
         """Stop the DbServer and the zworkers if any"""
-        logging.warn(self.master.stop())
-        z.context.term()
+        if ZMQ:
+            logging.warn(self.master.stop())
+            z.context.term()
         self.db.close()
 
 
@@ -173,11 +177,6 @@ def ensure_on():
                          'Please check the configuration')
             time.sleep(1)
             waiting_seconds -= 1
-
-    # check if we are talking to the right server
-    err = check_foreign()
-    if err:
-        sys.exit(err)
 
 
 @sap.Script


### PR DESCRIPTION
First step towards https://github.com/gem/oq-engine/issues/3918.
The second step is to remove the processpool distribution (https://github.com/gem/oq-engine/pull/3932).
The third step is to change `openquake.calculators.event_based.compute_hazard` to a generator function.
The second step is dangerous and may go in the next release, this step is safe instead. It implements the feature only for the distribution modes sequential, zmq and celery.