### PR TITLE
Introduce a key `distribution.multi_node` in openquake.cfg

### DIFF
--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -26,12 +26,15 @@ Note: you have to **restart every celery node** after a configuration change.
 
 ### Enable Celery
 
-In all the nodes, the following file should be modified to enable the *Celery* support:
+In all the nodes, the following file should be modified to enable *multi node* and *Celery* support:
 
 `/etc/openquake/openquake.cfg:`
 
 ```
 [distribution]
+# set multi_node = true if are on a cluster
+multi_node = true
+
 # enable celery only if you have a cluster
 oq_distribute = celery
 ```

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -109,15 +109,13 @@ if config.directory.custom_tmp:
 if 'OQ_DISTRIBUTE' not in os.environ:
     os.environ['OQ_DISTRIBUTE'] = config.distribution.oq_distribute
 
-if config.distribution.platform not in (
-        'single_machine',
-        'cluster_with_shared_dir',
-        'cluster_without_shared_dir'):
-    raise ValueError('Invalid platform=%s in %s' % (
-        config.distribution.platform, config.found))
+platform = config.distribution.get('platform', 'single_machine')
+if platform not in ('single_machine', 'cluster_with_shared_dir',
+                    'cluster_without_shared_dir'):
+    raise ValueError('Invalid platform=%s in %s' % (platform, config.found))
 
 if (config.distribution.oq_distribute == 'celery' and not
-        config.distribution.platform.startswith('cluster')):
+        platform.startswith('cluster')):
     sys.stderr.write(
         'oq_distribute is celery but you are not in a cluster? '
-        'probably you forgot to set the platform in openquake.cfg')
+        'probably you forgot to change the platform in openquake.cfg\n')

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -99,6 +99,7 @@ def boolean(flag):
         return False
     raise ValueError('Unknown flag %r' % s)
 
+
 config.read(soft_mem_limit=int, hard_mem_limit=int, port=int,
             multi_user=boolean)
 
@@ -107,3 +108,11 @@ if config.directory.custom_tmp:
 
 if 'OQ_DISTRIBUTE' not in os.environ:
     os.environ['OQ_DISTRIBUTE'] = config.distribution.oq_distribute
+
+
+if config.distribution.platform not in (
+        'single_machine',
+        'cluster_with_shared_dir',
+        'cluster_without_shared_dir'):
+    raise ValueError('Invalid platform=%s in %s' % (
+        config.distribution.platform, config.found))

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -101,7 +101,7 @@ def boolean(flag):
 
 
 config.read(soft_mem_limit=int, hard_mem_limit=int, port=int,
-            multi_user=boolean)
+            multi_user=boolean, multi_node=boolean)
 
 if config.directory.custom_tmp:
     os.environ['TMPDIR'] = config.directory.custom_tmp
@@ -109,13 +109,9 @@ if config.directory.custom_tmp:
 if 'OQ_DISTRIBUTE' not in os.environ:
     os.environ['OQ_DISTRIBUTE'] = config.distribution.oq_distribute
 
-platform = config.distribution.get('platform', 'single_machine')
-if platform not in ('single_machine', 'cluster_with_shared_dir',
-                    'cluster_without_shared_dir'):
-    raise ValueError('Invalid platform=%s in %s' % (platform, config.found))
+multi_node = config.distribution.get('multi_node', False)
 
-if (config.distribution.oq_distribute == 'celery' and not
-        platform.startswith('cluster')):
+if config.distribution.oq_distribute == 'celery' and not multi_node:
     sys.stderr.write(
         'oq_distribute is celery but you are not in a cluster? '
-        'probably you forgot to change the platform in openquake.cfg\n')
+        'probably you forgot to set `multi_node=true` in openquake.cfg\n')

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -109,10 +109,15 @@ if config.directory.custom_tmp:
 if 'OQ_DISTRIBUTE' not in os.environ:
     os.environ['OQ_DISTRIBUTE'] = config.distribution.oq_distribute
 
-
 if config.distribution.platform not in (
         'single_machine',
         'cluster_with_shared_dir',
         'cluster_without_shared_dir'):
     raise ValueError('Invalid platform=%s in %s' % (
         config.distribution.platform, config.found))
+
+if (config.distribution.oq_distribute == 'celery' and not
+        config.distribution.platform.startswith('cluster')):
+    sys.stderr.write(
+        'oq_distribute is celery but you are not in a cluster? '
+        'probably you forgot to set the platform in openquake.cfg')

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -14,6 +14,8 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 [distribution]
+platform = single_machine
+
 # enable celery only if you have a cluster
 oq_distribute = processpool
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -14,8 +14,8 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 [distribution]
-# the platform can also be cluster_with_shared_dir or cluster_without_shared_dir
-platform = single_machine
+# set multi_node = true if are on a cluster
+multi_node = false
 
 # enable celery only if you have a cluster
 oq_distribute = processpool

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -14,6 +14,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 [distribution]
+# the platform can also be cluster_with_shared_dir or cluster_without_shared_dir
 platform = single_machine
 
 # enable celery only if you have a cluster


### PR DESCRIPTION
I really need to distinguish the three cases `single_machine`, `cluster_with_shared_dir` and `cluster_without_shared_dir`, because the calculators will use different strategies depending on the available hardware.