### PR TITLE
Various improvements

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -461,7 +461,7 @@ class IterResult(object):
             self.progress('%s %3d%%', self.name, percent)
             self.prev_percent = percent
         elif res and res.count:
-            self.progress('Got output %d from task #%d',
+            self.progress('Got output #%d from task #%d',
                           res.count, res.mon.task_no)
         return done
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -306,10 +306,11 @@ class Result(object):
     :param mon: Monitor instance
     :param tb_str: traceback string (empty if there was no exception)
     """
-    def __init__(self, val, mon, tb_str=''):
+    def __init__(self, val, mon, tb_str='', count=0):
         self.pik = Pickled(val)
         self.mon = mon
         self.tb_str = tb_str
+        self.count = count
 
     def get(self):
         """
@@ -326,7 +327,7 @@ class Result(object):
         return val
 
     @classmethod
-    def new(cls, func, args, mon, splice=False):
+    def new(cls, func, args, mon, splice=False, count=0):
         """
         :returns: a new Result instance
         """
@@ -337,9 +338,10 @@ class Result(object):
             res = Result(None, mon, 'TASK_ENDED')
         except Exception:
             _etype, exc, tb = sys.exc_info()
-            res = Result(exc, mon, ''.join(traceback.format_tb(tb)))
+            res = Result(exc, mon, ''.join(traceback.format_tb(tb)),
+                         count=count)
         else:
-            res = Result(val, mon)
+            res = Result(val, mon, count=count)
         res.splice = splice
         return res
 
@@ -387,13 +389,15 @@ def safely_call(func, args, monitor=dummy_mon):
             def gfunc(*args):
                 yield func(*args)
         gobj = gfunc(*args)
-        while True:
-            res = Result.new(next, (gobj,), mon)  # StopIteration -> TASK_ENDED
+        for count in itertools.count():
+            res = Result.new(next, (gobj,), mon, count=count)
+            # StopIteration -> TASK_ENDED
             try:
                 zsocket.send(res)
             except Exception:  # like OverflowError
                 _etype, exc, tb = sys.exc_info()
-                err = Result(exc, mon, ''.join(traceback.format_tb(tb)))
+                err = Result(exc, mon, ''.join(traceback.format_tb(tb)),
+                             count=count)
                 zsocket.send(err)
             if res.tb_str == 'TASK_ENDED':
                 break
@@ -444,18 +448,21 @@ class IterResult(object):
         self.progress = progress
         self.hdf5 = hdf5
         self.received = []
-        self.prev_percent = 0
         self.log_percent()
 
-    def log_percent(self):
+    def log_percent(self, res=None):
         done, self.total = self.done_total()
         percent = int(float(done) / self.total * 100)
-        if percent > self.prev_percent:
-            if done == 1:  # first time
-                self.progress('Sent %s of data in %d task(s)',
-                              humansize(self.sent.sum()), self.total)
+        if not hasattr(self, 'prev_percent'):  # first time
+            self.prev_percent = 0
+            self.progress('Sent %s of data in %d task(s)',
+                          humansize(self.sent.sum()), self.total)
+        elif percent > self.prev_percent:
             self.progress('%s %3d%%', self.name, percent)
             self.prev_percent = percent
+        elif res and res.count:
+            self.progress('Got output %d from task #%d',
+                          res.count, res.mon.task_no)
         return done
 
     def __iter__(self):
@@ -477,7 +484,7 @@ class IterResult(object):
                     memory_rss(pid) for pid in Starmap.pids)) / GB
             else:
                 mem_gb = numpy.nan
-            self.log_percent()
+            self.log_percent(result)
             if not self.name.startswith('_'):  # no info for private tasks
                 self.save_task_info(result.mon, mem_gb)
             if result.splice:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -220,7 +220,6 @@ class EventBasedCalculator(base.HazardCalculator):
             param['samples'] = sm.samples
             for sg in sm.src_groups:
                 rlzs_by_gsim = self.rlzs_by_gsim_grp[sg.id]
-                self.csm.add_infos(sg.sources)
                 if sg.src_interdep == 'mutex':  # do not split
                     yield sg, self.src_filter, rlzs_by_gsim, param, monitor
                     num_tasks += 1

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -22,6 +22,7 @@ import numpy
 from nose.plugins.attrib import attr
 
 from openquake.baselib.general import gettemp
+from openquake.calculators import event_based
 from openquake.calculators.views import view
 from openquake.calculators.tests import CalculatorTestCase, strip_calc_id
 from openquake.calculators.export import export
@@ -225,6 +226,8 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
     @attr('qa', 'risk', 'event_based_risk')
     def test_case_miriam(self):
+        event_based.RUPTURES_PER_BLOCK = 20
+
         # this is a case with a grid and asset-hazard association
         self.run_calc(case_miriam.__file__, 'job.ini', exports='csv')
 

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -243,6 +243,10 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqual(years, [15, 29, 39, 43])
         self.assertEqualFiles('expected/rup_data.csv', fname)
 
+        # check split_time
+        split_time = self.calc.datastore['source_info']['split_time'].sum()
+        self.assertGreater(split_time, 0)
+
     @attr('qa', 'hazard', 'event_based')
     def test_case_9(self):
         # example with correlation: the site collection must not be filtered

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -794,6 +794,7 @@ class CompositeSourceModel(collections.Sequence):
         new = self.__class__(self.gsim_lt, self.source_model_lt, source_models,
                              self.optimize_same_id)
         new.info.update_eff_ruptures(new.get_num_ruptures().__getitem__)
+        new.infos = self.infos
         return new
 
     def get_weight(self, weight):
@@ -1001,3 +1002,7 @@ class SourceInfo(object):
         self.split_time = split_time
         self.num_split = num_split
         self.events = 0  # set in event based
+
+    def __repr__(self):
+        return '<%s>' % ' '.join('%s=%s' % (name, getattr(self, name))
+                                 for name in self.dt.names)


### PR DESCRIPTION
1. I have extended to logging system to also log (some of) the received outputs, with their incremental number which is nonzero and interesting only in the case of generator tasks
2. I have fixed a bug with a redundant call to `.add_infos`: the effect was a `split_time` of zero instead of the correct number
3. I have added a test: the split_time must be greater than zero in event_based calculations too
4. I have improved the `__repr__` of SourceInfo objects
5. I have reduced event_based.RUPTURES_PER_BLOCK = 20 in the case_miriam test: this makes sure that the generator tasks are yielding more than 2 outputs per task, so the test is interesting.