### PR TITLE
Raise src ID length limit in validation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Robin Gee]
+  * Raised the source ID length limit in the validation from 60 to 75 characters
+    to allow sources with longer IDs
+
   [Michele Simionato]
   * Introduced a `multi_node` flag in `openquake.cfg` and used it to
     fully parallelize the prefiltering in a cluster

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -261,7 +261,7 @@ class SimpleId(object):
             "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-" % value)
 
 
-MAX_ID_LENGTH = 60
+MAX_ID_LENGTH = 75
 ASSET_ID_LENGTH = 100
 
 simple_id = SimpleId(MAX_ID_LENGTH)

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -261,7 +261,7 @@ class SimpleId(object):
             "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-" % value)
 
 
-MAX_ID_LENGTH = 75
+MAX_ID_LENGTH = 75  # length required for some sources in US14 collapsed model
 ASSET_ID_LENGTH = 100
 
 simple_id = SimpleId(MAX_ID_LENGTH)


### PR DESCRIPTION
Raising the limit from 60 characters to 75.

This is helpful, for example, when long source IDs are created during the collapsing of logic tree branches, which is the case for the US14 model.