### PR TITLE
Do not propagate SIGINT to pool workers

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -545,7 +545,9 @@ class Starmap(object):
     @classmethod
     def init(cls, poolsize=None, distribute=OQ_DISTRIBUTE):
         if distribute == 'processpool' and not hasattr(cls, 'pool'):
+            sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
             cls.pool = multiprocessing.Pool(poolsize, init_workers)
+            signal.signal(signal.SIGINT, sigint_handler)
             m = Monitor('wakeup')
             ires = cls(
                 _wakeup, [(.2, m) for _ in range(cls.pool._processes)]


### PR DESCRIPTION
Fixes #3955 

That was not a regression, it was present in Engine 3.1 too. The solution (at least I'm not able to reproduce the issue anymore) is to avoid the `SIGINT` propagation to the workers in a pool.

Only the master process should catch it. `CTRL-C` will be ignored during the pool creation that may take a second, but I would consider that a corner-case and is not preventing another `CTRL-C` even on a cluster (since signal is simply ignored).
