### PR TITLE
Added a check on optimize_same_id_sources

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -685,6 +685,20 @@ class OqParam(valid.ParamSet):
             self.complex_fault_mesh_spacing = self.rupture_mesh_spacing
         return True
 
+    def is_valid_optimize_same_id_sources(self):
+        """
+        The `optimize_same_id_sources` can be true only in the classical
+        calculators.
+        """
+        if (self.optimize_same_id_sources and
+                'classical' in self.calculation_mode or
+                'disagg' in self.calculation_mode):
+            return True
+        elif self.optimize_same_id_sources:
+            return False
+        else:
+            return True
+
     def check_uniform_hazard_spectra(self):
         ok_imts = [imt for imt in self.imtls if imt == 'PGA' or
                    imt.startswith('SA')]

--- a/openquake/commonlib/tests/nrml_test.py
+++ b/openquake/commonlib/tests/nrml_test.py
@@ -189,5 +189,5 @@ xmlns:gml="http://www.opengis.net/gml"
         converter = SourceConverter(50., 1., 10, 0.1, 10.)
         with self.assertRaises(ValueError) as ctx:
             parse(fname, converter)
-        self.assertEqual('There are 2 srcs_weights but 1 source(s)',
-                         str(ctx.exception))
+        self.assertIn('There are 2 srcs_weights but 1 source(s)',
+                      str(ctx.exception))

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -380,3 +380,15 @@ class OqParamTestCase(unittest.TestCase):
                 uniform_hazard_spectra='1')
         self.assertIn("iml_disagg and poes_disagg cannot be set at the "
                       "same time", str(ctx.exception))
+
+    def test_optimize_same_id_sources(self):
+        with self.assertRaises(ValueError) as ctx:
+            OqParam(
+                calculation_mode='event_based', inputs=fakeinputs,
+                sites='0.1 0.2',
+                maximum_distance='400',
+                intensity_measure_types='PGA',
+                optimize_same_id_sources='true',
+            ).validate()
+        self.assertIn('can be true only in the classical\ncalculators',
+                      str(ctx.exception))


### PR DESCRIPTION
The check is here to prevent Desmond from making mistakes with the Tonga islands model.