### PR TITLE
Fixed the sourcewriter so that the srcs_weights are written only if nontrivial

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -970,7 +970,7 @@ def get_mesh_hcurves(oqparam):
 
 
 # used in utils/reduce_sm and utils/extract_source
-def reduce_source_model(smlt_file, source_ids):
+def reduce_source_model(smlt_file, source_ids, remove=True):
     """
     Extract sources from the composite source model
     """
@@ -986,8 +986,11 @@ def reduce_source_model(smlt_file, source_ids):
             for src_group in origmodel:
                 sg = copy.copy(src_group)
                 sg.nodes = []
-                weights = src_group['srcs_weights']
-                assert len(weights) == len(src_group.nodes)
+                weights = src_group.get('srcs_weights')
+                if weights:
+                    assert len(weights) == len(src_group.nodes)
+                else:
+                    weights = [1] * len(src_group.nodes)
                 src_group['srcs_weights'] = reduced_weigths = []
                 for src_node, weight in zip(src_group, weights):
                     if src_node['id'] in source_ids:
@@ -1000,7 +1003,7 @@ def reduce_source_model(smlt_file, source_ids):
             with open(path, 'wb') as f:
                 nrml.write([model], f, xmlns=root['xmlns'])
                 logging.warn('Reduced %s' % path)
-        else:
+        elif remove:  # remove the files completely reduced
             os.remove(path)
 
 

--- a/openquake/commonlib/tests/nrml_test.py
+++ b/openquake/commonlib/tests/nrml_test.py
@@ -189,5 +189,5 @@ xmlns:gml="http://www.opengis.net/gml"
         converter = SourceConverter(50., 1., 10, 0.1, 10.)
         with self.assertRaises(ValueError) as ctx:
             parse(fname, converter)
-        self.assertEqual('There are 2 srcs_weights but 1 source(s)',
-                         str(ctx.exception))
+        self.assertIn('There are 2 srcs_weights but 1 source(s)',
+                      str(ctx.exception))

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -805,7 +805,7 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
     def test_reduce_source_model(self):
         case2 = os.path.dirname(case_2.__file__)
         smlt = os.path.join(case2, 'source_model_logic_tree.xml')
-        readinput.reduce_source_model(smlt, [])
+        readinput.reduce_source_model(smlt, [], False)
 
 
 class GetCompositeRiskModelTestCase(unittest.TestCase):

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -560,7 +560,7 @@ def build_source_group(source_group):
         attrs['src_interdep'] = source_group.src_interdep
     if source_group.rup_interdep:
         attrs['rup_interdep'] = source_group.rup_interdep
-    if source_group.srcs_weights:
+    if source_group.srcs_weights and set(source_group.srcs_weights) != {1}:
         attrs['srcs_weights'] = ' '.join(map(str, source_group.srcs_weights))
     if source_group.grp_probability is not None:
         attrs['grp_probability'] = source_group.grp_probability

--- a/openquake/hazardlib/tests/source_model/alternative-mfds_4test.xml
+++ b/openquake/hazardlib/tests/source_model/alternative-mfds_4test.xml
@@ -9,7 +9,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="1.0"
         tectonicRegion="Active Shallow Crust"
         >
             <simpleFaultSource
@@ -48,7 +47,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="1.0"
         tectonicRegion="Subduction Interface"
         >
             <characteristicFaultSource

--- a/openquake/hazardlib/tests/source_model/mixed.xml
+++ b/openquake/hazardlib/tests/source_model/mixed.xml
@@ -9,7 +9,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="1.0"
         tectonicRegion="Stable Continental Crust"
         >
             <pointSource
@@ -50,7 +49,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="1.0"
         tectonicRegion="Subduction Interface"
         >
             <complexFaultSource
@@ -103,7 +101,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="1.0 1.0"
         tectonicRegion="Active Shallow Crust"
         >
             <areaSource
@@ -212,7 +209,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="1.0 1.0 1.0"
         tectonicRegion="Volcanic"
         >
             <characteristicFaultSource

--- a/openquake/hazardlib/tests/source_model/nonparametric-source.xml
+++ b/openquake/hazardlib/tests/source_model/nonparametric-source.xml
@@ -10,7 +10,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="1.0"
         tectonicRegion="Some TRT"
         >
             <nonParametricSeismicSource


### PR DESCRIPTION
This avoid, in case of a lot of sources, to have srcs_weights="1 1 1 1 1 ... 1" for thousand of times. While at it, I have also fixed the `reduce_sm` script to manage properly the srcs_weights.