### PR TITLE
Avoid KeyError in event_based_risk

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -168,8 +168,9 @@ class EbrCalculator(base.RiskCalculator):
             return  # this happens in the reportwriter
 
         # save memory in the fork
-        Starmap.shutdown()
-        Starmap.init()
+        if not parent:
+            Starmap.shutdown()
+            Starmap.init()
 
         self.L = len(self.riskmodel.lti)
         self.T = len(self.assetcol.tagcol)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -167,8 +167,9 @@ class EbrCalculator(base.RiskCalculator):
         if not self.oqparam.ground_motion_fields:
             return  # this happens in the reportwriter
 
-        # save memory in the fork
         if not parent:
+            # hazard + risk were done in the same calculation
+            # save memory by resetting the processpool (if any)
             Starmap.shutdown()
             Starmap.init()
 


### PR DESCRIPTION
This is the error:
```python
  File "/home/daniele/GIT/gem/openquake/oq-engine/openquake/risklib/riskmodels.py", line 353, in _call_
    epsilons = epsgetter(asset.ordinal, eids)
  File "/home/daniele/GIT/gem/openquake/oq-engine/openquake/risklib/riskinput.py", line 346, in epsilon_getter
    idx = [eid2idx[eid] for eid in eids]
  File "/home/daniele/GIT/gem/openquake/oq-engine/openquake/risklib/riskinput.py", line 346, in <listcomp>
    idx = [eid2idx[eid] for eid in eids]
KeyError: 5632
```