### PR TITLE
Made it possible to send sources, not source groups

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -179,8 +179,12 @@ class ClassicalCalculator(base.HazardCalculator):
 
         for sg in csm.src_groups:
             if sg.src_interdep == 'mutex' and len(sg) > 0:
+                par = param.copy()
+                par['src_interdep'] = sg.src_interdep
+                par['rup_interdep'] = sg.rup_interdep
+                par['grp_probability'] = sg.grp_probability
                 gsims = self.csm.info.gsim_lt.get_gsims(sg.trt)
-                yield sg, src_filter, gsims, param, monitor
+                yield sg, src_filter, gsims, par, monitor
                 num_tasks += 1
                 num_sources += len(sg.sources)
         # NB: csm.get_sources_by_trt discards the mutex sources

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -726,11 +726,7 @@ class CompositeSourceModel(collections.Sequence):
         for sm in self.source_models:
             for src_group in sm.src_groups:
                 self.add_infos(src_group)
-                if getattr(src_group, 'src_interdep', None) == 'mutex':
-                    # mutex sources cannot be split, just set the mutex_weight
-                    for src, sw in zip(src_group, src_group.srcs_weights):
-                        src.mutex_weight = sw
-                else:
+                if getattr(src_group, 'src_interdep', None) != 'mutex':
                     # split regular sources
                     srcs, stime = split_sources(src_group, min_mag)
                     for src in src_group:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -201,15 +201,15 @@ class ContextMaker(object):
         sctx = SitesContext(self.REQUIRES_SITES_PARAMETERS, sites)
         return sctx, dctx
 
-    def poe_map(self, src, sites, imtls, trunclevel):
+    def poe_map(self, src, sites, imtls, trunclevel, rup_indep):
         """
         :param src: a source object
         :param sites: a filtered SiteCollection
         :param imtls: intensity measure and levels
         :param trunclevel: truncation level
+        :param rup_indep: True if the ruptures are independent
         :returns: a ProbabilityMap instance
         """
-        rup_indep = not getattr(src, 'mutex_ruptures', 0)
         pmap = ProbabilityMap.build(
             len(imtls.array), len(self.gsims), sites.sids,
             initvalue=rup_indep)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -201,15 +201,15 @@ class ContextMaker(object):
         sctx = SitesContext(self.REQUIRES_SITES_PARAMETERS, sites)
         return sctx, dctx
 
-    def poe_map(self, src, sites, imtls, trunclevel, rup_indep=True):
+    def poe_map(self, src, sites, imtls, trunclevel):
         """
         :param src: a source object
         :param sites: a filtered SiteCollection
         :param imtls: intensity measure and levels
         :param trunclevel: truncation level
-        :param rup_indep: True if the ruptures are independent
         :returns: a ProbabilityMap instance
         """
+        rup_indep = not getattr(src, 'mutex_ruptures', 0)
         pmap = ProbabilityMap.build(
             len(imtls.array), len(self.gsims), sites.sids,
             initvalue=rup_indep)

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -87,29 +87,17 @@ class SourceGroup(collections.Sequence):
         # return SourceGroups, ordered by TRT string
         return sorted(source_stats_dict.values())
 
-    @property
-    def srcs_weights(self):
-        """
-        The weights of the underlying sources. If not specified, returns
-        an array of 1s.
-        """
-        if self._srcs_weights is None:
-            return list(numpy.ones(len(self.sources)))
-        return self._srcs_weights
-
     def __init__(self, trt, sources=None, name=None, src_interdep='indep',
-                 rup_interdep='indep', srcs_weights=None, grp_probability=None,
+                 rup_interdep='indep', grp_probability=None,
                  min_mag=None, max_mag=None, id=0, eff_ruptures=-1,
                  tot_ruptures=0):
         # checks
         self.trt = trt
-        self._check_init_variables(sources, name, src_interdep, rup_interdep,
-                                   srcs_weights)
+        self._check_init_variables(sources, name, src_interdep, rup_interdep)
         self.sources = []
         self.name = name
         self.src_interdep = src_interdep
         self.rup_interdep = rup_interdep
-        self._srcs_weights = srcs_weights
         self.grp_probability = grp_probability
         self.min_mag = min_mag
         self.max_mag = max_mag
@@ -121,8 +109,8 @@ class SourceGroup(collections.Sequence):
         self.source_model = None  # to be set later, in CompositionInfo
         self.eff_ruptures = eff_ruptures  # set later by get_rlzs_assoc
 
-    def _check_init_variables(self, src_list, name, src_interdep, rup_interdep,
-                              srcs_weights):
+    def _check_init_variables(self, src_list, name,
+                              src_interdep, rup_interdep):
         if src_interdep not in ('indep', 'mutex'):
             raise ValueError('source interdependence incorrect %s ' %
                              src_interdep)
@@ -783,10 +771,12 @@ class SourceConverter(RuptureConverter):
                 raise ValueError(
                     'There are %d srcs_weights but %d source(s) in %s'
                     % (len(srcs_weights), len(node), self.fname))
+            for src, sw in zip(sg, srcs_weights):
+                src.mutex_weight = sw
+
         sg.name = node.attrib.get('name')
         sg.src_interdep = node.attrib.get('src_interdep', 'indep')
         sg.rup_interdep = node.attrib.get('rup_interdep', 'indep')
-        sg._srcs_weights = srcs_weights
         sg.grp_probability = grp_probability
         return sg
 

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -755,6 +755,11 @@ class SourceConverter(RuptureConverter):
                      if k not in ('name', 'src_interdep', 'rup_interdep',
                                   'srcs_weights')}
         sg = SourceGroup(trt)
+        sg.name = node.attrib.get('name')
+        sg.src_interdep = node.attrib.get('src_interdep', 'indep')
+        sg.rup_interdep = node.attrib.get('rup_interdep', 'indep')
+        sg.grp_probability = grp_probability
+        mutex_ruptures = sg.rup_interdep == 'mutex'
         for src_node in node:
             src = self.convert_node(src_node)
             # transmit the group attributes to the underlying source
@@ -773,11 +778,7 @@ class SourceConverter(RuptureConverter):
                     % (len(srcs_weights), len(node), self.fname))
             for src, sw in zip(sg, srcs_weights):
                 src.mutex_weight = sw
-
-        sg.name = node.attrib.get('name')
-        sg.src_interdep = node.attrib.get('src_interdep', 'indep')
-        sg.rup_interdep = node.attrib.get('rup_interdep', 'indep')
-        sg.grp_probability = grp_probability
+                src.mutex_ruptures = mutex_ruptures
         return sg
 
 # ################### MultiPointSource conversion ######################## #

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -560,10 +560,11 @@ def build_source_group(source_group):
         attrs['src_interdep'] = source_group.src_interdep
     if source_group.rup_interdep:
         attrs['rup_interdep'] = source_group.rup_interdep
-    if source_group.srcs_weights and set(source_group.srcs_weights) != {1}:
-        attrs['srcs_weights'] = ' '.join(map(str, source_group.srcs_weights))
     if source_group.grp_probability is not None:
         attrs['grp_probability'] = source_group.grp_probability
+    srcs_weights = [getattr(src, 'mutex_weight', 1) for src in source_group]
+    if set(srcs_weights) != {1}:
+        attrs['srcs_weights'] = ' '.join(map(str, srcs_weights))
     return Node('sourceGroup', attrs, nodes=source_nodes)
 
 

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -150,7 +150,9 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
         src.mutex_ruptures = True
         group = SourceGroup(
             src.tectonic_region_type, [src], 'test', 'mutex', 'mutex')
-        param = dict(imtls=self.imtls, filter_distance='rjb')
+        param = dict(imtls=self.imtls, filter_distance='rjb',
+                     src_interdep=group.src_interdep,
+                     rup_interdep=group.rup_interdep)
         crv = classical(group, self.sites, gsim_by_trt, param)[0]
         npt.assert_almost_equal(numpy.array([0.35000, 0.32497, 0.10398]),
                                 crv[0].array[:, 0], decimal=4)
@@ -194,9 +196,6 @@ class NankaiTestCase(unittest.TestCase):
         source_model = os.path.join(os.path.dirname(__file__), 'nankai.xml')
         groups = nrml.to_python(source_model, SourceConverter(
             investigation_time=50., rupture_mesh_spacing=2.))
-        for group in groups:
-            for src, sw in zip(group, group.srcs_weights):
-                src.mutex_weight = sw
         site = Site(Point(135.68, 35.68), 800, True, z1pt0=100., z2pt5=1.)
         s_filter = SourceFilter(SiteCollection([site]), {})
         imtls = DictArray({'PGV': [20, 40, 80]})

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -145,8 +145,9 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
                 (rupture, PMF([(0.6, 0), (0.4, 1)]))]
         src = NonParametricSeismicSource('0', 'test', TRT.ACTIVE_SHALLOW_CRUST,
                                          data)
-        src.src_group_id = [0]
+        src.src_group_id = 0
         src.mutex_weight = 1
+        src.mutex_ruptures = True
         group = SourceGroup(
             src.tectonic_region_type, [src], 'test', 'mutex', 'mutex')
         param = dict(imtls=self.imtls, filter_distance='rjb')

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -33,7 +33,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         source_model = os.path.join(os.path.dirname(__file__), 'nankai.xml')
         # it has a single group containing 15 mutex sources
         [group] = nrml.to_python(source_model)
-        aae(group.srcs_weights,
+        aae([src.mutex_weight for src in group],
             [0.0125, 0.0125, 0.0125, 0.0125, 0.1625, 0.1625, 0.0125, 0.0125,
              0.025, 0.025, 0.05, 0.05, 0.325, 0.025, 0.1])
         seed = 42
@@ -44,7 +44,6 @@ class StochasticEventSetTestCase(unittest.TestCase):
             src.id = i
             nr = src.num_ruptures
             src.serial = rup_serial[start:start + nr]
-            src.mutex_weight = group.srcs_weights[i]
             start += nr
         lonlat = 135.68, 35.68
         site = Site(geo.Point(*lonlat), 800, True, z1pt0=100., z2pt5=1.)

--- a/openquake/hazardlib/tests/source_model/multi-point-source.xml
+++ b/openquake/hazardlib/tests/source_model/multi-point-source.xml
@@ -10,7 +10,6 @@ xmlns:gml="http://www.opengis.net/gml"
         name="group 1"
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="0.6 0.4"
         tectonicRegion="Stable Continental Crust"
         >
             <multiPointSource

--- a/openquake/qa_tests_data/classical/case_30/ssm/shallow/int_kt.xml
+++ b/openquake/qa_tests_data/classical/case_30/ssm/shallow/int_kt.xml
@@ -9,7 +9,6 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         rup_interdep="indep"
         src_interdep="indep"
-        srcs_weights="1.0"
         tectonicRegion="Subduction Interface"
         >
             <complexFaultSource


### PR DESCRIPTION
Currently `hazard_curve.classical` requires in input a SourceGroup object. With this change it will just require a set of sources, with the SourceGroup parameters moved to the `param` dictionary. This paves the way for further developments. While at it, I also made some simplification, such as moving completely the `srcs_weights` from the SourceGroup to the underlying sources. Notice that the number of lines of code has decreased.