### PR TITLE
Solved the fork bug

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -553,7 +553,7 @@ class Starmap(object):
             cls.dask_client = Client()
 
     @classmethod
-    def shutdown(cls, poolsize=None):
+    def shutdown(cls):
         if hasattr(cls, 'pool'):
             cls.pool.close()
             cls.pool.terminate()

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -539,6 +539,7 @@ class Starmap(object):
         if distribute == 'processpool' and not hasattr(cls, 'pool'):
             orig_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
             # we use spawn here to avoid deadlocks with logging, see
+            # https://github.com/gem/oq-engine/pull/3923 and
             # https://codewithoutrules.com/2018/09/04/python-multiprocessing/
             cls.pool = multiprocessing.get_context('spawn').Pool(
                 poolsize, init_workers)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -538,7 +538,10 @@ class Starmap(object):
     def init(cls, poolsize=None, distribute=OQ_DISTRIBUTE):
         if distribute == 'processpool' and not hasattr(cls, 'pool'):
             orig_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-            cls.pool = multiprocessing.Pool(poolsize, init_workers)
+            # we use spawn here to avoid deadlocks with logging, see
+            # https://codewithoutrules.com/2018/09/04/python-multiprocessing/
+            cls.pool = multiprocessing.get_context('spawn').Pool(
+                poolsize, init_workers)
             signal.signal(signal.SIGINT, orig_handler)
             cls.pids = [proc.pid for proc in cls.pool._pool]
         elif distribute == 'threadpool' and not hasattr(cls, 'pool'):

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -101,9 +101,8 @@ class CalculatorTestCase(unittest.TestCase):
             hc_id = self.calc.datastore.calc_id
             calc = self.get_calc(
                 testfile, inis[1], hazard_calculation_id=str(hc_id), **kw)
-            # run the second job.ini with zero tasks to avoid fork issues
             with calc._monitor:
-                exported = calc.run(export_dir=self.edir, concurrent_tasks=0)
+                exported = calc.run(export_dir=self.edir)
                 result.update(exported)
             duration[inis[1]] = calc._monitor.duration
             self.calc = calc

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -27,7 +27,7 @@ import sys
 import numpy
 
 from openquake.calculators import base
-from openquake.baselib import datastore, general
+from openquake.baselib import datastore, general, parallel
 from openquake.commonlib import readinput, oqvalidation
 
 
@@ -69,6 +69,7 @@ class CalculatorTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.duration = general.AccumDict()
+        parallel.Starmap.shutdown = lambda: None  # avoid restarting the pool
 
     def get_calc(self, testfile, job_ini, **kw):
         """

--- a/openquake/calculators/tests/gmf_ebrisk_test.py
+++ b/openquake/calculators/tests/gmf_ebrisk_test.py
@@ -107,8 +107,7 @@ class GmfEbRiskTestCase(CalculatorTestCase):
         self.run_calc(case_master.__file__, 'job.ini', insured_losses='false',
                       hazard_calculation_id=str(calc1.calc_id),
                       source_model_logic_tree_file='',
-                      gsim_logic_tree_file='',
-                      concurrent_tasks='0')  # to avoid fork bug
+                      gsim_logic_tree_file='')
         calc2 = self.calc.datastore  # two files event_based_risk
 
         check_csm_info(calc0, calc1)  # the csm_info arrays must be equal

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -62,7 +62,6 @@ class UcerfTestCase(CalculatorTestCase):
         # check the generated hazard maps
         self.run_calc(ucerf.__file__, 'job.ini',
                       calculation_mode='event_based',
-                      concurrent_tasks='0',  # avoid usual fork bug
                       hazard_calculation_id=str(self.calc.datastore.calc_id))
 
         # check the GMFs

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -19,10 +19,11 @@ import operator
 import collections
 import time
 import os
+import logging
 import numpy
 
 from openquake.baselib import hdf5
-from openquake.baselib.general import groupby, warn
+from openquake.baselib.general import groupby
 from openquake.baselib.node import context, striptag, Node
 from openquake.hazardlib import geo, mfd, pmf, source
 from openquake.hazardlib.tom import PoissonTOM
@@ -196,21 +197,18 @@ def get_set_num_ruptures(src):
         dt = time.time() - t0
         clsname = src.__class__.__name__
         if dt > 10:
-            # NB: I am not using logging.warn because it hangs when called
-            # from a worker with processpool distribution; see
-            # https://github.com/gem/oq-engine/pull/3923
             if 'Area' in clsname:
-                warn('%s.count_ruptures took %d seconds, perhaps the '
-                     'area discretization is too small', src, dt)
+                logging.warn('%s.count_ruptures took %d seconds, perhaps the '
+                             'area discretization is too small', src, dt)
             elif 'ComplexFault' in clsname:
-                warn('%s.count_ruptures took %d seconds, perhaps the c'
-                     'omplex_fault_mesh_spacing is too small', src, dt)
+                logging.warn('%s.count_ruptures took %d seconds, perhaps the c'
+                             'omplex_fault_mesh_spacing is too small', src, dt)
             elif 'SimpleFault' in clsname:
-                warn('%s.count_ruptures took %d seconds, perhaps the '
-                     'rupture_mesh_spacing is too small', src, dt)
+                logging.warn('%s.count_ruptures took %d seconds, perhaps the '
+                             'rupture_mesh_spacing is too small', src, dt)
             else:
                 # multiPointSource
-                warn('count_ruptures %s took %d seconds', src, dt)
+                logging.warn('count_ruptures %s took %d seconds', src, dt)
     return src.num_ruptures
 
 


### PR DESCRIPTION
The so called "fork bug" is insolvable because it is a *feature* of POSIX (see https://codewithoutrules.com/2018/09/04/python-multiprocessing/). To us the bug caused infinite pain:
it was the cause of the KeyError on macOS (and sometimes on Linux) on the day before yesterday, the reason why if you do not close the datastore before forking hp5y sometimes reads bogus numbers and sometimes segfaults, and also the reason why the global mosaic calculation for Mexico was hanging during logging.
However in Python 3 there is a builtin way to avoid forking that I failed to recognize before: `multiprocessing.get_context('spawn')`. With that all my work to remove the fork becomes useless (see https://github.com/gem/oq-engine/pull/3928).

The price to pay is a longer startup time, which is not acceptable in the tests (they would became too slow for Travis) unless with a smart trick one disable `Starmap.shutdown` in the tests, so that there is a single pool for all tests.