### PR TITLE
Made the SourceModelParser private

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -19,6 +19,7 @@ import os
 import csv
 import copy
 import zlib
+import pickle
 import shutil
 import zipfile
 import logging
@@ -444,6 +445,63 @@ def get_source_model_lt(oqparam):
                               oqparam.number_of_logic_tree_samples)
 
 
+def check_nonparametric_sources(fname, smodel, investigation_time):
+    """
+    :param fname:
+        full path to a source model file
+    :param smodel:
+        source model object
+    :param investigation_time:
+        investigation_time to compare with in the case of
+        nonparametric sources
+    :returns:
+        the nonparametric sources in the model
+    :raises:
+        a ValueError if the investigation_time is different from the expected
+    """
+    # NonParametricSeismicSources
+    np = [src for sg in smodel.src_groups for src in sg
+          if hasattr(src, 'data')]
+    if np and smodel.investigation_time != investigation_time:
+        raise ValueError(
+            'The source model %s contains an investigation_time '
+            'of %s, while the job.ini has %s' % (
+                fname, smodel.investigation_time, investigation_time))
+    return np
+
+
+class _SourceModelParser(object):
+    # a source model parser featuring a cache based on an
+    # openquake.commonlib.source.SourceConverter
+    def __init__(self, converter):
+        self.converter = converter
+        self.fname_hits = collections.Counter()  # fname -> number of calls
+        self.changed_sources = 0
+
+    def parse(self, fname, pik, apply_uncertainties):
+        """
+        :param fname:
+            the full pathname of a source model file
+        :param pik:
+            the pathname of the corresponding pickled file
+        :param apply_uncertainties:
+            a function modifying the sources
+        """
+        with open(pik, 'rb') as f:
+            sm = pickle.load(f)
+        check_nonparametric_sources(
+            fname, sm, self.converter.investigation_time)
+        for group in sm:
+            for src in group:
+                changed = apply_uncertainties(src)
+                if changed:
+                    # redo count_ruptures which can be slow
+                    src.num_ruptures = src.count_ruptures()
+                    self.changed_sources += 1
+        self.fname_hits[fname] += 1
+        return sm
+
+
 def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
                       in_memory=True):
     """
@@ -470,7 +528,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
         oqparam.width_of_mfd_bin,
         oqparam.area_source_discretization)
 
-    psr = nrml.SourceModelParser(converter)
+    psr = _SourceModelParser(converter)
     pik = {}
     if oqparam.calculation_mode.startswith('ucerf'):
         [grp] = nrml.to_python(oqparam.inputs["source_model"], converter)
@@ -492,8 +550,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
                 src_groups.append(sg)
             elif in_memory:
                 apply_unc = source_model_lt.make_apply_uncertainties(sm.path)
-                src_groups.extend(psr.parse(
-                    fname, pik[fname], apply_unc, oqparam.investigation_time))
+                src_groups.extend(psr.parse(fname, pik[fname], apply_unc))
             else:  # just collect the TRT models
                 src_groups.extend(logictree.read_source_groups(fname))
         num_sources = sum(len(sg.sources) for sg in src_groups)

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -468,6 +468,7 @@ class SourceConverter(RuptureConverter):
     def __init__(self, investigation_time=50., rupture_mesh_spacing=10.,
                  complex_fault_mesh_spacing=None, width_of_mfd_bin=1.0,
                  area_source_discretization=None):
+        self.investigation_time = investigation_time
         self.area_source_discretization = area_source_discretization
         self.rupture_mesh_spacing = rupture_mesh_spacing
         self.complex_fault_mesh_spacing = (


### PR DESCRIPTION
`nrml.to_python` should be used instead. Closes https://github.com/gem/oq-engine/issues/3981.
