### PR TITLE
Added a check on missing IMTs between hazard and risk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check for inconsistent IMTs between hazard and risk
   * Replaced the forking processpool with a spawning processpool
 
 python3-oq-engine (3.2.0-1~xenial01) xenial; urgency=low

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -452,6 +452,11 @@ class HazardCalculator(BaseCalculator):
                 raise ValueError(
                     'The parent calculation was using minimum_intensity=%s'
                     ' != %s' % (oqp.minimum_intensity, oq.minimum_intensity))
+            missing_imts = set(oq.imtls) - set(oqp.imtls)
+            if missing_imts:
+                raise ValueError(
+                    'The parent calculation is missing the IMT(s) %s' %
+                    ', '.join(missing_imts))
         elif pre_calculator:
             calc = calculators[pre_calculator](
                 self.oqparam, self.datastore.calc_id)


### PR DESCRIPTION
This happened to @CatalinaYepes in a calculation for Japan. One way to get in this situation is to use (by mistake) risk models for hazard and risk with different IMTs. Now one will get the clear error
```python
  File "/home/michele/oqcode/oq-engine/openquake/calculators/base.py", line 459, in pre_execute
    'check the risk model' % ', '.join(missing_imts))
ValueError: The parent calculation is missing the IMT(s) SA(2)
```
