### PR TITLE
Avoided a deepcopy of the source models

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1230,12 +1230,13 @@ class SourceModelLogicTree(object):
                 branchsets_and_uncertainties.append((branchset, branch.value))
             branchset = branch.child_branchset
 
+        if not branchsets_and_uncertainties:
+            return  # nothing changed
+
         def apply_uncertainties(source):
-            if not branchsets_and_uncertainties:
-                return False  # nothing changed
             for branchset, value in branchsets_and_uncertainties:
                 branchset.apply_uncertainty(value, source)
-            return True  # the source was changed
+
         return apply_uncertainties
 
     def samples_by_lt_path(self):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -489,8 +489,7 @@ class SourceModelFactory(object):
         """
         check_nonparametric_sources(fname, sm, investigation_time)
         if apply_uncertainties:
-            sm = copy.deepcopy(sm)
-            for group in sm:
+            for group in copy.deepcopy(sm):
                 for src in group:
                     apply_uncertainties(src)
                     self.changed_sources += 1
@@ -580,6 +579,9 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
         logging.warn('You are doing redundant calculations: please make sure '
                      'that different sources have different IDs and set '
                      'optimize_same_id_sources=true in your .ini file')
+    if make_sm.changed_sources:
+        logging.info('Modified %d sources in the composite source model',
+                     make_sm.changed_sources)
 
 
 def getid(src):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -485,11 +485,13 @@ class SourceModelFactory(object):
         :param investigation_time:
             the investigation_time in the job.ini
         :returns:
-            a copy of the original source model with possibly changed sources
+            a copy of the original source model with changed sources if any,
+            or the original model with unchanged sources
         """
         check_nonparametric_sources(fname, sm, investigation_time)
         if apply_uncertainties:
-            for group in copy.deepcopy(sm):
+            sm = copy.deepcopy(sm)
+            for group in sm:
                 for src in group:
                     apply_uncertainties(src)
                     self.changed_sources += 1

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -487,8 +487,8 @@ class SourceModelFactory(object):
         :returns:
             a copy of the original source model with possibly changed sources
         """
+        check_nonparametric_sources(fname, sm, investigation_time)
         if apply_uncertainties:
-            check_nonparametric_sources(fname, sm, investigation_time)
             sm = copy.deepcopy(sm)
             for group in sm:
                 for src in group:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -485,7 +485,7 @@ class SourceModelFactory(object):
         :param investigation_time:
             the investigation_time in the job.ini
         :returns:
-            a copy of the original source model with changed sources if any,
+            a copy of the original source model with changed sources (if any)
             or the original model with unchanged sources
         """
         check_nonparametric_sources(fname, sm, investigation_time)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -487,12 +487,12 @@ class SourceModelFactory(object):
         :returns:
             a copy of the original source model with possibly changed sources
         """
-        sm = copy.deepcopy(sm)
-        check_nonparametric_sources(fname, sm, investigation_time)
-        for group in sm:
-            for src in group:
-                changed = apply_uncertainties(src)
-                if changed:
+        if apply_uncertainties:
+            check_nonparametric_sources(fname, sm, investigation_time)
+            sm = copy.deepcopy(sm)
+            for group in sm:
+                for src in group:
+                    apply_uncertainties(src)
                     self.changed_sources += 1
                     # NB: redoing count_ruptures which can be slow
                     src.num_ruptures = src.count_ruptures()

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -481,7 +481,7 @@ class SourceModelFactory(object):
         :param sm:
             the original source model
         :param apply_uncertainties:
-            a function modifying the sources
+            a function modifying the sources (or None)
         :param investigation_time:
             the investigation_time in the job.ini
         :returns:


### PR DESCRIPTION
This will make `oq info --report` and the global mosaic tests a bit faster. For instance, for the case of Trevor Allen's model, the runtime of `oq info --report` goes down from 2325s to 1828s, which is noticeable.