### PR TITLE
Changed the rupture storage

### DIFF
--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -519,23 +519,23 @@ class RuptureGetter(object):
         grp_trt = self.dstore['csm_info'].grp_by("trt")
         events = self.dstore['events']
         ruptures = self.dstore['ruptures'][self.mask]
-        rupgeoms = self.dstore['rupgeoms'][self.mask]
         # NB: ruptures.sort(order='serial') causes sometimes a SystemError:
         # <ufunc 'greater'> returned a result with an error set
         # this is way I am sorting with Python and not with numpy below
-        data = sorted((serial, ridx) for ridx, serial in enumerate(
-            ruptures['serial']))
-        for serial, ridx in data:
-            rec = ruptures[ridx]
+        rupgeoms = self.dstore['rupgeoms']
+        for rec in sorted(ruptures, key=operator.itemgetter('serial')):
             evs = events[rec['eidx1']:rec['eidx2']]
             if self.grp_id is not None and self.grp_id != rec['grp_id']:
                 continue
             mesh = numpy.zeros((3, rec['sy'], rec['sz']), F32)
-            for i, arr in enumerate(rupgeoms[ridx]):  # i = 0, 1, 2
-                mesh[i] = arr.reshape(rec['sy'], rec['sz'])
+            geom = rupgeoms[rec['gidx1']:rec['gidx2']].reshape(
+                rec['sy'], rec['sz'])
+            mesh[0] = geom['lon']
+            mesh[1] = geom['lat']
+            mesh[2] = geom['depth']
             rupture_cls, surface_cls = code2cls[rec['code']]
             rupture = object.__new__(rupture_cls)
-            rupture.serial = serial
+            rupture.serial = rec['serial']
             rupture.surface = object.__new__(surface_cls)
             rupture.mag = rec['mag']
             rupture.rake = rec['rake']

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -147,7 +147,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # test the number of bytes saved in the rupture records
         nbytes = self.calc.datastore.get_attr('ruptures', 'nbytes')
-        self.assertEqual(nbytes, 1859)
+        self.assertEqual(nbytes, 1963)
 
         # test postprocessing
         self.calc.datastore.close()

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -22,7 +22,7 @@ import numpy
 from openquake.baselib import hdf5, general
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib.source.rupture import BaseRupture
-from openquake.hazardlib.geo.mesh import surface_to_array
+from openquake.hazardlib.geo.mesh import surface_to_array, point3d
 from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.hazardlib.imt import from_string
 from openquake.hazardlib import calc, probability_map
@@ -356,19 +356,19 @@ class RuptureSerializer(object):
     """
     rupture_dt = numpy.dtype([
         ('serial', U32), ('grp_id', U16), ('code', U8),
-        ('eidx1', U32), ('eidx2', U32), ('pmfx', I32),
-        ('mag', F32), ('rake', F32), ('occurrence_rate', F32),
+        ('eidx1', U32), ('eidx2', U32), ('gidx1', U32), ('gidx2', U32),
+        ('pmfx', I32), ('mag', F32), ('rake', F32), ('occurrence_rate', F32),
         ('hypo', (F32, 3)), ('sy', U16), ('sz', U16)])
 
     pmfs_dt = numpy.dtype([('serial', U32), ('pmf', hdf5.vfloat32)])
 
     @classmethod
-    def get_array_nbytes(cls, ebruptures):
+    def get_array_nbytes(cls, ebruptures, offset):
         """
         Convert a list of EBRuptures into a numpy composite array
         """
         lst = []
-        geom = []
+        geoms = []
         nbytes = 0
         for ebrupture in ebruptures:
             rup = ebrupture.rupture
@@ -379,13 +379,17 @@ class RuptureSerializer(object):
             assert sz < TWO16, 'The rupture mesh spacing is too small'
             hypo = rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z
             rate = getattr(rup, 'occurrence_rate', numpy.nan)
+            points = mesh.reshape(3, -1).T   # shape (n, 3)
+            n = len(points)
             tup = (ebrupture.serial, ebrupture.grp_id, rup.code,
-                   ebrupture.eidx1, ebrupture.eidx2,
+                   ebrupture.eidx1, ebrupture.eidx2, offset, offset + n,
                    getattr(ebrupture, 'pmfx', -1),
                    rup.mag, rup.rake, rate, hypo, sy, sz)
+            offset += n
             lst.append(tup)
-            geom.append(mesh.reshape(3, -1))
+            geoms.append(numpy.array([tuple(p) for p in points], point3d))
             nbytes += cls.rupture_dt.itemsize + mesh.nbytes
+        geom = numpy.concatenate(geoms)
         return numpy.array(lst, cls.rupture_dt), geom, nbytes
 
     def __init__(self, datastore):
@@ -395,8 +399,7 @@ class RuptureSerializer(object):
         if datastore['oqparam'].save_ruptures:
             datastore.create_dset('ruptures', self.rupture_dt, fillvalue=None,
                                   attrs={'nbytes': 0})
-            datastore.create_dset('rupgeoms', hdf5.vfloat32,
-                                  shape=(None, 3), fillvalue=None)
+            datastore.create_dset('rupgeoms', point3d, fillvalue=None)
 
     def save(self, ebruptures, eidx=0):
         """
@@ -420,11 +423,12 @@ class RuptureSerializer(object):
                 pmfbytes += self.pmfs_dt.itemsize + rup.pmf.nbytes
 
         # store the ruptures in a compact format
-        array, geom, nbytes = self.get_array_nbytes(ebruptures)
+        offset = len(self.datastore['rupgeoms'])
+        array, geom, nbytes = self.get_array_nbytes(ebruptures, offset)
         previous = self.datastore.get_attr('ruptures', 'nbytes', 0)
         dset = self.datastore.extend(
             'ruptures', array, nbytes=previous + nbytes)
-        self.datastore.hdf5.save_vlen('rupgeoms', geom)
+        self.datastore.extend('rupgeoms', geom)
 
         # save nbytes occupied by the PMFs
         if pmfbytes:


### PR DESCRIPTION
For consistency with the source geometries now even the rupture geometries are stored using indices and not variable-length arrays.