### PR TITLE
Mex

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -732,7 +732,6 @@ def _split_all(csm, h5, min_mag=0):
     srcs_by_grp_id = collections.defaultdict(list)
     for sm in csm.source_models:
         for src_group in sm.src_groups:
-            print(src_group)
             if src_group.src_interdep != 'mutex':
                 # split regular sources
                 for src in src_group:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -746,6 +746,7 @@ def _split_all(csm, h5, min_mag=0):
                     srcs_by_grp_id[src_group.id] = random_filter(
                         src_group, float(sample_factor))
             else:
+                srcs_by_grp_id[src_group.id] = src_group.sources
                 split_time.extend([0] * len(src_group))
                 num_split.extend([1] * len(src_group))
 

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -75,11 +75,9 @@ import io
 import os
 import re
 import sys
-import pickle
 import decimal
 import logging
 import operator
-import tempfile
 import collections
 
 import numpy


### PR DESCRIPTION
This is a case where the same source model `int_mex.xml` appeared in two different branches of the logic tree. Modifying `src_groups.sources` too early was a problem them.
