### PR TITLE
Used ses_seed in the event based demos

### DIFF
--- a/demos/hazard/EventBasedPSHA/job.ini
+++ b/demos/hazard/EventBasedPSHA/job.ini
@@ -2,7 +2,7 @@
 
 description = Event Based PSHA using Area Source
 calculation_mode = event_based
-random_seed = 23
+ses_seed = 24
 
 [geometry]
 
@@ -46,7 +46,7 @@ ground_motion_correlation_params =
 
 export_dir = /tmp
 save_ruptures = true
-
+ground_motion_fields = true
 hazard_curves_from_gmfs = true
 hazard_maps = true
 poes = 0.1

--- a/demos/risk/EventBasedRisk/job_hazard.ini
+++ b/demos/risk/EventBasedRisk/job_hazard.ini
@@ -2,6 +2,7 @@
 description = Stochastic Event-Based Hazard Demo (Nepal)
 calculation_mode = event_based
 concurrent_tasks = 16
+ses_seed = 42
 
 [exposure]
 exposure_file = exposure_model.xml


### PR DESCRIPTION
The users keep setting the wrong seed, so I am changing the demos to use the right one.
@raoanirudh see https://github.com/gem/oq-engine/issues/3460, the `ses_seed` is still undocumented.