### PR TITLE
Fixed Venetia's bug

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -162,7 +162,7 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
     for key in sorted(dskeys & exportable):
         try:
             size_mb = dstore.get_attr(key, 'nbytes') / MB
-        except KeyError:
+        except (KeyError, AttributeError):
             size_mb = None
         keysize.append((key, size_mb))
     ds_size = os.path.getsize(dstore.hdf5path) / MB


### PR DESCRIPTION
When running the risk for Italy Venetia's get the error:
```python
     File "/home/michele/oqcode/oq-engine/openquake/baselib/datastore.py", line 234, in get_attr
       obj = h5py.File.__getitem__(self.hdf5, key)
     File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
     File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
     File "/home/michele/py36/lib/python3.6/site-packages/h5py/_hl/group.py", line 177, in __getitem__
       oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
   AttributeError: 'tuple' object has no attribute 'id'
 ```
This is reproducible. The puzzling thing is that this error should not happen, a KeyError should happen instead, as it happens in smaller computations (i.e. our event based risk demo that tests exactly this situation). Looks like another quirk of h5py. Anyway, the fix is trivial.