### PR TITLE
Added a call to `check_mem_usage` in the workers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * If a worker runs close to out of memory, now a warning appears in the
+    main log
   * Fixed a bug with the minimum_magnitude feature and extended it to be
     tectonic region type dependent
   * Changed the rupture generation to yield bunches of ruptures, thus avoiding

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -222,9 +222,8 @@ def check_mem_usage(monitor=None, soft_percent=None, hard_percent=None):
         msg = 'Using over %d%% of the memory in %s!'
         calc_id = getattr(monitor, 'calc_id', 0)
         if calc_id:
-            msg += ' [calc_id=%d]' % calc_id
-            dbcmd('log', calc_id, datetime.utcnow(), 'WARNING', '', msg %
-                  (used_mem_percent, hostname))
+            dbcmd('log', calc_id, datetime.utcnow(), 'WARNING',
+                  '[calc_id=%d]' % calc_id, msg % (used_mem_percent, hostname))
         else:
             logging.warn(msg, used_mem_percent, hostname)
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -370,6 +370,7 @@ def safely_call(func, args, monitor=dummy_mon):
         return Result.new(func, args, monitor)
 
     mon = args[-1]
+    check_mem_usage(mon)  # log a warning if too much memory is used
     mon.operation = 'total ' + func.__name__
     mon.measuremem = True
     if mon is not monitor:

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -217,8 +217,11 @@ def check_mem_usage(monitor=Monitor(),
                           (used_mem_percent, hard_percent))
     elif used_mem_percent > soft_percent:
         hostname = socket.gethostname()
-        logging.warn('Using over %d%% of the memory in %s!',
-                     used_mem_percent, hostname)
+        msg = 'Using over %d%% of the memory in %s!'
+        calc_id = getattr(monitor, 'calc_id', 0)
+        if calc_id:
+            msg += ' [calc_id=%d]' % calc_id
+        logging.warn(msg, used_mem_percent, hostname)
 
 
 class Pickled(object):

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -156,6 +156,7 @@ import itertools
 import traceback
 import collections
 import multiprocessing.dummy
+from datetime import datetime
 import psutil
 import numpy
 try:
@@ -201,13 +202,14 @@ def oq_distribute(task=None):
     return dist
 
 
-def check_mem_usage(monitor=Monitor(),
-                    soft_percent=None, hard_percent=None):
+def check_mem_usage(monitor=None, soft_percent=None, hard_percent=None):
     """
     Display a warning if we are running out of memory
 
     :param int mem_percent: the memory limit as a percentage
     """
+    if monitor:
+        from openquake.commonlib.logs import dbcmd
     soft_percent = soft_percent or config.memory.soft_mem_limit
     hard_percent = hard_percent or config.memory.hard_mem_limit
     used_mem_percent = psutil.virtual_memory().percent
@@ -221,7 +223,10 @@ def check_mem_usage(monitor=Monitor(),
         calc_id = getattr(monitor, 'calc_id', 0)
         if calc_id:
             msg += ' [calc_id=%d]' % calc_id
-        logging.warn(msg, used_mem_percent, hostname)
+            dbcmd('log', calc_id, datetime.utcnow(), 'WARNING', '', msg %
+                  (used_mem_percent, hostname))
+        else:
+            logging.warn(msg, used_mem_percent, hostname)
 
 
 class Pickled(object):


### PR DESCRIPTION
Now that the forking bug has been solved we can finally close https://github.com/gem/oq-engine/issues/2999. By playing with `ulimit` one can reduce the memory available and induce warnings like the following:

```
[2018-09-25 15:35:12.00 #18946 WARNING] Using over 82% of the memory in thinkpad!
[2018-09-25 15:35:12.63 #18946 WARNING] Using over 83% of the memory in thinkpad!
```