### PR TITLE
Remove a piece of code that is preventing nohup from working

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -186,8 +186,14 @@ def raiseMasterKilled(signum, _stack):
     :param _stack: the current frame object, ignored
     """
     # Disable further CTRL-C to allow tasks revocation when Celery is used
-    if OQ_DISTRIBUTE.startswith('celery'):
-        signal.signal(signal.SIGINT, inhibitSigInt)
+    # this code has been disabled because it's causing issues with 'nohup':
+    # grep Sig /proc/$!/status: SigIgn:	0000000001001000
+    # last digit should be '1' and not '0'.
+    # A workaround would be using 'disown'. Code can be restored/removed after
+    # further investigation is performed.
+    # Ref: https://unix.stackexchange.com/a/420663
+    # if OQ_DISTRIBUTE.startswith('celery'):
+    #     signal.signal(signal.SIGINT, inhibitSigInt)
 
     msg = 'Received a signal %d' % signum
     if signum in (signal.SIGTERM, signal.SIGINT):


### PR DESCRIPTION
When running on a cluster we had to ignore a signal, in a certain condition. This seems to have a side effect of making `nohup` working badly.

I'm disabling that code for now. Further investigation is required, also to see if the new `spawn` mechanism works properly when calculation is orphan.

Before the change:
```bash
$ grep SigIgn /proc/$!/status
SigIgn:	0000000001001000
```

After the change
```bash
$ grep SigIgn /proc/$!/status
SigIgn:	0000000001001001
```

Explanation is here: https://unix.stackexchange.com/a/420663

This makes anyway `nohup` only working after the `splitting/filtering source` phase because if session is disconnect before that the computations becomes stuck.