### PR TITLE
Remove SIGHUP registration in the Engine

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -193,16 +193,6 @@ def raiseMasterKilled(signum, _stack):
     if signum in (signal.SIGTERM, signal.SIGINT):
         msg = 'The openquake master process was killed manually'
 
-    # kill the calculation only if os.getppid() != _PPID, i.e. the controlling
-    # terminal died; in the workers, do nothing
-    # NB: there is no SIGHUP on Windows
-    if hasattr(signal, 'SIGHUP'):
-        if signum == signal.SIGHUP:
-            if os.getppid() == _PPID:
-                return
-            else:
-                msg = 'The openquake master lost its controlling terminal'
-
     raise MasterKilled(msg)
 
 
@@ -213,8 +203,6 @@ def raiseMasterKilled(signum, _stack):
 try:
     signal.signal(signal.SIGTERM, raiseMasterKilled)
     signal.signal(signal.SIGINT, raiseMasterKilled)
-    if hasattr(signal, 'SIGHUP'):
-        signal.signal(signal.SIGHUP, raiseMasterKilled)
 except ValueError:
     pass
 


### PR DESCRIPTION
It's causing more issues than ones it solved and prevents the use of `hohup` (which is not ideal in the XXI century, but it looks common with our users).
The situation is even worse now that we switched to the `spawn` process manager: after a disconnection the computation was becoming stuck if filtering of sources was not completed/started yet or it was failing with ugly errors related to missing process descriptors.

After removing the signal registration I was able to complete a SHARE computation with nohup even after forcefully closing the session just after the start.

Before the change:
```bash
./psig -p 13945
[ 13945] Signals Queued: 0/514495
[ 13945] Signals Pending: 
[ 13945] Signals Pending (Shared): 
[ 13945] Signals Blocked: 
[ 13945] Signals Ignored: SIGPIPE,SIGXFSZ
[ 13945] Signals Caught: SIGHUP,SIGINT,SIGTERM,SIGWINCH
```

After:
```bash
./psig -p 18764
[ 18764] Signals Queued: 0/514495
[ 18764] Signals Pending: 
[ 18764] Signals Pending (Shared): 
[ 18764] Signals Blocked: 
[ 18764] Signals Ignored: SIGHUP,SIGPIPE,SIGXFSZ
[ 18764] Signals Caught: SIGINT,SIGTERM,SIGWINCH
```