### PR TITLE
Reintroduce NOHUP handler, but skip it if running with nohup

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -193,6 +193,16 @@ def raiseMasterKilled(signum, _stack):
     if signum in (signal.SIGTERM, signal.SIGINT):
         msg = 'The openquake master process was killed manually'
 
+    # kill the calculation only if os.getppid() != _PPID, i.e. the controlling
+    # terminal died; in the workers, do nothing
+    # NB: there is no SIGHUP on Windows
+    if hasattr(signal, 'SIGHUP'):
+        if signum == signal.SIGHUP:
+            if os.getppid() == _PPID:
+                return
+            else:
+                msg = 'The openquake master lost its controlling terminal'
+
     raise MasterKilled(msg)
 
 
@@ -203,6 +213,10 @@ def raiseMasterKilled(signum, _stack):
 try:
     signal.signal(signal.SIGTERM, raiseMasterKilled)
     signal.signal(signal.SIGINT, raiseMasterKilled)
+    if hasattr(signal, 'SIGHUP'):
+        # Do not register our SIGHUP handler if running with 'nohup'
+        if signal.getsignal(signal.SIGHUP) != signal.SIG_IGN:
+            signal.signal(signal.SIGHUP, raiseMasterKilled)
 except ValueError:
     pass
 


### PR DESCRIPTION
There's an easy way to check if we are running with `nohup`, so I'm reintroducing the feature of killing everything if `SIGHUP` is trapped, but only if it is not explicitly ignored via `nohup`.

Proof of concept:
```python
import signal

if signal.getsignal(signal.SIGHUP) != signal.SIG_IGN:
    print('SIGHUP REGISTERED')
else:
    print('DO NOT REGISTER SIGHUP')
```

```bash
$ python3 test.py
SIGHUP REGISTERED

$ nohup python3 test.py > out
$ cat out
DO NOT REGISTER SIGHUP
```

Before we were always overriding the default signal, which is `signal.SIG_DFL` without `nohup` and `signal.SIG_IGN` with `nohup`