### PR TITLE
Added a configuration parameter for dask

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -545,7 +545,7 @@ class Starmap(object):
         elif distribute == 'no' and hasattr(cls, 'pool'):
             cls.shutdown()
         elif distribute == 'dask':
-            cls.dask_client = Client()
+            cls.dask_client = Client(config.distribution.dask_scheduler)
 
     @classmethod
     def shutdown(cls):

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -25,6 +25,10 @@ terminate_workers_on_revoke = true
 # this is good for a single user situation, but turn this off on a cluster
 # otherwise a CTRL-C will kill the computations of other users
 
+# change this on a cluster if using oq_distribute = dask
+dask_scheduler = 127.0.0.1:1921
+
+
 [memory]
 # above this quantity (in %) of memory used a warning will be printed
 soft_mem_limit = 80


### PR DESCRIPTION
This is the missing step to be able to run dask on a cluster. Then one has to start a `dask-scheduler` on wilson and a `dask-worker --nprocs 64` on the worker machines.
