### PR TITLE
Using Python 3.6 __init_subclasses__ hook

### DIFF
--- a/openquake/commands/__main__.py
+++ b/openquake/commands/__main__.py
@@ -28,11 +28,8 @@ from openquake import commands
 PY_VER = sys.version_info[:3]
 
 # check for Python version
-if PY_VER < (3, 5):
-    sys.exit('Python 3.5+ is required, you are using %s', sys.executable)
-elif PY_VER < (3, 6):
-    print('DeprecationWarning: Python %s.%s.%s is deprecated. '
-          'Please upgrade to Python 3.6+' % PY_VER)
+if PY_VER < (3, 6):
+    sys.exit('Python 3.6+ is required, you are using %s', sys.executable)
 
 # force cluster users to use `oq engine` so that we have centralized logs
 if os.environ['OQ_DISTRIBUTE'] == 'celery' and 'run' in sys.argv:

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -153,8 +153,13 @@ class GroundShakingIntensityModel(object):
     superseded_by = None
     non_verified = False
 
+    @classmethod
     def __init_subclass__(cls):
         registry[cls.__name__] = cls
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        cls = self.__class__
         if cls.superseded_by:
             msg = '%s is deprecated - use %s instead' % (
                 cls.__name__, cls.superseded_by.__name__)
@@ -405,7 +410,8 @@ class GroundShakingIntensityModel(object):
         return hash(str(self))
 
     def __str__(self):
-        return "%s()" % self.__class__.__name__
+        kwargs = ', '.join('%s=%r' % kv for kv in self.kwargs.items())
+        return "%s(%s)" % (self.__class__.__name__, kwargs)
 
     def __repr__(self):
         """

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -412,7 +412,6 @@ class GroundShakingIntensityModel(object):
         Default string representation for GSIM instances. It contains
         the name and values of the arguments, if any.
         """
-        return str(self.__class__.__name__)
         return repr(str(self))
 
 

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -558,3 +558,7 @@ class GMPETable(GMPE):
         # linearly (or approximately linearly) with magnitude
         m_interpolator = interp1d(self.m_w, numpy.log10(iml_table), axis=1)
         return 10.0 ** m_interpolator(mag)
+
+    def __str__(self):
+        return "%s(gmpe_table='%s')" % (self.__class__.__name__,
+                                        os.path.basename(self.GMPE_TABLE))

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -323,7 +323,7 @@ class GMPETable(GMPE):
                         os.path.join(self.GMPE_DIR, gmpe_table))
             else:
                 raise IOError("GMPE Table Not Defined!")
-        super().__init__()
+        super().__init__(gmpe_table=gmpe_table)
         self.imls = None
         self.stddevs = {}
         self.m_w = None
@@ -558,7 +558,3 @@ class GMPETable(GMPE):
         # linearly (or approximately linearly) with magnitude
         m_interpolator = interp1d(self.m_w, numpy.log10(iml_table), axis=1)
         return 10.0 ** m_interpolator(mag)
-
-    def __str__(self):
-        return "%s(gmpe_table='%s')" % (self.__class__.__name__,
-                                        os.path.basename(self.GMPE_TABLE))

--- a/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
@@ -165,3 +165,7 @@ class NRCan15SiteTerm(GMPE):
     7.500  -0.692  -0.247  -0.00
     10.00  -0.650  -0.215  -0.00
     """)
+
+    def __str__(self):
+        return '%s(%s)' % (self.__class__.__name__,
+                           self.gmpe.__class__.__name__)

--- a/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
@@ -46,6 +46,7 @@ class NRCan15SiteTerm(GMPE):
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
     def __init__(self, gmpe_name):
+        super().__init__(gmpe_name=gmpe_name)
         self.gmpe = registry[gmpe_name]()
         self.set_parameters()
 
@@ -165,7 +166,3 @@ class NRCan15SiteTerm(GMPE):
     7.500  -0.692  -0.247  -0.00
     10.00  -0.650  -0.215  -0.00
     """)
-
-    def __str__(self):
-        return '%s(%s)' % (self.__class__.__name__,
-                           self.gmpe.__class__.__name__)


### PR DESCRIPTION
Thanks to this feature of Python 3.6 I was able to remove the metaclass MetaGSIM. @mmpagani will be happy because now the regular instantiation syntax `GSIM(value)` works again (before the metaclass magic forced the user to use the syntax `GSIM(name=value)`.

@daniviga after this PR the engine will stop working with Python 3.5.