### PR TITLE
Removed ownership check on get_job_id

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made it possible to run the risk over an hazard calculation of another user
   * Worked around the OverflowError: cannot serialize a bytes object larger
     than 4 GiB in event based calculations
   * Started using Python 3.6 features

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -34,11 +34,10 @@ HAZARD_CALCULATION_ARG = "--hazard-calculation-id"
 MISSING_HAZARD_MSG = "Please specify '%s=<id>'" % HAZARD_CALCULATION_ARG
 
 
-def get_job_id(job_id, username=None):
-    username = username or getpass.getuser()
-    job = logs.dbcmd('get_job', job_id, username)
+def get_job_id(job_id):
+    job = logs.dbcmd('get_job', job_id)
     if not job:
-        sys.exit('Job %s of %s not found' % (job_id, username))
+        sys.exit('Job %s not found' % job_id)
     return job.id
 
 


### PR DESCRIPTION
Since a hazard calculation takes several hour to run, Catalina wants to be able to run the risk over a calculation made by Julio without having to re-run the hazard. Now there is a stupid check forbidding that.