### PR TITLE
Added the ability to run multiple job.ini one after the other

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -49,7 +49,6 @@ U32 = numpy.uint32
 U64 = numpy.uint64
 F32 = numpy.float32
 TWO16 = 2 ** 16
-logversion = True
 
 
 class InvalidCalculationID(Exception):
@@ -160,17 +159,14 @@ class BaseCalculator(metaclass=abc.ABCMeta):
         """
         Run the calculation and return the exported outputs.
         """
-        global logversion
         with self._monitor:
             self._monitor.username = kw.get('username', '')
             self._monitor.hdf5 = self.datastore.hdf5
             self.set_log_format()
-            if logversion:  # make sure this is logged only once
-                logging.info('Running %s [--hc=%s]',
-                             self.oqparam.inputs['job_ini'],
-                             self.oqparam.hazard_calculation_id)
-                logging.info('Using engine version %s', engine_version)
-                logversion = False
+            logging.info('Running %s [--hc=%s]',
+                         self.oqparam.inputs['job_ini'],
+                         self.oqparam.hazard_calculation_id)
+            logging.info('Using engine version %s', engine_version)
             if concurrent_tasks is None:  # use the job.ini parameter
                 ct = self.oqparam.concurrent_tasks
             else:  # used the parameter passed in the command-line

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -164,12 +164,17 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
     else:
         hc_id = None
     if run:
-        job_ini = os.path.expanduser(run)
-        open(job_ini, 'rb').read()  # IOError if the file does not exist
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
-        run_job(os.path.expanduser(run), log_level, log_file,
-                exports, hazard_calculation_id=hc_id)
+        job_inis = os.path.expanduser(run).split(',')
+        if len(job_inis) > 2 and hc_id:
+            sys.exit('The multi-run functionality only works without --hc')
+        for i, job_ini in enumerate(job_inis):
+            open(job_ini, 'rb').read()  # IOError if the file does not exist
+            job_id = run_job(job_ini, log_level, log_file,
+                             exports, hazard_calculation_id=hc_id)
+            if i == 0:  # use the first calculation as base for the others
+                hc_id = job_id
     # hazard
     elif list_hazard_calculations:
         for line in logs.dbcmd(


### PR DESCRIPTION
Here is an example:

```bash
$ oq engine --run job_south_america_hazard.ini,job_argentina_risk.ini,job_bolivia_risk.ini,job_chile_risk.ini
```

Notice: NO SPACES around the commas! This feature could not work before because of the forking bug, but now it is trivial to implement. It assumes the first file is a hazard one while the other files are risk ones starting from the `--hazard_calculation_id` generated by the first calculation.