### PR TITLE
Update macOS install instructions to include Mojave, fix typos [skip CI]

### DIFF
--- a/doc/installing/development.md
+++ b/doc/installing/development.md
@@ -147,7 +147,7 @@ To exit from the OpenQuake development environment type `deactivate`. Before usi
 To load the virtual environment automatically at every login, add the following line at the bottom of your `~/.bashrc` (Linux) or `~/.profile` (macOS):
 
 ```bash
-source $HOME/openquake/qoenv/bin/activate
+source $HOME/openquake/oqenv/bin/activate
 ```
 
 You can also add a short-hand command to enable it:

--- a/doc/installing/macos.md
+++ b/doc/installing/macos.md
@@ -13,7 +13,7 @@ The OpenQuake Engine is available for macOS in the form of **self-installable bi
 
 Requirements are:
 
-- Mac OS X 10.10 (Yosemite), Mac OS X 10.11 (El Capitan), macOS 10.12 (Sierra), or macOS 10.13 (High Sierra)
+- Mac OS X 10.10 (Yosemite), Mac OS X 10.11 (El Capitan), macOS 10.12 (Sierra), macOS 10.13 (High Sierra), or macOS 10.14 (Mojave)
 - 4 GB of RAM (8 GB recommended)
 - 1.2 GB of free disk space
 - [Terminal](https://support.apple.com/guide/terminal/welcome) or [iTerm2](https://www.iterm2.com/) app

--- a/openquake/hazardlib/gsim/toro_1997.py
+++ b/openquake/hazardlib/gsim/toro_1997.py
@@ -31,7 +31,7 @@ from openquake.hazardlib.imt import PGA, SA
 
 class ToroEtAl1997MblgNSHMP2008(GMPE):
     """
-    Implements GMPE developed by G. R. Toro, N. A. Abrahamson, J. F. Sneider
+    Implements GMPE developed by G. R. Toro, N. A. Abrahamson, J. F. Schneider
     and published in "Model of Strong Ground Motions from Earthquakes in
     Central and Eastern North America: Best Estimates and Uncertainties"
     (Seismological Research Letters, Volume 68, Number 1, 1997) as utilized

--- a/openquake/hazardlib/gsim/toro_2002.py
+++ b/openquake/hazardlib/gsim/toro_2002.py
@@ -29,7 +29,7 @@ from openquake.hazardlib.imt import PGA, SA
 
 class ToroEtAl2002(GMPE):
     """
-    Implements GMPE developed by G. R. Toro, N. A. Abrahamson, J. F. Sneider
+    Implements GMPE developed by G. R. Toro, N. A. Abrahamson, J. F. Schneider
     and published in "Model of Strong Ground Motions from Earthquakes in
     Central and Eastern North America: Best Estimates and Uncertainties"
     (Seismological Research Letters, Volume 68, Number 1, 1997) and


### PR DESCRIPTION
- Updating the installation instructions for macOS to include 10.14 (Mojave). The current set of instructions still work correctly.
- Fixing a typo in the installation instructions for development.
- Also fixing misspellings of John F. Schneider's name in the GMPEs ToroEtAl1997 and ToroEtAl2002.