### PR TITLE
More work on prepare_site_model

### DIFF
--- a/doc/oq-commands.md
+++ b/doc/oq-commands.md
@@ -183,6 +183,32 @@ than the entire calculation. In this case you should extract only the
 sites you are interested in, while this command extracts everything.
 The extract/export system will be extended in the near future.
 
+plotting commands
+------------------
+
+The engine provides several plotting commands. They are all experimental
+and subject to change. The official away to plot the engine results is
+by using the QGIS plugin. Still, the `oq plot` commands are useful for
+debugging purpose. Here I will describe only the `plot_assets` command,
+which allows to plot the exposure used in a calculation together with
+the hazard sites:
+
+```bash
+$ oq help plot_assets
+usage: oq plot_assets [-h] [calc_id]
+
+Plot the sites and the assets
+
+positional arguments:
+  calc_id     a computation id [default: -1]
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+
+This is particularly interesting when the hazard sites do not coincide
+with the asset locations, which is normal when gridding the exposure.
+
 prepare_site_model
 ------------------
 
@@ -196,19 +222,25 @@ algorithm.
 
 ```bash
 $ oq help prepare_site_model
-usage: oq prepare_site_model [-h] [-g 0] [-o sites.csv] exposure_csv vs30_csv
+usage: oq prepare_site_model [-h] [-g 0] [-s 5] [-o sites.csv]
+                             exposure_xml vs30_csv
 
 Prepare a site_model.csv file from an exposure, a vs30 csv file and a grid
-spacing which can be 0 (meaning no grid).
+spacing which can be 0 (meaning no grid). Sites far away from the vs30
+records are discarded and you can see them with the command `oq plot_assets`.
+It is up to you decide if you need to fix your exposure or if it is right
+to ignore the discarded sites.
 
 positional arguments:
-  exposure_csv          exposure with header
+  exposure_xml          exposure in XML format
   vs30_csv              USGS file lon,lat,vs30 with no header
 
 optional arguments:
   -h, --help            show this help message and exit
   -g 0, --grid-spacing 0
                         grid spacing in km (or 0)
+  -s 5, --site-param-distance 5
+                        sites over this distance are discarded
   -o sites.csv, --output sites.csv
                         output file
 ```
@@ -216,12 +248,13 @@ optional arguments:
 The command work in two modes: with non-gridded exposures (the
 default) and with gridded exposures. In the first case the assets are
 aggregated in unique locations and for each location the vs30 coming
-from the closest vs30 record is taken. In the second case, i.e. when a
-grid spacing parameter is passed, a grid containing of all the
-exposure is built and the points with assets are associated to the
-vs30 records. The maximum association distance is given
-by the grid spacing multiply by the square root of 2, so by enlarging
-the grid spacing you can avoid discarding the assets.
+from the closest vs30 record is taken. If the closest vs30 record is
+over the `site_param_distance` - which by default is 5 km - the site
+is discarded.  In the second case, i.e. when a `grid_spacing`
+parameter is passed, a grid containing of all the exposure is built
+and the points with assets are associated to the vs30 records. The
+`site_param_distance` parameter is ignored, and the grid spacing
+multiplied by the square root of 2 is used instead.
 
 In large risk calculation one wants to *use the gridded mode always* because:
 
@@ -229,7 +262,7 @@ In large risk calculation one wants to *use the gridded mode always* because:
 2) the calculation is a lot faster and uses a lot less memory with a grid.
 
 Basically by using a grid you can turn an impossible calculation into a possible
-one. You should always use a grid unless you are doing a site specific analysis.
+one. You should always use a grid unless there are very few sites.
 
 The command is able to manage multiple files at once, just use commas with
 no spaces to separate the files. Here is an example of usage:

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -207,12 +207,15 @@ def view_contents(token, dstore):
     """
     Returns the size of the contents of the datastore and its total size
     """
-    oq = dstore['oqparam']
+    try:
+        desc = dstore['oqparam'].description
+    except KeyError:
+        desc = ''
     data = sorted((dstore.getsize(key), key) for key in dstore)
     rows = [(key, humansize(nbytes)) for nbytes, key in data]
     total = '\n%s : %s' % (
         dstore.hdf5path, humansize(os.path.getsize(dstore.hdf5path)))
-    return rst_table(rows, header=(oq.description, '')) + total
+    return rst_table(rows, header=(desc, '')) + total
 
 
 @view.add('csm_info')

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -28,13 +28,19 @@ def plot_assets(calc_id=-1):
     import matplotlib.pyplot as p
     from openquake.hmtk.plotting.patch import PolygonPatch
     dstore = datastore.read(calc_id)
-    oq = dstore['oqparam']
+    try:
+        region = dstore['oqparam'].region
+    except KeyError:
+        region = None
     sitecol = dstore['sitecol']
-    assetcol = dstore['assetcol'].array
+    try:
+        assetcol = dstore['assetcol'].value
+    except AttributeError:
+        assetcol = dstore['assetcol'].array
     fig = p.figure()
     ax = fig.add_subplot(111)
-    if oq.region:
-        pp = PolygonPatch(shapely.wkt.loads(oq.region), alpha=0.1)
+    if region:
+        pp = PolygonPatch(shapely.wkt.loads(region), alpha=0.1)
         ax.add_patch(pp)
     ax.grid(True)
     p.scatter(sitecol.complete.lons, sitecol.complete.lats, marker='.',

--- a/openquake/commands/prepare_site_model.py
+++ b/openquake/commands/prepare_site_model.py
@@ -54,7 +54,8 @@ def prepare_site_model(exposure_xml, vs30_csv, grid_spacing=0,
     and a grid spacing which can be 0 (meaning no grid). In case of
     no grid warnings are raised for long distance associations.
     """
-    with performance.Monitor(hdf5=datastore.hdf5new(), measuremem=True) as mon:
+    hdf5 = datastore.hdf5new()
+    with performance.Monitor(hdf5.path, hdf5, measuremem=True) as mon:
         mesh, assets_by_site = Exposure.read(
             exposure_xml).get_mesh_assets_by_site()
         if grid_spacing:
@@ -83,7 +84,8 @@ def prepare_site_model(exposure_xml, vs30_csv, grid_spacing=0,
         sites = compose_arrays(sids, vs30, 'site_id')
         write_csv(output, sites)
     if discarded:
-        print('WARNING: discarded %d sites [oq plot_assets]' % len(discarded))
+        print('Discarded %d sites with assets [use oq plot_assets]' % len(
+            discarded))
     print('Saved %d rows in %s' % (len(sitecol), output))
     print(mon)
     return sitecol

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -437,11 +437,11 @@ class PrepareSiteModelTestCase(unittest.TestCase):
         inputdir = os.path.dirname(case_16.__file__)
         output = gettemp(suffix='csv')
         grid_spacing = 10
-        exposure_csv = os.path.join(inputdir, 'exposure_res.csv')
+        exposure_csv = os.path.join(inputdir, 'exposure.xml')
         vs30_csv = os.path.join(inputdir, 'vs30.csv')
         sitecol = prepare_site_model.func(
             exposure_csv, vs30_csv, grid_spacing, output)
-        self.assertEqual(len(sitecol), 149)  # 149 non-empty grid points
+        self.assertEqual(len(sitecol), 6)  # 6 non-empty grid points
 
         # test no grid
         sc = prepare_site_model.func(exposure_csv, vs30_csv, 0, output)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -444,5 +444,5 @@ class PrepareSiteModelTestCase(unittest.TestCase):
         self.assertEqual(len(sitecol), 6)  # 6 non-empty grid points
 
         # test no grid
-        sc = prepare_site_model.func(exposure_csv, vs30_csv, 0, output)
-        self.assertEqual(len(sc), 148)  # 148 assets
+        sc = prepare_site_model.func(exposure_csv, vs30_csv, 0, 10, output)
+        self.assertEqual(len(sc), 4)  # 4 sites within 10 km from the params


### PR DESCRIPTION
Answered @CatalinaYepes feedback:

1. passed the exposure as .xml
2. filtered away the grid sites without assets

Example:
```bash
$ oq prepare_site_model Exposure/Exposure_Ecuador.xml Vs30/usgs_vs30_data/Ecuador.csv -g 10
Discarded 9 sites with assets [use oq plot_assets]
Saved 812 rows in sites.csv
<Monitor /home/michele/oqdata/calc_33246.hdf5, duration=4.24s, memory=58.37 MB>
```