### PR TITLE
In case of a grid + site model, remove sites silently

### DIFF
--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -296,6 +296,12 @@ stddev         838           555
         [fname, _sitefile] = out['gmf_data', 'csv']
         self.assertEqualFiles('expected/gmf-data.csv', fname)
 
+    @attr('qa', 'hazard', 'event_based')
+    def test_case_4b(self):
+        # case with site collection extracted from site_model.xml
+        self.run_calc(case_4a.__file__, 'job.ini')
+        self.assertEqual(len(self.calc.datastore['events']), 5)
+
     @attr('qa', 'hazard', 'event_based_risk')
     def test_case_6c(self):
         # case with asset_correlation=1

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -358,8 +358,13 @@ def get_site_collection(oqparam):
             # associate the site parameters to the mesh
             sitecol = site.SiteCollection.from_points(
                 mesh.lons, mesh.lats, mesh.depths, None, req_site_params)
-            sc, params, discarded = geo.utils.assoc(
-                sm, sitecol, oqparam.max_site_model_distance, 'warn')
+            if oqparam.region_grid_spacing:
+                sitecol, params, discarded = geo.utils.assoc(
+                    sm, sitecol, oqparam.region_grid_spacing * 1.414, 'filter')
+                sitecol.make_complete()
+            else:  # do not discard assets
+                sc, params, discarded = geo.utils.assoc(
+                    sm, sitecol, oqparam.max_site_model_distance, 'warn')
             for name in req_site_params:
                 sitecol._set(name, params[name])
     else:  # use the default site params

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -355,14 +355,18 @@ def get_site_collection(oqparam):
             sitecol = site.SiteCollection.from_points(
                 sm['lon'], sm['lat'], depth, sm, req_site_params)
         else:
-            # associate the site parameters to the mesh
             sitecol = site.SiteCollection.from_points(
                 mesh.lons, mesh.lats, mesh.depths, None, req_site_params)
             if oqparam.region_grid_spacing:
+                # associate the site parameters to the grid assuming they
+                # have been prepared correctly, i.e. they are on the location
+                # of the assets; discard empty sites silently
                 sitecol, params, discarded = geo.utils.assoc(
                     sm, sitecol, oqparam.region_grid_spacing * 1.414, 'filter')
                 sitecol.make_complete()
-            else:  # do not discard assets
+            else:
+                # associate the site parameters to the sites without
+                # discarding any site but warning for far away parameters
                 sc, params, discarded = geo.utils.assoc(
                     sm, sitecol, oqparam.max_site_model_distance, 'warn')
             for name in req_site_params:

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -235,6 +235,7 @@ class ClosestSiteModelTestCase(unittest.TestCase):
         oqparam.base_path = '/'
         oqparam.maximum_distance = 100
         oqparam.max_site_model_distance = 5
+        oqparam.region_grid_spacing = None
         oqparam.sites = [(1.0, 0, 0), (2.0, 0, 0)]
         oqparam.inputs = dict(site_model=sitemodel())
         with mock.patch('logging.warn') as warn:

--- a/openquake/qa_tests_data/event_based_risk/case_4a/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_4a/job.ini
@@ -1,0 +1,35 @@
+[general]
+description = Event Based Hazard
+calculation_mode = event_based
+random_seed = 24
+
+[vulnerability]
+structural_vulnerability_file = structural_vulnerability_model.xml
+
+[site_params]
+site_model_file = site_model.xml
+
+[erf]
+width_of_mfd_bin = 0.1
+# km
+rupture_mesh_spacing = 2.0
+area_source_discretization = 20
+
+[logic_trees]
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gmpe_logic_tree.xml
+
+[calculation]
+truncation_level = 3
+# km
+maximum_distance = 200.0
+# years
+
+[event_based_params]
+investigation_time = 1
+number_of_logic_tree_samples = 0
+ses_per_logic_tree_path = 100
+
+[output]
+ground_motion_fields = false
+export_dir = /tmp


### PR DESCRIPTION
This risk team follow this workflow:
1) they prepare the site_model.xml on the location of the assets
2) they use a region_grid_spacing so that the exposure is automatically gridded
In such conditions with the current master there are plenty of scary warnings saying that the closest site parameter is hundreds of km far away for the sites of the grid (this happened to both Catalina and Venetia). This is correct, but misleading. It is normal for most points of the grid to be empty (no assets) and therefore with no site parameters there, there should be no warning. In such a case the sites without close site parameters should be discarded silently. On the contrary, if there is no grid, nothing should be discarded and the engine should complain with a warning because in that case the sites comes directly from the asset locations in the normal risk workflow.