### PR TITLE
Restricted ChiouYoungs2008SWISS01 to StdDev.TOTAL

### DIFF
--- a/openquake/hazardlib/gsim/chiou_youngs_2008_swiss.py
+++ b/openquake/hazardlib/gsim/chiou_youngs_2008_swiss.py
@@ -24,10 +24,9 @@ Module exports
 """
 import numpy as np
 
+from openquake.hazardlib import const
 from openquake.hazardlib.gsim.chiou_youngs_2008_swiss_coeffs import (
-    COEFFS_FS_ROCK_SWISS01,
-    COEFFS_FS_ROCK_SWISS06,
-    COEFFS_FS_ROCK_SWISS04)
+    COEFFS_FS_ROCK_SWISS01, COEFFS_FS_ROCK_SWISS06, COEFFS_FS_ROCK_SWISS04)
 from openquake.hazardlib.gsim.chiou_youngs_2008 import ChiouYoungs2008
 from openquake.hazardlib.gsim.utils_swiss_gmpe import _apply_adjustments
 
@@ -56,6 +55,7 @@ class ChiouYoungs2008SWISS01(ChiouYoungs2008):
 
     Model implemented by laurentiu.danciu@gmail.com
     """
+    DEFINED_FOR_STANDARD_DEVIATION_TYPES = {const.StdDev.TOTAL}
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
 


### PR DESCRIPTION
This is for @mmpagani to look at. I discovered that the latest Australia model uses the GSIM ChiouYoungs2008SWISS01 and tries to use it for both inter and intra stddevs. Such case is not tested and fails with an error
```python
  File "/opt/openquake2/oq-engine/openquake/calculators/getters.py", line 348, in gen_gmv
    array = computer.compute(gs, num_events).transpose(1, 0, 2)
  File "/opt/openquake2/oq-engine/openquake/hazardlib/calc/gmf.py", line 136, in compute
    ).with_traceback(exc.__traceback__)
  File "/opt/openquake2/oq-engine/openquake/hazardlib/calc/gmf.py", line 132, in compute
    result[imti] = self._compute(None, gs, num_events, imt)
  File "/opt/openquake2/oq-engine/openquake/hazardlib/calc/gmf.py", line 187, in _compute
    [StdDev.INTER_EVENT, StdDev.INTRA_EVENT])
ValueError: not enough values to unpack (expected 2, got 0) for ChiouYoungs2008SWISS01(), PGA
```
As a workaround I have restricted the GSIM to only StdDev.TOTAL. If we want to do more, we need to fix the GSIM.