### PR TITLE
`oq engine --run` with space-separated job.ini files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -24,7 +24,7 @@
     in classical_damage calculations
   * Reduced the data transfer in the risk model by only considering the
     taxonomies relevant for the exposure
-  * Extended `oq engine --run` to accept a comma-separated list of files
+  * Extended `oq engine --run` to accept a list of files
   * Optimized the saving of the risk results in event based in the case of
     many sites and changed the command `oq show portfolio_loss` to show
     mean and standard deviation of the portfolio loss for each loss type

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -245,7 +245,7 @@ engine.flg('db_version', 'Show the current version of the openquake database')
 engine.flg('what_if_I_upgrade', 'Show what will happen to the openquake '
            'database if you upgrade')
 engine._add('run', '--run', help='Run a job with the specified config file',
-            metavar='CONFIG_FILE', nargs='*')
+            metavar='JOB_INI', nargs='*')
 engine._add('list_hazard_calculations', '--list-hazard-calculations', '--lhc',
             help='List hazard calculation information', action='store_true')
 engine._add('list_risk_calculations', '--list-risk-calculations', '--lrc',

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -169,7 +169,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
     if run:
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
-        job_inis = os.path.expanduser(run).split(',')
+        job_inis = [os.path.expanduser(f) for f in run]
         if len(job_inis) > 2 and hc_id:
             sys.exit('The multi-run functionality only works without --hc')
         for i, job_ini in enumerate(job_inis):
@@ -245,7 +245,7 @@ engine.flg('db_version', 'Show the current version of the openquake database')
 engine.flg('what_if_I_upgrade', 'Show what will happen to the openquake '
            'database if you upgrade')
 engine._add('run', '--run', help='Run a job with the specified config file',
-            metavar='CONFIG_FILE')
+            metavar='CONFIG_FILE', nargs='*')
 engine._add('list_hazard_calculations', '--list-hazard-calculations', '--lhc',
             help='List hazard calculation information', action='store_true')
 engine._add('list_risk_calculations', '--list-risk-calculations', '--lrc',

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -245,7 +245,7 @@ engine.flg('db_version', 'Show the current version of the openquake database')
 engine.flg('what_if_I_upgrade', 'Show what will happen to the openquake '
            'database if you upgrade')
 engine._add('run', '--run', help='Run a job with the specified config file',
-            metavar='JOB_INI', nargs='*')
+            metavar='JOB_INI', nargs='+')
 engine._add('list_hazard_calculations', '--list-hazard-calculations', '--lhc',
             help='List hazard calculation information', action='store_true')
 engine._add('list_risk_calculations', '--list-risk-calculations', '--lrc',

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -81,10 +81,9 @@ def run2(job_haz, job_risk, concurrent_tasks, pdb, exports, params):
     return rcalc
 
 
-def _run(job_ini, concurrent_tasks, pdb, loglevel, hc, exports, params):
+def _run(job_inis, concurrent_tasks, pdb, loglevel, hc, exports, params):
     global calc_path
     logging.basicConfig(level=getattr(logging, loglevel.upper()))
-    job_inis = job_ini.split(',')
     assert len(job_inis) in (1, 2), job_inis
     with performance.Monitor('total runtime', measuremem=True) as monitor:
         if len(job_inis) == 1:  # run hazard or risk
@@ -141,7 +140,7 @@ def run(job_ini, slowest, hc, param, concurrent_tasks=None, exports='',
 
 
 run.arg('job_ini', 'calculation configuration file '
-        '(or files, comma-separated)')
+        '(or files, space-separated)', nargs='+')
 run.opt('slowest', 'profile and show the slowest operations', type=int)
 run.opt('hc', 'previous calculation ID', type=valid.hazard_id)
 run.opt('param', 'override parameter with the syntax NAME=VALUE ...',

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -208,7 +208,7 @@ class RunShowExportTestCase(unittest.TestCase):
         # nosetests openquake/commonlib/
         job_ini = os.path.join(os.path.dirname(case_1.__file__), 'job.ini')
         with Print.patch() as cls.p:
-            calc = run._run(job_ini, 0, False, 'info', None, '', {})
+            calc = run._run([job_ini], 0, False, 'info', None, '', {})
         cls.calc_id = calc.datastore.calc_id
 
     def test_run_calc(self):


### PR DESCRIPTION
As requested by Paolo:
```bash
$ oq engine 
usage: oq engine [-h] [--log-file LOG_FILE] [--no-distribute] [-y]
                 [-c CONFIG_FILE] [--make-html-report YYYY-MM-DD|today] [-u]
                 [-d] [-w] [--run JOB_INI [JOB_INI ...]]
                 [--list-hazard-calculations] [--list-risk-calculations]
                 [--delete-calculation CALCULATION_ID]
                 [--delete-uncompleted-calculations]
                 [--hazard-calculation-id HAZARD_CALCULATION_ID]
                 [--list-outputs CALCULATION_ID] [--show-log CALCULATION_ID]
                 [--export-output OUTPUT_ID TARGET_DIR]
                 [--export-outputs CALCULATION_ID TARGET_DIR] [-e]
                 [-l {debug, info, warn, error, critical}]
```