### PR TITLE
Modified site term and added test to cover corner case + add reference

### DIFF
--- a/openquake/hazardlib/gsim/campbell_2003.py
+++ b/openquake/hazardlib/gsim/campbell_2003.py
@@ -187,6 +187,9 @@ class Campbell2003SHARE(Campbell2003):
     #: Required rupture parameters are magnitude and rake
     REQUIRES_RUPTURE_PARAMETERS = set(('mag', 'rake'))
 
+    #: Shear-wave velocity for reference soil conditions in [m s-1]
+    DEFINED_FOR_REFERENCE_VELOCITY = 800.
+
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         See :meth:`superclass method

--- a/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
@@ -56,6 +56,10 @@ class NRCan15SiteTerm(GMPE):
             tmps = '{:s} does not use vs30 nor a defined reference velocity'
             msg = tmps.format(str(self.gmpe))
             raise AttributeError(msg)
+        if not (hasattr(self.gmpe, 'REQUIRES_SITES_PARAMETERS')):
+            self.REQUIRES_SITES_PARAMETERS = set(('vs30'))
+        if 'vs30' not in self.gmpe.REQUIRES_SITES_PARAMETERS:
+            self.REQUIRES_SITES_PARAMETERS.add('vs30')
         #
         # Check compatibility of reference velocity
         if hasattr(self.gmpe, 'DEFINED_FOR_REFERENCE_VELOCITY'):

--- a/openquake/hazardlib/gsim/toro_2002.py
+++ b/openquake/hazardlib/gsim/toro_2002.py
@@ -173,6 +173,9 @@ class ToroEtAl2002SHARE(ToroEtAl2002):
     #: Required rupture parameters are magnitude and rake
     REQUIRES_RUPTURE_PARAMETERS = set(('mag', 'rake'))
 
+    #: Shear-wave velocity for reference soil conditions in [m s-1]
+    DEFINED_FOR_REFERENCE_VELOCITY = 800.
+
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         See :meth:`superclass method

--- a/openquake/hazardlib/tests/gsim/mgmpe/nrcan15_site_term_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/nrcan15_site_term_test.py
@@ -17,7 +17,7 @@
 import numpy as np
 import unittest
 
-from openquake.hazardlib.tests.gsim.mgmpe.dummy import Dummy
+from openquake.hazardlib.tests.gsim.mgmpe.dummy import Dummy, DummyGMPEOne
 from openquake.hazardlib import const
 from openquake.hazardlib.gsim.atkinson_boore_2006 import AtkinsonBoore2006
 from openquake.hazardlib.gsim.boore_atkinson_2008 import BooreAtkinson2008
@@ -197,3 +197,8 @@ class NRCan15SiteTermTestCase(unittest.TestCase):
         """ Tests that exception is raised """
         with self.assertRaises(AttributeError):
             mgmpe = NRCan15SiteTerm(gmpe_name='FukushimaTanaka1990')
+
+    def test_set_vs30_attribute(self):
+        mgmpe = NRCan15SiteTerm(gmpe_name='Campbell2003SHARE')
+        msg = '{:s} does not have vs30 in the required site parameters'
+        self.assertTrue('vs30' in mgmpe.REQUIRES_SITES_PARAMETERS, msg=msg)


### PR DESCRIPTION
This PR fixes a corner case related to the use of the NRCan15 modified GMPE (perhaps we should consider changing name) and adds the reference soil conditions for two GMPEs used in SHARE so that they can be also used with the site term.