### PR TITLE
Fixed view inputs when reqv is enabled

### DIFF
--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -104,6 +104,10 @@ class ClassicalTestCase(CalculatorTestCase):
  [0.00000000e+00 0.00000000e+00]
  [0.00000000e+00 0.00000000e+00]]>}''')
 
+        # check view inputs
+        lines = view('inputs', self.calc.datastore).splitlines()
+        self.assertEqual(len(lines), 10)
+
         [fname] = export(('hcurves', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/hcurve.csv', fname)
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -288,9 +288,13 @@ def view_params(token, dstore):
 def build_links(items):
     out = []
     for key, fname in items:
-        bname = os.path.basename(fname)
-        link = "`%s <%s>`_" % (bname, bname)
-        out.append((key, link))
+        if isinstance(fname, dict):
+            for k, v in fname.items():
+                b = os.path.basename(v)
+                out.append(('reqv:' + k, "`%s <%s>`_" % (b, b)))
+        else:
+            bname = os.path.basename(fname)
+            out.append((key, "`%s <%s>`_" % (bname, bname)))
     return sorted(out)
 
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -147,7 +147,7 @@ class OqParam(valid.ParamSet):
     sm_lt_path = valid.Param(valid.logic_tree_path, None)
     source_id = valid.Param(valid.source_id, None)
     specific_assets = valid.Param(valid.namelist, [])
-    pointsource_distance = valid.Param(valid.positivefloat, None)
+    pointsource_distance = valid.Param(valid.maximum_distance, {})
     taxonomies_from_model = valid.Param(valid.boolean, False)
     time_event = valid.Param(str, None)
     truncation_level = valid.Param(valid.NoneOr(valid.positivefloat), None)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -178,6 +178,9 @@ def get_params(job_inis, **kw):
         inputs['source'] = logictree.collect_info(smlt).smpaths
     elif 'source_model' in inputs:
         inputs['source'] = [inputs['source_model']]
+    if inputs.get('reqv'):
+        # using pointsource_distance=0 because of the reqv approximation
+        params['pointsource_distance'] = '0'
     return params
 
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -785,15 +785,15 @@ def get_composite_source_model(oqparam, monitor=None, in_memory=True,
     if not in_memory:
         return csm
 
-    if 'event_based' in oqparam.calculation_mode:
-        if oqparam.pointsource_distance == 0:
-            # remove splitting/floating ruptures
-            for src in csm.get_sources():
-                if hasattr(src, 'hypocenter_distribution'):
-                    src.hypocenter_distribution.reduce()
-                    src.nodal_plane_distribution.reduce()
-                    src.num_ruptures = src.count_ruptures()
+    # remove splitting/floating ruptures
+    for src in csm.get_sources():
+        if (oqparam.pointsource_distance.get(src.tectonic_region_type)
+                == 0 and hasattr(src, 'hypocenter_distribution')):
+            src.hypocenter_distribution.reduce()
+            src.nodal_plane_distribution.reduce()
+            src.num_ruptures = src.count_ruptures()
 
+    if 'event_based' in oqparam.calculation_mode:
         # initialize the rupture serial numbers before splitting/filtering; in
         # this way the serials are independent from the site collection
         csm.init_serials(oqparam.ses_seed)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -82,7 +82,7 @@ class ContextMaker(object):
         param = param or {}
         self.gsims = gsims
         self.maximum_distance = maximum_distance or {}
-        self.pointsource_distance = param.get('pointsource_distance')
+        self.pointsource_distance = param.get('pointsource_distance', {})
         for req in self.REQUIRES:
             reqset = set()
             for gsim in gsims:
@@ -208,9 +208,9 @@ class ContextMaker(object):
         """
         out = []
         with self.ir_mon:
-            if hasattr(src, 'location'):
-                close_sites, far_sites = sites.split(
-                    src.location, self.pointsource_distance)
+            pdist = self.pointsource_distance.get(src.tectonic_region_type)
+            if hasattr(src, 'location') and pdist:
+                close_sites, far_sites = sites.split(src.location, pdist)
                 if close_sites is None:  # all is far
                     out.append((list(src.iter_ruptures(False, False)),
                                 far_sites))

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -51,7 +51,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         param = dict(ses_per_logic_tree_path=10, filter_distance='rjb')
         gsims = [SiMidorikawa1999SInter()]
         dic = sample_ruptures(group, s_filter, gsims, param)
-        self.assertEqual(len(dic['eb_ruptures']), 8)
+        self.assertEqual(len(dic['eb_ruptures']), 5)
         self.assertEqual(len(dic['calc_times']), 15)  # mutex sources
 
         # test export
@@ -65,4 +65,4 @@ class StochasticEventSetTestCase(unittest.TestCase):
 
         # test no filtering 2
         ruptures = sample_ruptures(group)['eb_ruptures']
-        self.assertEqual(len(ruptures), 2)
+        self.assertEqual(len(ruptures), 1)

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -51,7 +51,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         param = dict(ses_per_logic_tree_path=10, filter_distance='rjb')
         gsims = [SiMidorikawa1999SInter()]
         dic = sample_ruptures(group, s_filter, gsims, param)
-        self.assertEqual(len(dic['eb_ruptures']), 5)
+        self.assertEqual(len(dic['eb_ruptures']), 8)
         self.assertEqual(len(dic['calc_times']), 15)  # mutex sources
 
         # test export
@@ -65,4 +65,4 @@ class StochasticEventSetTestCase(unittest.TestCase):
 
         # test no filtering 2
         ruptures = sample_ruptures(group)['eb_ruptures']
-        self.assertEqual(len(ruptures), 1)
+        self.assertEqual(len(ruptures), 2)


### PR DESCRIPTION
Yesterday change broke the full report with this error:
```
   DataStoreExportError: Could not export fullreport in rst
     File "/home/michele/oqcode/oq-engine/openquake/engine/export/core.py", line 65, in export_from_db
       exported = export(output_key, dstore)
     File "/home/michele/oqcode/oq-engine/openquake/baselib/general.py", line 546, in __call__
       return self[key](obj, *args, **kw)
     File "/home/michele/oqcode/oq-engine/openquake/calculators/export/hazard.py", line 916, in export_fullreport
       f.write(view('fullreport', dstore))
     File "/home/michele/oqcode/oq-engine/openquake/baselib/general.py", line 546, in __call__
       return self[key](obj, *args, **kw)
     File "/home/michele/oqcode/oq-engine/openquake/calculators/views.py", line 493, in view_fullreport
       return ReportWriter(dstore).make_report()
     File "/home/michele/oqcode/oq-engine/openquake/calculators/reportwriter.py", line 84, in make_report
       self.add(name)
     File "/home/michele/oqcode/oq-engine/openquake/calculators/reportwriter.py", line 77, in add
       text = views.view(name, self.dstore)
     File "/home/michele/oqcode/oq-engine/openquake/baselib/general.py", line 546, in __call__
       return self[key](obj, *args, **kw)
     File "/home/michele/oqcode/oq-engine/openquake/calculators/views.py", line 306, in view_inputs
       build_links(list(inputs.items()) + source_models),
     File "/home/michele/oqcode/oq-engine/openquake/calculators/views.py", line 291, in build_links
       bname = os.path.basename(fname)
     File "/usr/lib/python3.6/posixpath.py", line 146, in basename
       p = os.fspath(p)
   expected str, bytes or os.PathLike object, not dict
```
I have added a regression test. Moreover, I have enabled automatically `pointsource_distance=0` if the `reqv` approximation is on, and converted `pointsource_distance` into a dictionary keyed by TRT, just like the `maximum_distance`.