### PR TITLE
Made the shakemap feature more tolerant for wrong vulnerability models

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -730,7 +730,7 @@ class RiskCalculator(HazardCalculator):
         logging.info('Building GMFs')
         with self.monitor('building/saving GMFs'):
             gmfs = to_gmfs(shakemap, oq.cross_correlation, oq.site_effects,
-                           oq.truncation_level, E, oq.random_seed, oq.imtls)
+                           oq.truncation_level, E, oq.random_seed)
             save_gmf_data(self.datastore, sitecol, gmfs)
             events = numpy.zeros(E, readinput.stored_event_dt)
             events['eid'] = numpy.arange(E, dtype=U64)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -721,8 +721,8 @@ class RiskCalculator(HazardCalculator):
             smap = oq.shakemap_id if oq.shakemap_id else numpy.load(
                 oq.inputs['shakemap'])
             sitecol, shakemap, discarded = get_sitecol_shakemap(
-                smap, oq.imtls, haz_sitecol, oq.asset_hazard_distance or
-                oq.region_grid_spacing)
+                smap, oq.imtls, haz_sitecol, oq.asset_hazard_distance,
+                oq.discard_assets)
             if len(discarded):
                 self.datastore['discarded'] = discarded
             assetcol = assetcol.reduce_also(sitecol)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -415,6 +415,7 @@ class EventBasedCalculator(base.HazardCalculator):
             logging.info('Saving gmf_data/indices')
             with self.monitor('saving gmf_data/indices', measuremem=True,
                               autoflush=True):
+                self.datastore['gmf_data/imts'] = ' '.join(oq.imtls)
                 dset = self.datastore.create_dset(
                     'gmf_data/indices', hdf5.vuint32,
                     shape=(N, 2), fillvalue=None)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -304,6 +304,10 @@ class GmfGetter(object):
     def imtls(self):
         return self.oqparam.imtls
 
+    @property
+    def imts(self):
+        return list(self.oqparam.imtls)
+
     def init(self):
         """
         Initialize the computers. Should be called on the workers

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -59,6 +59,10 @@ class PmapGetter(object):
     def weights(self):
         return [rlz.weight for rlz in self.rlzs_assoc.realizations]
 
+    @property
+    def imts(self):
+        return list(self.imtls)
+
     def init(self):
         """
         Read the poes and set the .data attribute with the hazard curves
@@ -210,16 +214,16 @@ class GmfDataGetter(collections.Mapping):
     """
     A dictionary-like object {sid: dictionary by realization index}
     """
-    def __init__(self, dstore, sids, num_rlzs, imtls):
+    def __init__(self, dstore, sids, num_rlzs):
         self.dstore = dstore
         self.sids = sids
         self.num_rlzs = num_rlzs
-        self.imtls = imtls
 
     def init(self):
         if hasattr(self, 'data'):  # already initialized
             return
         self.dstore.open('r')  # if not already open
+        self.imts = self.dstore['gmf_data/imts'].value.split()
         self.eids = self.dstore['events']['eid']
         self.eids.sort()
         self.data = collections.OrderedDict()
@@ -233,7 +237,7 @@ class GmfDataGetter(collections.Mapping):
         # now some attributes set for API compatibility with the GmfGetter
         # number of ground motion fields
         # dictionary rlzi -> array(imts, events, nbytes)
-        self.gmdata = AccumDict(accum=numpy.zeros(len(self.imtls) + 1, F32))
+        self.gmdata = AccumDict(accum=numpy.zeros(len(self.imts) + 1, F32))
 
     def get_hazard(self, gsim=None):
         """

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -223,7 +223,10 @@ class GmfDataGetter(collections.Mapping):
         if hasattr(self, 'data'):  # already initialized
             return
         self.dstore.open('r')  # if not already open
-        self.imts = self.dstore['gmf_data/imts'].value.split()
+        try:
+            self.imts = self.dstore['gmf_data/imts'].value.split()
+        except KeyError:  # engine < 3.3
+            self.imts = list(self.dstore['oqparam'].imtls)
         self.eids = self.dstore['events']['eid']
         self.eids.sort()
         self.data = collections.OrderedDict()

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -86,4 +86,4 @@ class ScenarioCalculator(base.HazardCalculator):
             with self.monitor('saving gmfs', autoflush=True):
                 base.save_gmf_data(
                     self.datastore, self.sitecol,
-                    numpy.array(list(self.gmfa.values())))
+                    numpy.array(list(self.gmfa.values())), self.oqparam.imtls)

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -255,11 +255,13 @@ def cholesky(spatial_cov, cross_corr):
 def to_gmfs(shakemap, crosscorr, site_effects, trunclevel, num_gmfs, seed,
             imts=None):
     """
-    :returns: an array of GMFs of shape (R, N, E, M)
+    :returns: (IMT-strings, array of GMFs of shape (R, N, E, M)
     """
     std = shakemap['std']
     if imts is None or len(imts) == 0:
         imts = std.dtype.names
+    else:
+        imts = [imt for imt in imts if imt in std.dtype.names]
     val = {imt: numpy.log(shakemap['val'][imt]) - std[imt] ** 2 / 2.
            for imt in imts}
     imts_ = [imt.from_string(name) for name in imts]
@@ -286,4 +288,4 @@ def to_gmfs(shakemap, crosscorr, site_effects, trunclevel, num_gmfs, seed,
     gmfs = numpy.exp(numpy.dot(L, Z) + mu) / PCTG
     if site_effects:
         gmfs = amplify_gmfs(imts_, shakemap['vs30'], gmfs) * 0.8
-    return gmfs.reshape((1, M, N, num_gmfs)).transpose(0, 2, 3, 1)
+    return imts, gmfs.reshape((1, M, N, num_gmfs)).transpose(0, 2, 3, 1)

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -74,12 +74,14 @@ def download_array(shakemap_id, shakemap_url=SHAKEMAP_URL):
             return get_shakemap_array(f1, f2)
 
 
-def get_sitecol_shakemap(array_or_id, imts, sitecol=None, assoc_dist=None):
+def get_sitecol_shakemap(array_or_id, imts, sitecol=None,
+                         assoc_dist=None, discard_assets=False):
     """
     :param array_or_id: shakemap array or shakemap ID
     :param imts: required IMTs as a list of strings
     :param sitecol: SiteCollection used to reduce the shakemap
     :param assoc_dist: association distance
+    :param discard_assets: set to zero the risk on assets with missing IMTs
     :returns: a pair (filtered site collection, filtered shakemap)
     """
     if isinstance(array_or_id, str):  # shakemap ID
@@ -89,11 +91,14 @@ def get_sitecol_shakemap(array_or_id, imts, sitecol=None, assoc_dist=None):
     available_imts = set(array['val'].dtype.names)
     missing = set(imts) - available_imts
     if missing:
-        logging.error(
-            'The IMT %s is required but not in the available set %s, '
-            'please change the riskmodel otherwise you will have '
-            'incorrect zero losses for the associated taxonomies' %
-            (missing.pop(), ', '.join(available_imts)))
+        msg = ('The IMT %s is required but not in the available set %s, '
+               'please change the riskmodel otherwise you will have '
+               'incorrect zero losses for the associated taxonomies' %
+               (missing.pop(), ', '.join(available_imts)))
+        if discard_assets:
+            logging.error(msg)
+        else:
+            raise RuntimeError(msg)
 
     # build a copy of the ShakeMap with only the relevant IMTs
     dt = [(imt, F32) for imt in sorted(available_imts)]

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -89,19 +89,21 @@ def get_sitecol_shakemap(array_or_id, imts, sitecol=None, assoc_dist=None):
     available_imts = set(array['val'].dtype.names)
     missing = set(imts) - available_imts
     if missing:
-        raise ValueError('The IMT %s is required but not in the available set '
-                         '%s, please change the riskmodel' %
-                         (missing.pop(), ', '.join(available_imts)))
+        logging.error(
+            'The IMT %s is required but not in the available set %s, '
+            'please change the riskmodel otherwise you will have '
+            'incorrect zero losses for the associated taxonomies' %
+            (missing.pop(), ', '.join(available_imts)))
 
     # build a copy of the ShakeMap with only the relevant IMTs
-    dt = [(imt, F32) for imt in imts]
+    dt = [(imt, F32) for imt in available_imts]
     dtlist = [('lon', F32), ('lat', F32), ('vs30', F32),
               ('val', dt), ('std', dt)]
     data = numpy.zeros(len(array), dtlist)
     for name in ('lon',  'lat', 'vs30'):
         data[name] = array[name]
     for name in ('val', 'std'):
-        for im in imts:
+        for im in available_imts:
             data[name][im] = array[name][im]
 
     if sitecol is None:  # extract the sites from the shakemap

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -96,7 +96,7 @@ def get_sitecol_shakemap(array_or_id, imts, sitecol=None, assoc_dist=None):
             (missing.pop(), ', '.join(available_imts)))
 
     # build a copy of the ShakeMap with only the relevant IMTs
-    dt = [(imt, F32) for imt in available_imts]
+    dt = [(imt, F32) for imt in sorted(available_imts)]
     dtlist = [('lon', F32), ('lat', F32), ('vs30', F32),
               ('val', dt), ('std', dt)]
     data = numpy.zeros(len(array), dtlist)

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -169,7 +169,7 @@ class SiteCollection(object):
         self.complete = self
         n = len(shakemap_array)
         dtype = numpy.dtype([(p, site_param_dt[p])
-                             for p in 'sids vs30'.split()])
+                             for p in 'sids lon lat depth vs30'.split()])
         self.array = arr = numpy.zeros(n, dtype)
         arr['sids'] = numpy.arange(n, dtype=numpy.uint32)
         arr['lon'] = shakemap_array['lon']

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -17,7 +17,7 @@ CDIR = os.path.dirname(__file__)
 
 
 def mean_gmf(shakemap):
-    imts, gmfs = to_gmfs(
+    _, gmfs = to_gmfs(
         shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
         num_gmfs=10, seed=42)
     return [gmfs[..., i].mean() for i in range(len(imts))]
@@ -33,7 +33,7 @@ class ShakemapTestCase(unittest.TestCase):
         n = 4  # number of sites
         self.assertEqual(len(sitecol), n)
         gmf_by_imt = mean_gmf(shakemap)
-        aae(gmf_by_imt, [0.0374453, 0.0043595, 0.0157192, 0.0184141])
+        aae(gmf_by_imt, [0.0047045, 0.0184625, 0.0346171, 0.0175625])
 
     def test_amplify(self):
         res = amplify_ground_shaking(T=3.0, vs30=780, gmvs=[0.1, 0.2, 0.3])
@@ -78,13 +78,13 @@ class ShakemapTestCase(unittest.TestCase):
         shakemap['vs30'] = numpy.array([301.17] * 9)
         shakemap['val'] = val
         shakemap['std'] = std
-        imts, gmfs = to_gmfs(
+        _, gmfs = to_gmfs(
             shakemap, crosscorr='corr', site_effects=False, trunclevel=3,
             num_gmfs=2, seed=42)
         # shape (R, N, E, M)
         aae(gmfs[..., 0].sum(axis=1), [[0.3708301, 0.5671011]])  # PGA
 
-        imts, gmfs = to_gmfs(
+        _, gmfs = to_gmfs(
             shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
             num_gmfs=2, seed=42)
         aae(gmfs[..., 0].sum(axis=1), [[0.4101717, 0.6240185]])  # PGA

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -17,7 +17,7 @@ CDIR = os.path.dirname(__file__)
 
 
 def mean_gmf(shakemap):
-    gmfs = to_gmfs(
+    imts, gmfs = to_gmfs(
         shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
         num_gmfs=10, seed=42)
     return [gmfs[..., i].mean() for i in range(len(imts))]
@@ -33,7 +33,7 @@ class ShakemapTestCase(unittest.TestCase):
         n = 4  # number of sites
         self.assertEqual(len(sitecol), n)
         gmf_by_imt = mean_gmf(shakemap)
-        aae(gmf_by_imt, [0.0047045, 0.0184625, 0.0346171, 0.0175625])
+        aae(gmf_by_imt, [0.0374453, 0.0043595, 0.0157192, 0.0184141])
 
     def test_amplify(self):
         res = amplify_ground_shaking(T=3.0, vs30=780, gmvs=[0.1, 0.2, 0.3])
@@ -78,13 +78,13 @@ class ShakemapTestCase(unittest.TestCase):
         shakemap['vs30'] = numpy.array([301.17] * 9)
         shakemap['val'] = val
         shakemap['std'] = std
-        gmfs = to_gmfs(
+        imts, gmfs = to_gmfs(
             shakemap, crosscorr='corr', site_effects=False, trunclevel=3,
             num_gmfs=2, seed=42)
         # shape (R, N, E, M)
         aae(gmfs[..., 0].sum(axis=1), [[0.3708301, 0.5671011]])  # PGA
 
-        gmfs = to_gmfs(
+        imts, gmfs = to_gmfs(
             shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
             num_gmfs=2, seed=42)
         aae(gmfs[..., 0].sum(axis=1), [[0.4101717, 0.6240185]])  # PGA

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -249,7 +249,7 @@ class CompositeRiskModel(collections.Mapping):
             riskinput.gmdata = hazard_getter.gmdata
 
     def _gen_outputs(self, hazard_getter, hazard, dic):
-        imti = {imt: i for i, imt in enumerate(hazard_getter.imtls)}
+        imti = {imt: i for i, imt in enumerate(hazard_getter.imts)}
         with self.monitor('computing risk'):
             for taxonomy in sorted(dic):
                 riskmodel = self[taxonomy]


### PR DESCRIPTION
A vulnerability model with IMTs missing in the ShakeMap (i.e. SA(0.6), SA(2)) cannot be used and should raise an error. However, by setting `discard_assets=true` one can ignore the assets with taxonomies associated to the missing IMTs and still run the calculation.

NB: I am also adding the information about the used IMTs in `gmf_data/imts` in a backward-compatible way.