### PR TITLE
Introduce tiling for risk

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -767,6 +767,8 @@ class RiskCalculator(HazardCalculator):
         return riskinputs
 
     def _gen_riskinputs(self, kind, eps, num_events):
+        rinfo_dt = numpy.dtype([('sid', U16), ('num_assets', U16)])
+        rinfo = []
         assets_by_site = self.assetcol.assets_by_site()
         dstore = self.can_read_parent() or self.datastore
         for sid, assets in enumerate(assets_by_site):
@@ -784,12 +786,18 @@ class RiskCalculator(HazardCalculator):
             else:
                 # the datastore must be closed to avoid the HDF5 fork bug
                 assert dstore.hdf5 == (), '%s is not closed!' % dstore
-            for block in general.block_splitter(assets, 1000):
+            for block in general.block_splitter(
+                    assets, self.oqparam.assets_per_site_limit):
                 # dictionary of epsilons for the reduced assets
                 reduced_eps = {ass.ordinal: eps[ass.ordinal]
                                for ass in block
                                if eps is not None and len(eps)}
                 yield riskinput.RiskInput(getter, [block], reduced_eps)
+            rinfo.append((sid, len(block)))
+            if len(block) >= TWO16:
+                logging.error('There are %d assets on site #%d!',
+                              len(block), sid)
+        self.datastore['riskinput_info'] = numpy.array(rinfo, rinfo_dt)
 
     def execute(self):
         """

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -793,6 +793,9 @@ class RiskCalculator(HazardCalculator):
                                if eps is not None and len(eps)}
                 yield riskinput.RiskInput(getter, [block], reduced_eps)
                 rinfo.append((sid, len(block)))
+                if len(block) >= TWO16:
+                    logging.error('There are %d assets on site #%d!',
+                                  len(block), sid)
         self.datastore['riskinput_info'] = numpy.array(rinfo, rinfo_dt)
 
     def execute(self):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -798,13 +798,11 @@ class RiskCalculator(HazardCalculator):
         """
         if not hasattr(self, 'riskinputs'):  # in the reportwriter
             return
-        res = Starmap.apply(
-            self.core_task.__func__,
-            (self.riskinputs, self.riskmodel, self.param, self.monitor()),
-            concurrent_tasks=self.oqparam.concurrent_tasks or 1,
-            weight=get_weight
-        ).reduce(self.combine)
-        return res
+        smap = Starmap(self.core_task.__func__)
+        mon = self.monitor()
+        for ri in self.riskinputs:
+            smap.submit([ri], self.riskmodel, self.param, mon)
+        return smap.reduce(self.combine)
 
     def combine(self, acc, res):
         return acc + res

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -279,7 +279,7 @@ class EbrCalculator(base.RiskCalculator):
         """
         with self.monitor('saving losses', measuremem=True):
             self.save_losses(res)
-        return 1
+        return {}
 
     def post_execute(self, result):
         """

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -20,7 +20,8 @@ import operator
 import numpy
 
 from openquake.baselib.python3compat import zip, encode
-from openquake.baselib.general import AccumDict
+from openquake.baselib.parallel import Starmap
+from openquake.baselib.general import AccumDict, block_splitter
 from openquake.hazardlib.stats import set_rlzs_stats
 from openquake.risklib import riskinput
 from openquake.calculators import base
@@ -272,13 +273,27 @@ class EbrCalculator(base.RiskCalculator):
                     loss_maps[lt] = array[:, :, :, lti]
                 self.datastore[key][aids, :] = loss_maps
 
-    def combine(self, dummy, res):
+    def execute(self):
         """
-        :param dummy: unused parameter
-        :param res: a result dictionary
+        Parallelize on the riskinputs and returns a dictionary of results.
+        Require a `.core_task` to be defined with signature
+        (riskinputs, riskmodel, rlzs_assoc, monitor).
         """
-        with self.monitor('saving losses', measuremem=True):
-            self.save_losses(res)
+        if not hasattr(self, 'riskinputs'):  # in the reportwriter
+            return
+        func = self.core_task.__func__
+        rts = self.oqparam.risk_tile_size
+        blocks = list(block_splitter(self.riskinputs, rts))
+        n = len(blocks)
+        for i, block in enumerate(blocks, 1):
+            if n == 1:
+                mon = self.monitor(func.__name__)
+            else:
+                mon = self.monitor('%s:%d/%d' % (func.__name__, i, n))
+            for res in Starmap(func, [([ri], self.riskmodel, self.param, mon)
+                                      for ri in block], mon):
+                with self.monitor('saving losses', measuremem=True):
+                    self.save_losses(res)
         return {}
 
     def post_execute(self, result):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -52,6 +52,7 @@ class OqParam(valid.ParamSet):
         valid.NoneOr(valid.positivefloat), None)
     asset_correlation = valid.Param(valid.NoneOr(valid.FloatRange(0, 1)), 0)
     asset_life_expectancy = valid.Param(valid.positivefloat)
+    assets_per_site_limit = valid.Param(valid.positivefloat, 1000)
     avg_losses = valid.Param(valid.boolean, True)
     base_path = valid.Param(valid.utf8, '.')
     calculation_mode = valid.Param(valid.Choice(), '')  # -> get_oqparam

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -135,6 +135,7 @@ class OqParam(valid.ParamSet):
     complex_fault_mesh_spacing = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
     return_periods = valid.Param(valid.positiveints, None)
+    risk_tile_size = valid.Param(valid.positiveint, 2000)
     save_ruptures = valid.Param(valid.boolean, True)
     ses_per_logic_tree_path = valid.Param(valid.positiveint, 1)
     ses_seed = valid.Param(valid.positiveint, 42)


### PR DESCRIPTION
The goal is to be able to run continental scale event based risk calculation, i.e. *the whole of Canada in a single calculation* without running out of memory, with tiles of `risk_tile_size` sites each (default 2000). Another new parameter to control the memory consumption is `assets_per_site_limit` (default 1000). To be tested.