### PR TITLE
Added a way to disable spatial correlation in shakemaps and disabled it by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Disabled the spatial correlation in risk-from-ShakeMap by default
   * Optimized the rupture sampling where there is a large number of SESs
   * Extended the `reqv` feature to multiple tectonic region types and
     removed the spinning/floating for the TRTs using the feature

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -730,8 +730,9 @@ class RiskCalculator(HazardCalculator):
         logging.info('Building GMFs')
         with self.monitor('building/saving GMFs'):
             imts, gmfs = to_gmfs(
-                shakemap, oq.cross_correlation, oq.site_effects,
-                oq.truncation_level, E, oq.random_seed, oq.imtls)
+                shakemap, oq.spatial_correlation, oq.cross_correlation,
+                oq.site_effects, oq.truncation_level, E, oq.random_seed,
+                oq.imtls)
             save_gmf_data(self.datastore, sitecol, gmfs, imts)
             events = numpy.zeros(E, readinput.stored_event_dt)
             events['eid'] = numpy.arange(E, dtype=U64)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -146,6 +146,7 @@ class OqParam(valid.ParamSet):
     sites_slice = valid.Param(valid.simple_slice, (None, None))
     sm_lt_path = valid.Param(valid.logic_tree_path, None)
     source_id = valid.Param(valid.source_id, None)
+    spatial_correlation = valid.Param(valid.boolean, True)
     specific_assets = valid.Param(valid.namelist, [])
     pointsource_distance = valid.Param(valid.maximum_distance, {})
     taxonomies_from_model = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -146,7 +146,7 @@ class OqParam(valid.ParamSet):
     sites_slice = valid.Param(valid.simple_slice, (None, None))
     sm_lt_path = valid.Param(valid.logic_tree_path, None)
     source_id = valid.Param(valid.source_id, None)
-    spatial_correlation = valid.Param(valid.boolean, True)
+    spatial_correlation = valid.Param(valid.boolean, False)
     specific_assets = valid.Param(valid.namelist, [])
     pointsource_distance = valid.Param(valid.maximum_distance, {})
     taxonomies_from_model = valid.Param(valid.boolean, False)

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -18,7 +18,7 @@ CDIR = os.path.dirname(__file__)
 
 def mean_gmf(shakemap):
     _, gmfs = to_gmfs(
-        shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
+        shakemap, True, 'cross', site_effects=True, trunclevel=3,
         num_gmfs=10, seed=42)
     return [gmfs[..., i].mean() for i in range(len(imts))]
 
@@ -79,13 +79,26 @@ class ShakemapTestCase(unittest.TestCase):
         shakemap['val'] = val
         shakemap['std'] = std
         _, gmfs = to_gmfs(
-            shakemap, crosscorr='corr', site_effects=False, trunclevel=3,
+            shakemap, True, 'corr', site_effects=False, trunclevel=3,
             num_gmfs=2, seed=42)
         # shape (R, N, E, M)
         aae(gmfs[..., 0].sum(axis=1), [[0.3708301, 0.5671011]])  # PGA
 
         _, gmfs = to_gmfs(
-            shakemap, crosscorr='cross', site_effects=True, trunclevel=3,
+            shakemap, True, 'cross', site_effects=True, trunclevel=3,
             num_gmfs=2, seed=42)
         aae(gmfs[..., 0].sum(axis=1), [[0.4101717, 0.6240185]])  # PGA
         aae(gmfs[..., 2].sum(axis=1), [[0.3946015, 0.5385107]])  # SA(1.0)
+
+        # disable spatial correlation
+        _, gmfs = to_gmfs(
+            shakemap, False, 'corr', site_effects=False, trunclevel=3,
+            num_gmfs=2, seed=42)
+        # shape (R, N, E, M)
+        aae(gmfs[..., 0].sum(axis=1), [[0.4276304, 0.4276304]])  # PGA
+
+        _, gmfs = to_gmfs(
+            shakemap, False, 'cross', site_effects=True, trunclevel=3,
+            num_gmfs=2, seed=42)
+        aae(gmfs[..., 0].sum(axis=1), [[0.4729979, 0.4729979]])  # PGA
+        aae(gmfs[..., 2].sum(axis=1), [[0.3805843, 0.3805843]])  # SA(1.0)

--- a/openquake/qa_tests_data/scenario_risk/case_shakemap/job.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_shakemap/job.ini
@@ -4,3 +4,5 @@ random_seed = 152
 number_of_ground_motion_fields = 3
 shakemap_file = usp000fjta.npy
 asset_hazard_distance = 20
+spatial_correlation = true
+


### PR DESCRIPTION
This is needed to work around the error
```python
numpy.linalg.linalg.LinAlgError: Matrix is not positive definite
```
that sometimes happens due to numeric errors (I saw a spatial covariance array with a negative eigenvalue -1E-15 in a calculation provided by Petros). 