### PR TITLE
Fixed a bug in preclassical with optimize_same_id_sources=true

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -293,7 +293,8 @@ class PreCalculator(ClassicalCalculator):
     def execute(self):
         eff_ruptures = AccumDict(accum=0)
         for src in self.csm.get_sources():
-            eff_ruptures[src.src_group_id] += src.num_ruptures
+            for grp_id in src.src_group_ids:
+                eff_ruptures[grp_id] += src.num_ruptures
         self.store_csm_info(eff_ruptures)
         return {}
 

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -149,7 +149,7 @@ class ClassicalTestCase(CalculatorTestCase):
         # exercise the warning for no output when mean_hazard_curves='false'
         self.run_calc(
             case_7.__file__, 'job.ini', mean_hazard_curves='false',
-            poes='0.1')
+            calculation_mode='preclassical',  poes='0.1')
 
     @attr('qa', 'hazard', 'classical')
     def test_case_8(self):

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -186,6 +186,10 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles(
             'expected/hazard_curve-smltp_b1-gsimltp_b1.csv', fname)
 
+        # exercise preclassical
+        self.run_calc(case_4.__file__, 'job.ini',
+                      calculation_mode='preclassical')
+
     @attr('qa', 'hazard', 'event_based')
     def test_case_5(self):
         out = self.run_calc(case_5.__file__, 'job.ini', exports='csv')


### PR DESCRIPTION
And added two tests for the preclassical calculator. Discovered by @kejohnso:
```python
  File "/opt/openquake2/oq-engine/openquake/calculators/classical.py", line 296, in execute
    eff_ruptures[src.src_group_id] += src.num_ruptures
TypeError: unhashable type: 'list'
```