### PR TITLE
Fixed backarc bug

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -391,7 +391,10 @@ def get_site_collection(oqparam):
                 sc, params, discarded = geo.utils.assoc(
                     sm, sitecol, oqparam.max_site_model_distance, 'warn')
             for name in req_site_params:
-                sitecol._set(name, params[name])
+                if name == 'backarc' and name not in params.dtype.names:
+                    sitecol._set(name, 0)  # the default
+                else:
+                    sitecol._set(name, params[name])
     else:  # use the default site params
         sitecol = site.SiteCollection.from_points(
             mesh.lons, mesh.lats, mesh.depths, oqparam, req_site_params)


### PR DESCRIPTION
This affected @CatalinaYepes and @raoanirudh calculations with the error:
```python
  File "/opt/openquake2/oq-engine/openquake/calculators/base.py", line 577, in _read_risk_data
    haz_sitecol = readinput.get_site_collection(oq)
  File "/opt/openquake2/oq-engine/openquake/commonlib/readinput.py", line 394, in get_site_collection
    sitecol._set(name, params[name])
ValueError: no field of name backarc
```
The field `backarc` is optional with default 0, so let's use the default. Otherwise, do not use GSIMs requiring backarc, i.e. AbrahamsonEtAl2015SInterHigh.