### PR TITLE
Extended oq checksum to source model logic tree files

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -170,7 +170,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
         attrs['engine_version'] = engine_version
         attrs['date'] = datetime.now().isoformat()[:19]
         if 'checksum32' not in attrs:
-            attrs['checksum32'] = readinput.get_checksum32(self.oqparam)
+            attrs['checksum32'] = readinput.get_checksum32(self.oqparam.inputs)
         self.datastore.flush()
 
     def set_log_format(self):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1247,15 +1247,15 @@ def reduce_source_model(smlt_file, source_ids, remove=True):
             os.remove(path)
 
 
-def get_checksum32(oqparam):
+def get_checksum32(inputs):
     """
     Build an unsigned 32 bit integer from the input files of the calculation
     """
     # NB: using adler32 & 0xffffffff is the documented way to get a checksum
     # which is the same between Python 2 and Python 3
     checksum = 0
-    for key in sorted(oqparam.inputs):
-        fname = oqparam.inputs[key]
+    for key in sorted(inputs):
+        fname = inputs[key]
         if isinstance(fname, dict):
             for f in fname.values():
                 data = open(f, 'rb').read()


### PR DESCRIPTION
The usage would be
```bash
$ oq checksum AUS/in/ssmLT.xml 
41421368
```
Event the largest model we have (Australia) takes only 3 seconds.

**To be decided**: how to integrate the checksum in the mosaic tests. An idea is to have CI compute the checksum, store it into a file and publish it together with the hazard model (if the tests pass) somewhere.