### PR TITLE
Renamed input_zip -> input/zip in the datastore

### DIFF
--- a/openquake/calculators/export/__init__.py
+++ b/openquake/calculators/export/__init__.py
@@ -64,14 +64,14 @@ export = CallableDict(keyfunc)
 export.from_db = False  # overridden when exporting from db
 
 
-@export.add(('input_zip', 'zip'))
+@export.add(('input', 'zip'))
 def export_input_zip(ekey, dstore):
     """
     Export the data in the `input_zip` dataset as a .zip file
     """
     dest = dstore.export_path('input.zip')
-    nbytes = dstore.get_attr('input_zip', 'nbytes')
-    zbytes = dstore['input_zip'].value
+    nbytes = dstore.get_attr('input/zip', 'nbytes')
+    zbytes = dstore['input/zip'].value
     # when reading input_zip some terminating null bytes are truncated (for
     # unknown reasons) therefore they must be restored
     zbytes += b'\x00' * (nbytes - len(zbytes))

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -347,8 +347,8 @@ def run_calc(job_id, oqparam, log_level, log_file, exports,
                 bio = io.BytesIO()
                 zip(oqparam.inputs['job_ini'], bio, (), oqparam, logging.debug)
                 data = bio.getvalue()
-            calc.datastore['input_zip'] = numpy.array(data)
-            calc.datastore.set_attrs('input_zip', nbytes=len(data))
+            calc.datastore['input/zip'] = numpy.array(data)
+            calc.datastore.set_attrs('input/zip', nbytes=len(data))
 
             logs.dbcmd('update_job', job_id, {'status': 'executing',
                                               'pid': _PID})

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -293,7 +293,7 @@ DISPLAY_NAME = {
     'disagg_by_src': 'Disaggregation by Source',
     'realizations': 'Realizations',
     'fullreport': 'Full Report',
-    'input_zip': 'Input Files'
+    'input': 'Input Files'
 }
 
 # sanity check, all display name keys must be exportable


### PR DESCRIPTION
This is needed to work around a bug of `silx view` which hangs if there a top level dataset containing a large binary (in this case input_zip). With this change the viewer hangs only if the user clicks the folder input :-( Not the ideal solution, but the only way to progress, otherwise I cannot debug the Global Risk Model calculations. BTW, I cannot use HDFView since it is misbehaving (like displaying all NaNs in some cases instead of the correct values, which are displayed by silx).