### PR TITLE
Added a parameter `max_potential_paths`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Forbidden event based calculations with more than `max_potential_paths`
+    in the case of full enumeration
   * Saved a large amount of memory in event_based_risk calculations
   * Added a command `oq export losses_by_tag/<tagname> <calc_id>`
   * Extended `oq zip` to zip the risk files together with the hazard files

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -103,6 +103,7 @@ class OqParam(valid.ParamSet):
     maximum_distance = valid.Param(valid.maximum_distance)  # km
     asset_hazard_distance = valid.Param(valid.positivefloat, 20)  # km
     max_hazard_curves = valid.Param(valid.boolean, False)
+    max_potential_paths = valid.Param(valid.positiveint, 100)
     mean_hazard_curves = valid.Param(valid.boolean, True)
     std_hazard_curves = valid.Param(valid.boolean, False)
     max_loss_curves = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -761,8 +761,14 @@ def get_composite_source_model(oqparam, monitor=None, in_memory=True,
                              (trt, oqparam.inputs['job_ini']))
     gsim_lt = get_gsim_lt(oqparam, trts or ['*'])
     if oqparam.number_of_logic_tree_samples == 0:
-        logging.info('Potential number of logic tree paths = {:,d}'.format(
-            source_model_lt.num_paths * gsim_lt.get_num_paths()))
+        p = source_model_lt.num_paths * gsim_lt.get_num_paths()
+        if ('event_based' in oqparam.calculation_mode
+                and p > oqparam.max_potential_paths):
+            raise ValueError(
+                'There are too many potential logic tree paths (%d) '
+                'use sampling instead of full enumeration' % p)
+        logging.info('Potential number of logic tree paths = {:,d}'.format(p))
+
     if source_model_lt.on_each_source:
         logging.info('There is a logic tree on each source')
     if monitor is None:

--- a/openquake/qa_tests_data/event_based/case_5/job.ini
+++ b/openquake/qa_tests_data/event_based/case_5/job.ini
@@ -42,6 +42,7 @@ maximum_distance = 80.0
 [event_based_params]
 
 ses_per_logic_tree_path = 1
+max_potential_paths = 120
 
 [output]
 


### PR DESCRIPTION
This is to stop the risk team from making mistakes. If they try to run a calculation with full enumeration when there are more than 100 branches, the engine will refuse to continue and force them to use sampling instead.