### PR TITLE
Smart single file mode for event_based_risk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Implemented a smart single job.ini file mode for event based risk
   * Now warnings for invalid parameters are logged in the database too
   * Fixed `oq export avg_losses-stats` for the case of one realization
   * Added `oq export losses_by_tag` and `oq export curves_by_tag`

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -177,7 +177,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
         if len(job_inis) == 1 and not hc_id:
             # special case for single file event_based_risk
             txt = open(job_inis[0]).read()
-            if re.search('calculation_mode\s*=\s*event_based_risk', txt):
+            if re.search(r'calculation_mode\s*=\s*event_based_risk', txt):
                 hc_id = run_job(job_inis[0], log_level, log_file,
                                 exports, calculation_mode='event_based')
                 job_id = run_job(job_inis[0], log_level, log_file,

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -228,9 +228,9 @@ class OqParam(valid.ParamSet):
                 self.calculation_mode == 'ucerf_risk'):
             raise ValueError('You cannot use the --hc option with ucerf_risk')
         if self.hazard_precomputed() and self.job_type == 'risk':
-            self.check_missing('site_model', 'warn')
-            self.check_missing('gsim_logic_tree', 'warn')
-            self.check_missing('source_model_logic_tree', 'warn')
+            self.check_missing('site_model', 'info')
+            self.check_missing('gsim_logic_tree', 'info')
+            self.check_missing('source_model_logic_tree', 'info')
 
         # check the gsim_logic_tree
         if self.inputs.get('gsim_logic_tree'):
@@ -763,14 +763,14 @@ class OqParam(valid.ParamSet):
         """
         Make sure the given parameter is missing in the job.ini file
         """
-        assert action in ('warn', 'error'), action
+        assert action in ('debug', 'info', 'warn', 'error'), action
         if self.inputs.get(param):
-            msg = 'Please remove %s_file from %s, it makes no sense in %s' % (
+            msg = '%s_file in %s is ignored in %s' % (
                 param, self.inputs['job_ini'], self.calculation_mode)
             if action == 'error':
                 raise InvalidFile(msg)
             else:
-                logging.warn(msg)
+                getattr(logging, action)(msg)
 
     def hazard_precomputed(self):
         """

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -282,7 +282,7 @@ def zip(job_ini, archive_zip, risk_ini, oq=None, log=logging.info):
     general.zipfiles(files, archive_zip, log=log)
 
 
-def job_from_file(cfg_file, username, hazard_calculation_id=None):
+def job_from_file(cfg_file, username, **kw):
     """
     Create a full job profile from a job config file.
 
@@ -297,10 +297,12 @@ def job_from_file(cfg_file, username, hazard_calculation_id=None):
     :returns:
         a pair (job_id, oqparam)
     """
-    oq = readinput.get_oqparam(cfg_file, hc_id=hazard_calculation_id)
+    hc_id = kw.get('hazard_calculation_id')
+    oq = readinput.get_oqparam(cfg_file, hc_id=hc_id)
+    if 'calculation_mode' in kw:
+        oq.calculation_mode = kw.pop('calculation_mode')
     job_id = logs.dbcmd('create_job', oq.calculation_mode, oq.description,
-                        username, datastore.get_datadir(),
-                        hazard_calculation_id)
+                        username, datastore.get_datadir(), hc_id)
     return job_id, oq
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -504,7 +504,8 @@ def submit_job(job_ini, username, hazard_job_id=None):
     Create a job object from the given job.ini file in the job directory
     and run it in a new process. Returns the job ID and PID.
     """
-    job_id, oq = engine.job_from_file(job_ini, username, hazard_job_id)
+    job_id, oq = engine.job_from_file(
+        job_ini, username, hazard_calculation_id=hazard_job_id)
     pik = pickle.dumps(oq, protocol=0)  # human readable protocol
     code = RUNCALC % dict(job_id=job_id, hazard_job_id=hazard_job_id, pik=pik,
                           username=username)


### PR DESCRIPTION
A major source of errors for the global risk model is the splitting of the files in job_hazard.ini and job_risk.ini, for two reasons:

1) the number of required files is doubled
2) people keep using inconsistent parameters between the two files

With this smart hack a single file is needed (the one for risk but with all the hazard information) but still two calculations are generated. The change is totally backward compatible, i.e. using two different files is still supported since it has its uses.