### PR TITLE
Added an utility getsizeof

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -35,6 +35,7 @@ import importlib
 import itertools
 import subprocess
 import collections
+from collections.abc import Mapping, Container
 
 import numpy
 from decorator import decorator
@@ -1064,3 +1065,26 @@ def warn(msg, *args):
         sys.stderr.write('WARNING: ' + msg)
     else:
         sys.stderr.write('WARNING: ' + msg % args)
+
+
+def getsizeof(o, ids=None):
+    '''
+    Find the memory footprint of a Python object recursively, see
+    https://code.tutsplus.com/tutorials/understand-how-much-memory-your-python-objects-use--cms-25609
+    :param o: the object
+    :returns: the size in bytes
+    '''
+    ids = ids or set()
+    if id(o) in ids:
+        return 0
+
+    nbytes = sys.getsizeof(o)
+    ids.add(id(o))
+
+    if isinstance(o, Mapping):
+        return nbytes + sum(getsizeof(k, ids) + getsizeof(v, ids)
+                            for k, v in o.items())
+    elif isinstance(o, Container):
+        return nbytes + sum(getsizeof(x, ids) for x in o)
+
+    return nbytes


### PR DESCRIPTION
This is useful to understand what it is taking so much memory in event_based_risk. One discovers surprising truths: for instance this dictionary with 41 elements eid (numpy.uint64) to idx (numpy.uint32),
expected size 41 x (8 + 4) = 492 bytes take instead  3644 bytes (7x overhead):
```python
(Pdb++) eid2idx
{2250562863104: 0, 2250562928640: 1, 2250562994176: 2, 2250563059712: 3, 2254857830400: 4, 2254857830401: 5, 2254857830402: 6, 2254857895936: 7, 2254857895937: 8, 2254857895938: 9, 2254857961472: 10, 2254857961473: 11, 2254857961474: 12, 2254858027008: 13, 2254858027009: 14, 2254858027010: 15, 2259152797696: 16, 2259152863232: 17, 2259152928768: 18, 2259152994304: 19, 2263447764992: 20, 2263447764993: 21, 2263447764994: 22, 2263447764995: 23, 2263447830528: 24, 2263447830529: 25, 2263447830530: 26, 2263447830531: 27, 2263447896064: 28, 2263447896065: 29, 2263447896066: 30, 2263447896067: 31, 2263447961600: 32, 2263447961601: 33, 2263447961602: 34, 2263447961603: 35, 2340757438464: 36, 2340757504000: 37, 2340757569536: 38, 2340757635072: 39, 4342212460544: 40}
```