### PR TITLE
Stored in the event dataset the realization indices instead of the sample indices

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -77,7 +77,7 @@ def get_events(ebruptures):
     for ebr in ebruptures:
         for event in ebr.events:
             rec = (event['eid'], ebr.serial, ebr.grp_id, year, event['ses'],
-                   event['sample'])
+                   event['rlz'])
             events.append(rec)
     return numpy.array(events, readinput.stored_event_dt)
 
@@ -97,13 +97,11 @@ def max_gmf_size(ruptures_by_grp, rlzs_by_gsim,
     nbytes = 2 + 4 + 8 + 4 * num_imts
     n = 0
     for grp_id, ebruptures in ruptures_by_grp.items():
-        sample = 0
         for gsim, rlzs in rlzs_by_gsim[grp_id].items():
             for ebr in ebruptures:
-                for r, rlzi in enumerate(rlzs):
+                for rlzi in rlzs:
                     n += len(ebr.rupture.sctx.sids) * len(
-                        get_array(ebr.events, sample=sample + r))
-            sample += len(rlzs)
+                        get_array(ebr.events, rlz=rlzi))
     return n * nbytes
 
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -367,8 +367,8 @@ class GmfGetter(object):
             for computer in self.computers:
                 rup = computer.rupture
                 sids = computer.sids
-                all_eids = [get_array(rup.events, sample=sample + r)['eid']
-                            for r, rlzi in enumerate(rlzs)]
+                all_eids = [get_array(rup.events, rlz=rlzi)['eid']
+                            for rlzi in rlzs]
                 num_events = sum(len(eids) for eids in all_eids)
                 if num_events == 0:
                     continue

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -60,7 +60,7 @@ U64 = numpy.uint64
 Site = collections.namedtuple('Site', 'sid lon lat')
 stored_event_dt = numpy.dtype([
     ('eid', U64), ('rup_id', U32), ('grp_id', U16), ('year', U32),
-    ('ses', U16), ('sample', U16)])
+    ('ses', U16), ('rlz', U16)])
 
 
 class DuplicatedPoint(Exception):

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -35,7 +35,7 @@ F64 = numpy.float64
 U64 = numpy.uint64
 U16 = numpy.uint16
 event_dt = numpy.dtype(
-    [('eid', U64), ('grp_id', U16), ('ses', U16), ('sample', U16)])
+    [('eid', U64), ('grp_id', U16), ('ses', U16), ('rlz', U16)])
 
 
 def get_rlzi(eid):
@@ -187,7 +187,7 @@ def build_eb_ruptures(src, rlzs, num_ses, cmaker, s_sites, rup_n_occ=()):
             for sam_idx in range(nr):  # numpy.ndenumerate would be slower
                 for ses_idx, num_occ in enumerate(n_occ[sam_idx]):
                     for _ in range(num_occ):
-                        events[i]['sample'] = sam_idx
+                        events[i]['rlz'] = rlzs[sam_idx]
                         events[i]['ses'] = ses_idx + 1
                         i += 1
 


### PR DESCRIPTION
The realization indices are the interesting one. The change is backward compatible, i.e. one can use an old hazard calculation with the new code, provided the GMFs have been generated (which is essentially always the case). This is a preliminary towards https://github.com/gem/oq-engine/issues/4165.