### PR TITLE
Changed the association algorithm between events and SESs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the algorithm associating events to SESs for performance reasons
   * Reduced substantially the memory consumption in event based risk
   * Made it possible to read multiple site model files in the same calculation
   * Implemented a smart single job.ini file mode for event based risk

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -76,7 +76,7 @@ def get_events(ebruptures, num_ses):
     year = 0  # to be set later
     for ebr in ebruptures:
         numpy.random.seed(ebr.serial)
-        sess = numpy.random.choice(num_ses, ebr.multiplicity)
+        sess = numpy.random.choice(num_ses, ebr.multiplicity) + 1
         for event, ses in zip(ebr.events, sess):
             rec = (event['eid'], ebr.serial, ebr.grp_id, year,
                    ses, event['rlz'])

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -239,7 +239,7 @@ def compute_hazard(sources, src_filter, rlzs_by_gsim, param, monitor):
         res.ruptures_by_grp = {src.src_group_id: ebruptures}
     else:
         res.events_by_grp = {
-            src.src_group_id: event_based.get_events(ebruptures)}
+            src.src_group_id: event_based.get_events(ebruptures, num_ses)}
     res.eff_ruptures = {src.src_group_id: src.num_ruptures}
     if param.get('gmf'):
         getter = getters.GmfGetter(

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -34,8 +34,7 @@ TWO32 = 2 ** 32  # 4,294,967,296
 F64 = numpy.float64
 U64 = numpy.uint64
 U16 = numpy.uint16
-event_dt = numpy.dtype(
-    [('eid', U64), ('grp_id', U16), ('ses', U16), ('rlz', U16)])
+event_dt = numpy.dtype([('eid', U64), ('grp_id', U16), ('rlz', U16)])
 
 
 def get_rlzi(eid):
@@ -188,7 +187,6 @@ def build_eb_ruptures(src, rlzs, num_ses, cmaker, s_sites, rup_n_occ=()):
                 for ses_idx, num_occ in enumerate(n_occ[sam_idx]):
                     for _ in range(num_occ):
                         events[i]['rlz'] = rlzs[sam_idx]
-                        events[i]['ses'] = ses_idx + 1
                         i += 1
 
         # setting event IDs based on the rupture serial and the sample

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -55,11 +55,6 @@ class StochasticEventSetTestCase(unittest.TestCase):
         self.assertEqual(len(dic['eb_ruptures']), 5)
         self.assertEqual(len(dic['calc_times']), 15)  # mutex sources
 
-        # test export
-        mesh = numpy.array([lonlat], [('lon', float), ('lat', float)])
-        ebr = dic['eb_ruptures'][0]
-        ebr.export(mesh)
-
         # test no filtering 1
         ruptures = list(stochastic_event_set(group))
         self.assertEqual(len(ruptures), 19)

--- a/openquake/qa_tests_data/event_based/case_15/expected/ruptures.xml
+++ b/openquake/qa_tests_data/event_based/case_15/expected/ruptures.xml
@@ -16,7 +16,7 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
-                    id="0"
+                    id="1"
                     >
                         193273528320
                     </SES>
@@ -52,7 +52,7 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
-                    id="0"
+                    id="1"
                     >
                         292057776128
                     </SES>

--- a/openquake/qa_tests_data/event_based/case_15/expected/ruptures.xml
+++ b/openquake/qa_tests_data/event_based/case_15/expected/ruptures.xml
@@ -16,7 +16,7 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
-                    id="1"
+                    id="0"
                     >
                         193273528320
                     </SES>
@@ -52,7 +52,7 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
-                    id="1"
+                    id="0"
                     >
                         292057776128
                     </SES>

--- a/openquake/qa_tests_data/event_based/case_17/expected/ses.xml
+++ b/openquake/qa_tests_data/event_based/case_17/expected/ses.xml
@@ -16,12 +16,12 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
-                    id="0"
+                    id="1"
                     >
                         639950323713
                     </SES>
                     <SES
-                    id="1"
+                    id="2"
                     >
                         639950323712 639950323714 639950323715
                     </SES>
@@ -52,17 +52,17 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
-                    id="0"
+                    id="1"
                     >
                         644245291008 644245356545
                     </SES>
                     <SES
-                    id="1"
+                    id="2"
                     >
                         644245356544
                     </SES>
                     <SES
-                    id="2"
+                    id="3"
                     >
                         644245291009 644245356546
                     </SES>
@@ -93,17 +93,17 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
-                    id="0"
+                    id="1"
                     >
                         648540258304
                     </SES>
                     <SES
-                    id="1"
+                    id="2"
                     >
                         648540323840 648540323841
                     </SES>
                     <SES
-                    id="2"
+                    id="3"
                     >
                         648540258305
                     </SES>

--- a/openquake/qa_tests_data/event_based/case_17/expected/ses.xml
+++ b/openquake/qa_tests_data/event_based/case_17/expected/ses.xml
@@ -16,19 +16,14 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
+                    id="0"
+                    >
+                        639950323713
+                    </SES>
+                    <SES
                     id="1"
                     >
-                        639950323712 639950323713
-                    </SES>
-                    <SES
-                    id="2"
-                    >
-                        639950323714
-                    </SES>
-                    <SES
-                    id="3"
-                    >
-                        639950323715
+                        639950323712 639950323714 639950323715
                     </SES>
                 </stochasticEventSets>
                 <magnitude>
@@ -57,19 +52,19 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
+                    id="0"
+                    >
+                        644245291008 644245356545
+                    </SES>
+                    <SES
                     id="1"
                     >
-                        644245291008
+                        644245356544
                     </SES>
                     <SES
                     id="2"
                     >
-                        644245291009 644245356544 644245356545
-                    </SES>
-                    <SES
-                    id="3"
-                    >
-                        644245356546
+                        644245291009 644245356546
                     </SES>
                 </stochasticEventSets>
                 <magnitude>
@@ -98,12 +93,17 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <stochasticEventSets>
                     <SES
-                    id="1"
+                    id="0"
                     >
-                        648540258304 648540323840 648540323841
+                        648540258304
                     </SES>
                     <SES
-                    id="3"
+                    id="1"
+                    >
+                        648540323840 648540323841
+                    </SES>
+                    <SES
+                    id="2"
                     >
                         648540258305
                     </SES>

--- a/openquake/qa_tests_data/event_based/case_2/expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml
+++ b/openquake/qa_tests_data/event_based/case_2/expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml
@@ -9,18 +9,7 @@ xmlns:gml="http://www.opengis.net/gml"
     >
         <gmfSet
         investigationTime="1.0"
-        stochasticEventSetId="11"
-        >
-            <gmf
-            IMT="PGA"
-            ruptureId="7606387081216"
-            >
-                <node gmv="3.2905376E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
-            </gmf>
-        </gmfSet>
-        <gmfSet
-        investigationTime="1.0"
-        stochasticEventSetId="328"
+        stochasticEventSetId="213"
         >
             <gmf
             IMT="PGA"
@@ -31,13 +20,24 @@ xmlns:gml="http://www.opengis.net/gml"
         </gmfSet>
         <gmfSet
         investigationTime="1.0"
-        stochasticEventSetId="587"
+        stochasticEventSetId="252"
         >
             <gmf
             IMT="PGA"
             ruptureId="7679401525248"
             >
                 <node gmv="3.3172143E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
+            </gmf>
+        </gmfSet>
+        <gmfSet
+        investigationTime="1.0"
+        stochasticEventSetId="357"
+        >
+            <gmf
+            IMT="PGA"
+            ruptureId="7606387081216"
+            >
+                <node gmv="3.2905376E-01" lat="0.0000000E+00" lon="0.0000000E+00"/>
             </gmf>
         </gmfSet>
     </gmfCollection>

--- a/openquake/qa_tests_data/event_based/case_2/expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml
+++ b/openquake/qa_tests_data/event_based/case_2/expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml
@@ -9,7 +9,7 @@ xmlns:gml="http://www.opengis.net/gml"
     >
         <gmfSet
         investigationTime="1.0"
-        stochasticEventSetId="213"
+        stochasticEventSetId="214"
         >
             <gmf
             IMT="PGA"
@@ -20,7 +20,7 @@ xmlns:gml="http://www.opengis.net/gml"
         </gmfSet>
         <gmfSet
         investigationTime="1.0"
-        stochasticEventSetId="252"
+        stochasticEventSetId="253"
         >
             <gmf
             IMT="PGA"
@@ -31,7 +31,7 @@ xmlns:gml="http://www.opengis.net/gml"
         </gmfSet>
         <gmfSet
         investigationTime="1.0"
-        stochasticEventSetId="357"
+        stochasticEventSetId="358"
         >
             <gmf
             IMT="PGA"

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/rupture-nonstructural.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/rupture-nonstructural.xml
@@ -9,22 +9,22 @@ xmlns:gml="http://www.opengis.net/gml"
     >
         <stochasticEventSets>
             <SES
-            id="5"
+            id="6"
             >
                 236223201281
             </SES>
             <SES
-            id="7"
+            id="8"
             >
                 236223266817
             </SES>
             <SES
-            id="8"
+            id="9"
             >
                 236223201280
             </SES>
             <SES
-            id="13"
+            id="14"
             >
                 236223266816
             </SES>

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/rupture-nonstructural.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/rupture-nonstructural.xml
@@ -9,14 +9,24 @@ xmlns:gml="http://www.opengis.net/gml"
     >
         <stochasticEventSets>
             <SES
-            id="2"
+            id="5"
             >
-                236223266816 236223201280
+                236223201281
             </SES>
             <SES
-            id="16"
+            id="7"
             >
-                236223266817 236223201281
+                236223266817
+            </SES>
+            <SES
+            id="8"
+            >
+                236223201280
+            </SES>
+            <SES
+            id="13"
+            >
+                236223266816
             </SES>
         </stochasticEventSets>
         <magnitude>

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/rupture-structural.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/rupture-structural.xml
@@ -9,9 +9,14 @@ xmlns:gml="http://www.opengis.net/gml"
     >
         <stochasticEventSets>
             <SES
-            id="1"
+            id="4"
             >
-                240518234112 240518168576
+                240518234112
+            </SES>
+            <SES
+            id="15"
+            >
+                240518168576
             </SES>
         </stochasticEventSets>
         <magnitude>

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/rupture-structural.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/rupture-structural.xml
@@ -9,12 +9,12 @@ xmlns:gml="http://www.opengis.net/gml"
     >
         <stochasticEventSets>
             <SES
-            id="4"
+            id="5"
             >
                 240518234112
             </SES>
             <SES
-            id="15"
+            id="16"
             >
                 240518168576
             </SES>


### PR DESCRIPTION
This is another crucial step towards https://github.com/gem/oq-engine/issues/4165.
NB: in event_based/case_2/expected/gmf-smltp_b1-gsimltp_b1-ltr_0.xml the GMF values do not change, they just change order, as a quirk of the (deprecated) XML exporter.