### PR TITLE
Optimized the rupture sampling for many SES

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Changed the algorithm associating events to SESs for performance reasons
+  * Changed the algorithm associating events to SESs and made the event based
+    hazard calculator faster in the case of many SESs
   * Reduced substantially the memory consumption in event based risk
   * Made it possible to read multiple site model files in the same calculation
   * Implemented a smart single job.ini file mode for event based risk

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -78,8 +78,8 @@ def get_events(ebruptures, num_ses):
         numpy.random.seed(ebr.serial)
         sess = numpy.random.choice(num_ses, ebr.multiplicity)
         for event, ses in zip(ebr.events, sess):
-            rec = (event['eid'], ebr.serial, ebr.grp_id, year,
-                   ses, event['rlz'])
+            rec = (TWO32 * ebr.serial + event['eid'], ebr.serial,
+                   ebr.grp_id, year, ses, event['rlz'])
             events.append(rec)
     return numpy.array(events, readinput.stored_event_dt)
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -383,7 +383,7 @@ class GmfGetter(object):
                     arr[arr < miniml] = 0
                 n = 0
                 for r, rlzi in enumerate(rlzs):
-                    eids = TWO32 * rup.serial + numpy.array(all_eids[r])
+                    eids = U64(TWO32 * rup.serial) + numpy.array(all_eids[r])
                     e = len(eids)
                     if not e:
                         continue

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -71,12 +71,9 @@ def joint_prob_of_occurrence(gmvs_site_1, gmvs_site_2, gmv, time_span,
 
     def gmv_close(v):
         return (gmv - half_delta <= v <= gmv + half_delta)
-    count = 0
-    for gmv_site_1, gmv_site_2 in zip(gmvs_site_1, gmvs_site_2):
-        if gmv_close(gmv_site_1) and gmv_close(gmv_site_2):
-            count += 1
-
-    prob = 1 - math.exp(- (float(count) / num_ses))
+    count = sum(1 for gmv1, gmv2 in zip(gmvs_site_1, gmvs_site_2)
+                if gmv_close(gmv1) and gmv_close(gmv2))
+    prob = 1 - math.exp(- count / num_ses)
     return prob
 
 

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -131,7 +131,7 @@ def generate_event_set(ucerf, background_sids, src_filter, seed):
             ucerf.lsd, ucerf.msr, ucerf.aspect, ucerf.tectonic_region_type)
         ruptures.extend(background_ruptures)
         rupture_occ.extend(background_n_occ)
-    return ruptures, numpy.array(rupture_occ, numpy.uint16).reshape(-1, 1, 1)
+    return ruptures, rupture_occ
 
 
 def sample_background_model(
@@ -218,7 +218,7 @@ def compute_hazard(sources, src_filter, rlzs_by_gsim, param, monitor):
     cmaker = ContextMaker(rlzs_by_gsim, src_filter.integration_distance)
     num_ses = param['ses_per_logic_tree_path']
     samples = getattr(src, 'samples', 1)
-    n_occ = AccumDict(accum=numpy.zeros((samples, num_ses), numpy.uint16))
+    n_occ = AccumDict(accum=numpy.zeros(samples, numpy.uint16))
     with sampl_mon:
         for sam_idx in range(samples):
             for ses_idx, ses_seed in param['ses_seeds']:
@@ -226,7 +226,7 @@ def compute_hazard(sources, src_filter, rlzs_by_gsim, param, monitor):
                 rups, occs = generate_event_set(
                     src, background_sids, src_filter, seed)
                 for rup, occ in zip(rups, occs):
-                    n_occ[rup][sam_idx, ses_idx] = occ
+                    n_occ[rup][sam_idx] = occ
                     rup.serial = serial
                     serial += 1
     with filt_mon:

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -32,9 +32,10 @@ from openquake.hazardlib.contexts import ContextMaker, FarAwayRupture
 TWO16 = 2 ** 16  # 65,536
 TWO32 = 2 ** 32  # 4,294,967,296
 F64 = numpy.float64
-U64 = numpy.uint64
 U16 = numpy.uint16
-event_dt = numpy.dtype([('eid', U64), ('grp_id', U16), ('rlz', U16)])
+U32 = numpy.uint32
+U64 = numpy.uint64
+event_dt = numpy.dtype([('eid', U32), ('rlz', U16)])
 
 
 def get_rlzi(eid):
@@ -178,7 +179,6 @@ def build_eb_ruptures(src, rlzs, num_ses, cmaker, s_sites, rup_n_occ=()):
                 continue
             assert E < TWO16, E
             events = numpy.zeros(E, event_dt)
-            events['grp_id'] = src.src_group_id
             i = 0
             for sam_idx in range(nr):  # numpy.ndenumerate would be slower
                 for _ in range(n_occ[sam_idx]):
@@ -189,8 +189,7 @@ def build_eb_ruptures(src, rlzs, num_ses, cmaker, s_sites, rup_n_occ=()):
         ebr = EBRupture(rup, src.id, src.src_group_id, indices, events)
         start = 0
         for sam_idx, n in enumerate(n_occ):
-            eids = (U64(TWO32 * ebr.serial + TWO16 * rlzs[sam_idx]) +
-                    numpy.arange(n, dtype=U64))
+            eids = TWO16 * rlzs[sam_idx] + numpy.arange(n, dtype=U32)
             ebr.events[start:start + len(eids)]['eid'] = eids
             start += len(eids)
         ebrs.append(ebr)

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -134,11 +134,9 @@ def sample_ruptures(sources, param, src_filter=source_site_noop_filter,
 
 
 def fix_shape(occur, num_rlzs):
-    nr, num_ses = occur.shape
-    assert nr == 1, nr
-    n_occ = numpy.zeros((num_rlzs, num_ses), U16)
+    n_occ = numpy.zeros(num_rlzs, U16)
     for nr in range(num_rlzs):
-        n_occ[nr, :] = occur[0, :]
+        n_occ[nr] = occur
     return n_occ
 
 
@@ -175,8 +173,7 @@ def build_eb_ruptures(src, rlzs, num_ses, cmaker, s_sites, rup_n_occ=()):
 
         # creating events
         with cmaker.evs_mon:
-            occ = n_occ.sum(axis=1)  # occurrences by sam_idx
-            E = occ.sum()
+            E = n_occ.sum()
             if E == 0:
                 continue
             assert E < TWO16, E
@@ -184,15 +181,14 @@ def build_eb_ruptures(src, rlzs, num_ses, cmaker, s_sites, rup_n_occ=()):
             events['grp_id'] = src.src_group_id
             i = 0
             for sam_idx in range(nr):  # numpy.ndenumerate would be slower
-                for ses_idx, num_occ in enumerate(n_occ[sam_idx]):
-                    for _ in range(num_occ):
-                        events[i]['rlz'] = rlzs[sam_idx]
-                        i += 1
+                for _ in range(n_occ[sam_idx]):
+                    events[i]['rlz'] = rlzs[sam_idx]
+                    i += 1
 
         # setting event IDs based on the rupture serial and the sample
         ebr = EBRupture(rup, src.id, src.src_group_id, indices, events)
         start = 0
-        for sam_idx, n in enumerate(occ):
+        for sam_idx, n in enumerate(n_occ):
             eids = (U64(TWO32 * ebr.serial + TWO16 * rlzs[sam_idx]) +
                     numpy.arange(n, dtype=U64))
             ebr.events[start:start + len(eids)]['eid'] = eids

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -102,14 +102,14 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
             `~openquake.hazardlib.source.rupture.BaseProbabilisticRupture`.
         """
 
-    def sample_ruptures(self, num_rlzs, num_ses, ir_monitor):
+    def sample_ruptures(self, num_samples, num_ses, ir_monitor):
         """
-        :param num_rlzs: number of realizations of the source model
+        :param num_samples: number of realizations of the source model
         :param num_ses: number of stochastic event sets
         :param ir_monitor: a monitor object for .iter_ruptures()
-        :yields: pairs (rupture, num_occurrences[num_samples, num_ses])
+        :yields: pairs (rupture, num_occurrences[num_samples])
         """
-        shape = (num_rlzs, num_ses)
+        shape = (num_samples, num_ses)
         mutex_weight = getattr(self, 'mutex_weight', 1)
         with ir_monitor:
             ruptures = list(self.iter_ruptures())
@@ -120,9 +120,10 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
             if num_occ.any():
                 if mutex_weight < 1:
                     # consider only the occurrencies below the mutex_weight
-                    num_occ *= (numpy.random.random(shape) < mutex_weight)
+                    num_occ *= numpy.random.random(shape) < mutex_weight
+                occ = num_occ.sum(axis=1)
                 if num_occ.any():
-                    yield rup, num_occ
+                    yield rup, occ
 
     def __iter__(self):
         """

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -586,6 +586,7 @@ class EBRupture(object):
         attributes set, suitable for export in XML format.
         """
         rupture = self.rupture
+        self.events['eid'] += TWO32 * self.serial
         events_by_ses = general.group_array(self.events, 'ses')
         new = ExportedRupture(self.serial, events_by_ses, self.sids)
         new.mesh = mesh[self.sids]


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/4165. A large amount of time was spent in the function `build_eb_ruptures` inside a double loop on samples and SESs. Now there is a single loop on the samples and it is a lot faster. For instance for Chile with 5 samples and 20,000 SESs on Murray's machine I got:
```
before: building events 27,862s
after:  building events 15s
```
Overall the hazard calculation is now 20% faster. With more samples and SESs the gain is even bigger.
I have also changed the way the event ID are stored inside EBRuptures. Now they use 4 bytes instead of 8 bytes each. This improves a bit the performance of the GMFs calculation
```
======================== ======== ========= =======
operation                time_sec memory_mb counts 
======================== ======== ========= =======
building hazard          4,889    45        544 # before
building hazard          4,781    35        495 # after
```
and it might be a first step towards the solution of https://github.com/gem/oq-engine/issues/4157.