### PR TITLE
Fixed the attribute stats

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -230,7 +230,7 @@ class EbrCalculator(base.RiskCalculator):
                 'curves-stats', builder.loss_dt, (A, S, P), fillvalue=None)
             self.datastore.set_attrs(
                 'curves-stats', return_periods=builder.return_periods,
-                stats=' '.join(name for (name, func) in stats))
+                stats=[encode(name) for (name, func) in stats])
             if oq.conditional_loss_poes:
                 self.datastore.create_dset(
                     'loss_maps-stats', self.loss_maps_dt, (A, S),
@@ -346,4 +346,4 @@ class EbrCalculator(base.RiskCalculator):
             self.datastore['agg_curves-stats'] = arr_stats
             self.datastore.set_attrs(
                 'agg_curves-stats', return_periods=b.return_periods,
-                stats=' '.join(name for (name, func) in stats), units=units)
+                stats=[encode(name) for (name, func) in stats], units=units)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -568,7 +568,7 @@ def crm_attrs(dstore, what):
 def _get(dstore, name):
     try:
         dset = dstore[name + '-stats']
-        return dset, dset.attrs['stats'].split()
+        return dset, [b.decode('utf8') for b in dset.attrs['stats']]
     except KeyError:  # single realization
         return dstore[name + '-rlzs'], ['mean']
 

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -19,6 +19,7 @@
 Utilities to compute mean and quantile curves
 """
 import numpy
+from openquake.baselib.python3compat import encode
 
 _mean = None  # set by mean_curve and std_curve
 
@@ -211,4 +212,4 @@ def set_rlzs_stats(dstore, prefix, arrayNR=None):
         statnames, statfuncs = zip(*stats)
         weights = dstore['csm_info'].rlzs['weight']
         dstore[prefix + '-stats'] = compute_stats2(arrayNR, statfuncs, weights)
-        dstore.set_attrs(prefix + '-stats', stats=' '.join(statnames))
+        dstore.set_attrs(prefix + '-stats', stats=encode(statnames))


### PR DESCRIPTION
Sometimes it was a string, sometime an array. The change in https://github.com/gem/oq-engine/pull/4155 broke the plugin,  see https://travis-ci.org/gem/oq-irmt-qgis/builds/453602090.