### PR TITLE
Hack to run continental scale calculations with a single file

### DIFF
--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -175,11 +175,12 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             if log_file is not None else None
         job_inis = [os.path.expanduser(f) for f in run]
         if len(job_inis) == 1 and not hc_id:
-            # special case for single file event_based_risk
             # init logs before calling get_oqparam
             logs.init(level=getattr(logging, log_level.upper()))
             oq = readinput.get_oqparam(job_inis[0])
-            if oq.calculation_mode == 'event_based_risk':
+            if (oq.calculation_mode == 'event_based_risk' and
+                    'site_model' in oq.inputs):
+                # special case for single file global risk model
                 hc_id = run_job(job_inis[0], log_level, log_file,
                                 exports, calculation_mode='event_based',
                                 exposure_file='')

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -183,9 +183,12 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
                                 exports, calculation_mode='event_based',
                                 exposure_file='')
                 for exp_file in oq.inputs['exposure']:
-                    run_job(job_inis[0], log_level, log_file,
-                            exports, hazard_calculation_id=hc_id,
-                            exposure_file=exp_file)
+                    try:
+                        run_job(job_inis[0], log_level, log_file,
+                                exports, hazard_calculation_id=hc_id,
+                                exposure_file=exp_file)
+                    except Exception:  # skip failed computations
+                        pass
                 return
         for i, job_ini in enumerate(job_inis):
             open(job_ini, 'rb').read()  # IOError if the file does not exist

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -176,7 +176,8 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
         job_inis = [os.path.expanduser(f) for f in run]
         if len(job_inis) == 1 and not hc_id:
             # special case for single file event_based_risk
-            logs.init()  # init logs before calling get_oqparam
+            # init logs before calling get_oqparam
+            logs.init(level=getattr(logging, log_level.upper()))
             oq = readinput.get_oqparam(job_inis[0])
             if oq.calculation_mode == 'event_based_risk':
                 hc_id = run_job(job_inis[0], log_level, log_file,

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -176,12 +176,13 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
         job_inis = [os.path.expanduser(f) for f in run]
         if len(job_inis) == 1 and not hc_id:
             # special case for single file event_based_risk
+            logs.init()  # init logs before calling get_oqparam
             oq = readinput.get_oqparam(job_inis[0])
             if oq.calculation_mode == 'event_based_risk':
                 hc_id = run_job(job_inis[0], log_level, log_file,
                                 exports, calculation_mode='event_based',
                                 exposure_file='')
-                for exp_file in oq.inputs['exposure_file'].split():
+                for exp_file in oq.inputs['exposure']:
                     run_job(job_inis[0], log_level, log_file,
                             exports, hazard_calculation_id=hc_id,
                             exposure_file=exp_file)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -117,7 +117,7 @@ def normalize(key, fnames, base_path):
 
 def _update(params, items, base_path):
     for key, value in items:
-        if key in ('hazard_curves_csv', 'site_model_file'):
+        if key in ('hazard_curves_csv', 'site_model_file', 'exposure_file'):
             input_type, fnames = normalize(key, value.split(), base_path)
             params['inputs'][input_type] = fnames
         elif key.endswith(('_file', '_csv', '_hdf5')):
@@ -966,9 +966,9 @@ def get_exposure(oqparam):
     :returns:
         an :class:`Exposure` instance or a compatible AssetCollection
     """
-    logging.info('Reading the exposure')
+    [fname] = oqparam.inputs['exposure']
     exposure = asset.Exposure.read(
-        oqparam.inputs['exposure'], oqparam.calculation_mode,
+        fname, oqparam.calculation_mode,
         oqparam.region, oqparam.ignore_missing_costs)
     exposure.mesh, exposure.assets_by_site = exposure.get_mesh_assets_by_site()
     return exposure

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -862,11 +862,10 @@ def get_composite_source_model(oqparam, monitor=None, in_memory=True,
     if monitor.hdf5:
         csm.info.gsim_lt.store_gmpe_tables(monitor.hdf5)
 
-    if srcfilter and oqparam.prefilter_sources != 'no':
+    if (srcfilter and oqparam.prefilter_sources != 'no' and
+            oqparam.calculation_mode not in 'ucerf_hazard ucerf_risk'):
         mon = monitor('split_filter')
-        split = (split_all and oqparam.calculation_mode not in
-                 'ucerf_hazard ucerf_risk')
-        csm = parallel_split_filter(csm, srcfilter, split, mon)
+        csm = parallel_split_filter(csm, srcfilter, split_all, mon)
     return csm
 
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -966,9 +966,11 @@ def get_exposure(oqparam):
     :returns:
         an :class:`Exposure` instance or a compatible AssetCollection
     """
-    [fname] = oqparam.inputs['exposure']
+    fnames = oqparam.inputs['exposure']
+    if len(fnames) > 1:
+        raise NotImplementedError('Multifile exposure')
     exposure = asset.Exposure.read(
-        fname, oqparam.calculation_mode,
+        fnames[0], oqparam.calculation_mode,
         oqparam.region, oqparam.ignore_missing_costs)
     exposure.mesh, exposure.assets_by_site = exposure.get_mesh_assets_by_site()
     return exposure

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -396,7 +396,7 @@ class ExposureTestCase(unittest.TestCase):
         oqparam.base_path = '/'
         oqparam.calculation_mode = 'scenario_damage'
         oqparam.all_cost_types = ['occupants']
-        oqparam.inputs = {'exposure': self.exposure}
+        oqparam.inputs = {'exposure': [self.exposure]}
         oqparam.region = '''\
 POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         oqparam.time_event = None
@@ -412,7 +412,7 @@ POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         oqparam.calculation_mode = 'scenario_damage'
         oqparam.all_cost_types = ['structural']
         oqparam.insured_losses = False
-        oqparam.inputs = {'exposure': self.exposure0}
+        oqparam.inputs = {'exposure': [self.exposure0]}
         oqparam.region = '''\
 POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         oqparam.time_event = None
@@ -429,7 +429,7 @@ POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         oqparam.base_path = '/'
         oqparam.calculation_mode = 'scenario_damage'
         oqparam.all_cost_types = ['structural']
-        oqparam.inputs = {'exposure': self.exposure1}
+        oqparam.inputs = {'exposure': [self.exposure1]}
         oqparam.region = '''\
 POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         oqparam.time_event = None
@@ -445,7 +445,7 @@ POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         oqparam.calculation_mode = 'scenario_risk'
         oqparam.all_cost_types = ['structural']
         oqparam.insured_losses = True
-        oqparam.inputs = {'exposure': self.exposure,
+        oqparam.inputs = {'exposure': [self.exposure],
                           'structural_vulnerability': None}
         oqparam.region = '''\
 POLYGON((68.0 31.5, 69.5 31.5, 69.5 25.5, 68.0 25.5, 68.0 31.5))'''
@@ -464,7 +464,7 @@ POLYGON((68.0 31.5, 69.5 31.5, 69.5 25.5, 68.0 25.5, 68.0 31.5))'''
         oqparam.ignore_missing_costs = []
         oqparam.region = '''\
 POLYGON((68.0 31.5, 69.5 31.5, 69.5 25.5, 68.0 25.5, 68.0 31.5))'''
-        oqparam.inputs = {'exposure': self.exposure2,
+        oqparam.inputs = {'exposure': [self.exposure2],
                           'structural_vulnerability': None}
         with self.assertRaises(ValueError) as ctx:
             readinput.get_exposure(oqparam)
@@ -477,7 +477,7 @@ POLYGON((68.0 31.5, 69.5 31.5, 69.5 25.5, 68.0 25.5, 68.0 31.5))'''
         oqparam.base_path = '/'
         oqparam.calculation_mode = 'scenario_damage'
         oqparam.all_cost_types = ['structural']
-        oqparam.inputs = {'exposure': self.exposure3}
+        oqparam.inputs = {'exposure': [self.exposure3]}
         oqparam.region = '''\
 POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         oqparam.time_event = None

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -251,8 +251,8 @@ def zip_job(job_ini, archive_zip, risk_ini, oq=None, log=logging.info):
                     files.add(table)
 
     # collect exposure.csv, if any
-    exposure_xml = oq.inputs.get('exposure')
-    if exposure_xml:
+    exposures_xml = oq.inputs.get('exposure', [])
+    for exposure_xml in exposures_xml:
         dname = os.path.dirname(exposure_xml)
         expo = nrml.read(exposure_xml, stop='asset')[0]
         if not expo.assets:


### PR DESCRIPTION
While the final goal is to a run an entire continent with 2 calculations (1 hazard + 1 risk) this hack allows to run the continent with 1 hazard + E risk calculations, being E the number of exposure files.
To run the risk in a single file we would need an aggregation by country feature which is still missing. Also, probably the performance/memory consumption is not ready yet.
Lots of testing is needed before we can trust this feature. For the moment, I have a fast test in the oq-risk-tests repository, see https://gitlab.openquake.org/openquake/oq-risk-tests/-/jobs/3062.

Here is the job.ini: https://gitlab.openquake.org/openquake/oq-risk-tests/blob/master/test/event_based_risk/inputs/global/job.ini