### PR TITLE
Reduced the memory consumption event_based_risk

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -76,7 +76,7 @@ def event_based_risk(riskinputs, riskmodel, param, monitor):
         mon = monitor('build risk curves', measuremem=False)
         A = len(ri.aids)
         R = ri.hazard_getter.num_rlzs
-        agg = []  # triples (eids, li, losses)
+        agg = []  # pairs (eids[E], agglosses[E, LI])
         try:
             avg = numpy.zeros((A, R, L * I), F32)
         except MemoryError:
@@ -182,7 +182,6 @@ class EbrCalculator(base.RiskCalculator):
         self.E = len(self.eidrlz)
         eps = self.epsilon_getter()()
         self.riskinputs = self.build_riskinputs('gmf', eps, self.E)
-        self.param['num_events'] = self.E
         self.param['insured_losses'] = oq.insured_losses
         self.param['avg_losses'] = oq.avg_losses
         self.param['ses_ratio'] = oq.ses_ratio

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -81,7 +81,7 @@ def event_based_risk(riskinputs, riskmodel, param, monitor):
         except MemoryError:
             raise MemoryError(
                 'Building array avg of shape (%d, %d, %d)' % (A, R, L*I))
-        result = dict(aids=ri.aids, avglosses=avg)
+        result = dict(aids=ri.aids, avglosses=avg, agglosses=[])
         aid2idx = {aid: idx for idx, aid in enumerate(ri.aids)}
         if 'builder' in param:
             builder = param['builder']
@@ -121,7 +121,7 @@ def event_based_risk(riskinputs, riskmodel, param, monitor):
                         agglosses[:, l + L * i] += losses[:, i]
 
             # agglosses
-            yield dict(eids=out.eids, agglosses=agglosses)
+            result['agglosses'].append((out.eids, agglosses))
 
         if 'builder' in param:
             clp = param['conditional_loss_poes']
@@ -245,9 +245,8 @@ class EbrCalculator(base.RiskCalculator):
         :param dic:
             dictionary with agglosses, avglosses
         """
-        if 'eids' in dic:
-            self.agglosses[dic['eids']] += dic['agglosses']  # shape (E, LI)
-            return
+        for eids, agglosses in dic.pop('agglosses'):  # shape (E, LI)
+            self.agglosses[eids] += agglosses
         aids = dic.pop('aids')
         if self.oqparam.avg_losses:
             self.dset[aids, :, :] = dic.pop('avglosses')

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -120,7 +120,9 @@ def event_based_risk(riskinputs, riskmodel, param, monitor):
                     for i in range(I):
                         agglosses[:, l + L * i] += losses[:, i]
 
-            # agglosses
+            # NB: I could yield the agglosses per output, but then I would
+            # have millions of small outputs with big data transfer and slow
+            # saving time
             result['agglosses'].append((out.eids, agglosses))
 
         if 'builder' in param:


### PR DESCRIPTION
We do not need to create the array ` agg = numpy.zeros((E, L * I), F32)` which is mostly empty. For 10 million events and 2 loss types it means saving 80 MB per core, which does not look much. In reality however one saves a lot more memory, perhaps because of the missing `agg.nonzero()`. My analysis for Chile gives the following numbers:

   >>> ds['task_info/event_based_risk']['mem_gb'].max() # master              
   93.746605
   >>> ds['task_info/event_based_risk']['mem_gb'].max() # this branch
  13.510426

i.e. a 7x improvement.
