### PR TITLE
Removed the shortcut to skip the source_model_logic_tree file

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -178,8 +178,6 @@ def get_params(job_inis, **kw):
     smlt = inputs.get('source_model_logic_tree')
     if smlt:
         inputs['source'] = logictree.collect_info(smlt).smpaths
-    elif 'source_model' in inputs:
-        inputs['source'] = [inputs['source_model']]
     if inputs.get('reqv'):
         # using pointsource_distance=0 because of the reqv approximation
         params['pointsource_distance'] = '0'

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -67,58 +67,6 @@ export_dir = %s
             readinput.get_params([job_config])
         self.assertIn('is an absolute path', str(ctx.exception))
 
-    def test_get_oqparam_with_files(self):
-        temp_dir = tempfile.mkdtemp()
-        source_model_input = general.gettemp(dir=temp_dir)
-        site_model_input = general.gettemp(dir=temp_dir, content="foo")
-        job_config = general.gettemp(dir=temp_dir, content="""
-[general]
-calculation_mode = event_based
-[site]
-source_model_file = %s
-site_model_file = %s
-maximum_distance=1
-truncation_level=0
-random_seed=0
-intensity_measure_types = PGA
-investigation_time = 50
-export_dir = %s
-        """ % (os.path.basename(source_model_input),
-               os.path.basename(site_model_input), TMP))
-
-        try:
-            exp_base_path = os.path.dirname(job_config)
-
-            expected_params = {
-                'export_dir': TMP,
-                'base_path': exp_base_path,
-                'calculation_mode': 'event_based',
-                'truncation_level': 0.0,
-                'random_seed': 0,
-                'maximum_distance': {'default': 1},
-                'inputs': {'job_ini': job_config,
-                           'site_model': [site_model_input],
-                           'source': [source_model_input],
-                           'source_model': source_model_input},
-                'hazard_imtls': {'PGA': None},
-                'investigation_time': 50.0,
-                'risk_investigation_time': 50.0,
-            }
-
-            params = getparams(readinput.get_oqparam(job_config))
-            for key in expected_params:
-                self.assertEqual(expected_params[key], params[key])
-            items = sorted(params['inputs'].items())
-            keys, values = zip(*items)
-            self.assertEqual(('job_ini', 'site_model', 'source',
-                              'source_model'), keys)
-            self.assertEqual((job_config, [site_model_input],
-                              [source_model_input], source_model_input),
-                             values)
-
-        finally:
-            shutil.rmtree(temp_dir)
-
     def test_get_oqparam_with_sites_csv(self):
         sites_csv = general.gettemp('1.0,2.1\n3.0,4.1\n5.0,6.1')
         try:

--- a/openquake/qa_tests_data/classical/case_1/job.ini
+++ b/openquake/qa_tests_data/classical/case_1/job.ini
@@ -32,7 +32,7 @@ reference_depth_to_1pt0km_per_sec = 50.0
 
 [calculation]
 
-source_model_file = source_model.xml
+source_model_logic_tree_file = source_model_logic_tree.xml
 gsim_logic_tree_file = gsim_logic_tree.xml
 # years
 investigation_time = 1.0

--- a/openquake/qa_tests_data/classical/case_1/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/classical/case_1/source_model_logic_tree.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b11">
+                    <uncertaintyModel>source_model.xml</uncertaintyModel>
+                    <uncertaintyWeight>1</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/event_based/case_15/Hazard/Japan/ssmLT.xml
+++ b/openquake/qa_tests_data/event_based/case_15/Hazard/Japan/ssmLT.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b11">
+                    <uncertaintyModel>ssm/ssm01.xml</uncertaintyModel>
+                    <uncertaintyWeight>1</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/event_based/case_15/job.ini
+++ b/openquake/qa_tests_data/event_based/case_15/job.ini
@@ -13,7 +13,7 @@ width_of_mfd_bin = 0.1
 area_source_discretization = 10.0
 
 [logic_trees]
-source_model_file = Hazard/Japan/ssm/ssm01.xml
+source_model_logic_tree_file = Hazard/Japan/ssmLT.xml
 gsim_logic_tree_file = Hazard/Japan/gmmLT_sa.xml
 
 [hazard_calculation]

--- a/openquake/qa_tests_data/event_based/case_16/job.ini
+++ b/openquake/qa_tests_data/event_based/case_16/job.ini
@@ -16,7 +16,7 @@ width_of_mfd_bin = 0.2
 area_source_discretization = 20.0
 
 [logic_trees]
-source_model_file = as_model_full.xml
+source_model_logic_tree_file = source_model_logic_tree.xml
 gsim_logic_tree_file = gmpe_logic_tree.xml
 
 [hazard_calculation]

--- a/openquake/qa_tests_data/event_based/case_16/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/event_based/case_16/source_model_logic_tree.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b11">
+                    <uncertaintyModel>as_model_full.xml</uncertaintyModel>
+                    <uncertaintyWeight>1</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>


### PR DESCRIPTION
It was introduced months ago and kept secret, only for use in the tests. It makes things more complicated for https://github.com/gem/oq-engine/issues/4204, so it is time to remove it (also, I discovered today that it does not play well with sampling).