### PR TITLE
Removed the 'year' field from the `events` dataset

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -98,7 +98,6 @@ def get_events(ebruptures, rlzs_by_gsim, num_ses):
     Extract an array of dtype stored_event_dt from a list of EBRuptures
     """
     events = []
-    year = 0  # to be set later
     nr = sum(len(rlzs) for rlzs in rlzs_by_gsim.values())
     for ebr in ebruptures:
         numpy.random.seed(ebr.serial)
@@ -108,7 +107,7 @@ def get_events(ebruptures, rlzs_by_gsim, num_ses):
                                          ebr.samples).items():
             for eid in eids:
                 rec = (TWO32 * U64(ebr.serial) + eid, ebr.serial,
-                       ebr.grp_id, year, sess[i], rlz)
+                       ebr.grp_id, sess[i], rlz)
                 events.append(rec)
                 i += 1
     return numpy.array(events, readinput.stored_event_dt)
@@ -145,25 +144,6 @@ def set_counts(dstore, dsetname):
     dic = dict(zip(unique, counts))
     dstore.set_attrs(dsetname, by_grp=sorted(dic.items()))
     return dic
-
-
-def set_random_years(dstore, name, ses_seed, investigation_time):
-    """
-    Set on the `events` dataset year labels sensitive to the
-    SES ordinal and the investigation time.
-
-    :param dstore: a DataStore instance
-    :param name: name of the dataset ('events')
-    :param ses_seed: seed to use in numpy.random.choice
-    :param investigation_time: investigation time
-    """
-    events = dstore[name].value
-    numpy.random.seed(ses_seed)
-    years = numpy.random.choice(investigation_time, len(events)) + 1
-    year_of = dict(zip(numpy.sort(events['eid']), years))  # eid -> year
-    for event in events:
-        event['year'] = year_of[event['eid']]
-    dstore[name] = events
 
 
 # ######################## GMF calculator ############################ #
@@ -520,11 +500,6 @@ class EventBasedCalculator(base.HazardCalculator):
             if self.oqparam.save_ruptures:
                 logging.info('Setting {:,d} event years on {:,d} ruptures'.
                              format(num_events, self.rupser.nruptures))
-            with self.monitor('setting event years', measuremem=True,
-                              autoflush=True):
-                set_random_years(self.datastore, 'events',
-                                 self.oqparam.ses_seed,
-                                 int(self.oqparam.investigation_time))
 
     @cached_property
     def eid2idx(self):

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -245,8 +245,6 @@ class EventBasedTestCase(CalculatorTestCase):
     def test_case_8(self):
         out = self.run_calc(case_8.__file__, 'job.ini', exports='csv')
         [fname] = out['ruptures', 'csv']
-        years = sorted(self.calc.datastore['events']['year'])
-        self.assertEqual(years, [15, 29, 39, 43])
         self.assertEqualFiles('expected/rup_data.csv', fname)
 
     @attr('qa', 'hazard', 'event_based')
@@ -341,8 +339,6 @@ PGA     SA(0.3) SA(0.6)
     def test_case_18(self):  # oversampling, 3 realizations
         out = self.run_calc(case_18.__file__, 'job.ini', exports='csv')
         events = extract(self.calc.datastore, 'events')
-        years = numpy.unique(events['year'])
-        numpy.testing.assert_equal(years, [1])
         [fname, _sitefile] = out['gmf_data', 'csv']
         self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname,
                               delta=1E-6)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import os
-import sys
 import csv
 import copy
 import zlib
@@ -60,7 +59,7 @@ U64 = numpy.uint64
 
 Site = collections.namedtuple('Site', 'sid lon lat')
 stored_event_dt = numpy.dtype([
-    ('eid', U64), ('rup_id', U32), ('grp_id', U16), ('year', U32),
+    ('eid', U64), ('rup_id', U32), ('grp_id', U16),
     ('ses', U16), ('rlz', U16)])
 
 


### PR DESCRIPTION
This is a step towards the simplification of the `events` dataset discussed in https://github.com/gem/oq-engine/issues/4207. The years are now set at export time, since it is ultra-fast to do so, there is no need to keep that information.