### PR TITLE
Removed the field `rup_id` from the `events` dataset

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -106,8 +106,7 @@ def get_events(ebruptures, rlzs_by_gsim, num_ses):
         for rlz, eids in get_eids_by_rlz(ebr.n_occ, rlzs_by_gsim,
                                          ebr.samples).items():
             for eid in eids:
-                rec = (TWO32 * U64(ebr.serial) + eid, ebr.serial,
-                       ebr.grp_id, sess[i], rlz)
+                rec = (TWO32 * U64(ebr.serial) + eid, ebr.grp_id, sess[i], rlz)
                 events.append(rec)
                 i += 1
     return numpy.array(events, readinput.stored_event_dt)

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -40,6 +40,7 @@ F64 = numpy.float64
 U16 = numpy.uint16
 U32 = numpy.uint32
 U64 = numpy.uint64
+TWO32 = 2 ** 32
 stat_dt = numpy.dtype([('mean', F32), ('stddev', F32)])
 
 
@@ -235,7 +236,10 @@ def export_agg_losses_ebr(ekey, dstore):
     elt = numpy.zeros(len(agg_losses), elt_dt)
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     events = dstore['events'].value
-    events_by_rupid = group_array(events, 'rup_id')
+    events_by_rupid = collections.defaultdict(list)
+    for event in events:
+        rupid = event['eid'] // TWO32
+        events_by_rupid[rupid].append(event)
     year_of = year_dict(events['eid'], oq.investigation_time, oq.ses_seed)
     rup_data = {}
     event_by_eid = {}  # eid -> event
@@ -255,7 +259,7 @@ def export_agg_losses_ebr(ekey, dstore):
         rec['year'] = year_of[eid]
         rec['rlzi'] = row['rlzi']
         if rup_data:
-            rec['rup_id'] = rup_id = event['rup_id']
+            rec['rup_id'] = rup_id = event['eid'] // TWO32
             (rec['magnitude'], rec['centroid_lon'], rec['centroid_lat'],
              rec['centroid_depth']) = rup_data[rup_id]
         for lt, i in lti.items():

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -59,8 +59,7 @@ U64 = numpy.uint64
 
 Site = collections.namedtuple('Site', 'sid lon lat')
 stored_event_dt = numpy.dtype([
-    ('eid', U64), ('rup_id', U32), ('grp_id', U16),
-    ('ses', U16), ('rlz', U16)])
+    ('eid', U64), ('grp_id', U16), ('ses', U16), ('rlz', U16)])
 
 
 class DuplicatedPoint(Exception):


### PR DESCRIPTION
The rupture IDs can now be extracted from the event IDs, so there is no need to keep that information.
This is another step towards the simplification of the `events` dataset discussed in #4207. 