### PR TITLE
Storing the events fast

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Optimized the saving of the events
   * Removed the `save_ruptures` flag in the job.ini since ruptures must be saved
     always
   * Optimized the rupture generation in case of sampling and changed the

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -362,6 +362,10 @@ class EventBasedCalculator(base.HazardCalculator):
             with self.mon_evs:
                 rlzs_by_gsim = self.rlzs_by_gsim_grp[ruptures[0].grp_id]
                 events = get_events(ruptures, rlzs_by_gsim)
+                num_rlzs = sum(len(rlzs) for rlzs in rlzs_by_gsim.values())
+                eids = numpy.concatenate([rup.get_eids(num_rlzs)
+                                          for rup in ruptures])
+                numpy.testing.assert_equal(eids, events['eid'])
                 self.datastore.extend('events', events)
             return events
         return ()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -149,10 +149,7 @@ def compute_gmfs(ruptures, src_filter, rlzs_by_gsim, param, monitor):
         # use the ruptures sampled in prefiltering
         grp_id = ruptures[0].grp_id
         sitecol = src_filter.sitecol
-    if isinstance(ruptures, RuptureGetter):  # ruptures already saved
-        res.events = get_events(ruptures, rlzs_by_gsim)
-    else:
-        res['ruptures'] = {grp_id: ruptures}
+    res['ruptures'] = {grp_id: ruptures}
     getter = GmfGetter(
         rlzs_by_gsim, ruptures, sitecol,
         param['oqparam'], param['min_iml'])

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -826,7 +826,7 @@ def get_composite_source_model(oqparam, monitor=None, in_memory=True,
         return csm
 
     nr = sum(src.num_ruptures for src in csm.get_sources())
-    logging.info('The complete source model has {:,d} ruptures'.format(nr))
+    logging.info('The composite source model has {:,d} ruptures'.format(nr))
 
     if 'event_based' in oqparam.calculation_mode:
         # initialize the rupture serial numbers before splitting/filtering; in

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -825,6 +825,9 @@ def get_composite_source_model(oqparam, monitor=None, in_memory=True,
     if not in_memory:
         return csm
 
+    nr = sum(src.num_ruptures for src in csm.get_sources())
+    logging.info('The complete source model has {:,d} ruptures'.format(nr))
+
     if 'event_based' in oqparam.calculation_mode:
         # initialize the rupture serial numbers before splitting/filtering; in
         # this way the serials are independent from the site collection

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -606,7 +606,7 @@ class EBRupture(object):
         """
         num_events = self.n_occ if self.samples > 1 else self.n_occ * num_rlzs
         start = TWO32 * U64(self.serial)
-        return numpy.arange(start, start + U64(num_events), dtype=U64)
+        return numpy.arange(num_events, dtype=U64) + start
 
     def get_events_by_ses(self, events, num_ses):
         """

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -605,8 +605,7 @@ class EBRupture(object):
         :returns: an array of event IDs
         """
         num_events = self.n_occ if self.samples > 1 else self.n_occ * num_rlzs
-        start = TWO32 * U64(self.serial)
-        return numpy.arange(num_events, dtype=U64) + start
+        return TWO32 * U64(self.serial) + numpy.arange(num_events, dtype=U64)
 
     def get_events_by_ses(self, events, num_ses):
         """

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -599,6 +599,15 @@ class EBRupture(object):
             rlzs.extend([rlz] * len(eids))
         return numpy.fromiter(zip(all_eids, rlzs), events_dt)
 
+    def get_eids(self, num_rlzs):
+        """
+        :param num_rlzs: the number of realizations for the given group
+        :returns: an array of event IDs
+        """
+        num_events = self.n_occ if self.samples > 1 else self.n_occ * num_rlzs
+        start = TWO32 * U64(self.serial)
+        return numpy.arange(start, start + U64(num_events), dtype=U64)
+
     def get_events_by_ses(self, events, num_ses):
         """
         :returns: a dictionary ses index -> events array


### PR DESCRIPTION
This PR solves the second problem in https://github.com/gem/oq-engine/issues/4207, i.e. the fact that storing the events can dominate the computation time. Here is an example with Ecuador in cluster 1:
```
   ======================== ======== ========= =======
   operation                time_sec memory_mb counts 
   ======================== ======== ========= =======
   EventBasedCalculator.run 810      21,351    1      
   saving events            263      0.0       20,811 
   saving ruptures          72       0.0       20,811 
```
With this branch one gets
```
   EventBasedCalculator.run 601      21,510    1      
   saving ruptures          71       0.0       20,811 
   saving events            16       0.0       20,811 
 ```
i.e. we save over 200 seconds. In continental scale calculations the saved time can be of the order of hours.