### PR TITLE
Changed the default for individual_curves to false

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Changed the default for `individual_curves` to "false", which is the right
+    default for large calculations
   * Optimized the saving of the events
   * Removed the `save_ruptures` flag in the job.ini since ruptures must be saved
     always

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -88,7 +88,7 @@ class OqParam(valid.ParamSet):
     ignore_missing_costs = valid.Param(valid.namelist, [])
     ignore_covs = valid.Param(valid.boolean, False)
     iml_disagg = valid.Param(valid.floatdict, {})  # IMT -> IML
-    individual_curves = valid.Param(valid.boolean, True)
+    individual_curves = valid.Param(valid.boolean, False)
     inputs = valid.Param(dict, {})
     insured_losses = valid.Param(valid.boolean, False)
     intensity_measure_types = valid.Param(valid.intensity_measure_types, None)

--- a/openquake/qa_tests_data/event_based_risk/case_1/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1/job.ini
@@ -53,6 +53,7 @@ truncation_level = 3
 # km
 maximum_distance = 100.0
 return_periods = 30 60 120 240 480 960
+individual_curves = true
 
 [output]
 export_dir = /tmp

--- a/openquake/qa_tests_data/event_based_risk/case_2/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_2/job.ini
@@ -50,3 +50,4 @@ ses_per_logic_tree_path = 20
 truncation_level = 3
 # km
 maximum_distance = 100.0
+individual_curves = true

--- a/openquake/qa_tests_data/event_based_risk/case_2/job_ebrisk.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_2/job_ebrisk.ini
@@ -11,6 +11,7 @@ asset_hazard_distance = 20
 discard_assets = true
 investigation_time = 50.0
 insured_losses = True
+individual_curves = true
 avg_losses = True
 
 [geometry]

--- a/openquake/qa_tests_data/event_based_risk/case_2/job_loss.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_2/job_loss.ini
@@ -46,6 +46,7 @@ region = 81.1 26, 88 26, 88 30, 81.1 30
 
 risk_investigation_time = 50.0
 conditional_loss_poes =
+individual_curves = true
 
 [export]
 export_dir = /tmp

--- a/openquake/qa_tests_data/event_based_risk/case_6c/job_r.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_6c/job_r.ini
@@ -16,6 +16,7 @@ asset_hazard_distance = 20.0
 avg_losses = true
 risk_investigation_time = 1
 asset_correlation = 1.0
+individual_curves = true
 
 [export]
 export_dir = ./

--- a/openquake/qa_tests_data/event_based_risk/case_7a/job_r.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_7a/job_r.ini
@@ -16,6 +16,7 @@ asset_hazard_distance = 20.0
 avg_losses = true
 insured_losses = true
 risk_investigation_time = 1
+individual_curves = true
 
 [export]
 export_dir = ./

--- a/openquake/qa_tests_data/event_based_risk/case_master/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_master/job.ini
@@ -58,6 +58,7 @@ avg_losses = true
 insured_losses = true
 quantile_loss_curves = 0.15, 0.50, 0.85
 conditional_loss_poes = 0.02, 0.10
+individual_curves = true
 
 [export]
 export_dir = /tmp

--- a/openquake/qa_tests_data/event_based_risk/case_miriam/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_miriam/job.ini
@@ -69,3 +69,4 @@ structural_vulnerability_file = vulnerability_model.xml
 # conditional_loss_poes = 0.1, 0.01, 0.02
 avg_losses = true
 ignore_covs = true
+individual_curves = true

--- a/openquake/qa_tests_data/event_based_risk/occupants/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/occupants/job.ini
@@ -50,3 +50,4 @@ insured_losses = False
 risk_investigation_time = 1
 asset_correlation = 0.0
 conditional_loss_poes = 0.01 0.02
+individual_curves = true

--- a/openquake/qa_tests_data/gmf_ebrisk/case_1/job_risk.ini
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_1/job_risk.ini
@@ -10,5 +10,6 @@ gmfs_csv = gmf_scenario.csv
 investigation_time = 50
 region =  15.48 38.30, 15.63 38.30,  15.63 38.01,  15.48 38.01
 insured_losses = true
+individual_curves = true
 export_dir = /tmp/
 


### PR DESCRIPTION
Since in global risk calculations we are only interested in the statistics. In this way we should avoid piling up gigabytes of loss curves in the controller node.