### PR TITLE
Made it possible continental scale event based risk calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Implemented multi-exposure functionality in event based risk
   * Changed the event based calculator to store the ruptures incrementally
     without keeping them all in memory
   * Refactored the UCERF event based calculator to work as much as possible

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -119,12 +119,14 @@ class EBRunner(object):
         if job is None:
             # recompute the hazard and store the checksum
             self.hc_id = run_job(job_ini, log_level, log_file,
-                                 exports, calculation_mode='event_based')
+                                 exports, calculation_mode='event_based',
+                                 exposure_file='')
             logs.dbcmd('add_checksum', self.hc_id, checksum)
         elif not reuse_hazard or not os.path.exists(job.ds_calc_dir + '.hdf5'):
             # recompute and update the job associated to the checksum
             self.hc_id = run_job(job_ini, log_level, log_file,
-                                 exports, calculation_mode='event_based')
+                                 exports, calculation_mode='event_based',
+                                 exposure_file='')
             logs.dbcmd('update_job_checksum', self.hc_id, checksum)
         else:
             # sanity check
@@ -134,20 +136,8 @@ class EBRunner(object):
             logging.info('Reusing job #%d', job.id)
 
     def run_risk(self):
-        t0 = time.time()
-        exposures = self.oqparam.inputs['exposure']
-        for i, exp_file in enumerate(exposures, 1):
-            descr = self.oqparam.description + ' [%s %d of %d]' % (
-                os.path.basename(exp_file)[:-4], i, len(exposures))
-            try:
-                run_job(self.job_ini, self.log_level, self.log_file,
-                        self.exports, hazard_calculation_id=self.hc_id,
-                        exposure_file=exp_file, description=descr)
-            except Exception:  # skip failed computations
-                logging.error(exp_file, exc_info=True)
-        dt = time.time() - t0
-        logging.info('Ran %d risk calculations in %.1f minutes',
-                     len(self.oqparam.inputs['exposure']), dt / 60)
+        run_job(self.job_ini, self.log_level, self.log_file,
+                self.exports, hazard_calculation_id=self.hc_id)
 
 
 @sap.Script

--- a/openquake/commands/prepare_site_model.py
+++ b/openquake/commands/prepare_site_model.py
@@ -97,7 +97,7 @@ def prepare_site_model(exposure_xml, vs30_csv,
         fields.append('vs30measured')
     with performance.Monitor(hdf5.path, hdf5, measuremem=True) as mon:
         mesh, assets_by_site = Exposure.read(
-            exposure_xml, check_dupl=False).get_mesh_assets_by_site()
+            [exposure_xml], check_dupl=False).get_mesh_assets_by_site()
         mon.hdf5['assetcol'] = assetcol = site.SiteCollection.from_points(
             mesh.lons, mesh.lats, req_site_params=req_site_params)
         if grid_spacing:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -396,6 +396,9 @@ def get_site_collection(oqparam):
                     sitecol._set(name, 0)  # the default
                 else:
                     sitecol._set(name, params[name])
+    elif mesh is None:
+        raise InvalidFile('You are missing sites.csv or site_model.csv in %s'
+                          % oqparam.inputs['job_ini'])
     else:  # use the default site params
         sitecol = site.SiteCollection.from_points(
             mesh.lons, mesh.lats, mesh.depths, oqparam, req_site_params)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -944,11 +944,8 @@ def get_exposure(oqparam):
     :returns:
         an :class:`Exposure` instance or a compatible AssetCollection
     """
-    fnames = oqparam.inputs['exposure']
-    if len(fnames) > 1:
-        raise NotImplementedError('Multifile exposure')
     exposure = asset.Exposure.read(
-        fnames[0], oqparam.calculation_mode,
+        oqparam.inputs['exposure'], oqparam.calculation_mode,
         oqparam.region, oqparam.ignore_missing_costs)
     exposure.mesh, exposure.assets_by_site = exposure.get_mesh_assets_by_site()
     return exposure


### PR DESCRIPTION
Thanks to the huge improvements of the last weeks, it is now possible to run a continental scale calculation with a single command producing one hazard calculation and one risk calculation (before we were producing one risk calculation per country). What it is still missing is the ability to aggregate the result by country, plus a performance tuning. Here is a simple example that runs in seconds: https://gitlab.openquake.org/openquake/oq-risk-tests/blob/master/test/event_based_risk/inputs/global/job.ini