### PR TITLE
Extended oq prepare_site_model to the case of multi-exposures

### DIFF
--- a/doc/oq-commands.md
+++ b/doc/oq-commands.md
@@ -250,21 +250,23 @@ algorithm.
 
 ```bash
 $ oq help prepare_site_model
-usage: oq prepare_site_model [-h] [-g 0] [-s 5] [-o sites.csv]
-                             exposure_xml vs30_csv [vs30_csv ...]
+usage: oq prepare_site_model [-h] [-e EXPOSURE_XML [EXPOSURE_XML ...]] [-1]
+                             [-2] [-3] [-g 0] [-s 5] [-o sites.csv]
+                             vs30_csv [vs30_csv ...]
 
-Prepare a sites.csv file from an exposure xml file, a vs30 csv file and a
-grid spacing which can be 0 (meaning no grid). For each asset site or grid
-site the closest vs30 parameter is used. The command can also generate
-(on demand) the additional fields z1pt0, z2pt5 and vs30measured which may
-be needed by your hazard model, depending on the required GSIMs.
+Prepare a sites.csv file from an exposure xml file, a vs30 csv file and a grid
+spacing which can be 0 (meaning no grid). For each asset site or grid site the
+closest vs30 parameter is used. The command can also generate (on demand) the
+additional fields z1pt0, z2pt5 and vs30measured which may be needed by your
+hazard model, depending on the required GSIMs.
 
 positional arguments:
-  exposure_xml          exposure in XML format
   vs30_csv              files with lon,lat,vs30 and no header
 
 optional arguments:
   -h, --help            show this help message and exit
+  -e EXPOSURE_XML [EXPOSURE_XML ...], --exposure-xml EXPOSURE_XML [EXPOSURE_XML ...]
+                        exposure(s) in XML format
   -1, --z1pt0           build the z1pt0
   -2, --z2pt5           build the z2pt5
   -3, --vs30measured    build the vs30measured

--- a/openquake/commands/prepare_site_model.py
+++ b/openquake/commands/prepare_site_model.py
@@ -97,7 +97,7 @@ def prepare_site_model(exposure_xml, vs30_csv,
         fields.append('vs30measured')
     with performance.Monitor(hdf5.path, hdf5, measuremem=True) as mon:
         mesh, assets_by_site = Exposure.read(
-            [exposure_xml], check_dupl=False).get_mesh_assets_by_site()
+            exposure_xml, check_dupl=False).get_mesh_assets_by_site()
         mon.hdf5['assetcol'] = assetcol = site.SiteCollection.from_points(
             mesh.lons, mesh.lats, req_site_params=req_site_params)
         if grid_spacing:
@@ -137,7 +137,7 @@ def prepare_site_model(exposure_xml, vs30_csv,
     return sitecol
 
 
-prepare_site_model.arg('exposure_xml', 'exposure in XML format')
+prepare_site_model.opt('exposure_xml', 'exposure(s) in XML format', nargs='+')
 prepare_site_model.arg('vs30_csv', 'files with lon,lat,vs30 and no header',
                        nargs='+')
 prepare_site_model.flg('z1pt0', 'build the z1pt0', '-1')

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -439,10 +439,10 @@ class PrepareSiteModelTestCase(unittest.TestCase):
         inputdir = os.path.dirname(case_16.__file__)
         output = gettemp(suffix='.csv')
         grid_spacing = 50
-        exposure_csv = os.path.join(inputdir, 'exposure.xml')
+        exposure_xml = os.path.join(inputdir, 'exposure.xml')
         vs30_csv = os.path.join(inputdir, 'vs30.csv')
         sitecol = prepare_site_model.func(
-            exposure_csv, [vs30_csv], True, True, True,
+            [exposure_xml], [vs30_csv], True, True, True,
             grid_spacing, 5, output)
         sm = read_csv(output)
         self.assertEqual(sm['vs30measured'].sum(), 0)
@@ -450,6 +450,6 @@ class PrepareSiteModelTestCase(unittest.TestCase):
         self.assertEqual(len(sitecol), len(sm))
 
         # test no grid
-        sc = prepare_site_model.func(exposure_csv, [vs30_csv],
+        sc = prepare_site_model.func([exposure_xml], [vs30_csv],
                                      True, True, False, 0, 5, output)
         self.assertEqual(len(sc), 148)  # 148 sites within 5 km from the params


### PR DESCRIPTION
The syntax of the command has changed, now you must put a `-e` in front of the exposures.
```
$ oq prepare_site_model Vs30/usgs_vs30_data/*.csv -e Exposure/Exposure_*.xml -g 10
```