### PR TITLE
Fixed the eid -> rlz associations

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -121,14 +121,14 @@ def get_mean_curves(dstore):
 # ########################################################################## #
 
 
-def compute_gmfs(rupgetter, sitecol, rlzs_by_gsim, param, monitor):
+def compute_gmfs(rupgetter, sitecol, param, monitor):
     """
     Compute GMFs and optionally hazard curves
     """
     with monitor('getting ruptures'):
         ebruptures = list(rupgetter)
     getter = GmfGetter(
-        rlzs_by_gsim, ebruptures, sitecol,
+        rupgetter.rlzs_by_gsim, ebruptures, sitecol,
         param['oqparam'], param['min_iml'])
     return getter.compute_gmfs_curves(monitor)
 
@@ -198,11 +198,11 @@ class EventBasedCalculator(base.HazardCalculator):
             par = param.copy()
             par['samples'] = self.samples_by_grp[grp_id]
             rup_array = rups[start: start + nr]
-            ruptures = RuptureGetter(hdf5cache, code2cls, rup_array,
-                                     self.grp_trt[grp_id], par['samples'])
-            if ruptures:
-                yield ruptures, self.sitecol, rlzs_by_gsim, par
-                start += nr
+            rgetter = RuptureGetter(hdf5cache, code2cls, rup_array,
+                                    self.grp_trt[grp_id], par['samples'],
+                                    rlzs_by_gsim)
+            yield rgetter, self.sitecol, par
+            start += nr
         if self.datastore.parent:
             self.datastore.parent.close()
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -17,6 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import collections
 import itertools
+import mock
 import numpy
 from openquake.baselib import hdf5, datastore
 from openquake.baselib.general import AccumDict, group_array
@@ -432,10 +433,12 @@ def get_ruptures_by_grp(dstore, slc=slice(None)):
     csm_info = dstore['csm_info']
     grp_trt = csm_info.grp_by("trt")
     samples = csm_info.get_samples_by_grp()
+    rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rupdict = group_array(dstore['ruptures'][slc], 'grp_id')
     code2cls = get_code2cls(dstore.get_attrs('ruptures'))
     return {grp_id: RuptureGetter(
-        dstore.hdf5path, code2cls, rup_array, grp_trt[grp_id], samples[grp_id])
+        dstore.hdf5path, code2cls, rup_array, grp_trt[grp_id],
+        samples[grp_id], rlzs_by_gsim[grp_id])
             for grp_id, rup_array in rupdict.items()}
 
 
@@ -470,13 +473,28 @@ class RuptureGetter(object):
     :param rup_array:
         an array of rupture parameters with homogeneous grp_id
     """
-    def __init__(self, hdf5path, code2cls, rup_array, trt, samples):
+    def __init__(self, hdf5path, code2cls, rup_array, trt, samples,
+                 rlzs_by_gsim):
         self.hdf5path = hdf5path
         self.code2cls = code2cls
         self.rup_array = rup_array
         self.trt = trt
         self.samples = samples
+        self.rlzs_by_gsim = rlzs_by_gsim
         [self.grp_id] = numpy.unique(rup_array['grp_id'])
+
+    def get_eid_rlz(self):
+        """
+        :returns: a composite array with the associations eid->rlz
+        """
+        eid_rlz = []
+        for rup in self.rup_array:
+            ebr = EBRupture(mock.Mock(serial=rup['serial']), rup['srcidx'],
+                            self.grp_id, (), rup['n_occ'], self.samples)
+            for rlz, eids in ebr.get_eids_by_rlz(self.rlzs_by_gsim).items():
+                for eid in eids:
+                    eid_rlz.append((eid, rlz))
+        return numpy.array(eid_rlz, [('eid', U64), ('rlz', U16)])
 
     def __iter__(self):
         with datastore.read(self.hdf5path) as dstore:

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -32,10 +32,11 @@ class UcerfTestCase(CalculatorTestCase):
         self.run_calc(ucerf.__file__, 'job.ini')
         gmv_uc = view('global_gmfs', self.calc.datastore)
         # check the distribution of the events
-        self.assertEventsByRlz([58, 1, 1, 1, 3, 4, 1, 1, 2, 2, 4, 3, 2, 2, 3,
-                                3, 3, 3, 1, 1, 1, 1, 3, 3, 1, 1, 1, 1, 1, 1,
-                                1, 1, 2, 2, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 3,
-                                3, 2, 2])
+        self.assertEventsByRlz([2, 2, 2, 2, 6, 6, 2, 2, 2, 2, 6, 6, 2, 2, 3,
+                                3, 6, 6, 1, 1, 1, 1, 6, 6, 2, 2, 3, 3, 2, 2,
+                                2, 2, 3, 3, 2, 2, 3, 3, 3, 3, 2, 2, 3, 3,
+                                3, 3, 3, 3])
+
         # NB: there are no 58 events for the first realization, it is a bug,
         # but it will be fixed in the future
 
@@ -67,7 +68,7 @@ class UcerfTestCase(CalculatorTestCase):
         self.run_calc(ucerf.__file__, 'job_ebh.ini')
 
         # check the distribution of the events
-        self.assertEventsByRlz([35, 19])
+        self.assertEventsByRlz([29, 25])
         # NB: there are no 35 events for the first realization, it is a bug,
         # but it will be fixed in the future
 

--- a/openquake/calculators/tests/ucerf_test.py
+++ b/openquake/calculators/tests/ucerf_test.py
@@ -37,9 +37,6 @@ class UcerfTestCase(CalculatorTestCase):
                                 2, 2, 3, 3, 2, 2, 3, 3, 3, 3, 2, 2, 3, 3,
                                 3, 3, 3, 3])
 
-        # NB: there are no 58 events for the first realization, it is a bug,
-        # but it will be fixed in the future
-
         [fname] = export(('ruptures', 'csv'), self.calc.datastore)
         # check that we get the expected number of ruptures
         with open(fname) as f:
@@ -69,8 +66,6 @@ class UcerfTestCase(CalculatorTestCase):
 
         # check the distribution of the events
         self.assertEventsByRlz([29, 25])
-        # NB: there are no 35 events for the first realization, it is a bug,
-        # but it will be fixed in the future
 
         # check the GMFs
         gmdata = self.calc.datastore['gmdata'].value


### PR DESCRIPTION
Now they are performed in the controller node while sending the ruptures and it is fast enough (100,000 ruptures per minute on Murray's machine). In the future this part could be parallelized if the need should arise.