### PR TITLE
Stored more information about the discarded assets

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -519,8 +519,9 @@ class HazardCalculator(BaseCalculator):
                     self.oqparam, haz_sitecol, self.riskmodel.loss_types))
             if len(discarded):
                 self.datastore['discarded'] = discarded
-                msg = ('%d assets were discarded; use '
-                       '`oq plot_assets` to see them' % len(discarded))
+                msg = ('%d assets were discarded; use `oq show discarded` to'
+                       'show them and `oq plot_assets` to plot them' %
+                       len(discarded))
                 if hasattr(self, 'rup') or self.oqparam.discard_assets:
                     # just log a warning in case of scenario from rupture
                     # or when discard_assets is set to True

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -519,7 +519,7 @@ class HazardCalculator(BaseCalculator):
                     self.oqparam, haz_sitecol, self.riskmodel.loss_types))
             if len(discarded):
                 self.datastore['discarded'] = discarded
-                msg = ('%d sites with assets were discarded; use '
+                msg = ('%d assets were discarded; use '
                        '`oq plot_assets` to see them' % len(discarded))
                 if hasattr(self, 'rup') or self.oqparam.discard_assets:
                     # just log a warning in case of scenario from rupture

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+import numpy
 import shapely.wkt
 from openquake.baselib import sap, datastore
 from openquake.hazardlib.geo.utils import cross_idl
@@ -55,7 +56,7 @@ def plot_assets(calc_id=-1):
     p.scatter(assetcol['lon'], assetcol['lat'], marker='.', color='green')
     p.scatter(sitecol.lons, sitecol.lats, marker='+', color='black')
     if 'discarded' in dstore:
-        disc = dstore['discarded']
+        disc = numpy.unique(dstore['discarded'].value[['lon', 'lat']])
         p.scatter(disc['lon'], disc['lat'], marker='x', color='red')
     p.show()
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1008,7 +1008,7 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, cost_types=()):
         tot_assets = sum(len(assets) for assets in exposure.assets_by_site)
         sitecol, assets_by, discarded = geo.utils.assoc(
             exposure.assets_by_site, haz_sitecol,
-            oqparam.asset_hazard_distance, 'filter')
+            oqparam.asset_hazard_distance, 'filter', exposure.asset_refs)
         assets_by_site = [[] for _ in sitecol.complete.sids]
         num_assets = 0
         for sid, assets in zip(sitecol.sids, assets_by):

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -144,7 +144,8 @@ class _GeographicObjects(object):
         """
         assert mode in 'strict filter', mode
         self.objects.filtered  # self.objects must be a SiteCollection
-        asset_dt = numpy.dtype([('asset', vstr), ('lon', F32), ('lat', F32)])
+        asset_dt = numpy.dtype(
+            [('asset_ref', vstr), ('lon', F32), ('lat', F32)])
         assets_by_sid = collections.defaultdict(list)
         discarded = []
         for assets in assets_by_site:


### PR DESCRIPTION
Instead of only the coordinates of the discarded assets, now we store also the asset_refs as found in the exposure. For instance, in an example for the Vancouver region I get
```bash
$ oq show discarded
asset_ref,lon,lat
59025998-W2-LC,-128.15410,52.18151
59025977-W1-LC,-128.15030,52.16366
59025978-MH-MC,-128.14639,52.16172
59025978-MH-PC,-128.14639,52.16172
59025978-MH-LC,-128.14639,52.16172
```
and `oq plot_assets` produces the following plot:
![vancouver](https://user-images.githubusercontent.com/2463856/49231822-03229280-f3f3-11e8-9860-77708c234174.png)

The discarded assets (red crosses) are in the Vancouver Island. The site model is missing there so the solution is to get a better site model or to increase the `asset_hazard_distance`.