### PR TITLE
Improved discard assets message

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -519,17 +519,19 @@ class HazardCalculator(BaseCalculator):
                     self.oqparam, haz_sitecol, self.riskmodel.loss_types))
             if len(discarded):
                 self.datastore['discarded'] = discarded
-                msg = ('%d assets were discarded; use `oq show discarded` to'
-                       'show them and `oq plot_assets` to plot them' %
-                       len(discarded))
-                if hasattr(self, 'rup') or self.oqparam.discard_assets:
-                    # just log a warning in case of scenario from rupture
-                    # or when discard_assets is set to True
-                    logging.warn(msg)
-                else:  # raise an error
+                if hasattr(self, 'rup'):
+                    # this is normal for the case of scenario from rupture
+                    logging.info('%d assets were discarded because too far '
+                                 'from the rupture; use `oq show discarded` '
+                                 'to show them and `oq plot_assets` to plot '
+                                 'them' % len(discarded))
+                elif not self.oqparam.discard_assets:  # raise an error
                     self.datastore['sitecol'] = self.sitecol
                     self.datastore['assetcol'] = self.assetcol
-                    raise RuntimeError(msg)
+                    raise RuntimeError(
+                        '%d assets were discarded; use `oq show discarded` to'
+                        'show them and `oq plot_assets` to plot them' %
+                        len(discarded))
 
         # reduce the riskmodel to the relevant taxonomies
         taxonomies = set(taxo for taxo in self.assetcol.tagcol.taxonomy


### PR DESCRIPTION
See https://github.com/gem/oq-engine/issues/4259. It is normal to discard assets in scenario calculation, because of the maximum_distance, so the warning has been reduce to an info and the message has been made more clear.
