### PR TITLE
Removed all OrderedDicts

### DIFF
--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -18,7 +18,6 @@
 
 import os
 import sys
-import collections
 import configparser
 from openquake.baselib.general import git_suffix
 
@@ -27,7 +26,7 @@ __version__ = '3.3.0'
 __version__ += git_suffix(__file__)
 
 
-class DotDict(collections.OrderedDict):
+class DotDict(dict):
     """
     A string-valued dictionary that can be accessed with the "." notation
     """

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -500,7 +500,7 @@ def search_module(module, syspath=sys.path):
     return filepath
 
 
-class CallableDict(collections.OrderedDict):
+class CallableDict(dict):
     r"""
     A callable object built on top of a dictionary of functions, used
     as a smart registry or as a poor man generic function dispatching
@@ -805,15 +805,14 @@ def groupby(objects, key, reducegroup=list):
     :param objects: a sequence of objects with a key value
     :param key: the key function to extract the key value
     :param reducegroup: the function to apply to each group
-    :returns: an OrderedDict {key value: map(reducegroup, group)}
+    :returns: a dict {key value: map(reducegroup, group)}
 
     >>> groupby(['A1', 'A2', 'B1', 'B2', 'B3'], lambda x: x[0],
     ...         lambda group: ''.join(x[1] for x in group))
-    OrderedDict([('A', '12'), ('B', '123')])
+    {'A': '12', 'B': '123'}
     """
     kgroups = itertools.groupby(sorted(objects, key=key), key)
-    return collections.OrderedDict((k, reducegroup(group))
-                                   for k, group in kgroups)
+    return {k: reducegroup(group) for k, group in kgroups}
 
 
 def groupby2(records, kfield, vfield):
@@ -850,7 +849,7 @@ def _reducerecords(group):
 
 def group_array(array, *kfields):
     """
-    Convert an array into an OrderedDict kfields -> array
+    Convert an array into a dict kfields -> array
     """
     return groupby(array, operator.itemgetter(*kfields), _reducerecords)
 

--- a/openquake/baselib/sap.py
+++ b/openquake/baselib/sap.py
@@ -51,7 +51,6 @@ Parsers can be composed too.
 import sys
 import inspect
 import argparse
-from collections import OrderedDict
 
 
 NODEFAULT = object()
@@ -100,7 +99,7 @@ class Script(object):
         defaults = defaults or ()
         nodefaults = len(args) - len(defaults)
         alldefaults = (NODEFAULT,) * nodefaults + defaults
-        self.argdict = OrderedDict(zip(args, alldefaults))
+        self.argdict = dict(zip(args, alldefaults))
         self.description = descr = func.__doc__ if func.__doc__ else None
         self.parentparser = get_parentparser(parentparser, descr, help)
         self.names = []

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -848,7 +848,7 @@ def export_disagg_csv(ekey, dstore):
             poes = attrs['poe_agg']
         imt = from_string(attrs['imt'])
         lon, lat = attrs['location']
-        metadata = collections.OrderedDict()
+        metadata = {}
         # Loads "disaggMatrices" nodes
         if hasattr(rlz, 'sm_lt_path'):
             metadata['smlt_path'] = '_'.join(rlz.sm_lt_path)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -67,7 +67,7 @@ def extract_(dstore, dspath):
         return obj
 
 
-class Extract(collections.OrderedDict):
+class Extract(dict):
     """
     A callable dictionary of functions with a single instance called
     `extract`. Then `extract(dstore, fullkey)` dispatches to the function

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -24,8 +24,7 @@ from openquake.baselib.general import AccumDict, group_array
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib import calc, geo, probability_map, stats
 from openquake.hazardlib.geo.mesh import Mesh, RectangularMesh
-from openquake.hazardlib.source.rupture import (
-    BaseRupture, EBRupture, classes, TWO32)
+from openquake.hazardlib.source.rupture import BaseRupture, EBRupture, classes
 from openquake.risklib.riskinput import rsi2str
 from openquake.commonlib.calc import _gmvs_to_haz_curve
 
@@ -77,7 +76,7 @@ class PmapGetter(object):
         oq = self.dstore['oqparam']
         self.imtls = oq.imtls
         self.poes = oq.poes
-        self.data = collections.OrderedDict()
+        self.data = {}
         try:
             hcurves = self.get_hcurves(self.imtls)  # shape (R, N)
         except IndexError:  # no data
@@ -115,7 +114,7 @@ class PmapGetter(object):
     def get_hazard(self, gsim=None):
         """
         :param gsim: ignored
-        :returns: an OrderedDict rlzi -> datadict
+        :returns: an dict rlzi -> datadict
         """
         return self.data
 
@@ -226,7 +225,7 @@ class GmfDataGetter(collections.Mapping):
             self.imts = self.dstore['gmf_data/imts'].value.split()
         except KeyError:  # engine < 3.3
             self.imts = list(self.dstore['oqparam'].imtls)
-        self.data = collections.OrderedDict()
+        self.data = {}
         for sid in self.sids:
             self.data[sid] = data = self[sid]
             if not data:  # no GMVs, return 0, counted in no_damage
@@ -240,7 +239,7 @@ class GmfDataGetter(collections.Mapping):
     def get_hazard(self, gsim=None):
         """
         :param gsim: ignored
-        :returns: an OrderedDict rlzi -> datadict
+        :returns: an dict rlzi -> datadict
         """
         return self.data
 

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-import collections
 import logging
 import numpy
 
@@ -76,7 +75,7 @@ class ScenarioCalculator(base.HazardCalculator):
         """
         Compute the GMFs and return a dictionary gsim -> array(N, E, I)
         """
-        self.gmfa = collections.OrderedDict()
+        self.gmfa = {}
         if 'rupture_model' not in self.oqparam.inputs:
             return self.gmfa
         with self.monitor('computing gmfs'):

--- a/openquake/commonlib/hazard_writers.py
+++ b/openquake/commonlib/hazard_writers.py
@@ -20,8 +20,6 @@
 Classes for serializing various NRML XML artifacts.
 """
 import operator
-from collections import OrderedDict
-
 
 import numpy
 
@@ -36,7 +34,7 @@ SM_TREE_PATH = 'sourceModelTreePath'
 GSIM_TREE_PATH = 'gsimTreePath'
 
 #: Maps XML writer constructor keywords to XML attribute names
-_ATTR_MAP = OrderedDict([
+_ATTR_MAP = dict([
     ('statistics', 'statistics'),
     ('quantile_value', 'quantileValue'),
     ('smlt_path', 'sourceModelTreePath'),
@@ -615,9 +613,7 @@ class DisaggXMLWriter(object):
 
     #: Maps metadata keywords to XML attribute names for bin edge information
     #: passed to the constructor.
-    #: The dict here is an `OrderedDict` so as to give consistent ordering of
-    #: result attributes.
-    BIN_EDGE_ATTR_MAP = OrderedDict([
+    BIN_EDGE_ATTR_MAP = dict([
         ('mag_bin_edges', 'magBinEdges'),
         ('dist_bin_edges', 'distBinEdges'),
         ('lon_bin_edges', 'lonBinEdges'),

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1447,7 +1447,7 @@ class GsimLogicTree(object):
                     uncertainty = branch.uncertaintyModel
                     if uncertainty.text is None:  # expect MultiGMPE
                         with context(self.fname, uncertainty):
-                            gsimdict = collections.OrderedDict()
+                            gsimdict = {}
                             imts = []
                             for nod in uncertainty.getnodes('gsimByImt'):
                                 kw = nod.attrib.copy()

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -361,7 +361,7 @@ class OqParam(valid.ParamSet):
     @property
     def imtls(self):
         """
-        Returns an OrderedDict with the risk intensity measure types and
+        Returns a DictArray with the risk intensity measure types and
         levels, if given, or the hazard ones.
         """
         imtls = getattr(self, 'hazard_imtls', None) or self.risk_imtls

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -478,7 +478,7 @@ def get_rlzs_by_gsim(oqparam):
     """
     cinfo = source.CompositionInfo.fake(get_gsim_lt(oqparam))
     ra = cinfo.get_rlzs_assoc()
-    dic = collections.OrderedDict()
+    dic = {}
     for rlzi, gsim_by_trt in enumerate(ra.gsim_by_trt):
         dic[gsim_by_trt['*']] = [rlzi]
     return dic
@@ -1141,7 +1141,7 @@ def get_pmap_from_nrml(oqparam, fname):
         site mesh, curve array
     """
     hcurves_by_imt = {}
-    oqparam.hazard_imtls = imtls = collections.OrderedDict()
+    oqparam.hazard_imtls = imtls = {}
     for hcurves in nrml.read(fname):
         imt = hcurves['IMT']
         oqparam.investigation_time = hcurves['investigationTime']

--- a/openquake/commonlib/shapefileparser.py
+++ b/openquake/commonlib/shapefileparser.py
@@ -23,7 +23,6 @@ import os
 import numpy
 import operator
 import shapefile
-from collections import OrderedDict
 from openquake.baselib.general import groupby
 from openquake.hazardlib import geo
 from openquake.hazardlib.geo.surface import SimpleFaultSurface
@@ -113,7 +112,7 @@ def expand_src_param(values, shp_params):
         return dict([(key, None) for key, _ in shp_params])
     else:
         num_values = len(values)
-        return OrderedDict(
+        return dict(
             [(key, float(values[i]) if i < num_values else None)
                 for i, (key, _) in enumerate(shp_params)])
 
@@ -141,7 +140,7 @@ def extract_source_params(src):
                 data.append((param, None))
         else:
             data.append((param, None))
-    return OrderedDict(data)
+    return dict(data)
 
 
 def parse_area_geometry(node):
@@ -264,7 +263,7 @@ def get_attrs_dict(attrs, params):
             data.append((param, attrs[key]))
         else:
             data.append((param, None))
-    return OrderedDict(data)
+    return dict(data)
 
 
 def extract_geometry_params(src):
@@ -315,11 +314,9 @@ def extract_geometry_params(src):
         if dip and counter:
             dip /= counter
 
-        return OrderedDict([("usd", upper_depth),
-                            ("lsd", lower_depth),
-                            ("dip", dip)])
+        return dict([("usd", upper_depth), ("lsd", lower_depth), ("dip", dip)])
     else:
-        return OrderedDict()
+        return {}
 
 
 def extract_mfd_params(src):
@@ -351,15 +348,15 @@ def extract_mfd_params(src):
         if n_r > MAX_RATES:
             raise ValueError("Number of rates in source %s too large "
                              "to be placed into shapefile" % src.tag)
-        rate_dict = OrderedDict([(key, rates[i] if i < n_r else None)
-                                 for i, (key, _) in enumerate(RATE_PARAMS)])
+        rate_dict = dict([(key, rates[i] if i < n_r else None)
+                          for i, (key, _) in enumerate(RATE_PARAMS)])
     elif "YoungsCoppersmithMFD" in mfd_node.tag:
-        rate_dict = OrderedDict([(key, mfd_node.attrib['characteristicRate'])
-                                 for i, (key, _) in enumerate(RATE_PARAMS)])
+        rate_dict = dict([(key, mfd_node.attrib['characteristicRate'])
+                          for i, (key, _) in enumerate(RATE_PARAMS)])
     else:
-        rate_dict = OrderedDict([(key, None)
-                                 for i, (key, _) in enumerate(RATE_PARAMS)])
-    return OrderedDict(data), rate_dict
+        rate_dict = dict([(key, None)
+                          for i, (key, _) in enumerate(RATE_PARAMS)])
+    return dict(data), rate_dict
 
 
 def extract_source_nodal_planes(src):
@@ -617,7 +614,7 @@ def record_to_dict(record, fields):
         value = attr.strip()
         if value:
             data.append((name, value))
-    return OrderedDict(data)
+    return dict(data)
 
 
 def area_geometry_from_shp(shape, record):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -344,7 +344,7 @@ class CompositionInfo(object):
         return rlzs
 
     def __repr__(self):
-        info_by_model = collections.OrderedDict()
+        info_by_model = {}
         for sm in self.source_models:
             info_by_model[sm.path] = (
                 '_'.join(map(decode, sm.path)),

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -24,7 +24,6 @@ extracting a specific PMF from the result of :func:`disaggregation`.
 import sys
 import warnings
 import operator
-import collections
 import numpy
 import scipy.stats
 
@@ -499,7 +498,7 @@ def mag_lon_lat_pmf(matrix):
 
 # this dictionary is useful to extract a fixed set of
 # submatrices from the full disaggregation matrix
-pmf_map = collections.OrderedDict([
+pmf_map = dict([
     ('Mag', mag_pmf),
     ('Dist', dist_pmf),
     ('TRT', trt_pmf),

--- a/openquake/hazardlib/gsim/__init__.py
+++ b/openquake/hazardlib/gsim/__init__.py
@@ -21,7 +21,6 @@ Package :mod:`openquake.hazardlib.gsim` contains base and specific
 implementations of ground shaking intensity models. See
 :mod:`openquake.hazardlib.gsim.base`.
 """
-from collections import OrderedDict
 from openquake.baselib.general import import_all
 from openquake.hazardlib.gsim.base import registry
 
@@ -33,4 +32,4 @@ def get_available_gsims():
     Return an ordered dictionary with the available GSIM classes, keyed
     by class name.
     '''
-    return OrderedDict(sorted(registry.items()))
+    return dict(sorted(registry.items()))

--- a/openquake/hazardlib/scalerel/__init__.py
+++ b/openquake/hazardlib/scalerel/__init__.py
@@ -23,11 +23,8 @@ implementations of magnitude-area and area-magnitude scaling relationships.
 import os
 import inspect
 import importlib
-from collections import OrderedDict
-from openquake.hazardlib.scalerel.base import BaseMSR, BaseASR, BaseMSRSigma, \
-BaseASRSigma
-
-
+from openquake.hazardlib.scalerel.base import (
+    BaseMSR, BaseASR, BaseMSRSigma, BaseASRSigma)
 from openquake.hazardlib.scalerel.ceus2011 import CEUS2011
 from openquake.hazardlib.scalerel.peer import PeerMSR
 from openquake.hazardlib.scalerel.point import PointMSR
@@ -58,7 +55,7 @@ def _get_available_class(base_class):
                         and cls != base_class \
                         and not inspect.isabstract(cls):
                     gsims[cls.__name__] = cls
-    return OrderedDict((k, gsims[k]) for k in sorted(gsims))
+    return dict((k, gsims[k]) for k in sorted(gsims))
 
 
 def get_available_magnitude_scalerel():
@@ -67,6 +64,7 @@ def get_available_magnitude_scalerel():
     classes, keyed by class name.
     '''
     return _get_available_class(BaseMSR)
+
 
 def get_available_sigma_magnitude_scalerel():
     '''

--- a/openquake/hmtk/faults/mfd/__init__.py
+++ b/openquake/hmtk/faults/mfd/__init__.py
@@ -19,7 +19,6 @@
 import os
 import inspect
 import importlib
-from collections import OrderedDict
 from openquake.hmtk.faults.mfd.base import BaseMFDfromSlip
 
 
@@ -37,4 +36,4 @@ def get_available_mfds():
             for cls in mod.__dict__.values():
                 if inspect.isclass(cls) and issubclass(cls, BaseMFDfromSlip):
                     mfds[cls.__name__] = cls
-    return OrderedDict((k, mfds[k]) for k in sorted(mfds))
+    return dict((k, mfds[k]) for k in sorted(mfds))

--- a/openquake/hmtk/models.py
+++ b/openquake/hmtk/models.py
@@ -17,8 +17,6 @@
 are intended to be produced by NRML XML parsers and consumed by NRML XML
 serializers.
 """
-
-from collections import OrderedDict
 from collections import namedtuple
 
 
@@ -54,9 +52,9 @@ class SeismicSource(object):
     @property
     def attrib(self):
         """
-        General XML element attributes for a seismic source, as an OrderedDict.
+        General XML element attributes for a seismic source, as a dict.
         """
-        return OrderedDict([
+        return dict([
             ('id', str(self.id)),
             ('name', str(self.name)),
             ('tectonicRegion', str(self.trt)),
@@ -294,9 +292,9 @@ class IncrementalMFD(object):
     @property
     def attrib(self):
         """
-        An `OrderedDict` of XML element attributes for this MFD.
+        A dict of XML element attributes for this MFD.
         """
-        return OrderedDict([
+        return dict([
             ('minMag', str(self.min_mag)),
             ('binWidth', str(self.bin_width)),
         ])
@@ -326,9 +324,9 @@ class TGRMFD(object):
     @property
     def attrib(self):
         """
-        An `OrderedDict` of XML element attributes for this MFD.
+        An dict of XML element attributes for this MFD.
         """
-        return OrderedDict([
+        return dict([
             ('aValue', str(self.a_val)),
             ('bValue', str(self.b_val)),
             ('minMag', str(self.min_mag)),
@@ -360,9 +358,9 @@ class NodalPlane(object):
     @property
     def attrib(self):
         """
-        An `OrderedDict` of XML element attributes for this NodalPlane.
+        A dict of XML element attributes for this NodalPlane.
         """
-        return OrderedDict([
+        return dict([
             ('probability', str(self.probability)),
             ('strike', str(self.strike)),
             ('dip', str(self.dip)),
@@ -388,9 +386,9 @@ class HypocentralDepth(object):
     @property
     def attrib(self):
         """
-        An `OrderedDict` of XML element attribute for this HypocentralDepth.
+        An dict of XML element attribute for this HypocentralDepth.
         """
-        return OrderedDict([
+        return dict([
             ('probability', str(self.probability)),
             ('depth', str(self.depth)),
         ])

--- a/openquake/hmtk/parsers/strain/strain_csv_parser.py
+++ b/openquake/hmtk/parsers/strain/strain_csv_parser.py
@@ -53,7 +53,6 @@ to csv format.
 
 import csv
 import numpy as np
-from collections import OrderedDict
 from openquake.hmtk.strain.geodetic_strain import GeodeticStrain
 
 STRAIN_VARIABLES = ['exx', 'eyy', 'exy', 'var_exx', 'var_eyy', 'var_exy',
@@ -104,8 +103,7 @@ class ReadStrainCsv(object):
 
         datafile = open(self.filename, 'rU')
         reader = csv.DictReader(datafile)
-        self.strain.data = OrderedDict([(name, [])
-                                        for name in reader.fieldnames])
+        self.strain.data = dict([(name, []) for name in reader.fieldnames])
         for row in reader:
             for name in row.keys():
                 if 'region' in name.lower():

--- a/openquake/hmtk/registry.py
+++ b/openquake/hmtk/registry.py
@@ -43,12 +43,11 @@
 # liability for use of the software.
 
 import sys
-import collections
 import functools
 from decorator import decorator
 
 
-class CatalogueFunctionRegistry(collections.OrderedDict):
+class CatalogueFunctionRegistry(dict):
     """
     A collection of methods/functions working on catalogues.
 

--- a/openquake/hmtk/seismicity/selector.py
+++ b/openquake/hmtk/seismicity/selector.py
@@ -52,7 +52,6 @@ and earthquake catalogue
 '''
 
 import numpy as np
-from collections import OrderedDict
 from datetime import datetime
 from copy import deepcopy
 from openquake.hazardlib.geo.point import Point
@@ -426,7 +425,7 @@ class CatalogueSelector(object):
             cluster_cat = deepcopy(self.catalogue)
             cluster_cat.select_catalogue_events(idx)
             cluster_set.append((clid, cluster_cat))
-        return OrderedDict(cluster_set)
+        return dict(cluster_set)
 
     def within_bounding_box(self, limits):
         """
@@ -444,6 +443,7 @@ class CatalogueSelector(object):
         is_valid = np.logical_and(
             self.catalogue.data['longitude'] >= limits[0],
             np.logical_and(self.catalogue.data['longitude'] <= limits[2],
-                           np.logical_and(self.catalogue.data['latitude'] >= limits[1],
-                                          self.catalogue.data['latitude'] <= limits[3])))
+                           np.logical_and(
+                               self.catalogue.data['latitude'] >= limits[1],
+                               self.catalogue.data['latitude'] <= limits[3])))
         return self.select_catalogue(is_valid)

--- a/openquake/hmtk/seismicity/smoothing/smoothed_seismicity.py
+++ b/openquake/hmtk/seismicity/smoothing/smoothed_seismicity.py
@@ -51,7 +51,6 @@ Module :mod: openquake.hmtk.seismicity.smoothing.smoothed_seismicity implements 
 a general class for implementing seismicity smoothing algorithms
 '''
 import csv
-import collections
 
 from math import fabs, log
 import numpy as np
@@ -63,7 +62,7 @@ from openquake.hmtk.seismicity.smoothing.kernels.isotropic_gaussian import \
 from openquake.hmtk.registry import CatalogueFunctionRegistry
 
 
-class Grid(collections.OrderedDict):
+class Grid(dict):
     @classmethod
     def make_from_list(cls, grid_limits):
         new = cls()

--- a/openquake/hmtk/tests/faults/mfd/test_available_mfds.py
+++ b/openquake/hmtk/tests/faults/mfd/test_available_mfds.py
@@ -46,14 +46,13 @@
 # liability for use of the software.
 
 import unittest
-from collections import OrderedDict
 from openquake.hmtk.faults import mfd
 
 
 class TestAvailableMFDs(unittest.TestCase):
     '''
     Simple test of the module openquake.hmtk.faults.get_available_mfds(), which should
-    return an OrderedDict containing instances of all the available mfd classes
+    return a dict containing instances of all the available mfd classes
     '''
 
     def setUp(self):
@@ -71,7 +70,7 @@ class TestAvailableMFDs(unittest.TestCase):
         Characteristic
         '''
         self.mfds = mfd.get_available_mfds()
-        expected_dict = OrderedDict(
+        expected_dict = dict(
             [('AndersonLucoArbitrary',
               mfd.anderson_luco_arbitrary.AndersonLucoArbitrary),
              ('AndersonLucoAreaMmax',

--- a/openquake/hmtk/tests/parsers/strain/test_csv_parser.py
+++ b/openquake/hmtk/tests/parsers/strain/test_csv_parser.py
@@ -46,14 +46,13 @@
 # liability for use of the software.
 
 '''
-Test suite for openquake.hmtk.parsers.strain.strain_csv_parser - the reader and writer of
-the strain model in csv format
+Test suite for openquake.hmtk.parsers.strain.strain_csv_parser -
+the reader and writer of the strain model in csv format
 '''
 import os
 import csv
 import unittest
 import numpy as np
-from collections import OrderedDict
 from openquake.hmtk.strain.geodetic_strain import GeodeticStrain
 from openquake.hmtk.parsers.strain.strain_csv_parser import (ReadStrainCsv,
                                                              WriteStrainCsv)
@@ -147,7 +146,7 @@ class TestStrainCsvWriter(unittest.TestCase):
         '''
         self.writer = None
         self.model = GeodeticStrain()
-        self.model.data = OrderedDict([
+        self.model.data = dict([
             ('longitude', np.array([30., 30., 30.])),
             ('latitude', np.array([30., 30., 30.])),
             ('exx', np.array([1., 2., 3.])),

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -544,7 +544,7 @@ def calc_results(request, calc_id):
 
     # NB: export_output has as keys the list (output_type, extension)
     # so this returns an ordered map output_type -> extensions such as
-    # OrderedDict([('agg_loss_curve', ['xml', 'csv']), ...])
+    # {'agg_loss_curve': ['xml', 'csv'], ...}
     output_types = groupby(export, lambda oe: oe[0],
                            lambda oes: [e for o, e in oes])
     results = logs.dbcmd('get_outputs', calc_id)


### PR DESCRIPTION
In Python 3.6+ all dictionary are ordered, so the usage of OrderedDict has become redundant.