### PR TITLE
Parallelized the associations event ID -> realization ID

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Parallelized the associations event ID -> realization ID
   * Improved the message when assets are discarded in scenario calculations
   * Implemented aggregation by multiple tags, plus a special case for the
     country code in event based risk

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -286,9 +286,13 @@ def split_in_blocks(sequence, hint, weight=lambda item: 1, key=nokey):
     """
     if isinstance(sequence, int):
         return split_in_slices(sequence, hint)
-
-    if hint == 0:  # do not split
+    elif hint in (0, 1) and key is nokey:  # do not split
         return [sequence]
+    elif hint in (0, 1):  # split by key
+        blocks = []
+        for k, group in groupby(sequence, key).items():
+            blocks.append(group)
+        return blocks
     items = list(sequence) if key is nokey else sorted(sequence, key=key)
     assert hint > 0, hint
     assert len(items) > 0, len(items)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -462,9 +462,10 @@ class IterResult(object):
         if self.received:
             tot = sum(self.received)
             max_per_output = max(self.received)
-            logging.info('Received %s from %d outputs in %d seconds, biggest '
-                         'output=%s', humansize(tot), len(self.received),
-                         time.time() - t0, humansize(max_per_output))
+            logging.info(
+                'Received %s from %d %s outputs in %d seconds, biggest '
+                'output=%s', humansize(tot), len(self.received),
+                self.name, time.time() - t0, humansize(max_per_output))
             if nbytes:
                 logging.info('Received %s',
                              {k: humansize(v) for k, v in nbytes.items()})

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -18,14 +18,12 @@
 
 import os.path
 import logging
-import operator
 import collections
 import numpy
 
 from openquake.baselib import hdf5, datastore
 from openquake.baselib.python3compat import zip
-from openquake.baselib.general import (
-    AccumDict, split_in_blocks, cached_property)
+from openquake.baselib.general import AccumDict, cached_property
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.stats import compute_pmap_stats
 from openquake.hazardlib.calc.stochastic import sample_ruptures
@@ -35,7 +33,7 @@ from openquake.baselib import parallel
 from openquake.commonlib import calc, util
 from openquake.calculators import base
 from openquake.calculators.getters import (
-    GmfGetter, RuptureGetter, get_code2cls)
+    GmfGetter, RuptureGetter, get_rupture_getters)
 from openquake.calculators.classical import ClassicalCalculator
 
 U8 = numpy.uint8
@@ -177,7 +175,6 @@ class EventBasedCalculator(base.HazardCalculator):
         self.L = len(self.oqparam.imtls.array)
         zd = {r: ProbabilityMap(self.L) for r in range(self.R)}
         self.E = len(self.datastore['events'])
-        self.rlzi = numpy.zeros(self.E, U16)
         return zd
 
     def from_sources(self, par):
@@ -237,57 +234,44 @@ class EventBasedCalculator(base.HazardCalculator):
         sorted_ruptures.sort(order='serial')
         self.datastore['ruptures'] = sorted_ruptures
         self.datastore.set_attrs('ruptures', **attrs)
-        self.save_events(sorted_ruptures)
+        E = self.save_events(sorted_ruptures)
         self.check_overflow()  # check the number of events
-        return self.from_ruptures(par)
-
-    def from_ruptures(self, param):
-        """
-        :yields: the arguments for compute_gmfs_and_curves
-        """
-        oq = self.oqparam
-        concurrent_tasks = oq.concurrent_tasks
-        dstore = (self.datastore.parent if self.datastore.parent
-                  else self.datastore)
-        start = 0
-        with self.monitor('getting ruptures'):
-            rups = dstore.getitem('ruptures').value
-            code2cls = get_code2cls(dstore.get_attrs('ruptures'))
-            hdf5cache = dstore.hdf5cache()
-            with hdf5.File(hdf5cache, 'r+') as cache:
-                if 'rupgeoms' not in cache:
-                    dstore.hdf5.copy('rupgeoms', cache)
+        rgetters = self.get_rupture_getters()
         eid2rlz_mon = self.monitor('saving eid->rlz')
-        by_grp = operator.itemgetter(2)  # fields serial, srcidx, grp_id, ...
         smap = parallel.Starmap(RuptureGetter.get_eid_rlz,
                                 monitor=self.monitor('get_eid_rlz'),
                                 progress=logging.debug)
-        logging.info('Found {:,d} ruptures and {:,d} events'
-                     .format(len(rups), len(self.rlzi)))
-        for block in split_in_blocks(rups, concurrent_tasks or 1, key=by_grp):
-            nr = len(block)  # number of ruptures per block
-            grp_id = block[0]['grp_id']
-            rlzs_by_gsim = self.rlzs_by_gsim_grp[grp_id]
-            if not rlzs_by_gsim:
-                # this may happen if a source model has no sources, like
-                # in event_based_risk/case_3
-                continue
-            par = param.copy()
-            par['samples'] = self.samples_by_grp[grp_id]
-            rup_array = rups[start: start + nr]
-            rgetter = RuptureGetter(hdf5cache, code2cls, rup_array,
-                                    self.grp_trt[grp_id], par['samples'],
-                                    rlzs_by_gsim)
-            logging.info('Sending %d ruptures', nr)
+        for rgetter in rgetters:
             smap.submit(rgetter)
-            yield rgetter, self.sitecol, par
-            start += nr
+        self.rlzi = numpy.zeros(E, U16)
         for eid_rlz in smap:
             with eid2rlz_mon:
-                idxs = numpy.array(
-                    [self.eid2idx[eid] for eid in eid_rlz['eid']])
+                idxs = numpy.fromiter(
+                    (self.eid2idx[eid] for eid in eid_rlz['eid']), U16)
                 self.rlzi[idxs] = eid_rlz['rlz']
 
+        return self.from_ruptures(par, rgetters)
+
+    def get_rupture_getters(self):
+        dstore = (self.datastore.parent if self.datastore.parent
+                  else self.datastore)
+        hdf5cache = dstore.hdf5cache()
+        logging.info('Found {:,d} ruptures and {:,d} events'
+                     .format(len(dstore['ruptures']), len(dstore['events'])))
+        with hdf5.File(hdf5cache, 'r+') as cache:
+            if 'rupgeoms' not in cache:
+                dstore.hdf5.copy('rupgeoms', cache)
+        rgetters = get_rupture_getters(
+            dstore, split=self.oqparam.concurrent_tasks, hdf5cache=hdf5cache)
+        return rgetters
+
+    def from_ruptures(self, param, rgetters=None):
+        """
+        :yields: the arguments for compute_gmfs_and_curves
+        """
+        rgetters = rgetters or self.get_rupture_getters()
+        for rgetter in rgetters:
+            yield rgetter, self.sitecol, param
         if self.datastore.parent:
             self.datastore.parent.close()
 

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -246,14 +246,13 @@ def export_agg_losses_ebr(ekey, dstore):
     rup_data = {}
     event_by_eid = {}  # eid -> event
     # populate rup_data and event_by_eid
-    ruptures_by_grp = getters.get_ruptures_by_grp(dstore)
     # TODO: avoid reading the events twice
-    for grp_id, ruptures in ruptures_by_grp.items():
-        for ebr in ruptures:
+    for rgetter in getters.get_rupture_getters(dstore):
+        for ebr in rgetter:
             for event in events_by_rupid[ebr.serial]:
                 event_by_eid[event['eid']] = event
         if has_rup_data:
-            rup_data.update(get_rup_data(ruptures))
+            rup_data.update(get_rup_data(rgetter))
     for r, row in enumerate(agg_losses):
         rec = elt[r]
         event = event_by_eid[row['eid']]

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -475,7 +475,7 @@ class RuptureGetter(object):
         self.rlzs_by_gsim = rlzs_by_gsim
         [self.grp_id] = numpy.unique(rup_array['grp_id'])
 
-    def get_eid_rlz(self):
+    def get_eid_rlz(self, monitor=None):
         """
         :returns: a composite array with the associations eid->rlz
         """


### PR DESCRIPTION
This is useful when there are millions and millions of ruptures, otherwise the cluster will be waiting for the ruptures to be sent. There is also a good deal of refactoring.