### PR TITLE
Added a facility to zip source models and exposures

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Extended the command `oq zip` to zip source models and exposures
   * Parallelized the associations event ID -> realization ID
   * Improved the message when assets are discarded in scenario calculations
   * Implemented aggregation by multiple tags, plus a special case for the

--- a/doc/oq-commands.md
+++ b/doc/oq-commands.md
@@ -191,24 +191,30 @@ to a computation from a machine to another is `oq zip`:
 
 ```bash
 $ oq help zip
-usage: oq zip [-h] [-r RISK_INI] job_ini archive_zip
-
-Zip the given job.ini file into the given archive, together with all related
-files.
+usage: oq zip [-h] [-r] what [archive_zip]
 
 positional arguments:
-  job_ini               path to a job.ini file
-  archive_zip           path to a non-existing .zip file
+  what               path to a job.ini, a ssmLT.xml file, or an exposure.xml
+  archive_zip        path to a non-existing .zip file [default: '']
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -r RISK_INI, --risk-ini RISK_INI
-                        optional .ini file for risk
+  -h, --help         show this help message and exit
+  -r , --risk-file   optional file for risk
 ```
-
-A typical example of usage for a risk calculation would be
+For instance, if you have two configuration files `job_hazard.ini` and
+`job_risk.ini`, you can zip all the files they refer to with the command
 ```bash
-$ oq zip job_hazard.ini job.zip -r job_risk.ini
+$ oq zip job_hazard.ini -r job_risk.ini
+```
+`oq zip` is actually more powerful than that; other than job.ini files,
+it can also zip source models
+```bash
+$ oq zip ssmLT.xml
+```
+and exposures
+
+```bash
+$ oq zip my_exposure.xml
 ```
 
 plotting commands

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1048,6 +1048,7 @@ def zipfiles(fnames, archive, mode='w', log=lambda msg: None):
         for f in fnames:
             log('Archiving %s' % f)
             z.write(f, f[prefix:])
+    log('Generated %s', archive)
 
 
 def detach_process():

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1048,7 +1048,7 @@ def zipfiles(fnames, archive, mode='w', log=lambda msg: None):
         for f in fnames:
             log('Archiving %s' % f)
             z.write(f, f[prefix:])
-    log('Generated %s', archive)
+    log('Generated %s' % archive)
 
 
 def detach_process():

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1049,6 +1049,7 @@ def zipfiles(fnames, archive, mode='w', log=lambda msg: None):
             log('Archiving %s' % f)
             z.write(f, f[prefix:])
     log('Generated %s' % archive)
+    return archive
 
 
 def detach_process():

--- a/openquake/baselib/node.py
+++ b/openquake/baselib/node.py
@@ -674,7 +674,7 @@ def read_nodes(fname, filter_elem, nodefactory=Node, remove_comments=True):
             if filter_elem(el):
                 yield node_from_elem(el, nodefactory)
                 el.clear()  # save memory
-    except:
+    except Exception:
         etype, exc, tb = sys.exc_info()
         msg = str(exc)
         if not str(fname) in msg:
@@ -760,7 +760,7 @@ def context(fname, node):
     """
     try:
         yield node
-    except:
+    except Exception:
         etype, exc, tb = sys.exc_info()
         msg = 'node %s: %s, line %s of %s' % (
             striptag(node.tag), exc, getattr(node, 'lineno', '?'), fname)

--- a/openquake/commands/zip.py
+++ b/openquake/commands/zip.py
@@ -37,6 +37,6 @@ def zip(what, archive_zip='', risk_file=''):
         sys.exit('Cannot zip %s' % what)
 
 
-zip.arg('what', 'path to a job.ini or a ssmLT.xml file')
+zip.arg('what', 'path to a job.ini, a ssmLT.xml file, or an exposure.xml')
 zip.arg('archive_zip', 'path to a non-existing .zip file')
 zip.opt('risk_file', 'optional file for risk')

--- a/openquake/commands/zip.py
+++ b/openquake/commands/zip.py
@@ -23,18 +23,20 @@ from openquake.commonlib import oqzip
 
 
 @sap.Script
-def zip(what, archive_zip='', risk_ini=''):
+def zip(what, archive_zip='', risk_file=''):
     logging.basicConfig(level=logging.INFO)
-    if os.path.basename(what) == 'ssmLT.xml':
+    if os.path.isdir(what):
+        oqzip.zip_all(what)
+    elif os.path.basename(what) == 'ssmLT.xml':
         oqzip.zip_source_model(what, archive_zip)
     elif what.endswith('.xml'):  # assume exposure
         oqzip.zip_exposure(what, archive_zip)
     elif what.endswith('.ini'):  # a job.ini
-        oqzip.zip_job(what, archive_zip, risk_ini)
+        oqzip.zip_job(what, archive_zip, risk_file)
     else:
         sys.exit('Cannot zip %s' % what)
 
 
 zip.arg('what', 'path to a job.ini or a ssmLT.xml file')
 zip.arg('archive_zip', 'path to a non-existing .zip file')
-zip.opt('risk_ini', 'optional .ini file for risk')
+zip.opt('risk_file', 'optional file for risk')

--- a/openquake/commands/zip.py
+++ b/openquake/commands/zip.py
@@ -27,6 +27,8 @@ def zip(what, archive_zip='', risk_ini=''):
     logging.basicConfig(level=logging.INFO)
     if os.path.basename(what) == 'ssmLT.xml':
         oqzip.zip_source_model(what, archive_zip)
+    elif what.endswith('.xml'):  # assume exposure
+        oqzip.zip_exposure(what, archive_zip)
     elif what.endswith('.ini'):  # a job.ini
         oqzip.zip_job(what, archive_zip, risk_ini)
     else:

--- a/openquake/commands/zip.py
+++ b/openquake/commands/zip.py
@@ -15,10 +15,24 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import sys
+import os.path
+import logging
 from openquake.baselib import sap
 from openquake.commonlib import oqzip
 
-zip = sap.Script(oqzip.oqzip, name='zip')
-zip.arg('job_ini', 'path to a job.ini file')
+
+@sap.Script
+def zip(what, archive_zip='', risk_ini=''):
+    logging.basicConfig(level=logging.INFO)
+    if os.path.basename(what) == 'ssmLT.xml':
+        oqzip.zip_source_model(what, archive_zip)
+    elif what.endswith('.ini'):  # a job.ini
+        oqzip.zip_job(what, archive_zip, risk_ini)
+    else:
+        sys.exit('Cannot zip %s' % what)
+
+
+zip.arg('what', 'path to a job.ini or a ssmLT.xml file')
 zip.arg('archive_zip', 'path to a non-existing .zip file')
 zip.opt('risk_ini', 'optional .ini file for risk')

--- a/openquake/commonlib/oqzip.py
+++ b/openquake/commonlib/oqzip.py
@@ -21,16 +21,29 @@ import os.path
 import logging
 from openquake.baselib import general
 from openquake.hazardlib import nrml
-from openquake.commonlib import readinput
+from openquake.commonlib import readinput, logictree
 
 
-def oqzip(job_ini, archive_zip, risk_ini, oq=None, log=logging.info):
+def zip_source_model(ssmLT, archive_zip='', log=logging.info):
+    """
+    Zip the source model files starting from the smmLT.xml file
+    """
+    basedir = os.path.dirname(ssmLT)
+    archive_zip = archive_zip or os.path.join(basedir, 'ssmLT.zip')
+    if os.path.exists(archive_zip):
+        sys.exit('%s exists already' % archive_zip)
+    files = [os.path.abspath(ssmLT)] + logictree.collect_info(ssmLT).smpaths
+    general.zipfiles(files, archive_zip, log=log)
+
+
+def zip_job(job_ini, archive_zip='', risk_ini='', oq=None, log=logging.info):
     """
     Zip the given job.ini file into the given archive, together with all
     related files.
     """
     if not os.path.exists(job_ini):
         sys.exit('%s does not exist' % job_ini)
+    archive_zip = archive_zip or 'job.zip'
     if isinstance(archive_zip, str):  # actually it should be path-like
         if not archive_zip.endswith('.zip'):
             sys.exit('%s does not end with .zip' % archive_zip)
@@ -83,3 +96,4 @@ def oqzip(job_ini, archive_zip, risk_ini, oq=None, log=logging.info):
         else:
             files.add(os.path.normpath(fname))
     general.zipfiles(files, archive_zip, log=log)
+    logging.info('Generated %s', archive_zip)

--- a/openquake/commonlib/oqzip.py
+++ b/openquake/commonlib/oqzip.py
@@ -36,6 +36,13 @@ def zip_source_model(ssmLT, archive_zip='', log=logging.info):
     general.zipfiles(files, archive_zip, log=log)
 
 
+def zip_exposure(exposure_xml, archive_zip='', log=logging.info):
+    """
+    Zip an exposure.xml file with all its .csv subfiles (if any)
+    """
+    pass
+
+
 def zip_job(job_ini, archive_zip='', risk_ini='', oq=None, log=logging.info):
     """
     Zip the given job.ini file into the given archive, together with all

--- a/openquake/commonlib/oqzip.py
+++ b/openquake/commonlib/oqzip.py
@@ -25,6 +25,18 @@ from openquake.risklib.asset import Exposure
 from openquake.commonlib import readinput, logictree
 
 
+def zip_all(directory):
+    """
+    Zip source models and exposures recursively
+    """
+    for cwd, dirs, files in os.walk(directory):
+        if 'ssmLT.xml' in files:
+            zip_source_model(os.path.join(cwd, 'ssmLT.xml'))
+        for f in files:
+            if f.endswith('.xml') and 'exposure' in f.lower():
+                zip_exposure(os.path.join(cwd, f))
+
+
 def zip_source_model(ssmLT, archive_zip='', log=logging.info):
     """
     Zip the source model files starting from the smmLT.xml file

--- a/openquake/commonlib/oqzip.py
+++ b/openquake/commonlib/oqzip.py
@@ -29,12 +29,15 @@ def zip_all(directory):
     """
     Zip source models and exposures recursively
     """
+    zips = []
     for cwd, dirs, files in os.walk(directory):
         if 'ssmLT.xml' in files:
-            zip_source_model(os.path.join(cwd, 'ssmLT.xml'))
+            zips.append(zip_source_model(os.path.join(cwd, 'ssmLT.xml')))
         for f in files:
             if f.endswith('.xml') and 'exposure' in f.lower():
-                zip_exposure(os.path.join(cwd, f))
+                zips.append(zip_exposure(os.path.join(cwd, f)))
+    total = sum(os.path.getsize(z) for z in zips)
+    logging.info('Generated %s of zipped data', general.humansize(total))
 
 
 def zip_source_model(ssmLT, archive_zip='', log=logging.info):
@@ -46,7 +49,7 @@ def zip_source_model(ssmLT, archive_zip='', log=logging.info):
     if os.path.exists(archive_zip):
         sys.exit('%s exists already' % archive_zip)
     files = [os.path.abspath(ssmLT)] + logictree.collect_info(ssmLT).smpaths
-    general.zipfiles(files, archive_zip, log=log)
+    return general.zipfiles(files, archive_zip, log=log)
 
 
 def zip_exposure(exposure_xml, archive_zip='', log=logging.info):
@@ -57,7 +60,8 @@ def zip_exposure(exposure_xml, archive_zip='', log=logging.info):
     if os.path.exists(archive_zip):
         sys.exit('%s exists already' % archive_zip)
     [exp] = Exposure.read_headers([exposure_xml])
-    general.zipfiles([exposure_xml] + exp.datafiles, archive_zip, log=log)
+    return general.zipfiles(
+        [exposure_xml] + exp.datafiles, archive_zip, log=log)
 
 
 def zip_job(job_ini, archive_zip='', risk_ini='', oq=None, log=logging.info):
@@ -119,4 +123,4 @@ def zip_job(job_ini, archive_zip='', risk_ini='', oq=None, log=logging.info):
                 files.add(os.path.normpath(f))
         else:
             files.add(os.path.normpath(fname))
-    general.zipfiles(files, archive_zip, log=log)
+    return general.zipfiles(files, archive_zip, log=log)

--- a/openquake/commonlib/oqzip.py
+++ b/openquake/commonlib/oqzip.py
@@ -21,6 +21,7 @@ import os.path
 import logging
 from openquake.baselib import general
 from openquake.hazardlib import nrml
+from openquake.risklib.asset import Exposure
 from openquake.commonlib import readinput, logictree
 
 
@@ -40,7 +41,11 @@ def zip_exposure(exposure_xml, archive_zip='', log=logging.info):
     """
     Zip an exposure.xml file with all its .csv subfiles (if any)
     """
-    pass
+    archive_zip = archive_zip or exposure_xml[:-4] + '.zip'
+    if os.path.exists(archive_zip):
+        sys.exit('%s exists already' % archive_zip)
+    [exp] = Exposure.read_headers([exposure_xml])
+    general.zipfiles([exposure_xml] + exp.datafiles, archive_zip, log=log)
 
 
 def zip_job(job_ini, archive_zip='', risk_ini='', oq=None, log=logging.info):
@@ -103,4 +108,3 @@ def zip_job(job_ini, archive_zip='', risk_ini='', oq=None, log=logging.info):
         else:
             files.add(os.path.normpath(fname))
     general.zipfiles(files, archive_zip, log=log)
-    logging.info('Generated %s', archive_zip)

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -327,7 +327,7 @@ class ExposureTestCase(unittest.TestCase):
 </nrml>''', suffix='.xml')
 
     def test_get_metadata(self):
-        exp = asset.Exposure.read_header(self.exposure)
+        [exp] = asset.Exposure.read_headers([self.exposure])
         self.assertEqual(exp.description, 'Exposure model for buildings')
         self.assertIsNone(exp.insurance_limit_is_absolute)
         self.assertIsNone(exp.deductible_is_absolute)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -292,8 +292,8 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
             else:
                 logs.LOG.info('zipping the input files')
                 bio = io.BytesIO()
-                oqzip.oqzip(oqparam.inputs['job_ini'], bio, (), oqparam,
-                            logging.debug)
+                oqzip.zip_job(oqparam.inputs['job_ini'], bio, (), oqparam,
+                              logging.debug)
                 data = numpy.array(bio.getvalue())
                 del bio
             calc.datastore['input/zip'] = data

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -821,7 +821,7 @@ class Exposure(object):
         :param fname: path to an exposure file in XML format
         :returns: an Exposure object without assets
         """
-        return _get_exposure(fname, stop='assets')[0]
+        return _get_exposure(fname, stop='asset')[0]
 
     def __init__(self, *values):
         assert len(values) == len(self.fields)

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -719,9 +719,9 @@ def _get_exposure(fname, stop=None):
     if assets_text:
         # the <assets> tag contains a list of file names
         dirname = os.path.dirname(fname)
-        exp.files = [os.path.join(dirname, f) for f in assets_text.split()]
+        exp.datafiles = [os.path.join(dirname, f) for f in assets_text.split()]
     else:
-        exp.files = []
+        exp.datafiles = []
     return exp, exposure.assets
 
 
@@ -851,7 +851,7 @@ class Exposure(object):
         :yields: asset nodes
         """
         expected_header = self._csv_header()
-        for fname in self.files:
+        for fname in self.datafiles:
             with open(fname, encoding='utf-8') as f:
                 fields = next(csv.reader(f))
                 header = set(fields)
@@ -864,7 +864,7 @@ class Exposure(object):
                         'Unexpected header in %s\nExpected: %s\nGot: %s' %
                         (fname, sorted(expected_header), sorted(header)))
         occupancy_periods = self.occupancy_periods.split()
-        for fname in self.files:
+        for fname in self.datafiles:
             with open(fname, encoding='utf-8') as f:
                 for i, dic in enumerate(csv.DictReader(f), 1):
                     asset = Node('asset', lineno=i)


### PR DESCRIPTION
First step towards https://github.com/gem/oq-engine/issues/4204 and https://github.com/gem/oq-engine/issues/4257.

For instance, to zip all the source models in the mosaic:
```bash
$ oq zip /path/to/mosaic
...
INFO:root:Generated 1.22 GB of zipped data
```
The next step will be to use Git Large File Storage https://git-lfs.github.com/
Notice that we may very well decide to drop submodules (they are too difficult for our users anyway).