### PR TITLE
Fixed two bugs in applyToSources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Restored the check for invalid source IDs in applyToSources
   * Extended the command `oq zip` to zip source models and exposures
   * Parallelized the associations event ID -> realization ID
   * Improved the message when assets are discarded in scenario calculations

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -696,6 +696,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
                 sg = copy.copy(grp)
                 sg.id = grp_id
                 src = sg[0].new(sm.ordinal, sm.names)  # one source
+                source_ids.add(src.source_id)
                 src.src_group_id = grp_id
                 src.id = idx
                 if oqparam.number_of_logic_tree_samples:
@@ -727,7 +728,10 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
                 if monitor.hdf5:
                     store_sm(newsm, hdf5path, monitor)
             else:  # just collect the TRT models
-                src_groups.extend(logictree.read_source_groups(fname))
+                groups = logictree.read_source_groups(fname)
+                for group in groups:
+                    source_ids.update(src['id'] for src in group)
+                src_groups.extend(groups)
 
         if grp_id >= TWO16:
             # the limit is really needed only for event based calculations

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -738,7 +738,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
                 raise ValueError(
                     'The source %s is not in the source model, please fix '
                     'applyToSources in %s or the source model' %
-                    source_model_lt.filename)
+                    (srcid, source_model_lt.filename))
         num_sources = sum(len(sg.sources) for sg in src_groups)
         sm.src_groups = src_groups
         trts = [mod.trt for mod in src_groups]

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -550,7 +550,7 @@ def check_nonparametric_sources(fname, smodel, investigation_time):
 class SourceModelFactory(object):
     def __init__(self):
         self.fname_hits = collections.Counter()  # fname -> number of calls
-        self.changed_sources = 0
+        self.changes = 0
 
     def __call__(self, fname, sm, apply_uncertainties, investigation_time):
         """
@@ -572,7 +572,7 @@ class SourceModelFactory(object):
             newgroup = apply_uncertainties(group)
             newsm.src_groups.append(newgroup)
             if hasattr(newgroup, 'changed') and newgroup.changed.any():
-                self.changed_sources += newgroup.changed.sum()
+                self.changes += newgroup.changed.sum()
                 for src, changed in zip(newgroup, newgroup.changed):
                     # redoing count_ruptures can be slow
                     if changed:
@@ -763,16 +763,16 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
     for fname, hits in make_sm.fname_hits.items():
         if hits > 1:
             logging.info('%s has been considered %d times', fname, hits)
-            if not make_sm.changed_sources:
+            if not make_sm.changes:
                 dupl += hits
     if (dupl and not oqparam.optimize_same_id_sources and
             'event_based' not in oqparam.calculation_mode):
         logging.warn('You are doing redundant calculations: please make sure '
                      'that different sources have different IDs and set '
                      'optimize_same_id_sources=true in your .ini file')
-    if make_sm.changed_sources:
-        logging.info('Modified %d sources in the composite source model',
-                     make_sm.changed_sources)
+    if make_sm.changes:
+        logging.info('Applied %d changes to the composite source model',
+                     make_sm.changes)
 
 
 def getid(src):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -571,10 +571,12 @@ class SourceModelFactory(object):
         for group in sm:
             newgroup = apply_uncertainties(group)
             newsm.src_groups.append(newgroup)
-            if getattr(newgroup, 'applied_uncertainties', []):
-                self.changed_sources += len(newgroup)
-                for src in newgroup:  # redoing count_ruptures can be slow
-                    src.num_ruptures = src.count_ruptures()
+            if hasattr(newgroup, 'changed') and newgroup.changed.any():
+                self.changed_sources += newgroup.changed.sum()
+                for src, changed in zip(newgroup, newgroup.changed):
+                    # redoing count_ruptures can be slow
+                    if changed:
+                        src.num_ruptures = src.count_ruptures()
         self.fname_hits[fname] += 1
         return newsm
 

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -17,7 +17,6 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import shutil
 import tempfile
 import mock
 import unittest
@@ -31,7 +30,7 @@ from openquake.hazardlib import valid, InvalidFile
 from openquake.risklib import asset
 from openquake.risklib.riskinput import ValidationError
 from openquake.commonlib import readinput, writers, oqvalidation
-from openquake.qa_tests_data.classical import case_1, case_2
+from openquake.qa_tests_data.classical import case_1, case_2, case_21
 from openquake.qa_tests_data.event_based import case_16
 from openquake.qa_tests_data.event_based_risk import case_caracas
 
@@ -597,6 +596,14 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             readinput.get_composite_source_model(oq, in_memory=False)
         self.assertIn('Unknown TRT=act shallow crust', str(ctx.exception))
+
+    def test_applyToSources(self):
+        oq = readinput.get_oqparam('job.ini', case_21)
+        with mock.patch('logging.info') as info:
+            readinput.get_composite_source_model(oq)
+        self.assertEqual(
+            info.call_args[0],
+            ('Applied %d changes to the composite source model', 81))
 
 
 class GetCompositeRiskModelTestCase(unittest.TestCase):


### PR DESCRIPTION
First bug: the engine was happily accepting non existing source IDs in applyToSources.
Second bug: the number of modified sources was wrong (all the sources in the source group
instead of the ones listed in applyToSources).