### PR TITLE
Make the storing of performance info fast in sample_ruptures

### DIFF
--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -170,12 +170,13 @@ def build_ruptures(sources, src_filter, param, monitor):
                 for rup, occ in zip(rups, occs):
                     n_occ[rup] += occ
     tot_occ = sum(n_occ.values())
+    dic = {'eff_ruptures': {src.src_group_id: src.num_ruptures}}
     with filt_mon:
-        src.eb_ruptures = stochastic.build_eb_ruptures(
+        dic['eb_ruptures'] = stochastic.build_eb_ruptures(
             src, num_ses, cmaker, sitecol, n_occ.items())
     dt = time.time() - t0
-    src.calc_times = {src.id: numpy.array([tot_occ, len(sitecol), dt], F32)}
-    return [src]
+    dic['calc_times'] = {src.id: numpy.array([tot_occ, len(sitecol), dt], F32)}
+    return dic
 
 
 @base.calculators.add('ucerf_hazard')

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -342,7 +342,7 @@ class RuptureData(object):
             except AttributeError:  # for nonparametric sources
                 rate = numpy.nan
             data.append(
-                (ebr.serial, ebr.srcidx, ebr.n_occ.sum(), rate,
+                (ebr.serial, ebr.srcidx, ebr.n_occ, rate,
                  rup.mag, point.x, point.y, point.z, rup.surface.get_strike(),
                  rup.surface.get_dip(), rup.rake,
                  'MULTIPOLYGON(%s)' % decode(bounds)) + ruptparams)

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -110,14 +110,18 @@ def sample_ruptures(sources, param, src_filter=source_site_noop_filter,
                           src_filter.integration_distance,
                           param, monitor)
     num_ses = param['ses_per_logic_tree_path']
+    eff_ruptures = 0
+    grp_id = sources[0].src_group_id
     for src, sites in src_filter(sources):
         t0 = time.time()
         ebrs = build_eb_ruptures(src, num_ses, cmaker, sites)
         n_occ = sum(ebr.n_occ for ebr in ebrs)
         eb_ruptures.extend(ebrs)
+        eff_ruptures += src.num_ruptures
         dt = time.time() - t0
         calc_times[src.id] += numpy.array([n_occ, src.nsites, dt])
-    dic = dict(eb_ruptures=eb_ruptures, calc_times=calc_times)
+    dic = dict(eb_ruptures=eb_ruptures, calc_times=calc_times,
+               eff_ruptures={grp_id: eff_ruptures})
     return dic
 
 


### PR DESCRIPTION
We were storing a record for each source (say 1 million records); now we only store a record for each task (say 1000 records).