### PR TITLE
Return the ruptures as arrays

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -343,12 +343,10 @@ class HazardCalculator(BaseCalculator):
         :returns: an iterator over blocks of sources
         """
         ct = self.oqparam.concurrent_tasks or 1
-        minweight = source.MINWEIGHT * (math.sqrt(len(self.sitecol))
-                                        if self.sitecol else 1)
-        maxweight = self.csm.get_maxweight(weight, ct, minweight)
+        maxweight = self.csm.get_maxweight(weight, ct, source.MINWEIGHT)
         if not hasattr(self, 'logged'):
-            if maxweight == minweight:
-                logging.info('Using minweight=%d', minweight)
+            if maxweight == source.MINWEIGHT:
+                logging.info('Using minweight=%d', source.MINWEIGHT)
             else:
                 logging.info('Using maxweight=%d', maxweight)
             self.logged = True

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -184,9 +184,9 @@ class EventBasedCalculator(base.HazardCalculator):
                 calc_times += dic['calc_times']
             if dic['eff_ruptures']:
                 eff_ruptures += dic['eff_ruptures']
-            if dic['eb_ruptures']:
+            if dic['rup_array']:
                 with mon:
-                    self.rupser.save(dic['eb_ruptures'])
+                    self.rupser.save(dic['rup_array'])
         self.rupser.close()
 
         # logic tree reduction, must be called before storing the events

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -24,7 +24,7 @@ from openquake.baselib import hdf5, datastore, general
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib import calc, geo, probability_map, stats
 from openquake.hazardlib.geo.mesh import Mesh, RectangularMesh
-from openquake.hazardlib.source.rupture import BaseRupture, EBRupture, classes
+from openquake.hazardlib.source.rupture import EBRupture, classes
 from openquake.risklib.riskinput import rsi2str
 from openquake.commonlib.calc import _gmvs_to_haz_curve
 
@@ -32,8 +32,6 @@ U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
 U64 = numpy.uint64
-
-BaseRupture.init()  # initialize rupture codes
 
 
 class PmapGetter(object):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -514,9 +514,6 @@ class RuptureGetter(object):
                 rupture.hypocenter = geo.Point(*rec['hypo'])
                 rupture.occurrence_rate = rec['occurrence_rate']
                 rupture.tectonic_region_type = self.trt
-                pmfx = rec['pmfx']
-                if pmfx != -1:
-                    rupture.pmf = dstore['pmfs'][pmfx]
                 if surface_cls is geo.PlanarSurface:
                     rupture.surface = geo.PlanarSurface.from_array(
                         mesh[:, 0, :])

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -20,8 +20,9 @@ import numpy
 
 from openquake.hazardlib.calc.gmf import GmfComputer
 from openquake.hazardlib.gsim.base import ContextMaker
-from openquake.commonlib import readinput, source, calc
+from openquake.hazardlib.calc.stochastic import get_rup_array
 from openquake.hazardlib.source.rupture import EBRupture, events_dt
+from openquake.commonlib import readinput, source, calc
 from openquake.calculators import base
 
 
@@ -62,7 +63,7 @@ class ScenarioCalculator(base.HazardCalculator):
             events[rlz * E: rlz * E + E]['rlz'] = rlz
         self.datastore['events'] = events
         rupser = calc.RuptureSerializer(self.datastore)
-        rupser.save([ebr])
+        rupser.save(get_rup_array([ebr]))
         rupser.close()
         self.computer = GmfComputer(
             ebr, self.sitecol, oq.imtls, self.cmaker, oq.truncation_level,

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -172,8 +172,10 @@ def build_ruptures(sources, src_filter, param, monitor):
     tot_occ = sum(n_occ.values())
     dic = {'eff_ruptures': {src.src_group_id: src.num_ruptures}}
     with filt_mon:
-        dic['eb_ruptures'] = stochastic.build_eb_ruptures(
+        eb_ruptures = stochastic.build_eb_ruptures(
             src, num_ses, cmaker, sitecol, n_occ.items())
+        dic['rup_array'] = (stochastic.get_rup_array(eb_ruptures)
+                            if eb_ruptures else ())
     dt = time.time() - t0
     dic['calc_times'] = {src.id: numpy.array([tot_occ, len(sitecol), dt], F32)}
     return dic

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -39,6 +39,8 @@ F32 = numpy.float32
 U64 = numpy.uint64
 F64 = numpy.float64
 
+BaseRupture.init()
+
 # ############## utilities for the classical calculator ############### #
 
 

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -42,8 +42,6 @@ I32 = numpy.int32
 F32 = numpy.float32
 MAX_RUPTURES = 1000
 
-BaseRupture.init()  # initialize rupture codes
-
 
 def source_site_noop_filter(srcs):
     for src in srcs:
@@ -106,6 +104,9 @@ def get_rup_array(ebruptures):
     """
     Convert a list of EBRuptures into a numpy composite array
     """
+    if not BaseRupture._code:
+        BaseRupture.init()  # initialize rupture codes
+
     lst = []
     geoms = []
     nbytes = 0

--- a/openquake/hazardlib/geo/surface/gridded.py
+++ b/openquake/hazardlib/geo/surface/gridded.py
@@ -106,7 +106,7 @@ class GriddedSurface(BaseSurface):
         :returns:
             Numpy array of distances in km.
         """
-        raise NotImplementedError
+        raise NotImplementedError('GriddedSurface')
 
     def get_top_edge_depth(self):
         """
@@ -116,7 +116,7 @@ class GriddedSurface(BaseSurface):
             Float value, the vertical distance between the earth surface
             and the shallowest point in surface's top edge in km.
         """
-        raise NotImplementedError
+        raise NotImplementedError('GriddedSurface')
 
     def get_strike(self):
         """
@@ -150,7 +150,7 @@ class GriddedSurface(BaseSurface):
         :returns:
             Float value, the surface width
         """
-        raise NotImplementedError
+        raise NotImplementedError('GriddedSurface')
 
     def get_area(self):
         """
@@ -159,7 +159,7 @@ class GriddedSurface(BaseSurface):
         :returns:
             Float value, the surface area
         """
-        raise NotImplementedError
+        raise NotImplementedError('GriddedSurface')
 
     def get_middle_point(self):
         """
@@ -185,4 +185,4 @@ class GriddedSurface(BaseSurface):
         :param mesh:
             :class:`~openquake.hazardlib.geo.mesh.Mesh` of points
         """
-        raise NotImplementedError
+        raise NotImplementedError('GriddedSurface')

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -51,7 +51,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         param = dict(ses_per_logic_tree_path=10, filter_distance='rjb',
                      gsims=[SiMidorikawa1999SInter()])
         dic = sum(sample_ruptures(group, param, s_filter), {})
-        self.assertEqual(len(dic['eb_ruptures']), 5)
+        self.assertEqual(len(dic['rup_array']), 5)
         self.assertEqual(len(dic['calc_times']), 15)  # mutex sources
 
         # test no filtering 1
@@ -59,5 +59,5 @@ class StochasticEventSetTestCase(unittest.TestCase):
         self.assertEqual(len(ruptures), 19)
 
         # test no filtering 2
-        ruptures = sum(sample_ruptures(group, param), {})['eb_ruptures']
+        ruptures = sum(sample_ruptures(group, param), {})['rup_array']
         self.assertEqual(len(ruptures), 5)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/4274. The memory consumption on wilson went down from ~150 GB to ~3 GB and now we can generate the ruptures for all of South America with 25 branches and 20,000 SES without running out of memory, see https://oq1.wilson.openquake.org/engine/21995/outputs.
