### PR TITLE
Adds a magnitude scaling relation for Germany

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Graeme Weatherill]
+  * Adds magnitude scaling relation for Germany
+  
   [Michele Simionato]
   * Added a flag `fast_sampling`, by default False
   * Added an API `/extract/src_loss_table/<loss_type>`

--- a/doc/sphinx/openquake.hazardlib.scalerel.rst
+++ b/doc/sphinx/openquake.hazardlib.scalerel.rst
@@ -20,6 +20,14 @@ ceus2011
     :undoc-members:
     :show-inheritance:
 
+germany2018
+--------------------------------------------
+
+.. automodule:: openquake.hazardlib.scalerel.germany2018
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 gsc_offshore_thrusts
 --------------------------------------------------------
 

--- a/openquake/hazardlib/scalerel/__init__.py
+++ b/openquake/hazardlib/scalerel/__init__.py
@@ -26,6 +26,7 @@ import importlib
 from openquake.hazardlib.scalerel.base import (
     BaseMSR, BaseASR, BaseMSRSigma, BaseASRSigma)
 from openquake.hazardlib.scalerel.ceus2011 import CEUS2011
+from openquake.hazardlib.scalerel.germany2018 import GermanyMSR
 from openquake.hazardlib.scalerel.peer import PeerMSR
 from openquake.hazardlib.scalerel.point import PointMSR
 from openquake.hazardlib.scalerel.wc1994 import WC1994

--- a/openquake/hazardlib/scalerel/germany2018.py
+++ b/openquake/hazardlib/scalerel/germany2018.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2012-2018 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Module :mod:`openquake.hazardlib.scalerel.germany2018` implements
+:class:`GermanyMSR`.
+"""
+from openquake.hazardlib.scalerel.base import BaseMSRSigma
+
+
+class GermanyMSR(BaseMSRSigma):
+    """
+    Implements a magnitude-area scaling relationship used within the 2018
+    national seismic hazard model of Germany.
+
+    Log10 A = -2.44 + 0.59 * mag (sigma = 0.16)
+    """
+    def get_median_area(self, mag, rake):
+        """
+        The values are a function of magnitude only
+        """
+        return 10.0 ** (-2.44 + 0.59 * mag)
+
+    def get_std_dev_area(self, mag, rake):
+        """
+        Standard deviation fixed at 0.16
+        """
+        return 0.16

--- a/openquake/hazardlib/tests/scalerel/germany2018_test.py
+++ b/openquake/hazardlib/tests/scalerel/germany2018_test.py
@@ -1,0 +1,43 @@
+# The Hazard Library
+# Copyright (C) 2013-2018 GEM Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import unittest
+
+from openquake.hazardlib.scalerel.germany2018 import GermanyMSR
+
+
+class GermanyMSRTestCase(unittest.TestCase):
+    """
+    Tests for the magnitude-scaling relationship used in the 2018 Germany
+    national seismic hazard model
+    """
+
+    def setUp(self):
+        self.msr = GermanyMSR()
+
+    def test_get_median_area(self):
+        """
+        This tests the MSR
+        """
+        self.assertAlmostEqual(self.msr.get_median_area(4.0, None), 0.8317637,
+                               places=5)
+        self.assertAlmostEqual(self.msr.get_median_area(5.0, None), 3.2359365,
+                               places=5)
+        self.assertAlmostEqual(self.msr.get_median_area(6.0, None), 12.589254,
+                               places=5)
+        self.assertAlmostEqual(self.msr.get_median_area(7.0, None), 48.9778819,
+                               places=5)
+        self.assertAlmostEqual(self.msr.get_median_area(8.0, None), 190.546071,
+                               places=5)


### PR DESCRIPTION
Adds a magnitude scaling relation used for Germany in the 2018 National Seismic Hazard Map for Germany (Gruenthal et al., 2018)