### PR TITLE
Removed Decimal in the GSIM weights

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Used floats for the the GSIM realization weights, not Python Decimals
   * Added a flag `fast_sampling`, by default False
   * Added an API `/extract/src_loss_table/<loss_type>`
   * Removed the rupture filtering from `sample_ruptures` and optimized it in

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -38,7 +38,7 @@ from openquake.commonlib.writers import (
     build_header, scientificformat, FIVEDIGITS)
 from openquake.calculators import getters
 
-FLOAT = (float, numpy.float32, numpy.float64, decimal.Decimal)
+FLOAT = (float, numpy.float32, numpy.float64, float)
 INT = (int, numpy.int32, numpy.uint32, numpy.int64, numpy.uint64)
 F32 = numpy.float32
 U32 = numpy.uint32

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -19,7 +19,6 @@ import ast
 import os.path
 import numbers
 import operator
-import decimal
 import functools
 import itertools
 import collections
@@ -38,7 +37,7 @@ from openquake.commonlib.writers import (
     build_header, scientificformat, FIVEDIGITS)
 from openquake.calculators import getters
 
-FLOAT = (float, numpy.float32, numpy.float64, float)
+FLOAT = (float, numpy.float32, numpy.float64)
 INT = (int, numpy.int32, numpy.uint32, numpy.int64, numpy.uint64)
 F32 = numpy.float32
 U32 = numpy.uint32

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -75,7 +75,7 @@ class Print(object):
 
 class InfoTestCase(unittest.TestCase):
     EXPECTED = '''<CompositionInfo
-b1, x15.xml, grp=[0], weight=1.00: 1 realization(s)>
+b1, x15.xml, grp=[0], weight=1.0: 1 realization(s)>
 See http://docs.openquake.org/oq-engine/stable/effective-realizations.html for an explanation
 <RlzsAssoc(size=1, rlzs=1)
 0,AkkarBommer2010(): [0]>'''

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -309,7 +309,7 @@ class BranchSet(object):
         """
         for path in self._enumerate_paths([]):
             flat_path = []
-            weight = float('1.0')
+            weight = 1.0
             while path:
                 path, branch = path
                 weight *= branch.weight

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -33,7 +33,6 @@ import itertools
 import collections
 import operator
 from collections import namedtuple
-from decimal import Decimal
 import numpy
 from openquake.baselib import hdf5, node
 from openquake.baselib.general import groupby, duplicated
@@ -43,7 +42,7 @@ from openquake.hazardlib.gsim.base import CoeffsTable
 from openquake.hazardlib.gsim.multi import MultiGMPE
 from openquake.hazardlib.gsim.gmpe_table import GMPETable
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib import geo, valid, nrml, InvalidFile
+from openquake.hazardlib import geo, valid, nrml, InvalidFile, pmf
 from openquake.hazardlib.sourceconverter import (
     split_coords_2d, split_coords_3d, SourceGroup)
 
@@ -202,7 +201,7 @@ class Branch(object):
     :param branch_id:
         Value of ``@branchID`` attribute.
     :param weight:
-        Decimal value of weight assigned to the branch. A text node contents
+        float value of weight assigned to the branch. A text node contents
         of ``<uncertaintyWeight />`` child node.
     :param value:
         The actual uncertainty parameter value. A text node contents
@@ -310,7 +309,7 @@ class BranchSet(object):
         """
         for path in self._enumerate_paths([]):
             flat_path = []
-            weight = Decimal('1.0')
+            weight = float('1.0')
             while path:
                 path, branch = path
                 weight *= branch.weight
@@ -758,7 +757,7 @@ class SourceModelLogicTree(object):
                     "branchID '%s' is not unique" % branch_id)
             self.branches[branch_id] = branch
             branchset.branches.append(branch)
-        if weight_sum != 1.0:
+        if abs(weight_sum - 1.0) > pmf.PRECISION:
             raise ValidationError(
                 branchset_node, self.filename,
                 "branchset weights don't sum up to 1.0")
@@ -1442,7 +1441,7 @@ class GsimLogicTree(object):
                 weights = []
                 branch_ids = []
                 for branch in branchset:
-                    weight = Decimal(branch.uncertaintyWeight.text)
+                    weight = float(branch.uncertaintyWeight.text)
                     weights.append(weight)
                     branch_id = branch['branchID']
                     branch_ids.append(branch_id)
@@ -1471,7 +1470,7 @@ class GsimLogicTree(object):
                     bt = BranchTuple(
                         branchset, branch_id, gsim, weight, effective)
                     branches.append(bt)
-                assert sum(weights) == 1, weights
+                assert abs(sum(weights) - 1) < pmf.PRECISION, weights
                 if duplicated(branch_ids):
                     raise InvalidLogicTree(
                         'There where duplicated branchIDs in %s' % self.fname)

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1360,9 +1360,9 @@ class SourceModelLogicTreeTestCase(unittest.TestCase):
 class SampleTestCase(unittest.TestCase):
 
     def test_sample(self):
-        branches = [logictree.Branch(1, float('0.2'), 'A'),
-                    logictree.Branch(1, float('0.3'), 'B'),
-                    logictree.Branch(1, float('0.5'), 'C')]
+        branches = [logictree.Branch(1, 0.2, 'A'),
+                    logictree.Branch(1, 0.3, 'B'),
+                    logictree.Branch(1, 0.5, 'C')]
         samples = logictree.sample(branches, 1000, 42)
 
         def count(samples, value):
@@ -1377,14 +1377,14 @@ class SampleTestCase(unittest.TestCase):
         self.assertEqual(count(samples, value='C'), 497)
 
     def test_sample_broken_branch_weights(self):
-        branches = [logictree.Branch(0, float('0.1'), 0),
-                    logictree.Branch(1, float('0.2'), 1)]
+        branches = [logictree.Branch(0, 0.1, 0),
+                    logictree.Branch(1, 0.2, 1)]
         with self.assertRaises(ValueError):
             logictree.sample(branches, 1000, 42)
 
     def test_sample_one_branch(self):
         # always the same branch is returned
-        branches = [logictree.Branch(0, float('1.0'), 0)]
+        branches = [logictree.Branch(0, 1.0, 0)]
         bs = logictree.sample(branches, 10, 42)
         for b in bs:
             self.assertEqual(b.branch_id, 0)
@@ -1392,14 +1392,14 @@ class SampleTestCase(unittest.TestCase):
 
 class BranchSetEnumerateTestCase(unittest.TestCase):
     def test_enumerate(self):
-        b0 = logictree.Branch('0', float('0.64'), '0')
-        b1 = logictree.Branch('1', float('0.36'), '1')
-        b00 = logictree.Branch('0.0', float('0.33'), '0.0')
-        b01 = logictree.Branch('0.1', float('0.27'), '0.1')
-        b02 = logictree.Branch('0.2', float('0.4'), '0.2')
-        b10 = logictree.Branch('1.0', float('1.0'), '1.0')
-        b100 = logictree.Branch('1.0.0', float('0.1'), '1.0.0')
-        b101 = logictree.Branch('1.0.1', float('0.9'), '1.0.1')
+        b0 = logictree.Branch('0', 0.64, '0')
+        b1 = logictree.Branch('1', 0.36, '1')
+        b00 = logictree.Branch('0.0', 0.33, '0.0')
+        b01 = logictree.Branch('0.1', 0.27, '0.1')
+        b02 = logictree.Branch('0.2', 0.4, '0.2')
+        b10 = logictree.Branch('1.0', 1.0, '1.0')
+        b100 = logictree.Branch('1.0.0', 0.1, '1.0.0')
+        b101 = logictree.Branch('1.0.1', 0.9, '1.0.1')
         bs_root = logictree.BranchSet(None, None)
         bs_root.branches = [b0, b1]
         bs0 = logictree.BranchSet(None, None)
@@ -1443,7 +1443,7 @@ class BranchSetGetBranchByIdTestCase(unittest.TestCase):
 
     def test_nonexistent_branch(self):
         bs = logictree.BranchSet(None, None)
-        br = logictree.Branch('br', float('1.0'), None)
+        br = logictree.Branch('br', 1.0, None)
         bs.branches.append(br)
         self.assertRaises(AssertionError, bs.get_branch_by_id, 'bz')
 

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -256,7 +256,7 @@ validators = {
     'probability': valid.probability,
     'occurRates': valid.positivefloats,  # they can be > 1
     'weight': valid.probability,
-    'uncertaintyWeight': decimal.Decimal,
+    'uncertaintyWeight': float,
     'alongStrike': valid.probability,
     'downDip': valid.probability,
     'totalMomentRate': valid.positivefloat,

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -74,7 +74,6 @@ supplemented by a dictionary of validators.
 import io
 import re
 import sys
-import decimal
 import logging
 import operator
 import collections

--- a/openquake/hmtk/models.py
+++ b/openquake/hmtk/models.py
@@ -340,7 +340,7 @@ class NodalPlane(object):
 
     :param probability:
         Probability for this node in a Nodal Plane Distribution, as a
-        :class:`decimal.Decimal`.
+        :class:`float`.
     :param float strike:
         Strike angle.
     :param float dip:
@@ -374,7 +374,7 @@ class HypocentralDepth(object):
 
     :param probability:
         Probability for this node in a Hypocentral Depth Distribution, as a
-        :class:`decimal.Decimal`.
+        :class:`float`.
     :param float depth:
         Depth (in km).
     """

--- a/openquake/hmtk/models.py
+++ b/openquake/hmtk/models.py
@@ -281,7 +281,7 @@ class IncrementalMFD(object):
     :param float bin_width:
         Width of a single histogram bin.
     :param list occur_rates:
-        `list` of occurrence rates (`float` values).
+        `list` of occurrence rates (float values).
     """
 
     def __init__(self, min_mag=None, bin_width=None, occur_rates=None):
@@ -340,7 +340,7 @@ class NodalPlane(object):
 
     :param probability:
         Probability for this node in a Nodal Plane Distribution, as a
-        :class:`float`.
+        float.
     :param float strike:
         Strike angle.
     :param float dip:
@@ -374,7 +374,7 @@ class HypocentralDepth(object):
 
     :param probability:
         Probability for this node in a Hypocentral Depth Distribution, as a
-        :class:`float`.
+        float.
     :param float depth:
         Depth (in km).
     """

--- a/openquake/hmtk/sources/source_conversion_utils.py
+++ b/openquake/hmtk/sources/source_conversion_utils.py
@@ -44,11 +44,8 @@
 # The GEM Foundation, and the authors of the software, assume no
 # liability for use of the software.
 
-import abc
-from decimal import float
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.geo.nodalplane import NodalPlane
-from openquake.hazardlib import mfd
 from openquake.hazardlib.scalerel import get_available_scalerel
 from openquake.hazardlib.scalerel.base import BaseMSR
 from openquake.hazardlib.scalerel.wc1994 import WC1994

--- a/openquake/hmtk/sources/source_conversion_utils.py
+++ b/openquake/hmtk/sources/source_conversion_utils.py
@@ -45,7 +45,7 @@
 # liability for use of the software.
 
 import abc
-from decimal import Decimal
+from decimal import float
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib import mfd


### PR DESCRIPTION
I had already removed Decimal in the source model weights, but this part was missing. This is useful for the work on IMT-dependent weights.