### PR TITLE
Update the openquake.cfg patch used by packages

### DIFF
--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -1,8 +1,8 @@
 Index: oq-engine/openquake/engine/openquake.cfg
 ===================================================================
---- oq-engine.orig/openquake/engine/openquake.cfg	2018-06-14 15:52:40.006774324 +0200
-+++ oq-engine/openquake/engine/openquake.cfg	2018-06-14 15:53:55.484502255 +0200
-@@ -39,19 +39,20 @@
+--- a/openquake/engine/openquake.cfg
++++ b/openquake/engine/openquake.cfg
+@@ -46,19 +46,20 @@ vhost = openquake
  celery_queue = celery
  
  [dbserver]
@@ -28,5 +28,5 @@ Index: oq-engine/openquake/engine/openquake.cfg
 +# https://isc.sans.edu/port.html?port=1907
 +port = 1907
  # port range used by workers to send back results
- # to the master node; used only with a multi-node setup
+ # to the master node
  receiver_ports = 1912-1920


### PR DESCRIPTION
https://copr-be.cloud.fedoraproject.org/results/gem/openquake/epel-7-x86_64/00838534-python3-oq-engine/builder-live.log

```bash
+ /usr/bin/patch -p1 --fuzz=0
patching file openquake/engine/openquake.cfg
Hunk #1 FAILED at 39.
1 out of 1 hunk FAILED -- saving rejects to file openquake/engine/openquake.cfg.rej
```

Ubuntu was not catching the issue because uses more relaxed settings with `patch`