### PR TITLE
shared_dir is now mandatory

### DIFF
--- a/doc/docker/cluster.md
+++ b/doc/docker/cluster.md
@@ -18,6 +18,12 @@ $ docker-compose up --scale worker=N
 ```
 where `N` is the number of expected worker containers.
 
+### Shared directory
+
+Starting with the OpenQuake Engine 3.3 a [shared directory](../installing/cluster.md) must exists between the master node and workers. Docker compose already set a shared volume between containers([docker-compose.yml#L46](https://github.com/gem/oq-builders/blob/master/oq-docker/docker-compose.yml#L46)).
+When running containers on different nodes (which should be the case) you must adjust `docker-compose.yml` properly to use a shared storage backend.
+A configuration example for NFS is provided via the `oqdata-nfs` volume in [docker-compose.yml#L63](https://github.com/gem/oq-builders/blob/master/oq-docker/docker-compose.yml#L64).
+
 ## Deploy an OpenQuake Engine cluster manually
 
 ### OQ internal network

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -140,6 +140,37 @@ The default port for the DbServer (configured via the `openquake.cfg` configurat
 
 ******
 
+### error: OSError: Unable to open file (on a multi-node cluster)
+
+A more detailed stack trace:
+
+```python
+OSError:
+  File "/opt/openquake/lib/python3.6/site-packages/openquake/baselib/parallel.py", line 312, in new
+    val = func(*args)
+  File "/opt/openquake/lib/python3.6/site-packages/openquake/baselib/parallel.py", line 376, in gfunc
+    yield func(*args)
+  File "/opt/openquake/lib/python3.6/site-packages/openquake/calculators/classical.py", line 301, in build_hazard_stats
+    pgetter.init()  # if not already initialized
+  File "/opt/openquake/lib/python3.6/site-packages/openquake/calculators/getters.py", line 69, in init
+    self.dstore = hdf5.File(self.dstore, 'r')
+  File "/opt/openquake/lib64/python3.6/site-packages/h5py/_hl/files.py", line 312, in __init__
+    fid = make_fid(name, mode, userblock_size, fapl, swmr=swmr)
+  File "/opt/openquake/lib64/python3.6/site-packages/h5py/_hl/files.py", line 142, in make_fid
+    fid = h5f.open(name, flags, fapl=fapl)
+  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
+  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
+  File "h5py/h5f.pyx", line 78, in h5py.h5f.open
+OSError: Unable to open file (unable to open file: name = '/home/openquake/oqdata/cache_1.hdf5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)
+```
+
+This happens when the [shared dir](installing/cluster.md#shared_filesystem) is not configured properly and workers cannot access data from the master node.
+Please note that starting with OpenQuake Engine 3.3 the shared directory **is required** on multi-node deployments.
+
+You can get more information about setting up the shared directory on the [cluster installation page](installing/cluster.md#shared_filesystem).
+
+******
+
 ### error: [Errno 111] Connection refused
 
 A more detailed stack trace:

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -148,9 +148,9 @@ Cluster utilization: 0.00%
 ```
 
 
-## Shared filesystem (optional)
+## Shared filesystem
 
-OpenQuake 2.4 introduces the concept of _shared directory_ (aka _shared_dir_). This _shared dir_ allows the workers to read directly from the master's filesystem, thus increasing scalability and performance; this feature is optional: the old behaviour, transmitting data via `rabbitmq`, will be used when `shared_dir` isn't set.
+OpenQuake 2.4 introduced the concept of _shared directory_ (aka _shared_dir_). This _shared directory_ allows the workers to read directly from the master's filesystem, thus increasing scalability and performance; starting with OpenQuake 3.3 this feature is **mandatory** on a multi-node deployment.
 
 The _shared directory_ must be exported from the master node to the workers via a _POSIX_ compliant filesystem (like **NFS**). The export may be (and _should_ be) exported and/or mounted as **read-only** by the workers.
 
@@ -166,7 +166,6 @@ shared_dir = /home/openquake
 ```
 
 When `shared_dir` is set, the `oqdata` folders will be stored under `$shared_dir/<user>/oqdata` instead of `/home/<user>/oqdata`. See the comment in the `openquake.cfg` for further information.
-
 You need then to give `RWX` permission to the `shared_dir` on _master_ to the `openquake` group (which is usually created by packages) and add all the cluster users to the `openquake` group. For example:
 
 ```bash
@@ -178,6 +177,12 @@ $ chmod 2770 /home/openquake
 
 On the workers the _shared_dir_ should be mounted as the `openquake` user too, or access must be given to the user running `celeryd` (which is `openquake` by default in the official packages).
 
+Another possibility would be exporting the entire `/home` to the workers: in such case `oqdata` will have the default path `/home/<user>/oqdata` and setgid is not required. Please note that the `openquake` user on workers still needs to get access to the `oqdata` content, so make sure that permission are properly set (`traverse` on the user home and `read` access to oqdata).
+
+```
+[directory]
+shared_dir = /home
+```
 
 ## Network and security considerations
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -22,8 +22,6 @@ oq_distribute = processpool
 
 # make sure workers are terminated when tasks are revoked
 terminate_workers_on_revoke = true
-# this is good for a single user situation, but turn this off on a cluster
-# otherwise a CTRL-C will kill the computations of other users
 
 # change this on a cluster if using oq_distribute = dask
 dask_scheduler = 127.0.0.1:1921
@@ -72,10 +70,10 @@ task_out_port = 1911
 remote_python =
 
 [directory]
-# the base directory containing the <user>/oqdata directories;
-# if set, it should be on a shared filesystem; for instance in our
-# cluster it is /home/openquake; if not set, the oqdata directories
-# go into $HOME/oqdata, unless the user sets his own OQ_DATADIR variable
+# the base directory containing the <user>/oqdata directories:
+# if set, it should be on a shared filesystem; this is **mandatory** on a multi-node cluster
+# if not set, the oqdata directories go into $HOME/oqdata,
+# unless the user sets his own OQ_DATADIR variable
 shared_dir =
 # a custom path where to store temporary data; on Linux systems by default
 # temporary files are stored in /tmp, but on HPC and cloud systems the


### PR DESCRIPTION
Later on I will add some how-to about installing and configuring NFS, but this is not blocking the 3.3 branch detach anymore.