### PR TITLE
Import oq-engine docker stuff from oq-builders

### DIFF
--- a/debian/python3-oq-engine-master.docs
+++ b/debian/python3-oq-engine-master.docs
@@ -1,0 +1,1 @@
+openquake/engine/openquake.cfg.cluster-sample

--- a/debian/python3-oq-engine-worker.docs
+++ b/debian/python3-oq-engine-worker.docs
@@ -1,0 +1,1 @@
+openquake/engine/openquake.cfg.cluster-sample

--- a/doc/docker/advanced.md
+++ b/doc/docker/advanced.md
@@ -21,7 +21,7 @@ LOCKDOWN=enabled docker-compose up -d
 - [Introduction](../installing/docker.md)
 - [Single node deployment](single.md)
 - [Cluster deployment](cluster.md)
-- [Build from sources](https://github.com/gem/oq-builders/tree/master/oq-docker#build-openquake-docker-images)
+- [Build from sources](../../docker#build-openquake-docker-images)
 
 ***
 

--- a/doc/docker/cluster.md
+++ b/doc/docker/cluster.md
@@ -20,9 +20,9 @@ where `N` is the number of expected worker containers.
 
 ### Shared directory
 
-Starting with the OpenQuake Engine 3.3 a [shared directory](../installing/cluster.md) must exists between the master node and workers. Docker compose already set a shared volume between containers([docker-compose.yml#L46](https://github.com/gem/oq-builders/blob/master/oq-docker/docker-compose.yml#L46)).
+Starting with the OpenQuake Engine 3.3 a [shared directory](../installing/cluster.md) must exists between the master node and workers. Docker compose already set a shared volume between containers ([docker-compose.yml#L46](../../docker/docker-compose.yml#L46)).
 When running containers on different nodes (which should be the case) you must adjust `docker-compose.yml` properly to use a shared storage backend.
-A configuration example for NFS is provided via the `oqdata-nfs` volume in [docker-compose.yml#L63](https://github.com/gem/oq-builders/blob/master/oq-docker/docker-compose.yml#L64).
+A configuration example for NFS is provided via the `oqdata-nfs` volume in [docker-compose.yml#L63](../../docker/docker-compose.yml#L64).
 
 ## Deploy an OpenQuake Engine cluster manually
 
@@ -55,7 +55,7 @@ $ docker run -d --network=oq-cluster-net --name oq-cluster-worker_1 openquake/en
 - [Introduction](../installing/docker.md)
 - [Single node deployment](single.md)
 - [Advanced options](advanced.md)
-- [Build from sources](https://github.com/gem/oq-builders/tree/master/oq-docker#build-openquake-docker-images)
+- [Build from sources](../../docker#build-openquake-docker-images)
 
 ***
 

--- a/doc/docker/single.md
+++ b/doc/docker/single.md
@@ -70,7 +70,7 @@ You can print the list of containers and images using `$ docker ps -a` and `$ do
 - [Introduction](../installing/docker.md)
 - [Cluster deployment](cluster.md)
 - [Advanced options](advanced.md)
-- [Build from sources](https://github.com/gem/oq-builders/tree/master/oq-docker#build-openquake-docker-images)
+- [Build from sources](../../docker#build-openquake-docker-images)
 
 ***
 

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -65,6 +65,8 @@ receiver_ports = 1912-1920
 authkey = somethingstronger
 ```
 
+A full [sample configuration](../../openquake/engine/openquake.cfg.cluster-sample) is provided as reference.
+
 ### Configuring daemons
 
 The required daemons are:

--- a/doc/installing/docker.md
+++ b/doc/installing/docker.md
@@ -43,7 +43,7 @@ $ docker pull docker.io/openquake/engine:2.9
 - [Single node deployment](../docker/single.md)
 - [Cluster deployment](../docker/cluster.md)
 - [Advanced options](../docker/advanced.md)
-- [Build from sources](https://github.com/gem/oq-builders/tree/master/oq-docker#build-openquake-docker-images)
+- [Build from sources](../../docker#build-openquake-docker-images)
 
 ***
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,14 @@
+# vi:syntax=dockerfile
+FROM centos:7
+MAINTAINER Daniele Viganò <daniele@openquake.org>
+
+RUN curl -so /etc/yum.repos.d/gem-openquake-stable-epel-7.repo \
+    https://copr.fedorainfracloud.org/coprs/gem/openquake-stable/repo/epel-7/gem-openquake-stable-epel-7.repo
+RUN yum -q -y install oq-python36 && \
+    yum -q -y clean all
+
+RUN useradd -u 1000 openquake && \
+    mkdir /etc/openquake
+ENV LANG en_US.UTF-8
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile.engine
+++ b/docker/Dockerfile.engine
@@ -1,0 +1,32 @@
+# vi:syntax=dockerfile
+FROM openquake/base
+MAINTAINER Daniele Viganò <daniele@openquake.org>
+
+ARG oq_branch=master
+ARG tools_branch=master
+
+ENV PATH /opt/openquake/bin:$PATH
+ADD https://api.github.com/repos/gem/oq-engine/git/refs/heads/$oq_branch /tmp/nocache.json
+RUN curl -so /opt/openquake/requirements.txt https://raw.githubusercontent.com/gem/oq-engine/$oq_branch/requirements-py36-linux64.txt && \
+    pip3 -q install -r /opt/openquake/requirements.txt && \
+    pip3 -q install https://github.com/gem/oq-engine/archive/$oq_branch.zip && \
+    for app in oq-platform-standalone oq-platform-ipt oq-platform-taxtweb oq-platform-taxonomy; do \
+        if curl --output /dev/null --silent --head --fail --location https://github.com/gem/${app}/archive/$tools_branch.zip ; then \
+           pip3 -q install https://github.com/gem/${app}/archive/$tools_branch.zip; \
+        else \
+           pip3 -q install https://github.com/gem/${app}/archive/master.zip; \
+        fi \
+    done
+
+
+USER openquake
+ENV LANG en_US.UTF-8
+ENV HOME /home/openquake
+WORKDIR ${HOME}
+RUN mkdir oqdata
+
+ADD scripts/oq-start.sh ${HOME}
+
+EXPOSE 8800:8800
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["./oq-start.sh"]

--- a/docker/Dockerfile.master
+++ b/docker/Dockerfile.master
@@ -1,0 +1,9 @@
+# vi:syntax=dockerfile
+FROM openquake/engine
+MAINTAINER Daniele Viganò <daniele@openquake.org>
+
+ADD ../openquake/engine/openquake.cfg.cluster-sample /etc/openquake/openquake.cfg
+
+EXPOSE 8800:8800
+ENTRYPOINT ["/bin/bash"]
+CMD ["./oq-start.sh"]

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,0 +1,9 @@
+# vi:syntax=dockerfile
+FROM openquake/engine
+MAINTAINER Daniele Viganò <daniele@openquake.org>
+
+ADD scripts/celery-wait.sh ${HOME}
+ADD ../openquake/engine/openquake.cfg.cluster-sample /etc/openquake/openquake.cfg
+
+ENTRYPOINT ["/opt/openquake/bin/python3", "-m", "celery"]
+CMD ["worker", "--workdir", "/opt/openquake/lib/python3.6/site-packages/openquake/engine", "--purge", "-O", "fair"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,45 @@
+# OpenQuake Docker images
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/7/79/Docker_%28container_engine%29_logo.png" width="150px"> [![Build Status](https://ci.openquake.org/buildStatus/icon?job=builders/docker-builder)](https://ci.openquake.org/job/builders/docker-builder)
+
+End user documentation: ../doc/installing/docker.md
+
+
+## Python3 base image (required by all images)
+
+```bash
+$ docker build -t openquake/base -f Dockerfile.base .
+```
+
+## OpenQuake Engine (single node)
+
+```bash
+$ docker build -t openquake/engine -f Dockerfile.engine .
+```
+
+## OpenQuake Engine master node container (cluster)
+
+```bash
+$ docker build -t openquake/engine-master -f Dockerfile.master .
+```
+
+## OpenQuake Engine worker node container (cluster)
+
+```bash
+$ docker build -t openquake/engine-worker -f Dockerfile.worker .
+```
+
+## Custom build args
+
+```bash
+--build-arg oq_branch=master      ## oq-engine branch
+--build-arg tools_branch=mater    ## oq standalone tools branch
+```
+
+## Debug
+
+It's possible to enter a container as `root`, for debug purposes, running
+
+```bash
+$ docker exec -u 0 -t -i oq-cluster-master /bin/bash
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '2'
+services:
+  rabbitmq:
+    image: rabbitmq:3
+    environment:
+      - RABBITMQ_DEFAULT_VHOST=openquake 
+      - RABBITMQ_DEFAULT_USER=openquake
+      - RABBITMQ_DEFAULT_PASS=openquake
+    networks:
+      - cluster
+  # Engine is not actually executed and is
+  # exposed only to make sure it is built via
+  # docker-compose build
+  # engine:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile.engine
+  #   image: openquake/engine
+  #   command: '-c true'
+  master:
+    build:
+      context: .
+      dockerfile: Dockerfile.master
+    image: openquake/engine-master
+    # Uncomment to enable auth in WebUI/API
+    # environment:
+    #   - LOCKDOWN=true
+    volumes:
+      - oqdata:/home/openquake/oqdata
+    # Uncomment to use a local copy of the oq-engine
+    #   - ./path/to/oq-engine/openquake:/opt/openquake/lib/python3.6/site-packages/openquake
+    # Uncomment to use a custom openquake.cfg
+    #   - ./path/to/openquake.cfg:/etc/openquake/openquake.cfg
+    networks:
+      - cluster
+    ports:
+      - 8800:8800
+    depends_on:
+      - rabbitmq
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+    image: openquake/engine-worker
+    volumes:
+      - oqdata:/home/openquake/oqdata:ro
+    # Uncomment to use a local copy of the oq-engine
+    #   - ./path/to/oq-engine/openquake:/opt/openquake/lib/python3.6/site-packages/openquake
+    # Uncomment to use a custom openquake.cfg
+    #   - ./path/to/openquake.cfg:/etc/openquake/openquake.cfg
+    environment:
+      - OQ_RABBITMQ_HOST=rabbitmq
+    entrypoint: ["./celery-wait.sh"]
+    networks:
+      - cluster
+    depends_on:
+      - rabbitmq
+      - master
+
+# When running on multiple host the volume must be shared between every node
+# see the 'oqdata-nfs' example below
+volumes:
+  oqdata:
+  # oqdata-nfs:
+  #   driver: local
+  #   driver_opts:
+  #     type: nfs
+  #     o: nfsvers=4,addr=nfs-server,rw
+  #     device: ":/oqdata"
+
+networks:
+  cluster:

--- a/docker/scripts/celery-wait.sh
+++ b/docker/scripts/celery-wait.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+while :
+do
+    (echo > /dev/tcp/${OQ_RABBITMQ_HOST:-rabbitmq}/5672) >/dev/null 2>&1
+    result=$?
+    if [[ $result -eq 0 ]]; then
+        break
+    fi
+    sleep 1
+done
+
+# Start celery
+/opt/openquake/bin/celery worker --workdir /opt/openquake/lib/python3.6/site-packages/openquake/engine --purge -Ofair

--- a/docker/scripts/oq-start.sh
+++ b/docker/scripts/oq-start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This is required to load a custom  local_settings.py when 'oq webui' is used.
+export PYTHONPATH=$HOME
+
+/opt/openquake/bin/python3 -m openquake.server.dbserver &
+
+# Wait the DbServer to come up; may be replaced with a "oq dbserver wait"
+while :
+do
+    (echo > /dev/tcp/localhost/1908) >/dev/null 2>&1
+    result=$?
+    if [[ $result -eq 0 ]]; then
+        break
+    fi
+    sleep 1
+done
+
+if [ -n "$LOCKDOWN" ]; then
+    echo "LOCKDOWN = True" > $HOME/local_settings.py
+    oq webui migrate
+    echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin')" | oq shell 2>&1 >/dev/null
+fi
+
+if [ -t 1 ]; then
+    # TTY mode
+    oq webui start 0.0.0.0:8800 &> /tmp/webui.log &
+    /bin/bash
+else
+    # Headless mode
+    oq webui start 0.0.0.0:8800 2>&1 | tee /tmp/webui.log
+fi

--- a/openquake/engine/openquake.cfg.cluster-sample
+++ b/openquake/engine/openquake.cfg.cluster-sample
@@ -1,0 +1,82 @@
+# Copyright (C) 2010-2018 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+[distribution]
+# set multi_node = true if are on a cluster
+multi_node = true
+
+# enable celery only if you have a cluster
+oq_distribute = celery
+
+# make sure workers are terminated when tasks are revoked
+terminate_workers_on_revoke = true
+
+# change this on a cluster if using oq_distribute = dask
+dask_scheduler = 127.0.0.1:1921
+
+
+[memory]
+# above this quantity (in %) of memory used a warning will be printed
+soft_mem_limit = 90
+# above this quantity (in %) of memory used the job will be stopped
+# use a lower value to protect against loss of control when OOM occurs
+hard_mem_limit = 99
+
+[amqp]
+# RabbitMQ server address
+host = rabbitmq
+port = 5672
+user = openquake
+password = openquake
+vhost = openquake
+celery_queue = celery
+
+[dbserver]
+# enable multi_user if you have a multiple user installation
+multi_user = true
+file = /home/openquake/oqdata/db.sqlite3
+log = /home/openquake/oqdata/dbserver.log
+# daemon bind address; must be a valid IP address
+# example: 0.0.0.0
+listen = 0.0.0.0
+# address of the dbserver; can be an hostname too
+# example: master.hpc
+host = master
+# port 1908 has a good reputation:
+# https://isc.sans.edu/port.html?port=1908
+port = 1908
+# port range used by workers to send back results
+# to the master node
+receiver_ports = 1912-1920
+authkey = changeme
+
+[zworkers]
+host_cores = 127.0.0.1 -1
+ctrl_port = 1909
+task_in_port = 1910
+task_out_port = 1911
+remote_python =
+
+[directory]
+# the base directory containing the <user>/oqdata directories:
+# if set, it should be on a shared filesystem; this is **mandatory** on a multi-node cluster
+# if not set, the oqdata directories go into $HOME/oqdata,
+# unless the user sets his own OQ_DATADIR variable
+shared_dir =
+# a custom path where to store temporary data; on Linux systems by default
+# temporary files are stored in /tmp, but on HPC and cloud systems the
+# drive containing the root fs is usually quite small
+# path must exists otherwise default $TMPDIR will be used as fallback
+custom_tmp =

--- a/rpm/python3-oq-engine.spec.inc
+++ b/rpm/python3-oq-engine.spec.inc
@@ -201,6 +201,7 @@ fi
 ) >/dev/null || true
 
 %files master
+%doc openquake/engine/openquake.cfg.cluster-sample
 
 %post worker
 %systemd_post openquake-celery.service
@@ -212,6 +213,7 @@ fi
 %systemd_postun_with_restart openquake-celery.service
 
 %files worker
+%doc openquake/engine/openquake.cfg.cluster-sample
 %{_unitdir}/openquake-celery.service
 
 %changelog


### PR DESCRIPTION
With this PR we are moving the Docker stuff related to the oq-engine in its repo.

We are also now providing a sample configuration for a cluster deployments.

This addresses comments in https://github.com/gem/oq-engine-celery/pull/7
https://ci.openquake.org/job/zdevel_oq-engine/2818/