### PR TITLE
Update message box when an unsupported browser is used

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+  [Daniele Viganò]
+  * Added a warning box when an unsupported browser is used to view the WebUI
+  * Updated Docker containers to support a multi-node deployment
+    with a shared directory
+  * Moved the Docker containers source code from oq-builders
+  * Updated the documentation related to the shared directory
+    which is now mandatory for multi-node deployments
+
   [Matteo Nastasi]
   * Removed tests folders
 

--- a/openquake/server/static/lib/outdatedbrowser/lang/en.html
+++ b/openquake/server/static/lib/outdatedbrowser/lang/en.html
@@ -1,3 +1,3 @@
- <h6>Your browser is out of date!</h6>
- <p>Update your browser to view this website correctly. <a id="btnUpdateBrowser" href="http://outdatedbrowser.com/">Update my browser now </a></p>
+ <h6>Your browser is not supported</h6>
+ <p>Please update your browser in order to use this site and other GEM / OpenQuake web services <a id="btnUpdateBrowser" href="http://outdatedbrowser.com/">Download a supported browser</a></p>
  <p class="last"><a href="#" id="btnCloseUpdateBrowser" title="Close">&times;</a></p>

--- a/openquake/server/templates/engine/base.html
+++ b/openquake/server/templates/engine/base.html
@@ -108,8 +108,8 @@
     //-->
     $( document ).ready(function() {
         outdatedBrowser({
-            bgColor: '#f25648',
-            color: '#ffffff',
+            bgColor: '#1b75a5',
+            color: '#fefefe',
             lowerThan: 'borderImage',
             languagePath: '{{ STATIC_URL }}lib/outdatedbrowser/lang/en.html'
         })


### PR DESCRIPTION
As requested by @pslh 

![screenshot from 2018-12-20 15-27-52](https://user-images.githubusercontent.com/1818657/50290424-ea465380-046b-11e9-88df-7323c7e25592.png)

Screenshot is old, bu I'm too lazy to make a new one. Now the button says "Download a supported browser" (instead of "newer")