### PR TITLE
Added an API `/extract/event_info/eid`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Added an API `/extract/event_info/eid`
+  * Added an API `/extract/event_info/eidx`
   * Splitting the sources in classical calculators and not in event based
   * Removed `max_site_model_distance`
   * Extended the logic used in event_based_risk - read the hazard sites

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added an API `/extract/event_info/eid`
   * Splitting the sources in classical calculators and not in event based
   * Removed `max_site_model_distance`
   * Extended the logic used in event_based_risk - read the hazard sites

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -511,6 +511,7 @@ class RuptureGetter(object):
         dic = {'trt': self.trt, 'samples': self.samples}
         with datastore.read(self.hdf5path) as dstore:
             rupgeoms = dstore['rupgeoms']
+            source_ids = dstore['source_info']['source_id']
             rec = self.rup_array[0]
             geom = rupgeoms[rec['gidx1']:rec['gidx2']].reshape(
                 rec['sy'], rec['sz'])
@@ -525,6 +526,7 @@ class RuptureGetter(object):
             dic['grp_id'] = rec['grp_id']
             dic['n_occ'] = rec['n_occ']
             dic['serial'] = rec['serial']
+            dic['srcid'] = source_ids[rec['srcidx']]
         return dic
 
     def get_ruptures(self, srcfilter=None):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -503,6 +503,30 @@ class RuptureGetter(object):
                     eid_rlz.append((eid, rlz))
         return numpy.array(eid_rlz, [('eid', U64), ('rlz', U16)])
 
+    def get_rupdict(self):
+        """
+        :returns: a dictionary with the parameter of the rupture
+        """
+        assert len(self.rup_array) == 1, 'Please specify a slice of length 1'
+        dic = {'trt': self.trt, 'samples': self.samples}
+        with datastore.read(self.hdf5path) as dstore:
+            rupgeoms = dstore['rupgeoms']
+            rec = self.rup_array[0]
+            geom = rupgeoms[rec['gidx1']:rec['gidx2']].reshape(
+                rec['sy'], rec['sz'])
+            dic['lons'] = geom['lon']
+            dic['lats'] = geom['lat']
+            dic['deps'] = geom['depth']
+            rupclass, surclass = self.code2cls[rec['code']]
+            dic['rupture_class'] = rupclass.__name__
+            dic['surface_class'] = surclass.__name__
+            dic['hypo'] = rec['hypo']
+            dic['occurrence_rate'] = rec['occurrence_rate']
+            dic['grp_id'] = rec['grp_id']
+            dic['n_occ'] = rec['n_occ']
+            dic['serial'] = rec['serial']
+        return dic
+
     def get_ruptures(self, srcfilter=None):
         """
         :returns: a list of EBRuptures filtered by bounding box

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -505,7 +505,7 @@ class RuptureGetter(object):
 
     def get_rupdict(self):
         """
-        :returns: a dictionary with the parameter of the rupture
+        :returns: a dictionary with the parameters of the rupture
         """
         assert len(self.rup_array) == 1, 'Please specify a slice of length 1'
         dic = {'trt': self.trt, 'samples': self.samples}

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -128,7 +128,16 @@ class EventBasedTestCase(CalculatorTestCase):
 
         # testing event_info
         einfo = dict(extract(self.calc.datastore, 'event_info/0'))
-        # TODO: add test
+        self.assertEqual(einfo['trt'], 'active shallow crust')
+        self.assertEqual(einfo['rupture_class'],
+                         'ParametricProbabilisticRupture')
+        self.assertEqual(einfo['surface_class'], 'PlanarSurface')
+        self.assertEqual(einfo['serial'], 1066)
+        self.assertEqual(str(einfo['gsim']), "'MultiGMPE()'")
+        self.assertEqual(einfo['rlzi'], 0)
+        self.assertEqual(einfo['grp_id'], 0)
+        self.assertEqual(einfo['occurrence_rate'], 1.0)
+        self.assertEqual(list(einfo['hypo']), [0., 0., 4.])
 
         [fname, _sitefile] = out['gmf_data', 'csv']
         self.assertEqualFiles('expected/gmf-data.csv', fname)

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -29,6 +29,7 @@ from openquake.hazardlib.sourceconverter import RuptureConverter
 from openquake.commonlib.util import max_rel_diff_index
 from openquake.calculators.views import view
 from openquake.calculators.export import export
+from openquake.calculators.extract import extract
 from openquake.calculators.event_based import get_mean_curves
 from openquake.calculators.tests import CalculatorTestCase
 from openquake.qa_tests_data.event_based import (
@@ -124,6 +125,10 @@ class EventBasedTestCase(CalculatorTestCase):
     @attr('qa', 'hazard', 'event_based')
     def test_case_1(self):
         out = self.run_calc(case_1.__file__, 'job.ini', exports='csv,xml')
+
+        # testing event_info
+        einfo = dict(extract(self.calc.datastore, 'event_info/0'))
+        # TODO: add test
 
         [fname, _sitefile] = out['gmf_data', 'csv']
         self.assertEqualFiles('expected/gmf-data.csv', fname)


### PR DESCRIPTION
Still experimental for the moment. Here is how to use it from Python:
```python
from openquake.calculators.extract import extract
from openquake.baselib.datastore import read
   
dstore = read(-1)  # after running the hazard event based demo
print(dict(extract(dstore, 'event_info/192')))
```