### PR TITLE
20190111 rup weights

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Marco Pagani]
+  * Fixes the implementation on mutex ruptures
+
   [Michele Simionato]
   * Added a check to forbid to set `ses_per_logic_tree_path = 0`
   * Added an API `/extract/event_info/eidx`

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -99,7 +99,7 @@ def classical(group, src_filter, gsims, param, monitor=Monitor()):
         t0 = time.time()
         try:
             poemap = cmaker.poe_map(src, s_sites, imtls, trunclevel,
-                                    not rup_mutex)
+                                    rup_indep=not rup_mutex)
         except Exception as err:
             etype, err, tb = sys.exc_info()
             msg = '%s (source id=%s)' % (str(err), src.source_id)
@@ -190,6 +190,7 @@ def calc_hazard_curves(
             par['grp_probability'] = group.grp_probability
             it = [classical(group.sources, ss_filter, [gsim], par, mon)]
         else:  # split the group and apply `classical` in parallel
+            param['rup_interdep'] = group.rup_interdep
             it = apply(
                 classical, (group.sources, ss_filter, [gsim], param, mon),
                 weight=operator.attrgetter('weight'))

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -237,10 +237,8 @@ class ContextMaker(object):
         pmap = ProbabilityMap.build(
             len(imtls.array), len(self.gsims), s_sites.sids,
             initvalue=rup_indep)
-        weight = 1. / src.num_ruptures
         eff_ruptures = 0
         for rup, sites in self.get_rupture_sites(src, s_sites):
-            rup.weight = weight
             try:
                 with self.ctx_mon:
                     sctx, dctx = self.make_contexts(sites, rup)

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -51,17 +51,13 @@ class NonParametricSeismicSource(BaseSeismicSource):
         of occurrences equal to 0)
     """
     code = b'N'
-    _slots_ = BaseSeismicSource._slots_ + ['data', 'rupture_weights']
+    _slots_ = BaseSeismicSource._slots_ + ['data']
 
     MODIFICATIONS = set()
 
-    def __init__(self, source_id, name, tectonic_region_type, data,
-                 rupture_weights=None):
+    def __init__(self, source_id, name, tectonic_region_type, data):
         super().__init__(source_id, name, tectonic_region_type)
         self.data = data
-        if rupture_weights is None:
-            rupture_weights = numpy.empty((len(self.data)))
-        self.rupture_weights = rupture_weights
 
     def iter_ruptures(self):
         """
@@ -72,11 +68,11 @@ class NonParametricSeismicSource(BaseSeismicSource):
             Generator of instances of :class:`openquake.hazardlib.source.
             rupture.NonParametricProbabilisticRupture`.
         """
-        for (rup, pmf), wei in zip(self.data, self.rupture_weights):
+        for rup, pmf in self.data:
             if rup.mag >= self.min_mag:
                 yield NonParametricProbabilisticRupture(
                     rup.mag, rup.rake, self.tectonic_region_type,
-                    rup.hypocenter, rup.surface, pmf, weight=wei)
+                    rup.hypocenter, rup.surface, pmf, weight=rup.weight)
 
     def __iter__(self):
         if len(self.data) == 1:  # there is nothing to split

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -127,7 +127,7 @@ class NonParametricSeismicSource(BaseSeismicSource):
         """
         :returns: True if containing only GriddedRuptures, False otherwise
         """
-        for rup, pmf in self.data:
+        for rup, _ in self.data:
             if not isinstance(rup.surface, GriddedSurface):
                 return False
         return True

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -75,7 +75,7 @@ class BaseRupture(metaclass=abc.ABCMeta):
     attribute surface_nodes to an appropriate value.
     """
     _slots_ = '''mag rake tectonic_region_type hypocenter surface
-    rupture_slip_direction'''.split()
+    rupture_slip_direction weight'''.split()
     serial = 0  # set to a value > 0 by the engine
     _code = {}
     types = {}
@@ -101,7 +101,7 @@ class BaseRupture(metaclass=abc.ABCMeta):
             raise ValueError('Too many rupture codes: %d' % n)
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter,
-                 surface, rupture_slip_direction=None):
+                 surface, rupture_slip_direction=None, weight=None):
         if not mag > 0:
             raise ValueError('magnitude must be positive')
         NodalPlane.check_rake(rake)
@@ -111,6 +111,8 @@ class BaseRupture(metaclass=abc.ABCMeta):
         self.hypocenter = hypocenter
         self.surface = surface
         self.rupture_slip_direction = rupture_slip_direction
+        self.weight = weight
+
 
     @property
     def code(self):
@@ -177,7 +179,7 @@ class NonParametricProbabilisticRupture(BaseRupture):
         in increasing order, and if they are not defined with unit step
     """
     def __init__(self, mag, rake, tectonic_region_type, hypocenter, surface,
-                 pmf, rupture_slip_direction=None):
+                 pmf, rupture_slip_direction=None, weight=None):
         occ = numpy.array([occ for (prob, occ) in pmf.data])
         if not occ[0] == 0:
             raise ValueError('minimum number of ruptures must be zero')
@@ -189,7 +191,7 @@ class NonParametricProbabilisticRupture(BaseRupture):
                 'numbers of ruptures must be defined with unit step')
         super().__init__(
             mag, rake, tectonic_region_type, hypocenter, surface,
-            rupture_slip_direction)
+            rupture_slip_direction, weight)
         # an array of probabilities with sum 1
         self.probs_occur = numpy.array(
             [prob for (prob, occ) in pmf.data], numpy.float32)

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -124,6 +124,11 @@ class SourceGroup(collections.Sequence):
             for src in src_list:
                 assert src.tectonic_region_type == self.trt, (
                     src.tectonic_region_type, self.trt)
+                # Mutually exclusive ruptures can only be non-parametric
+                print(type(src))
+                if rup_interdep in ('mutex'):
+                    if not isinstance(src, NonParametricSeismicSource):
+                        raise ValueError('Wrong source typology')
 
     def update(self, src):
         """

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -154,7 +154,7 @@ class SourceGroup(collections.Sequence):
             src.min_mag = self.min_mag.get(self.trt) or self.min_mag['default']
         # checking mutex ruptures
         if (not isinstance(src, NonParametricSeismicSource) and
-                self.rup_interdep in ('mutex')):
+                self.rup_interdep == 'mutex'):
             msg = "Mutually exclusive ruptures can only be "
             msg += "modelled using non-parametric sources"
             raise ValueError(msg)

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -28,6 +28,7 @@ from openquake.baselib.node import context, striptag, Node
 from openquake.hazardlib import geo, mfd, pmf, source
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib import valid, InvalidFile
+from openquake.hazardlib.source import NonParametricSeismicSource
 
 U32 = numpy.uint32
 U64 = numpy.uint64

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -96,11 +96,11 @@ class SourceGroup(collections.Sequence):
                  tot_ruptures=0):
         # checks
         self.trt = trt
-        self._check_init_variables(sources, name, src_interdep, rup_interdep)
         self.sources = []
         self.name = name
         self.src_interdep = src_interdep
         self.rup_interdep = rup_interdep
+        self._check_init_variables(sources, name, src_interdep, rup_interdep)
         self.grp_probability = grp_probability
         self.min_mag = min_mag
         self.max_mag = max_mag
@@ -111,6 +111,7 @@ class SourceGroup(collections.Sequence):
                 self.update(src)
         self.source_model = None  # to be set later, in CompositionInfo
         self.eff_ruptures = eff_ruptures  # set later by get_rlzs_assoc
+        # check weights in case of mutually exclusive ruptures
         if rup_interdep == 'mutex':
             for src in self.sources:
                 assert isinstance(src, NonParametricSeismicSource)
@@ -133,6 +134,7 @@ class SourceGroup(collections.Sequence):
                 # Mutually exclusive ruptures can only belong to non-parametric
                 # sources
                 if rup_interdep in ('mutex'):
+                    print('muuutex')
                     if not isinstance(src, NonParametricSeismicSource):
                         msg = "Mutually exclusive ruptures can only be "
                         msg += "modelled using non-parametric sources"
@@ -151,6 +153,14 @@ class SourceGroup(collections.Sequence):
             src.tectonic_region_type, self.trt)
         if not src.min_mag:  # if not set already
             src.min_mag = self.min_mag.get(self.trt) or self.min_mag['default']
+        # checking mutex ruptures
+        if (not isinstance(src, NonParametricSeismicSource) and 
+                self.rup_interdep in ('mutex')):
+            msg = "Mutually exclusive ruptures can only be "
+            msg += "modelled using non-parametric sources"
+            raise ValueError(msg)
+
+
         nr = get_set_num_ruptures(src)
         if nr == 0:  # the minimum_magnitude filters all ruptures
             return

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -133,8 +133,7 @@ class SourceGroup(collections.Sequence):
                     src.tectonic_region_type, self.trt)
                 # Mutually exclusive ruptures can only belong to non-parametric
                 # sources
-                if rup_interdep in ('mutex'):
-                    print('muuutex')
+                if rup_interdep == 'mutex':
                     if not isinstance(src, NonParametricSeismicSource):
                         msg = "Mutually exclusive ruptures can only be "
                         msg += "modelled using non-parametric sources"
@@ -154,7 +153,7 @@ class SourceGroup(collections.Sequence):
         if not src.min_mag:  # if not set already
             src.min_mag = self.min_mag.get(self.trt) or self.min_mag['default']
         # checking mutex ruptures
-        if (not isinstance(src, NonParametricSeismicSource) and 
+        if (not isinstance(src, NonParametricSeismicSource) and
                 self.rup_interdep in ('mutex')):
             msg = "Mutually exclusive ruptures can only be "
             msg += "modelled using non-parametric sources"
@@ -774,7 +773,7 @@ class SourceConverter(RuptureConverter):
         trt = node.attrib.get('tectonicRegion')
         rup_pmf_data = []
         rups_weights = None
-        if 'rup_weights' in node.attrib.keys():
+        if 'rup_weights' in node.attrib:
             tmp = node.attrib.get('rup_weights')
             rups_weights = numpy.array([float(s) for s in tmp.split()])
         for i, rupnode in enumerate(node):

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -26,6 +26,7 @@ import numpy
 from openquake.baselib.general import CallableDict, groupby
 from openquake.baselib.node import Node, node_to_dict
 from openquake.hazardlib import nrml, sourceconverter, pmf
+from openquake.hazardlib.source import NonParametricSeismicSource
 
 obj_to_node = CallableDict(lambda obj: obj.__class__.__name__)
 
@@ -384,9 +385,17 @@ def get_source_attributes(source):
     :returns:
         Dictionary of source attributes
     """
-    return {"id": source.source_id,
-            "name": source.name,
-            "tectonicRegion": source.tectonic_region_type}
+    attrs = {"id": source.source_id,
+             "name": source.name,
+             "tectonicRegion": source.tectonic_region_type}
+    if isinstance(source, NonParametricSeismicSource):
+        if source.data[0][0].weight is not None:
+            weights = []
+            for data in source.data:
+                weights.append(data[0].weight)
+            attrs['rup_weights'] = numpy.array(weights)
+    print(attrs)
+    return attrs
 
 
 @obj_to_node.add('AreaSource')

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -143,6 +143,10 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
         rupture = _create_rupture(10., 6.)
         data = [(rupture, PMF([(0.7, 0), (0.3, 1)])),
                 (rupture, PMF([(0.6, 0), (0.4, 1)]))]
+        print(data[0][0])
+        data[0][0].weight = 0.5
+        data[1][0].weight = 0.5
+        print(data[0][0].weight)
         src = NonParametricSeismicSource('0', 'test', TRT.ACTIVE_SHALLOW_CRUST,
                                          data)
         src.src_group_id = 0

--- a/openquake/hazardlib/tests/calc/hazard_curve_rupture_mutex.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_rupture_mutex.py
@@ -1,0 +1,57 @@
+# The Hazard Library
+# Copyright (C) 2016-2018 GEM Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+import numpy
+import numpy.testing as npt
+
+from openquake.baselib.general import DictArray
+from openquake.hazardlib.source import NonParametricSeismicSource
+from openquake.hazardlib.source.rupture import BaseRupture
+from openquake.hazardlib.sourceconverter import SourceConverter
+from openquake.hazardlib.const import TRT
+from openquake.hazardlib.geo.surface import PlanarSurface, SimpleFaultSurface
+from openquake.hazardlib.geo import Point, Line
+from openquake.hazardlib.geo.geodetic import point_at
+from openquake.hazardlib.calc.filters import SourceFilter
+from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
+from openquake.hazardlib.calc.hazard_curve import classical
+from openquake.hazardlib.gsim.sadigh_1997 import SadighEtAl1997
+from openquake.hazardlib.gsim.si_midorikawa_1999 import SiMidorikawa1999SInter
+from openquake.hazardlib.gsim.campbell_2003 import Campbell2003
+from openquake.hazardlib.site import Site, SiteCollection
+from openquake.hazardlib.pmf import PMF
+from openquake.hazardlib.sourceconverter import SourceGroup
+from openquake.hazardlib import nrml
+
+
+class MutexRupturesTestCase(unittest.TestCase):
+
+    def test(self):
+        """ Test rupture calculation in case of mutually exclusive ruptures """
+        d = os.path.dirname(os.path.dirname(__file__))
+        source_model = os.path.join(d, 'source_model/nonparametric-source-mutex-ruptures.xml')
+        groups = nrml.to_python(source_model, SourceConverter(
+            investigation_time=50., rupture_mesh_spacing=2.))
+        site = Site(Point(143.5, 39.5), 800, z1pt0=100., z2pt5=1.)
+        sitecol = SiteCollection([site])
+        imtls = DictArray({'PGA': [0.01, 0.1, 0.2, 0.5]})
+        gsim_by_trt = {'Some TRT': Campbell2003()}
+        hcurves = calc_hazard_curves(groups, sitecol, imtls, gsim_by_trt)
+        # expected results obtained with an ipython notebook
+        expected = [4.3998728e-01, 1.1011728e-01, 7.5495312e-03, 8.5812844e-06]
+        npt.assert_almost_equal(hcurves['PGA'][0], expected)

--- a/openquake/hazardlib/tests/source_model/nonparametric-source-mutex-ruptures.xml
+++ b/openquake/hazardlib/tests/source_model/nonparametric-source-mutex-ruptures.xml
@@ -16,6 +16,7 @@ xmlns:gml="http://www.opengis.net/gml"
             id="1"
             name="Fake Non Parametric Source"
             tectonicRegion="Some TRT"
+            rup_weights="0.2 0.8"
             >
                 <singlePlaneRupture
                 probs_occur="0.4 0.6"

--- a/openquake/hazardlib/tests/source_model/nonparametric-source-mutex-ruptures.xml
+++ b/openquake/hazardlib/tests/source_model/nonparametric-source-mutex-ruptures.xml
@@ -16,14 +16,16 @@ xmlns:gml="http://www.opengis.net/gml"
             id="1"
             name="Fake Non Parametric Source"
             tectonicRegion="Some TRT"
-            rup_weights="0.2 0.8"
             >
-                <!-- first rupture -->
                 <singlePlaneRupture
                 probs_occur="0.4 0.6"
                 >
-                    <magnitude> 7.0 </magnitude>
-                    <rake> 90.0 </rake>
+                    <magnitude>
+                        7.0
+                    </magnitude>
+                    <rake>
+                        90.0
+                    </rake>
                     <hypocenter depth="26.101" lat="40.726" lon="143.0"/>
                     <planarSurface>
                         <topLeft depth="9.0" lat="41.6" lon="143.1"/>
@@ -32,12 +34,15 @@ xmlns:gml="http://www.opengis.net/gml"
                         <bottomRight depth="43.202" lat="39.852" lon="142.91"/>
                     </planarSurface>
                 </singlePlaneRupture>
-                <!-- second rupture -->
                 <singlePlaneRupture
                 probs_occur="0.6 0.4"
                 >
-                    <magnitude> 6.5 </magnitude>
-                    <rake> 90.0 </rake>
+                    <magnitude>
+                        6.5
+                    </magnitude>
+                    <rake>
+                        90.0
+                    </rake>
                     <hypocenter depth="26.101" lat="40.726" lon="143.0"/>
                     <planarSurface>
                         <topLeft depth="9.0" lat="41.6" lon="143.1"/>
@@ -46,7 +51,6 @@ xmlns:gml="http://www.opengis.net/gml"
                         <bottomRight depth="43.202" lat="39.852" lon="142.91"/>
                     </planarSurface>
                 </singlePlaneRupture>
-
             </nonParametricSeismicSource>
         </sourceGroup>
     </sourceModel>

--- a/openquake/hazardlib/tests/source_model/nonparametric-source-mutex-ruptures.xml
+++ b/openquake/hazardlib/tests/source_model/nonparametric-source-mutex-ruptures.xml
@@ -15,8 +15,8 @@ xmlns:gml="http://www.opengis.net/gml"
             <nonParametricSeismicSource
             id="1"
             name="Fake Non Parametric Source"
-            tectonicRegion="Some TRT"
             rup_weights="0.2 0.8"
+            tectonicRegion="Some TRT"
             >
                 <singlePlaneRupture
                 probs_occur="0.4 0.6"

--- a/openquake/hazardlib/tests/source_model/nonparametric-source-mutex-ruptures.xml
+++ b/openquake/hazardlib/tests/source_model/nonparametric-source-mutex-ruptures.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    investigation_time="1.0"
+    name="Test Source Model"
+    >
+        <sourceGroup
+        rup_interdep="mutex"
+        src_interdep="indep"
+        tectonicRegion="Some TRT"
+        >
+            <nonParametricSeismicSource
+            id="1"
+            name="Fake Non Parametric Source"
+            tectonicRegion="Some TRT"
+            rup_weights="0.2 0.8"
+            >
+                <!-- first rupture -->
+                <singlePlaneRupture
+                probs_occur="0.4 0.6"
+                >
+                    <magnitude> 7.0 </magnitude>
+                    <rake> 90.0 </rake>
+                    <hypocenter depth="26.101" lat="40.726" lon="143.0"/>
+                    <planarSurface>
+                        <topLeft depth="9.0" lat="41.6" lon="143.1"/>
+                        <topRight depth="9.0" lat="40.2" lon="143.91"/>
+                        <bottomLeft depth="43.202" lat="41.252" lon="142.07"/>
+                        <bottomRight depth="43.202" lat="39.852" lon="142.91"/>
+                    </planarSurface>
+                </singlePlaneRupture>
+                <!-- second rupture -->
+                <singlePlaneRupture
+                probs_occur="0.6 0.4"
+                >
+                    <magnitude> 6.5 </magnitude>
+                    <rake> 90.0 </rake>
+                    <hypocenter depth="26.101" lat="40.726" lon="143.0"/>
+                    <planarSurface>
+                        <topLeft depth="9.0" lat="41.6" lon="143.1"/>
+                        <topRight depth="9.0" lat="40.2" lon="143.91"/>
+                        <bottomLeft depth="43.202" lat="41.252" lon="142.07"/>
+                        <bottomRight depth="43.202" lat="39.852" lon="142.91"/>
+                    </planarSurface>
+                </singlePlaneRupture>
+
+            </nonParametricSeismicSource>
+        </sourceGroup>
+    </sourceModel>
+</nrml>

--- a/openquake/hazardlib/tests/source_model/rupture_mutex_wrong.xml
+++ b/openquake/hazardlib/tests/source_model/rupture_mutex_wrong.xml
@@ -1,0 +1,45 @@
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    name="Some Source Model"
+    >
+        <sourceGroup
+        name="group 1"
+        tectonicRegion="Active Shallow Crust"
+        rup_interdep="mutex"
+        src_interdep="indep"
+        >
+            <simpleFaultSource
+            id="1"
+            name="Mount Diablo Thrust"
+            tectonicRegion="Active Shallow Crust"
+            >
+                <simpleFaultGeometry>
+                    <gml:LineString>
+                        <gml:posList>
+                            -1.2182290E+02 3.7730100E+01 -1.2203880E+02 3.7877100E+01
+                        </gml:posList>
+                    </gml:LineString>
+                    <dip>
+                        4.5000000E+01
+                    </dip>
+                    <upperSeismoDepth> 1.0000000E+01 </upperSeismoDepth>
+                    <lowerSeismoDepth> 2.0000000E+01 </lowerSeismoDepth>
+                </simpleFaultGeometry>
+                <magScaleRel> WC1994 </magScaleRel>
+                <ruptAspectRatio> 1.5000000E+00 </ruptAspectRatio>
+                <incrementalMFD
+                binWidth="0.1"
+                minMag="6.0"
+                >
+                    <occurRates>
+                        1.0614989E-03 8.8291627E-04 7.3437777E-04 6.1082880E-04 5.0806530E-04
+                    </occurRates>
+                </incrementalMFD>
+                <rake> 30 </rake>
+            </simpleFaultSource>
+        </sourceGroup>
+    </sourceModel>
+</nrml>

--- a/openquake/hazardlib/tests/source_model/source_group_collection.xml
+++ b/openquake/hazardlib/tests/source_model/source_group_collection.xml
@@ -9,7 +9,7 @@ xmlns:gml="http://www.opengis.net/gml"
         <sourceGroup
         grp_probability="0.5"
         name="group1"
-        rup_interdep="mutex"
+        rup_interdep="indep"
         src_interdep="indep"
         srcs_weights="0.1 0.2 0.7"
         tectonicRegion="Stable Continental Crust"

--- a/openquake/hazardlib/tests/sourceconverter_test.py
+++ b/openquake/hazardlib/tests/sourceconverter_test.py
@@ -198,5 +198,5 @@ class SourceConverterTestCase(unittest.TestCase):
         grp = nrml.to_python(testfile)[0]
         src = grp[0]
         expected = numpy.array([0.2, 0.8])
-        computed = numpy.array(src.rupture_weights)
+        computed = numpy.array([src.data[0][0].weight, src.data[1][0].weight])
         numpy.testing.assert_equal(computed, expected)

--- a/openquake/hazardlib/tests/sourceconverter_test.py
+++ b/openquake/hazardlib/tests/sourceconverter_test.py
@@ -18,6 +18,7 @@
 import os
 import io
 import unittest
+from nose.tools import raises
 from openquake.hazardlib import nrml
 from openquake.hazardlib.sourceconverter import update_source_model
 
@@ -174,10 +175,19 @@ class PointToMultiPointTestCase(unittest.TestCase):
 
 
 class SourceConverterTestCase(unittest.TestCase):
+
     def test_wrong_trt(self):
-        # a group with sources of two different TRTs
+        """ Test consistency between group and sources TRTs """
         testfile = os.path.join(testdir, 'wrong-trt.xml')
         with self.assertRaises(ValueError) as ctx:
             nrml.to_python(testfile)
         self.assertIn('node pointSource: Found Cratonic, expected '
                       'Active Shallow Crust, line 67', str(ctx.exception))
+
+    @raises(Exception)
+    def test_wrong_source_type(self):
+        """ Test that only nonparametric sources are used with mutex ruptures 
+        """
+        testfile = os.path.join(testdir, 'rupture_mutex_wrong.xml')
+        with self.assertRaises(ValueError) as ctx:
+            nrml.to_python(testfile)

--- a/openquake/hazardlib/tests/sourceconverter_test.py
+++ b/openquake/hazardlib/tests/sourceconverter_test.py
@@ -184,7 +184,7 @@ class SourceConverterTestCase(unittest.TestCase):
                       'Active Shallow Crust, line 67', str(ctx.exception))
 
     def test_wrong_source_type(self):
-        """ Test that only nonparametric sources are used with mutex ruptures 
+        """ Test that only nonparametric sources are used with mutex ruptures
         """
         testfile = os.path.join(testdir, 'rupture_mutex_wrong.xml')
         with self.assertRaises(ValueError) as ctx:
@@ -192,7 +192,7 @@ class SourceConverterTestCase(unittest.TestCase):
 
     def test_non_parametric_mutex(self):
         """ Test non-parametric source with mutex ruptures """
-        fname  = 'nonparametric-source-mutex-ruptures.xml'
+        fname = 'nonparametric-source-mutex-ruptures.xml'
         testfile = os.path.join(testdir, fname)
         grp = nrml.to_python(testfile)[0]
         src = grp[0]

--- a/openquake/hazardlib/tests/sourceconverter_test.py
+++ b/openquake/hazardlib/tests/sourceconverter_test.py
@@ -18,6 +18,7 @@
 import os
 import io
 import unittest
+import numpy
 from nose.tools import raises
 from openquake.hazardlib import nrml
 from openquake.hazardlib.sourceconverter import update_source_model
@@ -158,7 +159,6 @@ class PointToMultiPointTestCase(unittest.TestCase):
         with io.BytesIO() as f:
             nrml.write(sm, f)
             got = f.getvalue().decode('utf-8')
-            print(got)
             self.assertEqual(got, expected)
 
     def test_complex(self):
@@ -170,7 +170,6 @@ class PointToMultiPointTestCase(unittest.TestCase):
         with io.BytesIO() as f:
             nrml.write(sm, f)
             got = f.getvalue().decode('utf-8')
-            print(got)
             self.assertEqual(got, multipoint)
 
 
@@ -191,3 +190,13 @@ class SourceConverterTestCase(unittest.TestCase):
         testfile = os.path.join(testdir, 'rupture_mutex_wrong.xml')
         with self.assertRaises(ValueError) as ctx:
             nrml.to_python(testfile)
+
+    def test_non_parametric_mutex(self):
+        """ Test non-parametric source with mutex ruptures """
+        fname  = 'nonparametric-source-mutex-ruptures.xml'
+        testfile = os.path.join(testdir, fname)
+        grp = nrml.to_python(testfile)[0]
+        src = grp[0]
+        expected = numpy.array([0.2, 0.8])
+        computed = numpy.array(src.rupture_weights)
+        numpy.testing.assert_equal(computed, expected)

--- a/openquake/hazardlib/tests/sourceconverter_test.py
+++ b/openquake/hazardlib/tests/sourceconverter_test.py
@@ -183,7 +183,6 @@ class SourceConverterTestCase(unittest.TestCase):
         self.assertIn('node pointSource: Found Cratonic, expected '
                       'Active Shallow Crust, line 67', str(ctx.exception))
 
-    @raises(Exception)
     def test_wrong_source_type(self):
         """ Test that only nonparametric sources are used with mutex ruptures 
         """

--- a/openquake/hazardlib/tests/sourcewriter_test.py
+++ b/openquake/hazardlib/tests/sourcewriter_test.py
@@ -36,6 +36,9 @@ ALT_MFDS = os.path.join(os.path.dirname(__file__),
 COLLECTION = os.path.join(os.path.dirname(__file__),
                           'source_model/source_group_collection.xml')
 
+MUTEX = os.path.join(os.path.dirname(__file__),
+                     'source_model/nonparametric-source-mutex-ruptures.xml')
+
 MULTIPOINT = os.path.join(os.path.dirname(__file__),
                           'source_model/multi-point-source.xml')
 
@@ -75,6 +78,9 @@ class SourceWriterTestCase(unittest.TestCase):
 
     def test_collection(self):
         self.check_round_trip(COLLECTION)
+
+    def test_collection(self):
+        self.check_round_trip(MUTEX)
 
     def test_multipoint(self):
         smodel = self.check_round_trip(MULTIPOINT)


### PR DESCRIPTION
This PR improves the handling of the mutually exclusive ruptures case. Mutually exclusive ruptures are now admitted only in case of non parametric sources.
In the .xml weights are specified in this way:
``` xml
            <nonParametricSeismicSource
            id="1"
            name="Fake Non Parametric Source"
            tectonicRegion="Some TRT"
            rup_weights="0.2 0.8"
            >
```
This functionality is useful for the implementation of the New Madrid cluster case in the US model.
