### PR TITLE
Reading the exposures in parallel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
+  [Michele Simionato]
+  * Parallelized the reading of the exposure
+
   [Marco Pagani]
-  * Fixes the implementation on mutex ruptures
+  * Fixed the implementation on mutex ruptures
 
   [Michele Simionato]
   * Changed the aggregated loss curves exporter

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -327,7 +327,7 @@ POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         oqparam.ignore_missing_costs = []
         oqparam.aggregate_by = []
 
-        with self.assertRaises(KeyError) as ctx:
+        with self.assertRaises(Exception) as ctx:
             readinput.get_exposure(oqparam)
         self.assertIn("node asset: 'number', line 17 of", str(ctx.exception))
 

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -767,7 +767,7 @@ class Exposure(object):
     @staticmethod
     def read(fnames, calculation_mode='', region_constraint='',
              ignore_missing_costs=(), asset_nodes=False, check_dupl=True,
-             asset_prefix='', tagcol=None, by_country=False):
+             tagcol=None, by_country=False):
         """
         Call `Exposure.read(fname)` to get an :class:`Exposure` instance
         keeping all the assets in memory or
@@ -775,8 +775,11 @@ class Exposure(object):
         Node objects (one Node for each asset).
         """
         if by_country:
-            prefix2cc = countries.from_exposures(  # E??_ -> countrycode
+            # E??_ -> countrycode
+            prefix2cc = countries.from_exposures(
                 os.path.basename(f) for f in fnames)
+        else:
+            prefix = ''
         if len(fnames) > 1:
             tagcol = _minimal_tagcol(fnames, by_country)
             for i, fname in enumerate(fnames, 1):
@@ -784,8 +787,8 @@ class Exposure(object):
                 if by_country:  # use the 3 letter ISO country code as prefix
                     prefix = prefix2cc[prefix]
                 if i == 1:  # first exposure
-                    exp = Exposure.read(
-                        [fname], calculation_mode, region_constraint,
+                    exp = Exposure.read1(
+                        fname, calculation_mode, region_constraint,
                         ignore_missing_costs, asset_nodes, check_dupl,
                         prefix, tagcol, by_country)
                     exp.description = 'Composite exposure[%d]' % len(fnames)
@@ -805,7 +808,15 @@ class Exposure(object):
             exp.exposures = [os.path.splitext(os.path.basename(f))[0]
                              for f in fnames]
             return exp
-        [fname] = fnames
+        return Exposure.read1(
+            fnames[0], calculation_mode, region_constraint,
+            ignore_missing_costs, asset_nodes, check_dupl,
+            prefix, tagcol, by_country)
+
+    @staticmethod
+    def read1(fname, calculation_mode='', region_constraint='',
+              ignore_missing_costs=(), asset_nodes=False, check_dupl=True,
+              asset_prefix='', tagcol=None, by_country=False):
         logging.info('Reading %s', fname)
         param = {'calculation_mode': calculation_mode}
         param['asset_prefix'] = asset_prefix

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -774,8 +774,7 @@ class Exposure(object):
         `Exposure.read(fname, asset_nodes=True)` to get an iterator over
         Node objects (one Node for each asset).
         """
-        if by_country:
-            # E??_ -> countrycode
+        if by_country:  # E??_ -> countrycode
             prefix2cc = countries.from_exposures(
                 os.path.basename(f) for f in fnames)
         else:
@@ -790,7 +789,7 @@ class Exposure(object):
                     exp = Exposure.read1(
                         fname, calculation_mode, region_constraint,
                         ignore_missing_costs, asset_nodes, check_dupl,
-                        prefix, tagcol, by_country)
+                        prefix, tagcol)
                     exp.description = 'Composite exposure[%d]' % len(fnames)
                 else:
                     logging.info('Reading %s', fname)
@@ -810,13 +809,12 @@ class Exposure(object):
             return exp
         return Exposure.read1(
             fnames[0], calculation_mode, region_constraint,
-            ignore_missing_costs, asset_nodes, check_dupl,
-            prefix, tagcol, by_country)
+            ignore_missing_costs, asset_nodes, check_dupl, prefix, tagcol)
 
     @staticmethod
     def read1(fname, calculation_mode='', region_constraint='',
               ignore_missing_costs=(), asset_nodes=False, check_dupl=True,
-              asset_prefix='', tagcol=None, by_country=False):
+              asset_prefix='', tagcol=None):
         logging.info('Reading %s', fname)
         param = {'calculation_mode': calculation_mode}
         param['asset_prefix'] = asset_prefix

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -801,7 +801,8 @@ class Exposure(object):
                             ignore_missing_costs, asset_nodes, check_dupl,
                             prefix, tagcol))
         exp = None
-        for exposure in parallel.Starmap(Exposure.read_exp, allargs):
+        for exposure in parallel.Starmap(Exposure.read_exp, allargs,
+                                         distribute='processpool'):
             if exp is None:  # first time
                 exp = exposure
                 exp.description = 'Composite exposure[%d]' % len(fnames)

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -801,8 +801,10 @@ class Exposure(object):
                             ignore_missing_costs, asset_nodes, check_dupl,
                             prefix, tagcol))
         exp = None
-        for exposure in parallel.Starmap(Exposure.read_exp, allargs,
-                                         distribute='processpool'):
+        for exposure in parallel.Starmap(
+                Exposure.read_exp, allargs,
+                distribute='no' if os.environ.get('OQ_DISTRIBUTE') == 'no'
+                else 'processpool'):
             if exp is None:  # first time
                 exp = exposure
                 exp.description = 'Composite exposure[%d]' % len(fnames)


### PR DESCRIPTION
For instance in the case of Europe there are 46 exposures. By reading in parallel the import time goes down from 9 minutes to 2 minutes, which is a decent speedup.