### PR TITLE
Shutdown the processpool after parallel_split_filter

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -888,6 +888,7 @@ def get_composite_source_model(oqparam, monitor=None, in_memory=True,
         split = not oqparam.is_event_based()
         csm = parallel_split_filter(csm, srcfilter, split,
                                     monitor('split_filter'))
+        parallel.Starmap.shutdown()  # save memory
     return csm
 
 


### PR DESCRIPTION
This saves a bit of memory. For the Australia calculation it means ~16 GB on wilson, better than nothing, but not enough to run the full calculation.