### PR TITLE
Speed-up store_source_info [aka Australia runs!]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Avoided the MemoryError on the controller node by speeding up the saving
+    of the information about the sources
   * Turned utils/reduce_sm into a proper command
   * Fixed a wrong coefficient in the ShakeMap amplification
   * Fixed a bug in the hazard curves export (the filename did not contain

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Avoided the MemoryError on the controller node by speeding up the saving
+  * Avoided the MemoryError in the controller node by speeding up the saving
     of the information about the sources
   * Turned utils/reduce_sm into a proper command
   * Fixed a wrong coefficient in the ShakeMap amplification

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -76,8 +76,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 if pmap:
                     acc[grp_id] |= pmap
                 self.nsites.append(len(pmap))
-        with self.monitor('store source_info', autoflush=True):
-            self.store_source_info(dic['calc_times'])
+        self.calc_times += dic['calc_times']
         return acc
 
     def zerodict(self):
@@ -120,11 +119,17 @@ class ClassicalCalculator(base.HazardCalculator):
                 'source_data', numpy.array(data, source_data_dt))
         self.csm.sources_by_trt.clear()  # save memory
         self.nsites = []
-        acc = smap.reduce(self.agg_dicts, self.zerodict())
+        self.calc_times = AccumDict(accum=numpy.zeros(3, F32))
+        try:
+            acc = smap.reduce(self.agg_dicts, self.zerodict())
+        finally:
+            with self.monitor('store source_info', autoflush=True):
+                self.store_csm_info(acc.eff_ruptures)
+                self.store_source_info(self.calc_times)
+            self.calc_times.clear()  # save a bit of memory
         if not self.nsites:
             raise RuntimeError('All sources were filtered out!')
         logging.info('Effective sites per task: %d', numpy.mean(self.nsites))
-        self.store_csm_info(acc.eff_ruptures)
         return acc
 
     def gen_args(self):

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -18,8 +18,8 @@
 import os
 import logging
 import operator
-
-from openquake.baselib import parallel
+import numpy as np
+from openquake.baselib import parallel, general
 from openquake.hazardlib.calc.hazard_curve import classical
 from openquake.calculators import base
 from openquake.calculators.classical import ClassicalCalculator
@@ -50,6 +50,7 @@ class UcerfClassicalCalculator(ClassicalCalculator):
         self.nsites = []  # used in agg_dicts
         param = dict(imtls=oq.imtls, truncation_level=oq.truncation_level,
                      filter_distance=oq.filter_distance)
+        self.calc_times = general.AccumDict(accum=np.zeros(3, np.float32))
         for sm in self.csm.source_models:  # one branch at the time
             [grp] = sm.src_groups
             gsims = self.csm.info.get_gsims(sm.ordinal)
@@ -68,4 +69,5 @@ class UcerfClassicalCalculator(ClassicalCalculator):
                 concurrent_tasks=oq.concurrent_tasks,
             ).reduce(self.agg_dicts, acc)
         self.store_csm_info(acc.eff_ruptures)
+        self.store_source_info(self.calc_times)
         return acc  # {grp_id: pmap}


### PR DESCRIPTION
The reason why the Australia calculation (but also the calculation for Italy by the INGV) fails is that the controller node is too slow: too much data comes from the workers, it is not saved fast enough, goes into the zmq queue and eventually the master node runs out of memory. The good news is that the aggregation of the hazard curves is fast, the problem is only in the function `store_source_info` which is 20x slower and which is used only for information purposes. The solution is easy: do not call for each task result, but only at the end, a single time.