### PR TITLE
Postfilter the ruptures after sampling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
+  [Michele Simionato]
+  * Only ruptures boundingbox-close to the site collection are stored
+
   [Marco Pagani]
   * Added cluster model to classical PSHA calculator
-  
+
   [Michele Simionato]
   * Fixed a bug in scenario_damage from ShakeMap with noDamageLimit=0
   * Avoided the MemoryError in the controller node by speeding up the saving

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -178,10 +178,10 @@ class EventBasedCalculator(base.HazardCalculator):
                     if 'ucerf' in oq.calculation_mode:
                         for i in range(oq.ses_per_logic_tree_path):
                             par['ses_seeds'] = [(ses_idx, oq.ses_seed + i + 1)]
-                            smap.submit(block, par)
+                            smap.submit(block, self.src_filter, par)
                             ses_idx += 1
                     else:
-                        smap.submit(block, par)
+                        smap.submit(block, self.src_filter, par)
         mon = self.monitor('saving ruptures')
         for dic in smap:
             if dic['calc_times']:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -606,7 +606,7 @@ class RuptureGetter(object):
             dic['srcid'] = source_ids[rec['srcidx']]
         return dic
 
-    def get_ruptures(self, srcfilter=None):
+    def get_ruptures(self, srcfilter=calc.filters.nofilter):
         """
         :returns: a list of EBRuptures filtered by bounding box
         """

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -614,7 +614,7 @@ class RuptureGetter(object):
         with datastore.read(self.hdf5path) as dstore:
             rupgeoms = dstore['rupgeoms']
             for rec in self.rup_array:
-                if srcfilter:
+                if srcfilter.integration_distance:
                     sids = srcfilter.close_sids(rec, self.trt, rec['mag'])
                     if len(sids) == 0:  # the rupture is far away
                         continue

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -356,10 +356,7 @@ class GmfGetter(object):
             return
         self.computers = []
         for ebr in self.rupgetter.get_ruptures(self.srcfilter):
-            if hasattr(ebr, 'sids'):  # filter the site collection
-                sitecol = self.sitecol.filtered(ebr.sids)
-            else:
-                sitecol = self.sitecol
+            sitecol = self.sitecol.filtered(ebr.sids)
             try:
                 computer = calc.gmf.GmfComputer(
                     ebr, sitecol, self.oqparam.imtls, self.cmaker,
@@ -655,8 +652,7 @@ class RuptureGetter(object):
                 ebr = EBRupture(rupture, rec['srcidx'], grp_id,
                                 rec['n_occ'], self.samples)
                 # not implemented: rupture_slip_direction
-                if sids is not None:
-                    ebr.sids = sids
+                ebr.sids = sids
                 ebrs.append(ebr)
         return ebrs
 

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -176,7 +176,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # test the number of bytes saved in the rupture records
         nbytes = self.calc.datastore.get_attr('ruptures', 'nbytes')
-        self.assertEqual(nbytes, 4134)
+        self.assertEqual(nbytes, 3180)
 
         # test postprocessing
         self.calc.datastore.close()

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -138,14 +138,13 @@ def sample_background_model(
 # #################################################################### #
 
 
-def build_ruptures(sources, param, monitor):
+def build_ruptures(sources, src_filter, param, monitor):
     """
     :param sources: a list with a single UCERF source
     :param param: extra parameters
     :param monitor: a Monitor instance
     :returns: an AccumDict grp_id -> EBRuptures
     """
-    src_filter = param['src_filter']
     [src] = sources
     res = AccumDict()
     res.calc_times = []
@@ -168,7 +167,7 @@ def build_ruptures(sources, param, monitor):
     dic = {'eff_ruptures': {src.src_group_id: src.num_ruptures}}
     eb_ruptures = [EBRupture(rup, src.id, src.src_group_id, n, samples)
                    for rup, n in n_occ.items()]
-    dic['rup_array'] = stochastic.get_rup_array(eb_ruptures)
+    dic['rup_array'] = stochastic.get_rup_array(eb_ruptures, src_filter)
     dt = time.time() - t0
     dic['calc_times'] = {src.id: numpy.array([tot_occ, len(sitecol), dt], F32)}
     return dic
@@ -197,4 +196,3 @@ class UCERFHazardCalculator(event_based.EventBasedCalculator):
         if not self.oqparam.imtls:
             raise ValueError('Missing intensity_measure_types!')
         self.precomputed_gmfs = False
-        self.param['src_filter'] = self.src_filter

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -223,7 +223,7 @@ def _digitize_lons(lons, lon_bins):
 def disaggregation(
         sources, site, imt, iml, gsim_by_trt, truncation_level,
         n_epsilons, mag_bin_width, dist_bin_width, coord_bin_width,
-        source_filter=filters.source_site_noop_filter, filter_distance='rjb'):
+        source_filter=filters.nofilter, filter_distance='rjb'):
     """
     Compute "Disaggregation" matrix representing conditional probability of an
     intensity mesaure type ``imt`` exceeding, at least once, an intensity

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -338,9 +338,14 @@ class SourceFilter(object):
            the site indices within the bounding box enlarged by the integration
            distance for the given TRT and magnitude
         """
-        if not self.integration_distance:  # do not filter
+        if self.sitecol is None:
+            return []
+        elif not self.integration_distance:  # do not filter
             return self.sitecol.sids
-        bbox = rec['minlon'], rec['minlat'], rec['maxlon'], rec['maxlat']
+        if hasattr(rec, 'dtype'):
+            bbox = rec['minlon'], rec['minlat'], rec['maxlon'], rec['maxlat']
+        else:
+            bbox = rec  # assume it is a 4-tuple
         maxdist = self.integration_distance(trt, mag)
         a1 = min(maxdist * KM_TO_DEGREES, 90)
         a2 = min(angular_distance(maxdist, bbox[1], bbox[3]), 180)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -424,4 +424,4 @@ class RtreeFilter(SourceFilter):
             index.close()
 
 
-source_site_noop_filter = SourceFilter(None, {})
+nofilter = SourceFilter(None, {})

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -27,6 +27,7 @@ from openquake.baselib import hdf5
 from openquake.baselib.general import AccumDict
 from openquake.baselib.performance import Monitor
 from openquake.baselib.python3compat import raise_
+from openquake.hazardlib.calc.filters import nofilter
 from openquake.hazardlib.source.rupture import BaseRupture, EBRupture
 from openquake.hazardlib.geo.mesh import surface_to_array, point3d
 
@@ -42,16 +43,8 @@ F32 = numpy.float32
 MAX_RUPTURES = 1000
 
 
-def source_site_noop_filter(srcs):
-    for src in srcs:
-        yield src, None
-
-
-source_site_noop_filter.integration_distance = {}
-
-
 # this is used in acceptance/stochastic_test.py, not in the engine
-def stochastic_event_set(sources, source_site_filter=source_site_noop_filter):
+def stochastic_event_set(sources, source_site_filter=nofilter):
     """
     Generates a 'Stochastic Event Set' (that is a collection of earthquake
     ruptures) representing a possible *realization* of the seismicity as
@@ -101,7 +94,7 @@ rupture_dt = numpy.dtype([
 
 
 # this is really fast
-def get_rup_array(ebruptures, srcfilter=None):
+def get_rup_array(ebruptures, srcfilter=nofilter):
     """
     Convert a list of EBRuptures into a numpy composite array, by filtering
     out the ruptures far away from every site

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -245,7 +245,7 @@ class SiteCollection(object):
            a filtered SiteCollection instance if `indices` is a proper subset
            of the available indices, otherwise returns the full SiteCollection
         """
-        if len(indices) == len(self):
+        if indices is None or len(indices) == len(self):
             return self
         new = object.__new__(self.__class__)
         indices = numpy.uint32(sorted(indices))

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -16,11 +16,9 @@
 import os
 import unittest
 import numpy
-from openquake.hazardlib import nrml, geo
-from openquake.hazardlib.calc.filters import SourceFilter
+from openquake.hazardlib import nrml, calc
 from openquake.hazardlib.calc.stochastic import (
     stochastic_event_set, sample_ruptures)
-from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.gsim.si_midorikawa_1999 import SiMidorikawa1999SInter
 
 aae = numpy.testing.assert_almost_equal
@@ -45,7 +43,8 @@ class StochasticEventSetTestCase(unittest.TestCase):
             start += nr
         param = dict(ses_per_logic_tree_path=10, filter_distance='rjb',
                      gsims=[SiMidorikawa1999SInter()])
-        dic = sum(sample_ruptures(group, param), {})
+        sf = calc.filters.SourceFilter(None, {})
+        dic = sum(sample_ruptures(group, sf, param), {})
         self.assertEqual(len(dic['rup_array']), 5)
         self.assertEqual(len(dic['calc_times']), 15)  # mutex sources
 
@@ -54,5 +53,5 @@ class StochasticEventSetTestCase(unittest.TestCase):
         self.assertEqual(len(ruptures), 19)
 
         # test no filtering 2
-        ruptures = sum(sample_ruptures(group, param), {})['rup_array']
+        ruptures = sum(sample_ruptures(group, sf, param), {})['rup_array']
         self.assertEqual(len(ruptures), 5)


### PR DESCRIPTION
In engine < 3.3 the ruptures were filtered with the `filter_distance` after the sampling and this was very slow, so I removed that part in engine 3.3. The consequence was that a lot more ruptures than needed were stored (i.e. ruptures outside of the maximum distance) and then discarded at reading time. This was deemed acceptable since the storing operation is fast, faster than distance filtering.
Now I am adding a simple filtering based on the rupture bounding box which is faster: ruptures outside of the maximum distance may still be saved, but not a huge amount. This will save disk space and data transfer; the saving will be a little faster at a cost of a little time spent on bounding box filtering.

NB: the ruptures are still filtered with `filter_distance` during the GMF calculation, that has not changed, so ruptures exceeding the maximum_distance will never have an effect, as before.

PS: users should be happier now, see https://groups.google.com/d/msg/openquake-users/I5t5OaljIfY/g_HcKqlSDQAJ