### PR TITLE
Optimized a bit ebrisk

### DIFF
--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -552,20 +552,19 @@ class RuptureGetter(object):
         [self.grp_id] = numpy.unique(rup_array['grp_id'])
         self.rlz2idx = {}
         nr = 0
+        rlzi = []
         for rlzs in rlzs_by_gsim.values():
             for rlz in rlzs:
                 self.rlz2idx[rlz] = nr
+                rlzi.append(rlz)
                 nr += 1
         n_occ = rup_array['n_occ'].sum()
         self.num_events = n_occ if samples > 1 else n_occ * nr
+        self.rlzs = numpy.array(rlzi)
 
     @property
     def num_rlzs(self):
         return len(self.rlz2idx)
-
-    @property
-    def rlz_offset(self):
-        return min(self.rlz2idx)
 
     def get_eid_rlz(self, monitor=None):
         """


### PR DESCRIPTION
Here are the numbers for Chile without average losses:

Before:
```
   $ oq2 show performance 22313
   ============================== ======== ========= ======
   operation                      time_sec memory_mb counts
   ============================== ======== ========= ======
   total ebrisk                   121,426  375       208   
   building risk                  111,250  45        208   
   getting hazard                 10,141   361       208   
   getting assets                 2,802    0.0       208   
   saving losses_by_event         496      0.0       208   
```
After:
```
   $ oq2 show performance 22314
   ============================== ======== ========= ======
   operation                      time_sec memory_mb counts
   ============================== ======== ========= ======
   total ebrisk                   108,084  389       208   
   building risk                  98,029   45        208   
   getting hazard                 10,021   373       208   
   getting assets                 2,760    0.0       208   
   saving losses_by_event         440      14        208   
```
The slowest task was taking 3,007s and now takes only 2,461s which is a 20% speedup.
First step towards https://github.com/gem/oq-engine/issues/4390