### PR TITLE
Allow only REST API to be exposed

### DIFF
--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -170,6 +170,9 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 1
 # confusion between different installations when the WebUI is used
 SERVER_NAME = socket.gethostname()
 
+# Expose the WebUI interface, otherwise only the REST API will be available
+WEBUI = True
+
 # OpenQuake Standalone tools (IPT, Taxtweb, Taxonomy Glossary)
 if STANDALONE:
     INSTALLED_APPS += (

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -174,7 +174,7 @@ SERVER_NAME = socket.gethostname()
 WEBUI = True
 
 # OpenQuake Standalone tools (IPT, Taxtweb, Taxonomy Glossary)
-if STANDALONE:
+if STANDALONE and WEBUI:
     INSTALLED_APPS += (
         'openquakeplatform',
     )

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -31,6 +31,9 @@ urlpatterns = [
     url(r'^v1/on_same_fs$', views.on_same_fs, name="on_same_fs"),
 ]
 
+# it is useful to disable the default redirect if the usage is via API only
+# 'collectstatic' and related configurationis on the reverse proxy
+# are also not required anymore for an API-only usage
 if settings.WEBUI:
     urlpatterns += [
         url(r'^$', RedirectView.as_view(url='/engine/', permanent=True)),

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -23,24 +23,27 @@ from django.views.generic.base import RedirectView
 from openquake.server import views
 
 urlpatterns = [
-    url(r'^$', RedirectView.as_view(url='/engine/', permanent=True)),
     url(r'^v1/engine_version$', views.get_engine_version),
     url(r'^v1/engine_latest_version$', views.get_engine_latest_version),
     url(r'^v1/calc/', include('openquake.server.v1.calc_urls')),
     url(r'^v1/valid/', views.validate_nrml),
     url(r'^v1/available_gsims$', views.get_available_gsims),
     url(r'^v1/on_same_fs$', views.on_same_fs, name="on_same_fs"),
-    url(r'^engine/?$', views.web_engine, name="index"),
-    url(r'^engine/(\d+)/outputs$',
-        views.web_engine_get_outputs, name="outputs"),
-    url(r'^engine/license$', views.license,
-        name="license"),
 ]
 
-for app in settings.STANDALONE_APPS:
-    app_name = app.split('_')[1]
-    urlpatterns.append(url(r'^%s/' % app_name, include('%s.urls' % app,
-                           namespace='%s' % app_name)))
+if settings.WEBUI:
+    urlpatterns += [
+        url(r'^$', RedirectView.as_view(url='/engine/', permanent=True)),
+        url(r'^engine/?$', views.web_engine, name="index"),
+        url(r'^engine/(\d+)/outputs$',
+            views.web_engine_get_outputs, name="outputs"),
+        url(r'^engine/license$', views.license,
+            name="license"),
+    ]
+    for app in settings.STANDALONE_APPS:
+        app_name = app.split('_')[1]
+        urlpatterns.append(url(r'^%s/' % app_name, include('%s.urls' % app,
+                               namespace='%s' % app_name)))
 
 if settings.LOCKDOWN:
     from django.contrib import admin


### PR DESCRIPTION
With this PR the WebUI and all the HTML part (i.e. tools) of the Engine server can be disabled leaving the REST API as the only end point exposed.

Behavior is not changed compared to the past with the default settings.

Closes https://github.com/gem/oq-engine/issues/4396