### PR TITLE
Doubled the speed of the ebrisk calculator

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -102,13 +102,14 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
             t0 = time.time()
             assets, tagidxs = assgetter.get(sid, tagnames)
             mon.duration += time.time() - t0
+            eidx = [eid2idx[eid] for eid in haz['eid']]
             for lt, asset, ratios in gen_risk(assets, riskmodel, haz, imts):
                 lti = riskmodel.lti[lt]
                 losses = ratios * asset.value(lt)
                 tidx = tagidxs[asset.ordinal]
-                for eid, rlz, loss in zip(haz['eid'], haz['rlzi'], losses):
-                    acc[(eid2idx[eid], lti) + tidx] += loss
-                    if param['avg_losses']:
+                acc[(eidx, lti) + tidx] += losses
+                if param['avg_losses']:
+                    for eid, rlz, loss in zip(haz['eid'], haz['rlzi'], losses):
                         losses_by_RN[rlz2idx[rlz], sid, lti] += loss
             times[sid] = time.time() - t0
     return {'losses': acc, 'eids': eids, 'losses_by_RN':

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -89,7 +89,6 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
         imts = getter.imts
         eids = rupgetter.get_eid_rlz()['eid']
         eid2idx = {eid: idx for idx, eid in enumerate(eids)}
-        rlz2idx = rupgetter.rlz2idx
         tagnames = param['aggregate_by']
         shape = assgetter.tagcol.agg_shape((len(eids), L), tagnames)
         acc = numpy.zeros(shape, F32)  # shape (E, L, T, ...)
@@ -109,8 +108,8 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
                 tidx = tagidxs[asset.ordinal]
                 acc[(eidx, lti) + tidx] += losses
                 if param['avg_losses']:
-                    for eid, rlz, loss in zip(haz['eid'], haz['rlzi'], losses):
-                        losses_by_RN[rlz2idx[rlz], sid, lti] += loss
+                    losses_by_RN[:, sid, lti] += rupgetter.E2R(
+                        losses, haz['rlzi'])
             times[sid] = time.time() - t0
     return {'losses': acc, 'eids': eids, 'losses_by_RN':
             (rupgetter.rlzs, losses_by_RN), 'times': times}

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -656,6 +656,12 @@ class RuptureGetter(object):
                 ebrs.append(ebr)
         return ebrs
 
+    def E2R(self, array, rlzi):
+        z = numpy.zeros((self.num_rlzs,) + array.shape[1:], array.dtype)
+        for a, r in zip(array, rlzi):
+            z[self.rlz2idx[r]] += a
+        return z
+
     def __len__(self):
         return len(self.rup_array)
 


### PR DESCRIPTION
Another step towards https://github.com/gem/oq-engine/issues/4390.
Before:
```
$ oq2 show performance 22315
============================== ======== ========= ======
operation                      time_sec memory_mb counts
============================== ======== ========= ======
total ebrisk                   180,235  310       208   
building risk                  170,169  36        208   
getting hazard                 10,032   307       208   
getting assets                 2,777    0.0       208   
saving losses_by_event         445      14        208   
```
After:
```
$ oq2 show performance 22316
============================== ======== ========= ======
operation                      time_sec memory_mb counts
============================== ======== ========= ======
total ebrisk                   97,050   389       208
building risk                  86,675   46        208
getting hazard                 10,341   373       208
getting assets                 2,794    0.0       208
saving losses_by_event         441      15        208
```

The speedup is in the calculation of the avg_losses.