### PR TITLE
Some refactoring of the ebrisk calculator

### DIFF
--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -349,6 +349,20 @@ class ProbabilisticEventBased(RiskModel):
             loss_ratios[i, idxs] = vf.sample(means, covs, idxs, epsilons)
         return loss_ratios
 
+    def get_loss_ratios(self, gmvs, imti):  # used in ebrisk
+        """
+        :param gmvs: an array of shape (E, M)
+        :param imti: a dictionary imt -> imt index
+        :returns: an array of shape (L, E)
+        """
+        E, L = len(gmvs), len(self.risk_functions)
+        loss_ratios = numpy.zeros((L, E), F32)
+        for lti, lt in enumerate(self.risk_functions):
+            vf = self.risk_functions[lt]
+            means, covs, idxs = vf.interpolate(gmvs[:, imti[vf.imt]])
+            loss_ratios[lti, idxs] = vf.sample(means, covs, idxs, None)
+        return loss_ratios
+
 
 @registry.add('classical_bcr')
 class ClassicalBCR(RiskModel):


### PR DESCRIPTION
The speed is the same, but the code is cleaner. Also, now I am logging the time spent in the avg_losses computation, which is the dominating factor for Chile:
```
   ============================== ======== ========= ===========
   operation                      time_sec memory_mb counts     
   ============================== ======== ========= ===========
   building risk                  88,946   111       208        
   building avg_losses            61,809   0.0       243,200,742
   getting hazard                 10,450   355       208        
   getting assets                 2,938    0.0       208        
   computing risk                 2,214    0.0       213,779    
```
Useful for https://github.com/gem/oq-engine/issues/4390.
