### PR TITLE
Saving only the mean losses_by_site

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -80,7 +80,7 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
     with monitor('getting hazard'):
         getter.init()  # instantiate the computers
         hazard = getter.get_hazard()  # sid -> (rlzi, sid, eid, gmv)
-    mon_avg = monitor('building avg_losses', measuremem=False)
+    mon_avg = monitor('computing losses_by_site', measuremem=False)
     mon_risk = monitor('computing risk', measuremem=False)
     with monitor('building risk'):
         imts = getter.imts

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -90,9 +90,9 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
         shape = assgetter.tagcol.agg_shape((len(eids), L), tagnames)
         acc = numpy.zeros(shape, F32)  # shape (E, L, T, ...)
         if param['avg_losses']:
-            losses_by_RN = numpy.zeros((rupgetter.num_rlzs, N, L), F32)
+            losses_by_N = numpy.zeros((N, L), F32)
         else:
-            losses_by_RN = None
+            losses_by_N = None
         times = numpy.zeros(N)  # risk time per site_id
         for sid, haz in hazard.items():
             t0 = time.time()
@@ -102,19 +102,19 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
             with mon_risk:
                 assets_ratios = get_assets_ratios(
                     assets_on_sid, riskmodel, haz['gmv'], imts)
-            for assets, ratios in assets_ratios:
-                for lt, lti in riskmodel.lti.items():
-                    loss_ratios = ratios[lti]
+            for assets, triples in assets_ratios:
+                for lt, imt, loss_ratios in triples:
+                    lti = riskmodel.lti[lt]
                     for asset in assets:
                         losses = loss_ratios * asset.value(lt)
                         acc[(eidx, lti) + tagidxs[asset.ordinal]] += losses
                         if param['avg_losses']:
                             with mon_avg:
-                                losses_by_RN[:, sid, lti] += rupgetter.E2R(
-                                    losses, haz['rlzi'])
+                                ls = losses * getter.weights[haz['rlzi']][imt]
+                                losses_by_N[sid, lti] += ls.sum()
             times[sid] = time.time() - t0
-    return {'losses': acc, 'eids': eids, 'losses_by_RN':
-            (rupgetter.rlzs, losses_by_RN), 'times': times}
+    return {'losses': acc, 'eids': eids, 'losses_by_N': losses_by_N,
+            'times': times}
 
 
 def compute_loss_curves_maps(hdf5path, multi_index, clp, individual_curves,
@@ -164,7 +164,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.param['riskmodel'] = self.riskmodel
         L = len(self.riskmodel.loss_types)
         self.num_taxonomies = self.assetcol.num_taxonomies_by_site()
-        self.datastore.create_dset('losses_by_site', F32, (self.N, self.R, L))
+        self.datastore.create_dset('losses_by_site', F32, (self.N, L))
         self.rupweights = []
 
     def acc0(self):
@@ -183,7 +183,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
     def agg_dicts(self, acc, dic):
         """
         :param dummy: unused parameter
-        :param dic: a dictionary with keys eids, losses, losses_by_RN
+        :param dic: a dictionary with keys eids, losses, losses_by_N
         """
         self.oqparam.ground_motion_fields = False  # hack
         if 'losses_by_event' not in set(self.datastore):  # first time
@@ -201,9 +201,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 lbe[list(sort_idx)] = numpy.array(sort_arr)
         if self.oqparam.avg_losses:
             with self.monitor('saving losses_by_site', autoflush=True):
-                rlzi, array = dic['losses_by_RN']
-                for r, arr in enumerate(array):
-                    self.datastore['losses_by_site'][:, rlzi[r]] += arr
+                self.datastore['losses_by_site'] += dic['losses_by_N']
         return acc + dic['times']
 
     def get_shape(self, *sizes):

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -353,15 +353,16 @@ class ProbabilisticEventBased(RiskModel):
         """
         :param gmvs: an array of shape (E, M)
         :param imti: a dictionary imt -> imt index
-        :returns: an array of shape (L, E)
+        :returns: triples (loss_type, imt, loss_ratios)
         """
-        E, L = len(gmvs), len(self.risk_functions)
-        loss_ratios = numpy.zeros((L, E), F32)
-        for lti, lt in enumerate(self.risk_functions):
-            vf = self.risk_functions[lt]
+        out = []
+        E = len(gmvs)
+        for lt, vf in self.risk_functions.items():
+            loss_ratios = numpy.zeros(E, F32)
             means, covs, idxs = vf.interpolate(gmvs[:, imti[vf.imt]])
-            loss_ratios[lti, idxs] = vf.sample(means, covs, idxs, None)
-        return loss_ratios
+            loss_ratios[idxs] = vf.sample(means, covs, idxs, None)
+            out.append((lt, vf.imt, loss_ratios))
+        return out
 
 
 @registry.add('classical_bcr')


### PR DESCRIPTION
This is enough for our purposes (plotting a map) and it makes the calculation of the losses by site 4x faster.
```
============================== ======== ========= ===========
operation                      time_sec memory_mb counts     
============================== ======== ========= ===========
building avg_losses            61,809   0.0       243,200,742 # before
building avg_losses            15,484   0.0       243,200,742 # now
```
The total runtime is now half than before and under 25 minutes for Chile on cluster2.