### PR TITLE
Speedup losses_by_site even more

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -103,13 +103,13 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
                 assets_ratios = get_assets_ratios(
                     assets_on_sid, riskmodel, haz['gmv'], imts)
             for assets, triples in assets_ratios:
-                for lt, imt, loss_ratios in triples:
-                    lti = riskmodel.lti[lt]
+                for lti, (lt, imt, loss_ratios) in enumerate(triples):
+                    w = weights[imt]
                     for asset in assets:
                         losses = loss_ratios * asset.value(lt)
                         acc[(eidx, lti) + tagidxs[asset.ordinal]] += losses
                         if param['avg_losses']:
-                            losses_by_N[sid, lti] += losses @ weights[imt]
+                            losses_by_N[sid, lti] += losses @ w
             times[sid] = time.time() - t0
     return {'losses': acc, 'eids': eids, 'losses_by_N': losses_by_N,
             'times': times}

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -96,6 +96,7 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
         times = numpy.zeros(N)  # risk time per site_id
         for sid, haz in hazard.items():
             t0 = time.time()
+            weights = getter.weights[haz['rlzi']]
             assets_on_sid, tagidxs = assgetter.get(sid, tagnames)
             mon.duration += time.time() - t0
             eidx = [eid2idx[eid] for eid in haz['eid']]
@@ -110,8 +111,7 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
                         acc[(eidx, lti) + tagidxs[asset.ordinal]] += losses
                         if param['avg_losses']:
                             with mon_avg:
-                                ls = losses * getter.weights[haz['rlzi']][imt]
-                                losses_by_N[sid, lti] += ls.sum()
+                                losses_by_N[sid, lti] += losses @ weights[imt]
             times[sid] = time.time() - t0
     return {'losses': acc, 'eids': eids, 'losses_by_N': losses_by_N,
             'times': times}


### PR DESCRIPTION
I gained nearly another order of magnitude by smarter array manipulations.
```
============================== ======== ========= ===========
operation                      time_sec memory_mb counts     
============================== ======== ========= ===========
building avg_losses        15,484   0.0       243,200,742 # before
building avg_losses        1,919    0.0       243,200,742 # now
```
Now Chile runs in less than 20 minutes.