### PR TITLE
Forced ebrisk to start from precomputed ruptures

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -455,4 +455,4 @@ class DataStore(collections.MutableMapping):
 
     def __repr__(self):
         status = 'open' if self.hdf5 else 'closed'
-        return '<%s %d, %s>' % (self.__class__.__name__, self.calc_id, status)
+        return '<%s %s %s>' % (self.__class__.__name__, self.hdf5path, status)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -764,7 +764,8 @@ class HazardCalculator(BaseCalculator):
                           avg_losses=oq.avg_losses)
 
         # store the `exposed_value` if there is an exposure
-        if 'exposed_value' not in self.datastore and hasattr(self, 'assetcol'):
+        if 'exposed_value' not in set(self.datastore) and hasattr(
+                self, 'assetcol'):
             self.datastore['exposed_value'] = self.assetcol.agg_value(
                 *oq.aggregate_by)
 

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -73,7 +73,7 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
     L = len(riskmodel.lti)
     N = len(srcfilter.sitecol.complete)
     mon = monitor('getting assets', measuremem=False)
-    with datastore.read(rupgetter.hdf5path) as dstore:
+    with datastore.read(srcfilter.hdf5path) as dstore:
         assgetter = getters.AssetGetter(dstore)
     getter = getters.GmfGetter(rupgetter, srcfilter, param['oqparam'])
     with monitor('getting hazard'):
@@ -153,7 +153,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         super().pre_execute(pre_calculator)
         # save a copy of the assetcol in hdf5cache
         self.hdf5cache = self.datastore.hdf5cache()
-        with hdf5.File(self.hdf5cache) as cache:
+        with hdf5.File(self.hdf5cache, 'w') as cache:
             cache['assetcol'] = self.assetcol
         self.param['aggregate_by'] = self.oqparam.aggregate_by
         self.N = len(self.sitecol.complete)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -216,7 +216,8 @@ class EventBasedCalculator(base.HazardCalculator):
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
         hdf5cache = dstore.hdf5cache()
-        with hdf5.File(hdf5cache, 'r+') as cache:
+        mode = 'r+' if os.path.exists(hdf5cache) else 'w'
+        with hdf5.File(hdf5cache, mode) as cache:
             if 'rupgeoms' not in cache:
                 dstore.hdf5.copy('rupgeoms', cache)
         yield from gen_rupture_getters(

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -105,7 +105,7 @@ def export_avg_losses(ekey, dstore):
     if kind == 'stats':
         weights = dstore['csm_info'].rlzs['weight']
         tags, stats = zip(*oq.hazard_stats())
-        if dskey in dstore:  # precomputed
+        if dskey in set(dstore):  # precomputed
             value = dstore[dskey].value  # shape (:, R, ...)
         else:  # computed on the fly
             value = compute_stats2(
@@ -188,6 +188,9 @@ def export_losses_by_event(ekey, dstore):
     :param ekey: export key, i.e. a pair (datastore key, fmt)
     :param dstore: datastore object
     """
+    if dstore['oqparam'].calculation_mode == 'ebrisk':
+        logging.warn('You cannot export losses_by_event from ebrisk yet')
+        return []
     dtlist = [('eid', U64), ('rlzi', U16)] + dstore['oqparam'].loss_dt_list()
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     dest = dstore.build_fname('losses_by_event', '', 'csv')

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -354,8 +354,8 @@ class GmfGetter(object):
         """
         if hasattr(self, 'computers'):  # init already called
             return
-        with hdf5.File(self.rupgetter.hdf5path, 'r') as cache:
-            self.weights = cache['csm_info/weights'].value
+        with hdf5.File(self.rupgetter.hdf5path, 'r') as parent:
+            self.weights = parent['csm_info/weights'].value
         self.computers = []
         for ebr in self.rupgetter.get_ruptures(self.srcfilter):
             sitecol = self.sitecol.filtered(ebr.sids)

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -216,19 +216,6 @@ class EventBasedRiskTestCase(CalculatorTestCase):
             self.assertEqualFiles('expected/' + strip_calc_id(fname),
                                   fname, delta=1E-5)
 
-    @attr('qa', 'risk', 'ebrisk')
-    def test_case_master2(self):
-        self.run_calc(case_master.__file__, 'job.ini',
-                      calculation_mode='ebrisk', aggregate_by='taxonomy',
-                      insured_losses='false')
-        # avg_losses-rlzs has shape (L=5, R=9)
-        # avg_losses-stats has shape (L=5, S=4)
-        fname = export(('avg_losses-stats', 'csv'), self.calc.datastore)[0]
-        self.assertEqualFiles('expected/avglosses.txt', fname)
-
-        fname = export(('losses_by_site', 'csv'), self.calc.datastore)[0]
-        self.assertEqualFiles('expected/avglosses_by_site.csv', fname)
-
     @attr('qa', 'risk', 'event_based_risk')
     def test_case_master(self):
         if sys.platform == 'darwin':
@@ -277,6 +264,21 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/curves_by_occupancy.csv', fnames[0])
 
         self.check_multi_tag(self.calc.datastore)
+
+        # test ebrisk calculator
+        self.run_calc(case_master.__file__, 'job.ini',
+                      hazard_calculation_id=str(self.calc.datastore.calc_id),
+                      calculation_mode='ebrisk',
+                      aggregate_by='taxonomy',
+                      insured_losses='false')
+
+        # avg_losses-rlzs has shape (L=5, R=9)
+        # avg_losses-stats has shape (L=5, S=4)
+        fname = export(('avg_losses-stats', 'csv'), self.calc.datastore)[0]
+        self.assertEqualFiles('expected/avglosses.txt', fname)
+
+        fname = export(('losses_by_site', 'csv'), self.calc.datastore)[0]
+        self.assertEqualFiles('expected/avglosses_by_site.csv', fname)
 
     def check_multi_tag(self, dstore):
         # multi-tag aggregations

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -216,7 +216,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
             self.assertEqualFiles('expected/' + strip_calc_id(fname),
                                   fname, delta=1E-5)
 
-    @attr('qa', 'risk', 'event_based_risk')
+    @attr('qa', 'risk', 'ebrisk')
     def test_case_master(self):
         if sys.platform == 'darwin':
             raise unittest.SkipTest('MacOSX')
@@ -265,10 +265,10 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         self.check_multi_tag(self.calc.datastore)
 
-        # test ebrisk calculator
+        # ------------------------- ebrisk calculator ---------------------- #
         self.run_calc(case_master.__file__, 'job.ini',
                       hazard_calculation_id=str(self.calc.datastore.calc_id),
-                      calculation_mode='ebrisk',
+                      calculation_mode='ebrisk', exports='',
                       aggregate_by='taxonomy',
                       insured_losses='false')
 

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -296,24 +296,27 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         for fname in fnames:
             self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname)
 
-    @attr('qa', 'risk', 'event_based_risk')
+    @attr('qa', 'risk', 'ebrisk')
     def test_case_miriam(self):
-        event_based.RUPTURES_PER_BLOCK = 20
-
         # this is a case with a grid and asset-hazard association
-        self.run_calc(case_miriam.__file__, 'job.ini',
-                      calculation_mode='ebrisk')
+        event_based.RUPTURES_PER_BLOCK = 20
+        self.run_calc(case_miriam.__file__, 'job.ini')
 
         # check minimum_magnitude >= 5.2
         minmag = self.calc.datastore['ruptures']['mag'].min()
         self.assertGreaterEqual(minmag, 5.2)
+
+        self.run_calc(case_miriam.__file__, 'job.ini',
+                      calculation_mode='ebrisk',
+                      hazard_calculation_id=str(self.calc.datastore.calc_id))
+
         # [fname] = export(('agg_loss_table', 'csv'), self.calc.datastore)
         # self.assertEqualFiles('expected/agg_losses-rlz000-structural.csv',
         #                       fname, delta=1E-5)
-        # fname = gettemp(view('portfolio_losses', self.calc.datastore))
-        # self.assertEqualFiles(
-        #    'expected/portfolio_losses.txt', fname, delta=1E-5)
-        # os.remove(fname)
+        fname = gettemp(view('portfolio_losses', self.calc.datastore))
+        self.assertEqualFiles(
+            'expected/portfolio_losses.txt', fname, delta=1E-5)
+        os.remove(fname)
 
         # this is a case with exposure and region_grid_spacing=1
         self.run_calc(case_miriam.__file__, 'job2.ini')

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -156,7 +156,7 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles(
             'expected/hazard_curve-smltp_b1-gsimltp_b1-PGA.xml', fname)
 
-    @attr('qa', 'hazard', 'event_based')
+    @attr('qa', 'hazard', 'ebrisk')
     def test_case_1_ruptures(self):
         self.run_calc(case_1.__file__, 'job_ruptures.ini')
         self.assertEqual(len(self.calc.datastore['ruptures']), 1)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -281,9 +281,14 @@ class OqParam(valid.ParamSet):
             raise ValueError('asset_correlation != {0, 1} is no longer'
                              ' supported')
 
-        # check for ebrisk
-        if self.calculation_mode == 'ebrisk' and self.insured_losses:
-            raise ValueError('ebrisk does not support insured losses')
+        # checks for ebrisk
+        if self.calculation_mode == 'ebrisk':
+            if self.insured_losses:
+                raise ValueError('ebrisk does not support insured losses')
+            elif self.hazard_calculation_id is None:
+                raise ValueError('ebrisk requires hazard_calculation_id')
+            elif self.number_of_logic_tree_samples == 0:
+                logging.warn('ebrisk is not meant for full enumeration')
 
         # check for GMFs from file
         if (self.inputs.get('gmfs', '').endswith('.csv') and not self.sites and
@@ -302,11 +307,6 @@ class OqParam(valid.ParamSet):
             if self.number_of_logic_tree_samples >= TWO16:
                 raise ValueError('number_of_logic_tree_samples too big: %d' %
                                  self.number_of_logic_tree_samples)
-
-        # check for ebrisk
-        if (self.calculation_mode == 'ebrisk' and
-                self.number_of_logic_tree_samples == 0):
-            logging.warn('ebrisk is not meant for full enumeration')
 
         # check grid + sites
         if (self.region_grid_spacing and 'site_model' in self.inputs

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import os
 import sys
 import time
 import operator
@@ -24,7 +25,7 @@ import numpy
 import rtree
 from scipy.interpolate import interp1d
 
-from openquake.baselib import hdf5, config
+from openquake.baselib import hdf5
 from openquake.baselib.general import gettemp
 from openquake.baselib.python3compat import raise_
 from openquake.hazardlib.geo.utils import (
@@ -263,12 +264,10 @@ class SourceFilter(object):
             IntegrationDistance(integration_distance)
             if isinstance(integration_distance, dict)
             else integration_distance)
-        if hdf5path and (
-                config.distribution.oq_distribute in ('no', 'processpool') or
-                config.directory.shared_dir):  # store the sitecol
+        if sitecol is not None and hdf5path and not os.path.exists(hdf5path):
+            # store the sitecol
             with hdf5.File(hdf5path, 'w') as h5:
-                if sitecol is not None:
-                    h5['sitecol'] = sitecol
+                h5['sitecol'] = sitecol
         else:  # keep the sitecol in memory
             self.__dict__['sitecol'] = sitecol
 

--- a/openquake/qa_tests_data/event_based_risk/case_miriam/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_miriam/job.ini
@@ -1,7 +1,8 @@
 [general]
 
 description = Virtual Island - City C, 2 SES, grid=0.1
-calculation_mode = event_based_risk
+calculation_mode = event_based
+ground_motion_fields = false
 filter_distance = rrup
 random_seed = 1024
 master_seed = 100


### PR DESCRIPTION
So that the risk guys are happy. Also fixed a bug that made it impossible to run the calculation unless the exposure was stored in the rupture file. I have changed `case_global` in oq-risk-tests to test the workflow. Notice that the `job_h.ini` file requires (even if looks surprising) the site model and intensity_measure_types parameters, on top of the less surprising source model and gsim logic tree files. The `job_h.ini` may contain the site model file (in that case the site model parameters need not to be specified) and the vulnerability functions (in that case the intensity measure types need not to be specified).