### PR TITLE
Some refactoring of ebrisk

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -999,6 +999,23 @@ def random_histogram(counts, nbins, seed):
     return numpy.histogram(numpy.random.random(counts), nbins, (0, 1))[0]
 
 
+def get_indices(integers):
+    """
+    :param integers: a sequence of integers (with repetitions)
+    :returns: a dict integer -> [(start, stop), ...]
+
+    >>> get_indices([0, 0, 3, 3, 3, 2, 2, 0])
+    {0: [(0, 2), (7, 8)], 3: [(2, 5)], 2: [(5, 7)]}
+    """
+    indices = AccumDict(accum=[])  # idx -> [(start, stop), ...]
+    start = 0
+    for i, vals in itertools.groupby(integers):
+        n = sum(1 for val in vals)
+        indices[i].append((start, start + n))
+        start += n
+    return indices
+
+
 def safeprint(*args, **kwargs):
     """
     Convert and print characters using the proper encoding

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -199,7 +199,7 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         oq = self.oqparam
         csm_info = self.datastore['csm_info']
-        grp_trt = csm_info.grp_by("trt")
+        trt_by_grp = csm_info.grp_by("trt")
         grp_source = csm_info.grp_by("name")
         if oq.disagg_by_src:
             src_name = {src.src_group_id: src.name
@@ -211,7 +211,7 @@ class ClassicalCalculator(base.HazardCalculator):
                     base.fix_ones(pmap)  # avoid saving PoEs == 1
                     key = 'poes/grp-%02d' % grp_id
                     self.datastore[key] = pmap
-                    self.datastore.set_attrs(key, trt=grp_trt[grp_id])
+                    self.datastore.set_attrs(key, trt=trt_by_grp[grp_id])
                     if oq.disagg_by_src:
                         data.append(
                             (grp_id, grp_source[grp_id], src_name[grp_id]))

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -173,11 +173,38 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.datastore.parent = datastore.read(oq.hazard_calculation_id)
         self.init_logic_tree(self.csm_info)
         iterargs = ((rgetter, self.src_filter, self.param)
-                    for rgetter in self.gen_rupture_getters(self.rup_weight))
+                    for rgetter in self.gen_rupture_getters())
         acc = parallel.Starmap(
             self.core_task.__func__, iterargs, self.monitor()
         ).reduce(self.agg_dicts, numpy.zeros(self.N))
         return acc
+
+    def gen_rupture_getters(self):
+        dstore = self.datastore.parent
+        csm_info = dstore['csm_info']
+        grp_trt = csm_info.grp_by("trt")
+        samples = csm_info.get_samples_by_grp()
+        code2cls = getters.get_code2cls(dstore.get_attrs('ruptures'))
+        maxweight = numpy.ceil(2E10 / (self.oqparam.concurrent_tasks or 1))
+        nr, ne = 0, 0
+        for grp_id, rlzs_by_gsim in csm_info.get_rlzs_by_gsim_grp().items():
+            start, stop = dstore.get_attr('ruptures', 'grp_indices')[grp_id]
+            rup_array = dstore['ruptures'][start:stop]
+            for block in general.block_splitter(
+                    rup_array, maxweight, self.rup_weight):
+                if not rlzs_by_gsim:
+                    # this may happen if a source model has no sources, like
+                    # in event_based_risk/case_3
+                    continue
+                rups = numpy.array(block)
+                rgetter = getters.RuptureGetter(
+                    dstore.hdf5path, code2cls, rups,
+                    grp_trt[grp_id], samples[grp_id], rlzs_by_gsim)
+                rgetter.weight = getattr(block, 'weight', len(block))
+                yield rgetter
+                nr += len(rups)
+                ne += rgetter.num_events
+        logging.info('Read %d ruptures and %d events', nr, ne)
 
     def rup_weight(self, rup):
         """

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -182,7 +182,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
     def gen_rupture_getters(self):
         dstore = self.datastore.parent
         csm_info = dstore['csm_info']
-        grp_trt = csm_info.grp_by("trt")
+        trt_by_grp = csm_info.grp_by("trt")
         samples = csm_info.get_samples_by_grp()
         code2cls = getters.get_code2cls(dstore.get_attrs('ruptures'))
         maxweight = numpy.ceil(2E10 / (self.oqparam.concurrent_tasks or 1))
@@ -199,7 +199,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 rups = numpy.array(block)
                 rgetter = getters.RuptureGetter(
                     dstore.hdf5path, code2cls, rups,
-                    grp_trt[grp_id], samples[grp_id], rlzs_by_gsim)
+                    trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim)
                 rgetter.weight = getattr(block, 'weight', len(block))
                 yield rgetter
                 nr += len(rups)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -117,7 +117,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.rupser = calc.RuptureSerializer(self.datastore)
 
     def init_logic_tree(self, csm_info):
-        self.grp_trt = csm_info.grp_by("trt")
+        self.trt_by_grp = csm_info.grp_by("trt")
         self.rlzs_assoc = csm_info.get_rlzs_assoc()
         self.rlzs_by_gsim_grp = csm_info.get_rlzs_by_gsim_grp()
         self.samples_by_grp = csm_info.get_samples_by_grp()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -25,7 +25,7 @@ import numpy
 
 from openquake.baselib import hdf5, datastore
 from openquake.baselib.python3compat import zip
-from openquake.baselib.general import AccumDict, cached_property
+from openquake.baselib.general import AccumDict, cached_property, get_indices
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.stats import compute_pmap_stats
 from openquake.hazardlib.calc.stochastic import sample_ruptures
@@ -60,23 +60,6 @@ def store_rlzs_by_grp(dstore):
         for gsim_id, rlzs in enumerate(arr):
             lst.append((int(grp[4:]), gsim_id, rlzs))
     dstore['csm_info/rlzs_by_grp'] = numpy.array(lst, rlzs_by_grp_dt)
-
-
-def get_indices(integers):
-    """
-    :param integers: a sequence of integers (with repetitions)
-    :returns: a dict integer -> [(start, stop), ...]
-
-    >>> get_indices([0, 0, 3, 3, 3, 2, 2, 0])
-    {0: [(0, 2), (7, 8)], 3: [(2, 5)], 2: [(5, 7)]}
-    """
-    indices = AccumDict(accum=[])  # idx -> [(start, stop), ...]
-    start = 0
-    for i, vals in itertools.groupby(integers):
-        n = sum(1 for val in vals)
-        indices[i].append((start, start + n))
-        start += n
-    return indices
 
 
 # ######################## GMF calculator ############################ #
@@ -151,7 +134,7 @@ class EventBasedCalculator(base.HazardCalculator):
         zd = {r: ProbabilityMap(self.L) for r in range(self.R)}
         return zd
 
-    def build_events_from_sources(self, par):
+    def build_events_from_sources(self):
         """
         Prefilter the composite source model and store the source_info
         """
@@ -172,6 +155,7 @@ class EventBasedCalculator(base.HazardCalculator):
             for sg in sm.src_groups:
                 if not sg.sources:
                     continue
+                par = self.param.copy()
                 par['gsims'] = gsims_by_trt[sg.trt]
                 for block in self.block_splitter(
                         sg.sources, weight_src, by_grp):
@@ -205,8 +189,13 @@ class EventBasedCalculator(base.HazardCalculator):
         sorted_ruptures = self.datastore.getitem('ruptures').value
         # order the ruptures by serial
         sorted_ruptures.sort(order='serial')
+        ngroups = len(self.csm.info.trt_by_grp)
+        grp_indices = numpy.zeros((ngroups, 2), U32)
+        grp_ids = sorted_ruptures['grp_id']
+        for grp_id, [startstop] in get_indices(grp_ids).items():
+            grp_indices[grp_id] = startstop
         self.datastore['ruptures'] = sorted_ruptures
-        self.datastore.set_attrs('ruptures', **attrs)
+        self.datastore.set_attrs('ruptures', grp_indices=grp_indices, **attrs)
         self.save_events(sorted_ruptures)
 
     def gen_rupture_getters(self, rup_weight):
@@ -319,10 +308,8 @@ class EventBasedCalculator(base.HazardCalculator):
                     'The event based calculator is restricted to '
                     '%d %s, got %d' % (max_[var], var, num_[var]))
 
-    def execute(self):
+    def set_param(self):
         oq = self.oqparam
-        self.offset = 0
-        self.indices = collections.defaultdict(list)  # sid, idx -> indices
         # set the minimum_intensity
         if hasattr(self, 'riskmodel') and not oq.minimum_intensity:
             # infer it from the risk models if not directly set in job.ini
@@ -333,24 +320,29 @@ class EventBasedCalculator(base.HazardCalculator):
                          'you may want to set a minimum_intensity')
         else:
             logging.info('minimum_intensity=%s', oq.minimum_intensity)
-        param = self.param.copy()
-        param.update(
+        self.param.update(
             oqparam=oq,
             gmf=oq.ground_motion_fields,
             truncation_level=oq.truncation_level,
             ruptures_per_block=oq.ruptures_per_block,
             imtls=oq.imtls, filter_distance=oq.filter_distance,
             ses_per_logic_tree_path=oq.ses_per_logic_tree_path)
+
+    def execute(self):
+        oq = self.oqparam
+        self.set_param()
+        self.offset = 0
+        self.indices = collections.defaultdict(list)  # sid, idx -> indices
         if oq.hazard_calculation_id and 'ruptures' in self.datastore:
             # from ruptures
             self.datastore.parent = datastore.read(oq.hazard_calculation_id)
             self.init_logic_tree(self.csm_info)
         else:
             # from sources
-            self.build_events_from_sources(param)
+            self.build_events_from_sources()
             if oq.ground_motion_fields is False:
                 return {}
-        iterargs = ((rgetter, self.src_filter, param)
+        iterargs = ((rgetter, self.src_filter, self.param)
                     for rgetter in self.gen_rupture_getters(self.rup_weight))
         # call compute_gmfs in parallel
         acc = parallel.Starmap(

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -211,7 +211,7 @@ class EventBasedCalculator(base.HazardCalculator):
                 dstore.hdf5.copy('rupgeoms', cache)
         yield from gen_rupture_getters(
             dstore, concurrent_tasks=self.oqparam.concurrent_tasks or 1,
-            hdf5cache=hdf5cache, rup_weight=rup_weight)
+            hdf5cache=hdf5cache)
         if self.datastore.parent:
             self.datastore.parent.close()
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -470,8 +470,7 @@ class GmfGetter(object):
 
 
 def gen_rupture_getters(dstore, slc=slice(None),
-                        concurrent_tasks=1, hdf5cache=None,
-                        rup_weight=None):
+                        concurrent_tasks=1, hdf5cache=None):
     """
     :yields: RuptureGetters
     """
@@ -482,13 +481,7 @@ def gen_rupture_getters(dstore, slc=slice(None),
     rup_array = dstore['ruptures'][slc]
     code2cls = get_code2cls(dstore.get_attrs('ruptures'))
     by_grp = operator.itemgetter(2)  # serial, srcidx, grp_id
-    if rup_weight:  # ebrisk
-        maxweight = numpy.ceil(2E10 / concurrent_tasks)
-        blocks = general.block_splitter(rup_array, maxweight, rup_weight,
-                                        key=by_grp)
-    else:  # event based
-        blocks = general.split_in_blocks(rup_array, concurrent_tasks,
-                                         key=by_grp)
+    blocks = general.split_in_blocks(rup_array, concurrent_tasks, key=by_grp)
     nr = 0
     ne = 0
     for block in blocks:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -475,7 +475,7 @@ def gen_rupture_getters(dstore, slc=slice(None),
     :yields: RuptureGetters
     """
     csm_info = dstore['csm_info']
-    grp_trt = csm_info.grp_by("trt")
+    trt_by_grp = csm_info.grp_by("trt")
     samples = csm_info.get_samples_by_grp()
     rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]
@@ -493,7 +493,7 @@ def gen_rupture_getters(dstore, slc=slice(None),
         rups = numpy.array(block)
         rgetter = RuptureGetter(
             hdf5cache or dstore.hdf5path, code2cls, rups,
-            grp_trt[grp_id], samples[grp_id], rlzs_by_gsim[grp_id])
+            trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim[grp_id])
         rgetter.weight = getattr(block, 'weight', len(block))
         yield rgetter
         nr += len(rups)


### PR DESCRIPTION
I have moved get_indices inside baselib.general and used it to store the group indices as an attribute of the  `ruptures` dataset. This is a preliminary step for https://github.com/gem/oq-engine/issues/4416.