### PR TITLE
Fixed a bug in split_filter with atomic groups and OQ_SAMPLE_SOURCES

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -183,29 +183,33 @@ def parallel_split_filter(csm, srcfilter, split, monitor):
     seed = int(os.environ.get('OQ_SAMPLE_SOURCES', 0))
     msg = 'Splitting/filtering' if split else 'Filtering'
     logging.info('%s sources with %s', msg, srcfilter.__class__.__name__)
-    sources = csm.get_sources()
+    trt_sources = csm.get_trt_sources()
+    tot_sources = sum(len(sources) for trt, sources in trt_sources)
     if split:
         dist = None  # use the default
     else:
         dist = ('no' if os.environ.get('OQ_DISTRIBUTE') == 'no'
                 else 'processpool')
-    smap = parallel.Starmap.apply(
-        split_filter if split else only_filter,
-        (sources, srcfilter, seed, monitor),
-        maxweight=RUPTURES_PER_BLOCK,
-        weight=operator.attrgetter('num_ruptures'),
-        distribute=dist, progress=logging.debug)
     if monitor.hdf5:
         source_info = monitor.hdf5['source_info']
         source_info.attrs['has_dupl_sources'] = csm.has_dupl_sources
     srcs_by_grp = collections.defaultdict(list)
-    arr = numpy.zeros((len(sources), 2), F32)
-    for splits, stime in smap:
-        for split in splits:
-            i = split.id
-            arr[i, 0] += stime[i]  # split_time
-            arr[i, 1] += 1         # num_split
-            srcs_by_grp[split.src_group_id].append(split)
+    arr = numpy.zeros((tot_sources, 2), F32)
+    for trt, sources in trt_sources:
+        if hasattr(sources, 'atomic') and sources.atomic:
+            split = False
+        smap = parallel.Starmap.apply(
+            split_filter if split else only_filter,
+            (sources, srcfilter, seed, monitor),
+            maxweight=RUPTURES_PER_BLOCK,
+            weight=operator.attrgetter('num_ruptures'),
+            distribute=dist, progress=logging.debug)
+        for splits, stime in smap:
+            for split in splits:
+                i = split.id
+                arr[i, 0] += stime[i]  # split_time
+                arr[i, 1] += 1         # num_split
+                srcs_by_grp[split.src_group_id].append(split)
     if not srcs_by_grp:
         raise RuntimeError('All sources were filtered away!')
     elif monitor.hdf5:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-import time
 import logging
 import operator
 import numpy
@@ -23,7 +22,6 @@ import numpy
 from openquake.baselib import parallel, hdf5, datastore
 from openquake.baselib.python3compat import encode
 from openquake.baselib.general import AccumDict
-from openquake.hazardlib.contexts import ContextMaker
 from openquake.hazardlib.calc.hazard_curve import classical, ProbabilityMap
 from openquake.hazardlib.stats import compute_pmap_stats
 from openquake.commonlib import calc
@@ -152,7 +150,7 @@ class ClassicalCalculator(base.HazardCalculator):
 
         if self.csm.has_dupl_sources and not opt:
             logging.warning('Found %d duplicated sources',
-                         self.csm.has_dupl_sources)
+                            self.csm.has_dupl_sources)
 
         for trt, sources in self.csm.get_trt_sources():
             gsims = self.csm.info.gsim_lt.get_gsims(trt)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -764,9 +764,10 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
                 dupl += hits
     if (dupl and not oqparam.optimize_same_id_sources and
             not oqparam.is_event_based()):
-        logging.warning('You are doing redundant calculations: please make sure '
-                     'that different sources have different IDs and set '
-                     'optimize_same_id_sources=true in your .ini file')
+        logging.warning(
+            'You are doing redundant calculations: please make sure '
+            'that different sources have different IDs and set '
+            'optimize_same_id_sources=true in your .ini file')
     if make_sm.changes:
         logging.info('Applied %d changes to the composite source model',
                      make_sm.changes)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -91,7 +91,6 @@ def _cluster(param, tom, imtls, gsims, grp_ids, pmap):
     return pmap
 
 
-
 def classical(group, src_filter, gsims, param, monitor=Monitor()):
     """
     Compute the hazard curves for a set of sources belonging to the same


### PR DESCRIPTION
This was causing the mosaic test for Japan to fail: https://gitlab.openquake.org/hazard/mosaic/mosaic/-/jobs/4437
An empty atomic group was arriving: with this fix, sources in an atomic group are never sampled, even if OQ_SAMPLE_SOURCES is set.