### PR TITLE
Stored information for nonparametric ruptures

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -73,8 +73,11 @@ def compute_disagg(sitecol, sources, cmaker, iml4, trti, bin_edges,
     """
     result = {'trti': trti, 'num_ruptures': 0}
     # all the time is spent in collect_bin_data
+    ruptures = []
+    for src in sources:
+        ruptures.extend(src.iter_ruptures())
     bin_data = disagg.collect_bin_data(
-        sources, sitecol, cmaker, iml4,
+        ruptures, sitecol, cmaker, iml4,
         oqparam.truncation_level, oqparam.num_epsilon_bins, monitor)
     if bin_data:  # dictionary poe, imt, rlzi -> pne
         for sid in sitecol.sids:

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -34,7 +34,8 @@ import numpy
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import const, site
 from openquake.hazardlib import imt as imt_module
-from openquake.hazardlib.gsim.base import GMPE, RuptureContext
+from openquake.hazardlib.contexts import RuptureContext
+from openquake.hazardlib.gsim.base import GMPE
 from openquake.baselib.python3compat import round
 
 


### PR DESCRIPTION
And made some other refactoring (such as `collect_bin_data` now depends on the ruptures, not on the sources) that will make it easier to implement disaggregation by ruptures (see https://github.com/gem/oq-engine/issues/4420, point 4) in which RuptureContexts will be generated from the datastore.