### PR TITLE
Implemented single file mode for ebrisk

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -84,9 +84,9 @@ def hdf5new(datadir=None):
     return new
 
 
-def extract_calc_id_datadir(hdf5path, datadir=None):
+def extract_calc_id_datadir(filename, datadir=None):
     """
-    Extract the calculation ID from the given hdf5path or integer:
+    Extract the calculation ID from the given filename or integer:
 
     >>> extract_calc_id_datadir('/mnt/ssd/oqdata/calc_25.hdf5')
     (25, '/mnt/ssd/oqdata')
@@ -97,20 +97,20 @@ def extract_calc_id_datadir(hdf5path, datadir=None):
     """
     datadir = datadir or get_datadir()
     try:
-        calc_id = int(hdf5path)
+        calc_id = int(filename)
     except ValueError:
-        hdf5path = os.path.abspath(hdf5path)
-        datadir = os.path.dirname(hdf5path)
-        mo = re.match(CALC_REGEX, os.path.basename(hdf5path))
+        filename = os.path.abspath(filename)
+        datadir = os.path.dirname(filename)
+        mo = re.match(CALC_REGEX, os.path.basename(filename))
         if mo is None:
-            raise ValueError('Cannot extract calc_id from %s' % hdf5path)
+            raise ValueError('Cannot extract calc_id from %s' % filename)
         calc_id = int(mo.group(2))
     return calc_id, datadir
 
 
 def read(calc_id, mode='r', datadir=None):
     """
-    :param calc_id: calculation ID or hdf5path
+    :param calc_id: calculation ID or filename
     :param mode: 'r' or 'w'
     :param datadir: the directory where to look
     :returns: the corresponding DataStore instance
@@ -124,7 +124,7 @@ def read(calc_id, mode='r', datadir=None):
     except KeyError:  # no oqparam
         hc_id = None
     if hc_id:
-        dstore.parent = read(hc_id, datadir=os.path.dirname(dstore.hdf5path))
+        dstore.parent = read(hc_id, datadir=os.path.dirname(dstore.filename))
     return dstore
 
 
@@ -153,7 +153,7 @@ class DataStore(collections.MutableMapping):
     def __init__(self, calc_id=None, datadir=None, params=(), mode=None):
         datadir = datadir or get_datadir()
         if isinstance(calc_id, str):  # passed a real path
-            self.hdf5path = calc_id
+            self.filename = calc_id
             self.calc_id, datadir = extract_calc_id_datadir(calc_id, datadir)
         else:
             if calc_id is None:  # use a new datastore
@@ -168,16 +168,16 @@ class DataStore(collections.MutableMapping):
                         'retrieve the %s' % (len(calc_ids), calc_id))
             else:  # use the given datastore
                 self.calc_id = calc_id
-            self.hdf5path = os.path.join(
+            self.filename = os.path.join(
                 datadir, 'calc_%s.hdf5' % self.calc_id)
         if not os.path.exists(datadir):
             os.makedirs(datadir)
         self.params = params
         self.parent = ()  # can be set later
         self.datadir = datadir
-        self.mode = mode or ('r+' if os.path.exists(self.hdf5path) else 'w')
-        if self.mode == 'r' and not os.path.exists(self.hdf5path):
-            raise IOError('File not found: %s' % self.hdf5path)
+        self.mode = mode or ('r+' if os.path.exists(self.filename) else 'w')
+        if self.mode == 'r' and not os.path.exists(self.filename):
+            raise IOError('File not found: %s' % self.filename)
         self.hdf5 = ()  # so that `key in self.hdf5` is valid
         self.open(self.mode)
 
@@ -190,9 +190,9 @@ class DataStore(collections.MutableMapping):
             if mode == 'r':
                 kw['swmr'] = True
             try:
-                self.hdf5 = hdf5.File(self.hdf5path, **kw)
+                self.hdf5 = hdf5.File(self.filename, **kw)
             except OSError as exc:
-                raise OSError('%s in %s' % (exc, self.hdf5path))
+                raise OSError('%s in %s' % (exc, self.filename))
 
     @property
     def export_dir(self):
@@ -364,7 +364,7 @@ class DataStore(collections.MutableMapping):
     def clear(self):
         """Remove the datastore from the file system"""
         self.close()
-        os.remove(self.hdf5path)
+        os.remove(self.filename)
 
     def getsize(self, key=None):
         """
@@ -372,7 +372,7 @@ class DataStore(collections.MutableMapping):
         If no key is given, returns the total size of all files.
         """
         if key is None:
-            return os.path.getsize(self.hdf5path)
+            return os.path.getsize(self.filename)
         return hdf5.ByteCounter.get_nbytes(
             h5py.File.__getitem__(self.hdf5, key))
 
@@ -412,7 +412,7 @@ class DataStore(collections.MutableMapping):
             self.hdf5[key] = val
         except RuntimeError as exc:
             raise RuntimeError('Could not save %s: %s in %s' %
-                               (key, exc, self.hdf5path))
+                               (key, exc, self.filename))
 
     def __delitem__(self, key):
         del self.hdf5[key]
@@ -434,7 +434,7 @@ class DataStore(collections.MutableMapping):
                     parent=self.parent,
                     calc_id=self.calc_id,
                     hdf5=(),
-                    hdf5path=self.hdf5path)
+                    filename=self.filename)
 
     def __iter__(self):
         if not self.hdf5:
@@ -455,4 +455,4 @@ class DataStore(collections.MutableMapping):
 
     def __repr__(self):
         status = 'open' if self.hdf5 else 'closed'
-        return '<%s %s %s>' % (self.__class__.__name__, self.hdf5path, status)
+        return '<%s %s %s>' % (self.__class__.__name__, self.filename, status)

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -95,11 +95,11 @@ def extend(dset, array, **attrs):
     return newlength
 
 
-def extend3(hdf5path, key, array, **attrs):
+def extend3(filename, key, array, **attrs):
     """
     Extend an HDF5 file dataset with the given array
     """
-    with h5py.File(hdf5path) as h5:
+    with h5py.File(filename) as h5:
         try:
             dset = h5[key]
         except KeyError:

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -441,7 +441,7 @@ class HazardCalculator(BaseCalculator):
         """
         return RtreeFilter(self.src_filter.sitecol,
                            self.oqparam.maximum_distance,
-                           self.src_filter.hdf5path)
+                           self.src_filter.filename)
 
     @property
     def E(self):
@@ -558,6 +558,7 @@ class HazardCalculator(BaseCalculator):
             self.assetcol = calc.assetcol
             self.riskmodel = calc.riskmodel
             self.rlzs_assoc = calc.rlzs_assoc
+            self.csm = calc.csm
         else:
             self.read_inputs()
         if self.riskmodel:
@@ -782,11 +783,11 @@ class HazardCalculator(BaseCalculator):
         R = len(self.rlzs_assoc.realizations)
         logging.info('There are %d realization(s)', R)
         if self.oqparam.imtls:
-            self.datastore['csm_info/weights'] = arr = build_weights(
+            self.datastore['weights'] = arr = build_weights(
                 self.rlzs_assoc.realizations, self.oqparam.imt_dt())
-            self.datastore.set_attrs('csm_info/weights', nbytes=arr.nbytes)
+            self.datastore.set_attrs('weights', nbytes=arr.nbytes)
             with hdf5.File(self.hdf5cache, 'r+') as cache:
-                cache['csm_info/weights'] = arr
+                cache['weights'] = arr
         if 'event_based' in self.oqparam.calculation_mode and R >= TWO16:
             # rlzi is 16 bit integer in the GMFs, so there is hard limit or R
             raise ValueError(

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -558,7 +558,8 @@ class HazardCalculator(BaseCalculator):
             self.assetcol = calc.assetcol
             self.riskmodel = calc.riskmodel
             self.rlzs_assoc = calc.rlzs_assoc
-            self.csm = calc.csm
+            if hasattr(calc, 'csm'):  # no scenario
+                self.csm = calc.csm
         else:
             self.read_inputs()
         if self.riskmodel:

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -65,22 +65,6 @@ class InvalidCalculationID(Exception):
     """
 
 
-PRECALC_MAP = dict(
-    classical=['psha'],
-    disaggregation=['psha'],
-    scenario_risk=['scenario'],
-    scenario_damage=['scenario'],
-    classical_risk=['classical'],
-    classical_bcr=['classical'],
-    classical_damage=['classical'],
-    event_based=['event_based', 'event_based_risk', 'ucerf_hazard', 'ebrisk'],
-    event_based_risk=['event_based', 'event_based_risk', 'ucerf_hazard',
-                      'ebrisk'],
-    ebrisk=['event_based', 'event_based_risk', 'ucerf_hazard'],
-    ucerf_classical=['ucerf_psha'],
-    ucerf_hazard=['ucerf_hazard'])
-
-
 def fix_ones(pmap):
     """
     Physically, an extremely small intensity measure level can have an
@@ -208,6 +192,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
     :param monitor: monitor object
     :param calc_id: numeric calculation ID
     """
+    accept_precalc = []
     from_engine = False  # set by engine.run_calc
     is_stochastic = False  # True for scenario and event based calculators
 
@@ -253,10 +238,10 @@ class BaseCalculator(metaclass=abc.ABCMeta):
             calculation_mode of the previous calculation
         """
         calc_mode = self.oqparam.calculation_mode
-        ok_mode = PRECALC_MAP[calc_mode]
+        ok_mode = self.accept_precalc
         if calc_mode != precalc_mode and precalc_mode not in ok_mode:
             raise InvalidCalculationID(
-                'In order to run a risk calculation of kind %r, '
+                'In order to run a calculation of kind %r, '
                 'you need to provide a calculation of kind %r, '
                 'but you provided a %r instead' %
                 (calc_mode, ok_mode, precalc_mode))

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -62,6 +62,7 @@ class ClassicalCalculator(base.HazardCalculator):
     Classical PSHA calculator
     """
     core_task = classical
+    accept_precalc = ['psha']
 
     def agg_dicts(self, acc, dic):
         """

--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -60,6 +60,7 @@ class ClassicalBCRCalculator(classical_risk.ClassicalRiskCalculator):
     Classical BCR Risk calculator
     """
     core_task = classical_bcr
+    accept_precalc = ['classical']
 
     def pre_execute(self):
         super().pre_execute()

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -53,6 +53,7 @@ class ClassicalDamageCalculator(classical_risk.ClassicalRiskCalculator):
     Scenario damage calculator
     """
     core_task = classical_damage
+    accept_precalc = ['classical']
 
     def post_execute(self, result):
         """

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -87,6 +87,7 @@ class ClassicalRiskCalculator(base.RiskCalculator):
     Classical Risk calculator
     """
     core_task = classical_risk
+    precalc = 'classical'
     accept_precalc = ['classical']
 
     def pre_execute(self):
@@ -97,7 +98,7 @@ class ClassicalRiskCalculator(base.RiskCalculator):
         if oq.insured_losses:
             raise ValueError(
                 'insured_losses are not supported for classical_risk')
-        super().pre_execute('classical')
+        super().pre_execute()
         if 'poes' not in self.datastore:  # when building short report
             return
         weights = [rlz.weight for rlz in self.rlzs_assoc.realizations]

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -87,6 +87,7 @@ class ClassicalRiskCalculator(base.RiskCalculator):
     Classical Risk calculator
     """
     core_task = classical_risk
+    accept_precalc = ['classical']
 
     def pre_execute(self):
         """

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -104,6 +104,7 @@ class DisaggregationCalculator(base.HazardCalculator):
     """
     Classical PSHA disaggregation calculator
     """
+    accept_precalc = ['psha']
     POE_TOO_BIG = '''\
 You are trying to disaggregate for poe=%s.
 However the source model #%d, '%s',

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -86,7 +86,7 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
     L = len(riskmodel.lti)
     N = len(srcfilter.sitecol.complete)
     mon = monitor('getting assets', measuremem=False)
-    with datastore.read(srcfilter.hdf5path) as dstore:
+    with datastore.read(srcfilter.filename) as dstore:
         assgetter = getters.AssetGetter(dstore)
     getter = getters.GmfGetter(rupgetter, srcfilter, param['oqparam'])
     with monitor('getting hazard'):
@@ -129,9 +129,9 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
             'times': times}
 
 
-def compute_loss_curves_maps(hdf5path, multi_index, clp, individual_curves,
+def compute_loss_curves_maps(filename, multi_index, clp, individual_curves,
                              monitor):
-    with datastore.read(hdf5path) as dstore:
+    with datastore.read(filename) as dstore:
         oq = dstore['oqparam']
         stats = oq.hazard_stats()
         builder = get_loss_builder(dstore)
@@ -162,10 +162,12 @@ class EbriskCalculator(event_based.EventBasedCalculator):
     """
     core_task = start_ebrisk
     is_stochastic = True
+    precalc = 'event_based'
     accept_precalc = ['event_based', 'event_based_risk', 'ucerf_hazard']
 
-    def pre_execute(self, pre_calculator=None):
-        super().pre_execute(pre_calculator)
+    def pre_execute(self):
+        self.oqparam.ground_motion_fields = False
+        super().pre_execute()
         # save a copy of the assetcol in hdf5cache
         self.hdf5cache = self.datastore.hdf5cache()
         with hdf5.File(self.hdf5cache, 'w') as cache:
@@ -183,21 +185,30 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         oq = self.oqparam
         self.set_param(num_taxonomies=self.assetcol.num_taxonomies_by_site(),
                        maxweight=numpy.ceil(2E10 / (oq.concurrent_tasks or 1)))
-        self.datastore.parent = datastore.read(oq.hazard_calculation_id)
+        parent = self.datastore.parent
+        if parent:
+            hdf5path = parent.filename
+            grp_indices = parent['ruptures'].attrs['grp_indices']
+        else:
+            hdf5path = self.datastore.hdf5cache()
+            grp_indices = self.datastore['ruptures'].attrs['grp_indices']
+            with hdf5.File(hdf5path, 'r+') as cache:
+                self.datastore.hdf5.copy('csm_info/weights', cache)
+                self.datastore.hdf5.copy('ruptures', cache)
+                self.datastore.hdf5.copy('rupgeoms', cache)
         self.init_logic_tree(self.csm_info)
         smap = parallel.Starmap(
             self.core_task.__func__, monitor=self.monitor())
-        dstore = self.datastore.parent
-        csm_info = dstore['csm_info']
-        trt_by_grp = csm_info.grp_by("trt")
-        samples = csm_info.get_samples_by_grp()
+        trt_by_grp = self.csm_info.grp_by("trt")
+        samples = self.csm_info.get_samples_by_grp()
+        rlzs_by_gsim_grp = self.csm_info.get_rlzs_by_gsim_grp()
         nr = 0
-        for grp_id, rlzs_by_gsim in csm_info.get_rlzs_by_gsim_grp().items():
-            start, stop = dstore.get_attr('ruptures', 'grp_indices')[grp_id]
+        for grp_id, rlzs_by_gsim in rlzs_by_gsim_grp.items():
+            start, stop = grp_indices[grp_id]
             for indices in general.block_splitter(
                     range(start, stop), base.RUPTURES_PER_BLOCK):
                 rgetter = getters.RuptureGetter(
-                    dstore.hdf5path, list(indices), grp_id,
+                    hdf5path, list(indices), grp_id,
                     trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim)
                 smap.submit(rgetter, self.src_filter, self.param)
             nr += stop - start
@@ -282,7 +293,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.datastore.close()
         acc = []
         for idx, _ in numpy.ndenumerate(first):
-            smap.submit(self.datastore.hdf5path, idx,
+            smap.submit(self.datastore.filename, idx,
                         oq.conditional_loss_poes, oq.individual_curves)
         for res in smap:
             idx = res.pop('idx')
@@ -291,7 +302,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                     acc.append((name, idx, arr))
         # copy performance information from the cache to the datastore
         pd = mon.hdf5['performance_data'].value
-        hdf5.extend3(self.datastore.hdf5path, 'performance_data', pd)
+        hdf5.extend3(self.datastore.filename, 'performance_data', pd)
         self.datastore.open('r+')  # reopen
         self.datastore['task_info/compute_loss_curves_and_maps'] = (
             mon.hdf5['task_info/compute_loss_curves_maps'].value)

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -162,6 +162,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
     """
     core_task = start_ebrisk
     is_stochastic = True
+    accept_precalc = ['event_based', 'event_based_risk', 'ucerf_hazard']
 
     def pre_execute(self, pre_calculator=None):
         super().pre_execute(pre_calculator)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -199,7 +199,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.datastore.set_attrs('ruptures', grp_indices=grp_indices, **attrs)
         self.save_events(sorted_ruptures)
 
-    def gen_rupture_getters(self, rup_weight):
+    def gen_rupture_getters(self):
         """
         :returns: a list of RuptureGetters
         """
@@ -272,7 +272,7 @@ class EventBasedCalculator(base.HazardCalculator):
         events = numpy.zeros(len(eids), rupture.events_dt)
         # when computing the events all ruptures must be considered,
         # including the ones far away that will be discarded later on
-        rgetters = self.gen_rupture_getters(None)
+        rgetters = self.gen_rupture_getters()
 
         # build the associations eid -> rlz in parallel
         smap = parallel.Starmap(RuptureGetter.get_eid_rlz,
@@ -346,7 +346,7 @@ class EventBasedCalculator(base.HazardCalculator):
             if oq.ground_motion_fields is False:
                 return {}
         iterargs = ((rgetter, self.src_filter, self.param)
-                    for rgetter in self.gen_rupture_getters(self.rup_weight))
+                    for rgetter in self.gen_rupture_getters())
         # call compute_gmfs in parallel
         acc = parallel.Starmap(
             self.core_task.__func__, iterargs, self.monitor()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -98,8 +98,7 @@ class EventBasedCalculator(base.HazardCalculator):
     """
     core_task = compute_gmfs
     is_stochastic = True
-    accept_precalc = ['event_based', 'event_based_risk', 'ucerf_hazard',
-                       'ebrisk']
+    accept_precalc = ['event_based', 'event_based_risk', 'ucerf_hazard']
     build_ruptures = sample_ruptures
 
     @cached_property

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -98,8 +98,9 @@ class EventBasedCalculator(base.HazardCalculator):
     """
     core_task = compute_gmfs
     is_stochastic = True
+    accept_precalc = ['event_based', 'event_based_risk', 'ucerf_hazard',
+                       'ebrisk']
     build_ruptures = sample_ruptures
-    rup_weight = None
 
     @cached_property
     def csm_info(self):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -158,6 +158,8 @@ class EbrCalculator(base.RiskCalculator):
     """
     core_task = event_based_risk
     is_stochastic = True
+    accept_precalc = ['event_based', 'event_based_risk', 'ucerf_hazard',
+                      'ebrisk']
 
     def pre_execute(self):
         oq = self.oqparam

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -158,12 +158,13 @@ class EbrCalculator(base.RiskCalculator):
     """
     core_task = event_based_risk
     is_stochastic = True
+    precalc = 'event_based'
     accept_precalc = ['event_based', 'event_based_risk', 'ucerf_hazard',
                       'ebrisk']
 
     def pre_execute(self):
         oq = self.oqparam
-        super().pre_execute('event_based')
+        super().pre_execute()
         parent = self.datastore.parent
         if not self.oqparam.ground_motion_fields:
             return  # this happens in the reportwriter

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -576,7 +576,7 @@ def export_gmf(ekey, dstore):
     nbytes = gmf_data.attrs['nbytes']
     logging.info('Internal size of the GMFs: %s', humansize(nbytes))
     if nbytes > GMF_MAX_SIZE:
-        logging.warning(GMF_WARNING, dstore.hdf5path)
+        logging.warning(GMF_WARNING, dstore.filename)
     fnames = []
     events_by_rlz = collections.defaultdict(list)
     data = gmf_data['data'].value

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -114,6 +114,7 @@ class ScenarioDamageCalculator(base.RiskCalculator):
     """
     core_task = scenario_damage
     is_stochastic = True
+    accept_precalc = ['scenario']
 
     def pre_execute(self):
         super().pre_execute('scenario')

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -114,10 +114,11 @@ class ScenarioDamageCalculator(base.RiskCalculator):
     """
     core_task = scenario_damage
     is_stochastic = True
+    precalc = 'scenario'
     accept_precalc = ['scenario']
 
     def pre_execute(self):
-        super().pre_execute('scenario')
+        super().pre_execute()
         E = self.oqparam.number_of_ground_motion_fields
         self.param['number_of_ground_motion_fields'] = E
         self.param['consequence_models'] = riskmodels.get_risk_models(

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -87,6 +87,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
     """
     core_task = scenario_risk
     is_stochastic = True
+    precalc = 'scenario'
     accept_precalc = ['scenario']
 
     def pre_execute(self):
@@ -95,7 +96,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
         with the unit of measure, used in the export phase.
         """
         oq = self.oqparam
-        super().pre_execute('scenario')
+        super().pre_execute()
         self.assetcol = self.datastore['assetcol']
         A = len(self.assetcol)
         E = oq.number_of_ground_motion_fields

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -87,6 +87,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
     """
     core_task = scenario_risk
     is_stochastic = True
+    accept_precalc = ['scenario']
 
     def pre_execute(self):
         """

--- a/openquake/calculators/tests/base_test.py
+++ b/openquake/calculators/tests/base_test.py
@@ -53,18 +53,3 @@ class BaseCalculatorTestCase(unittest.TestCase):
             self.assertRaises(ZeroDivisionError, calc.run)
         self.assertEqual(error.call_count, 0)
         self.assertEqual(critical.call_count, 1)
-
-
-class CheckHazardRiskConsistencyTestCase(unittest.TestCase):
-    def test_ok(self):
-        base.check_precalc_consistency('scenario_risk', 'scenario')
-
-    def test_inconsistent_mode(self):
-        with self.assertRaises(base.InvalidCalculationID) as ctx:
-            base.check_precalc_consistency('classical_risk', 'scenario')
-        msg = str(ctx.exception)
-        self.assertEqual(
-            msg, "In order to run a risk calculation of kind "
-            "'classical_risk', you need to provide a "
-            "calculation of kind ['classical'], "
-            "but you provided a 'scenario' instead")

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -30,6 +30,8 @@ class UcerfClassicalCalculator(ClassicalCalculator):
     """
     UCERF classical calculator.
     """
+    accept_precalc = ['ucerf_psha']
+
     def pre_execute(self):
         super().pre_execute()
         self.csm_info = self.csm.info

--- a/openquake/calculators/ucerf_event_based.py
+++ b/openquake/calculators/ucerf_event_based.py
@@ -179,6 +179,7 @@ class UCERFHazardCalculator(event_based.EventBasedCalculator):
     Event based PSHA calculator generating the ruptures and GMFs together
     """
     build_ruptures = build_ruptures
+    accept_precalc = ['ucerf_hazard']
 
     def pre_execute(self):
         """

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -201,7 +201,7 @@ def view_contents(token, dstore):
     data = sorted((dstore.getsize(key), key) for key in dstore)
     rows = [(key, humansize(nbytes)) for nbytes, key in data]
     total = '\n%s : %s' % (
-        dstore.hdf5path, humansize(os.path.getsize(dstore.hdf5path)))
+        dstore.filename, humansize(os.path.getsize(dstore.filename)))
     return rst_table(rows, header=(desc, '')) + total
 
 

--- a/openquake/commands/extract.py
+++ b/openquake/commands/extract.py
@@ -53,12 +53,12 @@ def extract(what, calc_id=-1, server_url='http://127.0.0.1:8800'):
     logging.basicConfig(level=logging.INFO)
     if calc_id < 0:
         calc_id = datastore.get_calc_ids()[calc_id]
-    hdf5path = None
+    filename = None
     if dbserver.get_status() == 'running':
         job = dbcmd('get_job', calc_id)
         if job is not None:
-            hdf5path = job.ds_calc_dir + '.hdf5'
-    dstore = engine.read(hdf5path or calc_id)
+            filename = job.ds_calc_dir + '.hdf5'
+    dstore = engine.read(filename or calc_id)
     parent_id = dstore['oqparam'].hazard_calculation_id
     if parent_id:
         dstore.parent = engine.read(parent_id)

--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -29,13 +29,13 @@ def purge_one(calc_id, user):
     """
     Remove one calculation ID from the database and remove its datastore
     """
-    hdf5path = os.path.join(datadir, 'calc_%s.hdf5' % calc_id)
+    filename = os.path.join(datadir, 'calc_%s.hdf5' % calc_id)
     err = dbcmd('del_calc', calc_id, user)
     if err:
         print(err)
-    if os.path.exists(hdf5path):  # not removed yet
-        os.remove(hdf5path)
-        print('Removed %s' % hdf5path)
+    if os.path.exists(filename):  # not removed yet
+        os.remove(filename)
+        print('Removed %s' % filename)
 
 
 # used in the reset command

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -121,8 +121,8 @@ def _run(job_inis, concurrent_tasks, pdb, loglevel, hc, exports, params):
 
     logging.info('Total time spent: %s s', monitor.duration)
     logging.info('Memory allocated: %s', general.humansize(monitor.mem))
-    print('See the output with hdfview %s' % calc.datastore.hdf5path)
-    calc_path, _ = os.path.splitext(calc.datastore.hdf5path)  # used below
+    print('See the output with hdfview %s' % calc.datastore.filename)
+    calc_path, _ = os.path.splitext(calc.datastore.filename)  # used below
     return calc
 
 

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1410,8 +1410,8 @@ class GsimLogicTree(object):
         """
         dirname = os.path.dirname(self.fname)
         for gmpe_table in sorted(self.gmpe_tables):
-            hdf5path = os.path.join(dirname, gmpe_table)
-            with hdf5.File(hdf5path, 'r') as f:
+            filename = os.path.join(dirname, gmpe_table)
+            with hdf5.File(filename, 'r') as f:
                 for group in f:
                     name = '%s/%s' % (gmpe_table, group)
                     if hasattr(f[group], 'value'):  # dataset, not group

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -286,8 +286,6 @@ class OqParam(valid.ParamSet):
         if self.calculation_mode == 'ebrisk':
             if self.insured_losses:
                 raise ValueError('ebrisk does not support insured losses')
-            elif self.hazard_calculation_id is None:
-                raise ValueError('ebrisk requires hazard_calculation_id')
             elif self.number_of_logic_tree_samples == 0:
                 logging.warning('ebrisk is not meant for full enumeration')
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -589,10 +589,10 @@ source_info_dt = numpy.dtype([
 ])
 
 
-def store_sm(smodel, hdf5path, monitor):
+def store_sm(smodel, filename, monitor):
     """
     :param smodel: a :class:`openquake.hazardlib.nrml.SourceModel` instance
-    :param hdf5path: path to an hdf5 file (cache_XXX.hdf5)
+    :param filename: path to an hdf5 file (cache_XXX.hdf5)
     :param monitor: a Monitor instance with an .hdf5 attribute
     """
     h5 = monitor.hdf5
@@ -601,8 +601,8 @@ def store_sm(smodel, hdf5path, monitor):
         source_geom = h5['source_geom']
         gid = len(source_geom)
         for sg in smodel:
-            if hdf5path:
-                with hdf5.File(hdf5path, 'r+') as hdf5cache:
+            if filename:
+                with hdf5.File(filename, 'r+') as hdf5cache:
                     hdf5cache['grp-%02d' % sg.id] = sg
             srcs = []
             geoms = []
@@ -637,7 +637,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
     :param in_memory:
         if True, keep in memory the sources, else just collect the TRTs
     :param srcfilter:
-        a SourceFilter instance with an .hdf5path pointing to the cache file
+        a SourceFilter instance with an .filename pointing to the cache file
     :returns:
         an iterator over :class:`openquake.commonlib.logictree.LtSourceModel`
         tuples
@@ -676,7 +676,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
     if monitor.hdf5:
         sources = hdf5.create(monitor.hdf5, 'source_info', source_info_dt)
         hdf5.create(monitor.hdf5, 'source_geom', point3d)
-        hdf5path = (getattr(srcfilter, 'hdf5path', None)
+        filename = (getattr(srcfilter, 'filename', None)
                     if oqparam.prefilter_sources == 'no' else None)
     source_ids = set()
     for sm in source_model_lt.gen_source_models(gsim_lt):
@@ -719,7 +719,7 @@ def get_source_models(oqparam, gsim_lt, source_model_lt, monitor,
                     grp_id += 1
                     src_groups.append(sg)
                 if monitor.hdf5:
-                    store_sm(newsm, hdf5path, monitor)
+                    store_sm(newsm, filename, monitor)
             else:  # just collect the TRT models
                 groups = logictree.read_source_groups(fname)
                 for group in groups:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -166,7 +166,7 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
         except (KeyError, AttributeError):
             size_mb = None
         keysize.append((key, size_mb))
-    ds_size = os.path.getsize(dstore.hdf5path) / MB
+    ds_size = os.path.getsize(dstore.filename) / MB
     logs.dbcmd('create_outputs', dstore.calc_id, keysize, ds_size)
 
 

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -251,38 +251,38 @@ class SourceFilter(object):
     Filter the sources by using `self.sitecol.within_bbox` which is
     based on numpy.
     """
-    def __init__(self, sitecol, integration_distance, hdf5path=None):
+    def __init__(self, sitecol, integration_distance, filename=None):
         if sitecol is not None and len(sitecol) < len(sitecol.complete):
             raise ValueError('%s is not complete!' % sitecol)
         elif sitecol is None:
             integration_distance = {}
-        self.hdf5path = hdf5path
+        self.filename = filename
         self.integration_distance = (
             IntegrationDistance(integration_distance)
             if isinstance(integration_distance, dict)
             else integration_distance)
-        if sitecol is not None and hdf5path and not os.path.exists(hdf5path):
+        if sitecol is not None and filename and not os.path.exists(filename):
             # store the sitecol
-            with hdf5.File(hdf5path, 'w') as h5:
+            with hdf5.File(filename, 'w') as h5:
                 h5['sitecol'] = sitecol
         else:  # keep the sitecol in memory
             self.__dict__['sitecol'] = sitecol
 
     def __getstate__(self):
-        return dict(hdf5path=self.hdf5path,
+        return dict(filename=self.filename,
                     integration_distance=self.integration_distance)
 
     @property
     def sitecol(self):
         """
-        Read the site collection from .hdf5path and cache it
+        Read the site collection from .filename and cache it
         """
         if 'sitecol' in vars(self):
             return self.__dict__['sitecol']
-        if self.hdf5path is None or not os.path.exists(self.hdf5path):
+        if self.filename is None or not os.path.exists(self.filename):
             # case of nofilter/None sitecol
             return
-        with hdf5.File(self.hdf5path, 'r') as h5:
+        with hdf5.File(self.filename, 'r') as h5:
             self.__dict__['sitecol'] = sc = h5.get('sitecol')
         return sc
 
@@ -399,9 +399,9 @@ class RtreeFilter(SourceFilter):
     :param integration_distance:
         Integration distance dictionary (TRT -> distance in km)
     """
-    def __init__(self, sitecol, integration_distance, hdf5path=None):
+    def __init__(self, sitecol, integration_distance, filename=None):
         assert sitecol, 'Mandatory in an RtreeFilter'
-        super().__init__(sitecol, integration_distance, hdf5path)
+        super().__init__(sitecol, integration_distance, filename)
         self.indexpath = gettemp()
         index = rtree.index.Index(self.indexpath)
         lonlats = zip(sitecol.lons, sitecol.lats)
@@ -434,7 +434,7 @@ class RtreeFilter(SourceFilter):
     def __getstate__(self):
         # NB: the RtreeFilter can be transferred on a single machine only
         # (on a cluster, even, with a shared_dir, there are permission errors)
-        return dict(hdf5path=self.hdf5path,
+        return dict(filename=self.filename,
                     indexpath=self.indexpath,
                     integration_distance=self.integration_distance)
 

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -1218,8 +1218,8 @@ class RjbEquivalent(object):
     >> reqv = RjbEquivalent('lookup.hdf5')
     >> reqv.get(repi_distances, mag)
     """
-    def __init__(self, hdf5path):
-        with hdf5.File(hdf5path, 'r') as f:
+    def __init__(self, filename):
+        with hdf5.File(filename, 'r') as f:
             self.repi = f['default/repi'].value  # shape D
             self.mags = f['default/mags'].value  # shape M
             self.reqv = f['default/reqv'].value  # shape D x M


### PR DESCRIPTION
Now you can run an ebrisk calculation even with a single job.ini file. This is useful for me (when running tests) but even in general, since computing the ruptures is usually fast and it is not a big deal to repeat their calculation. While at it, I reworked the precalculator mechanism. Using `--hc` is still available as before.
