### PR TITLE
Add csv located in ./gsim/mgmpe in py package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.md LICENSE CONTRIBUTORS.txt
 include openquake/engine/openquake.cfg
 include openquake/server/local_settings.py.pam
 include openquake/server/local_settings.py.standalone
+include openquake/hazardlib/gsim/mgmpe/*.csv
 
 recursive-include openquake/server/db *.sql
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,11 +2,11 @@ include README.md LICENSE CONTRIBUTORS.txt
 include openquake/engine/openquake.cfg
 include openquake/server/local_settings.py.pam
 include openquake/server/local_settings.py.standalone
-include openquake/hazardlib/gsim/mgmpe/*.csv
 
 recursive-include openquake/server/db *.sql
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf
 
 recursive-include openquake/qa_tests_data *.* README
 
+recursive-include openquake/hazardlib/gsim *.csv
 recursive-include openquake/commonlib/nrml_examples *.xml *.csv *.geojson


### PR DESCRIPTION
Fixes https://ci.openquake.org/job/macos/job/master_macos_smtk/label=macos,python=python3.6/854/console

It's the only csv around (excluding tests):

```bash
$ find openquake -name \*.csv | grep -v test
openquake/hazardlib/gsim/mgmpe/akkar_coeff_table.csv
```