### PR TITLE
Fixed portfolio_loss

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -371,19 +371,11 @@ def view_totlosses(token, dstore):
 def portfolio_loss(dstore):
     R = dstore['csm_info'].get_num_rlzs()
     array = dstore['losses_by_event'].value
-    if array.dtype.names:  # for event based risk
-        L, = array.dtype['loss'].shape
-        data = numpy.zeros((R, L), F32)
-        for row in array:
-            data[row['rlzi']] += row['loss']
-    else:  # for ebrisk
-        losses = dstore['losses_by_event'].value  # shape (E, L, ...)
-        L = losses.shape[1]
-        data = numpy.zeros((R, L), F32)
-        rlzs = dstore['events']['rlz']
-        for rlz, loss in zip(rlzs, losses):
-            for lti in range(L):
-                data[rlz, lti] += loss[lti].sum()
+    L = array.dtype['loss'].shape[0]  # loss has shape L, T...
+    data = numpy.zeros((R, L), F32)
+    for row in array:
+        for lti in range(L):
+            data[row['rlzi'], lti] += row['loss'][lti].sum()
     return data
 
 


### PR DESCRIPTION
This is a debug view used in the oq-risk-tests: https://gitlab.openquake.org/openquake/oq-risk-tests/-/jobs/4485
I just forgot to update it after the recent unification between the event loss table for event_based_risk and ebrisk.