### PR TITLE
Removed obsolete __metaclass__ hooks

### DIFF
--- a/openquake/hmtk/faults/fault_geometries.py
+++ b/openquake/hmtk/faults/fault_geometries.py
@@ -55,8 +55,6 @@ class BaseFaultGeometry(object):
     '''
     Abstract base class to support geometry parameters and methods
     '''
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def get_area(self):
         '''

--- a/openquake/hmtk/faults/mfd/anderson_luco_arbitrary.py
+++ b/openquake/hmtk/faults/mfd/anderson_luco_arbitrary.py
@@ -66,8 +66,6 @@ class BaseRecurrenceModel(object):
     '''
     Abstract base class to implement cumulative value formula
     '''
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def cumulative_value(self, slip_moment, mmax, mag_value, bbar, dbar):
         '''

--- a/openquake/hmtk/faults/mfd/anderson_luco_area_mmax.py
+++ b/openquake/hmtk/faults/mfd/anderson_luco_area_mmax.py
@@ -66,8 +66,6 @@ class BaseRecurrenceModel(object):
     '''
     Abstract base class to implement cumulative value formula
     '''
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def cumulative_value(self, slip, mmax, mag_value, bbar, dbar, beta):
         '''

--- a/openquake/hmtk/faults/mfd/base.py
+++ b/openquake/hmtk/faults/mfd/base.py
@@ -70,8 +70,6 @@ def _scale_moment(magnitude, in_nm=False):
 class BaseMFDfromSlip(object):
     '''Base class for calculating magnitude frequency distribution
     from a given slip value'''
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def setUp(self, mfd_conf):
         '''Initialises the parameters from the mfd type'''

--- a/openquake/hmtk/parsers/catalogue/base.py
+++ b/openquake/hmtk/parsers/catalogue/base.py
@@ -57,8 +57,6 @@ class BaseCatalogueParser(object):
     """
     A base class for a Catalogue Parser
     """
-    __metaclass__ = abc.ABCMeta
-
     def __init__(self, input_file):
         """
         Initialise the object and check input file existance
@@ -78,8 +76,6 @@ class BaseCatalogueWriter(object):
     """
     A base class for a Catalogue writer
     """
-    __metaclass__ = abc.ABCMeta
-
     def __init__(self, output_file):
         """
         Initialise the object and check output file existance. If file already

--- a/openquake/hmtk/parsers/source_model/base.py
+++ b/openquake/hmtk/parsers/source_model/base.py
@@ -57,8 +57,6 @@ class BaseSourceModelParser(object):
     """
     A base class for a Source Model Parser
     """
-    __metaclass__ = abc.ABCMeta
-
     def __init__(self, input_file):
         """
         Initialise the object and check input file existance

--- a/openquake/hmtk/seismicity/completeness/base.py
+++ b/openquake/hmtk/seismicity/completeness/base.py
@@ -57,8 +57,6 @@ class BaseCatalogueCompleteness(object):
     '''
     Abstract base class for implementation of the completeness algorithms
     '''
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def completeness(self, catalogue, config):
         '''

--- a/openquake/hmtk/seismicity/declusterer/base.py
+++ b/openquake/hmtk/seismicity/declusterer/base.py
@@ -57,8 +57,6 @@ class BaseCatalogueDecluster(object):
     """
     Abstract base class for implementation of declustering algorithms
     """
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def decluster(self, catalogue, config):
         """

--- a/openquake/hmtk/seismicity/declusterer/distance_time_windows.py
+++ b/openquake/hmtk/seismicity/declusterer/distance_time_windows.py
@@ -60,8 +60,6 @@ class BaseDistanceTimeWindow(object):
     Defines the space and time windows, within which an event is identified
     as a cluster.
     """
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def calc(self, magnitude):
         """

--- a/openquake/hmtk/seismicity/max_magnitude/base.py
+++ b/openquake/hmtk/seismicity/max_magnitude/base.py
@@ -115,8 +115,6 @@ class BaseMaximumMagnitude(object):
     Abstract base class for implementation of the maximum magnitude estimation
     based on instrumental/historical seismicity
     '''
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def get_mmax(self, catalogue, config):
         '''

--- a/openquake/hmtk/seismicity/occurrence/base.py
+++ b/openquake/hmtk/seismicity/occurrence/base.py
@@ -54,8 +54,6 @@ from openquake.hmtk.registry import CatalogueFunctionRegistry
 
 class SeismicityOccurrence(object):
     '''Implements recurrence calculations for instrumental seismicity'''
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def calculate(self, catalogue, config, completeness=None):
         """Implements recurrence calculation

--- a/openquake/hmtk/seismicity/smoothing/kernels/base.py
+++ b/openquake/hmtk/seismicity/smoothing/kernels/base.py
@@ -57,8 +57,6 @@ class BaseSmoothingKernel(object):
     Abstract Base Class to smooth a grid according the sets of
     regular smoothing kernels
     '''
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def smooth_data(self, data, config):
         '''


### PR DESCRIPTION
They were needed for Python 2, now they are useless.