### PR TITLE
Added toml to the dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -14,7 +14,6 @@
     realization closest to the mean hazard curve for each site
   * Removed the max_num_sites limit on the event based calculator
 
-
   [Valerio Poggi]
   * Added an AvgSA intensity measure type and a GenericGmpeAvgSA which is
     able to use it

--- a/requirements-py36-linux64.txt
+++ b/requirements-py36-linux64.txt
@@ -28,6 +28,7 @@ http://cdn.ftp.openquake.org/wheelhouse/linux/py/idna-2.6-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py/requests-2.20.0-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py/pyshp-1.2.3-py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py36/PyYAML-3.12-cp36-cp36m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/toml-0.10.0-py2.py3-none-any.whl
 
 ## Extra ##
 

--- a/requirements-py36-macos.txt
+++ b/requirements-py36-macos.txt
@@ -28,6 +28,7 @@ http://cdn.ftp.openquake.org/wheelhouse/macos/py/idna-2.6-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py/requests-2.20.0-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py/pyshp-1.2.3-py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py36/PyYAML-3.12-cp36-cp36m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/toml-0.10.0-py2.py3-none-any.whl
 
 ## Extra ##
 

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ install_requires = [
     'requests >=2.20, <2.21',
     'pyshp ==1.2.3',
     'PyYAML',
+    'toml',
 ]
 
 extras_require = {


### PR DESCRIPTION
This is needed for the plan described in https://github.com/gem/oq-engine/issues/4460. I am not specifying the toml version since the format is stable and every version should work even if the current release number is 0.10 (see https://pypi.org/project/toml/). I guess they did not have the courage to call it 1.0.