### PR TITLE
Small improvement in split_in_blocks

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -296,7 +296,7 @@ def split_in_blocks(sequence, hint, weight=lambda item: 1, key=nokey):
         for k, group in groupby(sequence, key).items():
             blocks.append(group)
         return blocks
-    items = list(sequence) if key is nokey else sorted(sequence, key=key)
+    items = sorted(sequence, key=lambda item: (key(item), weight(item)))
     assert hint > 0, hint
     assert len(items) > 0, len(items)
     total_weight = float(sum(weight(item) for item in items))

--- a/openquake/baselib/tests/general_test.py
+++ b/openquake/baselib/tests/general_test.py
@@ -19,8 +19,6 @@
 """
 Test related to code in openquake/utils/general.py
 """
-
-import numpy as np
 import mock
 import unittest
 from operator import attrgetter
@@ -103,7 +101,8 @@ class BlockSplitterTestCase(unittest.TestCase):
         self.assertEqual(len(blocks), 1)
         blocks = list(split_in_blocks('abcdefghi', 2, weights.get))
         self.assertEqual(len(blocks), 3)
-        self.assertEqual(repr(blocks), "[<WeightedSequence ['a', 'b'], weight=21>, <WeightedSequence ['c', 'd'], weight=115>, <WeightedSequence ['e', 'f', 'g', 'h', 'i'], weight=97>]")
+        self.assertEqual(repr(blocks), "[<WeightedSequence ['f', 'b', 'a', 'd', 'h', 'e', 'i'], weight=103>, <WeightedSequence ['g'], weight=30>, <WeightedSequence ['c'], weight=100>]")
+
 
     def test_split_with_kind(self):
         Source = namedtuple('Source', 'typology, weight')


### PR DESCRIPTION
With this change items are sorted by weight first, so more homogeneous tasks are generated, as seen even in the included test.