### PR TITLE
Update yu13 gmpe

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Robin Gee]
+  * Updated GMPE of Yu et al. (2013)
+
   [Michele Simionato]
   * Added a check when disaggregation is attempted on a source model
     with atomic source groups

--- a/openquake/hazardlib/gsim/yu_2013.py
+++ b/openquake/hazardlib/gsim/yu_2013.py
@@ -17,8 +17,10 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 """
-Module exports :class:`YuEtAl2013`, :class:`YuEtAl2013Tibet`,
-:class:`YuEtAl2013Eastern`, :class:`YuEtAl2013Stable`
+Module exports :class:`YuEtAl2013Ms`, :class:`YuEtAl2013MsTibet`,
+:class:`YuEtAl2013MsEastern`, :class:`YuEtAl2013MsStable`
+:class:`YuEtAl2013Mw`, :class:`YuEtAl2013MwTibet`,
+:class:`YuEtAl2013MwEastern`, :class:`YuEtAl2013MwStable`
 
 """
 import numpy as np
@@ -130,16 +132,18 @@ def get_ras(repi, theta, mag, coeff):
     :param coeff:
         GMPE coefficients
     """
-    rx = 150.
-    ras = 300.
-    dff = 1.e0
-    while abs(dff) > 1e-5:
-        #
-        # calculate the difference between epicentral distances
-        dff = fnc(ras, repi, theta, mag, coeff)
-        #
+    rx = 100.
+    ras = 200.
+    #
+    # calculate the difference between epicentral distances
+    dff = fnc(ras, repi, theta, mag, coeff)
+    while abs(dff) > 1e-3:
         # update the value of distance computed
-        ras -= np.sign(dff) * rx
+        if dff > 0.:
+            ras = ras - rx
+        else:
+            ras = ras + rx
+        dff = fnc(ras, repi, theta, mag, coeff)
         rx = rx / 2.
         if rx < 1e-3:
             break

--- a/openquake/hazardlib/tests/gsim/yu_2013_ms_test.py
+++ b/openquake/hazardlib/tests/gsim/yu_2013_ms_test.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2012-2018 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+from openquake.hazardlib.gsim.yu_2013 import (YuEtAl2013Ms, YuEtAl2013MsTibet,
+                                              YuEtAl2013MsEastern,
+                                              YuEtAl2013MsStable)
+
+
+from openquake.hazardlib.tests.gsim.utils import BaseGSIMTestCase
+
+
+class YuEtAl2013ActiveTestCase(BaseGSIMTestCase):
+    GSIM_CLASS = YuEtAl2013Ms
+
+    def test_mean(self):
+        self.check('YU2013/yu_2013_mean_active.csv',
+                   max_discrep_percentage=0.4)
+
+    def test_std_total(self):
+        self.check('YU2013/yu_2013_stddev_active.csv',
+                   max_discrep_percentage=0.1)
+
+
+class YuEtAl2013TibetTestCase(BaseGSIMTestCase):
+    GSIM_CLASS = YuEtAl2013MsTibet
+
+    def test_mean(self):
+        self.check('YU2013/yu_2013_mean_tibetan.csv',
+                   max_discrep_percentage=0.4)
+
+    def test_std_total(self):
+        self.check('YU2013/yu_2013_stddev_tibetan.csv',
+                   max_discrep_percentage=0.1)
+
+
+class YuEtAl2013EasternTestCase(BaseGSIMTestCase):
+    GSIM_CLASS = YuEtAl2013MsEastern
+
+    def test_mean(self):
+        self.check('YU2013/yu_2013_mean_eastern.csv',
+                   max_discrep_percentage=0.4)
+
+    def test_std_total(self):
+        self.check('YU2013/yu_2013_stddev_eastern.csv',
+                   max_discrep_percentage=0.1)
+
+
+class YuEtAl2013StableTestCase(BaseGSIMTestCase):
+    GSIM_CLASS = YuEtAl2013MsStable
+
+    def test_mean(self):
+        self.check('YU2013/yu_2013_mean_stable.csv',
+                   max_discrep_percentage=0.4)
+
+    def test_std_total(self):
+        self.check('YU2013/yu_2013_stddev_stable.csv',
+                   max_discrep_percentage=0.1)

--- a/openquake/hazardlib/tests/gsim/yu_2013_mw_test.py
+++ b/openquake/hazardlib/tests/gsim/yu_2013_mw_test.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2012-2018 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+from openquake.hazardlib.gsim.yu_2013 import (YuEtAl2013Mw, YuEtAl2013MwTibet,
+                                              YuEtAl2013MwEastern,
+                                              YuEtAl2013MwStable)
+
+
+from openquake.hazardlib.tests.gsim.utils import BaseGSIMTestCase
+
+
+class YuEtAl2013MwActiveTestCase(BaseGSIMTestCase):
+    GSIM_CLASS = YuEtAl2013Mw
+
+    def test_mean(self):
+        self.check('YU2013Mw/yu_2013_mean_active.csv',
+                   max_discrep_percentage=0.4)
+
+    def test_std_total(self):
+        self.check('YU2013Mw/yu_2013_stddev_active.csv',
+                   max_discrep_percentage=0.1)
+
+
+class YuEtAl2013MwTibetTestCase(BaseGSIMTestCase):
+    GSIM_CLASS = YuEtAl2013MwTibet
+
+    def test_mean(self):
+        self.check('YU2013Mw/yu_2013_mean_tibetan.csv',
+                   max_discrep_percentage=0.4)
+
+    def test_std_total(self):
+        self.check('YU2013Mw/yu_2013_stddev_tibetan.csv',
+                   max_discrep_percentage=0.1)
+
+
+class YuEtAl2013MwEasternTestCase(BaseGSIMTestCase):
+    GSIM_CLASS = YuEtAl2013MwEastern
+
+    def test_mean(self):
+        self.check('YU2013Mw/yu_2013_mean_eastern.csv',
+                   max_discrep_percentage=0.4)
+
+    def test_std_total(self):
+        self.check('YU2013Mw/yu_2013_stddev_eastern.csv',
+                   max_discrep_percentage=0.1)
+
+
+class YuEtAl2013MwStableTestCase(BaseGSIMTestCase):
+    GSIM_CLASS = YuEtAl2013MwStable
+
+    def test_mean(self):
+        self.check('YU2013Mw/yu_2013_mean_stable.csv',
+                   max_discrep_percentage=0.4)
+
+    def test_std_total(self):
+        self.check('YU2013Mw/yu_2013_stddev_stable.csv',
+                   max_discrep_percentage=0.1)


### PR DESCRIPTION
This PR updates the Yu (2013) GMPEs for China.  Changlong Li sent the latest version of the GMPEs via email on Feb 18, 2019.  The only changes are to the method:

`def get_ras(repi, theta, mag, coeff)`

This affects the Ms and Mw models. The changes are small because the tests are still passing.
