### PR TITLE
Remove DbServer log file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: python
 
 python:

--- a/debian/patches/openquake.cfg.patch
+++ b/debian/patches/openquake.cfg.patch
@@ -2,22 +2,20 @@ Index: oq-engine/openquake/engine/openquake.cfg
 ===================================================================
 --- a/openquake/engine/openquake.cfg
 +++ b/openquake/engine/openquake.cfg
-@@ -44,10 +44,10 @@
+@@ -44,9 +44,9 @@
  celery_queue = celery
  
  [dbserver]
 -# enable multi_user if you have a multiple user installation
 -multi_user = false
 -file = ~/oqdata/db.sqlite3
--log = ~/oqdata/dbserver.log
 +# run in multi_user mode
 +multi_user = true
 +file = /var/lib/openquake/db.sqlite3
-+log = /var/lib/openquake/dbserver.log
  # daemon bind address; must be a valid IP address
  # example: 0.0.0.0
  listen = 127.0.0.1
-@@ -56,9 +56,10 @@
+@@ -55,9 +55,10 @@
  # of the master node (on the master node cfg too)
  # example: master.hpc
  host = localhost

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -55,7 +55,6 @@ celery_queue = celery
 [dbserver]
 multi_user = true
 file = /var/lib/openquake/db.sqlite3
-log = /var/lib/openquake/dbserver.log
 # daemon bind address; must be a valid IP address
 listen = 0.0.0.0
 # address of the dbserver; can be an hostname too

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -47,7 +47,6 @@ celery_queue = celery
 # enable multi_user if you have a multiple user installation
 multi_user = false
 file = ~/oqdata/db.sqlite3
-log = ~/oqdata/dbserver.log
 # daemon bind address; must be a valid IP address
 # example: 0.0.0.0
 listen = 127.0.0.1

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -182,8 +182,7 @@ def ensure_on():
 
 @sap.Script
 def run_server(dbpath=os.path.expanduser(config.dbserver.file),
-               dbhostport=None, logfile=config.dbserver.log,
-               loglevel='WARN'):
+               dbhostport=None, loglevel='WARN'):
     """
     Run the DbServer on the given database file and port. If not given,
     use the settings in openquake.cfg.
@@ -210,13 +209,12 @@ def run_server(dbpath=os.path.expanduser(config.dbserver.file),
     actions.reset_is_running(db)
 
     # configure logging and start the server
-    logging.basicConfig(level=getattr(logging, loglevel), filename=logfile)
+    logging.basicConfig(level=getattr(logging, loglevel))
     DbServer(db, addr).start()  # expects to be killed with CTRL-C
 
 
 run_server.arg('dbpath', 'dbpath')
 run_server.arg('dbhostport', 'dbhost:port')
-run_server.arg('logfile', 'log file')
 run_server.opt('loglevel', 'WARN or INFO')
 
 if __name__ == '__main__':

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -66,7 +66,6 @@ STATICFILES_DIRS = [
 DATABASE = {
     'ENGINE': 'django.db.backends.sqlite3',
     'NAME': os.path.expanduser(config.dbserver.file),
-    'LOG': os.path.expanduser(config.dbserver.log),
     'USER': getpass.getuser(),
     'HOST': config.dbserver.host,
     'PORT': config.dbserver.port,


### PR DESCRIPTION
Closes #4505 

DbServer logging to file functionality is not working, so I'm removing it so we have less settings in `openquake.cfg`