### PR TITLE
Removed the site_model.xml exporter

### DIFF
--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -108,31 +108,6 @@ def export_ruptures_csv(ekey, dstore):
     return [dest]
 
 
-@export.add(('site_model', 'xml'))
-def export_site_model(ekey, dstore):
-    dest = dstore.export_path('site_model.xml')
-    site_model_node = Node('siteModel')
-    hdf2xml = dict(lons='lon', lats='lat', depths='depth',
-                   vs30measured='vs30Type')
-    for rec in dstore['sitecol'].array:
-        n = Node('site')
-        for hdffield in rec.dtype.names:
-            if hdffield == 'sids':  # skip
-                continue
-            elif hdffield == 'depth' and rec[hdffield] == 0:
-                continue
-            xmlfield = hdf2xml.get(hdffield, hdffield)
-            if hdffield == 'vs30measured':
-                value = 'measured' if rec[hdffield] else 'inferred'
-            else:
-                value = rec[hdffield]
-            n[xmlfield] = value
-        site_model_node.append(n)
-    with open(dest, 'wb') as f:
-        nrml.write([site_model_node], f)
-    return [dest]
-
-
 # #################### export Ground Motion fields ########################## #
 
 class GmfSet(object):

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -88,10 +88,6 @@ class ScenarioTestCase(CalculatorTestCase):
         medians = self.medians(case_4)['PGA']
         aae(medians, [0.41615372, 0.22797466, 0.1936226], decimal=2)
 
-        # this is a case with a site model
-        [fname] = export(('site_model', 'xml'), self.calc.datastore)
-        self.assertEqualFiles('site_model.xml', fname)
-
     def test_case_5(self):
         f1, f2 = self.frequencies(case_5, 0.5, 1.0)
         self.assertAlmostEqual(f1, 0.03, places=2)


### PR DESCRIPTION
It was not particularly useful since we prefer .csv nowadays. Moreover, it could have been confusing to the users since it was appearing in the list of outputs while it is actually an input (even if arguably an output).