### PR TITLE
Deprecated the hazard XML exporters

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Deprecated the XML exporters for hcurves, hmaps, uhs
   * Introduced a `sap.script` decorator
   * Used the WebExtractor in `oq importcalc`
   * Restored validation of the source_model_logic_tree.xml file

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -428,6 +428,7 @@ def get_metadata(realizations, kind):
     return metadata
 
 
+@deprecated('Use the CSV exported instead')
 @export.add(('uhs', 'xml'))
 def export_uhs_xml(ekey, dstore):
     oq = dstore['oqparam']
@@ -464,6 +465,7 @@ HazardCurve = collections.namedtuple('HazardCurve', 'location poes')
 HazardMap = collections.namedtuple('HazardMap', 'lon lat iml')
 
 
+@deprecated('Use the CSV exported instead')
 @export.add(('hcurves', 'xml'))
 def export_hcurves_xml(ekey, dstore):
     key, kind, fmt = get_kkf(ekey)
@@ -501,6 +503,7 @@ def export_hcurves_xml(ekey, dstore):
     return sorted(fnames)
 
 
+@deprecated('Use the CSV exported instead')
 @export.add(('hmaps', 'xml'))
 def export_hmaps_xml(ekey, dstore):
     key, kind, fmt = get_kkf(ekey)

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -428,7 +428,7 @@ def get_metadata(realizations, kind):
     return metadata
 
 
-@deprecated('Use the CSV exported instead')
+@deprecated('Use the CSV exporter instead')
 @export.add(('uhs', 'xml'))
 def export_uhs_xml(ekey, dstore):
     oq = dstore['oqparam']
@@ -465,7 +465,7 @@ HazardCurve = collections.namedtuple('HazardCurve', 'location poes')
 HazardMap = collections.namedtuple('HazardMap', 'lon lat iml')
 
 
-@deprecated('Use the CSV exported instead')
+@deprecated('Use the CSV exporter instead')
 @export.add(('hcurves', 'xml'))
 def export_hcurves_xml(ekey, dstore):
     key, kind, fmt = get_kkf(ekey)
@@ -503,7 +503,7 @@ def export_hcurves_xml(ekey, dstore):
     return sorted(fnames)
 
 
-@deprecated('Use the CSV exported instead')
+@deprecated('Use the CSV exporter instead')
 @export.add(('hmaps', 'xml'))
 def export_hmaps_xml(ekey, dstore):
     key, kind, fmt = get_kkf(ekey)
@@ -556,7 +556,7 @@ def export_hazard_npz(ekey, dstore):
     return [fname]
 
 
-@deprecated('Use the CSV exported instead')
+@deprecated('Use the CSV exporter instead')
 @export.add(('gmf_data', 'xml'))
 def export_gmf(ekey, dstore):
     """


### PR DESCRIPTION
See https://github.com/gem/oq-engine/issues/4486. People are still using the XML exporters, so we cannot remove them, but we can at least deprecate them so that people will get annoying warnings and will know that there are better exporters to use. Still, I do not plan to remove them any time soon.