### PR TITLE
Increase the DbServer start timeout to 30 secs

### DIFF
--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -171,10 +171,10 @@ def ensure_on():
                           '-l', 'INFO'])
 
         # wait for the dbserver to start
-        waiting_seconds = 10
+        waiting_seconds = 30
         while get_status() == 'not-running':
             if waiting_seconds == 0:
-                sys.exit('The DbServer cannot be started after 10 seconds. '
+                sys.exit('The DbServer cannot be started after 30 seconds. '
                          'Please check the configuration')
             time.sleep(1)
             waiting_seconds -= 1


### PR DESCRIPTION
Increase the DbServer start timeout to 30 secs (from 10). 10 seconds is sometime too small for slow for platforms like Windows or when running on heavy loaded machines with spinning drives.