### PR TITLE
Fix the abort command and mark killed jobs as 'aborted'

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Daniele Viganò]
+  * Fixed 'oq abort' and always mark killed jobs as 'aborted'
+
   [Michele Simionato]
   * Introduced a `sap.script` decorator
   * Used the WebExtractor in `oq importcalc`

--- a/openquake/commands/abort.py
+++ b/openquake/commands/abort.py
@@ -41,10 +41,16 @@ def abort(job_id):
             try:
                 os.kill(p.pid, signal.SIGTERM)
                 logs.dbcmd('set_status', job.id, 'aborted')
+                print('Job %d aborted' % job.id)
             except Exception as exc:
                 print(exc)
             break
     else:  # no break
-        print('%d aborted' % job.id)
+        # set job as failed is it was set as executing or running in the db
+        # but the correspongint process is not running
+        logs.dbcmd('set_status', job.id, 'failed')
+        print('Unable to find a process for job %d,'
+              ' setting it as failed' % job.id)
+
 
 abort.arg('job_id', 'job ID', type=int)

--- a/openquake/commands/abort.py
+++ b/openquake/commands/abort.py
@@ -46,8 +46,8 @@ def abort(job_id):
                 print(exc)
             break
     else:  # no break
-        # set job as failed is it was set as executing or running in the db
-        # but the correspongint process is not running
+        # set job as failed if it is set as 'executing' or 'running' in the db
+        # but the corresponding process is not running anymore
         logs.dbcmd('set_status', job.id, 'failed')
         print('Unable to find a process for job %d,'
               ' setting it as failed' % job.id)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -318,11 +318,15 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         logs.LOG.info('Calculation %d finished correctly in %d seconds',
                       job_id, duration)
         logs.dbcmd('finish', job_id, 'complete')
-    except BaseException:
+    except BaseException as exc:
+        if isinstance(exc, MasterKilled):
+            msg = 'aborted'
+        else:
+            msg = 'failed'
         tb = traceback.format_exc()
         try:
             logs.LOG.critical(tb)
-            logs.dbcmd('finish', job_id, 'failed')
+            logs.dbcmd('finish', job_id, msg)
         except BaseException:  # an OperationalError may always happen
             sys.stderr.write(tb)
         raise


### PR DESCRIPTION
The abort command was not properly managing 'orphan' jobs and was printing a misleading message.

Any job which has been killed either by 'ctrl-c' or 'oq abort' is now marked as killed.