### PR TITLE
Fixed the loss curves in ebrisk

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -558,7 +558,7 @@ class ArrayWrapper(object):
             assert shape[-1] == len(extra), (shape[-1], len(extra))
         tagnames = decode_array(self.tagnames)
         for i, tagname in enumerate(tagnames):
-            values = getattr(self, tagname)
+            values = getattr(self, tagname)[1:]
             assert len(values) == shape[i], (len(values), shape[i])
             tags.append(decode_array(values))
         if extra:

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -312,10 +312,9 @@ def compute_loss_curves_maps(filename, clp, individual_curves):
         stats = oq.hazard_stats().items()
         builder = get_loss_builder(dstore)
         R = len(dstore['weights'])
-        losses = [[] for _ in range(R)]
-        elt = dstore['losses_by_event'].value
-        for rec in elt:
-            losses[rec['rlzi']].append(rec['loss'])
+        rlzi = dstore['losses_by_event']['rlzi']
+        elt = dstore['losses_by_event']
+        losses = [elt[rlzi == r]['loss'] for r in range(R)]
     results = []
     for multi_index, _ in numpy.ndenumerate(elt[0]['loss']):
         result = {}

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -16,10 +16,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import time
+import logging
 import numpy
 
 from openquake.baselib import hdf5, datastore, parallel, performance, general
 from openquake.baselib.python3compat import zip, encode
+from openquake.risklib.scientific import losses_by_period
 from openquake.calculators import base, event_based, getters
 from openquake.calculators.export.loss_curves import get_loss_builder
 
@@ -265,51 +267,45 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         """
         self.datastore.set_attrs('task_info/start_ebrisk', times=times)
         oq = self.oqparam
-        elt_length = len(self.datastore['losses_by_event'])
         builder = get_loss_builder(self.datastore)
         self.build_datasets(builder)
-        mon = performance.Monitor(hdf5=hdf5.File(self.datastore.hdf5cache()))
-        smap = parallel.Starmap(compute_loss_curves_maps, monitor=mon)
-        self.datastore.close()
-        acc = []
-        ct = oq.concurrent_tasks or 1
-        for elt_slice in general.split_in_slices(elt_length, ct):
-            smap.submit(self.datastore.filename, elt_slice,
-                        oq.conditional_loss_poes, oq.individual_curves)
-        acc = smap.reduce(acc=[])
-        # copy performance information from the cache to the datastore
-        pd = mon.hdf5['performance_data'].value
-        hdf5.extend3(self.datastore.filename, 'performance_data', pd)
-        self.datastore.open('r+')  # reopen
-        self.datastore['task_info/compute_loss_curves_and_maps'] = (
-            mon.hdf5['task_info/compute_loss_curves_maps'].value)
+        acc = compute_loss_curves_maps(
+            self.datastore.filename, oq.conditional_loss_poes,
+            oq.individual_curves)
         with self.monitor('saving loss_curves and maps', autoflush=True):
             for name, idx, arr in acc:
                 for ij, val in numpy.ndenumerate(arr):
                     self.datastore[name][ij + idx] = val
 
         if oq.asset_loss_table and len(oq.aggregate_by) == 1:
+            logging.info('Checking the loss curves')
+            tags = getattr(self.assetcol.tagcol, oq.aggregate_by[0])[1:]
+            T = len(tags)
+            P = len(builder.return_periods)
             # sanity check on the loss curves for simple tag aggregation
-            stats = list(oq.hazard_stats().items())
             arr = self.assetcol.aggregate_by(
                 oq.aggregate_by, self.datastore['asset_loss_table'].value)
             # shape (T, E, L)
-            for t in range(2):
-                curves_rlzs, curves_stats = builder.build(arr[t], stats)
-                import pdb; pdb.set_trace()
-            
+            rlzs = self.datastore['events']['rlz']
+            curves = numpy.zeros((P, self.R, self.L, T))
+            for t in range(T):
+                for r in range(self.R):
+                    for l in range(self.L):
+                        curves[:, r, l, t] = losses_by_period(
+                            arr[t, rlzs == r, l],
+                            builder.return_periods,
+                            builder.num_events[r],
+                            builder.eff_time)
+            numpy.testing.assert_allclose(
+                curves, self.datastore['agg_curves-rlzs'].value)
 
-def compute_loss_curves_maps(filename, elt_slice, clp, individual_curves,
-                             monitor):
+
+def compute_loss_curves_maps(filename, clp, individual_curves):
     """
     :param filename: path to the datastore
-    :param elt_slice: slice of the event loss table
     :param clp: conditional loss poes used to computed the maps
     :param individual_curves: if True, build the individual curves and maps
-    :param monitor: a Monitor instance
-    :yields:
-        dictionaries with keys idx, agg_curves-rlzs, agg_curves-stats,
-        agg_maps-rlzs, agg_maps-stats
+    :returns: a list of triples [(name, multi_index, array), ...]
     """
     with datastore.read(filename) as dstore:
         oq = dstore['oqparam']
@@ -317,7 +313,7 @@ def compute_loss_curves_maps(filename, elt_slice, clp, individual_curves,
         builder = get_loss_builder(dstore)
         R = len(dstore['weights'])
         losses = [[] for _ in range(R)]
-        elt = dstore['losses_by_event'][elt_slice]
+        elt = dstore['losses_by_event'].value
         for rec in elt:
             losses[rec['rlzi']].append(rec['loss'])
     results = []

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -288,6 +288,10 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 for ij, val in numpy.ndenumerate(arr):
                     self.datastore[name][ij + idx] = val
 
+        if oq.asset_loss_table:  # sanity check on the loss curves
+            arr = self.assetcol.aggregate_by(
+                oq.aggregate_by, self.datastore['asset_loss_table'].value)
+            
 
 def compute_loss_curves_maps(filename, elt_slice, clp, individual_curves,
                              monitor):

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -288,9 +288,15 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 for ij, val in numpy.ndenumerate(arr):
                     self.datastore[name][ij + idx] = val
 
-        if oq.asset_loss_table:  # sanity check on the loss curves
+        if oq.asset_loss_table and len(oq.aggregate_by) == 1:
+            # sanity check on the loss curves for simple tag aggregation
+            stats = list(oq.hazard_stats().items())
             arr = self.assetcol.aggregate_by(
                 oq.aggregate_by, self.datastore['asset_loss_table'].value)
+            # shape (T, E, L)
+            for t in range(2):
+                curves_rlzs, curves_stats = builder.build(arr[t], stats)
+                import pdb; pdb.set_trace()
             
 
 def compute_loss_curves_maps(filename, elt_slice, clp, individual_curves,

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -19,7 +19,7 @@ import logging
 import operator
 import numpy
 
-from openquake.baselib.general import AccumDict
+from openquake.baselib.general import AccumDict, group_array
 from openquake.baselib.python3compat import zip, encode
 from openquake.hazardlib.stats import set_rlzs_stats
 from openquake.hazardlib.calc.stochastic import TWO32
@@ -333,7 +333,9 @@ class EbrCalculator(base.RiskCalculator):
                 dstore.set_attrs('rup_loss_table', ridx=ridx)
         logging.info('Building aggregate loss curves')
         with self.monitor('building agg_curves', measuremem=True):
-            array, arr_stats = b.build(dstore['losses_by_event'].value, stats)
+            lbr = group_array(dstore['losses_by_event'].value, 'rlzi')
+            dic = {r: arr['loss'] for r, arr in lbr.items()}
+            array, arr_stats = b.build(dic, stats)
         loss_types = ' '.join(self.oqparam.loss_dt().names)
         units = self.assetcol.cost_calculator.get_units(loss_types.split())
         if oq.individual_curves or self.R == 1:

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -86,7 +86,7 @@ def export_agg_curve_rlzs(ekey, dstore):
         rows = []
         for multi_idx, loss in numpy.ndenumerate(agg_curve[:, r]):
             p, l, *tagidxs = multi_idx
-            evalue = expvalue[tuple(t+1 for t in tagidxs) + (l % L,)]
+            evalue = expvalue[tuple(tagidxs) + (l % L,)]
             row = tagcol.get_tagvalues(tagnames, tagidxs) + (
                 loss, loss / evalue)
             rows.append((1 / periods[p], periods[p], loss_types[l]) + row)
@@ -155,7 +155,7 @@ def export_agg_losses(ekey, dstore):
         rows = []
         for multi_idx, loss in numpy.ndenumerate(value[:, r]):
             l, *tagidxs = multi_idx
-            evalue = expvalue[tuple(t+1 for t in tagidxs) + (l,)]
+            evalue = expvalue[tuple(tagidxs) + (l,)]
             row = tagcol.get_tagvalues(tagnames, tagidxs) + (
                 loss, evalue, loss / evalue)
             rows.append((dt.names[l],) + row)

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -347,3 +347,4 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         out = self.run_calc(case_6c.__file__, 'job_eb.ini', exports='csv')
         [fname] = out['agg_curves-rlzs', 'csv']
         self.assertEqualFiles('expected/agg_curves.csv', fname, delta=1E-5)
+        # TODO: check the loss maps

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -338,10 +338,12 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         self.run_calc(case_6c.__file__, 'job_h.ini')
         hc = str(self.calc.datastore.calc_id)
         out = self.run_calc(case_6c.__file__, 'job_r.ini', exports='csv',
-                            hazard_calculation_id=hc, concurrent_tasks='0')
+                            hazard_calculation_id=hc)
         [fname] = out['avg_losses-rlzs', 'csv']
         self.assertEqualFiles('expected/avg_losses.csv', fname, delta=1E-5)
 
     def test_asset_loss_table(self):
         # this is a case with L=1, R=1, T=2, P=3
-        self.run_calc(case_6c.__file__, 'job_eb.ini')
+        out = self.run_calc(case_6c.__file__, 'job_eb.ini', exports='csv')
+        [fname] = out['agg_curves-rlzs', 'csv']
+        self.assertEqualFiles('expected/agg_curves.csv', fname, delta=1E-5)

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -341,3 +341,10 @@ class EventBasedRiskTestCase(CalculatorTestCase):
                             hazard_calculation_id=hc, concurrent_tasks='0')
         [fname] = out['avg_losses-rlzs', 'csv']
         self.assertEqualFiles('expected/avg_losses.csv', fname, delta=1E-5)
+
+    def test_asset_loss_table(self):
+        # this is a case with L=1, R=1, T=2, P=3
+        self.run_calc(case_6c.__file__, 'job_eb.ini')
+        self.assertEqualFiles('expected/avg_losses.csv', fname, delta=1E-5)
+
+    

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -345,6 +345,3 @@ class EventBasedRiskTestCase(CalculatorTestCase):
     def test_asset_loss_table(self):
         # this is a case with L=1, R=1, T=2, P=3
         self.run_calc(case_6c.__file__, 'job_eb.ini')
-        self.assertEqualFiles('expected/avg_losses.csv', fname, delta=1E-5)
-
-    

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -634,8 +634,7 @@ class SitecolAssetcolTestCase(unittest.TestCase):
         assert_allclose(arr, [3.6306637e+09])
         arr = assetcol.agg_value('taxonomy')
         assert_allclose(arr,
-                        [[0.0000000e+00],
-                         [4.9882240e+06],
+                        [[4.9882240e+06],
                          [1.1328099e+08],
                          [4.2222912e+08],
                          [1.6412870e+07],
@@ -653,10 +652,9 @@ class SitecolAssetcolTestCase(unittest.TestCase):
                          [9.4132640e+06],
                          [1.0620092e+07]])
         arr = assetcol.agg_value('occupancy')
-        assert_allclose(assetcol.agg_value('occupancy'),
-                        [[0.0000000e+00], [3.6306644e+09]])
+        assert_allclose(assetcol.agg_value('occupancy'), [[3.6306644e+09]])
         arr = assetcol.agg_value('taxonomy', 'occupancy')
-        self.assertEqual(arr.shape, (18, 2, 1))
+        self.assertEqual(arr.shape, (17, 1, 1))
 
     def test_site_model_sites(self):
         # you cannot set them at the same time

--- a/openquake/qa_tests_data/event_based_risk/case_6c/expected/agg_curves.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_6c/expected/agg_curves.csv
@@ -1,0 +1,7 @@
+annual_frequency_of_exceedence,return_period,loss_type,NAME_1,loss_value,loss_ratio
+2.00000E-02,50,structural,RegionA,6.26185E+02,1.56546E-01
+2.00000E-02,50,structural,RegionB,9.93786E+02,9.93786E-02
+1.00000E-02,100,structural,RegionA,1.50019E+03,3.75048E-01
+1.00000E-02,100,structural,RegionB,1.38163E+03,1.38163E-01
+5.00000E-03,200,structural,RegionA,1.60462E+03,4.01156E-01
+5.00000E-03,200,structural,RegionB,1.74408E+03,1.74408E-01

--- a/openquake/qa_tests_data/event_based_risk/case_6c/exposure_model.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_6c/exposure_model.xml
@@ -13,7 +13,7 @@
       <costType name="business_interruption" type="per_asset" unit="USD/month" />
     </costTypes>
   </conversions>
-  
+  <tagNames>NAME_1</tagNames>
   <assets>
     <asset id="a1" number="1" area="100" taxonomy="tax1" >
       <location lon="-122.000" lat="38.113" />
@@ -28,6 +28,7 @@
         <occupancy occupants="4" period="transit" />
         <occupancy occupants="6" period="night" />
       </occupancies>
+      <tags NAME_1="RegionA" />
     </asset>
     
     <asset id="a2" number="1" area="100" taxonomy="tax1" >
@@ -43,6 +44,7 @@
         <occupancy occupants="4" period="transit" />
         <occupancy occupants="6" period="night" />
       </occupancies>
+      <tags NAME_1="RegionA" />
     </asset>
     
     <asset id="a3" number="1" area="100" taxonomy="tax1" >
@@ -58,6 +60,7 @@
         <occupancy occupants="4" period="transit" />
         <occupancy occupants="6" period="night" />
       </occupancies>
+      <tags NAME_1="RegionB" />
     </asset>
     
     <asset id="a4" number="1" area="100" taxonomy="tax1" >
@@ -73,6 +76,7 @@
         <occupancy occupants="4" period="transit" />
         <occupancy occupants="6" period="night" />
       </occupancies>
+      <tags NAME_1="RegionB" />
     </asset>
     
     <asset id="a5" number="1" area="100" taxonomy="tax1" >
@@ -88,6 +92,7 @@
         <occupancy occupants="4" period="transit" />
         <occupancy occupants="6" period="night" />
       </occupancies>
+      <tags NAME_1="RegionB" />
     </asset>
     
     <asset id="a6" number="1" area="100" taxonomy="tax1" >
@@ -103,6 +108,7 @@
         <occupancy occupants="4" period="transit" />
         <occupancy occupants="6" period="night" />
       </occupancies>
+      <tags NAME_1="RegionB" />
     </asset>
     
     <asset id="a7" number="1" area="100" taxonomy="tax1" >
@@ -118,6 +124,7 @@
         <occupancy occupants="4" period="transit" />
         <occupancy occupants="6" period="night" />
       </occupancies>
+      <tags NAME_1="RegionB" />
     </asset>
     
   </assets>

--- a/openquake/qa_tests_data/event_based_risk/case_6c/job_eb.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_6c/job_eb.ini
@@ -32,4 +32,5 @@ maximum_distance = 200.0
 investigation_time = 1
 number_of_logic_tree_samples = 0
 ses_per_logic_tree_path = 200
+conditional_loss_poes = .01
 asset_loss_table = true

--- a/openquake/qa_tests_data/event_based_risk/case_6c/job_eb.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_6c/job_eb.ini
@@ -1,0 +1,35 @@
+[general]
+description = ebrisk with asset_loss_table
+calculation_mode = ebrisk
+exposure_file = exposure_model.xml
+aggregate_by = NAME_1
+
+[boundaries]
+region = -122.6 38.3, -121.5 38.3, -121.5 37.9, -122.6 37.9
+
+[site_params]
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 5.0
+reference_depth_to_1pt0km_per_sec = 100.0
+
+[erf]
+width_of_mfd_bin = 0.1
+rupture_mesh_spacing = 2.0
+area_source_discretization = 10
+
+[logic_trees]
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gsim_logic_tree.xml
+
+[vulnerability]
+structural_vulnerability_file = vulnerability_model.xml
+
+[calculation]
+intensity_measure_types = PGA
+truncation_level = 3
+maximum_distance = 200.0
+investigation_time = 1
+number_of_logic_tree_samples = 0
+ses_per_logic_tree_path = 200
+asset_loss_table = true

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -475,10 +475,10 @@ class AssetCollection(object):
                              (len(self), A))
         if not tagnames:
             return array.sum(axis=0)
-        shape = [len(getattr(self.tagcol, tagname)) for tagname in tagnames]
+        shape = [len(getattr(self.tagcol, tagname))-1 for tagname in tagnames]
         acc = numpy.zeros(shape, (F32, shp) if shp else F32)
         for asset, row in zip(self.array, array):
-            acc[tuple(asset[tagnames])] += row
+            acc[tuple(idx - 1 for idx in asset[tagnames])] += row
         return acc
 
     def agg_value(self, *tagnames):

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1355,11 +1355,11 @@ class LossesByPeriodBuilder(object):
             array_stats = None
         return array, array_stats
 
-    # used in postproc
+    # used in event_based_risk postproc
     def build(self, losses_by_event, stats=()):
         """
         :param losses_by_event:
-            the aggregate loss table as an array
+            the aggregate loss table with shape R -> (E, L)
         :param stats:
             list of pairs [(statname, statfunc), ...]
         :returns:
@@ -1368,10 +1368,9 @@ class LossesByPeriodBuilder(object):
         P, R = len(self.return_periods), len(self.weights)
         L = len(self.loss_dt.names)
         array = numpy.zeros((P, R, L), F32)
-        dic = group_array(losses_by_event, 'rlzi')
-        for r in dic:
+        for r in losses_by_event:
             num_events = self.num_events[r]
-            losses = dic[r]['loss']
+            losses = losses_by_event[r]
             for l, lt in enumerate(self.loss_dt.names):
                 ls = losses[:, l].flatten()  # flatten only in ucerf
                 # NB: do not use squeeze or the gmf_ebrisk tests will break


### PR DESCRIPTION
As @raoanirudh discovered, the loss curves were computed incorrectly. I fixed the issue by removing the parallelization in `compute_loss_curves_maps`. It may be restored in the future. I have also added a sanity check: when asset_loss_table is true and there is a single aggregation tag, the loss curves are computed from the asset loss table and compared with the ones coming from the event loss table. Extending the check to multiple tags is left for the future. Finally, I have fixed an off-by-one error in AssetCollection.aggregate_by.