### PR TITLE
Avoided a double counting when saving the classical_split_filter performance info

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -506,8 +506,8 @@ class IterResult(object):
             else:
                 # measure only the memory used by the main process
                 mem_gb = memory_rss(os.getpid()) / GB
-            save_task_info(self, result, mem_gb)
             if not result.func_args:  # not subtask
+                save_task_info(self, result, mem_gb)
                 yield val
         if self.received:
             tot = sum(self.received)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -75,14 +75,15 @@ def classical_split_filter(srcs, srcfilter, gsims, params, monitor):
     maxweight ruptures.
     """
     sources = []
-    for src in srcs:
-        if src.num_ruptures >= params['maxweight']:
-            splits, stime = split_sources([src])
-            sources.extend(srcfilter.filter(splits))
-        elif list(srcfilter.filter([src])):
-            sources.append(src)
-    blocks = list(block_splitter(sources, params['maxweight'],
-                                 operator.attrgetter('num_ruptures')))
+    with monitor("splitting/filtering sources"):
+        for src in srcs:
+            if src.num_ruptures >= params['maxweight']:
+                splits, stime = split_sources([src])
+                sources.extend(srcfilter.filter(splits))
+            elif list(srcfilter.filter([src])):
+                sources.append(src)
+        blocks = list(block_splitter(sources, params['maxweight'],
+                                     operator.attrgetter('num_ruptures')))
     if blocks:
         for block in blocks[1:]:
             yield classical, block, srcfilter, gsims, params


### PR DESCRIPTION
And also stored the splitting/filtering info.