### PR TITLE
Fixed an ordering bug while reading the site models

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed two subtle bugs when reading site_model.csv files
   * Added /extract/exposure_metadata and /extract/asset_risk
 
   [Guillaume Daniel]

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -514,7 +514,7 @@ class IterResult(object):
             tot = sum(self.received)
             max_per_output = max(self.received)
             logging.info(
-                'Received %s from %d %r outputs in %d seconds, biggest '
+                'Received %s from %d %s outputs in %d seconds, biggest '
                 'output=%s', humansize(tot), len(self.received),
                 '|'.join(names), time.time() - t0, humansize(max_per_output))
             if nbytes:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -262,7 +262,8 @@ def read_csv(fname, sep=','):
     """
     with open(fname, encoding='utf-8-sig') as f:
         header = next(f).strip().split(sep)
-        dt = numpy.dtype([(h, float) for h in header])
+        dt = numpy.dtype([(h, numpy.bool if h == 'vs30measured' else float)
+                          for h in header])
         return numpy.loadtxt(f, dt, delimiter=sep)
 
 
@@ -354,7 +355,10 @@ def get_site_model(oqparam):
             if 'site_id' in sm.dtype.names:
                 raise InvalidFile('%s: you passed a sites.csv file instead of '
                                   'a site_model.csv file!' % fname)
-            arrays.append(sm)
+            z = numpy.zeros(len(sm), sorted(sm.dtype.descr))
+            for name in z.dtype.names:  # reorder the fields
+                z[name] = sm[name]
+            arrays.append(z)
             continue
         nodes = nrml.read(fname).siteModel
         params = [valid.site_param(node.attrib) for node in nodes]


### PR DESCRIPTION
When reading the site model in CSV format the field names were not ordered, and `vs30measured` was read as a float, not as a boolean.