### PR TITLE
Minor improvements to the job status cleanup

### DIFF
--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -55,7 +55,8 @@ def reset_is_running(db):
 
     :param db: a :class:`openquake.server.dbapi.Db` instance
     """
-    db('UPDATE job SET is_running=0 WHERE is_running=1')
+    db('UPDATE job SET is_running=0, status=?x WHERE is_running=1 '
+       'OR status=?x', 'failed', 'executing')
 
 
 def set_status(db, job_id, status):

--- a/openquake/server/manage.py
+++ b/openquake/server/manage.py
@@ -54,7 +54,6 @@ if __name__ == "__main__":
         if err:
             sys.exit(err)
         logs.dbcmd('upgrade_db')  # make sure the DB exists
-        logs.dbcmd('reset_is_running')  # reset the flag is_running
 
     setproctitle('oq-webui')
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
With this PR we are also resetting the status to 'failed', not only `is_running' since now we can easily differentiate failed jobs from aborted. We may decide to add a new status as suggest by Paul here #4606 

I also removed the job status reset in the WebUI starting procedure: the DbServer should take care of that and sometime it happens that I need to restart the WebUI without messing around runnign jobs.