### PR TITLE
Switch Travis to Xenial, which will allow us to use Py 3.7 in the future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 
 python:
  - "3.6"


### PR DESCRIPTION
Xenial is now official supported by Travis and will become the default soon.

Let's see if we are already compatible with it. It also support Python 3.7.