### PR TITLE
Restore a DB command needed by cluster scripts

### DIFF
--- a/doc/internals.md
+++ b/doc/internals.md
@@ -12,6 +12,7 @@ $ python -m openquake.server.db.upgrade_manager ~/oqdata/db.sqlite3
 
 ### Database commands
 
+- `oq db get_executing_jobs`
 - `oq db get_longest_jobs`
 - `oq db find <description>`
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -675,6 +675,28 @@ class List(list):
     _fields = ()
 
 
+def get_executing_jobs(db):
+    """
+    :param db:
+        a :class:`openquake.server.dbapi.Db` instance
+    :returns:
+        (id, pid, user_name, start_time) tuples
+    """
+    fields = 'id,pid,user_name,start_time'
+    running = List()
+    running._fields = fields.split(',')
+
+    query = ('''-- executing jobs
+SELECT %s FROM job WHERE status='executing' ORDER BY id desc''' % fields)
+    rows = db(query)
+    for r in rows:
+        # if r.pid is 0 it means that such information
+        # is not available in the database
+        if r.pid and psutil.pid_exists(r.pid):
+            running.append(r)
+    return running
+
+
 def get_longest_jobs(db):
     """
     :param db:


### PR DESCRIPTION
This action is used in many external scripts

Was deleted in https://github.com/gem/oq-engine/pull/4616/files