### PR TITLE
Reduce data transfer in hazard stats

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Reduced the data transfer in the computation of the hazard curves, causing
+    in some time huge speedups (over 100x)
   * Implemented a flag `modal_damage_state` to display only the most likely
     damage state in the output `dmg_by_asset` of scenario damage calculations
   * Reduced substantially the memory occupation in classical calculations

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -306,11 +306,11 @@ class ClassicalCalculator(base.HazardCalculator):
             self.datastore.create_dset('best_rlz', U32, (N,))
         logging.info('Building hazard statistics')
         ct = oq.concurrent_tasks
-        iterargs = (
+        allargs = [  # this list is very fast to generate
             (getters.PmapGetter(parent, self.rlzs_assoc, t.sids, oq.poes),
              N, hstats, oq.individual_curves)
-            for t in self.sitecol.split_in_tiles(ct))
-        parallel.Starmap(build_hazard_stats, iterargs, self.monitor()).reduce(
+            for t in self.sitecol.split_in_tiles(ct)]
+        parallel.Starmap(build_hazard_stats, allargs, self.monitor()).reduce(
             self.save_hazard_stats)
 
 

--- a/openquake/commonlib/rlzs_assoc.py
+++ b/openquake/commonlib/rlzs_assoc.py
@@ -280,7 +280,7 @@ def get_rlzs_assoc(cinfo, sm_lt_path=None, trts=None):
             gsim_rlzs = list(gsim_lt)
             all_trts = list(gsim_lt.values)
         else:
-            gsim_rlzs = cinfo.gsim_rlzs
+            gsim_rlzs = list(cinfo.gsim_lt)
             all_trts = list(cinfo.gsim_lt.values)
 
         rlzs = cinfo._get_rlzs(smodel, gsim_rlzs, cinfo.seed + offset)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -139,11 +139,6 @@ class CompositionInfo(object):
                     self.seed_samples_by_grp[grp.id] = seed, sm.samples
                 seed += sm.samples
 
-    @property
-    def gsim_rlzs(self):
-        # cannot be cached, otherwise the data transfer will kill you
-        return list(self.gsim_lt)
-
     def get_info(self, sm_id):
         """
         Extract a CompositionInfo instance containing the single

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -141,14 +141,8 @@ class CompositionInfo(object):
 
     @property
     def gsim_rlzs(self):
-        """
-        Build and cache the gsim logic tree realizations
-        """
-        try:
-            return self._gsim_rlzs
-        except AttributeError:
-            self._gsim_rlzs = list(self.gsim_lt)
-            return self._gsim_rlzs
+        # cannot be cached, otherwise the data transfer will kill you
+        return list(self.gsim_lt)
 
     def get_info(self, sm_id):
         """


### PR DESCRIPTION
This change reduces by two order of magnitudes the data transfer when computing the hazard statistics for India with 1000 realizations (done by @raoanirudh), thus making the calculation ultra-fast, from 42 minutes to less than 1 minute.