### PR TITLE
The ebrisk calculator gives bogus numbers when there is parallel reading of the exposure

### DIFF
--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -817,9 +817,7 @@ class Exposure(object):
                             prefix, tagcol))
         exp = None
         for exposure in parallel.Starmap(
-                Exposure.read_exp, allargs,
-                distribute='no' if os.environ.get('OQ_DISTRIBUTE') == 'no'
-                else 'processpool'):
+                Exposure.read_exp, allargs, distribute='no'):
             if exp is None:  # first time
                 exp = exposure
                 exp.description = 'Composite exposure[%d]' % len(fnames)


### PR DESCRIPTION
The reason is that the association asset -> taxonomy index -> risk functions become arbitrary (depending on the order of the tasks). For the moment I am solving by disabling the parallel reading, but a real solution is possible and will be implemented in the future. It will require ordering the tagcollection after the parallel reading.