### PR TITLE
Extended prepare_site_model to sites_csv files

### DIFF
--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -482,7 +482,7 @@ class PrepareSiteModelTestCase(unittest.TestCase):
         exposure_xml = os.path.join(inputdir, 'exposure.xml')
         vs30_csv = os.path.join(inputdir, 'vs30.csv')
         sitecol = prepare_site_model(
-            [exposure_xml], [vs30_csv], True, True, True,
+            [exposure_xml], [], [vs30_csv], True, True, True,
             grid_spacing, 5, output)
         sm = read_csv(output)
         self.assertEqual(sm['vs30measured'].sum(), 0)
@@ -490,6 +490,10 @@ class PrepareSiteModelTestCase(unittest.TestCase):
         self.assertEqual(len(sitecol), len(sm))
 
         # test no grid
-        sc = prepare_site_model([exposure_xml], [vs30_csv],
+        sc = prepare_site_model([exposure_xml], [], [vs30_csv],
                                 True, True, False, 0, 5, output)
         self.assertEqual(len(sc), 148)  # 148 sites within 5 km from the params
+
+        # test sites_csv
+        sc = prepare_site_model([], [output], [vs30_csv],
+                                True, True, False, 0, 5, output)

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -28,6 +28,7 @@ import os
 import re
 import ast
 import copy
+import time
 import logging
 import itertools
 import collections
@@ -480,9 +481,13 @@ class FakeSmlt(object):
         """
         :returns: the set of TRTs inside the source model file
         """
+        t0 = time.time()
         with open(self.filename, encoding='utf-8') as f:
             xml = f.read()
-        return set(TRT_REGEX.findall(xml))
+        res = set(TRT_REGEX.findall(xml))
+        dt = time.time() - t0
+        logging.info('Found TRTs in %s in %d seconds', self.filename, dt)
+        return res
 
     def __iter__(self):
         name = os.path.basename(self.filename)


### PR DESCRIPTION
This is useful for the hazard team when running calculations with a site model. The command here uses the same associations the risk team uses. The simplest usage is

```bash
$ oq prepare_site_model -s sites.csv vs30.csv
```
where sites.csv is a file of lon,lat with the hazard sites and vs30.csv is a file with lon,lat,vs30.
Then use the generated site_model.csv file in the the job.ini. Do NOT use the original sites.csv file in the job.ini.