### PR TITLE
Optimized collect_source_model_data

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Optimized the validation of the source model logic tree: now checking
+    the sources IDs is 5x faster
   * Went back to the old logic in sampling: the weights are used for the
     sampling and the statistics are computed with identical weights
   * Avoided to transfer the epsilons by storing them in the cache file

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -463,6 +463,9 @@ class FakeSmlt(object):
         self.num_samples = num_samples
         self.on_each_source = False
         self.num_paths = 1
+        with open(self.filename, encoding='utf-8') as f:
+            xml = f.read()
+        self.tectonic_region_type = set(TRT_REGEX.findall(xml))
 
     def gen_source_models(self, gsim_lt):
         """
@@ -478,14 +481,6 @@ class FakeSmlt(object):
         :returns: the sourcegroup unchanged
         """
         return sourcegroup
-
-    def get_trts(self):
-        """
-        :returns: the set of TRTs inside the source model file
-        """
-        with open(self.filename, encoding='utf-8') as f:
-            xml = f.read()
-        return set(TRT_REGEX.findall(xml))
 
     def __iter__(self):
         name = os.path.basename(self.filename)
@@ -606,20 +601,6 @@ class SourceModelLogicTree(object):
         """
         return (self.info.applytosources and
                 self.info.applytosources == self.source_ids)
-
-    def get_source_ids(self):
-        """
-        :returns:
-            the complete dictionary source model ID -> source IDs
-        """
-        return self.source_ids
-
-    def get_trts(self):
-        """
-        :returns:
-            the complete set of tectonic regions found in all the source models
-        """
-        return self.tectonic_region_types
 
     def parse_tree(self, tree_node, validate):
         """

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -45,7 +45,7 @@ from openquake.hazardlib import geo, valid, nrml, InvalidFile, pmf
 from openquake.hazardlib.sourceconverter import (
     split_coords_2d, split_coords_3d, SourceGroup)
 
-from openquake.baselib.node import striptag, node_from_elem, Node as N, context
+from openquake.baselib.node import node_from_elem, Node as N, context
 
 #: Minimum value for a seed number
 MIN_SINT_32 = -(2 ** 31)
@@ -54,7 +54,7 @@ MAX_SINT_32 = (2 ** 31) - 1
 
 TRT_REGEX = re.compile(r'tectonicRegion="([^"]+?)"')
 ID_REGEX = re.compile(r'id="([^"]+?)"')
-SOURCE_TYPE_REGEX = re.compile(r'\w+Source')
+SOURCE_TYPE_REGEX = re.compile(r'<(\w+Source)\b')
 
 
 def unique(objects, key=None):
@@ -580,9 +580,6 @@ class SourceModelLogicTree(object):
     FILTERS = ('applyToTectonicRegionType',
                'applyToSources',
                'applyToSourceType')
-
-    SOURCE_TYPES = ('point', 'area', 'complexFault', 'simpleFault',
-                    'characteristicFault')
 
     def __init__(self, filename, validate=True, seed=0, num_samples=0):
         self.filename = filename

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -829,7 +829,7 @@ def get_composite_source_model(oqparam, monitor=None, in_memory=True,
     """
     ucerf = oqparam.calculation_mode.startswith('ucerf')
     source_model_lt = get_source_model_lt(oqparam, validate=not ucerf)
-    trts = source_model_lt.get_trts()
+    trts = source_model_lt.tectonic_region_types
     trts_lower = {trt.lower() for trt in trts}
     reqv = oqparam.inputs.get('reqv', {})
     for trt in reqv:  # these are lowercase because they come from the job.ini


### PR DESCRIPTION
This reduces the startup time of the Italy model from around 15 minutes to less than 3 minutes. The trick is to use regular expressions instead of the XML parser when collecting TRTs, source IDs and source types. @nastasi-oq  would be happy. I am also removing some historical baggage that was once useful.