### PR TITLE
Fixed `hdf5.get_nbytes`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a MemoryError when counting the number of bytes stored in large
+    HDF5 datasets
   * Extended `asset_hazard_distance` to a dictionary for usage with multi_risk
   * Extended oq prepare_site_model to work with sites.csv files
   * Optimized the validation of the source model logic tree: now checking

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -211,7 +211,7 @@ def get_nbytes(dset):
     if 'nbytes' in dset.attrs:
         # look if the dataset has an attribute nbytes
         return dset.attrs['nbytes']
-    elif hasattr(dset, 'value'):
+    elif hasattr(dset, 'dtype'):
         # else extract nbytes from the underlying array
         return dset.size * numpy.zeros(1, dset.dtype).nbytes
 


### PR DESCRIPTION
This solves a problem encounted by @raoanirudh: 
```python
  File "/opt/openquake/oq-engine/openquake/baselib/hdf5.py", line 226, in get_nbytes
    nbytes = get_nbytes(dset)
  File "/opt/openquake/oq-engine/openquake/baselib/hdf5.py", line 214, in get_nbytes
    elif hasattr(dset, 'value'):
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/opt/openquake/lib/python3.6/site-packages/h5py/_hl/dataset.py", line 250, in value
    return self[()]
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/opt/openquake/lib/python3.6/site-packages/h5py/_hl/dataset.py", line 485, in __getitem__
    arr = numpy.ndarray(mshape, new_dtype, order='C')
MemoryError
```

The issue is that `dset.value` is a property, not an attribute: it means that `hasattr(dset, 'value')` actually 
reads the full array and it requires 200 GB of RAM in this case :-(
The solution is trivial.