### PR TITLE
Exposed the outputs when compare_with_classical=true

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Exposed the outputs of the classical calculation in event based
+    calculations with `compare_with_classical=true`
   * Made it possible to serialize together all kind of risk functions,
     including consequence functions that before were not HDF5-serializable
   * Fixed a MemoryError when counting the number of bytes stored in large

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -36,6 +36,7 @@ from openquake.calculators import base, extract
 from openquake.calculators.getters import (
     GmfGetter, RuptureGetter, gen_rupture_getters)
 from openquake.calculators.classical import ClassicalCalculator
+from openquake.engine import engine
 
 U8 = numpy.uint8
 U16 = numpy.uint16
@@ -439,6 +440,7 @@ class EventBasedCalculator(base.HazardCalculator):
             # model, however usually this is quite fast and do not dominate
             # the computation
             self.cl.run(close=False)
+            engine.expose_outputs(self.cl.datastore)
             cl_mean_curves = get_mean_curves(self.cl.datastore)
             eb_mean_curves = get_mean_curves(self.datastore)
             self.rdiff, index = util.max_rel_diff_index(

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -26,6 +26,7 @@ from openquake.baselib import performance, general, sap, datastore
 from openquake.hazardlib import valid
 from openquake.commonlib import readinput, oqvalidation, logs
 from openquake.calculators import base, views
+from openquake.server import dbserver
 
 calc_path = None  # set only when the flag --slowest is given
 
@@ -132,6 +133,7 @@ def run(job_ini, slowest=False, hc=None, param='', concurrent_tasks=None,
     """
     Run a calculation bypassing the database layer
     """
+    dbserver.ensure_on()
     if param:
         params = oqvalidation.OqParam.check(
             dict(p.split('=', 1) for p in param.split(',')))


### PR DESCRIPTION
As discovered by Michael this step was missing. Notice that it was done on purpose, so it is not a bug. The reason to not expose the outputs was to avoid the dependency on the DbServer for this feature, that was meant as a debug feature. In order to promote the feature to a production feature it is enough to add a `dbserver.ensure_on` to `oq run`, which is a good idea anyway (otherwise the `--hc` option does not work and it is something I wanted to do anyway).