### PR TITLE
Avoid mysterious MasterKilled error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Removed all calls to ProcessPool.shutdown to speed up the tests and to
+    avoid non-deterministic errors in atexit._run_exitfuncs
+
   [Marco Pagani]
   * Added tabular GMPEs as provided by Michal Kolaj, Natural Resources Canada
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -567,7 +567,7 @@ def save_task_info(self, res, mem_gb=0):
 def init_workers():
     """Waiting function, used to wake up the process pool"""
     setproctitle('oq-worker')
-    # unregister raiseMasterKilled in oq-workers to avoid deadlock
+    # unregister manage_signals in oq-workers to avoid deadlock
     # since processes are terminated via pool.terminate()
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
     # prctl is still useful (on Linux) to terminate all spawned processes

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -567,7 +567,7 @@ def save_task_info(self, res, mem_gb=0):
 def init_workers():
     """Waiting function, used to wake up the process pool"""
     setproctitle('oq-worker')
-    # unregister manage_signals in oq-workers to avoid deadlock
+    # unregister SIGTERM in oq-workers to avoid deadlock
     # since processes are terminated via pool.terminate()
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
     # prctl is still useful (on Linux) to terminate all spawned processes

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -600,15 +600,14 @@ class Starmap(object):
             cls.pids = [proc.pid for proc in cls.pool._pool]
         elif distribute == 'threadpool' and not hasattr(cls, 'pool'):
             cls.pool = multiprocessing.dummy.Pool(poolsize)
-        elif distribute == 'no' and hasattr(cls, 'pool'):
-            cls.shutdown()
         elif distribute == 'dask':
             cls.dask_client = Client(config.distribution.dask_scheduler)
 
     @classmethod
     def shutdown(cls):
+        # shutting down the pool during the runtime causes mysterious
+        # race conditions with errors inside atexit._run_exitfuncs
         if hasattr(cls, 'pool'):
-            print('shutting down pool')
             cls.pool.close()
             cls.pool.terminate()
             cls.pool.join()

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -608,6 +608,7 @@ class Starmap(object):
     @classmethod
     def shutdown(cls):
         if hasattr(cls, 'pool'):
+            print('shutting down pool')
             cls.pool.close()
             cls.pool.terminate()
             cls.pool.join()

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -332,7 +332,11 @@ def hazard_items(dic, mesh, *extras, **kw):
     """
     for item in kw.items():
         yield item
-    arr = dic[next(iter(dic))]
+    try:
+        field = next(iter(dic))
+    except StopIteration:
+        return
+    arr = dic[field]
     dtlist = [(str(field), arr.dtype) for field in sorted(dic)]
     for field, dtype, values in extras:
         dtlist.append((str(field), dtype))

--- a/openquake/commands/abort.py
+++ b/openquake/commands/abort.py
@@ -39,7 +39,7 @@ def abort(job_id):
     for p in psutil.process_iter():
         if p.name() == name:
             try:
-                os.kill(p.pid, signal.SIGTERM)
+                os.kill(p.pid, signal.SIGINT)
                 logs.dbcmd('set_status', job.id, 'aborted')
                 print('Job %d aborted' % job.id)
             except Exception as exc:

--- a/openquake/commands/abort.py
+++ b/openquake/commands/abort.py
@@ -39,7 +39,7 @@ def abort(job_id):
     for p in psutil.process_iter():
         if p.name() == name:
             try:
-                os.kill(p.pid, signal.SIGINT)
+                os.kill(p.pid, signal.SIGTERM)
                 logs.dbcmd('set_status', job.id, 'aborted')
                 print('Job %d aborted' % job.id)
             except Exception as exc:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -888,7 +888,6 @@ def get_composite_source_model(oqparam, monitor=None, in_memory=True,
         csm = csm.grp_by_src()  # one group per source
 
     csm.info.gsim_lt.check_imts(oqparam.imtls)
-    parallel.Starmap.shutdown()  # save memory
     return csm
 
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -185,7 +185,7 @@ def inhibitSigInt(signum, _stack):
 
 def raiseMasterKilled(signum, _stack):
     """
-    When a SIGTERM is received, raise the MasterKilled
+    When a SIGINT is received, raise the MasterKilled
     exception with an appropriate error message.
 
     :param int signum: the number of the received signal
@@ -196,7 +196,7 @@ def raiseMasterKilled(signum, _stack):
         signal.signal(signal.SIGINT, inhibitSigInt)
 
     msg = 'Received a signal %d' % signum
-    if signum in (signal.SIGTERM, signal.SIGINT):
+    if signum in (signal.SIGINT,):
         msg = 'The openquake master process was killed manually'
 
     # kill the calculation only if os.getppid() != _PPID, i.e. the controlling

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -199,7 +199,7 @@ def manage_signals(signum, _stack):
         raise MasterKilled('The openquake master process was killed manually')
 
     if signum == signal.SIGTERM:
-        raise SystemExit
+        raise SystemExit('SIGTERM')
 
     if hasattr(signal, 'SIGHUP'):  # there is no SIGHUP on Windows
         # kill the calculation only if os.getppid() != _PPID, i.e. the

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -198,6 +198,9 @@ def raiseMasterKilled(signum, _stack):
     if signum == signal.SIGINT:
         raise MasterKilled('The openquake master process was killed manually')
 
+    if signum == signal.SIGTERM:
+        raise SystemExit('SIGTERM')
+
     if hasattr(signal, 'SIGHUP'):  # there is no SIGHUP on Windows
         # kill the calculation only if os.getppid() != _PPID, i.e. the
         # controlling terminal died; in the workers, do nothing

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -183,10 +183,10 @@ def inhibitSigInt(signum, _stack):
     logs.LOG.warn('Killing job, please wait')
 
 
-def raiseMasterKilled(signum, _stack):
+def manage_signals(signum, _stack):
     """
-    When a SIGINT is received, raise the MasterKilled
-    exception with an appropriate error message.
+    Convert a SIGTERM into a SystemExit exception and a SIGINT/SIGHUP into
+    a MasterKilled exception with an appropriate error message.
 
     :param int signum: the number of the received signal
     :param _stack: the current frame object, ignored
@@ -199,7 +199,7 @@ def raiseMasterKilled(signum, _stack):
         raise MasterKilled('The openquake master process was killed manually')
 
     if signum == signal.SIGTERM:
-        raise SystemExit('SIGTERM')
+        raise SystemExit
 
     if hasattr(signal, 'SIGHUP'):  # there is no SIGHUP on Windows
         # kill the calculation only if os.getppid() != _PPID, i.e. the
@@ -209,17 +209,17 @@ def raiseMasterKilled(signum, _stack):
                 'The openquake master lost its controlling terminal')
 
 
-# register the raiseMasterKilled callback for SIGTERM
+# register the manage_signals callback for SIGTERM, SIGINT, SIGHUP
 # when using the Django development server this module is imported by a thread,
 # so one gets a `ValueError: signal only works in main thread` that
 # can be safely ignored
 try:
-    signal.signal(signal.SIGTERM, raiseMasterKilled)
-    signal.signal(signal.SIGINT, raiseMasterKilled)
+    signal.signal(signal.SIGTERM, manage_signals)
+    signal.signal(signal.SIGINT, manage_signals)
     if hasattr(signal, 'SIGHUP'):
         # Do not register our SIGHUP handler if running with 'nohup'
         if signal.getsignal(signal.SIGHUP) != signal.SIG_IGN:
-            signal.signal(signal.SIGHUP, raiseMasterKilled)
+            signal.signal(signal.SIGHUP, manage_signals)
 except ValueError:
     pass
 


### PR DESCRIPTION
This is affecting the oq-risk-tests:https://gitlab.openquake.org/openquake/oq-risk-tests/-/jobs/5584.
The solution was to not close the pool, so that the SIGTERM is never raised. I have also changed
the code managing the signals so that now the SIGTERM is converted into a SystemExit exception
rather than a MasterKilled exception. The tests pass: https://gitlab.openquake.org/openquake/oq-risk-tests/-/jobs/5591.
PS: there is also a Python 3.7 fix due to a change in the management of StopIteration.