### PR TITLE
Revert #4475

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Daniele Viganò]
-  * Multiple DbServer ZMQ connection are restored to avoid errors under heavy load
-    on slower machines
+  * Multiple DbServer ZMQ connections are restored to avoid errors under heavy load
+    and/or on slower machines
 
   [Michele Simionato]
   * Removed the ugly registration of custom signals at import time: now they

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,9 @@
+  [Daniele Viganò]
+  * Multiple DbServer ZMQ connection are restored to avoid errors under heavy load
+    on slower machines
+
   [Michele Simionato]
-  * Remove the ugly registration of custom signals at import time: now they
+  * Removed the ugly registration of custom signals at import time: now they
     are registered only if `engine.run_calc` is called
   * Removed the dependency from rtree
   * Removed all calls to ProcessPool.shutdown to speed up the tests and to

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -34,8 +34,6 @@ LOG = logging.getLogger()
 
 DBSERVER_PORT = int(os.environ.get('OQ_DBSERVER_PORT') or config.dbserver.port)
 
-sock = None
-
 
 def dbcmd(action, *args):
     """
@@ -44,15 +42,12 @@ def dbcmd(action, *args):
     :param action: database action to perform
     :param args: arguments
     """
-    global sock
-    if sock is None:
-        sock = zeromq.Socket(
-            'tcp://%s:%s' % (config.dbserver.host, DBSERVER_PORT),
-            zeromq.zmq.REQ, 'connect').__enter__()
-        # the socket will be closed when the calculation ends
-    res = sock.send((action,) + args)
-    if isinstance(res, parallel.Result):
-        return res.get()
+    sock = zeromq.Socket('tcp://%s:%s' % (config.dbserver.host, DBSERVER_PORT),
+                         zeromq.zmq.REQ, 'connect')
+    with sock:
+        res = sock.send((action,) + args)
+        if isinstance(res, parallel.Result):
+            return res.get()
     return res
 
 


### PR DESCRIPTION
Revert "Keeping open the DbServer client socket [skip hazardlib][demos]"

This reverts commit a483d58.

Closes #4650 since it does not work under heavy loads and/or on slower machine