### PR TITLE
Send SIGINT in oq abort instead of SIGTERM

### DIFF
--- a/openquake/commands/abort.py
+++ b/openquake/commands/abort.py
@@ -39,7 +39,7 @@ def abort(job_id):
     for p in psutil.process_iter():
         if p.name() == name:
             try:
-                os.kill(p.pid, signal.SIGTERM)
+                os.kill(p.pid, signal.SIGINT)
                 logs.dbcmd('set_status', job.id, 'aborted')
                 print('Job %d aborted' % job.id)
             except Exception as exc:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -199,7 +199,7 @@ def manage_signals(signum, _stack):
         raise MasterKilled('The openquake master process was killed manually')
 
     if signum == signal.SIGTERM:
-        raise SystemExit('SIGTERM')
+        raise SystemExit('Terminated')
 
     if hasattr(signal, 'SIGHUP'):  # there is no SIGHUP on Windows
         # kill the calculation only if os.getppid() != _PPID, i.e. the

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -359,7 +359,7 @@ def calc_abort(request, calc_id):
 
     if job.pid:  # is a spawned job
         try:
-            os.kill(job.pid, signal.SIGTERM)
+            os.kill(job.pid, signal.SIGINT)
         except Exception as exc:
             logging.error(exc)
         else:


### PR DESCRIPTION
`SIGTERM` must be trapped, otherwise the `except` here https://github.com/gem/oq-engine/blob/ebdc52d2aba2e449e4b8a7bac7cdbb87e44d25ce/openquake/engine/engine.py#L349 is not processed ad computations are left in `executing` state.

With this PR when a job is `ctrl-c`'ed or aborted it is marked as 'aborted'; if it's terminated by a `SIGTERM` will be marked as 'failed'.