### PR TITLE
Fix an issue with ulimit and Erlang when using Docker

### DIFF
--- a/doc/docker/cluster.md
+++ b/doc/docker/cluster.md
@@ -14,6 +14,7 @@ Containers can be also started in background using `$ docker-compose up -d`.
 More workers can be started via
 
 ```bash
+$ docker-compose pull
 $ docker-compose up --scale worker=N
 ```
 where `N` is the number of expected worker containers.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,13 @@ services:
       - RABBITMQ_DEFAULT_PASS=openquake
     networks:
       - cluster
+    # Make sure a proper ulimit is set:
+    # erl_child_setup will take forever otherwise
+    # see: https://groups.google.com/forum/#!topic/rabbitmq-users/hO06SB-QBqc
+    ulimits:
+      nofile:
+        soft: "65536"
+        hard: "65536"
   # Engine is not actually executed and is
   # exposed only to make sure it is built via
   # docker-compose build


### PR DESCRIPTION
Newer versions of Docker do not inherit `ulimit`s from host, so a newly container as for example

```bash
docker run --rm -ti fedora:29 ulimit -n
1073741816
```

this is causing troubles to RabbitMQ because  `erl_child_setup` tries to close all the descriptors first, preventing RabbitMQ to actually start (it takes ~1hrs to close 1 billion files).

With this PR a proper `ulimit` is set via docker-compose.