### PR TITLE
Added a limit of 2**32 events in event based calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,9 @@
+  [Michele Simionato]
+  * Added a limit of 2**32 events in event based calculations
+
   [Graeme Weatherill]
-  * Adds adaptation of Abrahamson et al. (2016) 'BC Hydro' GMPEs calibrated to Mediterranean data and with epistemic adjustment factors
+  * Adds adaptation of Abrahamson et al. (2016) 'BC Hydro' GMPEs calibrated
+    to Mediterranean data and with epistemic adjustment factors
   
   [Chris Van Houtte]
   * Added new class to bradley_2013b.py for hazard maps

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -292,6 +292,8 @@ class EventBasedCalculator(base.HazardCalculator):
             for er in eid_rlz:
                 events[i] = er
                 i += 1
+                if i >= TWO32:
+                    raise ValueError('There are more than %d events!' % i)
         events.sort(order='id')  # fast too
         n_unique_events = len(numpy.unique(events['id']))
         assert n_unique_events == len(events), (n_unique_events, len(events))


### PR DESCRIPTION
There is already a limit of 4 billion rows in the table gmf_data and it is better to die early rather than later.