### PR TITLE
Added an useful SourceModelLogicTree string representation

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -214,6 +214,12 @@ class Branch(object):
         self.value = value
         self.child_branchset = None
 
+    def __repr__(self):
+        if self.child_branchset:
+            return '%s%s' % (self.branch_id, self.child_branchset)
+        else:
+            return '%s' % self.branch_id
+
 
 # Define the keywords associated with the MFD
 MFD_UNCERTAINTY_TYPES = ['maxMagGRRelative', 'maxMagGRAbsolute',
@@ -447,6 +453,9 @@ class BranchSet(object):
             min_mag, bin_width, occur_rates = value
             mfd.modify('set_mfd', dict(min_mag=min_mag, bin_width=bin_width,
                                        occurrence_rates=occur_rates))
+
+    def __repr__(self):
+        return repr(self.branches)
 
 
 class FakeSmlt(object):
@@ -1228,6 +1237,9 @@ class SourceModelLogicTree(object):
         Returns a dictionary lt_path -> how many times that path was sampled
         """
         return collections.Counter(rlz.lt_path for rlz in self)
+
+    def __str__(self):
+        return '<%s%s>' % (self.__class__.__name__, repr(self.root_branchset))
 
 
 # used in GsimLogicTree

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -526,12 +526,14 @@ def get_source_model_lt(oqparam, validate=True):
     fname = oqparam.inputs.get('source_model_logic_tree')
     if fname:
         # NB: converting the random_seed into an integer is needed on Windows
-        return logictree.SourceModelLogicTree(
+        smlt = logictree.SourceModelLogicTree(
             fname, validate, seed=int(oqparam.random_seed),
             num_samples=oqparam.number_of_logic_tree_samples)
-    return logictree.FakeSmlt(oqparam.inputs['source_model'],
-                              int(oqparam.random_seed),
-                              oqparam.number_of_logic_tree_samples)
+    else:
+        smlt = logictree.FakeSmlt(oqparam.inputs['source_model'],
+                                  int(oqparam.random_seed),
+                                  oqparam.number_of_logic_tree_samples)
+    return smlt
 
 
 def check_nonparametric_sources(fname, smodel, investigation_time):

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1268,6 +1268,9 @@ class SourceModelLogicTreeTestCase(unittest.TestCase):
             )
         sb1, sb2, sb3 = lt.root_branchset.branches
         self.assertTrue(sb1.child_branchset is sb3.child_branchset)
+        self.assertEqual(
+            str(lt),
+            '<_TestableSourceModelLogicTree[sb1[b2], sb2[b3], sb3[b2]]>')
 
     def test_comments(self):
         source_model_logic_tree = _make_nrml("""\


### PR DESCRIPTION
For debugging purposes. NB: printing the logic tree can send out of memory any machine (try South Africa, for instance, with 1597399996853114634240 paths) but it is not a big problem in practice, because it will be done by a developer inside IPython when debugging. If he sees that after minutes nothing is coming out and memory is increasing he can just give a CTRL-C. Fortunately the printing is very slow and there is plenty of time for giving a CTRL-C before the memory explodes.