### PR TITLE
Use utf-8 encoding to open source model - avoid charset 0x81 problem …

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1178,7 +1178,8 @@ class SourceModelLogicTree(object):
                 branch.child_branchset = branchset
 
     def _get_source_model(self, source_model_file):
-        return open(os.path.join(self.basepath, source_model_file))
+        return open(os.path.join(self.basepath, source_model_file),
+					encoding='utf-8')
 
     def collect_source_model_data(self, branch_id, source_model):
         """


### PR DESCRIPTION
…on windows

Fixes issue #4707 on my Windows 10 installation of oq-engine 3.5. 
@micheles  I suspect there may be other places where we need to specify encoding with open() et al.
