### PR TITLE
Accepted list-like syntax for return_periods

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Accepted a list-like syntax like `return_periods=[30, 60, 120, 240, 480]`
+    in the job.ini, as written in the manual
   * Fixed a bug in the asset_risk exporter for uppercase tags
 
   [Paul Henshaw]
@@ -20,7 +22,7 @@ python3-oq-engine (3.5.0-1~xenial01) xenial; urgency=low
   [Graeme Weatherill]
   * Adds adaptation of Abrahamson et al. (2016) 'BC Hydro' GMPEs calibrated
     to Mediterranean data and with epistemic adjustment factors
-  
+
   [Chris Van Houtte]
   * Added new class to bradley_2013b.py for hazard maps
   * Modified test case_37 to test multiple sites

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -533,7 +533,7 @@ def positivefloats(value):
     :returns:
         a list of positive floats
     """
-    values = value.lstrip('[').rstrip(']').split()
+    values = value.strip('[]').split()
     floats = list(map(positivefloat, values))
     return floats
 
@@ -992,7 +992,7 @@ def integers(value):
     """
     if '.' in value:
         raise ValueError('There are decimal points in %s' % value)
-    values = value.lstrip('[').rstrip(']').replace(',', ' ').split()
+    values = value.strip('[]').replace(',', ' ').split()
     if not values:
         raise ValueError('Not a list of integers: %r' % value)
     try:

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -533,7 +533,8 @@ def positivefloats(value):
     :returns:
         a list of positive floats
     """
-    floats = list(map(positivefloat, value.split()))
+    values = value.lstrip('[').rstrip(']').split()
+    floats = list(map(positivefloat, values))
     return floats
 
 
@@ -991,7 +992,7 @@ def integers(value):
     """
     if '.' in value:
         raise ValueError('There are decimal points in %s' % value)
-    values = value.replace(',', ' ').split()
+    values = value.lstrip('[').rstrip(']').replace(',', ' ').split()
     if not values:
         raise ValueError('Not a list of integers: %r' % value)
     try:

--- a/openquake/qa_tests_data/event_based_risk/case_1/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1/job.ini
@@ -53,7 +53,7 @@ ses_per_logic_tree_path = 20
 truncation_level = 3
 # km
 maximum_distance = 100.0
-return_periods = 30 60 120 240 480 960
+return_periods = [30, 60, 120, 240, 480, 960]
 individual_curves = true
 
 [output]


### PR DESCRIPTION
Apparently the manual and IPT use this syntax (which was never meant to work).