### PR TITLE
Speedup the reading of the asset collection

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -608,6 +608,7 @@ class HazardCalculator(BaseCalculator):
         if 'exposure' in oq.inputs:
             exposure = self.read_exposure(haz_sitecol)
             self.datastore['assetcol'] = self.assetcol
+            self.datastore['cost_calculator'] = exposure.cost_calculator
             self.datastore['assetcol/num_taxonomies'] = (
                 self.assetcol.num_taxonomies_by_site())
             if hasattr(readinput.exposure, 'exposures'):

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -22,7 +22,6 @@ import numpy
 from openquake.baselib import hdf5, datastore, parallel, performance, general
 from openquake.baselib.python3compat import zip, encode
 from openquake.hazardlib.stats import set_rlzs_stats
-from openquake.commonlib import logictree
 from openquake.risklib.scientific import losses_by_period
 from openquake.risklib.riskinput import get_assets_by_taxo, cache_epsilons
 from openquake.calculators import base, event_based, getters

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -318,7 +318,7 @@ class EbrCalculator(base.RiskCalculator):
             dic = {r: arr['loss'] for r, arr in lbr.items()}
             array, arr_stats = b.build(dic, stats)
         loss_types = ' '.join(self.oqparam.loss_dt().names)
-        units = self.assetcol.cost_calculator.get_units(loss_types.split())
+        units = self.datastore['cost_calculator'].get_units(loss_types.split())
         if oq.individual_curves or self.R == 1:
             self.datastore['agg_curves-rlzs'] = array
             self.datastore.set_attrs(

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -504,7 +504,7 @@ agg_dt = numpy.dtype([('unit', (bytes, 6)), ('mean', F32), ('stddev', F32)])
 def export_agglosses(ekey, dstore):
     oq = dstore['oqparam']
     loss_dt = oq.loss_dt()
-    cc = dstore['assetcol/cost_calculator']
+    cc = dstore['cost_calculator']
     unit_by_lt = cc.units
     unit_by_lt['occupants'] = 'people'
     agglosses = dstore[ekey[0]]

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -433,7 +433,7 @@ def view_exposure_info(token, dstore):
     """
     assetcol = dstore['assetcol/array'][:]
     taxonomies = sorted(set(dstore['assetcol'].taxonomies))
-    cc = dstore['assetcol/cost_calculator']
+    cc = dstore['cost_calculator']
     ra_flag = ['relative', 'absolute']
     data = [('#assets', len(assetcol)),
             ('#taxonomies', len(taxonomies)),

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -383,7 +383,6 @@ class TagCollection(object):
 class AssetCollection(object):
     def __init__(self, exposure, assets_by_site, time_event):
         self.tagcol = exposure.tagcol
-        self.cost_calculator = exposure.cost_calculator
         self.time_event = time_event
         self.tot_sites = len(assets_by_site)
         self.array, self.occupancy_periods = build_asset_array(
@@ -544,8 +543,7 @@ class AssetCollection(object):
                  'tagnames': encode(self.tagnames),
                  'nbytes': self.array.nbytes}
         return dict(
-            array=self.array, cost_calculator=self.cost_calculator,
-            tagcol=self.tagcol), attrs
+            array=self.array, tagcol=self.tagcol), attrs
 
     def __fromh5__(self, dic, attrs):
         self.loss_types = attrs['loss_types'].split()
@@ -555,9 +553,6 @@ class AssetCollection(object):
         self.nbytes = attrs['nbytes']
         self.array = dic['array'].value
         self.tagcol = dic['tagcol']
-        self.cost_calculator = dic['cost_calculator']
-        self.cost_calculator.tagi = {
-            decode(tagname): i for i, tagname in enumerate(self.tagnames)}
 
     def __repr__(self):
         return '<%s with %d asset(s)>' % (self.__class__.__name__, len(self))

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -365,8 +365,6 @@ class TagCollection(object):
     def __fromh5__(self, dic, attrs):
         self.tagnames = [decode(name) for name in attrs['tagnames']]
         for tagname in dic:
-            setattr(self, tagname + '_idx',
-                    {tag: idx for idx, tag in enumerate(dic[tagname])})
             setattr(self, tagname, dic[tagname].value)
 
     def __iter__(self):


### PR DESCRIPTION
After the change in https://github.com/gem/oq-engine/pull/4683 the reading of the AssetCollection has become several times slower, so slow that it dominates the Chile computation. It turns out the culprit is the line
```python
setattr(self, tagname + '_idx', {tag: idx for idx, tag in enumerate(dic[tagname])})
```
when reading the TagCollection, which I have removed here, since it was not actually necessary.
While at it, I am also removing the cost_calculator from the AssetCollection since it does not
belong there anymore.
