### PR TITLE
Add missing gsim hdf5 in the python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,5 @@ recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf
 
 recursive-include openquake/qa_tests_data *.* README
 
-recursive-include openquake/hazardlib/gsim *.csv
+recursive-include openquake/hazardlib/gsim *.csv *.hdf5
 recursive-include openquake/commonlib/nrml_examples *.xml *.csv *.geojson


### PR DESCRIPTION
@mmpagani @micheles please remember that adding non-py files requires the `MANIFEST.in` to be updated correspondingly

Closes #4756  