### PR TITLE
Test if we forget to update the MANIFEST

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ cache:
 
 jobs:
   include:
-      - stage: tests
-        env: HAZARDLIB
-        script:
-            - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
-              pytest --doctest-module -xv openquake/baselib openquake/hazardlib openquake/hmtk;
-              fi
+  - stage: tests
+    env: HAZARDLIB
+    script:
+        - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
+          pytest --doctest-module -xv openquake/baselib openquake/hazardlib openquake/hmtk;
+          fi
   - stage: tests
     env: ENGINE
     before_script:
@@ -29,15 +29,15 @@ jobs:
         - pytest --doctest-module -xv openquake/commonlib
         - pytest --doctest-module -xv openquake/commands
         - oq webui migrate
-        after_success:  # old sphinx does not work well with Python 3.5.4+
-            - pip install sphinx==1.6.5
-            - cd doc/sphinx && make html && cd ../adv-manual && make html
-            - if [[ "$BRANCH" == "master" ]]; then
-                openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
-                chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
-                eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
-                rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -ax --delete build/html/ docs@ci.openquake.org:/var/www/docs.openquake.org/oq-engine/advanced/;
-              fi
+    after_success:  # old sphinx does not work well with Python 3.5.4+
+        - pip install sphinx==1.6.5
+        - cd doc/sphinx && make html && cd ../adv-manual && make html
+        - if [[ "$BRANCH" == "master" ]]; then
+            openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
+            chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
+            eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
+            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -ax --delete build/html/ docs@ci.openquake.org:/var/www/docs.openquake.org/oq-engine/advanced/;
+          fi
     after_script:
         - oq dbserver stop
   - stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ jobs:
     env: python
     script:
         - pip wheel --no-deps .
-        - zipinfo -1 openquake.engine*.whl | grep '^openquake/' | grep -v 'nrml_examples' | sort > zip
-        - find openquake/ -type f | grep -Ev 'openquake/__init__.py|/tests/|nrml_examples' | sort > find
-        - diff -uN find zip
+        - find openquake/ -type f | grep -Ev 'openquake/__init__.py|/tests/|nrml_examples' | sort > sources
+        - zipinfo -1 openquake.engine*.whl | grep '^openquake/' | grep -v 'nrml_examples' | sort > package
+        - diff -uN sources package
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else BRANCH=$TRAVIS_BRANCH; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,61 +11,60 @@ cache:
 
 jobs:
   include:
-      # - stage: tests
-      #   env: HAZARDLIB
-      #   script:
-      #       - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
-      #         pytest --doctest-module -xv openquake/baselib openquake/hazardlib openquake/hmtk;
-      #         fi
+      - stage: tests
+        env: HAZARDLIB
+        script:
+            - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
+              pytest --doctest-module -xv openquake/baselib openquake/hazardlib openquake/hmtk;
+              fi
   - stage: tests
     env: ENGINE
     before_script:
         - oq dbserver start &
     script:
         - pytest --doctest-module -xv openquake/engine
-          # - pytest --doctest-module -xv openquake/server
-          # - pytest --doctest-module -xv openquake/calculators
-          # - pytest --doctest-module -xv openquake/risklib
-          # - pytest --doctest-module -xv openquake/commonlib
-          # - pytest --doctest-module -xv openquake/commands
-          # - oq webui migrate
-          # after_success:  # old sphinx does not work well with Python 3.5.4+
-          #     - pip install sphinx==1.6.5
-          #     - cd doc/sphinx && make html && cd ../adv-manual && make html
-          #     - if [[ "$BRANCH" == "master" ]]; then
-          #         openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
-          #         chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
-          #         eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
-          #         rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -ax --delete build/html/ docs@ci.openquake.org:/var/www/docs.openquake.org/oq-engine/advanced/;
-          #       fi
+        - pytest --doctest-module -xv openquake/server
+        - pytest --doctest-module -xv openquake/calculators
+        - pytest --doctest-module -xv openquake/risklib
+        - pytest --doctest-module -xv openquake/commonlib
+        - pytest --doctest-module -xv openquake/commands
+        - oq webui migrate
+        after_success:  # old sphinx does not work well with Python 3.5.4+
+            - pip install sphinx==1.6.5
+            - cd doc/sphinx && make html && cd ../adv-manual && make html
+            - if [[ "$BRANCH" == "master" ]]; then
+                openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
+                chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
+                eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
+                rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -ax --delete build/html/ docs@ci.openquake.org:/var/www/docs.openquake.org/oq-engine/advanced/;
+              fi
     after_script:
         - oq dbserver stop
   - stage: tests
     env: DEMOS
     script:
-        - echo 'DEMOS'
         # Upload oqdata.zip to http://artifacts.openquake.org/travis/ only if
         # the commit message includes a [demos] tag at the end or branch is master
-        ## - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[demos\]' || test "$BRANCH" == "master"; then
-        ##     time bin/run-demos.sh $TRAVIS_BUILD_DIR/demos &&
-        ##     oq dbserver stop &&
-        ##     oq dump /tmp/oqdata.zip &&
-        ##     oq restore /tmp/oqdata.zip /tmp/oqdata &&
-        ##     helpers/zipdemos.sh $(pwd)/demos &&
-        ##     openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
-        ##     chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
-        ##     eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
-        ##     scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/oqdata.zip travis@ci.openquake.org:/var/www/artifacts.openquake.org/travis/oqdata-${BRANCH}.zip &&
-        ##     oq workers stop &&
-        ##     oq reset --yes &&
-        ##     oq dbserver status | grep -q 'dbserver not-running';
-        ##   fi
+        - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[demos\]' || test "$BRANCH" == "master"; then
+            time bin/run-demos.sh $TRAVIS_BUILD_DIR/demos &&
+            oq dbserver stop &&
+            oq dump /tmp/oqdata.zip &&
+            oq restore /tmp/oqdata.zip /tmp/oqdata &&
+            helpers/zipdemos.sh $(pwd)/demos &&
+            openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
+            chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
+            eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
+            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/oqdata.zip travis@ci.openquake.org:/var/www/artifacts.openquake.org/travis/oqdata-${BRANCH}.zip &&
+            oq workers stop &&
+            oq reset --yes &&
+            oq dbserver status | grep -q 'dbserver not-running';
+          fi
   - stage: packaging
     env: python
     script:
         - pip wheel --no-deps .
-        - zipinfo -1 openquake.engine*.whl | sort | grep '^openquake/' > zip
-        - find openquake/ -type f | grep -v '/tests/' | sort > find 
+        - zipinfo -1 openquake.engine*.whl | grep '^openquake/' | grep -v 'nrml_examples' | sort > zip
+        - find openquake/ -type f | grep -v 'openquake/__init__.py|/tests/|nrml_examples' | sort > find
         - diff -uN find zip
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,54 +11,62 @@ cache:
 
 jobs:
   include:
-  - stage: tests
-    env: HAZARDLIB
-    script:
-        - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
-          pytest --doctest-module -xv openquake/baselib openquake/hazardlib openquake/hmtk;
-          fi
+      # - stage: tests
+      #   env: HAZARDLIB
+      #   script:
+      #       - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
+      #         pytest --doctest-module -xv openquake/baselib openquake/hazardlib openquake/hmtk;
+      #         fi
   - stage: tests
     env: ENGINE
     before_script:
         - oq dbserver start &
     script:
         - pytest --doctest-module -xv openquake/engine
-        - pytest --doctest-module -xv openquake/server
-        - pytest --doctest-module -xv openquake/calculators
-        - pytest --doctest-module -xv openquake/risklib
-        - pytest --doctest-module -xv openquake/commonlib
-        - pytest --doctest-module -xv openquake/commands
-        - oq webui migrate
-    after_success:  # old sphinx does not work well with Python 3.5.4+
-        - pip install sphinx==1.6.5
-        - cd doc/sphinx && make html && cd ../adv-manual && make html
-        - if [[ "$BRANCH" == "master" ]]; then
-            openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
-            chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
-            eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
-            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -ax --delete build/html/ docs@ci.openquake.org:/var/www/docs.openquake.org/oq-engine/advanced/;
-          fi
+          # - pytest --doctest-module -xv openquake/server
+          # - pytest --doctest-module -xv openquake/calculators
+          # - pytest --doctest-module -xv openquake/risklib
+          # - pytest --doctest-module -xv openquake/commonlib
+          # - pytest --doctest-module -xv openquake/commands
+          # - oq webui migrate
+          # after_success:  # old sphinx does not work well with Python 3.5.4+
+          #     - pip install sphinx==1.6.5
+          #     - cd doc/sphinx && make html && cd ../adv-manual && make html
+          #     - if [[ "$BRANCH" == "master" ]]; then
+          #         openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
+          #         chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
+          #         eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
+          #         rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -ax --delete build/html/ docs@ci.openquake.org:/var/www/docs.openquake.org/oq-engine/advanced/;
+          #       fi
     after_script:
         - oq dbserver stop
   - stage: tests
     env: DEMOS
     script:
+        - echo 'DEMOS'
         # Upload oqdata.zip to http://artifacts.openquake.org/travis/ only if
         # the commit message includes a [demos] tag at the end or branch is master
-        - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[demos\]' || test "$BRANCH" == "master"; then
-            time bin/run-demos.sh $TRAVIS_BUILD_DIR/demos &&
-            oq dbserver stop &&
-            oq dump /tmp/oqdata.zip &&
-            oq restore /tmp/oqdata.zip /tmp/oqdata &&
-            helpers/zipdemos.sh $(pwd)/demos &&
-            openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
-            chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
-            eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
-            scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/oqdata.zip travis@ci.openquake.org:/var/www/artifacts.openquake.org/travis/oqdata-${BRANCH}.zip &&
-            oq workers stop &&
-            oq reset --yes &&
-            oq dbserver status | grep -q 'dbserver not-running';
-          fi
+        ## - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -q '\[demos\]' || test "$BRANCH" == "master"; then
+        ##     time bin/run-demos.sh $TRAVIS_BUILD_DIR/demos &&
+        ##     oq dbserver stop &&
+        ##     oq dump /tmp/oqdata.zip &&
+        ##     oq restore /tmp/oqdata.zip /tmp/oqdata &&
+        ##     helpers/zipdemos.sh $(pwd)/demos &&
+        ##     openssl aes-256-cbc -K $encrypted_806ab0daf95c_key -iv $encrypted_806ab0daf95c_iv -in $TRAVIS_BUILD_DIR/.deploy_rsa.enc -out $TRAVIS_BUILD_DIR/.deploy_rsa -d &&
+        ##     chmod 600 $TRAVIS_BUILD_DIR/.deploy_rsa &&
+        ##     eval $(ssh-agent -s) && ssh-add $TRAVIS_BUILD_DIR/.deploy_rsa &&
+        ##     scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/oqdata.zip travis@ci.openquake.org:/var/www/artifacts.openquake.org/travis/oqdata-${BRANCH}.zip &&
+        ##     oq workers stop &&
+        ##     oq reset --yes &&
+        ##     oq dbserver status | grep -q 'dbserver not-running';
+        ##   fi
+  - stage: packaging
+    env: python
+    script:
+        - pip wheel --no-deps .
+        - zipinfo -1 openquake.engine*.whl | sort | grep '^openquake/' > zip
+        - find openquake/ -type f | grep -v '/tests/' | sort > find 
+        - diff -uN find zip
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else BRANCH=$TRAVIS_BRANCH; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
     script:
         - pip wheel --no-deps .
         - zipinfo -1 openquake.engine*.whl | grep '^openquake/' | grep -v 'nrml_examples' | sort > zip
-        - find openquake/ -type f | grep -v 'openquake/__init__.py|/tests/|nrml_examples' | sort > find
+        - find openquake/ -type f | grep -Ev 'openquake/__init__.py|/tests/|nrml_examples' | sort > find
         - diff -uN find zip
 
 before_install:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,20 @@
+# README and related stuff
 include README.md LICENSE CONTRIBUTORS.txt
+# OpenQuake config file
 include openquake/engine/openquake.cfg
+
+# OpenQuake server config examples
 include openquake/server/local_settings.py.pam
 include openquake/server/local_settings.py.standalone
-
+# OpenQuake server data
 recursive-include openquake/server/db *.sql
 recursive-include openquake/server *.html *.css *.png *.js *.map *.ttf
-
-recursive-include openquake/qa_tests_data *.* README
-
+# HMTK data
+include openquake/hmtk/seismicity/occurrence/README.md
+include openquake/hmtk/strain/regionalisation/kreemer_polygons_area.txt
+# Hazardlib data
 recursive-include openquake/hazardlib/gsim *.csv *.hdf5
+# NRML sample data
 recursive-include openquake/commonlib/nrml_examples *.xml *.csv *.geojson
-recursive-include openquake/hmtk *.txt README.md
+# QA tests data
+recursive-include openquake/qa_tests_data *.* README

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,4 @@ recursive-include openquake/qa_tests_data *.* README
 
 recursive-include openquake/hazardlib/gsim *.csv *.hdf5
 recursive-include openquake/commonlib/nrml_examples *.xml *.csv *.geojson
+recursive-include openquake/hmtk *.txt README.md

--- a/openquake/hmtk/seismicity/occurrence/README.rd
+++ b/openquake/hmtk/seismicity/occurrence/README.rd
@@ -1,6 +1,0 @@
-Occurrence 
-=====
-
-The occurrence module contains methods for the calculation of the 
-parameters charaterising magnitude-frequency distributions widely
-used in seismic hazard analysis.


### PR DESCRIPTION
The test is broken because actually we have unpacked files. Let's @michele decide what to do with them.

```diff
--- sources	2019-05-28 14:41:20.360561439 +0000
+++ package	2019-05-28 14:41:20.312561439 +0000
@@ -411,8 +411,6 @@
 openquake/hmtk/seismicity/occurrence/__init__.py
 openquake/hmtk/seismicity/occurrence/kijko_smit.py
 openquake/hmtk/seismicity/occurrence/penalized_mle.py
-openquake/hmtk/seismicity/occurrence/README.md
-openquake/hmtk/seismicity/occurrence/README.rd
 openquake/hmtk/seismicity/occurrence/utils.py
 openquake/hmtk/seismicity/occurrence/weichert.py
 openquake/hmtk/seismicity/selector.py
@@ -433,7 +431,6 @@
 openquake/hmtk/strain/geodetic_strain.py
 openquake/hmtk/strain/__init__.py
 openquake/hmtk/strain/regionalisation/__init__.py
-openquake/hmtk/strain/regionalisation/kreemer_polygons_area.txt
 openquake/hmtk/strain/regionalisation/kreemer_regionalisation.py
 openquake/hmtk/strain/shift.py
 openquake/hmtk/strain/strain_utils.py
```

The check does not scale very well, but for now it's enough. A `check-manifest` exists but it does not work very well with our current repo structure