### PR TITLE
Fixed the unzip functionality

### DIFF
--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -357,7 +357,7 @@ class ZipTestCase(unittest.TestCase):
         zip_cmd(ini, xzip, None)
         names = sorted(zipfile.ZipFile(xzip).namelist())
         self.assertEqual(
-            ['exposure.csv', 'exposure.xml', 'gmpe_logic_tree.xml',
+            ['exposure.csv', 'exposure1.xml', 'gmpe_logic_tree.xml',
              'job.ini', 'source_model.xml', 'source_model_logic_tree.xml',
              'vulnerability_model_nonstco.xml',
              'vulnerability_model_stco.xml'],


### PR DESCRIPTION
This fixes the oq-risk-tests (i.e. the case of multiple zipped exposures with the same internal name), see https://gitlab.openquake.org/openquake/oq-risk-tests/-/jobs/5876.
Everything is now ready for @nastasi-oq who should change IPT in the this way:

1. produce the exposure archive with inside a file called exposure.xml that can be decoupled from the name of the archive
2. in the job.ini, change the exposure_file variable to point to the archive (i.e. the extension must be .zip, not .xml as now)
