### PR TITLE
Homogenize how the dbserver process is executed/started

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
   - stage: tests
     env: ENGINE
     before_script:
-        - oq dbserver start &
+        - oq dbserver start
     script:
         - pytest --doctest-module -xv openquake/engine
         - pytest --doctest-module -xv openquake/server

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -9,21 +9,21 @@ The OpenQuake code is automatically tested by Continuous integration systems, [J
 The full suite of tests for the OpenQuake Engine can be run using `nose` from [**source code**](installing/development.md):
 
 ```bash
-$ nosetests -v openquake
+$ pytest -v openquake
 ```
 
 Python packages can also be specified to run only a subset of tests. Some examples are:
 
 ```bash
 # Hazardlib
-$ nosetests -vs openquake.hazardlib
+$ pytest -vs openquake/hazardlib
 
 # Calculators
-$ nosetests -vs openquake.calculators
+$ pytest -vs openquake/calculators
 
 # Engine server
-$ oq dbserver start &
-$ nosetests -vs openquake.server
+$ oq dbserver start
+$ pytest -vs openquake/server
 ```
 
 See the [man page](http://nose.readthedocs.io/en/latest/man.html) of `nosetests` for further information and command options.

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -26,7 +26,8 @@ from openquake.server import dbserver as dbs
 
 @sap.script
 def dbserver(cmd, dbhostport=None,
-             dbpath=os.path.expanduser(config.dbserver.file)):
+             dbpath=os.path.expanduser(config.dbserver.file),
+             foreground=False):
     """
     start/stop/restart the database server, or return its status
     """
@@ -58,3 +59,4 @@ dbserver.arg('cmd', 'dbserver command',
              choices='start stop status restart'.split())
 dbserver.arg('dbhostport', 'dbhost:port')
 dbserver.arg('dbpath', 'dbpath')
+dbserver.flg('foreground', 'stay in foreground')

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -182,7 +182,7 @@ def ensure_on():
 
 @sap.script
 def run_server(dbpath=os.path.expanduser(config.dbserver.file),
-               dbhostport=None, loglevel='WARN'):
+               dbhostport=None, loglevel='WARN', foreground=False):
     """
     Run the DbServer on the given database file and port. If not given,
     use the settings in openquake.cfg.
@@ -210,6 +210,11 @@ def run_server(dbpath=os.path.expanduser(config.dbserver.file),
 
     # configure logging and start the server
     logging.basicConfig(level=getattr(logging, loglevel))
+    if hasattr(os, 'fork') and not (config.dbserver.multi_user or foreground):
+        # needed for https://github.com/gem/oq-engine/issues/3211
+        # but only if multi_user = False, otherwise init/supervisor
+        # will loose control of the process
+        detach_process()
     DbServer(db, addr).start()  # expects to be killed with CTRL-C
 
 
@@ -218,9 +223,4 @@ run_server.arg('dbhostport', 'dbhost:port')
 run_server.opt('loglevel', 'WARN or INFO')
 
 if __name__ == '__main__':
-    if hasattr(os, 'fork') and not config.dbserver.multi_user:
-        # needed for https://github.com/gem/oq-engine/issues/3211
-        # but only if multi_user = False, otherwise init/supervisor
-        # will loose control of the process
-        detach_process()
     run_server.callfunc()

--- a/packager.sh
+++ b/packager.sh
@@ -392,7 +392,7 @@ _devtest_innervm_run () {
         ssh "$lxc_ip" "set -e
                  export PYTHONPATH=\"\$PWD/oq-engine\"
                  echo 'Starting DbServer. Log is saved to /tmp/dbserver.log'
-                 cd oq-engine; nohup /opt/openquake/bin/python3 bin/oq dbserver start &>/tmp/dbserver.log </dev/null &"
+                 cd oq-engine; nohup /opt/openquake/bin/python3 bin/oq dbserver start &>/tmp/dbserver.log </dev/null"
 
         ssh "$lxc_ip" "export GEM_SET_DEBUG=$GEM_SET_DEBUG
                  set -e

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 3.4.0
 envlist = py{36,37}-{linux,macos}
 skipsdist = True
 
@@ -13,12 +14,12 @@ deps =
     py37-linux: -rrequirements-py37-linux64.txt
     py36-macos: -rrequirements-py36-macos.txt
     py37-macos: -rrequirements-py37-macos.txt
-
-# openquake.server is not currently supported
-# since it requires a DbServer from the same venv
-commands = 
+commands_pre =
     pip install -e .
+    oq dbserver start
+commands =
     pytest {posargs} --doctest-module -v openquake/engine
+    pytest {posargs} --doctest-module -v openquake/server
     pytest {posargs} --doctest-module -v openquake/calculators
     pytest {posargs} --doctest-module -v openquake/baselib
     pytest {posargs} --doctest-module -v openquake/hazardlib
@@ -26,3 +27,5 @@ commands =
     pytest {posargs} --doctest-module -v openquake/commonlib
     pytest {posargs} --doctest-module -v openquake/commands
     pytest {posargs} --doctest-module -v openquake/hmtk
+commands_post =
+    oq dbserver stop


### PR DESCRIPTION
Currently the DbServer behaves differently when it's started from `dbserver.py` and when  executed via `oq dbserver start`: in the first case it's atarted in background (unless `multi_user = true`), in the second case it always stays in foreground.

With this PR the DbServer is _always_ started in background unless `multi_user = true` or DbServer is started with `-f` (`oq dbservser start -f`) which is useful for debug (i.e. when `pdb` is injected).

1) scripts are simplified (no more `&`)
2) we can use the DbServer in tox, which I want to use in the future to remove lot of custom code we use in Jenkins (like for macos)