### PR TITLE
Solved absurd bug in tagcol.id

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -334,7 +334,11 @@ class File(h5py.File):
         else:
             pyclass = ''
         if isinstance(obj, (dict, Group)) and obj:
-            for k, v in sorted(obj.items()):
+            for k, v in obj.items():
+                # NB: there was a line sorted(obj.items()) here
+                # it was removed because it caused the absurd issue
+                # https://github.com/gem/oq-engine/issues/4761
+                # for an exposure with more than 65536 assets
                 if isinstance(k, tuple):  # multikey
                     k = '-'.join(k)
                 key = '%s/%s' % (path, quote_plus(k))

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -500,8 +500,7 @@ class AssetCollection(object):
                  'fields': ' '.join(self.fields),
                  'tagnames': encode(self.tagnames),
                  'nbytes': self.array.nbytes}
-        return dict(
-            array=self.array, tagcol=self.tagcol), attrs
+        return dict(array=self.array, tagcol=self.tagcol), attrs
 
     def __fromh5__(self, dic, attrs):
         self.loss_types = attrs['loss_types'].split()


### PR DESCRIPTION
The calculation in https://github.com/gem/oq-engine/issues/4761 breaks when exporting the average losses because the dataset `assetcol/tagcol/id` is replaced, because of an absurd bug in hdf5, with the content of the dataset `assetcol/tagcol/landusetype`, even if a print tells me that I am storing the right values. Apparently the bug only manifests itself when there are more than 65536 assets and the saving routine is sorting the keys of the tagcol dictionary. I have "solved" it by not sorting the keys, but it looks like there is something very wrong deep inside HDF5. I cannot reproduce the issue with a simple script, so I cannot report the bug to the h5py guys. Here is what I tried, and it works:
```python
import numpy
from openquake.baselib import hdf5

N = 2 ** 16 + 1
f = hdf5.File('/tmp/x.hdf5', 'w')
lst = []
letters = numpy.array(list('aàbcdeèfghiìjklmÉ'))
for i in range(N):
    lst.append(''.join(numpy.random.choice(letters, (i % 10) + 1)))
dic = dict(d1=numpy.array(lst, hdf5.vstr),
           d2=numpy.array(['a', 'baàbcdeèfc'], hdf5.vstr))
with f:
    for k, v in sorted(dic.items()):
        f['t/' + k] = v
```
Even with the sorting, the bug disappears if I use variable length ASCII strings or fixed length numpy strings.