### PR TITLE
Fixed --hc across users (again)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the --hc functionality across users
   * Optimized the reduction of the site collection on the exposure sites
   * Made more robust the gsim logic tree parser: lines like
     `<uncertaintyModel gmpe_table="../gm_tables/Woffshore_low_clC.hdf5">`

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -170,7 +170,7 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         oq = self.oqparam
         if oq.hazard_calculation_id and not oq.compare_with_classical:
-            parent = datastore.read(self.oqparam.hazard_calculation_id)
+            parent = util.read(self.oqparam.hazard_calculation_id)
             self.csm_info = parent['csm_info']
             parent.close()
             self.calc_stats(parent)  # post-processing

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -344,7 +344,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.indices = collections.defaultdict(list)  # sid, idx -> indices
         if oq.hazard_calculation_id and 'ruptures' in self.datastore:
             # from ruptures
-            self.datastore.parent = datastore.read(oq.hazard_calculation_id)
+            self.datastore.parent = util.read(oq.hazard_calculation_id)
             self.init_logic_tree(self.csm_info)
         else:
             # from sources


### PR DESCRIPTION
Solves this error for a calculation originally ran though the webui:
```python
     File "/opt/openquake/oq-engine/openquake/calculators/classical.py", line 173, in execute
       parent = datastore.read(self.oqparam.hazard_calculation_id)
     File "/opt/openquake/oq-engine/openquake/baselib/datastore.py", line 123, in read
       dstore = DataStore(calc_id, datadir, mode=mode)
     File "/opt/openquake/oq-engine/openquake/baselib/datastore.py", line 182, in __init__
       raise IOError('File not found: %s' % self.filename)
   OSError: File not found: /home/kjohnson/oqdata/calc_23600.hdf5
```