### PR TITLE
Reduced the data transfer in the PmapGetter

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -817,7 +817,9 @@ class RiskCalculator(HazardCalculator):
         else:
             dstore = self.datastore
         if kind == 'poe':  # hcurves, shape (R, N)
-            getter = getters.PmapGetter(dstore, self.rlzs_assoc, [sid])
+            by_grp = self.rlzs_assoc.by_grp()
+            ws = [rlz.weight for rlz in self.rlzs_assoc.realizations]
+            getter = getters.PmapGetter(dstore, by_grp, ws, [sid])
         else:  # gmf
             getter = getters.GmfDataGetter(dstore, [sid], self.R)
         if dstore is self.datastore:

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -53,6 +53,9 @@ F32 = numpy.float32
 TWO16 = 2 ** 16
 RUPTURES_PER_BLOCK = 100000  # used in classical_split_filter
 
+rlzs_by_grp_dt = numpy.dtype(
+    [('grp_id', U16), ('gsim_id', U16), ('rlzs', hdf5.vuint16)])
+
 
 class InvalidCalculationID(Exception):
     """
@@ -705,6 +708,14 @@ class HazardCalculator(BaseCalculator):
             logging.warning(
                 'The logic tree has %d realizations(!), please consider '
                 'sampling it', R)
+
+        # save a composite array with fields (grp_id, gsim_id, rlzs)
+        lst = []
+        for grp, arr in self.rlzs_assoc.by_grp().items():
+            for gsim_id, rlzs in enumerate(arr):
+                lst.append((int(grp[4:]), gsim_id, rlzs))
+        self.datastore['csm_info/rlzs_by_grp'] = numpy.array(
+            lst, rlzs_by_grp_dt)
         self.datastore.flush()
 
     def store_source_info(self, calc_times):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -330,8 +330,10 @@ class ClassicalCalculator(base.HazardCalculator):
             self.datastore.create_dset('best_rlz', U32, (N,))
         logging.info('Building hazard statistics')
         ct = oq.concurrent_tasks
+        by_grp = self.rlzs_assoc.by_grp()
+        weights = [rlz.weight for rlz in self.rlzs_assoc.realizations]
         allargs = [  # this list is very fast to generate
-            (getters.PmapGetter(parent, self.rlzs_assoc, t.sids, oq.poes),
+            (getters.PmapGetter(parent, by_grp, weights, t.sids, oq.poes),
              N, hstats, oq.individual_curves)
             for t in self.sitecol.split_in_tiles(ct)]
         parallel.Starmap(build_hazard_stats, allargs, self.monitor()).reduce(

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -158,8 +158,10 @@ producing too small PoEs.'''
         """
         dic = {}
         imtls = self.oqparam.imtls
+        by_grp = self.rlzs_assoc.by_grp()
+        ws = [rlz.weight for rlz in self.rlzs_assoc.realizations]
         pgetter = getters.PmapGetter(
-            self.datastore, self.rlzs_assoc, numpy.array([sid]))
+            self.datastore, by_grp, ws, numpy.array([sid]))
         for rlz in self.rlzs_assoc.realizations:
             try:
                 pmap = pgetter.get(rlz.ordinal)
@@ -458,8 +460,10 @@ producing too small PoEs.'''
         logging.warning('Disaggregation by source is experimental')
         oq = self.oqparam
         poes_disagg = oq.poes_disagg or (None,)
+        by_grp = self.rlzs_assoc.by_grp()
+        ws = [rlz.weight for rlz in self.rlzs_assoc.realizations]
         pmap_by_grp = getters.PmapGetter(
-            self.datastore, self.rlzs_assoc, self.sitecol.sids).pmap_by_grp
+            self.datastore, by_grp, ws, self.sitecol.sids).pmap_by_grp
         grp_ids = numpy.array(sorted(int(grp[4:]) for grp in pmap_by_grp))
         G = len(pmap_by_grp)
         P = len(poes_disagg)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -22,7 +22,7 @@ import collections
 import operator
 import numpy
 
-from openquake.baselib import hdf5, datastore
+from openquake.baselib import hdf5
 from openquake.baselib.python3compat import zip
 from openquake.baselib.general import AccumDict, cached_property, get_indices
 from openquake.hazardlib.probability_map import ProbabilityMap
@@ -46,21 +46,7 @@ U64 = numpy.uint64
 F32 = numpy.float32
 F64 = numpy.float64
 TWO32 = U64(2 ** 32)
-rlzs_by_grp_dt = numpy.dtype(
-    [('grp_id', U16), ('gsim_id', U16), ('rlzs', hdf5.vuint16)])
 by_grp = operator.attrgetter('src_group_id')
-
-
-def store_rlzs_by_grp(dstore):
-    """
-    Save in the datastore a composite array with fields (grp_id, gsim_id, rlzs)
-    """
-    lst = []
-    assoc = dstore['csm_info'].get_rlzs_assoc()
-    for grp, arr in assoc.by_grp().items():
-        for gsim_id, rlzs in enumerate(arr):
-            lst.append((int(grp[4:]), gsim_id, rlzs))
-    dstore['csm_info/rlzs_by_grp'] = numpy.array(lst, rlzs_by_grp_dt)
 
 
 # ######################## GMF calculator ############################ #
@@ -187,7 +173,6 @@ class EventBasedCalculator(base.HazardCalculator):
 
         # logic tree reduction, must be called before storing the events
         self.store_rlz_info(eff_ruptures)
-        store_rlzs_by_grp(self.datastore)
         self.init_logic_tree(self.csm.info)
         with self.monitor('store source_info', autoflush=True):
             self.store_source_info(calc_times)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -754,7 +754,9 @@ def extract_mean_std_curves(dstore, what):
     """
     Yield imls/IMT and poes/IMT containg mean and stddev for all sites
     """
-    getter = getters.PmapGetter(dstore)
+    rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
+    w = [rlz.weight for rlz in rlzs_assoc.realizations]
+    getter = getters.PmapGetter(dstore, rlzs_assoc.by_grp(), w)
     arr = getter.get_mean().array
     for imt in getter.imtls:
         yield 'imls/' + imt, getter.imtls[imt]

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -60,7 +60,10 @@ class PmapGetter(object):
     def __init__(self, dstore, by_grp, weights, sids=None, poes=()):
         self.dstore = dstore
         self.sids = dstore['sitecol'].sids if sids is None else sids
-        self.weights = weights
+        if len(weights[0].dic) == 1:  # no weights by IMT
+            self.weights = numpy.array([w['weight'] for w in weights])
+        else:
+            self.weights = weights
         self.array = by_grp
         self.poes = poes
         self.num_rlzs = len(weights)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -57,15 +57,13 @@ class PmapGetter(object):
     :param sids: the subset of sites to consider (if None, all sites)
     :param rlzs_assoc: a RlzsAssoc instance (if None, infers it)
     """
-    def __init__(self, dstore, rlzs_assoc=None, sids=None, poes=()):
+    def __init__(self, dstore, by_grp, weights, sids=None, poes=()):
         self.dstore = dstore
         self.sids = dstore['sitecol'].sids if sids is None else sids
-        rlzs_assoc = rlzs_assoc or dstore['csm_info'].get_rlzs_assoc()
-        self.weights = numpy.array(
-            [rlz.weight for rlz in rlzs_assoc.realizations])
-        self.array = rlzs_assoc.by_grp()
+        self.weights = weights
+        self.array = by_grp
         self.poes = poes
-        self.num_rlzs = len(rlzs_assoc.realizations)
+        self.num_rlzs = len(weights)
         self.eids = None
         self.nbytes = 0
         self.sids = sids

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -68,7 +68,9 @@ class DisaggregationTestCase(CalculatorTestCase):
 
         # disaggregation by source group
         rlzs_assoc = self.calc.datastore['csm_info'].get_rlzs_assoc()
-        pgetter = getters.PmapGetter(self.calc.datastore, rlzs_assoc)
+        by_grp = rlzs_assoc.by_grp()
+        ws = [rlz.weight for rlz in rlzs_assoc.realizations]
+        pgetter = getters.PmapGetter(self.calc.datastore, by_grp, ws)
         pgetter.init()
         pmaps = []
         for grp in sorted(pgetter.dstore['poes']):

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -672,7 +672,7 @@ def view_global_hcurves(token, dstore):
     oq = dstore['oqparam']
     nsites = len(dstore['sitecol'])
     rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
-    weights = [rlz.weights for rlz in rlzs_assoc.realizations]
+    weights = [rlz.weight for rlz in rlzs_assoc.realizations]
     mean = getters.PmapGetter(dstore, rlzs_assoc, weights).get_mean()
     array = calc.convert_to_array(mean, nsites, oq.imtls)
     res = numpy.zeros(1, array.dtype)
@@ -790,7 +790,7 @@ def view_pmap(token, dstore):
     grp = token.split(':')[1]  # called as pmap:grp
     pmap = {}
     rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
-    weights = [rlz.weights for rlz in rlzs_assoc.realizations]
+    weights = [rlz.weight for rlz in rlzs_assoc.realizations]
     pgetter = getters.PmapGetter(dstore, rlzs_assoc, weights)
     pmap = pgetter.get_mean(grp)
     return str(pmap)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -672,7 +672,8 @@ def view_global_hcurves(token, dstore):
     oq = dstore['oqparam']
     nsites = len(dstore['sitecol'])
     rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
-    mean = getters.PmapGetter(dstore, rlzs_assoc).get_mean()
+    weights = [rlz.weights for rlz in rlzs_assoc.realizations]
+    mean = getters.PmapGetter(dstore, rlzs_assoc, weights).get_mean()
     array = calc.convert_to_array(mean, nsites, oq.imtls)
     res = numpy.zeros(1, array.dtype)
     for name in array.dtype.names:
@@ -789,7 +790,8 @@ def view_pmap(token, dstore):
     grp = token.split(':')[1]  # called as pmap:grp
     pmap = {}
     rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
-    pgetter = getters.PmapGetter(dstore, rlzs_assoc)
+    weights = [rlz.weights for rlz in rlzs_assoc.realizations]
+    pgetter = getters.PmapGetter(dstore, rlzs_assoc, weights)
     pmap = pgetter.get_mean(grp)
     return str(pmap)
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -791,7 +791,7 @@ def view_pmap(token, dstore):
     pmap = {}
     rlzs_assoc = dstore['csm_info'].get_rlzs_assoc()
     weights = [rlz.weight for rlz in rlzs_assoc.realizations]
-    pgetter = getters.PmapGetter(dstore, rlzs_assoc, weights)
+    pgetter = getters.PmapGetter(dstore, rlzs_assoc.by_grp(), weights)
     pmap = pgetter.get_mean(grp)
     return str(pmap)
 

--- a/openquake/commonlib/rlzs_assoc.py
+++ b/openquake/commonlib/rlzs_assoc.py
@@ -170,23 +170,6 @@ class RlzsAssoc(object):
         """Array with the weight of the realizations"""
         return numpy.array([rlz.weight for rlz in self.realizations])
 
-    def combine_pmaps(self, pmap_by_grp):
-        """
-        :param pmap_by_grp: dictionary group string -> probability map
-        :returns: a list of probability maps, one per realization
-        """
-        grp = list(pmap_by_grp)[0]  # pmap_by_grp must be non-empty
-        num_levels = pmap_by_grp[grp].shape_y
-        pmaps = [probability_map.ProbabilityMap(num_levels, 1)
-                 for _ in self.realizations]
-        array = self.by_grp()
-        for grp in pmap_by_grp:
-            for gsim_idx, rlzis in enumerate(array[grp]):
-                pmap = pmap_by_grp[grp].extract(gsim_idx)
-                for rlzi in rlzis:
-                    pmaps[rlzi] |= pmap
-        return pmaps
-
     def get_rlz(self, rlzstr):
         r"""
         Get a Realization instance for a string of the form 'rlz-\d+'

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -117,7 +117,8 @@ def compute_pmap_stats(pmaps, stats, weights, imtls):
     out = p0.__class__.build(L, nstats, sids)
     for imt in imtls:
         slc = imtls(imt)
-        w = [weight[imt] for weight in weights]
+        w = [weight[imt] if hasattr(weight, 'dic') else weight
+             for weight in weights]
         if sum(w) == 0:  # expect no data for this IMT
             continue
         for i, array in enumerate(compute_stats(curves[:, :, slc], stats, w)):


### PR DESCRIPTION
For the computation of the statistics of Canada the improvement is from 48.79 GB to 4.98 GB, i.e. one order of magnitude. We also use 2.5 times less memory, therefore Canada statistics can be computed with just 4,000 tasks instead of 10,000.