### PR TITLE
Really solved the vstr bug

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -342,7 +342,12 @@ class File(h5py.File):
                 if isinstance(k, tuple):  # multikey
                     k = '-'.join(k)
                 key = '%s/%s' % (path, quote_plus(k))
-                self[key] = v
+                if isinstance(v, numpy.ndarray) and len(v) and isinstance(
+                        v[0], str):
+                    ds = self.create_dataset(key, v.shape, vstr)
+                    ds[:] = v
+                else:
+                    self[key] = v
             if isinstance(obj, Group):
                 self.save_attrs(
                     path, obj.attrs, __pyclass__=cls2dotname(Group))

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -342,10 +342,8 @@ class File(h5py.File):
                 if isinstance(k, tuple):  # multikey
                     k = '-'.join(k)
                 key = '%s/%s' % (path, quote_plus(k))
-                if isinstance(v, numpy.ndarray) and len(v) and isinstance(
-                        v[0], str):
-                    ds = self.create_dataset(key, v.shape, vstr)
-                    ds[:] = v
+                if isinstance(v, numpy.ndarray) and isinstance(v[0], str):
+                    self.create_dataset(key, v.shape, vstr)[:] = v
                 else:
                     self[key] = v
             if isinstance(obj, Group):


### PR DESCRIPTION
This solves https://github.com/gem/oq-engine/pull/4768: instead of storing arrays of strings directly, fixed-lenght datasets are first created and then populated. It makes it possibile to run risk for Canada.
A test affected by this bug for British Columbia will be added to oq-risk-tests.