### PR TITLE
Moved around the disaggregation code

### DIFF
--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -40,9 +40,7 @@ from openquake.hazardlib.gsim.base import ContextMaker
 
 
 def _imls(curves, poe, imt, imls, rlzi):
-    if poe is None:  # iml_disagg was set
-        return imls
-    # else return interpolated intensity measure levels
+    # return interpolated intensity measure levels
     levels = [numpy.interp(poe, curve[rlzi][imt][::-1], imls[::-1])
               if curve else numpy.nan for curve in curves]
     return numpy.array(levels)  # length N
@@ -61,9 +59,12 @@ def make_iml4(R, iml_disagg, imtls=None, poes_disagg=(None,), curves=()):
     imts = [from_string(imt) for imt in imtls]
     for m, imt in enumerate(imtls):
         imls = imtls[imt]
-        for p, poe in enumerate(poes_disagg):
-            for r in range(R):
-                arr[:, r, m, p] = _imls(curves, poe, imt, imls, r)
+        if poes_disagg == (None,):
+            arr[:, :, m, 0] = imls
+        else:
+            for p, poe in enumerate(poes_disagg):
+                for r in range(R):
+                    arr[:, r, m, p] = _imls(curves, poe, imt, imls, r)
     return ArrayWrapper(arr, dict(poes_disagg=poes_disagg, imts=imts))
 
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -326,53 +326,6 @@ class ContextMaker(object):
                 pne_array[:, slc, i] = pno
         return pne_array
 
-    def disaggregate(self, sitecol, ruptures, iml4, truncnorm, epsilons,
-                     monitor=Monitor()):
-        """
-        Disaggregate (separate) PoE in different contributions.
-
-        :param sitecol: a SiteCollection with N sites
-        :param ruptures: an iterator over ruptures with the same TRT
-        :param iml4: a 4d array of IMLs of shape (N, R, M, P)
-        :param truncnorm: an instance of scipy.stats.truncnorm
-        :param epsilons: the epsilon bins
-        :param monitor: a Monitor instance
-        :returns:
-            an AccumDict with keys (poe, imt, rlzi) and mags, dists, lons, lats
-        """
-        acc = AccumDict(accum=[])
-        ctx_mon = monitor('disagg_contexts', measuremem=False)
-        pne_mon = monitor('disaggregate_pne', measuremem=False)
-        clo_mon = monitor('get_closest', measuremem=False)
-        for rupture in ruptures:
-            with ctx_mon:
-                orig_dctx = DistancesContext(
-                    (param, get_distances(rupture, sitecol, param))
-                    for param in self.REQUIRES_DISTANCES)
-                self.add_rup_params(rupture)
-            with clo_mon:  # this is faster than computing orig_dctx
-                closest_points = rupture.surface.get_closest_points(sitecol)
-            cache = {}
-            for rlz, gsim in self.gsim_by_rlzi.items():
-                dctx = orig_dctx.roundup(gsim.minimum_distance)
-                for m, imt in enumerate(iml4.imts):
-                    for p, poe in enumerate(iml4.poes_disagg):
-                        iml = tuple(iml4.array[:, rlz, m, p])
-                        try:
-                            pne = cache[gsim, imt, iml]
-                        except KeyError:
-                            with pne_mon:
-                                pne = gsim.disaggregate_pne(
-                                    rupture, sitecol, dctx, imt, iml,
-                                    truncnorm, epsilons)
-                                cache[gsim, imt, iml] = pne
-                        acc[poe, str(imt), rlz].append(pne)
-            acc['mags'].append(rupture.mag)
-            acc['dists'].append(getattr(dctx, self.filter_distance))
-            acc['lons'].append(closest_points.lons)
-            acc['lats'].append(closest_points.lats)
-        return acc
-
 
 class BaseContext(metaclass=abc.ABCMeta):
     """


### PR DESCRIPTION
Instead of being split in four modules (gsim/base, contexts, calc/disagg and disaggregation) it is now split in only two modules (calc/disagg and disaggregation). Part of https://github.com/gem/oq-engine/issues/4420.