### PR TITLE
Speedup disaggregate_pne

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Optimized the speed of the disaggregation calculator
   * Changed the file names of the exported disaggregation outputs
   * Fixed an export agg_curves issue with pre-imported exposures
   * Fixed an export agg_curves issue when the hazard statistics are different


### PR DESCRIPTION
There were a lot of unneeded calls to `truncnorm.cdf` inside the rupture loop: the solution was to move the calls outside the loop. The speedup for a realistic calculation (Seattle) is  from 13,205s to 6,239s i.e. 2x.
