### PR TITLE
Removing the mock module since it is included in the standard library since Python 3.3

### DIFF
--- a/openquake/baselib/tests/general_test.py
+++ b/openquake/baselib/tests/general_test.py
@@ -19,7 +19,7 @@
 """
 Test related to code in openquake/utils/general.py
 """
-import mock
+import unittest.mock as mock
 import unittest
 from operator import attrgetter
 from collections import namedtuple

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -17,7 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import mock
+import unittest.mock as mock
 import time
 import shutil
 import pathlib

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -19,7 +19,7 @@ import collections
 import itertools
 import operator
 import logging
-import mock
+import unittest.mock as mock
 import numpy
 from openquake.baselib import hdf5, datastore, general
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -17,7 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import mock
+import unittest.mock as mock
 import numpy
 from openquake.baselib import parallel
 from openquake.hazardlib import InvalidFile

--- a/openquake/commands/checksum.py
+++ b/openquake/commands/checksum.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import sys
-import mock
+import unittest.mock as mock
 import os.path
 from openquake.baselib import sap
 from openquake.commonlib import readinput

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import os
-import mock
+import unittest.mock as mock
 import logging
 import operator
 import collections

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -17,7 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import os
 import sys
-import mock
+import unittest.mock as mock
 import shutil
 import zipfile
 import tempfile

--- a/openquake/commonlib/oqzip.py
+++ b/openquake/commonlib/oqzip.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import sys
-import mock
+import unittest.mock as mock
 import os.path
 import logging
 from openquake.baselib import general

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -21,7 +21,7 @@ Tests for python logic tree processor.
 """
 
 import os
-import mock
+import unittest.mock as mock
 import codecs
 import unittest
 import collections

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -17,7 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import mock
+import unittest.mock as mock
 import unittest
 import tempfile
 from openquake.baselib.general import gettemp

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -18,7 +18,7 @@
 
 import os
 import tempfile
-import mock
+import unittest.mock as mock
 import unittest
 from io import BytesIO
 

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -18,7 +18,7 @@
 
 import unittest
 import collections
-import mock
+import unittest.mock as mock
 
 import numpy
 from copy import deepcopy

--- a/openquake/hmtk/tests/registry_test.py
+++ b/openquake/hmtk/tests/registry_test.py
@@ -43,7 +43,7 @@
 # liability for use of the software.
 
 import unittest
-import mock
+import unittest.mock as mock
 from openquake.hmtk import registry
 
 

--- a/openquake/risklib/tests/riskmodels_test.py
+++ b/openquake/risklib/tests/riskmodels_test.py
@@ -19,7 +19,7 @@
 import os
 import pickle
 import unittest
-import mock
+import unittest.mock as mock
 import numpy
 from numpy.testing import assert_almost_equal
 from openquake.baselib.general import gettemp

--- a/openquake/server/tests/db/upgrade_manager_test.py
+++ b/openquake/server/tests/db/upgrade_manager_test.py
@@ -17,7 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import mock
+import unittest.mock as mock
 import sqlite3
 import unittest
 import tempfile

--- a/requirements-py36-linux64.txt
+++ b/requirements-py36-linux64.txt
@@ -8,7 +8,6 @@
 
 http://cdn.ftp.openquake.org/wheelhouse/v2/linux/py/pytz-2018.3-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v2/linux/py/setuptools-39.0.1-py2.py3-none-any.whl
-http://cdn.ftp.openquake.org/wheelhouse/v2/linux/py/mock-2.0.0-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v2/linux/py36/h5py-2.9.0-cp36-cp36m-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/v2/linux/py/nose-1.3.7-py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v2/linux/py36/numpy-1.14.2-cp36-cp36m-manylinux1_x86_64.whl

--- a/requirements-py36-macos.txt
+++ b/requirements-py36-macos.txt
@@ -8,7 +8,6 @@
 
 http://cdn.ftp.openquake.org/wheelhouse/v2/macos/py/pytz-2018.3-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v2/macos/py/setuptools-39.0.1-py2.py3-none-any.whl
-http://cdn.ftp.openquake.org/wheelhouse/v2/macos/py/mock-2.0.0-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v2/macos/py36/h5py-2.9.0-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/v2/macos/py/nose-1.3.7-py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v2/macos/py36/numpy-1.14.2-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl

--- a/requirements-py37-linux64.txt
+++ b/requirements-py37-linux64.txt
@@ -7,7 +7,6 @@
 
 http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py/pytz-2019.1-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py/setuptools-41.0.1-py2.py3-none-any.whl
-http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py/mock-2.0.0-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py37/h5py-2.9.0-cp37-cp37m-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py37/numpy-1.16.4-cp37-cp37m-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py37/scipy-1.3.0-cp37-cp37m-manylinux1_x86_64.whl

--- a/requirements-py37-macos.txt
+++ b/requirements-py37-macos.txt
@@ -7,7 +7,6 @@
 
 http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py/pytz-2019.1-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py/setuptools-41.0.1-py2.py3-none-any.whl
-http://cdn.ftp.openquake.org/wheelhouse/v3/linux/py/mock-2.0.0-py2.py3-none-any.whl
 http://cdn.ftp.openquake.org/wheelhouse/v3/macos/py37/h5py-2.9.0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/v3/macos/py37/numpy-1.16.4-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/v3/macos/py37/scipy-1.3.0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ PY_MODULES = ['openquake.commands.__main__']
 
 install_requires = [
     'setuptools',
-    'mock >=1.0, <2.1',
     'h5py >=2.9, <2.10',
     'numpy >=1.14, <1.17',
     'scipy >=1.0.1, <1.4',


### PR DESCRIPTION
I leave the rest to @daniviga.