### PR TITLE
Fixed a performance bug in the computation of the hazard statistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     env: HAZARDLIB
     script:
         - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
-          pytest -n auto --doctest-module -xv openquake/baselib openquake/hazardlib openquake/hmtk;
+          pytest --doctest-module -xv openquake/baselib openquake/hazardlib openquake/hmtk;
           fi
   - stage: tests
     env: ENGINE

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a performance bug in the generation of the hazard statistics, which
+    is now a few times faster and lighter in memory consumption
   * Removed the dependency from mock, since it is included in unittest.mock
   * For scenario, replaced the `branch_path` with the GSIM representation in
     the realizations output

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
   [Michele Simionato]
   * Fixed a performance bug in the generation of the hazard statistics, which
     is now a few times faster and lighter in memory consumption
+  * Fixed a bug with concurrent_tasks being inherited from the parent
+    calculation instead of using the standard default
   * Removed the dependency from mock, since it is included in unittest.mock
   * For scenario, replaced the `branch_path` with the GSIM representation in
     the realizations output

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -36,6 +36,7 @@ from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap import get_sitecol_shakemap, to_gmfs
 from openquake.risklib import riskinput
 from openquake.commonlib import readinput, logictree, source, calc, util
+from openquake.calculators.ucerf_base import UcerfFilter
 from openquake.calculators.export import export as exp
 from openquake.calculators import getters
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -36,7 +36,6 @@ from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap import get_sitecol_shakemap, to_gmfs
 from openquake.risklib import riskinput
 from openquake.commonlib import readinput, logictree, source, calc, util
-from openquake.calculators.ucerf_base import UcerfFilter
 from openquake.calculators.export import export as exp
 from openquake.calculators import getters
 
@@ -443,6 +442,9 @@ class HazardCalculator(BaseCalculator):
             self.check_precalc(parent['oqparam'].calculation_mode)
             self.datastore.parent = parent
             # copy missing parameters from the parent
+            if 'concurrent_tasks' not in vars(self.oqparam):
+                self.oqparam.concurrent_tasks = (
+                    self.oqparam.__class__.concurrent_tasks.default)
             params = {name: value for name, value in
                       vars(parent['oqparam']).items()
                       if name not in vars(self.oqparam)}

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -336,8 +336,8 @@ class ClassicalCalculator(base.HazardCalculator):
                 self.datastore.create_dset('hmaps-stats', F32, (N, S, M, P))
         if 'mean' in dict(hstats) and R > 1 and N <= FEWSITES:
             self.datastore.create_dset('best_rlz', U32, (N,))
-        logging.info('Building hazard statistics')
         ct = oq.concurrent_tasks
+        logging.info('Building hazard statistics with %d concurrent_tasks', ct)
         by_grp = self.rlzs_assoc.by_grp()
         weights = [rlz.weight for rlz in self.rlzs_assoc.realizations]
         allargs = [  # this list is very fast to generate

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -370,11 +370,7 @@ def build_hazard_stats(pgetter, N, hstats, individual_curves, monitor):
     used to specify the kind of output.
     """
     with monitor('combine pmaps'):
-        pgetter.init()  # if not already initialized
-        try:
-            pmaps = pgetter.get_pmaps()
-        except IndexError:  # no data
-            return {}
+        pmaps = pgetter.init()  # if not already initialized
         if sum(len(pmap) for pmap in pmaps) == 0:  # no data
             return {}
     R = len(pmaps)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -122,7 +122,12 @@ class PmapGetter(object):
         """
         # called by the risk with a single sid
         assert len(self.sids) == 1
-        pmaps = self.get_pmaps()
+        try:
+            pmaps = self.get_pmaps()
+        except IndexError:  # no hazard
+            L = len(self.imtls.array)
+            pmaps = [probability_map.ProbabilityMap(L, 1)
+                     for r in range(self.num_rlzs)]
         return {sid: [pmap.setdefault(sid, 0) for pmap in pmaps]
                 for sid in self.sids}
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -129,7 +129,8 @@ class PmapGetter(object):
         """
         # called by the risk with a single sid
         assert len(self.sids) == 1
-        return {sid: [pmap.setdefault(sid, 0) for pmap in self._pmaps]
+        pmaps = self.init()
+        return {sid: [pmap.setdefault(sid, 0) for pmap in pmaps]
                 for sid in self.sids}
 
     def get(self, rlzi, grp=None):

--- a/openquake/commands/importcalc.py
+++ b/openquake/commands/importcalc.py
@@ -55,7 +55,7 @@ def importcalc(calc_id):
         webex.close()
     with datastore.read(calc_id) as dstore:
         engine.expose_outputs(dstore, status=status)
-    logging.info('Imported calculation %d successfully', calc_id)
+    logging.info('Imported calculation %s successfully', calc_id)
 
 
 importcalc.arg('calc_id', 'calculation ID or pathname')

--- a/openquake/commands/importcalc.py
+++ b/openquake/commands/importcalc.py
@@ -36,14 +36,13 @@ def importcalc(calc_id):
     try:
         calc_id = int(calc_id)
     except ValueError:  # assume calc_id is a pathname
-        calc_id, datadir = datastore.extract_calc_id_datadir(calc_id)
         status = 'complete'
         remote = False
     else:
         remote = True
-    job = logs.dbcmd('get_job', calc_id)
-    if job is not None:
-        sys.exit('There is already a job #%d in the local db' % calc_id)
+        job = logs.dbcmd('get_job', calc_id)
+        if job is not None:
+            sys.exit('There is already a job #%d in the local db' % calc_id)
     if remote:
         datadir = datastore.get_datadir()
         webex = WebExtractor(calc_id)

--- a/openquake/qa_tests_data/classical_risk/case_master/job.ini
+++ b/openquake/qa_tests_data/classical_risk/case_master/job.ini
@@ -51,8 +51,7 @@ risk_investigation_time = 50
 lrem_steps_per_interval = 1
 
 [risk_outputs]
-insured_losses = false
-quantile_hazard_curves = 0.15, 0.50, 0.85
+quantiles = 0.15, 0.50, 0.85
 conditional_loss_poes = 0.02, 0.10
 
 [export]

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -278,6 +278,7 @@ class CompositeRiskModel(collections.abc.Mapping):
         [sid] = hazard_getter.sids
         if hazard is None:
             with monitor('getting hazard'):
+                hazard_getter.init()
                 hazard = hazard_getter.get_hazard()
         haz = hazard[sid]
         if isinstance(haz, dict):

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -278,7 +278,6 @@ class CompositeRiskModel(collections.abc.Mapping):
         [sid] = hazard_getter.sids
         if hazard is None:
             with monitor('getting hazard'):
-                hazard_getter.init()
                 hazard = hazard_getter.get_hazard()
         haz = hazard[sid]
         if isinstance(haz, dict):


### PR DESCRIPTION
The method pgetter.get_pmaps() was called twice (without need) and one copy of the probability maps was kept in memory as hazard curves (without need). This was making the calculations 3 times slower and using 3 times more memory than needed in the case of Canada.