### PR TITLE
Solved the memory issue when computing the statistical hazard curves

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
-  * Fixed a performance bug in the generation of the hazard statistics, which
-    is now a few times faster and lighter in memory consumption
+  * Changed the generation of the hazard statistics to consume very little
+    memory
   * Fixed a bug with concurrent_tasks being inherited from the parent
     calculation instead of using the standard default
   * Removed the dependency from mock, since it is included in unittest.mock

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -369,7 +369,7 @@ def _build_stat_curve(poes, imtls, stat, weights):
             ws = [w[imt] for w in weights]
             if sum(ws) == 0:  # expect no data for this IMT
                 continue
-            array[:, slc] = stat(poes[:, slc], ws)
+            array[slc] = stat(poes[:, slc], ws)
     else:
         array = stat(poes, weights)
     return ProbabilityCurve(array)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -176,6 +176,7 @@ def make_hmap(pmap, imtls, poes, sid=None):
     :param pmap: hazard curves in the form of a ProbabilityMap
     :param imtls: DictArray with M intensity measure types
     :param poes: P PoEs where to compute the maps
+    :param sid: not None when pmap is actually a ProbabilityCurve
     :returns: a ProbabilityMap with size (N, M, P)
     """
     if sid is None:

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -169,7 +169,7 @@ def _gmvs_to_haz_curve(gmvs, imls, ses_per_logic_tree_path):
 
 # ################## utilities for classical calculators ################ #
 
-def make_hmap(pmap, imtls, poes):
+def make_hmap(pmap, imtls, poes, sid=None):
     """
     Compute the hazard maps associated to the passed probability map.
 
@@ -178,15 +178,19 @@ def make_hmap(pmap, imtls, poes):
     :param poes: P PoEs where to compute the maps
     :returns: a ProbabilityMap with size (N, M, P)
     """
+    if sid is None:
+        sids = pmap.sids
+    else:  # passed a probability curve
+        pmap = {sid: pmap}
+        sids = [sid]
     M, P = len(imtls), len(poes)
-    hmap = probability_map.ProbabilityMap.build(M, P, pmap, dtype=F32)
+    hmap = probability_map.ProbabilityMap.build(M, P, sids, dtype=F32)
     if len(pmap) == 0:
         return hmap  # empty hazard map
     for i, imt in enumerate(imtls):
-        curves = numpy.array([pmap[sid].array[imtls(imt), 0]
-                              for sid in pmap.sids])
+        curves = numpy.array([pmap[sid].array[imtls(imt), 0] for sid in sids])
         data = compute_hazard_maps(curves, imtls[imt], poes)  # array (N, P)
-        for sid, value in zip(pmap.sids, data):
+        for sid, value in zip(sids, data):
             array = hmap[sid].array
             for j, val in enumerate(value):
                 array[i, j] = val

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -301,7 +301,7 @@ class CompositeRiskModel(collections.abc.Mapping):
         """
         if hasattr(haz, 'array'):  # classical
             eids = []
-            data = [haz.array[self.imtls(imt)] for imt in self.imtls]
+            data = [haz.array[self.imtls(imt), 0] for imt in self.imtls]
         elif isinstance(haz, numpy.ndarray):
             # NB: in GMF-based calculations the order in which
             # the gmfs are stored is random since it depends on

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -301,7 +301,7 @@ class CompositeRiskModel(collections.abc.Mapping):
         """
         if hasattr(haz, 'array'):  # classical
             eids = []
-            data = [haz.array[self.imtls(imt), 0] for imt in self.imtls]
+            data = [haz.array[self.imtls(imt)] for imt in self.imtls]
         elif isinstance(haz, numpy.ndarray):
             # NB: in GMF-based calculations the order in which
             # the gmfs are stored is random since it depends on


### PR DESCRIPTION
While the implementation in master is fast and elegant, we do not have enough memory to perform the Canada calculation unless the number of tasks is raised so much that the computation become slower for other reasons (or celery dies). The implementation in this PR is slower but consumes order of magnitudes less memory since it builds the statistical curves one-by-one. For instance, a task taking in input 300 sites will requires 300 times less memory than before. The speed is half than yesterday (and 50% faster than engine 3.5) but we do not really care, since the time spent in computing the statistics is nothing compared to the time spent in the real calculation, and twice nothing is still nothing (I am talking about something like 3/6 minutes vs 30 hours).