### PR TITLE
Fixed the parallelization of calc_hazard_curves

### DIFF
--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -266,8 +266,14 @@ class SourceFilter(object):
             self.__dict__['sitecol'] = sitecol
 
     def __getstate__(self):
-        return dict(filename=self.filename,
-                    integration_distance=self.integration_distance)
+        if self.filename:
+            # in the engine self.file is the .hdf5 cache file
+            return dict(filename=self.filename,
+                        integration_distance=self.integration_distance)
+        else:
+            # when using calc_hazard_curves without an .hdf5 cache file
+            return dict(filename=None, sitecol=self.sitecol,
+                        integration_distance=self.integration_distance)
 
     @property
     def sitecol(self):


### PR DESCRIPTION
Solves the error
```python
  File "/home/michele/oqcode/oq-engine/openquake/hazardlib/calc/filters.py", line 367, in filter
    indices = self.sitecol.within_bbox(box)
AttributeError: 'NoneType' object has no attribute 'within_bbox'
```
discovered by @mmpagani 