### PR TITLE
Allow oq abort to be used when status is created

### DIFF
--- a/openquake/commands/abort.py
+++ b/openquake/commands/abort.py
@@ -32,7 +32,7 @@ def abort(job_id):
     if job is None:
         print('There is no job %d' % job_id)
         return
-    elif job.status not in ('executing', 'running'):
+    elif job.status not in ('created', 'executing', 'running'):
         print('Job %d is %s' % (job.id, job.status))
         return
     name = 'oq-job-%d' % job.id


### PR DESCRIPTION
Sometime we need to abort job in `created` status