### PR TITLE
Do not autostart/autoenable celery in Ubuntu pkg [skip ci]

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -64,5 +64,15 @@ override_dh_quilt_patch:
 override_dh_gencontrol:
 	dh_gencontrol -- $(DEPENDS) $(RECOMMENDS)
 
+override_dh_systemd_start:
+	dh_systemd_start openquake-dbserver.webui
+	dh_systemd_start openquake-webui.webui
+	dh_systemd_start --no-start openquake-celery.service
+
+override_dh_systemd_enable:
+	dh_systemd_enable openquake-dbserver.webui
+	dh_systemd_enable openquake-webui.webui
+	dh_systemd_enable --no-enable openquake-celery.service
+
 %:
 	dh --with python3 --with quilt,systemd $@

--- a/debian/rules
+++ b/debian/rules
@@ -65,13 +65,13 @@ override_dh_gencontrol:
 	dh_gencontrol -- $(DEPENDS) $(RECOMMENDS)
 
 override_dh_systemd_start:
-	dh_systemd_start openquake-dbserver.webui
-	dh_systemd_start openquake-webui.webui
+	dh_systemd_start openquake-dbserver.service
+	dh_systemd_start openquake-webui.service
 	dh_systemd_start --no-start openquake-celery.service
 
 override_dh_systemd_enable:
-	dh_systemd_enable openquake-dbserver.webui
-	dh_systemd_enable openquake-webui.webui
+	dh_systemd_enable openquake-dbserver.service
+	dh_systemd_enable openquake-webui.service
 	dh_systemd_enable --no-enable openquake-celery.service
 
 %:

--- a/packager.sh
+++ b/packager.sh
@@ -591,7 +591,7 @@ celery_wait() {
 sudo systemctl start openquake-dbserver
 sleep 10
 # Restart openquake-celery after the changes made to openquake.cfg
-sudo systemctl restart openquake-celery
+sudo systemctl start openquake-celery
 sleep 10
 sudo systemctl status openquake-dbserver openquake-celery
 


### PR DESCRIPTION
https://ci.openquake.org/job/zdevel_oq-engine/2844/

Now that the shared_dir needs to be setup (manually) on workers it has no sense to start automatically celery. That package is also targeted to advanced user that needs to know what they are doing and they usually prefer to have full control on what a package does.

Documentation is already aligned with this PR since it's based on RHEL where packages never starts/enable services automatically. `DbServer` and `WebUI` services are left as they are.

It should fix definitely the race condition we have on Jenkins.