### PR TITLE
Fixed an issue with the QGIS plugin

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -678,7 +678,9 @@ def extract(request, calc_id, what):
             a = {}
             for key, val in vars(aw).items():
                 key = str(key)  # can be a numpy.bytes_
-                if isinstance(val, str):
+                if key.startswith('_'):
+                    continue
+                elif isinstance(val, str):
                     # without this oq extract would fail
                     a[key] = numpy.array(val.encode('utf-8'))
                 elif isinstance(val, dict):


### PR DESCRIPTION
The recent change in https://github.com/gem/oq-engine/pull/4828 added a private attribute `_extra` to the ArrayWrapper object, but I forgot to remove such attribute when transmitting the object to the plugin.
This should fix most of the errors in https://travis-ci.org/gem/oq-irmt-qgis/jobs/547596068