### PR TITLE
Fixed the Australia calculation

### DIFF
--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -239,11 +239,14 @@ def split_sources(srcs):
                 if has_samples:
                     split.samples = src.samples
         elif splits:  # single source
-            splits[0].id = src.id
+            [s] = splits
+            s.source_id = src.source_id
+            s.src_group_id = src.src_group_id
+            s.id = src.id
             if has_serial:
-                splits[0].serial = src.serial
+                s.serial = src.serial
             if has_samples:
-                splits[0].samples = src.samples
+                s.samples = src.samples
     return sources, split_time
 
 

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -18,7 +18,6 @@ Module :mod:`openquake.hazardlib.source.base` defines a base class for
 seismic sources.
 """
 import abc
-import math
 import numpy
 from openquake.baselib.slots import with_slots
 from openquake.hazardlib.geo import Point
@@ -88,7 +87,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         self.source_id = source_id
         self.name = name
         self.tectonic_region_type = tectonic_region_type
-        self.src_group_id = 0  # set by the engine
+        self.src_group_id = -1  # set by the engine
         self.num_ruptures = 0  # set by the engine
         self.seed = None  # set by the engine
         self.id = None  # set by the engine

--- a/openquake/hazardlib/tests/calc/filters_test.py
+++ b/openquake/hazardlib/tests/calc/filters_test.py
@@ -23,7 +23,7 @@ from openquake.hazardlib import nrml
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.calc.filters import (
-    IntegrationDistance, SourceFilter, angular_distance)
+    IntegrationDistance, SourceFilter, angular_distance, split_sources)
 
 
 class AngularDistanceTestCase(unittest.TestCase):
@@ -144,3 +144,18 @@ xmlns:gml="http://www.opengis.net/gml"
         </characteristicFaultSource>
     </sourceModel>
 </nrml>'''
+
+
+class SplitSourcesTestCase(unittest.TestCase):
+    def test(self):
+        # make sure the src_group_id is transferred also for single split
+        # sources, since this caused hard to track bugs
+        fname = gettemp(characteric_source)
+        [[char]] = nrml.to_python(fname)
+        char.id = 1
+        char.src_group_id = 1
+        os.remove(fname)
+        [src], _ = split_sources([char])
+        self.assertEqual(char.id, src.id)
+        self.assertEqual(char.source_id, src.source_id)
+        self.assertEqual(char.src_group_id, src.src_group_id)


### PR DESCRIPTION
After ~10 hours of debugging I discovered that the issue was the `src_group_id` not being transferred to the split sources in the case of a source with a single piece. The error was the very cryptic
```python
  File "/opt/openquake/oq-engine/openquake/calculators/classical.py", line 295, in post_execute
    self.datastore[key] = pmap
  File "/opt/openquake/oq-engine/openquake/baselib/datastore.py", line 423, in __setitem__
    self.hdf5[key] = val
  File "/opt/openquake/oq-engine/openquake/baselib/hdf5.py", line 334, in __setitem__
    obj, attrs = obj.__toh5__()
  File "/opt/openquake/oq-engine/openquake/hazardlib/probability_map.py", line 343, in __toh5__
    array[i] = self[sid].array
ValueError: could not broadcast input array from shape (120,6) into shape (120,7)
```
caused by the use of the default `src_group_id=0` instead of the right one.

Here are the results with pointsource_distance=0: https://oq1.wilson.openquake.org/engine/24136/outputs