### PR TITLE
Calibrate the source weights by measuring the time spent by computing a subsample

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Introduced a `task_duration` parameter and a mechanism to split the tasks
+    exceeding it (approximately)
   * Integrated `oq plot_memory` into `oq plot`
   * Improved the task distribution by splitting the heavy sources on the master
   * Removed `NaN` values for strike and dip when exporting griddedRuptures

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -52,7 +52,6 @@ U64 = numpy.uint64
 F32 = numpy.float32
 TWO16 = 2 ** 16
 TWO32 = 2 ** 32
-RUPTURES_PER_BLOCK = 200000  # used in classical_split_filter
 
 
 class InvalidCalculationID(Exception):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -193,7 +193,7 @@ class ClassicalCalculator(base.HazardCalculator):
         # except KeyError:
         #     logging.warn('No integration_distance')
         many_sites = len(self.sitecol) > int(config.general.max_sites_disagg)
-        task = classical_split_filter if many_sites else classical
+        task = self.core_task.__func__ if many_sites else classical
         with self.monitor('managing sources', autoflush=True):
             smap = parallel.Starmap(task, monitor=self.monitor())
             self.submit_sources(smap, many_sites)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -227,9 +227,8 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         oq = self.oqparam
         trt_sources = self.csm.get_trt_sources(optimize_dupl=True)
-        maxweight = min(
-            self.csm.get_maxweight(trt_sources, nrup, oq.concurrent_tasks),
-            base.RUPTURES_PER_BLOCK)
+        maxweight = self.csm.get_maxweight(
+            trt_sources, nrup, oq.concurrent_tasks)
         param = dict(
             truncation_level=oq.truncation_level, imtls=oq.imtls,
             filter_distance=oq.filter_distance, reqv=oq.get_reqv(),

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -192,11 +192,10 @@ class ClassicalCalculator(base.HazardCalculator):
         #        'integration_distance']
         # except KeyError:
         #     logging.warn('No integration_distance')
-        many_sites = len(self.sitecol) > int(config.general.max_sites_disagg)
-        task = self.core_task.__func__ if many_sites else classical
         with self.monitor('managing sources', autoflush=True):
-            smap = parallel.Starmap(task, monitor=self.monitor())
-            self.submit_sources(smap, many_sites)
+            smap = parallel.Starmap(
+                self.core_task.__func__, monitor=self.monitor())
+            self.submit_sources(smap)
         self.calc_times = AccumDict(accum=numpy.zeros(2, F32))
         try:
             acc = smap.reduce(self.agg_dicts, self.acc0())
@@ -221,11 +220,12 @@ class ClassicalCalculator(base.HazardCalculator):
         self.calc_times.clear()  # save a bit of memory
         return acc
 
-    def submit_sources(self, smap, many_sites):
+    def submit_sources(self, smap):
         """
         Send the sources split in tasks
         """
         oq = self.oqparam
+        many_sites = len(self.sitecol) > int(config.general.max_sites_disagg)
         trt_sources = self.csm.get_trt_sources(optimize_dupl=True)
         maxweight = self.csm.get_maxweight(
             trt_sources, nrup, oq.concurrent_tasks)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -227,8 +227,8 @@ class ClassicalCalculator(base.HazardCalculator):
         oq = self.oqparam
         many_sites = len(self.sitecol) > int(config.general.max_sites_disagg)
         trt_sources = self.csm.get_trt_sources(optimize_dupl=True)
-        maxweight = self.csm.get_maxweight(
-            trt_sources, nrup, oq.concurrent_tasks)
+        maxweight = min(self.csm.get_maxweight(
+            trt_sources, nrup, oq.concurrent_tasks), 1E6)
         param = dict(
             truncation_level=oq.truncation_level, imtls=oq.imtls,
             filter_distance=oq.filter_distance, reqv=oq.get_reqv(),

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -53,7 +53,8 @@ class UcerfClassicalCalculator(ClassicalCalculator):
         acc = self.acc0()
         self.nsites = []  # used in agg_dicts
         param = dict(imtls=oq.imtls, truncation_level=oq.truncation_level,
-                     filter_distance=oq.filter_distance, maxweight=1E10)
+                     filter_distance=oq.filter_distance, maxweight=1E10,
+                     task_duration=oq.task_duration)
         self.calc_times = general.AccumDict(accum=np.zeros(2, np.float32))
         [gsims] = sorted(self.csm.info.gsim_lt.values.values())
         sample = .001 if os.environ.get('OQ_SAMPLE_SOURCES') else None

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -151,6 +151,7 @@ class OqParam(valid.ParamSet):
     spatial_correlation = valid.Param(valid.Choice('yes', 'no', 'full'), 'yes')
     specific_assets = valid.Param(valid.namelist, [])
     pointsource_distance = valid.Param(valid.maximum_distance, {})
+    task_duration = valid.Param(valid.positiveint, 1000)  # in seconds
     taxonomies_from_model = valid.Param(valid.boolean, False)
     time_event = valid.Param(str, None)
     truncation_level = valid.Param(valid.NoneOr(valid.positivefloat), None)


### PR DESCRIPTION
The trick is to take one source every 20. The improvement on SEA is 5x on the slowest task:
```
Calculation 24251 finished correctly in 20896 seconds (master)
Calculation 24289 finished correctly in 6277 seconds (this branch)
max task duration: 19,038s ->  3,658s (5.2x)