### PR TITLE
Do not store information about the subtask outputs in performance_data

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -509,7 +509,7 @@ class IterResult(object):
                 mem_gb = memory_rss(os.getpid()) / GB
             if not result.func_args:  # not subtask
                 yield val
-            save_task_info(self, result, mem_gb)
+                save_task_info(self, result, mem_gb)
         if self.received:
             tot = sum(self.received)
             max_per_output = max(self.received)

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -46,6 +46,7 @@ def supertask(text, monitor):
     # a supertask spawning subtasks of kind get_length
     with monitor('waiting'):
         time.sleep(.1)
+    yield {}
     for block in general.block_splitter(text, max_weight=10):
         items = [(k, len(list(grp))) for k, grp in itertools.groupby(block)]
         if len(items) == 1:
@@ -126,7 +127,7 @@ class StarmapTestCase(unittest.TestCase):
         with hdf5.File(tmp) as h5:
             num = general.countby(h5['performance_data'][()], 'operation')
             self.assertEqual(num[b'waiting'], 4)
-            self.assertEqual(num[b'total supertask'], 18)  # outputs
+            self.assertEqual(num[b'total supertask'], 5)  # outputs
             self.assertEqual(num[b'total get_length'], 17)  # subtasks
             self.assertGreater(len(h5['task_info/supertask']), 0)
         shutil.rmtree(tmp.parent)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -226,11 +226,12 @@ class ClassicalCalculator(base.HazardCalculator):
         Send the sources split in tasks
         """
         oq = self.oqparam
-        N = len(self.sitecol)
+        N, L = len(self.sitecol), len(oq.imtls.array)
         trt_sources = self.csm.get_trt_sources(optimize_dupl=True)
         maxweight = min(self.csm.get_maxweight(
             trt_sources, weight, oq.concurrent_tasks), 1E6)
-        task_duration = (maxweight * N) ** 0.35  # heuristic, 2h for 1E11
+        task_duration = (maxweight * N * L) ** numpy.log10(3) / 150
+        # goes up to 3 hours
         param = dict(
             truncation_level=oq.truncation_level, imtls=oq.imtls,
             filter_distance=oq.filter_distance, reqv=oq.get_reqv(),

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -230,8 +230,8 @@ class ClassicalCalculator(base.HazardCalculator):
         trt_sources = self.csm.get_trt_sources(optimize_dupl=True)
         maxweight = min(self.csm.get_maxweight(
             trt_sources, weight, oq.concurrent_tasks), 1E6)
-        task_duration = (maxweight * N * L) ** numpy.log10(3) / 150
-        # goes up to 3 hours
+        task_duration = (maxweight * N * L) ** numpy.log10(4) / 4000
+        # goes up to 4 hours
         param = dict(
             truncation_level=oq.truncation_level, imtls=oq.imtls,
             filter_distance=oq.filter_distance, reqv=oq.get_reqv(),


### PR DESCRIPTION
and refined the task_duration algorithm. This is totally internal.