### PR TITLE
Fixed mfd.from toml

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -30,7 +30,7 @@ from openquake.baselib import (
     general, hdf5, datastore, __version__ as engine_version)
 from openquake.baselib.parallel import Starmap
 from openquake.baselib.performance import perf_dt, Monitor
-from openquake.hazardlib import InvalidFile
+from openquake.hazardlib import mfd, InvalidFile
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap import get_sitecol_shakemap, to_gmfs
@@ -408,6 +408,10 @@ class HazardCalculator(BaseCalculator):
                          'ruptures')
             if res:
                 logging.info(res)
+            # sanity check: the stored MFDs can be read again
+            # uncomment this when adding a new MFD class
+            for s in self.datastore['source_mfds']:
+                mfd.from_toml(s, oq.width_of_mfd_bin)
         self.init()  # do this at the end of pre-execute
 
     def save_multi_peril(self):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -410,8 +410,8 @@ class HazardCalculator(BaseCalculator):
                 logging.info(res)
             # sanity check: the stored MFDs can be read again
             # uncomment this when adding a new MFD class
-            for s in self.datastore['source_mfds']:
-                mfd.from_toml(s, oq.width_of_mfd_bin)
+            # for s in self.datastore['source_mfds']:
+            #     mfd.from_toml(s, oq.width_of_mfd_bin)
         self.init()  # do this at the end of pre-execute
 
     def save_multi_peril(self):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -410,8 +410,8 @@ class HazardCalculator(BaseCalculator):
                 logging.info(res)
             # sanity check: the stored MFDs can be read again
             # uncomment this when adding a new MFD class to test it
-            for s in self.datastore['source_mfds']:
-                mfd.from_toml(s, oq.width_of_mfd_bin)
+            # for s in self.datastore['source_mfds']:
+            #     mfd.from_toml(s, oq.width_of_mfd_bin)
         self.init()  # do this at the end of pre-execute
 
     def save_multi_peril(self):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -409,7 +409,7 @@ class HazardCalculator(BaseCalculator):
             if res:
                 logging.info(res)
             # sanity check: the stored MFDs can be read again
-            # uncomment this when adding a new MFD class
+            # uncomment this when adding a new MFD class to test it
             for s in self.datastore['source_mfds']:
                 mfd.from_toml(s, oq.width_of_mfd_bin)
         self.init()  # do this at the end of pre-execute

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -410,8 +410,8 @@ class HazardCalculator(BaseCalculator):
                 logging.info(res)
             # sanity check: the stored MFDs can be read again
             # uncomment this when adding a new MFD class
-            # for s in self.datastore['source_mfds']:
-            #     mfd.from_toml(s, oq.width_of_mfd_bin)
+            for s in self.datastore['source_mfds']:
+                mfd.from_toml(s, oq.width_of_mfd_bin)
         self.init()  # do this at the end of pre-execute
 
     def save_multi_peril(self):

--- a/openquake/hazardlib/mfd/__init__.py
+++ b/openquake/hazardlib/mfd/__init__.py
@@ -39,8 +39,12 @@ def from_toml(string, bin_width):
     Convert a TOML string into an MFD instance
     """
     [(name, params)] = toml.loads(string).items()
+    if name == 'multiMFD':
+        return multi_mfd.MultiMFD.from_params(params, bin_width)
     cls, *args = multi_mfd.ASSOC[name]
     kw = {}
     for param, value in params.items():
-        kw[multi_mfd.TOML2PY[param]] = value
-    return cls(bin_width=bin_width, **kw)
+        kw[multi_mfd.TOML2PY.get(param, param)] = value
+    if bin_width not in kw:
+        kw['bin_width'] = bin_width
+    return cls(**kw)

--- a/openquake/hazardlib/mfd/__init__.py
+++ b/openquake/hazardlib/mfd/__init__.py
@@ -41,10 +41,10 @@ def from_toml(string, bin_width):
     [(name, params)] = toml.loads(string).items()
     if name == 'multiMFD':
         return multi_mfd.MultiMFD.from_params(params, bin_width)
-    cls, *args = multi_mfd.ASSOC[name]
+    cls, *required = multi_mfd.ASSOC[name]
     kw = {}
     for param, value in params.items():
         kw[multi_mfd.TOML2PY.get(param, param)] = value
-    if bin_width not in kw:
+    if 'bin_width' in required and bin_width not in kw:
         kw['bin_width'] = bin_width
     return cls(**kw)

--- a/openquake/hazardlib/mfd/multi_mfd.py
+++ b/openquake/hazardlib/mfd/multi_mfd.py
@@ -45,8 +45,10 @@ ALIAS = dict(min_mag='minMag', max_mag='maxMag',
 
 TOML2PY = dict(_minMag='min_mag', _maxMag='max_mag',
                _aValue='a_val', _bValue='b_val',
+               _binWidth='bin_width',
                _characteristicMag='char_mag',
-               _characteristicRate='char_rate')
+               _characteristicRate='char_rate',
+               occurRates='occurrence_rates',)
 
 
 def _reshape(kwargs, lengths):
@@ -72,7 +74,10 @@ class MultiMFD(BaseMFD):
         MODIFICATIONS.update(vals[0].MODIFICATIONS)
 
     @classmethod
-    def from_node(cls, node, width_of_mfd_bin=None):
+    def from_node(cls, node, width_of_mfd_bin):
+        """
+        :returns: a MultiMFD instance from a node XML-like object
+        """
         kind = node['kind']
         size = node['size']
         kwargs = {}  # a dictionary name -> array of n elements
@@ -85,6 +90,28 @@ class MultiMFD(BaseMFD):
                 # missing bindWidth in GR MDFs is ok
         if 'occurRates' in ASSOC[kind][1:]:
             lengths = ~getattr(node, 'lengths')
+            if len(lengths) == 1:  # all occurRates are the same
+                lengths = [lengths[0]] * size
+            _reshape(kwargs, lengths)
+        return cls(kind, size, width_of_mfd_bin, **kwargs)
+
+    @classmethod
+    def from_params(cls, params, width_of_mfd_bin):
+        """
+        :returns: a MultiMFD instance from a TOML-like dictionary
+        """
+        kind = params['_kind']
+        size = params['_size']
+        kwargs = {}  # a dictionary name -> array of n elements
+        for field in ASSOC[kind][1:]:
+            try:
+                kwargs[field] = params[field]
+            except AttributeError:
+                if field != 'bin_width':
+                    raise
+                # missing bindWidth in GR MDFs is ok
+        if 'occurRates' in ASSOC[kind][1:]:
+            lengths = params['lengths']
             if len(lengths) == 1:  # all occurRates are the same
                 lengths = [lengths[0]] * size
             _reshape(kwargs, lengths)

--- a/openquake/hazardlib/mfd/multi_mfd.py
+++ b/openquake/hazardlib/mfd/multi_mfd.py
@@ -36,8 +36,8 @@ ASSOC = {
     'truncGutenbergRichterMFD': (
         TruncatedGRMFD, 'min_mag', 'max_mag', 'bin_width', 'a_val', 'b_val'),
     'YoungsCoppersmithMFD': (
-        YoungsCoppersmith1985MFD, 'min_mag', 'max_mag', 'a_val', 'b_val',
-        'char_mag', 'char_rate', 'bin_width')}
+        YoungsCoppersmith1985MFD, 'min_mag', 'max_mag', 'b_val',
+        'char_mag', 'char_rate', 'bin_width', 'total_moment_rate')}
 
 ALIAS = dict(min_mag='minMag', max_mag='maxMag',
              a_val='aValue', b_val='bValue', bin_width='binWidth',

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -608,22 +608,13 @@ class SourceConverter(RuptureConverter):
                     magnitudes=~mfd_node.magnitudes,
                     occurrence_rates=~mfd_node.occurRates)
             elif mfd_node.tag.endswith('YoungsCoppersmithMFD'):
-                if "totalMomentRate" in mfd_node.attrib:
-                    # Return Youngs & Coppersmith from the total moment rate
-                    return mfd.YoungsCoppersmith1985MFD.from_total_moment_rate(
-                        min_mag=mfd_node["minMag"], b_val=mfd_node["bValue"],
-                        char_mag=mfd_node["characteristicMag"],
-                        total_moment_rate=mfd_node["totalMomentRate"],
-                        bin_width=mfd_node["binWidth"])
-                elif "characteristicRate" in mfd_node.attrib:
-                    # Return Youngs & Coppersmith from the total moment rate
-                    return mfd.YoungsCoppersmith1985MFD.\
-                        from_characteristic_rate(
-                            min_mag=mfd_node["minMag"],
-                            b_val=mfd_node["bValue"],
-                            char_mag=mfd_node["characteristicMag"],
-                            char_rate=mfd_node["characteristicRate"],
-                            bin_width=mfd_node["binWidth"])
+                return mfd.YoungsCoppersmith1985MFD(
+                    min_mag=mfd_node["minMag"],
+                    b_val=mfd_node["bValue"],
+                    char_mag=mfd_node["characteristicMag"],
+                    char_rate=mfd_node.get("characteristicRate"),
+                    total_moment_rate=mfd_node.get("totalMomentRate"),
+                    bin_width=mfd_node["binWidth"])
             elif mfd_node.tag.endswith('multiMFD'):
                 return mfd.multi_mfd.MultiMFD.from_node(
                     mfd_node, self.width_of_mfd_bin)

--- a/openquake/hazardlib/tests/mfd/youngs_coppersmith_1985_test.py
+++ b/openquake/hazardlib/tests/mfd/youngs_coppersmith_1985_test.py
@@ -24,14 +24,14 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
     def test_negative_or_zero_min_mag(self):
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=-4.0, a_val=2.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
+            min_mag=-4.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
             bin_width=0.1
         )
         self.assertEqual(str(exc), 'minimum magnitude must be positive')
 
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=0.0, a_val=2.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
+            min_mag=0.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
             bin_width=0.1
         )
         self.assertEqual(str(exc), 'minimum magnitude must be positive')
@@ -39,14 +39,14 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
     def test_negative_or_zero_b_val(self):
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=-1.0, char_mag=6.0, char_rate=0.001,
+            min_mag=4.0, b_val=-1.0, char_mag=6.0, char_rate=0.001,
             bin_width=0.1
         )
         self.assertEqual(str(exc), 'b value must be positive')
 
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=0.0, char_mag=6.0, char_rate=0.001,
+            min_mag=4.0, b_val=0.0, char_mag=6.0, char_rate=0.001,
             bin_width=0.1
         )
         self.assertEqual(str(exc), 'b value must be positive')
@@ -54,7 +54,7 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
     def test_negative_or_zero_char_mag(self):
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=-6.0, char_rate=0.001,
+            min_mag=4.0, b_val=1.0, char_mag=-6.0, char_rate=0.001,
             bin_width=0.1
         )
         error = 'characteristic magnitude must be positive'
@@ -62,7 +62,7 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
 
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=0.0, char_rate=0.001,
+            min_mag=4.0, b_val=1.0, char_mag=0.0, char_rate=0.001,
             bin_width=0.1
         )
         self.assertEqual(str(exc), error)
@@ -70,14 +70,14 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
     def test_negative_or_zero_char_rate(self):
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=6.0, char_rate=-0.001,
+            min_mag=4.0, b_val=1.0, char_mag=6.0, char_rate=-0.001,
             bin_width=0.1
         )
         self.assertEqual(str(exc), 'characteristic rate must be positive')
 
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=6.0, char_rate=0.0,
+            min_mag=4.0, b_val=1.0, char_mag=6.0, char_rate=0.0,
             bin_width=0.1
         )
         self.assertEqual(str(exc), 'characteristic rate must be positive')
@@ -85,7 +85,7 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
     def test_bin_width_out_of_valid_range(self):
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
+            min_mag=4.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
             bin_width=-0.1
         )
         error = 'bin width must be in the range (0, 0.5] to allow for at ' \
@@ -95,14 +95,14 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
 
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
+            min_mag=4.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
             bin_width=0.0
         )
         self.assertEqual(str(exc), error)
 
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
+            min_mag=4.0, b_val=1.0, char_mag=6.0, char_rate=0.001,
             bin_width=0.6
         )
         self.assertEqual(str(exc), error)
@@ -110,7 +110,7 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
     def test_max_mag_GR_too_close_to_min_mag(self):
         exc = self.assert_mfd_error(
             YoungsCoppersmith1985MFD,
-            min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=4.3, char_rate=0.001,
+            min_mag=4.0, b_val=1.0, char_mag=4.3, char_rate=0.001,
             bin_width=0.1
         )
         error = ('Maximum magnitude of the G-R distribution (char_mag - 0.25) '
@@ -118,32 +118,10 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
                  'magnitude bin.')
         self.assertEqual(str(exc), error)
 
-    def test_rate_char_mag_not_equal_rate_char_mag_less_1_pt_25(self):
-        # Given the parameters below:
-        # min = 5.0
-        # b_val = 1
-        # char_mag = 6.5
-        # char_rate = 0.001
-        # we can compute an a_val that satisfies the condition using the
-        # following equations
-        # a_incr = b_val * (char_mag - 1.25) + log10(char_rate / 0.5)
-        # a_val = a_incr - log10(b_val * log(10))
-        # if we add 1e-4 to a_val, this raises the error
-        exc = self.assert_mfd_error(
-            YoungsCoppersmith1985MFD,
-            min_mag=5.0, a_val=2.1888143 + 1e-4, b_val=1.0, char_mag=6.5,
-            char_rate=0.001, bin_width=0.1
-        )
-        error = 'Rate of events at the characteristic magnitude is not ' \
-                'equal to the rate of events for magnitude equal to ' \
-                'char_mag - 1.25'
-        self.assertEqual(str(exc), error)
-
     def test_from_total_moment_rate(self):
         mfd = YoungsCoppersmith1985MFD.from_total_moment_rate(
             min_mag=5.0, b_val=0.85, char_mag=6.75,
-            total_moment_rate=6.38119198365e15, bin_width=0.1
-        )
+            total_moment_rate=6.38119198365e15, bin_width=0.1)
         computed_rates = mfd.get_annual_occurrence_rates()
         expected_rates = [(5.05, 0.00017054956240777723),
                           (5.15, 0.00014023312414148282),


### PR DESCRIPTION
This is the continuation of https://github.com/gem/oq-engine/pull/4874: now all kind of serialized MFDs can be read from the datastore.
NB: I had to change the signature of  `YoungsCoppersmith1985MFD` to make it more similar to the other MFDs and this is a good thing: it makes the sourceconvert simpler, and it makes MultiMFD classes  work with YoungsCoppersmith1985MFD.
