### PR TITLE
Fixed bug with `max_sites_disagg`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,9 @@
-python3-oq-engine (3.6.0-1~xenial01) xenial; urgency=low
-
   [Michele Simionato]
+  * Fixed a bug with the --config option: max_sites_disagg and serialize_jobs
+    could not be overridden
   * Implemented insured losses
+
+python3-oq-engine (3.6.0-1~xenial01) xenial; urgency=low
 
   [Michele Simionato]
   * In some cases `applyToSources` was giving a fake error about the source

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -21,9 +21,8 @@ import logging
 import operator
 import numpy
 
-from openquake.baselib import parallel, hdf5
+from openquake.baselib import parallel, hdf5, config
 from openquake.baselib.general import AccumDict, block_splitter
-from openquake.hazardlib.contexts import FEWSITES
 from openquake.hazardlib.calc.filters import split_sources
 from openquake.hazardlib.calc.hazard_curve import classical
 from openquake.hazardlib.probability_map import (
@@ -353,7 +352,8 @@ class ClassicalCalculator(base.HazardCalculator):
             self.datastore.create_dset('hcurves-stats', F32, (N, S, L))
             if oq.poes:
                 self.datastore.create_dset('hmaps-stats', F32, (N, S, M, P))
-        if 'mean' in dict(hstats) and R > 1 and N <= FEWSITES:
+        if ('mean' in dict(hstats) and R > 1 and
+                N <= config.general.max_sites_disagg):
             self.datastore.create_dset('best_rlz', U32, (N,))
         ct = oq.concurrent_tasks
         logging.info('Building hazard statistics with %d concurrent_tasks', ct)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -432,7 +432,8 @@ def build_hazard_stats(pgetter, N, hstats, individual_curves, monitor):
                     if poes:
                         hmap = calc.make_hmap(pc, pgetter.imtls, poes, sid)
                         pmap_by_kind['hmaps-stats'][s].update(hmap)
-                    if statname == 'mean' and R > 1 and N <= FEWSITES:
+                    if (statname == 'mean' and R > 1 and
+                            N <= config.general.max_sites_disagg):
                         rlz = pmap_by_kind['rlz_by_sid']
                         rlz[sid] = util.closest_to_ref(
                             [p.array for p in pcurves], pc.array)['rlz']

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -23,14 +23,14 @@ import logging
 import operator
 import numpy
 
-from openquake.baselib import parallel, hdf5
+from openquake.baselib import parallel, hdf5, config
 from openquake.baselib.general import AccumDict, block_splitter
 from openquake.baselib.python3compat import encode
 from openquake.hazardlib.calc import disagg
 from openquake.hazardlib.imt import from_string
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.gsim.base import ContextMaker
-from openquake.hazardlib.contexts import RuptureContext, FEWSITES
+from openquake.hazardlib.contexts import RuptureContext
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.calculators import getters, extract
 from openquake.calculators import base
@@ -140,10 +140,11 @@ The disaggregation PoE is too big or your model is wrong,
 producing too small PoEs.'''
 
     def init(self):
-        if self.N > FEWSITES:
+        few = config.general.max_sites_disagg
+        if self.N > few:
             raise ValueError(
                 'The max number of sites for disaggregation set in '
-                'openquake.cfg is %d, but you have %s' % (FEWSITES, self.N))
+                'openquake.cfg is %d, but you have %s' % (few, self.N))
         super().init()
 
     def execute(self):

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -142,7 +142,9 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
     if config_file:
         config.read(os.path.abspath(os.path.expanduser(config_file)),
                     soft_mem_limit=int, hard_mem_limit=int, port=int,
-                    multi_user=valid.boolean, multi_node=valid.boolean)
+                    multi_user=valid.boolean, multi_node=valid.boolean,
+                    serialize_jobs=valid.boolean, strict=valid.boolean,
+                    max_sites_disagg=int, code=exec)
 
     if no_distribute:
         os.environ['OQ_DISTRIBUTE'] = 'no'

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -26,9 +26,6 @@ from openquake.hazardlib.calc.filters import IntegrationDistance
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.geo.surface import PlanarSurface
 
-# if there are few sites store the rupdata
-FEWSITES = config.general.max_sites_disagg
-
 KNOWN_DISTANCES = frozenset(
     'rrup rx ry0 rjb rhypo repi rcdpp azimuth rvolc'.split())
 
@@ -270,7 +267,7 @@ class ContextMaker(object):
         """
         sitecol = sites.complete
         N = len(sitecol)
-        fewsites = N <= FEWSITES
+        fewsites = N <= config.general.max_sites_disagg
         rupdata = RupData(self, sites)
         for rup, sites in self._gen_rup_sites(src, sites):
             try:


### PR DESCRIPTION
Overriding  `max_sites_disagg` in a new `openquake.cfg` file passed with the `--config` option was not working. Idem for `serialize_jobs`.