### PR TITLE
Start/stop the zworkers in `engine.run_job` via the DbServer

### DIFF
--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -78,7 +78,7 @@ class WorkerMaster(object):
             if host == '127.0.0.1':  # localhost
                 args = [sys.executable]
             else:
-                args = ['ssh', host, self.remote_python]
+                args = ['ssh', '-t', host, self.remote_python]
             args += ['-m', 'openquake.baselib.workerpool',
                      ctrl_url, self.task_out_url, cores]
             starting.append(' '.join(args))

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import signal
 import subprocess
 import multiprocessing
@@ -64,6 +65,7 @@ class WorkerMaster(object):
         :param streamer:
             if True, starts a streamer with multiprocessing.Process
         """
+        # streamer=True is used only in the tests
         if streamer and not general.socket_ready(self.task_in_url):  # started
             self.streamer = multiprocessing.Process(
                 target=_streamer,
@@ -84,6 +86,7 @@ class WorkerMaster(object):
             starting.append(' '.join(args))
             po = subprocess.Popen(args)
             self.pids.append(po.pid)
+        time.sleep(1)  # wait a bit, useful in travis
         return 'starting %s' % starting
 
     def stop(self):

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -66,16 +66,18 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
     if ZMQ:  # start zworkers
         master = w.WorkerMaster(config.dbserver.host, **config.zworkers)
         logging.warning(master.start())
-    job_id = logs.init('job', getattr(logging, log_level.upper()))
-    with logs.handle(job_id, log_level, log_file):
-        job_ini = os.path.abspath(job_ini)
-        oqparam = eng.job_from_file(job_ini, job_id, username, **kw)
-        kw['username'] = username
-        eng.run_calc(job_id, oqparam, exports, **kw)
-        for line in logs.dbcmd('list_outputs', job_id, False):
-            safeprint(line)
-    if ZMQ:  # stop zworkers
-        logging.warning(master.stop())
+    try:
+        job_id = logs.init('job', getattr(logging, log_level.upper()))
+        with logs.handle(job_id, log_level, log_file):
+            job_ini = os.path.abspath(job_ini)
+            oqparam = eng.job_from_file(job_ini, job_id, username, **kw)
+            kw['username'] = username
+            eng.run_calc(job_id, oqparam, exports, **kw)
+    finally:
+        if ZMQ:  # stop zworkers
+            logging.warning(master.stop())
+    for line in logs.dbcmd('list_outputs', job_id, False):
+        safeprint(line)
     return job_id
 
 

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -64,8 +64,7 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
         Extra parameters like hazard_calculation_id and calculation_mode
     """
     if ZMQ:  # start zworkers
-        master = w.WorkerMaster(config.dbserver.host, **config.zworkers)
-        logging.warning(master.start())
+        logs.dbcmd('start_zworkers')
     try:
         job_id = logs.init('job', getattr(logging, log_level.upper()))
         with logs.handle(job_id, log_level, log_file):
@@ -75,7 +74,7 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
             eng.run_calc(job_id, oqparam, exports, **kw)
     finally:
         if ZMQ:  # stop zworkers
-            logging.warning(master.stop())
+            logs.dbcmd('stop_zworkers')
     for line in logs.dbcmd('list_outputs', job_id, False):
         safeprint(line)
     return job_id

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -19,7 +19,8 @@ import os
 import sys
 import getpass
 import logging
-from openquake.baselib import sap, config, datastore
+from openquake.baselib import (
+    sap, config, datastore, workerpool as w)
 from openquake.baselib.general import safeprint
 from openquake.hazardlib import valid
 from openquake.commonlib import logs, readinput
@@ -33,6 +34,8 @@ from openquake.commands.abort import abort
 
 HAZARD_CALCULATION_ARG = "--hazard-calculation-id"
 MISSING_HAZARD_MSG = "Please specify '%s=<id>'" % HAZARD_CALCULATION_ARG
+ZMQ = os.environ.get(
+    'OQ_DISTRIBUTE', config.distribution.oq_distribute) == 'zmq'
 
 
 def get_job_id(job_id, username=None):
@@ -60,6 +63,9 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
     :param kw:
         Extra parameters like hazard_calculation_id and calculation_mode
     """
+    if ZMQ:  # start zworkers
+        master = w.WorkerMaster(config.dbserver.host, **config.zworkers)
+        logging.warning(master.start())
     job_id = logs.init('job', getattr(logging, log_level.upper()))
     with logs.handle(job_id, log_level, log_file):
         job_ini = os.path.abspath(job_ini)
@@ -68,6 +74,8 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
         eng.run_calc(job_id, oqparam, exports, **kw)
         for line in logs.dbcmd('list_outputs', job_id, False):
             safeprint(line)
+    if ZMQ:  # stop zworkers
+        logging.warning(master.stop())
     return job_id
 
 

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -42,8 +42,9 @@ def dbcmd(action, *args):
     :param string action: database action to perform
     :param tuple args: arguments
     """
-    sock = zeromq.Socket('tcp://%s:%s' % (config.dbserver.host, DBSERVER_PORT),
-                         zeromq.zmq.REQ, 'connect')
+    sock = zeromq.Socket(
+        'tcp://%s:%s' % (config.dbserver.listen, DBSERVER_PORT),
+        zeromq.zmq.REQ, 'connect')
     with sock:
         res = sock.send((action,) + args)
         if isinstance(res, parallel.Result):

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -70,7 +70,6 @@ if OQ_DISTRIBUTE == 'zmq':
         for host, _cores in [hc.split() for hc in w.host_cores.split(',')]:
             url = 'tcp://%s:%s' % (host, w.ctrl_port)
             with z.Socket(url, z.zmq.REQ, 'connect') as sock:
-                time.sleep(10)
                 if not general.socket_ready(url):
                     logs.LOG.warn('%s is not running', host)
                     continue

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -70,6 +70,7 @@ if OQ_DISTRIBUTE == 'zmq':
         for host, _cores in [hc.split() for hc in w.host_cores.split(',')]:
             url = 'tcp://%s:%s' % (host, w.ctrl_port)
             with z.Socket(url, z.zmq.REQ, 'connect') as sock:
+                time.sleep(10)
                 if not general.socket_ready(url):
                     logs.LOG.warn('%s is not running', host)
                     continue

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -21,7 +21,7 @@ import operator
 from datetime import datetime
 
 from openquake.hazardlib import valid
-from openquake.baselib import datastore, general, config, workerpool as w
+from openquake.baselib import datastore, general
 from openquake.calculators.export import export
 from openquake.server import __file__ as server_path
 from openquake.server.db.schema.upgrades import upgrader
@@ -797,15 +797,15 @@ def get_job_from_checksum(db, checksum):
     return jobs[0]
 
 
-def start_zworkers(db):
+def start_zworkers(db, master):
     """
     Start the zmq workers
     """
-    w.WorkerMaster(config.dbserver.listen, **config.zworkers).start()
+    master.start()
 
 
-def stop_zworkers(db):
+def stop_zworkers(db, master):
     """
     Stop the zmq workers
     """
-    w.WorkerMaster(config.dbserver.listen, **config.zworkers).stop()
+    master.stop()

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -21,7 +21,7 @@ import operator
 from datetime import datetime
 
 from openquake.hazardlib import valid
-from openquake.baselib import datastore, general
+from openquake.baselib import datastore, general, config, workerpool as w
 from openquake.calculators.export import export
 from openquake.server import __file__ as server_path
 from openquake.server.db.schema.upgrades import upgrader
@@ -795,3 +795,17 @@ def get_job_from_checksum(db, checksum):
     if not jobs:
         return
     return jobs[0]
+
+
+def start_zworkers(db):
+    """
+    Start the zmq workers
+    """
+    w.WorkerMaster(config.dbserver.listen, **config.zworkers).start()
+
+
+def stop_zworkers(db):
+    """
+    Stop the zmq workers
+    """
+    w.WorkerMaster(config.dbserver.listen, **config.zworkers).stop()

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -130,7 +130,7 @@ def get_status(address=None):
     :param address: pair (hostname, port)
     :returns: 'running' or 'not-running'
     """
-    address = address or (config.dbserver.host, DBSERVER_PORT)
+    address = address or (config.dbserver.listen, DBSERVER_PORT)
     return 'running' if socket_ready(address) else 'not-running'
 
 

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -57,8 +57,6 @@ class DbServer(object):
         self.backend = 'inproc://dbworkers'
         self.num_workers = num_workers
         self.pid = os.getpid()
-        self.master = w.WorkerMaster(config.dbserver.host,
-                                     **config.zworkers)
 
     def dworker(self, sock):
         # a database worker responding to commands
@@ -99,11 +97,6 @@ class DbServer(object):
             logging.warning('Task streamer started from %s -> %s',
                             c.task_in_port, c.task_out_port)
 
-            # start zworkers and wait a bit for them
-            msg = self.master.start()
-            logging.warning(msg)
-            time.sleep(1)
-
         # start frontend->backend proxy for the database workers
         try:
             z.zmq.proxy(z.bind(self.frontend, z.zmq.ROUTER),
@@ -119,7 +112,6 @@ class DbServer(object):
     def stop(self):
         """Stop the DbServer and the zworkers if any"""
         if ZMQ:
-            logging.warning(self.master.stop())
             z.context.term()
         self.db.close()
 


### PR DESCRIPTION
In this way each calculation is self-contained (good for the memory).