### PR TITLE
Reading the ruptures from the datastore in disaggregation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
   [Michele Simionato]
-  * Reduced the memory consumption while sending disaggregatiion tasks
+  * Reduced the data transfer by reading the rupture data directly from the
+    datastore in disaggregation calculations
+  * Reduced the memory consumption sending disaggregation tasks incrementally
   * Added an extract API disagg_layer
   * Moved `max_sites_disagg` from openquake.cfg into the job.ini
   * Fixed a bug with the --config option: serialize_jobs could not be overridden

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Reduced the data transfer by reading the rupture data directly from the
+  * Reduced the data transfer by reading the data directly from the
     datastore in disaggregation calculations
   * Reduced the memory consumption sending disaggregation tasks incrementally
   * Added an extract API disagg_layer

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -270,6 +270,19 @@ def split_in_slices(number, num_slices):
     return slices
 
 
+def gen_slices(n, block_size):
+    """
+    Yields slices of lenght at most block_size
+    """
+    start = 0
+    while True:
+        stop = start + block_size
+        yield slice(start, min(stop, n))
+        start = stop
+        if start >= n:
+            break
+
+
 def split_in_blocks(sequence, hint, weight=lambda item: 1, key=nokey):
     """
     Split the `sequence` in a number of WeightedSequences close to `hint`.

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -23,7 +23,7 @@ from datetime import datetime
 import psutil
 import numpy
 
-from openquake.baselib.general import humansize, gettemp
+from openquake.baselib.general import humansize
 from openquake.baselib import hdf5
 
 perf_dt = numpy.dtype([('operation', (bytes, 50)), ('time_sec', float),
@@ -227,15 +227,15 @@ class Monitor(object):
             return '<%s>' % msg
 
 
-def dump(hdf5path, h5):
+def dump(temppath, perspath):
     """
     Dump the performance info into a persistent file,
     then remove the temporary file.
 
-    :param hdf5path: the temporary file
-    :param h5: an hdf5.File open for writing
+    :param temppath: the temporary file
+    :param perspath: the persistent file
     """
-    with hdf5.File(hdf5path, 'r') as h:
+    with hdf5.File(temppath, 'r') as h, hdf5.File(perspath, 'r+') as h5:
         if 'performance_data' not in h5:
             hdf5.create(h5, 'performance_data', perf_dt)
         hdf5.extend(h5['performance_data'], h['performance_data'][()])
@@ -244,4 +244,4 @@ def dump(hdf5path, h5):
             if fullname not in h5:
                 hdf5.create(h5, fullname, task_info_dt)
             hdf5.extend(h5[fullname], dset[()])
-    os.remove(hdf5path)
+    os.remove(temppath)

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -20,12 +20,11 @@ import os
 import unittest.mock as mock
 import time
 import shutil
-import pathlib
 import unittest
 import itertools
 import tempfile
 import numpy
-from openquake.baselib import parallel, performance, general, hdf5
+from openquake.baselib import parallel, general, hdf5
 
 try:
     import celery
@@ -118,18 +117,20 @@ class StarmapTestCase(unittest.TestCase):
                    ('aaaaaaaaeeeeiii',),
                    ('aaaaeeeeiiiiiooooooo',)]
         numchars = sum(len(arg) for arg, in allargs)  # 61
-        tmp = pathlib.Path(tempfile.mkdtemp(), 'calc_1.hdf5')
-        smap = parallel.Starmap(supertask, allargs)
+        tmpdir = tempfile.mkdtemp()
+        tmp = os.path.join(tmpdir, 'calc_1.hdf5')
+        hdf5.File(tmp, 'w').close()
+        smap = parallel.Starmap(supertask, allargs, hdf5path=tmp)
         res = smap.reduce()
         self.assertEqual(res, {'n': numchars})
         # check that the correct information is stored in the hdf5 file
-        with hdf5.File(smap.monitor.hdf5path, 'r') as h5:
+        with hdf5.File(tmp, 'r') as h5:
             num = general.countby(h5['performance_data'][()], 'operation')
             self.assertEqual(num[b'waiting'], 4)
             self.assertEqual(num[b'total supertask'], 5)  # outputs
             self.assertEqual(num[b'total get_length'], 17)  # subtasks
             self.assertGreater(len(h5['task_info/supertask']), 0)
-        shutil.rmtree(tmp.parent)
+        shutil.rmtree(tmpdir)
 
     @classmethod
     def tearDownClass(cls):

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -119,7 +119,7 @@ class StarmapTestCase(unittest.TestCase):
         numchars = sum(len(arg) for arg, in allargs)  # 61
         tmpdir = tempfile.mkdtemp()
         tmp = os.path.join(tmpdir, 'calc_1.hdf5')
-        hdf5.File(tmp, 'w').close()
+        hdf5.File(tmp, 'w').close()  # the file must exist
         smap = parallel.Starmap(supertask, allargs, hdf5path=tmp)
         res = smap.reduce()
         self.assertEqual(res, {'n': numchars})

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -922,7 +922,7 @@ class RiskCalculator(HazardCalculator):
             self.core_task.__func__,
             (self.riskinputs, self.riskmodel, self.param, self.monitor()),
             concurrent_tasks=self.oqparam.concurrent_tasks or 1,
-            weight=get_weight, h5=self.datastore.hdf5
+            weight=get_weight, hdf5path=self.datastore.filename
         ).reduce(self.combine)
         return res
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -195,7 +195,7 @@ class ClassicalCalculator(base.HazardCalculator):
         #     logging.warn('No integration_distance')
         with self.monitor('managing sources', autoflush=True):
             smap = parallel.Starmap(
-                self.core_task.__func__, h5=self.datastore.hdf5)
+                self.core_task.__func__, hdf5path=self.datastore.filename)
             self.submit_sources(smap)
         self.calc_times = AccumDict(accum=numpy.zeros(2, F32))
         try:
@@ -363,7 +363,8 @@ class ClassicalCalculator(base.HazardCalculator):
              N, hstats, oq.individual_curves, oq.max_sites_disagg)
             for t in self.sitecol.split_in_tiles(ct)]
         parallel.Starmap(build_hazard_stats, allargs,
-                         h5=self.datastore.hdf5).reduce(self.save_hazard_stats)
+                         hdf5path=self.datastore.filename).reduce(
+                             self.save_hazard_stats)
 
 
 @base.calculators.add('preclassical')

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -23,8 +23,8 @@ import logging
 import operator
 import numpy
 
-from openquake.baselib import parallel, hdf5
-from openquake.baselib.general import AccumDict, block_splitter
+from openquake.baselib import parallel, hdf5, general
+from openquake.baselib.general import AccumDict, gen_slices
 from openquake.baselib.python3compat import encode
 from openquake.hazardlib.calc import disagg
 from openquake.hazardlib.imt import from_string
@@ -32,7 +32,7 @@ from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.hazardlib.contexts import RuptureContext
 from openquake.hazardlib.tom import PoissonTOM
-from openquake.calculators import getters, extract
+from openquake.calculators import getters
 from openquake.calculators import base
 
 weight = operator.attrgetter('weight')
@@ -72,15 +72,16 @@ def _iml2s(rlzs, iml_disagg, imtls, poes_disagg, curves):
     return lst
 
 
-def compute_disagg(sitecol, rupdata, cmaker, iml2s, trti, bin_edges,
-                   oqparam, monitor):
+def compute_disagg(dstore, grp, slc, cmaker, iml2s, trti, bin_edges, monitor):
     # see https://bugs.launchpad.net/oq-engine/+bug/1279247 for an explanation
     # of the algorithm used
     """
-    :param sitecol:
-        a :class:`openquake.hazardlib.site.SiteCollection` instance
-    :param rupdata:
-        rupdata array
+    :param dstore:
+        a :class:`openquake.baselib.datastore.DataStore` instance
+    :param grp:
+        string of kind `grp-XX` describing a group of ruptures
+    :param slc:
+        a slice of ruptures
     :param cmaker:
         a :class:`openquake.hazardlib.gsim.base.ContextMaker` instance
     :param iml2s:
@@ -89,14 +90,17 @@ def compute_disagg(sitecol, rupdata, cmaker, iml2s, trti, bin_edges,
         tectonic region type index
     :param bin_egdes:
         a quintet (mag_edges, dist_edges, lon_edges, lat_edges, eps_edges)
-    :param oqparam:
-        the parameters in the job.ini file
     :param monitor:
         monitor of the currently running job
     :returns:
         a dictionary of probability arrays, with composite key
         (sid, rlzi, poe, imt, iml, trti).
     """
+    dstore.open('r')
+    oqparam = dstore['oqparam']
+    sitecol = dstore['sitecol']
+    rupdata = dstore['rup/' + grp][slc]
+    dstore.close()
     result = {'trti': trti, 'num_ruptures': 0}
     # all the time is spent in collect_bin_data
     RuptureContext.temporal_occurrence_model = PoissonTOM(
@@ -293,8 +297,12 @@ producing too small PoEs.'''
                     self.imldict[s, r, poe, imt] = iml2[m, p]
 
         # submit disagg tasks
-        smap = parallel.Starmap(compute_disagg, h5=self.datastore.hdf5)
+        slices_by_grp = AccumDict(accum=[])
         for grp, dset in self.datastore['rup'].items():
+            slices_by_grp[grp].extend(gen_slices(len(dset), 1000))
+        self.datastore.close()
+        smap = parallel.Starmap(compute_disagg, h5=self.datastore.hdf5)
+        for grp, slices in slices_by_grp.items():
             grp_id = int(grp[4:])
             trt = csm_info.trt_by_grp[grp_id]
             trti = trt_num[trt]
@@ -302,9 +310,9 @@ producing too small PoEs.'''
             cmaker = ContextMaker(
                 trt, rlzs_by_gsim, src_filter.integration_distance,
                 {'filter_distance': oq.filter_distance})
-            for block in block_splitter(dset[()], 1000):
-                smap.submit(src_filter.sitecol, numpy.array(block), cmaker,
-                            iml2s, trti, self.bin_edges, oq)
+            for slc in slices:
+                smap.submit(self.datastore, grp, slc, cmaker,
+                            iml2s, trti, self.bin_edges)
 
         self.num_ruptures = [0] * len(self.trts)
         results = smap.reduce(self.agg_result, AccumDict(accum={}))
@@ -341,6 +349,7 @@ producing too small PoEs.'''
         :param results:
             a dictionary (sid, rlzi, poe, imt) -> trti -> disagg matrix
         """
+        self.datastore.open('r+')
         T = len(self.trts)
         # build a dictionary (sid, rlzi, poe, imt) -> 6D matrix
         results = {k: _to_matrix(v, T) for k, v in results.items()}

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -207,7 +207,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 self.datastore.hdf5.copy('rupgeoms', cache)
         self.init_logic_tree(self.csm_info)
         smap = parallel.Starmap(
-            self.core_task.__func__, h5=self.datastore.hdf5)
+            self.core_task.__func__, hdf5path=self.datastore.filename)
         trt_by_grp = self.csm_info.grp_by("trt")
         samples = self.csm_info.get_samples_by_grp()
         rlzs_by_gsim_grp = self.csm_info.get_rlzs_by_gsim_grp()
@@ -312,7 +312,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
             dstore = self.datastore
         allargs = [(dstore.filename, builder, rlzi) for rlzi in range(self.R)]
         h5 = hdf5.File(self.datastore.hdf5cache())
-        acc = list(parallel.Starmap(compute_loss_curves_maps, allargs, h5=h5))
+        acc = list(parallel.Starmap(compute_loss_curves_maps, allargs,
+                                    hdf5path=h5.filename))
         # copy performance information from the cache to the datastore
         pd = h5['performance_data'][()]
         hdf5.extend3(self.datastore.filename, 'performance_data', pd)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -129,7 +129,7 @@ class EventBasedCalculator(base.HazardCalculator):
         gsims_by_trt = self.csm.gsim_lt.values
         logging.info('Building ruptures')
         smap = parallel.Starmap(
-            self.build_ruptures.__func__, h5=self.datastore.hdf5)
+            self.build_ruptures.__func__, hdf5path=self.datastore.filename)
         eff_ruptures = AccumDict(accum=0)  # grp_id => potential ruptures
         calc_times = AccumDict(accum=numpy.zeros(2, F32))
         ses_idx = 0
@@ -265,7 +265,8 @@ class EventBasedCalculator(base.HazardCalculator):
         # build the associations eid -> rlz in parallel
         smap = parallel.Starmap(RuptureGetter.get_eid_rlz,
                                 ((rgetter,) for rgetter in rgetters),
-                                progress=logging.debug, h5=self.datastore.hdf5)
+                                progress=logging.debug,
+                                hdf5path=self.datastore.filename)
         i = 0
         for eid_rlz in smap:  # 30 million of events associated in 1 minute!
             for er in eid_rlz:
@@ -343,7 +344,7 @@ class EventBasedCalculator(base.HazardCalculator):
                     for rgetter in self.gen_rupture_getters())
         # call compute_gmfs in parallel
         acc = parallel.Starmap(
-            self.core_task.__func__, iterargs, h5=self.datastore.hdf5
+            self.core_task.__func__, iterargs, hdf5path=self.datastore.filename
         ).reduce(self.agg_dicts, self.acc0())
 
         if self.indices:

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -69,7 +69,7 @@ class UcerfClassicalCalculator(ClassicalCalculator):
                 (srcs, self.src_filter, gsims, param, monitor),
                 weight=operator.attrgetter('weight'),
                 concurrent_tasks=oq.concurrent_tasks,
-                h5=self.datastore.hdf5
+                hdf5path=self.datastore.filename
             ).reduce(self.agg_dicts, acc)
             ucerf = grp.sources[0].orig
             logging.info('Getting background sources from %s', ucerf.source_id)
@@ -78,7 +78,7 @@ class UcerfClassicalCalculator(ClassicalCalculator):
                 classical, (srcs, self.src_filter, gsims, param, monitor),
                 weight=operator.attrgetter('weight'),
                 concurrent_tasks=oq.concurrent_tasks,
-                h5=self.datastore.hdf5
+                hdf5path=self.datastore.filename
             ).reduce(self.agg_dicts, acc)
         self.store_rlz_info(acc.eff_ruptures)
         self.store_source_info(self.calc_times)

--- a/openquake/commonlib/source_model_factory.py
+++ b/openquake/commonlib/source_model_factory.py
@@ -274,7 +274,8 @@ class SourceModelFactory(object):
         elif self.in_memory:
             logging.info('Reading the source model(s) in parallel')
             smap = parallel.Starmap(
-                nrml.read_source_models, distribute=dist, h5=self.hdf5)
+                nrml.read_source_models, distribute=dist,
+                hdf5path=self.hdf5.filename if self.hdf5 else None)
             for sm in self.source_model_lt.gen_source_models(self.gsim_lt):
                 for name in sm.names.split():
                     fname = os.path.abspath(os.path.join(smlt_dir, name))

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -228,6 +228,24 @@ def build_disagg_matrix(bdata, bins, mon=Monitor):
     return out
 
 
+# called by the engine
+def build_matrices(rupdata, singlesitecol, cmaker, iml2,
+                   trunclevel, num_epsilon_bins, bins, monitor):
+    """
+    :returns: {sid, rlzi, poe, imt: matrix}
+    """
+    result = {}
+    [sid] = singlesitecol.sids
+    bin_data = collect_bin_data(
+        rupdata, singlesitecol, cmaker, iml2,
+        trunclevel, num_epsilon_bins, monitor)
+    if bin_data:  # dictionary poe, imt, rlzi -> pne
+        for (poe, imt, rlzi), matrix in build_disagg_matrix(
+                bin_data, bins, monitor).items():
+            result[sid, rlzi, poe, imt] = matrix
+    return result
+
+
 def _digitize_lons(lons, lon_bins):
     """
     Return indices of the bins to which each value in lons belongs.

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -132,8 +132,8 @@ def disaggregate_pne(gsim, rupture, sctx, dctx, imt, iml, truncnorm,
 
 
 # in practice this is always called with a single site
-def collect_bin_data(rupdata, sitecol, cmaker, iml3,
-                     truncation_level, n_epsilons, monitor=Monitor()):
+def _collect_bin_data(rupdata, sitecol, cmaker, iml3,
+                      truncation_level, n_epsilons, monitor=Monitor()):
     """
     :param rupdata: array of ruptures
     :param sitecol: a SiteCollection instance with a single site
@@ -155,7 +155,7 @@ def lon_lat_bins(bb, coord_bin_width):
     """
     Define bin edges for disaggregation histograms.
 
-    Given bins data as provided by :func:`collect_bin_data`, this function
+    Given bins data as provided by :func:`_collect_bin_data`, this function
     finds edges of histograms, taking into account maximum and minimum values
     of magnitude, distance and coordinates as well as requested sizes/numbers
     of bins.
@@ -182,7 +182,7 @@ def get_bins(bin_edges, sid):
 
 
 # this is fast
-def build_disagg_matrix(bdata, bins, mon=Monitor):
+def _build_disagg_matrix(bdata, bins, mon=Monitor):
     """
     :param bdata: a dictionary of probabilities of no exceedence
     :param bins: bin edges
@@ -236,11 +236,11 @@ def build_matrices(rupdata, singlesitecol, cmaker, iml2,
     """
     result = {}
     [sid] = singlesitecol.sids
-    bin_data = collect_bin_data(
+    bin_data = _collect_bin_data(
         rupdata, singlesitecol, cmaker, iml2,
         trunclevel, num_epsilon_bins, monitor)
     if bin_data:  # dictionary poe, imt, rlzi -> pne
-        for (poe, imt, rlzi), matrix in build_disagg_matrix(
+        for (poe, imt, rlzi), matrix in _build_disagg_matrix(
                 bin_data, bins, monitor).items():
             result[sid, rlzi, poe, imt] = matrix
     return result
@@ -356,7 +356,7 @@ def disaggregation(
         contexts.RuptureContext.temporal_occurrence_model = (
             srcs[0].temporal_occurrence_model)
         rupdata = contexts.RupData(cmaker, sitecol).from_srcs(srcs)
-        bdata[trt] = collect_bin_data(
+        bdata[trt] = _collect_bin_data(
             rupdata, sitecol, cmaker, iml2, truncation_level, n_epsilons)
     if sum(len(bd.mags) for bd in bdata.values()) == 0:
         warnings.warn(
@@ -390,7 +390,7 @@ def disaggregation(
                           len(lon_bins) - 1, len(lat_bins) - 1,
                           len(eps_bins) - 1, len(trts)))
     for trt in bdata:
-        dic = build_disagg_matrix(bdata[trt], bin_edges)
+        dic = _build_disagg_matrix(bdata[trt], bin_edges)
         if dic:  # (poe, imt, rlzi) -> matrix
             [mat] = dic.values()
             matrix[..., trt_num[trt]] = mat

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -44,7 +44,7 @@ def disaggregate(cmaker, sitecol, rupdata, iml2, truncnorm, epsilons,
     Disaggregate (separate) PoE in different contributions.
 
     :param cmaker: a ContextMaker instance
-    :param sitecol: a SiteCollection with N=1 site
+    :param sitecol: a SiteCollection with 1 site
     :param ruptures: an iterator over ruptures with the same TRT
     :param iml2: a 2D array of IMLs of shape (M, P)
     :param truncnorm: an instance of scipy.stats.truncnorm
@@ -53,14 +53,13 @@ def disaggregate(cmaker, sitecol, rupdata, iml2, truncnorm, epsilons,
     :returns:
         an AccumDict with keys (poe, imt, rlzi) and mags, dists, lons, lats
     """
-    assert len(sitecol) == 1, sitecol
+    [sid] = sitecol.sids
     acc = AccumDict(accum=[], mags=[], dists=[], lons=[], lats=[])
     try:
         gsim = cmaker.gsim_by_rlzi[iml2.rlzi]
     except KeyError:
         return acc
     pne_mon = monitor('disaggregate_pne', measuremem=False)
-    [sid] = sitecol.sids
     acc['mags'] = rupdata['mag']
     acc['lons'] = rupdata['lon'][:, sid]
     acc['lats'] = rupdata['lat'][:, sid]
@@ -86,15 +85,15 @@ def disaggregate(cmaker, sitecol, rupdata, iml2, truncnorm, epsilons,
     return acc
 
 
-# in practice this is always called with a single site
 def disaggregate_pne(gsim, rupture, sctx, dctx, imt, iml, truncnorm,
                      epsilons, eps_bands):
     """
     Disaggregate (separate) PoE of ``iml`` in different contributions
     each coming from ``epsilons`` distribution bins.
 
-    Other parameters are the same as for `gsim.get_poes`, with
-    differences that ``truncation_level`` is required to be positive.
+    Other parameters are the same as for `gsim.get_poes`, with the
+    difference that ``truncation_level`` is required to be positive
+    and the site context must refer to a single site.
 
     :returns:
         Contribution to probability of exceedance of ``iml`` coming


### PR DESCRIPTION
Thanks to the changes for https://github.com/gem/oq-engine/issues/4901 it is now possible to read the ruptures from the datastore (there is nobody writing on it while being read by the workers). This avoids GBs of data transfer that would kill rabbitmq in large disaggregations. There is also a new helper function `disagg.build_matrices` called by the engine.