### PR TITLE
Filtered far away ruptures in disaggregation

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -293,9 +293,11 @@ producing too small PoEs.'''
                     self.imldict[s, r, poe, imt] = iml2[m, p]
 
         # submit disagg tasks
+        nrups = sum(len(dset) for dset in self.datastore['rup'].values())
+        blocksize = nrups // (oq.concurrent_tasks or 1) + 1
         slices_by_grp = AccumDict(accum=[])
         for grp, dset in self.datastore['rup'].items():
-            slices_by_grp[grp].extend(gen_slices(len(dset), 1000))
+            slices_by_grp[grp].extend(gen_slices(len(dset), blocksize))
         smap = parallel.Starmap(compute_disagg,
                                 hdf5path=self.datastore.filename)
         self.datastore.close()  # must stay after the smap

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -23,7 +23,7 @@ import logging
 import operator
 import numpy
 
-from openquake.baselib import parallel, hdf5, general
+from openquake.baselib import parallel, hdf5
 from openquake.baselib.general import AccumDict, gen_slices
 from openquake.baselib.python3compat import encode
 from openquake.hazardlib.calc import disagg
@@ -111,8 +111,9 @@ def compute_disagg(dstore, grp, slc, cmaker, iml2s, trti, bin_edges, monitor):
         res = disagg.build_matrices(
             rupdata, singlesitecol, cmaker, iml2, oqparam.truncation_level,
             oqparam.num_epsilon_bins, bins, monitor)
-        result.update(res)
-    return result  # sid, rlzi, poe, imt, iml -> array
+        for (poe, imt, rlz), matrix in res.items():
+            result[sid, rlz, poe, imt] = matrix
+    return result  # sid, rlz, poe, imt -> array
 
 
 def agg_probs(*probs):

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -232,18 +232,13 @@ def _build_disagg_matrix(bdata, bins, mon=Monitor):
 def build_matrices(rupdata, singlesitecol, cmaker, iml2,
                    trunclevel, num_epsilon_bins, bins, monitor):
     """
-    :returns: {sid, rlzi, poe, imt: matrix}
+    :returns: {poe, imt, rlz: matrix}
     """
-    result = {}
     [sid] = singlesitecol.sids
     bin_data = _collect_bin_data(
         rupdata, singlesitecol, cmaker, iml2,
         trunclevel, num_epsilon_bins, monitor)
-    if bin_data:  # dictionary poe, imt, rlzi -> pne
-        for (poe, imt, rlzi), matrix in _build_disagg_matrix(
-                bin_data, bins, monitor).items():
-            result[sid, rlzi, poe, imt] = matrix
-    return result
+    return _build_disagg_matrix(bin_data, bins, monitor)
 
 
 def _digitize_lons(lons, lon_bins):

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -58,7 +58,7 @@ def disaggregate(cmaker, sitecol, rupdata, iml2, truncnorm, epsilons,
     try:
         gsim = cmaker.gsim_by_rlzi[iml2.rlzi]
     except KeyError:
-        return acc
+        return pack(acc, 'mags dists lons lats'.split())
     pne_mon = monitor('disaggregate_pne', measuremem=False)
     acc['mags'] = rupdata['mag']
     acc['lons'] = rupdata['lon'][:, sid]
@@ -82,7 +82,7 @@ def disaggregate(cmaker, sitecol, rupdata, iml2, truncnorm, epsilons,
                         gsim, rctx, sitecol, dctx, imt, iml,
                         truncnorm, epsilons, eps_bands)
                 acc[poe, str(imt), iml2.rlzi].append(pne)
-    return acc
+    return pack(acc, 'mags dists lons lats'.split())
 
 
 def disaggregate_pne(gsim, rupture, sctx, dctx, imt, iml, truncnorm,
@@ -131,8 +131,8 @@ def disaggregate_pne(gsim, rupture, sctx, dctx, imt, iml, truncnorm,
     return rupture.get_probability_no_exceedance(poes)
 
 
-# in practice this is always called with a single site
-def _collect_bin_data(rupdata, sitecol, cmaker, iml3,
+# this is always called with a single site
+def _collect_bin_data(rupdata, sitecol, cmaker, iml2,
                       truncation_level, n_epsilons, monitor=Monitor()):
     """
     :param rupdata: array of ruptures
@@ -147,8 +147,7 @@ def _collect_bin_data(rupdata, sitecol, cmaker, iml3,
     # NB: instantiating truncnorm is slow and calls the infamous "doccer"
     tn = scipy.stats.truncnorm(-truncation_level, truncation_level)
     eps = numpy.linspace(-truncation_level, truncation_level, n_epsilons + 1)
-    acc = disaggregate(cmaker, sitecol, rupdata, iml3, tn, eps, monitor)
-    return pack(acc, 'mags dists lons lats'.split())
+    return disaggregate(cmaker, sitecol, rupdata, iml2, tn, eps, monitor)
 
 
 def lon_lat_bins(bb, coord_bin_width):

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -234,8 +234,10 @@ def build_matrices(rupdata, singlesitecol, cmaker, iml2,
     :returns: {poe, imt, rlz: matrix}
     """
     [sid] = singlesitecol.sids
+    dist = rupdata[cmaker.filter_distance][:, sid]
+    maxdist = cmaker.maximum_distance(cmaker.trt)
     bin_data = _collect_bin_data(
-        rupdata, singlesitecol, cmaker, iml2,
+        rupdata[dist < maxdist], singlesitecol, cmaker, iml2,
         trunclevel, num_epsilon_bins, monitor)
     return _build_disagg_matrix(bin_data, bins, monitor)
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -70,7 +70,7 @@ def disaggregate(cmaker, sitecol, rupdata, iml2, eps3, monitor=Monitor()):
     dists = rupdata[cmaker.filter_distance][:, sid]
     if gsim.minimum_distance:
         dists[dists < gsim.minimum_distance] = gsim.minimum_distance
-    rdata = rupdata[dists < maxdist]
+    rdata = rupdata[dists < maxdist]  # discard far away ruptures
     acc['mags'] = rdata['mag']
     acc['lons'] = rdata['lon'][:, sid]
     acc['lats'] = rdata['lat'][:, sid]


### PR DESCRIPTION
Surprisingly, this was not done. The speedup in the simplified Colombia calculation I have is 12x.
PS: I am also generating a number of tasks close to concurrent_tasks. This helps with saving the performance info too, because it is very slow if there are too many tasks.