### PR TITLE
Restored `oq show performance` on-the-fly

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * `oq show performance` can be called in the middle of a computation again
   * Filtered out the far away distances and reduced the time spent in
     saving the performance info by orders of magnitude in large disaggregations
   * Reduced the data transfer by reading the data directly from the

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Filtered out the far away distances and reduced the time spent in
+    saving the performance info by orders of magnitude in large disaggregations
   * Reduced the data transfer by reading the data directly from the
     datastore in disaggregation calculations
   * Reduced the memory consumption sending disaggregation tasks incrementally

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -194,7 +194,10 @@ class DataStore(collections.abc.MutableMapping):
             try:
                 self.hdf5 = hdf5.File(self.filename, **kw)
             except OSError as exc:
-                raise OSError('%s in %s' % (exc, self.filename))
+                if os.path.exists(self.filename + '~'):  # temporary file
+                    self.hdf5 = hdf5.File(self.filename + '~', **kw)
+                else:
+                    raise OSError('%s in %s' % (exc, self.filename))
 
     @property
     def export_dir(self):

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -19,7 +19,6 @@
 import os
 import ast
 import csv
-import uuid
 import inspect
 import logging
 import tempfile
@@ -40,13 +39,6 @@ vuint16 = h5py.special_dtype(vlen=numpy.uint16)
 vuint32 = h5py.special_dtype(vlen=numpy.uint32)
 vfloat32 = h5py.special_dtype(vlen=numpy.float32)
 vfloat64 = h5py.special_dtype(vlen=numpy.float64)
-
-
-def uuid1():
-    """
-    :returns: an unique .hdf5 filename without creating it
-    """
-    return os.path.join(tempfile.gettempdir(), str(uuid.uuid1()) + '.hdf5')
 
 
 def maybe_encode(value):

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -495,6 +495,7 @@ class IterResult(object):
                 mem_gb = memory_rss(os.getpid()) / GB
             if not result.func_args:  # not subtask
                 yield val
+                print('saving on', temp)
                 result.mon.save_task_info(
                     temp, result, self.argnames, self.sent, mem_gb)
                 result.mon.flush(temp)

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -246,4 +246,6 @@ def dump(temppath, perspath):
             if fullname not in h5:
                 hdf5.create(h5, fullname, task_info_dt)
             hdf5.extend(h5[fullname], dset[()])
+            for k, v in dset.attrs.items():
+                h5[fullname].attrs[k] = v
     os.remove(temppath)

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -33,7 +33,6 @@ class MonitorTestCase(unittest.TestCase):
             with mon:
                 time.sleep(0.1)
         self.assertGreater(mon.duration, 0.3)
-        mon.flush()
 
     def test_mem(self):
         mon = self.mon('test_mem', measuremem=True)
@@ -43,7 +42,6 @@ class MonitorTestCase(unittest.TestCase):
                 ls.append(list(range(100000)))  # allocate some RAM
                 time.sleep(0.1)
         self.assertGreaterEqual(mon.mem, 0)
-        mon.flush()
 
     def test_children(self):
         mon1 = self.mon('child1')
@@ -59,7 +57,6 @@ class MonitorTestCase(unittest.TestCase):
         self.assertEqual(list(data['counts']), [1, 2])
         total_time = data['time_sec'].sum()
         self.assertGreaterEqual(total_time, 0.3)
-        self.mon.flush()
 
     def test_pickleable(self):
         pickle.loads(pickle.dumps(self.mon))

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -123,15 +123,15 @@ class BaseCalculator(metaclass=abc.ABCMeta):
         self.datastore = datastore.DataStore(calc_id)
         self._monitor = Monitor(
             '%s.run' % self.__class__.__name__, measuremem=True)
+        self._monitor.hdf5path = self.datastore.filename  # autoflush
         self.oqparam = oqparam
-        if 'performance_data' not in self.datastore:
-            self.datastore.create_dset('performance_data', perf_dt)
 
     def monitor(self, operation='', **kw):
         """
         :returns: a new Monitor instance
         """
         mon = self._monitor(operation)
+        mon.hdf5path = self.datastore.filename  # flushable monitor
         self._monitor.calc_id = mon.calc_id = self.datastore.calc_id
         vars(mon).update(kw)
         return mon
@@ -214,7 +214,6 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                 readinput.exposure = None
                 readinput.gmfs = None
                 readinput.eids = None
-                self._monitor.flush()
 
                 if close:  # in the engine we close later
                     self.result = None

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -105,12 +105,13 @@ def compute_disagg(dstore, grp, slc, cmaker, iml2s, trti, bin_edges, monitor):
     # all the time is spent in collect_bin_data
     RuptureContext.temporal_occurrence_model = PoissonTOM(
         oqparam.investigation_time)
+    pne_mon = monitor('disaggregate_pne', measuremem=False)
     for sid, iml2 in zip(sitecol.sids, iml2s):
         singlesitecol = sitecol.filtered([sid])
         bins = disagg.get_bins(bin_edges, sid)
         res = disagg.build_matrices(
             rupdata, singlesitecol, cmaker, iml2, oqparam.truncation_level,
-            oqparam.num_epsilon_bins, bins, monitor)
+            oqparam.num_epsilon_bins, bins, pne_mon)
         for (poe, imt, rlz), matrix in res.items():
             result[sid, rlz, poe, imt] = matrix
     return result  # sid, rlz, poe, imt -> array

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -106,12 +106,13 @@ def compute_disagg(dstore, grp, slc, cmaker, iml2s, trti, bin_edges, monitor):
     RuptureContext.temporal_occurrence_model = PoissonTOM(
         oqparam.investigation_time)
     pne_mon = monitor('disaggregate_pne', measuremem=False)
+    mat_mon = monitor('build_disagg_matrix', measuremem=False)
     for sid, iml2 in zip(sitecol.sids, iml2s):
         singlesitecol = sitecol.filtered([sid])
         bins = disagg.get_bins(bin_edges, sid)
         res = disagg.build_matrices(
             rupdata, singlesitecol, cmaker, iml2, oqparam.truncation_level,
-            oqparam.num_epsilon_bins, bins, pne_mon)
+            oqparam.num_epsilon_bins, bins, pne_mon, mat_mon)
         for (poe, imt, rlz), matrix in res.items():
             result[sid, rlz, poe, imt] = matrix
     return result  # sid, rlz, poe, imt -> array

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -243,8 +243,6 @@ class EventBasedCalculator(base.HazardCalculator):
                 r, sid, imt = str2rsi(key)
                 array = acc[r].setdefault(sid, 0).array[imtls(imt), 0]
                 array[:] = 1. - (1. - array) * (1. - poes)
-        sav_mon.flush()
-        agg_mon.flush()
         self.datastore.flush()
         return acc
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -468,7 +468,7 @@ def view_fullreport(token, dstore):
     return ReportWriter(dstore).make_report()
 
 
-def performance_view(dstore):
+def performance_view(dstore, add_calc_id=True):
     """
     Returns the performance view as a numpy array.
     """
@@ -485,7 +485,8 @@ def performance_view(dstore):
         out.append((operation, time, mem, counts))
     out.sort(key=operator.itemgetter(1), reverse=True)  # sort by time
     dt = copy.copy(perf_dt)
-    dt.names = ('calc_%d' % dstore.calc_id,) + dt.names[1:]
+    if add_calc_id:
+        dt.names = ('calc_%d' % dstore.calc_id,) + dt.names[1:]
     return numpy.array(out, dt)
 
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import ast
+import copy
 import os.path
 import numbers
 import operator
@@ -483,7 +484,9 @@ def performance_view(dstore):
             mem = max(mem, memory_mb)
         out.append((operation, time, mem, counts))
     out.sort(key=operator.itemgetter(1), reverse=True)  # sort by time
-    return numpy.array(out, perf_dt)
+    dt = copy.copy(perf_dt)
+    dt.names = ('calc_%d' % dstore.calc_id,) + dt.names[1:]
+    return numpy.array(out, dt)
 
 
 @view.add('performance')

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -442,12 +442,16 @@ class EngineRunJobTestCase(unittest.TestCase):
             job_id = run_job(job_ini, log_level='error')
         self.assertIn('id | name', str(p))
 
-        # sanity check on the performance view: make sure that the most
-        # relevant information is stored (it can be lost for instance due
-        # to a wrong refactoring of the safely_call function)
+        # sanity check on the performance views: make sure that the most
+        # relevant information is stored (it can be lost due to a wrong
+        # refactoring of the monitoring and it happened several times)
         with read(job_id) as dstore:
             perf = view('performance', dstore)
             self.assertIn('total event_based_risk', perf)
+            task_info = view('task_info', dstore)
+            self.assertIn('compute_gmfs', task_info)
+            job_info = view('job_info', dstore)
+            self.assertIn('compute_gmfs', job_info)
 
     def test_smart_run(self):
         # test smart_run with gmf_ebrisk, since it was breaking

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -340,7 +340,7 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         logs.LOG.info('Exposing the outputs to the database')
         expose_outputs(calc.datastore)
         duration = time.time() - t0
-        records = views.performance_view(calc.datastore)
+        records = views.performance_view(calc.datastore, add_calc_id=False)
         logs.dbcmd('save_performance', job_id, records)
         calc.datastore.close()
         logs.LOG.info('Calculation %d finished correctly in %d seconds',

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -340,7 +340,6 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         logs.LOG.info('Exposing the outputs to the database')
         expose_outputs(calc.datastore)
         duration = time.time() - t0
-        calc._monitor.flush()
         records = views.performance_view(calc.datastore)
         logs.dbcmd('save_performance', job_id, records)
         calc.datastore.close()

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -46,7 +46,7 @@ def _eps3(truncation_level, n_epsilons):
     return tn, eps, eps_bands
 
 
-def disaggregate(cmaker, sitecol, rupdata, iml2, eps3, monitor=Monitor()):
+def disaggregate(cmaker, sitecol, rupdata, iml2, eps3, pne_mon):
     """
     Disaggregate (separate) PoE in different contributions.
 
@@ -55,7 +55,7 @@ def disaggregate(cmaker, sitecol, rupdata, iml2, eps3, monitor=Monitor()):
     :param rupdata: an array of rupture data with the same TRT
     :param iml2: a 2D array of IMLs of shape (M, P)
     :param eps3: a triple (truncnorm, epsilons, epsilon bands)
-    :param monitor: a Monitor instance
+    :param pne_mon: a Monitor instance
     :returns:
         an AccumDict with keys (poe, imt, rlzi) and mags, dists, lons, lats
     """
@@ -65,7 +65,6 @@ def disaggregate(cmaker, sitecol, rupdata, iml2, eps3, monitor=Monitor()):
         gsim = cmaker.gsim_by_rlzi[iml2.rlzi]
     except KeyError:
         return pack(acc, 'mags dists lons lats'.split())
-    pne_mon = monitor('disaggregate_pne', measuremem=False)
     maxdist = cmaker.maximum_distance(cmaker.trt)
     dists = rupdata[cmaker.filter_distance][:, sid]
     if gsim.minimum_distance:


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/4901.  While at it, I also reduced by `num_sites` times the number of monitor instantions in disaggregation, which was actually dominating the calculation time in the case of many sites.