### PR TITLE
Avoid the error for POE_TOO_BIG

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Sites for which the disaggregation PoE cannot be reached are discarded
+    and a warning is printed, rather than killing the whole computation
   * `oq show performance` can be called in the middle of a computation again
   * Filtered out the far away distances and reduced the time spent in
     saving the performance info by orders of magnitude in large disaggregations

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -38,6 +38,25 @@ from openquake.calculators import base
 weight = operator.attrgetter('weight')
 DISAGG_RES_FMT = '%(imt)s-%(sid)s-%(poe)s/'
 BIN_NAMES = 'mag', 'dist', 'lon', 'lat', 'eps', 'trt'
+POE_TOO_BIG = '''\
+You are trying to disaggregate for poe=%s.
+However the source model produces at most probabilities
+of %.7f for rlz=#%d, IMT=%s.
+The disaggregation PoE is too big or your model is wrong,
+producing too small PoEs.'''
+
+
+def _check_curve(sid, rlz, curve, imtls, poes_disagg):
+    # there may be sites where the sources are too small to produce
+    # an effect at the given poes_disagg
+    bad = 0
+    for imt in imtls:
+        max_poe = curve[imt].max()
+        for poe in poes_disagg:
+            if poe > max_poe:
+                logging.warning(POE_TOO_BIG, poe, max_poe, rlz, imt)
+                bad += 1
+    return bool(bad)
 
 
 def _to_matrix(matrices, num_trts):
@@ -135,12 +154,6 @@ class DisaggregationCalculator(base.HazardCalculator):
     """
     precalc = 'classical'
     accept_precalc = ['classical', 'disaggregation']
-    POE_TOO_BIG = '''\
-You are trying to disaggregate for poe=%s.
-However the source model produces at most probabilities
-of %.7f for rlz=#%d, IMT=%s.
-The disaggregation PoE is too big or your model is wrong,
-producing too small PoEs.'''
 
     def init(self):
         few = self.oqparam.max_sites_disagg
@@ -202,15 +215,20 @@ producing too small PoEs.'''
         the hazard curves.
         """
         oq = self.oqparam
+        # there may be sites where the sources are too small to produce
+        # an effect at the given poes_disagg
+        ok_sites = []
         for sid in self.sitecol.sids:
-            poes = curves[sid]
-            if poes is not None:
-                for imt in oq.imtls:
-                    max_poe = poes[imt].max()
-                    for poe in oq.poes_disagg:
-                        if poe > max_poe:
-                            raise ValueError(self.POE_TOO_BIG % (
-                                poe, max_poe, rlzs[sid], imt))
+            if curves[sid] is None:
+                ok_sites.append(sid)
+                continue
+            bad = _check_curve(sid, rlzs[sid], curves[sid],
+                               oq.imtls, oq.poes_disagg)
+            if not bad:
+                ok_sites.append(sid)
+        self.sitecol = self.sitecol.filtered(ok_sites)
+        if len(self.sitecol) == 0:
+            raise SystemExit('Cannot do any disaggregation')
 
     def full_disaggregation(self):
         """

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -229,6 +229,8 @@ class DisaggregationCalculator(base.HazardCalculator):
         self.sitecol = self.sitecol.filtered(ok_sites)
         if len(self.sitecol) == 0:
             raise SystemExit('Cannot do any disaggregation')
+        elif len(ok_sites) < self.N:
+            logging.warning('Doing the disaggregation on' % self.sitecol)
 
     def full_disaggregation(self):
         """

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -106,14 +106,10 @@ class DisaggregationTestCase(CalculatorTestCase):
         self.assertEqual(aw['poes'].shape, (2, 15))  # 2 rows
 
     def test_case_3(self):
-        with self.assertRaises(ValueError) as ctx:
+        # a case with poes_disagg too large
+        with self.assertRaises(SystemExit) as ctx:
             self.run_calc(case_3.__file__, 'job.ini')
-        self.assertEqual(str(ctx.exception), '''\
-You are trying to disaggregate for poe=0.1.
-However the source model produces at most probabilities
-of 0.0061466 for rlz=#4, IMT=PGA.
-The disaggregation PoE is too big or your model is wrong,
-producing too small PoEs.''')
+        self.assertEqual(str(ctx.exception), 'Cannot do any disaggregation')
 
     def test_case_4(self):
         # this is case with number of lon/lat bins different for site 0/site 1


### PR DESCRIPTION
The error makes a lot of sense if there is a single site (you cannot run a disaggregation for a PoE larger than the PoEs that can be generated by the model), less so in the multi-site situation. So I changed it to a warning and I am skipping the sites affected by the problem. If no sites are left, a `SystemExit('Cannot do any disaggregation')` is raised. This is necessary, otherwise @julgp calculation for Colombia cannot be run.