### PR TITLE
Solves a failure in Jenkins

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -162,7 +162,7 @@ except ImportError:
     def setproctitle(title):
         "Do nothing"
 
-from openquake.baselib import config, hdf5
+from openquake.baselib import config
 from openquake.baselib.zeromq import zmq, Socket
 from openquake.baselib.performance import Monitor, memory_rss, dump
 from openquake.baselib.general import (

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -248,5 +248,4 @@ def dump(temppath, perspath):
             hdf5.extend(h5[fullname], dset[()])
             for k, v in dset.attrs.items():
                 h5[fullname].attrs[k] = v
-        h5.flush()
     os.remove(temppath)

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -248,4 +248,5 @@ def dump(temppath, perspath):
             hdf5.extend(h5[fullname], dset[()])
             for k, v in dset.attrs.items():
                 h5[fullname].attrs[k] = v
+        h5.flush()
     os.remove(temppath)

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -294,6 +294,11 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         Compute and store average losses from the losses_by_event dataset,
         and then loss curves and maps.
         """
+        if len(times):  # store some info on the calculation times
+            self.datastore.set_attrs(
+                'task_info/start_ebrisk', times=times,
+                events_per_sid=numpy.mean(self.events_per_sid))
+
         oq = self.oqparam
         shp = self.get_shape(self.L)  # (L, T...)
         text = ' x '.join(
@@ -357,11 +362,6 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                             builder.eff_time)
             numpy.testing.assert_allclose(
                 curves, self.datastore['agg_curves-rlzs'][()])
-
-        if len(times):  # store some info on the calculation times
-            self.datastore.set_attrs(
-                'task_info/start_ebrisk', times=times,
-                events_per_sid=numpy.mean(self.events_per_sid))
 
 
 # 1) parallelizing by events does not work, we need all the events

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -295,9 +295,15 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         and then loss curves and maps.
         """
         if len(times):  # store some info on the calculation times
-            self.datastore.set_attrs(
-                'task_info/start_ebrisk', times=times,
-                events_per_sid=numpy.mean(self.events_per_sid))
+            try:
+                dset = self.datastore['task_info/start_ebrisk']
+            except KeyError:
+                # can happen for mysterious race conditions on some machines
+                pass
+            else:
+                # store the time information
+                dset.attrs['times'] = times
+                dset.attrs['events_per_sid'] = numpy.mean(self.events_per_sid)
 
         oq = self.oqparam
         shp = self.get_shape(self.L)  # (L, T...)

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -294,14 +294,14 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         Compute and store average losses from the losses_by_event dataset,
         and then loss curves and maps.
         """
-        if len(times):  # store some info on the calculation times
+        if len(times):
             try:
                 dset = self.datastore['task_info/start_ebrisk']
             except KeyError:
                 # can happen for mysterious race conditions on some machines
                 pass
             else:
-                # store the time information
+                # store the time information plus the events_per_sid info
                 dset.attrs['times'] = times
                 dset.attrs['events_per_sid'] = numpy.mean(self.events_per_sid)
 

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -294,10 +294,6 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         Compute and store average losses from the losses_by_event dataset,
         and then loss curves and maps.
         """
-        if len(times):
-            self.datastore.set_attrs(
-                'task_info/start_ebrisk', times=times,
-                events_per_sid=numpy.mean(self.events_per_sid))
         oq = self.oqparam
         shp = self.get_shape(self.L)  # (L, T...)
         text = ' x '.join(
@@ -361,6 +357,11 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                             builder.eff_time)
             numpy.testing.assert_allclose(
                 curves, self.datastore['agg_curves-rlzs'][()])
+
+        if len(times):  # store some info on the calculation times
+            self.datastore.set_attrs(
+                'task_info/start_ebrisk', times=times,
+                events_per_sid=numpy.mean(self.events_per_sid))
 
 
 # 1) parallelizing by events does not work, we need all the events


### PR DESCRIPTION
See https://ci.openquake.org/job/master_oq-engine/4930/ 
```python
KeyError: "Unable to open object (object 'start_ebrisk' doesn't exist)"
```
It looks like a race condition, the dataset `start_ebrisk` exists, it has just been added, but on some machines (like wilson) it is not seen. Since we are storing on it some debugging information, it is okay not to store it in case the dataset is not ready (the *austrich technique* rules!).
See https://ci.openquake.org/job/zdevel_oq-engine/2847/