### PR TITLE
Storing the distances are 32 bit floats in disaggregation

### DIFF
--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -80,7 +80,7 @@ def open8(fname, mode='r'):
 
 
 class CalculatorTestCase(unittest.TestCase):
-    OVERWRITE_EXPECTED = True
+    OVERWRITE_EXPECTED = False
     edir = None  # will be set to a temporary directory
 
     @classmethod

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -25,6 +25,7 @@ from openquake.hazardlib.calc.filters import IntegrationDistance
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.geo.surface import PlanarSurface
 
+F32 = numpy.float32
 KNOWN_DISTANCES = frozenset(
     'rrup rx ry0 rjb rhypo repi rcdpp azimuth rvolc'.split())
 
@@ -119,9 +120,9 @@ class RupData(object):
         for rup_param in self.cmaker.REQUIRES_RUPTURE_PARAMETERS:
             dtlist.append((rup_param, float))
         for dist_param in self.cmaker.REQUIRES_DISTANCES:
-            dtlist.append((dist_param, (float, (self.N,))))
-        dtlist.append(('lon', (float, (self.N,))))  # closest lons
-        dtlist.append(('lat', (float, (self.N,))))  # closest lats
+            dtlist.append((dist_param, (F32, (self.N,))))
+        dtlist.append(('lon', (F32, (self.N,))))  # closest lons
+        dtlist.append(('lat', (F32, (self.N,))))  # closest lats
         dtlist.append(('mutex_weight', float))
         dtlist.append(('probs_occur', vfloat64))
         return numpy.array(self.data, dtlist)

--- a/openquake/qa_tests_data/disagg/case_1/expected_output/rlz-0-PGA-sid-0-poe-0_Lon_Lat.csv
+++ b/openquake/qa_tests_data/disagg/case_1/expected_output/rlz-0-PGA-sid-0-poe-0_Lon_Lat.csv
@@ -1,8 +1,8 @@
-# generated_by='OpenQuake engine 3.7.0-git12a38adeeb', start_date='2019-07-18T06:00:43', checksum=1811660702, smlt_path='b1', gsimlt_path='b1', imt='PGA', investigation_time=50.0, lon=10.099999999999994, lat=40.1, poe='0.0200000', iml='5.4769062e-01'
+# generated_by='OpenQuake engine 3.7.0-gitb3a3883e20', start_date='2019-07-22T05:20:49', checksum=1811660702, smlt_path='b1', gsimlt_path='b1', imt='PGA', investigation_time=50.0, lon=10.099999999999994, lat=40.1, poe='0.0200000', iml='5.4769062e-01', rlz=0
 lon,lat,poe
 8.25000E+00,3.97500E+01,0.00000E+00
 8.25000E+00,4.12500E+01,0.00000E+00
-9.75000E+00,3.97500E+01,1.93174E-02
+9.75000E+00,3.97500E+01,1.93221E-02
 9.75000E+00,4.12500E+01,0.00000E+00
-1.12500E+01,3.97500E+01,4.81922E-06
+1.12500E+01,3.97500E+01,0.00000E+00
 1.12500E+01,4.12500E+01,0.00000E+00

--- a/openquake/qa_tests_data/disagg/case_1/expected_output/rlz-0-PGA-sid-0-poe-1_Lon_Lat.csv
+++ b/openquake/qa_tests_data/disagg/case_1/expected_output/rlz-0-PGA-sid-0-poe-1_Lon_Lat.csv
@@ -1,8 +1,8 @@
-# generated_by='OpenQuake engine 3.7.0-git12a38adeeb', start_date='2019-07-18T06:00:43', checksum=1811660702, smlt_path='b1', gsimlt_path='b1', imt='PGA', investigation_time=50.0, lon=10.099999999999994, lat=40.1, poe='0.1000000', iml='3.0051519e-01'
+# generated_by='OpenQuake engine 3.7.0-gitb3a3883e20', start_date='2019-07-22T05:20:49', checksum=1811660702, smlt_path='b1', gsimlt_path='b1', imt='PGA', investigation_time=50.0, lon=10.099999999999994, lat=40.1, poe='0.1000000', iml='3.0051519e-01', rlz=0
 lon,lat,poe
 8.25000E+00,3.97500E+01,0.00000E+00
 8.25000E+00,4.12500E+01,0.00000E+00
-9.75000E+00,3.97500E+01,9.28686E-02
+9.75000E+00,3.97500E+01,9.57559E-02
 9.75000E+00,4.12500E+01,0.00000E+00
-1.12500E+01,3.97500E+01,3.18280E-03
+1.12500E+01,3.97500E+01,0.00000E+00
 1.12500E+01,4.12500E+01,0.00000E+00

--- a/openquake/qa_tests_data/disagg/case_1/expected_output/rlz-0-SA(0.025)-sid-0-poe-0_Lon_Lat.csv
+++ b/openquake/qa_tests_data/disagg/case_1/expected_output/rlz-0-SA(0.025)-sid-0-poe-0_Lon_Lat.csv
@@ -1,8 +1,8 @@
-# generated_by='OpenQuake engine 3.7.0-git12a38adeeb', start_date='2019-07-18T06:00:43', checksum=1811660702, smlt_path='b1', gsimlt_path='b1', imt='SA', investigation_time=50.0, lon=10.099999999999994, lat=40.1, poe='0.0200000', iml='6.0068562e-01'
+# generated_by='OpenQuake engine 3.7.0-gitb3a3883e20', start_date='2019-07-22T05:20:49', checksum=1811660702, smlt_path='b1', gsimlt_path='b1', imt='SA', investigation_time=50.0, lon=10.099999999999994, lat=40.1, poe='0.0200000', iml='6.0068562e-01', rlz=0
 lon,lat,poe
 8.25000E+00,3.97500E+01,0.00000E+00
 8.25000E+00,4.12500E+01,0.00000E+00
-9.75000E+00,3.97500E+01,1.82745E-02
+9.75000E+00,3.97500E+01,1.82755E-02
 9.75000E+00,4.12500E+01,0.00000E+00
-1.12500E+01,3.97500E+01,1.01341E-06
+1.12500E+01,3.97500E+01,0.00000E+00
 1.12500E+01,4.12500E+01,0.00000E+00

--- a/openquake/qa_tests_data/disagg/case_1/expected_output/rlz-0-SA(0.025)-sid-0-poe-1_Lon_Lat.csv
+++ b/openquake/qa_tests_data/disagg/case_1/expected_output/rlz-0-SA(0.025)-sid-0-poe-1_Lon_Lat.csv
@@ -1,8 +1,8 @@
-# generated_by='OpenQuake engine 3.7.0-git12a38adeeb', start_date='2019-07-18T06:00:43', checksum=1811660702, smlt_path='b1', gsimlt_path='b1', imt='SA', investigation_time=50.0, lon=10.099999999999994, lat=40.1, poe='0.1000000', iml='3.2799818e-01'
+# generated_by='OpenQuake engine 3.7.0-gitb3a3883e20', start_date='2019-07-22T05:20:49', checksum=1811660702, smlt_path='b1', gsimlt_path='b1', imt='SA', investigation_time=50.0, lon=10.099999999999994, lat=40.1, poe='0.1000000', iml='3.2799818e-01', rlz=0
 lon,lat,poe
 8.25000E+00,3.97500E+01,0.00000E+00
 8.25000E+00,4.12500E+01,0.00000E+00
-9.75000E+00,3.97500E+01,8.93591E-02
+9.75000E+00,3.97500E+01,9.19872E-02
 9.75000E+00,4.12500E+01,0.00000E+00
-1.12500E+01,3.97500E+01,2.88582E-03
+1.12500E+01,3.97500E+01,0.00000E+00
 1.12500E+01,4.12500E+01,0.00000E+00


### PR DESCRIPTION
This halves the data transfer and storage requirements. Changes like the number 2.88582E-03 becoming 0 are explained by the small maximum_distance of 100 km in the test case_1: a rupture that before was inside is now outside because the 100 km have become 99.9999 km due the change to 32 bit floats.