### PR TITLE
Run RuptureGetter.get_eid_rlz sequentially if there are few events

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -260,10 +260,11 @@ class EventBasedCalculator(base.HazardCalculator):
         # including the ones far away that will be discarded later on
         rgetters = self.gen_rupture_getters()
 
-        # build the associations eid -> rlz in parallel
+        # build the associations eid -> rlz sequentially pr in parallel
+        distribute = 'no' if len(events) < 1E5 else None
         smap = parallel.Starmap(RuptureGetter.get_eid_rlz,
                                 ((rgetter,) for rgetter in rgetters),
-                                progress=logging.debug,
+                                progress=logging.debug, distribute=distribute,
                                 hdf5path=self.datastore.filename)
         i = 0
         for eid_rlz in smap:  # 30 million of events associated in 1 minute!


### PR DESCRIPTION
According to @daniviga, on Windows the task of kind `get_eid_rlz` are too fast and ZMQ hangs. So here I am changing the approach to run such tasks sequentially if there are few events and in parallel only when there are a lots of events (> 100,000): in that case the tasks should not be too fast. We should test how it goes.