### PR TITLE
Removed some scary warnings in presence of a site model

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed some misleading warnings for calculations with a site model
   * Added a check for missing `risk_investigation_time` in ebrisk
   * Reduced drastically (I measured improvements over 40x) memory occupation,
     data transfer and data storage for multi-sites disaggregation

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -17,6 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import unittest
 import unittest.mock as mock
 import numpy
 from openquake.baselib import parallel
@@ -316,12 +317,13 @@ hazard_uhs-std.csv
         [fname] = export(('realizations', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/realizations.csv', fname)
 
-        # check exporting a single realization in XML and CSV
-        [fname] = export(('uhs/rlz-001', 'xml'),  self.calc.datastore)
-        if NOT_DARWIN:  # broken on macOS
-            self.assertEqualFiles('expected/uhs-rlz-1.xml', fname)
+        # check exporting a single realization in CSV
         [fname] = export(('uhs/rlz-001', 'csv'),  self.calc.datastore)
         self.assertEqualFiles('expected/uhs-rlz-1.csv', fname)
+
+        # FIXME: the UHS XML exporter is randomly broken??'
+        # [fname] = export(('uhs/rlz-001', 'xml'),  self.calc.datastore)
+        # self.assertEqualFiles('expected/uhs-rlz-1.xml', fname)
 
         # extracting hmaps
         hmaps = extract(self.calc.datastore, 'hmaps')['all']['mean']

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -307,7 +307,6 @@ hazard_uhs-std.csv
             case_17.__file__)
 
     def test_case_18(self):  # GMPEtable
-        raise unittest.SkipTest('Currently broken on travis')
         self.assert_curves_ok(
             ['hazard_curve-mean_PGA.csv',
              'hazard_curve-mean_SA(0.2).csv',

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -307,6 +307,7 @@ hazard_uhs-std.csv
             case_17.__file__)
 
     def test_case_18(self):  # GMPEtable
+        raise unittest.SkipTest('Currently broken on travis')
         self.assert_curves_ok(
             ['hazard_curve-mean_PGA.csv',
              'hazard_curve-mean_SA(0.2).csv',
@@ -317,13 +318,11 @@ hazard_uhs-std.csv
         [fname] = export(('realizations', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/realizations.csv', fname)
 
-        # check exporting a single realization in CSV
+        # check exporting a single realization in CSV and XML
         [fname] = export(('uhs/rlz-001', 'csv'),  self.calc.datastore)
         self.assertEqualFiles('expected/uhs-rlz-1.csv', fname)
-
-        # FIXME: the UHS XML exporter is randomly broken??'
-        # [fname] = export(('uhs/rlz-001', 'xml'),  self.calc.datastore)
-        # self.assertEqualFiles('expected/uhs-rlz-1.xml', fname)
+        [fname] = export(('uhs/rlz-001', 'xml'),  self.calc.datastore)
+        self.assertEqualFiles('expected/uhs-rlz-1.xml', fname)
 
         # extracting hmaps
         hmaps = extract(self.calc.datastore, 'hmaps')['all']['mean']

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1635,7 +1635,7 @@ class GsimLogicTree(object):
             yield Realization(tuple(value), weight, tuple(lt_path),
                               i, tuple(lt_uid))
 
-    # tested in scenario/case_11
+    # tested in scenario/case_11; works only without a site model
     def get_integration_distance(self, mags_by_trt, oq):
         """
         :param mags_by_trt:

--- a/openquake/commonlib/source_model_factory.py
+++ b/openquake/commonlib/source_model_factory.py
@@ -309,7 +309,7 @@ class SourceModelFactory(object):
             else:
                 self.apply_uncertainties(sm, idx, dic)
             yield sm
-        if self.mags and self.hdf5:
+        if self.mags and self.hdf5 and not oq.inputs['site_model']:
             mags_by_trt = {trt: sorted(ms) for trt, ms in self.mags.items()}
             idist = self.gsim_lt.get_integration_distance(mags_by_trt, oq)
             self.hdf5['integration_distance'] = idist

--- a/openquake/commonlib/source_model_factory.py
+++ b/openquake/commonlib/source_model_factory.py
@@ -309,7 +309,7 @@ class SourceModelFactory(object):
             else:
                 self.apply_uncertainties(sm, idx, dic)
             yield sm
-        if self.mags and self.hdf5 and not oq.inputs['site_model']:
+        if self.mags and self.hdf5 and 'site_model' not in oq.inputs:
             mags_by_trt = {trt: sorted(ms) for trt, ms in self.mags.items()}
             idist = self.gsim_lt.get_integration_distance(mags_by_trt, oq)
             self.hdf5['integration_distance'] = idist


### PR DESCRIPTION
Things like:
```python
  File "/home/michele/oqcode/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2003.py", line 302, in get_mean_and_stddevs
    PGA())
  File "/home/michele/oqcode/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2003.py", line 158, in _compute_mean
    s_amp = self._compute_soil_amplification(C, vs30, pga_rock, imt)
  File "/home/michele/oqcode/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2003.py", line 181, in _compute_soil_amplification
    Sc, Sd, Se = cls._compute_site_class_dummy_variables(vs30)
  File "/home/michele/oqcode/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2003.py", line 196, in _compute_site_class_dummy_variables
    Sc[(vs30 > 360) & (vs30 <= 760)] = 1
RuntimeWarning: invalid value encountered in greater
```
They were generated by some debug code and do not have any ill effect on the computation.