### PR TITLE
Restored the clean version of Socket.__iter__

### DIFF
--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -126,16 +126,12 @@ class Socket(object):
             try:
                 ready = self.zsocket.poll(self.timeout)
                 if ready:
-                    args = self.zsocket.recv_pyobj()
+                    yield self.zsocket.recv_pyobj()
                 elif self.socket_type == zmq.PULL:
                     logging.debug('Timeout in %s', self)
-                    continue
-                else:
-                    continue
             except zmq.ZMQError:
                 # sending SIGTERM raises ZMQError
                 break
-            yield args
 
     def send(self, obj):
         """

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -124,8 +124,7 @@ class Socket(object):
         self.running = True
         while self.running:
             try:
-                ready = self.zsocket.poll(self.timeout)
-                if ready:
+                if self.zsocket.poll(self.timeout):
                     yield self.zsocket.recv_pyobj()
                 elif self.socket_type == zmq.PULL:
                     logging.debug('Timeout in %s', self)


### PR DESCRIPTION
Since it was not the culprit for the case_18 breaking test.