### PR TITLE
Cleaned up the task distribution

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -634,17 +634,16 @@ class Starmap(object):
         arg0 = args[0]  # this is assumed to be a sequence
         args = args[1:-1]
         if maxweight:  # block_splitter is lazy
-            task_args = ((blk,) + args for blk in block_splitter(
+            taskargs = ((blk,) + args for blk in block_splitter(
                 arg0, maxweight, weight, key))
         else:  # split_in_blocks is eager
-            task_args = [(blk,) + args for blk in split_in_blocks(
+            taskargs = [(blk,) + args for blk in split_in_blocks(
                 arg0, concurrent_tasks or 1, weight, key)]
-        return cls(task, task_args, distribute, progress,
-                   hdf5path).submit_all()
+        return cls(task, taskargs, distribute, progress, hdf5path).submit_all()
 
     def __init__(self, task_func, task_args=(), distribute=None,
                  progress=logging.info, hdf5path=None):
-        self.__class__.init(distribute)
+        self.__class__.init(distribute=distribute)
         self.task_func = task_func
         if hdf5path:
             match = re.search(r'(\d+)', os.path.basename(hdf5path))

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -178,18 +178,10 @@ from openquake.baselib.zeromq import zmq, Socket
 from openquake.baselib.performance import Monitor, memory_rss, dump
 from openquake.baselib.general import (
     split_in_blocks, block_splitter, AccumDict, humansize, CallableDict,
-    gettemp)
+    gettemp, socket_ready)
 
 cpu_count = multiprocessing.cpu_count()
 GB = 1024 ** 3
-OQ_DISTRIBUTE = os.environ.get('OQ_DISTRIBUTE', 'processpool').lower()
-if OQ_DISTRIBUTE == 'futures':  # legacy name
-    print('Warning: OQ_DISTRIBUTE=futures is deprecated', file=sys.stderr)
-    OQ_DISTRIBUTE = os.environ['OQ_DISTRIBUTE'] = 'processpool'
-if OQ_DISTRIBUTE not in ('no', 'processpool', 'threadpool', 'celery', 'zmq',
-                         'dask'):
-    raise ValueError('Invalid oq_distribute=%s' % OQ_DISTRIBUTE)
-
 submit = CallableDict()
 
 
@@ -204,7 +196,10 @@ def processpool_submit(self, func, args, monitor):
         safely_call, (func, args, self.task_no, monitor))
 
 
-threadpool_submit = submit.add('threadpool')(processpool_submit)
+@submit.add('threadpool')
+def threadpool_submit(self, func, args, monitor):
+    return self.pool.apply_async(
+        safely_call, (func, args, self.task_no, monitor))
 
 
 @submit.add('celery')
@@ -215,8 +210,10 @@ def celery_submit(self, func, args, monitor):
 @submit.add('zmq')
 def zmq_submit(self, func, args, monitor):
     if not hasattr(self, 'sender'):
-        task_in_url = 'tcp://%s:%s' % (config.dbserver.host,
-                                       config.zworkers.task_in_port)
+        hostport = config.dbserver.host, int(config.zworkers.task_in_port)
+        task_in_url = 'tcp://%s:%s' % hostport
+        if not socket_ready(hostport):
+            raise RuntimeError('There is no task streamer on %s' % task_in_url)
         self.sender = Socket(task_in_url, zmq.PUSH, 'connect').__enter__()
     return self.sender.send((func, args, self.task_no, monitor))
 
@@ -230,7 +227,11 @@ def oq_distribute(task=None):
     """
     :returns: the value of OQ_DISTRIBUTE or 'processpool'
     """
-    return os.environ.get('OQ_DISTRIBUTE', 'processpool').lower()
+    dist = os.environ.get('OQ_DISTRIBUTE', 'processpool').lower()
+    if dist not in ('no', 'processpool', 'threadpool', 'celery', 'zmq',
+                    'dask'):
+        raise ValueError('Invalid oq_distribute=%s' % dist)
+    return dist
 
 
 class Pickled(object):
@@ -436,7 +437,7 @@ def safely_call(func, args, task_no=0, mon=dummy_mon):
                 break
 
 
-if OQ_DISTRIBUTE.startswith('celery'):
+if oq_distribute().startswith('celery'):
     from celery import Celery
     from celery.task import task
 
@@ -444,7 +445,7 @@ if OQ_DISTRIBUTE.startswith('celery'):
     app.config_from_object('openquake.engine.celeryconfig')
     safetask = task(safely_call, queue='celery')  # has to be global
 
-elif OQ_DISTRIBUTE == 'dask':
+elif oq_distribute() == 'dask':
     from dask.distributed import Client
 
 
@@ -489,7 +490,7 @@ class IterResult(object):
                     self.nbytes += result.nbytes
             else:  # this should never happen
                 raise ValueError(result)
-            if OQ_DISTRIBUTE == 'processpool' and sys.platform != 'darwin':
+            if sys.platform != 'darwin':
                 # it normally works on macOS, but not in notebooks calling
                 # notebooks, which is the case relevant for Marco Pagani
                 mem_gb = (memory_rss(os.getpid()) + sum(
@@ -574,8 +575,9 @@ class Starmap(object):
     running_tasks = []  # currently running tasks
 
     @classmethod
-    def init(cls, poolsize=None, distribute=OQ_DISTRIBUTE):
-        if distribute == 'processpool' and not hasattr(cls, 'pool'):
+    def init(cls, poolsize=None, distribute=None):
+        cls.distribute = distribute or oq_distribute()
+        if cls.distribute == 'processpool' and not hasattr(cls, 'pool'):
             # unregister custom handlers before starting the processpool
             term_handler = signal.signal(signal.SIGTERM, signal.SIG_DFL)
             int_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -589,9 +591,9 @@ class Starmap(object):
             signal.signal(signal.SIGTERM, term_handler)
             signal.signal(signal.SIGINT, int_handler)
             cls.pids = [proc.pid for proc in cls.pool._pool]
-        elif distribute == 'threadpool' and not hasattr(cls, 'pool'):
+        elif cls.distribute == 'threadpool' and not hasattr(cls, 'pool'):
             cls.pool = multiprocessing.dummy.Pool(poolsize)
-        elif distribute == 'dask':
+        elif cls.distribute == 'dask':
             cls.dask_client = Client(config.distribution.dask_scheduler)
 
     @classmethod
@@ -642,7 +644,7 @@ class Starmap(object):
 
     def __init__(self, task_func, task_args=(), distribute=None,
                  progress=logging.info, hdf5path=None):
-        self.__class__.init(distribute=distribute or OQ_DISTRIBUTE)
+        self.__class__.init(distribute)
         self.task_func = task_func
         if hdf5path:
             match = re.search(r'(\d+)', os.path.basename(hdf5path))
@@ -653,7 +655,6 @@ class Starmap(object):
         self.monitor.calc_id = calc_id
         self.name = self.monitor.operation or task_func.__name__
         self.task_args = task_args
-        self.distribute = distribute or oq_distribute(task_func)
         self.progress = progress
         self.hdf5path = hdf5path or gettemp(suffix='.hdf5')
         try:

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -24,7 +24,7 @@ import unittest
 import itertools
 import tempfile
 import numpy
-from openquake.baselib import parallel, general, hdf5
+from openquake.baselib import parallel, general, hdf5, config
 
 try:
     import celery
@@ -64,6 +64,11 @@ class StarmapTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         parallel.Starmap.init()  # initialize the pool
+        if parallel.oq_distribute() == 'zmq':
+            host = config.dbserver.host
+            port = int(config.zworkers['task_in_port'])
+            if not general.socket_ready((host, port)):
+                raise unittest.SkipTest('The task streamer is off')
 
     def test_apply(self):
         res = parallel.Starmap.apply(

--- a/openquake/baselib/tests/workerpool_test.py
+++ b/openquake/baselib/tests/workerpool_test.py
@@ -21,7 +21,7 @@ import unittest
 from openquake.baselib import config
 from openquake.baselib.workerpool import WorkerMaster
 from openquake.baselib.parallel import Starmap
-from openquake.baselib.general import _get_free_port
+from openquake.baselib.general import _get_free_port, socket_ready
 from openquake.baselib.performance import Monitor
 
 
@@ -36,17 +36,16 @@ class WorkerPoolTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.z = config.zworkers.copy()
-        dic = dict(master_host='127.0.0.1',
-                   task_in_port=_get_free_port(),
-                   task_out_port=_get_free_port(),
-                   receiver_ports=_get_free_port())
+        dic = dict(master_host='127.0.0.1')
         config.zworkers.update(dic)
         ctrl_port = _get_free_port()
         host_cores = '127.0.0.1 4'
         cls.master = WorkerMaster(
             dic['master_host'], dic['task_in_port'], dic['task_out_port'],
             ctrl_port, host_cores)
-        cls.master.start(streamer=True)
+
+        hostport = dic['master_host'], int(dic['task_in_port'])
+        cls.master.start(streamer=not socket_ready(hostport))
 
     def test(self):
         mon = Monitor()

--- a/openquake/baselib/tests/workerpool_test.py
+++ b/openquake/baselib/tests/workerpool_test.py
@@ -22,10 +22,9 @@ from openquake.baselib import config
 from openquake.baselib.workerpool import WorkerMaster
 from openquake.baselib.parallel import Starmap
 from openquake.baselib.general import _get_free_port, socket_ready
-from openquake.baselib.performance import Monitor
 
 
-def double(x, mon):
+def double(x):
     return 2 * x
 
 
@@ -36,21 +35,17 @@ class WorkerPoolTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.z = config.zworkers.copy()
-        dic = dict(master_host='127.0.0.1')
-        config.zworkers.update(dic)
         ctrl_port = _get_free_port()
         host_cores = '127.0.0.1 4'
+        hostport = '127.0.0.1:%s' % cls.z['task_in_port']
         cls.master = WorkerMaster(
-            dic['master_host'], dic['task_in_port'], dic['task_out_port'],
+            '127.0.0.1', cls.z['task_in_port'], cls.z['task_out_port'],
             ctrl_port, host_cores)
-
-        hostport = dic['master_host'], int(dic['task_in_port'])
         cls.master.start(streamer=not socket_ready(hostport))
 
     def test(self):
-        mon = Monitor()
         iterargs = ((i,) for i in range(10))
-        smap = Starmap(double, iterargs, mon, distribute='zmq')
+        smap = Starmap(double, iterargs, distribute='zmq')
         self.assertEqual(sum(res for res in smap), 90)
         # sum[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
 


### PR DESCRIPTION
The important thing is the new check
```python
        if not socket_ready(hostport):
            raise RuntimeError('There is no task streamer on %s' % task_in_url)
```
in line with https://github.com/gem/oq-engine/issues/4906. A similar check in `parallel_test.py` makes sure that the tests do not hang when `oq_distribute=zmq` is set in openquake.cfg.