### PR TITLE
Simplified the zmq configuration

### DIFF
--- a/docker/conf/openquake.cfg.cluster-sample
+++ b/docker/conf/openquake.cfg.cluster-sample
@@ -71,7 +71,7 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_port = 1910
+task_in_url = tcp://127.0.0.1:1910
 task_out_port = 1911
 remote_python =
 

--- a/docker/conf/openquake.cfg.cluster-sample
+++ b/docker/conf/openquake.cfg.cluster-sample
@@ -71,7 +71,6 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_url = tcp://127.0.0.1:1911
 remote_python =
 
 [directory]

--- a/docker/conf/openquake.cfg.cluster-sample
+++ b/docker/conf/openquake.cfg.cluster-sample
@@ -71,8 +71,7 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_url = tcp://127.0.0.1:1910
-task_out_port = 1911
+task_in_url = tcp://127.0.0.1:1911
 remote_python =
 
 [directory]

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -210,9 +210,8 @@ def celery_submit(self, func, args, monitor):
 @submit.add('zmq')
 def zmq_submit(self, func, args, monitor):
     if not hasattr(self, 'sender'):
-        hostport = config.dbserver.host, config.zworkers.task_in_port
-        task_in_url = 'tcp://%s:%s' % hostport
-        self.sender = Socket(task_in_url, zmq.PUSH, 'connect').__enter__()
+        url = config.zworkers.task_in_url
+        self.sender = Socket(url, zmq.PUSH, 'connect').__enter__()
     return self.sender.send((func, args, self.task_no, monitor))
 
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -210,7 +210,7 @@ def celery_submit(self, func, args, monitor):
 @submit.add('zmq')
 def zmq_submit(self, func, args, monitor):
     if not hasattr(self, 'sender'):
-        self.sender = Socket('ipc://zworkers', zmq.PUSH, 'connect').__enter__()
+        self.sender = Socket(workerpool.IPC, zmq.PUSH, 'connect').__enter__()
     return self.sender.send((func, args, self.task_no, monitor))
 
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -210,8 +210,7 @@ def celery_submit(self, func, args, monitor):
 @submit.add('zmq')
 def zmq_submit(self, func, args, monitor):
     if not hasattr(self, 'sender'):
-        url = config.zworkers.task_in_url
-        self.sender = Socket(url, zmq.PUSH, 'connect').__enter__()
+        self.sender = Socket('ipc://zworkers', zmq.PUSH, 'connect').__enter__()
     return self.sender.send((func, args, self.task_no, monitor))
 
 

--- a/openquake/baselib/tests/workerpool_test.py
+++ b/openquake/baselib/tests/workerpool_test.py
@@ -33,11 +33,11 @@ class WorkerPoolTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.z = config.zworkers.copy()
         host_cores = '127.0.0.1 4'
-        hostport = '127.0.0.1:%s' % cls.z['task_in_port']
-        if not socket_ready(hostport):
+        url = cls.z['task_in_url'].split('//')[1]
+        if not socket_ready(url):
             raise unittest.SkipTest('The task streamer is off')
         cls.master = WorkerMaster(
-            '127.0.0.1', cls.z['task_in_port'], cls.z['task_out_port'],
+            '127.0.0.1', cls.z['task_in_url'], cls.z['task_out_port'],
             cls.z['ctrl_port'], host_cores)
         cls.master.start()
 

--- a/openquake/baselib/tests/workerpool_test.py
+++ b/openquake/baselib/tests/workerpool_test.py
@@ -33,8 +33,8 @@ class WorkerPoolTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.z = config.zworkers.copy()
         host_cores = '127.0.0.1 4'
-        url = cls.z['task_in_url'].split('//')[1]
-        if not socket_ready(url):
+        hostport = '127.0.0.1', int(cls.z['task_out_port'])
+        if not socket_ready(hostport):
             raise unittest.SkipTest('The task streamer is off')
         cls.master = WorkerMaster(
             '127.0.0.1', cls.z['task_in_url'], cls.z['task_out_port'],

--- a/openquake/baselib/tests/workerpool_test.py
+++ b/openquake/baselib/tests/workerpool_test.py
@@ -33,12 +33,11 @@ class WorkerPoolTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.z = config.zworkers.copy()
         host_cores = '127.0.0.1 4'
-        hostport = '127.0.0.1', int(cls.z['task_out_port'])
+        hostport = '127.0.0.1', int(cls.z['ctrl_port']) + 1
         if not socket_ready(hostport):
             raise unittest.SkipTest('The task streamer is off')
         cls.master = WorkerMaster(
-            '127.0.0.1', cls.z['task_in_url'], cls.z['task_out_port'],
-            cls.z['ctrl_port'], host_cores)
+            '127.0.0.1', cls.z['task_in_url'], cls.z['ctrl_port'], host_cores)
         cls.master.start()
 
     def test(self):

--- a/openquake/baselib/tests/workerpool_test.py
+++ b/openquake/baselib/tests/workerpool_test.py
@@ -37,7 +37,7 @@ class WorkerPoolTestCase(unittest.TestCase):
         if not socket_ready(hostport):
             raise unittest.SkipTest('The task streamer is off')
         cls.master = WorkerMaster(
-            '127.0.0.1', cls.z['task_in_url'], cls.z['ctrl_port'], host_cores)
+            '127.0.0.1', cls.z['ctrl_port'], host_cores)
         cls.master.start()
 
     def test(self):

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -12,10 +12,10 @@ except ImportError:
         "Do nothing"
 
 
-def _streamer(host, task_in_port, task_out_port):
+def _streamer(host, task_in_url, task_out_port):
     # streamer for zmq workers
     try:
-        z.zmq.proxy(z.bind('tcp://%s:%s' % (host, task_in_port), z.zmq.PULL),
+        z.zmq.proxy(z.bind(task_in_url, z.zmq.PULL),
                     z.bind('tcp://%s:%s' % (host, task_out_port), z.zmq.PUSH))
     except (KeyboardInterrupt, z.zmq.ZMQError):
         pass  # killed cleanly by SIGINT/SIGTERM
@@ -28,11 +28,10 @@ def check_status(**kw):
     c = config.zworkers.copy()
     c['master_host'] = config.dbserver.listen
     c.update(kw)
-    hostport = c['master_host'], int(c['task_in_port'])
-    task_in_url = 'tcp://%s:%s' % hostport
+    url = c['task_in_url']
     errors = []
-    if not general.socket_ready(hostport):
-        errors.append('The task streamer on %s is down' % task_in_url)
+    if not general.socket_ready(url.split('//')[1]):
+        errors.append('The task streamer on %s is down' % url)
     for host, status in WorkerMaster(**c).status():
         if status != 'running':
             errors.append('The workerpool on %s is down' % host)
@@ -48,13 +47,12 @@ class WorkerMaster(object):
     :param host_cores: names of the remote hosts and number of cores to use
     :param remote_python: path of the Python executable on the remote hosts
     """
-    def __init__(self, master_host, task_in_port, task_out_port, ctrl_port,
+    def __init__(self, master_host, task_in_url, task_out_port, ctrl_port,
                  host_cores, remote_python=None, receiver_ports=None):
         # receiver_ports is not used
         self.master_host = master_host
-        self.task_in_port = task_in_port
+        self.task_in_url = task_in_url
         self.task_out_port = task_out_port
-        self.task_in_url = 'tcp://%s:%s' % (master_host, task_in_port)
         self.task_out_url = 'tcp://%s:%s' % (master_host, task_out_port)
         self.ctrl_port = int(ctrl_port)
         self.host_cores = [hc.split() for hc in host_cores.split(',')]

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -28,9 +28,9 @@ def check_status(**kw):
     c = config.zworkers.copy()
     c['master_host'] = config.dbserver.listen
     c.update(kw)
-    url = c['task_in_url']
+    hostport = c['master_host'], int(c['task_out_port'])
     errors = []
-    if not general.socket_ready(url.split('//')[1]):
+    if not general.socket_ready(hostport:
         errors.append('The task streamer on %s is down' % url)
     for host, status in WorkerMaster(**c).status():
         if status != 'running':

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -11,11 +11,13 @@ except ImportError:
     def setproctitle(title):
         "Do nothing"
 
+IPC = 'ipc://zworkers'  # input point for the task streamer
+
 
 def _streamer(host, task_out_port):
     # streamer for zmq workers
     try:
-        z.zmq.proxy(z.bind('ipc://zworkers', z.zmq.PULL),
+        z.zmq.proxy(z.bind(IPC, z.zmq.PULL),
                     z.bind('tcp://%s:%s' % (host, task_out_port), z.zmq.PUSH))
     except (KeyboardInterrupt, z.zmq.ZMQError):
         pass  # killed cleanly by SIGINT/SIGTERM

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -30,7 +30,7 @@ def check_status(**kw):
     c.update(kw)
     hostport = c['master_host'], int(c['task_out_port'])
     errors = []
-    if not general.socket_ready(hostport:
+    if not general.socket_ready(hostport):
         errors.append('The task streamer on %s is down' % url)
     for host, status in WorkerMaster(**c).status():
         if status != 'running':

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -12,10 +12,10 @@ except ImportError:
         "Do nothing"
 
 
-def _streamer(host, task_in_url, task_out_port):
+def _streamer(host, task_out_port):
     # streamer for zmq workers
     try:
-        z.zmq.proxy(z.bind(task_in_url, z.zmq.PULL),
+        z.zmq.proxy(z.bind('ipc://zworkers', z.zmq.PULL),
                     z.bind('tcp://%s:%s' % (host, task_out_port), z.zmq.PUSH))
     except (KeyboardInterrupt, z.zmq.ZMQError):
         pass  # killed cleanly by SIGINT/SIGTERM
@@ -41,17 +41,14 @@ def check_status(**kw):
 class WorkerMaster(object):
     """
     :param master_host: hostname or IP of the master node
-    :param task_in_port: port where to send the tasks
-    :param task_out_port: port from where to read the tasks
     :param ctrl_port: port on which the worker pools listen
     :param host_cores: names of the remote hosts and number of cores to use
     :param remote_python: path of the Python executable on the remote hosts
     """
-    def __init__(self, master_host, task_in_url, ctrl_port,
-                 host_cores, remote_python=None, receiver_ports=None):
+    def __init__(self, master_host, ctrl_port, host_cores,
+                 remote_python=None, receiver_ports=None):
         # receiver_ports is not used
         self.master_host = master_host
-        self.task_in_url = task_in_url
         self.task_out_url = 'tcp://%s:%d' % (master_host, int(ctrl_port) + 1)
         self.ctrl_port = int(ctrl_port)
         self.host_cores = [hc.split() for hc in host_cores.split(',')]

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -28,10 +28,10 @@ def check_status(**kw):
     c = config.zworkers.copy()
     c['master_host'] = config.dbserver.listen
     c.update(kw)
-    hostport = c['master_host'], int(c['task_out_port'])
+    hostport = c['master_host'], int(c['ctrl_port']) + 1
     errors = []
     if not general.socket_ready(hostport):
-        errors.append('The task streamer on %s is down' % url)
+        errors.append('The task streamer on %s:%s is down' % hostport)
     for host, status in WorkerMaster(**c).status():
         if status != 'running':
             errors.append('The workerpool on %s is down' % host)
@@ -47,13 +47,12 @@ class WorkerMaster(object):
     :param host_cores: names of the remote hosts and number of cores to use
     :param remote_python: path of the Python executable on the remote hosts
     """
-    def __init__(self, master_host, task_in_url, task_out_port, ctrl_port,
+    def __init__(self, master_host, task_in_url, ctrl_port,
                  host_cores, remote_python=None, receiver_ports=None):
         # receiver_ports is not used
         self.master_host = master_host
         self.task_in_url = task_in_url
-        self.task_out_port = task_out_port
-        self.task_out_url = 'tcp://%s:%s' % (master_host, task_out_port)
+        self.task_out_url = 'tcp://%s:%d' % (master_host, int(ctrl_port) + 1)
         self.ctrl_port = int(ctrl_port)
         self.host_cores = [hc.split() for hc in host_cores.split(',')]
         self.remote_python = remote_python or sys.executable

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -71,7 +71,7 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
         if ZMQ:  # start zworkers
             master = w.WorkerMaster(config.dbserver.listen, **config.zworkers)
             logs.dbcmd('start_zworkers', master)
-            logging.info('Task servers: %s', master.status())
+            logging.info('WorkerPool %s', master.status())
         try:
             eng.run_calc(job_id, oqparam, exports, **kw)
         finally:

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -19,8 +19,7 @@ import os
 import sys
 import getpass
 import logging
-from openquake.baselib import (
-    sap, config, datastore, workerpool as w)
+from openquake.baselib import sap, config, datastore
 from openquake.baselib.general import safeprint
 from openquake.hazardlib import valid
 from openquake.commonlib import logs, readinput
@@ -68,15 +67,7 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
         job_ini = os.path.abspath(job_ini)
         oqparam = eng.job_from_file(job_ini, job_id, username, **kw)
         kw['username'] = username
-        if ZMQ:  # start zworkers
-            master = w.WorkerMaster(config.dbserver.listen, **config.zworkers)
-            logs.dbcmd('start_zworkers', master)
-            logging.info('WorkerPool %s', master.status())
-        try:
-            eng.run_calc(job_id, oqparam, exports, **kw)
-        finally:
-            if ZMQ:  # stop zworkers
-                logs.dbcmd('stop_zworkers', master)
+        eng.run_calc(job_id, oqparam, exports, **kw)
         for line in logs.dbcmd('list_outputs', job_id, False):
             safeprint(line)
     return job_id

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -71,7 +71,6 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_url = ipc://zworkers
 remote_python =
 
 [directory]

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -71,7 +71,7 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_port = 1910
+task_in_url = tcp://127.0.0.1:1910
 task_out_port = 1911
 remote_python =
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -71,7 +71,7 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_url = inproc://zworkers
+task_in_url = tcp://127.0.0.1:1910
 task_out_port = 1911
 remote_python =
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -71,7 +71,7 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_url = tcp://127.0.0.1:1910
+task_in_url = inproc://zworkers
 task_out_port = 1911
 remote_python =
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -60,7 +60,7 @@ host = localhost
 port = 1908
 # port range used by workers to send back results
 # to the master node
-receiver_ports = 1912-1920
+receiver_ports = 1911-1920
 authkey = changeme
 
 [webapi]
@@ -71,7 +71,7 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_url = tcp://127.0.0.1:1911
+task_in_url = ipc://zworkers
 remote_python =
 
 [directory]

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -71,8 +71,7 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-task_in_url = tcp://127.0.0.1:1910
-task_out_port = 1911
+task_in_url = tcp://127.0.0.1:1911
 remote_python =
 
 [directory]

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -92,10 +92,10 @@ class DbServer(object):
             c = config.zworkers
             threading.Thread(
                 target=w._streamer,
-                args=(self.master_host, c.task_in_url, int(c.ctrl_port) + 1)
+                args=(self.master_host, int(c.ctrl_port) + 1)
             ).start()
-            logging.warning('Task streamer started from %s -> %s',
-                            c.task_in_url, int(c.ctrl_port) + 1)
+            logging.warning('Task streamer started on port %d',
+                            int(c.ctrl_port) + 1)
 
         # start frontend->backend proxy for the database workers
         try:

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -92,10 +92,10 @@ class DbServer(object):
             c = config.zworkers
             threading.Thread(
                 target=w._streamer,
-                args=(self.master_host, c.task_in_url, c.task_out_port)
+                args=(self.master_host, c.task_in_url, int(c.ctrl_port) + 1)
             ).start()
             logging.warning('Task streamer started from %s -> %s',
-                            c.task_in_url, c.task_out_port)
+                            c.task_in_url, int(c.ctrl_port) + 1)
 
         # start frontend->backend proxy for the database workers
         try:

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -88,7 +88,7 @@ class DbServer(object):
         logging.warning('DB server started with %s on %s, pid %d',
                         sys.executable, self.frontend, self.pid)
         if ZMQ:
-            # start task_in->task_out streamer thread
+            # start task_in->task_server streamer thread
             c = config.zworkers
             threading.Thread(
                 target=w._streamer,

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -92,10 +92,10 @@ class DbServer(object):
             c = config.zworkers
             threading.Thread(
                 target=w._streamer,
-                args=(self.master_host, c.task_in_port, c.task_out_port)
+                args=(self.master_host, c.task_in_url, c.task_out_port)
             ).start()
             logging.warning('Task streamer started from %s -> %s',
-                            c.task_in_port, c.task_out_port)
+                            c.task_in_url, c.task_out_port)
 
         # start frontend->backend proxy for the database workers
         try:


### PR DESCRIPTION
Using ipc://zworkers saves a port number. task_out_port is simply assumed to be ctrl_port + 1. I have also moved starting/stopping the zworkers in `engine.run_calc` so that the WebUI works in zmq mode.