### PR TITLE
The zmq workers must be starting after polling the queue

### DIFF
--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -63,12 +63,12 @@ class WorkerMaster(object):
             master_host, self.ctrl_port + 1)
         self.pids = []
 
-    def wait_pools(self):
+    def wait_pools(self, seconds):
         """
         Wait until all workerpools start
         """
-        for _ in range(60):
-            time.sleep(.5)
+        for _ in range(seconds):
+            time.sleep(1)
             status = self.status()
             if all(st == 'running' for host, st in status):
                 break

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -336,7 +336,7 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         if OQ_DISTRIBUTE == 'zmq':  # start zworkers
             master = w.WorkerMaster(config.dbserver.listen, **config.zworkers)
             logs.dbcmd('start_zworkers', master)
-            logging.info('WorkerPool %s',  master.wait_pools())
+            logging.info('WorkerPool %s',  master.wait_pools(seconds=30))
         t0 = time.time()
         calc.run(exports=exports,
                  hazard_calculation_id=hazard_calculation_id,

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -58,11 +58,6 @@ GET_JOBS = '''--- executing or submitted
 SELECT * FROM job WHERE status IN ('executing', 'submitted')
 AND is_running=1 AND pid > 0 ORDER BY id'''
 
-
-class TimeoutError(RuntimeError):
-    pass
-
-
 if OQ_DISTRIBUTE == 'zmq':
 
     def set_concurrent_tasks_default(job_id):
@@ -306,17 +301,6 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
     :param exports:
         A comma-separated string of export types.
     """
-    if OQ_DISTRIBUTE == 'zmq':  # start zworkers
-        master = w.WorkerMaster(config.dbserver.listen, **config.zworkers)
-        logs.dbcmd('start_zworkers', master)
-        for _ in range(60):
-            time.sleep(.5)
-            status = master.status()
-            if all(st == 'running' for host, st in status):
-                break
-        else:
-            raise TimeoutError(status)
-        logging.info('WorkerPool %s', status)
     register_signals()
     setproctitle('oq-job-%d' % job_id)
     calc = base.calculators(oqparam, calc_id=job_id)
@@ -349,6 +333,10 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
             del data  # save memory
 
         poll_queue(job_id, _PID, poll_time=15)
+        if OQ_DISTRIBUTE == 'zmq':  # start zworkers
+            master = w.WorkerMaster(config.dbserver.listen, **config.zworkers)
+            logs.dbcmd('start_zworkers', master)
+            logging.info('WorkerPool %s',  master.wait_pools())
         t0 = time.time()
         calc.run(exports=exports,
                  hazard_calculation_id=hazard_calculation_id,

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -35,7 +35,7 @@ import random
 from django.test import Client
 from openquake.baselib.general import gettemp
 from openquake.commonlib.logs import dbcmd
-from openquake.engine.engine import TimeoutError
+from openquake.baselib.workerpool import TimeoutError
 from openquake.engine.export import core
 from openquake.server.db import actions
 from openquake.server.dbserver import db, get_status


### PR DESCRIPTION
If job A is running and job B is in queue, at the end of job A job B must restart the zmq workers that were stopped by A.