### PR TITLE
Make StdDev.TOTAL mandatory at class level

### DIFF
--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -193,7 +193,13 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
 
     @classmethod
     def __init_subclass__(cls):
-        registry[cls.__name__] = cls
+        stddevtypes = cls.DEFINED_FOR_STANDARD_DEVIATION_TYPES
+        if not isinstance(stddevtypes, abc.abstractproperty):  # concrete class
+            if const.StdDev.TOTAL not in stddevtypes:
+                raise ValueError('%s.DEFINED_FOR_STANDARD_DEVIATION_TYPES is '
+                                 'not defined for const.StdDev.TOTAL' %
+                                 cls.__name__)
+            registry[cls.__name__] = cls
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs

--- a/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
@@ -21,6 +21,7 @@ Module :mod:`openquake.hazardlib.mgmp.nrcan15_site_term` implements
 
 import copy
 import numpy as np
+from openquake.hazardlib import const
 from openquake.hazardlib.gsim.base import CoeffsTable
 from openquake.hazardlib.gsim.base import GMPE, registry
 from openquake.hazardlib.gsim.boore_atkinson_2008 import BooreAtkinson2008
@@ -41,7 +42,7 @@ class NRCan15SiteTerm(GMPE):
     REQUIRES_RUPTURE_PARAMETERS = set()
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = ''
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = set()
-    DEFINED_FOR_STANDARD_DEVIATION_TYPES = set()
+    DEFINED_FOR_STANDARD_DEVIATION_TYPES = {const.StdDev.TOTAL}
     DEFINED_FOR_TECTONIC_REGION_TYPE = ''
     DEFINED_FOR_REFERENCE_VELOCITY = None
 

--- a/openquake/hazardlib/gsim/mgmpe/split_sigma_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/split_sigma_gmpe.py
@@ -42,7 +42,7 @@ class SplitSigmaGMPE(GMPE):
     REQUIRES_RUPTURE_PARAMETERS = set()
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = set()
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = ''
-    DEFINED_FOR_STANDARD_DEVIATION_TYPES = set()
+    DEFINED_FOR_STANDARD_DEVIATION_TYPES = {const.StdDev.TOTAL}
     DEFINED_FOR_TECTONIC_REGION_TYPE = ''
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
@@ -51,8 +51,6 @@ class SplitSigmaGMPE(GMPE):
         # Create the original GMPE
         self.gmpe = registry[gmpe_name]()
         self.set_parameters()
-        assert self.DEFINED_FOR_STANDARD_DEVIATION_TYPES == set([
-            const.StdDev.TOTAL]), "this GMM already supports several STD types"
 
         # Set options for obtaining within and between stds
         self.between_absolute = between_absolute

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -45,7 +45,7 @@ class _FakeGSIMTestCase(unittest.TestCase):
             DEFINED_FOR_TECTONIC_REGION_TYPE = None
             DEFINED_FOR_INTENSITY_MEASURE_TYPES = set()
             DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = None
-            DEFINED_FOR_STANDARD_DEVIATION_TYPES = set()
+            DEFINED_FOR_STANDARD_DEVIATION_TYPES = {const.StdDev.TOTAL}
             REQUIRES_SITES_PARAMETERS = set()
             REQUIRES_RUPTURE_PARAMETERS = set()
             REQUIRES_DISTANCES = set()
@@ -83,10 +83,6 @@ class _FakeGSIMTestCase(unittest.TestCase):
 
 class GetPoEsTestCase(_FakeGSIMTestCase):
     def test_no_truncation(self):
-        self.gsim_class.DEFINED_FOR_STANDARD_DEVIATION_TYPES = frozenset(
-            self.gsim_class.DEFINED_FOR_STANDARD_DEVIATION_TYPES |
-            {const.StdDev.TOTAL})
-
         def get_mean_and_stddevs(sites, rup, dists, imt, stddev_types):
             self.assertEqual(imt, self.DEFAULT_IMT())
             self.assertEqual(stddev_types, [const.StdDev.TOTAL])

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -143,9 +143,6 @@ class GetPoEsTestCase(_FakeGSIMTestCase):
         self.assertAlmostEqual(poe2, 0.43432352175355504, places=6)
 
     def test_several_contexts(self):
-        self.gsim_class.DEFINED_FOR_STANDARD_DEVIATION_TYPES = frozenset(
-            self.gsim_class.DEFINED_FOR_STANDARD_DEVIATION_TYPES |
-            {const.StdDev.TOTAL})
         mean_stddev = numpy.array([[3, 4], [5, 6]])
 
         def get_mean_and_stddevs(sites, rup, dists, imt, stddev_types):
@@ -171,7 +168,7 @@ class TGMPE(GMPE):
     DEFINED_FOR_TECTONIC_REGION_TYPE = None
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = None
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = None
-    DEFINED_FOR_STANDARD_DEVIATION_TYPES = None
+    DEFINED_FOR_STANDARD_DEVIATION_TYPES = {const.StdDev.TOTAL}
     REQUIRES_SITES_PARAMETERS = None
     REQUIRES_RUPTURE_PARAMETERS = None
     REQUIRES_DISTANCES = None
@@ -182,7 +179,7 @@ class TIPE(IPE):
     DEFINED_FOR_TECTONIC_REGION_TYPE = None
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = None
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = None
-    DEFINED_FOR_STANDARD_DEVIATION_TYPES = None
+    DEFINED_FOR_STANDARD_DEVIATION_TYPES = {const.StdDev.TOTAL}
     REQUIRES_SITES_PARAMETERS = None
     REQUIRES_RUPTURE_PARAMETERS = None
     REQUIRES_DISTANCES = None


### PR DESCRIPTION
In this way the user will get an error at import time if she forgets to define it.