### PR TITLE
Hide but do not delete removed calcs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Daniele Viganò]
+  * Deleted calculations are not removed from the database anymore
   * Removed the 'oq dbserver restart' command since it was broken
 
   [Richard Styron]

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -70,8 +70,8 @@ def set_status(db, job_id, status):
     """
     assert status in (
         'created', 'submitted', 'executing', 'complete', 'aborted', 'failed'
-    ), status
-    if status in ('created', 'complete', 'failed', 'aborted'):
+        'deleted'), status
+    if status in ('created', 'complete', 'failed', 'aborted', 'deleted'):
         is_running = 0
     else:  # 'executing'
         is_running = 1
@@ -127,7 +127,8 @@ def delete_uncompleted_calculations(db, user):
     :param db: a :class:`openquake.server.dbapi.Db` instance
     :param user: user name
     """
-    db("DELETE FROM job WHERE user_name=?x AND status != 'complete'", user)
+    db("UPDATE job SET status = 'deleted'"
+       " WHERE user_name=?x AND status != 'complete'", user)
 
 
 def get_job(db, job_id, username=None):
@@ -153,10 +154,12 @@ def get_job(db, job_id, username=None):
 
     # else negative job_id
     if username:
-        joblist = db('SELECT * FROM job WHERE user_name=?x '
-                     'ORDER BY id DESC LIMIT ?x', username, -job_id)
+        joblist = db('SELECT * FROM job WHERE user_name=?x'
+                     " AND status != 'deleted' ORDER BY id DESC LIMIT ?x",
+                     username, -job_id)
     else:
-        joblist = db('SELECT * FROM job ORDER BY id DESC LIMIT ?x', -job_id)
+        joblist = db("SELECT * FROM job WHERE status != 'deleted'"
+                     ' ORDER BY id DESC LIMIT ?x', -job_id)
     if not joblist:  # no jobs
         return
     else:
@@ -192,8 +195,8 @@ def list_calculations(db, job_type, user_name):
     :param user_name: an user name
     """
     jobs = db('SELECT *, %s FROM job WHERE user_name=?x '
-              'AND job_type=?x ORDER BY start_time' % JOB_TYPE,
-              user_name, job_type)
+              "AND job_type=?x AND status != 'deleted' ORDER BY start_time"
+              % JOB_TYPE, user_name, job_type)
     out = []
     if len(jobs) == 0:
         out.append('None')
@@ -350,8 +353,8 @@ def del_calc(db, job_id, user, force=False):
         return {"error": 'Cannot delete calculation %d:'
                 ' ID does not exist' % job_id}
 
-    deleted = db('DELETE FROM job WHERE id=?x AND user_name=?x',
-                 job_id, user).rowcount
+    deleted = db('UPDATE job SET status=?x WHERE id=?x AND user_name=?x',
+                 'deleted', job_id, user).rowcount
     if not deleted:
         return {"error": 'Cannot delete calculation %d: it belongs to '
                 '%s and you are %s' % (job_id, owner, user)}
@@ -561,7 +564,7 @@ def get_calcs(db, request_get_dict, allowed_users, user_acl_on=False, id=None):
         users_filter = 1
 
     jobs = db('SELECT * FROM job WHERE ?A AND %s AND %s'
-              ' ORDER BY id DESC LIMIT %d'
+              " AND status != 'deleted' ORDER BY id DESC LIMIT %d"
               % (users_filter, time_filter, limit), filterdict, allowed_users)
     return [(job.id, job.user_name, job.status, job.calculation_mode,
              job.is_running, job.description, job.pid,

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -543,10 +543,6 @@ def get_calcs(db, request_get_dict, allowed_users, user_acl_on=False, id=None):
         is_running = request_get_dict.get('is_running')
         filterdict['is_running'] = valid.boolean(is_running)
 
-    if 'relevant' in request_get_dict:
-        relevant = request_get_dict.get('relevant')
-        filterdict['relevant'] = valid.boolean(relevant)
-
     if 'limit' in request_get_dict:
         limit = int(request_get_dict.get('limit'))
     else:

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -127,8 +127,8 @@ def delete_uncompleted_calculations(db, user):
     :param db: a :class:`openquake.server.dbapi.Db` instance
     :param user: user name
     """
-    db("UPDATE job SET status = 'deleted'"
-       " WHERE user_name=?x AND status != 'complete'", user)
+    db("UPDATE job SET status = 'deleted' "
+       "WHERE user_name=?x AND status != 'complete'", user)
 
 
 def get_job(db, job_id, username=None):
@@ -154,12 +154,12 @@ def get_job(db, job_id, username=None):
 
     # else negative job_id
     if username:
-        joblist = db('SELECT * FROM job WHERE user_name=?x'
-                     " AND status != 'deleted' ORDER BY id DESC LIMIT ?x",
+        joblist = db('SELECT * FROM job WHERE user_name=?x '
+                     "AND status != 'deleted' ORDER BY id DESC LIMIT ?x",
                      username, -job_id)
     else:
-        joblist = db("SELECT * FROM job WHERE status != 'deleted'"
-                     ' ORDER BY id DESC LIMIT ?x', -job_id)
+        joblist = db("SELECT * FROM job WHERE status != 'deleted' "
+                     'ORDER BY id DESC LIMIT ?x', -job_id)
     if not joblist:  # no jobs
         return
     else:
@@ -353,8 +353,8 @@ def del_calc(db, job_id, user, force=False):
         return {"error": 'Cannot delete calculation %d:'
                 ' ID does not exist' % job_id}
 
-    deleted = db('UPDATE job SET status=?x WHERE id=?x AND user_name=?x',
-                 'deleted', job_id, user).rowcount
+    deleted = db("UPDATE job SET status='deleted' WHERE id=?x AND user_name=?x",
+                 job_id, user).rowcount
     if not deleted:
         return {"error": 'Cannot delete calculation %d: it belongs to '
                 '%s and you are %s' % (job_id, owner, user)}
@@ -559,8 +559,8 @@ def get_calcs(db, request_get_dict, allowed_users, user_acl_on=False, id=None):
     else:
         users_filter = 1
 
-    jobs = db('SELECT * FROM job WHERE ?A AND %s AND %s'
-              " AND status != 'deleted' ORDER BY id DESC LIMIT %d"
+    jobs = db('SELECT * FROM job WHERE ?A AND %s AND %s '
+              "AND status != 'deleted' ORDER BY id DESC LIMIT %d"
               % (users_filter, time_filter, limit), filterdict, allowed_users)
     return [(job.id, job.user_name, job.status, job.calculation_mode,
              job.is_running, job.description, job.pid,

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -418,7 +418,7 @@
     var Calculations = Backbone.Collection.extend(
         {
             model: Calculation,
-            url: gem_oq_server_url + "/v1/calc/list?relevant=true"
+            url: gem_oq_server_url + "/v1/calc/list"
         });
     var calculations = new Calculations();
 

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -45,6 +45,7 @@
       </thead>
       <tbody>
         <% _.each(calculations, function(calc) { %>
+        <% if (calc.get('status') == 'deleted') { return 0; } %>
         <tr class="<%= (calc.get('status') == 'created' || calc.get('is_running') == true) ? 'warning' : (calc.get('status') == 'complete' ? 'success' : 'error') %>">
           <td><%= calc.get('id') || 'New' %></td>
           <td><%= calc.get('owner') %></td>

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -250,8 +250,8 @@ class EngineServerTestCase(unittest.TestCase):
             sys.stderr.write('Empty traceback, please check!\n')
 
         self.post('%s/remove' % job_id)
-        # make sure job_id is no more in the list of relevant jobs
-        job_ids = [job['id'] for job in self.get('list', relevant=True)]
+        # make sure job_id is no more in the list of jobs
+        job_ids = [job['id'] for job in self.get('list')]
         self.assertFalse(job_id in job_ids)
 
     def test_err_2(self):


### PR DESCRIPTION
Instead of removing calculation from the DB we are marking it as 'deleted' and those are filtered out in outputs.

I also removed the unused `relevant` field. I left it into the DB since `drop column` is not supported by SQLite and the table needs to be recreated, which may be inconvenient for large databases. 