### PR TITLE
Changed `oq show task` to display the number of effective ruptures per task

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -129,14 +129,15 @@ class ClassicalCalculator(base.HazardCalculator):
         :param dic: dict with keys pmap, calc_times, rup_data
         """
         with self.monitor('aggregate curves', autoflush=True):
-            self.calc_times += dic['calc_times']
-            srcids = U32(sorted(dic['calc_times']))
-            self.sources_by_task[dic['task_no']] = srcids
+            d = dic['calc_times']  # srcid -> eff_rups, eff_sites, dt
+            self.calc_times += d
+            srcids = U32(sorted(d))
+            eff_rups = sum(d[srcid][0] for srcid in d)
+            self.sources_by_task[dic['task_no']] = (eff_rups, srcids)
             for grp_id, pmap in dic['pmap'].items():
                 if pmap:
                     acc[grp_id] |= pmap
-                for src_id, (nr, ns, dt) in dic['calc_times'].items():
-                    acc.eff_ruptures[grp_id] += nr
+                acc.eff_ruptures[grp_id] += eff_rups
 
             rup_data = dic['rup_data']
             if len(rup_data['grp_id']):
@@ -204,9 +205,12 @@ class ClassicalCalculator(base.HazardCalculator):
                 self.store_source_info(self.calc_times)
             if self.sources_by_task:
                 num_tasks = max(self.sources_by_task) + 1
-                sbt = numpy.zeros(num_tasks, hdf5.vuint32)
+                sbt = numpy.zeros(
+                    num_tasks, [('eff_ruptures', U32),
+                                ('srcids', hdf5.vuint32)])
                 for task_no in range(num_tasks):
-                    sbt[task_no] = self.sources_by_task.get(task_no, U32([]))
+                    sbt[task_no] = self.sources_by_task.get(
+                        task_no, (0, U32([])))
                 self.datastore['sources_by_task'] = sbt
                 self.sources_by_task.clear()
         if not self.calc_times:

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -619,14 +619,13 @@ def view_task_hazard(token, dstore):
     data.sort(order='duration')
     rec = data[int(index)]
     taskno = rec['taskno']
-    srcids = dstore['sources_by_task'][taskno]
+    eff_ruptures, srcids = dstore['sources_by_task'][taskno]
     arr = dstore['source_info'][
         'source_id', 'num_sites', 'eff_ruptures'][srcids]
-    st = [stats('nsites', arr['num_sites'] / arr['eff_ruptures']),
-          stats('eff_ruptures', arr['eff_ruptures'])]
+    st = [stats('nsites', arr['num_sites'] / arr['eff_ruptures'])]
     srcs = arr['source_id']
-    res = ('\ntaskno=%d, duration=%d s, sources="%s"'
-           % (taskno, rec['duration'], ' '.join(srcs)))
+    res = '\ntaskno=%d, eff_ruptures=%d, duration=%d s, sources="%s"' % (
+        taskno, eff_ruptures, rec['duration'], ' '.join(srcs))
     return rst_table(st, header='variable mean stddev min max n'.split()) + res
 
 


### PR DESCRIPTION
Useful for investigating slow tasks.