### PR TITLE
Improved the source weight

### DIFF
--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -56,7 +56,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         """
         if not self.num_ruptures:
             self.num_ruptures = self.count_ruptures()
-        return self.num_ruptures
+        return self.num_ruptures * self.nsites
 
     @property
     def nsites(self):


### PR DESCRIPTION
Here are the numbers for a reduced SHARE calculation with task_duration=120s:
```
michele@wilson:~$ oq1 show task_info 26761  # before 1,097 s
====================== ======= ======= ======= ======= =======
operation-duration     mean    stddev  min     max     outputs
classical              113     19      10      272     1,533  
classical_split_filter 34      39      0.45395 280     960    

michele@wilson:~$ oq1 show task_info 26760  # after 1,036 s
====================== ======= ======= ======= ======= =======
operation-duration     mean    stddev  min     max     outputs
classical              112     16      33      215     1,553  
classical_split_filter 33      38      0.40327 276     960   
```