### PR TITLE
Not computing distances twice when storing rup_data

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -112,7 +112,7 @@ class RupData(object):
                 self.add(rup, src.id, sites)
         return {k: numpy.array(v) for k, v in self.data.items()}
 
-    def add(self, rup, src_id, sites):
+    def add(self, rup, src_id, sctx, dctx):
         rate = rup.occurrence_rate
         if numpy.isnan(rate):  # for nonparametric ruptures
             probs_occur = rup.probs_occur
@@ -125,11 +125,11 @@ class RupData(object):
         for rup_param in self.cmaker.REQUIRES_RUPTURE_PARAMETERS:
             self.data[rup_param].append(getattr(rup, rup_param))
 
-        self.data['sid_'].append(numpy.int16(sites.sids))
+        self.data['sid_'].append(numpy.int16(sctx.sids))
         for dst_param in self.cmaker.REQUIRES_DISTANCES:
             self.data[dst_param + '_'].append(
-                F32(get_distances(rup, sites, dst_param)))
-        closest = rup.surface.get_closest_points(sites)
+                F32(getattr(dctx, dst_param)))
+        closest = rup.surface.get_closest_points(sctx)
         self.data['lon_'].append(F32(closest.lons))
         self.data['lat_'].append(F32(closest.lats))
 
@@ -302,7 +302,7 @@ class ContextMaker(object):
             nrups += 1
             nsites += len(sctx)
             if fewsites:  # store rupdata
-                rupdata.add(rup, src.id, sctx)
+                rupdata.add(rup, src.id, sctx, dctx)
         poemap.nrups = nrups
         poemap.nsites = nsites
         poemap.data = rupdata.data

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -128,10 +128,10 @@ class RupData(object):
         self.data['sid_'].append(numpy.int16(sctx.sids))
         for dst_param in self.cmaker.REQUIRES_DISTANCES:
             if dctx is None:  # compute the distances
-                dist = get_distances(rup, sctx, dst_param)
+                dists = get_distances(rup, sctx, dst_param)
             else:  # reuse already computed distances
-                dist = getattr(dctx, dst_param)
-            self.data[dst_param + '_'].append(F32(dist))
+                dists = getattr(dctx, dst_param)
+            self.data[dst_param + '_'].append(F32(dists))
         closest = rup.surface.get_closest_points(sctx)
         self.data['lon_'].append(F32(closest.lons))
         self.data['lat_'].append(F32(closest.lats))

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -112,7 +112,7 @@ class RupData(object):
                 self.add(rup, src.id, sites)
         return {k: numpy.array(v) for k, v in self.data.items()}
 
-    def add(self, rup, src_id, sctx, dctx):
+    def add(self, rup, src_id, sctx, dctx=None):
         rate = rup.occurrence_rate
         if numpy.isnan(rate):  # for nonparametric ruptures
             probs_occur = rup.probs_occur
@@ -127,8 +127,11 @@ class RupData(object):
 
         self.data['sid_'].append(numpy.int16(sctx.sids))
         for dst_param in self.cmaker.REQUIRES_DISTANCES:
-            self.data[dst_param + '_'].append(
-                F32(getattr(dctx, dst_param)))
+            if dctx is None:  # compute the distances
+                dist = get_distances(rup, sctx, dst_param)
+            else:  # reuse already computed distances
+                dist = getattr(dctx, dst_param)
+            self.data[dst_param + '_'].append(F32(dist))
         closest = rup.surface.get_closest_points(sctx)
         self.data['lon_'].append(F32(closest.lons))
         self.data['lat_'].append(F32(closest.lats))


### PR DESCRIPTION
This has a minor impact, but it is still an improvement.