### PR TITLE
Fixed the TOML representation of areaSource and multiPointSource coordinates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ jobs:
     env: HAZARDLIB
     script:
         - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
-          pytest --doctest-modules -xv openquake/baselib openquake/hazardlib openquake/hmtk --tb=short;
+          pytest --doctest-modules -xv openquake/baselib --tb=short;
+          OQ_DISTRIBUTE=no pytest --doctest-modules -xv -nauto openquake/hazardlib openquake/hmtk --tb=short;
           fi
   - stage: tests
     env: ENGINE
@@ -69,6 +70,7 @@ install:
       pip download -r requirements-py36-linux64.txt -r requirements-extra-py36-linux64.txt -d wheels &&
       pip -q install wheels/* ;
     fi
+  - pip install pytest-xdist
   - pip -q install -e .
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ jobs:
     env: HAZARDLIB
     script:
         - if echo "$TRAVIS_COMMIT_MESSAGE" | grep -vq '\[skip hazardlib\]' || test "$BRANCH" == "master"; then
-          pytest --doctest-modules -xv openquake/baselib --tb=short;
-          pytest --doctest-modules -xv openquake/hazardlib/tests/calc -k Parallel --tb=short;
-          pytest --doctest-modules -n auto -xv openquake/hazardlib openquake/hmtk -k "not Parallel" --tb=short;
+          pytest --doctest-modules -xv openquake/baselib openquake/hazardlib openquake/hmtk --tb=short;
           fi
   - stage: tests
     env: ENGINE
@@ -71,7 +69,6 @@ install:
       pip download -r requirements-py36-linux64.txt -r requirements-extra-py36-linux64.txt -d wheels &&
       pip -q install wheels/* ;
     fi
-  - pip install pytest-xdist
   - pip -q install -e .
 
 before_script:

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -44,8 +44,9 @@ def build_area_source_geometry(area_source):
         Instance of :class:`openquake.baselib.node.Node`
     """
     geom = []
-    for lon_lat in zip(area_source.polygon.lons, area_source.polygon.lats):
-        geom.extend(lon_lat)
+    for lon, lat in zip(area_source.polygon.lons, area_source.polygon.lats):
+        # NB: converting numpy.float64 -> float is good for TOML
+        geom.extend((float(lon), float(lat)))
     poslist_node = Node("gml:posList", text=geom)
     linear_ring_node = Node("gml:LinearRing", nodes=[poslist_node])
     exterior_node = Node("gml:exterior", nodes=[linear_ring_node])
@@ -483,8 +484,9 @@ def build_multi_point_source_node(multi_point_source):
     # parse geometry
     pos = []
     for p in multi_point_source.mesh:
-        pos.append(p.x)
-        pos.append(p.y)
+        # converting numpy.float64 -> float is good for TOML
+        pos.append(float(p.x))
+        pos.append(float(p.y))
     mesh_node = Node('gml:posList', text=pos)
     upper_depth_node = Node(
         "upperSeismoDepth", text=multi_point_source.upper_seismogenic_depth)
@@ -494,8 +496,8 @@ def build_multi_point_source_node(multi_point_source):
         "multiPointGeometry",
         nodes=[mesh_node, upper_depth_node, lower_depth_node])]
     # parse common distributed attributes
-    source_nodes.extend(get_distributed_seismicity_source_nodes(
-        multi_point_source))
+    source_nodes.extend(
+        get_distributed_seismicity_source_nodes(multi_point_source))
     return Node("multiPointSource",
                 get_source_attributes(multi_point_source),
                 nodes=source_nodes)

--- a/openquake/hazardlib/tests/expected_sources.toml
+++ b/openquake/hazardlib/tests/expected_sources.toml
@@ -108,7 +108,7 @@ _depth = 8.0
 _probability = 0.5
 
 [areaSource.areaGeometry."gml:Polygon"."gml:exterior"."gml:LinearRing"]
-"gml:posList" = [ "-122.5", "37.5", "-121.5", "37.5", "-121.5", "38.5", "-122.5", "38.5",]
+"gml:posList" = [ -122.5, 37.5, -121.5, 37.5, -121.5, 38.5, -122.5, 38.5,]
 [simpleFaultSource]
 _id = "3"
 _name = "Mount Diablo Thrust"
@@ -292,7 +292,7 @@ magScaleRel = "PeerMSR"
 ruptAspectRatio = 1.0
 
 [multiPointSource.multiPointGeometry]
-"gml:posList" = [ "0.0", "1.0", "0.5", "1.0",]
+"gml:posList" = [ 0.0, 1.0, 0.5, 1.0,]
 upperSeismoDepth = 10.0
 lowerSeismoDepth = 20.0
 
@@ -328,7 +328,7 @@ magScaleRel = "PeerMSR"
 ruptAspectRatio = 1.0
 
 [multiPointSource.multiPointGeometry]
-"gml:posList" = [ "0.1", "1.1",]
+"gml:posList" = [ 0.1000000014901161, 1.100000023841858,]
 upperSeismoDepth = 5.0
 lowerSeismoDepth = 10.0
 

--- a/openquake/hazardlib/tests/expected_sources.toml
+++ b/openquake/hazardlib/tests/expected_sources.toml
@@ -328,7 +328,7 @@ magScaleRel = "PeerMSR"
 ruptAspectRatio = 1.0
 
 [multiPointSource.multiPointGeometry]
-"gml:posList" = [ 1.0, 2.0,]
+"gml:posList" = [ 0.1000000014901161, 1.100000023841858,]
 upperSeismoDepth = 5.0
 lowerSeismoDepth = 10.0
 

--- a/openquake/hazardlib/tests/expected_sources.toml
+++ b/openquake/hazardlib/tests/expected_sources.toml
@@ -328,7 +328,7 @@ magScaleRel = "PeerMSR"
 ruptAspectRatio = 1.0
 
 [multiPointSource.multiPointGeometry]
-"gml:posList" = [ 0.1000000014901161, 1.100000023841858,]
+"gml:posList" = [ 1.0, 2.0,]
 upperSeismoDepth = 5.0
 lowerSeismoDepth = 10.0
 

--- a/openquake/hazardlib/tests/source_model/multi-point-source.xml
+++ b/openquake/hazardlib/tests/source_model/multi-point-source.xml
@@ -66,7 +66,7 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <multiPointGeometry>
                     <gml:posList>
-                        0.1 1.1
+                        0.10000000149011612 1.100000023841858
                     </gml:posList>
                     <upperSeismoDepth>
                         5.0

--- a/openquake/hazardlib/tests/source_model/multi-point-source.xml
+++ b/openquake/hazardlib/tests/source_model/multi-point-source.xml
@@ -66,7 +66,7 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <multiPointGeometry>
                     <gml:posList>
-                        1.0 2.0
+                        0.10000000149011612 1.100000023841858
                     </gml:posList>
                     <upperSeismoDepth>
                         5.0

--- a/openquake/hazardlib/tests/source_model/multi-point-source.xml
+++ b/openquake/hazardlib/tests/source_model/multi-point-source.xml
@@ -66,7 +66,7 @@ xmlns:gml="http://www.opengis.net/gml"
             >
                 <multiPointGeometry>
                     <gml:posList>
-                        0.10000000149011612 1.100000023841858
+                        1.0 2.0
                     </gml:posList>
                     <upperSeismoDepth>
                         5.0


### PR DESCRIPTION
There were annoying quotes, because TOML does not understand numpy.float64 numbers.