### PR TITLE
Remove a duplicate output display name

### DIFF
--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -263,7 +263,6 @@ DISPLAY_NAME = {
     'events': 'Events',
     'damages-rlzs': 'Asset Damage Distribution',
     'damages-stats': 'Asset Damage Statistics',
-    'dmg_by_event': 'Aggregate Event Damages',
     'avg_losses': 'Average Asset Losses',
     'avg_losses-rlzs': 'Average Asset Losses',
     'avg_losses-stats': 'Average Asset Losses Statistics',


### PR DESCRIPTION
`dmg_by_event` was repeated in the dict of display names; remove the second appearance.