### PR TITLE
Fix bug in NGA East GMPE Instantiation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Graeme Weatherill]
+  * Fixed bug in NGA East instantiation and added test
+  
   [Michele Simionato]
   * In the agglosses output of scenario_risk the losses were incorrectly
     multiplied by the realization weight

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -465,6 +465,7 @@ class NGAEastBaseGMPE(GMPETable):
         self.phi_s2ss_quantile = phi_s2ss_quantile
         self._setup_standard_deviations(fle=None)
         super().__init__(gmpe_table=gmpe_table)
+        super().init()
 
     def _setup_standard_deviations(self, fle):
         # setup tau


### PR DESCRIPTION
Fixes a potential issue in the use of the NGA East GMPEs raised here: https://github.com/gem/oq-engine/issues/4979

When instantiating the NGA East GMPEs in an environment like ipython/Jupyter the data normally read from the hdf5 files were not being parsed, as such the GMPE would not be defined for any IMTs, REQUIRES_DISTANCES would be empty etc.). This is because the instantiation was only calling `.__init__()` from the superclass and not the more recently added `.init()`. This was not being found in in the tests because they call `.init()` automatically. A test case PSHA calculation using the NGA East GMPEs was working correctly without the fix, so this would seem to only affect openquake.hazardlib usage w/o the main engine. A test has been added to ensure that all arguments are parsed from the hdf5 at instantiation.