### PR TITLE
Added command `oq workers inspect`

### DIFF
--- a/openquake/commands/workers.py
+++ b/openquake/commands/workers.py
@@ -33,4 +33,5 @@ def workers(cmd):
     print(getattr(master, cmd)())
 
 
-workers.arg('cmd', 'command', choices='start stop status restart'.split())
+workers.arg('cmd', 'command',
+            choices='start stop status restart inspect'.split())


### PR DESCRIPTION
In this way it is possible to see the number of tasks which are executing at a given time. This is useful to inspect jobs that appear to be stuck. I am merging this because I want to try it on wilson.