### PR TITLE
Disable OpenBLAS threads to avoid oversubscription

### DIFF
--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -22,6 +22,7 @@ import configparser
 from unittest.mock import patch
 with patch.dict(os.environ, OPENBLAS_NUM_THREADS='1'):
     # disable OpenBLAS threads before the first numpy import
+    # see https://github.com/numpy/numpy/issues/11826
     from openquake.baselib.general import git_suffix
 
 # the version is managed by packager.sh with a sed

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -19,7 +19,10 @@
 import os
 import sys
 import configparser
-from openquake.baselib.general import git_suffix
+from unittest.mock import patch
+with patch.dict(os.environ, OPENBLAS_NUM_THREADS='1'):
+    # before the first numpy import
+    from openquake.baselib.general import git_suffix
 
 # the version is managed by packager.sh with a sed
 __version__ = '3.7.0'

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -21,7 +21,7 @@ import sys
 import configparser
 from unittest.mock import patch
 with patch.dict(os.environ, OPENBLAS_NUM_THREADS='1'):
-    # before the first numpy import
+    # disable OpenBLAS threads before the first numpy import
     from openquake.baselib.general import git_suffix
 
 # the version is managed by packager.sh with a sed

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -35,7 +35,6 @@ import importlib
 import itertools
 import subprocess
 from collections.abc import Mapping, Container, MutableSequence
-
 import numpy
 from decorator import decorator
 from openquake.baselib.python3compat import decode


### PR DESCRIPTION
This works for the engine, we do not need https://github.com/joblib/threadpoolctl which would be the general (but new and untested) solution.

Notice that users importing openquake as a library will get their OpenBLAS automagically disabled, without warning, so the approach here is suboptimal, but we will live with that. The alternative would be to set the environment variable before starting celery/zmq/multiprocessing/... but it is more work that it is probably not worth doing.