### PR TITLE
Stopping the DbServer must stop the zworkers

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -329,10 +329,9 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
             del data  # save memory
 
         poll_queue(job_id, _PID, poll_time=15)
-        if OQ_DISTRIBUTE == 'zmq':  # start zworkers
-            master = w.WorkerMaster(config.dbserver.listen, **config.zworkers)
-            logs.dbcmd('start_zworkers', master)
-            logging.info('WorkerPool %s',  master.wait_pools(seconds=30))
+        if OQ_DISTRIBUTE == 'zmq':
+            logs.dbcmd('zmq_start')  # start zworkers
+            logs.dbcmd('zmq_wait')  # wait for them to go up
         if OQ_DISTRIBUTE.startswith(('celery', 'zmq')):
             set_concurrent_tasks_default(job_id)
         t0 = time.time()
@@ -365,7 +364,7 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         # in such a situation, we simply log the cleanup error without
         # taking further action, so that the real error can propagate
         if OQ_DISTRIBUTE == 'zmq':  # stop zworkers
-            logs.dbcmd('stop_zworkers', master)
+            logs.dbcmd('zmq_stop')
         try:
             if OQ_DISTRIBUTE.startswith('celery'):
                 celery_cleanup(TERMINATE)

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -793,17 +793,3 @@ def get_job_from_checksum(db, checksum):
     if not jobs:
         return
     return jobs[0]
-
-
-def start_zworkers(db, master):
-    """
-    Start the zmq workers
-    """
-    master.start()
-
-
-def stop_zworkers(db, master):
-    """
-    Stop the zmq workers
-    """
-    master.stop()

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -117,6 +117,7 @@ class DbServer(object):
     def stop(self):
         """Stop the DbServer and the zworkers if any"""
         if ZMQ:
+            self.zmaster.stop()
             z.context.term()
         self.db.close()
 

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -57,6 +57,10 @@ class DbServer(object):
         self.backend = 'inproc://dbworkers'
         self.num_workers = num_workers
         self.pid = os.getpid()
+        if ZMQ:
+            self.zmaster = w.WorkerMaster(address[0], **config.zworkers)
+        else:
+            self.zmaster = None
 
     def dworker(self, sock):
         # a database worker responding to commands
@@ -65,6 +69,9 @@ class DbServer(object):
                 cmd, args = cmd_[0], cmd_[1:]
                 if cmd == 'getpid':
                     sock.send(self.pid)
+                    continue
+                elif cmd.startswith('zmq_') and self.zmaster:
+                    sock.send(getattr(self.zmaster, cmd[4:])())
                     continue
                 try:
                     func = getattr(actions, cmd)


### PR DESCRIPTION
This could also solve the problem with zmq zombies, since now `popen.terminate()` is called explicitly at the end of each calculation.