### PR TITLE
Changed the event IDs management

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -247,7 +247,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         if len(elt):
             elt['event_id'] = self.event_ids[elt['event_id']]
             with self.monitor('saving losses_by_event', autoflush=True):
-                self.datastore.extend('losses_by_event', dic['elt'])
+                self.datastore.extend('losses_by_event', elt)
         with self.monitor('saving agg_losses-rlzs', autoflush=True):
             for r, aggloss in dic['agg_losses'].items():
                 self.datastore['agg_losses-rlzs'][:, r] += aggloss

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -58,9 +58,6 @@ def _calc(gmfgetter, assets_by_site, param,
     tagnames = param['aggregate_by']
     e0 = gmfgetter.rupgetter.e0[0]
     events = gmfgetter.rupgetter.get_eid_rlz()
-    # numpy.testing.assert_equal(events['eid'], sorted(events['eid']))
-    eid2idx = dict(zip(events['eid'],
-                       range(e0, e0 + gmfgetter.rupgetter.num_events)))
     eid2rlz = dict(events)
     with mon_haz:
         hazard = gmfgetter.get_hazard_by_sid()  # sid -> (sid, eid, gmv)
@@ -75,8 +72,7 @@ def _calc(gmfgetter, assets_by_site, param,
         if param['avg_losses']:
             ws = gmfgetter.weights[[eid2rlz[eid] for eid in haz['eid']]]
         assets_by_taxo = get_assets_by_taxo(assets_on_sid, epspath)
-        eidx = numpy.array([eid2idx[eid] for eid in haz['eid']]) - e0
-        haz['eid'] = eidx + e0
+        eidx = haz['eid'] - e0
         with mon_risk:
             out = get_output(crmodel, assets_by_taxo, haz)
         with mon_agg:
@@ -141,6 +137,8 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
     res = {'elt': elt, 'agg_losses': agg, 'times': times,
            'events_per_sid': num_events_per_sid, 'gmf_nbytes': gmf_nbytes}
     res['losses_by_A'] = param['lba'].losses_by_A
+    # NB: without resetting the cache the sequential avg_losses would be wrong!
+    del param['lba'].__dict__['losses_by_A']
     if param['asset_loss_table']:
         res['alt_eidx'] = alt, rupgetter.e0[0] + numpy.arange(E)
     return res
@@ -234,6 +232,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                      ngroups, len(rlzs_by_gsim_grp))
         self.events_per_sid = []
         self.gmf_nbytes = 0
+        self.event_ids = self.datastore['events']['id']
         res = smap.reduce(self.agg_dicts, numpy.zeros(self.N))
         logging.info('Produced %s of GMFs', general.humansize(self.gmf_nbytes))
         return res
@@ -244,7 +243,9 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         :param dics: dictionaries with keys eids, losses, losses_by_N
         """
         self.oqparam.ground_motion_fields = False  # hack
-        if len(dic['elt']):
+        elt = dic['elt']
+        if len(elt):
+            elt['event_id'] = self.event_ids[elt['event_id']]
             with self.monitor('saving losses_by_event', autoflush=True):
                 self.datastore.extend('losses_by_event', dic['elt'])
         with self.monitor('saving agg_losses-rlzs', autoflush=True):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -412,7 +412,7 @@ class GmfGetter(object):
 def group_by_rlz(data, rlzs):
     """
     :param data: a composite array of D elements with a field `eid`
-    :param eid2rlz: an array of E >= D elements
+    :param rlzs: an array of E >= D elements
     :returns: a dictionary rlzi -> data for each realization
     """
     acc = general.AccumDict(accum=[])

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -32,6 +32,7 @@ U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
 U64 = numpy.uint64
+TWO32 = U64(2 ** 32)
 by_taxonomy = operator.attrgetter('taxonomy')
 code2cls = BaseRupture.init()
 
@@ -363,9 +364,9 @@ class GmfGetter(object):
             data = self.get_gmfdata()
         return general.group_array(data, 'sid')
 
-    def compute_gmfs_curves(self, monitor):
+    def compute_gmfs_curves(self, rlzs, monitor):
         """
-        :param eid2rlz: a dictionary event_id -> rlz_id
+        :param rlzs: an array of shapeE
         :returns: a dict with keys gmfdata, indices, hcurves
         """
         oq = self.oqparam
@@ -375,11 +376,10 @@ class GmfGetter(object):
         if oq.hazard_curves_from_gmfs:
             hc_mon = monitor('building hazard curves', measuremem=False)
             with monitor('building hazard', measuremem=True):
-                eid2rlz = dict(self.rupgetter.get_eid_rlz())
                 gmfdata = self.get_gmfdata()  # returned later
                 hazard = self.get_hazard_by_sid(data=gmfdata)
             for sid, hazardr in hazard.items():
-                dic = group_by_rlz(hazardr, eid2rlz)
+                dic = group_by_rlz(hazardr, rlzs)
                 for rlzi, array in dic.items():
                     with hc_mon:
                         gmvs = array['gmv']
@@ -409,15 +409,15 @@ class GmfGetter(object):
         return res
 
 
-def group_by_rlz(data, eid2rlz):
+def group_by_rlz(data, rlzs):
     """
     :param data: a composite array of D elements with a field `eid`
-    :param eid2rlz: an array of E >= D elements or a dictionary
+    :param eid2rlz: an array of E >= D elements
     :returns: a dictionary rlzi -> data for each realization
     """
     acc = general.AccumDict(accum=[])
     for rec in data:
-        acc[eid2rlz[rec['eid']]].append(rec)
+        acc[rlzs[rec['eid']]].append(rec)
     return {rlzi: numpy.array(recs) for rlzi, recs in acc.items()}
 
 
@@ -426,6 +426,10 @@ def gen_rupture_getters(dstore, slc=slice(None),
     """
     :yields: RuptureGetters
     """
+    try:
+        e0s = dstore['eslices'][:, 0]
+    except KeyError:
+        e0s = None
     if dstore.parent:
         dstore = dstore.parent
     csm_info = dstore['csm_info']
@@ -441,9 +445,13 @@ def gen_rupture_getters(dstore, slc=slice(None),
             # in event_based_risk/case_3
             continue
         for block in general.block_splitter(arr, maxweight):
+            if e0s is None:
+                e0 = [TWO32 * U64(rec['serial']) for rec in block]
+            else:
+                e0 = e0s[nr: nr + len(block)]
             rgetter = RuptureGetter(
                 hdf5cache or dstore.filename, numpy.array(block), grp_id,
-                trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim[grp_id])
+                trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim[grp_id], e0)
             yield rgetter
             nr += len(block)
             ne += rgetter.num_events
@@ -551,9 +559,10 @@ class RuptureGetter(object):
         for rup in self.rup_array:
             ebr = EBRupture(mock.Mock(serial=rup['serial']), rup['srcidx'],
                             self.grp_id, rup['n_occ'], self.samples)
+            e0 = TWO32 * U64(ebr.serial)
             for rlz, eids in ebr.get_eids_by_rlz(self.rlzs_by_gsim).items():
                 for eid in eids:
-                    eid_rlz.append((eid, rlz))
+                    eid_rlz.append((eid + e0, rlz))
         return numpy.array(eid_rlz, [('eid', U64), ('rlz', U16)])
 
     def get_rupdict(self):
@@ -642,7 +651,9 @@ class RuptureGetter(object):
                                 rec['n_occ'], self.samples)
                 # not implemented: rupture_slip_direction
                 ebr.sids = sids
-                if self.e0 is not None:
+                if self.e0 is None:
+                    ebr.e0 = TWO32 * U64(ebr.serial)
+                else:
                     ebr.e0 = self.e0[i]
                 ebrs.append(ebr)
         return ebrs

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -556,10 +556,9 @@ class RuptureGetter(object):
         :returns: a composite array with the associations eid->rlz
         """
         eid_rlz = []
-        for rup in self.rup_array:
+        for e0, rup in zip(self.e0, self.rup_array):
             ebr = EBRupture(mock.Mock(serial=rup['serial']), rup['srcidx'],
                             self.grp_id, rup['n_occ'], self.samples)
-            e0 = TWO32 * U64(ebr.serial)
             for rlz, eids in ebr.get_eids_by_rlz(self.rlzs_by_gsim).items():
                 for eid in eids:
                     eid_rlz.append((eid + e0, rlz))

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -63,9 +63,10 @@ class ScenarioCalculator(base.HazardCalculator):
         E = oq.number_of_ground_motion_fields
         n_occ = numpy.array([E])
         ebr = EBRupture(self.rup, 0, 0, n_occ)
+        ebr.e0 = TWO32 * U64(ebr.serial)
         events = numpy.zeros(E * R, events_dt)
         for rlz, eids in ebr.get_eids_by_rlz(rlzs_by_gsim).items():
-            events[rlz * E: rlz * E + E]['id'] = eids + TWO32 * U64(ebr.serial)
+            events[rlz * E: rlz * E + E]['id'] = eids + ebr.e0
             events[rlz * E: rlz * E + E]['rlz'] = rlz
         self.datastore['events'] = self.events = events
         rupser = calc.RuptureSerializer(self.datastore)

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -25,6 +25,9 @@ from openquake.hazardlib.source.rupture import EBRupture, events_dt
 from openquake.commonlib import readinput, source, calc
 from openquake.calculators import base
 
+TWO32 = 2 ** 32
+U64 = numpy.uint64
+
 
 @base.calculators.add('scenario')
 class ScenarioCalculator(base.HazardCalculator):
@@ -62,7 +65,7 @@ class ScenarioCalculator(base.HazardCalculator):
         ebr = EBRupture(self.rup, 0, 0, n_occ)
         events = numpy.zeros(E * R, events_dt)
         for rlz, eids in ebr.get_eids_by_rlz(rlzs_by_gsim).items():
-            events[rlz * E: rlz * E + E]['id'] = eids
+            events[rlz * E: rlz * E + E]['id'] = eids + TWO32 * U64(ebr.serial)
             events[rlz * E: rlz * E + E]['rlz'] = rlz
         self.datastore['events'] = self.events = events
         rupser = calc.RuptureSerializer(self.datastore)

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -103,9 +103,11 @@ class GmfComputer(object):
         # `rupture` can be an EBRupture instance
         if hasattr(rupture, 'srcidx'):
             self.srcidx = rupture.srcidx  # the source the rupture comes from
+            self.e0 = rupture.e0
             rupture = rupture.rupture  # the underlying rupture
         else:
             self.srcidx = '?'
+            self.e0 = 0
         try:
             self.sctx, self.dctx = rupture.sctx, rupture.dctx
         except AttributeError:
@@ -144,7 +146,7 @@ class GmfComputer(object):
                 arr[arr < miniml] = 0
             n = 0
             for rlzi in rlzs:
-                eids = eids_by_rlz[rlzi]
+                eids = eids_by_rlz[rlzi] + self.e0
                 e = len(eids)
                 for ei, eid in enumerate(eids):
                     gmf = array[:, :, n + ei]  # shape (N, M)

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -553,8 +553,7 @@ class EBRupture(object):
         if self.samples == 1:  # full enumeration or akin to it
             for rlzs in rlzs_by_gsim.values():
                 for rlz in rlzs:
-                    dic[rlz] = numpy.arange(j, j + self.n_occ, dtype=U64) + (
-                        TWO32 * U64(self.serial))
+                    dic[rlz] = numpy.arange(j, j + self.n_occ, dtype=U32)
                     j += self.n_occ
         else:  # associated eids to the realizations
             rlzs = numpy.concatenate(list(rlzs_by_gsim.values()))
@@ -562,8 +561,7 @@ class EBRupture(object):
             histo = general.random_histogram(
                 self.n_occ, self.samples, self.serial)
             for rlz, n in zip(rlzs, histo):
-                dic[rlz] = numpy.arange(j, j + n, dtype=U64) + (
-                    TWO32 * U64(self.serial))
+                dic[rlz] = numpy.arange(j, j + n, dtype=U32)
                 j += n
         return dic
 
@@ -575,7 +573,8 @@ class EBRupture(object):
         for rlz, eids in self.get_eids_by_rlz(rlzs_by_gsim).items():
             all_eids.extend(eids)
             rlzs.extend([rlz] * len(eids))
-        return numpy.fromiter(zip(all_eids, rlzs), events_dt)
+        evs = U64(all_eids) + U64(self.serial) * TWO32
+        return numpy.fromiter(zip(evs, rlzs), events_dt)
 
     def get_eids(self, num_rlzs):
         """


### PR DESCRIPTION
Despite the relatively small number of lines changed, this is a major improvement, which has been years in the making. Now the calculators use 32 bit event indices internally, instead of 64 bit event IDs. This simplification should be what is needed to solve the slow tasks issue.
This PR also fixes a subtle bug with the `losses_by_A` cache, causing wrong average losses to be computed in the ebrisk calculator when disabling the parallelization.