### PR TITLE
Do not sort site coordinates if site_ids are provided by user

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,13 @@
-  [Michele Simionato]
+[Anirudh Rao]
+  * Fixed a bug in the gmf CSV importer: the coordinates were being
+  sorted and new site_ids assigned even though the user input sites
+  csv file had site_ids defined
+  * Replaced the nonzero covs in test_case_2 in gmf_ebrisk_test to
+  ensure replicability of numbers
+  * Corrected the expected number for test_case_2 in gmf_ebrisk_test
+  based on hand calculations
+
+[Michele Simionato]
   * Fixed a bug in the rupture CSV exporter: the boundaries of a GriddedRupture
     were exported with lons and lats inverted
   * Added some metadata to the CSV risk outputs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-[Anirudh Rao]
+  [Anirudh Rao]
   * Fixed a bug in the gmf CSV importer: the coordinates were being
   sorted and new site_ids assigned even though the user input sites
   csv file had site_ids defined
@@ -7,7 +7,7 @@
   * Corrected the expected number for test_case_2 in gmf_ebrisk_test
   based on hand calculations
 
-[Michele Simionato]
+  [Michele Simionato]
   * Fixed a bug in the rupture CSV exporter: the boundaries of a GriddedRupture
     were exported with lons and lats inverted
   * Added some metadata to the CSV risk outputs

--- a/openquake/calculators/tests/gmf_ebrisk_test.py
+++ b/openquake/calculators/tests/gmf_ebrisk_test.py
@@ -52,7 +52,7 @@ class GmfEbRiskTestCase(CalculatorTestCase):
         self.assertEqual(len(alt), 3)
         self.assertEqual(set(alt['rlzi']), set([0]))  # single rlzi
         totloss = alt['loss'].sum()
-        aae(totloss, 1.82)
+        aae(totloss, 1.82, decimal=4)
 
     def test_case_3(self):
         # case with 13 sites, 10 eids, and several 0 values

--- a/openquake/calculators/tests/gmf_ebrisk_test.py
+++ b/openquake/calculators/tests/gmf_ebrisk_test.py
@@ -52,7 +52,7 @@ class GmfEbRiskTestCase(CalculatorTestCase):
         self.assertEqual(len(alt), 3)
         self.assertEqual(set(alt['rlzi']), set([0]))  # single rlzi
         totloss = alt['loss'].sum()
-        aae(totloss, 0.46601775)
+        aae(totloss, 1.82)
 
     def test_case_3(self):
         # case with 13 sites, 10 eids, and several 0 values

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -321,7 +321,7 @@ def get_mesh(oqparam):
         start, stop = oqparam.sites_slice
         c = (coords[start:stop] if header[0] == 'site_id'
              else sorted(coords[start:stop]))
-        return geo.Mesh.from_coords(c)
+        return geo.Mesh.from_coords(c, sort=False)
     elif 'hazard_curves' in oqparam.inputs:
         fname = oqparam.inputs['hazard_curves']
         if isinstance(fname, list):  # for csv

--- a/openquake/qa_tests_data/gmf_ebrisk/case_2/vulnerability_2IM.xml
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_2/vulnerability_2IM.xml
@@ -15,13 +15,13 @@ xmlns:gml="http://www.opengis.net/gml"
             <imls
             imt="PGA"
             >
-                1.0000E-01 2.0000E-01 3.0000E-01 5.0000E-01 7.0000E-01
+                0.1 0.2 0.3 0.5 0.7
             </imls>
             <meanLRs>
-                3.5000E-03 7.0000E-02 1.4000E-01 2.8000E-01 5.6000E-01
+                0.0035 0.07 0.14 0.28 0.56
             </meanLRs>
             <covLRs>
-                1.0000E-01 2.0000E-01 3.0000E-01 4.0000E-01 5.0000E-01
+                0 0 0 0 0
             </covLRs>
         </vulnerabilityFunction>
         <vulnerabilityFunction
@@ -31,13 +31,13 @@ xmlns:gml="http://www.opengis.net/gml"
             <imls
             imt="SA(0.3)"
             >
-                1.0000E-01 2.0000E-01 3.0000E-01 5.0000E-01 7.0000E-01
+                0.1 0.2 0.3 0.5 0.7
             </imls>
             <meanLRs>
-                5.0000E-02 1.0000E-01 2.0000E-01 4.0000E-01 8.0000E-01
+                0.05 0.1 0.2 0.4 0.8
             </meanLRs>
             <covLRs>
-                5.0000E-02 6.0000E-02 7.0000E-02 8.0000E-02 9.0000E-02
+                0 0 0 0 0
             </covLRs>
         </vulnerabilityFunction>
     </vulnerabilityModel>


### PR DESCRIPTION
Calculations starting from ground motion fields input by the user require at least two input files related to the gmf data:
1. A sites.csv file, listing {site_id, lon, lat} tuples
2. A gmfs.csv file, listing {event_id, site_id, gmv[IMT1], gmv[IMT2], ...} tuples

The site coordinates defined in the sites file do not need to be in sorted order; the only requirement should be to ensure there is no duplication of either the site_ids or the coordinates.

However currently, when creating the site mesh from the site coordinates read from the csv file, the coordinates always get sorted and are assigned new site ids (if the input coordinates were not in sorted order), breaking the link with the user-specified site_ids and thus also with the gmf data.

This patch will avoid sorting the coordinates when the site_ids are explicitly provided in the user input sites file.