### PR TITLE
Reduced data transfer in ebrisk

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -232,7 +232,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         ires = parallel.Starmap.apply(
             self.core_task.__func__,
             (rupgetters, self.src_filter, self.crmodel, self.param,
-             self.monitor()), key=lambda rg: rg.grp_id)
+             self.monitor()), key=lambda rg: rg.grp_id,
+            concurrent_tasks=oq.concurrent_tasks)
         res = ires.reduce(self.agg_dicts, numpy.zeros(self.N))
         logging.info('Produced %s of GMFs', general.humansize(self.gmf_nbytes))
         return res

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -99,16 +99,15 @@ def _calc(computers, gmv_dt, events, min_iml, rlzs_by_gsim, weights,
 
 
 def ebrisk(rupgetters, srcfilter, crmodel, param, monitor):
-    mon_rup = monitor('getting ruptures')
     mon_haz = monitor('getting hazard')
     mon_risk = monitor('computing risk', measuremem=False)
     mon_agg = monitor('aggregating losses', measuremem=False)
     computers = []
-    for rupgetter in rupgetters:
-        gg = getters.GmfGetter(rupgetter, srcfilter, param['oqparam'])
-        with mon_rup:
+    with monitor('getting ruptures'):
+        for rupgetter in rupgetters:
+            gg = getters.GmfGetter(rupgetter, srcfilter, param['oqparam'])
             gg.init()
-        computers.extend(gg.computers)
+            computers.extend(gg.computers)
     if not computers:  # all filtered out
         return {}
     with monitor('getting assets', measuremem=False):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -503,6 +503,19 @@ class RuptureGetter(object):
                 nr += 1
         self.rlzs = numpy.array(rlzi)
 
+    def __iter__(self):
+        for i, ridx in enumerate(self.rup_indices):
+            rg = object.__new__(self.__class__)
+            rg.rup_indices = [ridx]
+            rg.filename = self.filename
+            rg.grp_id = self.grp_id
+            rg.trt = self.trt
+            rg.samples = self.samples
+            rg.rlzs_by_gsim = self.rlzs_by_gsim
+            rg.e0 = numpy.array([self.e0[i]])
+            rg.rlzs = self.rlzs
+            yield rg
+
     @general.cached_property
     def rup_array(self):
         with hdf5.File(self.filename, 'r') as h5:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -492,14 +492,6 @@ class RuptureGetter(object):
         self.samples = samples
         self.rlzs_by_gsim = rlzs_by_gsim
         self.e0 = e0
-        nr = 0
-        rlzi = []
-        for gsim, rlzs in rlzs_by_gsim.items():
-            assert not isinstance(gsim, str)
-            for rlz in rlzs:
-                rlzi.append(rlz)
-                nr += 1
-        self.rlzs = numpy.array(rlzi)
 
     def split(self, srcfilter):
         """
@@ -516,7 +508,6 @@ class RuptureGetter(object):
             rg.samples = self.samples
             rg.rlzs_by_gsim = self.rlzs_by_gsim
             rg.e0 = numpy.array([self.e0[i]])
-            rg.rlzs = self.rlzs
             rg.weight = len(srcfilter.close_sids(
                 array[i], self.trt, array[i]['mag']))
             if rg.weight:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -317,14 +317,6 @@ class GmfGetter(object):
     def imts(self):
         return list(self.oqparam.imtls)
 
-    @property
-    def weight(self):
-        """
-        :returns: the number of affected sites
-        """
-        self.init()
-        return sum(len(c.sids) for c in self.computers)
-
     def init(self):
         """
         Initialize the computers. Should be called on the workers
@@ -529,6 +521,15 @@ class RuptureGetter(object):
     @property
     def num_rlzs(self):
         return len(self.rlz2idx)
+
+    def set_weight(self, srcfilter):
+        """
+        :returns: the estimated number of affected sites
+        """
+        self.weight = 0
+        for rec in self.rup_array:
+            sids = srcfilter.close_sids(rec, self.trt, rec['mag'])
+            self.weight += len(sids)
 
     def get_eid_rlz(self):
         """

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -317,6 +317,14 @@ class GmfGetter(object):
     def imts(self):
         return list(self.oqparam.imtls)
 
+    @property
+    def weight(self):
+        """
+        :returns: the number of affected sites
+        """
+        self.init()
+        return sum(len(c.sids) for c in self.computers)
+
     def init(self):
         """
         Initialize the computers. Should be called on the workers

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -528,8 +528,9 @@ class RuptureGetter(object):
         """
         self.weight = 0
         for rec in self.rup_array:
-            sids = srcfilter.close_sids(rec, self.trt, rec['mag'])
-            self.weight += len(sids)
+            mag = rec['mag']
+            sids = srcfilter.close_sids(rec, self.trt, mag)
+            self.weight += len(sids) * 5 ** (mag - 5.)
 
     def get_eid_rlz(self):
         """


### PR DESCRIPTION
This avoids running over the 4 GB pickle limit on the Canada calculation, while losing something on the slow tasks but not too much. The Panama calculation #27504 on cluster1 takes 4529s.