### PR TITLE
Log number of cores available when using *pool

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -78,7 +78,7 @@ if OQ_DISTRIBUTE == 'zmq':
         logs.LOG.warn('Using %d zmq workers', num_workers)
 
 elif OQ_DISTRIBUTE.startswith('celery'):
-    import celery.task.control
+    import celery.task.control  # noqa: E402
 
     def set_concurrent_tasks_default(job_id):
         """
@@ -329,6 +329,9 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
             del data  # save memory
 
         poll_queue(job_id, _PID, poll_time=15)
+        if OQ_DISTRIBUTE.endswith('pool'):
+            logs.LOG.warn('Using %d cores on %s',
+                          parallel.cpu_count, platform.node())
         if OQ_DISTRIBUTE == 'zmq':
             logs.dbcmd('zmq_start')  # start zworkers
             logs.dbcmd('zmq_wait')  # wait for them to go up


### PR DESCRIPTION
It is useful to know for debugging purposes

```
[2019-09-02 15:04:34,050 #5 INFO] daniele running /home/daniele/GIT/gem/oq-engine/demos/hazard/AreaSourceClassicalPSHA/job.ini [--hc=None]
[2019-09-02 15:04:34,055 #5 INFO] Using engine version 3.7.0-git58297f6ffe
[2019-09-02 15:04:34,433 #5 INFO] Zipping the input files
[2019-09-02 15:04:34,454 #5 WARNING] Using 4 cores on gemlatitude5450
[2019-09-02 15:04:34,468 #5 INFO] Checksum of the input files: 291315673
[2019-09-02 15:04:34,473 #5 INFO] Reading the risk model if present
[2019-09-02 15:04:34,574 #5 INFO] Read 624 hazard sites
[2019-09-02 15:04:34,586 #5 INFO] Validated source_model_logic_tree.xml in 0.00 seconds
```