### PR TITLE
Stored the time to compute the GMFs for each rupture in ebrisk

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -56,10 +56,14 @@ def _calc(computers, gmv_dt, events, min_iml, rlzs_by_gsim, weights,
     tagnames = param['aggregate_by']
     eid2rlz = dict(events)
     eid2idx = {eid: idx for idx, eid in enumerate(eid2rlz)}
-    with mon_haz:
-        hazard = numpy.concatenate(
-            [numpy.array(c.compute_all(min_iml, rlzs_by_gsim), gmv_dt)
-             for c in computers])
+    gmfs = []
+    haztimes = []
+    for c in computers:
+        with mon_haz:
+            gmfs.extend(c.compute_all(min_iml, rlzs_by_gsim))
+        haztimes.append((c.rupture.ridx, mon_haz.dt))
+    hazard = numpy.array(gmfs, gmv_dt)
+    haztimes = numpy.array(haztimes, [('ridx', U32), ('dt', F32)])
 
     for sid, haz in general.group_array(hazard, 'sid').items():
         gmf_nbytes += haz.nbytes
@@ -95,11 +99,11 @@ def _calc(computers, gmv_dt, events, min_iml, rlzs_by_gsim, weights,
                             losses @ ws * param['ses_ratio'])
     if len(hazard):
         num_events_per_sid /= len(hazard)
-    return num_events_per_sid, gmf_nbytes
+    return haztimes, num_events_per_sid, gmf_nbytes
 
 
 def ebrisk(rupgetters, srcfilter, crmodel, param, monitor):
-    mon_haz = monitor('getting hazard')
+    mon_haz = monitor('getting hazard', measuremem=False)
     mon_risk = monitor('computing risk', measuremem=False)
     mon_agg = monitor('aggregating losses', measuremem=False)
     computers = []
@@ -124,14 +128,14 @@ def ebrisk(rupgetters, srcfilter, crmodel, param, monitor):
     alt = numpy.zeros((A, E, L), F32) if param['asset_loss_table'] else None
     acc = numpy.zeros(shape, F32)  # shape (E, L, T...)
     # NB: IMT-dependent weights are not supported in ebrisk
-    num_events_per_sid, gmf_nbytes = _calc(
+    haztimes, num_events_per_sid, gmf_nbytes = _calc(
         computers, gg.gmv_dt, events, gg.min_iml, gg.rlzs_by_gsim, gg.weights,
         assets_by_site, crmodel, param, alt, acc, mon_haz, mon_risk, mon_agg)
     elt = numpy.fromiter(  # this is ultra-fast
         ((event['id'], event['rlz'], losses)  # losses (L, T...)
          for event, losses in zip(events, acc) if losses.sum()), elt_dt)
     res = {'elt': elt, 'events_per_sid': num_events_per_sid,
-           'gmf_nbytes': gmf_nbytes}
+           'gmf_nbytes': gmf_nbytes, 'haztimes': haztimes}
     if param['avg_losses']:
         res['losses_by_A'] = param['lba'].losses_by_A
         # without resetting the cache the sequential avg_losses would be wrong!
@@ -245,6 +249,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
             return 1
         self.oqparam.ground_motion_fields = False  # hack
         elt = dic['elt']
+        self.datastore.extend('haztimes', dic['haztimes'])
         if len(elt):
             with self.monitor('saving losses_by_event', autoflush=True):
                 elt['event_id'] = self.event_ids[elt['event_id']]

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -337,6 +337,7 @@ class EventBasedCalculator(base.HazardCalculator):
         if not oq.imtls:
             raise InvalidFile('There are no intensity measure types in %s' %
                               oq.inputs['job_ini'])
+        self.datastore.create_dset('gmf_data/data', oq.gmf_data_dt())
         if oq.hazard_curves_from_gmfs:
             self.param['rlz_by_event'] = self.datastore['events']['rlz']
         iterargs = ((rgetter, self.src_filter, self.param)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -575,7 +575,7 @@ class RuptureGetter(object):
         ebrs = []
         with datastore.read(self.filename) as dstore:
             rupgeoms = dstore['rupgeoms']
-            for e0, rec in zip(self.e0, self.rup_array):
+            for e0, rec, ri in zip(self.e0, self.rup_array, self.rup_indices):
                 if srcfilter.integration_distance:
                     sids = srcfilter.close_sids(rec, self.trt)
                     if len(sids) == 0:  # the rupture is far away
@@ -618,6 +618,7 @@ class RuptureGetter(object):
                                 rec['n_occ'], self.samples)
                 # not implemented: rupture_slip_direction
                 ebr.sids = sids
+                ebr.ridx = ri
                 if self.e0 is None:
                     ebr.e0 = TWO32 * U64(ebr.serial)
                 else:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -292,7 +292,6 @@ class GmfGetter(object):
         self.min_iml = oqparam.min_iml
         self.N = len(self.sitecol)
         self.num_rlzs = sum(len(rlzs) for rlzs in self.rlzs_by_gsim.values())
-        self.gmv_dt = oqparam.gmf_data_dt()
         self.sig_eps_dt = sig_eps_dt(oqparam.imtls)
         M32 = (F32, len(oqparam.imtls))
         self.gmv_eid_dt = numpy.dtype([('gmv', M32), ('eid', U64)])
@@ -348,9 +347,10 @@ class GmfGetter(object):
         for computer in self.computers:
             data = computer.compute_all(
                 self.min_iml, self.rlzs_by_gsim, self.sig_eps)
-            alldata.append(numpy.array(data, self.gmv_dt))
+            # from eid 32 bit -> 64 bit
+            alldata.append(data)
         if not alldata:
-            return numpy.zeros(0, self.gmv_dt)
+            return []
         return numpy.concatenate(alldata)
 
     def get_hazard_by_sid(self, data=None):
@@ -360,6 +360,8 @@ class GmfGetter(object):
         """
         if data is None:
             data = self.get_gmfdata()
+            if len(data) == 0:
+                return {}
         return general.group_array(data, 'sid')
 
     def compute_gmfs_curves(self, rlzs, monitor):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -347,7 +347,6 @@ class GmfGetter(object):
         for computer in self.computers:
             data = computer.compute_all(
                 self.min_iml, self.rlzs_by_gsim, self.sig_eps)
-            # from eid 32 bit -> 64 bit
             alldata.append(data)
         if not alldata:
             return []
@@ -360,8 +359,8 @@ class GmfGetter(object):
         """
         if data is None:
             data = self.get_gmfdata()
-            if len(data) == 0:
-                return {}
+        if len(data) == 0:
+            return {}
         return general.group_array(data, 'sid')
 
     def compute_gmfs_curves(self, rlzs, monitor):

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -151,7 +151,9 @@ class GmfComputer(object):
                         if gmv.sum():
                             data.append((sid, eid, gmv))
                 n += e
-        return data
+        m = (len(min_iml),)
+        gmv_dt = [('sid', U32), ('eid', U32), ('gmv', (F32, m))]
+        return numpy.array(data, gmv_dt)
 
     def compute(self, gsim, num_events, seed=None):
         """


### PR DESCRIPTION
And some refactoring. For the Panama calculation on cluster1 I get pairs (rupidx, dt) like the following:
```python
In [12]: times[-1]
Out[12]: (142060, 136.43831)

In [13]: times[-2]
Out[13]: (142061, 124.60216)

In [14]: times[-3]
Out[14]: (138971, 97.62555)

In [15]: times[-4]
Out[15]: (138969, 93.006004)

In [16]: times[-5]
Out[16]: (139203, 92.27035)

In [17]: times[-6]
Out[17]: (139010, 88.55245)

In [18]: times[-100]
Out[18]: (138858, 24.84024)

In [22]: times[-20000]
Out[22]: (143475, 1.4566448)
```