### PR TITLE
Refactored split_task

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -840,6 +840,9 @@ def split_task(func, *args, duration=1000,
     weights = numpy.fromiter(map(weight, elements), float)
     idx = weights.argmax()
     before = elements[:idx],
+    # it is essential to get the heaviest element to estimate the duration
+    # of the task; taking the first element will result in an inaccurate
+    # estimate, generating too many tasks and running out of memory
     heaviest = elements[idx]
     after = elements[idx + 1:],
     t0 = time.time()

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -824,25 +824,23 @@ def split_task(func, *args, duration=1000,
     :yields: a partial result, 0 or more task objects, 0 or 1 partial result
     """
     # in ebrisk elements are GmfComputers with a fixed order
-    n = len(args[0])
+    elements = args[0]
+    n = len(elements)
     # print('task_no=%d, num_elements=%d' % (args[-1].task_no, n))
     assert n > 0, 'Passed an empty sequence!'
     if n == 1:
         yield func(*args)
         return
-    weights = numpy.fromiter(map(weight, args[0]), float)
+    weights = numpy.fromiter(map(weight, elements), float)
     idx = weights.argmax()
-    before = args[0][:idx]
-    this = args[0][idx]
-    after = args[0][idx + 1:]
+    before = elements[:idx]
+    this = elements[idx]
+    after = elements[idx + 1:]
     t0 = time.time()
     res = func(*([this],) + args[1:])
     dt = (time.time() - t0) / weight(this)  # time per unit of weight
     for block in block_splitter(before, duration, lambda el: weight(el) * dt):
         yield (func, block) + args[1:-1]
     yield res
-    blocks = list(block_splitter(after, duration, lambda el: weight(el) * dt))
-    if blocks:
-        for block in blocks[:-1]:
-            yield (func, block) + args[1:-1]
-        yield func(*(blocks[-1],) + args[1:])
+    for block in block_splitter(after, duration, lambda el: weight(el) * dt):
+        yield (func, block) + args[1:-1]

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -199,7 +199,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 self.datastore.hdf5.copy('ruptures', cache)
                 self.datastore.hdf5.copy('rupgeoms', cache)
         num_cores = oq.__class__.concurrent_tasks.default // 2 or 1
-        ruptures_per_block = numpy.ceil(nruptures / num_cores)
+        ruptures_per_block = numpy.ceil(nruptures / (oq.concurrent_tasks or 1))
         logging.info('Using %d ruptures per block (over %d rups, %d events)',
                      ruptures_per_block, nruptures, self.E)
         self.set_param(

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -198,7 +198,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 self.datastore.hdf5.copy('weights', cache)
                 self.datastore.hdf5.copy('ruptures', cache)
                 self.datastore.hdf5.copy('rupgeoms', cache)
-        ruptures_per_block = numpy.ceil(nruptures / (oq.concurrent_tasks or 1))
+        num_cores = oq.__class__.concurrent_tasks.default // 2 or 1
+        ruptures_per_block = numpy.ceil(nruptures / num_cores)
         logging.info('Using %d ruptures per block (over %d rups, %d events)',
                      ruptures_per_block, nruptures, self.E)
         self.set_param(
@@ -234,8 +235,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.event_ids = self.datastore['events']['id']
         smap = parallel.Starmap(
             self.core_task.__func__, allargs,
-            num_cores=oq.__class__.concurrent_tasks.default // 2,
-            hdf5path=self.datastore.filename)
+            num_cores=num_cores, hdf5path=self.datastore.filename)
         res = smap.reduce(self.agg_dicts, numpy.zeros(self.N))
         logging.info('Produced %s of GMFs', general.humansize(self.gmf_nbytes))
         return res


### PR DESCRIPTION
The duration of the task must be estimated starting from the heaviest element, otherwise it is not accurate, it produces too many tasks and causes the Canada calculation to run out of memory.