### PR TITLE
Small renaming

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -425,6 +425,11 @@ class ArrayWrapper(object):
             array, attrs = (), dict(obj)
         elif hasattr(obj, '__toh5__'):
             return obj
+        elif hasattr(obj, 'attrs'):  # is a dataset
+            array, attrs = obj[()], dict(obj.attrs)
+            shape_descr = attrs.get('shape_descr', [])
+            for descr in map(decode, shape_descr):
+                attrs[descr] = ['?'] + list(attrs[descr])
         else:  # assume obj is an array
             array, attrs = obj, {}
         return cls(array, attrs)
@@ -520,7 +525,7 @@ class ArrayWrapper(object):
         out = []
         tags = []
         idxs = []
-        for i, tagname in enumerate(self.shape_descr):
+        for i, tagname in enumerate(map(decode, self.shape_descr)):
             values = getattr(self, tagname)[1:]
             if len(values) != shape[i]:
                 raise ValueError(

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -496,7 +496,7 @@ class ArrayWrapper(object):
         length D1 * ... * DN. Zero values are discarded.
 
         >>> from pprint import pprint
-        >>> dic = dict(tagnames=['taxonomy', 'occupancy'],
+        >>> dic = dict(shape_descr=['taxonomy', 'occupancy'],
         ...            taxonomy=['?', 'RC', 'WOOD'],
         ...            occupancy=['?', 'RES', 'IND', 'COM'])
         >>> arr = numpy.zeros((2, 3))
@@ -516,13 +516,11 @@ class ArrayWrapper(object):
                 raise ValueError(
                     'There are %d extra-fields but %d dimensions in %s' %
                     (len(self._extra), shape[-1], self))
-        tagnames = decode_array(self.tagnames)
-        # the tagnames are bytestrings so they must be decoded
-        fields = tuple(tagnames) + self._extra
+        fields = tuple(self.shape_descr) + self._extra
         out = []
         tags = []
         idxs = []
-        for i, tagname in enumerate(tagnames):
+        for i, tagname in enumerate(self.shape_descr):
             values = getattr(self, tagname)[1:]
             if len(values) != shape[i]:
                 raise ValueError(

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -289,7 +289,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         aggregate_by = {'aggregate_by': oq.aggregate_by}
         for tagname in oq.aggregate_by:
             aggregate_by[tagname] = getattr(self.assetcol.tagcol, tagname)[1:]
-        units = self.datastore['cost_calculator'].get_units(loss_types.split())
+        units = self.datastore['cost_calculator'].get_units(loss_types)
         shp = self.get_shape(P, self.R, self.L)  # shape P, R, L, T...
         shape_descr = (['return_periods', 'stats', 'loss_types'] +
                        oq.aggregate_by)

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -285,7 +285,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         S = len(stats)
         P = len(builder.return_periods)
         C = len(oq.conditional_loss_poes)
-        loss_types = ' '.join(self.crmodel.loss_types)
+        loss_types = self.crmodel.loss_types
         aggregate_by = {'aggregate_by': oq.aggregate_by}
         for tagname in oq.aggregate_by:
             aggregate_by[tagname] = getattr(self.assetcol.tagcol, tagname)[1:]

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -297,7 +297,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.datastore.set_attrs(
             'agg_curves-rlzs', return_periods=builder.return_periods,
             shape_descr=shape_descr, loss_types=loss_types, units=units,
-            **aggregate_by)
+            rlzs=numpy.arange(self.R), **aggregate_by)
         if oq.conditional_loss_poes:
             shp = self.get_shape(C, self.R, self.L)  # shape C, R, L, T...
             self.datastore.create_dset('agg_maps-rlzs', F32, shp)

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -291,7 +291,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
             aggregate_by[tagname] = getattr(self.assetcol.tagcol, tagname)[1:]
         units = self.datastore['cost_calculator'].get_units(loss_types)
         shp = self.get_shape(P, self.R, self.L)  # shape P, R, L, T...
-        shape_descr = (['return_periods', 'stats', 'loss_types'] +
+        shape_descr = (['return_periods', 'rlzs', 'loss_types'] +
                        oq.aggregate_by)
         self.datastore.create_dset('agg_curves-rlzs', F32, shp)
         self.datastore.set_attrs(
@@ -302,6 +302,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
             shp = self.get_shape(C, self.R, self.L)  # shape C, R, L, T...
             self.datastore.create_dset('agg_maps-rlzs', F32, shp)
         if self.R > 1:
+            shape_descr = (['return_periods', 'stats', 'loss_types'] +
+                           oq.aggregate_by)
             shp = self.get_shape(P, S, self.L)  # shape P, S, L, T...
             self.datastore.create_dset('agg_curves-stats', F32, shp)
             self.datastore.set_attrs(

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -282,7 +282,7 @@ class EbrCalculator(base.RiskCalculator):
                  for (eid, rlz), losses in zip(self.events, self.agglosses)
                  if losses.any()), elt_dt)
             self.datastore['losses_by_event'] = agglosses
-            loss_types = ' '.join(self.oqparam.loss_dt().names)
+            loss_types = self.oqparam.loss_dt().names
             self.datastore.set_attrs('losses_by_event', loss_types=loss_types)
         self.postproc()
 
@@ -316,8 +316,8 @@ class EbrCalculator(base.RiskCalculator):
             lbr = group_array(dstore['losses_by_event'][()], 'rlzi')
             dic = {r: arr['loss'] for r, arr in lbr.items()}
             array, arr_stats = b.build(dic, stats)
-        loss_types = ' '.join(oq.loss_dt().names)
-        units = self.datastore['cost_calculator'].get_units(loss_types.split())
+        loss_types = oq.loss_dt().names
+        units = self.datastore['cost_calculator'].get_units(loss_types)
         if oq.individual_curves or self.R == 1:
             self.datastore['agg_curves-rlzs'] = array  # shape (P, R, L)
             self.datastore.set_attrs(

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -67,6 +67,7 @@ def get_rup_data(ebruptures):
 
 
 # this is used by event_based_risk and ebrisk
+# TODO: use ArrayWrapper.to_table()
 @export.add(('agg_curves-rlzs', 'csv'), ('agg_curves-stats', 'csv'))
 def export_agg_curve_rlzs(ekey, dstore):
     oq = dstore['oqparam']

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -127,7 +127,7 @@ def export_agg_maps_csv(ekey, dstore):
     kinds = (['rlz-%03d' % r for r in range(R)] if ekey[0].endswith('-rlzs')
              else list(oq.hazard_stats()))
     clp = [str(p) for p in oq.conditional_loss_poes]
-    dic = dict(tagnames=['clp', 'kind', 'loss_type'] + oq.aggregate_by,
+    dic = dict(shape_descr=['clp', 'kind', 'loss_type'] + oq.aggregate_by,
                clp=['?'] + clp, kind=['?'] + kinds,
                loss_type=('?',) + oq.loss_dt().names)
     for tagname in oq.aggregate_by:
@@ -266,7 +266,7 @@ def export_losses_by_event(ekey, dstore):
     tagcol = dstore['assetcol/tagcol']
     lbe = dstore['losses_by_event'][()]
     lbe.sort(order='event_id')
-    dic = dict(tagnames=['event_id'] + oq.aggregate_by)
+    dic = dict(shape_descr=['event_id'] + oq.aggregate_by)
     for tagname in oq.aggregate_by:
         dic[tagname] = getattr(tagcol, tagname)
     dic['event_id'] = ['?'] + list(lbe['event_id'])

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -589,7 +589,7 @@ def extract_aggregate(dstore, what):
                           loss_types)
     for tagname in tagnames:
         setattr(aw, tagname, getattr(assetcol.tagcol, tagname))
-    aw.tagnames = encode(tagnames)
+    aw.shape_descr = tagnames
     return aw
 
 

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -149,7 +149,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
                            self.oqparam.number_of_ground_motion_fields)
             lbe['loss'] = res
             self.datastore['losses_by_event'] = lbe
-            loss_types = ' '.join(self.oqparam.loss_dt().names)
+            loss_types = self.oqparam.loss_dt().names
             self.datastore.set_attrs('losses_by_event', loss_types=loss_types)
 
             # all losses


### PR DESCRIPTION
I am renaming tagnames -> shape_descr for consistency with other parts of the engine. This is a step towards https://github.com/gem/oq-engine/issues/5051.

PS: I am also finally replacing the space-separated attribute `loss_types` with a list. This should break something on the QGIS side but the tests are green: https://travis-ci.org/gem/oq-irmt-qgis/jobs/581540097 (edit: @ptormene says that the breakage is in a branch, but he fixed it now).