### PR TITLE
Changed ebrisk to produce an output avg_losses-stats instead of avg_losses

### DIFF
--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -113,7 +113,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         # this is a case with insured losses
         self.run_calc(case_1.__file__, 'job_eb.ini')
 
-        [fname] = export(('avg_losses', 'csv'), self.calc.datastore)
+        [fname] = export(('avg_losses-stats', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname)
 
         aw = extract(self.calc.datastore, 'agg_losses/structural')
@@ -151,7 +151,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         # 1 assets, 2 samples
         self.run_calc(case_master.__file__, 'job12.ini', exports='csv')
         # alt = extract(self.calc.datastore, 'asset_loss_table')
-        [fname] = export(('avg_losses', 'csv'), self.calc.datastore)
+        [fname] = export(('avg_losses-stats', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/avg_loss_12.csv', fname)
 
     def test_case_2(self):
@@ -301,7 +301,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         fname = export(('agg_maps-stats', 'csv'), self.calc.datastore)[0]
         self.assertEqualFiles('expected/aggmaps.csv', fname, delta=1E-5)
 
-        fname = export(('avg_losses', 'csv'), self.calc.datastore)[0]
+        fname = export(('avg_losses-stats', 'csv'), self.calc.datastore)[0]
         self.assertEqualFiles('expected/avg_losses-mean.csv',
                               fname, delta=1E-5)
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -263,7 +263,6 @@ DISPLAY_NAME = {
     'events': 'Events',
     'damages-rlzs': 'Asset Damage Distribution',
     'damages-stats': 'Asset Damage Statistics',
-    'avg_losses': 'Average Asset Losses',
     'avg_losses-rlzs': 'Average Asset Losses',
     'avg_losses-stats': 'Average Asset Losses Statistics',
     'loss_curves-rlzs': 'Asset Loss Curves',


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/4993, superseding https://github.com/gem/oq-engine/pull/5001. Now the plugin should not have problem anymore displaying the avg_losses for ebrisk. It is important to make sure that it is reading the `stats` attribute from the dataset, but I think that it is already the case.