### PR TITLE
Some refactoring of the ebrisk calculator

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -776,7 +776,6 @@ class Starmap(object):
             if self.calc_id != res.mon.calc_id:
                 logging.warning('Discarding a result from job %s, since this '
                                 'is job %d', res.mon.calc_id, self.calc_id)
-                continue
             elif res.msg == 'TASK_ENDED':
                 self.log_percent()
                 if self.queue:
@@ -788,7 +787,6 @@ class Starmap(object):
             elif res.func_args:  # resubmit subtask
                 func, *args = res.func_args
                 self.submit(*args, func=func, monitor=res.mon)
-                yield res
                 self.todo += 1
             else:
                 yield res

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -141,6 +141,7 @@ def ebrisk(rupgetters, srcfilter, param, monitor):
             computers.extend(gg.computers)
     if not computers:  # all filtered out
         return {}
+    rupgetters.clear()
     computers.sort(key=lambda c: c.rupture.ridx)
     param['hdf5cache'] = srcfilter.filename
     acc = dict(gmfs=[], events=[], gmf_info=[])
@@ -152,6 +153,7 @@ def ebrisk(rupgetters, srcfilter, param, monitor):
         acc['gmf_info'].append(
             (c.rupture.ridx, mon_haz.task_no, len(c.sids),
              data.nbytes, mon_haz.dt))
+    computers.clear()
     acc = _calc_risk(acc, param, monitor)
     return acc
 
@@ -216,6 +218,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 self.datastore.hdf5.copy('rupgeoms', cache)
         num_cores = oq.__class__.concurrent_tasks.default // 2 or 1
         per_block = numpy.ceil(n_occ.sum() / (oq.concurrent_tasks or 1))
+        if per_block > 5000:
+            per_block = 5000
         logging.info('Using %d occurrences per block (over %d occurrences, '
                      '%d events)', per_block, n_occ.sum(), self.E)
         self.set_param(

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -136,10 +136,11 @@ def ebrisk(rupgetters, srcfilter, param, monitor):
         return {}
     computers.sort(key=lambda c: c.rupture.ridx)
     with monitor('getting assets'):
-        param['hdf5cache'] = srcfilter.filename
         with datastore.read(srcfilter.filename) as dstore:
             assetcol = dstore['assetcol']
             assets_by_site = assetcol.assets_by_site()
+    param['hdf5cache'] = srcfilter.filename
+    del param['oqparam']
     gmfs = []
     events = []
     gmftimes = []

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -495,8 +495,6 @@ class RuptureGetter(object):
         """
         :returns: a list of RuptureGetters with 1 rupture each
         """
-        with hdf5.File(srcfilter.filename, 'r') as cache:
-            num_taxonomies = cache['num_taxonomies'][()]
         out = []
         array = self.rup_array
         for i, ridx in enumerate(self.rup_indices):
@@ -510,7 +508,7 @@ class RuptureGetter(object):
             rg.e0 = numpy.array([self.e0[i]])
             n_occ = array[i]['n_occ']
             sids = srcfilter.close_sids(array[i], self.trt)
-            rg.weight = num_taxonomies[sids].sum() * n_occ
+            rg.weight = len(sids) * n_occ
             if rg.weight:
                 out.append(rg)
         return out

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -321,8 +321,6 @@ class GmfGetter(object):
         """
         if hasattr(self, 'computers'):  # init already called
             return
-        with hdf5.File(self.rupgetter.filename, 'r') as parent:
-            self.weights = parent['weights'][()]
         self.computers = []
         for ebr in self.rupgetter.get_ruptures(self.srcfilter):
             sitecol = self.sitecol.filtered(ebr.sids)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -656,18 +656,21 @@ def view_task_ebrisk(token, dstore):
     task_info = dstore['task_info/ebrisk'][()]
     task_info.sort(order='duration')
     info = task_info[idx]
-    times = get_array(dstore['gmftimes'][()], task_no=info['taskno'])
-    extra = times[['nsites', 'ntaxos', 'dt']]
+    times = get_array(dstore['gmf_info'][()], task_no=info['taskno'])
+    extra = times[['nsites', 'gmfbytes', 'dt']]
     ds = dstore.parent if dstore.parent else dstore
     rups = ds['ruptures']['rup_id', 'code', 'n_occ', 'mag'][times['ridx']]
     codeset = set('code_%d' % code for code in numpy.unique(rups['code']))
     tbl = rst_table(util.compose_arrays(rups, extra))
     codes = ['%s: %s' % it for it in ds.getitem('ruptures').attrs.items()
              if it[0] in codeset]
-    return '%s\n%s\nHazard time for task %d: %d/%d s, n_occ=%d, w=%d' % (
-        tbl, '\n'.join(codes), info['taskno'],
-        extra['dt'].sum(), info['duration'], rups['n_occ'].sum(),
-        (rups['n_occ'] * extra['ntaxos']).sum())
+    msg = '%s\n%s\nHazard time for task %d: %d of %d s, ' % (
+        tbl, '\n'.join(codes), info['taskno'], extra['dt'].sum(),
+        info['duration'])
+    msg += 'gmfbytes=%s, n_occ=%d, w=%d' % (
+        humansize(extra['gmfbytes'].sum()), rups['n_occ'].sum(),
+        (rups['n_occ'] * extra['nsites']).sum())
+    return msg
 
 
 @view.add('hmap')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -667,8 +667,8 @@ def view_task_ebrisk(token, dstore):
     msg = '%s\n%s\nHazard time for task %d: %d of %d s, ' % (
         tbl, '\n'.join(codes), info['taskno'], extra['dt'].sum(),
         info['duration'])
-    msg += 'gmfbytes=%s, n_occ=%d, w=%d' % (
-        humansize(extra['gmfbytes'].sum()), rups['n_occ'].sum(),
+    msg += 'gmfbytes=%s, w=%d' % (
+        humansize(extra['gmfbytes'].sum()),
         (rups['n_occ'] * extra['nsites']).sum())
     return msg
 


### PR DESCRIPTION
And added more performance information, like the number of GMFs generated per task. The Panama calculation with task_duration=300 got faster too:
```
Received 501.31 MB in 963 seconds
operation-duration           mean    stddev  min     max     outputs
ebrisk                       155     68      18      664     478    
start_ebrisk                 71      111     0.04274 671     1,327  
```
(the RuptureGetter weight is still `num_taxonomies[sids].sum() * n_occ`).