### PR TITLE
Removed references to the branchingLevel from the manual

### DIFF
--- a/doc/manual/oqum/glossary.tex
+++ b/doc/manual/oqum/glossary.tex
@@ -44,15 +44,6 @@
 }
 
 
-\newglossaryentry{branchinglevel}{
-	name=branching level,
-	description={It indicates the position where a \gls{branchset} or a
-	\gls{branch} is located in a logic tree structure. For example, the first
-	branching level of the \gls{seismicsourcelogictree} always contains one
-	or several \glspl{initialseismicsourceinputmodel}}
-}
-
-
 \newglossaryentry{branchset}{
 	name=branch set,
 	description={The structure describing the epistemic uncertainty on a

--- a/doc/manual/oqum/hazard/01a_logic_trees.tex
+++ b/doc/manual/oqum/hazard/01a_logic_trees.tex
@@ -28,17 +28,12 @@ following:
     weights/probabilities assigned to the set  of branches always correspond
     to one.
 
-    \item[branching level]: it is the largest container. It is not used in
-	modelling uncertainty, but it is useful in maintaining a logic and an
-	order in the structure of the tree.
-
 \end{description}
 
 Below we provide a simple schema illustrating the skeleton of xml file
 containing the desciption of a logic tree:
 
 \begin{minted}[firstline=1,firstnumber=1,fontsize=\footnotesize,frame=single,bgcolor=lightgray]{xml}
-<logicTreeBranchingLevel branchingLevelID=ID>
     <logicTreeBranchSet branchSetID=ID
                         uncertaintyType=TYPE>
         <logicTreeBranch>
@@ -46,22 +41,21 @@ containing the desciption of a logic tree:
             <uncertaintyWeight>WEIGHT</uncertaintyWeight>
         </logicTreeBranch>
     </logicTreeBranchSet>
-</logicTreeBranchingLevel>
 \end{minted}
 
 As it appears from this example, the structure of a logic tree is a set of
 nested elements.
 
 A schematic representation of the elemental components of a logic tree
-structure is provided in Figure~\ref{glts}. A branching level identifies the
-position where branching occurs while  a branch set identifies a collection of
+structure is provided in Figure~\ref{glts}.
+A branch set identifies a collection of
 branches (i.e. individual branches)  whose weights sum to 1.
 
 \begin{figure}[!ht]
 \centering
 \includegraphics[width=13cm]{figures/hazard/GenericLogicTreeStructure.pdf}
-\caption{Generic Logic Tree structure as described in terms of branching
-levels, branch sets, and individual branches.}
+\caption{Generic Logic Tree structure as described in terms of branch sets,
+and individual branches.}
 \label{glts}
 \end{figure}
 
@@ -76,36 +70,16 @@ In the NRML schema, a logic tree structure is defined through the
 </logicTree>
 \end{minted}
 
-A \Verb+logicTree+ contains as a sequence of \Verb+logicTreeBranchingLevel+ elements. The position in the sequence of a \Verb+logicTreeBranchingLevel+ specifies the level of the tree where it is located. That is, the first \texttt{logicTreeBranchingLevel} element in the sequence represents  the first level in the tree, the second element the second level in the tree, and so on.
+A \Verb+logicTree+ contains as a sequence of \Verb+logicTreeBranchSet+ elements.
 
-\begin{minted}[firstline=1,firstnumber=1,fontsize=\footnotesize,frame=single,bgcolor=lightgray]{xml}
-<logicTree logicTreeID="ID">
-	<logicTreeBranchingLevel branchingLevelID="ID_1">
-		...
-	</logicTreeBranchingLevel>
-	<logicTreeBranchingLevel branchingLevelID="ID_2">
-		...
-	</logicTreeBranchingLevel>
-	....
-	<logicTreeBranchingLevel branchingLevelID="ID_N">
-		...
-	</logicTreeBranchingLevel>
-</logicTree>
-\end{minted}
+There are no restrictions on the number of branch set that can be defined.
 
-There are no restrictions on the number of tree levels that can be defined.
-
-A \Verb+logicTreeBranchingLevel+ is defined as a sequence of
-\Verb+logicTreeBranchSet+ elements where each \Verb+logicTreeBranchSet+
-defines a particular epistemic uncertainty inside a branching level.
-
-A branch set has two required attributes: \Verb+branchSetID+ and
+Each \Verb+logicTreeBranchSet+
+has two required attributes: \Verb+branchSetID+ and
 \Verb+uncertaintyType+. The latter defines the type of epistemic uncertainty this branch set is describing.
 
 \begin{minted}[firstline=1,firstnumber=1,fontsize=\footnotesize,frame=single,bgcolor=lightgray]{xml}
 <logicTree logicTreeID="ID">
-...
-	<logicTreeBranchingLevel branchingLevelID="ID_#">
 		<logicTreeBranchSet branchSetID="ID_1"
 			uncertaintyType="UNCERTAINTY_TYPE">
 			...
@@ -119,7 +93,6 @@ A branch set has two required attributes: \Verb+branchSetID+ and
 			uncertaintyType="UNCERTAINTY_TYPE">
 			...
 		</logicTreeBranchSet>
-	</logicTreeBranchingLevel>
 ...
 </logicTree>
 \end{minted}
@@ -162,8 +135,6 @@ Possible values for the \Verb+uncertaintyType+ attribute are:
 
 \end{itemize}
 
-There are no restrictions on the number of branch sets that can be defined inside a branching level.
-
 A \Verb+branchSet+ is defined as a sequence of \Verb+logicTreeBranch+
 elements, each specified by an \Verb+uncertaintyModel+ element (a string
 identifying an uncertainty model; the content of the string varies with the \texttt{uncertaintyType} attribute value of the branchSet element) and the \texttt{uncertaintyWeight} element (specifying the probability/weight associated to the uncertaintyModel):
@@ -171,8 +142,7 @@ identifying an uncertainty model; the content of the string varies with the \tex
 \begin{minted}[firstline=1,firstnumber=1,fontsize=\footnotesize,frame=single,bgcolor=lightgray]{xml}
 < logicTree  logicTreeID="ID">
 ...
-	< logicTreeBranchingLevel  branchingLevelID="ID_#">
-		...
+
 		< logicTreeBranchSet  branchSetID="ID_#"
 				uncertaintyType="UNCERTAINTY_TYPE">
 			< logicTreeBranch  branchID="ID_1">
@@ -193,8 +163,6 @@ identifying an uncertainty model; the content of the string varies with the \tex
 				</uncertaintyWeight>
 			</logicTreeBranch>
 		</logicTreeBranchSet>
-		...
-	</logicTreeBranchingLevel>
 ...
 </logicTree >
 \end{minted}
@@ -292,7 +260,7 @@ attributes allowing for complex tree definitions:
 \begin{itemize}
 
     \item \Verb+applyToBranches+: specifies to which \Verb+logicTreeBranch+
-	elements (one or more), in the previous branching level, the branch set
+	elements (one or more), in the previous branch sets, the branch set
 	is linked to. The linking is established by defining the IDs of the
 	branches to link to:
 
@@ -301,7 +269,7 @@ attributes allowing for complex tree definitions:
 	\end{Verbatim}
 
     The default is the keyword ALL, which means that a branch set is by
-    default linked to all branches in the previous branching level. By
+    default linked to all branches in the previous branch set. By
     specifying one or  more branches to which the branch set links to, non-
     symmetric logic trees can be defined.
 

--- a/doc/manual/oqum/hazard/01b_seismic_source_system.tex
+++ b/doc/manual/oqum/hazard/01b_seismic_source_system.tex
@@ -8,13 +8,10 @@ incorporated into the calculation of seismic hazard.
 \subsection{The Seismic Source Logic Tree}
 
 The structure of the Seismic Source Logic Tree consists of at least one
-\gls{branchinglevel}. This branching level is the one used to define the
-\gls{initialseismicsourceinputmodel} (or a number of initial seismic source
-models, see Figure~\ref{fig:psha_input}).
-
+\gls{branchset}.
 The example provided below shows the simplest Seismic Source Logic Tree
 structure that can be defined in a \gls{pshainputmodel} for \gls{acr:oqe}.
-It's a logic tree with just one branching level containing one \gls{branchset}
+It's a logic tree with just one\gls{branchset}
 with one branch used to define the initial seismic source model (its weight
 will be equal to one).
 
@@ -52,7 +49,6 @@ tectonic region using the following syntax in the source model logic tree:
 <nrml xmlns:gml="http://www.opengis.net/gml"
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="sourceModel"
                                 branchSetID="bs1">
                 <logicTreeBranch branchID="b1">
@@ -63,7 +59,6 @@ tectonic region using the following syntax in the source model logic tree:
                     <uncertaintyWeight>1.0</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
     </logicTree>
 </nrml>
 \end{minted}

--- a/doc/manual/oqum/hazard/verbatim/input_gmlt.xml
+++ b/doc/manual/oqum/hazard/verbatim/input_gmlt.xml
@@ -2,7 +2,6 @@
 <nrml xmlns:gml="http://www.opengis.net/gml"
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="gmpeModel"
                     branchSetID="bs1"
                     applyToTectonicRegionType="Active Shallow Crust">
@@ -15,6 +14,5 @@
                 </logicTreeBranch>
 
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
     </logicTree>
 </nrml>

--- a/doc/manual/oqum/hazard/verbatim/input_gmlt_demo.xml
+++ b/doc/manual/oqum/hazard/verbatim/input_gmlt_demo.xml
@@ -2,7 +2,6 @@
 <nrml xmlns:gml="http://www.opengis.net/gml"
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="gmpeModel"
                     branchSetID="bs1"
                     applyToTectonicRegionType="Active Shallow Crust">
@@ -15,6 +14,5 @@
                 </logicTreeBranch>
 
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
     </logicTree>
 </nrml>

--- a/doc/manual/oqum/hazard/verbatim/input_gmlt_demo_LogicTreeCase1ClassicalPSHA.xml
+++ b/doc/manual/oqum/hazard/verbatim/input_gmlt_demo_LogicTreeCase1ClassicalPSHA.xml
@@ -4,7 +4,6 @@
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
 
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="gmpeModel"
                applyToTectonicRegionType="Active Shallow Crust"
                branchSetID="bs1">
@@ -21,9 +20,7 @@
                    <uncertaintyWeight>0.5</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
-        <logicTreeBranchingLevel branchingLevelID="bl2">
             <logicTreeBranchSet uncertaintyType="gmpeModel"
               applyToTectonicRegionType="Stable Continental Crust"
               branchSetID="bs2">
@@ -38,7 +35,6 @@
                   <uncertaintyWeight>0.5</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
     </logicTree>
 </nrml>

--- a/doc/manual/oqum/hazard/verbatim/input_gmlt_demo_LogicTreeCase2ClassicalPSHA.xml
+++ b/doc/manual/oqum/hazard/verbatim/input_gmlt_demo_LogicTreeCase2ClassicalPSHA.xml
@@ -3,7 +3,6 @@
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
 
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="sourceModel"
                                 branchSetID="bs1">
                 <logicTreeBranch branchID="b11">
@@ -13,9 +12,7 @@
                     <uncertaintyWeight>1.0</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
-        <logicTreeBranchingLevel branchingLevelID="bl2">
             <logicTreeBranchSet uncertaintyType="abGRAbsolute"
                                 applyToSources="1"
                                 branchSetID="bs21">
@@ -32,9 +29,7 @@
                     <uncertaintyWeight>0.334</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
-        <logicTreeBranchingLevel branchingLevelID="bl3">
             <logicTreeBranchSet uncertaintyType="abGRAbsolute"
                                 applyToSources="2"
                                 branchSetID="bs31">
@@ -51,9 +46,7 @@
                     <uncertaintyWeight>0.334</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
-        <logicTreeBranchingLevel branchingLevelID="bl4">
             <logicTreeBranchSet uncertaintyType="maxMagGRAbsolute"
                                 applyToSources="1"
                                 branchSetID="bs41">
@@ -70,9 +63,7 @@
                     <uncertaintyWeight>0.334</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
-        <logicTreeBranchingLevel branchingLevelID="bl5">
             <logicTreeBranchSet uncertaintyType="maxMagGRAbsolute"
                                 applyToSources="2"
                                 branchSetID="bs51">
@@ -89,7 +80,6 @@
                     <uncertaintyWeight>0.334</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
     </logicTree>
 </nrml>

--- a/doc/manual/oqum/hazard/verbatim/input_sslt.xml
+++ b/doc/manual/oqum/hazard/verbatim/input_sslt.xml
@@ -2,7 +2,6 @@
 <nrml xmlns:gml="http://www.opengis.net/gml"
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="sourceModel"
                                 branchSetID="bs1">
                 <logicTreeBranch branchID="b1">
@@ -11,6 +10,5 @@
                     <uncertaintyWeight>1.0</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
     </logicTree>
 </nrml>

--- a/doc/manual/oqum/hazard/verbatim/input_sslt_demo_LogicTreeCase1ClassicalPSHA.xml
+++ b/doc/manual/oqum/hazard/verbatim/input_sslt_demo_LogicTreeCase1ClassicalPSHA.xml
@@ -3,8 +3,6 @@
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
 
-        <logicTreeBranchingLevel branchingLevelID="bl1">
-
             <logicTreeBranchSet uncertaintyType="sourceModel"
                                 branchSetID="bs1">
                 <logicTreeBranch branchID="b1">
@@ -20,8 +18,6 @@
                     <uncertaintyWeight>0.5</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-
-        </logicTreeBranchingLevel>
 
     </logicTree>
 </nrml>

--- a/doc/manual/oqum/hazard/verbatim/input_sslt_demo_LogicTreeCase3ClassicalPSHA.xml
+++ b/doc/manual/oqum/hazard/verbatim/input_sslt_demo_LogicTreeCase3ClassicalPSHA.xml
@@ -3,7 +3,6 @@
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
 
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="sourceModel"
                                 branchSetID="bs1">
                 <logicTreeBranch branchID="b11">
@@ -13,9 +12,7 @@
                     <uncertaintyWeight>1.0</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
-        <logicTreeBranchingLevel branchingLevelID="bl2">
             <logicTreeBranchSet uncertaintyType="bGRRelative"
                                 branchSetID="bs21">
                 <logicTreeBranch branchID="b21">
@@ -31,9 +28,7 @@
                     <uncertaintyWeight>0.334</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
-        <logicTreeBranchingLevel branchingLevelID="bl3">
             <logicTreeBranchSet uncertaintyType="maxMagGRRelative"
                                 branchSetID="bs31">
                 <logicTreeBranch branchID="b31">
@@ -49,7 +44,6 @@
                     <uncertaintyWeight>0.334</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
     </logicTree>
 </nrml>

--- a/doc/manual/oqum/hazard/verbatim/input_sslt_simple_lt.xml
+++ b/doc/manual/oqum/hazard/verbatim/input_sslt_simple_lt.xml
@@ -3,7 +3,6 @@
       xmlns="http://openquake.org/xmlns/nrml/0.5">
     <logicTree logicTreeID="lt1">
 
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="sourceModel"
                                 branchSetID="bs1">
                 <logicTreeBranch branchID="b1">
@@ -22,9 +21,7 @@
                     <uncertaintyWeight>0.5</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
-        <logicTreeBranchingLevel branchingLevelID="bl2">
             <logicTreeBranchSet branchSetID="bs21" 
                     uncertaintyType="maxMagGRRelative">
                 <logicTreeBranch branchID="b211">
@@ -36,7 +33,6 @@
                     <uncertaintyWeight>0.4</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
 
     </logicTree>
 </nrml>

--- a/doc/manual/oqum/risk/verbatim/input_scenario_gmlt.xml
+++ b/doc/manual/oqum/risk/verbatim/input_scenario_gmlt.xml
@@ -3,7 +3,6 @@
       xmlns="http://openquake.org/xmlns/nrml/0.5">
 
 <logicTree logicTreeID="lt1">
-  <logicTreeBranchingLevel branchingLevelID="bl1">
     <logicTreeBranchSet uncertaintyType="gmpeModel" 
                         branchSetID="bs1" 
                         applyToTectonicRegionType="Active Shallow Crust">
@@ -19,7 +18,6 @@
       </logicTreeBranch>
 
     </logicTreeBranchSet>
-  </logicTreeBranchingLevel>
 </logicTree>
 
 </nrml>


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/5067. Here is the updated manual:
https://ci.openquake.org/job/builders/job/pdf-builder/144/artifact/oq-engine/doc/manual/oq-manual.pdf