### PR TITLE
Added some fast aggregation routines

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Optimized the aggregation by tag
   * Fixed a bug with the binning when disaggregating around the date line
   * Fixed a prefiltering bug with complex fault sources: in some cases, blocks
     ruptures were incorrectly discarded

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -881,7 +881,7 @@ def multi_index(shape, axis=None):
     :param axis: None or an integer in the range 0 .. L -1
     :yields: tuples of indices containing a slice(None) at the axis position
     """
-    if any(s > TWO16 for s in shape):
+    if any(s >= TWO16 for s in shape):
         raise ValueError('Shape too big: ' + str(shape))
     ranges = (range(s) for s in shape)
     if axis is None:

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -873,6 +873,20 @@ def group_array(array, *kfields):
     return groupby(array, operator.itemgetter(*kfields), _reducerecords)
 
 
+class FastAgg(object):
+    def __init__(self, keys):
+        self.uniq, self.inv = numpy.unique(keys, return_inverse=True)
+
+    def __call__(self, values):
+        assert len(values) == len(self.inv), (len(values), len(self.inv))
+        shp = values.shape[1:]
+        res = numpy.zeros((len(self.uniq),) + shp, values.dtype)
+        for idx, _ in numpy.ndenumerate(numpy.zeros(shp)):
+            tup = (slice(None),) + idx
+            res[tup] = numpy.bincount(self.inv, values[tup])
+        return res
+
+
 def count(groupiter):
     return sum(1 for row in groupiter)
 

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -928,9 +928,14 @@ def fast_agg2(tags, values=None, axis=0):
     :returns: (M unique tags, M aggregated values)
 
     >>> values = numpy.array([[.1, .11], [.2, .22], [.3, .33], [.4, .44]])
-    >>> fast_agg2(values, ['A', 'B', 'B', 'A'])
+    >>> fast_agg2(['A', 'B', 'B', 'A'], values)
     (array(['A', 'B'], dtype='<U1'), array([[0.5 , 0.55],
            [0.5 , 0.55]]))
+
+    It can also be used to count the number of tags:
+
+    >>> fast_agg2(['A', 'B', 'B', 'A', 'A'])
+    (array(['A', 'B'], dtype='<U1'), array([3., 2.]))
     """
     uniq, indices = numpy.unique(tags, return_inverse=True)
     return uniq, fast_agg(indices, values, axis)

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -879,7 +879,8 @@ def multi_index(shape, axis=None):
     """
     :param shape: a shape of lenght L with P = S1 * S2 * ... * SL
     :param axis: None or an integer in the range 0 .. L -1
-    :yields: tuples of indices containing a slice(None) at the axis position
+    :yields:
+        P tuples of indices with a slice(None) at the axis position (if any)
     """
     if any(s >= TWO16 for s in shape):
         raise ValueError('Shape too big: ' + str(shape))

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1038,6 +1038,8 @@ def save_exposed_values(dstore, assetcol, lossnames, tagnames):
             aval[array['ordinal'], lti] = array['value-' + lt[:-4]]
         elif lt in assetcol.fields:
             aval[array['ordinal'], lti] = array['value-' + lt]
+    import time
+    t0 = time.time()
     for n in range(len(tagnames) + 1, -1, -1):
         for names in itertools.combinations(tagnames, n):
             name = 'exposed_values/' + '_'.join(('agg',) + names)
@@ -1048,3 +1050,4 @@ def save_exposed_values(dstore, assetcol, lossnames, tagnames):
             for tagname in tagnames:
                 attrs[tagname] = getattr(assetcol.tagcol, tagname)[1:]
             dstore.set_attrs(name, **attrs)
+    logging.info('Stored in %.1f seconds', time.time()-t0)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1038,7 +1038,7 @@ def save_exposed_values(dstore, assetcol, lossnames, tagnames):
             aval[array['ordinal'], lti] = array['value-' + lt[:-4]]
         elif lt in assetcol.fields:
             aval[array['ordinal'], lti] = array['value-' + lt]
-    for n in range(len(tagnames) + 1):
+    for n in range(len(tagnames) + 1, -1, -1):
         for names in itertools.combinations(tagnames, n):
             name = 'exposed_values/' + '_'.join(('agg',) + names)
             logging.info('Storing %s', name)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1038,8 +1038,6 @@ def save_exposed_values(dstore, assetcol, lossnames, tagnames):
             aval[array['ordinal'], lti] = array['value-' + lt[:-4]]
         elif lt in assetcol.fields:
             aval[array['ordinal'], lti] = array['value-' + lt]
-    import time
-    t0 = time.time()
     for n in range(len(tagnames) + 1, -1, -1):
         for names in itertools.combinations(tagnames, n):
             name = 'exposed_values/' + '_'.join(('agg',) + names)
@@ -1050,4 +1048,3 @@ def save_exposed_values(dstore, assetcol, lossnames, tagnames):
             for tagname in tagnames:
                 attrs[tagname] = getattr(assetcol.tagcol, tagname)[1:]
             dstore.set_attrs(name, **attrs)
-    logging.info('Stored in %.1f seconds', time.time()-t0)

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -102,12 +102,12 @@ def _calc_risk(hazard, param, monitor):
                     if param['asset_loss_table']:
                         alt[aid, eidx, lti] = losses
                     losses_by_lt[lt] = losses
-                    acc['lossbytes'] += losses.nbytes + 8 * len(losses)
                 for loss_idx, losses in lba.compute(asset, losses_by_lt):
                     arr[(eidx, loss_idx) + tagidxs] += losses
                     if param['avg_losses']:
                         lba.losses_by_A[aid, loss_idx] += (
                             losses @ ws * param['ses_ratio'])
+                    acc['lossbytes'] += losses.nbytes
     if len(gmfs):
         acc['events_per_sid'] /= len(gmfs)
     acc['gmf_info'] = numpy.array(

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -102,7 +102,7 @@ def _calc_risk(hazard, param, monitor):
                     if param['asset_loss_table']:
                         alt[aid, eidx, lti] = losses
                     losses_by_lt[lt] = losses
-                    acc['lossbytes'] += losses.nbytes
+                    acc['lossbytes'] += losses.nbytes + 8 * len(losses)
                 for loss_idx, losses in lba.compute(asset, losses_by_lt):
                     arr[(eidx, loss_idx) + tagidxs] += losses
                     if param['avg_losses']:

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -27,7 +27,7 @@ import numpy
 
 from openquake.baselib.general import (
     humansize, groupby, countby, AccumDict, CallableDict,
-    get_array, group_array)
+    get_array, group_array, fast_agg2)
 from openquake.baselib.performance import perf_dt
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import valid
@@ -932,3 +932,16 @@ def view_gmvs(token, dstore):
     data = dstore['gmf_data/data'][()]
     gmvs = data[data['sid'] == sid]['gmv']
     return rst_table(gmvs)
+
+
+@view.add('events_by_mag')
+def view_events_by_mag(token, dstore):
+    """
+    Show how many events there are for each magnitude
+    """
+    rups = dstore['ruptures'][()]
+    num_evs = dict(zip(*fast_agg2(dstore['events']['rup_id'])))
+    counts = {}
+    for mag, grp in group_array(rups, 'mag').items():
+        counts[mag] = sum(num_evs[rup_id] for rup_id in grp['rup_id'])
+    return rst_table(counts.items(), ['mag', 'num_events'])

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -431,13 +431,13 @@ class AssetCollection(object):
         elif len(tagnames) == 1:
             # fast track for single-tag aggregation
             # for the Canada exposure it is 30x faster
-            # fast_agg(values, assets['taxonomy'])  => 47.6 ms
-            # fast_agg2(values, assets[['taxonomy']]) => 1.4 s
+            # fast_agg(assets['taxonomy'], values)  => 47.6 ms
+            # fast_agg2(assets[['taxonomy']], values) => 1.4 s
             [tagname] = tagnames
-            avalues = general.fast_agg(array, self.array[tagname])[1:]
+            avalues = general.fast_agg(self.array[tagname], array)[1:]
             tags = [(i + 1,) for i in range(len(avalues))]
         else:  # multi-tag aggregation
-            tags, avalues = general.fast_agg2(array, self.array[tagnames])
+            tags, avalues = general.fast_agg2(self.array[tagnames], array)
         shape = [len(getattr(self.tagcol, tagname))-1 for tagname in tagnames]
         arr = numpy.zeros(shape, (F32, tuple(shp)) if shp else F32)
         for tag, aval in zip(tags, avalues):

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -428,10 +428,11 @@ class AssetCollection(object):
                              (len(self), A))
         if not tagnames:
             return array.sum(axis=0)
+        fast_agg = general.FastAgg(self.array[tagnames])
         shape = [len(getattr(self.tagcol, tagname))-1 for tagname in tagnames]
-        acc = numpy.zeros(shape, (F32, shp) if shp else F32)
-        for asset, row in zip(self.array, array):
-            acc[tuple(idx - 1 for idx in asset[tagnames])] += row
+        acc = numpy.zeros(shape, (F32, tuple(shp)) if shp else F32)
+        for idx, agg in zip(fast_agg.uniq, fast_agg(array)):
+            acc[tuple(i - 1 for i in idx)] = agg
         return acc
 
     def agg_value(self, loss_types, *tagnames):

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -428,12 +428,12 @@ class AssetCollection(object):
                              (len(self), A))
         if not tagnames:
             return array.sum(axis=0)
-        fast_agg = general.FastAgg(self.array[tagnames])
+        tags, avalues = general.fast_agg2(array, self.array[tagnames])
         shape = [len(getattr(self.tagcol, tagname))-1 for tagname in tagnames]
-        acc = numpy.zeros(shape, (F32, tuple(shp)) if shp else F32)
-        for idx, agg in zip(fast_agg.uniq, fast_agg(array)):
-            acc[tuple(i - 1 for i in idx)] = agg
-        return acc
+        arr = numpy.zeros(shape, (F32, tuple(shp)) if shp else F32)
+        for tag, aval in zip(tags, avalues):
+            arr[tuple(i - 1 for i in tag)] = aval
+        return arr
 
     def agg_value(self, loss_types, *tagnames):
         """


### PR DESCRIPTION
We are up to 2 orders of magnitude faster than before in the asset aggregation phase. This is useless for the calculation itself (saving a few seconds does not matter, for Canada with 4 tags I am saving 80 seconds over 89 seconds) but it is extremely useful for data analysis.
For instance now there is a fast view showing the number of events per magnitude. For Canada
I get
```
$ oq show events_by_mag
======= ==========
mag     num_events
======= ==========
5.55000 1,377,930
5.65000 1,132,873
5.75000 932,429
5.85000 769,145
5.95000 634,674
6.05000 539,195
6.15000 448,296
6.25000 371,869
6.35000 309,582
6.45000 257,444
6.55000 265,631
6.65000 222,776
6.75000 166,723
6.85000 139,909
6.95000 107,146
7.05000 129,037
7.15000 108,948
7.25000 85,294
7.35000 69,540
7.45000 55,960
7.55000 46,329
7.65000 37,797
7.75000 31,174
7.85000 23,973
7.95000 20,626
8.05000 13,483
8.15000 9,478
8.25000 6,409
8.35000 4,168
8.45000 3,226
8.55000 2,570
8.65000 2,257
8.75000 2,165
8.85000 2,054
8.95000 2,258
9.05000 2,031
9.15000 1,018
9.25000 673
9.35000 43
9.45000 51
```
