### PR TITLE
Introduced a task_sent dataset

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -191,14 +191,14 @@ class DataStore(collections.abc.MutableMapping):
         Open the underlying .hdf5 file and the parent, if any
         """
         if self.hdf5 == ():  # not already open
-            kw = dict(mode=mode, libver='latest')
-            if mode == 'r':
-                kw['swmr'] = True
+            kw = dict(mode=mode)
             try:
                 self.hdf5 = hdf5.File(self.filename, **kw)
             except OSError as exc:
-                # there was an hdf5.File(self.filename + '~', **kw)
-                raise OSError('%s in %s' % (exc, self.filename))
+                if os.path.exists(self.filename + '~'):  # temporary file
+                    self.hdf5 = hdf5.File(self.filename + '~', **kw)
+                else:
+                    raise OSError('%s in %s' % (exc, self.filename))
 
     @property
     def export_dir(self):

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -195,10 +195,12 @@ class DataStore(collections.abc.MutableMapping):
             try:
                 self.hdf5 = hdf5.File(self.filename, **kw)
             except OSError as exc:
-                if os.path.exists(self.filename + '~'):  # temporary file
-                    self.hdf5 = hdf5.File(self.filename + '~', **kw)
-                else:
-                    raise OSError('%s in %s' % (exc, self.filename))
+                raise OSError('%s in %s' % (exc, self.filename))
+                # TODO: restore the line below when SWMR mode will be on
+                # if os.path.exists(self.filename + '~'):  # temporary file
+                #     self.hdf5 = hdf5.File(self.filename + '~', **kw)
+                # else:
+                #     raise OSError('%s in %s' % (exc, self.filename))
 
     @property
     def export_dir(self):

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -502,7 +502,7 @@ class IterResult(object):
         self.received = []
         self.nbytes = AccumDict()
         temp = self.hdf5path + '~'
-        init_performance(temp)
+        init_performance(temp, swmr=True)
         try:
             yield from self._iter(temp)
             if self.received:

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -448,7 +448,7 @@ class IterResult(object):
     :param done_total:
         a function returning the number of done tasks and the total
     :param sent:
-        the number of bytes sent (0 if OQ_DISTRIBUTE=no)
+        a nested dictionary name -> {argname: number of bytes sent}
     :param progress:
         a logging function for the progress report
     :param hdf5path:
@@ -490,8 +490,7 @@ class IterResult(object):
                 mem_gb = memory_rss(os.getpid()) / GB
             if not result.func_args:  # real output
                 name = result.mon.operation[6:]  # strip 'total '
-                result.mon.save_task_info(
-                    temp, result, name, self.sent[name], mem_gb)
+                result.mon.save_task_info(temp, result, name, mem_gb)
                 result.mon.flush(temp)
                 yield val
 
@@ -517,7 +516,7 @@ class IterResult(object):
                     logging.info('Received %s', nb)
                 if 'calc_' in self.hdf5path:
                     # collect performance info
-                    dump(temp, self.hdf5path)
+                    dump(temp, self.hdf5path, self.sent)
         finally:
             if os.path.exists(temp):
                 os.remove(temp)

--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -24,6 +24,8 @@ import tempfile
 import numpy
 from openquake.baselib.datastore import DataStore, read
 
+perf_tables = ['performance_data', 'task_info', 'task_sent']
+
 
 class DataStoreTestCase(unittest.TestCase):
     def setUp(self):
@@ -34,14 +36,13 @@ class DataStoreTestCase(unittest.TestCase):
 
     def test_hdf5(self):
         # store numpy arrays as hdf5 files
-        self.assertEqual(len(self.dstore), 2)  # performance_data, task_info
+        self.assertEqual(len(self.dstore), len(perf_tables))
+        # performance_data, task_info, task_sent
         self.dstore['/key1'] = value1 = numpy.array(['a', 'b'], dtype=bytes)
         self.dstore['/key2'] = numpy.array([1, 2])
-        self.assertEqual(list(self.dstore),
-                         ['key1', 'key2', 'performance_data', 'task_info'])
+        self.assertEqual(list(self.dstore), ['key1', 'key2'] + perf_tables)
         del self.dstore['/key2']
-        self.assertEqual(list(self.dstore),
-                         ['key1', 'performance_data', 'task_info'])
+        self.assertEqual(list(self.dstore), ['key1'] + perf_tables)
         numpy.testing.assert_equal(self.dstore['key1'], value1)
 
         self.assertGreater(self.dstore.getsize('key1'), 0)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -318,15 +318,14 @@ def view_job_info(token, dstore):
     to the workers and back in a classical calculation.
     """
     data = [['task', 'sent', 'received']]
-    task_info = dstore['task_info']
-    for task, array in group_array(task_info[()], 'taskname').items():
-        sent = 'sent_' + task
-        if sent in task_info.attrs:
-            sent = sorted(ast.literal_eval(task_info.attrs[sent]).items(),
-                          key=operator.itemgetter(1), reverse=True)
-            sent = ['%s=%s' % (k, humansize(v)) for k, v in sent[:3]]
-            recv = array['received'].sum()
-            data.append((task, ' '.join(sent), humansize(recv)))
+    task_info = dstore['task_info'][()]
+    task_sent = dict(dstore['task_sent'][()])
+    for task, array in group_array(task_info, 'taskname').items():
+        sent = sorted(ast.literal_eval(task_sent[task]).items(),
+                      key=operator.itemgetter(1), reverse=True)
+        sent = ['%s=%s' % (k, humansize(v)) for k, v in sent[:3]]
+        recv = array['received'].sum()
+        data.append((task, ' '.join(sent), humansize(recv)))
     return rst_table(data)
 
 


### PR DESCRIPTION
Apparently, it is impossible to write attributes in SWMR mode, with the risk of segfaults. The solution is to store the `task_sent` information in a dataset and not as an attribute of `task_info`.