### PR TITLE
Removed `DataStore.extend`

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -290,24 +290,6 @@ class DataStore(collections.abc.MutableMapping):
         return hdf5.create(
             self.hdf5, key, dtype, shape, compression, fillvalue, attrs)
 
-    def extend(self, key, array, **attrs):
-        """
-        Extend the dataset associated to the given key; create it if needed
-
-        :param key: name of the dataset
-        :param array: array to store
-        :param attrs: a dictionary of attributes
-        """
-        try:
-            dset = self.hdf5[key]
-        except KeyError:
-            dset = hdf5.create(self.hdf5, key, array.dtype,
-                               shape=(None,) + array.shape[1:])
-        hdf5.extend(dset, array)
-        for k, v in attrs.items():
-            dset.attrs[k] = v
-        return dset
-
     def save(self, key, kw):
         """
         Update the object associated to `key` with the `kw` dictionary;

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -991,13 +991,15 @@ def import_gmfs(dstore, fname, sids):
     dic = general.group_array(arr, 'sid')
     lst = []
     offset = 0
+    gmvlst = []
     for sid in sids:
         n = len(dic.get(sid, []))
         lst.append((offset, offset + n))
         if n:
             offset += n
             gmvs = dic[sid]
-            dstore.extend('gmf_data/data', gmvs)
+            gmvlst.append(gmvs)
+    dstore['gmf_data/data'] = numpy.concatenate(gmvlst)
     dstore['gmf_data/indices'] = numpy.array(lst, U32)
     dstore['gmf_data/imts'] = ' '.join(imts)
     dstore['weights'] = numpy.ones(1)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -161,7 +161,14 @@ class ClassicalCalculator(base.HazardCalculator):
                     if vlen:
                         self.datastore.hdf5.save_vlen('rup/' + k, v)
                     else:
-                        self.datastore.extend('rup/' + k, v)
+                        # NB: creating dataset on the fly is ugly
+                        try:
+                            dset = self.datastore['rup/' + k]
+                        except KeyError:
+                            dset = self.datastore.create_dset(
+                                'rup/' + k, v.dtype,
+                                shape=(None,) + v.shape[1:])
+                        hdf5.extend(dset, v)
         return acc
 
     def acc0(self):

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -269,7 +269,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         hdf5.extend(self.datastore['gmf_info'], dic['gmf_info'])
         if len(elt):
             with self.monitor('saving losses_by_event'):
-                hdf5.extend(self.datastore.getitem('losses_by_event'), elt)
+                hdf5.extend(self.datastore['losses_by_event'], elt)
         if self.oqparam.avg_losses:
             with self.monitor('saving avg_losses'):
                 self.datastore['avg_losses-stats'][:, 0] += dic['losses_by_A']

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -35,7 +35,7 @@ from openquake.baselib import parallel
 from openquake.commonlib import calc, util, logs
 from openquake.calculators import base, extract
 from openquake.calculators.getters import (
-    GmfGetter, RuptureGetter, gen_rupture_getters)
+    GmfGetter, RuptureGetter, gen_rupture_getters, sig_eps_dt)
 from openquake.calculators.classical import ClassicalCalculator
 from openquake.engine import engine
 
@@ -49,11 +49,6 @@ by_grp = operator.attrgetter('src_group_id')
 
 
 # ######################## GMF calculator ############################ #
-
-def update_nbytes(dstore, key, array):
-    nbytes = dstore.get_attr(key, 'nbytes', 0)
-    dstore.set_attrs(key, nbytes=nbytes + array.nbytes)
-
 
 def get_mean_curves(dstore):
     """
@@ -211,12 +206,9 @@ class EventBasedCalculator(base.HazardCalculator):
         with sav_mon:
             data = result.pop('gmfdata')
             if len(data):
-                self.datastore.extend('gmf_data/data', data)
+                hdf5.extend(self.datastore['gmf_data/data'], data)
                 sig_eps = result.pop('sig_eps')
-                self.datastore.extend('gmf_data/sigma_epsilon', sig_eps)
-                # it is important to save the number of bytes while the
-                # computation is going, to see the progress
-                update_nbytes(self.datastore, 'gmf_data/data', data)
+                hdf5.extend(self.datastore['gmf_data/sigma_epsilon'], sig_eps)
                 for sid, start, stop in result['indices']:
                     self.indices[sid, 0].append(start + self.offset)
                     self.indices[sid, 1].append(stop + self.offset)
@@ -341,6 +333,8 @@ class EventBasedCalculator(base.HazardCalculator):
             raise InvalidFile('There are no intensity measure types in %s' %
                               oq.inputs['job_ini'])
         self.datastore.create_dset('gmf_data/data', oq.gmf_data_dt())
+        self.datastore.create_dset('gmf_data/sigma_epsilon',
+                                   sig_eps_dt(oq.imtls))
         if oq.hazard_curves_from_gmfs:
             self.param['rlz_by_event'] = self.datastore['events']['rlz_id']
         iterargs = ((rgetter, srcfilter, self.param)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -296,10 +296,8 @@ class RuptureSerializer(object):
         offset = len(self.datastore['rupgeoms'])
         rup_array.array['gidx1'] += offset
         rup_array.array['gidx2'] += offset
-        previous = self.datastore.get_attr('ruptures', 'nbytes', 0)
-        self.datastore.extend(
-            'ruptures', rup_array, nbytes=previous + rup_array.nbytes)
-        self.datastore.extend('rupgeoms', rup_array.geom)
+        hdf5.extend(self.datastore['ruptures'], rup_array)
+        hdf5.extend(self.datastore['rupgeoms'], rup_array.geom)
         # TODO: PMFs for nonparametric ruptures are not stored
         self.datastore.flush()
 


### PR DESCRIPTION
Like `hdf5.extend3`, functions creating datasets on the fly does not play well with the SWMR mode.
For the same reason I am also removing `update_nbytes` which is updating dataset attributes.
Part of https://github.com/gem/oq-engine/issues/5094.