### PR TITLE
Remove early usage of the SWMR mode in classical

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -760,8 +760,6 @@ class HazardCalculator(BaseCalculator):
         # save a composite array with fields (grp_id, gsim_id, rlzs)
         if rlzs_by_grp:
             self.datastore['rlzs_by_grp'] = rlzs_by_grp
-            for dset in self.datastore['rlzs_by_grp'].values():
-                dset.flush()  # for the readers
 
     def store_source_info(self, calc_times):
         """

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -205,7 +205,7 @@ class ClassicalCalculator(base.HazardCalculator):
             self.calc_stats()  # post-processing
             return {}
 
-        self.datastore.swmr_on()
+        #self.datastore.swmr_on()
         with self.monitor('managing sources'):
             smap = parallel.Starmap(
                 self.core_task.__func__, h5=self.datastore.hdf5)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -360,6 +360,9 @@ class ClassicalCalculator(base.HazardCalculator):
         ct = oq.concurrent_tasks
         logging.info('Building hazard statistics with %d concurrent_tasks', ct)
         weights = [rlz.weight for rlz in self.rlzs_assoc.realizations]
+        for grp in self.datastore['poes'].values():
+            for dset in grp.values():
+                dset.flush()  # for the readers
         allargs = [  # this list is very fast to generate
             (getters.PmapGetter(self.datastore, weights, t.sids, oq.poes),
              N, hstats, oq.individual_curves, oq.max_sites_disagg)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -360,9 +360,6 @@ class ClassicalCalculator(base.HazardCalculator):
         ct = oq.concurrent_tasks
         logging.info('Building hazard statistics with %d concurrent_tasks', ct)
         weights = [rlz.weight for rlz in self.rlzs_assoc.realizations]
-        for grp in self.datastore['poes'].values():
-            for dset in grp.values():
-                dset.flush()  # for the readers
         allargs = [  # this list is very fast to generate
             (getters.PmapGetter(self.datastore, weights, t.sids, oq.poes),
              N, hstats, oq.individual_curves, oq.max_sites_disagg)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -205,7 +205,6 @@ class ClassicalCalculator(base.HazardCalculator):
             self.calc_stats()  # post-processing
             return {}
 
-        #self.datastore.swmr_on()
         with self.monitor('managing sources'):
             smap = parallel.Starmap(
                 self.core_task.__func__, h5=self.datastore.hdf5)
@@ -256,10 +255,7 @@ class ClassicalCalculator(base.HazardCalculator):
         logging.info('ruptures_per_task = %(maxweight)d, '
                      'task_duration = %(task_duration)ds', param)
 
-        if oq.read_sitecol:
-            srcfilter = self.src_filter(self.datastore.filename)
-        else:
-            srcfilter = self.src_filter()
+        srcfilter = self.src_filter()
         for trt, sources in trt_sources:
             heavy_sources = []
             gsims = self.csm.info.gsim_lt.get_gsims(trt)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -118,7 +118,6 @@ class OqParam(valid.ParamSet):
     poes_disagg = valid.Param(valid.probabilities, [])
     quantile_hazard_curves = quantiles = valid.Param(valid.probabilities, [])
     random_seed = valid.Param(valid.positiveint, 42)
-    read_sitecol = valid.Param(valid.boolean, False)
     reference_depth_to_1pt0km_per_sec = valid.Param(
         valid.positivefloat, numpy.nan)
     reference_depth_to_2pt5km_per_sec = valid.Param(


### PR DESCRIPTION
It was breaking Robin's calculations. Now everything works at the price of transferring the site collection
and not being able to use `oq show performance` while the calculation is running. I am also removing some experimental code. Part of https://github.com/gem/oq-engine/issues/5094.