### PR TITLE
Decoded attribute `stats` in avg_losses-stats

### DIFF
--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -23,6 +23,7 @@ avoid an external dependency.
 """
 import math
 import builtins
+import numpy
 
 
 def encode(val):
@@ -48,7 +49,9 @@ def decode(val):
     :param: a unicode or bytes object
     :returns: a unicode object
     """
-    if isinstance(val, str):
+    if isinstance(val, (list, tuple, numpy.ndarray)):
+        return [decode(v) for v in val]
+    elif isinstance(val, str):
         # it was an already decoded unicode object
         return val
     else:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -313,7 +313,7 @@ class EventBasedCalculator(base.HazardCalculator):
             # from ruptures, do not transfer sitecol
             self.datastore.parent = util.read(oq.hazard_calculation_id)
             self.init_logic_tree(self.csm_info)
-            srcfilter = self.src_filter(self.datastore.parent.filename)
+            srcfilter = self.src_filter(self.datastore.filename)
         else:
             # from sources, transfer sitecol
             srcfilter = self.src_filter()

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -29,7 +29,7 @@ import numpy
 from openquake.baselib import config, hdf5
 from openquake.baselib.hdf5 import ArrayWrapper
 from openquake.baselib.general import group_array, println
-from openquake.baselib.python3compat import encode
+from openquake.baselib.python3compat import encode, decode
 from openquake.calculators import getters
 from openquake.commonlib import calc, util, oqvalidation
 
@@ -579,13 +579,13 @@ def extract_agg_losses(dstore, what):
         stats = None
         losses = dstore['losses_by_asset'][:, :, L]['mean']
     elif 'avg_losses' in dstore:  # ebrisk
-        stats = [b'mean']
+        stats = ['mean']
         losses = dstore['avg_losses'][:, L].reshape(-1, 1)
     elif 'avg_losses-stats' in dstore:  # event_based_risk, classical_risk
-        stats = dstore['avg_losses-stats'].attrs['stats']
+        stats = decode(dstore['avg_losses-stats'].attrs['stats'])
         losses = dstore['avg_losses-stats'][:, :, L]
     elif 'avg_losses-rlzs' in dstore:  # event_based_risk, classical_risk
-        stats = [b'mean']
+        stats = ['mean']
         losses = dstore['avg_losses-rlzs'][:, :, L]
     else:
         raise KeyError('No losses found in %s' % dstore)
@@ -655,7 +655,7 @@ def extract_losses_by_asset(dstore, what):
             yield 'rlz-%03d' % rlz.ordinal, data
     elif 'avg_losses-stats' in dstore:
         avg_losses = dstore['avg_losses-stats'][()]
-        stats = dstore['avg_losses-stats'].attrs['stats']
+        stats = decode(dstore['avg_losses-stats'].attrs['stats'])
         for s, stat in enumerate(stats):
             losses = cast(avg_losses[:, s], loss_dt)
             data = util.compose_arrays(assets, losses)
@@ -865,7 +865,7 @@ def crm_attrs(dstore, what):
 def _get(dstore, name):
     try:
         dset = dstore[name + '-stats']
-        return dset, [b.decode('utf8') for b in dset.attrs['stats']]
+        return dset, decode(dset.attrs['stats'])
     except KeyError:  # single realization
         return dstore[name + '-rlzs'], ['mean']
 

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -109,7 +109,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname)
 
         aw = extract(self.calc.datastore, 'agg_losses/structural')
-        self.assertEqual(aw.stats, [b'mean'])
+        self.assertEqual(aw.stats, ['mean'])
         self.assertEqual(aw.array, numpy.float32([767.82324]))
 
         fnames = export(('agg_curves-stats', 'csv'), self.calc.datastore)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/5101. Here is the build on the plugin side: https://travis-ci.org/gem/oq-irmt-qgis/builds/587561841: @ptormene will have to change something, in particular the line  `[str(stat, 'utf8') for stat in npz['stats']] -> npz['stats']`.