### PR TITLE
Fixed the SMWR mode by closing/reopening the datastore

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -205,6 +205,7 @@ class ClassicalCalculator(base.HazardCalculator):
             self.calc_stats()  # post-processing
             return {}
 
+        self.datastore.swmr_on()
         with self.monitor('managing sources'):
             smap = parallel.Starmap(
                 self.core_task.__func__, h5=self.datastore.hdf5)
@@ -331,6 +332,8 @@ class ClassicalCalculator(base.HazardCalculator):
         if oq.hazard_calculation_id is None and 'poes' in self.datastore:
             self.datastore['disagg_by_grp'] = numpy.array(
                 sorted(data), grp_extreme_dt)
+            self.datastore.close()  # for SWMR safety
+            self.datastore.open('r+')
             self.calc_stats()
 
     def calc_stats(self):

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -344,7 +344,9 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         logging.info('Producing %d(loss_types) x %s loss curves', self.L, text)
         builder = get_loss_builder(self.datastore)
         self.build_datasets(builder)
-        self.datastore.flush()  # so that the readers see the data
+        self.datastore.close()  # so that the readers see the data
+        self.datastore.open('r+')
+        self.datastore.swmr_on()
         args = [(self.datastore.filename, builder, oq.ses_ratio, rlzi)
                 for rlzi in range(self.R)]
         acc = list(parallel.Starmap(postprocess, args,


### PR DESCRIPTION
It is possible to create new datasets after the SMWR has been enabled, but they will not be seen by the readers, even if they are flushed. The solution is to close and reopen the datastore. In this way the SMWR mode can be enable early and `oq show performance` can work also for the classical calculator.
Part of https://github.com/gem/oq-engine/issues/5094.