### PR TITLE
Extended the task queue to classical, disaggregation and event based hazard calculators

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Extended the task queue to most calculators
+  * Removed the `cache_XXX.hdf5` files by using the SWMR mode of h5py
+
   [Kris Vanneste]
   * Updated the coefficients table for the atkinson_2015 to the actual
     values in the paper.

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -688,7 +688,7 @@ class Starmap(object):
             self.progress('Sent %s of data in %d %s task(s)',
                           humansize(nbytes), total, self.name)
             if self.task_queue:
-                self.progress('%d tasks in queue', len(self.task_queue))
+                self.progress('%d task(s) in queue', len(self.task_queue))
         elif percent > self.prev_percent:
             self.progress('%s %3d%% [of %d tasks]',
                           self.name, percent, len(self.tasks))

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -687,7 +687,8 @@ class Starmap(object):
             nbytes = sum(self.sent[fname].values())
             self.progress('Sent %s of data in %d %s task(s)',
                           humansize(nbytes), total, self.name)
-            self.progress('%d tasks in queue', len(self.task_queue))
+            if self.task_queue:
+                self.progress('%d tasks in queue', len(self.task_queue))
         elif percent > self.prev_percent:
             self.progress('%s %3d%% [of %d tasks]',
                           self.name, percent, len(self.tasks))

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -191,7 +191,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.rparams = sorted(rparams)
         self.sources_by_task = {}  # task_no => src_ids
         return zd
-        
+
     def execute(self):
         """
         Run in parallel `core_task(sources, sitecol, monitor)`, by
@@ -261,6 +261,7 @@ class ClassicalCalculator(base.HazardCalculator):
         for trt, sources in trt_sources:
             gsims = self.csm.info.gsim_lt.get_gsims(trt)
             if hasattr(sources, 'atomic') and sources.atomic:
+                # do not split atomic groups
                 yield classical, sources, srcfilter, gsims, param
             else:  # regroup the sources in blocks
                 for block in block_splitter(sources, maxweight, weight):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -210,7 +210,7 @@ class ClassicalCalculator(base.HazardCalculator):
             self.core_task.__func__, h5=self.datastore.hdf5,
             num_cores=oq.num_cores)
         with self.monitor('managing sources'):
-            smap.task_queue = list(self.task_queue())
+            smap.task_queue = list(self.gen_task_queue())
         self.calc_times = AccumDict(accum=numpy.zeros(3, F32))
         try:
             acc = smap.get_results().reduce(self.agg_dicts, self.acc0())
@@ -234,7 +234,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.calc_times.clear()  # save a bit of memory
         return acc
 
-    def task_queue(self):
+    def gen_task_queue(self):
         """
         Build a task queue to be attached to the Starmap instance
         """

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -208,7 +208,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.datastore.swmr_on()
         smap = parallel.Starmap(
             self.core_task.__func__, h5=self.datastore.hdf5,
-            num_cores=oq.__class__.concurrent_tasks.default // 2 or 1)
+            num_cores=oq.num_cores)
         with self.monitor('managing sources'):
             smap.task_queue = list(self.task_queue())
         self.calc_times = AccumDict(accum=numpy.zeros(3, F32))

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -191,7 +191,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.rparams = sorted(rparams)
         self.sources_by_task = {}  # task_no => src_ids
         return zd
-
+        
     def execute(self):
         """
         Run in parallel `core_task(sources, sitecol, monitor)`, by
@@ -206,13 +206,14 @@ class ClassicalCalculator(base.HazardCalculator):
             return {}
 
         self.datastore.swmr_on()
+        smap = parallel.Starmap(
+            self.core_task.__func__, h5=self.datastore.hdf5,
+            num_cores=oq.__class__.concurrent_tasks.default // 2)
         with self.monitor('managing sources'):
-            smap = parallel.Starmap(
-                self.core_task.__func__, h5=self.datastore.hdf5)
-            self.submit_sources(smap)
+            smap.task_queue = list(self.task_queue())
         self.calc_times = AccumDict(accum=numpy.zeros(3, F32))
         try:
-            acc = smap.reduce(self.agg_dicts, self.acc0())
+            acc = smap.get_results().reduce(self.agg_dicts, self.acc0())
             self.store_rlz_info(acc.eff_ruptures)
         finally:
             with self.monitor('store source_info'):
@@ -233,9 +234,9 @@ class ClassicalCalculator(base.HazardCalculator):
         self.calc_times.clear()  # save a bit of memory
         return acc
 
-    def submit_sources(self, smap):
+    def task_queue(self):
         """
-        Send the sources split in tasks
+        Build a task queue to be attached to the Starmap instance
         """
         oq = self.oqparam
         N, L = len(self.sitecol), len(oq.imtls.array)
@@ -258,20 +259,13 @@ class ClassicalCalculator(base.HazardCalculator):
 
         srcfilter = self.src_filter()
         for trt, sources in trt_sources:
-            heavy_sources = []
             gsims = self.csm.info.gsim_lt.get_gsims(trt)
             if hasattr(sources, 'atomic') and sources.atomic:
-                smap.submit(sources, srcfilter, gsims, param, func=classical)
+                yield classical, sources, srcfilter, gsims, param
             else:  # regroup the sources in blocks
                 for block in block_splitter(sources, maxweight, weight):
-                    if block.weight > maxweight:
-                        heavy_sources.extend(block)
-                    smap.submit(block, srcfilter, gsims, param)
-
-            # heavy source are split on the master node
-            if heavy_sources:
-                logging.info('Found %d heavy sources %s, ...',
-                             len(heavy_sources), heavy_sources[0])
+                    yield (classical_split_filter, block, srcfilter,
+                           gsims, param)
 
     def save_hazard(self, acc, pmap_by_kind):
         """

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -208,7 +208,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.datastore.swmr_on()
         smap = parallel.Starmap(
             self.core_task.__func__, h5=self.datastore.hdf5,
-            num_cores=oq.__class__.concurrent_tasks.default // 2)
+            num_cores=oq.__class__.concurrent_tasks.default // 2 or 1)
         with self.monitor('managing sources'):
             smap.task_queue = list(self.task_queue())
         self.calc_times = AccumDict(accum=numpy.zeros(3, F32))

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -308,7 +308,8 @@ class DisaggregationCalculator(base.HazardCalculator):
                                     self.iml2s, trti, self.bin_edges))
         self.datastore.swmr_on()
         results = parallel.Starmap(
-            compute_disagg, allargs, h5=self.datastore.hdf5
+            compute_disagg, allargs, h5=self.datastore.hdf5,
+            num_cores=oq.num_cores
         ).reduce(self.agg_result, AccumDict(accum={}))
         self.datastore.open('r+')
         return results  # sid -> trti-> 7D array

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -206,7 +206,6 @@ class EbriskCalculator(event_based.EventBasedCalculator):
             grp_indices = self.datastore['ruptures'].attrs['grp_indices']
             n_occ = self.datastore['ruptures']['n_occ']
             dstore = self.datastore
-        num_cores = oq.__class__.concurrent_tasks.default // 2 or 1
         per_block = numpy.ceil(n_occ.sum() / (oq.concurrent_tasks or 1))
         logging.info('Using %d occurrences per block (over %d occurrences, '
                      '%d events)', per_block, n_occ.sum(), self.E)
@@ -247,7 +246,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.datastore.swmr_on()
         smap = parallel.Starmap(
             self.core_task.__func__, allargs,
-            num_cores=num_cores, h5=self.datastore.hdf5)
+            num_cores=oq.num_cores, h5=self.datastore.hdf5)
         res = smap.reduce(self.agg_dicts, numpy.zeros(self.N))
         gmf_bytes = self.datastore['gmf_info']['gmfbytes'].sum()
         logging.info(

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -145,7 +145,7 @@ class EventBasedCalculator(base.HazardCalculator):
                             allargs.append((block, srcfilter, par))
         smap = parallel.Starmap(
             self.build_ruptures.__func__, allargs, h5=self.datastore.hdf5,
-            num_cores=oq.__class__.concurrent_tasks.default // 2 or 1)
+            num_cores=oq.num_cores)
         mon = self.monitor('saving ruptures')
         for dic in smap:
             if dic['calc_times']:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -137,6 +137,7 @@ class EventBasedCalculator(base.HazardCalculator):
                     for block in self.block_splitter(sg.sources, key=by_grp):
                         if 'ucerf' in oq.calculation_mode:
                             for i in range(oq.ses_per_logic_tree_path):
+                                par = par.copy()  # avoid mutating the dict
                                 par['ses_seeds'] = [
                                     (ses_idx, oq.ses_seed + i + 1)]
                                 allargs.append((block, srcfilter, par))

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -113,6 +113,7 @@ class OqParam(valid.ParamSet):
     modal_damage_state = valid.Param(valid.boolean, False)
     number_of_ground_motion_fields = valid.Param(valid.positiveint)
     number_of_logic_tree_samples = valid.Param(valid.positiveint, 0)
+    num_cores = valid.Param(valid.positiveint, multiprocessing.cpu_count())
     num_epsilon_bins = valid.Param(valid.positiveint)
     poes = valid.Param(valid.probabilities, [])
     poes_disagg = valid.Param(valid.probabilities, [])

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -74,6 +74,7 @@ if OQ_DISTRIBUTE == 'zmq':
                     logs.LOG.warn('%s is not running', host)
                     continue
                 num_workers += sock.send('get_num_workers')
+        OqParam.num_cores.default = num_workers
         OqParam.concurrent_tasks.default = num_workers * 2
         logs.LOG.warn('Using %d zmq workers', num_workers)
 
@@ -91,6 +92,7 @@ elif OQ_DISTRIBUTE.startswith('celery'):
             logs.dbcmd('finish', job_id, 'failed')
             sys.exit(1)
         ncores = sum(stats[k]['pool']['max-concurrency'] for k in stats)
+        OqParam.num_cores.default = ncores
         OqParam.concurrent_tasks.default = ncores * 2
         logs.LOG.warn('Using %s, %d cores', ', '.join(sorted(stats)), ncores)
 


### PR DESCRIPTION
The goal is to avoid running out of memory with the Australia calculation. Moreover, since it was [requested on the mailing list](https://groups.google.com/d/msg/openquake-users/_ZTF0FXez3c/zrh_xrvpBAAJ), I am also adding a `num_cores` configuration parameter so that the user can limit the number of used cores.