### PR TITLE
Taking into account the maximum_distance when inferring the task_duration

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -246,7 +246,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if oq.task_duration is None:  # inferred
             # from 1 minute up to 9 hours
             factor = (max(oq.maximum_distance.values()) / 200) ** 2
-            td = factor * max((maxweight * N * L) ** numpy.log10(4) / 3000, 60)
+            td = factor * max((maxweight * N * L) ** numpy.log10(4) / 2000, 60)
         else:  # user given
             td = oq.task_duration
         param = dict(

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -245,7 +245,8 @@ class ClassicalCalculator(base.HazardCalculator):
             trt_sources, weight, oq.concurrent_tasks), 1E6)
         if oq.task_duration is None:  # inferred
             # from 1 minute up to 9 hours
-            td = max((maxweight * N * L) ** numpy.log10(4) / 2000, 60)
+            factor = (max(oq.maximum_distance.values()) / 200) ** 2
+            td = factor * max((maxweight * N * L) ** numpy.log10(4) / 3000, 60)
         else:  # user given
             td = oq.task_duration
         param = dict(


### PR DESCRIPTION
This part was missing, so the estimate task duration for Robin's calculations with 600 km of maximum distance was off by more than one order of magnitude.