### PR TITLE
Changed task_info and job_info datasets to fix `oq plot`

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -29,7 +29,7 @@ from openquake.baselib import hdf5
 perf_dt = numpy.dtype([('operation', '<S50'), ('time_sec', float),
                        ('memory_mb', float), ('counts', int)])
 task_info_dt = numpy.dtype(
-    [('taskname', 'S50'), ('taskno', numpy.uint32),
+    [('taskname', '<S50'), ('taskno', numpy.uint32),
      ('weight', numpy.float32), ('duration', numpy.float32),
      ('received', numpy.int64), ('mem_gb', numpy.float32)])
 

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -26,14 +26,14 @@ import numpy
 from openquake.baselib.general import humansize
 from openquake.baselib import hdf5
 
-perf_dt = numpy.dtype([('operation', (bytes, 50)), ('time_sec', float),
+perf_dt = numpy.dtype([('operation', '<S50'), ('time_sec', float),
                        ('memory_mb', float), ('counts', int)])
 task_info_dt = numpy.dtype(
-    [('taskname', hdf5.vstr), ('taskno', numpy.uint32),
+    [('taskname', 'S50'), ('taskno', numpy.uint32),
      ('weight', numpy.float32), ('duration', numpy.float32),
      ('received', numpy.int64), ('mem_gb', numpy.float32)])
 
-task_sent_dt = numpy.dtype([('taskname', hdf5.vstr), ('sent', hdf5.vstr)])
+task_sent_dt = numpy.dtype([('taskname', '<S50'), ('sent', hdf5.vstr)])
 
 
 def init_performance(hdf5file, swmr=False):

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -455,10 +455,10 @@ def extract_task_info(dstore, what):
     dic = group_array(dstore['task_info'][()], 'taskname')
     if 'kind' in what:
         name = parse(what)['kind'][0]
-        yield name, dic[name]
+        yield name, dic[encode(name)]
         return
     for name in dic:
-        yield name, dic[name]
+        yield decode(name), dic[name]
 
 
 def _agg(losses, idxs):

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -204,7 +204,8 @@ def make_figure_memory(extractors, what):
     start = 0
     for task_name in task_info:
         mem = task_info[task_name]['mem_gb']
-        ax.plot(range(start, start + len(mem)), mem, label=task_name)
+        ax.plot(range(start, start + len(mem)), mem,
+                label=task_name)
         start += len(mem)
     ax.legend()
     return plt

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -204,8 +204,7 @@ def make_figure_memory(extractors, what):
     start = 0
     for task_name in task_info:
         mem = task_info[task_name]['mem_gb']
-        ax.plot(range(start, start + len(mem)), mem,
-                label=task_name)
+        ax.plot(range(start, start + len(mem)), mem, label=task_name)
         start += len(mem)
     ax.legend()
     return plt


### PR DESCRIPTION
Due to the limitations of the NPZ format, variable-length strings cannot be used. Now
```$ oq plot 'task_info?kind=classical_split_filter' -w``` works again.
