### PR TITLE
Managed the case of few sources (i.e. not enough task submissions)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,7 +7,7 @@
   [Michele Simionato]
   * Changed the ruptures CSV exporter to use commas instead of tabs
   * Added a check forbidding `aggregate_by` for non-ebrisk calculators
-  * Extended the task queue to most calculators
+  * Introduced a task queue
   * Removed the `cache_XXX.hdf5` files by using the SWMR mode of h5py
 
   [Kris Vanneste]

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -775,9 +775,9 @@ class Starmap(object):
                 logging.warning('Discarding a result from job %s, since this '
                                 'is job %d', res.mon.calc_id, self.calc_id)
             elif res.msg == 'TASK_ENDED':
+                self.todo -= 1
                 self._submit_many(
                     queue, max(self.num_cores - self.todo, 1))
-                self.todo -= 1
                 self.log_percent()
             elif res.msg:
                 logging.warning(res.msg)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -262,8 +262,8 @@ class ClassicalCalculator(base.HazardCalculator):
             pointsource_distance=oq.pointsource_distance,
             max_sites_disagg=oq.max_sites_disagg,
             task_duration=td, maxweight=maxweight)
-        logging.info(f'ruptures_per_task = {maxweight}, '
-                     f'maxdist = {maxdist} km, task_duration = {td} s')
+        logging.info(f'ruptures_per_task={maxweight}, '
+                     f'maxdist={maxdist} km, task_duration={td} s')
 
         srcfilter = self.src_filter()
         for trt, sources in trt_sources:


### PR DESCRIPTION
The calculation of @rcgee "PSHA for PRD - preliminary model - v7 - grid uniform - Y13" contains only 9 area sources. It was slow because the new queue mechanism was using only 9 cores. This PR fixes the issue and makes uses of all the available cores.