### PR TITLE
Fixed the default user_name in create_job

### DIFF
--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -17,6 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import psutil
+import getpass
 import operator
 from datetime import datetime
 
@@ -98,7 +99,7 @@ def create_job(db, datadir):
     """
     calc_id = get_calc_id(db, datadir) + 1
     job = dict(id=calc_id, is_running=1, description='just created',
-               user_name='openquake', calculation_mode='to be set',
+               user_name=getpass.getuser(), calculation_mode='to be set',
                ds_calc_dir=os.path.join('%s/calc_%s' % (datadir, calc_id)))
     return db('INSERT INTO job (?S) VALUES (?X)',
               job.keys(), job.values()).lastrowid


### PR DESCRIPTION
The default was 'openquake', making it impossible to delete the job from a development installation. Discovered by @ptormene 