### PR TITLE
Small optimization for non-spinning point sources

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -314,7 +314,7 @@ class ContextMaker(object):
     def _gen_rup_sites(self, src, sites):
         # implements the pointsource_distance feature
         pdist = self.pointsource_distance.get(src.tectonic_region_type)
-        if hasattr(src, 'location') and pdist:
+        if hasattr(src, 'location') and pdist and src.count_nphc() > 1:
             close_sites, far_sites = sites.split(src.location, pdist)
             if close_sites is None:  # all is far
                 for rup in src.iter_ruptures(False, False):

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -192,14 +192,19 @@ class PointSource(ParametricSeismicSource):
                 if not npdist:
                     break
 
+    def count_nphc(self):
+        """
+        :returns: the number of nodal planes times the number of hypocenters
+        """
+        return len(self.nodal_plane_distribution.data) * len(
+            self.hypocenter_distribution.data)
+
     def count_ruptures(self):
         """
         See :meth:
         `openquake.hazardlib.source.base.BaseSeismicSource.count_ruptures`.
         """
-        return (len(self.get_annual_occurrence_rates()) *
-                len(self.nodal_plane_distribution.data) *
-                len(self.hypocenter_distribution.data))
+        return len(self.get_annual_occurrence_rates()) * self.count_nphc()
 
     def _get_rupture_surface(self, mag, nodal_plane, hypocenter):
         """


### PR DESCRIPTION
Ignore the pointsource_distance if the rupture is not spinning nor floating.