### PR TITLE
Turn the task queue from LIFO to FIFO

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -751,8 +751,9 @@ class Starmap(object):
 
     def _submit_many(self, queue, howmany):
         for _ in range(howmany):
-            if queue:
-                func, *args = queue.pop()
+            if queue:  # remove in FIFO order
+                func, *args = queue[0]
+                del queue[0]
                 self.submit(*args, func=func)
                 self.todo += 1
                 logging.debug('%d tasks todo, %d in queue',


### PR DESCRIPTION
The task queue was LIFO to avoid running out of memory with the Australia calculation. But after the refinement with the task duration it does not run out of memory anymore so it can be turned into a FIFO queue which has the advantage to giving more time to the slowest tasks.