### PR TITLE
Simplified `get_composite_source_model`

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -824,7 +824,7 @@ def view_act_ruptures_by_src(token, dstore):
 
 
 Source = collections.namedtuple(
-    'Source', 'source_id code num_ruptures checksum')
+    'Source', 'source_id code num_ruptures toml')
 
 
 class String(str):
@@ -840,13 +840,13 @@ def view_dupl_sources(token, dstore):
     """
     Show the sources with the same ID and the truly duplicated sources
     """
-    array = dstore['source_info']['source_id', 'checksum', 'num_ruptures']
-    dic = group_array(array, 'source_id', 'checksum')
+    array = dstore['source_info']['source_id', 'toml', 'num_ruptures']
+    dic = group_array(array, 'source_id', 'toml')
     dupl = []
     uniq = []
     muls = []
     nr = 0
-    for (source_id, checksum), group in dic.items():
+    for (source_id, toml), group in dic.items():
         mul = len(group)
         nr += group[0]['num_ruptures']
         if mul > 1:  # duplicate

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -824,7 +824,7 @@ def view_act_ruptures_by_src(token, dstore):
 
 
 Source = collections.namedtuple(
-    'Source', 'source_id code num_ruptures toml')
+    'Source', 'source_id code num_ruptures checksum')
 
 
 class String(str):
@@ -840,13 +840,13 @@ def view_dupl_sources(token, dstore):
     """
     Show the sources with the same ID and the truly duplicated sources
     """
-    array = dstore['source_info']['source_id', 'toml', 'num_ruptures']
-    dic = group_array(array, 'source_id', 'toml')
+    array = dstore['source_info']['source_id', 'checksum', 'num_ruptures']
+    dic = group_array(array, 'source_id', 'checksum')
     dupl = []
     uniq = []
     muls = []
     nr = 0
-    for (source_id, toml), group in dic.items():
+    for (source_id, checksum), group in dic.items():
         mul = len(group)
         nr += group[0]['num_ruptures']
         if mul > 1:  # duplicate

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -64,11 +64,11 @@ def source_model_info(nodes):
 
 def print_csm_info(fname):
     """
-    Parse the composite source model without instantiating the sources and
+    Parse the composite source model and
     prints information about its composition and the full logic tree
     """
     oqparam = readinput.get_oqparam(fname)
-    csm = readinput.get_composite_source_model(oqparam, in_memory=False)
+    csm = readinput.get_composite_source_model(oqparam)
     print(csm.info)
     print('See http://docs.openquake.org/oq-engine/stable/'
           'effective-realizations.html for an explanation')

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -125,7 +125,7 @@ See http://docs.openquake.org/oq-engine/stable/effective-realizations.html for a
         path = os.path.join(os.path.dirname(case_9.__file__), 'job.ini')
         with Print.patch() as p:
             info(None, None, None, None, None, None, None, path)
-        self.assertIn('RlzsAssoc(size=1, rlzs=2)', str(p))
+        self.assertIn('RlzsAssoc(size=2, rlzs=2)', str(p))
 
     def test_report(self):
         path = os.path.join(os.path.dirname(case_9.__file__), 'job.ini')

--- a/openquake/commonlib/source_model_factory.py
+++ b/openquake/commonlib/source_model_factory.py
@@ -222,6 +222,10 @@ class SourceModelFactory(object):
         spinning_off = self.oqparam.pointsource_distance == {'default': 0.0}
         if spinning_off:
             logging.info('Removing nodal plane and hypocenter distributions')
+        # NB: the source models file are often NOT in the shared directory
+        # (for instance in oq-engine/demos) so the processpool must be used
+        dist = ('no' if os.environ.get('OQ_DISTRIBUTE') == 'no'
+                else 'processpool')
         smlt_dir = os.path.dirname(self.source_model_lt.filename)
         converter = sourceconverter.SourceConverter(
             oq.investigation_time,
@@ -257,7 +261,7 @@ class SourceModelFactory(object):
                 yield sm
         else:
             logging.info('Reading the source model(s) in parallel')
-            smap = parallel.Starmap(nrml.read_source_models,
+            smap = parallel.Starmap(nrml.read_source_models, distribute=dist,
                                     h5=self.hdf5 if self.hdf5 else None)
             # NB: h5 is None in logictree_test.py
             for ltm in lt_models:

--- a/openquake/commonlib/source_model_factory.py
+++ b/openquake/commonlib/source_model_factory.py
@@ -207,7 +207,7 @@ class SourceModelFactory(object):
             srcs = []
             for src in sg:
                 toml = sourcewriter.tomldump(src)
-                src.checksum = zlib.adler32(toml)
+                src.checksum = zlib.adler32(toml.encode('utf8'))
                 srcs.append((sg.id, src.source_id, src.code,
                              src.num_ruptures, 0, 0, 0,
                              src.checksum, toml))

--- a/openquake/commonlib/source_model_factory.py
+++ b/openquake/commonlib/source_model_factory.py
@@ -206,12 +206,11 @@ class SourceModelFactory(object):
         for sg in smodel:
             srcs = []
             for src in sg:
-                dic = {k: v for k, v in vars(src).items()
-                       if k != 'id' and k != 'src_group_id'}
-                src.checksum = zlib.adler32(pickle.dumps(dic))
+                toml = sourcewriter.tomldump(src)
+                src.checksum = zlib.adler32(toml)
                 srcs.append((sg.id, src.source_id, src.code,
                              src.num_ruptures, 0, 0, 0,
-                             src.checksum, sourcewriter.tomldump(src)))
+                             src.checksum, toml))
             if sources:
                 hdf5.extend(sources, numpy.array(srcs, source_info_dt))
 

--- a/openquake/commonlib/source_model_factory.py
+++ b/openquake/commonlib/source_model_factory.py
@@ -21,13 +21,10 @@ import os.path
 import functools
 import collections
 import logging
-import pickle
-import zlib
 import numpy
 
 from openquake.baselib import hdf5, parallel
 from openquake.hazardlib import nrml, sourceconverter, sourcewriter, calc
-from openquake.commonlib import logictree
 
 TWO16 = 2 ** 16  # 65,536
 source_info_dt = numpy.dtype([
@@ -38,8 +35,7 @@ source_info_dt = numpy.dtype([
     ('calc_time', numpy.float32),      # 5
     ('num_sites', numpy.float32),      # 6
     ('eff_ruptures', numpy.float32),   # 7
-    ('checksum', numpy.uint32),        # 8
-    ('toml', hdf5.vstr),               # 9
+    ('toml', hdf5.vstr),               # 8
 ])
 
 
@@ -207,10 +203,8 @@ class SourceModelFactory(object):
             srcs = []
             for src in sg:
                 toml = sourcewriter.tomldump(src)
-                src.checksum = zlib.adler32(toml.encode('utf8'))
                 srcs.append((sg.id, src.source_id, src.code,
-                             src.num_ruptures, 0, 0, 0,
-                             src.checksum, toml))
+                             src.num_ruptures, 0, 0, 0, toml))
             if sources:
                 hdf5.extend(sources, numpy.array(srcs, source_info_dt))
 
@@ -252,7 +246,7 @@ class SourceModelFactory(object):
                 idx += 1
                 grp_id += 1
                 data = [((sg.id, src.source_id, src.code, 0, 0, -1,
-                          src.num_ruptures, idx, ''))]
+                          src.num_ruptures, ''))]
                 hdf5.extend(sources, numpy.array(data, source_info_dt))
                 yield sm
         else:

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -427,19 +427,6 @@ exposure_file = %s''' % os.path.basename(self.exposure4))
 
 
 class GetCompositeSourceModelTestCase(unittest.TestCase):
-    # test the case in_memory=False, used when running `oq info job.ini`
-
-    def test_nrml04(self):
-        oq = readinput.get_oqparam('job.ini', case_1)
-        csm = readinput.get_composite_source_model(oq, in_memory=False)
-        srcs = csm.get_sources()  # a single PointSource
-        self.assertEqual(len(srcs), 1)
-
-    def test_nrml05(self):
-        oq = readinput.get_oqparam('job.ini', case_2)
-        csm = readinput.get_composite_source_model(oq, in_memory=False)
-        srcs = csm.get_sources()  # two PointSources
-        self.assertEqual(len(srcs), 2)
 
     def test_reduce_source_model(self):
         case2 = os.path.dirname(case_2.__file__)
@@ -452,7 +439,7 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
         fname = oq.inputs['reqv'].pop('active shallow crust')
         oq.inputs['reqv']['act shallow crust'] = fname
         with self.assertRaises(ValueError) as ctx:
-            readinput.get_composite_source_model(oq, in_memory=False)
+            readinput.get_composite_source_model(oq)
         self.assertIn('Unknown TRT=act shallow crust', str(ctx.exception))
 
     def test_applyToSources(self):


### PR DESCRIPTION
By removing the `in_memory` flag which was very little used. Also, by computing the checksum from the TOML representation we can gain a few seconds. Finally, I am going back at reading the sources locally, thus closing https://github.com/gem/oq-engine/issues/5138.