### PR TITLE
Add a subprocess.wait() after terminate() in workerpool

### DIFF
--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -127,6 +127,11 @@ class WorkerMaster(object):
                 stopped.append(host)
         for popen in self.popens:
             popen.terminate()
+            # To have Popen fully dealocate the file descriptors for
+            # the spawned ssh process we must call wait() after terminate().
+            # This is due because we are not consuming any output
+            # from the spawned processes
+            popen.wait()
         self.popens = []
         return 'stopped %s' % stopped
 

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -127,10 +127,9 @@ class WorkerMaster(object):
                 stopped.append(host)
         for popen in self.popens:
             popen.terminate()
-            # To have Popen fully dealocate the file descriptors for
-            # the spawned ssh process we must call wait() after terminate().
-            # This is due because we are not consuming any output
-            # from the spawned processes
+            # since we are not consuming any output from the spawned process,
+            # we must call wait() after terminate() to have Popen()
+            # fully dealocate the process file descriptors
             popen.wait()
         self.popens = []
         return 'stopped %s' % stopped


### PR DESCRIPTION
This avoids zombies after workers have been stopped in `zmq` mode.