### PR TITLE
Switch docker images to CentOS 8

### DIFF
--- a/doc/installing/docker.md
+++ b/doc/installing/docker.md
@@ -11,6 +11,7 @@ For more information about operating system support (which includes Linux, macOS
 
 Each container includes:
 
+- CentOS 8
 - Python 3.6
 - Python dependencies (numpy, scipy, h5py...)
 - OpenQuake Engine and Hazardlib

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -17,23 +17,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-FROM centos:7
+FROM centos:8
 LABEL maintainer="Daniele Viganò <daniele@openquake.org>" \
       vendor="GEM Foundation"
 
 ARG repo=openquake-stable
 
-## CentOS 7
-RUN curl -so /etc/yum.repos.d/gem-${repo}-epel-7.repo \
-    https://copr.fedorainfracloud.org/coprs/gem/${repo}/repo/epel-7/gem-${repo}-epel-7.repo && \
-    yum -q -y install oq-python36 && \
-    yum -q -y clean all
-
-## Fedora / CentOS 8
-# RUN dnf install -y dnf-plugins-core && \
-#     dnf copr enable -y gem/$repo && \
-#     dnf install -y oq-python36 && \
-#     dnf clean all
+RUN dnf install -y dnf-plugins-core && \
+    dnf copr enable -y gem/$repo && \
+    dnf install -y oq-python36 && \
+    dnf clean all
 
 RUN useradd -u 1000 openquake && \
     mkdir /etc/openquake

--- a/docker/Dockerfile.engine
+++ b/docker/Dockerfile.engine
@@ -26,14 +26,14 @@ ARG tools_branch=master
 
 ENV PATH /opt/openquake/bin:$PATH
 ADD https://api.github.com/repos/gem/oq-engine/git/refs/heads/$oq_branch /tmp/nocache.json
-RUN pip3 -q install -r https://raw.githubusercontent.com/gem/oq-engine/$oq_branch/requirements-py36-linux64.txt \
+RUN pip3 --disable-pip-version-check -q install -r https://raw.githubusercontent.com/gem/oq-engine/$oq_branch/requirements-py36-linux64.txt \
                 -r https://raw.githubusercontent.com/gem/oq-engine/$oq_branch/requirements-extra-py36-linux64.txt && \
-    pip3 -q install https://github.com/gem/oq-engine/archive/$oq_branch.zip && \
+    pip3 --disable-pip-version-check -q install https://github.com/gem/oq-engine/archive/$oq_branch.zip && \
     for app in oq-platform-standalone oq-platform-ipt oq-platform-taxtweb oq-platform-taxonomy; do \
         if curl --output /dev/null --silent --head --fail --location https://github.com/gem/${app}/archive/$tools_branch.zip ; then \
-           pip3 -q install https://github.com/gem/${app}/archive/$tools_branch.zip; \
+           pip3 --disable-pip-version-check -q install https://github.com/gem/${app}/archive/$tools_branch.zip; \
         else \
-           pip3 -q install https://github.com/gem/${app}/archive/master.zip; \
+           pip3 --disable-pip-version-check -q install https://github.com/gem/${app}/archive/master.zip; \
         fi \
     done
 


### PR DESCRIPTION
CentOS 8 docker images are now available. Let's switch to it: benefits are: smaller images size, a more efficient Glibc, a unified workflow with Fedora.