### PR TITLE
Add splitting/filtering to the preclassical tasks

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -108,12 +108,12 @@ def preclassical(srcs, srcfilter, gsims, params, monitor):
     """
     calc_times = AccumDict(accum=numpy.zeros(3, F32))  # nrups, nsites, time
     pmap = AccumDict(accum=0)
-    for src in srcs:
+    for src, _sites in srcfilter(srcs):
         t0 = time.time()
-        if srcfilter.get_close_sites(src) is None:
-            continue
-        dt = time.time() - t0
-        calc_times[src.id] += F32([src.num_ruptures, src.nsites, dt])
+        splits, _stime = split_sources([src])
+        for s, _sites in srcfilter(splits):
+            calc_times[src.id] += F32([s.num_ruptures, s.nsites, 0])
+        calc_times[src.id][2] = time.time() - t0  # delta t
         for grp_id in src.src_group_ids:
             pmap[grp_id] += 0
     return dict(pmap=pmap, calc_times=calc_times, rup_data={'grp_id': []},

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -216,7 +216,7 @@ class ClassicalTestCase(CalculatorTestCase):
 ====== ========= ============ ============
 grp_id num_sites num_ruptures eff_ruptures
 ====== ========= ============ ============
-0      150       447          447         
+0      0.33557   447          447         
 ====== ========= ============ ============""")
 
     def test_case_15(self):

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -216,7 +216,7 @@ class ClassicalTestCase(CalculatorTestCase):
 ====== ========= ============ ============
 grp_id num_sites num_ruptures eff_ruptures
 ====== ========= ============ ============
-0      10        447          447         
+0      150       447          447         
 ====== ========= ============ ============""")
 
     def test_case_15(self):

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -228,6 +228,7 @@ def view_ruptures_per_grp(token, dstore):
     info = dstore['source_info'][()]
     agg = fast_agg3(
         info, 'grp_id', ['num_sites', 'num_ruptures', 'eff_ruptures'])
+    agg['num_sites'] /= agg['eff_ruptures']
     return rst_table(agg)
 
 

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -129,7 +129,6 @@ class SourceReader(object):
     def __call__(self, ltmodel, apply_unc, fname, fileno, monitor):
         fname_hits = collections.Counter()  # fname -> number of calls
         mags = set()
-        source_ids = set()
         src_groups = []
         [sm] = nrml.read_source_models([fname], self.converter, monitor)
         newsm = self.makesm(fname, sm, apply_unc)
@@ -147,7 +146,6 @@ class SourceReader(object):
                     srcmags = [item[0] for item in
                                src.get_annual_occurrence_rates()]
                 mags.update(srcmags)
-                source_ids.add(src.source_id)
                 toml = sourcewriter.tomldump(src)
                 checksum = zlib.adler32(toml.encode('utf8'))
                 sg.info[i] = (ltmodel.ordinal, 0, src.source_id,
@@ -155,7 +153,7 @@ class SourceReader(object):
                               src.wkt(), toml)
             src_groups.append(sg)
         return dict(fname_hits=fname_hits, changes=newsm.changes,
-                    src_groups=src_groups, mags=mags, source_ids=source_ids,
+                    src_groups=src_groups, mags=mags,
                     ordinal=ltmodel.ordinal, fileno=fileno)
 
 


### PR DESCRIPTION
In this way the estimate for the effective ruptures is more reliable, even if the calculation becomes slower (50 minutes for full Australia instead of 10 minutes). I am also fixing the view `ruptures_per_trt`.