### PR TITLE
Saved a lot of memory in calculations with subtasks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced substantially the memory occupation in the task queue
   * Added an API `/extract/sources` and an experimental `oq plot sources`
   * Added a check on valid input keys in the job.ini
   * Fixed the check on dependent calculations

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -141,6 +141,7 @@ fast sources.
 import os
 import re
 import sys
+import gzip
 import time
 import socket
 import signal
@@ -234,7 +235,8 @@ class Pickled(object):
         self.clsname = obj.__class__.__name__
         self.calc_id = str(getattr(obj, 'calc_id', ''))  # for monitors
         try:
-            self.pik = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
+            self.pik = gzip.compress(
+                pickle.dumps(obj, pickle.HIGHEST_PROTOCOL))
         except TypeError as exc:  # can't pickle, show the obj in the message
             raise TypeError('%s: %s' % (exc, obj))
 
@@ -249,7 +251,7 @@ class Pickled(object):
 
     def unpickle(self):
         """Unpickle the underlying object"""
-        return pickle.loads(self.pik)
+        return pickle.loads(gzip.decompress(self.pik))
 
 
 def get_pickled_sizes(obj):

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -482,11 +482,14 @@ class IterResult(object):
             if isinstance(result, BaseException):
                 # this happens with WorkerLostError with celery
                 raise result
-            elif isinstance(result, Result) and not result.func:
-                val = result.get()
-                self.received.append(len(result.pik))
-                if hasattr(result, 'nbytes'):
-                    self.nbytes += result.nbytes
+            elif isinstance(result, Result):
+                if result.func:  # result contains subtask arguments
+                    self.received.append(sum(len(p) for p in result.pik))
+                else:
+                    val = result.get()
+                    self.received.append(len(result.pik))
+                    if hasattr(result, 'nbytes'):
+                        self.nbytes += result.nbytes
             else:  # this should never happen
                 raise ValueError(result)
             if sys.platform != 'darwin':

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -312,7 +312,7 @@ class Result(object):
             # store the size in bytes of the content
             self.nbytes = {k: len(Pickled(v)) for k, v in val.items()}
         elif isinstance(val, tuple) and callable(val[0]):
-            self.func_args = val
+            self.func_args = (val[0], val[1:])
         self.pik = Pickled(val)
         self.mon = mon
         self.tb_str = tb_str

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -701,7 +701,7 @@ class Starmap(object):
             self.prev_percent = percent
         return done
 
-    def submit(self, *args, func=None, monitor=None):
+    def submit(self, args, func=None, monitor=None):
         """
         Submit the given arguments to the underlying task
         """
@@ -756,7 +756,7 @@ class Starmap(object):
             if queue:  # remove in FIFO order
                 func, *args = queue[0]
                 del queue[0]
-                self.submit(*args, func=func)
+                self.submit(args, func=func)
                 self.todo += 1
                 logging.debug('%d tasks todo, %d in queue',
                               self.todo, len(queue))
@@ -767,7 +767,7 @@ class Starmap(object):
             first_args = queue[:self.num_cores]
             queue = self.task_queue = queue[self.num_cores:]
             for func, *args in first_args:
-                self.submit(*args, func=func)
+                self.submit(args, func=func)
         if not hasattr(self, 'socket'):  # no submit was ever made
             return ()
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -221,6 +221,15 @@ def oq_distribute(task=None):
     return dist
 
 
+if config.general.compress:
+    # must be a global config since every change requires a DbServer restart
+    compress = gzip.compress
+    decompress = gzip.decompress
+else:
+    compress = lambda x: x
+    decompress = lambda x: x
+
+
 class Pickled(object):
     """
     An utility to manually pickling/unpickling objects.
@@ -235,8 +244,7 @@ class Pickled(object):
         self.clsname = obj.__class__.__name__
         self.calc_id = str(getattr(obj, 'calc_id', ''))  # for monitors
         try:
-            self.pik = gzip.compress(
-                pickle.dumps(obj, pickle.HIGHEST_PROTOCOL))
+            self.pik = compress(pickle.dumps(obj, pickle.HIGHEST_PROTOCOL))
         except TypeError as exc:  # can't pickle, show the obj in the message
             raise TypeError('%s: %s' % (exc, obj))
 
@@ -251,7 +259,7 @@ class Pickled(object):
 
     def unpickle(self):
         """Unpickle the underlying object"""
-        return pickle.loads(gzip.decompress(self.pik))
+        return pickle.loads(decompress(self.pik))
 
 
 def get_pickled_sizes(obj):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -271,10 +271,10 @@ class ClassicalCalculator(base.HazardCalculator):
             gsims = self.csm_info.gsim_lt.get_gsims(trt)
             if atomic:
                 # do not split atomic groups
-                yield f1, sources, srcfilter, gsims, param
+                yield f1, (sources, srcfilter, gsims, param)
             else:  # regroup the sources in blocks
                 for block in block_splitter(sources, maxweight, weight):
-                    yield f2, block, srcfilter, gsims, param
+                    yield f2, (block, srcfilter, gsims, param)
 
     def save_hazard(self, acc, pmap_by_kind):
         """

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -15,6 +15,7 @@
 
 [general]
 strict = false
+compress = false
 
 [distribution]
 # set multi_node = true if are on a cluster


### PR DESCRIPTION
The Australia calculation was using 90+ GB of RAM on the controller node because I was passing the attribute `.func_args` of the Result object which is big. In this PR I am only passing the `.func` attribute, which is small, while the arguments are passed in pickled form in the `.pik` attribute. This also avoids pickling/unpickling twice the arguments of subtasks. With this change the Australia calculation takes less than 30 GB of RAM on the controller node.

PS: I am also adding support for compression of the data transferred, but it is disabled by default. It is likely not worth the affort but it is there for experimentation purposes.