### PR TITLE
Do not transfer the SourceFilter in ebrisk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced the sent data transfer in ebrisk calculations
   * Replaced the `pointsource_distance` concept with a `collapse_distance`
   * Deprecated the old syntax for the `reqv` feature
   * Added short aliases for hazard statistics `mean`, `max` and `std`

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -224,7 +224,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         eslices = self.datastore['eslices']
         allargs = []
         allpairs = list(enumerate(n_occ))
-        srcfilter = self.src_filter()
+        srcfilter = self.src_filter(self.datastore.tempname)
         for grp_id, rlzs_by_gsim in rlzs_by_gsim_grp.items():
             start, stop = grp_indices[grp_id]
             if start == stop:  # no ruptures for the given grp_id

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -200,6 +200,7 @@ def cache_epsilons(dstore, oq, assetcol, crmodel, E):
                 numpy.random.seed(seed)
                 eps[:, i] = numpy.random.normal(size=A)
     with hdf5.File(dstore.tempname, 'w') as cache:
+        cache['sitecol'] = dstore['sitecol']
         cache['epsilon_matrix'] = eps
     return dstore.tempname
 


### PR DESCRIPTION
This can reduce the data transfer a lot. For instance for Canada the data transfer in the SourceFilter is one order of magnitude larger than the remaining data transfer:
```
michele@wilson:~$ oq1 show job_info 28937 
============ ==================================================== ========
task         sent                                                 received
start_ebrisk srcfilter=10.37 GB param=752 MB rupgetter=124.73 MB  27.95 GB
ebrisk       srcfilter=19.54 GB param=1.38 GB rupgetters=183.3 MB 20.34 GB
============ ==================================================== ========
```
