### PR TITLE
Refined the point source weight

### DIFF
--- a/openquake/calculators/ucerf_base.py
+++ b/openquake/calculators/ucerf_base.py
@@ -172,7 +172,6 @@ class UCERFSource(BaseSeismicSource):
     code = b'U'
     MODIFICATIONS = set()
     tectonic_region_type = DEFAULT_TRT
-    RUPTURE_WEIGHT = 1  # not very heavy
 
     def __init__(
             self, source_file, investigation_time, start_date, min_mag,

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -17,7 +17,6 @@
 Module :mod:`openquake.hazardlib.source.area` defines :class:`AreaSource`.
 """
 import math
-import numpy
 from copy import deepcopy
 from openquake.hazardlib import geo, mfd
 from openquake.hazardlib.source.point import PointSource
@@ -46,10 +45,7 @@ class AreaSource(ParametricSeismicSource):
     _slots_ = ParametricSeismicSource._slots_ + '''upper_seismogenic_depth
     lower_seismogenic_depth nodal_plane_distribution hypocenter_distribution
     polygon area_discretization'''.split()
-
     MODIFICATIONS = set(())
-
-    RUPTURE_WEIGHT = 0.1
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -56,7 +56,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         """
         if not self.num_ruptures:
             self.num_ruptures = self.count_ruptures()
-        if self.code == b'P':  # point source
+        if hasattr(self, 'nodal_plane_distribution'):  # point source
             nr = len(self.get_annual_occurrence_rates())  # ignore hcd, npd
         else:
             nr = self.num_ruptures

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -41,7 +41,6 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
     """
     _slots_ = ['source_id', 'name', 'tectonic_region_type',
                'src_group_id', 'num_ruptures', 'id', 'min_mag']
-    RUPTURE_WEIGHT = 1.  # overridden in (Multi)PointSource, AreaSource
     ngsims = 1
     min_mag = 0  # set in get_oqparams and CompositeSourceModel.filter
     splittable = True
@@ -57,7 +56,11 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         """
         if not self.num_ruptures:
             self.num_ruptures = self.count_ruptures()
-        return self.num_ruptures * math.sqrt(self.nsites)
+        if self.code == b'P':  # point source
+            nr = len(self.get_annual_occurrence_rates())  # ignore hcd, npd
+        else:
+            nr = self.num_ruptures
+        return nr * math.sqrt(self.nsites)
 
     @property
     def nsites(self):

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -149,12 +149,8 @@ class ComplexFaultSource(ParametricSeismicSource):
     """
     code = b'C'
     # a slice of the rupture_slices, thus splitting the source
-
     _slots_ = ParametricSeismicSource._slots_ + '''edges rake'''.split()
-
     MODIFICATIONS = set(('set_geometry',))
-
-    RUPTURE_WEIGHT = 4.0  # makes ComplexFaultSources heavy
 
     def __init__(self, source_id, name, tectonic_region_type, mfd,
                  rupture_mesh_spacing, magnitude_scaling_relationship,

--- a/openquake/hazardlib/source/multi.py
+++ b/openquake/hazardlib/source/multi.py
@@ -47,7 +47,6 @@ class MultiPointSource(ParametricSeismicSource):
     """
     code = b'M'
     MODIFICATIONS = set(())
-    RUPTURE_WEIGHT = 0.1
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, magnitude_scaling_relationship, rupture_aspect_ratio,

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -17,7 +17,6 @@
 Module :mod:`openquake.hazardlib.source.point` defines :class:`PointSource`.
 """
 import math
-import numpy
 from openquake.baselib.slots import with_slots
 from openquake.hazardlib.scalerel import PointMSR
 from openquake.hazardlib.geo import Point, geodetic
@@ -106,10 +105,7 @@ class PointSource(ParametricSeismicSource):
     lower_seismogenic_depth location nodal_plane_distribution
     hypocenter_distribution
     '''.split()
-
     MODIFICATIONS = set(())
-
-    RUPTURE_WEIGHT = 0.1
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/hazardlib/source/rupture_collection.py
+++ b/openquake/hazardlib/source/rupture_collection.py
@@ -31,9 +31,7 @@ class RuptureCollectionSource(ParametricSeismicSource):
     # the mosaic test for Canada is sensitive to such _slots_
     _slots_ = ['source_id', 'name', 'tectonic_region_type', 'num_ruptures',
                'min_mag', 'mfd']
-
     MODIFICATIONS = set()
-    RUPTURE_WEIGHT = 4.0  # the same as ComplexFaultSources
 
     def __init__(self, source_id, name, tectonic_region_type, mfd, ruptures):
         self.source_id = source_id


### PR DESCRIPTION
Having introduced the collapse distance, point sources have become effectively lighter.
Here I am refining their weight by ignoring hypocenter and nodal plane distributions. This solves
the issue of slow tasks. In the case of Philippines this reduces the slowest task by a factor of 6, from 3024 to 488 seconds and the total runtime of the calculation by more than a factor of 2.