### PR TITLE
Some refactoring of get_poes

### DIFF
--- a/openquake/hazardlib/const.py
+++ b/openquake/hazardlib/const.py
@@ -109,6 +109,5 @@ class StdDev(ConstantContainer):
     #: of inter- and intra-event squared standard deviations, represents
     #: the total ground shaking variability, and is the only one that
     #: is used for calculating a probability of intensity exceedance
-    #: (see
-    #: :meth:`openquake.hazardlib.gsim.base.GroundShakingIntensityModel.get_poes`).
+    #: (see :func:`openquake.hazardlib.gsim.base.get_poes`).
     TOTAL = 'Total'

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -24,6 +24,7 @@ import numpy
 from openquake.baselib.general import AccumDict
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import imt as imt_module
+from openquake.hazardlib.gsim import base
 from openquake.hazardlib.calc.filters import IntegrationDistance
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.geo.surface import PlanarSurface
@@ -326,7 +327,7 @@ class ContextMaker(object):
                 if not (hasattr(gsim, 'weight') and gsim.weight[imt] == 0):
                     # set by the engine when parsing the gsim logictree;
                     # when 0 ignore the gsim: see _build_trts_branches
-                    poes[:, imtls(imt), g] = gsim.get_poes(
+                    poes[:, imtls(imt), g] = base.get_poes(
                         mean_std[g, :, :, m], imtls[imt], self.trunclevel)
         return rupture.get_probability_no_exceedance(poes)
 
@@ -538,8 +539,7 @@ class RuptureContext(BaseContext):
             rupture occurrence causes a ground shaking value exceeding a
             ground motion level at a site. First dimension represent sites,
             second dimension intensity measure levels. ``poes`` can be obtained
-            calling the :meth:`method
-            <openquake.hazardlib.gsim.base.GroundShakingIntensityModel.get_poes>
+            calling the :func:`func <openquake.hazardlib.gsim.base.get_poes>
         """
         if numpy.isnan(self.occurrence_rate):  # nonparametric rupture
             # Uses the formula

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -22,7 +22,7 @@ import time
 import warnings
 import numpy
 
-from openquake.baselib.general import AccumDict
+from openquake.baselib.general import AccumDict, DictArray
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import imt as imt_module
 from openquake.hazardlib.gsim import base
@@ -187,7 +187,7 @@ class ContextMaker(object):
         self.ctx_mon = monitor('make_contexts', measuremem=False)
         self.poe_mon = monitor('get_poes', measuremem=False)
         self.gmf_mon = monitor('computing mean_std', measuremem=False)
-        self.loglevels = copy.copy(self.imtls)
+        self.loglevels = DictArray(self.imtls)
         with warnings.catch_warnings():
             # avoid RuntimeWarning: divide by zero encountered in log
             warnings.simplefilter("ignore")

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -327,7 +327,7 @@ class ContextMaker(object):
                 if not (hasattr(gsim, 'weight') and gsim.weight[imt] == 0):
                     # set by the engine when parsing the gsim logictree;
                     # when 0 ignore the gsim: see _build_trts_branches
-                    poes[:, imtls(imt), g] = base.get_poes(
+                    poes[:, imtls(imt), g] = gsim.get_poes(
                         mean_std[g, :, :, m], imtls[imt], self.trunclevel)
         return rupture.get_probability_no_exceedance(poes)
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -85,7 +85,7 @@ def get_poes(mean_std, imls, truncation_level, gsims=None):
         An array of shape (2, N) with mean and standard deviation for
         the current intensity measure type
     :param imls:
-        List of interested intensity measure levels
+        Logarithms of interested intensity measure levels
     :param truncation_level:
         Can be ``None``, which means that the distribution of intensity
         is treated as Gaussian distribution with possible values ranging
@@ -122,13 +122,9 @@ def get_poes(mean_std, imls, truncation_level, gsims=None):
                          'or None')
     mean, stddev = mean_std
     shp = mean.shape + (1,)
-    with warnings.catch_warnings():
-        # avoid RuntimeWarning: divide by zero encountered in log
-        warnings.simplefilter("ignore")
-        imls = numpy.log(imls)
-
     if truncation_level == 0:  # just compare imls to mean
         return imls <= mean.reshape(shp)
+
     # else use real normal distribution
     values = (imls - mean.reshape(shp)) / stddev.reshape(shp)
     if truncation_level is None:

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -75,6 +75,69 @@ def gsim_imt_dt(sorted_gsims, sorted_imts):
     return numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
 
 
+def get_poes(mean_std, imls, truncation_level):
+    """
+    Calculate and return probabilities of exceedance (PoEs) of one or more
+    intensity measure levels (IMLs) of one intensity measure type (IMT)
+    for one or more pairs "site -- rupture".
+
+    :param mean_std:
+        An array of shape (2, N) with mean and standard deviation for
+        the current intensity measure type
+    :param imls:
+        List of interested intensity measure levels
+    :param truncation_level:
+        Can be ``None``, which means that the distribution of intensity
+        is treated as Gaussian distribution with possible values ranging
+        from minus infinity to plus infinity.
+
+        When set to zero, the mean intensity is treated as an exact
+        value (standard deviation is not even computed for that case)
+        and resulting array contains 0 in places where IMT is strictly
+        lower than the mean value of intensity and 1.0 where IMT is equal
+        or greater.
+
+        When truncation level is positive number, the intensity
+        distribution is processed as symmetric truncated Gaussian with
+        range borders being ``mean - truncation_level * stddev`` and
+        ``mean + truncation_level * stddev``. That is, the truncation
+        level expresses how far the range borders are from the mean
+        value and is defined in units of sigmas. The resulting PoEs
+        for that mode are values of complementary cumulative distribution
+        function of that truncated Gaussian applied to IMLs.
+
+    :returns:
+        A dictionary of the same structure as parameter ``imts`` (see
+        above). Instead of lists of IMLs values of the dictionaries
+        have 2d numpy arrays of corresponding PoEs, first dimension
+        represents sites and the second represents IMLs.
+
+    :raises ValueError:
+        If truncation level is not ``None`` and neither non-negative
+        float number, and if ``imts`` dictionary contain wrong or
+        unsupported IMTs (see :attr:`DEFINED_FOR_INTENSITY_MEASURE_TYPES`).
+    """
+    if truncation_level is not None and truncation_level < 0:
+        raise ValueError('truncation level must be zero, positive number '
+                         'or None')
+    mean, stddev = mean_std
+    mean = mean.reshape(mean.shape + (1, ))
+    stddev = stddev.reshape(stddev.shape + (1, ))
+    with warnings.catch_warnings():
+        # avoid RuntimeWarning: divide by zero encountered in log
+        warnings.simplefilter("ignore")
+        imls = numpy.log(imls)
+
+    if truncation_level == 0:  # just compare imls to mean
+        return imls <= mean
+    # else use real normal distribution
+    values = (imls - mean) / stddev
+    if truncation_level is None:
+        return _norm_sf(values)
+    else:
+        return _truncnorm_sf(truncation_level, values)
+
+
 class MetaGSIM(abc.ABCMeta):
     """
     A metaclass converting set class attributes into frozensets, to avoid
@@ -291,65 +354,6 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
             arr[0, :, m] = mean
             arr[1, :, m] = std
         return arr
-
-    def get_poes(self, mean_std, imls, truncation_level):
-        """
-        Calculate and return probabilities of exceedance (PoEs) of one or more
-        intensity measure levels (IMLs) of one intensity measure type (IMT)
-        for one or more pairs "site -- rupture".
-
-        :param mean_std:
-            An array of shape (2, N) with mean and standard deviation for
-            the current intensity measure type
-        :param imls:
-            List of interested intensity measure levels
-        :param truncation_level:
-            Can be ``None``, which means that the distribution of intensity
-            is treated as Gaussian distribution with possible values ranging
-            from minus infinity to plus infinity.
-
-            When set to zero, the mean intensity is treated as an exact
-            value (standard deviation is not even computed for that case)
-            and resulting array contains 0 in places where IMT is strictly
-            lower than the mean value of intensity and 1.0 where IMT is equal
-            or greater.
-
-            When truncation level is positive number, the intensity
-            distribution is processed as symmetric truncated Gaussian with
-            range borders being ``mean - truncation_level * stddev`` and
-            ``mean + truncation_level * stddev``. That is, the truncation
-            level expresses how far the range borders are from the mean
-            value and is defined in units of sigmas. The resulting PoEs
-            for that mode are values of complementary cumulative distribution
-            function of that truncated Gaussian applied to IMLs.
-
-        :returns:
-            A dictionary of the same structure as parameter ``imts`` (see
-            above). Instead of lists of IMLs values of the dictionaries
-            have 2d numpy arrays of corresponding PoEs, first dimension
-            represents sites and the second represents IMLs.
-
-        :raises ValueError:
-            If truncation level is not ``None`` and neither non-negative
-            float number, and if ``imts`` dictionary contain wrong or
-            unsupported IMTs (see :attr:`DEFINED_FOR_INTENSITY_MEASURE_TYPES`).
-        """
-        if truncation_level is not None and truncation_level < 0:
-            raise ValueError('truncation level must be zero, positive number '
-                             'or None')
-        mean, stddev = mean_std
-        mean = mean.reshape(mean.shape + (1, ))
-        stddev = stddev.reshape(stddev.shape + (1, ))
-        imls = self.to_distribution_values(imls)
-        if truncation_level == 0:  # just compare imls to mean
-            return imls <= mean
-
-        # else use real normal distribution
-        values = (imls - mean) / stddev
-        if truncation_level is None:
-            return _norm_sf(values)
-        else:
-            return _truncnorm_sf(truncation_level, values)
 
     @abc.abstractmethod
     def to_distribution_values(self, values):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -253,6 +253,7 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
     superseded_by = None
     non_verified = False
     experimental = False
+    get_poes = staticmethod(get_poes)
 
     @classmethod
     def __init_subclass__(cls):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -123,14 +123,13 @@ def get_poes(mean_std, imtls, truncation_level, gsims=None):
     mean, stddev = mean_std  # shape (N, M) each
     N, L = len(mean), len(imtls.array)
     out = numpy.zeros((N, L))
-    lvl = 0
     for m, imt in enumerate(imtls):
-        for iml in imtls[imt]:
-            if truncation_level == 0:  # just compare imls to mean
-                out[:, lvl] = iml <= mean[:, m]
-            else:
-                out[:, lvl] = (iml - mean[:, m]) / stddev[:, m]
-            lvl += 1
+        imls = imtls[imt]
+        if truncation_level == 0:  # just compare imls to mean
+            out[:, imtls(imt)] = imls <= mean[:, m].reshape(N, 1)
+        else:
+            m, s = mean[:, m].reshape(N, 1), stddev[:, m].reshape(N, 1)
+            out[:, imtls(imt)] = (imls - m) / s
     if truncation_level == 0:
         return out
     elif truncation_level is None:

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -127,7 +127,7 @@ def get_poes(mean_std, imtls, truncation_level, gsims=None):
     for m, imt in enumerate(imtls):
         for iml in imtls[imt]:
             if truncation_level == 0:  # just compare imls to mean
-                out[:, lvl] = imtls[imt] <= mean[:, m]
+                out[:, lvl] = iml <= mean[:, m]
             else:
                 out[:, lvl] = (iml - mean[:, m]) / stddev[:, m]
             lvl += 1

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -75,7 +75,7 @@ def gsim_imt_dt(sorted_gsims, sorted_imts):
     return numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
 
 
-def get_poes(mean_std, imls, truncation_level):
+def get_poes(mean_std, imls, truncation_level, gsims=None):
     """
     Calculate and return probabilities of exceedance (PoEs) of one or more
     intensity measure levels (IMLs) of one intensity measure type (IMT)
@@ -121,17 +121,16 @@ def get_poes(mean_std, imls, truncation_level):
         raise ValueError('truncation level must be zero, positive number '
                          'or None')
     mean, stddev = mean_std
-    mean = mean.reshape(mean.shape + (1, ))
-    stddev = stddev.reshape(stddev.shape + (1, ))
+    shp = mean.shape + (1,)
     with warnings.catch_warnings():
         # avoid RuntimeWarning: divide by zero encountered in log
         warnings.simplefilter("ignore")
         imls = numpy.log(imls)
 
     if truncation_level == 0:  # just compare imls to mean
-        return imls <= mean
+        return imls <= mean.reshape(shp)
     # else use real normal distribution
-    values = (imls - mean) / stddev
+    values = (imls - mean.reshape(shp)) / stddev.reshape(shp)
     if truncation_level is None:
         return _norm_sf(values)
     else:

--- a/openquake/hazardlib/gsim/nshmp_2014.py
+++ b/openquake/hazardlib/gsim/nshmp_2014.py
@@ -121,7 +121,7 @@ def get_mean_and_stddevs(self, sctx, rctx, dctx, imt, stddev_types):
 DEFAULT_WEIGHTING = [(0.185, -1.), (0.63, 0.), (0.185, 1.)]
 
 
-def get_weighted_poes(gsim, mean_std, imls, truncation_level,
+def get_weighted_poes(gsim, mean_std, imtls, truncation_level,
                       weighting=DEFAULT_WEIGHTING):
     """
     This function implements the NGA West 2 GMPE epistemic uncertainty
@@ -133,11 +133,12 @@ def get_weighted_poes(gsim, mean_std, imls, truncation_level,
         Weightings as a list of tuples of (weight, number standard deviations
         of the epistemic uncertainty adjustment)
     """
-    mean = np.array(mean_std[0])  # make a copy
-    output = np.zeros([len(mean), len(imls)])
+    mean = np.array(mean_std[0])  # make a copy, shape (N, M)
+    output = np.zeros([len(mean), len(imtls.array)])
     for w, s in weighting:
-        mean_std[0] = mean + s * gsim.adjustment
-        output += base.get_poes(mean_std, imls, truncation_level) * w
+        for m in range(len(imtls)):
+            mean_std[0, :, m] = mean[:, m] + s * gsim.adjustment
+        output += base.get_poes(mean_std, imtls, truncation_level) * w
     return output
 
 

--- a/openquake/hazardlib/gsim/nshmp_2014.py
+++ b/openquake/hazardlib/gsim/nshmp_2014.py
@@ -28,9 +28,9 @@ Module exports :class:`AbrahamsonEtAl2014NSHMPUpper`
                :class:`Idriss2014NSHMPUpper`
                :class:`Idriss2014NSHMPLower`
 """
-import copy
 import numpy as np
 # NGA West 2 GMPEs
+from openquake.hazardlib.gsim import base
 from openquake.hazardlib.gsim.abrahamson_2014 import AbrahamsonEtAl2014
 from openquake.hazardlib.gsim.boore_2014 import BooreEtAl2014
 from openquake.hazardlib.gsim.campbell_bozorgnia_2014 import \
@@ -137,8 +137,7 @@ def get_weighted_poes(gsim, mean_std, imls, truncation_level,
     output = np.zeros([len(mean), len(imls)])
     for w, s in weighting:
         mean_std[0] = mean + s * gsim.adjustment
-        output += gsim.__class__.__base__.get_poes(
-            gsim, mean_std, imls, truncation_level) * w
+        output += base.get_poes(mean_std, imls, truncation_level) * w
     return output
 
 

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -182,12 +182,11 @@ class PoissonTOM(BaseTOM):
         :param occurrence_rate:
             The average number of events per year.
         :param poes:
-            2D numpy array containing conditional probabilities that the 
+            2D numpy array containing conditional probabilities that the
             rupture occurrence causes a ground shaking value exceeding a
             ground motion level at a site. First dimension represent sites,
             second dimension intensity measure levels. ``poes`` can be obtained
-            calling the :meth:`method
-            <openquake.hazardlib.gsim.base.GroundShakingIntensityModel.get_poes>`.
+            calling the :func:`func <openquake.hazardlib.gsim.base.get_poes>`.
         :return:
             2D numpy array containing probabilities of no exceedance. First
             dimension represents sites, second dimensions intensity measure


### PR DESCRIPTION
First step towards https://github.com/gem/oq-engine/issues/5175. I have moved the computation of the log levels outside the inner loop and changed the signature of get_poes to use the `imtls` instead of the `imls`.