### PR TITLE
Removed asset_loss_table from ebrisk

### DIFF
--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -188,9 +188,14 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         os.remove(fname)
 
     def test_case_12(self):
-        # 1 assets, 2 samples
+        # 2 assets, 2 samples, aggregate_by=id
         self.run_calc(case_master.__file__, 'job12.ini', exports='csv')
-        # alt = extract(self.calc.datastore, 'asset_loss_table')
+        # check size of the event_loss_table
+        arr = self.calc.datastore['losses_by_event'][()]
+        self.assertEqual(len(arr), 16)
+        self.assertEqual(arr['event_id'].nbytes, 64)
+        self.assertEqual(arr['rlzi'].nbytes, 32)
+        self.assertEqual(arr['loss'].nbytes, 128)
         [fname] = export(('avg_losses-stats', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/avg_loss_12.csv', fname)
 
@@ -369,9 +374,6 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         fname = gettemp(view('portfolio_losses', self.calc.datastore))
         self.assertEqualFiles(
             'expected/portfolio_losses.txt', fname, delta=1E-5)
-        # check asset_loss_table
-        tot = self.calc.datastore['asset_loss_table'][()].sum()
-        self.assertEqual(tot, 15787827.0)
 
         # this is a case with exposure, site model and region_grid_spacing
         self.run_calc(case_miriam.__file__, 'job2.ini')

--- a/openquake/qa_tests_data/event_based_risk/case_master/expected/avg_loss_12.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_master/expected/avg_loss_12.csv
@@ -1,3 +1,4 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.7.0-git32c45d90c9', start_date='2019-09-10T03:56:55', checksum=3351128348, investigation_time=5.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.8.0-gitdd2585023d', start_date='2019-10-12T07:04:54', checksum=3332310124, investigation_time=10.0, risk_investigation_time=50.0"
 cresta,id,occupancy,state,taxonomy,lon,lat,structural
-"0.11","a1","Res","01","tax1",-122.00000,38.11300,2.54883E+03
+"0.11","a2","Res","01","tax1",-122.00000,38.10300,2.49416E+02
+"0.11","a1","Res","01","tax1",-122.00000,38.11300,1.76549E+03

--- a/openquake/qa_tests_data/event_based_risk/case_master/exposure_model_1.xml
+++ b/openquake/qa_tests_data/event_based_risk/case_master/exposure_model_1.xml
@@ -30,6 +30,21 @@
       </occupancies>
       <tags state="01" cresta="0.11" occupancy="Res" />
     </asset>
+    <asset id="a2" number="1" area="100" taxonomy="tax1">
+      <location lon="-122.000" lat="38.103" />
+      <costs>
+        <cost type="structural" value="1000" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="nonstructural" value="1500" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="contents" value="500" deductible="0.1" insuranceLimit="0.8" />
+        <cost type="business_interruption" value="200" deductible="0.1" insuranceLimit="0.8" />
+      </costs>
+      <occupancies>
+        <occupancy occupants="6" period="day" />
+        <occupancy occupants="4" period="transit" />
+        <occupancy occupants="2" period="night" />
+      </occupancies>
+      <tags state="01" cresta="0.11" occupancy="Res" />
+    </asset>
   </assets>
 </exposureModel>
 

--- a/openquake/qa_tests_data/event_based_risk/case_master/job12.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_master/job12.ini
@@ -1,6 +1,7 @@
 [general]
 description = 1 asset, 2 samples
 calculation_mode = ebrisk
+aggregate_by =  id
 
 [exposure]
 exposure_file = exposure_model_1.xml
@@ -36,7 +37,6 @@ ses_per_logic_tree_path = 20
 structural_vulnerability_file = structural_vulnerability_model.xml
 risk_investigation_time = 50
 asset_correlation = 0.0
-asset_loss_table = true
 
 [export]
 export_dir = /tmp


### PR DESCRIPTION
Since it can be generated with the line `aggregate_by=id`. Remember that the tables losses_by_event in a ebrisk is a generalized event loss table containing an array of values for each event, with size determined by the number of tags.