### PR TITLE
Fix `oq workers inspect`

### DIFF
--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -203,7 +203,7 @@ class WorkerPool(object):
         self.task_server_url = task_server_url
         self.num_workers = (multiprocessing.cpu_count()
                             if num_workers == '-1' else int(num_workers))
-        self.executing = tempfile.gettempdir()
+        self.executing = tempfile.mkdtemp()
         self.pid = os.getpid()
 
     def start(self):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -134,7 +134,7 @@ class OqParam(valid.ParamSet):
     number_of_logic_tree_samples = valid.Param(valid.positiveint, 0)
     num_cores = valid.Param(valid.positiveint, None)
     num_epsilon_bins = valid.Param(valid.positiveint)
-    oversubmit = valid.Param(valid.boolean, False)
+    oversubmit = valid.Param(valid.boolean, True)
     poes = valid.Param(valid.probabilities, [])
     poes_disagg = valid.Param(valid.probabilities, [])
     pointsource_distance = valid.Param(valid.positivefloat, None)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -134,7 +134,7 @@ class OqParam(valid.ParamSet):
     number_of_logic_tree_samples = valid.Param(valid.positiveint, 0)
     num_cores = valid.Param(valid.positiveint, None)
     num_epsilon_bins = valid.Param(valid.positiveint)
-    oversubmit = valid.Param(valid.boolean, True)
+    oversubmit = valid.Param(valid.boolean, False)
     poes = valid.Param(valid.probabilities, [])
     poes_disagg = valid.Param(valid.probabilities, [])
     pointsource_distance = valid.Param(valid.positivefloat, None)


### PR DESCRIPTION
For some reason, using `multiprocessing.sharedctypes.Value` was sometimes giving negative values for the number of tasks currently running on a worker. Here instead I create an empty file for each running task (removed when it finishes) and simply count the files. It works fine.