### PR TITLE
Refined the task splitting

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -115,8 +115,8 @@ def classical_split_filter(srcs, srcfilter, gsims, params, monitor):
         else:
             light.append(src)
     if heavy:
-        # produce at max 10 subtasks for the heavy sources
-        maxw = sum(weight(src) for src in heavy) / 10
+        # produce at max 20 subtasks for the heavy sources
+        maxw = sum(weight(src) for src in heavy) / 20
         for block in block_splitter(heavy, maxw, weight):
             yield classical, block, srcfilter, gsims, params
     if light:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -58,7 +58,7 @@ def estimate_duration(weight_by_trt, gsims_by_trt, maxdist, N, L, C):
     for trt in weight_by_trt:
         factor += weight_by_trt[trt] ** .333 * (maxdist[trt] / 300) ** 2 \
                   * len(gsims_by_trt[trt]) / T
-    return 2 * L * N ** .333 * factor / C
+    return 10 * (L * N) ** .333 * factor / C
 
 
 def get_src_ids(sources):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -110,8 +110,7 @@ def classical_split_filter(srcs, srcfilter, gsims, params, monitor):
             sources.extend(srcfilter.filter(splits))
     light = []
     for src in sources:
-        if src.nsites > 1000:
-            # run a task for each heavy source
+        if src.weight > params['max_weight']:
             yield classical, [src], srcfilter, gsims, params
         else:
             light.append(src)
@@ -291,7 +290,7 @@ class ClassicalCalculator(base.HazardCalculator):
             filter_distance=oq.filter_distance, reqv=oq.get_reqv(),
             collapse_factor=oq.collapse_factor, max_radius=oq.max_radius,
             pointsource_distance=oq.pointsource_distance,
-            max_sites_disagg=oq.max_sites_disagg,
+            max_sites_disagg=oq.max_sites_disagg, max_weight=maxweight,
             task_duration=td)
         logging.info(f'maxweight=%d, task_duration=%d s', maxweight, td)
         srcfilter = self.src_filter(self.datastore.tempname)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -108,9 +108,16 @@ def classical_split_filter(srcs, srcfilter, gsims, params, monitor):
         for src, _sites in srcfilter(srcs):
             splits, _stime = split_sources([src])
             sources.extend(srcfilter.filter(splits))
-    if sources:
+    light = []
+    for src in sources:
+        if src.nsites > 1000:
+            # run a task for each heavy source
+            yield classical, [src], srcfilter, gsims, params
+        else:
+            light.append(src)
+    if light:
         yield from parallel.split_task(
-                classical, sources, srcfilter, gsims, params, monitor,
+                classical, light, srcfilter, gsims, params, monitor,
                 duration=params['task_duration'])
 
 

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -61,7 +61,7 @@ class ClassicalTestCase(CalculatorTestCase):
             self.assertIn('sent', info)
             self.assertIn('received', info)
 
-            slow = view('task:classical_split_filter:-1', self.calc.datastore)
+            slow = view('task:classical:-1', self.calc.datastore)
             self.assertIn('taskno', slow)
             self.assertIn('duration', slow)
             self.assertIn('sources', slow)

--- a/openquake/calculators/ucerf_classical.py
+++ b/openquake/calculators/ucerf_classical.py
@@ -54,7 +54,7 @@ class UcerfClassicalCalculator(ClassicalCalculator):
         self.nsites = []  # used in agg_dicts
         self.maxdists = []
         param = dict(imtls=oq.imtls, truncation_level=oq.truncation_level,
-                     filter_distance=oq.filter_distance, maxweight=1E10,
+                     filter_distance=oq.filter_distance, max_weight=1E10,
                      task_duration=1000)
         self.calc_times = general.AccumDict(accum=np.zeros(3, np.float32))
         [gsims] = self.csm.info.get_gsims_by_trt().values()

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -134,7 +134,7 @@ class OqParam(valid.ParamSet):
     number_of_logic_tree_samples = valid.Param(valid.positiveint, 0)
     num_cores = valid.Param(valid.positiveint, None)
     num_epsilon_bins = valid.Param(valid.positiveint)
-    oversubmit = valid.Param(valid.boolean, True)
+    oversubmit = valid.Param(valid.boolean, False)
     poes = valid.Param(valid.probabilities, [])
     poes_disagg = valid.Param(valid.probabilities, [])
     pointsource_distance = valid.Param(valid.positivefloat, None)


### PR DESCRIPTION
Our user Murray found terribly slow tasks in a classical calculation for Montreal. The cause was the presence of split sources (point sources) with `weight > maxweight`. Such sources should produce new subtasks, but not too many to avoid producing tens of thousands of them. Some heuristic has been used here to conclude the calculation in a reasonable amount of time.