### PR TITLE
Restore a css class in engine/includes/footer.html

### DIFF
--- a/openquake/server/templates/engine/includes/footer.html
+++ b/openquake/server/templates/engine/includes/footer.html
@@ -1,4 +1,4 @@
-  <footer id="footer">        
+  <footer id="footer" class="footer">
     <div class="container">
       <div class="pull-left">
         <a href="https://github.com/gem/oq-engine" target="_blank">OpenQuake Engine</a> <em>{{ oq_engine_version }}</em> |


### PR DESCRIPTION
We must retain the class `footer` to keep compatibility with `base.css`

The change also fixes `oq-platform-standalone` which has indeed the same issue.

Fixes #5205 