### PR TITLE
Making host_cores optional

### DIFF
--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -54,12 +54,13 @@ class WorkerMaster(object):
     :param host_cores: names of the remote hosts and number of cores to use
     :param remote_python: path of the Python executable on the remote hosts
     """
-    def __init__(self, master_host, ctrl_port, host_cores,
+    def __init__(self, master_host, ctrl_port, host_cores=None,
                  remote_python=None, receiver_ports=None):
         # NB: receiver_ports is not used but needed for compliance
         self.master_host = master_host
         self.ctrl_port = int(ctrl_port)
-        self.host_cores = [hc.split() for hc in host_cores.split(',')]
+        self.host_cores = ([hc.split() for hc in host_cores.split(',')]
+                           if host_cores else [])
         self.remote_python = remote_python or sys.executable
         self.task_server_url = 'tcp://%s:%d' % (
             master_host, self.ctrl_port + 1)

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -271,7 +271,7 @@ def _store_results(smap, lt_models, source_model_lt, gsim_lt, oq, h5):
                 hdf5.extend(sources, sg.info)
 
     if h5:
-        h5['source_mags'] = sorted(dic['mags'])
+        h5['source_mags'] = sorted(mags)
 
     # log if some source file is being used more than once
     dupl = 0

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -349,8 +349,8 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         if OQ_DISTRIBUTE.endswith('pool'):
             logs.LOG.warning('Using %d cores on %s',
                              parallel.Starmap.num_cores, platform.node())
-        if OQ_DISTRIBUTE == 'zmq':
-            logs.dbcmd('zmq_start')  # start zworkers
+        if OQ_DISTRIBUTE == 'zmq' and hasattr(config.workers, 'host_cores'):
+            logs.dbcmd('zmq_start')  # start the zworkers
             logs.dbcmd('zmq_wait')  # wait for them to go up
         set_concurrent_tasks_default(calc)
         t0 = time.time()
@@ -381,8 +381,8 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         # if there was an error in the calculation, this part may fail;
         # in such a situation, we simply log the cleanup error without
         # taking further action, so that the real error can propagate
-        if OQ_DISTRIBUTE == 'zmq':  # stop zworkers
-            logs.dbcmd('zmq_stop')
+        if OQ_DISTRIBUTE == 'zmq' and hasattr(config.workers, 'host_cores'):
+            logs.dbcmd('zmq_stop')  # stop the zworkers
         try:
             if OQ_DISTRIBUTE.startswith('celery'):
                 celery_cleanup(TERMINATE)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -349,7 +349,7 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         if OQ_DISTRIBUTE.endswith('pool'):
             logs.LOG.warning('Using %d cores on %s',
                              parallel.Starmap.num_cores, platform.node())
-        if OQ_DISTRIBUTE == 'zmq' and hasattr(config.workers, 'host_cores'):
+        if OQ_DISTRIBUTE == 'zmq' and 'host_cores' in config.zworkers:
             logs.dbcmd('zmq_start')  # start the zworkers
             logs.dbcmd('zmq_wait')  # wait for them to go up
         set_concurrent_tasks_default(calc)
@@ -381,7 +381,7 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         # if there was an error in the calculation, this part may fail;
         # in such a situation, we simply log the cleanup error without
         # taking further action, so that the real error can propagate
-        if OQ_DISTRIBUTE == 'zmq' and hasattr(config.workers, 'host_cores'):
+        if OQ_DISTRIBUTE == 'zmq' and 'host_cores' in config.zworkers:
             logs.dbcmd('zmq_stop')  # stop the zworkers
         try:
             if OQ_DISTRIBUTE.startswith('celery'):

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -67,7 +67,11 @@ if OQ_DISTRIBUTE == 'zmq':
         """
         num_workers = 0
         w = config.zworkers
-        for host, _cores in [hc.split() for hc in w.host_cores.split(',')]:
+        try:
+            host_cores = [hc.split() for hc in w.host_cores.split(',')]
+        except AttributeError:
+            host_cores = []
+        for host, _cores in host_cores:
             url = 'tcp://%s:%s' % (host, w.ctrl_port)
             with z.Socket(url, z.zmq.REQ, 'connect') as sock:
                 if not general.socket_ready(url):

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -78,6 +78,10 @@ if OQ_DISTRIBUTE == 'zmq':
                     logs.LOG.warn('%s is not running', host)
                     continue
                 num_workers += sock.send('get_num_workers')
+        if num_workers == 0:
+            num_workers = os.cpu_count()
+            logs.LOG.warn('Missing host_cores, no idea about how many cores '
+                          'are available, using %d', num_workers)
         parallel.Starmap.num_cores = num_workers
         parallel.Starmap.oversubmit = calc.oqparam.oversubmit
         OqParam.concurrent_tasks.default = num_workers * 2


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/5208.

There are a few caveats.

1. without `host_cores` in openquake.cfg it is impossible to know the number of available cores
2. it is impossible to use the command `oq workers start/stop/inspect`
3. the workerpools have to be started manually with a command like `python -m openquake.baselib.workerpool tcp://127.0.0.1:1909 tcp://localhost:1910 -1`
