### PR TITLE
Removed check on duplicated sites

### DIFF
--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -298,7 +298,10 @@ class SiteCollection(object):
         # subsequent calculation. note that this doesn't protect arrays from
         # being changed by calling itemset()
         arr.flags.writeable = False
-        assert len(numpy.unique(self[['lon', 'lat']])) == len(self)
+
+        # NB: in test_correlation.py we define a SiteCollection with
+        # non-unique sites, so we cannot do an
+        # assert len(numpy.unique(self[['lon', 'lat']])) == len(self)
 
     def __eq__(self, other):
         return not self.__ne__(other)


### PR DESCRIPTION
This fixes the error in master https://travis-ci.org/gem/oq-engine/jobs/599945749 introduced by https://github.com/gem/oq-engine/pull/5216.
Check with @mmpagani about what is the meaning of duplicated sites in the site collection, as
in test_correlation.py.