### PR TITLE
Added an upper limit on the size of event based calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Raised an early error for extra-large GMF calculations
+  * Reduced the GMF storage by using 32 bit per event ID instead of 64 bit
   * Raised an error in case of duplicated sites in the site model
   * Fixed the case of implicit grid with a site model: sites could be
     incorrectly discarded

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -276,7 +276,9 @@ class EventBasedCalculator(base.HazardCalculator):
         Raise a ValueError if the number of sites is larger than 65,536 or the
         number of IMTs is larger than 256 or the number of ruptures is larger
         than 4,294,967,296. The limits are due to the numpy dtype used to
-        store the GMFs (gmv_dt). They could be relaxed in the future.
+        store the GMFs (gmv_dt). There also a limit of 4,294,967,296 on the
+        number of sites times the number of events, to avoid producing too
+        many GMFs. In that case split the calculation or be smarter.
         """
         oq = self.oqparam
         max_ = dict(sites=TWO32, events=TWO32, imts=2**8)
@@ -289,8 +291,8 @@ class EventBasedCalculator(base.HazardCalculator):
                     (n, oq.max_sites_per_gmf))
             elif n * self.E > TWO32:
                 raise ValueError(
-                    'A calculation with %d sites and %d events is impossibly '
-                    'large' % (n, self.E))
+                    'A GMF calculation with %d sites and %d events is '
+                    'impossibly large' % (n, self.E))
         for var in num_:
             if num_[var] > max_[var]:
                 raise ValueError(

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -44,7 +44,6 @@ U32 = numpy.uint32
 F32 = numpy.float32
 F64 = numpy.float64
 TWO32 = numpy.float64(2 ** 32)
-MAX_NO_GMFS = 1E11  # heuristic
 by_grp = operator.attrgetter('src_group_id')
 
 
@@ -280,8 +279,8 @@ class EventBasedCalculator(base.HazardCalculator):
         Raise a ValueError if the number of sites is larger than 65,536 or the
         number of IMTs is larger than 256 or the number of ruptures is larger
         than 4,294,967,296. The limits are due to the numpy dtype used to
-        store the GMFs (gmv_dt). There also a limit of 1E11 on the
-        number of sites times the number of events, to avoid producing too
+        store the GMFs (gmv_dt). There also a limit of max_potential_gmfs on
+        the number of sites times the number of events, to avoid producing too
         many GMFs. In that case split the calculation or be smarter.
         """
         oq = self.oqparam
@@ -293,7 +292,7 @@ class EventBasedCalculator(base.HazardCalculator):
                 raise ValueError(
                     'You cannot compute the GMFs for %d > %d sites' %
                     (n, oq.max_sites_per_gmf))
-            elif n * self.E > MAX_NO_GMFS:
+            elif n * self.E > oq.max_potential_gmfs:
                 raise ValueError(
                     'A GMF calculation with %d sites and %d events is '
                     'impossibly large' % (n, self.E))

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -558,7 +558,7 @@ class OqParam(valid.ParamSet):
         :returns: a composite data type for the GMFs
         """
         return numpy.dtype(
-            [('sid', U32), ('eid', U64), ('gmv', (F32, (len(self.imtls),)))])
+            [('sid', U32), ('eid', U32), ('gmv', (F32, (len(self.imtls),)))])
 
     def no_imls(self):
         """

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -122,6 +122,7 @@ class OqParam(valid.ParamSet):
     maximum_distance = valid.Param(valid.maximum_distance)  # km
     asset_hazard_distance = valid.Param(valid.floatdict, {'default': 15})  # km
     max = valid.Param(valid.boolean, False)
+    max_potential_gmfs = valid.Param(valid.positiveint, 1E11)
     max_potential_paths = valid.Param(valid.positiveint, 100)
     max_sites_per_gmf = valid.Param(valid.positiveint, 65536)
     max_sites_disagg = valid.Param(valid.positiveint, 10)


### PR DESCRIPTION
For 10 million of events we can manage at maximum 10,000 sites (probably a lot less). This is useful to stop users trying to run impossibly large calculations after the rupture generation phase and not in the middle of the GMF generation phase, while presumably running out of memory.
See the CAVEAT in https://github.com/gem/oq-engine/pull/5217, part of https://github.com/gem/oq-engine/issues/5211.