### PR TITLE
Fixed GriddedSurface.get_surface_boundaries

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fix: the boundaries for nonparametric ruptures were incorrectly exported
   * Added more validations for predefined hazard, like forbidding the site model
 
   [Marco Pagani]

--- a/openquake/hazardlib/geo/surface/gridded.py
+++ b/openquake/hazardlib/geo/surface/gridded.py
@@ -33,7 +33,7 @@ def bbox2poly(bbox):
     """
     :returns: a list of pairs corrisponding to a polygon
     """
-    x1, y1, x2, y2 = bbox
+    x1, x2, y2, y1 = bbox  # west, east, north, south
     return (x1, y1), (x2, y1), (x2, y2), (x1, y2), (x1, y1)
 
 
@@ -99,7 +99,7 @@ class GriddedSurface(BaseSurface):
         :returns: (min_max lons, min_max lats)
         """
         xs, ys = zip(*bbox2poly(self.get_bounding_box()))
-        return [xs], [ys], [[0, 0, 0, 0, 0]]
+        return [xs], [ys], [(0, 0, 0, 0, 0)]
 
     def get_rx_distance(self, mesh):
         """

--- a/openquake/hazardlib/geo/surface/gridded.py
+++ b/openquake/hazardlib/geo/surface/gridded.py
@@ -29,6 +29,14 @@ from openquake.hazardlib.geo.surface.base import BaseSurface
 from openquake.hazardlib.geo.mesh import Mesh
 
 
+def bbox2poly(bbox):
+    """
+    :returns: a list of pairs corrisponding to a polygon
+    """
+    x1, y1, x2, y2 = bbox
+    return (x1, y1), (x2, y1), (x2, y2), (x1, y2), (x1, y1)
+
+
 class GriddedSurface(BaseSurface):
     """
     Gridded surface defined by an unstructured cloud of points. This surface
@@ -83,15 +91,15 @@ class GriddedSurface(BaseSurface):
         """
         :returns: (min_max lons, min_max lats)
         """
-        min_lon, max_lon, max_lat, min_lat = self.get_bounding_box()
-        return [[min_lon, max_lon]], [[min_lat, max_lat]]
+        xs, ys = zip(*bbox2poly(self.get_bounding_box()))
+        return [xs], [ys]
 
     def get_surface_boundaries_3d(self):
         """
         :returns: (min_max lons, min_max lats)
         """
-        min_lon, max_lon, max_lat, min_lat = self.get_bounding_box()
-        return [[min_lon, max_lon]], [[min_lat, max_lat]], [[0, 0]]
+        xs, ys = zip(*bbox2poly(self.get_bounding_box()))
+        return [xs], [ys], [[0, 0, 0, 0, 0]]
 
     def get_rx_distance(self, mesh):
         """

--- a/openquake/hazardlib/tests/geo/surface/gridded_test.py
+++ b/openquake/hazardlib/tests/geo/surface/gridded_test.py
@@ -110,9 +110,10 @@ class GriddedSurfaceTestCaseIDL(unittest.TestCase):
         self.assertEqual((179.5, -179.5, 1., 0.), self.surf.get_bounding_box())
 
     def test_surface_boundaries_3d(self):
-        boundaries = self.surf.get_surface_boundaries_3d()
-        self.assertEqual(boundaries,
-                         ([[179.5, -179.5]], [[0.0, 1.0]], [[0, 0]]))
+        xs, ys, zs = self.surf.get_surface_boundaries_3d()
+        self.assertEqual(xs, [(179.5, -179.5, -179.5, 179.5, 179.5)])
+        self.assertEqual(ys, [(0.0, 0.0, 1.0, 1.0, 0.0)])
+        self.assertEqual(zs, [(0, 0, 0, 0, 0)])
 
     def test_get_middle_point(self):
         point = self.surf.get_middle_point()


### PR DESCRIPTION
@julgp discovered that the geometries exported by the engine for nonparametric surfaces were broken. The problem was that I was exporting the bounding box, not the associated polygon.
The good news is that there is no need to repeat any calculation, the bug was purely in the exporter.