### PR TITLE
Fixed disaggregation with a parent calculation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed disaggregation with a parent calculation
   * Models with duplicated values in the hypocenter and/or nodal plane
     distributions are now automatically optimized
   * Fixed an issue with missing noDamageLimit causing NaN values in

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -293,6 +293,8 @@ class DisaggregationCalculator(base.HazardCalculator):
         indices_by_grp = get_indices(gid)  # grp_id -> [(start, stop),...]
         blocksize = len(gid) // (oq.concurrent_tasks or 1) + 1
         allargs = []
+        dstore = (self.datastore.parent if self.datastore.parent
+                  else self.datastore)
         for grp_id, trt in csm_info.trt_by_grp.items():
             trti = trt_num[trt]
             rlzs_by_gsim = self.rlzs_assoc.get_rlzs_by_gsim(grp_id)
@@ -303,7 +305,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                  'filter_distance': oq.filter_distance, 'imtls': oq.imtls})
             for start, stop in indices_by_grp[grp_id]:
                 for slc in gen_slices(start, stop, blocksize):
-                    allargs.append((self.datastore, slc, cmaker,
+                    allargs.append((dstore, slc, cmaker,
                                     self.iml2s, trti, self.bin_edges))
         results = parallel.Starmap(
             compute_disagg, allargs, h5=self.datastore.hdf5


### PR DESCRIPTION
Even for the disaggregation demo I was getting the error
```
$ oq run job.ini --hc 44102
OSError: Unable to open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable') in /home/michele/oqdata/calc_44117.hdf5
```