### PR TITLE
Added `require_file` in the job.ini

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added `require_file` in the job.ini to check the existence of required files
   * Made it possible to disaggregate on multiple realizations
     with the parameters `rlz_index` or `num_rlzs_disagg`
   * Fixed downloading the ShakeMaps (again)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Added `require_file` in the job.ini to check the existence of required files
+  * Added `require_file` in the job.ini to declare required files
   * Made it possible to disaggregate on multiple realizations
     with the parameters `rlz_index` or `num_rlzs_disagg`
   * Fixed downloading the ShakeMaps (again)

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1399,6 +1399,7 @@ class GsimLogicTree(object):
                 ','.join(trts))
         self.values = collections.defaultdict(list)  # {trt: gsims}
         self._ltnode = ltnode or nrml.read(fname).logicTree
+        self.fnames = set()
         self.gmpe_tables = set()  # populated right below
         self.branches = self._build_trts_branches(trts)
         if tectonic_region_types and not self.branches:
@@ -1563,6 +1564,9 @@ class GsimLogicTree(object):
                         GMPETable.GMPE_DIR = os.path.dirname(self.filename)
                     try:
                         gsim = valid.gsim(uncertainty)
+                        self.fnames.update(
+                            getattr(gsim, name) for name in dir(gsim)
+                            if name.endswith('_file'))
                     except Exception as exc:
                         raise ValueError(
                             "%s in file %s" % (exc, self.filename)) from exc

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -42,7 +42,7 @@ KNOWN_INPUTS = {'rupture_model', 'exposure', 'site_model',
                 'source_model', 'shakemap', 'gmfs', 'gsim_logic_tree',
                 'source_model_logic_tree', 'hazard_curves', 'insurance',
                 'sites', 'job_ini', 'multi_peril', 'taxonomy_mapping',
-                'fragility', 'reqv', 'input_zip',
+                'fragility', 'reqv', 'input_zip', 'require',
                 'nonstructural_vulnerability',
                 'nonstructural_fragility',
                 'nonstructural_consequence',
@@ -160,6 +160,7 @@ class OqParam(valid.ParamSet):
     rupture_mesh_spacing = valid.Param(valid.positivefloat)
     complex_fault_mesh_spacing = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
+    require = valid.Param(valid.namelist, None)
     return_periods = valid.Param(valid.positiveints, None)
     ruptures_per_block = valid.Param(valid.positiveint, 50000)
     ses_per_logic_tree_path = valid.Param(

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -474,6 +474,11 @@ def get_gsim_lt(oqparam, trts=['*']):
     gsim_file = os.path.join(
         oqparam.base_path, oqparam.inputs['gsim_logic_tree'])
     gsim_lt = logictree.GsimLogicTree(gsim_file, trts)
+    fnames = [os.path.join(oqparam.base_path, f) for f in gsim_lt.fnames]
+    missing = set(fnames) - set(oqparam.inputs.get('require', {}).values())
+    if missing:
+        raise NameError('The gsim_logic_tree requires %s which is not listed '
+                        'in %s' % (missing, oqparam.inputs['job_ini']))
     gmfcorr = oqparam.correl_model
     for trt, gsims in gsim_lt.values.items():
         for gsim in gsims:


### PR DESCRIPTION
Once upon a time, all files required by a calculation were listed in the job.ini file. However, after the introduction of parametric GMPEs, it is possible to list files in the gsim_logic_tree file. This is bad for two reasons:

1. it breaks `oq zip` and the datastore will miss files, thus making the calculation not transferable to another machine
2. if there is a missing file the error will be discovered when reading the logic tree, while it should be
discovered earlier, when reading the job.ini

To solve these issues it is now required to specify the required files in the job.ini with a dictionary-like
syntax, like the following:
```
require_file = {
  'b14': 'kappa_factors_b14.csv',
  'cy14': 'kappa_factors_cy14.csv',
  're19-5': 'kappa_factors_re19-5.csv',
  'c14': 'kappa_factors_c14.csv',
  're19-10': 'kappa_factors_re19-10.csv',
  'ya15': 'kappa_factors_ya15.csv'}
```