### PR TITLE
Supported generic file-reading GMPEs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added general support for file-reading GMPEs
   * Made it possible to disaggregate on multiple realizations
     with the parameters `rlz_index` or `num_rlzs_disagg`
   * Fixed downloading the ShakeMaps (again)

--- a/doc/adv-manual/parametric-gmpes.rst
+++ b/doc/adv-manual/parametric-gmpes.rst
@@ -45,8 +45,8 @@ in the dataset ``csm_info/gsim_lt/branches``.
 
 The examples below will make it clear how it works.
 
-GMPETable
-------------------------
+GMPETable and other file-dependent GMPEs
+-----------------------------------------
 
 Historically, the first parametric GMPE was the GMPETable, introduced many
 years ago to support the Canada model. The GMPETable class has a single
@@ -125,6 +125,28 @@ forever, but we recommend you to use the new TOML-based syntax, which is
 more general. The old syntax has the limitation of being non-hierarchic,
 making it impossible to define MultiGMPEs involving parametric GMPEs:
 this is why we switched to TOML.
+
+It is possible to define other GMPEs taking one or more filenames as argument.
+Everything will work provided you respect the following rules:
+
+1. in the gsim logic tree file you must use relative path names (relative to it)
+2. in the GMPE code the file must be read at initialization time, not later
+3. in the GMPE code the name of the file argument must end with ``_file`` or
+   ``_table``. 
+
+The constraint about reading at initialization time makes it possible
+for the engine to work on a cluster. The issue is that GMPEs are
+instantiate in the controller not and used in the worker nodes, which
+in general *do not have access to the filesystem* of the controller.
+If the files are read after instantiation, you will get a file not
+found error when running on a cluster.
+
+The constraint on the argument name makes it possible for the engine
+to collect all the files required by the GMPEs; in this way the `oq zip`
+command can work and it is possible to store in the datastore all the
+required files. Without it, it would not be possible from the datastore
+to reconstruct the inputs, thus making it impossible to ship the
+calculation to a different machine.
 
 MultiGMPE
 -----------------

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1445,10 +1445,12 @@ class GsimLogicTree(object):
                     tuple(b.weight[weight] for weight in sorted(weights))
                     for b in self.branches]
         dic = {'branches': numpy.array(branches, dt)}
+        attrs = {}
 
         # manage gmpe_tables, if any
         if hasattr(self, 'filename'):  # missing for fake logic trees
             dirname = os.path.dirname(self.filename)
+            attrs['basedir'] = dirname
             for gmpe_table in sorted(self.gmpe_tables):
                 dic[os.path.basename(gmpe_table)] = d = {}
                 with hdf5.File(os.path.join(dirname, gmpe_table), 'r') as f:
@@ -1460,7 +1462,7 @@ class GsimLogicTree(object):
                                     python3compat.decode(dset.attrs['metric']))
                         else:
                             d[group] = {k: ds[()] for k, ds in dset.items()}
-        return dic, {}
+        return dic, attrs
 
     def __fromh5__(self, dic, attrs):
         self.branches = []
@@ -1472,7 +1474,7 @@ class GsimLogicTree(object):
             else:
                 br_id = branch['branch']
                 gsim_ = branch['uncertainty']
-            gsim = valid.gsim(gsim_)
+            gsim = valid.gsim(gsim_, attrs['basedir'])
             self.values[branch['trt']].append(gsim)
             weight = object.__new__(ImtWeight)
             # branch has dtype ('trt', 'branch', 'uncertainty', 'weight', ...)
@@ -1534,6 +1536,7 @@ class GsimLogicTree(object):
             # where the logictree file is
             basedir = os.path.dirname(self.filename)
         else:
+            import pdb; pdb.set_trace()
             basedir = ''
         for branching_level in self._ltnode:
             for branchset in _bsnodes(self.filename, branching_level):

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1530,6 +1530,11 @@ class GsimLogicTree(object):
         trts = []
         branches = []
         branchsetids = set()
+        if isinstance(self.filename, str):
+            # where the logictree file is
+            basedir = os.path.dirname(self.filename)
+        else:
+            basedir = ''
         for branching_level in self._ltnode:
             for branchset in _bsnodes(self.filename, branching_level):
                 if branchset['uncertaintyType'] != 'gmpeModel':
@@ -1557,12 +1562,8 @@ class GsimLogicTree(object):
                     branch_id = branch['branchID']
                     branch_ids.append(branch_id)
                     uncertainty = to_toml(branch.uncertaintyModel)
-                    if isinstance(self.filename, str):
-                        # a bit hackish: set the GMPE_DIR equal to the
-                        # directory where the gsim_logic_tree file is
-                        GMPETable.GMPE_DIR = os.path.dirname(self.filename)
                     try:
-                        gsim = valid.gsim(uncertainty)
+                        gsim = valid.gsim(uncertainty, basedir)
                     except Exception as exc:
                         raise ValueError(
                             "%s in file %s" % (exc, self.filename)) from exc

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1532,12 +1532,7 @@ class GsimLogicTree(object):
         trts = []
         branches = []
         branchsetids = set()
-        if isinstance(self.filename, str):
-            # where the logictree file is
-            basedir = os.path.dirname(self.filename)
-        else:
-            import pdb; pdb.set_trace()
-            basedir = ''
+        basedir = os.path.dirname(self.filename)
         for branching_level in self._ltnode:
             for branchset in _bsnodes(self.filename, branching_level):
                 if branchset['uncertaintyType'] != 'gmpeModel':

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -804,7 +804,7 @@ def get_input_files(oqparam, hazard=False):
             gsim_lt = get_gsim_lt(oqparam)
             for gsims in gsim_lt.values.values():
                 for gsim in gsims:
-                    table = getattr(gsim, 'GMPE_TABLE', None)
+                    table = getattr(gsim, 'gmpe_file', None)
                     if table:
                         fnames.append(table)
             fnames.append(fname)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -805,7 +805,7 @@ def get_input_files(oqparam, hazard=False):
             for gsims in gsim_lt.values.values():
                 for gsim in gsims:
                     for attr in dir(gsim):
-                        if attr.endswith('_file'):
+                        if attr.endswith(('_file', '_table')):
                             fnames.add(getattr(gsim, attr))
             fnames.add(fname)
         elif key == 'source_model':  # UCERF

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -793,7 +793,7 @@ def get_input_files(oqparam, hazard=False):
     :param hazard: if True, consider only the hazard files
     :returns: input path names in a specific order
     """
-    fnames = []  # files entering in the checksum
+    fnames = set()  # files entering in the checksum
     for key in oqparam.inputs:
         fname = oqparam.inputs[key]
         if hazard and key not in ('site_model', 'source_model_logic_tree',
@@ -804,33 +804,33 @@ def get_input_files(oqparam, hazard=False):
             gsim_lt = get_gsim_lt(oqparam)
             for gsims in gsim_lt.values.values():
                 for gsim in gsims:
-                    table = getattr(gsim, 'gmpe_file', None)
-                    if table:
-                        fnames.append(table)
-            fnames.append(fname)
+                    for attr in dir(gsim):
+                        if attr.endswith('_file'):
+                            fnames.add(getattr(gsim, attr))
+            fnames.add(fname)
         elif key == 'source_model':  # UCERF
             f = oqparam.inputs['source_model']
-            fnames.append(f)
+            fnames.add(f)
             fname = nrml.read(f).sourceModel.UCERFSource['filename']
-            fnames.append(os.path.join(os.path.dirname(f), fname))
+            fnames.add(os.path.join(os.path.dirname(f), fname))
         elif key == 'exposure':  # fname is a list
             for exp in asset.Exposure.read_headers(fname):
-                fnames.extend(exp.datafiles)
-            fnames.extend(fname)
+                fnames.update(exp.datafiles)
+            fnames.update(fname)
         elif isinstance(fname, dict):
-            fnames.extend(fname.values())
+            fnames.update(fname.values())
         elif isinstance(fname, list):
             for f in fname:
                 if f == oqparam.input_dir:
                     raise InvalidFile('%s there is an empty path in %s' %
                                       (oqparam.inputs['job_ini'], key))
-            fnames.extend(fname)
+            fnames.update(fname)
         elif key == 'source_model_logic_tree':
             for smpaths in logictree.collect_info(fname).smpaths.values():
-                fnames.extend(smpaths)
-            fnames.append(fname)
+                fnames.update(smpaths)
+            fnames.add(fname)
         else:
-            fnames.append(fname)
+            fnames.add(fname)
     return sorted(fnames)
 
 

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -2208,43 +2208,6 @@ class GsimLogicTreeTestCase(unittest.TestCase):
         # the percentages will be close to 40% and 60%
         self.assertEqual(counter, {('b1',): 413, ('b2',): 587})
 
-    def test_gsim_with_kwargs(self):
-        class FakeGMPETable(object):
-            REQUIRES_SITES_PARAMETERS = ()
-
-            def __init__(self, gmpe_table):
-                self.kwargs = {'gmpe_table': gmpe_table}
-
-            def init(self):
-                pass
-
-            def __str__(self):
-                return 'FakeGMPETable(%s)' % self.kwargs
-
-        registry['FakeGMPETable'] = FakeGMPETable
-        try:
-            xml = _make_nrml("""\
-            <logicTree logicTreeID="lt1">
-                <logicTreeBranchingLevel branchingLevelID="bl1">
-                    <logicTreeBranchSet uncertaintyType="gmpeModel"
-                                branchSetID="bs1"
-                                applyToTectonicRegionType="Shield">
-                        <logicTreeBranch branchID="b1">
-                            <uncertaintyModel gmpe_table="Wcrust_rjb_med.hdf5">
-                                FakeGMPETable
-                            </uncertaintyModel>
-                            <uncertaintyWeight>1.0</uncertaintyWeight>
-                        </logicTreeBranch>
-                    </logicTreeBranchSet>
-                </logicTreeBranchingLevel>
-            </logicTree>
-            """)
-            gsim_lt = self.parse_valid(xml, ['Shield'])
-            self.assertEqual(repr(gsim_lt), '''<GsimLogicTree
-Shield,b1,FakeGMPETable({'gmpe_table': 'Wcrust_rjb_med.hdf5'}),w=1.0>''')
-        finally:
-            del registry['FakeGMPETable']
-
 
 class LogicTreeProcessorTestCase(unittest.TestCase):
     def setUp(self):

--- a/openquake/hazardlib/gsim/can15/nbcc2015_aa13.py
+++ b/openquake/hazardlib/gsim/can15/nbcc2015_aa13.py
@@ -59,7 +59,7 @@ class NBCC2015_AA13_Base(GMPETable):
     gsim/nga_east.html
     """
     experimental = True
-    GMPE_TABLE = ""
+    gmpe_file = ""
     DEFINED_FOR_TECTONIC_REGION_TYPE = ""
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = set([PGA, PGV, SA])
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.RotD50
@@ -167,7 +167,7 @@ class NBCC2015_AA13_stablecrust_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Stable Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Stable Crust Low"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "ENA_low_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "ENA_low_clC.hdf5")
 
 
 class NBCC2015_AA13_stablecrust_central(NBCC2015_AA13_Base):
@@ -178,7 +178,7 @@ class NBCC2015_AA13_stablecrust_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Stable Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Stable Crust Central"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "ENA_med_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "ENA_med_clC.hdf5")
 
 
 class NBCC2015_AA13_stablecrust_high(NBCC2015_AA13_Base):
@@ -189,7 +189,7 @@ class NBCC2015_AA13_stablecrust_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Stable Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Stable Crust High"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "ENA_high_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "ENA_high_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrust_low(NBCC2015_AA13_Base):
@@ -200,7 +200,7 @@ class NBCC2015_AA13_activecrust_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Active Crust Low"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "Wcrust_low_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "Wcrust_low_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrust_central(NBCC2015_AA13_Base):
@@ -211,7 +211,7 @@ class NBCC2015_AA13_activecrust_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Active Crust Central"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "Wcrust_med_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "Wcrust_med_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrust_high(NBCC2015_AA13_Base):
@@ -222,7 +222,7 @@ class NBCC2015_AA13_activecrust_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Active Crust High"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "Wcrust_high_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "Wcrust_high_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrustFRjb_low(NBCC2015_AA13_Base):
@@ -233,7 +233,7 @@ class NBCC2015_AA13_activecrustFRjb_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust Fault"
     REQUIRES_DISTANCES = set(('rjb',))
     gsim = "AA13 Active Crust Fault Low"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WcrustFRjb_low_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WcrustFRjb_low_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrustFRjb_central(NBCC2015_AA13_Base):
@@ -244,7 +244,7 @@ class NBCC2015_AA13_activecrustFRjb_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust Fault"
     REQUIRES_DISTANCES = set(('rjb',))
     gsim = "AA13 Active Crust Fault Central"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WcrustFRjb_med_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WcrustFRjb_med_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrustFRjb_high(NBCC2015_AA13_Base):
@@ -255,7 +255,7 @@ class NBCC2015_AA13_activecrustFRjb_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust Fault"
     REQUIRES_DISTANCES = set(('rjb',))
     gsim = "AA13 Active Crust Fault High"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WcrustFRjb_high_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WcrustFRjb_high_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab30_low(NBCC2015_AA13_Base):
@@ -266,7 +266,7 @@ class NBCC2015_AA13_inslab30_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 30"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 30 Low"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinslabD30_low_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD30_low_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab30_central(NBCC2015_AA13_Base):
@@ -277,7 +277,7 @@ class NBCC2015_AA13_inslab30_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 30"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 30 Central"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinslabD30_med_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD30_med_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab30_high(NBCC2015_AA13_Base):
@@ -288,7 +288,7 @@ class NBCC2015_AA13_inslab30_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 30"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 30 High"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinslabD30_high_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD30_high_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab50_low(NBCC2015_AA13_Base):
@@ -299,7 +299,7 @@ class NBCC2015_AA13_inslab50_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 50"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 50 Low"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinslabD50_low_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD50_low_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab50_central(NBCC2015_AA13_Base):
@@ -310,7 +310,7 @@ class NBCC2015_AA13_inslab50_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 50"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 50 Central"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinslabD50_med_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD50_med_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab50_high(NBCC2015_AA13_Base):
@@ -321,7 +321,7 @@ class NBCC2015_AA13_inslab50_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 50"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 50 High"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinslabD50_high_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD50_high_clC.hdf5")
 
 
 class NBCC2015_AA13_interface_low(NBCC2015_AA13_Base):
@@ -332,7 +332,7 @@ class NBCC2015_AA13_interface_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Interface"
     REQUIRES_DISTANCES = set(('rrup',))
     gsim = "AA13 Subduction Interface Low"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_lowclC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_lowclC.hdf5")
 
 
 class NBCC2015_AA13_interface_central(NBCC2015_AA13_Base):
@@ -343,7 +343,7 @@ class NBCC2015_AA13_interface_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Interface"
     REQUIRES_DISTANCES = set(('rrup',))
     gsim = "AA13 Subduction Interface Central"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_medclC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_medclC.hdf5")
 
 
 class NBCC2015_AA13_interface_high(NBCC2015_AA13_Base):
@@ -354,7 +354,7 @@ class NBCC2015_AA13_interface_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Interface"
     REQUIRES_DISTANCES = set(('rrup',))
     gsim = "AA13 Subduction Interface High"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_highclC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_highclC.hdf5")
 
 
 class NBCC2015_AA13_offshore_low(NBCC2015_AA13_Base):
@@ -365,7 +365,7 @@ class NBCC2015_AA13_offshore_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Offshore"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Offshore Low"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "Woffshore_low_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "Woffshore_low_clC.hdf5")
 
 
 class NBCC2015_AA13_offshore_central(NBCC2015_AA13_Base):
@@ -376,7 +376,7 @@ class NBCC2015_AA13_offshore_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Offshore"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Offshore Central"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "Woffshore_med_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "Woffshore_med_clC.hdf5")
 
 
 class NBCC2015_AA13_offshore_high(NBCC2015_AA13_Base):
@@ -387,4 +387,4 @@ class NBCC2015_AA13_offshore_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Offshore"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Offshore High"
-    GMPE_TABLE = os.path.join(BASE_PATH_AA13, "Woffshore_high_clC.hdf5")
+    gmpe_file = os.path.join(BASE_PATH_AA13, "Woffshore_high_clC.hdf5")

--- a/openquake/hazardlib/gsim/can15/nbcc2015_aa13.py
+++ b/openquake/hazardlib/gsim/can15/nbcc2015_aa13.py
@@ -59,7 +59,7 @@ class NBCC2015_AA13_Base(GMPETable):
     gsim/nga_east.html
     """
     experimental = True
-    gmpe_file = ""
+    gmpe_table = ""
     DEFINED_FOR_TECTONIC_REGION_TYPE = ""
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = set([PGA, PGV, SA])
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.RotD50
@@ -167,7 +167,7 @@ class NBCC2015_AA13_stablecrust_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Stable Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Stable Crust Low"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "ENA_low_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "ENA_low_clC.hdf5")
 
 
 class NBCC2015_AA13_stablecrust_central(NBCC2015_AA13_Base):
@@ -178,7 +178,7 @@ class NBCC2015_AA13_stablecrust_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Stable Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Stable Crust Central"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "ENA_med_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "ENA_med_clC.hdf5")
 
 
 class NBCC2015_AA13_stablecrust_high(NBCC2015_AA13_Base):
@@ -189,7 +189,7 @@ class NBCC2015_AA13_stablecrust_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Stable Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Stable Crust High"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "ENA_high_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "ENA_high_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrust_low(NBCC2015_AA13_Base):
@@ -200,7 +200,7 @@ class NBCC2015_AA13_activecrust_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Active Crust Low"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "Wcrust_low_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "Wcrust_low_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrust_central(NBCC2015_AA13_Base):
@@ -211,7 +211,7 @@ class NBCC2015_AA13_activecrust_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Active Crust Central"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "Wcrust_med_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "Wcrust_med_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrust_high(NBCC2015_AA13_Base):
@@ -222,7 +222,7 @@ class NBCC2015_AA13_activecrust_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Active Crust High"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "Wcrust_high_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "Wcrust_high_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrustFRjb_low(NBCC2015_AA13_Base):
@@ -233,7 +233,7 @@ class NBCC2015_AA13_activecrustFRjb_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust Fault"
     REQUIRES_DISTANCES = set(('rjb',))
     gsim = "AA13 Active Crust Fault Low"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WcrustFRjb_low_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WcrustFRjb_low_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrustFRjb_central(NBCC2015_AA13_Base):
@@ -244,7 +244,7 @@ class NBCC2015_AA13_activecrustFRjb_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust Fault"
     REQUIRES_DISTANCES = set(('rjb',))
     gsim = "AA13 Active Crust Fault Central"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WcrustFRjb_med_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WcrustFRjb_med_clC.hdf5")
 
 
 class NBCC2015_AA13_activecrustFRjb_high(NBCC2015_AA13_Base):
@@ -255,7 +255,7 @@ class NBCC2015_AA13_activecrustFRjb_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Active Crust Fault"
     REQUIRES_DISTANCES = set(('rjb',))
     gsim = "AA13 Active Crust Fault High"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WcrustFRjb_high_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WcrustFRjb_high_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab30_low(NBCC2015_AA13_Base):
@@ -266,7 +266,7 @@ class NBCC2015_AA13_inslab30_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 30"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 30 Low"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD30_low_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinslabD30_low_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab30_central(NBCC2015_AA13_Base):
@@ -277,7 +277,7 @@ class NBCC2015_AA13_inslab30_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 30"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 30 Central"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD30_med_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinslabD30_med_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab30_high(NBCC2015_AA13_Base):
@@ -288,7 +288,7 @@ class NBCC2015_AA13_inslab30_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 30"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 30 High"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD30_high_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinslabD30_high_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab50_low(NBCC2015_AA13_Base):
@@ -299,7 +299,7 @@ class NBCC2015_AA13_inslab50_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 50"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 50 Low"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD50_low_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinslabD50_low_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab50_central(NBCC2015_AA13_Base):
@@ -310,7 +310,7 @@ class NBCC2015_AA13_inslab50_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 50"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 50 Central"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD50_med_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinslabD50_med_clC.hdf5")
 
 
 class NBCC2015_AA13_inslab50_high(NBCC2015_AA13_Base):
@@ -321,7 +321,7 @@ class NBCC2015_AA13_inslab50_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Inslab 50"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Subduction Inslab 50 High"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinslabD50_high_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinslabD50_high_clC.hdf5")
 
 
 class NBCC2015_AA13_interface_low(NBCC2015_AA13_Base):
@@ -332,7 +332,7 @@ class NBCC2015_AA13_interface_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Interface"
     REQUIRES_DISTANCES = set(('rrup',))
     gsim = "AA13 Subduction Interface Low"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_lowclC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_lowclC.hdf5")
 
 
 class NBCC2015_AA13_interface_central(NBCC2015_AA13_Base):
@@ -343,7 +343,7 @@ class NBCC2015_AA13_interface_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Interface"
     REQUIRES_DISTANCES = set(('rrup',))
     gsim = "AA13 Subduction Interface Central"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_medclC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_medclC.hdf5")
 
 
 class NBCC2015_AA13_interface_high(NBCC2015_AA13_Base):
@@ -354,7 +354,7 @@ class NBCC2015_AA13_interface_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Subduction Interface"
     REQUIRES_DISTANCES = set(('rrup',))
     gsim = "AA13 Subduction Interface High"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_highclC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "WinterfaceCombo_highclC.hdf5")
 
 
 class NBCC2015_AA13_offshore_low(NBCC2015_AA13_Base):
@@ -365,7 +365,7 @@ class NBCC2015_AA13_offshore_low(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Offshore"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Offshore Low"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "Woffshore_low_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "Woffshore_low_clC.hdf5")
 
 
 class NBCC2015_AA13_offshore_central(NBCC2015_AA13_Base):
@@ -376,7 +376,7 @@ class NBCC2015_AA13_offshore_central(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Offshore"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Offshore Central"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "Woffshore_med_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "Woffshore_med_clC.hdf5")
 
 
 class NBCC2015_AA13_offshore_high(NBCC2015_AA13_Base):
@@ -387,4 +387,4 @@ class NBCC2015_AA13_offshore_high(NBCC2015_AA13_Base):
     DEFINED_FOR_TECTONIC_REGION_TYPE = "Offshore"
     REQUIRES_DISTANCES = set(('rhypo',))
     gsim = "AA13 Offshore High"
-    gmpe_file = os.path.join(BASE_PATH_AA13, "Woffshore_high_clC.hdf5")
+    gmpe_table = os.path.join(BASE_PATH_AA13, "Woffshore_high_clC.hdf5")

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -299,7 +299,7 @@ class GMPETable(GMPE):
 
     REQUIRES_RUPTURE_PARAMETERS = {"mag"}
 
-    GMPE_TABLE = None
+    gmpe_file = None
 
     amplification = None
 
@@ -308,20 +308,20 @@ class GMPETable(GMPE):
         Executes the preprocessing steps at the instantiation stage to read in
         the tables from hdf5 and hold them in memory.
         """
-        fname = self.kwargs.get('gmpe_table', self.GMPE_TABLE)
+        fname = self.kwargs.get('gmpe_table', self.gmpe_file)
         if fname is None:
-            raise ValueError('You forgot to set %s.GMPE_TABLE!' %
+            raise ValueError('You forgot to set %s.gmpe_file!' %
                              self.__class__.__name__)
         elif os.path.isabs(fname):
-            self.GMPE_TABLE = fname
+            self.gmpe_file = fname
         elif not hasattr(self, 'GMPE_DIR'):
             # when called from GsimLogicTree.__fromh5__ GMPE_DIR is missing
             return
         else:
             # NB: (hackish) GMPE_DIR must be set externally
-            self.GMPE_TABLE = os.path.abspath(
+            self.gmpe_file = os.path.abspath(
                 os.path.join(self.GMPE_DIR, fname))
-        with h5py.File(self.GMPE_TABLE, "r") as fle:
+        with h5py.File(self.gmpe_file, "r") as fle:
             try:
                 # this is the format inside the datastore
                 self.distance_type = fle["distance_type"][()]

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -312,15 +312,8 @@ class GMPETable(GMPE):
         if fname is None:
             raise ValueError('You forgot to set %s.gmpe_file!' %
                              self.__class__.__name__)
-        elif os.path.isabs(fname):
-            self.gmpe_file = fname
-        elif not hasattr(self, 'GMPE_DIR'):
-            # when called from GsimLogicTree.__fromh5__ GMPE_DIR is missing
-            return
-        else:
-            # NB: (hackish) GMPE_DIR must be set externally
-            self.gmpe_file = os.path.abspath(
-                os.path.join(self.GMPE_DIR, fname))
+        assert os.path.isabs(fname)
+        self.gmpe_file = fname
         with h5py.File(self.gmpe_file, "r") as fle:
             try:
                 # this is the format inside the datastore

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -299,7 +299,7 @@ class GMPETable(GMPE):
 
     REQUIRES_RUPTURE_PARAMETERS = {"mag"}
 
-    gmpe_file = None
+    gmpe_table = None
 
     amplification = None
 
@@ -308,13 +308,13 @@ class GMPETable(GMPE):
         Executes the preprocessing steps at the instantiation stage to read in
         the tables from hdf5 and hold them in memory.
         """
-        fname = self.kwargs.get('gmpe_table', self.gmpe_file)
+        fname = self.kwargs.get('gmpe_table', self.gmpe_table)
         if fname is None:
-            raise ValueError('You forgot to set %s.gmpe_file!' %
+            raise ValueError('You forgot to set %s.gmpe_table!' %
                              self.__class__.__name__)
         assert os.path.isabs(fname)
-        self.gmpe_file = fname
-        with h5py.File(self.gmpe_file, "r") as fle:
+        self.gmpe_table = fname
+        with h5py.File(self.gmpe_table, "r") as fle:
             try:
                 # this is the format inside the datastore
                 self.distance_type = fle["distance_type"][()]

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -560,16 +560,16 @@ class NGAEastGMPE(NGAEastBaseGMPE):
     subdirectory fixed to the path of the present file. The GMPE table option
     is therefore no longer needed
     """
-    gmpe_file = ""
+    gmpe_table = ""
 
     def __init__(self, tau_model="global", phi_model="global",
                  phi_s2ss_model=None, tau_quantile=None,
                  phi_ss_quantile=None, phi_s2ss_quantile=None):
-        if not self.gmpe_file:
+        if not self.gmpe_table:
             raise NotImplementedError("NGA East Fixed-Table GMPE requires "
                                       "input table")
         super().__init__(
-            gmpe_table=self.gmpe_file,
+            gmpe_table=self.gmpe_table,
             tau_model=tau_model, phi_model=phi_model,
             phi_s2ss_model=phi_s2ss_model, tau_quantile=tau_quantile,
             phi_ss_quantile=phi_ss_quantile,
@@ -758,18 +758,18 @@ class NGAEastGMPETotalSigma(NGAEastBaseGMPETotalSigma):
     GMPE table is fixed. This forms the main base-class for the total sigma
     version of the core set of NGA East models
     """
-    gmpe_file = ""
+    gmpe_table = ""
 
     def __init__(self, tau_model="global", phi_model="global",
                  phi_s2ss_model=None, sigma_quantile=None):
         """
         Instantiates the GMPE without the hdf5 table fort the median values
         """
-        if not self.gmpe_file:
+        if not self.gmpe_table:
             raise NotImplementedError("NGA East Fixed-Table GMPE requires "
                                       "input table")
         super().__init__(
-            self.gmpe_file, tau_model=tau_model, phi_model=phi_model,
+            self.gmpe_table, tau_model=tau_model, phi_model=phi_model,
             phi_s2ss_model=phi_s2ss_model, sigma_quantile=sigma_quantile)
 
 
@@ -791,7 +791,7 @@ class Boore2015NGAEastA04(NGAEastGMPE):
     Ground Motion Models for the Central and Eastern North America Region",
     PEER Report 2015/04, Pacific Earthquake Engineering Research Center
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_A04_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_A04_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastA04TotalSigma(NGAEastGMPETotalSigma):
@@ -799,7 +799,7 @@ class Boore2015NGAEastA04TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Atkinson (2004) attenuation model
     for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_A04_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_A04_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastAB14(NGAEastGMPE):
@@ -807,7 +807,7 @@ class Boore2015NGAEastAB14(NGAEastGMPE):
     Boore (2015) NGA East GMPE using the Atkinson & Boore (2014) attenuation
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_AB14_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_AB14_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastAB14TotalSigma(NGAEastGMPETotalSigma):
@@ -815,7 +815,7 @@ class Boore2015NGAEastAB14TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Atkinson & Boore (2014) attenuation
     model for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_AB14_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_AB14_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastAB95(NGAEastGMPE):
@@ -823,7 +823,7 @@ class Boore2015NGAEastAB95(NGAEastGMPE):
     Boore (2015) NGA East GMPE using the Atkinson & Boore (1995) attenuation
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_AB95_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_AB95_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastAB95TotalSigma(NGAEastGMPETotalSigma):
@@ -831,7 +831,7 @@ class Boore2015NGAEastAB95TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Atkinson & Boore (1995) attenuation
     model for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_AB95_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_AB95_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastBCA10D(NGAEastGMPE):
@@ -839,7 +839,7 @@ class Boore2015NGAEastBCA10D(NGAEastGMPE):
     Boore (2015) NGA East GMPE using the Boore et al (2010) attenuation
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_BCA10D_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_BCA10D_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastBCA10DTotalSigma(NGAEastGMPETotalSigma):
@@ -847,7 +847,7 @@ class Boore2015NGAEastBCA10DTotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Boore et al (2010) attenuation
     model for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_BCA10D_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_BCA10D_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastBS11(NGAEastGMPE):
@@ -855,7 +855,7 @@ class Boore2015NGAEastBS11(NGAEastGMPE):
     Boore (2015) NGA East GMPE using the Boatwright and Seekins (2011)
     attenuation model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_BS11_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_BS11_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastBS11TotalSigma(NGAEastGMPETotalSigma):
@@ -863,14 +863,14 @@ class Boore2015NGAEastBS11TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Boatwright and Seekins (2011)
     attenuation model for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_BS11_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_BS11_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastSGD02(NGAEastGMPE):
     """
     Boore (2015) NGA East GMPE using the Silva et al (2002) attenuation model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_SGD02_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_SGD02_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastSGD02TotalSigma(NGAEastGMPETotalSigma):
@@ -878,7 +878,7 @@ class Boore2015NGAEastSGD02TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Silva et al (2002) attenuation model
     for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_SGD02_J15_Adjusted.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_BOORE_SGD02_J15_Adjusted.hdf5")
 
 
 # Darragh, Abrahamson, Silva and Gregor (2015) suite
@@ -892,7 +892,7 @@ class DarraghEtAl2015NGAEast1CCSP(NGAEastGMPE):
     Hard Rock Ground Motion Models for Region 2 of Central and Eastern
     North America" in ...
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_1CCSP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_DARRAGH_1CCSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast1CCSPTotalSigma(NGAEastGMPETotalSigma):
@@ -901,7 +901,7 @@ class DarraghEtAl2015NGAEast1CCSPTotalSigma(NGAEastGMPETotalSigma):
     constant stress parameter (1CCSP) for use with the total sigma aleatory
     uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_1CCSP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_DARRAGH_1CCSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast1CVSP(NGAEastGMPE):
@@ -909,7 +909,7 @@ class DarraghEtAl2015NGAEast1CVSP(NGAEastGMPE):
     NGA East model of Darragh et al. (2015) adopting the single-corner
     variable stress parameter (1CVSP)
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_1CVSP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_DARRAGH_1CVSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast1CVSPTotalSigma(NGAEastGMPETotalSigma):
@@ -918,7 +918,7 @@ class DarraghEtAl2015NGAEast1CVSPTotalSigma(NGAEastGMPETotalSigma):
     variable stress parameter (1CVSP) for use with the total sigma aleatory
     uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_1CVSP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_DARRAGH_1CVSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast2CCSP(NGAEastGMPE):
@@ -926,7 +926,7 @@ class DarraghEtAl2015NGAEast2CCSP(NGAEastGMPE):
     NGA East model of Darragh et al. (2015) adopting the two-corner
     constant stress parameter (2CCSP)
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_2CCSP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_DARRAGH_2CCSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast2CCSPTotalSigma(NGAEastGMPETotalSigma):
@@ -935,7 +935,7 @@ class DarraghEtAl2015NGAEast2CCSPTotalSigma(NGAEastGMPETotalSigma):
     constant stress parameter (2CCSP) for use with the total sigma aleatory
     uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_2CCSP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_DARRAGH_2CCSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast2CVSP(NGAEastGMPE):
@@ -943,7 +943,7 @@ class DarraghEtAl2015NGAEast2CVSP(NGAEastGMPE):
     NGA East model of Darragh et al. (2015) adopting the two-corner
     variable stress parameter (1CVSP)
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_2CVSP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_DARRAGH_2CVSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast2CVSPTotalSigma(NGAEastGMPETotalSigma):
@@ -952,7 +952,7 @@ class DarraghEtAl2015NGAEast2CVSPTotalSigma(NGAEastGMPETotalSigma):
     variable stress parameter (2CVSP) for use with the total sigma aleatory
     uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_2CVSP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_DARRAGH_2CVSP.hdf5")
 
 # Yenier & Atkinson (2015)
 
@@ -965,7 +965,7 @@ class YenierAtkinson2015NGAEast(NGAEastGMPE):
     Application to Central and Eastern North America" in PEER 2015/04, Chapter
     4
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_YENIER_ATKINSON.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_YENIER_ATKINSON.hdf5")
 
 
 class YenierAtkinson2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -973,7 +973,7 @@ class YenierAtkinson2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     NGA East Model of Yenier & Atkinson (2015) for use with the total sigma
     aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_YENIER_ATKINSON.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_YENIER_ATKINSON.hdf5")
 
 
 # Pezeschk et al. (2015)
@@ -987,7 +987,7 @@ class PezeschkEtAl2015NGAEastM1SS(NGAEastGMPE):
     Motion Prediction Equations for Eastern North America using a Hybrid
     Empirical Method" in PEER 2015/04, Chapter 5
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_PEZESCHK_M1SS.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_PEZESCHK_M1SS.hdf5")
 
 
 class PezeschkEtAl2015NGAEastM1SSTotalSigma(NGAEastGMPETotalSigma):
@@ -995,14 +995,14 @@ class PezeschkEtAl2015NGAEastM1SSTotalSigma(NGAEastGMPETotalSigma):
     NGA East Model of Pezeschk et al (2015) for the large-M simulation scaling
     for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_PEZESCHK_M1SS.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_PEZESCHK_M1SS.hdf5")
 
 
 class PezeschkEtAl2015NGAEastM2ES(NGAEastGMPE):
     """
     NGA East Model of Pezeschk et al (2015) for the large-M empirical scaling
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_PEZESCHK_M2ES.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_PEZESCHK_M2ES.hdf5")
 
 
 class PezeschkEtAl2015NGAEastM2ESTotalSigma(NGAEastGMPETotalSigma):
@@ -1010,7 +1010,7 @@ class PezeschkEtAl2015NGAEastM2ESTotalSigma(NGAEastGMPETotalSigma):
     NGA East Model of Pezeschk et al (2015) for the large-M empirical scaling
     for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_PEZESCHK_M2ES.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_PEZESCHK_M2ES.hdf5")
 
 # Frankel (2015)
 
@@ -1024,7 +1024,7 @@ class Frankel2015NGAEast(NGAEastGMPE):
     Earthquakes Using Hybrid Broadband Seismograms from Finite-Fault
     Simulation with Constant Stress-Drop Scaling" in PEER 2015/04, Chapter 6
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_FRANKEL_J15.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_FRANKEL_J15.hdf5")
 
 
 class Frankel2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1032,7 +1032,7 @@ class Frankel2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     NGA East Model of Frankel (2015) for application to Central & Eastern
     United States for use with the total sigma aleatory uncertainty model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_FRANKEL_J15.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_FRANKEL_J15.hdf5")
 
 # Shahjouei & Pezeschk (2015)
 
@@ -1046,7 +1046,7 @@ class ShahjoueiPezeschk2015NGAEast(NGAEastGMPE):
     for Central and Eastern North America using Hybrid Broadband Simulations
     and NGA-West2 GMPEs" in PEER 2015/04, Chapter 7
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_SHAHJOUEI_PEZESCHK.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_SHAHJOUEI_PEZESCHK.hdf5")
 
 
 class ShahjoueiPezeschk2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1055,7 +1055,7 @@ class ShahjoueiPezeschk2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_SHAHJOUEI_PEZESCHK.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_SHAHJOUEI_PEZESCHK.hdf5")
 
 # Al Noman and Cramer (2015)
 
@@ -1068,7 +1068,7 @@ class AlNomanCramer2015NGAEast(NGAEastGMPE):
     Al Noman & Cramer (2015) "Empirical Ground-Motion Prediction Equations for
     Eastern North America" in PEER 2015/04, Chapter 8
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_ALNOMAN_CRAMER.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_ALNOMAN_CRAMER.hdf5")
 
 
 class AlNomanCramer2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1077,7 +1077,7 @@ class AlNomanCramer2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_ALNOMAN_CRAMER.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_ALNOMAN_CRAMER.hdf5")
 
 # Graizer (2015)
 
@@ -1090,7 +1090,7 @@ class Graizer2015NGAEast(NGAEastGMPE):
     Graizer, V (2015) "Ground-Motion Prediction Equations for the Central and
     Eastern United States" in PEER 2015/04, Chapter 9
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_GRAIZER.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_GRAIZER.hdf5")
 
 
 class Graizer2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1099,7 +1099,7 @@ class Graizer2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     United States, for use with the total sigma aleatory uncertainty
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_GRAIZER.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_GRAIZER.hdf5")
 
 # Hassani & Atkinson (2015)
 
@@ -1112,7 +1112,7 @@ class HassaniAtkinson2015NGAEast(NGAEastGMPE):
     Hassani, B & Atkinson, GA (2015) "Referenced Empirical Ground-Motion Model
     for Eastern North America" in PEER 2015/04, Chapter 10
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_HASSANI_ATKINSON.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_HASSANI_ATKINSON.hdf5")
 
 
 class HassaniAtkinson2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1121,7 +1121,7 @@ class HassaniAtkinson2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_HASSANI_ATKINSON.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_HASSANI_ATKINSON.hdf5")
 
 # Hollenback et al. (2015)
 
@@ -1134,7 +1134,7 @@ class HollenbackEtAl2015NGAEastGP(NGAEastGMPE):
     Hollenback, J, Keuhn, N, Goulet, CA and Abrahamson, NA (2015) "PEER NGA-
     East Median Ground Motion Models" in PEER 2015/04, Chapter 11
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_PEER_GP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_PEER_GP.hdf5")
 
 
 class HollenbackEtAl2015NGAEastGPTotalSigma(NGAEastGMPETotalSigma):
@@ -1143,7 +1143,7 @@ class HollenbackEtAl2015NGAEastGPTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_PEER_GP.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_PEER_GP.hdf5")
 
 
 class HollenbackEtAl2015NGAEastEX(NGAEastGMPE):
@@ -1154,7 +1154,7 @@ class HollenbackEtAl2015NGAEastEX(NGAEastGMPE):
     Hollenback, J, Keuhn, N, Goulet, CA and Abrahamson, NA (2015) "PEER NGA-
     East Median Ground Motion Models" in PEER 2015/04, Chapter 11
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_PEER_EX.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_PEER_EX.hdf5")
 
 
 class HollenbackEtAl2015NGAEastEXTotalSigma(NGAEastGMPETotalSigma):
@@ -1163,4 +1163,4 @@ class HollenbackEtAl2015NGAEastEXTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    gmpe_file = os.path.join(PATH, "NGAEast_PEER_EX.hdf5")
+    gmpe_table = os.path.join(PATH, "NGAEast_PEER_EX.hdf5")

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -560,16 +560,16 @@ class NGAEastGMPE(NGAEastBaseGMPE):
     subdirectory fixed to the path of the present file. The GMPE table option
     is therefore no longer needed
     """
-    GMPE_TABLE = ""
+    gmpe_file = ""
 
     def __init__(self, tau_model="global", phi_model="global",
                  phi_s2ss_model=None, tau_quantile=None,
                  phi_ss_quantile=None, phi_s2ss_quantile=None):
-        if not self.GMPE_TABLE:
+        if not self.gmpe_file:
             raise NotImplementedError("NGA East Fixed-Table GMPE requires "
                                       "input table")
         super().__init__(
-            gmpe_table=self.GMPE_TABLE,
+            gmpe_table=self.gmpe_file,
             tau_model=tau_model, phi_model=phi_model,
             phi_s2ss_model=phi_s2ss_model, tau_quantile=tau_quantile,
             phi_ss_quantile=phi_ss_quantile,
@@ -758,18 +758,18 @@ class NGAEastGMPETotalSigma(NGAEastBaseGMPETotalSigma):
     GMPE table is fixed. This forms the main base-class for the total sigma
     version of the core set of NGA East models
     """
-    GMPE_TABLE = ""
+    gmpe_file = ""
 
     def __init__(self, tau_model="global", phi_model="global",
                  phi_s2ss_model=None, sigma_quantile=None):
         """
         Instantiates the GMPE without the hdf5 table fort the median values
         """
-        if not self.GMPE_TABLE:
+        if not self.gmpe_file:
             raise NotImplementedError("NGA East Fixed-Table GMPE requires "
                                       "input table")
         super().__init__(
-            self.GMPE_TABLE, tau_model=tau_model, phi_model=phi_model,
+            self.gmpe_file, tau_model=tau_model, phi_model=phi_model,
             phi_s2ss_model=phi_s2ss_model, sigma_quantile=sigma_quantile)
 
 
@@ -791,7 +791,7 @@ class Boore2015NGAEastA04(NGAEastGMPE):
     Ground Motion Models for the Central and Eastern North America Region",
     PEER Report 2015/04, Pacific Earthquake Engineering Research Center
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_A04_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_A04_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastA04TotalSigma(NGAEastGMPETotalSigma):
@@ -799,7 +799,7 @@ class Boore2015NGAEastA04TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Atkinson (2004) attenuation model
     for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_A04_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_A04_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastAB14(NGAEastGMPE):
@@ -807,7 +807,7 @@ class Boore2015NGAEastAB14(NGAEastGMPE):
     Boore (2015) NGA East GMPE using the Atkinson & Boore (2014) attenuation
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_AB14_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_AB14_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastAB14TotalSigma(NGAEastGMPETotalSigma):
@@ -815,7 +815,7 @@ class Boore2015NGAEastAB14TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Atkinson & Boore (2014) attenuation
     model for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_AB14_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_AB14_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastAB95(NGAEastGMPE):
@@ -823,7 +823,7 @@ class Boore2015NGAEastAB95(NGAEastGMPE):
     Boore (2015) NGA East GMPE using the Atkinson & Boore (1995) attenuation
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_AB95_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_AB95_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastAB95TotalSigma(NGAEastGMPETotalSigma):
@@ -831,7 +831,7 @@ class Boore2015NGAEastAB95TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Atkinson & Boore (1995) attenuation
     model for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_AB95_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_AB95_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastBCA10D(NGAEastGMPE):
@@ -839,7 +839,7 @@ class Boore2015NGAEastBCA10D(NGAEastGMPE):
     Boore (2015) NGA East GMPE using the Boore et al (2010) attenuation
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_BCA10D_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_BCA10D_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastBCA10DTotalSigma(NGAEastGMPETotalSigma):
@@ -847,7 +847,7 @@ class Boore2015NGAEastBCA10DTotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Boore et al (2010) attenuation
     model for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_BCA10D_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_BCA10D_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastBS11(NGAEastGMPE):
@@ -855,7 +855,7 @@ class Boore2015NGAEastBS11(NGAEastGMPE):
     Boore (2015) NGA East GMPE using the Boatwright and Seekins (2011)
     attenuation model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_BS11_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_BS11_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastBS11TotalSigma(NGAEastGMPETotalSigma):
@@ -863,14 +863,14 @@ class Boore2015NGAEastBS11TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Boatwright and Seekins (2011)
     attenuation model for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_BS11_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_BS11_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastSGD02(NGAEastGMPE):
     """
     Boore (2015) NGA East GMPE using the Silva et al (2002) attenuation model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_SGD02_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_SGD02_J15_Adjusted.hdf5")
 
 
 class Boore2015NGAEastSGD02TotalSigma(NGAEastGMPETotalSigma):
@@ -878,7 +878,7 @@ class Boore2015NGAEastSGD02TotalSigma(NGAEastGMPETotalSigma):
     Boore (2015) NGA East GMPE using the Silva et al (2002) attenuation model
     for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_BOORE_SGD02_J15_Adjusted.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_BOORE_SGD02_J15_Adjusted.hdf5")
 
 
 # Darragh, Abrahamson, Silva and Gregor (2015) suite
@@ -892,7 +892,7 @@ class DarraghEtAl2015NGAEast1CCSP(NGAEastGMPE):
     Hard Rock Ground Motion Models for Region 2 of Central and Eastern
     North America" in ...
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_DARRAGH_1CCSP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_1CCSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast1CCSPTotalSigma(NGAEastGMPETotalSigma):
@@ -901,7 +901,7 @@ class DarraghEtAl2015NGAEast1CCSPTotalSigma(NGAEastGMPETotalSigma):
     constant stress parameter (1CCSP) for use with the total sigma aleatory
     uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_DARRAGH_1CCSP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_1CCSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast1CVSP(NGAEastGMPE):
@@ -909,7 +909,7 @@ class DarraghEtAl2015NGAEast1CVSP(NGAEastGMPE):
     NGA East model of Darragh et al. (2015) adopting the single-corner
     variable stress parameter (1CVSP)
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_DARRAGH_1CVSP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_1CVSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast1CVSPTotalSigma(NGAEastGMPETotalSigma):
@@ -918,7 +918,7 @@ class DarraghEtAl2015NGAEast1CVSPTotalSigma(NGAEastGMPETotalSigma):
     variable stress parameter (1CVSP) for use with the total sigma aleatory
     uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_DARRAGH_1CVSP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_1CVSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast2CCSP(NGAEastGMPE):
@@ -926,7 +926,7 @@ class DarraghEtAl2015NGAEast2CCSP(NGAEastGMPE):
     NGA East model of Darragh et al. (2015) adopting the two-corner
     constant stress parameter (2CCSP)
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_DARRAGH_2CCSP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_2CCSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast2CCSPTotalSigma(NGAEastGMPETotalSigma):
@@ -935,7 +935,7 @@ class DarraghEtAl2015NGAEast2CCSPTotalSigma(NGAEastGMPETotalSigma):
     constant stress parameter (2CCSP) for use with the total sigma aleatory
     uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_DARRAGH_2CCSP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_2CCSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast2CVSP(NGAEastGMPE):
@@ -943,7 +943,7 @@ class DarraghEtAl2015NGAEast2CVSP(NGAEastGMPE):
     NGA East model of Darragh et al. (2015) adopting the two-corner
     variable stress parameter (1CVSP)
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_DARRAGH_2CVSP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_2CVSP.hdf5")
 
 
 class DarraghEtAl2015NGAEast2CVSPTotalSigma(NGAEastGMPETotalSigma):
@@ -952,7 +952,7 @@ class DarraghEtAl2015NGAEast2CVSPTotalSigma(NGAEastGMPETotalSigma):
     variable stress parameter (2CVSP) for use with the total sigma aleatory
     uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_DARRAGH_2CVSP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_DARRAGH_2CVSP.hdf5")
 
 # Yenier & Atkinson (2015)
 
@@ -965,7 +965,7 @@ class YenierAtkinson2015NGAEast(NGAEastGMPE):
     Application to Central and Eastern North America" in PEER 2015/04, Chapter
     4
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_YENIER_ATKINSON.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_YENIER_ATKINSON.hdf5")
 
 
 class YenierAtkinson2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -973,7 +973,7 @@ class YenierAtkinson2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     NGA East Model of Yenier & Atkinson (2015) for use with the total sigma
     aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_YENIER_ATKINSON.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_YENIER_ATKINSON.hdf5")
 
 
 # Pezeschk et al. (2015)
@@ -987,7 +987,7 @@ class PezeschkEtAl2015NGAEastM1SS(NGAEastGMPE):
     Motion Prediction Equations for Eastern North America using a Hybrid
     Empirical Method" in PEER 2015/04, Chapter 5
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_PEZESCHK_M1SS.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_PEZESCHK_M1SS.hdf5")
 
 
 class PezeschkEtAl2015NGAEastM1SSTotalSigma(NGAEastGMPETotalSigma):
@@ -995,14 +995,14 @@ class PezeschkEtAl2015NGAEastM1SSTotalSigma(NGAEastGMPETotalSigma):
     NGA East Model of Pezeschk et al (2015) for the large-M simulation scaling
     for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_PEZESCHK_M1SS.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_PEZESCHK_M1SS.hdf5")
 
 
 class PezeschkEtAl2015NGAEastM2ES(NGAEastGMPE):
     """
     NGA East Model of Pezeschk et al (2015) for the large-M empirical scaling
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_PEZESCHK_M2ES.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_PEZESCHK_M2ES.hdf5")
 
 
 class PezeschkEtAl2015NGAEastM2ESTotalSigma(NGAEastGMPETotalSigma):
@@ -1010,7 +1010,7 @@ class PezeschkEtAl2015NGAEastM2ESTotalSigma(NGAEastGMPETotalSigma):
     NGA East Model of Pezeschk et al (2015) for the large-M empirical scaling
     for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_PEZESCHK_M2ES.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_PEZESCHK_M2ES.hdf5")
 
 # Frankel (2015)
 
@@ -1024,7 +1024,7 @@ class Frankel2015NGAEast(NGAEastGMPE):
     Earthquakes Using Hybrid Broadband Seismograms from Finite-Fault
     Simulation with Constant Stress-Drop Scaling" in PEER 2015/04, Chapter 6
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_FRANKEL_J15.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_FRANKEL_J15.hdf5")
 
 
 class Frankel2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1032,7 +1032,7 @@ class Frankel2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     NGA East Model of Frankel (2015) for application to Central & Eastern
     United States for use with the total sigma aleatory uncertainty model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_FRANKEL_J15.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_FRANKEL_J15.hdf5")
 
 # Shahjouei & Pezeschk (2015)
 
@@ -1046,7 +1046,7 @@ class ShahjoueiPezeschk2015NGAEast(NGAEastGMPE):
     for Central and Eastern North America using Hybrid Broadband Simulations
     and NGA-West2 GMPEs" in PEER 2015/04, Chapter 7
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_SHAHJOUEI_PEZESCHK.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_SHAHJOUEI_PEZESCHK.hdf5")
 
 
 class ShahjoueiPezeschk2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1055,7 +1055,7 @@ class ShahjoueiPezeschk2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_SHAHJOUEI_PEZESCHK.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_SHAHJOUEI_PEZESCHK.hdf5")
 
 # Al Noman and Cramer (2015)
 
@@ -1068,7 +1068,7 @@ class AlNomanCramer2015NGAEast(NGAEastGMPE):
     Al Noman & Cramer (2015) "Empirical Ground-Motion Prediction Equations for
     Eastern North America" in PEER 2015/04, Chapter 8
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_ALNOMAN_CRAMER.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_ALNOMAN_CRAMER.hdf5")
 
 
 class AlNomanCramer2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1077,7 +1077,7 @@ class AlNomanCramer2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_ALNOMAN_CRAMER.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_ALNOMAN_CRAMER.hdf5")
 
 # Graizer (2015)
 
@@ -1090,7 +1090,7 @@ class Graizer2015NGAEast(NGAEastGMPE):
     Graizer, V (2015) "Ground-Motion Prediction Equations for the Central and
     Eastern United States" in PEER 2015/04, Chapter 9
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_GRAIZER.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_GRAIZER.hdf5")
 
 
 class Graizer2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1099,7 +1099,7 @@ class Graizer2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     United States, for use with the total sigma aleatory uncertainty
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_GRAIZER.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_GRAIZER.hdf5")
 
 # Hassani & Atkinson (2015)
 
@@ -1112,7 +1112,7 @@ class HassaniAtkinson2015NGAEast(NGAEastGMPE):
     Hassani, B & Atkinson, GA (2015) "Referenced Empirical Ground-Motion Model
     for Eastern North America" in PEER 2015/04, Chapter 10
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_HASSANI_ATKINSON.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_HASSANI_ATKINSON.hdf5")
 
 
 class HassaniAtkinson2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
@@ -1121,7 +1121,7 @@ class HassaniAtkinson2015NGAEastTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_HASSANI_ATKINSON.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_HASSANI_ATKINSON.hdf5")
 
 # Hollenback et al. (2015)
 
@@ -1134,7 +1134,7 @@ class HollenbackEtAl2015NGAEastGP(NGAEastGMPE):
     Hollenback, J, Keuhn, N, Goulet, CA and Abrahamson, NA (2015) "PEER NGA-
     East Median Ground Motion Models" in PEER 2015/04, Chapter 11
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_PEER_GP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_PEER_GP.hdf5")
 
 
 class HollenbackEtAl2015NGAEastGPTotalSigma(NGAEastGMPETotalSigma):
@@ -1143,7 +1143,7 @@ class HollenbackEtAl2015NGAEastGPTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_PEER_GP.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_PEER_GP.hdf5")
 
 
 class HollenbackEtAl2015NGAEastEX(NGAEastGMPE):
@@ -1154,7 +1154,7 @@ class HollenbackEtAl2015NGAEastEX(NGAEastGMPE):
     Hollenback, J, Keuhn, N, Goulet, CA and Abrahamson, NA (2015) "PEER NGA-
     East Median Ground Motion Models" in PEER 2015/04, Chapter 11
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_PEER_EX.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_PEER_EX.hdf5")
 
 
 class HollenbackEtAl2015NGAEastEXTotalSigma(NGAEastGMPETotalSigma):
@@ -1163,4 +1163,4 @@ class HollenbackEtAl2015NGAEastEXTotalSigma(NGAEastGMPETotalSigma):
     Eastern United States, for use with the total sigma aleatory uncertainty
     model
     """
-    GMPE_TABLE = os.path.join(PATH, "NGAEast_PEER_EX.hdf5")
+    gmpe_file = os.path.join(PATH, "NGAEast_PEER_EX.hdf5")

--- a/openquake/hazardlib/tests/gsim/gmpe_table_test.py
+++ b/openquake/hazardlib/tests/gsim/gmpe_table_test.py
@@ -418,7 +418,7 @@ class GSIMTableGoodTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             GMPETable(gmpe_table=None)
         self.assertEqual(str(err.exception),
-                         "You forgot to set GMPETable.gmpe_file!")
+                         "You forgot to set GMPETable.gmpe_table!")
         with self.assertRaises(OSError) as err:
             GMPETable(gmpe_table='/do/not/exists/table.hdf5')
         self.assertIn("No such file or directory", str(err.exception))
@@ -741,7 +741,7 @@ class GSIMTableQATestCase(BaseGSIMTestCase):
     STD_TOTAL_FILE = "gsimtables/Wcrust_rjb_med_TOTAL.csv"
 
     def setUp(self):
-        self.GSIM_CLASS.gmpe_file = os.path.join(BASE_DATA_PATH,
+        self.GSIM_CLASS.gmpe_table = os.path.join(BASE_DATA_PATH,
                                                   "Wcrust_rjb_med.hdf5")
 
     def test_mean(self):
@@ -751,4 +751,4 @@ class GSIMTableQATestCase(BaseGSIMTestCase):
         self.check(self.STD_TOTAL_FILE, max_discrep_percentage=0.7)
 
     def tearDown(self):
-        self.GSIM_CLASS.gmpe_file = None
+        self.GSIM_CLASS.gmpe_table = None

--- a/openquake/hazardlib/tests/gsim/gmpe_table_test.py
+++ b/openquake/hazardlib/tests/gsim/gmpe_table_test.py
@@ -418,7 +418,7 @@ class GSIMTableGoodTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             GMPETable(gmpe_table=None)
         self.assertEqual(str(err.exception),
-                         "You forgot to set GMPETable.GMPE_TABLE!")
+                         "You forgot to set GMPETable.gmpe_file!")
         with self.assertRaises(OSError) as err:
             GMPETable(gmpe_table='/do/not/exists/table.hdf5')
         self.assertIn("No such file or directory", str(err.exception))
@@ -741,7 +741,7 @@ class GSIMTableQATestCase(BaseGSIMTestCase):
     STD_TOTAL_FILE = "gsimtables/Wcrust_rjb_med_TOTAL.csv"
 
     def setUp(self):
-        self.GSIM_CLASS.GMPE_TABLE = os.path.join(BASE_DATA_PATH,
+        self.GSIM_CLASS.gmpe_file = os.path.join(BASE_DATA_PATH,
                                                   "Wcrust_rjb_med.hdf5")
 
     def test_mean(self):
@@ -751,4 +751,4 @@ class GSIMTableQATestCase(BaseGSIMTestCase):
         self.check(self.STD_TOTAL_FILE, max_discrep_percentage=0.7)
 
     def tearDown(self):
-        self.GSIM_CLASS.GMPE_TABLE = None
+        self.GSIM_CLASS.gmpe_file = None

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -20,6 +20,7 @@
 Validation library for the engine, the desktop tools, and anything else
 """
 
+import os
 import re
 import ast
 import logging
@@ -73,7 +74,7 @@ class FromFile(object):
 
 
 # more tests are in tests/valid_test.py
-def gsim(value):
+def gsim(value, basedir=''):
     """
     Convert a string in TOML format into a GSIM instance
 
@@ -83,6 +84,9 @@ def gsim(value):
     if not value.startswith('['):  # assume the GSIM name
         value = '[%s]' % value
     [(gsim_name, kwargs)] = toml.loads(value).items()
+    for k, v in kwargs.items():
+        if k.endswith(('_file', '_table')):
+            kwargs[k] = os.path.join(basedir, v)
     minimum_distance = float(kwargs.pop('minimum_distance', 0))
     if gsim_name == 'FromFile':
         return FromFile()


### PR DESCRIPTION
The trick is to use the convention of ending the filename argument with `_file` (i.e. `kappa_file`).  The logic tree reader will magically replace the local filename with an absolute filename by taking as base directory the directory where the gsim logic tree file is. This PR supersedes
https://github.com/gem/oq-engine/pull/5263.

NB: `oq zip` will work automatically. For backward compatibility with GMPETables ending the filename argument with `_table` is also supported.