### PR TITLE
Export the rupture bounding box in valid WKT

### DIFF
--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -86,10 +86,7 @@ def export_ruptures_csv(ekey, dstore):
         for r in arr:
             poly = r['boundary'].decode('utf8')
             obj = shapely.wkt.loads(poly)
-            if not obj.is_valid:
-                # this happens when the bounding box collapse to a line
-                # or a point, i.e. maxlon=minlon or maxlat=minlat
-                print('Rupture %d has an invalid %s' % (r['rupid'], poly))
+            assert obj.is_valid, (r['rupid'], poly)
 
     comment = dstore.metadata
     comment.update(investigation_time=oq.investigation_time,

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1110,7 +1110,7 @@ def extract_rupture_info(dstore, what):
             coords = ['%.5f %.5f' % xy for xy in bbox2poly(r['bbox'])]
             coordset = set(coords)
             if len(coordset) == 1:  # degenerate to point boundind box
-                boundary = 'POINT((%s))' % coords[0]
+                boundary = 'POINT(%s)' % coords[0]
             elif len(coordset) < 5:  # degenerate to line bounding box
                 boundary = 'LINESTRING(%s)' % ', '.join(coordset)
             else:  # regular bounding box with 5 vertices

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1108,7 +1108,13 @@ def extract_rupture_info(dstore, what):
         rup_data = RuptureData(rgetter.trt, rgetter.rlzs_by_gsim)
         for r, rup in zip(rup_data.to_array(rups), rups):
             coords = ['%.5f %.5f' % xy for xy in bbox2poly(r['bbox'])]
-            boundary = 'POLYGON((%s))' % ', '.join(coords)
+            coordset = set(coords)
+            if len(coordset) == 1:  # degenerate to point boundind box
+                boundary = 'POINT((%s))' % coords[0]
+            elif len(coordset) < 5:  # degenerate to line bounding box
+                boundary = 'LINESTRING(%s)' % ', '.join(coordset)
+            else:  # regular bounding box with 5 vertices
+                boundary = 'POLYGON((%s))' % ', '.join(coords)
             rows.append(
                 (r['rup_id'], r['multiplicity'], r['mag'],
                  r['lon'], r['lat'], r['depth'],


### PR DESCRIPTION
Solves the case of degenerate bounding boxes by exporting as POINTs and LINESTRINGs.
Closes https://github.com/gem/oq-engine/issues/5227.