### PR TITLE
Changed how the input files are saved in the datastore

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import io
 import os
 import re
 import gzip
@@ -388,6 +389,13 @@ class DataStore(collections.abc.MutableMapping):
                 yield from self.retrieve_files(fullk)
             else:
                 yield fullk, gzip.decompress(bytes(numpy.asarray(v[()])))
+
+    def getfile(self, key):
+        """
+        :returns: a BytesIO object
+        """
+        data = bytes(numpy.asarray(self[key][()]))
+        return io.BytesIO(gzip.decompress(data))
 
     @property
     def metadata(self):

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -390,7 +390,7 @@ class DataStore(collections.abc.MutableMapping):
             else:
                 yield fullk, gzip.decompress(bytes(numpy.asarray(v[()])))
 
-    def getfile(self, key):
+    def get_file(self, key):
         """
         :returns: a BytesIO object
         """

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -378,17 +378,16 @@ class DataStore(collections.abc.MutableMapping):
             data = gzip.compress(open(fname, 'rb').read())
             self[where + fname[prefix:]] = numpy.void(data)
 
-    def retrieve_files(self, grp=None):
+    def retrieve_files(self, prefix='input'):
         """
         :yields: pairs (relative path, data)
         """
-        grp = grp or self['input']
-        for k, v in grp.items():
+        for k, v in self[prefix].items():
+            fullk = prefix + '/' + k
             if hasattr(v, 'items'):
-                yield from self.retrieve_files(v)
+                yield from self.retrieve_files(fullk)
             else:
-                a = numpy.asarray(v[()])
-                yield k, gzip.decompress(bytes(a))
+                yield fullk, gzip.decompress(bytes(numpy.asarray(v[()])))
 
     @property
     def metadata(self):

--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -96,4 +96,4 @@ class DataStoreTestCase(unittest.TestCase):
         self.dstore.store_files(fnames)
         for name, data in self.dstore.retrieve_files():
             print(name)
-        print(self.dstore.getfile(name))
+        print(self.dstore.get_file(name))

--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -86,3 +86,13 @@ class DataStoreTestCase(unittest.TestCase):
             read(42, datadir=tmp)
         self.assertIn('permission denied', str(ctx.exception).lower())
         os.remove(fname)
+
+    def test_store_retrieve_files(self):
+        fnames = []
+        for cwd, dirs, files in os.walk(os.path.dirname(__file__)):
+            for f in files:
+                if f.endswith('.py'):
+                    fnames.append(os.path.join(cwd, f))
+        self.dstore.store_files(fnames)
+        for name, data in self.dstore.retrieve_files():
+            print(name)

--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -96,3 +96,4 @@ class DataStoreTestCase(unittest.TestCase):
         self.dstore.store_files(fnames)
         for name, data in self.dstore.retrieve_files():
             print(name)
+        print(self.dstore.getfile(name))

--- a/openquake/calculators/export/__init__.py
+++ b/openquake/calculators/export/__init__.py
@@ -15,6 +15,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import zipfile
+import logging
 from openquake.baselib.general import CallableDict
 from openquake.commonlib.writers import write_csv
 
@@ -70,10 +72,9 @@ def export_input_zip(ekey, dstore):
     Export the data in the `input_zip` dataset as a .zip file
     """
     dest = dstore.export_path('input.zip')
-    nbytes = dstore.get_attr('input/zip', 'nbytes')
-    zbytes = dstore['input/zip'][()]
-    # when reading input_zip some terminating null bytes are truncated (for
-    # unknown reasons) therefore they must be restored
-    zbytes += b'\x00' * (nbytes - len(zbytes))
-    open(dest, 'wb').write(zbytes)
+    with zipfile.ZipFile(
+            dest, 'w', zipfile.ZIP_DEFLATED, allowZip64=True) as z:
+        for k, data in dstore.retrieve_files():
+            logging.info('Archiving %s' % k)
+            z.writestr(k, data)
     return [dest]

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -308,7 +308,7 @@ class GMPETable(GMPE):
         Executes the preprocessing steps at the instantiation stage to read in
         the tables from hdf5 and hold them in memory.
         """
-        fname = self.kwargs.get('gmpe_table', self.gmpe_table)
+        fname = self.kwargs['gmpe_table']
         if fname is None:
             raise ValueError('You forgot to set %s.gmpe_table!' %
                              self.__class__.__name__)

--- a/openquake/hazardlib/tests/gsim/gmpe_table_test.py
+++ b/openquake/hazardlib/tests/gsim/gmpe_table_test.py
@@ -33,9 +33,8 @@ from openquake.hazardlib.tests.gsim.utils import BaseGSIMTestCase
 from openquake.hazardlib import imt as imt_module
 
 
-BASE_DATA_PATH = os.path.join(os.path.dirname(__file__),
-                              "data",
-                              "gsimtables")
+BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "gsimtables")
+GMPE_TABLE = os.path.join(BASE_DATA_PATH, "Wcrust_rjb_med.hdf5")
 
 
 def midpoint(low, high, point=0.5):
@@ -740,15 +739,10 @@ class GSIMTableQATestCase(BaseGSIMTestCase):
     MEAN_FILE = "gsimtables/Wcrust_rjb_med_MEAN.csv"
     STD_TOTAL_FILE = "gsimtables/Wcrust_rjb_med_TOTAL.csv"
 
-    def setUp(self):
-        self.GSIM_CLASS.gmpe_table = os.path.join(BASE_DATA_PATH,
-                                                  "Wcrust_rjb_med.hdf5")
-
     def test_mean(self):
-        self.check(self.MEAN_FILE, max_discrep_percentage=0.7)
+        self.check(self.MEAN_FILE, max_discrep_percentage=0.7,
+                   gmpe_table=GMPE_TABLE)
 
     def test_std_total(self):
-        self.check(self.STD_TOTAL_FILE, max_discrep_percentage=0.7)
-
-    def tearDown(self):
-        self.GSIM_CLASS.gmpe_table = None
+        self.check(self.STD_TOTAL_FILE, max_discrep_percentage=0.7,
+                   gmpe_table=GMPE_TABLE)


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/5269. This is first step to remove the redundance in the GMPE tables which currently are stored twice in the datastore.