### PR TITLE
Extended pointsource_distance to non-point sources

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -440,7 +440,15 @@ class PmapMaker():
         acc = AccumDict(accum=[])
         distmax = max(dctx.rrup.max() for rup, sctx, dctx in ctxs)
         for rup, sctx, dctx in ctxs:
-            tup = [getattr(rup, p) for p in self.REQUIRES_RUPTURE_PARAMETERS]
+            tup = []
+            for p in self.REQUIRES_RUPTURE_PARAMETERS:
+                if (p != 'mag' and self.pointsource_distance is not None and
+                        dctx.rrup.min() > self.pointsource_distance):
+                    tup.append(0)
+                    # all nonmag rupture parameters are collapsed to 0
+                    # over the pointsource_distance
+                else:
+                    tup.append(getattr(rup, p))
             for name in self.REQUIRES_DISTANCES:
                 dists = getattr(dctx, name)
                 tup.extend(I16(dists / distmax / precision))


### PR DESCRIPTION
The effect is minimal. In disaggregation/case_1 I get
`Considered 2954/3271 ruptures => Considered 2897/3271 ruptures`
and in oq-risk-tests disaggregation/case_1
`Considered 120492/120536 ruptures => Considered 117963/120536 ruptures`
and the change is on the last digit: 
`Subduction Interface,7.02098E-05 => Subduction Interface,7.02099E-05`
