### PR TITLE
Forbid the instantiation of CoeffsTable in get_mean_and_stddevs

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -785,12 +785,12 @@ def view_act_ruptures_by_src(token, dstore):
 @view.add('bad_ruptures')
 def view_bad_ruptures(token, dstore):
     """
-    Display the ruptures with an invalid bounding box
+    Display the ruptures degenating to a point
     """
     data = dstore['ruptures']['id', 'code', 'mag',
                               'minlon', 'maxlon', 'minlat', 'maxlat']
-    bad = data[numpy.logical_or(data['minlon'] == data['maxlon'],
-                                data['minlat'] == data['maxlat'])]
+    bad = data[numpy.logical_and(data['minlon'] == data['maxlon'],
+                                 data['minlat'] == data['maxlat'])]
     return rst_table(bad)
 
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -91,10 +91,10 @@ def get_mean_std(sctx, rctx, dctx, imts, gsims):
                                                     [const.StdDev.TOTAL])
             arr[0, :, m, g] = mean
             arr[1, :, m, g] = std
-        if CoeffsTable.num_instances > num_tables:
-            raise RuntimeError('Instantiating CoeffsTable inside '
-                               '%s.get_mean_and_stddevs' %
-                               gsim.__class__.__name)
+            if CoeffsTable.num_instances > num_tables:
+                raise RuntimeError('Instantiating CoeffsTable inside '
+                                   '%s.get_mean_and_stddevs' %
+                                   gsim.__class__.__name__)
     return arr
 
 
@@ -706,7 +706,7 @@ class CoeffsTable(object):
         else:
             raise TypeError("CoeffsTable cannot be constructed with inputs "
                             "of the form '%s'" % table.__class__.__name__)
-        self.num_instances += 1
+        self.__class__.num_instances += 1
 
     def _setup_table_from_str(self, table, sa_damping):
         """

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -83,6 +83,7 @@ def get_mean_std(sctx, rctx, dctx, imts, gsims):
     M = len(imts)
     G = len(gsims)
     arr = numpy.zeros((2, N, M, G))
+    num_tables = CoeffsTable.num_instances
     for g, gsim in enumerate(gsims):
         d = dctx.roundup(gsim.minimum_distance)
         for m, imt in enumerate(imts):
@@ -90,6 +91,10 @@ def get_mean_std(sctx, rctx, dctx, imts, gsims):
                                                     [const.StdDev.TOTAL])
             arr[0, :, m, g] = mean
             arr[1, :, m, g] = std
+        if CoeffsTable.num_instances > num_tables:
+            raise RuntimeError('Instantiating CoeffsTable inside '
+                               '%s.get_mean_and_stddevs' %
+                               gsim.__class__.__name)
     return arr
 
 
@@ -678,6 +683,8 @@ class CoeffsTable(object):
     ...           imt.PGV(): {"a": 0.5, "b": 10.0}}
     >>> ct = CoeffsTable(sa_damping=5, table=coeffs)
     """
+    num_instances = 0
+    
     def __init__(self, **kwargs):
         if 'table' not in kwargs:
             raise TypeError('CoeffsTable requires "table" kwarg')
@@ -699,6 +706,7 @@ class CoeffsTable(object):
         else:
             raise TypeError("CoeffsTable cannot be constructed with inputs "
                             "of the form '%s'" % table.__class__.__name__)
+        self.num_instances += 1
 
     def _setup_table_from_str(self, table, sa_damping):
         """


### PR DESCRIPTION
It is a performance bug, so it must be forbidden.
Also, changed the view bad_ruptures to display only the point ruptures.