### PR TITLE
Changed from filter_split -> split_filter

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -86,12 +86,11 @@ def classical_split_filter(srcs, srcfilter, gsims, params, monitor):
         yield classical(srcs, srcfilter, gsims, params, monitor)
         return
     # NB: splitting all the sources improves the distribution significantly,
-    # compared to splitting only the big source
+    # compared to splitting only the big sources
     sources = []
-    with monitor("filtering/splitting sources"):
-        for src, _sites in srcfilter(srcs):
-            splits, _stime = split_sources([src])
-            sources.extend(srcfilter.filter(splits))
+    with monitor("splitting/filtering sources"):
+        splits, _stime = split_sources(srcs)
+        sources.extend(srcfilter.filter(splits))
     if sources:
         sources.sort(key=weight)
         totsites = len(srcfilter.sitecol)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -131,7 +131,9 @@ def preclassical(srcs, srcfilter, gsims, params, monitor):
     """
     calc_times = AccumDict(accum=numpy.zeros(3, F32))  # nrups, nsites, time
     pmap = AccumDict(accum=0)
-    for src in srcs:
+    with monitor("splitting/filtering sources"):
+        splits, _stime = split_sources(srcs)
+    for src in splits:
         t0 = time.time()
         if srcfilter.get_close_sites(src) is None:
             continue

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -226,7 +226,7 @@ class ClassicalTestCase(CalculatorTestCase):
 ====== ========= ============ ============
 grp_id num_sites num_ruptures eff_ruptures
 ====== ========= ============ ============
-0      0.02237   447          447         
+0      0.33557   447          447         
 ====== ========= ============ ============""")
 
     def test_case_15(self):


### PR DESCRIPTION
This avoids the error
```
   The maximum distance 600 is too large, the bounding box is larger than
   half the globe: 219 degrees
```
affecting the calculation for Canada.