### PR TITLE
Report (and use?) the number of visible cores, not total system cores

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -592,7 +592,7 @@ def getargnames(task_func):
 class Starmap(object):
     pids = ()
     running_tasks = []  # currently running tasks
-    num_cores = multiprocessing.cpu_count()
+    num_cores = len(psutil.Process().cpu_affinity())
     oversubmit = False
 
     @classmethod

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -592,6 +592,7 @@ def getargnames(task_func):
 class Starmap(object):
     pids = ()
     running_tasks = []  # currently running tasks
+    # Use only the "visible" cores, not the total system cores.
     num_cores = len(psutil.Process().cpu_affinity())
     oversubmit = False
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -335,8 +335,9 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         return
     try:
         if OQ_DISTRIBUTE.endswith('pool'):
+            # Report the number of "visible" cores, not the total system cores
             logs.LOG.warning('Using %d cores on %s',
-                             parallel.Starmap.num_cores, platform.node())
+                             len(os.sched_getaffinity(0)), platform.node())
         if OQ_DISTRIBUTE == 'zmq' and config.zworkers['host_cores']:
             logs.dbcmd('zmq_start')  # start the zworkers
             logs.dbcmd('zmq_wait')  # wait for them to go up

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -335,7 +335,6 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         return
     try:
         if OQ_DISTRIBUTE.endswith('pool'):
-            # Report the number of "visible" cores, not the total system cores
             logs.LOG.warning('Using %d cores on %s',
                              parallel.Starmap.num_cores, platform.node())
         if OQ_DISTRIBUTE == 'zmq' and config.zworkers['host_cores']:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -337,7 +337,7 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
         if OQ_DISTRIBUTE.endswith('pool'):
             # Report the number of "visible" cores, not the total system cores
             logs.LOG.warning('Using %d cores on %s',
-                             len(os.sched_getaffinity(0)), platform.node())
+                             parallel.Starmap.num_cores, platform.node())
         if OQ_DISTRIBUTE == 'zmq' and config.zworkers['host_cores']:
             logs.dbcmd('zmq_start')  # start the zworkers
             logs.dbcmd('zmq_wait')  # wait for them to go up


### PR DESCRIPTION
In a cgroups limited environment, like a SLURM cluster, the number of processors available is different from the number of procs available in the whole system.

Example of a "limited" env:
```bash
$ srun -N 1 --ntasks-per-core=1 -c 10 --pty bash
$ grep 'model name' /proc/cpuinfo |wc -l
36    # Total number of cores in the whole system
$ nproc
10    # Cores usable
$ python3 -c 'import multiprocessing as mp; import os; print(mp.cpu_count(), len(os.sched_getaffinity(0)))'
36 10
```

This is only a "graphical" fix in the logs; right now oq spawns a number of processes matching the whole system cores available, while it should use only the ones available, as reported in the multiprocessing doc:
https://docs.python.org/3.8/library/multiprocessing.html#multiprocessing.cpu_count

This causes a tremendous overhead because processes are fighting for resources.
I can't find the place where the number of processes to use for multiprocessing is defined, any help would be appreciated.
Let me know if you think this may be useful for oq.