### PR TITLE
Get ini defaults

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Matteo Nastasi]
+  * Add '/v1/ini_defaults' web api entry point to retrieve all default
+    values for ini attributes (attrs without a default are not returned)
+
   [Michele Simionato]
   * Added more check on the IMTs and made it possible to import a GMF.csv
     file with more IMTs than needed

--- a/doc/web-api.md
+++ b/doc/web-api.md
@@ -310,14 +310,16 @@ Parameters: None
 
 Response:
 ```json
-{'aggregate_by': [],
- 'area_source_discretization': None,
- 'ash_wet_amplification_factor': 1.0,
- 'asset_correlation': 0,
- 'asset_hazard_distance': {u'default': 15},
- 'asset_loss_table': False,
- 'assets_per_site_limit': 1000,
- 'avg_losses': True,
+{"aggregate_by": [],
+ "area_source_discretization": null,
+ "ash_wet_amplification_factor": 1.0,
+ "asset_correlation": 0,
+ "asset_hazard_distance": {"default": 15},
+ "asset_loss_table": false,
+ "assets_per_site_limit": 1000,
+ "avg_losses": true,
+ "base_path": ".",
+ "calculation_mode": "",
  ...
  }
 ```

--- a/doc/web-api.md
+++ b/doc/web-api.md
@@ -286,6 +286,8 @@ a JSON object, containing:
 
 Check if a given filename exists and if the first 32 bytes of its content have the same checksum passed as argument of POST.
 
+*(developed for internal purposes)*
+
 Parameters:
 
     * filename: filename (with path) of file to be checked
@@ -297,6 +299,28 @@ a JSON object, containing:
 
     * success: a boolean indicating that filename is accessible by engine server and that calculated checksum matches passed parameter
 
+
+#### GET /v1/ini_defaults
+
+Retrieve all default values for ini file parameters (parameters without a default value are not returned).
+
+*(developed for internal purposes)*
+
+Parameters: None
+
+Response:
+```json
+{'aggregate_by': [],
+ 'area_source_discretization': None,
+ 'ash_wet_amplification_factor': 1.0,
+ 'asset_correlation': 0,
+ 'asset_hazard_distance': {u'default': 15},
+ 'asset_loss_table': False,
+ 'assets_per_site_limit': 1000,
+ 'avg_losses': True,
+ ...
+ }
+```
 
 #### POST /accounts/ajax_login/
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -97,7 +97,7 @@ class OqParam(valid.ParamSet):
     filter_distance = valid.Param(valid.Choice('rrup'), None)
     ground_motion_correlation_model = valid.Param(
         valid.NoneOr(valid.Choice(*GROUND_MOTION_CORRELATION_MODELS)), None)
-    ground_motion_correlation_params = valid.Param(valid.dictionary)
+    ground_motion_correlation_params = valid.Param(valid.dictionary, {})
     ground_motion_fields = valid.Param(valid.boolean, True)
     gsim = valid.Param(valid.utf8, '[FromFile]')
     hazard_calculation_id = valid.Param(valid.NoneOr(valid.positiveint), None)

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -275,6 +275,10 @@ class EngineServerTestCase(unittest.TestCase):
         resp = self.c.get('/v1/available_gsims')
         self.assertIn(b'ChiouYoungs2014PEER', resp.content)
 
+    def test_ini_defaults(self):
+        resp = self.c.get('/v1/ini_defaults')
+        self.assertEqual(resp.status_code, 200)
+
     def test_validate_zip(self):
         with open(os.path.join(self.datadir, 'archive_err_1.zip'), 'rb') as a:
             resp = self.post('validate_zip', dict(archive=a))

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     url(r'^v1/valid/', views.validate_nrml),
     url(r'^v1/available_gsims$', views.get_available_gsims),
     url(r'^v1/on_same_fs$', views.on_same_fs, name="on_same_fs"),
+    url(r'^v1/ini_defaults$', views.get_ini_defaults, name="ini_defaults"),
 ]
 
 # it is useful to disable the default redirect if the usage is via API only

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -44,7 +44,8 @@ from django.shortcuts import render
 from openquake.baselib import datastore
 from openquake.baselib.general import groupby, gettemp, zipfiles
 from openquake.baselib.parallel import safely_call
-from openquake.hazardlib import nrml, gsim
+from openquake.hazardlib import nrml, gsim, valid
+
 
 from openquake.commonlib import readinput, oqvalidation, logs
 from openquake.calculators import base
@@ -211,6 +212,21 @@ def get_available_gsims(request):
     """
     gsims = list(gsim.get_available_gsims())
     return HttpResponse(content=json.dumps(gsims), content_type=JSON)
+
+
+@cross_domain_ajax
+@require_http_methods(['GET'])
+def get_ini_defaults(request):
+    """
+    Return a list of ini attributes with a default value
+    """
+    ini_defs = {}
+    for name in dir(oqvalidation.OqParam):
+        obj = getattr(oqvalidation.OqParam, name)
+        if (isinstance(obj, valid.Param)
+                and obj.default is not valid.Param.NODEFAULT):
+            ini_defs[name] = obj.default
+    return HttpResponse(content=json.dumps(ini_defs), content_type=JSON)
 
 
 def _make_response(error_msg, error_line, valid):


### PR DESCRIPTION
With this PR add the command ``/v1/ini_defaults`` to retrieve default values for all ini file parameters.
Tests are green here: https://ci.openquake.org/job/zdevel_oq-engine/2860/
