### PR TITLE
cpu_affinity is not available on macOS

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,6 +55,7 @@ Giovanni Lanzano        March 2019
 Guillaume Daniel        April 2019
 Richard Styron          July 2019
 Kris Vanneste           September 2019
+Alberto Chiusole        November 2019
 
 Project management
 ------------------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Alberto Chiusole]
-  * changed the way how the available number of CPU cores is computed
+  * Changed the way how the available number of CPU cores is computed
 
   [Michele Simionato]
   * Renamed ordinal -> rlz_id in the realizations.csv output

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Alberto Chiusole]
+  * changed the way how the available number of CPU cores is computed
+
   [Michele Simionato]
   * Renamed ordinal -> rlz_id in the realizations.csv output
   * Added more check on the IMTs and made it possible to import a GMF.csv

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -594,9 +594,9 @@ class Starmap(object):
     running_tasks = []  # currently running tasks
     # use only the "visible" cores, not the total system cores
     # if the underlying OS supports it (macOS does not)
-    if hasattr(psutil.Process(), 'cpu_affinity'):
+    try:
         num_cores = len(psutil.Process().cpu_affinity())
-    else:
+    except AttributeError:
         num_cores = psutil.cpu_count()
     oversubmit = False
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -592,8 +592,12 @@ def getargnames(task_func):
 class Starmap(object):
     pids = ()
     running_tasks = []  # currently running tasks
-    # Use only the "visible" cores, not the total system cores.
-    num_cores = len(psutil.Process().cpu_affinity())
+    # use only the "visible" cores, not the total system cores
+    # if the underlying OS supports it (macOS does not)
+    if hasattr(psutil.Process(), 'cpu_affinity'):
+        num_cores = len(psutil.Process().cpu_affinity())
+    else:
+        num_cores = psutil.cpu_count()
     oversubmit = False
 
     @classmethod


### PR DESCRIPTION
I was too optimistic: `cpu_affinity` is not available on macOS (it is on FreeBSD, _but_ not on mac, sigh!)
Jenkins spotted it: https://ci.openquake.org/job/macos/job/master_macos_engine/label=mojave,python=python3.7/5220/console
Now it runs: https://ci.openquake.org/job/macos/job/zdevel_macos_engine/label=mojave,python=python3.7/2/console

I also updated the changelog and added @bebosudo to contributors.

Regression introduced by #5301 