### PR TITLE
Three subtle fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the "sites are overdetermined" check, since it now unneeded
   * Renamed id -> asset_id in all the relevant CSV exporters
   * Renamed rlzi -> rlz_id in the dmg_by_event.csv output
   * Renamed rupid -> rup_id in the ruptures.csv output

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -188,7 +188,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 eff_rups += rec[0]
                 if rec[0]:
                     eff_sites += rec[1] / rec[0]
-            self.sources_by_task[extra['task_no']] = (
+            self.by_task[extra['task_no']] = (
                 eff_rups, eff_sites, U32(srcids))
             for grp_id, pmap in dic['pmap'].items():
                 if pmap:
@@ -249,7 +249,7 @@ class ClassicalCalculator(base.HazardCalculator):
         dparams = [p[:-1] for p in self.rparams if p.endswith('_')]
         logging.info('Scalar parameters %s', rparams)
         logging.info('Vector parameters %s', dparams)
-        self.sources_by_task = {}  # task_no => src_ids
+        self.by_task = {}  # task_no => src_ids
         self.totrups = 0  # total number of ruptures before collapsing
         return zd
 
@@ -325,21 +325,21 @@ class ClassicalCalculator(base.HazardCalculator):
                              'point sources %d km', maxdist)
             with self.monitor('store source_info'):
                 self.store_source_info(self.calc_times)
-            if self.sources_by_task:
-                num_tasks = max(self.sources_by_task) + 1,
-                er = self.datastore.create_dset('sources_by_task/eff_ruptures',
+            if self.by_task:
+                num_tasks = max(self.by_task) + 1,
+                er = self.datastore.create_dset('by_task/eff_ruptures',
                                                 U32, num_tasks)
-                es = self.datastore.create_dset('sources_by_task/eff_sites',
+                es = self.datastore.create_dset('by_task/eff_sites',
                                                 U32, num_tasks)
-                si = self.datastore.create_dset('sources_by_task/srcids',
+                si = self.datastore.create_dset('by_task/srcids',
                                                 hdf5.vuint32, num_tasks,
                                                 fillvalue=None)
-                for task_no, rec in self.sources_by_task.items():
+                for task_no, rec in self.by_task.items():
                     effrups, effsites, srcids = rec
                     er[task_no] = effrups
                     es[task_no] = effsites
                     si[task_no] = srcids
-                self.sources_by_task.clear()
+                self.by_task.clear()
         numrups = sum(arr[0] for arr in self.calc_times.values())
         if self.totrups != numrups:
             logging.info('Considered %d/%d ruptures', numrups, self.totrups)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -326,15 +326,19 @@ class ClassicalCalculator(base.HazardCalculator):
             with self.monitor('store source_info'):
                 self.store_source_info(self.calc_times)
             if self.sources_by_task:
-                num_tasks = max(self.sources_by_task) + 1
-                sbt = numpy.zeros(
-                    num_tasks, [('eff_ruptures', U32),
-                                ('eff_sites', U32),
-                                ('srcids', hdf5.vuint32)])
-                for task_no in range(num_tasks):
-                    sbt[task_no] = self.sources_by_task.get(
-                        task_no, (0, 0, U32([])))
-                self.datastore['sources_by_task'] = sbt
+                num_tasks = max(self.sources_by_task) + 1,
+                er = self.datastore.create_dset('sources_by_task/eff_ruptures',
+                                                U32, num_tasks)
+                es = self.datastore.create_dset('sources_by_task/eff_sites',
+                                                U32, num_tasks)
+                si = self.datastore.create_dset('sources_by_task/srcids',
+                                                hdf5.vuint32, num_tasks,
+                                                fillvalue=None)
+                for task_no, rec in self.sources_by_task.items():
+                    effrups, effsites, srcids = rec
+                    er[task_no] = effrups
+                    es[task_no] = effsites
+                    si[task_no] = srcids
                 self.sources_by_task.clear()
         numrups = sum(arr[0] for arr in self.calc_times.values())
         if self.totrups != numrups:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -93,6 +93,7 @@ def classical_split_filter(srcs, srcfilter, gsims, params, monitor):
         splits, _stime = split_sources(srcs)
         sources = list(srcfilter.filter(splits))
     if not sources:
+        yield {'pmap': {}}
         return
     maxw = min(sum(src.weight for src in sources)/5, params['max_weight'])
     if maxw < MINWEIGHT*5:  # task too small to be resubmitted

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -574,7 +574,9 @@ def view_task_hazard(token, dstore):
     data.sort(order='duration')
     rec = data[int(index)]
     taskno = rec['taskno']
-    eff_ruptures, eff_sites, srcids = dstore['sources_by_task'][taskno]
+    eff_ruptures = dstore['sources_by_task/eff_ruptures'][taskno]
+    eff_sites = dstore['sources_by_task/eff_sites'][taskno]
+    srcids = dstore['sources_by_task/srcids'][taskno]
     srcs = dstore['source_info']['source_id'][srcids]
     res = ('taskno=%d, eff_ruptures=%d, eff_sites=%d, duration=%d s\n'
            'sources="%s"' % (taskno, eff_ruptures, eff_sites, rec['duration'],

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -566,17 +566,17 @@ def view_task_hazard(token, dstore):
      $ oq show task:classical:-1  # the slowest task
     """
     _, name, index = token.split(':')
-    if 'sources_by_task' not in dstore:
-        return 'Missing sources_by_task'
+    if 'by_task' not in dstore:
+        return 'Missing by_task'
     data = get_array(dstore['task_info'][()], taskname=encode(name))
     if len(data) == 0:
         raise RuntimeError('No task_info for %s' % name)
     data.sort(order='duration')
     rec = data[int(index)]
     taskno = rec['taskno']
-    eff_ruptures = dstore['sources_by_task/eff_ruptures'][taskno]
-    eff_sites = dstore['sources_by_task/eff_sites'][taskno]
-    srcids = dstore['sources_by_task/srcids'][taskno]
+    eff_ruptures = dstore['by_task/eff_ruptures'][taskno]
+    eff_sites = dstore['by_task/eff_sites'][taskno]
+    srcids = dstore['by_task/srcids'][taskno]
     srcs = dstore['source_info']['source_id'][srcids]
     res = ('taskno=%d, eff_ruptures=%d, eff_sites=%d, duration=%d s\n'
            'sources="%s"' % (taskno, eff_ruptures, eff_sites, rec['duration'],

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -804,16 +804,6 @@ class OqParam(valid.ParamSet):
         return os.path.isdir(self.export_dir) and os.access(
             self.export_dir, os.W_OK)
 
-    def is_valid_sites(self):
-        """
-        The sites are overdetermined
-        """
-        if 'site_model' in self.inputs and (
-                self.sites or 'sites' in self.inputs
-                or 'hazard_curves' in self.inputs):
-            return False
-        return True
-
     def is_valid_complex_fault_mesh_spacing(self):
         """
         The `complex_fault_mesh_spacing` parameter can be None only if

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -495,6 +495,5 @@ class SitecolAssetcolTestCase(unittest.TestCase):
         self.assertEqual(len(discarded), 0)
 
     def test_site_model_sites(self):
-        # you cannot set them at the same time
-        with self.assertRaises(ValueError):
-            readinput.get_oqparam('job.ini', case_16, sites='0 0')
+        # you can set them at the same time
+        readinput.get_oqparam('job.ini', case_16, sites='0 0')


### PR DESCRIPTION
1. The splitting/filterering performance info was not stored if the sources were completely filtered out
2. The `sources_by_task` dataset was invalid for the case of large calculations (i.e. Australia) due to a bug in HDF5 with variable-length fields so the information has been stored without structured arrays
3. The "sites overdetermined" check is now useless (after https://github.com/gem/oq-engine/commit/8c7f1128187d518285d7d5d7b4638cadee9b85ba) and actually harmful, so it has been removed