### PR TITLE
Implement a plugin system for consequences

### DIFF
--- a/openquake/calculators/multi_risk.py
+++ b/openquake/calculators/multi_risk.py
@@ -50,8 +50,9 @@ def get_dmg_csq(crm, assets_by_site, gmf):
                 [rm], [w] = crm.get_rmodels_weights(taxonomy)
                 fracs = rm.scenario_damage(loss_type, assets, [gmv])
                 for asset, frac in zip(assets, fracs):
-                    dmg = asset['number'] * frac[0, :D]
-                    csq = asset['value-' + loss_type] * frac[0, D]
+                    dmg = asset['number'] * frac  # shape (1, D)
+                    csq = crm.compute_csq(
+                        'economic_loss', asset, frac, loss_type)
                     out[asset['ordinal'], l, 0, :D] = dmg
                     out[asset['ordinal'], l, 0, D] = csq
     return out

--- a/openquake/calculators/multi_risk.py
+++ b/openquake/calculators/multi_risk.py
@@ -51,10 +51,9 @@ def get_dmg_csq(crm, assets_by_site, gmf):
                 fracs = rm.scenario_damage(loss_type, assets, [gmv])
                 for asset, frac in zip(assets, fracs):
                     dmg = asset['number'] * frac  # shape (1, D)
-                    csq = crm.compute_csq(
-                        'economic_loss', asset, frac, loss_type)
+                    csq = crm.compute_csq(asset, frac, loss_type)
                     out[asset['ordinal'], l, 0, :D] = dmg
-                    out[asset['ordinal'], l, 0, D] = csq
+                    out[asset['ordinal'], l, 0, D] = csq['losses']
     return out
 
 

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -40,20 +40,18 @@ def scenario_damage(riskinputs, crmodel, param, monitor):
     :returns:
         a dictionary {'d_asset': [(l, r, a, mean-stddev), ...],
                       'd_event': damage array of shape R, L, E, D,
-                      'c_asset': [(l, r, a, mean-stddev), ...],
-                      'c_event': damage array of shape R, L, E}
+                      + optional consequences}
 
-    `d_asset` and `d_tag` are related to the damage distributions
-    whereas `c_asset` and `c_tag` are the consequence distributions.
-    If there is no consequence model `c_asset` is an empty list and
-    `c_tag` is a zero-valued array.
+    `d_asset` and `d_tag` are related to the damage distributions.
     """
     L = len(crmodel.loss_types)
     D = len(crmodel.damage_states)
     E = param['number_of_ground_motion_fields']
     R = riskinputs[0].hazard_getter.num_rlzs
-    result = dict(d_asset=[], d_event=numpy.zeros((E, R, L, D), F64),
-                  c_asset=[], c_event=numpy.zeros((E, R, L), F64))
+    result = dict(d_asset=[], d_event=numpy.zeros((E, R, L, D), F64))
+    for name in scientific.consequence:
+        result[name + '_by_asset'] = []
+        result[name + '_by_event'] = numpy.zeros((E, R, L), F64)
     for ri in riskinputs:
         for out in ri.gen_outputs(crmodel, monitor):
             r = out.rlzi
@@ -63,13 +61,12 @@ def scenario_damage(riskinputs, crmodel, param, monitor):
                     result['d_event'][:, r, l] += dmg
                     result['d_asset'].append(
                         (l, r, asset['ordinal'], scientific.mean_std(dmg)))
-                    csq = crmodel.compute_csq(
-                        'economic_loss', asset, fractions, loss_type)
-                    if csq is not None:
-                        result['c_asset'].append(
+                    csq = crmodel.compute_csq(asset, fractions, loss_type)
+                    for name, value in csq.items():
+                        result[name + '_by_asset'].append(
                             (l, r, asset['ordinal'],
-                             scientific.mean_std(csq)))
-                        result['c_event'][:, r, l] += csq
+                             scientific.mean_std(value)))
+                        result[name + '_by_event'][:, r, l] += value
     return result
 
 
@@ -122,13 +119,17 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         self.datastore['dmg_by_event'] = d_event
 
         # consequence distributions
-        if result['c_asset']:
-            dtlist = [('event_id', U32), ('rlz_id', U16), ('loss', (F32, (L,)))]
-            stat_dt = numpy.dtype([('mean', F32), ('stddev', F32)])
-            c_asset = numpy.zeros((N, R, L), stat_dt)
-            for (l, r, a, stat) in result['c_asset']:
-                c_asset[a, r, l] = stat
-            self.datastore['losses_by_asset'] = c_asset
-            self.datastore['losses_by_event'] = numpy.fromiter(
-                ((eid + rlzi * F, rlzi, F32(result['c_event'][eid, rlzi]))
-                 for rlzi in range(R) for eid in range(F)), dtlist)
+        del result['d_asset']
+        del result['d_event']
+        dtlist = [('event_id', U32), ('rlz_id', U16), ('loss', (F32, (L,)))]
+        stat_dt = numpy.dtype([('mean', F32), ('stddev', F32)])
+        for name, csq in result.items():
+            if name.endswith('_by_asset'):
+                c_asset = numpy.zeros((N, R, L), stat_dt)
+                for (l, r, a, stat) in result[name]:
+                    c_asset[a, r, l] = stat
+                self.datastore[name] = c_asset
+            elif name.endswith('_by_event'):
+                self.datastore[name] = numpy.fromiter(
+                    ((eid + rlzi * F, rlzi, F32(result[name][eid, rlzi]))
+                     for rlzi in range(R) for eid in range(F)), dtlist)

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -96,7 +96,7 @@ def get_output(crmodel, assets_by_taxo, haz, rlzi=None):
                     dat = data[rm.imti[lt]]
                 arrays.append(rm(lt, assets_, dat, eids, epsilons))
             res = arrays[0] if len(arrays) == 1 else numpy.average(
-                arrays, weights=weights)
+                arrays, weights=weights, axis=0)
             ls.append(res)
         arr = numpy.concatenate(ls)
         dic[lt] = arr[assets_by_taxo.idxs] if len(arr) else arr

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -20,7 +20,6 @@ import ast
 import copy
 import functools
 import collections
-import logging
 from urllib.parse import unquote_plus
 import numpy
 
@@ -543,6 +542,31 @@ class CompositeRiskModel(collections.abc.Mapping):
 
     def has(self, kind):
         return _extract(self._riskmodels, kind)
+
+    def compute_csq(self, name, asset, fractions, loss_type):
+        """
+        :param name: name of the consequence
+        :param asset: asset record
+        :param fractions: array of probabilies of shape (E, D)
+        :param loss_type: loss type as a string
+        :returns: an array of length E
+        """
+        if not self.has('consequence'):
+            return
+        conseq = scientific.consequence[name]
+        try:
+            # consider the taxonomy mapping
+            cfs, ws = self.get_csq_funcs_weights(
+                asset['taxonomy'], loss_type)
+        except KeyError:  # missing cf for a loss_type
+            return
+        arrays = []
+        for cf in cfs:
+            arrays.append(
+                conseq(cf, asset, fractions[:, 1:], loss_type))
+        csq = arrays[0] if len(arrays) == 1 else numpy.average(
+            arrays, weights=ws)
+        return csq
 
     def init(self, oqparam):
         self.imtls = oqparam.imtls

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -561,7 +561,8 @@ class CompositeRiskModel(collections.abc.Mapping):
         for name, func in scientific.consequence.items():
             arrays = []
             for cf in cfs:
-                arrays.append(func(cf, asset, fractions[:, 1:], loss_type))
+                coeffs = [param[0] for param in cf.params]
+                arrays.append(func(coeffs, asset, fractions[:, 1:], loss_type))
             csq[name] = arrays[0] if len(arrays) == 1 else numpy.average(
                 arrays, weights=ws, axis=0)
         return csq

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -382,22 +382,14 @@ class RiskModel(object):
         :param assets: a list of A assets of the same taxonomy
         :param gmvs_eids: pairs (gmvs, eids), each one with E elements
         :param _eps: dummy parameter, unused
-        :returns: an array of shape (A, E, D + 1) elements
+        :returns: an array of shape (A, E, D) elements
 
         where N is the number of points, E the number of events
         and D the number of damage states.
         """
         ffs = self.risk_functions[loss_type, 'fragility']
         damages = scientific.scenario_damage(ffs, gmvs).T
-        E, D = damages.shape
-        dmg_csq = numpy.zeros((E, D + 1))
-        dmg_csq[:, :D] = damages
-        c_model = self.risk_functions.get((loss_type, 'consequence'))
-        if c_model:  # compute consequences
-            means = [0] + [par[0] for par in c_model.params]
-            # NB: we add a 0 in front for nodamage state
-            dmg_csq[:, D] = damages @ means  # consequence ratio
-        return numpy.array([dmg_csq] * len(assets))
+        return numpy.array([damages] * len(assets))
 
     def classical_damage(
             self, loss_type, assets, hazard_curve, eids=None, eps=None):
@@ -662,6 +654,19 @@ class CompositeRiskModel(collections.abc.Mapping):
             rmodels.append(self._riskmodels[key])
             weights.append(weight)
         return rmodels, weights
+
+    def get_csq_funcs_weights(self, taxidx, loss_type):
+        """
+        :returns:
+            a list of weighted consequence functions for the given taxonomy
+            index and loss type
+        """
+        cfuncs, weights = [], []
+        for key, weight in self.tmap[taxidx]:
+            rfs = self._riskmodels[key].risk_functions
+            cfuncs.append(rfs[loss_type, 'consequence'])
+            weights.append(weight)
+        return cfuncs, weights
 
     def __iter__(self):
         return iter(sorted(self._riskmodels))

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1505,13 +1505,12 @@ consequence = CallableDict()
 
 
 @consequence.add('losses')
-def economic_losses(csqfunc, asset, dmgdist, loss_type):
+def economic_losses(coeffs, asset, dmgdist, loss_type):
     """
-    :param csqfunc: consequence function (i.e. coefficients per damage state)
+    :param coeffs: coefficients per damage state
     :param asset: asset record
     :param dmgdist: an array of probabilies of shape (E, D - 1)
     :param loss_type: loss type string
     :returns: array of economic losses of length E
     """
-    means = [param[0] for param in csqfunc.params]
-    return dmgdist @ means * asset['value-' + loss_type]
+    return dmgdist @ coeffs * asset['value-' + loss_type]

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1497,3 +1497,21 @@ class LossesByAsset(object):
         :returns: an array of shape (A, L)
         """
         return numpy.zeros((self.A, len(self.loss_names)), F32)
+
+
+# ####################### Consequences ##################################### #
+
+consequence = CallableDict()
+
+
+@consequence.add('economic_loss')
+def economic_loss(csqfunc, asset, dmgdist, loss_type):
+    """
+    :param csqfunc: consequence function (i.e. coefficients per damage state)
+    :param asset: asset record
+    :param dmgdist: an array of probabilies of shape (E, D - 1)
+    :param loss_type: loss type string
+    :returns: array of economic losses of length E
+    """
+    means = [param[0] for param in csqfunc.params]
+    return dmgdist @ means * asset['value-' + loss_type]

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1504,8 +1504,8 @@ class LossesByAsset(object):
 consequence = CallableDict()
 
 
-@consequence.add('economic_loss')
-def economic_loss(csqfunc, asset, dmgdist, loss_type):
+@consequence.add('losses')
+def economic_losses(csqfunc, asset, dmgdist, loss_type):
     """
     :param csqfunc: consequence function (i.e. coefficients per damage state)
     :param asset: asset record


### PR DESCRIPTION
... and implement economic losses as a built-in plugin. This a first step in a much longer process. For instance now we can only manage consequences by taxonomy, but we need also consequences by occupancy and in the general consequences by tagName. Part of https://github.com/gem/oq-engine/issues/5319.