### PR TITLE
Upgrade to Django 2.2 to be compatible with recent SQLite

### DIFF
--- a/requirements-py36-linux64.txt
+++ b/requirements-py36-linux64.txt
@@ -19,7 +19,7 @@ https://wheelhouse.openquake.org/v2/linux/py/docutils-0.14-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/decorator-4.3.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/pbr-4.0.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/six-1.11.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/linux/py/Django-2.0.4-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/linux/py/Django-2.2.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/certifi-2018.1.18-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/urllib3-1.22-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/chardet-3.0.4-py2.py3-none-any.whl

--- a/requirements-py36-linux64.txt
+++ b/requirements-py36-linux64.txt
@@ -20,6 +20,7 @@ https://wheelhouse.openquake.org/v2/linux/py/decorator-4.3.0-py2.py3-none-any.wh
 https://wheelhouse.openquake.org/v2/linux/py/pbr-4.0.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/six-1.11.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/Django-2.2.7-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/linux/py/sqlparse-0.3.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/certifi-2018.1.18-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/urllib3-1.22-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/chardet-3.0.4-py2.py3-none-any.whl

--- a/requirements-py36-macos.txt
+++ b/requirements-py36-macos.txt
@@ -19,7 +19,7 @@ https://wheelhouse.openquake.org/v2/macos/py/docutils-0.14-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/decorator-4.3.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/pbr-4.0.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/six-1.11.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/Django-2.0.4-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/macos/py/Django-2.2.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/certifi-2018.1.18-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/urllib3-1.22-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/chardet-3.0.4-py2.py3-none-any.whl

--- a/requirements-py36-macos.txt
+++ b/requirements-py36-macos.txt
@@ -20,6 +20,7 @@ https://wheelhouse.openquake.org/v2/macos/py/decorator-4.3.0-py2.py3-none-any.wh
 https://wheelhouse.openquake.org/v2/macos/py/pbr-4.0.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/six-1.11.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/Django-2.2.7-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/macso/py/sqlparse-0.3.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/certifi-2018.1.18-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/urllib3-1.22-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/chardet-3.0.4-py2.py3-none-any.whl

--- a/requirements-py36-win64.txt
+++ b/requirements-py36-win64.txt
@@ -20,6 +20,7 @@ https://wheelhouse.openquake.org/v2/windows/py/decorator-4.3.0-py2.py3-none-any.
 https://wheelhouse.openquake.org/v2/windows/py/pbr-4.0.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py/six-1.11.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py/Django-2.2.7-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/sqlparse-0.3.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py/certifi-2018.1.18-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py/urllib3-1.22-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py/chardet-3.0.4-py2.py3-none-any.whl

--- a/requirements-py36-win64.txt
+++ b/requirements-py36-win64.txt
@@ -3,31 +3,31 @@
 # !! must update pip first! so wheels will be used !!
 
 # GEM Mirror
-# We also provide pre-compiled macosx_10_9_x86_64 wheels for
+# We also provide pre-compiled win_amd64 wheels for
 # h5py, Shapely, psutil, PyYAML, Basemap
 
-https://wheelhouse.openquake.org/v2/macos/py/pytz-2018.3-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/setuptools-39.0.1-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/pytz-2018.3-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/setuptools-39.0.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py36/h5py-2.8.0-cp36-cp36m-win_amd64.whl
-https://wheelhouse.openquake.org/v2/macos/py/nose-1.3.7-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/nose-1.3.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py36/numpy-1.16.5-cp36-cp36m-win_amd64.whl
 https://wheelhouse.openquake.org/v2/windows/py36/scipy-1.3.1-cp36-cp36m-win_amd64.whl
 https://wheelhouse.openquake.org/v2/windows/py36/pyzmq-17.0.0-cp36-cp36m-win_amd64.whl
 https://wheelhouse.openquake.org/v2/windows/py36/psutil-5.4.3-cp36-cp36m-win_amd64.whl
 https://wheelhouse.openquake.org/v2/windows/py36/Shapely-1.6.4.post1-cp36-cp36m-win_amd64.whl
-https://wheelhouse.openquake.org/v2/macos/py/docutils-0.14-py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/decorator-4.3.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/pbr-4.0.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/six-1.11.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/Django-2.0.4-py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/certifi-2018.1.18-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/urllib3-1.22-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/chardet-3.0.4-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/idna-2.6-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/requests-2.20.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/pyshp-1.2.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/docutils-0.14-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/decorator-4.3.0-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/pbr-4.0.0-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/six-1.11.0-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/Django-2.2.7-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/certifi-2018.1.18-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/urllib3-1.22-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/chardet-3.0.4-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/idna-2.6-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/requests-2.20.0-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/pyshp-1.2.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py36/PyYAML-3.12-cp36-cp36m-win_amd64.whl
-https://wheelhouse.openquake.org/v2/macos/py/toml-0.10.0-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/toml-0.10.0-py2.py3-none-any.whl
 
 ### setproctitle ###
 # comment the following lines to skip installation
@@ -37,9 +37,9 @@ https://wheelhouse.openquake.org/v2/windows/py36/setproctitle-1.1.10-cp36-cp36m-
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-https://wheelhouse.openquake.org/v2/macos/py/python_dateutil-2.7.2-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/pyparsing-2.2.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py/cycler-0.10.0-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/python_dateutil-2.7.2-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/pyparsing-2.2.0-py2.py3-none-any.whl
+https://wheelhouse.openquake.org/v2/windows/py/cycler-0.10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py36/kiwisolver-1.0.1-cp36-none-win_amd64.whl
 https://wheelhouse.openquake.org/v2/windows/py36/matplotlib-2.2.2-cp36-cp36m-win_amd64.whl
 https://wheelhouse.openquake.org/v2/windows/py36/pyproj-1.9.5.1-cp36-cp36m-win_amd64.whl

--- a/requirements-py37-linux64.txt
+++ b/requirements-py37-linux64.txt
@@ -17,7 +17,7 @@ https://wheelhouse.openquake.org/v3/linux/py/docutils-0.14-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/decorator-4.4.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/pbr-5.2.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/six-1.12.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v3/linux/py/Django-2.2.4-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/linux/py/Django-2.2.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/sqlparse-0.3.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/certifi-2019.3.9-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/chardet-3.0.4-py2.py3-none-any.whl

--- a/requirements-py37-macos.txt
+++ b/requirements-py37-macos.txt
@@ -17,7 +17,7 @@ https://wheelhouse.openquake.org/v3/macos/py/docutils-0.14-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/decorator-4.4.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/pbr-5.2.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/six-1.12.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v3/macos/py/Django-2.2.4-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/macos/py/Django-2.2.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/sqlparse-0.3.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/certifi-2019.3.9-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/chardet-3.0.4-py2.py3-none-any.whl

--- a/requirements-py37-win64.txt
+++ b/requirements-py37-win64.txt
@@ -2,7 +2,7 @@
 # !! must update pip first! so wheels will be used !!
 
 # GEM Mirror
-# We also provide pre-compiled windowsx_10_9_x86_64 wheels for
+# We also provide pre-compiled win_amd64 wheels for
 # h5py, Shapely, psutil, PyYAML, Basemap
 
 https://wheelhouse.openquake.org/v3/windows/py/pytz-2019.1-py2.py3-none-any.whl
@@ -17,7 +17,7 @@ https://wheelhouse.openquake.org/v3/windows/py/docutils-0.14-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py/decorator-4.4.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py/pbr-5.2.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py/six-1.12.0-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v3/windows/py/Django-2.2.4-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/windows/py/Django-2.2.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py/sqlparse-0.3.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py/certifi-2019.3.9-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py/chardet-3.0.4-py2.py3-none-any.whl


### PR DESCRIPTION
The current version of Django (2.0.4 quite ancient!) does not work with newer SQLite (Fedora, Ubuntu 19.04+, Windows, macOS) releases because of https://code.djangoproject.com/ticket/29182

That's a tricky bug that I spotted while working on the ACL thing for @micheles . It does not affect the Engine itself since we are not using the Django ORM but it affects the WebUI when authentication is enabled.

I'm taking the opportunity to upgrade to the latest Django 2.2 (which was anyway scheduled for oq-libs v3) which also includes many security patches and it's an LTR release.

This has a downstream impact on `oq-libs` and `oq-platform-standalone`