### PR TITLE
Make WebUI ACL more flexible

### DIFF
--- a/openquake/server/local_settings.py.pam
+++ b/openquake/server/local_settings.py.pam
@@ -4,7 +4,10 @@
 
 from openquake.server.settings import INSTALLED_APPS, AUTHENTICATION_BACKENDS
 
+# Enable authentication
 LOCKDOWN = True
+# Disable sharing of results across users
+ACL_ON = True
 
 INSTALLED_APPS += (
     'django_pam',

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -105,7 +105,9 @@ MIDDLEWARE = (
     'django.middleware.csrf.CsrfViewMiddleware',
 )
 
+# Authentication is not enabled by default
 LOCKDOWN = False
+# Allow all users to see other users outputs by default
 ACL_ON = False
 
 # Add additional paths (as regular expressions) that don't require
@@ -202,8 +204,6 @@ except ImportError:
         pass
 
 if LOCKDOWN:
-
-    ACL_ON = True
 
     AUTHENTICATION_BACKENDS += (
         'django.contrib.auth.backends.ModelBackend',

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -30,6 +30,13 @@ if settings.LOCKDOWN:
     from django.contrib.auth.models import User
 
 
+def is_superuser(request):
+    if settings.LOCKDOWN and hasattr(request, 'user'):
+        if request.user.is_superuser:
+            return True
+    return False
+
+
 def get_user(request):
     """
     Returns the users from `request` if authentication is enabled, otherwise
@@ -70,10 +77,10 @@ def get_acl_on(request):
     Returns `True` if ACL should be honorated, returns otherwise `False`.
     """
     acl_on = settings.ACL_ON
-    if settings.LOCKDOWN and hasattr(request, 'user'):
+    if is_superuser(request):
         # ACL is always disabled for superusers
-        if request.user.is_superuser:
-            acl_on = False
+        acl_on = False
+
     return acl_on
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -353,7 +353,7 @@ def calc_list(request, id=None):
     # always filter calculation list unless user is a superuser
     calc_data = logs.dbcmd('get_calcs', request.GET,
                            utils.get_valid_users(request),
-                           not request.user.is_superuser, id)
+                           not utils.is_superuser(request), id)
 
     response_data = []
     username = psutil.Process(os.getpid()).username()
@@ -401,7 +401,7 @@ def calc_abort(request, calc_id):
 
     # only the owner or superusers can abort a calculation
     if (job.user_name not in utils.get_valid_users(request) and
-            not request.user.is_superuser):
+            not utils.is_superuser(request)):
         message = {'error': ('User %s has no permission to abort job %s' %
                              (request.user, job.id))}
         return HttpResponse(content=json.dumps(message), content_type=JSON,

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -399,9 +399,11 @@ def calc_abort(request, calc_id):
         message = {'error': 'Job %s is not running' % job.id}
         return HttpResponse(content=json.dumps(message), content_type=JSON)
 
-    if not utils.user_has_permission(request, job.user_name):
+    # only the owner or superusers can abort a calculation
+    if (job.user_name not in utils.get_valid_users(request) and
+            not request.user.is_superuser):
         message = {'error': ('User %s has no permission to abort job %s' %
-                             (job.user_name, job.id))}
+                             (request.user, job.id))}
         return HttpResponse(content=json.dumps(message), content_type=JSON,
                             status=403)
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -350,9 +350,10 @@ def calc_list(request, id=None):
     Responses are in JSON.
     """
     base_url = _get_base_url(request)
+    # always filter calculation list unless user is a superuser
     calc_data = logs.dbcmd('get_calcs', request.GET,
                            utils.get_valid_users(request),
-                           utils.get_acl_on(request), id)
+                           not request.user.is_superuser, id)
 
     response_data = []
     username = psutil.Process(os.getpid()).username()


### PR DESCRIPTION
As requested by @micheles :

- `ACL_ON` is `False` by default: all users can have access to all outputs/exports
- List of calculations is always filtered (on users or groups) unless a request comes from a `superuser`
- Abort can be fired only when request comes from the owner or `superuser`: this prevents other users to kill jobs even when `ACL_ON = False`
- There was a bug in the failed abort error message (the wrong user was reported)