### PR TITLE
Storing the (partial) asset damage table

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Storing the asset damage table in scenario_damage and event based damage,
+    but only for assets and events above a `collapse_threshold` parameter
   * Avoided transferring the GMFs upfront in scenario_damage, scenario_risk
     and event_based_damage
   * Added a check for duplicate sites in the site model file

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -902,7 +902,7 @@ def multi_index(shape, axis=None):
         yield tuple(lst)
 
 
-def fast_agg(indices, values=None, axis=0):
+def fast_agg(indices, values=None, axis=0, factor=None):
     """
     :param indices: N indices in the range 0 ... M - 1 with M < N
     :param values: N values (can be arrays)
@@ -927,7 +927,8 @@ def fast_agg(indices, values=None, axis=0):
     lst.insert(axis, M)
     res = numpy.zeros(lst, values.dtype)
     for mi in multi_index(shp, axis):
-        res[mi] = numpy.bincount(indices, values[mi])
+        vals = values[mi] if factor is None else values[mi] * factor
+        res[mi] = numpy.bincount(indices, vals)
     return res
 
 
@@ -951,7 +952,7 @@ def fast_agg2(tags, values=None, axis=0):
     return uniq, fast_agg(indices, values, axis)
 
 
-def fast_agg3(structured_array, kfield, vfields):
+def fast_agg3(structured_array, kfield, vfields, factor=None):
     """
     Aggregate a structured array with a key field (the kfield)
     and some value fields (the vfields).
@@ -965,7 +966,7 @@ def fast_agg3(structured_array, kfield, vfields):
     dic = {}
     dtlist = [(kfield, structured_array.dtype[kfield])]
     for name in vfields:
-        dic[name] = fast_agg(indices, structured_array[name])
+        dic[name] = fast_agg(indices, structured_array[name], factor=factor)
         dtlist.append((name, structured_array.dtype[name]))
     res = numpy.zeros(len(uniq), dtlist)
     res[kfield] = uniq

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -88,7 +88,7 @@ def scenario_damage(riskinputs, crmodel, param, monitor):
                         for eid, value in zip(out.eids, values):
                             by_event[eid][l] += value
         aed = numpy.zeros(len(dddic), param['aed_dt'])
-        for i, ((aid, eid), ddd) in enumerate(dddic.items()):
+        for i, ((aid, eid), ddd) in enumerate(sorted(dddic.items())):
             aed[i] = (aid, eid, ddd)
         yield {'aed': aed}
     yield result

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -19,7 +19,7 @@
 import logging
 import numpy
 from openquake.baselib import hdf5
-from openquake.baselib.general import AccumDict
+from openquake.baselib.general import AccumDict, get_indices
 from openquake.risklib import scientific
 from openquake.calculators import base
 
@@ -109,11 +109,19 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         super().pre_execute()
         self.param['collapse_threshold'] = self.oqparam.collapse_threshold
         self.param['aed_dt'] = aed_dt = self.crmodel.aid_eid_ddd_dt()
-        self.datastore.create_dset('dd_data', aed_dt)
+        A = len(self.assetcol)
+        self.datastore.create_dset('dd_data/data', aed_dt)
+        self.datastore.create_dset('dd_data/indices', U32, (A, 2))
         self.riskinputs = self.build_riskinputs('gmf')
+        self.start = 0
 
     def combine(self, acc, res):
-        hdf5.extend(self.datastore['dd_data'], res.pop('aed'))
+        aed = res.pop('aed')
+        for aid, [(i1, i2)] in get_indices(aed['aid']).items():
+            self.datastore['dd_data/indices'][aid] = (
+                self.start + i1, self.start + i2)
+        self.start += len(aed)
+        hdf5.extend(self.datastore['dd_data/data'], aed)
         return acc + res
 
     def post_execute(self, result):

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -62,7 +62,7 @@ def scenario_damage(riskinputs, crmodel, param, monitor):
         result[name + '_by_asset'] = []
     mon = monitor('getting hazard', measuremem=False)
     for ri in riskinputs:
-        dddic = AccumDict(accum=numpy.zeros((L, D - 1), F32))  # aid,eid->ddd
+        ddic = AccumDict(accum=numpy.zeros((L, D - 1), F32))  # aid,eid->dd
         with mon:
             ri.hazard_getter.init()
         for out in ri.gen_outputs(crmodel, monitor):
@@ -76,7 +76,7 @@ def scenario_damage(riskinputs, crmodel, param, monitor):
                         eid = out.eids[e]
                         acc[eid][l] += dmgdist
                         if dmgdist[-1] >= collapse_threshold:
-                            dddic[aid, eid][l] = fractions[e, 1:]
+                            ddic[aid, eid][l] = fractions[e, 1:]
                     result['d_asset'].append(
                         (l, r, asset['ordinal'], scientific.mean_std(dmg)))
                     csq = crmodel.compute_csq(asset, fractions, loss_type)
@@ -87,9 +87,9 @@ def scenario_damage(riskinputs, crmodel, param, monitor):
                         by_event = result[name + '_by_event']
                         for eid, value in zip(out.eids, values):
                             by_event[eid][l] += value
-        aed = numpy.zeros(len(dddic), param['aed_dt'])
-        for i, ((aid, eid), ddd) in enumerate(sorted(dddic.items())):
-            aed[i] = (aid, eid, ddd)
+        aed = numpy.zeros(len(ddic), param['aed_dt'])
+        for i, ((aid, eid), dd) in enumerate(sorted(ddic.items())):
+            aed[i] = (aid, eid, dd)
         yield {'aed': aed}
     yield result
 
@@ -107,7 +107,7 @@ class ScenarioDamageCalculator(base.RiskCalculator):
     def pre_execute(self):
         super().pre_execute()
         self.param['collapse_threshold'] = self.oqparam.collapse_threshold
-        self.param['aed_dt'] = aed_dt = self.crmodel.aid_eid_ddd_dt()
+        self.param['aed_dt'] = aed_dt = self.crmodel.aid_eid_dd_dt()
         A = len(self.assetcol)
         self.datastore.create_dset('dd_data/data', aed_dt)
         self.datastore.create_dset('dd_data/indices', U32, (A, 2))

--- a/openquake/calculators/tests/scenario_damage_test.py
+++ b/openquake/calculators/tests/scenario_damage_test.py
@@ -36,7 +36,8 @@ aae = numpy.testing.assert_almost_equal
 class ScenarioDamageTestCase(CalculatorTestCase):
     def assert_ok(self, pkg, job_ini, exports='csv', kind='dmg'):
         test_dir = os.path.dirname(pkg.__file__)
-        out = self.run_calc(test_dir, job_ini, exports=exports)
+        out = self.run_calc(test_dir, job_ini, exports=exports,
+                            collapse_threshold='0')
         got = out[kind + '_by_asset', exports]
         expected_dir = os.path.join(test_dir, 'expected')
         expected = sorted(f for f in os.listdir(expected_dir)

--- a/openquake/calculators/tests/scenario_damage_test.py
+++ b/openquake/calculators/tests/scenario_damage_test.py
@@ -19,6 +19,7 @@
 import os
 import numpy
 
+from openquake.baselib.general import fast_agg3
 from openquake.hazardlib import InvalidFile
 from openquake.commonlib.writers import write_csv
 from openquake.qa_tests_data.scenario_damage import (
@@ -43,6 +44,16 @@ class ScenarioDamageTestCase(CalculatorTestCase):
         self.assertEqual(len(got), len(expected))
         for fname, actual in zip(expected, got):
             self.assertEqualFiles('expected/%s' % fname, actual)
+        self.check_dmg_by_event()
+
+    def check_dmg_by_event(self):
+        number = self.calc.datastore['assetcol/array']['number']
+        data = self.calc.datastore['dd_data'][()]
+        if len(data):
+            data_by_eid = fast_agg3(data, 'eid', ['ddd'], number[data['aid']])
+            dmg_by_event = self.calc.datastore['dmg_by_event'][()]
+            for rec1, rec2 in zip(data_by_eid, dmg_by_event):
+                aae(rec1['ddd'], rec2['dmg'][:, 1:], decimal=1)
 
     def test_case_1(self):
         # test with a single event and a missing tag

--- a/openquake/calculators/tests/scenario_damage_test.py
+++ b/openquake/calculators/tests/scenario_damage_test.py
@@ -48,7 +48,7 @@ class ScenarioDamageTestCase(CalculatorTestCase):
 
     def check_dmg_by_event(self):
         number = self.calc.datastore['assetcol/array']['number']
-        data = self.calc.datastore['dd_data'][()]
+        data = self.calc.datastore['dd_data/data'][()]
         if len(data):
             data_by_eid = fast_agg3(data, 'eid', ['ddd'], number[data['aid']])
             dmg_by_event = self.calc.datastore['dmg_by_event'][()]

--- a/openquake/calculators/tests/scenario_damage_test.py
+++ b/openquake/calculators/tests/scenario_damage_test.py
@@ -50,10 +50,10 @@ class ScenarioDamageTestCase(CalculatorTestCase):
         number = self.calc.datastore['assetcol/array']['number']
         data = self.calc.datastore['dd_data/data'][()]
         if len(data):
-            data_by_eid = fast_agg3(data, 'eid', ['ddd'], number[data['aid']])
+            data_by_eid = fast_agg3(data, 'eid', ['dd'], number[data['aid']])
             dmg_by_event = self.calc.datastore['dmg_by_event'][()]
             for rec1, rec2 in zip(data_by_eid, dmg_by_event):
-                aae(rec1['ddd'], rec2['dmg'][:, 1:], decimal=1)
+                aae(rec1['dd'], rec2['dmg'][:, 1:], decimal=1)
 
     def test_case_1(self):
         # test with a single event and a missing tag

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -78,7 +78,7 @@ class OqParam(valid.ParamSet):
     avg_losses = valid.Param(valid.boolean, True)
     base_path = valid.Param(valid.utf8, '.')
     calculation_mode = valid.Param(valid.Choice())  # -> get_oqparam
-    collapse_threshold = valid.Param(valid.probability, 0)
+    collapse_threshold = valid.Param(valid.probability, 0.5)
     coordinate_bin_width = valid.Param(valid.positivefloat)
     compare_with_classical = valid.Param(valid.boolean, False)
     concurrent_tasks = valid.Param(

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -609,14 +609,14 @@ class CompositeRiskModel(collections.abc.Mapping):
         D = len(self.damage_states)
         return numpy.dtype([('eid', U32), ('dmg', (F32, (L, D)))])
 
-    def aid_eid_ddd_dt(self):
+    def aid_eid_dd_dt(self):
         """
-        :returns: a dtype (aid, eid, ddd)
+        :returns: a dtype (aid, eid, dd)
         """
         L = len(self.lti)
         D1 = len(self.damage_states) - 1
         return numpy.dtype(
-            [('aid', U32), ('eid', U32), ('ddd', (F32, (L, D1)))])
+            [('aid', U32), ('eid', U32), ('dd', (F32, (L, D1)))])
 
     def vectorize_cons_model(self, tagcol):
         """

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -30,6 +30,7 @@ from openquake.hazardlib import valid, nrml, InvalidFile
 from openquake.hazardlib.sourcewriter import obj_to_node
 from openquake.risklib import scientific
 
+U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
 F64 = numpy.float64
@@ -608,6 +609,15 @@ class CompositeRiskModel(collections.abc.Mapping):
         L = len(self.lti)
         D = len(self.damage_states)
         return numpy.dtype([('eid', U32), ('dmg', (F32, (L, D)))])
+
+    def aid_eid_ddd_dt(self):
+        """
+        :returns: a dtype (aid, eid, ddd)
+        """
+        L = len(self.lti)
+        D1 = len(self.damage_states) - 1
+        return numpy.dtype(
+            [('aid', U32), ('eid', U32), ('ddd', (U16, (L, D1)))])
 
     def vectorize_cons_model(self, tagcol):
         """

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -30,7 +30,6 @@ from openquake.hazardlib import valid, nrml, InvalidFile
 from openquake.hazardlib.sourcewriter import obj_to_node
 from openquake.risklib import scientific
 
-U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
 F64 = numpy.float64
@@ -617,7 +616,7 @@ class CompositeRiskModel(collections.abc.Mapping):
         L = len(self.lti)
         D1 = len(self.damage_states) - 1
         return numpy.dtype(
-            [('aid', U32), ('eid', U32), ('ddd', (U16, (L, D1)))])
+            [('aid', U32), ('eid', U32), ('ddd', (F32, (L, D1)))])
 
     def vectorize_cons_model(self, tagcol):
         """


### PR DESCRIPTION
But only for assets and events above a `collapse_threshold` parameter (or something like that, to be discussed), otherwise we would immediately run out of disk space: even a small calculations with ~2000 sites, ~20000 assets like the one for Messina by Catarina produces 100GB of data for the parameters we usually use i.e. 1M years, minimum_magnitude=5, minimum_intensity=0.05.
The idea is to keep only the extreme events for large calculations while for small calculations we could keep everything for calibration purposes.