### PR TITLE
Fixed a bug in ebrisk with aggregate_by when building the rup_loss_table

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a bug in ebrisk with aggregate_by when building the rup_loss_table
   * Storing the asset loss table in scenario_risk, but only for assets and
     events above over a `loss_ratio_threshold` parameter
   * Storing the asset damage table in scenario_damage and event based damage,

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -53,11 +53,11 @@ def build_loss_tables(dstore):
     oq = dstore['oqparam']
     R = dstore['csm_info'].get_num_rlzs()
     lbe = dstore['losses_by_event'][()]
-    loss = lbe['loss']
+    loss = lbe['loss']  # shape (E, L, T...)
     shp = (R,) + lbe.dtype['loss'].shape
     rup_id = dstore['events']['rup_id']
     if len(shp) > 2:
-        loss = loss.sum(axis=tuple(range(1, len(shp) - 1)))
+        loss = loss.sum(axis=tuple(range(2, len(shp))))  # shape (E, L)
     losses_by_rupid = general.fast_agg(rup_id[lbe['event_id']], loss)
     lst = [('rup_id', U32)] + [(name, F32) for name in oq.loss_names]
     tbl = numpy.zeros(len(losses_by_rupid), lst)


### PR DESCRIPTION
This was discovere in a calculation for the Cariboo region that has been added to the oq-risk-tests.