### PR TITLE
Storing only the highest losses in the asset loss table

### DIFF
--- a/demos/risk/EventBasedRisk/job_eb.ini
+++ b/demos/risk/EventBasedRisk/job_eb.ini
@@ -28,6 +28,7 @@ maximum_distance = 200.0
 ses_per_logic_tree_path = 1
 minimum_intensity = 0.05
 minimum_magnitude = 5.3
+minimum_asset_loss = {'structural': 1E5, 'nonstructural': 2E4}
 
 [exposure]
 region = 78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -58,17 +58,23 @@ stats_dt = numpy.dtype([('mean', F32), ('std', F32),
 
 
 # this is used for the minimum_intensity dictionaries
-def equivalent(dic1, dic2):
+def consistent(dic1, dic2):
     """
-    Check if two dictionaries name -> value are equivalent
+    Check if two dictionaries with default are consistent:
+
+    >>> consistent({'PGA': 0.05, 'SA(0.3)': 0.05}, {'default': 0.05})
+    True
+    >>> consistent({'SA(0.3)': 0.1, 'SA(0.6)': 0.05},
+    ... {'default': 0.1, 'SA(0.3)': 0.1, 'SA(0.6)': 0.05})
+    True
     """
     if dic1 == dic2:
         return True
     v1 = set(dic1.values())
     v2 = set(dic2.values())
-    missing = set(dic2) - set(dic1)
-    if len(v1) == 1 and len(v2) == 1 and v1.pop() == v2.pop():
-        # {'PGA': 0.05, 'SA(0.3)': 0.05} is equivalent to {'default': 0.05}
+    missing = set(dic2) - set(dic1) - {'default'}
+    if len(v1) == 1 and len(v2) == 1 and v1 == v2:
+        # {'PGA': 0.05, 'SA(0.3)': 0.05} is consistent with {'default': 0.05}
         return True
     return not missing
 
@@ -475,7 +481,7 @@ class HazardCalculator(BaseCalculator):
                 raise ValueError(
                     'The parent calculation was using investigation_time=%s'
                     ' != %s' % (oqp.investigation_time, oq.investigation_time))
-            if not equivalent(oqp.minimum_intensity, oq.minimum_intensity):
+            if not consistent(oqp.minimum_intensity, oq.minimum_intensity):
                 raise ValueError(
                     'The parent calculation was using minimum_intensity=%s'
                     ' != %s' % (oqp.minimum_intensity, oq.minimum_intensity))

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -66,10 +66,11 @@ def equivalent(dic1, dic2):
         return True
     v1 = set(dic1.values())
     v2 = set(dic2.values())
+    missing = set(dic2) - set(dic1)
     if len(v1) == 1 and len(v2) == 1 and v1.pop() == v2.pop():
         # {'PGA': 0.05, 'SA(0.3)': 0.05} is equivalent to {'default': 0.05}
         return True
-    return False
+    return not missing
 
 
 def get_stats(seq):

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -225,8 +225,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         eslices = self.datastore['eslices']
         allargs = []
         srcfilter = self.src_filter(self.datastore.tempname)
-        events_per_block = min(numpy.ceil(  # at max 5000 events per block
-            self.E / (oq.concurrent_tasks or 1)), 5000)
+        events_per_block = min(numpy.ceil(  # at max 2000 events per block
+            self.E / (oq.concurrent_tasks or 1)), 2000)
         for grp_id, rlzs_by_gsim in rlzs_by_gsim_grp.items():
             start, stop = grp_indices[grp_id]
             if start == stop:  # no ruptures for the given grp_id

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -225,8 +225,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         eslices = self.datastore['eslices']
         allargs = []
         srcfilter = self.src_filter(self.datastore.tempname)
-        rups_per_block = min(numpy.ceil(  # at max 500 ruptures per block
-            len(dstore['ruptures']) / (oq.concurrent_tasks or 1)), 500)
+        events_per_block = min(numpy.ceil(  # at max 5000 events per block
+            self.E / (oq.concurrent_tasks or 1)), 5000)
         for grp_id, rlzs_by_gsim in rlzs_by_gsim_grp.items():
             start, stop = grp_indices[grp_id]
             if start == stop:  # no ruptures for the given grp_id
@@ -238,7 +238,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim,
                 eslices[fe:fe + stop - start, 0])
             for rgetters in general.block_splitter(
-                    rgetter.split(), rups_per_block):
+                    rgetter.split(), events_per_block,
+                    operator.attrgetter('weight')):
                 allargs.append((rgetters, srcfilter, self.param))
             fe += stop - start
         logging.info('Sending %d/%d source groups with ruptures',

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -21,6 +21,7 @@ import numpy
 
 from openquake.baselib import datastore, hdf5, parallel, general
 from openquake.baselib.python3compat import zip
+from openquake.hazardlib.calc.filters import getdefault
 from openquake.risklib import riskmodels
 from openquake.risklib.scientific import LossesByAsset
 from openquake.risklib.riskinput import (
@@ -104,7 +105,7 @@ def _calc_risk(hazard, param, monitor):
                         losses = lratios * asset['value-' + lt]
                     losses_by_lt[lt] = losses
                     for loss, eid in highest_losses(losses, out.eids, n):
-                        if loss >= minimum_loss[lti]:
+                        if loss > minimum_loss[lti]:
                             alt[aid, eid][lti] = loss
                 for loss_idx, losses in lba.compute(asset, losses_by_lt):
                     arr[(eidx, loss_idx) + tagidxs] += losses
@@ -181,7 +182,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.param['ses_ratio'] = oq.ses_ratio
         self.param['aggregate_by'] = oq.aggregate_by
         self.param['highest_losses'] = oq.highest_losses
-        self.param['minimum_loss'] = [oq.minimum_asset_loss[ln]
+        self.param['minimum_loss'] = [getdefault(oq.minimum_asset_loss, ln)
                                       for ln in oq.loss_names]
         self.param['ael_dt'] = ael_dt = self.crmodel.aid_eid_loss_dt(
             oq.loss_names)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -18,7 +18,6 @@
 
 import os.path
 import logging
-import collections
 import operator
 import numpy
 
@@ -327,7 +326,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.set_param()
         self.offset = 0
         srcfilter = self.src_filter(self.datastore.tempname)
-        self.indices = collections.defaultdict(list)  # sid, idx -> indices
+        self.indices = AccumDict(accum=[])  # sid, idx -> indices
         if oq.hazard_calculation_id:  # from ruptures
             self.datastore.parent = util.read(oq.hazard_calculation_id)
             self.init_logic_tree(self.datastore.parent['csm_info'])

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -523,6 +523,7 @@ class RuptureGetter(object):
             rg.samples = self.samples
             rg.rlzs_by_gsim = self.rlzs_by_gsim
             rg.e0 = numpy.array([self.e0[i]])
+            rg.weight = array[i]['n_occ']
             out.append(rg)
         return out
 

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -44,7 +44,7 @@ def _event_slice(num_gmfs, r):
 
 def highest_losses(losses, eids, n):
     """
-    >>> highest_losses([1, 2, 3, 4, 5], [.4, .2, .5, .7, .1], 3)
+    >>> highest_losses([.4, .2, .5, .7, .1], [1, 2, 3, 4, 5],  3)
     [(0.4, 1), (0.5, 3), (0.7, 4)]
     """
     return sorted(zip(losses, eids))[-n:]

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -130,6 +130,7 @@ class OqParam(valid.ParamSet):
     max_sites_disagg = valid.Param(valid.positiveint, 10)
     mean_hazard_curves = mean = valid.Param(valid.boolean, True)
     std = valid.Param(valid.boolean, False)
+    minimum_asset_loss = valid.Param(valid.floatdict, {})
     minimum_intensity = valid.Param(valid.floatdict, {})  # IMT -> minIML
     minimum_magnitude = valid.Param(valid.floatdict, {'default': 0})
     modal_damage_state = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -117,7 +117,7 @@ class OqParam(valid.ParamSet):
         valid.intensity_measure_types_and_levels, None)
     interest_rate = valid.Param(valid.positivefloat)
     investigation_time = valid.Param(valid.positivefloat, None)
-    loss_ratio_threshold = valid.Param(valid.probability, .1)
+    highest_losses = valid.Param(valid.positiveint, 10)
     lrem_steps_per_interval = valid.Param(valid.positiveint, 0)
     steps_per_interval = valid.Param(valid.positiveint, 1)
     master_seed = valid.Param(valid.positiveint, 0)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -130,7 +130,7 @@ class OqParam(valid.ParamSet):
     max_sites_disagg = valid.Param(valid.positiveint, 10)
     mean_hazard_curves = mean = valid.Param(valid.boolean, True)
     std = valid.Param(valid.boolean, False)
-    minimum_asset_loss = valid.Param(valid.floatdict, {})
+    minimum_asset_loss = valid.Param(valid.floatdict, {'default': 0})
     minimum_intensity = valid.Param(valid.floatdict, {})  # IMT -> minIML
     minimum_magnitude = valid.Param(valid.floatdict, {'default': 0})
     modal_damage_state = valid.Param(valid.boolean, False)

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -609,11 +609,14 @@ class CompositeRiskModel(collections.abc.Mapping):
         D = len(self.damage_states)
         return numpy.dtype([('eid', U32), ('dmg', (F32, (L, D)))])
 
-    def aid_eid_loss_dt(self):
+    def aid_eid_loss_dt(self, loss_names=None):
         """
         :returns: a dtype (aid, eid, loss)
         """
-        L = len(self.lti),
+        if loss_names:
+            L = len(loss_names),
+        else:
+            L = len(self.lti),
         return numpy.dtype([('aid', U32), ('eid', U32), ('loss', (F32, L))])
 
     def aid_eid_dd_dt(self):


### PR DESCRIPTION
First step towards https://github.com/gem/oq-engine/issues/5343. The `highest_losses` parameter may disappear, in the sense that in the future it may be decided by the engine and not by the user.
 Also, I introduced a `minimum_asset_loss` dictionary in the job.ini.

NB: in this first attempt the asset loss table is kept fully in memory. This will likely change later on,
to avoid things like `storing asset loss table 2,177s`.