### PR TITLE
Using pandas if available

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -24,6 +24,10 @@ import getpass
 import collections
 import numpy
 import h5py
+try:
+    import pandas
+except ImportError:
+    pass
 
 from openquake.baselib import hdf5, config, performance
 
@@ -395,6 +399,23 @@ class DataStore(collections.abc.MutableMapping):
         """
         data = bytes(numpy.asarray(self[key][()]))
         return io.BytesIO(gzip.decompress(data))
+
+    def read_df(self, key):
+        """
+        :returns: pandas DataFrame associated to the dataset
+        """
+        dset = self.getitem(key)
+        dtlist = []
+        for name in dset.dtype.names:
+            dt = dset.dtype[name]
+            if dt.shape:  # vector field
+                templ = name + '_%d' * len(dt.shape)
+                for i, _ in numpy.ndenumerate(numpy.zeros(dt.shape)):
+                    dtlist.append((templ % i, dt.base))
+            else:  # scalar field
+                dtlist.append((name, dt))
+        data = dset[()].view(dtlist)
+        return pandas.DataFrame(data)
 
     @property
     def metadata(self):

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -414,7 +414,16 @@ class DataStore(collections.abc.MutableMapping):
                     dtlist.append((templ % i, dt.base))
             else:  # scalar field
                 dtlist.append((name, dt))
-        data = dset[()].view(dtlist)
+        data = numpy.zeros(len(dset), dtlist)
+        for name in dset.dtype.names:
+            arr = dset[name]
+            dt = dset.dtype[name]
+            if dt.shape:  # vector field
+                templ = name + '_%d' * len(dt.shape)
+                for i, _ in numpy.ndenumerate(numpy.zeros(dt.shape)):
+                    data[templ % i] = arr[(slice(None),) + i]
+            else:  # scalar field
+                data[name] = arr
         return pandas.DataFrame(data)
 
     @property


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/5343. Here is an example of usage:
```python
>>> from openquake.baselib import datastore
>>> dstore = datastore.read(2835)
>>> print(dstore.read_df('gmf_data/data'))
      sid   eid     gmv_0
0       0   790  0.012536
1       0   791  0.018987
2       0   792  0.014679
3       0   793  0.027218
4       0   794  0.005744
...   ...   ...       ...
3159    0  3159  0.076038
3160    0  3160  0.053839
3161    0  3161  0.082616
3162    0  3162  0.110607
3163    0  3163  0.186109

[3164 rows x 3 columns]
```