### PR TITLE
Improved (again) the task distribution in ebrisk

### DIFF
--- a/demos/risk/EventBasedRisk/job_eb.ini
+++ b/demos/risk/EventBasedRisk/job_eb.ini
@@ -35,7 +35,6 @@ region = 78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5
 exposure_file = exposure_model.xml
 
 [risk_calculation]
-max_gmfs_size = 10_000
 asset_hazard_distance = 20
 individual_curves = true
 

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -31,9 +31,10 @@ from openquake.baselib import hdf5
 # Can't read data (address of object past end of allocation)
 # this is why below I am using '<S50' byte strings
 perf_dt = numpy.dtype([('operation', '<S50'), ('time_sec', float),
-                       ('memory_mb', float), ('counts', int)])
+                       ('memory_mb', float), ('counts', int),
+                       ('task_no', numpy.int16)])
 task_info_dt = numpy.dtype(
-    [('taskname', '<S50'), ('taskno', numpy.uint32),
+    [('taskname', '<S50'), ('task_no', numpy.uint32),
      ('weight', numpy.float32), ('duration', numpy.float32),
      ('received', numpy.int64), ('mem_gb', numpy.float32)])
 
@@ -121,6 +122,7 @@ class Monitor(object):
         self.counts = 0
         self.address = None
         self.username = getpass.getuser()
+        self.task_no = -1  # overridden in parallel
 
     @property
     def dt(self):
@@ -153,7 +155,8 @@ class Monitor(object):
         if self.counts:
             time_sec = self.duration
             memory_mb = self.mem / 1024. / 1024. if self.measuremem else 0
-            data.append((self.operation, time_sec, memory_mb, self.counts))
+            data.append((self.operation, time_sec, memory_mb, self.counts,
+                         self.task_no))
         return numpy.array(data, perf_dt)
 
     def __enter__(self):

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -175,7 +175,8 @@ def pool_starmap(func, allargs, h5):
     import multiprocessing
     with multiprocessing.get_context('spawn').Pool() as pool:
         for i, res in enumerate(pool.starmap(func, allargs)):
-            perf = numpy.array([(func.__name__, 0, 0, i)], performance.perf_dt)
+            perf = numpy.array([(func.__name__, 0, 0, i, i)],
+                               performance.perf_dt)
             hdf5.extend(h5['performance_data'], perf)
             yield res
 

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -144,7 +144,7 @@ def ebrisk(rupgetter, srcfilter, param, monitor):
         hazard['gmf_info'].append(
             (c.rupture.id, mon_haz.task_no, len(c.sids),
              data.nbytes, mon_haz.dt))
-    return calc_risk(hazard, param, monitor)
+    return calc_risk(hazard, param, monitor) if hazard['gmfs'] else {}
 
 
 @base.calculators.add('ebrisk')

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -38,7 +38,7 @@ F64 = numpy.float64
 TWO32 = 2 ** 32
 get_n_occ = operator.itemgetter(1)
 
-gmf_info_dt = numpy.dtype([('ridx', U32), ('task_no', U16),
+gmf_info_dt = numpy.dtype([('rup_id', U32), ('task_no', U16),
                            ('nsites', U16), ('gmfbytes', F32), ('dt', F32)])
 
 
@@ -119,13 +119,9 @@ def calc_risk(hazard, param, monitor):
     return acc
 
 
-def len_gmfs(hazard):
-    return sum(len(gmfs) for gmfs in hazard['gmfs'])
-
-
-def ebrisk(rupgetters, srcfilter, param, monitor):
+def ebrisk(rupgetter, srcfilter, param, monitor):
     """
-    :param rupgetters: RuptureGetters with 1 rupture each
+    :param rupgetter: RuptureGetter with multiple ruptures
     :param srcfilter: a SourceFilter
     :param param: dictionary of parameters coming from oqparam
     :param monitor: a Monitor instance
@@ -134,9 +130,9 @@ def ebrisk(rupgetters, srcfilter, param, monitor):
     mon_haz = monitor('getting hazard', measuremem=False)
     mon_rup = monitor('getting ruptures', measuremem=False)
     hazard = dict(gmfs=[], events=[], gmf_info=[])
-    for rupgetter in rupgetters:
+    for rg in rupgetter.split():
         with mon_rup:
-            gg = getters.GmfGetter(rupgetter, srcfilter, param['oqparam'])
+            gg = getters.GmfGetter(rg, srcfilter, param['oqparam'])
             gg.init()
         if not gg.computers:  # filtered out rupture
             continue
@@ -146,13 +142,9 @@ def ebrisk(rupgetters, srcfilter, param, monitor):
             hazard['gmfs'].append(data)
             hazard['events'].append(c.rupture.get_events(gg.rlzs_by_gsim))
         hazard['gmf_info'].append(
-            (c.rupture.ridx, mon_haz.task_no, len(c.sids),
+            (c.rupture.id, mon_haz.task_no, len(c.sids),
              data.nbytes, mon_haz.dt))
-        if len_gmfs(hazard) > param['max_gmfs_size']:
-            yield calc_risk, hazard, param
-            hazard = dict(gmfs=[], events=[], gmf_info=[])
-    if len_gmfs(hazard):
-        yield calc_risk(hazard, param, monitor)
+    return calc_risk(hazard, param, monitor)
 
 
 @base.calculators.add('ebrisk')
@@ -172,7 +164,6 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.param['lba'] = lba = (
             LossesByAsset(self.assetcol, oq.loss_names,
                           self.policy_name, self.policy_dict))
-        self.param['max_gmfs_size'] = oq.max_gmfs_size
         self.param['ses_ratio'] = oq.ses_ratio
         self.param['aggregate_by'] = oq.aggregate_by
         self.param['highest_losses'] = oq.highest_losses
@@ -203,48 +194,18 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.datastore.flush()  # just to be sure
         oq = self.oqparam
         parent = self.datastore.parent
-        if parent:
-            grp_indices = parent['ruptures'].attrs['grp_indices']
-            dstore = parent
-            csm_info = parent['csm_info']
-        else:
-            grp_indices = self.datastore['ruptures'].attrs['grp_indices']
-            dstore = self.datastore
-            csm_info = self.csm_info
+        csm_info = parent['csm_info'] if parent else self.csm_info
+        self.init_logic_tree(csm_info)
         self.set_param(
             hdf5path=self.datastore.filename,
-            task_duration=oq.task_duration or 1200,  # 20min
             tempname=cache_epsilons(
                 self.datastore, oq, self.assetcol, self.crmodel, self.E))
-
-        self.init_logic_tree(csm_info)
-        trt_by_grp = csm_info.grp_by("trt")
-        samples = csm_info.get_samples_by_grp()
-        rlzs_by_gsim_grp = csm_info.get_rlzs_by_gsim_grp()
-        ngroups = 0
-        fe = 0
-        eslices = self.datastore['eslices']
-        allargs = []
         srcfilter = self.src_filter(self.datastore.tempname)
-        events_per_block = min(numpy.ceil(  # at max 2000 events per block
-            self.E / (oq.concurrent_tasks or 1)), 2000)
-        for grp_id, rlzs_by_gsim in rlzs_by_gsim_grp.items():
-            start, stop = grp_indices[grp_id]
-            if start == stop:  # no ruptures for the given grp_id
-                continue
-            ngroups += 1
-            rup_array = dstore['ruptures'][start:stop]
-            rgetter = getters.RuptureGetter(
-                rup_array, dstore.filename, grp_id,
-                trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim,
-                eslices[fe:fe + stop - start, 0])
-            for rgetters in general.block_splitter(
-                    rgetter.split(), events_per_block,
-                    operator.attrgetter('weight')):
-                allargs.append((rgetters, srcfilter, self.param))
-            fe += stop - start
-        logging.info('Sending %d/%d source groups with ruptures',
-                     ngroups, len(rlzs_by_gsim_grp))
+        maxw = self.E / (oq.concurrent_tasks or 1)
+        logging.info('Reading %d ruptures', len(self.datastore['ruptures']))
+        allargs = ((rgetter, srcfilter, self.param)
+                   for rgetter in getters.gen_rupture_getters(
+                           self.datastore, maxweight=maxw))
         self.events_per_sid = []
         self.lossbytes = 0
         self.datastore.swmr_on()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -83,7 +83,8 @@ class EventBasedCalculator(base.HazardCalculator):
     def init(self):
         if hasattr(self, 'csm'):
             self.check_floating_spinning()
-        self.rupser = calc.RuptureSerializer(self.datastore)
+        if not self.datastore.parent:
+            self.rupser = calc.RuptureSerializer(self.datastore)
 
     def init_logic_tree(self, csm_info):
         self.trt_by_grp = csm_info.grp_by("trt")
@@ -192,14 +193,16 @@ class EventBasedCalculator(base.HazardCalculator):
         with self.monitor('saving events'):
             self.save_events(sorted_ruptures)
 
-    def gen_rupture_getters(self):
+    def gen_rupture_getters(self, num_events=0):
         """
         :returns: a list of RuptureGetters
         """
+        oq = self.oqparam
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
+        E = num_events or len(dstore['events'])
         yield from gen_rupture_getters(
-            dstore, concurrent_tasks=self.oqparam.concurrent_tasks or 1)
+            dstore, maxweight=E / (oq.concurrent_tasks or 1))
         if self.datastore.parent:
             self.datastore.parent.close()
 
@@ -244,7 +247,7 @@ class EventBasedCalculator(base.HazardCalculator):
         events = numpy.zeros(len(eids), rupture.events_dt)
         # when computing the events all ruptures must be considered,
         # including the ones far away that will be discarded later on
-        rgetters = self.gen_rupture_getters()
+        rgetters = self.gen_rupture_getters(len(events))
 
         # build the associations eid -> rlz sequentially or in parallel
         # this is very fast: I saw 30 million events associated in 1 minute!
@@ -352,6 +355,7 @@ class EventBasedCalculator(base.HazardCalculator):
 
         # compute_gmfs in parallel
         self.datastore.swmr_on()
+        logging.info('Reading %d ruptures', len(self.datastore['ruptures']))
         iterargs = ((rgetter, srcfilter, self.param)
                     for rgetter in self.gen_rupture_getters())
         acc = parallel.Starmap(

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -20,11 +20,14 @@ import itertools
 import operator
 import unittest.mock as mock
 import numpy
+from scipy.spatial import cKDTree
 from openquake.baselib import hdf5, datastore, general
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib import calc, probability_map, stats
 from openquake.hazardlib.source.rupture import (
     EBRupture, BaseRupture, events_dt, get_rupture)
+from openquake.hazardlib.geo.utils import spherical_to_cartesian
+from openquake.hazardlib.calc.filters import SourceFilter, getdefault
 from openquake.risklib.riskinput import rsi2str
 from openquake.commonlib.calc import _gmvs_to_haz_curve
 
@@ -443,8 +446,7 @@ def group_by_rlz(data, rlzs):
     return {rlzi: numpy.array(recs) for rlzi, recs in acc.items()}
 
 
-def gen_rupture_getters(dstore, slc=slice(None), concurrent_tasks=1,
-                        filename=None):
+def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5, filename=None):
     """
     :yields: RuptureGetters
     """
@@ -459,14 +461,27 @@ def gen_rupture_getters(dstore, slc=slice(None), concurrent_tasks=1,
     samples = csm_info.get_samples_by_grp()
     rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]
-    maxweight = numpy.ceil(len(rup_array) / (concurrent_tasks or 1))
     nr, ne = 0, 0
+    maxdist = dstore['oqparam'].maximum_distance
+    if 'sitecol' in dstore:
+        srcfilter = SourceFilter(dstore['sitecol'], maxdist)
+        kdt = cKDTree(srcfilter.sitecol.xyz)
     for grp_id, arr in general.group_array(rup_array, 'grp_id').items():
         if not rlzs_by_gsim[grp_id]:
             # this may happen if a source model has no sources, like
             # in event_based_risk/case_3
             continue
-        for block in general.block_splitter(arr, maxweight):
+
+        if 'sitecol' in dstore:
+            def weight(rec, md=getdefault(maxdist, trt_by_grp[grp_id])):
+                xyz = spherical_to_cartesian(*rec['hypo'])
+                nsites = len(kdt.query_ball_point(xyz, md, eps=.001))
+                return rec['n_occ'] * numpy.ceil((nsites + 1) / 1000)
+        else:
+            def weight(rec):
+                return rec['n_occ']
+
+        for block in general.block_splitter(arr, maxweight, weight):
             if e0s is None:
                 e0 = numpy.zeros(len(block), U32)
             else:
@@ -474,6 +489,7 @@ def gen_rupture_getters(dstore, slc=slice(None), concurrent_tasks=1,
             rgetter = RuptureGetter(
                 numpy.array(block), filename or dstore.filename, grp_id,
                 trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim[grp_id], e0)
+            rgetter.weight = block.weight
             yield rgetter
             nr += len(block)
             ne += rgetter.num_events
@@ -595,7 +611,6 @@ class RuptureGetter(object):
                                 rec['n_occ'], self.samples)
                 # not implemented: rupture_slip_direction
                 ebr.sids = sids
-                ebr.ridx = rec['id']
                 ebr.e0 = 0 if self.e0 is None else e0
                 ebr.id = rec['id']  # rup_id  in the datastore
                 ebrs.append(ebr)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -428,16 +428,18 @@ def performance_view(dstore, add_calc_id=True):
         counts = 0
         time = 0
         mem = 0
-        for _operation, time_sec, memory_mb, counts_ in group:
-            counts += counts_
-            time += time_sec
-            mem = max(mem, memory_mb)
+        for rec in group:
+            counts += rec['counts']
+            time += rec['time_sec']
+            mem = max(mem, rec['memory_mb'])
         out.append((operation, time, mem, counts))
     out.sort(key=operator.itemgetter(1), reverse=True)  # sort by time
-    dt = copy.copy(perf_dt)
     if add_calc_id:
-        dt.names = ('calc_%d' % dstore.calc_id,) + dt.names[1:]
-    return numpy.array(out, dt)
+        dtlist = [('calc_%d' % dstore.calc_id, perf_dt['operation'])]
+    else:
+        dtlist = [('operation', perf_dt['operation'])]
+    dtlist.extend((n, perf_dt[n]) for n in perf_dt.names[1:-1])
+    return numpy.array(out, dtlist)
 
 
 @view.add('performance')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -575,7 +575,7 @@ def view_task_hazard(token, dstore):
         raise RuntimeError('No task_info for %s' % name)
     data.sort(order='duration')
     rec = data[int(index)]
-    taskno = rec['taskno']
+    taskno = rec['task_no']
     eff_ruptures = dstore['by_task/eff_ruptures'][taskno]
     eff_sites = dstore['by_task/eff_sites'][taskno]
     srcids = dstore['by_task/srcids'][taskno]

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -124,8 +124,7 @@ class OqParam(valid.ParamSet):
     maximum_distance = valid.Param(valid.maximum_distance)  # km
     asset_hazard_distance = valid.Param(valid.floatdict, {'default': 15})  # km
     max = valid.Param(valid.boolean, False)
-    max_gmfs_size = valid.Param(valid.positiveint, 1E6)
-    max_potential_gmfs = valid.Param(valid.positiveint, 1E11)
+    max_potential_gmfs = valid.Param(valid.positiveint, 2E11)
     max_potential_paths = valid.Param(valid.positiveint, 100)
     max_sites_per_gmf = valid.Param(valid.positiveint, 65536)
     max_sites_disagg = valid.Param(valid.positiveint, 10)


### PR DESCRIPTION
The idea here is to use `KDTree.query_ball_point` to count the number of sites affected by a rupture. This is fast enough (1M ruptures in 5 minutes) to make it practical to weight all the ruptures upfront and to produce tasks more homogeneous than before. I am also

1. Unifying event_based and ebrisk in the call to get_rupture_getters, thus saving lines of code
2. Removing the distinction between ebrisk and calc_risk tasks, thus reducing the data transfer
3. Storing the `ruptures` dataset only when needed, avoiding littering the datastores with empty rupture datasets
4. Storing in the `performance_data` table the `task_no`information, thus making it easier to understand why the slow tasks are slow.

All in all, the runtime of the British Columbia calculation went down from 7800 to 5000 seconds.
There is room for further improvement, still.