### PR TITLE
Avoided the need for prefiltering the ruptures twice

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -733,11 +733,6 @@ class HazardCalculator(BaseCalculator):
 
         # compute exposure stats
         if hasattr(self, 'assetcol'):
-            arr = self.assetcol.array
-            num_assets = list(general.countby(arr, 'site_id').values())
-            self.datastore['assets_by_site'] = get_stats(num_assets)
-            num_taxos = self.assetcol.num_taxonomies_by_site()
-            self.datastore['taxonomies_by_site'] = get_stats(num_taxos)
             save_exposed_values(
                 self.datastore, self.assetcol, oq.loss_names, oq.aggregate_by)
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -193,20 +193,6 @@ class EventBasedCalculator(base.HazardCalculator):
         with self.monitor('saving events'):
             self.save_events(sorted_ruptures)
 
-    def gen_rupture_getters(self, num_events=0, weight_rup=False):
-        """
-        :returns: a list of RuptureGetters
-        """
-        oq = self.oqparam
-        dstore = (self.datastore.parent if self.datastore.parent
-                  else self.datastore)
-        E = num_events or len(dstore['events'])
-        yield from gen_rupture_getters(
-            dstore, maxweight=E / (oq.concurrent_tasks or 1),
-            weight_rup=weight_rup)
-        if self.datastore.parent:
-            self.datastore.parent.close()
-
     def agg_dicts(self, acc, result):
         """
         :param acc: accumulator dictionary
@@ -248,7 +234,9 @@ class EventBasedCalculator(base.HazardCalculator):
         events = numpy.zeros(len(eids), rupture.events_dt)
         # when computing the events all ruptures must be considered,
         # including the ones far away that will be discarded later on
-        rgetters = self.gen_rupture_getters(len(events))
+        maxweight = len(events) / (self.oqparam.concurrent_tasks or 1)
+        rgetters = gen_rupture_getters(self.datastore, maxweight=maxweight,
+                                       weight_rup=operator.itemgetter('n_occ'))
 
         # build the associations eid -> rlz sequentially or in parallel
         # this is very fast: I saw 30 million events associated in 1 minute!
@@ -358,7 +346,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.datastore.swmr_on()
         logging.info('Reading %d ruptures', len(self.datastore['ruptures']))
         allargs = [(rgetter, srcfilter, self.param)
-                   for rgetter in self.gen_rupture_getters(weight_rup=True)]
+                   for rgetter in gen_rupture_getters(self.datastore)]
         logging.info('Generated %d tasks', len(allargs))
         acc = parallel.Starmap(
             self.core_task.__func__, allargs, h5=self.datastore.hdf5,

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -55,12 +55,11 @@ def export_ruptures_xml(ekey, dstore):
     """
     fmt = ekey[-1]
     oq = dstore['oqparam']
-    sf = filters.SourceFilter(dstore['sitecol'], oq.maximum_distance)
     num_ses = oq.ses_per_logic_tree_path
     ruptures_by_grp = {}
     for rgetter in gen_rupture_getters(dstore):
         ebrs = [ebr.export(rgetter.rlzs_by_gsim, num_ses)
-                for ebr in rgetter.get_ruptures(sf)]
+                for ebr in rgetter.get_ruptures()]
         if ebrs:
             ruptures_by_grp[rgetter.grp_id] = ebrs
     dest = dstore.export_path('ses.' + fmt)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1164,9 +1164,8 @@ def extract_rupture_info(dstore, what):
               ('strike', F32), ('dip', F32), ('rake', F32)]
     rows = []
     boundaries = []
-    sf = filters.SourceFilter(dstore['sitecol'], oq.maximum_distance)
     for rgetter in getters.gen_rupture_getters(dstore):
-        rups = rgetter.get_ruptures(sf, min_mag)
+        rups = rgetter.get_ruptures(min_mag)
         rup_data = RuptureData(rgetter.trt, rgetter.rlzs_by_gsim)
         for r, rup in zip(rup_data.to_array(rups), rups):
             coords = ['%.5f %.5f' % xyz[:2] for xyz in zip(*r['boundaries'])]

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -350,7 +350,7 @@ class GmfGetter(object):
         if hasattr(self, 'computers'):  # init already called
             return
         self.computers = []
-        for ebr in self.rupgetter.get_ruptures(self.srcfilter):
+        for ebr in self.rupgetter.get_ruptures():
             sitecol = self.sitecol.filtered(ebr.sids)
             try:
                 computer = calc.gmf.GmfComputer(
@@ -585,7 +585,7 @@ class RuptureGetter(object):
             dic['srcid'] = source_ids[rec['srcidx']]
         return dic
 
-    def get_ruptures(self, srcfilter=calc.filters.nofilter, min_mag=0):
+    def get_ruptures(self, min_mag=0):
         """
         :returns: a list of EBRuptures filtered by bounding box
         """

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -448,7 +448,7 @@ def weight_rup(rup):
     if rup.sids is None:
         rup.weight = rup['n_occ']
     else:
-        rup.weight = rup['n_occ'] * len(rup.sids)
+        rup.weight = rup['n_occ'] * numpy.ceil(len(rup.sids) / 1000)
     return rup.weight
 
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -474,7 +474,7 @@ def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5,
             proxies = []
             for rec in arr:
                 sids = srcfilter.close_sids(rec, trt)
-                if sids:
+                if len(sids):
                     proxies.append(RuptureProxy(rec, sids))
         else:
             proxies = map(RuptureProxy, arr)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -24,7 +24,7 @@ from openquake.baselib import hdf5, datastore, general
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib import calc, probability_map, stats
 from openquake.hazardlib.source.rupture import (
-    EBRupture, BaseRupture, events_dt, get_rupture)
+    EBRupture, BaseRupture, events_dt, RuptureProxy)
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.risklib.riskinput import rsi2str
 from openquake.commonlib.calc import _gmvs_to_haz_curve
@@ -601,16 +601,11 @@ class RuptureGetter(object):
                         continue
                 else:
                     sids = None
+                proxy = RuptureProxy(rec, sids)
                 geom = rupgeoms[rec['gidx1']:rec['gidx2']].reshape(
                     rec['sx'], rec['sy'])
-                rupture = get_rupture(rec, geom, self.trt)
-                grp_id = rec['grp_id']
-                ebr = EBRupture(rupture, rec['srcidx'], grp_id,
-                                rec['n_occ'], self.samples)
-                # not implemented: rupture_slip_direction
-                ebr.sids = sids
+                ebr = proxy.to_ebr(geom, self.trt, self.samples)
                 ebr.e0 = 0 if self.e0 is None else e0
-                ebr.id = rec['id']  # rup_id  in the datastore
                 ebrs.append(ebr)
         return ebrs
 

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -760,13 +760,11 @@ class EBRupture(object):
 
 
 class RuptureProxy(object):
+    weight = 1  # overridden in calculators.getters
+
     def __init__(self, rec, sids=None):
         self.rec = rec
         self.sids = sids
-        if sids is None:
-            self.weight = rec['n_occ']
-        else:
-            self.weight = rec['n_occ'] * numpy.ceil(len(sids) / 1000)
 
     def __getitem__(self, name):
         return self.rec[name]

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -760,9 +760,16 @@ class EBRupture(object):
 
 
 class RuptureProxy(object):
-    def __init__(self, rec, sids):
+    def __init__(self, rec, sids=None):
         self.rec = rec
         self.sids = sids
+        if sids is None:
+            self.weight = rec['n_occ']
+        else:
+            self.weight = rec['n_occ'] * numpy.ceil(len(sids) / 1000)
+
+    def __getitem__(self, name):
+        return self.rec[name]
 
     def to_ebr(self, geom, trt, samples):
         # not implemented: rupture_slip_direction

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -757,3 +757,18 @@ class EBRupture(object):
     def __repr__(self):
         return '<%s %d[%d]>' % (
             self.__class__.__name__, self.rup_id, self.n_occ)
+
+
+class RuptureProxy(object):
+    def __init__(self, rec, sids):
+        self.rec = rec
+        self.sids = sids
+
+    def to_ebr(self, geom, trt, samples):
+        # not implemented: rupture_slip_direction
+        rupture = get_rupture(self.rec, geom, trt)
+        ebr = EBRupture(rupture, self.rec['srcidx'], self.rec['grp_id'],
+                        self.rec['n_occ'], samples)
+        ebr.sids = self.sids
+        ebr.id = self.rec['id']
+        return ebr


### PR DESCRIPTION
Thanks to the change in https://github.com/gem/oq-engine/pull/5369 it is now finally possible to speedup `RuptureGetter.get_ruptures` significantly by making use of the prefiltering already performed in the master node. For instance in the case of Chile there is a 5x speedup resulting in nearly halving the total runtime.
```
# master
total ebrisk                                70,079   2,740     212
getting ruptures                            33,918   0.0       1,159,570
getting hazard                              19,272   0.0       1,144,859
aggregating losses                          14,747   0.0       114,454

# this branch
total ebrisk                                40,926   2,801     212      
getting hazard                              18,588   0.0       1,144,859
aggregating losses                          13,811   0.0       114,454  
getting ruptures                            6,564    0.0       1,159,570
```
The cost is a much larger data transfer in the RuptureGetter (from 83 MB to 1.47 GB, nearly 20x) but it is a non-issue now that we have zmq.