### PR TITLE
Improved the task weights for ebrisk (again)

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -213,7 +213,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                 self.datastore, oq, self.assetcol, self.crmodel, self.E))
         srcfilter = self.src_filter(self.datastore.tempname)
         maxw = self.E / (oq.concurrent_tasks or 1)
-        logging.info('Reading %d ruptures', len(self.datastore['ruptures']))
+        logging.info('Sending %d ruptures', len(self.datastore['ruptures']))
         self.events_per_sid = []
         self.lossbytes = 0
         self.datastore.swmr_on()

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -91,12 +91,10 @@ def calc_risk(gmfs, param, monitor):
                 aid = asset['ordinal']
                 losses_by_lt = {}
                 for lti, lt in enumerate(crmodel.loss_types):
-                    lratios = out[lt][a]
                     if lt == 'occupants':
-                        losses = lratios * asset['occupants_None']
+                        losses_by_lt[lt] = out[lt][a] * asset['occupants_None']
                     else:
-                        losses = lratios * asset['value-' + lt]
-                    losses_by_lt[lt] = losses
+                        losses_by_lt[lt] = out[lt][a] * asset['value-' + lt]
                 for loss_idx, losses in lba.compute(asset, losses_by_lt):
                     if param['aggregate_by']:
                         for loss, eid in zip(losses, out.eids):

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -98,9 +98,10 @@ def calc_risk(gmfs, param, monitor):
                         losses = lratios * asset['value-' + lt]
                     losses_by_lt[lt] = losses
                 for loss_idx, losses in lba.compute(asset, losses_by_lt):
-                    for loss, eid in zip(losses, out.eids):
-                        if loss >= minimum_loss[loss_idx]:
-                            alt[aid, eid][loss_idx] = loss
+                    if param['aggregate_by']:
+                        for loss, eid in zip(losses, out.eids):
+                            if loss >= minimum_loss[loss_idx]:
+                                alt[aid, eid][loss_idx] = loss
                     arr[eidx, loss_idx] += losses
                     if param['avg_losses']:
                         lba.losses_by_A[aid, loss_idx] += (

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -22,7 +22,6 @@ import numpy
 
 from openquake.baselib import datastore, hdf5, parallel, general
 from openquake.baselib.python3compat import zip
-from openquake.hazardlib.calc.filters import getdefault
 from openquake.risklib import riskmodels
 from openquake.risklib.scientific import LossesByAsset
 from openquake.risklib.riskinput import (

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -18,6 +18,7 @@
 import collections
 import itertools
 import operator
+import logging
 import unittest.mock as mock
 import numpy
 from openquake.baselib import hdf5, datastore, general
@@ -478,6 +479,7 @@ def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5, filename=None):
             # in event_based_risk/case_3
             continue
         trt = trt_by_grp[grp_id]
+        logging.info('Reading ruptures of group #%d, %s', grp_id, trt)
         for proxies in general.block_splitter(
                 gen(arr), maxweight, operator.attrgetter('weight')):
             if e0s is None:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -18,7 +18,6 @@
 import collections
 import itertools
 import operator
-import logging
 import unittest.mock as mock
 import numpy
 from openquake.baselib import hdf5, datastore, general
@@ -479,7 +478,6 @@ def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5, filename=None):
             # in event_based_risk/case_3
             continue
         trt = trt_by_grp[grp_id]
-        logging.info('Reading ruptures of group #%d, %s', grp_id, trt)
         for proxies in general.block_splitter(
                 gen(arr), maxweight, operator.attrgetter('weight')):
             if e0s is None:

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -95,12 +95,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
     def test_case_1_eb(self):
         # this is a case with no insured losses, no tags
-        self.run_calc(case_1.__file__, 'job_eb.ini', concurrent_tasks='4',
-                      minimum_loss_fraction='0.01')
-
-        # check on the asset_loss_table, num_losses per asset
-        aids = self.calc.datastore['asset_loss_table/data']['asset_id']
-        numpy.testing.assert_equal(numpy.bincount(aids), [18, 8, 14, 14])
+        self.run_calc(case_1.__file__, 'job_eb.ini', concurrent_tasks='4')
 
         [fname] = export(('avg_losses-stats', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -18,7 +18,6 @@
 import os
 import sys
 import time
-import math
 import operator
 import collections.abc
 from contextlib import contextmanager

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -766,6 +766,10 @@ class RuptureProxy(object):
         self.rec = rec
         self.sids = sids
 
+    @property
+    def weight(self):
+        return 1 if self.sids is None else numpy.log2(1 + len(self.sids))
+
     def __getitem__(self, name):
         return self.rec[name]
 


### PR DESCRIPTION
The BC calculation goes down from 4 hours to 3 hours. I have improved the submission of the ruptures, that now is continuous with the prefiltering and not delayed.
```
$ oq1 show task_info 33863  # before
================== ===== ====== === ===== =======
operation-duration mean  stddev min max   outputs
calc_risk          1,354 332    229 2,494 434    
ebrisk             577   838    20  5,652 669    
post_ebrisk        1,082 402    433 2,257 50     
================== ===== ====== === ===== =======
$ oq1 show task_info 33866  # now
================== ===== ====== === ===== =======
operation-duration mean  stddev min max   outputs
calc_risk          1,386 310    420 2,641 349    
ebrisk             573   566    14  3,662 899    
post_ebrisk        1,001 424    412 1,988 50     
```
The slowest task goes down from 94 to 61 minutes.