### PR TITLE
Fixed a bug with the maxweight in gen_rupture_getters and some cleanup

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -384,12 +384,11 @@ def gettemp(content=None, dir=None, prefix="tmp", suffix="tmp"):
             os.makedirs(dir)
     fh, path = tempfile.mkstemp(dir=dir, prefix=prefix, suffix=suffix)
     _tmp_paths.append(path)
-    if content:
-        fh = os.fdopen(fh, "wb")
-        if hasattr(content, 'encode'):
-            content = content.encode('utf8')
-        fh.write(content)
-        fh.close()
+    with os.fdopen(fh, "wb") as fh:
+        if content:
+            if hasattr(content, 'encode'):
+                content = content.encode('utf8')
+            fh.write(content)
     return path
 
 

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -223,7 +223,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         smap = parallel.Starmap(
             self.core_task.__func__, h5=self.datastore.hdf5)
         for rgetter in getters.gen_rupture_getters(
-                self.datastore, maxweight=maxw):
+                self.datastore, maxweight=maxw, srcfilter=srcfilter):
             smap.submit((rgetter, srcfilter, self.param))
         smap.reduce(self.agg_dicts)
         if self.indices:

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -213,7 +213,6 @@ class EbriskCalculator(event_based.EventBasedCalculator):
             tempname=cache_epsilons(
                 self.datastore, oq, self.assetcol, self.crmodel, self.E))
         srcfilter = self.src_filter(self.datastore.tempname)
-        maxw = self.E / (oq.concurrent_tasks or 1)
         logging.info('Sending %d ruptures', len(self.datastore['ruptures']))
         self.events_per_sid = []
         self.numlosses = 0
@@ -223,7 +222,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         smap = parallel.Starmap(
             self.core_task.__func__, h5=self.datastore.hdf5)
         for rgetter in getters.gen_rupture_getters(
-                self.datastore, maxweight=maxw, srcfilter=srcfilter):
+                self.datastore, srcfilter=srcfilter):
             smap.submit((rgetter, srcfilter, self.param))
         smap.reduce(self.agg_dicts)
         if self.indices:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -349,7 +349,8 @@ class EventBasedCalculator(base.HazardCalculator):
         self.datastore.swmr_on()
         logging.info('Reading %d ruptures', len(self.datastore['ruptures']))
         iterargs = ((rgetter, srcfilter, self.param)
-                    for rgetter in gen_rupture_getters(self.datastore))
+                    for rgetter in gen_rupture_getters(self.datastore,
+                                                       srcfilter=srcfilter))
         acc = parallel.Starmap(
             self.core_task.__func__, iterargs, h5=self.datastore.hdf5,
             num_cores=oq.num_cores

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -23,9 +23,9 @@ import operator
 import collections
 import numpy
 
-from openquake.baselib.general import group_array, deprecated
+from openquake.baselib.general import group_array, deprecated, AccumDict
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib.calc import disagg, filters
+from openquake.hazardlib.calc import disagg
 from openquake.calculators.views import view
 from openquake.calculators.extract import extract, get_mesh, get_info
 from openquake.calculators.export import export
@@ -56,12 +56,11 @@ def export_ruptures_xml(ekey, dstore):
     fmt = ekey[-1]
     oq = dstore['oqparam']
     num_ses = oq.ses_per_logic_tree_path
-    ruptures_by_grp = {}
+    ruptures_by_grp = AccumDict(accum=[])
     for rgetter in gen_rupture_getters(dstore):
         ebrs = [ebr.export(rgetter.rlzs_by_gsim, num_ses)
                 for ebr in rgetter.get_ruptures()]
-        if ebrs:
-            ruptures_by_grp[rgetter.grp_id] = ebrs
+        ruptures_by_grp[rgetter.grp_id].extend(ebrs)
     dest = dstore.export_path('ses.' + fmt)
     writer = hazard_writers.SESXMLWriter(dest)
     writer.serialize(ruptures_by_grp, oq.investigation_time)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -448,7 +448,7 @@ def group_by_rlz(data, rlzs):
     return {rlzi: numpy.array(recs) for rlzi, recs in acc.items()}
 
 
-def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5, srcfilter=None):
+def gen_rupture_getters(dstore, slc=slice(None), srcfilter=None):
     """
     :yields: RuptureGetters
     """
@@ -461,6 +461,8 @@ def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5, srcfilter=None):
     samples = csm_info.get_samples_by_grp()
     rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]
+    ct = dstore['oqparam'].concurrent_tasks
+    maxweight = len(dstore['ruptures']) / (ct or 1)
 
     def gen(arr):
         if srcfilter:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -448,7 +448,7 @@ def group_by_rlz(data, rlzs):
     return {rlzi: numpy.array(recs) for rlzi, recs in acc.items()}
 
 
-def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5):
+def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5, srcfilter=None):
     """
     :yields: RuptureGetters
     """
@@ -461,12 +461,6 @@ def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5):
     samples = csm_info.get_samples_by_grp()
     rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]
-    nr = 0
-    maxdist = dstore['oqparam'].maximum_distance
-    if 'sitecol' in dstore:
-        srcfilter = SourceFilter(dstore['sitecol'], maxdist)
-    else:
-        srcfilter = None
 
     def gen(arr):
         if srcfilter:
@@ -479,6 +473,7 @@ def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5):
 
     light_rgetters = []
     ntasks = 0
+    nr = 0
     for grp_id, arr in general.group_array(rup_array, 'grp_id').items():
         if not rlzs_by_gsim[grp_id]:
             # this may happen if a source model has no sources, like

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -448,7 +448,7 @@ def group_by_rlz(data, rlzs):
     return {rlzi: numpy.array(recs) for rlzi, recs in acc.items()}
 
 
-def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5, filename=None):
+def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5):
     """
     :yields: RuptureGetters
     """
@@ -494,7 +494,7 @@ def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5, filename=None):
             else:
                 e0 = e0s[nr: nr + len(proxies)]
             rgetter = RuptureGetter(
-                proxies, filename or dstore.filename, grp_id,
+                proxies, dstore.filename, grp_id,
                 trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim[grp_id], e0)
             if rgetter.weight < maxweight / 2:
                 light_rgetters.append(rgetter)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -456,8 +456,6 @@ def gen_rupture_getters(dstore, slc=slice(None), maxweight=1E5):
         e0s = dstore['eslices'][:, 0]
     except KeyError:
         e0s = None
-    if dstore.parent:
-        dstore = dstore.parent
     csm_info = dstore['csm_info']
     trt_by_grp = csm_info.grp_by("trt")
     samples = csm_info.get_samples_by_grp()

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -349,7 +349,7 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/global_gmfs.txt', tmp)
 
     def test_case_17(self):  # oversampling and save_ruptures
-        # also, the grp-00 does not produce ruptures
+        # also, grp-00 does not produce ruptures
         expected = [
             'hazard_curve-mean.csv',
             'hazard_curve-rlz-001.csv',


### PR DESCRIPTION
There were actually two bugs:

1. the maxweight was hard-coded in the event based case
2. when fixing the issue, then some ruptures were not exported for small maxweight, because then a grp_id would produce multiple getters.