### PR TITLE
Improved the fix on the SWMR error in https://github.com/gem/oq-engine/pull/5385

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -271,7 +271,9 @@ class EbrCalculator(base.RiskCalculator):
             self.datastore.set_attrs('losses_by_event', loss_types=loss_types)
         if oq.avg_losses:
             set_rlzs_stats(self.datastore, 'avg_losses')
-        os.environ['OQ_DISTRIBUTE'] = 'no'  # temporary hack
+        if self.datastore.hdf5.mode is None:  # instead of r+
+            logging.warn('Disabling task distribution')
+            os.environ['OQ_DISTRIBUTE'] = 'no'  # avoid SWMR issues
         prc = post_risk.PostRiskCalculator(oq, self.datastore.calc_id)
         prc.datastore.parent = self.datastore.parent
         prc.run()

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -273,10 +273,10 @@ class EbrCalculator(base.RiskCalculator):
         if oq.avg_losses:
             set_rlzs_stats(self.datastore, 'avg_losses')
         prc = post_risk.PostRiskCalculator(oq, self.datastore.calc_id)
-        prc.datastore.parent = self.datastore.parent
-        if self.datastore.hdf5.mode is None:  # instead of r+
+        if self.datastore.hdf5.mode is None:  # no parent
             logging.warn('Disabling task distribution')
             with unittest.mock.patch.dict(os.environ, OQ_DISTRIBUTE='no'):
                 prc.run()
-        else:
+        else:  # mode is r+
+            prc.datastore.parent = self.datastore.parent
             prc.run()


### PR DESCRIPTION
Disabling the task distribution only when there is no parent.