### PR TITLE
Restored the num_cores functionality of engine 3.7

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -805,7 +805,6 @@ class Starmap(object):
             first_args = self.task_queue[:num_cores]
             self.task_queue[:] = self.task_queue[num_cores:]
             for func, args in first_args:
-                print('sending', func)
                 self.submit(args, func=func)
         if not hasattr(self, 'socket'):  # no submit was ever made
             return ()

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -828,7 +828,9 @@ class Starmap(object):
                 yield res
             elif res.func:  # add subtask
                 self.task_queue.append((res.func, res.pik))
-                if self.todo < num_cores:
+                if self.num_cores is None:
+                    self._submit_many(1)  # oversubmit
+                elif self.todo < num_cores:
                     self._submit_many(num_cores - self.todo)
             else:
                 yield res

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -805,6 +805,7 @@ class Starmap(object):
             first_args = self.task_queue[:num_cores]
             self.task_queue[:] = self.task_queue[num_cores:]
             for func, args in first_args:
+                print('sending', func)
                 self.submit(args, func=func)
         if not hasattr(self, 'socket'):  # no submit was ever made
             return ()
@@ -818,10 +819,7 @@ class Starmap(object):
                                 'is job %d', res.mon.calc_id, self.calc_id)
             elif res.msg == 'TASK_ENDED':
                 self.todo -= 1
-                if self.num_cores:
-                    self._submit_many(max(self.num_cores - self.todo, 2))
-                else:
-                    self._submit_many(1)
+                self._submit_many(1)
                 logging.debug('%d tasks todo, %d in queue',
                               self.todo, len(self.task_queue))
                 self.log_percent()
@@ -830,8 +828,8 @@ class Starmap(object):
                 self.task_queue.append((res.func, res.pik))
                 if self.num_cores is None:
                     self._submit_many(1)  # oversubmit
-                elif self.todo < num_cores:
-                    self._submit_many(num_cores - self.todo)
+                elif self.todo < self.num_cores:
+                    self._submit_many(self.num_cores - self.todo)
             else:
                 yield res
         self.log_percent()

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -29,7 +29,7 @@ import numpy
 
 from openquake.baselib import (
     general, hdf5, datastore, __version__ as engine_version)
-from openquake.baselib.parallel import Starmap
+from openquake.baselib import parallel
 from openquake.baselib.performance import Monitor, init_performance
 from openquake.hazardlib import InvalidFile
 from openquake.hazardlib.calc.filters import SourceFilter
@@ -160,7 +160,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
         # info about Calculator.run since the file will be closed later on
         self.oqparam = oqparam
         if oqparam.num_cores:
-            Starmap.num_cores = oqparam.num_cores
+            parallel.CT = oqparam.num_cores * 2
 
     def monitor(self, operation='', **kw):
         """
@@ -937,7 +937,7 @@ class RiskCalculator(HazardCalculator):
         """
         if not hasattr(self, 'riskinputs'):  # in the reportwriter
             return
-        res = Starmap.apply(
+        res = parallel.Starmap.apply(
             self.core_task.__func__,
             (self.riskinputs, self.crmodel, self.param, self.monitor()),
             concurrent_tasks=self.oqparam.concurrent_tasks or 1,

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -80,8 +80,7 @@ if OQ_DISTRIBUTE == 'zmq':
             num_workers = os.cpu_count()
             logs.LOG.warn('Missing host_cores, no idea about how many cores '
                           'are available, using %d', num_workers)
-        parallel.Starmap.num_cores = num_workers
-        parallel.Starmap.oversubmit = calc.oqparam.oversubmit
+        parallel.CT = num_workers * 2
         OqParam.concurrent_tasks.default = num_workers * 2
         logs.LOG.warn('Using %d zmq workers', num_workers)
 
@@ -99,8 +98,7 @@ elif OQ_DISTRIBUTE.startswith('celery'):
             logs.dbcmd('finish', calc.datastore.calc_id, 'failed')
             sys.exit(1)
         ncores = sum(stats[k]['pool']['max-concurrency'] for k in stats)
-        parallel.Starmap.num_cores = ncores
-        parallel.Starmap.oversubmit = calc.oqparam.oversubmit
+        parallel.CT = ncores * 2
         OqParam.concurrent_tasks.default = ncores * 2
         logs.LOG.warn('Using %s, %d cores', ', '.join(sorted(stats)), ncores)
 
@@ -336,7 +334,7 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
     try:
         if OQ_DISTRIBUTE.endswith('pool'):
             logs.LOG.warning('Using %d cores on %s',
-                             parallel.Starmap.num_cores, platform.node())
+                             parallel.CT, platform.node())
         if OQ_DISTRIBUTE == 'zmq' and config.zworkers['host_cores']:
             logs.dbcmd('zmq_start')  # start the zworkers
             logs.dbcmd('zmq_wait')  # wait for them to go up


### PR DESCRIPTION
I temporarily removed it in master. Notice that tasks like `compute_gmfs` are launched upfront so they cannot respect the `num_cores` limit anyway.