### PR TITLE
[Doc] Recommend a shallow clone of the engine repo [skip CI]

### DIFF
--- a/doc/installing/development-windows.md
+++ b/doc/installing/development-windows.md
@@ -23,12 +23,13 @@ pip uninstall openquake.engine
 ### Download the OpenQuake source code
 
 To be able to download the OpenQuake source code you must have [GIT](https://git-scm.com/download/windows) installed and available in the system `PATH`. If the `git` command is not available in
-the `oq-console.bat` terminal please use `GIT Bash` to run this step and then switch back to `oq-console.bat`.
+the `oq-console.bat` terminal please use `GIT Bash` to run this step and then switch back to `oq-console.bat`. 
 
+Considering that the complete repository is quite large given its long history, we recommend shallow cloning the repository to download only the latest revision. In case you need the source code with the full history of the repository, you should execute the `git clone` command below without the `--depth=1` flag.
 
 ```cmd
 mkdir src && cd src
-git clone https://github.com/gem/oq-engine.git
+git clone https://github.com/gem/oq-engine.git --depth=1
 ```
 
 ### Install OpenQuake

--- a/doc/installing/development-windows.md
+++ b/doc/installing/development-windows.md
@@ -25,12 +25,15 @@ pip uninstall openquake.engine
 To be able to download the OpenQuake source code you must have [GIT](https://git-scm.com/download/windows) installed and available in the system `PATH`. If the `git` command is not available in
 the `oq-console.bat` terminal please use `GIT Bash` to run this step and then switch back to `oq-console.bat`. 
 
-Considering that the complete repository is quite large given its long history, we recommend shallow cloning the repository to download only the latest revision. In case you need the source code with the full history of the repository, you should execute the `git clone` command below without the `--depth=1` flag.
+Considering that the complete repository is quite large given its long history, we recommend shallow cloning the repository to download only the latest revision.
 
 ```cmd
 mkdir src && cd src
 git clone https://github.com/gem/oq-engine.git --depth=1
 ```
+In case you needed the source code with the full history of the repository, you
+can convert the shallow clone into a full repository with the command
+`git fetch --unshallow`.
 
 ### Install OpenQuake
 

--- a/doc/installing/development.md
+++ b/doc/installing/development.md
@@ -96,10 +96,11 @@ pip install -U pip setuptools
 ```
 
 ### Download the OpenQuake source code
+Considering that the complete repository is quite large given its long history, we recommend shallow cloning the repository to download only the latest revision. In case you need the source code with the full history of the repository, you should execute the `git clone` command below without the `--depth=1` flag.
 
 ```bash
 mkdir src && cd src
-git clone https://github.com/gem/oq-engine.git
+git clone https://github.com/gem/oq-engine.git --depth=1
 ```
 
 ### Install OpenQuake

--- a/doc/installing/development.md
+++ b/doc/installing/development.md
@@ -96,12 +96,16 @@ pip install -U pip setuptools
 ```
 
 ### Download the OpenQuake source code
-Considering that the complete repository is quite large given its long history, we recommend shallow cloning the repository to download only the latest revision. In case you need the source code with the full history of the repository, you should execute the `git clone` command below without the `--depth=1` flag.
+Considering that the complete repository is quite large given its long history, we recommend shallow cloning the repository to download only the latest revision.
 
 ```bash
 mkdir src && cd src
 git clone https://github.com/gem/oq-engine.git --depth=1
 ```
+
+In case you needed the source code with the full history of the repository, you
+can convert the shallow clone into a full repository with the command
+`git fetch --unshallow`.
 
 ### Install OpenQuake
 


### PR DESCRIPTION
Update installation instructions for development, recommending a shallow clone of the engine repo with unit depth by default.

See: https://github.com/gem/oq-engine/issues/4883