### PR TITLE
Fixed event_based from CSV headers

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -991,7 +991,8 @@ def import_gmfs(dstore, fname, sids):
     :param sids: the site IDs (complete)
     :returns: event_ids, num_rlzs
     """
-    array = hdf5.read_csv(fname, {'sid': U32, 'eid': U32, None: F32}).array
+    array = hdf5.read_csv(fname, {'sid': U32, 'eid': U32, None: F32},
+                          renamedict=dict(site_id='sid', event_id='eid')).array
     names = array.dtype.names
     if names[0] == 'rlzi':  # backward compatbility
         names = names[1:]  # discard the field rlzi

--- a/openquake/qa_tests_data/gmf_ebrisk/case_1/gmf_scenario.csv
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_1/gmf_scenario.csv
@@ -1,4 +1,4 @@
-sid,eid,gmv_PGA
+site_id,event_id,gmv_PGA
 0,0,0.60403156
 0,1,0.33487797
 0,2,0.39260185


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/5386, caused by the recent name changes. With the fix, the old names `sid` and `eid` are still accepted.