### PR TITLE
Improved the error message if the `event_id` does not start from zero in the gmfs.csv files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Improved the error message if the `event_id` does not start from zero in
+    the gmfs.csv files
   * Changed the rupture exporter to export LINESTRINGs instead of degenerate
     POLYGONs
   * Introduced `minimum_loss_fraction` functionality in ebrisk

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1014,9 +1014,15 @@ def import_gmfs(dstore, fname, sids):
                 arr['gmv'][:, m] = array[name]
         else:
             arr[name] = array[name]
+
+    n = len(numpy.unique(array[['sid', 'eid']]))
+    if n != len(array):
+        raise ValueError('Duplicated site_id, event_id in %s' % fname)
     # store the events
     eids = numpy.unique(array['eid'])
     eids.sort()
+    if eids[0] != 0:
+        raise ValueError('The event_id must start from zero in %s' % fname)
     E = len(eids)
     events = numpy.zeros(E, rupture.events_dt)
     events['id'] = eids

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -248,7 +248,10 @@ class PolygonPlotter():
         self.maxxs.append(maxx)
         self.minys.append(miny)
         self.maxys.append(maxy)
-        self.ax.add_patch(PolygonPatch(poly, **kw))
+        try:
+            self.ax.add_patch(PolygonPatch(poly, **kw))
+        except ValueError:  # LINESTRING, not POLYGON
+            pass
 
     def set_lim(self):
         if self.minxs and self.maxxs:


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/5327.