### PR TITLE
adding pointsource_distance to view_params 

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -239,6 +239,7 @@ def view_params(token, dstore):
               'ses_per_logic_tree_path', 'truncation_level',
               'rupture_mesh_spacing', 'complex_fault_mesh_spacing',
               'width_of_mfd_bin', 'area_source_discretization',
+              'pointsource_distance',
               'ground_motion_correlation_model', 'minimum_intensity',
               'random_seed', 'master_seed', 'ses_seed']
     if 'risk' in oq.calculation_mode:


### PR DESCRIPTION
This PR adds the pointsource_distance specified in the job.ini (or otherwise "None") to the view_params in openquake/calculators/views.py so that it appears in report_<id>.rst. 