### PR TITLE
Added a mechanism to overridde the job.ini parameters

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -70,8 +70,6 @@
   * Renamed ordinal -> rlz_id in the realizations.csv output
 
   [Alberto Chiusole]
-  * Restored the `export_dir` to be relative to the current directory
-    and not to the input directory
   * Changed the way how the available number of CPU cores is computed
 
   [Kendra Johnson, Robin Gee]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added an option `oq engine --param` to override the job.ini parameters
   * Internal: reduced the number of NGAEastUSGS classes from 39 to 1
   * Internal: reduced the number of NGAEast classes from 44 to 2
   * Internal: reduced the 15 NSHMP2014 classes to a single class

--- a/doc/manual/oqum/help.txt
+++ b/doc/manual/oqum/help.txt
@@ -61,3 +61,6 @@ optional arguments:
   -l, --log-level {debug, info, warn, error, critical}
                         Defaults to "info"
   -r, --reuse-hazard    Reuse the event based hazard if available
+  --param PARAM, -p PARAM
+                        Override parameters specified with the syntax
+                        NAME1=VALUE1,NAME2=VALUE2,...

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -22,7 +22,7 @@ import logging
 from openquake.baselib import sap, config, datastore
 from openquake.baselib.general import safeprint
 from openquake.hazardlib import valid
-from openquake.commonlib import logs, readinput
+from openquake.commonlib import logs, readinput, oqvalidation
 from openquake.engine import engine as eng
 from openquake.engine.export import core
 from openquake.engine.utils import confirm
@@ -67,7 +67,7 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
         job_ini = os.path.abspath(job_ini)
         oqparam = eng.job_from_file(job_ini, job_id, username, **kw)
         kw['username'] = username
-        eng.run_calc(job_id, oqparam, exports, **kw)
+        eng.run_calc(job_id, oqparam, exports)
         for line in logs.dbcmd('list_outputs', job_id, False):
             safeprint(line)
     return job_id
@@ -103,7 +103,8 @@ def del_calculation(job_id, confirmed=False):
                 print(resp['error'])
 
 
-def smart_run(job_ini, oqparam, log_level, log_file, exports, reuse_hazard):
+def smart_run(job_ini, oqparam, log_level, log_file, exports,
+              reuse_hazard, **params):
     """
     Run calculations by storing their hazard checksum and reusing previous
     calculations if requested.
@@ -114,7 +115,7 @@ def smart_run(job_ini, oqparam, log_level, log_file, exports, reuse_hazard):
     reuse = reuse_hazard and job and os.path.exists(job.ds_calc_dir + '.hdf5')
     # recompute the hazard and store the checksum
     if not reuse:
-        hc_id = run_job(job_ini, log_level, log_file, exports)
+        hc_id = run_job(job_ini, log_level, log_file, exports, **params)
         if job is None:
             logs.dbcmd('add_checksum', hc_id, haz_checksum)
         elif not reuse_hazard or not os.path.exists(job.ds_calc_dir + '.hdf5'):
@@ -123,7 +124,7 @@ def smart_run(job_ini, oqparam, log_level, log_file, exports, reuse_hazard):
         hc_id = job.id
         logging.info('Reusing job #%d', job.id)
         run_job(job_ini, log_level, log_file,
-                exports, hazard_calculation_id=hc_id)
+                exports, hazard_calculation_id=hc_id, **params)
 
 
 @sap.Script  # do not use sap.script, other oq engine will break
@@ -133,7 +134,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
            delete_calculation, delete_uncompleted_calculations,
            hazard_calculation_id, list_outputs, show_log,
            export_output, export_outputs, exports='',
-           log_level='info', reuse_hazard=False):
+           log_level='info', reuse_hazard=False, param=''):
     """
     Run a calculation using the traditional command line API
     """
@@ -193,6 +194,8 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
     else:
         hc_id = None
     if run:
+        params = oqvalidation.OqParam.check(
+            dict(p.split('=', 1) for p in param.split(',')))
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
         job_inis = [os.path.expanduser(f) for f in run]
@@ -202,12 +205,12 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             # not using logs.handle that logs on the db
             oq = readinput.get_oqparam(job_inis[0])
             smart_run(job_inis[0], oq, log_level, log_file,
-                      exports, reuse_hazard)
+                      exports, reuse_hazard, **params)
             return
         for i, job_ini in enumerate(job_inis):
             open(job_ini, 'rb').read()  # IOError if the file does not exist
             job_id = run_job(job_ini, log_level, log_file,
-                             exports, hazard_calculation_id=hc_id)
+                             exports, hazard_calculation_id=hc_id, **params)
             if not hc_id:  # use the first calculation as base for the others
                 hc_id = job_id
     # hazard
@@ -309,3 +312,6 @@ engine.opt('exports', 'Comma-separated string specifing the export formats, '
 engine.opt('log_level', 'Defaults to "info"',
            choices=['debug', 'info', 'warn', 'error', 'critical'])
 engine.flg('reuse_hazard', 'Reuse the event based hazard if available')
+engine._add('param', '--param', '-p',
+            help='Override parameters specified with the syntax '
+            'NAME1=VALUE1,NAME2=VALUE2,...')

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -195,7 +195,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
         hc_id = None
     if run:
         params = oqvalidation.OqParam.check(
-            dict(p.split('=', 1) for p in param.split(',')))
+            dict(p.split('=', 1) for p in param.split(','))) if param else {}
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
         job_inis = [os.path.expanduser(f) for f in run]

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -38,6 +38,7 @@ U64 = numpy.uint64
 F32 = numpy.float32
 F64 = numpy.float64
 
+
 def check_same_levels(imtls):
     """
     :param imtls: a dictionary (or dict-like) imt -> imls
@@ -805,7 +806,8 @@ class OqParam(valid.ParamSet):
         and the user must have the permission to write on it.
         """
         if self.export_dir and not os.path.isabs(self.export_dir):
-            self.export_dir = os.getcwd()
+            self.export_dir = os.path.normpath(
+                os.path.join(self.input_dir, self.export_dir))
             logging.info('Using export_dir=%s', self.export_dir)
         if not self.export_dir:
             self.export_dir = os.path.expanduser('~')  # home directory

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -814,7 +814,7 @@ class OqParam(valid.ParamSet):
             logging.warning('export_dir not specified. Using export_dir=%s'
                             % self.export_dir)
             return True
-        elif not os.path.exists(self.export_dir):
+        if not os.path.exists(self.export_dir):
             try:
                 os.makedirs(self.export_dir)
             except PermissionError:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -251,7 +251,7 @@ def job_from_file(job_ini, job_id, username, **kw):
     :returns:
         an oqparam instance
     """
-    hc_id = kw.get('hazard_calculation_id')
+    hc_id = kw.pop('hazard_calculation_id', None)
     try:
         oq = readinput.get_oqparam(job_ini, hc_id=hc_id, **kw)
     except Exception:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -253,7 +253,7 @@ def job_from_file(job_ini, job_id, username, **kw):
     """
     hc_id = kw.get('hazard_calculation_id')
     try:
-        oq = readinput.get_oqparam(job_ini, hc_id=hc_id)
+        oq = readinput.get_oqparam(job_ini, hc_id=hc_id, **kw)
     except Exception:
         logs.dbcmd('finish', job_id, 'deleted')
         raise


### PR DESCRIPTION
And reverted the export_dir to be relative to the input_dir, as before https://github.com/gem/oq-engine/pull/5305. Here is an example of usage:

 $ oq engine --run demos/hazard/AreaSourceClassicalPSHA/job.ini --exports csv --param export_dir=/tmp/pippo
