### PR TITLE
Removed deprecation

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -177,10 +177,6 @@ class EbrCalculator(base.RiskCalculator):
                 'avg_losses-rlzs', F32, (self.A, self.R, self.L))
         self.agglosses = numpy.zeros((self.E, self.L), F32)
         if 'builder' in self.param:
-            logging.warning(
-                'Building the loss curves and maps for each asset is '
-                'deprecated: consider building the aggregate curves and '
-                'maps with the ebrisk calculator instead')
             self.build_datasets(self.param['builder'])
         if parent:
             parent.close()  # avoid concurrent reading issues
@@ -278,5 +274,4 @@ class EbrCalculator(base.RiskCalculator):
             with unittest.mock.patch.dict(os.environ, OQ_DISTRIBUTE='no'):
                 prc.run()
         else:  # mode is r+
-            prc.datastore.parent = self.datastore.parent
             prc.run()


### PR DESCRIPTION
The event_based_risk calculator is still good for building asset specific loss curves and maps.