### PR TITLE
Fixed misprint in usgs_ceus_2019.py

### DIFF
--- a/openquake/hazardlib/gsim/usgs_ceus_2019.py
+++ b/openquake/hazardlib/gsim/usgs_ceus_2019.py
@@ -267,4 +267,4 @@ NGAEastUSGSSammons17 usgs_17'''.splitlines()
 for line in lines:
     alias, key = line.split()
     gsim_aliases[alias] = (f'[NGAEastUSGSGMPE]\n'
-                           'gmpe_table="nga_east_{key}.hdf5"')
+                           f'gmpe_table="nga_east_{key}.hdf5"')


### PR DESCRIPTION
It was affecting the aliases->TOML association. Now one gets correctly
```python
In [1]: from openquake.hazardlib.gsim.base import gsim_aliases  
   ...: for alias, toml in gsim_aliases.items():  
   ...:    if 'Sammo' in alias: print(alias, toml)  
   ...:                                                                         
NGAEastUSGSSammons1 [NGAEastUSGSGMPE]
gmpe_table="nga_east_usgs_1.hdf5"
NGAEastUSGSSammons2 [NGAEastUSGSGMPE]
gmpe_table="nga_east_usgs_2.hdf5"
...
```