### PR TITLE
Update fault_models.py

### DIFF
--- a/openquake/hmtk/faults/fault_models.py
+++ b/openquake/hmtk/faults/fault_models.py
@@ -461,7 +461,7 @@ class mtkActiveFault(object):
             if np.max(model.magnitudes) > mmax:
                 mmax = np.max(model.magnitudes)
         if collapse:
-            self.mfd = ([self.collapse_branches(mmin, bin_width, mmax)],
+            self.mfd = ([self.collapse_branches(mmin, model.recurrence.bin_width, mmax)],
                         [1.0],
                         [rendered_msr])
         else:


### PR DESCRIPTION
When a non-default bin width is given the collapsed version does not use the specified bin width instead it uses the default. This commit uses the bin width specified from the recurrence model.