### PR TITLE
Extended `oq check_input` to accept multiple files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Extended `oq check_input` to accept multiple files
   * Changed the scenario damage calculator to use discrete damage distributions
   * Forced the "number" attribute in the exposure must be an integer in the
     range 1..65535, extrema included

--- a/demos/risk/ClassicalDamage/exposure_model.xml
+++ b/demos/risk/ClassicalDamage/exposure_model.xml
@@ -89620,7 +89620,7 @@
 				</occupancies>
 				<tags NAME_1="East" NAME_2="Sagarmatha" NAME_3="Udayapur" NAME_4="TriyugaN.P." />
 			</asset>
-			<asset id="a9041" number="76825"  taxonomy="Stone-Masonry" >
+			<asset id="a9041" number="60825"  taxonomy="Stone-Masonry" >
 				<location lon="85.30417" lat="27.7625" />
 				<costs>
 					<cost type="structural" value="11340"/>

--- a/demos/risk/EventBasedRisk/exposure_model.xml
+++ b/demos/risk/EventBasedRisk/exposure_model.xml
@@ -98583,7 +98583,7 @@
 				</occupancies>
 				<tags NAME_1="East" NAME_2="Sagarmatha" NAME_3="Udayapur" NAME_4="TriyugaN.P." />
 			</asset>
-			<asset id="a9041" number="76825"  taxonomy="Stone-Masonry" >
+			<asset id="a9041" number="60825"  taxonomy="Stone-Masonry" >
 				<location lon="85.30417" lat="27.7625" />
 				<costs>
 					<cost type="structural" value="11340"/>

--- a/demos/risk/ScenarioDamage/exposure_model.xml
+++ b/demos/risk/ScenarioDamage/exposure_model.xml
@@ -89620,7 +89620,7 @@
 				</occupancies>
 				<tags NAME_1="East" NAME_2="Sagarmatha" NAME_3="Udayapur" NAME_4="TriyugaN.P." />
 			</asset>
-			<asset id="a9041" number="76825"  taxonomy="Stone-Masonry" >
+			<asset id="a9041" number="60825"  taxonomy="Stone-Masonry" >
 				<location lon="85.30417" lat="27.7625" />
 				<costs>
 					<cost type="structural" value="11340"/>

--- a/openquake/commands/check_input.py
+++ b/openquake/commands/check_input.py
@@ -24,15 +24,16 @@ from openquake.risklib import read_nrml  # this is necessary
 
 
 @sap.script
-def check_input(job_ini_or_zip_or_nrml):
-    if job_ini_or_zip_or_nrml.endswith('.xml'):
-        try:
-            print(nrml.to_python(job_ini_or_zip_or_nrml))
-        except Exception as exc:
-            sys.exit(exc)
-    else:
-        calc = base.calculators(readinput.get_oqparam(job_ini_or_zip_or_nrml))
-        calc.read_inputs()
+def check_input(job_ini_or_zip_or_nrmls):
+    for job_ini_or_zip_or_nrml in job_ini_or_zip_or_nrmls:
+        if job_ini_or_zip_or_nrml.endswith('.xml'):
+            try:
+                print(nrml.to_python(job_ini_or_zip_or_nrml))
+            except Exception as exc:
+                sys.exit(exc)
+        else:
+            base.calculators(readinput.get_oqparam(
+                job_ini_or_zip_or_nrml)).read_inputs()
 
 
-check_input.arg('job_ini_or_zip_or_nrml', 'Check the input')
+check_input.arg('job_ini_or_zip_or_nrmls', 'Check the input', nargs='+')

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -473,12 +473,12 @@ class CheckInputTestCase(unittest.TestCase):
         job_zip = os.path.join(list(test_data.__path__)[0],
                                'archive_err_1.zip')
         with self.assertRaises(ValueError):
-            check_input(job_zip)
+            check_input([job_zip])
 
     def test_valid(self):
         job_ini = os.path.join(list(test_data.__path__)[0],
                                'event_based_hazard/job.ini')
-        check_input(job_ini)
+        check_input([job_ini])
 
 
 class PrepareSiteModelTestCase(unittest.TestCase):


### PR DESCRIPTION
So that a command like
```bash
$ find demos -name exposure\*.xml|xargs oq check_input 
```
can be given. Also, fixed the exposures in the demos.