### PR TITLE
Lowered the limit on the maximum disagg matrix size to 1E6

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -349,7 +349,7 @@ class DisaggregationCalculator(base.HazardCalculator):
             if sid == 0:
                 logging.info('nbins=%s for site=#%d', shape_dic, sid)
             matrix_size = numpy.prod(shape)
-            if matrix_size > 1E7:
+            if matrix_size > 1E6:
                 raise ValueError(
                     'The disaggregation matrix for site #%d is too large '
                     '(%d elements): fix the binnning!' % (sid, matrix_size))


### PR DESCRIPTION
To stop @rcgee ;-) In her case the problem was a coordinate_bin_width = 0.2, which was too small for the problem at hand, generating a disaggregation matrix too large with over 5M elements.
