### PR TITLE
Supported Python 3.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Internal: we are now shutting down the ProcessPool explicitly in order
+    to support Python 3.8
   * Internal: removed the class hazardlib.gsim.base.IPE
   * Changed the aggregate loss curves generation to not use the partial
     asset loss table, with a huge memory reduction

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -19,7 +19,7 @@ import os
 import sys
 import getpass
 import logging
-from openquake.baselib import sap, config, datastore
+from openquake.baselib import sap, config, datastore, parallel
 from openquake.baselib.general import safeprint
 from openquake.hazardlib import valid
 from openquake.commonlib import logs, readinput, oqvalidation
@@ -70,6 +70,7 @@ def run_job(job_ini, log_level='info', log_file=None, exports='',
         eng.run_calc(job_id, oqparam, exports)
         for line in logs.dbcmd('list_outputs', job_id, False):
             safeprint(line)
+    parallel.Starmap.shutdown()
     return job_id
 
 

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -22,7 +22,7 @@ import os.path
 import cProfile
 import pstats
 
-from openquake.baselib import performance, general, sap, datastore
+from openquake.baselib import performance, general, sap, datastore, parallel
 from openquake.hazardlib import valid
 from openquake.commonlib import readinput, oqvalidation, logs
 from openquake.calculators import base, views
@@ -130,6 +130,7 @@ def _run(job_inis, concurrent_tasks, pdb, loglevel, hc, exports, params):
     logging.info('Memory allocated: %s', general.humansize(monitor.mem))
     print('See the output with silx view %s' % calc.datastore.filename)
     calc_path, _ = os.path.splitext(calc.datastore.filename)  # used below
+    parallel.Starmap.shutdown()
     return calc
 
 


### PR DESCRIPTION
All the tests were green already. The demos were broken but easily fixed by shutting down the ProcessPool explicitly.