### PR TITLE
Fixed memory issue in nrcan15_site_term.py

### DIFF
--- a/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
@@ -72,7 +72,7 @@ class NRCan15SiteTerm(GMPE):
         for spec of input and result values.
         """
         # Prepare sites
-        sites_rock = copy.deepcopy(sites)
+        sites_rock = copy.copy(sites)
         sites_rock.vs30 = np.ones_like(sites_rock.vs30) * 760.
         # compute mean and standard deviation
         mean, stddvs = self.gmpe.get_mean_and_stddevs(sites_rock, rup, dists,


### PR DESCRIPTION
The Brazil model is running out of memory on the workers, consuming more than 128 GB of RAM.
The culprit is a `copy.deepcopy` that can be replaced safely with a `copy.copy`. The problem is visible only in this calculation because it is large enough (~200,000 sites).

```python
(Pdb) sites_rock.vs30
array([1000., 1500., 1000., 1500.])
sites_rock = copy.copy(sites)
sites_rock.vs30 = np.ones_like(sites_rock.vs30) * 760.
(Pdb) sites_rock.vs30
array([760., 760., 760., 760.])
(Pdb) sites.vs30
array([1000., 1500., 1000., 1500.])
```
Closes https://github.com/gem/oq-engine/issues/5445.