### PR TITLE
Speedup of the ebrisk calculator

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Speedup of the ebrisk calculator
   * Extended the `minimum_intensity` feature to the classical calculator
   * Solved a memory bug when using the nrcan site term: due to a deepcopy
     the engine could run out of memory in the workers for large site collections

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -98,10 +98,8 @@ def calc_risk(gmfs, param, monitor):
             eidx = numpy.array([eid2idx[eid] for eid in haz['eid']])  # fast
             out = get_output(crmodel, assets_by_taxo, haz)  # slow
         with mon_agg:
-            for lti, lt in enumerate(crmodel.loss_types):
-                tagidxs = assets[aggby] if aggby else None
-                acc['numlosses'] += lba.agg(eidx, out, minimum_loss,
-                                            tagidxs, lt, ws)
+            tagidxs = assets[aggby] if aggby else None
+            acc['numlosses'] += lba.agg(eidx, out, minimum_loss, tagidxs, ws)
     if len(gmfs):
         acc['events_per_sid'] /= len(gmfs)
     acc['elt'] = numpy.fromiter(  # this is ultra-fast

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -101,7 +101,8 @@ def calc_risk(gmfs, param, monitor):
             out = get_output(crmodel, assets_by_taxo, haz)  # slow
         with mon_agg:
             tagidxs = assets[aggby] if aggby else None
-            acc['numlosses'] += lba.agg(eidx, out, minimum_loss, tagidxs, ws)
+            acc['numlosses'] += lba.aggregate(
+                out, eidx, minimum_loss, tagidxs, ws)
     if len(gmfs):
         acc['events_per_sid'] /= len(gmfs)
     acc['elt'] = numpy.fromiter(  # this is ultra-fast

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -94,6 +94,8 @@ def calc_risk(gmfs, param, monitor):
             acc['events_per_sid'] += len(haz)
             if param['avg_losses']:
                 ws = weights[[eid2rlz[eid] for eid in haz['eid']]]
+            else:
+                ws = None
             assets_by_taxo = get_assets_by_taxo(assets, tempname)  # fast
             eidx = numpy.array([eid2idx[eid] for eid in haz['eid']])  # fast
             out = get_output(crmodel, assets_by_taxo, haz)  # slow

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -34,6 +34,7 @@ def get_assets_by_taxo(assets, tempname=None):
     :returns: assets_by_taxo with attributes eps and idxs
     """
     assets_by_taxo = AccumDict(group_array(assets, 'taxonomy'))
+    assets_by_taxo.assets = assets
     assets_by_taxo.idxs = numpy.argsort(numpy.concatenate([
         a['ordinal'] for a in assets_by_taxo.values()]))
     assets_by_taxo.eps = {}
@@ -76,7 +77,7 @@ def get_output(crmodel, assets_by_taxo, haz, rlzi=None):
         data = []
     else:
         raise ValueError('Unexpected haz=%s' % haz)
-    dic = dict(eids=eids)
+    dic = dict(eids=eids, assets=assets_by_taxo.assets)
     if rlzi is not None:
         dic['rlzi'] = rlzi
     for l, lt in enumerate(crmodel.loss_types):

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -77,7 +77,8 @@ def get_output(crmodel, assets_by_taxo, haz, rlzi=None):
         data = []
     else:
         raise ValueError('Unexpected haz=%s' % haz)
-    dic = dict(eids=eids, assets=assets_by_taxo.assets)
+    dic = dict(eids=eids, assets=assets_by_taxo.assets,
+               loss_types=crmodel.loss_types)
     if rlzi is not None:
         dic['rlzi'] = rlzi
     for l, lt in enumerate(crmodel.loss_types):

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1508,7 +1508,7 @@ class LossesByAsset(object):
         """
         numlosses = numpy.zeros(2, int)
         for lni, losses in self.gen_losses(out):
-            if ws is not None:  # slow with millions of assets
+            if ws is not None:
                 aids = out.assets['ordinal']
                 self.losses_by_A[aids, lni] += losses @ ws
             self.losses_by_E[eidx, lni] += losses.sum(axis=0)

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1495,9 +1495,9 @@ class LossesByAsset(object):
             items.append((self.lni[lt + '_ins'], ins_losses))
         return items
 
-    def agg(self, alt, eidx, out, minimum_loss, tagidxs, lt, ws):
+    def agg(self, eidx, out, minimum_loss, tagidxs, lt, ws):
         """
-        Build the asset loss table from the given output
+        Populate .losses_by_A, .losses_by_E and .alt
         """
         lratios = out[lt]
         if lt == 'occupants':
@@ -1515,7 +1515,7 @@ class LossesByAsset(object):
                 if tagidxs is not None:
                     for loss, eid in zip(losses, out.eids):
                         if loss >= minimum_loss[loss_idx]:
-                            alt[idx][eid][loss_idx] += loss
+                            self.alt[idx][eid][loss_idx] += loss
                             kept += 1
                 self.losses_by_E[eidx, loss_idx] += losses
                 numlosses += numpy.array([kept, len(losses)])

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1496,32 +1496,33 @@ class LossesByAsset(object):
             items.append((self.lni[lt + '_ins'], ins_losses))
         return items
 
-    def agg(self, eidx, out, minimum_loss, tagidxs, lt, ws):
+    def agg(self, eidx, out, minimum_loss, tagidxs, ws):
         """
         Populate .losses_by_A, .losses_by_E and .alt
         """
-        lratios = out[lt]
-        if lt == 'occupants':
-            field = 'occupants_None'
-        else:
-            field = 'value-' + lt
         numlosses = numpy.zeros(2, int)
-        for a, asset in enumerate(out.assets):
-            if tagidxs is not None:
-                idx = ','.join(map(str, tagidxs[a]))
-            aid = asset['ordinal']
-            ls = asset[field] * lratios[a]
-            for loss_idx, losses in self._compute(asset, ls, lt):
-                kept = 0
+        for lt in out.loss_types:
+            lratios = out[lt]
+            if lt == 'occupants':
+                field = 'occupants_None'
+            else:
+                field = 'value-' + lt
+            for a, asset in enumerate(out.assets):
                 if tagidxs is not None:
-                    for loss, eid in zip(losses, out.eids):
-                        if loss >= minimum_loss[loss_idx]:
-                            self.alt[idx][eid][loss_idx] += loss
-                            kept += 1
-                self.losses_by_E[eidx, loss_idx] += losses
-                numlosses += numpy.array([kept, len(losses)])
-                if ws is not None:  # slow with millions of assets
-                    self.losses_by_A[aid, loss_idx] += losses @ ws
+                    idx = ','.join(map(str, tagidxs[a]))
+                aid = asset['ordinal']
+                ls = asset[field] * lratios[a]
+                for loss_idx, losses in self._compute(asset, ls, lt):
+                    kept = 0
+                    if tagidxs is not None:
+                        for loss, eid in zip(losses, out.eids):
+                            if loss >= minimum_loss[loss_idx]:
+                                self.alt[idx][eid][loss_idx] += loss
+                                kept += 1
+                    self.losses_by_E[eidx, loss_idx] += losses
+                    numlosses += numpy.array([kept, len(losses)])
+                    if ws is not None:  # slow with millions of assets
+                        self.losses_by_A[aid, loss_idx] += losses @ ws
         return numlosses
 
 

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1465,6 +1465,7 @@ class LossesByAsset(object):
     :param policy_name: the name of the policy field (can be empty)
     :param policy_dict: dict loss_type -> array(deduct, limit) (can be empty)
     """
+    alt = None  # set by the ebrisk calculator
     losses_by_E = None  # set by the ebrisk calculator
 
     @cached_property


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/issues/5454. Now I managed to get a visible speedup for the Italy model on my workstation (more than 7x in aggregating losses).
Before
```
calc_48623                                  time_sec memory_mb counts 
=========================================== ======== ========= =======
total ebrisk                                23_329   64        4_260  
aggregating losses                          8_173    0.0       324_541
computing risk                              6_827    0.0       324_541
getting assets                              3_539    110       3_851  
EbriskCalculator.run                        2_428    2_146     1      
getting crmodel                             1_263    1.45312   3_851  
getting hazard                              228      0.0       11_496 
```
After
```calc_49065                                  time_sec memory_mb counts 
=========================================== ======== ========= =======
total ebrisk                                16_287   63        4_260  
computing risk                              6_990    0.0       324_541
getting assets                              3_561    110       3_851  
EbriskCalculator.run                        1_718    2_193     1      
getting crmodel                             1_304    1.44922   3_851  
aggregating losses                          1_163    0.0       324_541
getting hazard                              237      0.0       11_496 
```
Note for @raoanirudh : one can get over an order of magnitude speedup simply by reducing the number of concurrent tasks from 1600 (the value that was set in the global risk model file) to 20:
```
calc_49081                                  time_sec memory_mb counts
=========================================== ======== ========= ======
total ebrisk                                1_528    72        51    
computing risk                              1_060    0.0       48_234
EbriskCalculator.run                        250      1_899     1     
getting hazard                              205      0.0       11_496
aggregating losses                          131      0.0       48_234 
getting assets                              40       110       48    
```