### PR TITLE
Do not store the performance view in the database anymore

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -343,12 +343,9 @@ def run_calc(job_id, oqparam, exports, hazard_calculation_id=None, **kw):
                  hazard_calculation_id=hazard_calculation_id, **kw)
         logs.LOG.info('Exposing the outputs to the database')
         expose_outputs(calc.datastore)
-        duration = time.time() - t0
-        records = views.performance_view(calc.datastore, add_calc_id=False)
-        logs.dbcmd('save_performance', job_id, records)
         calc.datastore.close()
         logs.LOG.info('Calculation %d finished correctly in %d seconds',
-                      job_id, duration)
+                      job_id, time.time() - t0)
         logs.dbcmd('finish', job_id, 'complete')
     except BaseException as exc:
         if isinstance(exc, MasterKilled):

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -417,22 +417,6 @@ def get_output(db, output_id):
     return out.ds_key, out.oq_job_id, os.path.dirname(out.ds_calc_dir)
 
 
-def save_performance(db, job_id, records):
-    """
-    Save in the database the performance information about the given job.
-
-    :param db: a :class:`openquake.server.dbapi.Db` instance
-    :param job_id: a job ID
-    :param records: a list of performance records
-    """
-    # NB: rec['counts'] is a numpy.uint64 which is not automatically converted
-    # into an int in Ubuntu 12.04, so we convert it manually below
-    rows = [(job_id, rec['operation'], rec['time_sec'], rec['memory_mb'],
-             int(rec['counts'])) for rec in records]
-    db.insert('performance',
-              'job_id operation time_sec memory_mb counts'.split(), rows)
-
-
 # used in make_report
 def fetch(db, templ, *args):
     """


### PR DESCRIPTION
In 7 years I never needed to look at the db performance info, the reason being that old versions of the engine store different information, so it is difficult/impossible to compare. Also, it is easier to compare the datastores rather than the databases, especially now that we have pandas. Moreover, with larger calculations the speed penalty for storing the information is sensible and it is always there, even if never used. I am not dropping the performance table, though (on purpose).