### PR TITLE
Replaced minimum_loss_fraction with minimum_asset_loss in ebrisk

### DIFF
--- a/demos/risk/EventBasedRisk/job_eb.ini
+++ b/demos/risk/EventBasedRisk/job_eb.ini
@@ -37,6 +37,7 @@ exposure_file = exposure_model.xml
 [risk_calculation]
 asset_hazard_distance = 20
 individual_curves = true
+minimum_asset_loss = {'structural': 1000, 'nonstructural': 1000}
 
 [outputs]
 

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -143,7 +143,6 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         # extract agg_curves with tags
         self.run_calc(case_1.__file__, 'job_eb.ini',
-                      minimum_loss_fraction='0',
                       aggregate_by='policy,taxonomy')
 
         aw = extract(self.calc.datastore, 'agg_curves?kind=stats&'
@@ -301,8 +300,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
     def test_case_master_eb(self):
         self.run_calc(case_master.__file__, 'job.ini',
                       calculation_mode='ebrisk', exports='',
-                      concurrent_tasks='4', aggregate_by='id',
-                      minimum_loss_fraction='0.01')
+                      concurrent_tasks='4', aggregate_by='id')
 
         # tot_losses-rlzs has shape (L=5, R=9)
         # tot_losses-stats has shape (L=5, S=4)
@@ -422,7 +420,7 @@ class EventBasedRiskTestCase(CalculatorTestCase):
     def test_asset_loss_table(self):
         # this is a case with L=1, R=1, T1=2, P=3
         out = self.run_calc(case_6c.__file__, 'job_eb.ini', exports='csv',
-                            minimum_loss_fraction='0.01')
+                            minimum_asset_loss='100')
         [fname] = out['agg_curves-rlzs', 'csv']
         self.assertEqualFiles('expected/agg_curves_eb.csv', fname, delta=1E-5)
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -87,7 +87,7 @@ class OqParam(valid.ParamSet):
         siteclass='reference_siteclass',
         backarc='reference_backarc')
     aggregate_by = valid.Param(valid.namelist, [])
-    minimum_loss_fraction = valid.Param(valid.positivefloat, 0.05)
+    minimum_asset_loss = valid.Param(valid.floatdict, {'default': 0})
     area_source_discretization = valid.Param(
         valid.NoneOr(valid.positivefloat), None)
     asset_correlation = valid.Param(valid.NoneOr(valid.FloatRange(0, 1)), 0)


### PR DESCRIPTION
As requested by @raoanirudh . We should probably also offer an option to set the minimum loss ratio (think of the case of many cheap assets: they would completely cut out by a minimum_asset_loss too small but not by a minimum loss ratio).