### PR TITLE
Removed dbpath argument in oq dbserver

### DIFF
--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -43,8 +43,7 @@ def dbserver(cmd, dbhostport=None, loglevel='INFO', foreground=False):
             print('dbserver already stopped')
     elif cmd == 'start':
         if status == 'not-running':
-            dbs.run_server(os.path.expanduser(config.dbserver.file),
-                           dbhostport, loglevel, foreground)
+            dbs.run_server(dbhostport, loglevel, foreground)
         else:
             print('dbserver already running')
 

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -25,9 +25,7 @@ from openquake.server import dbserver as dbs
 
 
 @sap.script
-def dbserver(cmd, dbhostport=None,
-             dbpath=os.path.expanduser(config.dbserver.file),
-             loglevel='INFO', foreground=False):
+def dbserver(cmd, dbhostport=None, loglevel='INFO', foreground=False):
     """
     start/stop/restart the database server, or return its status
     """
@@ -45,7 +43,8 @@ def dbserver(cmd, dbhostport=None,
             print('dbserver already stopped')
     elif cmd == 'start':
         if status == 'not-running':
-            dbs.run_server(dbpath, dbhostport, loglevel, foreground)
+            dbs.run_server(os.path.expanduser(config.dbserver.file),
+                           dbhostport, loglevel, foreground)
         else:
             print('dbserver already running')
 
@@ -53,6 +52,5 @@ def dbserver(cmd, dbhostport=None,
 dbserver.arg('cmd', 'dbserver command',
              choices='start stop status'.split())
 dbserver.arg('dbhostport', 'dbhost:port')
-dbserver.arg('dbpath', 'dbpath')
 dbserver.opt('loglevel', 'DEBUG|INFO|WARN')
 dbserver.flg('foreground', 'stay in foreground')

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -180,8 +180,7 @@ def ensure_on():
             waiting_seconds -= 1
 
 
-def run_server(dbpath=os.path.expanduser(config.dbserver.file),
-               dbhostport=None, loglevel='WARN', foreground=False):
+def run_server(dbhostport=None, loglevel='WARN', foreground=False):
     """
     Run the DbServer on the given database file and port. If not given,
     use the settings in openquake.cfg.
@@ -196,7 +195,7 @@ def run_server(dbpath=os.path.expanduser(config.dbserver.file),
         addr = (config.dbserver.listen, DBSERVER_PORT)
 
     # create the db directory if needed
-    dirname = os.path.dirname(dbpath)
+    dirname = os.path.dirname(os.path.expanduser(config.dbserver.file))
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 


### PR DESCRIPTION
The `dbpath` argument is misleading because it gives the impression that it can be changed from the command line, but this is not the case. The only way to change the DbServer path is to change the `openquake.cfg `file. See https://github.com/gem/oq-engine/issues/5472.