### PR TITLE
Fixed export input

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Internal: fixed `oq export input -e zip` that was flattening the tree
+    structure of the input files in the exported zip archive
   * Implemented GMFs amplification
   * Introduced the flag `approx_ddd` to support the old algorithm in
     scenario_damage calculations; it is automatically used for exposures

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -420,7 +420,8 @@ class DataStore(collections.abc.MutableMapping):
             if hasattr(v, 'items'):
                 yield from self.retrieve_files(prefix + '/' + k)
             else:
-                yield k, gzip.decompress(bytes(numpy.asarray(v[()])))
+                yield prefix + '/' + k, gzip.decompress(
+                    bytes(numpy.asarray(v[()])))
 
     def get_file(self, key):
         """

--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -96,4 +96,4 @@ class DataStoreTestCase(unittest.TestCase):
         self.dstore.store_files(fnames)
         for name, data in self.dstore.retrieve_files():
             print(name)
-        print(self.dstore.get_file('input/' + name))
+        print(self.dstore.get_file(name))

--- a/openquake/calculators/export/__init__.py
+++ b/openquake/calculators/export/__init__.py
@@ -69,7 +69,7 @@ export.from_db = False  # overridden when exporting from db
 @export.add(('input', 'zip'))
 def export_input_zip(ekey, dstore):
     """
-    Export the data in the `input_zip` dataset as a .zip file
+    Export the data in the `input` datagroup as a .zip file
     """
     dest = dstore.export_path('input.zip')
     with zipfile.ZipFile(


### PR DESCRIPTION
It was flattening the tree structure of the input files in the exported zip archive. Discovered in the disaggregation calculation for Colombia, part of https://github.com/gem/oq-engine/issues/5490.