### PR TITLE
Fix extract in a corner case for which a key exists but its val is None

### DIFF
--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -146,7 +146,7 @@ def array_of_strings_to_bytes(arr, key):
     unchanged in the other cases.
     """
     if arr is None:
-        return []
+        return ()
     if not isinstance(arr, numpy.ndarray) or arr.dtype != numpy.dtype('O'):
         return arr
     if arr.ndim == 1:

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -145,6 +145,8 @@ def array_of_strings_to_bytes(arr, key):
     dimensions or contains non-strings (these are errors). Return `arr`
     unchanged in the other cases.
     """
+    if arr is None:
+        return []
     if not isinstance(arr, numpy.ndarray) or arr.dtype != numpy.dtype('O'):
         return arr
     if arr.ndim == 1:

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -737,8 +737,6 @@ def extract(request, calc_id, what):
                 elif isinstance(val, dict):
                     # this is hack: we are losing the values
                     a[key] = list(val)
-                elif val is None:
-                    a[key] = []
                 else:
                     a[key] = utils.array_of_strings_to_bytes(val, key)
             numpy.savez_compressed(fname, **a)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -737,6 +737,8 @@ def extract(request, calc_id, what):
                 elif isinstance(val, dict):
                     # this is hack: we are losing the values
                     a[key] = list(val)
+                elif val is None:
+                    a[key] = []
                 else:
                     a[key] = utils.array_of_strings_to_bytes(val, key)
             numpy.savez_compressed(fname, **a)


### PR DESCRIPTION
If in the extracted object there is a key for which the value is None, it would still export it with type object. Instead of None, I am using an empty list, and it seems to work correctly (although I am not sure if it is the right thing to do). I instinctively did it this way, because in my failing example I had a 'stats' key with value None, so in that case it was natural to see it as an empty list.