### PR TITLE
Added a limit of 1000 sources when disagg_by_src=true

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a limit of 1000 sources when disagg_by_src=true
   * Fixed random HDF5 bug in disaggregation calculations
   * Internal: fixed `oq export input -e zip` that was flattening the tree
     structure of the input files in the exported zip archive

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -427,6 +427,12 @@ class HazardCalculator(BaseCalculator):
             with self.monitor('composite source model', measuremem=True):
                 self.csm = csm = readinput.get_composite_source_model(
                     oq, self.datastore.hdf5)
+                ns = len(csm.get_sources())
+                if ns > 1000:
+                    j = oq.inputs['job_ini']
+                    raise InvalidFile(
+                        '%s: disagg_by_src can be set only if there are <=1000'
+                        ' sources, but %d were found in the model' % (j, ns))
                 self.csm_info = csm.info
                 self.datastore['source_model_lt'] = csm.source_model_lt
                 res = views.view('dupl_sources', self.datastore)


### PR DESCRIPTION
The way `disagg_by_src` is currently implemented, it cannot manage too many sources (particularly because of HDF5 absurd bugs when there are many datasets with lots of data). The solution is to stop the user early. This happened in the Colombia disaggregation https://github.com/gem/oq-engine/issues/5490.