### PR TITLE
Using openquake.cfg more in zmq

### DIFF
--- a/openquake/baselib/tests/workerpool_test.py
+++ b/openquake/baselib/tests/workerpool_test.py
@@ -36,8 +36,7 @@ class WorkerPoolTestCase(unittest.TestCase):
         hostport = '127.0.0.1', int(cls.z['ctrl_port']) + 1
         if not socket_ready(hostport):
             raise unittest.SkipTest('The task streamer is off')
-        cls.master = WorkerMaster(
-            '127.0.0.1', cls.z['ctrl_port'], host_cores)
+        cls.master = WorkerMaster(cls.z['ctrl_port'], host_cores)
         cls.master.start()
 
     def test(self):

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -56,7 +56,7 @@ class WorkerMaster(object):
     def __init__(self, ctrl_port, host_cores=None,
                  remote_python=None, receiver_ports=None):
         # NB: receiver_ports is not used but needed for compliance
-        self.master_host = config.dbserver.listen
+        self.master_host = config.dbserver.host
         self.ctrl_port = int(ctrl_port)
         self.host_cores = ([hc.split() for hc in host_cores.split(',')]
                            if host_cores else [])

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -19,11 +19,11 @@ class TimeoutError(RuntimeError):
     pass
 
 
-def _streamer(host):
+def _streamer():
     # streamer for zmq workers
     port = int(config.zworkers.ctrl_port)
     task_input_url = 'tcp://127.0.0.1:%d' % (port + 2)
-    task_server_url = 'tcp://%s:%s' % (host, port + 1)
+    task_server_url = 'tcp://%s:%s' % (config.dbserver.listen, port + 1)
     try:
         z.zmq.proxy(z.bind(task_input_url, z.zmq.PULL),
                     z.bind(task_server_url, z.zmq.PUSH))
@@ -36,9 +36,8 @@ def check_status(**kw):
     :returns: a non-empty error string if the streamer or worker pools are down
     """
     c = config.zworkers.copy()
-    c['master_host'] = config.dbserver.listen
     c.update(kw)
-    hostport = c['master_host'], int(c['ctrl_port']) + 1
+    hostport = config.dbserver.listen, int(c['ctrl_port']) + 1
     errors = []
     if not general.socket_ready(hostport):
         errors.append('The task streamer on %s:%s is down' % hostport)
@@ -50,21 +49,20 @@ def check_status(**kw):
 
 class WorkerMaster(object):
     """
-    :param master_host: hostname or IP of the master node
     :param ctrl_port: port on which the worker pools listen
     :param host_cores: names of the remote hosts and number of cores to use
     :param remote_python: path of the Python executable on the remote hosts
     """
-    def __init__(self, master_host, ctrl_port, host_cores=None,
+    def __init__(self, ctrl_port, host_cores=None,
                  remote_python=None, receiver_ports=None):
         # NB: receiver_ports is not used but needed for compliance
-        self.master_host = master_host
+        self.master_host = config.dbserver.listen
         self.ctrl_port = int(ctrl_port)
         self.host_cores = ([hc.split() for hc in host_cores.split(',')]
                            if host_cores else [])
         self.remote_python = remote_python or sys.executable
         self.task_server_url = 'tcp://%s:%d' % (
-            master_host, self.ctrl_port + 1)
+            self.master_host, self.ctrl_port + 1)
         self.popens = []
 
     def wait(self, seconds=30):
@@ -262,5 +260,6 @@ class WorkerPool(object):
 
 if __name__ == '__main__':
     # start a workerpool without a streamer
-    ctrl_url, task_server_url, num_workers = sys.argv[1:]
-    WorkerPool(ctrl_url, task_server_url, num_workers).start()
+    worker_url, master_url, num_workers = sys.argv[1:]
+    # in Dockerfile.worker: tcp://0.0.0.0:1909 tcp://master:1910 -1
+    WorkerPool(worker_url, master_url, num_workers).start()

--- a/openquake/commands/workers.py
+++ b/openquake/commands/workers.py
@@ -33,8 +33,7 @@ def workers(cmd):
             getpass.getuser() != 'openquake'):
         sys.exit('oq workers only works in single user mode')
 
-    master = workerpool.WorkerMaster(config.dbserver.host,
-                                     **config.zworkers)
+    master = workerpool.WorkerMaster(**config.zworkers)
     pprint(getattr(master, cmd)())
 
 

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -52,13 +52,12 @@ class DbServer(object):
     """
     def __init__(self, db, address, num_workers=5):
         self.db = db
-        self.master_host = address[0]
         self.frontend = 'tcp://%s:%s' % address
         self.backend = 'inproc://dbworkers'
         self.num_workers = num_workers
         self.pid = os.getpid()
         if ZMQ:
-            self.zmaster = w.WorkerMaster(address[0], **config.zworkers)
+            self.zmaster = w.WorkerMaster(**config.zworkers)
         else:
             self.zmaster = None
 
@@ -99,9 +98,7 @@ class DbServer(object):
         if ZMQ:
             # start task_in->task_server streamer thread
             c = config.zworkers
-            threading.Thread(
-                target=w._streamer, args=(self.master_host,), daemon=True
-            ).start()
+            threading.Thread(target=w._streamer, daemon=True).start()
             logging.warning('Task streamer started on port %d',
                             int(c.ctrl_port) + 1)
         # start frontend->backend proxy for the database workers


### PR DESCRIPTION
No need to pass the master url everywhere since it is already in the configuration file.