### PR TITLE
Made the calc_id parameter mandatory when instantiating a calculator

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -151,7 +151,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
     from_engine = False  # set by engine.run_calc
     is_stochastic = False  # True for scenario and event based calculators
 
-    def __init__(self, oqparam, calc_id=None):
+    def __init__(self, oqparam, calc_id):
         self.datastore = datastore.DataStore(calc_id)
         init_performance(self.datastore.hdf5)
         self._monitor = Monitor(

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -30,7 +30,7 @@ import numpy
 from openquake.calculators import base
 from openquake.calculators.export import export
 from openquake.baselib import datastore, general, parallel
-from openquake.commonlib import readinput, oqvalidation, writers
+from openquake.commonlib import readinput, oqvalidation, writers, logs
 
 
 NOT_DARWIN = sys.platform != 'darwin'
@@ -121,7 +121,7 @@ class CalculatorTestCase(unittest.TestCase):
         oq = oqvalidation.OqParam(**params)
         oq.validate()
         # change this when debugging the test
-        return base.calculators(oq)
+        return base.calculators(oq, logs.init())
 
     def run_calc(self, testfile, job_ini, **kw):
         """

--- a/openquake/commands/check_input.py
+++ b/openquake/commands/check_input.py
@@ -19,7 +19,7 @@ import sys
 import logging
 from openquake.baselib import sap
 from openquake.risklib.asset import Exposure
-from openquake.commonlib import readinput
+from openquake.commonlib import readinput, logs
 from openquake.calculators import base
 from openquake.hazardlib import nrml
 from openquake.risklib import read_nrml  # this is necessary
@@ -41,7 +41,7 @@ def check_input(job_ini_or_zip_or_nrmls):
                 sys.exit(exc)
         else:
             oq = readinput.get_oqparam(job_ini_or_zip_or_nrml)
-            base.calculators(oq, calc_id=None).read_inputs()
+            base.calculators(oq, logs.init()).read_inputs()
 
 
 check_input.arg('job_ini_or_zip_or_nrmls', 'Check the input', nargs='+')

--- a/openquake/commands/check_input.py
+++ b/openquake/commands/check_input.py
@@ -40,8 +40,8 @@ def check_input(job_ini_or_zip_or_nrmls):
             except Exception as exc:
                 sys.exit(exc)
         else:
-            base.calculators(readinput.get_oqparam(
-                job_ini_or_zip_or_nrml)).read_inputs()
+            oq = readinput.get_oqparam(job_ini_or_zip_or_nrml)
+            base.calculators(oq, calc_id=None).read_inputs()
 
 
 check_input.arg('job_ini_or_zip_or_nrmls', 'Check the input', nargs='+')

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -314,7 +314,8 @@ def validate_zip(request):
         return HttpResponseBadRequest('Missing archive file')
     job_zip = archive.temporary_file_path()
     try:
-        base.calculators(readinput.get_oqparam(job_zip)).read_inputs()
+        oq = readinput.get_oqparam(job_zip)
+        base.calculators(oq, calc_id=None).read_inputs()
     except Exception as exc:
         return _make_response(str(exc), None, valid=False)
     else:


### PR DESCRIPTION
This is pedagogical: it forces people to call `logs.init()` before instantiating a calculator.