### PR TITLE
Fixed extract_sources

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -497,8 +497,10 @@ def extract_sources(dstore, what):
         raise ValueError('There is no source model #%d' % sm_id)
     wkt_gz = gzip.compress(';'.join(info['wkt']).encode('utf8'))
     src_gz = gzip.compress(';'.join(info['source_id']).encode('utf8'))
-    arr = info[['grp_id', 'code', 'num_ruptures', 'calc_time', 'num_sites',
-                'eff_ruptures']]
+    oknames = [n for n in info.dtype.names if n not in ('source_id', 'wkt')]
+    arr = numpy.zeros(len(info), [(n, info.dtype[n]) for n in oknames])
+    for n in oknames:
+        arr[n] = info[n]
     return ArrayWrapper(
         arr, {'sm_id': sm_id, 'wkt_gz': wkt_gz, 'src_gz': src_gz})
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -28,7 +28,7 @@ import requests
 from h5py._hl.dataset import Dataset
 from h5py._hl.group import Group
 import numpy
-from openquake.baselib import config, hdf5
+from openquake.baselib import config, hdf5, general
 from openquake.baselib.hdf5 import ArrayWrapper
 from openquake.baselib.general import group_array, println
 from openquake.baselib.python3compat import encode, decode
@@ -1325,6 +1325,7 @@ class WebExtractor(Extractor):
         resp = self.sess.get(url)
         if resp.status_code != 200:
             raise WebAPIError(resp.text)
+        logging.info('Read %s of data' % general.humansize(len(resp.content)))
         npz = numpy.load(io.BytesIO(resp.content))
         attrs = {k: npz[k] for k in npz if k != 'array'}
         try:

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -222,6 +222,12 @@ class EngineServerTestCase(unittest.TestCase):
         got = loadnpz(self.c.get(extract_url))
         self.assertEqual(len(got['rlz-000']), 0)
 
+        # check extract_sources
+        extract_url = '/v1/calc/%s/extract/sources?sm_id=0' % job_id
+        got = loadnpz(self.c.get(extract_url))
+        self.assertEqual(list(got), ['sm_id', 'wkt_gz', 'src_gz', 'array'])
+        self.assertGreater(len(got['array']), 0)
+
     def test_classical(self):
         job_id = self.postzip('classical.zip')
         self.wait()


### PR DESCRIPTION
We were getting errors like this one:
```
      data = _read_bytes(fp, read_size, "array data")
    File "/home/michele/py38/lib/python3.8/site-packages/numpy/lib/format.py", line 873, in _read_bytes
      raise ValueError(msg % (error_template, size, len(data)))
   ValueError: EOF: reading array data, expected 205410 bytes got 185990
```
The issue was that `info[['grp_id', 'code', 'num_ruptures', 'calc_time', ...]]` is not a proper array (even if it looks like one) and numpy is not able to serialize it in npz format properly. The solution was to create an array ex-novo.