### PR TITLE
Add extract_sitecol, returning the sitecol array

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -386,6 +386,16 @@ def extract_hcurves(dstore, what):
     yield from params.items()
 
 
+@extract.add('sitecol')
+def extract_sitecol(dstore, what):
+    """
+    Extracts the site collection array (not the complete object, otherwise it
+    would need to be pickled).
+    Use it as /extract/sitecol
+    """
+    return dstore['sitecol'].array
+
+
 @extract.add('hmaps')
 def extract_hmaps(dstore, what):
     """

--- a/openquake/commands/show.py
+++ b/openquake/commands/show.py
@@ -68,8 +68,8 @@ def show(what='contents', calc_id=-1, extra=()):
         print(view(what, ds))
     elif what.split('/', 1)[0] in extract:
         obj = extract(ds, what, *extra)
-        if hasattr(obj, 'array'):
-            print(obj.array)
+        if hasattr(obj, 'dtype') and obj.dtype.names:
+            print(write_csv(io.BytesIO(), obj).decode('utf8'))
         else:
             print(obj)
     elif what in ds:

--- a/openquake/commands/show.py
+++ b/openquake/commands/show.py
@@ -67,7 +67,11 @@ def show(what='contents', calc_id=-1, extra=()):
     if view.keyfunc(what) in view:
         print(view(what, ds))
     elif what.split('/', 1)[0] in extract:
-        print(extract(ds, what, *extra))
+        obj = extract(ds, what, *extra)
+        if hasattr(obj, 'array'):
+            print(obj.array)
+        else:
+            print(obj)
     elif what in ds:
         obj = ds.getitem(what)
         if hasattr(obj, 'items'):  # is a group of datasets

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -226,7 +226,8 @@ class RunShowExportTestCase(unittest.TestCase):
 
         with Print.patch() as p:
             show('sitecol', self.calc_id)
-        self.assertEqual(str(p), '[(0, 0., 0., -0.1, 800.,  True)]')
+        self.assertEqual(str(p), 'sids,lon,lat,depth,vs30,vs30measured\n'
+                         '0,0.00000,0.00000,-0.10000,8.000000E+02,1')
 
         with Print.patch() as p:
             show('slow_sources', self.calc_id)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -226,8 +226,7 @@ class RunShowExportTestCase(unittest.TestCase):
 
         with Print.patch() as p:
             show('sitecol', self.calc_id)
-        self.assertEqual(str(p), 'sids,lon,lat,depth,vs30,vs30measured\n'
-                         '0,0.00000,0.00000,-0.10000,8.000000E+02,1')
+        self.assertEqual(str(p), '[(0, 0., 0., -0.1, 800.,  True)]')
 
         with Print.patch() as p:
             show('slow_sources', self.calc_id)


### PR DESCRIPTION
Without this explicit extractor, the full sitecol object would be retrieved implicitly, and it would be pickled.
Part of https://github.com/gem/oq-engine/issues/5487.