### PR TITLE
Export

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Robin Gee]
+  * Change the header of the exported sigma_epsilon_XX.csv file to indicate 
+  that values correspond to inter event sigma
+
   [Graeme Weatherill]
   * Enhances SERA adaptation of the Abrahamson et al. (2015) `BC Hydro` GMPE to
     add in a configurable smoothed tapering term on the forearc/backarc scaling

--- a/doc/implementing-new-gsim.md
+++ b/doc/implementing-new-gsim.md
@@ -10,6 +10,8 @@ https://help.github.com/articles/fork-a-repo
 - Implement the new GMPE using as an example of a GMPE already in the oq-engine whose functional form is similar to the new GMPE.
 https://github.com/gem/oq-engine/tree/master/openquake/hazardlib/gsim
 
+- Acceleration should be returned in units of g, and standard deviation values in natural logarithm. If this is not consistent with the original GMPE, then a conversion needs to be made.
+
 - Create verification tables following the examples that you find here:
 https://github.com/gem/oq-engine/tree/master/openquake/hazardlib/tests/gsim/data
 Usually we create verification tables using an independent code provided by the original authors of the new GMPE. If this is not possible - if available - we use an independent implementation available within code accessible on the web. If verification tables are missing this must be clearly stated as in this example https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/gsim/raghukanth_iyengar_2007.py#L119

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -62,9 +62,9 @@ def sig_eps_dt(imts):
     """
     lst = [('eid', U32), ('rlz_id', U16)]
     for imt in imts:
-        lst.append(('sig_' + imt, F32))
+        lst.append(('sig_inter_' + imt, F32))
     for imt in imts:
-        lst.append(('eps_' + imt, F32))
+        lst.append(('eps_inter_' + imt, F32))
     return numpy.dtype(lst)
 
 

--- a/openquake/qa_tests_data/event_based/blocksize/expected/sig-eps.csv
+++ b/openquake/qa_tests_data/event_based/blocksize/expected/sig-eps.csv
@@ -1,4 +1,4 @@
-event_id,rlz_id,sig_PGA,eps_PGA
+event_id,rlz_id,sig_inter_PGA,eps_inter_PGA
 0,0,2.929506E-01,1.021841E+00
 1,0,3.336481E-01,1.102556E+00
 2,0,3.136589E-01,1.182088E+00

--- a/openquake/qa_tests_data/event_based/case_2/expected/sig-eps.csv
+++ b/openquake/qa_tests_data/event_based/case_2/expected/sig-eps.csv
@@ -1,2 +1,2 @@
-event_id,rlz_id,sig_PGA,eps_PGA
+event_id,rlz_id,sig_inter_PGA,eps_inter_PGA
 0,0,0.000000E+00,0.000000E+00


### PR DESCRIPTION
Looking at the sigma_epsilon_XX.csv file computed from a scenario or evt-based calculation, it was not clear what values were being exported. This PR changed the headers to indicate that the values correspond to inter event sigma. I also add a sentence to implementing-new-gsim.md to clarify the units.