### PR TITLE
Added a check against negative number of cores in openquake.cfg

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check against negative number of cores in openquake.cfg
   * Raised a clear error message if the enlarged bounding box of the sources
     does not contain any site or if it is larger than half the globe
 

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -7,7 +7,8 @@ import tempfile
 import subprocess
 import multiprocessing
 import psutil
-from openquake.baselib import zeromq as z, general, parallel, config, sap
+from openquake.baselib import (
+    zeromq as z, general, parallel, config, sap, InvalidFile)
 try:
     from setproctitle import setproctitle
 except ImportError:
@@ -59,6 +60,10 @@ class WorkerMaster(object):
         self.ctrl_port = int(ctrl_port)
         self.host_cores = ([hc.split() for hc in host_cores.split(',')]
                            if host_cores else [])
+        for host, cores in self.host_cores:
+            if int(cores) < -1:
+                raise InvalidFile('openquake.cfg: found %s %s' %
+                                  (host, cores))
         self.remote_python = remote_python or sys.executable
         self.popens = []
 


### PR DESCRIPTION
Our users managed to do that. The only valid negative number is `-1` meaning all cores.