### PR TITLE
Added an option `--calc-id` to `oq run`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Internal: added an option `--calc-id` to `oq run`
   * Added a check against negative number of cores in openquake.cfg
   * Raised a clear error message if the enlarged bounding box of the sources
     does not contain any site or if it is larger than half the globe

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -40,7 +40,7 @@ from openquake.risklib import riskinput, riskmodels
 from openquake.commonlib import readinput, logictree, source, calc, util
 from openquake.calculators.ucerf_base import UcerfFilter
 from openquake.calculators.export import export as exp
-from openquake.calculators import getters, views
+from openquake.calculators import getters
 
 get_taxonomy = operator.attrgetter('taxonomy')
 get_weight = operator.attrgetter('weight')

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -90,11 +90,12 @@ def run2(job_haz, job_risk, calc_id, concurrent_tasks, pdb, loglevel,
 
 
 # run with processpool unless OQ_DISTRIBUTE is set to something else
-def _run(job_inis, concurrent_tasks, pdb, loglevel, hc, exports, params):
+def _run(job_inis, concurrent_tasks, calc_id, pdb, loglevel, hc, exports,
+         params):
     global calc_path
     assert len(job_inis) in (1, 2), job_inis
     # set the logs first of all
-    calc_id = logs.init(level=getattr(logging, loglevel.upper()))
+    calc_id = logs.init(calc_id, getattr(logging, loglevel.upper()))
     # disable gzip_input
     base.BaseCalculator.gzip_inputs = lambda self: None
     with performance.Monitor('total runtime', measuremem=True) as monitor:
@@ -135,7 +136,7 @@ def _run(job_inis, concurrent_tasks, pdb, loglevel, hc, exports, params):
 
 @sap.script
 def run(job_ini, slowest=False, hc=None, param='', concurrent_tasks=None,
-        exports='', loglevel='info', pdb=None):
+        exports='', loglevel='info', calc_id='nojob', pdb=None):
     """
     Run a calculation bypassing the database layer
     """
@@ -156,7 +157,7 @@ def run(job_ini, slowest=False, hc=None, param='', concurrent_tasks=None,
         print(get_pstats(pstat, slowest))
         return
     try:
-        return _run(job_ini, concurrent_tasks, pdb, loglevel,
+        return _run(job_ini, concurrent_tasks, calc_id, pdb, loglevel,
                     hc, exports, params)
     finally:
         parallel.Starmap.shutdown()
@@ -173,4 +174,5 @@ run.opt('exports', 'export formats as a comma-separated string',
         type=valid.export_formats)
 run.opt('loglevel', 'logging level',
         choices='debug info warn error critical'.split())
+run.opt('calc_id', 'calculation ID (if "nojob" infer it)', type=int)
 run.flg('pdb', 'enable post mortem debugging', '-d')

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -213,7 +213,7 @@ class RunShowExportTestCase(unittest.TestCase):
         """
         job_ini = os.path.join(os.path.dirname(case_1.__file__), 'job.ini')
         with Print.patch() as cls.p:
-            calc = run._run([job_ini], 0, False, 'info', None, '', {})
+            calc = run._run([job_ini], 0, 'nojob', False, 'info', None, '', {})
         cls.calc_id = calc.datastore.calc_id
 
     def test_run_calc(self):

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -161,7 +161,9 @@ def init(calc_id='nojob', level=logging.INFO):
     elif calc_id == 'nojob':  # produce a calc_id without creating a job
         calc_id = datastore.get_last_calc_id() + 1
     else:
-        assert isinstance(calc_id, int), calc_id
+        path = os.path.join(datastore.get_datadir(), 'calc_%d.hdf5' % calc_id)
+        if os.path.exists(path):
+            raise OSError('%s already exists' % path)
     fmt = '[%(asctime)s #{} %(levelname)s] %(message)s'.format(calc_id)
     for handler in logging.root.handlers:
         f = logging.Formatter(fmt, datefmt='%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
Solves the issue described in https://github.com/gem/oq-engine/pull/5476 and now engine calculations can be trivially parallelized, provided the calculation IDs are passed in advance and available:
```bash
for i in {1..5}; do oq run ScenarioCase1/job.ini --calc-id=$i & done
```