### PR TITLE
Add a note about api rate limit in check_obsolete_version

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -411,6 +411,14 @@ def check_obsolete_version(calculation_mode='WebUI'):
         current = version_triple(__version__)
         latest = version_triple(tag_name)
     except Exception:  # page not available or wrong version tag
+        # NOTE: for unauthenticated requests, the rate limit allows for up
+        # to 60 requests per hour. Therefore, sometimes the api returns the
+        # following message:
+        # b'{"message":"API rate limit exceeded for aaa.aaa.aaa.aaa. (But'
+        # ' here\'s the good news: Authenticated requests get a higher rate'
+        # ' limit. Check out the documentation for more details.)",'
+        # ' "documentation_url":'
+        # ' "https://developer.github.com/v3/#rate-limiting"}'
         return
     if current < latest:
         return ('Version %s of the engine is available, but you are '

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -419,6 +419,12 @@ def check_obsolete_version(calculation_mode='WebUI'):
         # ' limit. Check out the documentation for more details.)",'
         # ' "documentation_url":'
         # ' "https://developer.github.com/v3/#rate-limiting"}'
+        msg = ('An error occurred while calling %s/engine/latest to check'
+               'if the installed version of the engine is up to date.' %
+               OQ_API)
+        if data:
+            msg += '\n' + data.decode('utf8')
+        logging.warning(msg, exc_info=True)
         return
     if current < latest:
         return ('Version %s of the engine is available, but you are '

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -424,7 +424,7 @@ def check_obsolete_version(calculation_mode='WebUI'):
                OQ_API)
         if data:
             msg += '\n' + data.decode('utf8')
-        logging.warning(msg, exc_info=True)
+        logging.warning(msg)
         return
     if current < latest:
         return ('Version %s of the engine is available, but you are '


### PR DESCRIPTION
When the rate limit is exceeded, the warning about the availability of a newer version of the engine is not displayed.