### PR TITLE
Fixed case_global_eb

### DIFF
--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -449,9 +449,9 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/hazard_curve-rlz-000-PGA.csv', f0)
         self.assertEqualFiles('expected/hazard_curve-rlz-001-PGA.csv', f1)
 
-        # check number of groups, must be 2
+        # check number of groups
         n = len(self.calc.datastore['csm_info/sg_data'])
-        self.assertEqual(n, 2)
+        self.assertEqual(n, 3)
 
     def test_overflow(self):
         too_many_imts = {'SA(%s)' % period: [0.1, 0.2, 0.3]

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -267,6 +267,7 @@ def get_ltmodels(oq, gsim_lt, source_model_lt, h5=None):
     return _store_results(smap, lt_models, source_model_lt, gsim_lt, oq, h5)
 
 
+# NB: using this breaks case_global_eb
 def merge_groups(groups):
     """
     :param groups:
@@ -312,7 +313,7 @@ def _store_results(smap, lt_models, source_model_lt, gsim_lt, oq, h5):
     # global checks
     grp_id = 0
     for ltm in lt_models:
-        for grp in merge_groups(groups[ltm.ordinal]):
+        for grp in groups[ltm.ordinal]:
             grp.id = grp_id
             for src in grp:
                 src.src_group_id = grp_id


### PR DESCRIPTION
Fixes https://gitlab.openquake.org/openquake/oq-risk-tests/-/jobs/15428, it was a regression introduced by the addition of `merge_groups`. Part of https://github.com/gem/oq-engine/issues/5517.