### PR TITLE
Remove csm_info/sg_data

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -411,7 +411,7 @@ class ClassicalCalculator(base.HazardCalculator):
             a dictionary grp_id -> hazard curves
         """
         oq = self.oqparam
-        trt_by_grp = self.csm_info.grp_by_trt()
+        trt_by_grp = self.csm_info.trt_by_grp
         data = []
         with self.monitor('saving probability maps'):
             for grp_id, pmap in pmap_by_grp_id.items():

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -411,7 +411,7 @@ class ClassicalCalculator(base.HazardCalculator):
             a dictionary grp_id -> hazard curves
         """
         oq = self.oqparam
-        trt_by_grp = self.csm_info.grp_by("trt")
+        trt_by_grp = self.csm_info.grp_by_trt()
         grp_name = {grp.id: grp.name for sm in self.csm_info.source_models
                     for grp in sm.src_groups}
         data = []

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -42,7 +42,7 @@ F32 = numpy.float32
 F64 = numpy.float64
 MINWEIGHT = 1000
 weight = operator.attrgetter('weight')
-grp_extreme_dt = numpy.dtype([('grp_id', U16), ('grp_name', hdf5.vstr),
+grp_extreme_dt = numpy.dtype([('grp_id', U16), ('grp_trt', hdf5.vstr),
                              ('extreme_poe', F32)])
 
 
@@ -412,8 +412,6 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         oq = self.oqparam
         trt_by_grp = self.csm_info.grp_by_trt()
-        grp_name = {grp.id: grp.name for sm in self.csm_info.source_models
-                    for grp in sm.src_groups}
         data = []
         with self.monitor('saving probability maps'):
             for grp_id, pmap in pmap_by_grp_id.items():
@@ -426,7 +424,7 @@ class ClassicalCalculator(base.HazardCalculator):
                     extreme = max(
                         get_extreme_poe(pmap[sid].array, oq.imtls)
                         for sid in pmap)
-                    data.append((grp_id, grp_name[grp_id], extreme))
+                    data.append((grp_id, trt_by_grp[grp_id], extreme))
         if oq.hazard_calculation_id is None and 'poes' in self.datastore:
             self.datastore['disagg_by_grp'] = numpy.array(
                 sorted(data), grp_extreme_dt)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -88,7 +88,7 @@ class EventBasedCalculator(base.HazardCalculator):
             self.rupser = calc.RuptureSerializer(self.datastore)
 
     def init_logic_tree(self, csm_info):
-        self.trt_by_grp = csm_info.grp_by_trt()
+        self.trt_by_grp = csm_info.trt_by_grp
         self.rlzs_assoc = csm_info.get_rlzs_assoc()
         self.rlzs_by_gsim_grp = csm_info.get_rlzs_by_gsim_grp()
         self.samples_by_grp = csm_info.get_samples_by_grp()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -88,7 +88,7 @@ class EventBasedCalculator(base.HazardCalculator):
             self.rupser = calc.RuptureSerializer(self.datastore)
 
     def init_logic_tree(self, csm_info):
-        self.trt_by_grp = csm_info.grp_by("trt")
+        self.trt_by_grp = csm_info.grp_by_trt()
         self.rlzs_assoc = csm_info.get_rlzs_assoc()
         self.rlzs_by_gsim_grp = csm_info.get_rlzs_by_gsim_grp()
         self.samples_by_grp = csm_info.get_samples_by_grp()

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -457,7 +457,7 @@ def gen_rgetters(dstore, slc=slice(None)):
     :yields: unfiltered RuptureGetters
     """
     csm_info = dstore['csm_info']
-    trt_by_grp = csm_info.grp_by("trt")
+    trt_by_grp = csm_info.grp_by_trt()
     samples = csm_info.get_samples_by_grp()
     rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]
@@ -485,7 +485,7 @@ def gen_rupture_getters(dstore, srcfilter, slc=slice(None)):
     :yields: filtered RuptureGetters
     """
     csm_info = dstore['csm_info']
-    trt_by_grp = csm_info.grp_by("trt")
+    trt_by_grp = csm_info.grp_by_trt()
     samples = csm_info.get_samples_by_grp()
     rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -464,7 +464,7 @@ def gen_rgetters(dstore, slc=slice(None)):
     ct = dstore['oqparam'].concurrent_tasks or 1
     nr = len(dstore['ruptures'])
     for grp_id, arr in general.group_array(rup_array, 'grp_id').items():
-        if not rlzs_by_gsim[grp_id]:  # the model has no sources
+        if not rlzs_by_gsim.get(grp_id, []):  # the model has no sources
             continue
         for block in general.split_in_blocks(arr, len(arr) / nr * ct):
             rgetter = RuptureGetter(

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -457,7 +457,7 @@ def gen_rgetters(dstore, slc=slice(None)):
     :yields: unfiltered RuptureGetters
     """
     csm_info = dstore['csm_info']
-    trt_by_grp = csm_info.grp_by_trt()
+    trt_by_grp = csm_info.trt_by_grp
     samples = csm_info.get_samples_by_grp()
     rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]
@@ -485,7 +485,7 @@ def gen_rupture_getters(dstore, srcfilter, slc=slice(None)):
     :yields: filtered RuptureGetters
     """
     csm_info = dstore['csm_info']
-    trt_by_grp = csm_info.grp_by_trt()
+    trt_by_grp = csm_info.trt_by_grp
     samples = csm_info.get_samples_by_grp()
     rlzs_by_gsim = csm_info.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -261,11 +261,12 @@ hazard_uhs-std.csv
         cinfo = self.calc.datastore['csm_info']
         ra0 = cinfo.get_rlzs_assoc()
         self.assertEqual(
-            sorted(ra0.by_grp()), ['grp-00', 'grp-01', 'grp-02', 'grp-03'])
+            sorted(ra0.by_grp()),
+            ['grp-00', 'grp-01', 'grp-02', 'grp-03', 'grp-04', 'grp-05'])
 
         # reduction of the source model logic tree
         ra = cinfo.get_rlzs_assoc(sm_lt_path=['SM2', 'a3b1'])
-        self.assertEqual(len(ra.by_grp()), 1)
+        self.assertEqual(len(ra.by_grp()), 2)
         numpy.testing.assert_equal(
             len(ra.by_grp()['grp-01']),
             len(ra0.by_grp()['grp-00']))
@@ -288,8 +289,9 @@ hazard_uhs-std.csv
 
         # not reducing the gsim logic tree
         ra = cinfo.get_rlzs_assoc(trts=['Stable Continental Crust'])
-        self.assertEqual(sorted(ra.by_grp()),
-                         ['grp-00', 'grp-01', 'grp-02', 'grp-03'])
+        self.assertEqual(
+            sorted(ra.by_grp()),
+            ['grp-00', 'grp-01', 'grp-02', 'grp-03', 'grp-04', 'grp-05'])
         numpy.testing.assert_equal(ra.by_grp()['grp-00'], [[0, 1], [2, 3]])
 
         # check deserialization of source_model_lt

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -61,10 +61,11 @@ class DisaggregationTestCase(CalculatorTestCase):
             fmt='csv')
 
         # check disagg_by_src, poe=0.02, 0.1, imt=PGA, SA(0.025)
-        self.assertEqual(len(out['disagg_by_src', 'csv']), 4)
-        for fname in out['disagg_by_src', 'csv']:
-            self.assertEqualFiles('expected_output/%s' % strip_calc_id(fname),
-                                  fname)
+        
+        #self.assertEqual(len(out['disagg_by_src', 'csv']), 4)
+        #for fname in out['disagg_by_src', 'csv']:
+        #    self.assertEqualFiles('expected_output/%s' % strip_calc_id(fname),
+        #                          fname)
 
         # disaggregation by source group
         rlzs_assoc = self.calc.datastore['csm_info'].get_rlzs_assoc()
@@ -166,5 +167,4 @@ class DisaggregationTestCase(CalculatorTestCase):
                                        'poe-0.05-SA(0.25)-sid-1'])
         arr = dbs['poe-0.01-PGA-sid-0'][()]
         numpy.testing.assert_almost_equal(
-            arr, [0.00000000e+00, 0.00000000e+00,
-                  5.38093847e-05, 9.94706034e-03])
+            arr, [0, 5.38093847e-05, 0, 9.94706034e-03])

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -449,10 +449,6 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/hazard_curve-rlz-000-PGA.csv', f0)
         self.assertEqualFiles('expected/hazard_curve-rlz-001-PGA.csv', f1)
 
-        # check number of groups
-        n = len(self.calc.datastore['csm_info/sg_data'])
-        self.assertEqual(n, 3)
-
     def test_overflow(self):
         too_many_imts = {'SA(%s)' % period: [0.1, 0.2, 0.3]
                          for period in numpy.arange(0.1,  1, 0.001)}

--- a/openquake/calculators/tests/gmf_ebrisk_test.py
+++ b/openquake/calculators/tests/gmf_ebrisk_test.py
@@ -31,12 +31,11 @@ aae = numpy.testing.assert_almost_equal
 
 
 def check_csm_info(calc1, calc2):
-    data1 = (calc1['csm_info/sg_data'][()], calc1['csm_info/sm_data'][()])
-    data2 = (calc2['csm_info/sg_data'][()], calc2['csm_info/sm_data'][()])
-    for val1, val2 in zip(data1, data2):
-        for name in val1.dtype.names:
-            if name not in ('name', 'path'):  # avoid comparing strings
-                aae(val1[name], val2[name])
+    val1 = calc1['csm_info/sm_data'][()]
+    val2 = calc2['csm_info/sm_data'][()]
+    for name in val1.dtype.names:
+        if name not in ('name', 'path'):  # avoid comparing strings
+            aae(val1[name], val2[name])
 
 
 class GmfEbRiskTestCase(CalculatorTestCase):

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -517,7 +517,7 @@ def view_required_params_per_trt(token, dstore):
     """
     csm_info = dstore['csm_info']
     tbl = []
-    for grp_id, trt in sorted(csm_info.grp_by("trt").items()):
+    for grp_id, trt in sorted(csm_info.grp_by_trt().items()):
         gsims = csm_info.gsim_lt.get_gsims(trt)
         maker = ContextMaker(trt, gsims)
         distances = sorted(maker.REQUIRES_DISTANCES)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -517,7 +517,7 @@ def view_required_params_per_trt(token, dstore):
     """
     csm_info = dstore['csm_info']
     tbl = []
-    for grp_id, trt in sorted(csm_info.grp_by_trt().items()):
+    for grp_id, trt in sorted(csm_info.trt_by_grp.items()):
         gsims = csm_info.gsim_lt.get_gsims(trt)
         maker = ContextMaker(trt, gsims)
         distances = sorted(maker.REQUIRES_DISTANCES)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -78,7 +78,7 @@ class Print(object):
 
 class InfoTestCase(unittest.TestCase):
     EXPECTED = '''<CompositionInfo
-b1, x15.xml, grp=[0], weight=1.0: 1 realization(s)>
+b1, x15.xml, weight=1.0: 1 realization(s)>
 See http://docs.openquake.org/oq-engine/stable/effective-realizations.html for an explanation
 <RlzsAssoc(size=1, rlzs=1)>'''
 

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -77,11 +77,13 @@ Realization = namedtuple('Realization', 'value weight ordinal lt_path samples')
 Realization.pid = property(lambda self: '_'.join(self.lt_path))  # path ID
 
 rlz_dt = numpy.dtype([
-    ('ordinal', numpy.uint16),
+    ('ordinal', numpy.uint32),
     ('lt_path', hdf5.vstr),
     ('weight', numpy.float64),
     ('value', hdf5.vstr),
-    ('samples', numpy.uint16),
+    ('samples', numpy.uint32),
+    ('seed', numpy.uint32),
+    ('offset', numpy.uint32),
 ])
 
 
@@ -1105,9 +1107,12 @@ class SourceModelLogicTree(object):
         """
         rlzs = get_effective_rlzs(self)
         arr = numpy.zeros(len(rlzs), rlz_dt)
+        offset = 0
         for rlz in rlzs:
             arr[rlz.ordinal] = (rlz.ordinal, rlz.lt_path, rlz.weight,
-                                rlz.value, rlz.samples)
+                                rlz.value, rlz.samples,
+                                self.seed + rlz.ordinal, offset)
+            offset += rlz.samples
         return arr
 
     def get_trti_eri(self):

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -82,7 +82,6 @@ rlz_dt = numpy.dtype([
     ('weight', numpy.float64),
     ('value', hdf5.vstr),
     ('samples', numpy.uint32),
-    ('seed', numpy.uint32),
     ('offset', numpy.uint32),
 ])
 
@@ -1110,8 +1109,7 @@ class SourceModelLogicTree(object):
         offset = 0
         for rlz in rlzs:
             arr[rlz.ordinal] = (rlz.ordinal, rlz.lt_path, rlz.weight,
-                                rlz.value, rlz.samples,
-                                self.seed + rlz.ordinal, offset)
+                                rlz.value, rlz.samples, offset)
             offset += rlz.samples
         return arr
 

--- a/openquake/commonlib/rlzs_assoc.py
+++ b/openquake/commonlib/rlzs_assoc.py
@@ -130,14 +130,14 @@ class RlzsAssoc(object):
         """
         dic = {}  # grp -> rlzis
         for sm in self.csm_info.source_models:
-            for sg in sm.src_groups:
-                rlzs_by_gsim = self.get_rlzs_by_gsim(sg.trt, sm.ordinal)
+            for grp_id in self.csm_info.grp_ids(sm.ordinal):
+                rlzs_by_gsim = self.get_rlzs_by_gsim(grp_id)
                 if not rlzs_by_gsim:
                     continue
                 rows = list(rlzs_by_gsim.values())
                 if len(set(map(len, rows))) == 1:  # all the same length
                     rows = numpy.array(rows)  # convert rows into 2D array
-                dic['grp-%02d' % sg.id] = rows
+                dic['grp-%02d' % grp_id] = rows
         return dic
 
     def _init(self):

--- a/openquake/commonlib/rlzs_assoc.py
+++ b/openquake/commonlib/rlzs_assoc.py
@@ -103,11 +103,14 @@ class RlzsAssoc(object):
         :param sm_id: source model ordinal (or None)
         :returns: a dictionary gsim -> rlzs
         """
-        if isinstance(trt_or_grp_id, (int, U16, U32)):  # grp_id
+        try:
+            int(trt_or_grp_id)
+        except ValueError:
+            # assume TRT string
+            trt = trt_or_grp_id
+        else:  # assume integer
             trt = self.csm_info.trt_by_grp[trt_or_grp_id]
             sm_id = self.csm_info.get_sm_by_grp()[trt_or_grp_id]
-        else:  # assume TRT string
-            trt = trt_or_grp_id
         acc = collections.defaultdict(list)
         if sm_id is None:  # full dictionary
             for rlz, gsim_by_trt in zip(self.realizations, self.gsim_by_trt):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -109,7 +109,12 @@ class CompositionInfo(object):
         self.init()
 
     def init(self):
-        self.trt_by_grp = self.grp_by_trt()
+        self.trt_by_grp = {}
+        n = len(self.source_models)
+        trts = list(self.gsim_lt.values)
+        for smodel in self.source_models:
+            for grp_id in self.grp_ids(smodel.ordinal):
+                self.trt_by_grp[grp_id] = trts[grp_id // n]
 
     def get_info(self, sm_id):
         """
@@ -263,18 +268,6 @@ class CompositionInfo(object):
         """
         return {grp_id: sm.ordinal for sm in self.source_models
                 for grp_id in self.grp_ids(sm.ordinal)}
-
-    def grp_by_trt(self):
-        """
-        :returns: a dictionary grp_id -> trt
-        """
-        dic = {}
-        n = len(self.source_models)
-        trts = list(self.gsim_lt.values)
-        for smodel in self.source_models:
-            for grp_id in self.grp_ids(smodel.ordinal):
-                dic[grp_id] = trts[grp_id // n]
-        return dic
 
     def __repr__(self):
         info_by_model = {}

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -139,21 +139,6 @@ class CompositionInfo(object):
         else:
             return "complex" + num_gsims, num_paths
 
-    def get_rlz_by_gsim(self, grp_id):
-        trti, eri = divmod(grp_id, len(self.source_models))
-        sm = self.source_models[eri]
-        if self.num_samples:
-            gsim_rlzs = self.gsim_lt.sample(sm.samples, self.seed + sm.ordinal)
-        elif hasattr(self, 'gsim_rlzs'):  # cache
-            gsim_rlzs = self.gsim_rlzs
-        else:
-            self.gsim_rlzs = gsim_rlzs = logictree.get_effective_rlzs(
-                self.gsim_lt)
-        rlz_by_gsim = {}
-        for i, gsim_rlz in enumerate(gsim_rlzs):
-            rlz_by_gsim[gsim_rlz.value[trti]] = self.offset + i
-        return rlz_by_gsim
-
     def grp_ids(self, eri):
         nt = len(self.gsim_lt.values)
         ns = len(self.source_models)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -47,6 +47,8 @@ source_model_dt = numpy.dtype([
     ('weight', F32),
     ('path', hdf5.vstr),
     ('samples', U32),
+    ('seed', U32),
+    ('offset', U32),
 ])
 
 src_group_dt = numpy.dtype(
@@ -180,7 +182,7 @@ class CompositionInfo(object):
         sm_data = []
         for sm in self.source_models:
             sm_data.append((sm.names, sm.weight, '_'.join(sm.path),
-                            sm.samples))
+                            sm.samples, sm.seed, sm.offset))
             for src_group in sm.src_groups:
                 sg_data.append((src_group.id, src_group.name,
                                 trti[src_group.trt], src_group.eff_ruptures,
@@ -211,7 +213,7 @@ class CompositionInfo(object):
             path = tuple(str(decode(rec['path'])).split('_'))
             sm = source_reader.LtSourceModel(
                 rec['name'], rec['weight'], path, srcgroups,
-                sm_id, rec['samples'])
+                sm_id, rec['samples'], rec['seed'], rec['offset'])
             self.source_models.append(sm)
         self.init()
 

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -281,14 +281,10 @@ class CompositionInfo(object):
         for sm in self.source_models:
             info_by_model[sm.path] = (
                 '_'.join(map(decode, sm.path)),
-                decode(sm.names),
-                [sg.id for sg in sm.src_groups],
-                sm.weight,
-                self.get_num_rlzs(sm))
-        summary = ['%s, %s, grp=%s, weight=%s: %d realization(s)' % ibm
+                decode(sm.names), sm.weight, self.get_num_rlzs(sm))
+        summary = ['%s, %s, weight=%s: %d realization(s)' % ibm
                    for ibm in info_by_model.values()]
-        return '<%s\n%s>' % (
-            self.__class__.__name__, '\n'.join(summary))
+        return '<%s\n%s>' % (self.__class__.__name__, '\n'.join(summary))
 
 
 class CompositeSourceModel(collections.abc.Sequence):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -140,6 +140,10 @@ class CompositionInfo(object):
             return "complex" + num_gsims, num_paths
 
     def grp_ids(self, eri):
+        """
+        :param eri: effective realization index
+        :returns: array of T group IDs, being T the number of TRTs
+        """
         nt = len(self.gsim_lt.values)
         ns = len(self.source_models)
         return eri + numpy.arange(nt) * ns

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -146,13 +146,16 @@ class CompositionInfo(object):
         else:
             return "complex" + num_gsims, num_paths
 
-    def get_rg(self, grp_id):
+    def get_rlz_by_gsim(self, grp_id):
         trti, eri = divmod(grp_id, len(self.source_models))
         sm = self.source_models[eri]
         if self.num_samples:
             gsim_rlzs = self.gsim_lt.sample(sm.samples, self.seed + sm.ordinal)
-        else:
+        elif hasattr(self, 'gsim_rlzs'):  # cache
             gsim_rlzs = self.gsim_rlzs
+        else:
+            self.gsim_rlzs = gsim_rlzs = logictree.get_effective_rlzs(
+                self.gsim_lt)
         rlz_by_gsim = {}
         for i, gsim_rlz in enumerate(gsim_rlzs):
             rlz_by_gsim[gsim_rlz.value[trti]] = self.offset + i

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -90,14 +90,13 @@ class LtSourceModel(object):
     describing the source model in the logic tree.
     """
     def __init__(self, names, weight, path, src_groups, ordinal, samples,
-                 seed, offset):
+                 offset):
         self.names = ' '.join(names.split())  # replace newlines with spaces
         self.weight = weight
         self.path = path
         self.src_groups = src_groups
         self.ordinal = ordinal
         self.samples = samples
-        self.seed = seed
         self.offset = offset
 
     @property
@@ -131,8 +130,7 @@ class LtSourceModel(object):
             sg.sources = []
             src_groups.append(sg)
         return self.__class__(self.names, self.weight, self.path, src_groups,
-                              self.ordinal, self.samples, self.seed,
-                              self.offset)
+                              self.ordinal, self.samples, self.offset)
 
     def __repr__(self):
         samples = ', samples=%d' % self.samples if self.samples > 1 else ''
@@ -235,7 +233,7 @@ def get_ltmodels(oq, gsim_lt, source_model_lt, h5=None):
     for rlz in rlzs:
         ltm = LtSourceModel(
             rlz['value'], rlz['weight'], rlz['lt_path'], [],
-            rlz['ordinal'], rlz['samples'], rlz['seed'], rlz['offset'])
+            rlz['ordinal'], rlz['samples'], rlz['offset'])
         lt_models.append(ltm)
     if oq.calculation_mode.startswith('ucerf'):
         seed = source_model_lt.seed

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -236,7 +236,6 @@ def get_ltmodels(oq, gsim_lt, source_model_lt, h5=None):
             rlz['ordinal'], rlz['samples'], rlz['offset'])
         lt_models.append(ltm)
     if oq.calculation_mode.startswith('ucerf'):
-        seed = source_model_lt.seed
         idx = 0
         [grp] = nrml.to_python(oq.inputs["source_model"], converter)
         for grp_id, ltm in enumerate(lt_models):
@@ -249,7 +248,7 @@ def get_ltmodels(oq, gsim_lt, source_model_lt, h5=None):
             src.samples = ltm.samples
             sg.sources = [src]
             data = [((grp_id, grp_id, src.source_id, src.code,
-                      0, 0, -1, src.num_ruptures, 0, '', seed + idx, idx))]
+                      0, 0, -1, src.num_ruptures, 0, ''))]
             sg.info = numpy.array(data, source_info_dt)
         return lt_models
 

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -89,13 +89,16 @@ class LtSourceModel(object):
     A container of SourceGroup instances with some additional attributes
     describing the source model in the logic tree.
     """
-    def __init__(self, names, weight, path, src_groups, ordinal, samples):
+    def __init__(self, names, weight, path, src_groups, ordinal, samples,
+                 seed, offset):
         self.names = ' '.join(names.split())  # replace newlines with spaces
         self.weight = weight
         self.path = path
         self.src_groups = src_groups
         self.ordinal = ordinal
         self.samples = samples
+        self.seed = seed
+        self.offset = offset
 
     @property
     def name(self):
@@ -128,7 +131,8 @@ class LtSourceModel(object):
             sg.sources = []
             src_groups.append(sg)
         return self.__class__(self.names, self.weight, self.path, src_groups,
-                              self.ordinal, self.samples)
+                              self.ordinal, self.samples, self.seed,
+                              self.offset)
 
     def __repr__(self):
         samples = ', samples=%d' % self.samples if self.samples > 1 else ''
@@ -231,9 +235,10 @@ def get_ltmodels(oq, gsim_lt, source_model_lt, h5=None):
     for rlz in rlzs:
         ltm = LtSourceModel(
             rlz['value'], rlz['weight'], rlz['lt_path'], [],
-            rlz['ordinal'], rlz['samples'])
+            rlz['ordinal'], rlz['samples'], rlz['seed'], rlz['offset'])
         lt_models.append(ltm)
     if oq.calculation_mode.startswith('ucerf'):
+        seed = source_model_lt.seed
         idx = 0
         [grp] = nrml.to_python(oq.inputs["source_model"], converter)
         for grp_id, ltm in enumerate(lt_models):
@@ -246,7 +251,7 @@ def get_ltmodels(oq, gsim_lt, source_model_lt, h5=None):
             src.samples = ltm.samples
             sg.sources = [src]
             data = [((grp_id, grp_id, src.source_id, src.code,
-                      0, 0, -1, src.num_ruptures, 0, ''))]
+                      0, 0, -1, src.num_ruptures, 0, '', seed + idx, idx))]
             sg.info = numpy.array(data, source_info_dt)
         return lt_models
 

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -129,7 +129,6 @@ def classical(group, src_filter, gsims, param, monitor=Monitor()):
     if cluster:
         tom = getattr(group, 'temporal_occurrence_model')
         pmap = _cluster(param['imtls'], tom, gsims, pmap)
-
     return dict(pmap=pmap, calc_times=calc_times, rup_data=rup_data,
                 extra=extra)
 


### PR DESCRIPTION
... and some lines of code. I have also temporarily disabled the `disagg_by_src` feature.
The big change is that now the group IDs are statically generated from the effective realization index via the method CompositionInfo.grp_ids. This will allow impressive simplications in future PRs.

Continuation of https://github.com/gem/oq-engine/pull/5551