### PR TITLE
Removed rlzs_by_grp

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -805,7 +805,7 @@ class HazardCalculator(BaseCalculator):
                     assert sg.eff_ruptures != -1, sg
             self.datastore['csm_info'] = self.csm_info
 
-        R = len(self.rlzs_assoc.realizations)
+        R = self.R
         logging.info('There are %d realization(s)', R)
         rlzs_by_grp = self.rlzs_assoc.by_grp()
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -499,7 +499,6 @@ class HazardCalculator(BaseCalculator):
             self.datastore['assetcol'] = self.assetcol
             self.datastore['csm_info'] = fake = source.CompositionInfo.fake()
             self.rlzs_assoc = fake.get_rlzs_assoc()
-            self.datastore['rlzs_by_grp'] = self.rlzs_assoc.by_grp()
             self.save_crmodel()
         elif oq.hazard_calculation_id:
             parent = util.read(oq.hazard_calculation_id)
@@ -807,7 +806,6 @@ class HazardCalculator(BaseCalculator):
 
         R = self.R
         logging.info('There are %d realization(s)', R)
-        rlzs_by_grp = self.rlzs_assoc.by_grp()
 
         if self.oqparam.imtls:
             self.datastore['weights'] = arr = build_weights(
@@ -816,7 +814,6 @@ class HazardCalculator(BaseCalculator):
 
         if ('event_based' in self.oqparam.calculation_mode and R >= TWO16
                 or R >= TWO32):
-            # rlzi is 16 bit integer in the GMFs and 32 bit in rlzs_by_grp
             raise ValueError(
                 'The logic tree has too many realizations (%d), use sampling '
                 'instead' % R)
@@ -824,10 +821,6 @@ class HazardCalculator(BaseCalculator):
             logging.warning(
                 'The logic tree has %d realizations(!), please consider '
                 'sampling it', R)
-
-        # save vlen-arrays of rlz indices, one per group
-        if rlzs_by_grp:
-            self.datastore['rlzs_by_grp'] = rlzs_by_grp
 
     def store_source_info(self, calc_times):
         """

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -443,7 +443,7 @@ class DisaggregationCalculator(base.HazardCalculator):
     def build_disagg_by_src(self, rlzs):
         logging.warning('Disaggregation by source is experimental')
         oq = self.oqparam
-        groups = list(self.datastore['rlzs_by_grp'])
+        groups = list(self.csm_info.get_rlzs_by_grp())
         M = len(oq.imtls)
         P = len(self.poes_disagg)
         for (s, z), rlz in numpy.ndenumerate(rlzs):

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -305,7 +305,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         for grp_id, trt in csm_info.trt_by_grp.items():
             logging.info('Group #%d, sending rup_data for %s', grp_id, trt)
             trti = trt_num[trt]
-            rlzs_by_gsim = self.rlzs_assoc.get_rlzs_by_gsim(grp_id)
+            rlzs_by_gsim = self.csm_info.get_rlzs_by_gsim(grp_id)
             cmaker = ContextMaker(
                 trt, rlzs_by_gsim,
                 {'truncation_level': oq.truncation_level,

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -109,8 +109,7 @@ class PmapGetter(object):
         oq = self.dstore['oqparam']
         self.imtls = oq.imtls
         self.poes = self.poes or oq.poes
-        rlzs_by_grp = self.dstore['rlzs_by_grp']
-        self.rlzs_by_grp = {k: dset[()] for k, dset in rlzs_by_grp.items()}
+        self.rlzs_by_grp = self.dstore['csm_info'].get_rlzs_by_grp()
 
         # populate _pmap_by_grp
         self._pmap_by_grp = {}

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -54,7 +54,7 @@ class ScenarioCalculator(base.HazardCalculator):
                                     'filter_distance': oq.filter_distance})
         super().pre_execute()
         self.datastore['oqparam'] = oq
-        self.rlzs_assoc = cinfo.get_rlzs_assoc()
+        self.rlzs_assoc = cinfo.get_rlzs_assoc()  # TODO: remove this
         self.store_rlz_info()
         rlzs_by_gsim = self.rlzs_assoc.get_rlzs_by_gsim(0)
         E = oq.number_of_ground_motion_fields

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -167,4 +167,4 @@ class DisaggregationTestCase(CalculatorTestCase):
                                        'poe-0.05-SA(0.25)-sid-1'])
         arr = dbs['poe-0.01-PGA-sid-0'][()]
         numpy.testing.assert_almost_equal(
-            arr, [0, 5.38093847e-05, 0, 9.94706034e-03])
+            arr, [0, 0, 5.38093847e-05, 9.94706034e-03])

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1106,11 +1106,9 @@ class SourceModelLogicTree(object):
         """
         rlzs = get_effective_rlzs(self)
         arr = numpy.zeros(len(rlzs), rlz_dt)
-        offset = 0
         for rlz in rlzs:
             arr[rlz.ordinal] = (rlz.ordinal, rlz.lt_path, rlz.weight,
-                                rlz.value, rlz.samples, offset)
-            offset += rlz.samples
+                                rlz.value, rlz.samples, 0)
         return arr
 
     def get_trti_eri(self):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -161,6 +161,8 @@ class CompositionInfo(object):
                 for grp_id in self.grp_ids(sm.ordinal)}
 
     def get_rlzs_by_gsim(self, grp_id):
+        """
+        """
         trti, eri = divmod(grp_id, len(self.source_models))
         sm = self.source_models[eri]
         if self.num_samples:
@@ -179,12 +181,19 @@ class CompositionInfo(object):
         """
         :returns: a dictionary src_group_id -> gsim -> rlzs
         """
-        self.rlzs_assoc = self.get_rlzs_assoc()
         dic = {}
         for sm in self.source_models:
             for grp_id in self.grp_ids(sm.ordinal):
                 dic[grp_id] = self.get_rlzs_by_gsim(grp_id)
         return dic
+
+    def get_rlzs_by_grp(self):
+        dic = {}
+        for sm in self.source_models:
+            for grp_id in self.grp_ids(sm.ordinal):
+                grp = 'grp-%02d' % grp_id
+                dic[grp] = list(self.get_rlzs_by_gsim(grp_id).values())
+        return dic  # grp_id -> lists of rlzi
 
     def __getnewargs__(self):
         # with this CompositionInfo instances will be unpickled correctly

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -180,7 +180,10 @@ class CompositionInfo(object):
             rlzs.append(rlz)
         return rlzs
 
-    def realizations(self):
+    def get_realizations(self):
+        """
+        :returns: the complete list of LtRealizations
+        """
         rlzs = []
         for sm in self.source_models:
             for grp_id in self.grp_ids(sm.ordinal):
@@ -222,17 +225,8 @@ class CompositionInfo(object):
         # with this CompositionInfo instances will be unpickled correctly
         return self.seed, self.num_samples, self.source_models
 
-    def trt2i(self):
-        """
-        :returns: trt -> trti
-        """
-        trts = sorted(set(src_group.trt for sm in self.source_models
-                          for src_group in sm.src_groups))
-        return {trt: i for i, trt in enumerate(trts)}
-
     def __toh5__(self):
         # save csm_info/sm_data in the datastore
-        trti = self.trt2i()
         sm_data = []
         for sm in self.source_models:
             sm_data.append((sm.names, sm.weight, '_'.join(sm.path),
@@ -241,7 +235,7 @@ class CompositionInfo(object):
             gsim_lt=self.gsim_lt,
             sm_data=numpy.array(sm_data, source_model_dt)),
                 dict(seed=self.seed, num_samples=self.num_samples,
-                     trts=hdf5.array_of_vstr(sorted(trti))))
+                     trts=hdf5.array_of_vstr(self.gsim_lt.values)))
 
     def __fromh5__(self, dic, attrs):
         # TODO: this is called more times than needed, maybe we should cache it

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -162,6 +162,7 @@ class CompositionInfo(object):
 
     def get_rlzs_by_gsim(self, grp_id):
         """
+        :returns: a dictionary gsim -> rlzs
         """
         trti, eri = divmod(grp_id, len(self.source_models))
         sm = self.source_models[eri]
@@ -188,6 +189,9 @@ class CompositionInfo(object):
         return dic
 
     def get_rlzs_by_grp(self):
+        """
+        :returns: a dictionary src_group_id -> [rlzis, ...]
+        """
         dic = {}
         for sm in self.source_models:
             for grp_id in self.grp_ids(sm.ordinal):

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -26,7 +26,7 @@ from openquake.baselib.python3compat import decode
 from openquake.baselib.general import groupby, AccumDict
 from openquake.hazardlib import source, sourceconverter
 from openquake.commonlib import logictree, source_reader
-from openquake.commonlib.rlzs_assoc import get_rlzs_assoc
+from openquake.commonlib.rlzs_assoc import get_rlzs_assoc, LtRealization
 
 
 MINWEIGHT = source.MINWEIGHT
@@ -74,42 +74,6 @@ def get_field(data, field, default):
         return data[field]
     except ValueError:  # field missing in old engines
         return default
-
-
-class LtRealization(object):
-    """
-    Composite realization build on top of a source model realization and
-    a GSIM realization.
-    """
-    def __init__(self, ordinal, sm_lt_path, gsim_rlz, weight):
-        self.ordinal = ordinal
-        self.sm_lt_path = tuple(sm_lt_path)
-        self.gsim_rlz = gsim_rlz
-        self.weight = weight
-
-    def __repr__(self):
-        return '<%d,%s,w=%s>' % (self.ordinal, self.pid, self.weight)
-
-    @property
-    def gsim_lt_path(self):
-        return self.gsim_rlz.lt_path
-
-    @property
-    def pid(self):
-        """An unique identifier for effective realizations"""
-        return '_'.join(self.sm_lt_path) + '~' + self.gsim_rlz.pid
-
-    def __lt__(self, other):
-        return self.ordinal < other.ordinal
-
-    def __eq__(self, other):
-        return repr(self) == repr(other)
-
-    def __ne__(self, other):
-        return repr(self) != repr(other)
-
-    def __hash__(self):
-        return hash(repr(self))
 
 
 class CompositionInfo(object):

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -229,11 +229,18 @@ def get_ltmodels(oq, gsim_lt, source_model_lt, h5=None):
         oq.area_source_discretization, oq.minimum_magnitude,
         not spinning_off, oq.source_id)
     rlzs = source_model_lt.get_eff_rlzs()
+    if not source_model_lt.num_samples:
+        num_gsim_rlzs = gsim_lt.get_num_paths()
     lt_models = []
+    offset = 0
     for rlz in rlzs:
         ltm = LtSourceModel(
             rlz['value'], rlz['weight'], rlz['lt_path'], [],
-            rlz['ordinal'], rlz['samples'], rlz['offset'])
+            rlz['ordinal'], rlz['samples'], offset)
+        if source_model_lt.num_samples:
+            offset += rlz['samples']
+        else:
+            offset += num_gsim_rlzs
         lt_models.append(ltm)
     if oq.calculation_mode.startswith('ucerf'):
         idx = 0


### PR DESCRIPTION
We are finally beginning to see the promised simplifications,  consequence of https://github.com/gem/oq-engine/pull/5551. In the near future future we will be able to remove the time-honored RlzsAssoc object.