### PR TITLE
Fixes bin_width bug in hmtk fault model collapse

### DIFF
--- a/openquake/hmtk/faults/active_fault_model.py
+++ b/openquake/hmtk/faults/active_fault_model.py
@@ -92,7 +92,7 @@ class mtkActiveFaultModel(object):
         return len(self.faults)
 
     def build_fault_model(self, collapse=False, rendered_msr=WC1994(),
-                          mfd_config=None):
+                          bin_width=0.1, mfd_config=None):
         '''
         Constructs a full fault model with epistemic uncertainty by
         enumerating all the possible recurrence models of each fault as
@@ -112,6 +112,7 @@ class mtkActiveFaultModel(object):
         self.source_model = mtkSourceModel(self.id, self.name)
         for fault in self.faults:
             fault.generate_recurrence_models(collapse,
+                                             bin_width=bin_width,
                                              config=mfd_config,
                                              rendered_msr=rendered_msr)
             src_model, src_weight = fault.generate_fault_source_model()

--- a/openquake/hmtk/tests/faults/fault_data/collapse_test_output.xml
+++ b/openquake/hmtk/tests/faults/fault_data/collapse_test_output.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    name="Template Simple Fault"
+    >
+        <sourceGroup
+        rup_interdep="indep"
+        src_interdep="indep"
+        tectonicRegion="Active Shallow Crust"
+        >
+            <simpleFaultSource
+            id="1_1"
+            name="A Simple Fault"
+            tectonicRegion="Active Shallow Crust"
+            >
+                <simpleFaultGeometry>
+                    <gml:LineString>
+                        <gml:posList>
+                            30.0 30.0 30.0 31.0
+                        </gml:posList>
+                    </gml:LineString>
+                    <dip>
+                        30.0
+                    </dip>
+                    <upperSeismoDepth>
+                        0.0
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        20.0
+                    </lowerSeismoDepth>
+                </simpleFaultGeometry>
+                <magScaleRel>
+                    WC1994
+                </magScaleRel>
+                <ruptAspectRatio>
+                    1.5
+                </ruptAspectRatio>
+                <incrementalMFD
+                binWidth="0.05"
+                minMag="4.5"
+                >
+                    <occurRates>
+                        0.09701824738362441 0.08848169322917848 0.08069626330957536 0.07359586683385133 0.06712022828426645 0.061214375735294355 0.05582817419499374 0.05091590000728428 0.04643585270220507 0.04235000099914531 0.03862365995795423 0.03522519653725092 0.032125761060415294 0.029299042309656756 0.02672104416915446 0.024369881921176846 0.0222255964659369 0.02026998488808484 0.01848644593151391 0.016859839070707653 0.015376355982281726 0.01402340332563597 0.01278949583763972 0.011664158833824717 0.010637839288417121 0.009701824738362601 0.00884816932291802 0.0080696263309577 0.007359586683385259 0.006712022828426775 0.0061214375735295316 0.005582817419499494 0.005091590000728505 0.004643585270220573 0.004235000099914619 0.0038623659957954825 0.0035225196537251734 0.0032125761060415817 0.0029299042309657254 0.00267210441691548 0.0024369881921177255 0.0022225596465937263 0.0020269984888085218 0.0018486445931514212 0.0016859839070707907 0.0015376355982281882 0.0014023403325636177 0.001278949583763988 0.0011664158833824892 0.0010637839288417292 0.011026158980652363
+                    </occurRates>
+                </incrementalMFD>
+                <rake>
+                    -90.0
+                </rake>
+            </simpleFaultSource>
+        </sourceGroup>
+    </sourceModel>
+</nrml>

--- a/openquake/hmtk/tests/faults/fault_data/collapse_test_simple_fault_example_4branch.yml
+++ b/openquake/hmtk/tests/faults/fault_data/collapse_test_simple_fault_example_4branch.yml
@@ -1,0 +1,79 @@
+#*****************************************************************************
+#FAULT FILE IN YAML (Yet Another Markup Language) FORMAT
+#*****************************************************************************
+#\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+tectonic_regionalisation: 
+    - Name: Active Shallow Crust
+      Code: 001
+      # Magnitude scaling relation (see http://docs.openquake.org/oq-hazardlib) 
+      #for currently available choices!
+      Magnitude_Scaling_Relation: {
+          Value: [WC1994], 
+          Weight: [1.0]}
+      # Shear Modulus (in gigapascals, GPa)
+      Shear_Modulus: {
+          Value: [30.0], 
+          Weight: [1.0]}
+      # Fault displacement to length ratio
+      Displacement_Length_Ratio: {
+          Value: [1.25E-5],
+          Weight: [1.0]}
+          
+#\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+Fault_Model_ID: 001
+Fault_Model_Name: Template Simple Fault
+Fault_Model:
+    - ID: 001
+      Tectonic_Region: Active Shallow Crust
+      Fault_Name: A Simple Fault
+      Fault_Geometry: {
+          Fault_Typology: Simple,
+          # For simple typology, defines the trace in terms of Long., Lat.
+          Fault_Trace: [30.0, 30.0,
+                        30.0, 31.0],
+
+          # Upper Seismogenic Depth (km)
+          Upper_Depth:      0.0,
+          # Lower Seismogenic Depth (km)
+          Lower_Depth:     20.0,
+          Strike: ,
+          # Dip (degrees)
+          Dip:     30.}
+      Rake: -90.0
+      Slip_Type: Thrust
+      Slip_Completeness_Factor: 1
+      #slip [value_1, value_2, ... value_n]
+      #     [weight_1, weight_2, ... weight_n]
+      Slip: {
+          Value: [5., 7.],
+          Weight: [0.5, 0.5]}
+      #Aseismic Slip Factor 
+      Aseismic: 0.0
+      MFD_Model: 
+         
+        - Model_Name: AndersonLucoArbitrary
+          # Example constructor of the Anderson & Luco (1983) - Arbitrary Exponential 
+          # Type - chooses between type 1 ('First'), type 2 ('Second') or type 3 ('Third')
+          Model_Type: First
+          MFD_spacing: 0.05
+          Model_Weight: 1
+          # Maximum Magnitude of the exponential distribution
+          Maximum_Magnitude: 7.0
+          Minimum_Magnitude: 4.5
+          # b-value of the exponential distribution as [expected, uncertainty]
+          b_value: [0.8, 0.05]
+      Megazone: 
+      Shear_Modulus: {
+          Value: [30.],
+          Weight: [1.0]}
+      Magnitude_Scaling_Relation: {
+          Value: [WC1994],
+          Weight: [1.0]}
+      Scaling_Relation_Sigma: {
+          Value: [0.0], 
+          Weight: [1.0]}
+      Aspect_Ratio: 1.5
+      Displacement_Length_Ratio: {
+          Value: [1.25E-5],
+          Weight:[1.0]}

--- a/openquake/hmtk/tests/faults/test_active_fault_model.py
+++ b/openquake/hmtk/tests/faults/test_active_fault_model.py
@@ -49,9 +49,10 @@
 Module to test :openquake.hmtk.faults.active_fault_model.mtkActiveFaultModel
 '''
 
-
+import os
 import unittest
 import numpy as np
+from openquake.hazardlib import nrml
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo.line import Line
 from openquake.hazardlib.scalerel.wc1994 import WC1994
@@ -60,6 +61,8 @@ from openquake.hmtk.sources.complex_fault_source import mtkComplexFaultSource
 from openquake.hmtk.faults.fault_models import mtkActiveFault
 from openquake.hmtk.faults.fault_geometries import (SimpleFaultGeometry,
                                                     ComplexFaultGeometry)
+from openquake.hmtk.parsers.faults.fault_yaml_parser import FaultYmltoSource
+
 from openquake.hmtk.faults.active_fault_model import mtkActiveFaultModel
 
 
@@ -198,3 +201,35 @@ class TestmtkActiveFaultModel(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             np.log10(np.array(model4.mfd.occurrence_rates)),
             np.array([-3.34033387, -2.93297054, -3.34033387]))
+
+
+BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), 'fault_data')
+
+
+class TestmtkActiveFaultModelCollapse(unittest.TestCase):
+    """
+    Test case for the collapsing of the branches with a different MFD bin
+    """
+    def setUp(self):
+        self.expected_source = nrml.read(
+            os.path.join(BASE_DATA_PATH, "collapse_test_output.xml"))[0]
+        self.src = self.expected_source[0][0]
+
+    def test_collapse_fault_model(self):
+        input_file = os.path.join(
+            BASE_DATA_PATH,
+            "collapse_test_simple_fault_example_4branch.yml")
+        mesh_spacing = 1.0
+        reader = FaultYmltoSource(input_file)
+        fault_model, tectonic_region = reader.read_file(mesh_spacing)
+        fault_model.build_fault_model(collapse=True,
+                                      bin_width=0.05,
+                                      rendered_msr=WC1994())
+        expected_mfd = self.src.incrementalMFD
+        model_mfd = fault_model.faults[0].mfd[0][0]
+        self.assertAlmostEqual(expected_mfd["binWidth"],
+                               model_mfd.bin_width, 7)
+        self.assertAlmostEqual(expected_mfd["minMag"], model_mfd.min_mag, 7)
+        expected_rates = np.array(expected_mfd.occurRates.text)
+        np.testing.assert_array_almost_equal(model_mfd.occur_rates,
+                                             expected_rates, 7)


### PR DESCRIPTION
Fixes the bug described here: https://github.com/gem/oq-engine/pull/5427

1. Adds the `bin_width` keyword input to `openquake.hmtk.faults.mtkActiveFaultModel.build_fault_model` 

2. Incorporates a test for collapsed branches with a bin width different from 0.1, using the test case files supplied by @AvinashSingh786
