### PR TITLE
Added a limit on the maximum data transfer in disaggregation

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1349,3 +1349,16 @@ def categorize(values, nchars=2):
     prod = itertools.product(*[BASE64] * nchars)
     dic = {uvalue: ''.join(chars) for uvalue, chars in zip(uvalues, prod)}
     return numpy.array([dic[v] for v in values], (numpy.string_, nchars))
+
+
+def get_array_nbytes(sizedict):
+    """
+    :param sizedict: mapping name -> num_dimensions
+    :returns: (size of the array in bytes, descriptive message)
+
+    >>> get_array_nbytes(dict(nsites=2, nbins=5))
+    (80, '(nsites=2) * (nbins=5) * 8 bytes = 80 B')
+    """
+    nbytes = numpy.prod(list(sizedict.values())) * 8
+    prod = ' * '.join('(%s=%d)' % item for item in sizedict.items())
+    return nbytes, '%s * 8 bytes = %s' % (prod, humansize(nbytes))

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -310,11 +310,11 @@ class DisaggregationCalculator(base.HazardCalculator):
                         self.imldict[s, rlz, poe, imt] = self.iml4[s, m, p, z]
 
         # submit #groups disaggregation tasks
-        self.datastore.swmr_on()
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
-        smap = parallel.Starmap(compute_disagg, h5=self.datastore.hdf5)
         indices = get_indices(dstore, oq.concurrent_tasks or 1)
+        self.datastore.swmr_on()
+        smap = parallel.Starmap(compute_disagg, h5=self.datastore.hdf5)
         for grp_id, trt in self.csm_info.trt_by_grp.items():
             logging.info('Group #%d, sending rup_data for %s', grp_id, trt)
             trti = trt_num[trt]

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -306,7 +306,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         shapedic['concurrent_tasks'] = oq.concurrent_tasks
         nbytes, msg = get_array_nbytes(shapedic)
         if nbytes > oq.max_data_transfer:
-            raise ValueError('Data transfer too big\n%s' % msg)
+            raise ValueError('Estimated data transfer too big\n%s' % msg)
         logging.info('Estimated data transfer: %s', msg)
         self.imldict = {}  # sid, rlz, poe, imt -> iml
         for s in self.sitecol.sids:

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -125,11 +125,10 @@ def compute_disagg(dstore, idxs, cmaker, iml4, trti, bin_edges,
     pne_mon = monitor('disaggregate_pne', measuremem=False)
     mat_mon = monitor('build_disagg_matrix', measuremem=False)
     gmf_mon = monitor('computing mean_std', measuremem=False)
-    result = dict(disagg.build_matrices(
-        rupdata, sitecol, cmaker, iml4, oq.num_epsilon_bins,
-        bin_edges, pne_mon, mat_mon, gmf_mon))
-    result['trti'] = trti
-    return result  # sid -> array
+    for sid, mat in disagg.build_matrices(
+            rupdata, sitecol, cmaker, iml4, oq.num_epsilon_bins,
+            bin_edges, pne_mon, mat_mon, gmf_mon):
+        yield {'trti': trti, sid: mat}
 
 
 def agg_probs(*probs):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -147,6 +147,7 @@ class OqParam(valid.ParamSet):
     maximum_distance = valid.Param(valid.maximum_distance)  # km
     asset_hazard_distance = valid.Param(valid.floatdict, {'default': 15})  # km
     max = valid.Param(valid.boolean, False)
+    max_data_transfer = valid.Param(valid.positivefloat, 1E11)
     max_potential_gmfs = valid.Param(valid.positiveint, 2E11)
     max_potential_paths = valid.Param(valid.positiveint, 100)
     max_sites_per_gmf = valid.Param(valid.positiveint, 65536)
@@ -874,7 +875,7 @@ class OqParam(valid.ParamSet):
                 raise InvalidFile(msg)
             else:
                 getattr(logging, action)(msg)
-
+        
     def hazard_precomputed(self):
         """
         :returns: True if the hazard is precomputed

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -147,7 +147,7 @@ class OqParam(valid.ParamSet):
     maximum_distance = valid.Param(valid.maximum_distance)  # km
     asset_hazard_distance = valid.Param(valid.floatdict, {'default': 15})  # km
     max = valid.Param(valid.boolean, False)
-    max_data_transfer = valid.Param(valid.positivefloat, 1E11)
+    max_data_transfer = valid.Param(valid.positivefloat, 2E11)
     max_potential_gmfs = valid.Param(valid.positiveint, 2E11)
     max_potential_paths = valid.Param(valid.positiveint, 100)
     max_sites_per_gmf = valid.Param(valid.positiveint, 65536)


### PR DESCRIPTION
@kejohnso is running a calculation with 864 realizations and thus transferring 864 times more data than in the past. No wonder that we are running out of memory. I am adding a limit to stop users to do that. Just reduce `num_rlzs_disagg` otherwise you will get an error like this one:
```python
ValueError: Estimated data transfer too big
(mag=21) * (dist=12) * (lon=6) * (lat=7) * (eps=7) * (N=9) * (M=1) * (P=1) * (Z=864) * (concurrent_tasks=160) * 8 bytes = 686.77 GB
```