### PR TITLE
Moving the parsing of the source models completely in apply_uncertainties

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -218,7 +218,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         tl = oq.truncation_level
         src_filter = self.src_filter()
         if hasattr(self, 'csm'):
-            for sg in self.csm.src_groups:
+            for sg in self.csm.get_src_groups():
                 if sg.atomic:
                     raise NotImplementedError(
                         'Atomic groups are not supported yet')

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -790,9 +790,8 @@ class SourceModelLogicTree(object):
         dirname = os.path.dirname(self.filename)
         [sm] = nrml.read_source_models([fname], converter)
         base_ids = set(src.source_id for sg in sm.src_groups for src in sg)
-        newsm = nrml.SourceModel(copy.copy(sm.src_groups), sm.name,
-                                 sm.investigation_time, sm.start_time)
-        newsm.changes = 0
+        src_groups = sm.src_groups
+        sm.changes = 0
         path = ltpath
         branchset = self.root_branchset
         branchsets_and_uncertainties = []
@@ -809,7 +808,8 @@ class SourceModelLogicTree(object):
                     raise InvalidFile(
                         '%s contains source(s) %s already present in %s' %
                         (extname, common, sm.fname))
-                newsm.src_groups.extend(ext.src_groups)
+                sm.src_groups = copy.copy(src_groups)
+                sm.src_groups.extend(ext.src_groups)
             elif branchset.uncertainty_type != 'sourceModel':
                 branchsets_and_uncertainties.append(
                     (branchset, branch.value))
@@ -826,9 +826,9 @@ class SourceModelLogicTree(object):
                             changes += 1
                     if changes:  # redoing count_ruptures can be slow
                         source.num_ruptures = source.count_ruptures()
-                        newsm.changes += changes
-                newsm.src_groups[i] = sg
-        return newsm
+                        sm.changes += changes
+                sm.src_groups[i] = sg
+        return sm
 
     def get_trti_eri(self):
         """

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -776,18 +776,19 @@ class SourceModelLogicTree(object):
         self.source_ids[branch_id].extend(ID_REGEX.findall(xml))
         self.source_types.update(SOURCE_TYPE_REGEX.findall(xml))
 
-    def apply_uncertainties(self, ltpath, sm, converter):
+    def apply_uncertainties(self, ltpath, fname, converter):
         """
         :param ltpath:
             List of branch IDs
-        :param sm:
-            A :class:`openquake.hazardlib.nrml.SourceModel` instance
+        :param fname:
+            Path to a source model file
         :param converter:
-            A :class:`openquake.hazardlib.sourceconverter.SourceConverter`
+            class:`openquake.hazardlib.sourceconverter.SourceConverter` object
         :return:
             A copy of the original group with modified sources
         """
         dirname = os.path.dirname(self.filename)
+        [sm] = nrml.read_source_models([fname], converter)
         base_ids = set(src.source_id for sg in sm.src_groups for src in sg)
         newsm = nrml.SourceModel(copy.copy(sm.src_groups), sm.name,
                                  sm.investigation_time, sm.start_time)

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -79,8 +79,7 @@ class SourceReader(object):
         fname_hits = collections.Counter()  # fname -> number of calls
         mags = set()
         src_groups = []
-        [sm] = nrml.read_source_models([fname], self.converter)
-        newsm = apply_unc(path, sm, self.converter)
+        newsm = apply_unc(path, fname, self.converter)
         fname_hits[fname] += 1
         for sg in newsm:
             # sample a source for each group

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -97,8 +97,7 @@ class SourceReader(object):
                 src.checksum = zlib.adler32(
                     pickle.dumps(dic, pickle.HIGHEST_PROTOCOL))
                 src._wkt = src.wkt()
-        return dict(fname_hits=fname_hits, changes=sm.changes,
-                    src_groups=sm.src_groups, mags=mags,
+        return dict(fname_hits=fname_hits, sm=sm, mags=mags,
                     ordinal=ordinal, fileno=fileno)
 
 
@@ -176,13 +175,13 @@ def _store_results(smap, sm_rlzs, source_model_lt, gsim_lt, oq, h5):
     fname_hits = collections.Counter()
     for dic in sorted(smap, key=operator.itemgetter('fileno')):
         sm_rlz = sm_rlzs[dic['ordinal']]
-        sm_rlz.src_groups.extend(dic['src_groups'])
+        sm_rlz.src_groups.extend(dic['sm'])
         fname_hits += dic['fname_hits']
-        changes += dic['changes']
+        changes += dic['sm'].changes
         mags.update(dic['mags'])
         gsim_file = oq.inputs.get('gsim_logic_tree')
         if gsim_file:  # check TRTs
-            for src_group in dic['src_groups']:
+            for src_group in dic['sm']:
                 if src_group.trt not in gsim_lt.values:
                     raise ValueError(
                         "Found in %r a tectonic region type %r "

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -78,10 +78,9 @@ class SourceReader(object):
     def __call__(self, ordinal, path, apply_unc, fname, fileno, monitor):
         fname_hits = collections.Counter()  # fname -> number of calls
         mags = set()
-        src_groups = []
-        newsm = apply_unc(path, fname, self.converter)
+        sm = apply_unc(path, fname, self.converter)
         fname_hits[fname] += 1
-        for sg in newsm:
+        for sg in sm:
             # sample a source for each group
             if os.environ.get('OQ_SAMPLE_SOURCES'):
                 sg.sources = random_filtered_sources(
@@ -98,9 +97,8 @@ class SourceReader(object):
                 src.checksum = zlib.adler32(
                     pickle.dumps(dic, pickle.HIGHEST_PROTOCOL))
                 src._wkt = src.wkt()
-            src_groups.append(sg)
-        return dict(fname_hits=fname_hits, changes=newsm.changes,
-                    src_groups=src_groups, mags=mags,
+        return dict(fname_hits=fname_hits, changes=sm.changes,
+                    src_groups=sm.src_groups, mags=mags,
                     ordinal=ordinal, fileno=fileno)
 
 


### PR DESCRIPTION
It was half here and half in source_reader.py. It may change again in the future.