### PR TITLE
Sources are not split when sampling ruptures anymore

### DIFF
--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -175,10 +175,6 @@ def split_sources(srcs):
         min_mag = src.min_mag
         if mag_b < min_mag:  # discard the source completely
             continue
-        has_serial = hasattr(src, 'serial')
-        if has_serial:
-            src.serial = numpy.arange(
-                src.serial, src.serial + src.num_ruptures)
         if not splittable(src):
             sources.append(src)
             split_time[src.id] = time.time() - t0
@@ -199,15 +195,10 @@ def split_sources(srcs):
         sources.extend(splits)
         has_samples = hasattr(src, 'samples')
         if len(splits) > 1:
-            start = 0
             for i, split in enumerate(splits):
                 split.source_id = '%s:%s' % (src.source_id, i)
                 split.src_group_id = src.src_group_id
                 split.id = src.id
-                if has_serial:
-                    nr = split.num_ruptures
-                    split.serial = src.serial[start:start + nr]
-                    start += nr
                 if has_samples:
                     split.samples = src.samples
         elif splits:  # single source
@@ -215,8 +206,6 @@ def split_sources(srcs):
             s.source_id = src.source_id
             s.src_group_id = src.src_group_id
             s.id = src.id
-            if has_serial:
-                s.serial = src.serial
             if has_samples:
                 s.samples = src.samples
     return sources, split_time


### PR DESCRIPTION
Therefore we can remove some obsolete lines of code.