### PR TITLE
Call `src.count_ruptures()` later

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Optimized get_composite_source_model (in the case of a complex source
+    specific logic trees a speedup of 80x was measured)
   * Internal: fixed `oq info source_model_logic_tree.xml`
   * Avoided reading multiple times the source models in the case of complex
     logic trees

--- a/openquake/commonlib/lt.py
+++ b/openquake/commonlib/lt.py
@@ -284,8 +284,7 @@ def apply_uncertainties(bset_values, src_group):
                 if ok:
                     apply_uncertainty(bset.uncertainty_type, src, value)
                     sg.changes += 1
-            # redoing count_ruptures can be slow
-            src.num_ruptures = src.count_ruptures()
+            src.num_ruptures = 0  # .count_ruptures will be needed again
         else:
             src = copy.copy(source)  # this is ultra-fast
         sg.sources.append(src)

--- a/openquake/commonlib/lt.py
+++ b/openquake/commonlib/lt.py
@@ -284,7 +284,6 @@ def apply_uncertainties(bset_values, src_group):
                 if ok:
                     apply_uncertainty(bset.uncertainty_type, src, value)
                     sg.changes += 1
-            src.num_ruptures = 0  # .count_ruptures will be needed again
         else:
             src = copy.copy(source)  # this is ultra-fast
         sg.sources.append(src)

--- a/openquake/commonlib/source.py
+++ b/openquake/commonlib/source.py
@@ -387,6 +387,8 @@ class CompositeSourceModel(collections.abc.Sequence):
         for sg in self.src_groups:
             for src in sg:
                 src.serial = serial
+                if not src.num_ruptures:
+                    src.num_ruptures = src.count_ruptures()
                 serial += src.num_ruptures * len(src.grp_ids)
 
     def get_nonparametric_sources(self):

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -110,7 +110,6 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             nodal_plane_distribution=npd,
             hypocenter_distribution=hd,
             temporal_occurrence_model=PoissonTOM(50.))
-        point.num_ruptures = point.count_ruptures()
         return point
 
     @property
@@ -145,7 +144,6 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             polygon=polygon,
             area_discretization=2,
             temporal_occurrence_model=PoissonTOM(50.))
-        area.num_ruptures = area.count_ruptures()
         return area
 
     @property
@@ -174,7 +172,6 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             temporal_occurrence_model=PoissonTOM(50.),
             hypo_list=numpy.array([[0.25, 0.25, 0.3], [0.75, 0.75, 0.7]]),
             slip_list=numpy.array([[90, 0.7], [135, 0.3]]))
-        simple.num_ruptures = simple.count_ruptures()
         return simple
 
     @property
@@ -216,7 +213,6 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             edges=edges,
             rake=30.0,
             temporal_occurrence_model=PoissonTOM(50.))
-        cmplx.num_ruptures = cmplx.count_ruptures()
         return cmplx
 
     @property
@@ -242,7 +238,6 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             surface=surface,
             rake=30.0,
             temporal_occurrence_model=PoissonTOM(50.))
-        char.num_ruptures = char.count_ruptures()
         return char
 
     @property
@@ -285,7 +280,6 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             surface=complex_surface,
             rake=60.0,
             temporal_occurrence_model=PoissonTOM(50.0))
-        char.num_ruptures = char.count_ruptures()
         return char
 
     @property
@@ -317,7 +311,6 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             surface=multi_surface,
             rake=90.0,
             temporal_occurrence_model=PoissonTOM(50.0))
-        char.num_ruptures = char.count_ruptures()
         return char
 
     def test_point_to_hazardlib(self):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -172,6 +172,8 @@ def split_sources(srcs):
     split_time = {}  # src.id -> time
     for src in srcs:
         t0 = time.time()
+        if not src.num_ruptures:  # not set yet
+            src.num_ruptures = src.count_ruptures()
         mag_a, mag_b = src.get_min_max_mag()
         min_mag = src.min_mag
         if mag_b < min_mag:  # discard the source completely

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -106,8 +106,7 @@ def classical(group, src_filter, gsims, param, monitor=Monitor()):
     trts = set()
     for src in group:
         if not src.num_ruptures:
-            # src.num_ruptures is set when parsing the XML, but not when
-            # the source is instantiated manually, so it is set here
+            # src.num_ruptures may not be set, so it is set here
             src.num_ruptures = src.count_ruptures()
         # set the proper TOM in case of a cluster
         if cluster:

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -42,7 +42,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
     serial = 0  # set in init_serials
     checksum = 0  # set in source_reader
     grp_id = ()
-    
+
     @abc.abstractproperty
     def MODIFICATIONS(self):
         pass

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -205,7 +205,7 @@ class SourceGroup(collections.abc.Sequence):
             src.tectonic_region_type, self.trt)
         if not src.min_mag:  # if not set already
             src.min_mag = self.min_mag.get(self.trt) or self.min_mag['default']
-            if not src.get_annual_occurrence_rates():  # filtered out
+            if not src.get_mags():  # filtered out
                 return
         # checking mutex ruptures
         if (not isinstance(src, NonParametricSeismicSource) and

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -205,6 +205,8 @@ class SourceGroup(collections.abc.Sequence):
             src.tectonic_region_type, self.trt)
         if not src.min_mag:  # if not set already
             src.min_mag = self.min_mag.get(self.trt) or self.min_mag['default']
+            if not src.get_annual_occurrence_rates():  # filtered out
+                return
         # checking mutex ruptures
         if (not isinstance(src, NonParametricSeismicSource) and
                 self.rup_interdep == 'mutex'):

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -38,7 +38,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         start = 0
         for i, src in enumerate(group):
             src.id = i
-            nr = src.num_ruptures
+            nr = src.count_ruptures()
             src.serial = start + seed
             start += nr
         param = dict(ses_per_logic_tree_path=10, filter_distance='rjb',


### PR DESCRIPTION
There is no need to call `src.count_ruptures` when reading the source models, it can be done later, in the `execute` phase (for classical) or in `init_serials` (for event based). This gives an 80x speedup in Guillaume's calculation `get_composite_source_model`. As a bonus, 40 lines of code were removed.