### PR TITLE
Restored NonParametricSeismicSource.wkt

### DIFF
--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -265,7 +265,7 @@ def make_figure_sources(extractors, what):
     """
     $ oq plot sources?sm_id=0&limit=100
     $ oq plot sources?sm_id=0source_id=1&source_id=2
-    $ oq plot sources?sm_id=0code=A&code=B
+    $ oq plot sources?sm_id=0code=A&code=N
     """
     # NB: matplotlib is imported inside since it is a costly import
     import matplotlib.pyplot as plt

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -158,9 +158,10 @@ class NonParametricSeismicSource(BaseSeismicSource):
     def __repr__(self):
         return '<%s gridded=%s>' % (self.__class__.__name__, self.is_gridded())
 
-    def wkt(self):
+    @property
+    def polygon(self):
         """
-        :returns: the geometry as a WKT string
+        The convex hull of the underlying mesh of points
         """
         lons = numpy.concatenate(
             [rup.surface.mesh.lons.flatten() for rup, pmf in self.data])
@@ -171,7 +172,13 @@ class NonParametricSeismicSource(BaseSeismicSource):
         points['lat'] = lats
         points = numpy.unique(points)
         mesh = Mesh(points['lon'], points['lat'])
-        return mesh.get_convex_hull().wkt
+        return mesh.get_convex_hull()
+
+    def wkt(self):
+        """
+        :returns: the geometry as a WKT string
+        """
+        return self.polygon.wkt
 
     def get_one_rupture(self, rupture_mutex=False):
         """

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -163,9 +163,9 @@ class NonParametricSeismicSource(BaseSeismicSource):
         :returns: the geometry as a WKT string
         """
         lons = numpy.concatenate(
-            [rup.surface.mesh.lons for rup, pmf in self.data])
+            [rup.surface.mesh.lons.flatten() for rup, pmf in self.data])
         lats = numpy.concatenate(
-            [rup.surface.mesh.lats for rup, pmf in self.data])
+            [rup.surface.mesh.lats.flatten() for rup, pmf in self.data])
         points = numpy.zeros(len(lons), [('lon', F32), ('lat', F32)])
         points['lon'] = lons
         points['lat'] = lats

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -162,10 +162,16 @@ class NonParametricSeismicSource(BaseSeismicSource):
         """
         :returns: the geometry as a WKT string
         """
-        return ''
-        # polys = [rup.surface.mesh.get_convex_hull()._polygon2d
-        #          for rup, pmf in self.data]
-        # return shapely.geometry.MultiPolygon(polys).wkt
+        lons = numpy.concatenate(
+            [rup.surface.mesh.lons for rup, pmf in self.data])
+        lats = numpy.concatenate(
+            [rup.surface.mesh.lats for rup, pmf in self.data])
+        points = numpy.zeros(len(lons), [('lon', F32), ('lat', F32)])
+        points['lon'] = lons
+        points['lat'] = lats
+        points = numpy.unique(points)
+        mesh = Mesh(points['lon'], points['lat'])
+        return mesh.get_convex_hull().wkt
 
     def get_one_rupture(self, rupture_mutex=False):
         """


### PR DESCRIPTION
Workaound for https://github.com/gem/oq-engine/issues/5648. This is good enough for my purposes (i.e. debugging). For South America, `get_composite_source_model` takes only 200 s now.