### PR TITLE
Reduced the rupture storage for disaggregation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Reduced the storage required for site specific calculations in the case
+    of complex logic trees
   * Restored the computation of the mean disaggregation when multiple
     realizations are requested
   * Slightly changed the syntax of `oq info` (see `oq info --help`) and added

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -160,7 +160,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 acc.eff_ruptures[trt] += eff_rups
 
             rup_data = dic['rup_data']
-            nr = len(rup_data['grp_id'])
+            nr = len(rup_data['grp_id_'])
             if nr:
                 default = (numpy.ones(nr, F32) * numpy.nan,
                            [numpy.zeros(0, F32)] * nr)
@@ -184,7 +184,7 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         zd = AccumDict()
         num_levels = len(self.oqparam.imtls.array)
-        rparams = {'grp_id', 'occurrence_rate',
+        rparams = {'grp_id_', 'occurrence_rate',
                    'weight', 'probs_occur', 'sid_', 'lon_', 'lat_', 'rrup_'}
         gsims_by_trt = self.full_lt.get_gsims_by_trt()
         n = len(self.full_lt.sm_rlzs)
@@ -203,8 +203,8 @@ class ClassicalCalculator(base.HazardCalculator):
         for k in self.rparams:
             # variable length arrays
             vlen = k.endswith('_') or k == 'probs_occur'
-            if k == 'grp_id':
-                dt = U16
+            if k == 'grp_id_':
+                dt = hdf5.vuint16
             elif k == 'sid_':
                 dt = hdf5.vuint16
             elif vlen:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -160,7 +160,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 acc.eff_ruptures[trt] += eff_rups
 
             rup_data = dic['rup_data']
-            nr = len(rup_data['grp_id_'])
+            nr = len(rup_data.get('grp_id_', []))
             if nr:
                 default = (numpy.ones(nr, F32) * numpy.nan,
                            [numpy.zeros(0, F32)] * nr)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -139,12 +139,16 @@ def agg_probs(*probs):
 
 
 def get_indices(dstore, concurrent_tasks):
-    grp_ids = dstore['rup/grp_id'][()]
-    blocksize = numpy.ceil(len(grp_ids) / concurrent_tasks)
+    acc = AccumDict(accum=[])  # grp_id -> indices
+    n = 0
+    for idx, grp_ids in enumerate(dstore['rup/grp_id_'][()]):
+        n += len(grp_ids)
+        for grp_id in grp_ids:
+            acc[grp_id].append(idx)
+    blocksize = numpy.ceil(n / concurrent_tasks)
     indices = []
     for grp_id in dstore['full_lt'].trt_by_grp:
-        idxs, = numpy.where(grp_ids == grp_id)
-        blocks = list(block_splitter(idxs, blocksize))
+        blocks = list(block_splitter(acc[grp_id], blocksize))
         indices.append(blocks)
     return indices
 

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -442,7 +442,7 @@ hazard_uhs-std.csv
                 nruptures.append((par, len(rupdata)))
             self.assertEqual(
                 nruptures,
-                [('dip', 3202), ('grp_id', 3202), ('hypo_depth', 3202),
+                [('dip', 3202), ('grp_id_', 3202), ('hypo_depth', 3202),
                  ('lat_', 3202), ('lon_', 3202), ('mag', 3202),
                  ('occurrence_rate', 3202), ('probs_occur', 3202),
                  ('rake', 3202), ('rjb_', 3202), ('rrup_', 3202),

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -330,7 +330,6 @@ class ContextMaker(object):
                 msg = '%s (source id=%s)' % (str(err), srcs[0].source_id)
                 raise etype(msg).with_traceback(tb)
         rdata = {k: numpy.array(v) for k, v in rup_data.items()}
-        rdata['grp_id'] = numpy.uint16(rup_data['grp_id'])
         extra = dict(totrups=totrups)
         return pmap, rdata, calc_times, extra
 
@@ -425,9 +424,8 @@ class PmapMaker(object):
                         numrups += len(ctxs)
                 for rup, r_sites, dctx in ctxs:
                     if self.fewsites:  # store rupdata
-                        for grp_id in src.grp_ids:
-                            rupdata.add(rup, r_sites, dctx)
-                            rupdata.data['grp_id'].append(grp_id)
+                        rupdata.add(rup, r_sites, dctx)
+                        rupdata.data['grp_id_'].append(src.grp_ids)
                     sids, poes = self._sids_poes(rup, r_sites, dctx)
                     with self.pne_mon:
                         pnes = rup.get_probability_no_exceedance(poes)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -402,6 +402,7 @@ class PmapMaker(object):
         totrups = 0
         rupdata = RupData(self.cmaker, rup_data)
         for src in srcs:
+            grp_ids = numpy.array(src.grp_ids)
             t0 = time.time()
             with self.cmaker.mon('iter_ruptures', measuremem=False):
                 self.mag_rups = [
@@ -421,7 +422,7 @@ class PmapMaker(object):
                 for rup, r_sites, dctx in ctxs:
                     if self.fewsites:  # store rupdata
                         rupdata.add(rup, r_sites, dctx)
-                        rupdata.data['grp_id_'].append(src.grp_ids)
+                        rupdata.data['grp_id_'].append(grp_ids)
                     sids, poes = self._sids_poes(rup, r_sites, dctx)
                     with self.pne_mon:
                         pnes = rup.get_probability_no_exceedance(poes)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -325,10 +325,6 @@ class ContextMaker(object):
                 totrups += pmaker.make(srcs, sites, pmap, rup_data, calc_times)
             except StopIteration:
                 break
-            except Exception as err:
-                etype, err, tb = sys.exc_info()
-                msg = '%s (source id=%s)' % (str(err), srcs[0].source_id)
-                raise etype(msg).with_traceback(tb)
         rdata = {k: numpy.array(v) for k, v in rup_data.items()}
         extra = dict(totrups=totrups)
         return pmap, rdata, calc_times, extra


### PR DESCRIPTION
As it was before, in case of multiple grp_ids the same rupture was stored multiple times. For instance for case_master we were storing 1091 duplicated ruptures while now we store 548 unique ruptures.