### PR TITLE
Added a check for missing TRTs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check for missing TRTs in the GSIM logic tree file
   * Reduced the storage required for site specific calculations in the case
     of complex logic trees
   * Restored the computation of the mean disaggregation when multiple
@@ -36,7 +37,7 @@
   * Avoided submitting too many tasks in the disaggregation calculator
   * Added a parameter `discard_trts` for manual reduction of GSIM logic tree
   * Fixed a bug in case of duplicated nodal planes affecting the Italy model
-  * Removed dynamic reduction of the gsim logic tree (i.e. now the
+  * Removed dynamic reduction of the GSIM logic tree (i.e. now the
     logic tree is known upfront, before calculating the PoES)
 
   [Paolo Tormene]

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -768,8 +768,8 @@ class GsimLogicTree(object):
             for trt in trts:
                 values[trt] = self.values[trt]
                 if not values[trt]:
-                    raise InvalidFile('%s is missing the TRT %r' %
-                                      (self.filename, trt))
+                    raise InvalidLogicTree('%s is missing the TRT %r' %
+                                           (fname, trt))
             self.values = values
         if trts and not self.branches:
             raise InvalidLogicTree(

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -763,8 +763,15 @@ class GsimLogicTree(object):
         self.bs_id_by_trt = {}
         self.branches = self._build_trts_branches(trts)  # sorted by trt
         if trts != ['*']:
-            self.values = {trt: self.values[trt] for trt in trts}
-        if tectonic_region_types and not self.branches:
+            # reduce self.values to the listed TRTs
+            values = {}
+            for trt in trts:
+                values[trt] = self.values[trt]
+                if not values[trt]:
+                    raise InvalidFile('%s is missing the TRT %r' %
+                                      (self.filename, trt))
+            self.values = values
+        if trts and not self.branches:
             raise InvalidLogicTree(
                 '%s is missing in %s' % (set(tectonic_region_types), fname))
 

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -456,7 +456,8 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
         oq = readinput.get_oqparam('job.ini', case_16)
         with self.assertRaises(logictree.InvalidLogicTree) as c:
             readinput.get_gsim_lt(oq, ['active Shallow Crust'])
-        self.assertIn("{'active Shallow Crust'} is missing", str(c.exception))
+        self.assertIn("is missing the TRT 'active Shallow Crust'",
+                      str(c.exception))
 
     def test_wrong_trts_in_reqv(self):
         # invalid TRT in job.ini [reqv]


### PR DESCRIPTION
As discovered by Jamal and Graeme if the gmpe_logic_tree_file is missing a TRT one gets a really strange error with sampling:
```python
   ctree.py", line 994, in <listcomp>
       brlists = [sample([b for b in self.branches if b.trt == trt],
     File "/home/michele/oq-engine/openquake/hazardlib/lt.py", line 330, in sample
       idxs = numpy.random.choice(len(weights), num_samples, p=weights)
     File "mtrand.pyx", line 1119, in mtrand.RandomState.choice
   ValueError: 'a' must be greater than 0 unless no samples are taken
```
Now one gets a nice error early.