### PR TITLE
Added a check on classical calculations which are too big to be run

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check on classical calculations which are too large to run
   * Added a flag `collapse_ruptures` and a new collapsing algorithm
   * Added a check for missing TRTs in the GSIM logic tree file
   * Reduced the storage required for site specific calculations

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -453,7 +453,7 @@ class HazardCalculator(BaseCalculator):
         G = max(len(gsims) for gsims in full_lt.gsim_lt.values.values())
         E = len(full_lt.sm_rlzs)
         upperlimit = self.N * L * G * E * 8
-        if upperlimit > TWO32:
+        if upperlimit >= TWO32:
             raise ValueError(TOOBIG % (self.N, L, G, E,
                                        general.humansize(upperlimit)))
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -55,15 +55,6 @@ F32 = numpy.float32
 TWO16 = 2 ** 16
 TWO32 = 2 ** 32
 
-TOOBIG = '''\
-The calculation is too big:
-num_sites = %d
-num_levels = %d
-num_gsims = %d
-eff_sm_rlzs = %d
-The estimated memory per core is %s > 4 GB.
-You MUST reduce one or more of the listed parameters.'''
-
 source_info_dt = numpy.dtype([
     ('source_id', hdf5.vstr),          # 0
     ('gidx', numpy.uint16),            # 1
@@ -448,14 +439,6 @@ class HazardCalculator(BaseCalculator):
         if s != 1:
             logging.info('Rupture spinning factor = %s', s)
 
-    def check_size(self, L, full_lt):
-        G = max(len(gsims) for gsims in full_lt.gsim_lt.values.values())
-        E = len(full_lt.sm_rlzs)
-        upperlimit = self.N * L * G * E * 8
-        if upperlimit >= TWO32:
-            raise ValueError(TOOBIG % (self.N, L, G, E,
-                                       general.humansize(upperlimit)))
-
     def read_inputs(self):
         """
         Read risk data and sources if any
@@ -470,9 +453,6 @@ class HazardCalculator(BaseCalculator):
         if ('source_model_logic_tree' in oq.inputs and
                 oq.hazard_calculation_id is None):
             full_lt = readinput.get_full_lt(oq)
-            L = len(oq.imtls.array)
-            if L:  # L is 0 for case_1_ruptures
-                self.check_size(L, full_lt)
             with self.monitor('composite source model', measuremem=True):
                 self.csm = csm = readinput.get_composite_source_model(
                     oq, full_lt, self.datastore.hdf5)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -54,7 +54,6 @@ U32 = numpy.uint32
 F32 = numpy.float32
 TWO16 = 2 ** 16
 TWO32 = 2 ** 32
-FOURGB = 2 ** 34
 
 TOOBIG = '''\
 The calculation is too big:
@@ -454,7 +453,7 @@ class HazardCalculator(BaseCalculator):
         G = max(len(gsims) for gsims in full_lt.gsim_lt.values.values())
         E = len(full_lt.sm_rlzs)
         upperlimit = self.N * L * G * E * 8
-        if upperlimit > FOURGB:
+        if upperlimit > TWO32:
             raise ValueError(TOOBIG % (self.N, L, G, E,
                                        general.humansize(upperlimit)))
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -62,8 +62,7 @@ num_levels = %d
 num_gsims = %d
 eff_sm_rlzs = %d
 The estimated memory per core is %s > 4 GB.
-You MUST reduce it.
-'''
+You MUST reduce one or more of the listed parameters.'''
 
 source_info_dt = numpy.dtype([
     ('source_id', hdf5.vstr),          # 0

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -43,6 +43,9 @@ weight = operator.attrgetter('weight')
 grp_extreme_dt = numpy.dtype([('grp_id', U16), ('grp_trt', hdf5.vstr),
                              ('extreme_poe', F32)])
 
+MAXMEMORY = '''Estimated upper memory limit per core:
+%d sites x %d levels x %d gsims x %d (models) * 8 bytes = %s'''
+
 
 def get_extreme_poe(array, imtls):
     """
@@ -224,8 +227,8 @@ class ClassicalCalculator(base.HazardCalculator):
         max_num_gsims = max(len(gsims) for gsims in gsims_by_trt.values())
         max_num_grp_ids = max(len(grp_ids) for grp_ids in self.gidx)
         pmapbytes = self.N * num_levels * max_num_gsims * max_num_grp_ids * 8
-        logging.info('Estimated maximum memory in the pmaps: %s',
-                     humansize(pmapbytes))
+        logging.info(MAXMEMORY % (self.N, num_levels, max_num_gsims,
+                                  max_num_grp_ids, humansize(pmapbytes)))
         return zd
 
     def execute(self):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -38,6 +38,7 @@ U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
 F64 = numpy.float64
+TWO32 = 2 ** 32
 MINWEIGHT = 1000
 weight = operator.attrgetter('weight')
 grp_extreme_dt = numpy.dtype([('grp_id', U16), ('grp_trt', hdf5.vstr),
@@ -45,6 +46,15 @@ grp_extreme_dt = numpy.dtype([('grp_id', U16), ('grp_trt', hdf5.vstr),
 
 MAXMEMORY = '''Estimated upper memory limit per core:
 %d sites x %d levels x %d gsims x %d (models) * 8 bytes = %s'''
+
+TOOBIG = '''\
+The calculation is too big:
+num_sites = %d
+num_levels = %d
+num_gsims = %d
+src_multiplicity = %d
+The estimated memory per core is %s > 4 GB.
+You MUST reduce one or more of the listed parameters.'''
 
 
 def get_extreme_poe(array, imtls):
@@ -227,6 +237,10 @@ class ClassicalCalculator(base.HazardCalculator):
         max_num_gsims = max(len(gsims) for gsims in gsims_by_trt.values())
         max_num_grp_ids = max(len(grp_ids) for grp_ids in self.gidx)
         pmapbytes = self.N * num_levels * max_num_gsims * max_num_grp_ids * 8
+        if pmapbytes > TWO32:
+            logging.error(
+                TOOBIG % (self.N, num_levels, max_num_gsims, max_num_grp_ids,
+                          humansize(pmapbytes)))
         logging.info(MAXMEMORY % (self.N, num_levels, max_num_gsims,
                                   max_num_grp_ids, humansize(pmapbytes)))
         return zd

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -52,7 +52,7 @@ The calculation is too big:
 num_sites = %d
 num_levels = %d
 num_gsims = %d
-src_multiplicity = %d
+(num_models) = %d
 The estimated memory per core is %s > 4 GB.
 You MUST reduce one or more of the listed parameters.'''
 

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -71,8 +71,8 @@ def print_full_lt(fname):
     prints information about its composition and the full logic tree
     """
     oqparam = readinput.get_oqparam(fname)
-    csm = readinput.get_composite_source_model(oqparam)
-    print(csm.full_lt)
+    full_lt = readinput.get_full_lt(oqparam)
+    print(full_lt)
     print('See http://docs.openquake.org/oq-engine/stable/'
           'effective-realizations.html for an explanation')
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -586,14 +586,13 @@ def get_source_model_lt(oqparam):
     return smlt
 
 
-def get_composite_source_model(oqparam, h5=None):
+def get_full_lt(oqparam):
     """
-    Parse the XML and build a complete composite source model in memory.
-
     :param oqparam:
         an :class:`openquake.commonlib.oqvalidation.OqParam` instance
-    :param h5:
-         an open hdf5.File where to store the source info
+    :returns:
+        a :class:`openquake.commonlib.logictree.FullLogicTree`
+        instance
     """
     source_model_lt = get_source_model_lt(oqparam)
     trts = source_model_lt.tectonic_region_types
@@ -619,10 +618,26 @@ def get_composite_source_model(oqparam, h5=None):
                 'use sampling instead of full enumeration or reduce the '
                 'source model with oq reduce_sm' % p)
         logging.info('Potential number of logic tree paths = {:_d}'.format(p))
-
     if source_model_lt.on_each_source:
         logging.info('There is a logic tree on each source')
-    csm = get_csm(oqparam, source_model_lt, gsim_lt, h5)
+    full_lt = logictree.FullLogicTree(source_model_lt, gsim_lt)
+    return full_lt
+
+
+def get_composite_source_model(oqparam, full_lt=None, h5=None):
+    """
+    Parse the XML and build a complete composite source model in memory.
+
+    :param oqparam:
+        an :class:`openquake.commonlib.oqvalidation.OqParam` instance
+    :param full_lt:
+        a :class:`openquake.commonlib.logictree.FullLogicTree` or None
+    :param h5:
+         an open hdf5.File where to store the source info
+    """
+    if full_lt is None:
+        full_lt = get_full_lt(oqparam)
+    csm = get_csm(oqparam, full_lt, h5)
     grp_ids = csm.get_grp_ids()
     gidx = {tuple(arr): i for i, arr in enumerate(grp_ids)}
     if oqparam.is_event_based():

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -38,7 +38,8 @@ from openquake.commonlib.source_reader import get_csm
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.mfd import TruncatedGRMFD, EvenlyDiscretizedMFD
-from openquake.commonlib.logictree import SourceModelLogicTree, GsimLogicTree
+from openquake.commonlib.logictree import (
+    SourceModelLogicTree, GsimLogicTree, FullLogicTree)
 
 
 DATADIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -2133,7 +2134,7 @@ class LogicTreeSourceSpecificUncertaintyTest(unittest.TestCase):
         gs_lt = GsimLogicTree(fname_gmc)
 
         mags = [5.7, 5.98, 6.26, 6.54, 6.82, 7.1]
-        csm = get_csm(oqparam, ssc_lt, gs_lt)
+        csm = get_csm(oqparam, FullLogicTree(ssc_lt, gs_lt))
         for src in csm.src_groups[0][0]:
             if src.source_id == 'a2':
                 self.assertEqual(src.mfd.max_mag, 6.5)


### PR DESCRIPTION
Because of the 4GB limit of pickle. For instance running the new Italy model will give an
```
ERROR: The calculation is too big:
num_sites = 5165
num_levels = 650
num_gsims = 3
(num_models) = 94
The estimated memory per core is 7.05 GB > 4 GB.
You MUST reduce one or more of the listed parameters.
```
in the log (but not stopping the calculation right away for the moment).