### PR TITLE
Added a warning against magnitude-dependent maximum_distance

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Added a warning against magnitude-dependent maximum_distance
+
   [Marco Pagani]
   * Fixed a bug in the coeff table of YEA97
   

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -78,9 +78,9 @@ class IntegrationDistance(collections.abc.Mapping):
 
     >>> maxdist = IntegrationDistance({'default': 400})
     >>> maxdist('Some TRT')
-    400.0
+    400
     >>> maxdist('Some TRT', mag=2.5)
-    400.0
+    400
     """
     def __init__(self, dic):
         self.dic = dic  # TRT -> float

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -83,15 +83,8 @@ class IntegrationDistance(collections.abc.Mapping):
     400.0
     """
     def __init__(self, dic):
-        self.dic = {}  # TRT -> float or list of pairs
+        self.dic = dic  # TRT -> float
         self.magdist = {}  # TRT -> (magnitudes, distances), set by the engine
-        for trt, value in dic.items():
-            if isinstance(value, (list, numpy.ndarray)):
-                # assume a list of pairs (magstring, dist)
-                self.magdist[trt] = {'%.2f' % mag: dist for mag, dist in value}
-                self.dic[trt] = value[-1][-1]
-            else:
-                self.dic[trt] = float(value)
 
     def __call__(self, trt, mag=None):
         if mag and trt in self.magdist:

--- a/openquake/hazardlib/tests/calc/filters_test.py
+++ b/openquake/hazardlib/tests/calc/filters_test.py
@@ -34,26 +34,16 @@ class AngularDistanceTestCase(unittest.TestCase):
 
 class IntegrationDistanceTestCase(unittest.TestCase):
     def test_bounding_box(self):
-        maxdist = IntegrationDistance({'default': [
-            (3, 30), (4, 40), (5, 100), (6, 200), (7, 300), (8, 400)]})
+        maxdist = IntegrationDistance({'default': 400})
 
         aae(maxdist('ANY_TRT'), 400)
         bb = maxdist.get_bounding_box(0, 10, 'ANY_TRT')
         aae(bb, [-3.6527738, 6.40272, 3.6527738, 13.59728])
 
-        aae(maxdist('ANY_TRT', mag=7), 400)
-        bb = maxdist.get_bounding_box(0, 10, 'default', mag=7)
-        aae(bb, [-2.7395804, 7.30204,  2.7395804, 12.69796])
-
-        aae(maxdist('default', mag=6), 200)
-        bb = maxdist.get_bounding_box(0, 10, 'default', mag=6)
-        aae(bb, [-1.8263869, 8.20136, 1.8263869, 11.79864])
-
 
 class SourceFilterTestCase(unittest.TestCase):
     def test_get_bounding_boxes(self):
-        maxdist = IntegrationDistance({'default': [
-            (3, 30), (4, 40), (5, 100), (6, 200), (7, 300), (8, 400)]})
+        maxdist = IntegrationDistance({'default': 40})
         sitecol = SiteCollection([
             Site(location=Point(10, 20, 30),
                  vs30=1.2, vs30measured=True,
@@ -62,14 +52,13 @@ class SourceFilterTestCase(unittest.TestCase):
                  vs30=55.4, vs30measured=False,
                  z1pt0=66.7, z2pt5=88.9, backarc=False)])
         srcfilter = SourceFilter(sitecol, maxdist)
-        bb1, bb2 = srcfilter.get_bounding_boxes(mag=4)
+        bb1, bb2 = srcfilter.get_bounding_boxes()
         # bounding boxes in the form min_lon, min_lat, max_lon, max_lat
         aae(bb1, (9.6171855, 19.640272, 10.3828145, 20.359728))
         aae(bb2, (-1.5603623, -3.759728, -0.8396377, -3.040272))
 
     def test_international_date_line(self):
-        maxdist = IntegrationDistance({'default': [
-            (3, 30), (4, 40), (5, 100), (6, 200), (7, 300), (8, 400)]})
+        maxdist = IntegrationDistance({'default': 40})
         sitecol = SiteCollection([
             Site(location=Point(179, 80),
                  vs30=1.2, vs30measured=True,

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -893,10 +893,15 @@ def maximum_distance(value):
     """
     dic = floatdict(value)
     for trt, magdists in dic.items():
-        if isinstance(magdists, list):  # could be a scalar otherwise
+        if isinstance(magdists, list):
             magdists.sort()  # make sure the list is sorted by magnitude
             for mag, dist in magdists:  # validate the magnitudes
                 magnitude(mag)
+            dic[trt] = dist  # keep only the maximum distance
+            logging.warning(
+                'The engine does not accept magnitude-dependent '
+                'maximum_distances anymore; please replace %s with %s' %
+                (magdists, dist))
     return IntegrationDistance(dic)
 
 

--- a/openquake/qa_tests_data/event_based/case_14/job.ini
+++ b/openquake/qa_tests_data/event_based/case_14/job.ini
@@ -21,7 +21,7 @@ number_of_logic_tree_samples = 3
 [hazard_calculation]
 ses_seed = 23
 truncation_level = 3
-maximum_distance = 100
+maximum_distance = [(8, 100), (6, 50)]
 investigation_time = 100
 ses_per_logic_tree_path = 1
 intensity_measure_types = PGA


### PR DESCRIPTION
The feature has been removed a few releases ago and silently ignored in the best case; in the worst case (i.e. in event based) it was giving an error, as discovered by @CatalinaYepes . Now the engine does not break and it is not silent either.

Setting a magnitude-dependent maximum_distance is still possible, but it must be done from code, not from the `job.ini`. Also, a distance must be set for each possible magnitude in the model: using ranges of magnitudes is not possible, even if it could be implemented.