### PR TITLE
Small fixes to the report generation

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -460,7 +460,8 @@ class HazardCalculator(BaseCalculator):
                 self.full_lt = csm.full_lt
         self.init()  # do this at the end of pre-execute
 
-        if not oq.hazard_calculation_id:
+        if (not oq.hazard_calculation_id and
+                oq.calculation_mode != 'preclassical'):
             self.gzip_inputs()
 
     def save_multi_peril(self):

--- a/openquake/calculators/reportwriter.py
+++ b/openquake/calculators/reportwriter.py
@@ -20,11 +20,11 @@
 """
 Utilities to build a report writer generating a .rst report for a calculation
 """
-from openquake.baselib.python3compat import decode
 import os
 import sys
 import logging
-from openquake.baselib.python3compat import encode
+from openquake.baselib import parallel
+from openquake.baselib.python3compat import encode, decode
 from openquake.commonlib import readinput, logs
 from openquake.calculators import views
 
@@ -143,7 +143,10 @@ def build_report(job_ini, output_dir=None):
         calc.execute()
     logging.info('Making the .rst report')
     rw = ReportWriter(calc.datastore)
-    rw.make_report()
+    try:
+        rw.make_report()
+    finally:
+        parallel.Starmap.shutdown()
     report = (os.path.join(output_dir, 'report.rst') if output_dir
               else calc.datastore.export_path('report.rst'))
     try:

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -22,7 +22,7 @@ import operator
 import collections
 import numpy
 from decorator import FunctionMaker
-from openquake.baselib import sap, parallel
+from openquake.baselib import sap
 from openquake.baselib.general import groupby, gen_subclasses
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import gsim, nrml, imt
@@ -166,16 +166,13 @@ def info(what, report=False):
     elif what.endswith(('.ini', '.zip')):
         if os.environ.get('OQ_DISTRIBUTE') not in ('no', 'processpool'):
             os.environ['OQ_DISTRIBUTE'] = 'processpool'
-        try:
-            with Monitor('info', measuremem=True) as mon:
-                if report:
-                    print('Generated', reportwriter.build_report(what))
-                else:
-                    print_full_lt(what)
-            if mon.duration > 1:
-                print(mon)
-        finally:
-            parallel.Starmap.shutdown()
+        with Monitor('info', measuremem=True) as mon:
+            if report:
+                print('Generated', reportwriter.build_report(what))
+            else:
+                print_full_lt(what)
+        if mon.duration > 1:
+            print(mon)
     elif what:
         print("No info for '%s'" % what)
 

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -255,6 +255,7 @@ validators = {
     'probability': valid.probability,
     'occurRates': valid.positivefloats,  # they can be > 1
     'weight': valid.probability,
+    'uncertaintyModel': valid.uncertainty_model,
     'uncertaintyWeight': float,
     'alongStrike': valid.probability,
     'downDip': valid.probability,

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -1090,6 +1090,13 @@ def simple_slice(value):
     return (start, stop)
 
 
+def uncertainty_model(value):
+    """
+    Format whitespace in XML nodes of kind uncertaintyModel
+    """
+    return ' '.join(value.split())
+
+
 # used for the exposure validation
 cost_type = Choice('structural', 'nonstructural', 'contents',
                    'business_interruption')

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -1094,7 +1094,9 @@ def uncertainty_model(value):
     """
     Format whitespace in XML nodes of kind uncertaintyModel
     """
-    return ' '.join(value.split())
+    if value.lstrip().startswith('['):  # TOML, do not mess with newlines
+        return value.strip()
+    return ' '.join(value.split())  # remove newlines too
 
 
 # used for the exposure validation

--- a/openquake/qa_tests_data/event_based/case_14/report.rst
+++ b/openquake/qa_tests_data/event_based/case_14/report.rst
@@ -3,8 +3,8 @@ Hazard South Africa
 
 ============== ===================
 checksum32     2_508_160_232      
-date           2020-03-13T11:21:26
-engine_version 3.9.0-gitfb3ef3a732
+date           2020-03-31T07:29:22
+engine_version 3.9.0-git805a678d6e
 ============== ===================
 
 num_sites = 10, num_levels = 1, num_rlzs = 3
@@ -59,63 +59,50 @@ grp_id gsims                                      distances siteparams ruptparam
 1      '[AkkarEtAlRjb2014]' '[BooreAtkinson2008]' rjb       vs30       mag rake  
 ====== ========================================== ========= ========== ==========
 
-Number of ruptures per source group
------------------------------------
-====== ========= ============ ============
-grp_id num_sites num_ruptures eff_ruptures
-====== ========= ============ ============
-0      0.13115   36_461       488         
-1      0.14789   19_539       426         
-====== ========= ============ ============
-
 Slowest sources
 ---------------
-========= ====== ==== ============ ========= ========= ============
-source_id grp_id code num_ruptures calc_time num_sites eff_ruptures
-========= ====== ==== ============ ========= ========= ============
-18        0      A    480          0.00470   0.16667   282         
-18        1      A    320          0.00464   0.25000   188         
-21        0      A    84           0.00118   0.16667   66          
-21        1      A    168          0.00118   0.08333   132         
-20        0      A    23_199       4.611E-04 0.03030   132         
-20        1      A    12_654       2.794E-04 0.05556   54          
-22        1      A    52           2.387E-04 0.03846   52          
-22        0      A    8            2.038E-04 0.25000   8.00000     
-========= ====== ==== ============ ========= ========= ============
+========= ==== =========== ========= ========= ============
+source_id code num_sources calc_time num_sites eff_ruptures
+========= ==== =========== ========= ========= ============
+18        A    2           0.00957   0.20000   470         
+22        A    2           0.00365   0.06667   60          
+21        A    2           0.00239   0.11111   198         
+20        A    2           8.078E-04 0.03763   186         
+========= ==== =========== ========= ========= ============
 
 Computation times by source typology
 ------------------------------------
 ==== =========
 code calc_time
 ==== =========
-A    0.01289  
+A    0.01642  
 ==== =========
 
 Information about the tasks
 ---------------------------
-================== ======= ======= ======= ======= =======
-operation-duration mean    stddev  min     max     outputs
-preclassical       0.12492 0.08313 0.01453 0.22230 6      
-read_source_model  0.04668 0.05624 0.00358 0.13294 5      
-================== ======= ======= ======= ======= =======
+================== ======= ========= ======= ======= =======
+operation-duration mean    stddev    min     max     outputs
+preclassical       0.07949 0.09271   0.00354 0.23176 10     
+read_source_model  0.00247 1.507E-04 0.00230 0.00271 5      
+================== ======= ========= ======= ======= =======
 
 Data transfer
 -------------
 ================= ============================================ ========
 task              sent                                         received
-read_source_model converter=1.62 KB fname=495 B srcfilter=20 B 12.76 KB
-preclassical      srcs=18.83 KB params=3.63 KB gsims=2.3 KB    2.27 KB 
+read_source_model converter=1.62 KB fname=495 B srcfilter=20 B 9.54 KB 
+preclassical      srcs=23.56 KB params=6.22 KB gsims=3.84 KB   8.83 KB 
 ================= ============================================ ========
 
 Slowest operations
 ------------------
 =========================== ======== ========= ======
-calc_66941                  time_sec memory_mb counts
+calc_41331                  time_sec memory_mb counts
 =========================== ======== ========= ======
-composite source model      1.01091  0.0       1     
-total preclassical          0.74950  2.25781   6     
-splitting/filtering sources 0.52598  0.75391   6     
-total read_source_model     0.23339  0.46875   5     
-store source_info           0.00219  0.0       1     
-aggregate curves            0.00150  0.0       4     
+composite source model      0.82970  1.48438   1     
+total preclassical          0.79490  2.12500   10    
+splitting/filtering sources 0.54452  1.01172   10    
+total read_source_model     0.01234  0.64844   5     
+aggregate curves            0.00269  0.00781   8     
+store source_info           0.00121  0.0       1     
 =========================== ======== ========= ======


### PR DESCRIPTION
1. Do not gzip the source model, it is wasting time and space
2. Shutdown the ProcessPool properly
3. Display the names of the source models without annoying newlines