### PR TITLE
Enhanced `oq check_input` to check complex fault geometries

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Enhanced `oq check_input` to check complex fault geometries
   * Added a warning against magnitude-dependent maximum_distance
 
   [Marco Pagani]

--- a/openquake/commands/check_input.py
+++ b/openquake/commands/check_input.py
@@ -17,12 +17,24 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import sys
 import logging
-from openquake.baselib import sap
+from openquake.baselib import sap, parallel
 from openquake.risklib.asset import Exposure
 from openquake.commonlib import readinput, logs
 from openquake.calculators import base
 from openquake.hazardlib import nrml
 from openquake.risklib import read_nrml  # this is necessary
+
+
+def check_complex_fault(src):
+    """
+    Make sure all the underlying rupture surfaces are valid
+    """
+    for rup in src.iter_ruptures():
+        try:
+            rup.surface.get_dip()
+        except Exception as exc:
+            yield '%s: %s' % (src.source_id, exc)
+            break
 
 
 @sap.script
@@ -41,7 +53,14 @@ def check_input(job_ini_or_zip_or_nrmls):
                 sys.exit(exc)
         else:
             oq = readinput.get_oqparam(job_ini_or_zip_or_nrml)
-            base.calculators(oq, logs.init()).read_inputs()
+            calc = base.calculators(oq, logs.init())
+            base.BaseCalculator.gzip_inputs = lambda self: None  # disable
+            calc.read_inputs()
+            if hasattr(calc, 'csm'):
+                faults = [(src,) for src in calc.csm.get_sources()
+                          if src.code == b'C']
+                for err in parallel.Starmap(check_complex_fault, faults):
+                    logging.error(err)
 
 
 check_input.arg('job_ini_or_zip_or_nrmls', 'Check the input', nargs='+')

--- a/openquake/commands/check_input.py
+++ b/openquake/commands/check_input.py
@@ -61,6 +61,7 @@ def check_input(job_ini_or_zip_or_nrmls):
                           if src.code == b'C']
                 for err in parallel.Starmap(check_complex_fault, faults):
                     logging.error(err)
+                parallel.Starmap.shutdown()
 
 
 check_input.arg('job_ini_or_zip_or_nrmls', 'Check the input', nargs='+')

--- a/openquake/commands/check_input.py
+++ b/openquake/commands/check_input.py
@@ -15,26 +15,16 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import os
 import sys
 import logging
-from openquake.baselib import sap, parallel
+from unittest import mock
+from openquake.baselib import sap
 from openquake.risklib.asset import Exposure
 from openquake.commonlib import readinput, logs
 from openquake.calculators import base
 from openquake.hazardlib import nrml
 from openquake.risklib import read_nrml  # this is necessary
-
-
-def check_complex_fault(src):
-    """
-    Make sure all the underlying rupture surfaces are valid
-    """
-    for rup in src.iter_ruptures():
-        try:
-            rup.surface.get_dip()
-        except Exception as exc:
-            yield '%s: %s' % (src.source_id, exc)
-            break
 
 
 @sap.script
@@ -55,13 +45,8 @@ def check_input(job_ini_or_zip_or_nrmls):
             oq = readinput.get_oqparam(job_ini_or_zip_or_nrml)
             calc = base.calculators(oq, logs.init())
             base.BaseCalculator.gzip_inputs = lambda self: None  # disable
-            calc.read_inputs()
-            if hasattr(calc, 'csm'):
-                faults = [(src,) for src in calc.csm.get_sources()
-                          if src.code == b'C']
-                for err in parallel.Starmap(check_complex_fault, faults):
-                    logging.error(err)
-                parallel.Starmap.shutdown()
+            with mock.patch.dict(os.environ, {'OQ_CHECK_INPUT': '1'}):
+                calc.read_inputs()
 
 
 check_input.arg('job_ini_or_zip_or_nrmls', 'Check the input', nargs='+')

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -39,7 +39,7 @@ from openquake.baselib.node import Node
 from openquake.hazardlib.const import StdDev
 from openquake.hazardlib.calc.gmf import CorrelationButNoInterIntraStdDevs
 from openquake.hazardlib import (
-    geo, site, imt, valid, sourceconverter, nrml, InvalidFile)
+    source, geo, site, imt, valid, sourceconverter, nrml, InvalidFile)
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.risklib import asset, riskmodels
@@ -688,6 +688,8 @@ def get_composite_source_model(oqparam, full_lt=None, h5=None):
         h5['grp_ids'] = grp_ids
     csm.gsim_lt.check_imts(oqparam.imtls)
     csm.source_info = data
+    if os.environ.get('OQ_CHECK_INPUT'):
+        source.check_complex_faults(csm.get_sources())
     return csm
 
 

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -274,12 +274,12 @@ class CompositeSourceModel:
         assert len(keys) < TWO16, len(keys)
         return [numpy.array(grp_ids, numpy.uint32) for grp_ids in sorted(keys)]
 
-    def get_nonparametric_sources(self):
+    def get_sources(self):
         """
-        :returns: list of non parametric sources in the composite source model
+        :returns: list of sources in the composite source model
         """
         return [src for src_group in self.src_groups
-                for src in src_group if hasattr(src, 'data')]
+                for src in src_group]
 
     def get_floating_spinning_factors(self):
         """

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -579,10 +579,10 @@ class RectangularMesh(Mesh):
         """
         assert 1 not in self.lons.shape, (
             "inclination and azimuth are only defined for mesh of more than "
-            "one row and more than one column of points")
+            "one row and more than one column of points ")
         assert ((self.depths[1:] - self.depths[:-1]) >= 0).all(), (
             "get_mean_inclination_and_azimuth() requires next mesh row "
-            "to be not shallower than the previous one")
+            "to be not shallower than the previous one ")
 
         points, along_azimuth, updip, diag = self.triangulate()
 

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -579,10 +579,10 @@ class RectangularMesh(Mesh):
         """
         assert 1 not in self.lons.shape, (
             "inclination and azimuth are only defined for mesh of more than "
-            "one row and more than one column of points ")
+            "one row and more than one column of points")
         assert ((self.depths[1:] - self.depths[:-1]) >= 0).all(), (
             "get_mean_inclination_and_azimuth() requires next mesh row "
-            "to be not shallower than the previous one ")
+            "to be not shallower than the previous one")
 
         points, along_azimuth, updip, diag = self.triangulate()
 


### PR DESCRIPTION
Here is how it works:
```
$ oq check_input SAM/in/job.ini
...
[2020-04-02 05:22:35 #41641 INFO] check_complex_fault 0 B sent, 9 submitted, 0 queued
[2020-04-02 05:22:40 #41641 ERROR] LAN_inter: get_mean_inclination_and_azimuth() requires next mesh row to be not shallower than the previous one 
[2020-04-02 05:22:40 #41641 INFO] check_complex_fault  11% [9 submitted, 0 queued]
[2020-04-02 05:22:47 #41641 INFO] check_complex_fault  22% [9 submitted, 0 queued]
[2020-04-02 05:23:22 #41641 INFO] check_complex_fault  33% [9 submitted, 0 queued]
[2020-04-02 05:23:25 #41641 INFO] check_complex_fault  44% [9 submitted, 0 queued]
[2020-04-02 05:23:35 #41641 INFO] check_complex_fault  55% [9 submitted, 0 queued]
[2020-04-02 05:23:40 #41641 INFO] check_complex_fault  66% [9 submitted, 0 queued]
[2020-04-02 05:24:41 #41641 INFO] check_complex_fault  77% [9 submitted, 0 queued]
[2020-04-02 05:24:47 #41641 INFO] check_complex_fault  88% [9 submitted, 0 queued]
[2020-04-02 05:26:24 #41641 INFO] check_complex_fault 100% [9 submitted, 0 queued]
```
So the only problematic source in SAM is LAN_inter. The check should be added to the mosaic tests. The way to do it is to add a line
```
OQ_CHECK_INPUT: '1'
```
in the file .gitlab-ci.yml of the mosaic repo.