### PR TITLE
Reduced the data transfer in ruptures

### DIFF
--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -60,8 +60,10 @@ def export_ruptures_xml(ekey, dstore):
     num_ses = oq.ses_per_logic_tree_path
     ruptures_by_grp = AccumDict(accum=[])
     for rgetter in gen_rgetters(dstore):
-        ebrs = [ebr.export(rgetter.rlzs_by_gsim, num_ses)
-                for ebr in rgetter.get_ruptures()]
+        ebrs = []
+        for proxy in rgetter.get_proxies():
+            ebr = proxy.to_ebr(rgetter.trt, rgetter.samples)
+            ebrs.append(ebr.export(rgetter.rlzs_by_gsim, num_ses))
         ruptures_by_grp[rgetter.grp_id].extend(ebrs)
     dest = dstore.export_path('ses.' + fmt)
     writer = hazard_writers.SESXMLWriter(dest)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1054,7 +1054,8 @@ def extract_rupture(dstore, rup_id):
     """
     ridx = list(dstore['ruptures']['id']).index(int(rup_id))
     [getter] = getters.gen_rgetters(dstore, slice(ridx, ridx + 1))
-    [ebr] = getter.get_ruptures()
+    [proxy] = getter.get_proxies()
+    ebr = proxy.to_ebr(getter.trt, getter.samples)
     return ArrayWrapper((), ebr.rupture.todict())
 
 
@@ -1198,8 +1199,9 @@ class RuptureData(object):
     Container for information about the ruptures of a given
     tectonic region type.
     """
-    def __init__(self, trt, gsims):
+    def __init__(self, trt, samples, gsims):
         self.trt = trt
+        self.samples = samples
         self.cmaker = ContextMaker(trt, gsims)
         self.params = sorted(self.cmaker.REQUIRES_RUPTURE_PARAMETERS -
                              set('mag strike dip rake hypo_depth'.split()))
@@ -1211,12 +1213,13 @@ class RuptureData(object):
             ('boundaries', hdf5.vfloat32)] +
             [(param, F32) for param in self.params])
 
-    def to_array(self, ebruptures):
+    def to_array(self, proxies):
         """
-        Convert a list of ebruptures into an array of dtype RuptureRata.dt
+        Convert a list of rupture proxies into an array of dtype RuptureRata.dt
         """
         data = []
-        for ebr in ebruptures:
+        for proxy in proxies:
+            ebr = proxy.to_ebr(self.trt, self.samples)
             rup = ebr.rupture
             self.cmaker.add_rup_params(rup)
             ruptparams = tuple(getattr(rup, param) for param in self.params)
@@ -1253,9 +1256,10 @@ def extract_rupture_info(dstore, what):
     rows = []
     boundaries = []
     for rgetter in getters.gen_rgetters(dstore):
-        rups = rgetter.get_ruptures(min_mag)
-        rup_data = RuptureData(rgetter.trt, rgetter.rlzs_by_gsim)
-        for r, rup in zip(rup_data.to_array(rups), rups):
+        proxies = rgetter.get_proxies(min_mag)
+        rup_data = RuptureData(
+            rgetter.trt, rgetter.samples, rgetter.rlzs_by_gsim)
+        for r in rup_data.to_array(proxies):
             coords = ['%.5f %.5f' % xyz[:2] for xyz in zip(*r['boundaries'])]
             coordset = sorted(set(coords))
             if len(coordset) < 4:   # degenerate to line

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -790,12 +790,12 @@ class RuptureProxy(object):
     A proxy for a rupture record.
 
     :param rec: a record with the rupture parameters
-    :param sids: IDs of the sites affected by the rupture
+    :param nsites: approx number of sites affected by the rupture
     :param samples: how many times the rupture is sampled
     """
-    def __init__(self, rec, sids=None, samples=1):
+    def __init__(self, rec, nsites=None, samples=1):
         self.rec = rec
-        self.sids = sids
+        self.nsites = nsites
         self.samples = samples
 
     @property
@@ -806,20 +806,20 @@ class RuptureProxy(object):
             number of occurrences, number of samples and number of sites
         """
         return self.samples * self['n_occ'] * (
-            100 if self.sids is None else max(len(self.sids), 100))
+            100 if self.nsites is None else max(self.nsites, 100))
 
     def __getitem__(self, name):
         return self.rec[name]
 
-    def to_ebr(self, geom, trt, samples):
+    # NB: requires the .geom attribute to be set
+    def to_ebr(self, trt, samples):
         """
         :returns: EBRupture instance associated to the underlying rupture
         """
         # not implemented: rupture_slip_direction
-        rupture = get_rupture(self.rec, geom, trt)
+        rupture = get_rupture(self.rec, self.geom, trt)
         ebr = EBRupture(rupture, self.rec['srcidx'], self.rec['grp_id'],
                         self.rec['n_occ'], samples)
-        ebr.sids = self.sids
         ebr.id = self.rec['id']
         ebr.e0 = self.rec['e0']
         return ebr


### PR DESCRIPTION
Do not transfer the site indices: this has a large impact in large calculations. For SERA which has nearly 4 million ruptures and 184,756 sites the saving is impressive (26x):
```
   before: rupgetter=49.18 GB (#37935)
   after : rupgetter=1.89 GB (#37947)
```
The price to pay is a small slowdown in getting ruptures which changes nothing in the context of the full calculation.

Still there is a lot of data transfer in the parameters (14.25 GB) which perhaps can be reduced.