### PR TITLE
Fixed a recent regression in UCERF

### DIFF
--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -43,6 +43,7 @@ code2cls = BaseRupture.init()
 # ############## utilities for the classical calculator ############### #
 
 
+# used only in the view global_hcurves
 def convert_to_array(pmap, nsites, imtls, inner_idx=0):
     """
     Convert the probability map into a composite array with header
@@ -57,14 +58,14 @@ def convert_to_array(pmap, nsites, imtls, inner_idx=0):
     # build the export dtype, of the form PGA-0.1, PGA-0.2 ...
     for imt, imls in imtls.items():
         for iml in imls:
-            lst.append(('%s-%s' % (imt, iml), F32))
+            lst.append(('%s-%.3f' % (imt, iml), F32))
     curves = numpy.zeros(nsites, numpy.dtype(lst))
     for sid, pcurve in pmap.items():
         curve = curves[sid]
         idx = 0
         for imt, imls in imtls.items():
             for iml in imls:
-                curve['%s-%s' % (imt, iml)] = pcurve.array[idx, inner_idx]
+                curve['%s-%.3f' % (imt, iml)] = pcurve.array[idx, inner_idx]
                 idx += 1
     return curves
 

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -89,6 +89,7 @@ def get_csm(oq, full_lt, h5=None):
             src_groups.append(sg)
             src = sg[0].new(sm_rlz.ordinal, sm_rlz.value)  # one source
             sg.mags = numpy.unique(numpy.round(src.mags))
+            del src.__dict__['mags']  # remove cache
             src.checksum = src.grp_id = src.id = grp_id
             src.samples = sm_rlz.samples
             if classical:


### PR DESCRIPTION
The magnitude cache betrayed me :-( The current tests are not sensitive to this bug, so I have added a new test in oq-risk-tests for site-specific classical UCERF (see https://gitlab.openquake.org/openquake/oq-risk-tests/merge_requests/49). This was really hard to find, even if the fix is a one-liner.