### PR TITLE
Changed the rupture storage for disaggregation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced the rupture storage in classical calculations by using compression
   * Improved the task distribution in the classical calculator, avoiding
     generating too few or too many tasks
   * Enhanced `oq check_input` to check complex fault geometries

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -417,6 +417,13 @@ class HazardCalculator(BaseCalculator):
         """
         return len(self.sitecol.complete) if self.sitecol else None
 
+    @property
+    def few_sites(self):
+        """
+        :returns: True if there are less than max_sites_disagg
+        """
+        return len(self.sitecol.complete) <= self.oqparam.max_sites_disagg
+
     def check_overflow(self):
         """Overridden in event based"""
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -230,7 +230,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 self.datastore.create_dset('rup/' + k, hdf5.vfloat32)
             elif k.endswith('_'):  # array of shape (U, N)
                 self.datastore.create_dset(
-                    'rup/' + k, F32, shape=(None, self.N))
+                    'rup/' + k, F32, shape=(None, self.N), compression='gzip')
             else:
                 self.datastore.create_dset('rup/' + k, F32)
         self.by_task = {}  # task_no => src_ids

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -130,17 +130,17 @@ def compute_disagg(dstore, idxs, cmaker, iml4, trti, bin_edges, monitor):
         ctxs = []
         ok, = numpy.where(
             rupdata['rrup_'][:, sid] <= cmaker.maximum_distance(cmaker.trt))
-        for ridx in ok:
+        for ridx in ok:  # consider only the ruptures close to the site
             rctx = RuptureContext((par, rupdata[par][ridx])
                                   for par in rupdata if not par.endswith('_'))
             dctx = DistancesContext((par[:-1], rupdata[par][ridx, [sid]])
                                     for par in rupdata if par.endswith('_'))
             ctxs.append((rctx, dctx))
-        mat = disagg.build_matrix(
+        matrix = disagg.build_matrix(
             cmaker, singlesite, ctxs, iml3, iml4.imts, rlzs,
             oq.num_epsilon_bins, bins, pne_mon, mat_mon, gmf_mon)
-        if mat.any():
-            yield {'trti': trti, sid: mat}
+        if matrix.any():
+            yield {'trti': trti, sid: matrix}
 
 
 def agg_probs(*probs):

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -25,7 +25,7 @@ import numpy
 
 from openquake.baselib import parallel, hdf5
 from openquake.baselib.general import (
-    AccumDict, block_splitter, get_array_nbytes)
+    AccumDict, block_splitter, get_array_nbytes, humansize)
 from openquake.baselib.python3compat import encode
 from openquake.hazardlib import stats
 from openquake.hazardlib.calc import disagg
@@ -306,7 +306,9 @@ class DisaggregationCalculator(base.HazardCalculator):
         shapedic['concurrent_tasks'] = oq.concurrent_tasks
         nbytes, msg = get_array_nbytes(shapedic)
         if nbytes > oq.max_data_transfer:
-            raise ValueError('Estimated data transfer too big\n%s' % msg)
+            raise ValueError(
+                'Estimated data transfer too big\n%s > max_data_transfer=%s' %
+                (msg, humansize(oq.max_data_transfer)))
         logging.info('Estimated data transfer: %s', msg)
         self.imldict = {}  # sid, rlz, poe, imt -> iml
         for s in self.sitecol.sids:

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -30,7 +30,7 @@ from openquake.baselib.python3compat import encode
 from openquake.hazardlib import stats
 from openquake.hazardlib.calc import disagg
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib.gsim.base import ContextMaker
+from openquake.hazardlib.gsim.base import ContextMaker, DistancesContext
 from openquake.hazardlib.contexts import RuptureContext
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.commonlib import util
@@ -123,10 +123,24 @@ def compute_disagg(dstore, idxs, cmaker, iml4, trti, bin_edges, monitor):
     pne_mon = monitor('disaggregate_pne', measuremem=False)
     mat_mon = monitor('build_disagg_matrix', measuremem=True)
     gmf_mon = monitor('disagg mean_std', measuremem=False)
-    for sid, mat in disagg.build_matrices(
-            rupdata, sitecol, cmaker, iml4, oq.num_epsilon_bins,
-            bin_edges, pne_mon, mat_mon, gmf_mon):
-        yield {'trti': trti, sid: mat}
+    for sid, iml3 in zip(sitecol.sids, iml4):
+        singlesite = sitecol.filtered([sid])
+        bins = disagg.get_bins(bin_edges, sid)
+        rlzs = [iml4.rlzs[sid, z] for z in range(iml4.shape[-1])]
+        ctxs = []
+        ok, = numpy.where(
+            rupdata['rrup_'][:, sid] <= cmaker.maximum_distance(cmaker.trt))
+        for ridx in ok:
+            rctx = RuptureContext((par, rupdata[par][ridx])
+                                  for par in rupdata if not par.endswith('_'))
+            dctx = DistancesContext((par[:-1], rupdata[par][ridx, [sid]])
+                                    for par in rupdata if par.endswith('_'))
+            ctxs.append((rctx, dctx))
+        mat = disagg.build_matrix(
+            cmaker, singlesite, ctxs, iml3, iml4.imts, rlzs,
+            oq.num_epsilon_bins, bins, pne_mon, mat_mon, gmf_mon)
+        if mat.any():
+            yield {'trti': trti, sid: mat}
 
 
 def agg_probs(*probs):
@@ -164,6 +178,8 @@ class DisaggregationCalculator(base.HazardCalculator):
     accept_precalc = ['classical', 'disaggregation']
 
     def init(self):
+        if self.N >= 32768:
+            raise ValueError('You can disaggregate at max 32,768 sites')
         few = self.oqparam.max_sites_disagg
         if self.N > few:
             raise ValueError(

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -68,7 +68,10 @@ def get_info(dstore):
     stats = {stat: s for s, stat in enumerate(oq.hazard_stats())}
     loss_types = {lt: l for l, lt in enumerate(oq.loss_dt().names)}
     imt = {imt: i for i, imt in enumerate(oq.imtls)}
-    num_rlzs = dstore['full_lt'].get_num_rlzs()
+    try:
+        num_rlzs = dstore['full_lt'].get_num_rlzs()
+    except KeyError:  # engine version < 3.9
+        num_rlzs = dstore['csm_info'].get_num_rlzs()
     return dict(stats=stats, num_rlzs=num_rlzs, loss_types=loss_types,
                 imtls=oq.imtls, investigation_time=oq.investigation_time,
                 poes=oq.poes, imt=imt, uhs_dt=oq.uhs_dt(),

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -71,7 +71,7 @@ def get_info(dstore):
     try:
         num_rlzs = dstore['full_lt'].get_num_rlzs()
     except KeyError:  # engine version < 3.9
-        num_rlzs = dstore['csm_info'].get_num_rlzs()
+        num_rlzs = len(dstore['weights'])
     return dict(stats=stats, num_rlzs=num_rlzs, loss_types=loss_types,
                 imtls=oq.imtls, investigation_time=oq.investigation_time,
                 poes=oq.poes, imt=imt, uhs_dt=oq.uhs_dt(),

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -452,8 +452,7 @@ hazard_uhs-std.csv
                  ('lat_', 3202), ('lon_', 3202), ('mag', 3202),
                  ('occurrence_rate', 3202), ('probs_occur', 3202),
                  ('rake', 3202), ('rjb_', 3202), ('rrup_', 3202),
-                 ('rx_', 3202), ('sid_', 3202),
-                 ('weight', 3202), ('ztor', 3202)])
+                 ('rx_', 3202), ('weight', 3202), ('ztor', 3202)])
 
     def test_case_30_sampling(self):
         # IMT-dependent weights with sampling by cheating

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -83,6 +83,7 @@ class DisaggregationTestCase(CalculatorTestCase):
 
     def test_case_2(self):
         # this is a case with disagg_outputs = Mag and 4 realizations
+        # site #0 is partially discarded
         if sys.platform == 'darwin':
             raise unittest.SkipTest('MacOSX')
         self.assert_curves_ok(

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -59,9 +59,8 @@ def _disaggregate(cmaker, sitecol, rupdata, iml2, eps3,
     except KeyError:
         return pack(acc, 'mags dists lons lats pnes'.split())
     maxdist = cmaker.maximum_distance(cmaker.trt)
-    fildist = rupdata[cmaker.filter_distance + '_'][:, sid]
-    for ridx, dist in enumerate(fildist):
-        if dist >= maxdist:
+    for ridx, dist in enumerate(rupdata['rrup_'][:, sid]):
+        if dist >= maxdist:  # discard the rupture
             continue
         elif gsim.minimum_distance and dist < gsim.minimum_distance:
             dist = gsim.minimum_distance
@@ -80,8 +79,8 @@ def _disaggregate(cmaker, sitecol, rupdata, iml2, eps3,
                 sitecol, rctx, dctx, iml2.imts, [gsim])[..., 0]  # (2, N, M)
         with pne_mon:
             iml = numpy.array(
-                [to_distribution_values(lvl, imt) for imt, lvl in zip(
-                    iml2.imts, iml2)])  # shape (M, P)
+                [to_distribution_values(lvl, imt)
+                 for imt, lvl in zip(iml2.imts, iml2)])  # shape (M, P)
             pne = _disaggregate_pne(rctx, mean_std, iml, *eps3)
             acc['pnes'].append(pne)
     return pack(acc, 'mags dists lons lats pnes'.split())

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -184,53 +184,29 @@ def _build_disagg_matrix(bdata, bins):
 
 
 # called by the engine
-def build_matrices(rupdata, sitecol, cmaker, iml4,
-                   num_epsilon_bins, bin_edges,
-                   pne_mon, mat_mon, gmf_mon):
+def build_matrix(cmaker, singlesite, ctxs, iml3, imts, rlzs,
+                 num_epsilon_bins, bins, pne_mon, mat_mon, gmf_mon):
     """
-    :param rupdata: a dictionary of rupture data
-    :param sitecol: a site collection of N elements
     :param cmaker: a ContextMaker
-    :param iml4: an array of shape (N, M, P, Z)
+    :param singlesite: a site collection of 1 element
+    :param ctxs: a list of pairs (rctx, dctx)
+    :param iml3: an array of shape (M, P, Z)
+    :param imts: intensity measure types
+    :param rlzs: Z realizations for the given site
     :param num_epsilon_bins: number of epsilons bins
-    :param bin_edges: edges of the bins
-    :yield: (sid, 8dmatrix) if the matrix is nonzero
+    :param bins: disaggregation bins
+    :yield: 8D disaggregation matrix
     """
-    if len(sitecol) >= 32768:
-        raise ValueError('You can disaggregate at max 32,768 sites')
-    eps3 = _eps3(cmaker.trunclevel, num_epsilon_bins)  # this is slow
-    M, P, Z = iml4.shape[1:]
-    for sid, iml3 in zip(sitecol.sids, iml4):
-        singlesite = sitecol.filtered([sid])
-        ctxs = []
-        ok, = numpy.where(
-            rupdata['rrup_'][:, sid] <= cmaker.maximum_distance(cmaker.trt))
-        for ridx in ok:
-            rctx = contexts.RuptureContext(
-                (par, rupdata[par][ridx])
-                for par in rupdata if not par.endswith('_'))
-            dctx = contexts.DistancesContext(
-                (par[:-1], rupdata[par][ridx, [sid]])
-                for par in rupdata if par.endswith('_'))
-            ctxs.append((rctx, dctx))
-        bins = get_bins(bin_edges, sid)
-        arr = numpy.zeros([len(b) - 1 for b in bins] + [M, P, Z])
-        for z in range(Z):
-            rlz = iml4.rlzs[sid, z]
-            iml2 = hdf5.ArrayWrapper(
-                iml3[:, :, z], dict(rlzi=rlz, imts=iml4.imts))
-            try:
-                bdata = _disaggregate(
-                    cmaker, singlesite, ctxs, iml2, eps3, pne_mon, gmf_mon)
-                if bdata.pnes.sum():
-                    with mat_mon:
-                        arr[..., z] = _build_disagg_matrix(bdata, bins)
-            except Exception as exc:
-                msg = 'Error in task %s for site #%d, rlz #%d: %s' % (
-                    getattr(pne_mon, 'task_no', 0), sid, rlz, exc)
-                raise exc.__class__(msg) from exc
-        if arr.any():  # nonzero
-            yield sid, arr
+    eps3 = _eps3(cmaker.trunclevel, num_epsilon_bins)
+    arr = numpy.zeros([len(b) - 1 for b in bins] + list(iml3.shape))
+    for z, rlz in enumerate(rlzs):
+        iml2 = hdf5.ArrayWrapper(iml3[:, :, z], dict(rlzi=rlz, imts=imts))
+        bdata = _disaggregate(
+            cmaker, singlesite, ctxs, iml2, eps3, pne_mon, gmf_mon)
+        if bdata.pnes.sum():
+            with mat_mon:
+                arr[..., z] = _build_disagg_matrix(bdata, bins)
+    return arr
 
 
 def _digitize_lons(lons, lon_bins):

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -188,21 +188,21 @@ def build_matrix(cmaker, singlesite, ctxs, iml3, imts, rlzs,
                  num_epsilon_bins, bins, pne_mon, mat_mon, gmf_mon):
     """
     :param cmaker: a ContextMaker
-    :param singlesite: a site collection of 1 element
+    :param singlesite: a site collection with a single site
     :param ctxs: a list of pairs (rctx, dctx)
     :param iml3: an array of shape (M, P, Z)
-    :param imts: intensity measure types
+    :param imts: a list of intensity measure types
     :param rlzs: Z realizations for the given site
     :param num_epsilon_bins: number of epsilons bins
-    :param bins: disaggregation bins
-    :yield: 8D disaggregation matrix
+    :param bins: bin edges for the given site
+    :returns: 8D disaggregation matrix
     """
     eps3 = _eps3(cmaker.trunclevel, num_epsilon_bins)
     arr = numpy.zeros([len(b) - 1 for b in bins] + list(iml3.shape))
     for z, rlz in enumerate(rlzs):
         iml2 = hdf5.ArrayWrapper(iml3[:, :, z], dict(rlzi=rlz, imts=imts))
-        bdata = _disaggregate(
-            cmaker, singlesite, ctxs, iml2, eps3, pne_mon, gmf_mon)
+        bdata = _disaggregate(cmaker, singlesite, ctxs, iml2, eps3,
+                              pne_mon, gmf_mon)
         if bdata.pnes.sum():
             with mat_mon:
                 arr[..., z] = _build_disagg_matrix(bdata, bins)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -385,12 +385,12 @@ class PmapMaker(object):
                 ctxs = self.collapse_the_ctxs(ctxs)
             self.numrups += len(ctxs)
             for rup, dctx in ctxs:
+                self.rupdata.add(rup, sites, dctx)
                 mask = (dctx.rrup <= self.maximum_distance(
                     rup.tectonic_region_type, rup.mag))
                 r_sites = sites.filter(mask)
                 for name in self.REQUIRES_DISTANCES:
                     setattr(dctx, name, getattr(dctx, name)[mask])
-                self.rupdata.add(rup, r_sites, dctx)
                 self.rupdata.data['grp_id'].append(grp_ids)
                 self.numsites += len(r_sites)
                 yield rup, r_sites, dctx

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -470,7 +470,7 @@ class PmapMaker(object):
                     ctxs.extend(self._ctxs(rups, sites, grp_ids))
                 else:  # many sites
                     for rup in rups:
-                        ctxs.extend(self._ctxs([rup], rup.sites, grp_ids))
+                        ctxs.extend(self._ctxs([rup], sites, grp_ids))
             self._update_pmap(ctxs)
             self.calc_times[src_id] += numpy.array(
                 [self.numrups, self.numsites, time.time() - t0])
@@ -572,7 +572,6 @@ class PmapMaker(object):
 
         def _add(rupiter, sites):
             for rup in rupiter:
-                rup.sites = sites
                 rups.append(rup)
         for src in srcs:
             self.totrups += src.num_ruptures

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -469,7 +469,7 @@ class PmapMaker(object):
                     ctxs.extend(self._ctxs(rups, sites, grp_ids))
                 else:  # many sites
                     for rup in rups:
-                        ctxs.extend(self._ctxs([rup], sites, grp_ids))
+                        ctxs.extend(self._ctxs([rup], rup.sites, grp_ids))
             self._update_pmap(ctxs)
             self.calc_times[src_id] += numpy.array(
                 [self.numrups, self.numsites, time.time() - t0])
@@ -571,6 +571,7 @@ class PmapMaker(object):
 
         def _add(rupiter, sites):
             for rup in rupiter:
+                rup.sites = sites
                 rups.append(rup)
         for src in srcs:
             self.totrups += src.num_ruptures

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -111,7 +111,7 @@ class RupData(object):
                 self.add(rup, sites)
         return {k: numpy.array(v) for k, v in self.data.items()}
 
-    def add(self, rup, sctx, dctx=None):
+    def add(self, rup, sctx, dctx):
         rate = rup.occurrence_rate
         if numpy.isnan(rate):  # for nonparametric ruptures
             probs_occur = rup.probs_occur
@@ -125,11 +125,8 @@ class RupData(object):
 
         self.data['sid_'].append(numpy.int16(sctx.sids))
         for dst_param in (self.cmaker.REQUIRES_DISTANCES | {'rrup'}):
-            if dctx is None:  # compute the distances
-                dists = get_distances(rup, sctx, dst_param)
-            else:  # reuse already computed distances
-                dists = getattr(dctx, dst_param)
-            self.data[dst_param + '_'].append(F32(dists))
+            dists = F32(getattr(dctx, dst_param))
+            self.data[dst_param + '_'].append(dists)
         closest = rup.surface.get_closest_points(sctx)
         self.data['lon_'].append(F32(closest.lons))
         self.data['lat_'].append(F32(closest.lats))


### PR DESCRIPTION
We are storing redundant data for each site, but thanks to the compression we are actually saving space compared to before. For instance for the disaggregation case_multi the disk space is down
from 223 MB to only 53 MB. Also, the index manipulations are now a lot simpler.