### PR TITLE
Fixed the tot_losses exporter in ebrisk calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Fixed the tot_curves exporter in ebrisk calculations
+  * Fixed the tot_curves and tot_losses exporters in ebrisk calculations
   * Reduced the rupture storage in classical calculations by using compression
   * Improved the task distribution in the classical calculator, avoiding
     generating too few or too many tasks

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -162,14 +162,14 @@ def export_agg_losses(ekey, dstore):
     """
     dskey = ekey[0]
     oq = dstore['oqparam']
+    aggregate_by = oq.aggregate_by if dskey.startswith('agg_') else []
     name, value, tags = _get_data(dstore, dskey, oq.hazard_stats())
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     assetcol = dstore['assetcol']
-    aggname = '_'.join(['agg'] + (oq.aggregate_by if dskey.startswith(
-        'agg_') else []))
+    aggname = '_'.join(['agg'] + aggregate_by)
     expvalue = dstore['exposed_values/' + aggname][()]
     # shape (T1, T2, ..., L)
-    tagnames = tuple(dstore['oqparam'].aggregate_by)
+    tagnames = tuple(aggregate_by)
     header = ('loss_type',) + tagnames + (
         'loss_value', 'exposed_value', 'loss_ratio')
     md = dstore.metadata

--- a/openquake/qa_tests_data/event_based_risk/case_master/expected/agglosses.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_master/expected/agglosses.csv
@@ -1,5 +1,5 @@
-#,,,"generated_by='OpenQuake engine 3.9.0-gitca5771995e', start_date='2020-03-12T14:53:43', checksum=2856676237, investigation_time=1.0, risk_investigation_time=50.0"
-loss_type,id,loss_value,exposed_value,loss_ratio
+#,,,"generated_by='OpenQuake engine 3.9.0-git0aeea7c55f', start_date='2020-04-06T10:23:15', checksum=2856676237, investigation_time=1.0, risk_investigation_time=50.0"
+loss_type,loss_value,exposed_value,loss_ratio
 business_interruption,4.17183E+03,1.40000E+04,2.97988E-01
 contents,3.03626E+04,3.50000E+04,8.67502E-01
 nonstructural,4.20796E+04,1.05000E+05,4.00758E-01


### PR DESCRIPTION
It was containing extra fields coming from aggregate_by (incorrectly).