### PR TITLE
Fixed sorting bug in /extract/rupture_info

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed an ordering bug in /extract/rupture_info affecting the QGIS plugin
   * Fixed `oq engine --eo output_id output_dir` for the Full Report output
   * Added year and ses_id to the events table
   * Removed NaNs in the low return period part of the loss curves

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -90,6 +90,7 @@ def export_ruptures_csv(ekey, dstore):
     comment = dstore.metadata
     comment.update(investigation_time=oq.investigation_time,
                    ses_per_logic_tree_path=oq.ses_per_logic_tree_path)
+    arr.array.sort(order='rup_id')
     writers.write_csv(dest, arr, comment=comment)
     return [dest]
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1274,7 +1274,6 @@ def extract_rupture_info(dstore, what):
                  r['lon'], r['lat'], r['depth'],
                  rgetter.trt, r['strike'], r['dip'], r['rake']))
     arr = numpy.array(rows, dtlist)
-    arr.sort(order='rup_id')
     geoms = gzip.compress('\n'.join(boundaries).encode('utf-8'))
     return ArrayWrapper(arr, dict(investigation_time=oq.investigation_time,
                                   boundaries=geoms))

--- a/openquake/calculators/scenario.py
+++ b/openquake/calculators/scenario.py
@@ -78,7 +78,7 @@ class ScenarioCalculator(base.HazardCalculator):
         self.computer = GmfComputer(
             ebr, self.sitecol, oq.imtls, self.cmaker, oq.truncation_level,
             oq.correl_model, self.amplifier)
-        M32 = (numpy.float32, len(self.oqparam.imtls))
+        M32 = (numpy.float32, (len(self.oqparam.imtls),))
         self.sig_eps_dt = [('eid', numpy.uint64), ('sig', M32), ('eps', M32)]
 
     def init(self):

--- a/openquake/qa_tests_data/event_based/case_25/expected/ruptures.csv
+++ b/openquake/qa_tests_data/event_based/case_25/expected/ruptures.csv
@@ -1,4 +1,4 @@
-#,,,,,,,,,"generated_by='OpenQuake engine 3.9.0-git90b332a75d', start_date='2020-03-14T05:02:12', checksum=2320426248, investigation_time=1.0, ses_per_logic_tree_path=50"
+#,,,,,,,,,"generated_by='OpenQuake engine 3.9.0-gite5250ba032', start_date='2020-04-08T15:03:31', checksum=2320426248, investigation_time=1.0, ses_per_logic_tree_path=50"
 rup_id,multiplicity,mag,centroid_lon,centroid_lat,centroid_depth,trt,strike,dip,rake
 0,294,4.500000E+00,5.000000E-01,5.191449E-11,4.000000E+00,active shallow crust,0.000000E+00,9.000000E+01,0.000000E+00
 1,180,4.500000E+00,5.000000E-01,5.000000E-01,4.000000E+00,active shallow crust,0.000000E+00,9.000000E+01,0.000000E+00

--- a/openquake/qa_tests_data/event_based/case_5/expected/ruptures.csv
+++ b/openquake/qa_tests_data/event_based/case_5/expected/ruptures.csv
@@ -1,4 +1,4 @@
-#,,,,,,,,,"generated_by='OpenQuake engine 3.9.0-gite5250ba032', start_date='2020-04-08T14:59:06', checksum=779146337, investigation_time=30.0, ses_per_logic_tree_path=1"
+#,,,,,,,,,"generated_by='OpenQuake engine 3.9.0-git09adbd04df', start_date='2020-04-08T15:05:52', checksum=779146337, investigation_time=30.0, ses_per_logic_tree_path=1"
 rup_id,multiplicity,mag,centroid_lon,centroid_lat,centroid_depth,trt,strike,dip,rake
-1,1,5.300000E+00,1.094866E+01,4.726679E+01,9.000000E+00,Stable Shallow Crust,0.000000E+00,9.000000E+01,-9.000000E+01
 0,1,4.900000E+00,1.244109E+01,5.023590E+01,1.100000E+01,Volcanic,0.000000E+00,9.000000E+01,0.000000E+00
+1,1,5.300000E+00,1.094866E+01,4.726679E+01,9.000000E+00,Stable Shallow Crust,0.000000E+00,9.000000E+01,-9.000000E+01

--- a/openquake/qa_tests_data/event_based/case_5/expected/ruptures.csv
+++ b/openquake/qa_tests_data/event_based/case_5/expected/ruptures.csv
@@ -1,4 +1,4 @@
-#,,,,,,,,,"generated_by='OpenQuake engine 3.9.0-git73ef99aae6', start_date='2020-03-05T08:08:56', checksum=779146337, investigation_time=30.0, ses_per_logic_tree_path=1"
+#,,,,,,,,,"generated_by='OpenQuake engine 3.9.0-gite5250ba032', start_date='2020-04-08T14:59:06', checksum=779146337, investigation_time=30.0, ses_per_logic_tree_path=1"
 rup_id,multiplicity,mag,centroid_lon,centroid_lat,centroid_depth,trt,strike,dip,rake
-0,1,4.900000E+00,1.244109E+01,5.023590E+01,1.100000E+01,Volcanic,0.000000E+00,9.000000E+01,0.000000E+00
 1,1,5.300000E+00,1.094866E+01,4.726679E+01,9.000000E+00,Stable Shallow Crust,0.000000E+00,9.000000E+01,-9.000000E+01
+0,1,4.900000E+00,1.244109E+01,5.023590E+01,1.100000E+01,Volcanic,0.000000E+00,9.000000E+01,0.000000E+00


### PR DESCRIPTION
In /extract/rupture_info we were sorting the rupture parameters by rup_id but not the geometries!