### PR TITLE
Make `curves-rlzs` and `curves-stats` readable as DataFrames

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -140,7 +140,7 @@ def read(calc_id, mode='r', datadir=None):
 def dset2df(dset, index):
     """
     Converts an HDF5 dataset with an attribute shape_descr into a Pandas
-    dataframe.
+    dataframe. NB: this is very slow for large datasets.
     """
     shape_descr = [v.decode('utf-8') for v in dset.attrs['shape_descr']]
     out = []
@@ -157,9 +157,8 @@ def dset2df(dset, index):
         tags.append(values)
         idxs.append(range(len(values)))
     dtlist.append(('value', dset.dtype))
-    for idx, values in zip(itertools.product(*idxs),
-                           itertools.product(*tags)):
-        out.append(values + (dset[idx],))
+    for idx, vals in zip(itertools.product(*idxs), itertools.product(*tags)):
+        out.append(vals + (dset[idx],))
     return pandas.DataFrame.from_records(numpy.array(out, dtlist), index)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -194,16 +194,26 @@ class EbrCalculator(base.RiskCalculator):
         self.loss_maps_dt = (F32, (C, L))
         if oq.individual_curves or R == 1:
             self.datastore.create_dset('curves-rlzs', F32, (A, R, P, L))
+            shape_descr = ['assets', 'rlzs', 'return_periods', 'loss_types']
             self.datastore.set_attrs(
-                'curves-rlzs', return_periods=builder.return_periods)
+                'curves-rlzs', shape_descr=shape_descr,
+                assets=self.assetcol.tagcol.id[1:],
+                return_periods=builder.return_periods,
+                rlzs=numpy.arange(R),
+                loss_types=oq.loss_names)
         if oq.conditional_loss_poes:
             self.datastore.create_dset(
                 'loss_maps-rlzs', self.loss_maps_dt, (A, R), fillvalue=None)
         if R > 1:
             self.datastore.create_dset('curves-stats', F32, (A, S, P, L))
+            shape_descr = ['assets', 'stats', 'return_periods', 'loss_types']
             self.datastore.set_attrs(
-                'curves-stats', return_periods=builder.return_periods,
-                stats=[encode(name) for (name, func) in stats])
+                'curves-stats', shape_descr=shape_descr,
+                assets=self.assetcol.tagcol.id[1:],
+                stats=[encode(name) for (name, func) in stats],
+                return_periods=builder.return_periods,
+                loss_types=oq.loss_names
+            )
             if oq.conditional_loss_poes:
                 self.datastore.create_dset(
                     'loss_maps-stats', self.loss_maps_dt, (A, S),

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -300,6 +300,13 @@ class EventBasedRiskTestCase(CalculatorTestCase):
 
         self.check_multi_tag(self.calc.datastore)
 
+        # check curves-rlzs and curves-stats are readable
+        df1 = self.calc.datastore.read_df('curves-rlzs', 'assets')
+        aae(df1.columns, ['rlzs', 'return_periods', 'loss_types', 'value'])
+
+        df2 = self.calc.datastore.read_df('curves-stats', 'assets')
+        aae(df2.columns, ['stats', 'return_periods', 'loss_types', 'value'])
+
     def test_case_master_eb(self):
         self.run_calc(case_master.__file__, 'job.ini',
                       calculation_mode='ebrisk', exports='',

--- a/openquake/commonlib/util.py
+++ b/openquake/commonlib/util.py
@@ -160,7 +160,7 @@ def compose_arrays(a1, a2, firstfield='etag'):
 def get_assets(dstore):
     """
     :param dstore: a datastore with keys 'assetcol'
-    :returns: an array of records (asset_ref, tag1, ..., tagN, lon, lat)
+    :returns: an array of records (tag1, ..., tagN, lon, lat)
     """
     assetcol = dstore['assetcol']
     tagnames = sorted(assetcol.tagnames)


### PR DESCRIPTION
Useful when debugging event based risk calculations. For instance 
```python
>>> datastore.read(43777).read_df('curves-stats', 'assets') 
         stats  return_periods     loss_types          value
assets                                                       
b'a_0'  b'mean'               5  b'structural'       0.000000
b'a_0'  b'mean'              10  b'structural'       0.000000
b'a_0'  b'mean'              25  b'structural'       0.000000
b'a_0'  b'mean'              50  b'structural'       0.000000
b'a_0'  b'mean'             100  b'structural'    3992.613037
...         ...             ...            ...            ...
b'a_1'  b'mean'             250  b'structural'    1109.425781
b'a_1'  b'mean'             500  b'structural'   32759.187500
b'a_1'  b'mean'            1000  b'structural'  148674.546875
b'a_1'  b'mean'            1500  b'structural'            NaN
b'a_1'  b'mean'            2500  b'structural'            NaN
```