### PR TITLE
Fixed the usual hdf5 damn bug

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -259,7 +259,6 @@ def extract_assets(dstore, what):
     dic.update(dic1)
     dic.update(dic2)
     arr = dstore['assetcol/array'][()]
-    arr = arr[list(arr.dtype.names[1:])]  # strip asset_id
     for tag, vals in qdict.items():
         cond = numpy.zeros(len(arr), bool)
         for val in vals:

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -570,7 +570,7 @@ def build_asset_array(assets_by_site, tagnames=(), time_event=None):
     int_fields = [(str(name), U32) for name in tagnames]
     tagi = {str(name): i for i, name in enumerate(tagnames)}
     asset_dt = numpy.dtype(
-        [('asset_id', hdf5.vstr), ('ordinal', U32), ('lon', F32), ('lat', F32),
+        [('asset_id', '<S20'), ('ordinal', U32), ('lon', F32), ('lat', F32),
          ('site_id', U32), ('number', F32), ('area', F32)] + [
              (str(name), float) for name in float_fields] + int_fields)
     num_assets = sum(len(assets) for assets in assets_by_site)


### PR DESCRIPTION
After the change https://github.com/gem/oq-engine/pull/5751 the usual bug with variable-lengths fields came back for large exposures. Fortunately oq-risk-tests/test_bc was sensible to it.
Fixing it in the most brutal way, by truncating the `asset_id` to 20 characters, which is sub-optimal but acceptable given the the asset_id is not used as a primary key.