### PR TITLE
Renamed collapse_ctxs -> collapse_level

### DIFF
--- a/demos/hazard/LogicTreeCase2ClassicalPSHA/job.ini
+++ b/demos/hazard/LogicTreeCase2ClassicalPSHA/job.ini
@@ -33,7 +33,7 @@ investigation_time = 50.0
 intensity_measure_types_and_levels = {"PGA": [0.005, 0.007, 0.0098, 0.0137, 0.0192, 0.0269, 0.0376, 0.0527, 0.0738, 0.103, 0.145, 0.203, 0.284, 0.397, 0.556, 0.778, 1.09, 1.52, 2.13]}
 truncation_level = 3
 maximum_distance = 200.0
-collapse_ctxs = true
+collapse_level = 2
 
 [output]
 

--- a/demos/hazard/MultiPointClassicalPSHA/job.ini
+++ b/demos/hazard/MultiPointClassicalPSHA/job.ini
@@ -4,7 +4,7 @@ description = SSA 2018 PSHA
 calculation_mode = classical
 random_seed = 19
 concurrent_tasks = 4
-collapse_ctxs = true
+collapse_level = 2
 
 [geometry]
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -800,7 +800,7 @@ class HazardCalculator(BaseCalculator):
 
         # used in the risk calculators
         self.param = dict(individual_curves=oq.individual_curves,
-                          collapse_ctxs=oq.collapse_ctxs,
+                          collapse_level=oq.collapse_level,
                           avg_losses=oq.avg_losses, amplifier=self.amplifier)
 
         # compute exposure stats

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -379,7 +379,7 @@ class ClassicalCalculator(base.HazardCalculator):
             pointsource_distance=self.psd,
             point_rupture_bins=oq.point_rupture_bins,
             shift_hypo=oq.shift_hypo, max_weight=max_weight,
-            collapse_ctxs=oq.collapse_ctxs,
+            collapse_level=oq.collapse_level,
             max_sites_disagg=oq.max_sites_disagg)
         srcfilter = self.src_filter(self.datastore.tempname)
         for sg in src_groups:

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -102,7 +102,7 @@ class OqParam(valid.ParamSet):
     calculation_mode = valid.Param(valid.Choice())  # -> get_oqparam
     collapse_gsim_logic_tree = valid.Param(valid.namelist, [])
     collapse_threshold = valid.Param(valid.probability, 0.5)
-    collapse_ctxs = valid.Param(valid.boolean, False)
+    collapse_level = valid.Param(valid.Choice(0, 1, 2), 0)
     coordinate_bin_width = valid.Param(valid.positivefloat)
     compare_with_classical = valid.Param(valid.boolean, False)
     concurrent_tasks = valid.Param(

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -102,7 +102,7 @@ class OqParam(valid.ParamSet):
     calculation_mode = valid.Param(valid.Choice())  # -> get_oqparam
     collapse_gsim_logic_tree = valid.Param(valid.namelist, [])
     collapse_threshold = valid.Param(valid.probability, 0.5)
-    collapse_level = valid.Param(valid.Choice(0, 1, 2), 0)
+    collapse_level = valid.Param(valid.Choice('0', '1', '2'), 0)
     coordinate_bin_width = valid.Param(valid.positivefloat)
     compare_with_classical = valid.Param(valid.boolean, False)
     concurrent_tasks = valid.Param(
@@ -263,6 +263,7 @@ class OqParam(valid.ParamSet):
                 names_vals.pop('region_constraint'))
         self.risk_investigation_time = (
             self.risk_investigation_time or self.investigation_time)
+        self.collapse_level = int(self.collapse_level)
         if ('intensity_measure_types_and_levels' in names_vals and
                 'intensity_measure_types' in names_vals):
             logging.warning('Ignoring intensity_measure_types since '

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -96,6 +96,7 @@ export_dir = %s
                 'complex_fault_mesh_spacing': 5.0,
                 'truncation_level': 3.0,
                 'random_seed': 5,
+                'collapse_level': 0,
                 'maximum_distance': {'default': 1.0},
                 'inputs': {'job_ini': source,
                            'sites': sites_csv},

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -405,7 +405,7 @@ class PmapMaker(object):
         # generate triples (rup, sites, dctx)
         rup_param = not numpy.isnan([r.occurrence_rate for r in rups]).any()
         collapse_level = self.rup_indep and rup_param and self.collapse_level
-        if (collapse_level >0 and len(sites.complete) == 1 and
+        if (collapse_level and len(sites.complete) == 1 and
                 self.pointsource_distance != {}):
             rups = self.collapse_point_ruptures(rups, sites)
             # print_finite_size(rups)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -154,7 +154,7 @@ class ContextMaker(object):
     def __init__(self, trt, gsims, param=None, monitor=Monitor()):
         param = param or {}
         self.max_sites_disagg = param.get('max_sites_disagg', 10)
-        self.collapse_ctxs = param.get('collapse_ctxs', False)
+        self.collapse_level = param.get('collapse_level', False)
         self.point_rupture_bins = param.get('point_rupture_bins', 20)
         self.trt = trt
         self.gsims = gsims
@@ -404,13 +404,13 @@ class PmapMaker(object):
     def _gen_ctxs(self, rups, sites, grp_ids):
         # generate triples (rup, sites, dctx)
         rup_param = not numpy.isnan([r.occurrence_rate for r in rups]).any()
-        collapse_ctxs = self.rup_indep and rup_param and self.collapse_ctxs
-        if (collapse_ctxs and len(sites.complete) == 1 and
+        collapse_level = self.rup_indep and rup_param and self.collapse_level
+        if (collapse_level >0 and len(sites.complete) == 1 and
                 self.pointsource_distance != {}):
             rups = self.collapse_point_ruptures(rups, sites)
             # print_finite_size(rups)
         ctxs = self.cmaker.make_ctxs(rups, sites, grp_ids, filt=False)
-        if collapse_ctxs:
+        if collapse_level > 1:
             ctxs = self.collapse_the_ctxs(ctxs)
         self.numrups += len(ctxs)
         if ctxs:

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -93,7 +93,7 @@ class CollapseTestCase(unittest.TestCase):
             src.id = i
         res = classical(srcs, self.srcfilter, self.gsims,
                         dict(imtls=self.imtls, truncation_level2=2,
-                             collapse_ctxs=True))
+                             collapse_level=2))
         pmap = res['pmap']
         effrups = sum(nr for nr, ns, dt in res['calc_times'].values())
         curves = [pmap[grp_id].array[0, :, 0] for grp_id in sorted(pmap)]

--- a/openquake/qa_tests_data/classical/case_24/job.ini
+++ b/openquake/qa_tests_data/classical/case_24/job.ini
@@ -46,7 +46,7 @@ intensity_measure_types_and_levels = {
 truncation_level = 3
 maximum_distance = 200
 pointsource_distance = 100
-collapse_ctxs = true
+collapse_level = 2
 
 [output]
 


### PR DESCRIPTION
collapse_level = 0 => no collapse unless pointsource_distance is set
collapse_level = 1 => collapse the point ruptures in single site situations
collapse_level = 2 => collapse also the contexts

By default `collapse_level = 0` is set, to avoid magic going on without the user consent.