### PR TITLE
Fixed bug with `oq engine --run --params`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a type error in the command `oq engine --run --params`
   * Restored the flag `split_sources` for testing purposes
   * Fixed a BOM bug in CSV exposures
   * When exporting the loss curves per asset now we also export the loss ratio

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -191,8 +191,8 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
     else:
         hc_id = None
     if run:
-        params = oqvalidation.OqParam.check(
-            dict(p.split('=', 1) for p in param.split(','))) if param else {}
+        params = dict(p.split('=', 1) for p in param.split(','))
+        oqvalidation.OqParam.check(params)
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
         job_inis = [os.path.expanduser(f) for f in run]

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -142,8 +142,8 @@ def run(job_ini, slowest=False, hc=None, param='', concurrent_tasks=None,
     """
     dbserver.ensure_on()
     if param:
-        params = oqvalidation.OqParam.check(
-            dict(p.split('=', 1) for p in param.split(',')))
+        params = dict(p.split('=', 1) for p in param.split(','))
+        oqvalidation.OqParam.check(params)
     else:
         params = {}
     if slowest:

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -1279,19 +1279,17 @@ class ParamSet(hdf5.LiteralAttrs, metaclass=MetaParamSet):
     @classmethod
     def check(cls, dic):
         """
-        Convert a dictionary name->string into a dictionary name->value
-        by converting the string. If the name does not correspond to a
-        known parameter, just ignore it and print a warning.
+        Check if a dictionary name->string can be converted into a dictionary
+        name->value. If the name does not correspond to a known parameter,
+        print a warning.
         """
-        res = {}
         for name, text in dic.items():
             try:
                 p = getattr(cls, name)
             except AttributeError:
                 logging.warning('Ignored unknown parameter %s', name)
             else:
-                res[name] = p.validator(text)
-        return res
+                p.validator(text)
 
     @classmethod
     def from_(cls, dic):


### PR DESCRIPTION
The parameters where converted too early.