### PR TITLE
Changed oq extract to save in .npz format

### DIFF
--- a/openquake/commands/extract.py
+++ b/openquake/commands/extract.py
@@ -38,7 +38,7 @@ def extract(what, calc_id=-1, webapi=True, local=False):
             fname = '%s_%d.txt' % (w, calc_id)
             open(fname, 'w').write(obj.toml())
         else:  # a regular ArrayWrapper
-            fname = '%s_%d.hdf5' % (w, calc_id)
+            fname = '%s_%d.npz' % (w, calc_id)
             obj.save(fname)
         print('Saved', fname)
     if mon.duration > 1:

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -133,38 +133,3 @@ def check_webserver_running(url="http://localhost:8800", max_retries=30):
         logging.warning('Unable to connect to %s within %s retries'
                         % (url, max_retries))
     return success
-
-
-def fix_array(arr, key):
-    """
-    :param arr: array or array-like object
-    :param key: string associated to the error (appear in the error message)
-
-    If `arr` is a numpy array with dtype object containing strings, convert
-    it into a numpy array containing bytes, unless it has more than 2
-    dimensions or contains non-strings (these are errors). Return `arr`
-    unchanged in the other cases.
-    """
-    if arr is None:
-        return ()
-    if not isinstance(arr, numpy.ndarray):
-        return arr
-    if arr.dtype != numpy.dtype('O'):
-        d = arr.dtype.descr
-        if len(d) > 1 and isinstance(d[0][1], tuple):
-            # for extract_assets d[0] is the pair
-            # ('id', ('|S20', {'h5py_encoding': 'ascii'}))
-            # this is a horrible workaround for the h5py 2.10.0 issue
-            # https://github.com/numpy/numpy/issues/14142#issuecomment-620980980
-            arr.dtype = [(n, str(arr.dtype[n])) for n in arr.dtype.names]
-        return arr
-    if arr.ndim == 1:
-        return numpy.array([s.encode('utf8') for s in arr])
-    elif arr.ndim == 2:
-        return numpy.array([[col.encode('utf8') for col in row]
-                            for row in arr])
-    else:
-        raise NotImplementedError('The array for %s has shape %s' %
-                                  (key, arr.shape))
-
-    return arr

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -30,7 +30,6 @@ import zlib
 import pickle
 import urllib.parse as urlparse
 import re
-import numpy
 import psutil
 from urllib.parse import unquote_plus
 from xml.parsers.expat import ExpatError
@@ -733,19 +732,7 @@ def extract(request, calc_id, what):
             n = len(request.path_info)
             query_string = unquote_plus(request.get_full_path()[n:])
             aw = _extract(ds, what + query_string)
-            a = {}
-            for key, val in vars(aw).items():
-                if key.startswith('_'):
-                    continue
-                elif isinstance(val, str):
-                    # without this oq extract would fail
-                    a[key] = numpy.array(val.encode('utf-8'))
-                elif isinstance(val, dict):
-                    # this is hack: we are losing the values
-                    a[key] = list(val)
-                else:
-                    a[key] = utils.fix_array(val, key)
-            numpy.savez_compressed(fname, **a)
+            aw.save(fname)
     except Exception as exc:
         tb = ''.join(traceback.format_tb(exc.__traceback__))
         return HttpResponse(


### PR DESCRIPTION
This is useful, because in this way one can now the exact size of the extractions. For instance for the Colombia disaggregation case (oq1 38206) disagg_layer.npz is of 99 MB.
