### PR TITLE
Less monitoring in the inner loop of disagg._disaggregate

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -91,7 +91,7 @@ def _iml3(rlzs, iml_disagg, imtls, poes_disagg, curves):
     return dic
 
 
-def compute_disagg(dstore, idxs, cmaker, iml3, trti, bin_edges, monitor):
+def compute_disagg(dstore, idxs, cmaker, iml3, trti, bin_edges, oq, monitor):
     # see https://bugs.launchpad.net/oq-engine/+bug/1279247 for an explanation
     # of the algorithm used
     """
@@ -114,7 +114,6 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, bin_edges, monitor):
     """
     with monitor('reading rupdata', measuremem=True):
         dstore.open('r')
-        oq = dstore['oqparam']
         sitecol = dstore['sitecol']
         rupdata = {k: dstore['rup/' + k][idxs] for k in dstore['rup']}
     RuptureContext.temporal_occurrence_model = PoissonTOM(
@@ -337,7 +336,7 @@ class DisaggregationCalculator(base.HazardCalculator):
             for idxs in indices[grp_id]:
                 for imt in oq.imtls:
                     smap.submit((dstore, idxs, cmaker, self.iml3[imt], trti,
-                                 self.bin_edges))
+                                 self.bin_edges, oq))
         results = smap.reduce(self.agg_result, AccumDict(accum={}))
         return results  # sid -> trti-> 8D array
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -149,14 +149,6 @@ def _disagg_eps(lvl, truncnorm, epsilons, eps_bands):
     # disaggregate PoE of `iml` in different contributions,
     # each coming from ``epsilons`` distribution bins
     E = len(eps_bands)
-    if E == 1:  # shortcut
-        if lvl < epsilons[0]:
-            return 1.
-        elif lvl > epsilons[1]:
-            return 0.
-        else:
-            return truncnorm.sf(lvl)
-    # E > 1
     bin = numpy.searchsorted(epsilons, lvl)
     if bin == 0:
         return eps_bands

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -137,16 +137,15 @@ def _disaggregate(cmaker, site1, ctxs, iml1, eps3,
                 site1, rctx, dctx, [iml1.imt], [gsim]).reshape(2)
     with pne_mon:
         imls = to_distribution_values(iml1, iml1.imt)  # shape P
-        for u, (rctx, dctx) in enumerate(ctxs):
-            poes = numpy.zeros((P, E))
-            for p, iml in enumerate(imls):
-                lvl = (iml - mean_std[0, u]) / mean_std[1, u]
-                poes[p] = _disagg_eps(mean_std, lvl, *eps3)
-            bdata.pnes[u] = rctx.get_probability_no_exceedance(poes)
+        for p, iml in enumerate(imls):
+            lvls = (iml - mean_std[0]) / mean_std[1]
+            for u, (rctx, dctx) in enumerate(ctxs):
+                poes = _disagg_eps(lvls[u], *eps3)
+                bdata.pnes[u, p] = rctx.get_probability_no_exceedance(poes)
     return bdata
 
 
-def _disagg_eps(mean_std, lvl, truncnorm, epsilons, eps_bands):
+def _disagg_eps(lvl, truncnorm, epsilons, eps_bands):
     # disaggregate PoE of `iml` in different contributions,
     # each coming from ``epsilons`` distribution bins
     E = len(eps_bands)


### PR DESCRIPTION
It turns out this was slowing down the calculation. This is the improvement on case_multi on my
workstation, a good 20%, at the cost of a bigger memory usage:
```
calc_48106                   time_sec memory_mb counts   # before
============================ ======== ========= =========
total compute_disagg         2_055    51        1_400    
disaggregate_pne             904      0.0       5_288_396
disagg mean_std              676      0.0       5_288_396
DisaggregationCalculator.run 274      17        1        

calc_48118                   time_sec memory_mb counts  # now
============================ ======== ========= ======
total compute_disagg         1_637    176       1_400 
disagg mean_std              605      0.0       1_460 
disaggregate_pne             598      0.0       1_460 
DisaggregationCalculator.run 216      17        1     
```