### PR TITLE
Vectorized the disaggregation formula

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Vectorized the disaggregation formula
   * Do not perform the disaggregation by epsilon when not required
   * Introduced management of uncertainty in the GMF amplifi
   * Changed the disaggregation calculator to distribute by IMT, thus reducing

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -321,7 +321,10 @@ class DisaggregationCalculator(base.HazardCalculator):
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
         M = len(oq.imtls)
-        indices = get_indices(dstore, numpy.ceil(oq.concurrent_tasks/M) or 1)
+        tasks_per_imt = numpy.ceil(oq.concurrent_tasks / M) or 1
+        rups_per_task = len(dstore['rup/mag']) / tasks_per_imt
+        logging.info('Considering ~%d ruptures per task', rups_per_task)
+        indices = get_indices(dstore, tasks_per_imt)
         self.datastore.swmr_on()
         smap = parallel.Starmap(compute_disagg, h5=self.datastore.hdf5)
         trt_num = {trt: i for i, trt in enumerate(self.trts)}

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -148,25 +148,14 @@ def _disaggregate(cmaker, site1, ctxs, iml1, eps3,
 def _disagg_eps(lvl, truncnorm, epsilons, eps_bands):
     # disaggregate PoE of `iml` in different contributions,
     # each coming from ``epsilons`` distribution bins
-    E = len(eps_bands)
+    res = numpy.zeros(len(eps_bands))
     bin = numpy.searchsorted(epsilons, lvl)
-    if bin == 0:
-        return eps_bands
-    elif bin > E:
-        return numpy.zeros(E)
-    else:
-        # for other cases (when `lvl` falls somewhere in the
-        # histogram):
-        return numpy.concatenate([
-            # take zeros for bins that are on the left hand side
-            # from the bin `lvl` falls into,
-            numpy.zeros(bin - 1),
-            # ... area of the portion of the bin containing ``lvl`
-            # (the portion is limited on the left hand side by
-            # ``lvl`` and on the right hand side by the bin edge),
-            [truncnorm.sf(lvl) - eps_bands[bin:].sum()],
-            # ... and all bins on the right go unchanged.
-            eps_bands[bin:]])
+    for e in range(len(res)):
+        if e == bin - 1:
+            res[e] = truncnorm.sf(lvl) - eps_bands[bin:].sum()
+        elif e >= bin:
+            res[e] = eps_bands[e]
+    return res
 
 
 # used in calculators/disaggregation


### PR DESCRIPTION
This is actually a partial vectorization (I vectorized only the levels (iml - mean_std[0]) / mean_std[1] and associated arrays) but it is enough to get a 6.5x speedup in disaggregate_pne:
```
calc_48206                   time_sec memory_mb counts  # now
============================ ======== ========= ======
total compute_disagg         1_123    180       1_400 
disagg mean_std              608      0.0       1_460 
disaggregate_pne             90       0.0       1_460 
DisaggregationCalculator.run 145      17        1     

calc_48118                   time_sec memory_mb counts  # was
============================ ======== ========= ======
total compute_disagg         1_637    176       1_400 
disagg mean_std              605      0.0       1_460 
disaggregate_pne             598      0.0       1_460 
DisaggregationCalculator.run 216      17        1
```
For the case of the disaggregation calculation for Colombia we gain a factor of 2 speedup.