### PR TITLE
Vectorized even more disagg.disaggregate

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -142,7 +142,8 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, bin_edges, oq, monitor):
                 if par.endswith('_'):
                     setattr(ctx, par[:-1], rupdata[par][ridx, [sid]])
             ctxs.append(ctx)
-
+        if not ctxs:
+            continue
         eps3 = disagg._eps3(cmaker.trunclevel, oq.num_epsilon_bins)
         matrix = numpy.zeros([len(b) - 1 for b in bins] + list(iml2.shape))
         for z, gsim in gsim_by_z.items():

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -352,7 +352,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                 trt, self.full_lt.get_rlzs_by_gsim(grp_id),
                 {'truncation_level': oq.truncation_level,
                  'maximum_distance': src_filter.integration_distance,
-                 'filter_distance': oq.filter_distance, 'imtls': oq.imtls})
+                 'imtls': oq.imtls})
             for idxs in indices[grp_id]:
                 for imt in oq.imtls:
                     smap.submit((dstore, idxs, cmaker, self.iml3[imt], trti,

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -127,23 +127,23 @@ def disaggregate(mean_std, rups, imt, imls, eps3,
             bdata.dists[u] = rup.rrup[0]
         for p, iml in enumerate(imls):
             lvls = (iml - mean_std[0]) / mean_std[1]
-            tn = truncnorm.sf(lvls)
+            survival = truncnorm.sf(lvls)
             bins = numpy.searchsorted(epsilons, lvls)
             for e, eps_band in enumerate(eps_bands):
-                poes = _disagg_eps(tn, bins, e, eps_band, cum_bands)
+                poes = _disagg_eps(survival, bins, e, eps_band, cum_bands)
                 for u, rup in enumerate(rups):
                     bdata.pnes[u, p, e] = rup.get_probability_no_exceedance(
                         poes[u])
     return bdata
 
 
-def _disagg_eps(truncnorm, bins, e, eps_band, cum_bands):
+def _disagg_eps(survival, bins, e, eps_band, cum_bands):
     # disaggregate PoE of `iml` in different contributions,
     # each coming from ``epsilons`` distribution bins
     res = numpy.zeros(len(bins))
     res[bins <= e] = eps_band  # left bins
     inside = bins == e + 1  # inside bins
-    res[inside] = truncnorm[inside] - cum_bands[bins[inside]]
+    res[inside] = survival[inside] - cum_bands[bins[inside]]
     return res
 
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -133,7 +133,7 @@ def disaggregate(mean_std, rups, imt, imls, eps3,
                 poes = _disagg_eps(tn, bins, e, eps_band, cum_bands)
                 for u, rup in enumerate(rups):
                     bdata.pnes[u, p, e] = rup.get_probability_no_exceedance(
-                        poes[u])            '''
+                        poes[u])
     return bdata
 
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -118,7 +118,7 @@ def disaggregate(mean_std, rups, imt, imls, eps3,
                     pnes=numpy.zeros((U, P, E)))
     with pne_mon:
         truncnorm, epsilons, eps_bands = eps3
-        cum_bands = [eps_bands[e:].sum() for e in range(E)] + [0]
+        cum_bands = numpy.array([eps_bands[e:].sum() for e in range(E)] + [0])
         imls = to_distribution_values(imls, imt)  # shape P
         for u, rup in enumerate(rups):
             bdata.mags[u] = rup.mag
@@ -140,11 +140,9 @@ def _disagg_eps(truncnorm, bins, eps_bands, cum_bands):
     # each coming from ``epsilons`` distribution bins
     res = numpy.zeros((len(bins), len(eps_bands)))
     for e, eps_band in enumerate(eps_bands):
-        for u, bin in enumerate(bins):
-            if e == bin - 1:
-                res[u, e] = truncnorm[u] - cum_bands[bin]
-            elif e >= bin:
-                res[u, e] = eps_band
+        ok = e == bins - 1
+        res[ok, e] = truncnorm[ok] - cum_bands[bins[ok]]
+        res[e >= bins, e] = eps_band
     return res
 
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -129,20 +129,21 @@ def disaggregate(mean_std, rups, imt, imls, eps3,
             lvls = (iml - mean_std[0]) / mean_std[1]
             tn = truncnorm.sf(lvls)
             bins = numpy.searchsorted(epsilons, lvls)
-            poes = _disagg_eps(tn, bins, eps_bands, cum_bands)
-            for u, rup in enumerate(rups):
-                bdata.pnes[u, p] = rup.get_probability_no_exceedance(poes[u])
+            for e, eps_band in enumerate(eps_bands):
+                poes = _disagg_eps(tn, bins, e, eps_band, cum_bands)
+                for u, rup in enumerate(rups):
+                    bdata.pnes[u, p, e] = rup.get_probability_no_exceedance(
+                        poes[u])            '''
     return bdata
 
 
-def _disagg_eps(truncnorm, bins, eps_bands, cum_bands):
+def _disagg_eps(truncnorm, bins, e, eps_band, cum_bands):
     # disaggregate PoE of `iml` in different contributions,
     # each coming from ``epsilons`` distribution bins
-    res = numpy.zeros((len(bins), len(eps_bands)))
-    for e, eps_band in enumerate(eps_bands):
-        res[bins <= e, e] = eps_band  # left bins
-        inside = bins == e + 1  # inside bins
-        res[inside, e] = truncnorm[inside] - cum_bands[bins[inside]]
+    res = numpy.zeros(len(bins))
+    res[bins <= e] = eps_band  # left bins
+    inside = bins == e + 1  # inside bins
+    res[inside] = truncnorm[inside] - cum_bands[bins[inside]]
     return res
 
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -140,9 +140,9 @@ def _disagg_eps(truncnorm, bins, eps_bands, cum_bands):
     # each coming from ``epsilons`` distribution bins
     res = numpy.zeros((len(bins), len(eps_bands)))
     for e, eps_band in enumerate(eps_bands):
-        ok = e == bins - 1
-        res[ok, e] = truncnorm[ok] - cum_bands[bins[ok]]
-        res[e >= bins, e] = eps_band
+        res[bins <= e, e] = eps_band  # left bins
+        inside = bins == e + 1  # inside bins
+        res[inside, e] = truncnorm[inside] - cum_bands[bins[inside]]
     return res
 
 

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -21,8 +21,6 @@ Module :mod:`openquake.hazardlib.tom` contains implementations of probability
 density functions for earthquake temporal occurrence modeling.
 """
 import abc
-import math
-
 import numpy
 import scipy.stats
 

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -121,7 +121,7 @@ class PoissonTOM(BaseTOM):
         :return:
             Float value between 0 and 1 inclusive.
         """
-        return 1 - math.exp(- occurrence_rate * self.time_span)
+        return 1 - numpy.exp(- occurrence_rate * self.time_span)
 
     def get_probability_n_occurrences(self, occurrence_rate, num):
         """


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/5812. For the Colombia computation
now the time spent in `disaggregate_pne` is down to 361_726s  (calc 38230) from 495_298s (calc 38215). The bottleneck is even more `disagg mean_std`.