### PR TITLE
26x speedup in extracting PMFs with a bit of numpy literacy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Optimized the computation of the disaggregation PMFs by orders of magnitude
+    by using numpy.prod
   * Changed the disaggregation calculator to distribute by magnitude bin,
     thus reducing a lot the data transfer
   * Raised a clear error for amplification calculations with missing intensity

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -446,24 +446,65 @@ class DisaggregationCalculator(base.HazardCalculator):
             if many_rlzs:  # rescale the weights
                 weights = numpy.array([self.ws[r][imt] for r in rlzs])
                 weights /= weights.sum()  # normalize to 1
-            self._save('disagg', s, imt, mat8)
-            #if many_rlzs:  # compute the mean matrices
-            #        mean = numpy.average(mat7, -1, weights)
-            #       if mean.any():  # nonzero
-            #            self._save('disagg', s, 'mean', poe, imt, mean)
+            for p, poe in enumerate(self.poes_disagg):
+                mat7 = mat8[..., p, :]
+                for z in range(self.Z):
+                    mat6 = mat7[..., z]
+                    if mat6.any():  # nonzero
+                        self._save('disagg', s, rlzs[z], poe, imt, mat6)
+                if many_rlzs:  # compute the mean matrices
+                    mean = numpy.average(mat7, -1, weights)
+                    if mean.any():  # nonzero
+                        self._save('disagg', s, 'mean', poe, imt, mean)
         self.datastore.set_attrs('disagg', **attrs)
 
-    def _save(self, dskey, site_id, imt_str, matrix8):
+    def _save(self, dskey, site_id, rlz_id, poe, imt_str, matrix6):
         disagg_outputs = self.oqparam.disagg_outputs
-        disp_name = 'disagg/%s-sid-%d/' % (imt_str, site_id)
+        lon = self.sitecol.lons[site_id]
+        lat = self.sitecol.lats[site_id]
+        try:
+            rlz = 'rlz-%d-' % rlz_id
+        except TypeError:  # for the mean
+            rlz = ''
+        disp_name = dskey + '/' + DISAGG_RES_FMT % dict(
+            rlz=rlz, imt=imt_str, sid='sid-%d' % site_id,
+            poe='poe-%d' % self.poe_id[poe])
+        mag, dist, lonsd, latsd, eps = self.bin_edges
+        lons, lats = lonsd[site_id], latsd[site_id]
         with self.monitor('extracting PMFs'):
             poe_agg = []
-            aggmatrix = agg_probs(*matrix8)
+            aggmatrix = agg_probs(*matrix6)
             for key, fn in disagg.pmf_map.items():
                 if not disagg_outputs or key in disagg_outputs:
-                    pmf = fn(matrix8 if key.endswith('TRT') else aggmatrix)
+                    pmf = fn(matrix6 if key.endswith('TRT') else aggmatrix)
                     self.datastore[disp_name + key] = pmf
                     poe_agg.append(1. - numpy.prod(1. - pmf))
+
+        attrs = self.datastore.hdf5[disp_name].attrs
+        attrs['site_id'] = site_id
+        attrs['rlzi'] = rlz_id
+        attrs['imt'] = imt_str
+        try:
+            attrs['iml'] = self.imldic[site_id, rlz_id, poe, imt_str]
+        except KeyError:  # for the mean
+            pass
+        attrs['mag_bin_edges'] = mag
+        attrs['dist_bin_edges'] = dist
+        attrs['lon_bin_edges'] = lons
+        attrs['lat_bin_edges'] = lats
+        attrs['eps_bin_edges'] = eps
+        attrs['trt_bin_edges'] = self.trts
+        attrs['location'] = (lon, lat)
+        # sanity check: all poe_agg should be the same
+        attrs['poe_agg'] = poe_agg
+        if poe and site_id in self.ok_sites:
+            attrs['poe'] = poe
+            poe_agg = numpy.mean(attrs['poe_agg'])
+            if abs(1 - poe_agg / poe) > .1:
+                logging.warning(
+                    'Site #%d: poe_agg=%s is quite different from the expected'
+                    ' poe=%s; perhaps the number of intensity measure'
+                    ' levels is too small?', site_id, poe_agg, poe)
 
     def build_disagg_by_src(self, rlzs):
         logging.warning('Disaggregation by source is experimental')

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -382,125 +382,20 @@ def disaggregation(
     return bin_edges + (trts,), matrix
 
 
-def mag_pmf(matrix):
-    """
-    Fold full disaggregation matrix to magnitude PMF.
-
-    :returns:
-        1d array, a histogram representing magnitude PMF.
-    """
-    nmags, ndists, nlons, nlats, neps = matrix.shape
-    mag_pmf = numpy.zeros(nmags)
-    for i in range(nmags):
-        mag_pmf[i] = numpy.prod(
-            [1. - matrix[i, j, k, l, m]
-             for j in range(ndists)
-             for k in range(nlons)
-             for l in range(nlats)
-             for m in range(neps)])
-    return 1. - mag_pmf
+MAG, DIS, LON, LAT, EPS = 0, 1, 2, 3, 4
 
 
-def dist_pmf(matrix):
-    """
-    Fold full disaggregation matrix to distance PMF.
-
-    :returns:
-        1d array, a histogram representing distance PMF.
-    """
-    nmags, ndists, nlons, nlats, neps = matrix.shape
-    dist_pmf = numpy.zeros(ndists)
-    for j in range(ndists):
-        dist_pmf[j] = numpy.prod(
-            [1. - matrix[i, j, k, l, m]
-             for i in range(nmags)
-             for k in range(nlons)
-             for l in range(nlats)
-             for m in range(neps)])
-    return 1. - dist_pmf
+def compose(*axis):
+    return lambda x: 1. - numpy.prod(1. - x, axis)
 
 
-def trt_pmf(matrices):
-    """
-    Fold full disaggregation matrix to tectonic region type PMF.
-
-    :param matrices:
-        a matrix with T submatrices
-    :returns:
-        an array of T probabilities one per each tectonic region type
-    """
-    ntrts, nmags, ndists, nlons, nlats, neps = matrices.shape
-    pmf = numpy.zeros(ntrts)
-    for t in range(ntrts):
-        pmf[t] = 1. - numpy.prod(
-            [1. - matrices[t, i, j, k, l, m]
-             for i in range(nmags)
-             for j in range(ndists)
-             for k in range(nlons)
-             for l in range(nlats)
-             for m in range(neps)])
-    return pmf
-
-
-def mag_dist_pmf(matrix):
-    """
-    Fold full disaggregation matrix to magnitude / distance PMF.
-
-    :returns:
-        2d array. First dimension represents magnitude histogram bins,
-        second one -- distance histogram bins.
-    """
-    nmags, ndists, nlons, nlats, neps = matrix.shape
-    mag_dist_pmf = numpy.zeros((nmags, ndists))
-    for i in range(nmags):
-        for j in range(ndists):
-            mag_dist_pmf[i, j] = numpy.prod(
-                [1. - matrix[i, j, k, l, m]
-                 for k in range(nlons)
-                 for l in range(nlats)
-                 for m in range(neps)])
-    return 1. - mag_dist_pmf
-
-
-def mag_dist_eps_pmf(matrix):
-    """
-    Fold full disaggregation matrix to magnitude / distance / epsilon PMF.
-
-    :returns:
-        3d array. First dimension represents magnitude histogram bins,
-        second one -- distance histogram bins, third one -- epsilon
-        histogram bins.
-    """
-    nmags, ndists, nlons, nlats, neps = matrix.shape
-    mag_dist_eps_pmf = numpy.zeros((nmags, ndists, neps))
-    for i in range(nmags):
-        for j in range(ndists):
-            for m in range(neps):
-                mag_dist_eps_pmf[i, j, m] = numpy.prod(
-                    [1. - matrix[i, j, k, l, m]
-                     for k in range(nlons)
-                     for l in range(nlats)])
-    return 1. - mag_dist_eps_pmf
-
-
-def lon_lat_pmf(matrix):
-    """
-    Fold full disaggregation matrix to longitude / latitude PMF.
-
-    :returns:
-        2d array. First dimension represents longitude histogram bins,
-        second one -- latitude histogram bins.
-    """
-    nmags, ndists, nlons, nlats, neps = matrix.shape
-    lon_lat_pmf = numpy.zeros((nlons, nlats))
-    for k in range(nlons):
-        for l in range(nlats):
-            lon_lat_pmf[k, l] = numpy.prod(
-                [1. - matrix[i, j, k, l, m]
-                 for i in range(nmags)
-                 for j in range(ndists)
-                 for m in range(neps)])
-    return 1. - lon_lat_pmf
+mag_pmf = compose(DIS, LON, LAT, EPS)
+dist_pmf = compose(MAG, LON, LAT, EPS)
+mag_dist_pmf = compose(LON, LAT, EPS)
+mag_dist_eps_pmf = compose(LON, LAT)
+lon_lat_pmf = compose(DIS, MAG, EPS)
+mag_lon_lat_pmf = compose(DIS, EPS)
+trt_pmf = compose(1, 2, 3, 4, 5)
 
 
 def lon_lat_trt_pmf(matrices):
@@ -515,27 +410,6 @@ def lon_lat_trt_pmf(matrices):
     """
     res = numpy.array([lon_lat_pmf(mat) for mat in matrices])
     return res.transpose(1, 2, 0)
-
-
-def mag_lon_lat_pmf(matrix):
-    """
-    Fold full disaggregation matrix to magnitude / longitude / latitude PMF.
-
-    :returns:
-        3d array. First dimension represents magnitude histogram bins,
-        second one -- longitude histogram bins, third one -- latitude
-        histogram bins.
-    """
-    nmags, ndists, nlons, nlats, neps = matrix.shape
-    mag_lon_lat_pmf = numpy.zeros((nmags, nlons, nlats))
-    for i in range(nmags):
-        for k in range(nlons):
-            for l in range(nlats):
-                mag_lon_lat_pmf[i, k, l] = numpy.prod(
-                    [1. - matrix[i, j, k, l, m]
-                     for j in range(ndists)
-                     for m in range(neps)])
-    return 1. - mag_lon_lat_pmf
 
 
 # this dictionary is useful to extract a fixed set of

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -385,20 +385,20 @@ def disaggregation(
 MAG, DIS, LON, LAT, EPS = 0, 1, 2, 3, 4
 
 
-def compose(*axis):
+def collapse(*axis):
     """
     :returns: a function to compose probability arrays along the given axis
     """
     return lambda x: 1. - numpy.prod(1. - x, axis)
 
 
-mag_pmf = compose(DIS, LON, LAT, EPS)
-dist_pmf = compose(MAG, LON, LAT, EPS)
-mag_dist_pmf = compose(LON, LAT, EPS)
-mag_dist_eps_pmf = compose(LON, LAT)
-lon_lat_pmf = compose(DIS, MAG, EPS)
-mag_lon_lat_pmf = compose(DIS, EPS)
-trt_pmf = compose(1, 2, 3, 4, 5)  # applied on matrices TRT MAG DIS LON LAT EPS
+mag_pmf = collapse(DIS, LON, LAT, EPS)
+dist_pmf = collapse(MAG, LON, LAT, EPS)
+mag_dist_pmf = collapse(LON, LAT, EPS)
+mag_dist_eps_pmf = collapse(LON, LAT)
+lon_lat_pmf = collapse(DIS, MAG, EPS)
+mag_lon_lat_pmf = collapse(DIS, EPS)
+trt_pmf = collapse(1, 2, 3, 4, 5)  # applied on matrix TRT MAG DIS LON LAT EPS
 
 
 def lon_lat_trt_pmf(matrices):

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -386,6 +386,9 @@ MAG, DIS, LON, LAT, EPS = 0, 1, 2, 3, 4
 
 
 def compose(*axis):
+    """
+    :returns: a function to compose probability arrays along the given axis
+    """
     return lambda x: 1. - numpy.prod(1. - x, axis)
 
 
@@ -395,7 +398,7 @@ mag_dist_pmf = compose(LON, LAT, EPS)
 mag_dist_eps_pmf = compose(LON, LAT)
 lon_lat_pmf = compose(DIS, MAG, EPS)
 mag_lon_lat_pmf = compose(DIS, EPS)
-trt_pmf = compose(1, 2, 3, 4, 5)
+trt_pmf = compose(1, 2, 3, 4, 5)  # applied on matrices TRT MAG DIS LON LAT EPS
 
 
 def lon_lat_trt_pmf(matrices):


### PR DESCRIPTION
Using `numpy.prod` as it was intended to be, reduces the saving time from 52 minutes to 2 minutes in the disaggregation for Colombia (it had become the limiting factor). It also remove 120+ lines of code. Considering all the other speedups implemented recently, we are down to less than 2 hours for a calculation that took 10+ hours one week ago. Here are some figures:
 ```
   calc_38242                   time_sec  memory_mb counts 
   ============================ ========= ========= =======
   total compute_disagg         1_179_890 93        435_500
   disagg mean_std              495_354   0.0       435_500
   disaggregate_pne             350_269   0.0       435_500
   build_disagg_matrix          18_847    1.46094   435_500
   reading rupdata              12_488    117       1_144  
   DisaggregationCalculator.run 6_193     9_186     1      
   aggregating disagg matrices  263       0.30859   435_500
   extracting PMFs              121       0.07422   32_500 
 ```