### PR TITLE
Removed the need to set intensity_measure_types_and_levels in event based calculations with amplification

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,9 @@
   [Michele Simionato]
+  * Fixed bug in GMF amplification without intensity_measure_types_and_levels
   * Optimized the computation of the disaggregation PMFs by orders of magnitude
     by using numpy.prod
   * Changed the disaggregation calculator to distribute by magnitude bin,
     thus reducing a lot the data transfer
-  * Raised a clear error for amplification calculations with missing intensity
-    measure types and levels
   * Vectorized the disaggregation formula
   * Do not perform the disaggregation by epsilon when not required
   * Introduced management of uncertainty in the GMF amplifi

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -768,6 +768,12 @@ class DictArray(Mapping):
         else:
             self.L1 = None
 
+    def isnan(self):
+        """
+        :returns: true if all the underlying values are NaNs
+        """
+        return numpy.isnan(self.array).all()
+
     def new(self, array):
         """
         Convert an array of compatible length into a DictArray:

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -340,20 +340,12 @@ class EventBasedTestCase(CalculatorTestCase):
 
     def test_case_16(self):
         # an example with site model raising warnings and autogridded exposure
-        self.run_calc(case_16.__file__, 'job.ini',
-                      ground_motion_fields='false')
+        # and GMF amplification too
+        self.run_calc(case_16.__file__, 'job.ini')
         hid = str(self.calc.datastore.calc_id)
         self.run_calc(case_16.__file__, 'job.ini', hazard_calculation_id=hid)
         tmp = gettemp(view('global_gmfs', self.calc.datastore))
         self.assertEqualFiles('expected/global_gmfs.txt', tmp)
-
-        # validation test for missing intensity_measure_types_and_levels
-        with self.assertRaises(ValueError) as ctx:
-            self.run_calc(case_16.__file__, 'job.ini',
-                          intensity_measure_types='PGA',
-                          intensity_measure_types_and_levels='')
-        self.assertEqual(str(ctx.exception),
-                         'There are no intensity_measure_types_and_levels!')
 
     def test_case_17(self):  # oversampling
         # also, grp-00 does not produce ruptures

--- a/openquake/hazardlib/tests/site_amplification_test.py
+++ b/openquake/hazardlib/tests/site_amplification_test.py
@@ -20,7 +20,7 @@ import unittest
 import numpy
 from openquake.baselib import InvalidFile
 from openquake.baselib.hdf5 import read_csv
-from openquake.baselib.general import gettemp
+from openquake.baselib.general import gettemp, DictArray
 from openquake.hazardlib.site import ampcode_dt
 from openquake.hazardlib.site_amplification import Amplifier
 
@@ -68,12 +68,12 @@ A,1,0.3
 '''
 
 
-
 class AmplifierTestCase(unittest.TestCase):
     vs30 = numpy.array([760])
     imls = [.001, .002, .005, .01, .02, .05, .1, .2, .5, 1., 1.2]
     soil_levels = numpy.array([.002, .005, .01, .02, .05, .1, .2])
-    imtls = {'PGA': imls, 'SA(0.1)': imls, 'SA(0.2)': imls, 'SA(0.5)': imls}
+    imtls = DictArray({'PGA': imls, 'SA(0.1)': imls, 'SA(0.2)': imls,
+                       'SA(0.5)': imls})
     hcurve = [[.999, .995, .99, .98, .95, .9, .8, .7, .1, .05, .01],  # PGA
               [.999, .995, .99, .98, .95, .9, .8, .7, .1, .05, .01],  # SA(0.1)
               [.999, .995, .99, .98, .95, .9, .8, .7, .1, .05, .01],  # SA(0.2)
@@ -171,7 +171,7 @@ class AmplifierTestCase(unittest.TestCase):
     def test_gmf_with_uncertainty(self):
         fname = gettemp(gmf_ampl_func)
         aw = read_csv(fname, {'ampcode': ampcode_dt, None: numpy.float64})
-        imtls = {'PGA': self.imls}
+        imtls = DictArray({'PGA': self.imls})
         a = Amplifier(imtls, aw, self.soil_levels)
         res = []
         nsim = 10000

--- a/openquake/qa_tests_data/event_based/case_16/job.ini
+++ b/openquake/qa_tests_data/event_based/case_16/job.ini
@@ -26,10 +26,7 @@ maximum_distance = 300
 investigation_time = 200
 number_of_logic_tree_samples = 0
 ses_per_logic_tree_path = 1
-intensity_measure_types_and_levels = {
-  'PGA': logscale(0.005, 2.0, 10),
-  'SA(0.3)': logscale(0.005, 2.0, 10),
-  'SA(0.6)': logscale(0.005, 2.0, 10)}
+intensity_measure_types = PGA, SA(0.3), SA(0.6)
 amplification_file = amplification.csv
 vs30_tolerance = 600
 


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/5816: the levels were checked but not used!