### PR TITLE
More refactoring of the hazardlib contexts

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -381,7 +381,8 @@ class ClassicalCalculator(base.HazardCalculator):
             point_rupture_bins=oq.point_rupture_bins,
             shift_hypo=oq.shift_hypo, max_weight=max_weight,
             collapse_level=oq.collapse_level,
-            max_sites_disagg=oq.max_sites_disagg)
+            max_sites_disagg=oq.max_sites_disagg,
+            num_probs_occur=self.csm.get_num_probs_occur())
         srcfilter = self.src_filter(self.datastore.tempname)
         for sg in src_groups:
             gsims = gsims_by_trt[sg.trt]

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -156,10 +156,8 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
         # 6D-matrix #distbins, #lonbins, #latbins, #epsbins, P, Z
         matrix = numpy.zeros([len(b) - 1 for b in bins] + list(iml2.shape))
         for z, gsim in gsim_by_z.items():
-            with gmf_mon:
-                ms = disagg.get_mean_stdv(ctxs, iml3.imt, gsim)
             bdata = disagg.disaggregate(
-                ms, ctxs, iml3.imt, iml2[:, z], eps3, pne_mon)
+                ctxs, gsim, iml3.imt, iml2[:, z], eps3, pne_mon, gmf_mon)
             if bdata.pnes.sum():
                 with mat_mon:
                     matrix[..., z] = disagg.build_disagg_matrix(bdata, bins)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -139,12 +139,16 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
         ctxs = []
         ok, = numpy.where(
             rupdata['rrup_'][:, sid] <= cmaker.maximum_distance(cmaker.trt))
-        for ridx in ok:  # consider only the ruptures close to the site
-            ctx = RuptureContext((par, rupdata[par][ridx])
-                                 for par in rupdata if not par.endswith('_'))
+        for u in ok:  # consider only the ruptures close to the site
+            ctx = RuptureContext()
             for par in rupdata:
-                if par.endswith('_'):
-                    setattr(ctx, par[:-1], rupdata[par][ridx, [sid]])
+                if not par.endswith('_'):
+                    setattr(ctx, par, rupdata[par][u])
+                else:  # site-dependent parameter
+                    setattr(ctx, par[:-1], rupdata[par][u, [sid]])
+            ctx.sids = singlesite.sids
+            for par in cmaker.REQUIRES_SITES_PARAMETERS:
+                setattr(ctx, par, singlesite[par])
             ctxs.append(ctx)
         if not ctxs:
             continue
@@ -153,7 +157,7 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
         matrix = numpy.zeros([len(b) - 1 for b in bins] + list(iml2.shape))
         for z, gsim in gsim_by_z.items():
             with gmf_mon:
-                ms = disagg.get_mean_stdv(singlesite, ctxs, iml3.imt, gsim)
+                ms = disagg.get_mean_stdv(ctxs, iml3.imt, gsim)
             bdata = disagg.disaggregate(
                 ms, ctxs, iml3.imt, iml2[:, z], eps3, pne_mon)
             if bdata.pnes.sum():

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -282,6 +282,13 @@ class CompositeSourceModel:
         return [src for src_group in self.src_groups
                 for src in src_group]
 
+    def get_num_probs_occur(self):
+        """
+        :returns: the number of probs_occur from the underlying nonpar sources
+        """
+        return max(getattr(src, 'num_probs_occur', 0)
+                   for src in self.get_sources())
+
     def get_floating_spinning_factors(self):
         """
         :returns: (floating rupture factor, spinning rupture factor)

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -36,7 +36,7 @@ from openquake.hazardlib.geo.utils import (angular_distance, KM_TO_DEGREES,
                                            cross_idl)
 from openquake.hazardlib.site import SiteCollection
 from openquake.hazardlib.gsim.base import (
-    ContextMaker, get_mean_std, to_distribution_values)
+    ContextMaker, to_distribution_values)
 
 BIN_NAMES = 'mag', 'dist', 'lon', 'lat', 'eps', 'trt'
 BinData = collections.namedtuple('BinData', 'dists, lons, lats, pnes')
@@ -230,9 +230,8 @@ def _digitize_lons(lons, lon_bins):
         return numpy.digitize(lons, lon_bins) - 1
 
 
-def get_mean_stdv(site1, ctxs, imt, gsim):
+def get_mean_stdv(ctxs, imt, gsim):
     """
-    :param site1: site collection with a single site
     :param ctxs: a list of RuptureContexts with distances
     :param imt: Intensity Measure Type
     :param gsim: GMPE instance
@@ -240,9 +239,7 @@ def get_mean_stdv(site1, ctxs, imt, gsim):
     U = len(ctxs)
     ms = numpy.zeros((2, U), numpy.float32)
     for u, ctx in enumerate(ctxs):
-        if gsim.minimum_distance and ctx.rrup[0] < gsim.minimum_distance:
-            ctx.rrup = numpy.float32([gsim.minimum_distance])
-        ms[:, u] = get_mean_std(site1, ctx, ctx, [imt], [gsim]).reshape(2)
+        ms[:, u] = ctx.get_mean_std([imt], [gsim]).reshape(2)
     return ms
 
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -109,20 +109,24 @@ def _eps3(truncation_level, n_epsilons):
 
 
 # this is inside an inner loop
-def disaggregate(mean_std, ctxs, imt, imls, eps3,
-                 pne_mon=performance.Monitor()):
+def disaggregate(ctxs, gsim, imt, imls, eps3,
+                 pne_mon=performance.Monitor(),
+                 gmf_mon=performance.Monitor()):
     # disaggregate (separate) PoE in different contributions
     U, P, E = len(ctxs), len(imls), len(eps3[2])
     bdata = BinData(dists=numpy.zeros(U), lons=numpy.zeros(U),
                     lats=numpy.zeros(U),  pnes=numpy.zeros((U, P, E)))
-    with pne_mon:
+    with gmf_mon:
         truncnorm, epsilons, eps_bands = eps3
         cum_bands = numpy.array([eps_bands[e:].sum() for e in range(E)] + [0])
         imls = to_distribution_values(imls, imt)  # shape P
+        mean_std = numpy.zeros((2, U), numpy.float32)
         for u, ctx in enumerate(ctxs):
+            mean_std[:, u] = ctx.get_mean_std([imt], [gsim]).reshape(2)
             bdata.lons[u] = ctx.clon[0]  # lon of the closest rupture
             bdata.lats[u] = ctx.clat[0]  # lat of the closest rupture
             bdata.dists[u] = ctx.rrup[0]
+    with pne_mon:
         for p, iml in enumerate(imls):
             lvls = (iml - mean_std[0]) / mean_std[1]
             survival = truncnorm.sf(lvls)
@@ -228,21 +232,6 @@ def _digitize_lons(lons, lon_bins):
         return numpy.array(idx)
     else:
         return numpy.digitize(lons, lon_bins) - 1
-
-
-def get_mean_stdv(ctxs, imt, gsim):
-    """
-    :param ctxs: a list of RuptureContexts with distances
-    :param imt: Intensity Measure Type
-    :param gsim: GMPE instance
-    """
-    U = len(ctxs)
-    ms = numpy.zeros((2, U), numpy.float32)
-    for u, ctx in enumerate(ctxs):
-        if gsim.minimum_distance and ctx.rrup[0] < gsim.minimum_distance:
-            ctx.rrup = numpy.float32([gsim.minimum_distance])
-        ms[:, u] = ctx.get_mean_std([imt], [gsim]).reshape(2)
-    return ms
 
 
 def magbin_groups(rups, mag_bins):
@@ -353,8 +342,7 @@ def disaggregation(
     for trt in cmaker:
         gsim = gsim_by_trt[trt]
         for magi, ctxs in enumerate(magbin_groups(rups[trt], mag_bins)):
-            mean_std = get_mean_stdv(ctxs, imt, gsim)
-            bdata[trt, magi] = disaggregate(mean_std, ctxs, imt, imls, eps3)
+            bdata[trt, magi] = disaggregate(ctxs, gsim, imt, imls, eps3)
 
     if sum(len(bd.dists) for bd in bdata.values()) == 0:
         warnings.warn(

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -239,6 +239,8 @@ def get_mean_stdv(ctxs, imt, gsim):
     U = len(ctxs)
     ms = numpy.zeros((2, U), numpy.float32)
     for u, ctx in enumerate(ctxs):
+        if gsim.minimum_distance and ctx.rrup[0] < gsim.minimum_distance:
+            ctx.rrup = numpy.float32([gsim.minimum_distance])
         ms[:, u] = ctx.get_mean_std([imt], [gsim]).reshape(2)
     return ms
 
@@ -351,7 +353,7 @@ def disaggregation(
     for trt in cmaker:
         gsim = gsim_by_trt[trt]
         for magi, ctxs in enumerate(magbin_groups(rups[trt], mag_bins)):
-            mean_std = get_mean_stdv(sitecol, ctxs, imt, gsim)
+            mean_std = get_mean_stdv(ctxs, imt, gsim)
             bdata[trt, magi] = disaggregate(mean_std, ctxs, imt, imls, eps3)
 
     if sum(len(bd.dists) for bd in bdata.values()) == 0:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -320,7 +320,8 @@ class ContextMaker(object):
             for par in self.REQUIRES_SITES_PARAMETERS:
                 setattr(ctx, par, r_sites[par])
             ctx.sids = r_sites.sids
-            vars(ctx).update(vars(dctx))
+            for par in self.REQUIRES_DISTANCES | {'rrup'}:
+                setattr(ctx, par, getattr(dctx, par))
             ctx.grp_ids = grp_ids
             if not filt:
                 closest = rup.surface.get_closest_points(sites)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -31,7 +31,7 @@ from openquake.baselib import hdf5, parallel
 from openquake.baselib.general import (
     AccumDict, DictArray, groupby, groupby_bin)
 from openquake.baselib.performance import Monitor
-from openquake.hazardlib import imt as imt_module
+from openquake.hazardlib import const, imt as imt_module
 from openquake.hazardlib.gsim import base
 from openquake.hazardlib.calc.filters import IntegrationDistance
 from openquake.hazardlib.probability_map import ProbabilityMap
@@ -99,8 +99,9 @@ class RupData(object):
     """
     A class to collect rupture information into an AccumDict
     """
-    def __init__(self, cmaker, data=None):
+    def __init__(self, cmaker, num_probs_occur, data=None):
         self.cmaker = cmaker
+        self.num_probs_occur = num_probs_occur
         self.data = AccumDict(accum=[]) if data is None else data
 
     def add(self, ctxs, sites, grp_ids):
@@ -151,6 +152,7 @@ class ContextMaker(object):
         self.max_sites_disagg = param.get('max_sites_disagg', 10)
         self.collapse_level = param.get('collapse_level', False)
         self.point_rupture_bins = param.get('point_rupture_bins', 20)
+        self.num_probs_occur = param.get('num_probs_occur', 0)
         self.trt = trt
         self.gsims = gsims
         self.maximum_distance = (
@@ -286,7 +288,7 @@ class ContextMaker(object):
 
         :raises ValueError:
             If any of declared required parameters (site, rupture and
-        distance parameters) is unknown.
+            distance parameters) is unknown.
         """
         if filt:
             sites, dctx = self.filter(sites, rupture)
@@ -339,18 +341,21 @@ class ContextMaker(object):
         gmv = numpy.zeros((nmags, ndists))
         for m, d in itertools.product(range(nmags), range(ndists)):
             mag, dist = mags[m], dists[d]
-            rup = RuptureContext()
+            ctx = RuptureContext()
             for par in self.REQUIRES_RUPTURE_PARAMETERS:
-                setattr(rup, par, 0)
-            rup.mag = mag
-            rup.width = .01  # 10 meters to avoid warnings in abrahamson_2014
-            dctx = DistancesContext(
-                (dst, numpy.array([dist])) for dst in self.REQUIRES_DISTANCES)
+                setattr(ctx, par, 0)
+            for dst in self.REQUIRES_DISTANCES:
+                setattr(ctx, dst, numpy.array([dist]))
+            for par in self.REQUIRES_SITES_PARAMETERS:
+                setattr(ctx, par, getattr(sitecol1, par))
+            ctx.sids = sitecol1.sids
+            ctx.mag = mag
+            ctx.width = .01  # 10 meters to avoid warnings in abrahamson_2014
             means = []
             for gsim in self.gsims:
                 try:
-                    mean = base.get_mean_std(  # shape (2, N, M, G) -> M
-                        sitecol1, rup, dctx, self.imts, [gsim])[0, 0, :, 0]
+                    mean = ctx.get_mean_std(  # shape (2, N, M, G) -> M
+                        self.imts, [gsim])[0, 0, :, 0]
                 except ValueError:  # magnitude outside of supported range
                     continue
                 means.append(mean.max())
@@ -429,8 +434,8 @@ class PmapMaker(object):
         for ctx in ctxs:
             # this must be fast since it is inside an inner loop
             with self.gmf_mon:
-                mean_std = base.get_mean_std(  # shape (2, N, M, G)
-                    ctx, ctx, ctx, self.imts, self.gsims)
+                # shape (2, N, M, G)
+                mean_std = ctx.get_mean_std(self.imts, self.gsims)
             with self.poe_mon:
                 ll = self.loglevels
                 poes = base.get_poes(mean_std, ll, self.trunclevel, self.gsims)
@@ -491,6 +496,7 @@ class PmapMaker(object):
     def _make_src_mutex(self):
         for src, sites in self.srcfilter(self.group):
             t0 = time.time()
+            N = len(sites.complete)
             self.totrups += src.num_ruptures
             self.numrups = 0
             self.numsites = 0
@@ -500,8 +506,16 @@ class PmapMaker(object):
                 pmap = {grp_id: ProbabilityMap(L, G) for grp_id in src.grp_ids}
                 ctxs = self.cmaker.make_ctxs(
                     rups, sites, numpy.array(src.grp_ids), filt=True)
+                if self.fewsites:
+                    ctxs = self.cmaker.make_ctxs(
+                        rups, sites, numpy.array(src.grp_ids), filt=False)
+                    self.rupdata.add(ctxs, sites.complete, src.grp_ids)
+                    self.numsites += N * len(ctxs)
+                else:
+                    ctxs = self.cmaker.make_ctxs(  # rctx, sctx, dctx
+                        rups, sites, numpy.array(src.grp_ids), filt=True)
+                    self.numsites += sum(len(ctx.sids) for ctx in ctxs)
                 self.numrups += len(ctxs)
-                self.numsites += sum(len(ctx.sids) for ctx in ctxs)
             self._update_pmap(ctxs, pmap)
             for grp_id in src.grp_ids:
                 p = pmap[grp_id]
@@ -514,7 +528,7 @@ class PmapMaker(object):
         return self.pmap
 
     def make(self):
-        self.rupdata = RupData(self.cmaker)
+        self.rupdata = RupData(self.cmaker, self.num_probs_occur)
         imtls = self.cmaker.imtls
         L, G = len(imtls.array), len(self.gsims)
         self.pmap = AccumDict(accum=ProbabilityMap(L, G))  # grp_id -> pmap
@@ -750,6 +764,28 @@ class RuptureContext(BaseContext):
                 setattr(ctx, dist, array)
         return ctx
 
+    def get_mean_std(self, imts, gsims):
+        """
+        :returns: an array of shape (2, N, M, G) with means and stddevs
+        """
+        N = len(self.sids)
+        M = len(imts)
+        G = len(gsims)
+        arr = numpy.zeros((2, N, M, G))
+        num_tables = base.CoeffsTable.num_instances
+        for g, gsim in enumerate(gsims):
+            new = self.roundup(gsim.minimum_distance)
+            for m, imt in enumerate(imts):
+                mean, [std] = gsim.get_mean_and_stddevs(self, self, new, imt,
+                                                        [const.StdDev.TOTAL])
+                arr[0, :, m, g] = mean
+                arr[1, :, m, g] = std
+                if base.CoeffsTable.num_instances > num_tables:
+                    raise RuntimeError('Instantiating CoeffsTable inside '
+                                       '%s.get_mean_and_stddevs' %
+                                       gsim.__class__.__name__)
+        return arr
+
     def get_probability_no_exceedance(self, poes):
         """
         Compute and return the probability that in the time span for which the
@@ -783,9 +819,9 @@ class RuptureContext(BaseContext):
             #
             # `p(k|T)` is given by the attribute probs_occur and
             # `p(X<x|rup)` is computed as ``1 - poes``.
-            p_kT = self.probs_occur
             prob_no_exceed = numpy.array(
-                [v * ((1 - poes) ** i) for i, v in enumerate(p_kT)])
+                [v * ((1 - poes) ** i)
+                 for i, v in enumerate(self.probs_occur)])
             prob_no_exceed = numpy.sum(prob_no_exceed, axis=0)
             if isinstance(prob_no_exceed, numpy.ndarray):
                 prob_no_exceed[prob_no_exceed > 1.] = 1.  # sanity check

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -106,14 +106,14 @@ class DisaggregateTestCase(unittest.TestCase):
         mag_bins, dist_bins, lon_bins, lat_bins, eps_bins, trt_bins = bin_edges
         aaae = numpy.testing.assert_array_almost_equal
         aaae(mag_bins, [3, 6, 9])
-        aaae(dist_bins, [8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48,
-                         52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 96, 100,
-                         104, 108, 112])
+        aaae(dist_bins, [4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52,
+                         56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 96, 100, 104,
+                         108, 112])
         aaae(lon_bins, [-0.904195, 0.1, 1.104195])
         aaae(lat_bins, [-0.904194, 0.1, 1.104194])
         aaae(eps_bins, [-1, -0.3333333, 0.3333333, 1])
         self.assertEqual(trt_bins, [self.trt])
-        aaae(matrix.shape, (2, 26, 2, 2, 3, 1))
+        aaae(matrix.shape, (2, 27, 2, 2, 3, 1))
         aaae(matrix.sum(), 6.14179818e-11)
 
 

--- a/openquake/hazardlib/tests/gsim/chiou_youngs_2014_test.py
+++ b/openquake/hazardlib/tests/gsim/chiou_youngs_2014_test.py
@@ -105,20 +105,6 @@ class ChiouYoungs2014NearFaultTestCase(BaseGSIMTestCase):
                    max_discrep_percentage=0.05)
 
 
-class ChiouYoungs2014NearFaultTestCase(BaseGSIMTestCase):
-    GSIM_CLASS = ChiouYoungs2014NearFaultEffect
-
-    # First five tests use data ported from Kenneth Campbell
-    # tables for verifying NGA models, available from OpenSHA, see
-    # http://opensha.usc.edu/docs/opensha/NGA/Campbell_NGA_tests.zip
-    # This data is distributed under different license, see LICENSE.txt
-    # in tests/gsim/data/NGA
-
-    def test_mean_near_fault(self):
-        self.check('NGA/CY14/CY14_MEDIAN_RCDPP.csv',
-                   max_discrep_percentage=0.05)
-
-
 class ChiouYoungs2014NearFaultDistanceTaperTestCase(BaseGSIMTestCase):
 
     def make_rupture(self):


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/5826. This is also in preparation for https://github.com/gem/oq-engine/issues/5814. Now the RuptureContext has a nice method `.get_mean_std(self.imts, self.gsims)`.

While at it, I discovered that ChiouYoungs2014NearFaultTestCase was duplicate and I removed it.
I also hazardlib/tests/calc/disagg_test.py: the better bins are the ones below, computed before considering the gsim-dependent minimum_distance.