### PR TITLE
Added error for max_sites_disagg < N

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Raised an early error when `max_sites_disagg` is below the number of
+    sites in disaggregation calculations
   * Extended the amplification framework to use different intensity levels
     for different amplification functions
   * Optimized the disaggregation in the case of multiple realizations

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -453,6 +453,11 @@ class HazardCalculator(BaseCalculator):
             # can be None for the ruptures-only calculator
             with hdf5.File(self.datastore.tempname, 'w') as tmp:
                 tmp['sitecol'] = self.sitecol
+        elif (oq.calculation_mode == 'disaggregation' and
+              oq.max_sites_disagg < len(self.sitecol)):
+            raise ValueError(
+                'Please set max_sites_disagg=%d in %s' % (
+                    len(self.sitecol), oq.inputs['job_ini']))
         if ('source_model_logic_tree' in oq.inputs and
                 oq.hazard_calculation_id is None):
             full_lt = readinput.get_full_lt(oq)


### PR DESCRIPTION
This happened to Thomas: he had 14 cities, but max_sites_disagg was 10, so the disaggregation
failed with
```python
     File "/opt/openquake/oq-engine/openquake/calculators/disaggregation.py", line 185, in get_indices_by_grp_mag
       df = pandas.DataFrame(dict(gidx=dstore['rup/grp_id'][:],
     File "/opt/openquake/oq-engine/openquake/baselib/datastore.py", line 499, in __getitem__
       raise KeyError('No %r found in %s' % (key, self))
   KeyError: "No 'rup/grp_id' found in <DataStore /home/tchartier/oqdata/calc_38533.hdf5 open>"
```
Now an error will be raised before starting even the classical calculation.