### PR TITLE
Optimized even more the disaggregation with complex logic trees

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -347,7 +347,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                      format(U, blocksize))
 
         grp_ids = dstore['grp_ids'][:]
-        rlzs_by_gsim = self.full_lt.get_rlzs_by_gsim2(grp_ids)
+        rlzs_by_gsim = self.full_lt.get_rlzs_by_gsim_list(grp_ids)
         num_eff_rlzs = len(self.full_lt.sm_rlzs)
         for gidx, magi in indices:
             trti = grp_ids[gidx][0] // num_eff_rlzs

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -352,8 +352,6 @@ class DisaggregationCalculator(base.HazardCalculator):
         for gidx, magi in indices:
             trti = grp_ids[gidx][0] // num_eff_rlzs
             trt = self.trts[trti]
-            logging.info('Group #%d, %d ruptures for %s, magbin=%s',
-                         gidx, len(indices[gidx, magi]), trt, magi)
             cmaker = ContextMaker(
                 trt, rlzs_by_gsim[gidx],
                 {'truncation_level': oq.truncation_level,

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -176,23 +176,17 @@ def agg_probs(*probs):
     return 1. - acc
 
 
-def get_indices_by_grp_mag(dstore, mag_edges):
+def get_indices_by_gidx_mag(dstore, mag_edges):
     """
-    :returns: a dictionary grp_id, magi -> indices
+    :returns: a dictionary gidx, magi -> indices
     """
-    acc = AccumDict(accum=[])  # grp_id, magi -> indices
-    grp_ids = dstore['grp_ids'][:]
+    acc = AccumDict(accum=[])  # gidx, magi -> indices
     df = pandas.DataFrame(dict(gidx=dstore['rup/grp_id'][:],
                                mag=dstore['rup/mag'][:]))
-    tot = 0
     for (gidx, mag), d in df.groupby(['gidx', 'mag']):
         magi = numpy.searchsorted(mag_edges, mag) - 1
-        for grp_id in grp_ids[gidx]:
-            acc[grp_id, magi].extend(d.index)
-            tot += len(d)
-    for grp_id, magi in acc:
-        acc[grp_id, magi] = sorted(acc[grp_id, magi])
-    return acc
+        acc[gidx, magi].extend(d.index)
+    return {gm: sorted(idxs) for gm, idxs in acc.items()}
 
 
 def get_outputs_size(shapedic, disagg_outputs):
@@ -343,8 +337,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
         mag_edges = self.bin_edges[0]
-        indices = get_indices_by_grp_mag(dstore, mag_edges)
-        trt_num = {trt: i for i, trt in enumerate(self.trts)}
+        indices = get_indices_by_gidx_mag(dstore, mag_edges)
         allargs = []
         M = len(oq.imtls)
         U = len(dstore['rup/mag'])
@@ -352,17 +345,21 @@ class DisaggregationCalculator(base.HazardCalculator):
         blocksize = int(numpy.ceil(U / (oq.concurrent_tasks or 1) * M))
         logging.info('Found {:_d} ruptures, sending up to {:_d} per task'.
                      format(U, blocksize))
-        for grp_id, magi in indices:
-            trt = self.full_lt.trt_by_grp[grp_id]
-            trti = trt_num[trt]
+
+        grp_ids = dstore['grp_ids'][:]
+        rlzs_by_gsim = self.full_lt.get_rlzs_by_gsim2(grp_ids)
+        num_eff_rlzs = len(self.full_lt.sm_rlzs)
+        for gidx, magi in indices:
+            trti = grp_ids[gidx][0] // num_eff_rlzs
+            trt = self.trts[trti]
             logging.info('Group #%d, %d ruptures for %s, magbin=%s',
-                         grp_id, len(indices[grp_id, magi]), trt, magi)
+                         gidx, len(indices[gidx, magi]), trt, magi)
             cmaker = ContextMaker(
-                trt, self.full_lt.get_rlzs_by_gsim(grp_id),
+                trt, rlzs_by_gsim[gidx],
                 {'truncation_level': oq.truncation_level,
                  'maximum_distance': oq.maximum_distance,
                  'imtls': oq.imtls})
-            for idxs in block_splitter(indices[grp_id, magi], blocksize):
+            for idxs in block_splitter(indices[gidx, magi], blocksize):
                 for imt in oq.imtls:
                     allargs.append((dstore, idxs, cmaker, self.iml3[imt],
                                     trti, magi, self.bin_edges[1:], oq))

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1307,7 +1307,7 @@ class FullLogicTree(object):
                 dic[grp] = list(self.get_rlzs_by_gsim(grp_id).values())
         return dic  # grp_id -> lists of rlzi
 
-    def get_rlzs_by_gsim2(self, list_of_grp_ids):
+    def get_rlzs_by_gsim_list(self, list_of_grp_ids):
         """
         :returns: a list gidx -> rlzs_by_gsim
         """

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1307,6 +1307,19 @@ class FullLogicTree(object):
                 dic[grp] = list(self.get_rlzs_by_gsim(grp_id).values())
         return dic  # grp_id -> lists of rlzi
 
+    def get_rlzs_by_gsim2(self, list_of_grp_ids):
+        """
+        :returns: a list gidx -> rlzs_by_gsim
+        """
+        out = []
+        for gidx, grp_ids in enumerate(list_of_grp_ids):
+            dic = AccumDict(accum=set())
+            for grp_id in grp_ids:
+                for gsim, rlzs in self.get_rlzs_by_gsim(grp_id).items():
+                    dic[gsim].update(rlzs)
+            out.append(dic)
+        return out
+
     def __getnewargs__(self):
         # with this FullLogicTree instances will be unpickled correctly
         return self.seed, self.num_samples, self.sm_rlzs


### PR DESCRIPTION
By avoiding sending the ruptures multiple times and by producing a decent number of tasks (before they were too many). The change has drastic effects on models like the Korea or PAC. Here are the figures for PAC:
```
   calc_38239                   time_sec memory_mb counts  # before
   ============================ ======== ========= ======
   total compute_disagg         87_225   166       7_616
   disagg mean_std              42_950   0.0       10_020
   reading rupdata              29_389   170       4_796
   disaggregate_pne             19_560   0.0       10_020
   DisaggregationCalculator.run 1_715    1_255     1
   build_disagg_matrix          257      0.35156   10_020
   aggregating disagg matrices  6.05714  1.78516   7_616
   extracting PMFs              2.26275  0.0       3_460
   
   calc_38248                   time_sec memory_mb counts  # now
   ============================ ======== ========= ======
   total compute_disagg         21_081   166       347   
   disaggregate_pne             20_078   0.0       437   
   disagg mean_std              1_471    0.0       437   
   reading rupdata              1_145    170       189   
   DisaggregationCalculator.run 448      129       1     
   build_disagg_matrix          9.05709  0.0       437   
   extracting PMFs              2.13947  0.0       3_460 
   aggregating disagg matrices  0.28812  1.67578   347   
```
We are 4 times faster!