### PR TITLE
Forbidden setting both rlz_index and num_rlzs_disagg

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -295,7 +295,7 @@ class DisaggregationCalculator(base.HazardCalculator):
 
         # build array rlzs (N, Z)
         if oq.rlz_index is None:
-            Z = oq.num_rlzs_disagg
+            Z = oq.num_rlzs_disagg or 1
             rlzs = numpy.zeros((self.N, Z), int)
             if self.R > 1:
                 for sid in self.sitecol.sids:

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -166,7 +166,7 @@ class OqParam(valid.ParamSet):
     number_of_logic_tree_samples = valid.Param(valid.positiveint, 0)
     num_cores = valid.Param(valid.positiveint, None)
     num_epsilon_bins = valid.Param(valid.positiveint)
-    num_rlzs_disagg = valid.Param(valid.positiveint, 1)
+    num_rlzs_disagg = valid.Param(valid.positiveint, None)
     poes = valid.Param(valid.probabilities, [])
     poes_disagg = valid.Param(valid.probabilities, [])
     pointsource_distance = valid.Param(valid.MagDist.new, None)
@@ -347,6 +347,10 @@ class OqParam(valid.ParamSet):
             if self.disagg_outputs and not any(
                     'Eps' in out for out in self.disagg_outputs):
                 self.num_epsilon_bins = 1
+            if (self.rlz_index is not None
+                    and self.num_rlzs_disagg is not None):
+                raise InvalidFile('%s: you cannot set rlzs_index and '
+                                  'num_rlzs_disagg at the same time' % job_ini)
 
         # checks for classical_damage
         if self.calculation_mode == 'classical_damage':

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -56,7 +56,10 @@ def get_edges_shapedic(oq, sitecol, mags_by_trt):
     :returns: (mag dist lon lat eps trt) edges and shape dictionary
     """
     tl = oq.truncation_level
-    Z = oq.num_rlzs_disagg if oq.rlz_index is None else len(oq.rlz_index)
+    if oq.rlz_index is None:
+        Z = oq.num_rlzs_disagg or 1
+    else:
+        Z = len(oq.rlz_index)
     eps_edges = numpy.linspace(-tl, tl, oq.num_epsilon_bins + 1)
 
     # build mag_edges


### PR DESCRIPTION
Because it would not be clear what the engine would do (it honors `rlz_index` and ignores `num_rlzs_disagg`).