### PR TITLE
Better monitoring of disaggregation

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -92,6 +92,50 @@ def _iml3(rlzs, iml_disagg, imtls, poes_disagg, curves):
     return dic
 
 
+def _prepare(rupdata, sid, cmaker, sitecol, iml3, cfactors):
+    # returns ctxs and zs_by_gsim
+    maxdist = cmaker.maximum_distance(cmaker.trt)
+    ok, = numpy.where(rupdata['rrup_'][:, sid] <= maxdist)
+    singlesite = sitecol.filtered([sid])
+    ctxs = []
+    for u in ok:  # consider only the ruptures close to the site
+        ctx = RuptureContext()
+        for par in rupdata:
+            if not par.endswith('_'):
+                setattr(ctx, par, rupdata[par][u])
+            else:  # site-dependent parameter
+                setattr(ctx, par[:-1], rupdata[par][u, [sid]])
+        for par in cmaker.REQUIRES_SITES_PARAMETERS:
+            setattr(ctx, par, singlesite[par])
+        ctx.sids = singlesite.sids
+        ctxs.append(ctx)
+    if not ctxs:
+        return [], {}
+
+    # z indices by gsim
+    Z = iml3.shape[-1]
+    zs_by_gsim = AccumDict(accum=[])
+    for gsim, rlzs in cmaker.gsims.items():
+        for z in range(Z):
+            if iml3.rlzs[sid, z] in rlzs:
+                zs_by_gsim[gsim].append(z)
+
+    # sanity check: the zs are disjoint
+    counts = numpy.zeros(Z, numpy.uint8)
+    for zs in zs_by_gsim.values():
+        counts[zs] += 1
+    assert (counts <= 1).all(), counts
+
+    # collapse the contexts if the collapse_level is high enough
+    if cmaker.collapse_level >= 2:
+        ctxs_collapsed = cmaker.collapse_the_ctxs(ctxs)
+        cfactors.append(len(ctxs_collapsed) / len(ctxs))
+        ctxs = ctxs_collapsed
+    else:
+        cfactors.append(1.)
+    return ctxs, zs_by_gsim
+
+
 def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
                    monitor):
     # see https://bugs.launchpad.net/oq-engine/+bug/1279247 for an explanation
@@ -116,7 +160,7 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
     :returns:
         a dictionary sid -> 8D-array
     """
-    res = {}
+    res = {'trti': trti, 'magi': magi, 'imti': iml3.imti}
     with monitor('reading rupdata', measuremem=True):
         dstore.open('r')
         sitecol = dstore['sitecol']
@@ -127,49 +171,17 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
     pne_mon = monitor('disaggregate_pne', measuremem=False)
     mat_mon = monitor('build_disagg_matrix', measuremem=False)
     ms_mon = monitor('disagg mean_std', measuremem=False)
+    pre_mon = monitor('preparing contexts', measuremem=False)
     eps3 = disagg._eps3(cmaker.trunclevel, oq.num_epsilon_bins)
-    maxdist = cmaker.maximum_distance(cmaker.trt)
+    cfactors = []
     for sid, iml2 in zip(sitecol.sids, iml3):
-        ok, = numpy.where(rupdata['rrup_'][:, sid] <= maxdist)
-        singlesite = sitecol.filtered([sid])
-        ctxs = []
-        for u in ok:  # consider only the ruptures close to the site
-            ctx = RuptureContext()
-            for par in rupdata:
-                if not par.endswith('_'):
-                    setattr(ctx, par, rupdata[par][u])
-                else:  # site-dependent parameter
-                    setattr(ctx, par[:-1], rupdata[par][u, [sid]])
-            for par in cmaker.REQUIRES_SITES_PARAMETERS:
-                setattr(ctx, par, singlesite[par])
-            ctx.sids = singlesite.sids
-            ctxs.append(ctx)
+        with pre_mon:
+            ctxs, zs_by_gsim = _prepare(
+                rupdata, sid, cmaker, sitecol, iml3, cfactors)
         if not ctxs:
             continue
         # dist_bins, lon_bins, lat_bins, eps_bins
         bins = bin_edges[0], bin_edges[1][sid], bin_edges[2][sid], bin_edges[3]
-
-        # z indices by gsim
-        Z = iml3.shape[-1]
-        zs_by_gsim = AccumDict(accum=[])
-        for gsim, rlzs in cmaker.gsims.items():
-            for z in range(Z):
-                if iml3.rlzs[sid, z] in rlzs:
-                    zs_by_gsim[gsim].append(z)
-
-        # sanity check: the zs are disjoint
-        counts = numpy.zeros(Z, numpy.uint8)
-        for zs in zs_by_gsim.values():
-            counts[zs] += 1
-        assert (counts <= 1).all(), counts
-
-        # collapse the contexts if the collapse_level is high enough
-        if cmaker.collapse_level >= 2:
-            ctxs_collapsed = cmaker.collapse_the_ctxs(ctxs)
-            cfactor = len(ctxs_collapsed) / len(ctxs)
-            ctxs = ctxs_collapsed
-        else:
-            cfactor = 1.
         bdata = disagg.disaggregate(
             ctxs, zs_by_gsim, iml3.imt, iml2, eps3, ms_mon, pne_mon)
         if bdata.pnes.sum():
@@ -178,8 +190,7 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
                 matrix = disagg.build_disagg_matrix(bdata, bins)
                 if matrix.any():
                     res[sid] = matrix
-    res.update({'trti': trti, 'magi': magi, 'imti': iml3.imti,
-                'collapse_factor': cfactor})
+    res['collapse_factor'] = numpy.mean(cfactors)
     return res
 
 

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -116,6 +116,7 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
     :returns:
         a dictionary sid -> 8D-array
     """
+    res = {}
     with monitor('reading rupdata', measuremem=True):
         dstore.open('r')
         sitecol = dstore['sitecol']
@@ -176,8 +177,10 @@ def compute_disagg(dstore, idxs, cmaker, iml3, trti, magi, bin_edges, oq,
             with mat_mon:
                 matrix = disagg.build_disagg_matrix(bdata, bins)
                 if matrix.any():
-                    yield {'trti': trti, 'magi': magi, 'imti': iml3.imti,
-                           sid: matrix, 'collapse_factor': cfactor}
+                    res[sid] = matrix
+    res.update({'trti': trti, 'magi': magi, 'imti': iml3.imti,
+                'collapse_factor': cfactor})
+    return res
 
 
 def agg_probs(*probs):


### PR DESCRIPTION
We were not monitoring the time spent in `prepare contexts`, which is dominating the Colombia calculation! Here are some figures on cluster2:
```
calc_38618                   time_sec memory_mb counts
============================ ======== ========= =======
total compute_disagg         179_182  347       468
preparing contexts           123_774  0.0       234_000
reading rupdata              18_379   422       468
disaggregate_pne             18_245   0.0       234_000
disagg mean_std              15_791   0.0       234_000
```