### PR TITLE
Tripled the speed of disaggregation for SGC (again)

### DIFF
--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -487,7 +487,7 @@ def iproduct(*sizes):
 def export_disagg_csv_xml(ekey, dstore):
     oq = dstore['oqparam']
     sitecol = dstore['sitecol']
-    iml4 = dstore['iml4/array']
+    iml4 = dstore['iml4']
     N, M, P, Z = iml4.shape
     imts = list(oq.imtls)
     rlzs = dstore['full_lt'].get_realizations()
@@ -502,7 +502,7 @@ def export_disagg_csv_xml(ekey, dstore):
         if sum(arr.sum() for arr in dic.values()) == 0:  # no data
             continue
         imt = from_string(imts[m])
-        r = dstore['iml4/rlzs'][s, z]
+        r = iml4.rlzs[s, z]
         rlz = rlzs[r]
         iml = iml4[s, m, p, z]
         poe_agg = dstore['poe4'][s, m, p, z]

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -700,7 +700,7 @@ def view_mean_disagg(token, dstore):
     Display mean quantities for the disaggregation. Useful for checking
     differences between two calculations.
     """
-    N, M, P, Z = dstore['iml4/array'].shape
+    N, M, P, Z = dstore['iml4'].shape
     tbl = []
     kd = {key: dset[:] for key, dset in sorted(dstore['disagg'].items())}
     oq = dstore['oqparam']

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -113,13 +113,13 @@ def _eps3(truncation_level, n_epsilons):
 
 
 # this is inside an inner loop
-def disaggregate(ctxs, mean_std, zs_by_gsim, iml3, eps3, sid, bin_edges=(),
+def disaggregate(ctxs, mean_std, zs_by_g, iml3, eps3, sid, bin_edges=(),
                  pne_mon=performance.Monitor(),
                  mat_mon=performance.Monitor()):
     """
     :param ctxs: a list of U fat RuptureContexts
     :param imts: a list of Intensity Measure Type objects
-    :param zs_by_gims: a dictionary gsim -> Z indices
+    :param zs_by_g: a dictionary g -> Z indices
     :param imt: an Intensity Measure Type
     :param iml3: an array of shape (M, P, Z)
     :param eps3: a triplet (truncnorm, epsilons, eps_bands)
@@ -141,7 +141,7 @@ def disaggregate(ctxs, mean_std, zs_by_gsim, iml3, eps3, sid, bin_edges=(),
     with pne_mon:
         poes = numpy.zeros((U, E, M, P, Z))
         pnes = numpy.ones((U, E, M, P, Z))
-        for g, zs in enumerate(zs_by_gsim.values()):
+        for g, zs in zs_by_g.items():
             for (m, p, z), iml in numpy.ndenumerate(iml3):
                 if z in zs:
                     lvls = (iml - mean_std[0, :, sid, m, g]) / (

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -36,6 +36,7 @@ from openquake.hazardlib.geo.utils import get_longitudinal_extent
 from openquake.hazardlib.geo.utils import (angular_distance, KM_TO_DEGREES,
                                            cross_idl)
 from openquake.hazardlib.site import SiteCollection
+from openquake.hazardlib.imt import from_string
 from openquake.hazardlib.gsim.base import (
     ContextMaker, to_distribution_values)
 
@@ -113,7 +114,7 @@ def _eps3(truncation_level, n_epsilons):
 
 
 # this is inside an inner loop
-def disaggregate(ctxs, mean_std, zs_by_g, iml3, eps3, sid, bin_edges=(),
+def disaggregate(ctxs, mean_std, zs_by_g, iml2dict, eps3, sid=0, bin_edges=(),
                  pne_mon=performance.Monitor(),
                  mat_mon=performance.Monitor()):
     """
@@ -121,17 +122,23 @@ def disaggregate(ctxs, mean_std, zs_by_g, iml3, eps3, sid, bin_edges=(),
     :param imts: a list of Intensity Measure Type objects
     :param zs_by_g: a dictionary g -> Z indices
     :param imt: an Intensity Measure Type
-    :param iml3: an array of shape (M, P, Z)
+    :param iml2dict: a dictionary of arrays imt -> (P, Z)
     :param eps3: a triplet (truncnorm, epsilons, eps_bands)
     :param pne_mon: monitor for the probabilities of no exceedance
     """
     # disaggregate (separate) PoE in different contributions
-    U, E = len(ctxs), len(eps3[2])
-    M, P, Z = iml3.shape
+    U, E, M = len(ctxs), len(eps3[2]), len(iml2dict)
+    iml2 = next(iter(iml2dict.values()))
+    P, Z = iml2.shape
     dists = numpy.zeros(U)
     lons = numpy.zeros(U)
     lats = numpy.zeros(U)
-    iml3 = iml3.copy()
+
+    # switch to logarithmic intensities
+    iml3 = numpy.zeros((M, P, Z))
+    for m, (imt, iml2) in enumerate(iml2dict.items()):
+        iml3[m] = to_distribution_values(iml2, imt)
+
     truncnorm, epsilons, eps_bands = eps3
     cum_bands = numpy.array([eps_bands[e:].sum() for e in range(E)] + [0])
     for u, ctx in enumerate(ctxs):
@@ -156,6 +163,18 @@ def disaggregate(ctxs, mean_std, zs_by_g, iml3, eps3, sid, bin_edges=(),
         return bindata
     with mat_mon:
         return _build_disagg_matrix(bindata, bin_edges)
+
+
+def get_mean_std(ctxs, imts, gsims):
+    """
+    :returns: array of shape (2, U, N, M, G)
+    """
+    U, N, M, G = len(ctxs), len(ctxs[0].sids), len(imts), len(gsims)
+    mean_std = numpy.zeros((2, U, N, M, G), numpy.float32)
+    imts = [from_string(imt) for imt in imts]
+    for u, ctx in enumerate(ctxs):
+        mean_std[:, u, ctx.sids] = ctx.get_mean_std(imts, gsims)
+    return mean_std
 
 
 def _disagg_eps(survival, bins, eps_bands, cum_bands):
@@ -339,7 +358,7 @@ def disaggregation(
     by_trt = groupby(sources, operator.attrgetter('tectonic_region_type'))
     bdata = {}  # by trt, magi
     sitecol = SiteCollection([site])
-    iml3 = numpy.array([[[iml]]])
+    iml2 = numpy.array([[iml]])
     eps3 = _eps3(truncation_level, n_epsilons)
 
     rups = AccumDict(accum=[])
@@ -362,8 +381,9 @@ def disaggregation(
     for trt in cmaker:
         gsim = gsim_by_trt[trt]
         for magi, ctxs in enumerate(_magbin_groups(rups[trt], mag_bins)):
+            mean_std = get_mean_std(ctxs, [str(imt)], [gsim])
             bdata[trt, magi] = disaggregate(
-                ctxs, [imt], {gsim: [0]}, iml3, eps3)
+                ctxs, mean_std, {0: [0]}, {imt: iml2}, eps3)
 
     if sum(len(bd.dists) for bd in bdata.values()) == 0:
         warnings.warn(


### PR DESCRIPTION
The trick was going back to compute mean and stddev vectorized by sites, since they were the dominating factor. The total runtime of the disaggregation is now ~5 minutes (was 10+ hours).
The computation is totally dominated by the classical part. Here are some figures on cluster2:
```

calc_38650                   time_sec memory_mb counts  # before
============================ ======== ========= ======
total compute_disagg         24_870   387       176   
disagg mean_std              16_332   0.0       88_000
preparing contexts           4_366    0.0       88_000
disaggregate_pne             2_355    0.0       88_000
reading rupdata              1_421    198       176   
DisaggregationCalculator.run 898      4_437     1     
build_disagg_matrix          330      0.0       88_000
saving disagg results        21       158       1     
aggregating disagg matrices  7.48529  308       176   

calc_38654                   time_sec memory_mb counts
============================ ======== ========= ======  # after
total compute_disagg         9_141    386       176   
disagg mean_std              4_470    0.0       176   
disaggregate_pne             2_695    0.0       88_000
reading rupdata              1_379    198       176   
build_disagg_matrix          353      0.0       88_000
DisaggregationCalculator.run 268      4_436     1     
saving disagg results        30       158       1     
aggregating disagg matrices  7.85745  311       176   
preparing contexts           3.48618  0.0       176   
```