### PR TITLE
Added a warning about suspiciously large complex fault sources

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -38,7 +38,7 @@ from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap import get_sitecol_shakemap, to_gmfs
 from openquake.risklib import riskinput, riskmodels
-from openquake.commonlib import readinput, logictree, calc, util
+from openquake.commonlib import readinput, logictree, util
 from openquake.calculators.ucerf_base import UcerfFilter
 from openquake.calculators.export import export as exp
 from openquake.calculators import getters

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -379,7 +379,15 @@ class ClassicalCalculator(base.HazardCalculator):
             return src.weight * g
 
         logging.info('Weighting the sources')
-        totweight = sum(sum(srcweight(src) for src in sg) for sg in src_groups)
+        totweight = 0
+        for sg in src_groups:
+            for src in sg:
+                totweight += srcweight(src)
+                if src.code == b'C' and src.num_ruptures > 10_000:
+                    msg = ('{} is suspiciously large, containing {:_d} '
+                           'ruptures with complex_fault_mesh_spacing={} km')
+                    spc = oq.complex_fault_mesh_spacing
+                    logging.warning(msg.format(src, src.num_ruptures, spc))
         C = oq.concurrent_tasks or 1
         if oq.calculation_mode == 'preclassical':
             f1 = f2 = preclassical


### PR DESCRIPTION
Users often forget to set the `complex_fault_mesh_spacing` parameter. Then calculations become slower than they need to be, especially single site calculations. Now the user will get warnings like the following:
```
[WARNING] <ComplexFaultSource int_col (Interface Colombia - no segmented)> is suspiciously large, containing 372_598 ruptures with complex_fault_mesh_spacing=2.0 km
[WARNING] <ComplexFaultSource int_col0 (Interface Colombia - segment 0)> is suspiciously large, containing 86_478 ruptures with complex_fault_mesh_spacing=2.0 km
[WARNING] <ComplexFaultSource int_col1 (Interface Colombia - segment 1)> is suspiciously large, containing 64_161 ruptures with complex_fault_mesh_spacing=2.0 km
[WARNING] <ComplexFaultSource int_col2 (Interface Colombia - segment 2)> is suspiciously large, containing 31_097 ruptures with complex_fault_mesh_spacing=2.0 km
```
I am printing the warning for sources containing more than 10,000 ruptures (limit arbitrarily chosen by me).