### PR TITLE
Called `check_complex_fault` when serializing the source in XML

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Called `check_complex_fault` when serializing the source in XML
   * Restored scenario_damage with fractional asset number
   * Added a view `oq extract disagg_by_src`
   * Fixed error with large ShakeMap calculations ('events' not found)

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -28,7 +28,8 @@ from openquake.baselib import hdf5
 from openquake.baselib.general import CallableDict, groupby
 from openquake.baselib.node import Node, node_to_dict
 from openquake.hazardlib import nrml, sourceconverter, pmf
-from openquake.hazardlib.source import NonParametricSeismicSource
+from openquake.hazardlib.source import (
+    NonParametricSeismicSource, check_complex_fault)
 from openquake.hazardlib.tom import PoissonTOM
 
 obj_to_node = CallableDict(lambda obj: obj.__class__.__name__)
@@ -554,6 +555,8 @@ def build_complex_fault_source_node(fault_source):
     :returns:
         Instance of :class:`openquake.baselib.node.Node`
     """
+    list(check_complex_fault(fault_source))  # check get_dip
+
     # Parse geometry
     source_nodes = [build_complex_fault_geometry(fault_source)]
     # Parse common fault source attributes


### PR DESCRIPTION
It should avoid generating invalid models, at the cost of making the serialization slower.