### PR TITLE
Removed sphinx from the packager since it is tested in travis

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -453,10 +453,6 @@ _builddoc_innervm_run () {
     # install sources of this package
     git archive --prefix ${GEM_GIT_PACKAGE}/ HEAD | ssh "$lxc_ip" "tar xv"
 
-    ssh "$lxc_ip" "set -e ; sudo /opt/openquake/bin/pip install sphinx ; cd oq-engine; export PATH=/opt/openquake/bin:\$PATH ; export PYTHONPATH=\$PWD ; cd doc/sphinx ; MPLBACKEND=Agg make html"
-
-    scp -r "${lxc_ip}:oq-engine/doc/sphinx/build/html" "out_${BUILD_UBUVER}/" || true
-
     # TODO: version check
     trap ERR
 


### PR DESCRIPTION
And because Jenkins is broken every day now: https://ci.openquake.org/job/master_oq-engine/5263/console

This change may break something and the only way to know is to try it.