### PR TITLE
Fixed `oq show oqparam`

### DIFF
--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -276,6 +276,11 @@ class RunShowExportTestCase(unittest.TestCase):
         self.assertEqual('__pyclass__ openquake.hazardlib.site.SiteCollection',
                          str(p))
 
+    def test_show_oqparam(self):
+        with Print.patch() as p:
+            show('oqparam', self.calc_id)
+        self.assertIn('"inputs": {', str(p))
+
     def test_export_calc(self):
         tempdir = tempfile.mkdtemp()
         with Print.patch() as p:


### PR DESCRIPTION
It was not working anymore. This will make some people happy. Here is an example:
```
$ oq show oqparam
{
  "area_source_discretization": null,
  "base_path": "/home/michele/oq-engine/openquake/qa_tests_data/classical/case_1",
  "calculation_mode": "classical",
  "collapse_level": 0,
  "complex_fault_mesh_spacing": 1.0,
  "concurrent_tasks": 0,
  "description": "Classical Hazard QA Test, Case 1",
  "export_dir": "/tmp",
  "exports": "",
  "hazard_imtls": {
    "PGA": [
      0.1,
      0.4,
      0.6
    ],
    "SA(0.1)": [
      0.1,
      0.4,
      0.6
    ]
  },
  "inputs": {
    "gsim_logic_tree": "/home/michele/oq-engine/openquake/qa_tests_data/classical/case_1/gsim_logic_tree.xml",
    "job_ini": "/home/michele/oq-engine/openquake/qa_tests_data/classical/case_1/job.ini",
    "source_model_logic_tree": "/home/michele/oq-engine/openquake/qa_tests_data/classical/case_1/source_model_logic_tree.xml"
  },
  "investigation_time": 1.0,
  "maximum_distance": {
    "default": 200.0
  },
  "mean": false,
  "number_of_logic_tree_samples": 0,
  "pdb": false,
  "poes": [],
  "quantiles": [],
  "random_seed": 1066,
  "reference_depth_to_1pt0km_per_sec": 50.0,
  "reference_depth_to_2pt5km_per_sec": 2.5,
  "reference_vs30_type": "measured",
  "reference_vs30_value": 800.0,
  "risk_investigation_time": 1.0,
  "rlz_ids": [],
  "rupture_mesh_spacing": 1.0,
  "sites": [
    [
      0.0,
      0.0,
      -0.1
    ]
  ],
  "truncation_level": 2.0,
  "width_of_mfd_bin": 1.0
}
```