### PR TITLE
Added warning against numeric errors in scenario_damage and event_based_damage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed bug in event_based_damage: the number of buildings in no damage
+    state was incorrect
   * Changed the rlz->events association in scenario calculations to be
     consistent with event based
   * Added commands `oq nrml_to csv` and  `oq nrml_to gpkg`

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -19,7 +19,7 @@
 import logging
 import numpy
 from openquake.baselib import hdf5
-from openquake.baselib.general import AccumDict, get_indices, fast_agg
+from openquake.baselib.general import AccumDict, get_indices
 from openquake.hazardlib.stats import set_rlzs_stats
 from openquake.calculators import base
 

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -215,7 +215,8 @@ class ScenarioDamageCalculator(base.RiskCalculator):
                        asset_id=self.assetcol['id'],
                        loss_type=oq.loss_names,
                        dmg_state=dstates)
-        self.sanity_check()
+        if self.R > 1:
+            self.sanity_check()
 
         # damage by event: make sure the sum of the buildings is consistent
         tot = self.assetcol['number'].sum()
@@ -282,4 +283,3 @@ class EventBasedDamageCalculator(ScenarioDamageCalculator):
         if dic['got'] != dic['expected']:
             logging.info('Due to numeric errors the total number of assets '
                          'is imprecise: %s', dic)
-

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-000.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-000.csv
@@ -1,6 +1,6 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.10.0-gitc5935f7279', start_date='2020-05-21T06:49:58', checksum=1405139117, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.10.0-git8fb00efe4e', start_date='2020-06-18T07:43:28', checksum=1405139117, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,policy,taxonomy,lon,lat,structural~no_damage,structural~LS1,structural~LS2
-a0,"A","RM",81.29850,29.10980,3.500000E-01,5.000000E-01,5.000000E-01
-a1,"A","RC",83.08230,27.90060,5.075000E+01,2.855000E+01,2.070000E+01
-a2,"B","W",85.74770,27.90150,1.829500E+02,8.095000E+01,8.610000E+01
-a3,"B","RM",85.74770,27.90150,1.650000E+00,1.000000E+00,8.500000E-01
+a0,A,RM,81.29850,29.10980,2.000000E+00,5.000000E-01,5.000000E-01
+a1,A,RC,83.08230,27.90060,4.507500E+02,2.855000E+01,2.070000E+01
+a2,B,W,85.74770,27.90150,8.329500E+02,8.095000E+01,8.610000E+01
+a3,B,RM,85.74770,27.90150,8.150001E+00,1.000000E+00,8.500000E-01

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-001.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-001.csv
@@ -1,6 +1,6 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.10.0-gitc5935f7279', start_date='2020-05-21T06:49:58', checksum=1405139117, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.10.0-git8fb00efe4e', start_date='2020-06-18T07:43:28', checksum=1405139117, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,policy,taxonomy,lon,lat,structural~no_damage,structural~LS1,structural~LS2
-a0,"A","RM",81.29850,29.10980,5.000000E-01,5.500000E-01,3.000000E-01
-a1,"A","RC",83.08230,27.90060,5.180000E+01,2.545000E+01,2.275000E+01
-a2,"B","W",85.74770,27.90150,1.818500E+02,8.320000E+01,8.495000E+01
-a3,"B","RM",85.74770,27.90150,1.750000E+00,1.050000E+00,7.000000E-01
+a0,A,RM,81.29850,29.10980,2.150000E+00,5.500000E-01,3.000000E-01
+a1,A,RC,83.08230,27.90060,4.518000E+02,2.545000E+01,2.275000E+01
+a2,B,W,85.74770,27.90150,8.318500E+02,8.320000E+01,8.495000E+01
+a3,B,RM,85.74770,27.90150,8.250000E+00,1.050000E+00,7.000000E-01


### PR DESCRIPTION
32 bit sums are imprecise, but it is expected.  This PR also fixes the issue with the number of buildings in no damage state (we were missing buildings due to an incorrect counting of events producing zero damage).