### PR TITLE
Fixed a bug in event based when a rupture occurs more than 65535 times

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a bug in event based when a rupture occurs more than 65535 times
   * Added a demo EventBasedDamage
   * Fixed bug in event_based_damage: the number of buildings in no damage
     state was incorrect

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -87,7 +87,7 @@ def stochastic_event_set(sources, source_site_filter=nofilter, **kwargs):
 
 rupture_dt = numpy.dtype([
     ('id', U32), ('serial', U32), ('source_id', '<S16'), ('grp_id', U16),
-    ('code', U8), ('n_occ', U16), ('mag', F32), ('rake', F32),
+    ('code', U8), ('n_occ', U32), ('mag', F32), ('rake', F32),
     ('occurrence_rate', F32),
     ('minlon', F32), ('minlat', F32), ('maxlon', F32), ('maxlat', F32),
     ('hypo', (F32, 3)), ('geom_id', U32), ('s1', U16), ('s2', U16),
@@ -107,7 +107,6 @@ def get_rup_array(ebruptures, srcfilter=nofilter):
     geoms = []
     nbytes = 0
     for ebrupture in ebruptures:
-        assert ebrupture.n_occ < TWO16, ebrupture.n_occ
         rup = ebrupture.rupture
         mesh = surface_to_array(rup.surface)
         sy, sz = mesh.shape[1:]  # sanity checks;  sx == 3

--- a/openquake/qa_tests_data/event_based/case_1/expected/hazard_curve-smltp_b1-gsimltp_b1-PGA.xml
+++ b/openquake/qa_tests_data/event_based/case_1/expected/hazard_curve-smltp_b1-gsimltp_b1-PGA.xml
@@ -19,7 +19,7 @@ xmlns:gml="http://www.opengis.net/gml"
                 </gml:pos>
             </gml:Point>
             <poEs>
-                1.038074568E-01 1.022239216E-02 1.011987566E-03
+                4.555068910E-01 5.734036490E-02 7.149321027E-03
             </poEs>
         </hazardCurve>
     </hazardCurves>

--- a/openquake/qa_tests_data/event_based/case_1/expected/hazard_curve-smltp_b1-gsimltp_b1.csv
+++ b/openquake/qa_tests_data/event_based/case_1/expected/hazard_curve-smltp_b1-gsimltp_b1.csv
@@ -1,3 +1,3 @@
-#,,,,,"generated_by='OpenQuake engine 3.10.0-gitea7793a694', start_date='2020-06-12T09:24:21', checksum=1865168388, kind='mean', investigation_time=1.0, imt='PGA'"
+#,,,,,"generated_by='OpenQuake engine 3.10.0-gitbe4d639e9d', start_date='2020-06-19T07:21:37', checksum=1865168388, kind='mean', investigation_time=1.0, imt='PGA'"
 lon,lat,depth,poe-0.1000000,poe-0.4000000,poe-0.6000000
-0.00000,0.00000,0.00000,1.038075E-01,1.022239E-02,1.011988E-03
+0.00000,0.00000,0.00000,4.555069E-01,5.734036E-02,7.149321E-03


### PR DESCRIPTION
Discovered thanks to the great unification in https://github.com/gem/oq-engine/pull/5937. The solution was to upcast the field `n_occ` from 16 bit to 32 bit.