### PR TITLE
Logging an error for duplicate sources

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -742,12 +742,7 @@ def get_composite_source_model(oqparam, full_lt=None, h5=None):
                 srcmags = ['%.2f' % item[0] for item in
                            src.get_annual_occurrence_rates()]
             mags[sg.trt].update(srcmags)
-    logging.info('There are %d sources with %d unique IDs', ns + 1, len(data))
-    false_duplicates = [src_id for src_id in data
-                        if data[src_id][MULTIPLICITY] > 1]
-    if false_duplicates:
-        logging.info('Found different sources with same ID: %s',
-                     numpy.array(false_duplicates))
+    logging.info('There are %d sources', ns + 1)
     if h5:
         attrs = dict(atomic=any(grp.atomic for grp in csm.src_groups))
         # avoid hdf5 damned bug by creating source_info in advance

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -29,6 +29,7 @@ from openquake.hazardlib import nrml, sourceconverter, calc, InvalidFile
 from openquake.hazardlib.lt import apply_uncertainties
 
 TWO16 = 2 ** 16  # 65,536
+by_id = operator.attrgetter('source_id')
 
 
 def random_filtered_sources(sources, srcfilter, seed):
@@ -60,6 +61,28 @@ def read_source_model(fname, converter, srcfilter, monitor):
         for i, sg in enumerate(sm.src_groups):
             sg.sources = random_filtered_sources(sg.sources, srcfilter, i)
     return {fname: sm}
+
+
+def check_dupl_ids(smdict):
+    """
+    Print a warning in case of duplicate source IDs referring to different
+    sources
+    """
+    sources = general.AccumDict(accum=[])
+    for sm in smdict.values():
+        for sg in sm.src_groups:
+            for src in sg.sources:
+                sources[src.source_id].append(src)
+    for src_id, srcs in sources.items():
+        if len(srcs) > 1:  # duplicate IDs must have all the same checksum
+            checksums = set()
+            for src in srcs:
+                dic = {k: v for k, v in vars(src).items()
+                       if k not in 'grp_id samples'}
+                checksums.add(zlib.adler32(pickle.dumps(dic, protocol=4)))
+            if len(checksums) > 1:
+                logging.warning('There are multiple different sources with the'
+                                ' same ID %s', srcs)
 
 
 def get_csm(oq, full_lt, h5=None):
@@ -123,6 +146,7 @@ def get_csm(oq, full_lt, h5=None):
                               h5=h5 if h5 else None).reduce()
     if len(smdict) > 1:  # really parallel
         parallel.Starmap.shutdown()  # save memory
+    check_dupl_ids(smdict)
     groups = _build_groups(full_lt, smdict)
 
     # checking the changes

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -326,8 +326,7 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
         String representation of a source, displaying the source class name
         and the source id.
         """
-        return '<%s %s (%s)>' % (
-            self.__class__.__name__, self.source_id, self.name)
+        return '<%s %s>' % (self.__class__.__name__, self.source_id)
 
     def get_one_rupture(self, rupture_mutex=False):
         """


### PR DESCRIPTION
Different sources with the same ID. For instance
```
$ oq run openquake/qa_tests_data/classical_damage/case_master/job_haz.ini 
...
[2020-06-24 15:16:04 #53021 WARNING] There are multiple different sources with the same ID
[<SimpleFaultSource 2>, <CharacteristicFaultSource 2>]
```
In the future such warning could become an error, thus breaking several mosaic models.