### PR TITLE
Update minimum_intensity documentation in manual

### DIFF
--- a/doc/manual/oqum/risk/02_config_event_based_risk.tex
+++ b/doc/manual/oqum/risk/02_config_event_based_risk.tex
@@ -54,8 +54,8 @@ The new parameters introduced in this example are described below:
     calculation.
     If this parameter is not set, the \glsdesc{acr:oqe} extracts the minimum
     thresholds for each intensity measure type from the vulnerability
-    models provided, picking the first intensity value for which the mean loss
-    ratio is nonzero.
+    models provided, picking the lowest intensity value for which a mean loss
+    ratio is provided.
 
   \item \Verb+return_periods+: this parameter specifies the list of return
     periods (in years) for computing the aggregate loss curve.


### PR DESCRIPTION
Bring the documentation in the manual for the default value of the `minimum_intensity` parameter in line with how the engine currently handles it. Closes #2110