### PR TITLE
Changed `oq engine --reuse-hazard` to just reuse the source model

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Changed `oq engine --reuse-hazard` to just reuse the source model, if
+    possible
   * Added command `oq recompute_losses <calc_id> <aggregate_by>`
   * Fixed `noDamageLimit`, `minIML`, `maxIML` not being honored in continuous
     fragility functions

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -178,9 +178,7 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             # init logs before calling get_oqparam
             logs.init('nojob', getattr(logging, log_level.upper()))
             # not using logs.handle that logs on the db
-            oq = readinput.get_oqparam(job_inis[0])
-            run_job(job_inis[0], oq, log_level, log_file,
-                    exports, reuse_hazard, **pars)
+            run_job(job_inis[0], log_level, log_file, exports, **pars)
             return
         for i, job_ini in enumerate(job_inis):
             open(job_ini, 'rb').read()  # IOError if the file does not exist

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -40,7 +40,7 @@ from openquake.commands.export import export
 from openquake.commands.extract import extract
 from openquake.commands.sample import sample
 from openquake.commands.reduce_sm import reduce_sm
-from openquake.commands.engine import run_job, smart_run
+from openquake.commands.engine import run_job
 from openquake.commands.db import db
 from openquake.commands.to_shapefile import to_shapefile
 from openquake.commands.from_shapefile import from_shapefile
@@ -493,12 +493,6 @@ class EngineRunJobTestCase(unittest.TestCase):
         with read(job_id) as dstore:
             perf = view('performance', dstore)
             self.assertIn('total event_based_risk', perf)
-
-    def test_smart_run(self):
-        # test smart_run with gmf_ebrisk, since it was breaking
-        ini = os.path.join(os.path.dirname(ebrisk.__file__), 'job_risk.ini')
-        oqparam = get_oqparam(ini)
-        smart_run(ini, oqparam, 'info', None, '', False)
 
     def test_oqdata(self):
         # the that the environment variable OQ_DATADIR is honored


### PR DESCRIPTION
Reusing the whole hazard was impossible across engine versions.