### PR TITLE
Remove unused parameter from a scenario_damage test

### DIFF
--- a/openquake/qa_tests_data/scenario_damage/case_8/job.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_8/job.ini
@@ -1,8 +1,7 @@
-[general]-
+[general]
 description = Shakemap Abruzzo
 calculation_mode = scenario_damage
 random_seed = 45
-ignore_covs = true
 spatial_correlation = no
 number_of_ground_motion_fields = 25
 truncation_level = 3


### PR DESCRIPTION
The `ignore_covs` parameter is not used in damage calculations