### PR TITLE
Reduce by 13 times the memory consumption in the Colombia calculation

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -31,6 +31,7 @@ from openquake.baselib.general import (
 from openquake.baselib.python3compat import encode
 from openquake.hazardlib import stats
 from openquake.hazardlib.calc import disagg
+from openquake.hazardlib.imt import from_string
 from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.hazardlib.contexts import RuptureContext
 from openquake.hazardlib.tom import PoissonTOM
@@ -144,35 +145,37 @@ def compute_disagg(dstore, idxs, cmaker, iml4, trti, magi, bin_edges, oq,
     mat_mon = monitor('build_disagg_matrix', measuremem=False)
     ms_mon = monitor('disagg mean_std', measuremem=True)
     eps3 = disagg._eps3(cmaker.trunclevel, oq.num_epsilon_bins)
-    with ms_mon:
-        ctxs = _prepare_ctxs(rupdata, cmaker, sitecol)  # ultra-fast
-        mean_std = disagg.get_mean_std(ctxs, oq.imtls, cmaker.gsims)
+    ctxs = _prepare_ctxs(rupdata, cmaker, sitecol)  # ultra-fast
+    res = {'trti': trti, 'magi': magi}
+    for m, im in enumerate(oq.imtls):
+        imt = from_string(im)
+        with ms_mon:
+            mean_std = disagg.get_mean_std(ctxs, [imt], cmaker.gsims)
 
-    for s, iml3 in enumerate(iml4):
-        iml2dict = {imt: iml3[m] for m, imt in enumerate(oq.imtls)}
+        for s, iml3 in enumerate(iml4):
+            # z indices by gsim
+            M, P, Z = iml3.shape
+            zs_by_g = AccumDict(accum=[])
+            for g, rlzs in enumerate(cmaker.gsims.values()):
+                for z in range(Z):
+                    if iml4.rlzs[s, z] in rlzs:
+                        zs_by_g[g].append(z)
 
-        # z indices by gsim
-        M, P, Z = iml3.shape
-        zs_by_g = AccumDict(accum=[])
-        for g, rlzs in enumerate(cmaker.gsims.values()):
-            for z in range(Z):
-                if iml4.rlzs[s, z] in rlzs:
-                    zs_by_g[g].append(z)
+            # sanity check: the zs are disjoint
+            counts = numpy.zeros(Z, numpy.uint8)
+            for zs in zs_by_g.values():
+                counts[zs] += 1
+            assert (counts <= 1).all(), counts
 
-        # sanity check: the zs are disjoint
-        counts = numpy.zeros(Z, numpy.uint8)
-        for zs in zs_by_g.values():
-            counts[zs] += 1
-        assert (counts <= 1).all(), counts
-
-        # dist_bins, lon_bins, lat_bins, eps_bins
-        bins = bin_edges[0], bin_edges[1][s], bin_edges[2][s], bin_edges[3]
-        # build 7D-matrix #distbins, #lonbins, #latbins, #epsbins, M, P, Z
-        matrix = disagg.disaggregate(
-            ctxs, mean_std, zs_by_g, iml2dict, eps3, s, bins, pne_mon, mat_mon)
-        if matrix.any():
-            yield {'trti': trti, 'magi': magi, s: matrix}
-
+            # dist_bins, lon_bins, lat_bins, eps_bins
+            bins = bin_edges[0], bin_edges[1][s], bin_edges[2][s], bin_edges[3]
+            # build 7D-matrix #distbins, #lonbins, #latbins, #epsbins, M, P, Z
+            matrix = disagg.disaggregate(
+                ctxs, mean_std, zs_by_g, {imt: iml3[m]}, eps3, s, bins,
+                pne_mon, mat_mon)[..., 0, :, :]  # 6D-matrix
+            if matrix.any():
+                res[s, m] = matrix
+    return res
 
 # the weight is the number of sites within 100 km from the rupture
 RupIndex = collections.namedtuple('RupIndex', 'index weight')
@@ -414,9 +417,9 @@ class DisaggregationCalculator(base.HazardCalculator):
         with self.monitor('aggregating disagg matrices'):
             trti = result.pop('trti')
             magi = result.pop('magi')
-            for sid, probs in result.items():
-                before = acc[sid].get((trti, magi), 0)
-                acc[sid][trti, magi] = agg_probs(before, probs)
+            for (s, m), probs in result.items():
+                before = acc[s, m].get((trti, magi), 0)
+                acc[s, m][trti, magi] = agg_probs(before, probs)
         return acc
 
     def save_bin_edges(self):
@@ -457,8 +460,8 @@ class DisaggregationCalculator(base.HazardCalculator):
         """
         T = len(self.trts)
         Ma = len(self.bin_edges[0]) - 1  # num_mag_bins
-        # build a dictionary s -> 9D matrix of shape (T, Ma, ..., E, M, P, Z)
-        results = {s: _matrix(dic, T, Ma) for s, dic in results.items()}
+        # build a dictionary s, m -> 9D matrix of shape (T, Ma, ..., E, P, Z)
+        results = {sm: _matrix(dic, T, Ma) for sm, dic in results.items()}
         # get the number of outputs
         shp = (self.N, len(self.poes_disagg), len(self.imts), self.Z)
         logging.info('Extracting and saving the PMFs for %d outputs '
@@ -473,28 +476,26 @@ class DisaggregationCalculator(base.HazardCalculator):
         Save the computed PMFs in the datastore
 
         :param results:
-            a dict s -> 9D-matrix of shape (T, Ma, D, Lo, La, E, M, P, Z)
+            a dict s, m -> 8D-matrix of shape (T, Ma, D, Lo, La, E, P, Z)
         :para out:
             a dict kind -> PMF matrix to be populated
         """
         outputs = self.oqparam.disagg_outputs
-        for s, mat9 in results.items():
+        for (s, m), mat8 in results.items():
             if s not in self.ok_sites:
                 continue
             for p, poe in enumerate(self.poes_disagg):
-                mat8 = mat9[..., p, :]
-                poe2 = pprod(mat8, axis=(0, 1, 2, 3, 4, 5))
-                self.datastore['poe4'][s, :, p] = poe2  # shape (M, Z)
+                mat7 = mat8[..., p, :]
+                poe2 = pprod(mat7, axis=(0, 1, 2, 3, 4, 5))
+                self.datastore['poe4'][s, m, p] = poe2  # shape Z
                 poe_agg = poe2.mean()
                 if poe and abs(1 - poe_agg / poe) > .1:
                     logging.warning(
                         'Site #%d: poe_agg=%s is quite different from the '
                         'expected poe=%s; perhaps the number of intensity '
                         'measure levels is too small?', s, poe_agg, poe)
-                for m, imt in enumerate(self.imts):
-                    mat7 = mat8[..., m, :]
-                    mat6 = agg_probs(*mat7)  # 6D
-                    for key in outputs:
-                        pmf = disagg.pmf_map[key](
-                            mat7 if key.endswith('TRT') else mat6)
-                        out[key][s, m, p, :] = pmf
+                mat6 = agg_probs(*mat7)  # 6D
+                for key in outputs:
+                    pmf = disagg.pmf_map[key](
+                        mat7 if key.endswith('TRT') else mat6)
+                    out[key][s, m, p, :] = pmf

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -379,7 +379,7 @@ def disaggregation(
     for trt in cmaker:
         gsim = gsim_by_trt[trt]
         for magi, ctxs in enumerate(_magbin_groups(rups[trt], mag_bins)):
-            mean_std = get_mean_std(ctxs, [str(imt)], [gsim])
+            mean_std = get_mean_std(ctxs, [imt], [gsim])
             bdata[trt, magi] = disaggregate(
                 ctxs, mean_std, {0: [0]}, {imt: iml2}, eps3)
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -36,7 +36,6 @@ from openquake.hazardlib.geo.utils import get_longitudinal_extent
 from openquake.hazardlib.geo.utils import (angular_distance, KM_TO_DEGREES,
                                            cross_idl)
 from openquake.hazardlib.site import SiteCollection
-from openquake.hazardlib.imt import from_string
 from openquake.hazardlib.gsim.base import (
     ContextMaker, to_distribution_values)
 
@@ -171,7 +170,6 @@ def get_mean_std(ctxs, imts, gsims):
     """
     U, N, M, G = len(ctxs), len(ctxs[0].sids), len(imts), len(gsims)
     mean_std = numpy.zeros((2, U, N, M, G), numpy.float32)
-    imts = [from_string(imt) for imt in imts]
     for u, ctx in enumerate(ctxs):
         mean_std[:, u, ctx.sids] = ctx.get_mean_std(imts, gsims)
     return mean_std


### PR DESCRIPTION
13 is the number of IMTs. The price to pay is that we are slower than before (~10 times slower in disaggregate_pne, 4x in total)
```
# before
calc_39576                   time_sec memory_mb counts   
============================ ======== ========= =========
total compute_disagg         80_590   846       119_414  
disagg mean_std              36_956   11_977    178      
disaggregate_pne             28_380   0.0       199_182  
reading rupdata              7_647    1_723     178      

# after, at 91%
calc_39577                  time_sec memory_mb counts   
=========================== ======== ========= =========
total compute_disagg        338_794  1_041     2_106    
disaggregate                298_315  0.0       2_356_614
disagg mean_std             34_097   722       2_106    
reading rupdata             6_132    1_918     162      
```