### PR TITLE
Reduced memory consumption in disaggregation (again)

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -108,12 +108,14 @@ def _prepare_ctxs(rupdata, cmaker, sitecol):
     return numpy.array(ctxs)
 
 
-def block_read(dstore, k, idxs, blocksize=10000):
+def block_read(dstore, k, idxs, blocksize=100000):
     """
-    >>> dic = {'rup/mag': numpy.arange(10)}
-    >>> block_read(dic, 'mag', numpy.array([2, 4, 6, 7]), 3)
+    >>> dstore = {'rup/rrup_': numpy.arange(10)}
+    >>> block_read(dstore, 'rrup_', numpy.array([2, 4, 6, 7]), 3)
     array([2, 4, 6, 7])
     """
+    if not k.endswith('_'):  # rupture parameter
+        return dstore['rup/' + k][:][idxs]
     dset = dstore['rup/' + k]
     n = len(dset)
     lst = []


### PR DESCRIPTION
At the cost of slowing down the rupture reading for large calculations. Now finally the Colombia disaggregation can be done with 7 million ruptures, even if just barely on cluster2:
```
  # parent 39581
   calc_39596                   time_sec  memory_mb counts   
   ============================ ========= ========= =========
   total compute_disagg         1_053_801 2_032     658      
   disaggregate                 452_134   0.0       9_266_777
   reading rupdata              431_131   1_071     658      
   disagg mean_std              168_746   1_175     8_554    
   DisaggregationCalculator.run 18_232    19_065    1        
   aggregating disagg matrices  405       950       658      
   saving disagg results        102       346       1        
 ```