### PR TITLE
Make the return periods consistent in disaggregation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * In disaggregation, force poes_disagg == poes
   * Fixed multi-site disaggregation: ruptures far away were not discarded,
     just considered distant 9999 km
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -345,10 +345,6 @@ class ClassicalCalculator(base.HazardCalculator):
                                 num_cores=oq.num_cores)
         self.submit_tasks(smap)
         acc0 = self.acc0()  # create the rup/ datasets BEFORE swmr_on()
-        dic = {name: len(dset) for name, dset in self.datastore.items()
-               if name.startswith('rup_')}
-        if dic:  # few sites
-            logging.info('%s', dic)
         self.datastore.swmr_on()
         smap.h5 = self.datastore.hdf5
         self.calc_times = AccumDict(accum=numpy.zeros(3, F32))
@@ -498,6 +494,10 @@ class ClassicalCalculator(base.HazardCalculator):
         :param pmap_by_key:
             a dictionary key -> hazard curves
         """
+        nr = {name: len(dset['mag']) for name, dset in self.datastore.items()
+              if name.startswith('rup_')}
+        if nr:  # few sites, log the number of ruptures per magnitude
+            logging.info('%s', nr)
         oq = self.oqparam
         data = []
         weights = [rlz.weight for rlz in self.realizations]

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -345,6 +345,10 @@ class ClassicalCalculator(base.HazardCalculator):
                                 num_cores=oq.num_cores)
         self.submit_tasks(smap)
         acc0 = self.acc0()  # create the rup/ datasets BEFORE swmr_on()
+        dic = {name: len(dset) for name, dset in self.datastore.items()
+               if name.startswith('rup_')}
+        if dic:  # few sites
+            logging.info('%s', dic)
         self.datastore.swmr_on()
         smap.h5 = self.datastore.hdf5
         self.calc_times = AccumDict(accum=numpy.zeros(3, F32))

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -336,6 +336,14 @@ class OqParam(valid.ParamSet):
 
         # checks for disaggregation
         if self.calculation_mode == 'disaggregation':
+            if not self.poes_disagg and self.poes:
+                self.poes_disagg = self.poes
+            elif not self.poes and self.poes_disagg:
+                self.poes = self.poes_disagg
+            elif self.poes != self.poes_disagg:
+                raise InvalidFile(
+                    'poes_disagg != poes: %s!=%s in %s' %
+                    (self.poes_disagg, self.poes, self.inputs['job_ini']))
             if not self.poes_disagg and not self.iml_disagg:
                 raise InvalidFile('poes_disagg or iml_disagg must be set '
                                   'in %(job_ini)s' % self.inputs)

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -356,7 +356,6 @@ class OqParamTestCase(unittest.TestCase):
                 gsim='BooreAtkinson2008',
                 reference_vs30_value='200',
                 sites='0.1 0.2',
-                poes='0.2',
                 maximum_distance='400',
                 intensity_measure_types_and_levels="{'PGV': [0.1, 0.2, 0.3]}",
                 uniform_hazard_spectra='1')
@@ -375,5 +374,5 @@ class OqParamTestCase(unittest.TestCase):
                 iml_disagg="{'PGV': [0.1, 0.2, 0.3]}",
                 poes_disagg="0.1",
                 uniform_hazard_spectra='1')
-        self.assertIn("iml_disagg and poes_disagg cannot be set at the "
-                      "same time", str(ctx.exception))
+        self.assertIn("poes_disagg != poes: [0.1]!=[0.2] in job.ini",
+                      str(ctx.exception))

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -371,6 +371,7 @@ class SiteCollection(object):
         for seq in split_in_blocks(range(len(self)), hint or 1):
             sc = SiteCollection.__new__(SiteCollection)
             sc.array = self.array[numpy.array(seq, int)]
+            sc.complete = self
             tiles.append(sc)
         return tiles
 


### PR DESCRIPTION
This avoids error in the SGC calculation (they already happened). It is still possible to generate hazard maps with different poes, just run two calculations, a classical one followed by a disaggregation one.