### PR TITLE
Further speedup of the disaggregation

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -137,6 +137,10 @@ def compute_disagg(dstore, idxs, cmaker, iml4, trti, magstr, bin_edges, oq,
         sitecol = dstore['sitecol']
         rupdata = {k: d[:][idxs] for k, d in dstore['rup_%s' % magstr].items()}
         ctxs = _prepare_ctxs(rupdata, cmaker, sitecol)  # ultra-fast
+        all_ctxs = [[] for sid in sitecol.sids]
+        for ctx in ctxs:
+            for sid in ctx.idx:
+                all_ctxs[sid].append(ctx)
         del rupdata
 
     magi = numpy.searchsorted(bin_edges[0], float(magstr)) - 1
@@ -161,13 +165,16 @@ def compute_disagg(dstore, idxs, cmaker, iml4, trti, magstr, bin_edges, oq,
 
         # disaggregate by site, IMT
         for s, iml3 in enumerate(iml4):
+            close_ctxs = all_ctxs[s]
+            if not close_ctxs:
+                continue
             # dist_bins, lon_bins, lat_bins, eps_bins
             bins = (bin_edges[1], bin_edges[2][s], bin_edges[3][s],
                     bin_edges[4])
             with dis_mon:
                 # 7D-matrix #distbins, #lonbins, #latbins, #epsbins, M=1, P, Z
                 matrix = disagg.disaggregate(
-                    ctxs, g_by_z[s], {imt: iml3[m]}, eps3, s, bins)[
+                    close_ctxs, g_by_z[s], {imt: iml3[m]}, eps3, s, bins)[
                         ..., 0, :, :]  # 6D-matrix
                 if matrix.any():
                     res[s, m] = matrix

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -142,7 +142,10 @@ def disaggregate(ctxs, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
     G = ctxs[0].mean_std.shape[-1]
     mean_std = numpy.zeros((2, U, M, G), numpy.float32)
     for u, ctx in enumerate(ctxs):
-        idx = ctx.idx[sid]
+        if not hasattr(ctx, 'idx'):  # assume single site
+            idx = 0
+        else:
+            idx = ctx.idx[sid]
         dists[u] = ctx.rrup[idx]  # distance to the site
         lons[u] = ctx.clon[idx]  # closest point of the rupture lon
         lats[u] = ctx.clat[idx]  # closest point of the rupture lat

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -142,10 +142,7 @@ def disaggregate(ctxs, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
     G = ctxs[0].mean_std.shape[-1]
     mean_std = numpy.zeros((2, U, M, G), numpy.float32)
     for u, ctx in enumerate(ctxs):
-        try:
-            idx = ctx.idx[sid]
-        except KeyError:  # far away site
-            continue
+        idx = ctx.idx[sid]
         dists[u] = ctx.rrup[idx]  # distance to the site
         lons[u] = ctx.clon[idx]  # closest point of the rupture lon
         lats[u] = ctx.clat[idx]  # closest point of the rupture lat
@@ -161,7 +158,7 @@ def disaggregate(ctxs, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
     for u, ctx in enumerate(ctxs):
         pnes[u] *= ctx.get_probability_no_exceedance(poes[u])  # this is slow
     bindata = BinData(dists, lons, lats, pnes)
-    DEBUG[sid].append(pnes.mean())
+    DEBUG[idx].append(pnes.mean())
     if not bin_edges:
         return bindata
     return _build_disagg_matrix(bindata, bin_edges)

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -142,10 +142,14 @@ def disaggregate(ctxs, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
     G = ctxs[0].mean_std.shape[-1]
     mean_std = numpy.zeros((2, U, M, G), numpy.float32)
     for u, ctx in enumerate(ctxs):
-        dists[u] = ctx.rrup[sid]  # distance to the site
-        lons[u] = ctx.clon[sid]  # closest point of the rupture lon
-        lats[u] = ctx.clat[sid]  # closest point of the rupture lat
-        mean_std[:, u] = ctx.mean_std[:, sid]  # (2, N, M, G) => (2, M, G)
+        try:
+            idx = ctx.idx[sid]
+        except KeyError:  # far away site
+            continue
+        dists[u] = ctx.rrup[idx]  # distance to the site
+        lons[u] = ctx.clon[idx]  # closest point of the rupture lon
+        lats[u] = ctx.clat[idx]  # closest point of the rupture lat
+        mean_std[:, u] = ctx.mean_std[:, idx]  # (2, N, M, G) => (2, M, G)
     poes = numpy.zeros((U, E, M, P, Z))
     pnes = numpy.ones((U, E, M, P, Z))
     for (m, p, z), iml in numpy.ndenumerate(iml3):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -774,7 +774,10 @@ class RuptureContext(BaseContext):
             for m, imt in enumerate(imts):
                 mean, [std] = gsim.get_mean_and_stddevs(self, self, new, imt,
                                                         [const.StdDev.TOTAL])
-                arr[0, :, m, g] = mean
+                try:
+                    arr[0, :, m, g] = mean
+                except:
+                    import pdb; pdb.set_trace()
                 arr[1, :, m, g] = std
                 if base.CoeffsTable.num_instances > num_tables:
                     raise RuntimeError('Instantiating CoeffsTable inside '


### PR DESCRIPTION
For Colombia with pointsource_distance=0 we pass from
```
calc_39635                   time_sec memory_mb counts   
============================ ======== ========= =========
total compute_disagg         132_929  1_810     274      
disaggregate                 77_929   0.0       3_221_660
disagg mean_std              44_797   534       3_562    
reading rupdata              9_771    350       274      
```
to
```
calc_39642                   time_sec memory_mb counts   
============================ ======== ========= =========
total compute_disagg         111_637  1_675     274      
disaggregate                 81_847   0.0       3_221_660
disagg mean_std              27_698   126       3_562    
reading rupdata              2_000    381       274      
```
with a big improvement in "reading rupdata" (5x) and "disagg_mean_std" (nearly 2x).