### PR TITLE
Reduced tremendously the data transfer in disaggregation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced tremendously the data transfer in disaggregation calculations
   * Internal: introduced compress/decompress utilities
   * Reduced the memory and disk space occupation in classical calculations with
     few sites; also changed slightly the rupture collapsing mechanism


### PR DESCRIPTION
Over an order of magnitude for Colombia (14x).
Before:
```
[#39657 INFO] Estimated data transfer:
(dist=15) * (lon=12) * (lat=12) * (eps=1) * (N=1119) * (M=13) * (P=5) *
(Z=1) * (tasks=1309) * 8 bytes = 1.5 TB
```
After:
```
[#39658 INFO] Estimated data transfer:
(N=1119) * (M=13) * (P=5) * (Z=1) * (size=159) * (tasks=1309) * 8 bytes = 112.79 GB
```
The trick is to aggregate the matrices in the workers, before transferring them.
There is also a huge improvement (14x) on the memory required on the master node to keep the matrices.