### PR TITLE
Speedup the generation of the disaggregation arguments

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -28,8 +28,7 @@ import numpy
 from openquake.baselib import parallel, hdf5
 from openquake.baselib.python3compat import encode
 from openquake.baselib.general import (
-    AccumDict, DictArray, block_splitter, groupby, humansize,
-    get_array_nbytes, decompress)
+    AccumDict, DictArray, block_splitter, groupby, humansize, get_array_nbytes)
 from openquake.hazardlib.contexts import ContextMaker, get_effect
 from openquake.hazardlib.calc.filters import split_sources, getdefault
 from openquake.hazardlib.calc.hazard_curve import classical
@@ -149,6 +148,7 @@ def store_ctxs(dstore, rdt, dic):
     offset = len(rctx)
     nr = len(dic['mag'])
     rdata = numpy.zeros(nr, rdt)
+    rdata['nsites'] = [len(s) for s in dic['sids_']]
     rdata['idx'] = numpy.arange(offset, offset + nr)
     rdt_names = set(dic) & set(n[0] for n in rdt)
     for name in rdt_names:
@@ -245,7 +245,7 @@ class ClassicalCalculator(base.HazardCalculator):
             mags.update(dset[:])
         mags = sorted(mags)
         if self.few_sites:
-            self.rdt = []
+            self.rdt = [('nsites', U16)]
             dparams = ['sids_']
             for rparam in rparams:
                 if rparam.endswith('_'):

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -244,7 +244,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         poes = []
         for z, rlz in enumerate(rlzs):
             pmap = self.pgetter.get(rlz)
-            if z == 0:
+            if z == 0 and sid in pmap:
                 self.curves.append(pmap[sid].array[:, 0])
             poes.append(pmap[sid].convert(self.oqparam.imtls)
                         if sid in pmap else None)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -369,8 +369,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         U, G = 0, 0
         for mag in mags:
             rctx = dstore['mag_%s/rctx' % mag][:]
-            nsids = numpy.array(
-                [len(sids) for sids in dstore['mag_%s/sids_' % mag]])
+            nsites = rctx['nsites']
             for gidx, gids in enumerate(grp_ids):
                 idxs, = numpy.where(rctx['gidx'] == gidx)
                 if len(idxs) == 0:
@@ -387,7 +386,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                 nsplits = numpy.ceil(len(idxs) / maxweight)
                 for idx in numpy.array_split(idxs, nsplits):
                     nr = len(idx)
-                    U = max(U, nsids[idx].sum())
+                    U = max(U, nsites[idx].sum())
                     allargs.append((dstore, rctx[idx], cmaker, self.iml4,
                                     trti, mag, self.bin_edges, oq))
                     task_inputs.append((trti, mag, nr))

--- a/openquake/commands/importcalc.py
+++ b/openquake/commands/importcalc.py
@@ -36,7 +36,6 @@ def importcalc(calc_id):
     try:
         calc_id = int(calc_id)
     except ValueError:  # assume calc_id is a pathname
-        status = 'complete'
         remote = False
     else:
         remote = True
@@ -46,7 +45,6 @@ def importcalc(calc_id):
     if remote:
         datadir = datastore.get_datadir()
         webex = WebExtractor(calc_id)
-        status = webex.status['status']
         hc_id = webex.oqparam.hazard_calculation_id
         if hc_id:
             sys.exit('The job has a parent (#%d) and cannot be '
@@ -54,7 +52,7 @@ def importcalc(calc_id):
         webex.dump('%s/calc_%d.hdf5' % (datadir, calc_id))
         webex.close()
     with datastore.read(calc_id) as dstore:
-        engine.expose_outputs(dstore, status=status)
+        engine.expose_outputs(dstore, status='complete')
     logging.info('Imported calculation %s successfully', calc_id)
 
 


### PR DESCRIPTION
From 10 minutes to 2 seconds (300x) by simply storing the number of affected sites per rupture. Also fixed the WebExtractor and stored information about the vertical hazard curves (see https://github.com/gem/oq-engine/issues/3277).