### PR TITLE
Avoided parsing the source_model_logic_tree multiple times

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -265,6 +265,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                 readinput.exposure = None
                 readinput.gmfs = None
                 readinput.eids = None
+                readinput.smlt_cache.clear()
                 readinput.gsim_lt_cache.clear()
 
                 # remove temporary hdf5 file, if any

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -237,7 +237,7 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/ruptures.csv', fname, delta=1E-6)
 
         tmp = gettemp(extract(self.calc.datastore, 'ruptures').array)
-        self.assertEqualFiles('expected/ruptures_full.csv', tmp, delta=1E-6)  
+        self.assertEqualFiles('expected/ruptures_full.csv', tmp, delta=1E-6)
 
         # check MFD
         aw = extract(self.calc.datastore, 'event_based_mfd?kind=mean')

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -262,11 +262,14 @@ class SourceModelLogicTree(object):
         self.__fromh5__(arr, dic)
         return self
 
-    def __init__(self, filename, seed=0, num_samples=0):
+    def __init__(self, filename, seed=0, num_samples=0,
+                 sampling_method='early_weights'):
         self.filename = filename
         self.basepath = os.path.dirname(filename)
-        self.seed = seed
+        # NB: converting the random_seed into an integer is needed on Windows
+        self.seed = int(seed)
         self.num_samples = num_samples
+        self.sampling_method = sampling_method
         self.branches = {}  # branch_id -> branch
         self.bsetdict = {}
         self.previous_branches = []

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -1207,6 +1207,13 @@ class FullLogicTree(object):
         """
         return self.source_model_lt.num_samples
 
+    @property
+    def sampling_method(self):
+        """
+        :returns: the source_model_lt ``sampling_method`` parameter
+        """
+        return self.source_model_lt.sampling_method
+
     def get_trti_eri(self, grp_id):
         """
         :returns: (trti, eri)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -197,6 +197,8 @@ class OqParam(valid.ParamSet):
         valid.NoneOr(valid.positivefloat), None)
     return_periods = valid.Param(valid.positiveints, None)
     ruptures_per_block = valid.Param(valid.positiveint, 500)  # for UCERF
+    sampling_method = valid.Param(
+        valid.Choice('early_weights', 'late_weights'), 'early_weights')
     save_disk_space = valid.Param(valid.boolean, False)
     ses_per_logic_tree_path = valid.Param(
         valid.compose(valid.nonzero, valid.positiveint), 1)

--- a/openquake/commonlib/oqzip.py
+++ b/openquake/commonlib/oqzip.py
@@ -55,7 +55,9 @@ def zip_source_model(ssmLT, archive_zip='', log=logging.info):
         sys.exit('%s exists already' % archive_zip)
     smlt = logictree.SourceModelLogicTree(ssmLT)
     files = list(smlt.hdf5_files) + smlt.info.smpaths
-    oq = mock.Mock(inputs={'source_model_logic_tree': ssmLT})
+    oq = mock.Mock(inputs={'source_model_logic_tree': ssmLT},
+                   random_seed=42, number_of_logic_tree_samples=0,
+                   sampling_method='early_weights')
     checksum = readinput.get_checksum32(oq)
     checkfile = os.path.join(os.path.dirname(ssmLT), 'CHECKSUM.txt')
     with open(checkfile, 'w') as f:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -656,18 +656,18 @@ def get_source_model_lt(oqparam):
         instance
     """
     fname = oqparam.inputs['source_model_logic_tree']
-    if fname in smlt_cache:
-        return smlt_cache[fname]
-    smlt = logictree.SourceModelLogicTree(
-        fname, oqparam.random_seed,
-        oqparam.number_of_logic_tree_samples, oqparam.sampling_method)
+    try:
+        smlt = smlt_cache[fname]
+    except KeyError:
+        smlt = smlt_cache[fname] = logictree.SourceModelLogicTree(
+            fname, oqparam.random_seed,
+            oqparam.number_of_logic_tree_samples, oqparam.sampling_method)
     if oqparam.discard_trts:
         trts = set(trt.strip() for trt in oqparam.discard_trts.split(','))
         # smlt.tectonic_region_types comes from applyToTectonicRegionType
         smlt.tectonic_region_types = smlt.tectonic_region_types - trts
     if 'ucerf' in oqparam.calculation_mode:
         smlt.tectonic_region_types = {'Active Shallow Crust'}
-    smlt_cache[fname] = smlt
     return smlt
 
 

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1287,11 +1287,7 @@ class SampleTestCase(unittest.TestCase):
         samples = lt.sample(branches, 1000, 42)
 
         def count(samples, value):
-            counter = 0
-            for s in samples:
-                if s.value == value:
-                    counter += 1
-            return counter
+            return sum(s.value == value for s in samples)
 
         self.assertEqual(count(samples, value='A'), 225)
         self.assertEqual(count(samples, value='B'), 278)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -312,7 +312,7 @@ class ContextMaker(object):
             :class:`openquake.hazardlib.source.rupture.BaseRupture`
 
         :returns:
-            Tuple of two items: sites and distances context.
+            Tuple of three items: rupture, sites and distances context.
 
         :raises ValueError:
             If any of declared required parameters (site, rupture and

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -45,6 +45,7 @@ def norm_cdf(x, a, s):
     else:
         return norm.cdf(x, loc=a, scale=s)
 
+
 def mean_curve(values, weights=None):
     """
     Compute the mean by using numpy.average on the first axis.


### PR DESCRIPTION
The same SourceModelLogicTree class is instantiated three times in a calculation:
1. in zip_job
2. in get_checksum32
3. in get_source_model_lt

This is fast in all cases except Australia, but still it is cleaner to cache SourceModelLogicTree instances, as it is already done for GsimLogicTree instances. I am also paving the way to different sampling methods, see https://github.com/gem/oq-engine/issues/6027.