### PR TITLE
Made it possible to redefine ``GMPE.__str__``

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -835,7 +835,7 @@ class GsimLogicTree(object):
         dt = [('trt', hdf5.vstr), ('branch', hdf5.vstr),
               ('uncertainty', hdf5.vstr)] + [
             (weight, float) for weight in sorted(weights)]
-        branches = [(b.trt, b.id, b.gsim) +
+        branches = [(b.trt, b.id, repr(b.gsim)) +
                     tuple(b.weight[weight] for weight in sorted(weights))
                     for b in self.branches if b.effective]
         dic = {}

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -86,7 +86,7 @@ def to_toml(uncertainty):
         kvs = []
     text = gsim_aliases.get(text, text)  # use the gsim alias if any
     if not text.startswith('['):  # a bare GSIM name was passed
-        text = '[%s]' % repr(text)[1:-1]
+        text = '[%s]' % text
     for k, v in kvs:
         try:
             v = ast.literal_eval(v)

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -86,7 +86,7 @@ def to_toml(uncertainty):
         kvs = []
     text = gsim_aliases.get(text, text)  # use the gsim alias if any
     if not text.startswith('['):  # a bare GSIM name was passed
-        text = '[%s]' % text
+        text = '[%s]' % repr(text)[1:-1]
     for k, v in kvs:
         try:
             v = ast.literal_eval(v)


### PR DESCRIPTION
Avoids the error
```python
  File "/opt/openquake/src/oq-engine/openquake/commonlib/logictree.py", line 859, in __fromh5__
    gsim = valid.gsim(branch['uncertainty'])
  File "/opt/openquake/src/oq-engine/openquake/hazardlib/valid.py", line 118, in gsim
    [(gsim_name, kwargs)] = toml.loads(value).items()
  File "/opt/openquake/lib/python3.6/site-packages/toml/decoder.py", line 401, in loads
    original, pos)
toml.decoder.TomlDecodeError: Invalid group name 'CanadaSHM6 AA13 Stable Crust High'. Try quoting it. (line 1 column 1 char 0)
```
experienced by our Canadian users.