### PR TITLE
Removed a wrong assert in get_eids_by_rlz

### DIFF
--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -140,7 +140,7 @@ class GmfComputer(object):
         eids_by_rlz = self.ebrupture.get_eids_by_rlz(rlzs_by_gsim, self.offset)
         mag = self.ebrupture.rupture.mag
         data = []
-        O = sum(len(sp.outputs) for sp in self.sec_perils)
+        No = sum(len(sp.outputs) for sp in self.sec_perils)
         for gs, rlzs in rlzs_by_gsim.items():
             num_events = sum(len(eids_by_rlz[rlzi]) for rlzi in rlzs)
             # NB: the trick for performance is to keep the call to
@@ -164,7 +164,7 @@ class GmfComputer(object):
                         tup = tuple([eid, rlzi] + list(sig[:, n + ei]) +
                                     list(eps[:, n + ei]))
                         sig_eps.append(tup)
-                    sp_out = numpy.zeros((O,) + gmfa.shape)  # O, N, M
+                    sp_out = numpy.zeros((No,) + gmfa.shape)  # No, N, M
                     for m, imt in enumerate(self.imts):
                         o = 0
                         for sp in self.sec_perils:
@@ -174,7 +174,7 @@ class GmfComputer(object):
                             o = o1
                     for i, gmv in enumerate(gmfa):
                         if gmv.sum():
-                            if O:
+                            if No:
                                 data.append((sids[i], eid, gmv) +
                                             tuple(sp_out[:, i, :]))
                             else:

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -721,9 +721,8 @@ class EBRupture(object):
                     j += self.n_occ
         else:  # associated eids to the realizations
             rlzs = numpy.concatenate(list(rlzs_by_gsim.values()))
-            assert len(rlzs) == self.samples, (len(rlzs), self.samples)
             histo = general.random_histogram(
-                self.n_occ, self.samples, self.rup_id)
+                self.n_occ, len(rlzs), self.rup_id)
             for rlz, n in zip(rlzs, histo):
                 dic[rlz] = numpy.arange(j, j + n, dtype=U32) + offset
                 j += n


### PR DESCRIPTION
Distribution by gsim (https://github.com/gem/oq-engine/pull/6044) broke the assert in get_eids_by_rlz, thus breaking the mosaic: https://gitlab.openquake.org/hazard/mosaic/mosaic/-/jobs/23095
