### PR TITLE
Improved sending/saving of tasks in scenario_risk and damage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Speed-up risk saving in scenario_risk and scenario_damage
+
   [Antonio Ettorre]
   * Bumped GDAL to version 3.1.2
 
@@ -9,6 +12,7 @@
   * Parallelized by GSIM when there is a single rupture
 
   [Francis Bernales]
+  * Added the Stewart et al. (2016) GMPE 
   * Added the Bozorgnia & Campbell (2016) GMPE
   * Added the Gulerce et al. (2017) GMPE
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1042,7 +1042,8 @@ class RiskCalculator(HazardCalculator):
         maxw = sum(ri.weight for ri in self.riskinputs) / ct
         smap = parallel.Starmap(
             self.core_task.__func__, h5=self.datastore.hdf5)
-        for block in general.block_splitter(self.riskinputs, maxw, get_weight):
+        for block in general.block_splitter(
+                self.riskinputs, maxw, get_weight, sort=True):
             logging.info('Sending hazard for %d sites', len(block))
             for ri in block:
                 # we must use eager reading for performance reasons:

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1044,8 +1044,8 @@ class RiskCalculator(HazardCalculator):
             self.core_task.__func__, h5=self.datastore.hdf5)
         for block in general.block_splitter(
                 self.riskinputs, maxw, get_weight, sort=True):
-            if len(block) > 1000:
-                logging.info('Sending hazard for %d sites', len(block))
+            logging.info('Sending hazard for %d assets, %d sites',
+                         block.weight, len(block))
             for ri in block:
                 # we must use eager reading for performance reasons:
                 # concurrent reading on the workers would be extra-slow;

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -978,9 +978,6 @@ class RiskCalculator(HazardCalculator):
             riskinputs = list(self._gen_riskinputs(kind))
         assert riskinputs
         logging.info('Built %d risk inputs', len(riskinputs))
-        #if self.oqparam.calculation_mode in (
-        #        'event_based_damage', 'scenario_damage', 'scenario_risk'):
-        #    self.datastore.swmr_on()
         return riskinputs
 
     def get_getter(self, kind, sid):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1044,7 +1044,8 @@ class RiskCalculator(HazardCalculator):
             self.core_task.__func__, h5=self.datastore.hdf5)
         for block in general.block_splitter(
                 self.riskinputs, maxw, get_weight, sort=True):
-            logging.info('Sending hazard for %d sites', len(block))
+            if len(block) > 1000:
+                logging.info('Sending hazard for %d sites', len(block))
             for ri in block:
                 # we must use eager reading for performance reasons:
                 # concurrent reading on the workers would be extra-slow;

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -156,14 +156,12 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         self.datastore.create_dset('dd_data/data', aed_dt, compression='gzip')
         self.datastore.create_dset('dd_data/indices', U32, (A, 2))
         self.riskinputs = self.build_riskinputs('gmf')
-        self.start = 0
 
     def combine(self, acc, res):
         with self.monitor('saving dd_data', measuremem=True):
             aed = res.pop('aed', ())
             if len(aed) == 0:
                 return acc + res
-            self.start += len(aed)
             hdf5.extend(self.datastore['dd_data/data'], aed)
             return acc + res
 

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -159,16 +159,16 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         self.start = 0
 
     def combine(self, acc, res):
-        # this is fast
-        aed = res.pop('aed', ())
-        if len(aed) == 0:
+        with self.monitor('saving dd_data', measuremem=True):
+            aed = res.pop('aed', ())
+            if len(aed) == 0:
+                return acc + res
+            for aid, [(i1, i2)] in get_indices(aed['aid']).items():
+                self.datastore['dd_data/indices'][aid] = (
+                    self.start + i1, self.start + i2)
+            self.start += len(aed)
+            hdf5.extend(self.datastore['dd_data/data'], aed)
             return acc + res
-        for aid, [(i1, i2)] in get_indices(aed['aid']).items():
-            self.datastore['dd_data/indices'][aid] = (
-                self.start + i1, self.start + i2)
-        self.start += len(aed)
-        hdf5.extend(self.datastore['dd_data/data'], aed)
-        return acc + res
 
     def post_execute(self, result):
         """

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -19,7 +19,7 @@
 import logging
 import numpy
 from openquake.baselib import hdf5
-from openquake.baselib.general import AccumDict, get_indices
+from openquake.baselib.general import AccumDict
 from openquake.hazardlib.stats import set_rlzs_stats
 from openquake.calculators import base
 
@@ -163,9 +163,6 @@ class ScenarioDamageCalculator(base.RiskCalculator):
             aed = res.pop('aed', ())
             if len(aed) == 0:
                 return acc + res
-            for aid, [(i1, i2)] in get_indices(aed['aid']).items():
-                self.datastore['dd_data/indices'][aid] = (
-                    self.start + i1, self.start + i2)
             self.start += len(aed)
             hdf5.extend(self.datastore['dd_data/data'], aed)
             return acc + res
@@ -184,11 +181,8 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         R = self.R
         D = len(dstates)
         A = len(self.assetcol)
-        indices = self.datastore['dd_data/indices'][()]
         if not len(self.datastore['dd_data/data']):
             logging.warning('There is no damage at all!')
-        events_per_asset = (indices[:, 1] - indices[:, 0]).mean()
-        logging.info('Found ~%d dmg distributions per asset', events_per_asset)
 
         # avg_ratio = ratio used when computing the averages
         oq = self.oqparam

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -21,7 +21,7 @@ import numpy
 
 from openquake.baselib import hdf5
 from openquake.baselib.python3compat import zip
-from openquake.baselib.general import AccumDict, get_indices
+from openquake.baselib.general import AccumDict
 from openquake.hazardlib.stats import set_rlzs_stats
 from openquake.risklib import scientific, riskinput
 from openquake.calculators import base
@@ -150,9 +150,6 @@ class ScenarioRiskCalculator(base.RiskCalculator):
             ael = res.pop('ael', ())
             if len(ael) == 0:
                 return acc + res
-            for aid, [(i1, i2)] in get_indices(ael['asset_id']).items():
-                self.datastore['loss_data/indices'][aid] = (
-                    self.start + i1, self.start + i2)
             self.start += len(ael)
             hdf5.extend(self.datastore['loss_data/data'], ael)
             return acc + res

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -79,11 +79,8 @@ def scenario_risk(riskinputs, crmodel, param, monitor):
     E = param['E']
     L = len(crmodel.loss_types)
     result = dict(agg=numpy.zeros((E, L), F32), avg=[])
-    mon = monitor('getting hazard', measuremem=False)
     acc = AccumDict(accum=numpy.zeros(L, F64))  # aid,eid->loss
     for ri in riskinputs:
-        with mon:
-            ri.hazard_getter.init()
         for out in ri.gen_outputs(crmodel, monitor, param['tempname']):
             r = out.rlzi
             for l, loss_type in enumerate(crmodel.loss_types):

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -146,7 +146,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
         Combine the outputs from scenario_risk and incrementally store
         the asset loss table
         """
-        with self.monitor('saving dd_data', measuremem=True):
+        with self.monitor('saving loss_data', measuremem=True):
             ael = res.pop('ael', ())
             if len(ael) == 0:
                 return acc + res

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -146,15 +146,16 @@ class ScenarioRiskCalculator(base.RiskCalculator):
         Combine the outputs from scenario_risk and incrementally store
         the asset loss table
         """
-        ael = res.pop('ael', ())
-        if len(ael) == 0:
+        with self.monitor('saving dd_data', measuremem=True):
+            ael = res.pop('ael', ())
+            if len(ael) == 0:
+                return acc + res
+            for aid, [(i1, i2)] in get_indices(ael['asset_id']).items():
+                self.datastore['loss_data/indices'][aid] = (
+                    self.start + i1, self.start + i2)
+            self.start += len(ael)
+            hdf5.extend(self.datastore['loss_data/data'], ael)
             return acc + res
-        for aid, [(i1, i2)] in get_indices(ael['asset_id']).items():
-            self.datastore['loss_data/indices'][aid] = (
-                self.start + i1, self.start + i2)
-        self.start += len(ael)
-        hdf5.extend(self.datastore['loss_data/data'], ael)
-        return acc + res
 
     def post_execute(self, result):
         """

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -136,7 +136,6 @@ class ScenarioRiskCalculator(base.RiskCalculator):
         A = len(self.assetcol)
         self.datastore.create_dset('loss_data/data', dt)
         self.datastore.create_dset('loss_data/indices', U32, (A, 2))
-        self.start = 0
 
     def combine(self, acc, res):
         """
@@ -147,7 +146,6 @@ class ScenarioRiskCalculator(base.RiskCalculator):
             ael = res.pop('ael', ())
             if len(ael) == 0:
                 return acc + res
-            self.start += len(ael)
             hdf5.extend(self.datastore['loss_data/data'], ael)
             return acc + res
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -346,8 +346,10 @@ def run_calc(job_id, oqparam, exports, log_level='info', log_file=None, **kw):
             calc.run(exports=exports, **kw)
             logging.info('Exposing the outputs to the database')
             expose_outputs(calc.datastore)
-            logging.info('Calculation %d finished correctly in %d seconds',
-                         job_id, time.time() - t0)
+            path = calc.datastore.filename
+            size = general.humansize(os.path.getsize(path))
+            logging.info('Stored %s on %s in %d seconds',
+                         size, path, time.time() - t0)
             logs.dbcmd('finish', job_id, 'complete')
             calc.datastore.close()
             for line in logs.dbcmd('list_outputs', job_id, False):


### PR DESCRIPTION
For Tiegan's scenario_risk calculation `saving loss_data`goes down from 1_292 s to 490 s, simply by not storing the indices.
Also, time is saved by starting the tasks on-the-fly and not all at the same time resulting in a 35% speedup overall.