### PR TITLE
Fix for the sourcewriter

### DIFF
--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -349,12 +349,11 @@ def convert_nonParametricSeismicSource(fname, node):
     nps.splittable = 'rup_weights' not in node.attrib
     path = os.path.splitext(fname)[0] + '.hdf5'
     hdf5_fname = path if os.path.exists(path) else None
-    if hdf5_fname:
-        # read the rupture data from the HDF5 file
-        assert node.text is None, node.text
+    if hdf5_fname and node.text is None:
+        # gridded source, read the rupture data from the HDF5 file
         with hdf5.File(hdf5_fname, 'r') as h:
             dic = {k: d[:] for k, d in h[node['id']].items()}
-        nps.fromdict(dic, rups_weights)
+            nps.fromdict(dic, rups_weights)
     else:
         # read the rupture data from the XML nodes
         num_probs = None

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -660,7 +660,8 @@ def write_source_model(dest, sources_or_groups, name=None,
         # remove duplicate content from nodes
         for grp_node in nodes:
             for src_node in grp_node:
-                src_node.nodes = []
+                if src_node["id"] in ddict:
+                    src_node.nodes = []
         # save HDF5 file
         dest5 = os.path.splitext(dest)[0] + '.hdf5'
         with hdf5.File(dest5, 'w') as h:


### PR DESCRIPTION
`src_node.nodes = []` must be called only on nonparametric sources.