### PR TITLE
Reading less from the datastore for gmf calculations

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -992,11 +992,12 @@ class RiskCalculator(HazardCalculator):
         if 'gmf_data' not in dstore:
             raise InvalidFile('Did you forget gmfs_csv in %s?'
                               % self.oqparam.inputs['job_ini'])
+        rlzs = dstore['events']['rlz_id']
         assets_by_site = self.assetcol.assets_by_site()
         for sid, assets in enumerate(assets_by_site):
             if len(assets) == 0:
                 continue
-            getter = getters.GmfDataGetter(dstore, [sid], self.R)
+            getter = getters.GmfDataGetter(dstore, [sid], rlzs, self.R)
             if len(dstore['gmf_data/data']) == 0:
                 raise RuntimeError(
                     'There are no GMFs available: perhaps you did set '

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -263,9 +263,10 @@ class GmfDataGetter(collections.abc.Mapping):
     """
     A dictionary-like object {sid: dictionary by realization index}
     """
-    def __init__(self, dstore, sids, num_rlzs):
+    def __init__(self, dstore, sids, rlzs, num_rlzs):
         self.dstore = dstore
         self.sids = sids
+        self.rlzs = rlzs
         self.num_rlzs = num_rlzs
         assert len(sids) == 1, sids
 
@@ -273,11 +274,6 @@ class GmfDataGetter(collections.abc.Mapping):
         if hasattr(self, 'data'):  # already initialized
             return
         self.dstore.open('r')  # if not already open
-        try:
-            self.imts = self.dstore['gmf_data/imts'][()].split()
-        except KeyError:  # engine < 3.3
-            self.imts = list(self.dstore['oqparam'].imtls)
-        self.rlzs = self.dstore['events']['rlz_id']
         self.data = self[self.sids[0]]
         if not self.data:  # no GMVs, return 0, counted in no_damage
             self.data = {rlzi: 0 for rlzi in range(self.num_rlzs)}
@@ -285,6 +281,7 @@ class GmfDataGetter(collections.abc.Mapping):
         # number of ground motion fields
         # dictionary rlzi -> array(imts, events, nbytes)
         self.E = len(self.rlzs)
+        del self.rlzs
 
     def get_hazard(self, gsim=None):
         """


### PR DESCRIPTION
Makes things a bit faster. For Tiegan's calculation from 1_987 to 1_865 seconds, with less memory used and less data transfer (12.73 GB sent ->  10.47 GB sent).