### PR TITLE
Added /extract/relevant_events

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added /extract/relevant_events
   * Removed the GMF npz exporter
   * Speed-up risk saving in scenario_risk and scenario_damage
 

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -521,7 +521,7 @@ class DataStore(collections.abc.MutableMapping):
         """
         unique = set()
         dset = self.getitem(key)
-        for slc in general.gen_slices(0, len(dset), 1E7):
+        for slc in general.gen_slices(0, len(dset), 10_000_000):
             arr = numpy.unique(dset[slc][field])
             unique.update(arr)
         return sorted(unique)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -324,6 +324,9 @@ class EventBasedCalculator(base.HazardCalculator):
                     num_evs[sid] = (stop - start).sum()
             avg_events_by_sid = num_evs[()].sum() / N
             logging.info('Found ~%d GMVs per site', avg_events_by_sid)
+            logging.info('Storing relevant event IDs')
+            rel_events = self.datastore.read_unique('gmf_data/data', 'eid')
+            self.datastore['relevant_events'] = rel_events
         elif oq.ground_motion_fields:
             raise RuntimeError('No GMFs were generated, perhaps they were '
                                'all below the minimum_intensity threshold')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -324,9 +324,9 @@ class EventBasedCalculator(base.HazardCalculator):
                     num_evs[sid] = (stop - start).sum()
             avg_events_by_sid = num_evs[()].sum() / N
             logging.info('Found ~%d GMVs per site', avg_events_by_sid)
-            logging.info('Storing relevant event IDs')
             rel_events = self.datastore.read_unique('gmf_data/data', 'eid')
             self.datastore['relevant_events'] = rel_events
+            logging.info('Stored %d relevant event IDs', len(rel_events))
         elif oq.ground_motion_fields:
             raise RuntimeError('No GMFs were generated, perhaps they were '
                                'all below the minimum_intensity threshold')

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -395,6 +395,11 @@ class EventBasedTestCase(CalculatorTestCase):
         [gmf, _, _] = export(('gmf_data', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/gmf-data.csv', gmf)
 
+        # check the relevant_events
+        E = len(self.calc.datastore['events'])
+        e = len(extract(self.calc.datastore, 'relevant_events'))
+        self.assertAlmostEqual(e/E, 0.1954023)
+
         # run again the GMF calculation, but this time from stored ruptures
         hid = str(self.calc.datastore.calc_id)
         self.run_calc(case_20.__file__, 'job.ini', hazard_calculation_id=hid)


### PR DESCRIPTION
Addresses https://github.com/gem/oq-irmt-qgis/issues/740 server-side. For the Colombia calculation ('/home/pslh/oqdata/calc_40007.hdf5') storing the relevant events takes 1 minute (vs 4 hours total).