### PR TITLE
Improved oq compare

### DIFF
--- a/openquake/commands/compare.py
+++ b/openquake/commands/compare.py
@@ -34,7 +34,7 @@ def getdata(what, calc_ids, sitecol, sids):
     for extractor in extractors[1:]:
         oq = extractor.oqparam
         numpy.testing.assert_equal(
-            extractor.get('sitecol').array, sitecol.array)
+            extractor.get('sitecol')[['lon', 'lat']], sitecol[['lon', 'lat']])
         if what == 'hcurves':
             numpy.testing.assert_equal(oq.imtls.array, imtls.array)
         elif what == 'hmaps':

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -305,8 +305,9 @@ class OqParam(valid.ParamSet):
         elif 'intensity_measure_types' in names_vals:
             self.hazard_imtls = dict.fromkeys(self.intensity_measure_types)
             if 'maximum_intensity' in names_vals:
+                minint = self.minimum_intensity or {'default': 1E-2}
                 for imt in self.hazard_imtls:
-                    i1 = calc.filters.getdefault(self.minimum_intensity, 1E-3)
+                    i1 = calc.filters.getdefault(minint, imt)
                     i2 = calc.filters.getdefault(self.maximum_intensity, imt)
                     self.hazard_imtls[imt] = list(valid.logscale(i1, i2, 20))
             delattr(self, 'intensity_measure_types')

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-import os
+
 import re
 import ast
 import sys
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 import numpy
 from scipy.spatial import cKDTree, distance
 
-from openquake.baselib import hdf5, general
+from openquake.baselib import general
 from openquake.baselib.python3compat import raise_
 from openquake.hazardlib.geo.utils import (
     KM_TO_DEGREES, angular_distance, fix_lon, get_bounding_box, cross_idl,


### PR DESCRIPTION
And fixed a bug in the case of missing minimum_intensity. The test will be added in oq-risk-tests. The error was:
```python
  File "/home/michele/oq-engine/openquake/commands/compare.py", line 36, in getdata
    numpy.testing.assert_equal(
  File "/home/michele/py38/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 349, in assert_equal
    return assert_array_equal(actual, desired, err_msg, verbose)
  File "/home/michele/py38/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 935, in assert_array_equal
    assert_array_compare(operator.__eq__, x, y, err_msg=err_msg,
  File "/home/michele/py38/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 846, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Arrays are not equal

Mismatched elements: 139 / 139 (100%)
 x: array([(  0, 14.798304, 37.620817, 0., 800.,  True, 30., nan, b'D', False),
       (  1, 14.798441, 37.710749, 0., 800.,  True, 30., nan, b'D', False),
       (  2, 14.798579, 37.800681, 0., 800.,  True, 30., nan, b'D', False),...
 y: array([(  0, 14.798304, 37.620817, 0., 800.,  True, 30., nan, b'D', False),
       (  1, 14.798441, 37.710749, 0., 800.,  True, 30., nan, b'D', False),
       (  2, 14.798579, 37.800681, 0., 800.,  True, 30., nan, b'D', False),...
```
for the etna calculation in oq-risk-tests.