### PR TITLE
Removed prefiltering of the ruptures

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -308,7 +308,7 @@ class EventBasedCalculator(base.HazardCalculator):
         # compute_gmfs in parallel
         nr = len(self.datastore['ruptures'])
         self.datastore.swmr_on()
-        logging.info('Reading %d ruptures', nr)
+        logging.info('Reading {:_d} ruptures'.format(nr))
         iterargs = ((rgetter, self.param)
                     for rgetter in gen_rupture_getters(
                             self.datastore, self.srcfilter,

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -63,7 +63,7 @@ def export_ruptures_xml(ekey, dstore):
         ebrs = []
         for proxy in rgetter.get_proxies():
             events_by_ses = group_array(events[proxy['id']], 'ses_id')
-            ebr = proxy.to_ebr(rgetter.trt, rgetter.samples)
+            ebr = proxy.to_ebr(rgetter.trt)
             ebrs.append(ebr.export(events_by_ses))
         ruptures_by_grp[rgetter.grp_id].extend(ebrs)
     dest = dstore.export_path('ses.' + fmt)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1222,9 +1222,8 @@ class RuptureData(object):
     Container for information about the ruptures of a given
     tectonic region type.
     """
-    def __init__(self, trt, samples, gsims):
+    def __init__(self, trt, gsims):
         self.trt = trt
-        self.samples = samples
         self.cmaker = ContextMaker(trt, gsims)
         self.params = sorted(self.cmaker.REQUIRES_RUPTURE_PARAMETERS -
                              set('mag strike dip rake hypo_depth'.split()))
@@ -1242,7 +1241,7 @@ class RuptureData(object):
         """
         data = []
         for proxy in proxies:
-            ebr = proxy.to_ebr(self.trt, self.samples)
+            ebr = proxy.to_ebr(self.trt)
             rup = ebr.rupture
             ctx = self.cmaker.make_rctx(rup)
             ruptparams = tuple(getattr(ctx, param) for param in self.params)
@@ -1280,8 +1279,7 @@ def extract_rupture_info(dstore, what):
     boundaries = []
     for rgetter in getters.gen_rgetters(dstore):
         proxies = rgetter.get_proxies(min_mag)
-        rup_data = RuptureData(
-            rgetter.trt, rgetter.samples, rgetter.rlzs_by_gsim)
+        rup_data = RuptureData(rgetter.trt, rgetter.rlzs_by_gsim)
         for r in rup_data.to_array(proxies):
             coords = ['%.5f %.5f' % xyz[:2] for xyz in zip(*r['boundaries'])]
             coordset = sorted(set(coords))

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -336,12 +336,12 @@ class GmfGetter(object):
         """
         Yield a GmfComputer instance for each non-discarded rupture
         """
-        trt, samples = self.rupgetter.trt, self.rupgetter.samples
+        trt = self.rupgetter.trt
         with mon:
             proxies = self.rupgetter.get_proxies()
         for proxy in proxies:
             with mon:
-                ebr = proxy.to_ebr(trt, samples)
+                ebr = proxy.to_ebr(trt)
                 sids = self.srcfilter.close_sids(proxy, trt)
                 sitecol = self.sitecol.filtered(sids)
                 try:
@@ -448,7 +448,6 @@ def gen_rgetters(dstore, slc=slice(None)):
     """
     full_lt = dstore['full_lt']
     trt_by_grp = full_lt.trt_by_grp
-    samples = full_lt.get_samples_by_grp()
     rlzs_by_gsim = full_lt.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][slc]
     nr = len(dstore['ruptures'])
@@ -458,15 +457,15 @@ def gen_rgetters(dstore, slc=slice(None)):
         for block in general.split_in_blocks(arr, len(arr) / nr):
             rgetter = RuptureGetter(
                 [RuptureProxy(rec) for rec in block], dstore.filename, grp_id,
-                trt_by_grp[grp_id], samples[grp_id], rlzs_by_gsim[grp_id])
+                trt_by_grp[grp_id], rlzs_by_gsim[grp_id])
             yield rgetter
 
 
-def _gen(arr, srcfilter, trt, samples):
+def _gen(arr, srcfilter, trt):
     for rec in arr:
         sids = srcfilter.close_sids(rec, trt)
         if len(sids):
-            yield RuptureProxy(rec, len(sids), samples)
+            yield RuptureProxy(rec, len(sids))
 
 
 def gen_rupture_getters(dstore, srcfilter, ct):
@@ -478,7 +477,6 @@ def gen_rupture_getters(dstore, srcfilter, ct):
     """
     full_lt = dstore['full_lt']
     trt_by_grp = full_lt.trt_by_grp
-    samples = full_lt.get_samples_by_grp()
     rlzs_by_gsim = full_lt.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][()]
     maxweight = rup_array['n_occ'].sum() / (ct or 1)
@@ -488,9 +486,9 @@ def gen_rupture_getters(dstore, srcfilter, ct):
             key=operator.itemgetter('grp_id')):
         grp_id = block[0]['grp_id']
         trt = trt_by_grp[grp_id]
-        proxies = list(_gen(block, srcfilter, trt, samples[grp_id]))
+        proxies = list(_gen(block, srcfilter, trt))
         rgetter = RuptureGetter(proxies, dstore.filename, grp_id,
-                                trt, samples[grp_id], rlzs_by_gsim[grp_id])
+                                trt, rlzs_by_gsim[grp_id])
         yield rgetter
         logging.info('Sent task %d: %d ruptures', nblocks, len(block))
         nblocks += 1
@@ -503,7 +501,7 @@ def get_ebruptures(dstore):
     ebrs = []
     for rgetter in gen_rgetters(dstore):
         for proxy in rgetter.get_proxies():
-            ebrs.append(proxy.to_ebr(rgetter.trt, rgetter.samples))
+            ebrs.append(proxy.to_ebr(rgetter.trt))
     return ebrs
 
 
@@ -518,19 +516,15 @@ class RuptureGetter(object):
         source group index
     :param trt:
         tectonic region type string
-    :param samples:
-        number of samples of the group
     :param rlzs_by_gsim:
         dictionary gsim -> rlzs for the group
     """
-    def __init__(self, proxies, filename, grp_id, trt, samples,
-                 rlzs_by_gsim):
+    def __init__(self, proxies, filename, grp_id, trt, rlzs_by_gsim):
         self.proxies = proxies
         self.weight = sum(proxy.weight for proxy in proxies)
         self.filename = filename
         self.grp_id = grp_id
         self.trt = trt
-        self.samples = samples
         self.rlzs_by_gsim = rlzs_by_gsim
         self.num_events = sum(int(proxy['n_occ']) for proxy in proxies)
 
@@ -545,7 +539,7 @@ class RuptureGetter(object):
         eid_rlz = []
         for rup in self.proxies:
             ebr = EBRupture(mock.Mock(rup_id=rup['serial']), rup['source_id'],
-                            self.grp_id, rup['n_occ'], self.samples)
+                            self.grp_id, rup['n_occ'])
             for rlz_id, eids in ebr.get_eids_by_rlz(self.rlzs_by_gsim).items():
                 for eid in eids:
                     eid_rlz.append((eid + rup['e0'], rup['id'], rlz_id))
@@ -556,7 +550,7 @@ class RuptureGetter(object):
         :returns: a dictionary with the parameters of the rupture
         """
         assert len(self.proxies) == 1, 'Please specify a slice of length 1'
-        dic = {'trt': self.trt, 'samples': self.samples}
+        dic = {'trt': self.trt}
         with datastore.read(self.filename) as dstore:
             rupgeoms = dstore['rupgeoms']
             rec = self.proxies[0].rec

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -475,18 +475,14 @@ def gen_rupture_getters(dstore, srcfilter, ct):
     rlzs_by_gsim = full_lt.get_rlzs_by_gsim_grp()
     rup_array = dstore['ruptures'][()]
     maxweight = rup_array['n_occ'].sum() / (ct or 1)
-    nblocks = 0
     for block in general.block_splitter(
             rup_array, maxweight, operator.itemgetter('n_occ'),
             key=operator.itemgetter('grp_id')):
         grp_id = block[0]['grp_id']
         trt = trt_by_grp[grp_id]
         proxies = [RuptureProxy(rec) for rec in block]
-        rgetter = RuptureGetter(proxies, dstore.filename, grp_id,
-                                trt, rlzs_by_gsim[grp_id])
-        yield rgetter
-        logging.info('Sent task %d: %d ruptures', nblocks, len(block))
-        nblocks += 1
+        yield RuptureGetter(proxies, dstore.filename, grp_id,
+                            trt, rlzs_by_gsim[grp_id])
 
 
 def get_ebruptures(dstore):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -343,6 +343,8 @@ class GmfGetter(object):
             with mon:
                 ebr = proxy.to_ebr(trt)
                 sids = self.srcfilter.close_sids(proxy, trt)
+                if len(sids) == 0:  # filtered away
+                    continue
                 sitecol = self.sitecol.filtered(sids)
                 try:
                     computer = calc.gmf.GmfComputer(
@@ -461,13 +463,6 @@ def gen_rgetters(dstore, slc=slice(None)):
             yield rgetter
 
 
-def _gen(arr, srcfilter, trt):
-    for rec in arr:
-        sids = srcfilter.close_sids(rec, trt)
-        if len(sids):
-            yield RuptureProxy(rec, len(sids))
-
-
 def gen_rupture_getters(dstore, srcfilter, ct):
     """
     :param dstore: a :class:`openquake.baselib.datastore.DataStore`
@@ -486,7 +481,7 @@ def gen_rupture_getters(dstore, srcfilter, ct):
             key=operator.itemgetter('grp_id')):
         grp_id = block[0]['grp_id']
         trt = trt_by_grp[grp_id]
-        proxies = list(_gen(block, srcfilter, trt))
+        proxies = [RuptureProxy(rec) for rec in block]
         rgetter = RuptureGetter(proxies, dstore.filename, grp_id,
                                 trt, rlzs_by_gsim[grp_id])
         yield rgetter

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -420,7 +420,8 @@ class GmfGetter(object):
                             hcurves[rsi2str(rlzi, sid, imt)] = poes[m]
         if not oq.ground_motion_fields:
             return dict(gmfdata=(), hcurves=hcurves)
-        gmfdata = self.get_gmfdata(mon)
+        if not oq.hazard_curves_from_gmfs:
+            gmfdata = self.get_gmfdata(mon)
         if len(gmfdata) == 0:
             return dict(gmfdata=[])
         times = numpy.array([tup + (monitor.task_no,) for tup in self.times],

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -299,8 +299,8 @@ class RuptureImporter(object):
         rgetters = gen_rgetters(self.datastore)
         # build the associations eid -> rlz sequentially or in parallel
         # this is very fast: I saw 30 million events associated in 1 minute!
-        logging.info('Building assocs event_id -> rlz_id for {:_d} events'
-                     ' and {:_d} ruptures'.format(len(events), len(rup_array)))
+        logging.info('Associating event_id -> rlz_id for {:_d} events '
+                     'and {:_d} ruptures'.format(len(events), len(rup_array)))
         if len(events) < 1E5:
             it = map(RuptureGetter.get_eid_rlz, rgetters)
         else:

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -670,7 +670,7 @@ class EBRupture(object):
     object, containing an array of site indices affected by the rupture,
     as well as the IDs of the corresponding seismic events.
     """
-    def __init__(self, rupture, source_id, grp_id, n_occ, samples=1, id=None):
+    def __init__(self, rupture, source_id, grp_id, n_occ, id=None):
         # NB: when reading an exported ruptures.xml the rup_id will be 0
         # for the first rupture; it used to be the seed instead
         assert rupture.rup_id >= 0  # sanity check
@@ -678,7 +678,6 @@ class EBRupture(object):
         self.source_id = source_id
         self.grp_id = grp_id
         self.n_occ = n_occ
-        self.samples = samples
         self.id = id  # id of the rupture on the DataStore, to be overridden
 
     @property
@@ -763,12 +762,10 @@ class RuptureProxy(object):
 
     :param rec: a record with the rupture parameters
     :param nsites: approx number of sites affected by the rupture
-    :param samples: how many times the rupture is sampled
     """
-    def __init__(self, rec, nsites=None, samples=1):
+    def __init__(self, rec, nsites=None):
         self.rec = rec
         self.nsites = nsites
-        self.samples = samples
 
     @property
     def weight(self):
@@ -777,21 +774,21 @@ class RuptureProxy(object):
             heuristic weight for the underlying rupture, depending on the
             number of occurrences, number of samples and number of sites
         """
-        return self.samples * self['n_occ'] * (
+        return self['n_occ'] * (
             100 if self.nsites is None else max(self.nsites, 100))
 
     def __getitem__(self, name):
         return self.rec[name]
 
     # NB: requires the .geom attribute to be set
-    def to_ebr(self, trt, samples):
+    def to_ebr(self, trt):
         """
         :returns: EBRupture instance associated to the underlying rupture
         """
         # not implemented: rupture_slip_direction
         rupture = _get_rupture(self.rec, self.geom, trt)
         ebr = EBRupture(rupture, self.rec['source_id'], self.rec['grp_id'],
-                        self.rec['n_occ'], samples)
+                        self.rec['n_occ'])
         ebr.id = self.rec['id']
         ebr.e0 = self.rec['e0']
         return ebr


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6113. The price to pay is a worse situation with the slow tasks, but it does not look tragic. Still in the future I may need to work on that. Thanks to the change in https://github.com/gem/oq-engine/pull/6110 many simplifications are possible and some have been implemented here.
Here are the slow tasks for the OASIS calculation on the spot machine:
```
$ oq show task_info 47  # slowest 3.6x the mean
================== ==== ====== ======= ===== =======
operation-duration mean stddev min     max   outputs
compute_gmfs       620  553    0.59579 2_227 244 
```