### PR TITLE
10x reduction in data transfer for the Poland calculation

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -335,7 +335,7 @@ class OqParam(valid.ParamSet):
             gsim_lt = logictree.GsimLogicTree(path, ['*'])
 
             # check the IMTs vs the GSIMs
-            self._gsims_by_trt = gsim_lt.values
+            self._trts = set(gsim_lt.values)
             for gsims in gsim_lt.values.values():
                 self.check_gsims(gsims)
         elif self.gsim is not None:
@@ -825,17 +825,17 @@ class OqParam(valid.ParamSet):
             return True  # don't apply validation
         gsim_lt = self.inputs['gsim_logic_tree']
         trts = set(self.maximum_distance)
-        unknown = ', '.join(trts - set(self._gsims_by_trt) - set(['default']))
+        unknown = ', '.join(trts - self._trts - {'default'})
         if unknown:
             self.error = ('setting the maximum_distance for %s which is '
                           'not in %s' % (unknown, gsim_lt))
             return False
         for trt, val in self.maximum_distance.items():
-            if trt not in self._gsims_by_trt and trt != 'default':
+            if trt not in self._trts and trt != 'default':
                 self.error = 'tectonic region %r not in %s' % (trt, gsim_lt)
                 return False
-        if 'default' not in trts and trts < set(self._gsims_by_trt):
-            missing = ', '.join(set(self._gsims_by_trt) - trts)
+        if 'default' not in trts and trts < self._trts:
+            missing = ', '.join(self._trts - trts)
             self.error = 'missing distance for %s and no default' % missing
             return False
         return True

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -142,12 +142,11 @@ class OqParamTestCase(unittest.TestCase):
             maximum_distance='{"wrong TRT": 200}')
         oq.inputs['source_model_logic_tree'] = 'something'
 
-        oq._gsims_by_trt = {'Active Shallow Crust': []}
+        oq._trts = {'Active Shallow Crust'}
         self.assertFalse(oq.is_valid_maximum_distance())
         self.assertIn('setting the maximum_distance for wrong TRT', oq.error)
 
-        oq._gsims_by_trt = {'Active Shallow Crust': [],
-                            'Stable Continental Crust': []}
+        oq._trts = {'Active Shallow Crust', 'Stable Continental Crust'}
         oq.maximum_distance = {'Active Shallow Crust': 200}
         self.assertFalse(oq.is_valid_maximum_distance())
         self.assertEqual('missing distance for Stable Continental Crust '


### PR DESCRIPTION
From 6 GB to 600 MB. The issue was that the Kotha GMPEs require a lot of bytes and they were transferred in `oqparam._gsims_by_trt`. But there is no need to keep them in `oqparam._gsims_by_trt`: keeping the TRTs is enough :-)
Also the memory occupation went down from 47 GB to 37 GB.