### PR TITLE
Psutil fix2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Current stable version is the **OpenQuake Engine 3.10** 'Ulomov'. The documentat
 
 ### General overview
 
-* [About](https://github.com/gem/oq-engine/blob/master/doc/about.md)
+* [About](doc/about.md)
 * [FAQ](https://github.com/gem/oq-engine/blob/master/doc/faq.md)
 * [Manuals](https://www.globalquakemodel.org/single-post/OpenQuake-Engine-Manual)
 * [OQ Commands](https://github.com/gem/oq-engine/blob/master/doc/oq-commands.md)

--- a/README.md
+++ b/README.md
@@ -42,49 +42,49 @@ Current stable version is the **OpenQuake Engine 3.10** 'Ulomov'. The documentat
 ### General overview
 
 * [About](doc/about.md)
-* [FAQ](https://github.com/gem/oq-engine/blob/master/doc/faq.md)
+* [FAQ](doc/faq.md)
 * [Manuals](https://www.globalquakemodel.org/single-post/OpenQuake-Engine-Manual)
-* [OQ Commands](https://github.com/gem/oq-engine/blob/master/doc/oq-commands.md)
-* [Architecture](https://github.com/gem/oq-engine/blob/master/doc/sphinx/architecture.rst)
-* [Calculation Workflow](https://github.com/gem/oq-engine/blob/master/doc/calculation-workflow.md)
-* [Hardware Suggestions](https://github.com/gem/oq-engine/blob/master/doc/hardware-suggestions.md)
-* [Continuous integration and testing](https://github.com/gem/oq-engine/blob/master/doc/testing.md)
-* [Glossary of Terms](https://github.com/gem/oq-engine/blob/master/doc/glossary.md)
+* [OQ Commands](doc/oq-commands.md)
+* [Architecture](doc/sphinx/architecture.rst)
+* [Calculation Workflow](doc/calculation-workflow.md)
+* [Hardware Suggestions](doc/hardware-suggestions.md)
+* [Continuous integration and testing](doc/testing.md)
+* [Glossary of Terms](doc/glossary.md)
 
 #### For contributors
 
-* [Development Philosophy and Coding Guidelines](https://github.com/gem/oq-engine/blob/master/doc/development-guidelines.md)
+* [Development Philosophy and Coding Guidelines](doc/development-guidelines.md)
 * [Source Code/API Documentation](http://docs.openquake.org/oq-engine/)
-* [HTTP REST API](https://github.com/gem/oq-engine/blob/master/doc/web-api.md)
-* [Implementing a new GSIM](https://github.com/gem/oq-engine/blob/master/doc/implementing-new-gsim.md)
+* [HTTP REST API](doc/web-api.md)
+* [Implementing a new GSIM](doc/implementing-new-gsim.md)
 
 ### Installation
 
-* [Technology stack and requirements](https://github.com/gem/oq-engine/blob/master/doc/requirements.md)
-* [Which installation method should I use?](https://github.com/gem/oq-engine/blob/master/doc/installing/README.md)
+* [Technology stack and requirements](doc/requirements.md)
+* [Which installation method should I use?](doc/installing/README.md)
 
 #### Linux
 
-* [Installing on Ubuntu](https://github.com/gem/oq-engine/blob/master/doc/installing/ubuntu.md)
-* [Installing on RedHat and derivatives](https://github.com/gem/oq-engine/blob/master/doc/installing/rhel.md)
-* [Installing on other flavors (without sudo)](https://github.com/gem/oq-engine/blob/master/doc/installing/linux-generic.md)
-* [Installing from sources](https://github.com/gem/oq-engine/blob/master/doc/installing/development.md)
-* [Installing on a cluster](https://github.com/gem/oq-engine/blob/master/doc/installing/cluster.md)
+* [Installing on Ubuntu](doc/installing/ubuntu.md)
+* [Installing on RedHat and derivatives](doc/installing/rhel.md)
+* [Installing on other flavors (without sudo)](doc/installing/linux-generic.md)
+* [Installing from sources](doc/installing/development.md)
+* [Installing on a cluster](doc/installing/cluster.md)
 
 #### macOS
 
-* [Installing on macOS](https://github.com/gem/oq-engine/blob/master/doc/installing/macos.md)
-* [Installing from sources](https://github.com/gem/oq-engine/blob/master/doc/installing/development.md#macos)
+* [Installing on macOS](doc/installing/macos.md)
+* [Installing from sources](doc/installing/development.md#macos)
 
 #### Windows
 
-* [Installing on Windows](https://github.com/gem/oq-engine/blob/master/doc/installing/windows.md)
-* [Installing from sources](https://github.com/gem/oq-engine/blob/master/doc/installing/development-windows.md)
-* [Starting the software](https://github.com/gem/oq-engine/blob/master/doc/running/windows.md)
+* [Installing on Windows](doc/installing/windows.md)
+* [Installing from sources](doc/installing/development-windows.md)
+* [Starting the software](doc/running/windows.md)
 
 #### Cloud
 
-* [Deploy a Docker container](https://github.com/gem/oq-engine/blob/master/doc/installing/docker.md)
+* [Deploy a Docker container](doc/installing/docker.md)
 
 #### Mirrors
 
@@ -94,8 +94,8 @@ The main download server ([downloads.openquake.org](https://downloads.openquake.
 
 ### Running the OpenQuake Engine
 
-* [Using the command line](https://github.com/gem/oq-engine/blob/master/doc/running/unix.md)
-* [Using the WebUI](https://github.com/gem/oq-engine/blob/master/doc/running/server.md)
+* [Using the command line](doc/running/unix.md)
+* [Using the WebUI](doc/running/server.md)
 
 ### Visualizing outputs via QGIS
 
@@ -109,7 +109,7 @@ The main download server ([downloads.openquake.org](https://downloads.openquake.
 
 ## License
 
-The OpenQuake Engine is released under the **[GNU Affero Public License 3](https://github.com/gem/oq-engine/blob/master/LICENSE)**.
+The OpenQuake Engine is released under the **[GNU Affero Public License 3](LICENSE)**.
 
 ## Contacts
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The **OpenQuake Engine** is an open source application that allows users to comp
 +## OpenQuake Engine version 2.6 (Gutenberg)
  
 -Current stable version is the **OpenQuake Engine 2.5** 'Fourier'. The documentation is available at https://github.com/gem/oq-engine/tree/engine-2.5#openquake-engine.
--* [What's new](https://github.com/gem/oq-engine/blob/engine-2.5/doc/whats-new.md)
+-* [What's new](../engine-2.5/doc/whats-new.md)
 -
 +Starting from OpenQuake version 2.0 we have introduced a "code name" to honour earthquake scientists.
  
 +The code name for version 2.6 is **Gutenberg**, in memory of [Beno Gutenberg](https://en.wikipedia.org/wiki/Beno_Gutenberg).
-+* [What's new](https://github.com/gem/oq-engine/blob/engine-2.6/doc/whats-new.md)
++* [What's new](../engine-2.6/doc/whats-new.md)
 + 
 +## Documentation
 -## Documentation (master tree)
@@ -33,7 +33,7 @@ The **OpenQuake Engine** is an open source application that allows users to comp
 
 Current stable version is the **OpenQuake Engine 3.10** 'Ulomov'. The documentation is available at https://github.com/gem/oq-engine/tree/engine-3.10#openquake-engine.
 
-* [What's new](https://github.com/gem/oq-engine/blob/engine-3.10/doc/whats-new.md)
+* [What's new](../engine-3.10/doc/whats-new.md)
 
 ## Documentation (master tree)
 

--- a/doc/installing/README.md
+++ b/doc/installing/README.md
@@ -29,6 +29,50 @@ The OpenQuake Engine is also available on **[PyPI](https://pypi.python.org/pypi/
 $ pip install openquake.engine
 ```
 
+If the installation fails the problem could be that some dependency needs compilation environment to be installed, in these cases you can install our already compiled dependencies from our repository with the command:
+
+#### For Linux
+
+##### For Python 3.8
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py38-linux64.txt openquake.engine
+```
+
+##### For Python 3.6
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py36-linux64.txt openquake.engine
+```
+
+#### For Windows
+
+##### For Python 3.8
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py38-win64.txt openquake.engine
+```
+
+##### For Python 3.6
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py36-win64.txt openquake.engine
+```
+
+#### For Mac
+
+##### For Python 3.8
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py38-macos.txt openquake.engine
+```
+
+##### For Python 3.6
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py36-macos.txt openquake.engine
+```
+
 ## Multi users
 
 ### Linux

--- a/doc/installing/overview.md
+++ b/doc/installing/overview.md
@@ -29,6 +29,50 @@ The OpenQuake Engine is also available on **[PyPI](https://pypi.python.org/pypi/
 $ pip install openquake.engine
 ```
 
+If the installation fails the problem could be that some dependency needs compilation environment to be installed, in these cases you can install our already compiled dependencies from our repository with the command:
+
+#### For Linux
+
+##### For Python 3.8
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py38-linux64.txt openquake.engine
+```
+
+##### For Python 3.6
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py36-linux64.txt openquake.engine
+```
+
+#### For Windows
+
+##### For Python 3.8
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py38-win64.txt openquake.engine
+```
+
+##### For Python 3.6
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py36-win64.txt openquake.engine
+```
+
+#### For Mac
+
+##### For Python 3.8
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py38-macos.txt openquake.engine
+```
+
+##### For Python 3.6
+
+```
+$ pip install -r https://raw.githubusercontent.com/gem/oq-engine/master/requirements-py36-macos.txt openquake.engine
+```
+
 ## Multi users
 
 ### Linux


### PR DESCRIPTION
Add fallback documentation to install missing, already built, dependencies if wheels are not provided on pypi for a specific system. 