### PR TITLE
Fix missing glossary

### DIFF
--- a/doc/manual/bibliography/hazard.bib
+++ b/doc/manual/bibliography/hazard.bib
@@ -1470,7 +1470,7 @@
 }
 
 @ARTICLE{Thingbaijam2017,
-  author = {Thingbaijam, K. K. S. and Mai, P.M., Goda, K. },
+  author = {Thingbaijam, K. K. S. and Mai, P. M. and Goda, K.},
   title = {New Empirical Earthquake Source-Scaling Laws},
   journal = {Bulletin of the Seismological Society of America},
   year = {2017},

--- a/doc/manual/build.sh
+++ b/doc/manual/build.sh
@@ -17,11 +17,11 @@ sed -i "s/version X\.Y\.Z/version $VERSION/; s/ENGINE\.X\.Y\.Z/ENGINE\.$VERSION/
 
 (pdflatex -halt-on-error -shell-escape -interaction=nonstopmode oq-manual.tex
 bibtex oq-manual
-pdflatex -halt-on-error -shell-escape -interaction=nonstopmode oq-manual.tex
-makeindex oq-manual.idx
+makeindex oq-manual
 makeglossaries oq-manual
 pdflatex -halt-on-error -shell-escape -interaction=nonstopmode oq-manual.tex
-makeglossaries oq-manual) | tee -a full_log.log | egrep -i "error|warning|missing"
+makeglossaries oq-manual
+pdflatex -halt-on-error -shell-escape -interaction=nonstopmode oq-manual.tex) | tee -a full_log.log | egrep -i "error|warning|missing"
 
 echo -e "\n\n=== FINAL RUN ===\n\n"
 pdflatex -halt-on-error -shell-escape -interaction=nonstopmode oq-manual.tex | tee -a full_log.log | egrep -i "error|warning|missing"

--- a/doc/manual/oq-manual.tex
+++ b/doc/manual/oq-manual.tex
@@ -30,9 +30,9 @@
 \documentclass[11pt,fleqn]{book} % ------------------ Left-justified equations -
 \input{configuration/configuration} % ------------- Load packages and template -
 \graphicspath{{figures/}} % -------------- Directory where pictures are stored -
+\input{oqum/glossary} % ---------------------------------------- Load glossary -
 
 \begin{document}
-\input{oqum/glossary} % ---------------------------------------- Load glossary -
 
 %-------------------------------------------------------------------------------
 %  COVER PAGE


### PR DESCRIPTION
The manual glossary was missing since v3.2, i.e., more than two years now (see #3460). A combination of the following commits fixes the issue:
- Fix the author list for a bibliography entry that was broken
- Load the glossary in the preamble, before the {document} section (recommended practice)
- Run pdflatex twice after makeglossaries (recommended practice)
[oq-manual.pdf](https://github.com/gem/oq-engine/files/5328023/oq-manual.pdf)
