### PR TITLE
Fixes missing kwargs for some GMPEs

### DIFF
--- a/openquake/hazardlib/gsim/akkar_2014.py
+++ b/openquake/hazardlib/gsim/akkar_2014.py
@@ -73,8 +73,8 @@ class AkkarEtAlRjb2014(GMPE):
     #: coefficients in table 4.a, pages 22-23, are used.
     REQUIRES_DISTANCES = {'rjb'}
 
-    def __init__(self, adjustment_factor=1.0):
-        super().__init__()
+    def __init__(self, adjustment_factor=1.0, **kwargs):
+        super().__init__(**kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/akkar_2014.py
+++ b/openquake/hazardlib/gsim/akkar_2014.py
@@ -74,7 +74,7 @@ class AkkarEtAlRjb2014(GMPE):
     REQUIRES_DISTANCES = {'rjb'}
 
     def __init__(self, adjustment_factor=1.0, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(adjustment_factor=adjustment_factor, **kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/ameri_2017.py
+++ b/openquake/hazardlib/gsim/ameri_2017.py
@@ -73,8 +73,8 @@ class AmeriEtAl2017Rjb(GMPE):
     #: Required distance measure is Rjb (eq. 1).
     REQUIRES_DISTANCES = {'rjb'}
 
-    def __init__(self, adjustment_factor=1.0):
-        super().__init__()
+    def __init__(self, adjustment_factor=1.0, **kwargs):
+        super().__init__(**kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/ameri_2017.py
+++ b/openquake/hazardlib/gsim/ameri_2017.py
@@ -74,7 +74,7 @@ class AmeriEtAl2017Rjb(GMPE):
     REQUIRES_DISTANCES = {'rjb'}
 
     def __init__(self, adjustment_factor=1.0, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(adjustment_factor=adjustment_factor, **kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/bchydro_2016_epistemic.py
+++ b/openquake/hazardlib/gsim/bchydro_2016_epistemic.py
@@ -267,7 +267,7 @@ class BCHydroSERASInter(AbrahamsonEtAl2015SInter):
     REQUIRES_SITES_PARAMETERS = set(('vs30', 'backarc_distance'))
 
     def __init__(self, **kwargs):
-        super().__init__(ergodic=kwargs.get("ergodic", True))
+        super().__init__(ergodic=kwargs.get("ergodic", True), **kwargs)
         self.theta6_adj = kwargs.get("theta6_adjustment", 0.0)
         self.sigma_mu_epsilon = kwargs.get("sigma_mu_epsilon", 0.0)
         faba_type = kwargs.get("faba_taper_model", "Step")
@@ -343,7 +343,7 @@ class BCHydroSERASInterLow(AbrahamsonEtAl2015SInterLow):
     REQUIRES_SITES_PARAMETERS = set(('vs30', 'backarc_distance'))
 
     def __init__(self, **kwargs):
-        super().__init__(ergodic=kwargs.get("ergodic", True))
+        super().__init__(ergodic=kwargs.get("ergodic", True), **kwargs)
         self.theta6_adj = kwargs.get("theta6_adjustment", 0.0)
         self.sigma_mu_epsilon = kwargs.get("sigma_mu_epsilon", 0.0)
         faba_type = kwargs.get("faba_taper_model", "Step")
@@ -421,7 +421,7 @@ class BCHydroSERASInterHigh(AbrahamsonEtAl2015SInterHigh):
     REQUIRES_SITES_PARAMETERS = set(('vs30', 'backarc_distance'))
 
     def __init__(self, **kwargs):
-        super().__init__(ergodic=kwargs.get("ergodic", True))
+        super().__init__(ergodic=kwargs.get("ergodic", True), **kwargs)
         self.theta6_adj = kwargs.get("theta6_adjustment", 0.0)
         self.sigma_mu_epsilon = kwargs.get("sigma_mu_epsilon", 0.0)
         faba_type = kwargs.get("faba_taper_model", "Step")
@@ -506,7 +506,7 @@ class BCHydroSERASSlab(AbrahamsonEtAl2015SSlab):
     REQUIRES_SITES_PARAMETERS = set(('vs30', 'backarc_distance'))
 
     def __init__(self, **kwargs):
-        super().__init__(ergodic=kwargs.get("ergodic", True))
+        super().__init__(ergodic=kwargs.get("ergodic", True), **kwargs)
         self.theta6_adj = kwargs.get("theta6_adjustment", 0.0)
         self.sigma_mu_epsilon = kwargs.get("sigma_mu_epsilon", 0.0)
         faba_type = kwargs.get("faba_taper_model", "Step")
@@ -584,7 +584,7 @@ class BCHydroSERASSlabLow(AbrahamsonEtAl2015SSlabLow):
     REQUIRES_SITES_PARAMETERS = set(('vs30', 'backarc_distance'))
 
     def __init__(self, **kwargs):
-        super().__init__(ergodic=kwargs.get("ergodic", True))
+        super().__init__(ergodic=kwargs.get("ergodic", True), **kwargs)
         self.theta6_adj = kwargs.get("theta6_adjustment", 0.0)
         self.sigma_mu_epsilon = kwargs.get("sigma_mu_epsilon", 0.0)
         faba_type = kwargs.get("faba_taper_model", "Step")
@@ -662,7 +662,7 @@ class BCHydroSERASSlabHigh(AbrahamsonEtAl2015SSlabHigh):
     REQUIRES_SITES_PARAMETERS = set(('vs30', 'backarc_distance'))
 
     def __init__(self, **kwargs):
-        super().__init__(ergodic=kwargs.get("ergodic", True))
+        super().__init__(ergodic=kwargs.get("ergodic", True), **kwargs)
         self.theta6_adj = kwargs.get("theta6_adjustment", 0.0)
         self.sigma_mu_epsilon = kwargs.get("sigma_mu_epsilon", 0.0)
         faba_type = kwargs.get("faba_taper_model", "Step")

--- a/openquake/hazardlib/gsim/bindi_2014.py
+++ b/openquake/hazardlib/gsim/bindi_2014.py
@@ -86,8 +86,8 @@ class BindiEtAl2014Rjb(GMPE):
     #: Required distance measure is Rjb (eq. 1).
     REQUIRES_DISTANCES = {'rjb'}
 
-    def __init__(self, adjustment_factor=1.0):
-        super().__init__()
+    def __init__(self, adjustment_factor=1.0, **kwargs):
+        super().__init__(**kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/bindi_2014.py
+++ b/openquake/hazardlib/gsim/bindi_2014.py
@@ -87,7 +87,7 @@ class BindiEtAl2014Rjb(GMPE):
     REQUIRES_DISTANCES = {'rjb'}
 
     def __init__(self, adjustment_factor=1.0, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(adjustment_factor=adjustment_factor, **kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/bindi_2017.py
+++ b/openquake/hazardlib/gsim/bindi_2017.py
@@ -72,8 +72,8 @@ class BindiEtAl2017Rjb(GMPE):
     #: Required distance measure is Rjb
     REQUIRES_DISTANCES = {'rjb'}
 
-    def __init__(self, adjustment_factor=1.0):
-        super().__init__()
+    def __init__(self, adjustment_factor=1.0, **kwargs):
+        super().__init__(**kwargs)
         self.adjustment_factor = np.log(float(adjustment_factor))
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/bindi_2017.py
+++ b/openquake/hazardlib/gsim/bindi_2017.py
@@ -73,7 +73,7 @@ class BindiEtAl2017Rjb(GMPE):
     REQUIRES_DISTANCES = {'rjb'}
 
     def __init__(self, adjustment_factor=1.0, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(adjustment_factor=adjustment_factor, **kwargs)
         self.adjustment_factor = np.log(float(adjustment_factor))
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/germany_2018.py
+++ b/openquake/hazardlib/gsim/germany_2018.py
@@ -64,8 +64,8 @@ class CauzziEtAl2014RhypoGermany(CauzziEtAl2014):
     REQUIRES_DISTANCES = {"rhypo", "rrup"}
     REQUIRES_RUPTURE_PARAMETERS = {"rake", "mag", "width"}
 
-    def __init__(self, adjustment_factor=1.0):
-        super().__init__()
+    def __init__(self, adjustment_factor=1.0, **kwargs):
+        super().__init__(**kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def _compute_mean(self, C, rup, dists, sites, imt):
@@ -106,8 +106,8 @@ class DerrasEtAl2014RhypoGermany(DerrasEtAl2014):
     REQUIRES_DISTANCES = {'rjb', 'rhypo'}
     REQUIRES_RUPTURE_PARAMETERS = {"rake", "mag", "hypo_depth", "width"}
 
-    def __init__(self, adjustment_factor=1.0):
-        super().__init__()
+    def __init__(self, adjustment_factor=1.0, **kwargs):
+        super().__init__(**kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/germany_2018.py
+++ b/openquake/hazardlib/gsim/germany_2018.py
@@ -65,7 +65,7 @@ class CauzziEtAl2014RhypoGermany(CauzziEtAl2014):
     REQUIRES_RUPTURE_PARAMETERS = {"rake", "mag", "width"}
 
     def __init__(self, adjustment_factor=1.0, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(adjustment_factor=adjustment_factor, **kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def _compute_mean(self, C, rup, dists, sites, imt):
@@ -107,7 +107,7 @@ class DerrasEtAl2014RhypoGermany(DerrasEtAl2014):
     REQUIRES_RUPTURE_PARAMETERS = {"rake", "mag", "hypo_depth", "width"}
 
     def __init__(self, adjustment_factor=1.0, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(adjustment_factor=adjustment_factor, **kwargs)
         self.adjustment_factor = np.log(adjustment_factor)
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/kotha_2020.py
+++ b/openquake/hazardlib/gsim/kotha_2020.py
@@ -168,11 +168,11 @@ class KothaEtAl2020(GMPE):
     #: Required distance measure is Rjb (eq. 1).
     REQUIRES_DISTANCES = {'rjb'}
 
-    def __init__(self, sigma_mu_epsilon=0.0, c3=None, ergodic=True):
+    def __init__(self, sigma_mu_epsilon=0.0, c3=None, ergodic=True, **kwargs):
         """
         Instantiate setting the sigma_mu_epsilon and c3 terms
         """
-        super().__init__()
+        super().__init__(**kwargs)
         if isinstance(c3, dict):
             # Inputing c3 as a dictionary sorted by the string representation
             # of the IMT

--- a/openquake/hazardlib/gsim/kotha_2020.py
+++ b/openquake/hazardlib/gsim/kotha_2020.py
@@ -172,7 +172,8 @@ class KothaEtAl2020(GMPE):
         """
         Instantiate setting the sigma_mu_epsilon and c3 terms
         """
-        super().__init__(**kwargs)
+        super().__init__(sigma_mu_epsilon=sigma_mu_epsilon, c3=c3,
+                         ergodic=ergodic, **kwargs)
         if isinstance(c3, dict):
             # Inputing c3 as a dictionary sorted by the string representation
             # of the IMT

--- a/openquake/hazardlib/gsim/mgmpe/cy14_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/cy14_site_term.py
@@ -49,8 +49,8 @@ class CY14SiteTerm(GMPE):
     DEFINED_FOR_TECTONIC_REGION_TYPE = ''
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
-    def __init__(self, gmpe_name):
-        super().__init__(gmpe_name=gmpe_name)
+    def __init__(self, gmpe_name, **kwargs):
+        super().__init__(gmpe_name=gmpe_name, **kwargs)
         self.gmpe = registry[gmpe_name]()
         self.set_parameters()
         #

--- a/openquake/hazardlib/gsim/mgmpe/generic_gmpe_avgsa.py
+++ b/openquake/hazardlib/gsim/mgmpe/generic_gmpe_avgsa.py
@@ -62,7 +62,8 @@ class GenericGmpeAvgSA(GMPE):
 
     def __init__(self, gmpe_name, avg_periods, corr_func='none', **kwargs):
 
-        super().__init__(gmpe_name=gmpe_name, **kwargs)
+        super().__init__(gmpe_name=gmpe_name, avg_periods=avg_periods,
+                         corr_func=corr_func, **kwargs)
         self.gmpe = registry[gmpe_name](**kwargs)
         self.set_parameters()
         self.avg_periods = avg_periods

--- a/openquake/hazardlib/gsim/mgmpe/generic_gmpe_avgsa.py
+++ b/openquake/hazardlib/gsim/mgmpe/generic_gmpe_avgsa.py
@@ -62,7 +62,7 @@ class GenericGmpeAvgSA(GMPE):
 
     def __init__(self, gmpe_name, avg_periods, corr_func='none', **kwargs):
 
-        super().__init__(gmpe_name=gmpe_name)
+        super().__init__(gmpe_name=gmpe_name, **kwargs)
         self.gmpe = registry[gmpe_name](**kwargs)
         self.set_parameters()
         self.avg_periods = avg_periods

--- a/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
@@ -46,8 +46,8 @@ class NRCan15SiteTerm(GMPE):
     DEFINED_FOR_TECTONIC_REGION_TYPE = ''
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
-    def __init__(self, gmpe_name):
-        super().__init__(gmpe_name=gmpe_name)
+    def __init__(self, gmpe_name, **kwargs):
+        super().__init__(gmpe_name=gmpe_name, **kwargs)
         self.gmpe = registry[gmpe_name]()
         self.set_parameters()
         #

--- a/openquake/hazardlib/gsim/mgmpe/split_sigma_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/split_sigma_gmpe.py
@@ -46,8 +46,9 @@ class SplitSigmaGMPE(GMPE):
     DEFINED_FOR_TECTONIC_REGION_TYPE = ''
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
-    def __init__(self, gmpe_name, within_absolute=None, between_absolute=None):
-        super().__init__(gmpe_name=gmpe_name)
+    def __init__(self, gmpe_name, within_absolute=None, between_absolute=None,
+                 **kwargs):
+        super().__init__(gmpe_name=gmpe_name, **kwargs)
         # Create the original GMPE
         self.gmpe = registry[gmpe_name]()
         self.set_parameters()

--- a/openquake/hazardlib/gsim/mgmpe/split_sigma_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/split_sigma_gmpe.py
@@ -48,7 +48,8 @@ class SplitSigmaGMPE(GMPE):
 
     def __init__(self, gmpe_name, within_absolute=None, between_absolute=None,
                  **kwargs):
-        super().__init__(gmpe_name=gmpe_name, **kwargs)
+        super().__init__(gmpe_name=gmpe_name, within_absolute=within_absolute,
+                         between_absolute=between_absolute, **kwargs)
         # Create the original GMPE
         self.gmpe = registry[gmpe_name]()
         self.set_parameters()

--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -66,13 +66,14 @@ class ParkerEtAl2020SInter(GMPE):
     #: interface events
     REQUIRES_DISTANCES = {'rrup'}
 
-    def __init__(self, region=None, saturation_region=None, basin=None):
+    def __init__(self, region=None, saturation_region=None, basin=None,
+                 **kwargs):
         """
         Enable setting regions to prevent messy overriding
         and code duplication.
         """
         super().__init__(region=region, saturation_region=saturation_region,
-                         basin=basin)
+                         basin=basin, **kwargs)
         self.region = region
         if saturation_region is None:
             self.saturation_region = region

--- a/openquake/hazardlib/gsim/sera_amplification_models.py
+++ b/openquake/hazardlib/gsim/sera_amplification_models.py
@@ -99,7 +99,8 @@ class PitilakisEtAl2018(GMPE):
     DEFINED_FOR_REFERENCE_VELOCITY = 800.0
 
     def __init__(self, gmpe_name, reference_velocity=None, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(gmpe_name=gmpe_name,
+                         reference_velocity=reference_velocity, **kwargs)
         if isinstance(gmpe_name, str):
             self.gmpe = registry[gmpe_name](**kwargs)
         else:

--- a/openquake/hazardlib/gsim/sera_amplification_models.py
+++ b/openquake/hazardlib/gsim/sera_amplification_models.py
@@ -99,7 +99,7 @@ class PitilakisEtAl2018(GMPE):
     DEFINED_FOR_REFERENCE_VELOCITY = 800.0
 
     def __init__(self, gmpe_name, reference_velocity=None, **kwargs):
-        super().__init__()
+        super().__init__(**kwargs)
         if isinstance(gmpe_name, str):
             self.gmpe = registry[gmpe_name](**kwargs)
         else:
@@ -319,7 +319,7 @@ class Eurocode8Amplification(PitilakisEtAl2018):
     DEFINED_FOR_REFERENCE_VELOCITY = 800.0
 
     def __init__(self, gmpe_name, reference_velocity=800.0, **kwargs):
-        super().__init__(gmpe_name=gmpe_name)
+        super().__init__(gmpe_name=gmpe_name, **kwargs)
         self.rock_vs30 = reference_velocity if reference_velocity else\
             self.DEFINED_FOR_REFERENCE_VELOCITY
         for name in uppernames:
@@ -533,7 +533,7 @@ class SandikkayaDinsever2018(GMPE):
 
     def __init__(self, gmpe_name, reference_velocity=760., region=None,
                  phi_0=None, **kwargs):
-        super().__init__()
+        super().__init__(**kwargs)
         if isinstance(gmpe_name, str):
             self.gmpe = registry[gmpe_name](**kwargs)
         else:

--- a/openquake/hazardlib/gsim/tromans_2019.py
+++ b/openquake/hazardlib/gsim/tromans_2019.py
@@ -222,7 +222,10 @@ class TromansEtAl2019(GMPE):
     def __init__(self, gmpe_name, branch="central",
                  homoskedastic_sigma=False,  scaling_factor=None,
                  vskappa=None, phi_ds2s=True, **kwargs):
-        super().__init__(gmpe_name=gmpe_name, **kwargs)
+        super().__init__(gmpe_name=gmpe_name, branch=branch,
+                         homoskedastic_sigma=homoskedastic_sigma,
+                         scaling_factor=scaling_factor, vskappa=vskappa,
+                         phi_ds2s=phi_ds2s, **kwargs)
         self.gmpe = registry[gmpe_name]()
         # Update the required_parameters
         for name in uppernames:

--- a/openquake/hazardlib/gsim/tromans_2019.py
+++ b/openquake/hazardlib/gsim/tromans_2019.py
@@ -221,8 +221,8 @@ class TromansEtAl2019(GMPE):
 
     def __init__(self, gmpe_name, branch="central",
                  homoskedastic_sigma=False,  scaling_factor=None,
-                 vskappa=None, phi_ds2s=True):
-        super().__init__(gmpe_name=gmpe_name)
+                 vskappa=None, phi_ds2s=True, **kwargs):
+        super().__init__(gmpe_name=gmpe_name, **kwargs)
         self.gmpe = registry[gmpe_name]()
         # Update the required_parameters
         for name in uppernames:
@@ -310,10 +310,11 @@ class TromansEtAl2019SigmaMu(TromansEtAl2019):
 
     def __init__(self, gmpe_name, branch="central", sigma_mu_epsilon=0.0,
                  homoskedastic_sigma=False,  scaling_factor=None,
-                 vskappa=None):
+                 vskappa=None, **kwargs):
         super().__init__(gmpe_name=gmpe_name, branch=branch,
                          homoskedastic_sigma=homoskedastic_sigma,
-                         scaling_factor=scaling_factor, vskappa=vskappa)
+                         scaling_factor=scaling_factor, vskappa=vskappa,
+                         **kwargs)
         self.sigma_mu_epsilon = sigma_mu_epsilon
 
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):

--- a/openquake/hazardlib/gsim/yenier_atkinson_2015.py
+++ b/openquake/hazardlib/gsim/yenier_atkinson_2015.py
@@ -71,7 +71,8 @@ class YenierAtkinson2015BSSA(GMPE):
     #: Required distance measures is Rrup
     REQUIRES_DISTANCES = {'rrup'}
 
-    def __init__(self, focal_depth=None, region='CENA'):
+    def __init__(self, focal_depth=None, region='CENA', **kwargs):
+        super().__init__(**kwargs) 
         self.focal_depth = focal_depth
         self.region = region
 

--- a/openquake/hazardlib/gsim/yenier_atkinson_2015.py
+++ b/openquake/hazardlib/gsim/yenier_atkinson_2015.py
@@ -72,7 +72,7 @@ class YenierAtkinson2015BSSA(GMPE):
     REQUIRES_DISTANCES = {'rrup'}
 
     def __init__(self, focal_depth=None, region='CENA', **kwargs):
-        super().__init__(**kwargs) 
+        super().__init__(focal_depth=focal_depth, region=region, **kwargs) 
         self.focal_depth = focal_depth
         self.region = region
 


### PR DESCRIPTION
Quite a few GMPEs call `super().__init__` without parsing the `**kwargs`. This prevents certain features such as the mixture model from being used with these GMPEs. As far as I can tell this is simply an oversight and  `**kwargs` should always be passed. This PR fixes all instances of this that I can find.