### PR TITLE
Restored reading from the workers in classical_risk and classical_damage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Restored reading from the workers in classical_risk and classical_damage
   * Implemented `sensitivity_analysis`
   * Fixed an npz saving error in /extract/assets affecting the QGIS plugin
   * Improved submitting calculations to the WebAPI: now they can be run on a zmq

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -265,25 +265,30 @@ class Monitor(object):
         vars(new).update(kw)
         return new
 
-    def save_pik(self, key, obj):
+    def save(self, key, obj):
         """
         :param key: key in the _tmp.hdf5 file
         :param obj: big object to store in pickle format
         """
         tmp = self.filename[:-5] + '_tmp.hdf5'
-        f = (hdf5.File(tmp, 'r+') if os.path.exists(tmp)
-             else hdf5.File(tmp, 'w'))
+        f = hdf5.File(tmp, 'a') if os.path.exists(tmp) else hdf5.File(tmp, 'w')
         with f:
-            f[key] = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+            if isinstance(obj, numpy.ndarray):
+                f[key] = obj
+            else:
+                f[key] = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
 
-    def read_pik(self, key):
+    def read(self, key):
         """
         :param key: key in the _tmp.hdf5 file
         :return: unpickled object
         """
         tmp = self.filename[:-5] + '_tmp.hdf5'
         with hdf5.File(tmp, 'r') as f:
-            return pickle.loads(f[key][()])
+            data = f[key][()]
+            if data.shape:
+                return data
+            return pickle.loads(data)
 
     def __repr__(self):
         calc_id = ' #%s ' % self.calc_id if self.calc_id else ' '

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1049,7 +1049,7 @@ class RiskCalculator(HazardCalculator):
         maxw = sum(ri.weight for ri in self.riskinputs) / ct
         smap = parallel.Starmap(
             self.core_task.__func__, h5=self.datastore.hdf5)
-        smap.monitor.save_pik('crmodel', self.crmodel)
+        smap.monitor.save('crmodel', self.crmodel)
         for block in general.block_splitter(
                 self.riskinputs, maxw, get_weight, sort=True):
             for ri in block:

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1029,7 +1029,7 @@ class RiskCalculator(HazardCalculator):
                 continue
             # hcurves, shape (R, N)
             ws = [rlz.weight for rlz in self.realizations]
-            getter = getters.PmapGetter(dstore, ws, [sid])
+            getter = getters.PmapGetter(dstore, ws, [sid], self.oqparam.imtls)
             for block in general.block_splitter(
                     assets, self.oqparam.assets_per_site_limit):
                 yield riskinput.RiskInput(sid, getter, numpy.array(block))

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -515,7 +515,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if nr:  # few sites, log the number of ruptures per magnitude
             logging.info('%s', nr)
         oq = self.oqparam
-        if oq.calculation_mode.endswith(('risk', 'damage')):
+        if oq.calculation_mode.endswith(('risk', 'damage', 'bcr')):
             with hdf5.File(self.datastore.tempname, 'a') as cache:
                 cache['oqparam'] = oq
                 cache['rlzs_by_grp'] = self.full_lt.get_rlzs_by_grp()
@@ -536,7 +536,7 @@ class ClassicalCalculator(base.HazardCalculator):
                     trt = self.full_lt.trt_by_grp[key]
                     name = 'poes/grp-%02d' % key
                     self.datastore[name] = pmap
-                    if oq.calculation_mode.endswith(('risk', 'damage')):
+                    if oq.calculation_mode.endswith(('risk', 'damage', 'bcr')):
                         with hdf5.File(self.datastore.tempname, 'a') as cache:
                             cache[name] = pmap
                     extreme = max(

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -515,6 +515,9 @@ class ClassicalCalculator(base.HazardCalculator):
         if nr:  # few sites, log the number of ruptures per magnitude
             logging.info('%s', nr)
         oq = self.oqparam
+        with hdf5.File(self.datastore.tempname, 'a') as cache:
+            cache['oqparam'] = oq
+            cache['rlzs_by_grp'] = self.full_lt.get_rlzs_by_grp()
         data = []
         weights = [rlz.weight for rlz in self.realizations]
         pgetter = getters.PmapGetter(self.datastore, weights)
@@ -531,6 +534,8 @@ class ClassicalCalculator(base.HazardCalculator):
                     trt = self.full_lt.trt_by_grp[key]
                     name = 'poes/grp-%02d' % key
                     self.datastore[name] = pmap
+                    with hdf5.File(self.datastore.tempname, 'a') as cache:
+                        cache[name] = pmap
                     extreme = max(
                         get_extreme_poe(pmap[sid].array, oq.imtls)
                         for sid in pmap)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -515,9 +515,10 @@ class ClassicalCalculator(base.HazardCalculator):
         if nr:  # few sites, log the number of ruptures per magnitude
             logging.info('%s', nr)
         oq = self.oqparam
-        with hdf5.File(self.datastore.tempname, 'a') as cache:
-            cache['oqparam'] = oq
-            cache['rlzs_by_grp'] = self.full_lt.get_rlzs_by_grp()
+        if oq.calculation_mode.endswith(('risk', 'damage')):
+            with hdf5.File(self.datastore.tempname, 'a') as cache:
+                cache['oqparam'] = oq
+                cache['rlzs_by_grp'] = self.full_lt.get_rlzs_by_grp()
         data = []
         weights = [rlz.weight for rlz in self.realizations]
         pgetter = getters.PmapGetter(
@@ -535,8 +536,9 @@ class ClassicalCalculator(base.HazardCalculator):
                     trt = self.full_lt.trt_by_grp[key]
                     name = 'poes/grp-%02d' % key
                     self.datastore[name] = pmap
-                    with hdf5.File(self.datastore.tempname, 'a') as cache:
-                        cache[name] = pmap
+                    if oq.calculation_mode.endswith(('risk', 'damage')):
+                        with hdf5.File(self.datastore.tempname, 'a') as cache:
+                            cache[name] = pmap
                     extreme = max(
                         get_extreme_poe(pmap[sid].array, oq.imtls)
                         for sid in pmap)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -74,7 +74,7 @@ def get_extreme_poe(array, imtls):
 
 
 def classical_(srcs, gsims, params, monitor):
-    srcfilter = monitor.read_pik('srcfilter')
+    srcfilter = monitor.read('srcfilter')
     return classical(srcs, srcfilter, gsims, params, monitor)
 
 
@@ -84,7 +84,7 @@ def classical_split_filter(srcs, gsims, params, monitor):
     PoEs. Yield back subtasks if the split sources contain more than
     maxweight ruptures.
     """
-    srcfilter = monitor.read_pik('srcfilter')
+    srcfilter = monitor.read('srcfilter')
     # first check if we are sampling the sources
     ss = int(os.environ.get('OQ_SAMPLE_SOURCES', 0))
     if ss:
@@ -129,7 +129,7 @@ def preclassical(srcs, gsims, params, monitor):
     calc_times = AccumDict(accum=numpy.zeros(3, F32))  # nrups, nsites, time
     pmap = AccumDict(accum=0)
     with monitor("splitting/filtering sources"):
-        srcfilter = monitor.read_pik('srcfilter')
+        srcfilter = monitor.read('srcfilter')
         splits, _stime = split_sources(srcs)
     totrups = 0
     maxradius = 0
@@ -363,7 +363,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 self.datastore['effect_by_mag_dst'] = aw
         smap = parallel.Starmap(classical, h5=self.datastore.hdf5,
                                 num_cores=oq.num_cores)
-        smap.monitor.save_pik('srcfilter', self.src_filter())
+        smap.monitor.save('srcfilter', self.src_filter())
         self.submit_tasks(smap)
         acc0 = self.acc0()  # create the rup/ datasets BEFORE swmr_on()
         self.datastore.swmr_on()

--- a/openquake/calculators/classical_bcr.py
+++ b/openquake/calculators/classical_bcr.py
@@ -41,7 +41,7 @@ def classical_bcr(riskinputs, param, monitor):
     """
     R = riskinputs[0].hazard_getter.num_rlzs
     result = AccumDict(accum=numpy.zeros((R, 3), F32))
-    crmodel = monitor.read_pik('crmodel')
+    crmodel = monitor.read('crmodel')
     for ri in riskinputs:
         for out in ri.gen_outputs(crmodel, monitor):
             for asset, (eal_orig, eal_retro, bcr) in zip(

--- a/openquake/calculators/classical_damage.py
+++ b/openquake/calculators/classical_damage.py
@@ -38,7 +38,7 @@ def classical_damage(riskinputs, param, monitor):
     :yields:
         dictionaries asset_ordinal -> damage(R, L, D)
     """
-    crmodel = monitor.read_pik('crmodel')
+    crmodel = monitor.read('crmodel')
     for ri in riskinputs:
         R = ri.hazard_getter.num_rlzs
         L = len(crmodel.lti)

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -36,7 +36,7 @@ def classical_risk(riskinputs, param, monitor):
     :param monitor:
         :class:`openquake.baselib.performance.Monitor` instance
     """
-    crmodel = monitor.read_pik('crmodel')
+    crmodel = monitor.read('crmodel')
     result = dict(loss_curves=[], stat_curves=[])
     weights = [w['default'] for w in param['weights']]
     statnames, stats = zip(*param['stats'])

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -249,7 +249,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         self.M = len(self.imts)
         ws = [rlz.weight for rlz in self.full_lt.get_realizations()]
         self.pgetter = getters.PmapGetter(
-            self.datastore, ws, self.sitecol.sids)
+            self.datastore, ws, self.sitecol.sids, oq.imtls, oq.poes)
 
         # build array rlzs (N, Z)
         if oq.rlz_index is None:

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -56,7 +56,7 @@ def calc_risk(gmfs, param, monitor):
     with monitor('getting assets'):
         assets_df = dstore.read_df('assetcol/array', 'ordinal')
     with monitor('getting crmodel'):
-        crmodel = monitor.read_pik('crmodel')
+        crmodel = monitor.read('crmodel')
         weights = dstore['weights'][()]
     L = len(param['lba'].loss_names)
     elt_dt = [('event_id', U32), ('loss', (F32, (L,)))]
@@ -116,7 +116,7 @@ def start_ebrisk(rgetter, param, monitor):
     """
     Launcher for ebrisk tasks
     """
-    srcfilter = monitor.read_pik('srcfilter')
+    srcfilter = monitor.read('srcfilter')
     rgetters = list(rgetter.split(srcfilter, param['maxweight']))
     for rg in rgetters[:-1]:
         msg = 'produced subtask'
@@ -141,7 +141,7 @@ def ebrisk(rupgetter, param, monitor):
     mon_haz = monitor('getting hazard', measuremem=True)
     gmfs = []
     gmf_info = []
-    srcfilter = monitor.read_pik('srcfilter')
+    srcfilter = monitor.read('srcfilter')
     gg = getters.GmfGetter(rupgetter, srcfilter, param['oqparam'],
                            param['amplifier'])
     nbytes = 0
@@ -247,8 +247,8 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.datastore.swmr_on()
         self.indices = general.AccumDict(accum=[])  # rlzi -> [(start, stop)]
         smap = parallel.Starmap(start_ebrisk, h5=self.datastore.hdf5)
-        smap.monitor.save_pik('srcfilter', srcfilter)
-        smap.monitor.save_pik('crmodel', self.crmodel)
+        smap.monitor.save('srcfilter', srcfilter)
+        smap.monitor.save('crmodel', self.crmodel)
         for rg in getters.gen_rupture_getters(
                 self.datastore, oq.concurrent_tasks):
             smap.submit((rg, self.param))

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -70,7 +70,7 @@ def compute_gmfs(rupgetter, param, monitor):
     Compute GMFs and optionally hazard curves
     """
     oq = param['oqparam']
-    srcfilter = monitor.read_pik('srcfilter')
+    srcfilter = monitor.read('srcfilter')
     getter = GmfGetter(rupgetter, srcfilter, oq, param['amplifier'],
                        param['sec_perils'])
     return getter.compute_gmfs_curves(monitor)
@@ -319,7 +319,7 @@ class EventBasedCalculator(base.HazardCalculator):
         smap = parallel.Starmap(
             self.core_task.__func__, iterargs, h5=self.datastore.hdf5,
             num_cores=oq.num_cores)
-        smap.monitor.save_pik('srcfilter', self.srcfilter)
+        smap.monitor.save('srcfilter', self.srcfilter)
         acc = smap.reduce(self.agg_dicts, self.acc0())
         if 'gmf_data' not in self.datastore:
             return acc

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -46,7 +46,7 @@ def event_based_risk(riskinputs, param, monitor):
     :returns:
         a dictionary of numpy arrays of shape (L, R)
     """
-    crmodel = monitor.read_pik('crmodel')
+    crmodel = monitor.read('crmodel')
     L = len(crmodel.lti)
     tempname = param['tempname']
     for ri in riskinputs:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -123,7 +123,10 @@ class PmapGetter(object):
         oq = self.dstore['oqparam']
         self.imtls = oq.imtls
         self.poes = self.poes or oq.poes
-        self.rlzs_by_grp = self.dstore['full_lt'].get_rlzs_by_grp()
+        if 'rlzs_by_grp' in self.dstore:
+            self.rlzs_by_grp = self.dstore['rlzs_by_grp']
+        else:
+            self.rlzs_by_grp = self.dstore['full_lt'].get_rlzs_by_grp()
 
         # populate _pmap_by_grp
         self._pmap_by_grp = {}

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -75,13 +75,14 @@ class PmapGetter(object):
     :param dstore: a DataStore instance or file system path to it
     :param sids: the subset of sites to consider (if None, all sites)
     """
-    def __init__(self, dstore, weights, sids=None, poes=()):
+    def __init__(self, dstore, weights, sids, imtls=(), poes=()):
         self.dstore = dstore
-        self.sids = dstore['sitecol'].sids if sids is None else sids
         if len(weights[0].dic) == 1:  # no weights by IMT
             self.weights = numpy.array([w['weight'] for w in weights])
         else:
             self.weights = weights
+        self.sids = sids
+        self.imtls = imtls
         self.poes = poes
         self.num_rlzs = len(weights)
         self.eids = None
@@ -118,11 +119,6 @@ class PmapGetter(object):
             self.dstore = hdf5.File(self.dstore, 'r')
         else:
             self.dstore.open('r')  # if not
-        if self.sids is None:
-            self.sids = self.dstore['sitecol'].sids
-        oq = self.dstore['oqparam']
-        self.imtls = oq.imtls
-        self.poes = self.poes or oq.poes
         if 'rlzs_by_grp' in self.dstore:
             self.rlzs_by_grp = self.dstore['rlzs_by_grp']
         else:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -200,35 +200,6 @@ class PmapGetter(object):
                         res[sid, rlz] = general.agg_probs(res[sid, rlz], poes)
         return res.reshape(self.N, self.R, self.M, -1)
 
-    def items(self, kind=''):
-        """
-        Extract probability maps from the datastore, possibly generating
-        on the fly the ones corresponding to the individual realizations.
-        Yields pairs (tag, pmap).
-
-        :param kind:
-            the kind of PoEs to extract; if not given, returns the realization
-            if there is only one or the statistics otherwise.
-        """
-        num_rlzs = len(self.weights)
-        if not kind or kind == 'all':  # use default
-            if 'hcurves' in self.dstore:
-                for k in sorted(self.dstore['hcurves']):
-                    yield k, self.dstore['hcurves/' + k][()]
-            elif num_rlzs == 1:
-                yield 'mean', self.get(0)
-            return
-        if 'poes' in self.dstore and kind in ('rlzs', 'all'):
-            for rlzi in range(num_rlzs):
-                hcurves = self.get(rlzi)
-                yield 'rlz-%03d' % rlzi, hcurves
-        elif 'poes' in self.dstore and kind.startswith('rlz-'):
-            yield kind, self.get(int(kind[4:]))
-        if 'hcurves' in self.dstore and kind == 'stats':
-            for k in sorted(self.dstore['hcurves']):
-                if not k.startswith('rlz'):
-                    yield k, self.dstore['hcurves/' + k][()]
-
     def get_mean(self, grp=None):
         """
         Compute the mean curve as a ProbabilityMap

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -69,7 +69,7 @@ def scenario_damage(riskinputs, param, monitor):
 
     `d_asset` and `d_tag` are related to the damage distributions.
     """
-    crmodel = monitor.read_pik('crmodel')
+    crmodel = monitor.read('crmodel')
     L = len(crmodel.loss_types)
     D = len(crmodel.damage_states)
     consequences = crmodel.get_consequences()

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -75,7 +75,7 @@ def scenario_risk(riskinputs, param, monitor):
         R the number of realizations  and statistics is an array of shape
         (n, R, 4), with n the number of assets in the current riskinput object
     """
-    crmodel = monitor.read_pik('crmodel')
+    crmodel = monitor.read('crmodel')
     E = param['E']
     L = len(crmodel.loss_types)
     result = dict(agg=numpy.zeros((E, L), F32), avg=[])

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -205,7 +205,8 @@ class ClassicalTestCase(CalculatorTestCase):
             case_11.__file__)
 
         # checking PmapGetter.get_pcurve
-        pgetter = PmapGetter(self.calc.datastore, self.calc.weights)
+        pgetter = PmapGetter(self.calc.datastore, self.calc.weights,
+                             self.calc.sitecol.sids, self.calc.oqparam.imtls)
         poes = pgetter.get_hcurves(pgetter.init())[0]
         mean = self.calc.datastore.sel('hcurves-stats', stat='mean', sid=0)
         mean2 = poes.T @ numpy.array([w['weight'] for w in self.calc.weights])

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -68,7 +68,10 @@ class DisaggregationTestCase(CalculatorTestCase):
         # disaggregation by source group
         rlzs = self.calc.datastore['full_lt'].get_realizations()
         ws = [rlz.weight for rlz in rlzs]
-        pgetter = getters.PmapGetter(self.calc.datastore, ws)
+        sids = self.calc.sitecol.sids
+        oq = self.calc.oqparam
+        pgetter = getters.PmapGetter(self.calc.datastore, ws, sids,
+                                     oq.imtls, oq.poes)
         pgetter.init()
         pmaps = []
         for grp in sorted(pgetter.dstore['poes']):

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -601,10 +601,11 @@ def view_global_hcurves(token, dstore):
     curves.
     """
     oq = dstore['oqparam']
-    nsites = len(dstore['sitecol'])
+    sitecol = dstore['sitecol']
+    nsites = len(sitecol)
     rlzs = dstore['full_lt'].get_realizations()
     weights = [rlz.weight for rlz in rlzs]
-    mean = getters.PmapGetter(dstore, weights).get_mean()
+    mean = getters.PmapGetter(dstore, weights, sitecol.sids).get_mean()
     array = calc.convert_to_array(mean, nsites, oq.imtls)
     res = numpy.zeros(1, array.dtype)
     for name in array.dtype.names:
@@ -729,7 +730,8 @@ def view_pmap(token, dstore):
     pmap = {}
     rlzs = dstore['full_lt'].get_realizations()
     weights = [rlz.weight for rlz in rlzs]
-    pgetter = getters.PmapGetter(dstore, weights)
+    pgetter = getters.PmapGetter(dstore, weights, dstore['sitecol'].sids,
+                                 dstore['oqparam'].imtls)
     pmap = pgetter.get_mean(grp)
     return str(pmap)
 

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -146,7 +146,8 @@ class RiskInput(object):
         hazard_getter = self.hazard_getter
         [sid] = hazard_getter.sids
         if haz is None:
-            haz = hazard_getter.get_hazard()
+            with monitor('getting hazard', measuremem=False):
+                haz = hazard_getter.get_hazard()
         if isinstance(haz, dict):  # scenario, event_based
             items = haz.items()
         else:  # list of length R, classical


### PR DESCRIPTION
A refactoring for event based risk (read the hazard from the workers -> read the hazard from the master, justified and wanted in that case) caused the same unwanted changed of logic even for classical_damage, classical_risk and classical_bcr. This is is performance disaster: 5 minutes of parallel processing of the PoEs became 26 hours of sequential processing of PoEs. Unfortunately the effect is visible only in large calculations so it cannot be caught by the current tests. The bug entered in engine 3.10 and was pointed out by EUCENTRE. Here is the solution.