### PR TITLE
Removed area_source_discretization from the sourcewriter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the sourcewriter to not save the `area_source_discretization`
   * Restored reading from the workers in classical_risk and classical_damage
   * Implemented `sensitivity_analysis`
   * Fixed an npz saving error in /extract/assets affecting the QGIS plugin

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -142,7 +142,7 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
             nodal_plane_distribution=npd,
             hypocenter_distribution=hd,
             polygon=polygon,
-            area_discretization=2,
+            area_discretization=1,
             temporal_occurrence_model=PoissonTOM(50.))
         return area
 

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -58,7 +58,7 @@ def build_area_source_geometry(area_source):
     lower_depth_node = Node(
         "lowerSeismoDepth", text=area_source.lower_seismogenic_depth)
     return Node(
-        "areaGeometry", {'discretization': area_source.area_discretization},
+        "areaGeometry",
         nodes=[polygon_node, upper_depth_node, lower_depth_node])
 
 

--- a/openquake/hazardlib/tests/expected_sources.toml
+++ b/openquake/hazardlib/tests/expected_sources.toml
@@ -73,7 +73,6 @@ magScaleRel = "PeerMSR"
 ruptAspectRatio = 1.5
 
 [areaSource.areaGeometry]
-_discretization = 2.0
 upperSeismoDepth = 0.0
 lowerSeismoDepth = 10.0
 

--- a/openquake/hazardlib/tests/source_model/mixed.xml
+++ b/openquake/hazardlib/tests/source_model/mixed.xml
@@ -105,9 +105,7 @@ xmlns:gml="http://www.opengis.net/gml"
             id="1"
             name="Quito"
             >
-                <areaGeometry
-                discretization="2.0"
-                >
+                <areaGeometry>
                     <gml:Polygon>
                         <gml:exterior>
                             <gml:LinearRing>


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6118.
The idea for the future is that the engine should be able to figure out the right area source discretization parameter, so it should not be hard-coded in the XML.