### PR TITLE
Avoid numpy warnings caused by log(0) in classical_damage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Avoided warnings in classical_damage due to PoE == 1
   * Changed the sourcewriter to not save the `area_source_discretization`
   * Restored reading from the workers in classical_risk and classical_damage
   * Implemented `sensitivity_analysis`

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -22,7 +22,6 @@ This module includes the scientific API of the oq-risklib
 import abc
 import copy
 import bisect
-import warnings
 import itertools
 import collections
 from functools import lru_cache
@@ -923,10 +922,9 @@ def annual_frequency_of_exceedence(poe, t_haz):
     :param t_haz: hazard investigation time
     :returns: array of frequencies (with +inf values where poe=1)
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        # avoid RuntimeWarning: divide by zero encountered in log
-        return - numpy.log(1. - poe) / t_haz
+    arr = 1. - poe
+    arr[arr == 0] = 1E-16  # cutoff to avoid log(0)
+    return - numpy.log(arr) / t_haz
 
 
 def classical_damage(


### PR DESCRIPTION
It happened to Murray:
```python
/home/michele/oq-engine/openquake/risklib/scientific.py:968: RuntimeWarning: invalid value encountered in matmul
```
The reason is that `annual_frequency_of_exceedence(poes, investigation_time)` contained NaN values due to PoEs==1 in
the formula  `- numpy.log(1-poes / t_haz)`