### PR TITLE
Refined tiling by not splitting the sources and not transferring the SiteCollection

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -71,11 +71,14 @@ def get_extreme_poe(array, imtls):
     return max(array[imtls(imt).stop - 1].max() for imt in imtls)
 
 
-def classical1(srcs, gsims, params, slc, monitor):
+def classical1(srcs, gsims, params, slc, monitor=None):
     """
     Read the SourceFilter, get the current slice of it (if tiling is
     enabled) and then call the classical calculator in hazardlib
     """
+    if monitor is None:  # fix mispassed parameters (for disagg_by_src)
+        monitor = slc
+        slc = slice(None)
     srcfilter = monitor.read('srcfilter')[slc]
     return classical(srcs, srcfilter, gsims, params, monitor)
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -72,6 +72,10 @@ def get_extreme_poe(array, imtls):
 
 
 def classical1(srcs, gsims, params, slc, monitor):
+    """
+    Read the SourceFilter, get the current slice of it (if tiling is
+    enabled) and then call the classical calculator in hazardlib
+    """
     srcfilter = monitor.read('srcfilter')[slc]
     return classical(srcs, srcfilter, gsims, params, monitor)
 


### PR DESCRIPTION
This should save memory at the expense of slow tasks. This indeed the case and the memory required by the master for the small SAM calculation on the spot machine goes down from 14_698 MB to 5_977 MB. Unfortunately, this does not solve the issue, since most on the memory is in the workers (for the contexts probably). The slow tasks are also ferocious, 90% of the total
computation time:
```
   calc_176                     time_sec memory_mb counts    
   ============================ ======== ========= ==========
   total classical1             136_597  726       484       
   composing pnes               55_797   0.0       38_293_174
   make_contexts                25_893   0.0       1_183_548 
   get_poes                     16_707   0.0       38_293_174
   computing mean_std           9_511    0.0       38_293_174
   total classical_split_filter 1_701    25        579       
   ClassicalCalculator.run      1_578    5_977     1
   
   operation-duration     mean    stddev  min     max     outputs
   classical1             282     175     0.01743 1_429   484    
   classical_split_filter 26      13      0.48608 59      64     
```
Part of https://github.com/gem/oq-engine/issues/6046.