### PR TITLE
Added a view extreme_gmvs

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -719,7 +719,7 @@ def view_extreme_gmvs(token, dstore):
     if ':' in token:
         maxgmv = float(token.split(':')[1])
     else:
-        maxgmv = 10
+        maxgmv = 10  # 10g is default value defining extreme GMVs
     imt0 = list(dstore['oqparam'].imtls)[0]
     if imt0.startswith(('PGA', 'SA(')):
         df = get_gmv0(dstore)


### PR DESCRIPTION
To see the events generating ground motion values > 10g (the default):
```
$ oq show extreme_gmvs 40931
          gmv_0  sid  rlz   rup
1564  10.166684    0    4   776
2575  10.455394   68    4  1360
1534  11.595870   13    4   750
888   11.630899  253    4   296
1766  11.766963  178    4   910
2575  12.970544   74    4  1360
4686  13.502361  189    4  2755
2551  13.816976   66    4  1343
4587  17.019506  161    4  2678
2551  17.739002  106    4  1343
```
To see the events generating ground motion values > 5g:
```
$ oq show extreme_gmvs:5 40931
...
```