### PR TITLE
Automatically remove duplicate source IDs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Internal: automatically convert the source IDs into unique IDs
   * Changed scenario calculations to depend on the `ses_seed`, not the
     `random_seed`
   * Added check on the versions of numpy, scipy and pandas between master and

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -541,7 +541,7 @@ def extract_sources(dstore, what):
     codes = qdict.get('code', None)
     if codes is not None:
         codes = [code.encode('utf8') for code in codes]
-    fields = 'source_id code multiplicity num_sites eff_ruptures'
+    fields = 'source_id code num_sites eff_ruptures'
     info = dstore['source_info'][()][fields.split()]
     wkt = dstore['source_wkt'][()]
     arrays = []

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -314,10 +314,8 @@ hazard_uhs-std.csv
              'hazard_curve-smltp_b2-gsimltp_b1-ltr_3.csv',
              'hazard_curve-smltp_b2-gsimltp_b1-ltr_4.csv'],
             case_17.__file__)
-        arr = self.calc.datastore['source_info'][:]
-        mul = dict(arr[['source_id', 'multiplicity']])
-        self.assertEqual(mul['A'], 2)  # different, multiplicity > 1
-        self.assertEqual(mul['B'], 1)  # duplicates
+        ids = self.calc.datastore['source_info']['source_id']
+        numpy.testing.assert_equal(ids, ['A;0', 'A;1', 'B'])
 
     def test_case_18(self):  # GMPEtable
         self.assert_curves_ok(

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -372,28 +372,15 @@ hazard_uhs-std.csv
         # there are 3 sources x 12 sm_rlzs
         [sg] = self.calc.csm.src_groups  # 1 source group with 7 sources
         self.assertEqual(len(sg), 7)
-        tbl = []
-        for src in sg:
-            tbl.append((src.source_id, src.checksum) + src.grp_ids)
-        tbl.sort()
-        '''
-        self.assertEqual(tbl,
-                         [['CHAR1', 1020111046, 2, 5, 8, 11],
-                          ['CHAR1', 1117683992, 0, 3, 6, 9],
-                          ['CHAR1', 1442321585, 1, 4, 7, 10],
-                          ['COMFLT1', 2221824602, 3, 4, 5, 9, 10, 11],
-                          ['COMFLT1', 3381942518, 0, 1, 2, 6, 7, 8],
-                          ['SFLT1', 4233779789, 6, 7, 8, 9, 10, 11],
-                          ['SFLT1', 4256912415, 0, 1, 2, 3, 4, 5]])
-        '''
         dupl = sum(len(src.grp_ids) - 1 for src in sg)
         self.assertEqual(dupl, 29)  # there are 29 duplicated sources
 
         # another way to look at the duplicated sources; protects against
         # future refactorings breaking the pandas readability of source_info
         df = self.calc.datastore.read_df('source_info', 'source_id')
-        dic = dict(df['multiplicity'])
-        self.assertEqual(dic, {'CHAR1': 3, 'COMFLT1': 2, 'SFLT1': 2})
+        numpy.testing.assert_equal(
+            list(df.index), ['CHAR1;0', 'CHAR1;1', 'CHAR1;2', 'COMFLT1;0',
+                             'COMFLT1;1', 'SFLT1;0', 'SFLT1;1'])
 
         # check pandas readability of hcurves-rlzs and hcurves-stats
         df = self.calc.datastore.read_df('hcurves-rlzs', 'lvl')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -156,7 +156,7 @@ def view_slow_sources(token, dstore, maxrows=20):
     """
     Returns the slowest sources
     """
-    info = dstore['source_info']['source_id', 'code', 'multiplicity',
+    info = dstore['source_info']['source_id', 'code',
                                  'calc_time', 'num_sites', 'eff_ruptures']
     info = info[info['eff_ruptures'] > 0]
     info.sort(order='calc_time')

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -263,8 +263,7 @@ class RunShowExportTestCase(unittest.TestCase):
 
         with Print.patch() as p:
             show('slow_sources', self.calc_id)
-        self.assertIn('source_id code multiplicity '
-                      'calc_time num_sites', str(p))
+        self.assertIn('source_id code calc_time num_sites', str(p))
 
     def test_show_attrs(self):
         with Print.patch() as p:
@@ -578,7 +577,7 @@ class ReduceSourceModelTestCase(unittest.TestCase):
         calc_id = calc.datastore.calc_id
         with mock.patch('logging.info') as info:
             reduce_sm(calc_id)
-        self.assertIn('there are duplicated source IDs', info.call_args[0][0])
+        self.assertIn('Removed %d/%d sources', info.call_args[0][0])
         shutil.rmtree(temp_dir)
 
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -977,7 +977,15 @@ tag2code = {'ar': b'A',
             'no': b'N'}
 
 
+# tested in commands_test
 def reduce_sm(paths, source_ids):
+    """
+    :param paths: list of source_model.xml files
+    :param source_ids: dictionary src_id -> array[src_id, code]
+    :returns: dictionary with keys good, total, model, path, xmlns
+
+    NB: duplicate sources are not removed from the XML
+    """
     if isinstance(source_ids, dict):  # in oq reduce_sm
         def ok(src_node):
             code = tag2code[re.search(r'\}(\w\w)', src_node.tag).group(1)]

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -68,15 +68,14 @@ source_info_dt = numpy.dtype([
     ('source_id', hdf5.vstr),          # 0
     ('gidx', numpy.uint16),            # 1
     ('code', (numpy.string_, 1)),      # 2
-    ('multiplicity', numpy.uint32),    # 3
-    ('calc_time', numpy.float32),      # 4
-    ('num_sites', numpy.uint32),       # 5
-    ('eff_ruptures', numpy.uint32),    # 6
-    ('checksum', numpy.uint32),        # 7
-    ('serial', numpy.uint32),          # 8
-    ('trti', numpy.uint8),             # 9
+    ('calc_time', numpy.float32),      # 3
+    ('num_sites', numpy.uint32),       # 4
+    ('eff_ruptures', numpy.uint32),    # 5
+    ('checksum', numpy.uint32),        # 6
+    ('serial', numpy.uint32),          # 7
+    ('trti', numpy.uint8),             # 8
 ])
-MULTIPLICITY, SERIAL = 3, 8
+SERIAL = 7
 
 
 class DuplicatedPoint(Exception):
@@ -754,14 +753,10 @@ def get_composite_source_model(oqparam, h5=None):
         if hasattr(sg, 'mags'):  # UCERF
             mags[sg.trt].update('%.2f' % mag for mag in sg.mags)
         for src in sg:
-            if src.source_id in data:
-                multiplicity = data[src.source_id][MULTIPLICITY] + 1
-            else:
-                multiplicity = 1
-                ns += 1
+            ns += 1
             src.gidx = gidx[tuple(src.grp_ids)]
             row = [src.source_id, src.gidx, src.code,
-                   multiplicity, 0, 0, 0, src.checksum, src.serial or ns,
+                   0, 0, 0, src.checksum, src.serial or ns,
                    full_lt.trti[src.tectonic_region_type]]
             wkts.append(src._wkt)  # this is a bit slow but okay
             data[src.source_id] = row

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -59,16 +59,15 @@ def read_source_model(fname, converter, monitor):
     return {fname: sm}
 
 
-def check_dupl_ids(smdict):
+def check_dupl_ids(src_groups):
     """
     Print a warning in case of duplicate source IDs referring to different
     sources
     """
     sources = general.AccumDict(accum=[])
-    for sm in smdict.values():
-        for sg in sm.src_groups:
-            for src in sg.sources:
-                sources[src.source_id].append(src)
+    for sg in src_groups:
+        for src in sg.sources:
+            sources[src.source_id].append(src)
     first = True
     for src_id, srcs in sources.items():
         if len(srcs) > 1:  # duplicate IDs must have all the same checksum
@@ -140,8 +139,8 @@ def get_csm(oq, full_lt, h5=None):
                               h5=h5 if h5 else None).reduce()
     if len(smdict) > 1:  # really parallel
         parallel.Starmap.shutdown()  # save memory
-    check_dupl_ids(smdict)
     groups = _build_groups(full_lt, smdict)
+    check_dupl_ids(groups)
 
     # checking the changes
     changes = sum(sg.changes for sg in groups)

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -140,7 +140,6 @@ def get_csm(oq, full_lt, h5=None):
     if len(smdict) > 1:  # really parallel
         parallel.Starmap.shutdown()  # save memory
     groups = _build_groups(full_lt, smdict)
-    check_dupl_ids(groups)
 
     # checking the changes
     changes = sum(sg.changes for sg in groups)
@@ -251,6 +250,7 @@ def _get_csm(full_lt, groups):
             src._wkt = src.wkt()
             idx += 1
     src_groups.extend(atomic)
+    check_dupl_ids(src_groups)
     return CompositeSourceModel(full_lt, src_groups)
 
 


### PR DESCRIPTION
See for instance classical/case_17: there are two different sources with the same source ID there ("A"): the solution is to introduce two different source IDs "A;0" and "A;1" so that it is possible to store information by source ID without confusions.

NB: if you want to use applyToSources you must still make sure that the source ID is unique, applyToSource="A;0" would not work (and I do not want it to work: it would be too magic). See also case_11 where applyToSource="1" produces three different sources "1;0", "1;1", "1;2" with different values of maxMagGRRelative, or case_20 where 3 original sources becomes 36 duplicated sources and then 7 unique sources.