### PR TITLE
Fixed prepare_site_model bug with grid spacing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a bug in `oq prepare_site_model` when sites.csv is
+    the same as the vs30.csv file and there is a grid spacing
   * Speeding up the preclassical calculator
   * Added an entry point /extract/eids_by_gsim for the QGIS plugin
   * Internal: automatically convert the source IDs into unique IDs

--- a/openquake/commands/prepare_site_model.py
+++ b/openquake/commands/prepare_site_model.py
@@ -144,7 +144,7 @@ def prepare_site_model(exposure_xml, sites_csv, vs30_csv,
             haz_sitecol = site.SiteCollection.from_points(
                 lons, lats, req_site_params=req_site_params)
             if grid_spacing:
-                grid = mesh.get_convex_hull().dilate(
+                grid = haz_sitecol.mesh.get_convex_hull().dilate(
                     grid_spacing).discretize(grid_spacing)
                 haz_sitecol = site.SiteCollection.from_points(
                     grid.lons, grid.lats, req_site_params=req_site_params)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -562,6 +562,10 @@ class PrepareSiteModelTestCase(unittest.TestCase):
         sc = prepare_site_model([], [vs30_csv], [vs30_csv],
                                 True, True, False, 0, 5, output)
 
+        # test sites_csv == vs30_csv and grid spacing
+        sc = prepare_site_model([], [vs30_csv], [vs30_csv],
+                                True, True, False, 10, 5, output)
+
 
 class ReduceSourceModelTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Signaled by Partner RE. They use `oq prepare_site_model` to generate a grid:
```
$ oq prepare_site_model Turkey.csv -s Turkey.csv --z1pt0 --z2pt5 --grid-spacing=10 --output site_model.csv
```
