### PR TITLE
Changed the poes storage - 3

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -543,12 +543,14 @@ class HazardCalculator(BaseCalculator):
             self.datastore['sitecol'] = self.sitecol
             self.datastore['assetcol'] = self.assetcol
             self.datastore['full_lt'] = fake = logictree.FullLogicTree.fake()
+            self.datastore['rlzs_by_grp'] = fake.get_rlzs_by_grp()
             with hdf5.File(self.datastore.tempname, 'a') as t:
                 t['oqparam'] = oq
                 t['rlzs_by_grp'] = fake.get_rlzs_by_grp()
                 t['_poes'] = poes
             self.realizations = fake.get_realizations()
             self.save_crmodel()
+            self.datastore.swmr_on()
         elif oq.hazard_calculation_id:
             parent = util.read(oq.hazard_calculation_id)
             self.check_precalc(parent['oqparam'].calculation_mode)
@@ -998,7 +1000,7 @@ class RiskCalculator(HazardCalculator):
             if self.oqparam.hazard_calculation_id:
                 dstore = self.datastore.parent
             elif kind == 'poe':
-                dstore = self.datastore.tempname
+                dstore = self.datastore
             else:
                 dstore = self.datastore
             meth = getattr(self, '_gen_riskinputs_' + kind)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -546,8 +546,6 @@ class HazardCalculator(BaseCalculator):
             self.datastore['rlzs_by_grp'] = fake.get_rlzs_by_grp()
             with hdf5.File(self.datastore.tempname, 'a') as t:
                 t['oqparam'] = oq
-                t['rlzs_by_grp'] = fake.get_rlzs_by_grp()
-                t['_poes'] = poes
             self.realizations = fake.get_realizations()
             self.save_crmodel()
             self.datastore.swmr_on()
@@ -999,8 +997,6 @@ class RiskCalculator(HazardCalculator):
         with self.monitor('building riskinputs'):
             if self.oqparam.hazard_calculation_id:
                 dstore = self.datastore.parent
-            elif kind == 'poe':
-                dstore = self.datastore
             else:
                 dstore = self.datastore
             meth = getattr(self, '_gen_riskinputs_' + kind)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -540,8 +540,6 @@ class ClassicalCalculator(base.HazardCalculator):
         oq = self.oqparam
         rlzs_by_grp = self.full_lt.get_rlzs_by_grp()
         slice_by_grp = getters.get_slice_by_grp(rlzs_by_grp)
-        G_ = sum(len(vals) for vals in rlzs_by_grp.values())
-        poes_shape = (self.N, len(oq.imtls.array), G_)
         data = []
         weights = [rlz.weight for rlz in self.realizations]
         pgetter = getters.PmapGetter(

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -576,7 +576,6 @@ class ClassicalCalculator(base.HazardCalculator):
         if oq.hazard_calculation_id is None and '_poes' in self.datastore:
             self.datastore['disagg_by_grp'] = numpy.array(
                 sorted(data), grp_extreme_dt)
-            self.datastore.swmr_on()
             self.calc_stats()
 
     def calc_stats(self):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -375,6 +375,7 @@ class ClassicalCalculator(base.HazardCalculator):
         size = numpy.prod(poes_shape) * 8
         logging.info('Required %s for the ProbabilityMaps', humansize(size))
         self.datastore['rlzs_by_grp'] = rlzs_by_grp
+        self.datastore.create_dset('_poes', F64, poes_shape)
         self.datastore.swmr_on()
         smap.h5 = self.datastore.hdf5
         self.calc_times = AccumDict(accum=numpy.zeros(3, F32))
@@ -541,7 +542,6 @@ class ClassicalCalculator(base.HazardCalculator):
         slice_by_grp = getters.get_slice_by_grp(rlzs_by_grp)
         G_ = sum(len(vals) for vals in rlzs_by_grp.values())
         poes_shape = (self.N, len(oq.imtls.array), G_)
-        dset = self.datastore.create_dset('_poes', F64, poes_shape)
         if oq.calculation_mode.endswith(('risk', 'damage', 'bcr')):
             with hdf5.File(self.datastore.tempname, 'a') as cache:
                 cache['oqparam'] = oq
@@ -565,7 +565,7 @@ class ClassicalCalculator(base.HazardCalculator):
                     base.fix_ones(pmap)  # avoid saving PoEs == 1
                     arr = pmap.array(self.N)
                     slc = slice_by_grp['grp-%02d' % key]
-                    dset[:, :, slc] = arr
+                    self.datastore['_poes'][:, :, slc] = arr
                     if oq.calculation_mode.endswith(('risk', 'damage', 'bcr')):
                         with hdf5.File(self.datastore.tempname, 'a') as cache:
                             cache['_poes'][:, :, slc] = arr


### PR DESCRIPTION
Last pull request. After the work in the previous two PRs we can finally remove the duplication of the poes, a workaround due to an incorrect usage of the SWMR mode. Now the `_poes` dataset is created in advance and everything works.