### PR TITLE
Fixed zero hmaps for individual_curves=true

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -699,6 +699,9 @@ def build_hazard(pgetter, N, hstats, individual_curves,
     pmap_by_kind = {}
     if R > 1 and individual_curves or not hstats:
         pmap_by_kind['hcurves-rlzs'] = [ProbabilityMap(L) for r in range(R)]
+        if poes:
+            pmap_by_kind['hmaps-rlzs'] = [
+                ProbabilityMap(M, P) for r in range(R)]
     if hstats:
         pmap_by_kind['hcurves-stats'] = [ProbabilityMap(L) for r in range(S)]
         if poes:
@@ -727,6 +730,7 @@ def build_hazard(pgetter, N, hstats, individual_curves,
                 for pmap, pc in zip(pmap_by_kind['hcurves-rlzs'], pcurves):
                     pmap[sid] = pc
                 if poes:
-                    pmap_by_kind['hmaps-rlzs'] = [
-                        calc.make_hmap(pc, imtls, poes, sid) for pc in pcurves]
+                    for r, pc in enumerate(pcurves):
+                        hmap = calc.make_hmap(pc, imtls, poes, sid)
+                        pmap_by_kind['hmaps-rlzs'][r].update(hmap)
     return pmap_by_kind

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -162,8 +162,10 @@ class ClassicalTestCase(CalculatorTestCase):
              'hazard_curve-smltp_b2-gsimltp_b1.csv'],
             case_7.__file__)
 
-        # exercising extract/mean_std_curves
-        # extract(self.calc.datastore, 'mean_std_curves')
+        # checking the individual hazard maps are nonzero
+        iml = self.calc.datastore.sel(
+            'hmaps-rlzs', imt="PGA", site_id=0).squeeze()
+        aac(iml, [.2, .2])  # for the two realizations
 
         # exercise the warning for no output when mean_hazard_curves='false'
         self.run_calc(

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -165,7 +165,7 @@ class ClassicalTestCase(CalculatorTestCase):
         # checking the individual hazard maps are nonzero
         iml = self.calc.datastore.sel(
             'hmaps-rlzs', imt="PGA", site_id=0).squeeze()
-        aac(iml, [.2, .2])  # for the two realizations
+        aac(iml, [0.167078, 0.134646], atol=.0001)  # for the two realizations
 
         # exercise the warning for no output when mean_hazard_curves='false'
         self.run_calc(

--- a/openquake/qa_tests_data/classical/case_7/job.ini
+++ b/openquake/qa_tests_data/classical/case_7/job.ini
@@ -44,4 +44,4 @@ maximum_distance = 200.0
 
 individual_curves = true
 mean = true
-poes = .001
+poes = .5

--- a/openquake/qa_tests_data/classical/case_7/job.ini
+++ b/openquake/qa_tests_data/classical/case_7/job.ini
@@ -44,5 +44,4 @@ maximum_distance = 200.0
 
 individual_curves = true
 mean = true
-quantile_hazard_curves =
-poes =
+poes = .001


### PR DESCRIPTION
It never worked in the case of more than 1 site, but nobody ever discovered that befor Jin Ma: see https://groups.google.com/g/openquake-users/c/2pq2qrZ4L-g/m/86Gjf6ujBwAJ.
The statistics instead have always been correct.