### PR TITLE
Saving memory and reducing slow tasks in calculations with large src_multiplicity

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -448,6 +448,8 @@ class ClassicalCalculator(base.HazardCalculator):
         max_num_gsims = max(len(gsims) for gsims in gsims_by_trt.values())
         max_num_grp_ids = max(
             len(grp_ids) for grp_ids in self.datastore['grp_ids'])
+        if max_num_grp_ids > 2:
+            logging.warning('max_num_grp_ids=%d', max_num_grp_ids)
         num_levels = len(oq.imtls.array)
         pmapbytes = T * num_levels * max_num_gsims * max_num_grp_ids * 8
         if pmapbytes > TWO32:
@@ -486,6 +488,7 @@ class ClassicalCalculator(base.HazardCalculator):
                         if oq.disagg_by_src
                         else block_splitter(sg, 2 * max_weight * ntiles,
                                             operator.attrgetter('weight'),
+                                            key=operator.attrgetter('grp_id'),
                                             sort=True))
                 blocks = list(blks)
                 nb = len(blocks)

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -60,7 +60,8 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
                 self.hypocenter_distribution.data)
         else:
             rescale = 1
-        return self.num_ruptures * self.ngsims * nsites_factor / rescale
+        g = len(self.grp_ids)
+        return self.num_ruptures * self.ngsims * nsites_factor * g / rescale
 
     @property
     def grp_ids(self):


### PR DESCRIPTION
Such as the ZAF model. The improvement is spectacular, we use less than half the memory and the slowest task is more than twice as fast. Here are the figures with OQ_SAMPLE_SOURCES=.1:
```
# master
total runtime: 4_111s
max memory per core: 2_040M
slowest task: 2_270s

# this branch
total runtime: 3_598s
max memory per core: 786M
slowest task: 954s
```