### PR TITLE
Huge improvement in classical calculations with src_multiplicity

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Huge speedup in models with src_multicity > 1
+  * Huge speedup in models with src_multiplicity > 1
   * Fixed bug in source model logic tree sampling with more than 2 branchsets
   * Fixed hazard maps all zeros for individual_curves=true and more than 1 site
   * Fixed a bug in `oq prepare_site_model` when sites.csv is

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Huge speedup in models with src_multicity > 1
   * Fixed bug in source model logic tree sampling with more than 2 branchsets
   * Fixed hazard maps all zeros for individual_curves=true and more than 1 site
   * Fixed a bug in `oq prepare_site_model` when sites.csv is

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -492,7 +492,6 @@ class ClassicalCalculator(base.HazardCalculator):
                     smap.submit((block, gsims, param), f2)
 
             w = sum(src.weight for src in sg)
-            logging.info('TRT = %s', sg.trt)
             it = sorted(oq.maximum_distance.ddic[sg.trt].items())
             md = '%s->%d ... %s->%d' % (it[0] + it[-1])
             logging.info('max_dist={}, gsims={}, weight={:_d}, blocks={}'.

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -335,7 +335,7 @@ class ClassicalCalculator(base.HazardCalculator):
             for sg in self.csm.src_groups:
                 if not sg.atomic:
                     srcs = [src for src in sg if src.nsites]
-                    sg.sources = srcs[0]
+                    sg.sources = [srcs[0]]
 
         mags = self.datastore['source_mags']  # by TRT
         if len(mags) == 0:  # everything was discarded

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -198,8 +198,8 @@ class ClassicalCalculator(base.HazardCalculator):
             return acc
         if self.oqparam.disagg_by_src:
             # store the poes for the given source
-            acc[extra['source_id']] = {
-                grp_id: pmap for grp_id in extra['grp_ids']}
+            pmap.grp_ids = extra['grp_ids']
+            acc[extra['source_id']] = pmap
 
         trt = extra.pop('trt')
         self.maxradius = max(self.maxradius, extra.pop('maxradius'))

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -165,14 +165,14 @@ class PmapGetter(object):
                 pcurves[rlzi] |= c
         return pcurves
 
-    def get_hcurves(self, pmap_by_grp_id, rlzs_by_grp):  # in disagg_by_src
+    def get_hcurves(self, pmap, rlzs_by_grp):  # in disagg_by_src
         """
         :param pmap_by_grp_id: a dictionary of ProbabilityMaps by group ID
         :returns: an array of PoEs of shape (N, R, M, L)
         """
         self.init()
         res = numpy.zeros((self.N, self.R, self.L))
-        for grp_id, pmap in pmap_by_grp_id.items():
+        for grp_id in pmap.grp_ids:
             rlzs = rlzs_by_grp['grp-%02d' % grp_id]
             for sid, pc in pmap.items():
                 for gsim_idx, rlzis in enumerate(rlzs):

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -304,7 +304,7 @@ hazard_uhs-std.csv
              'hazard_curve-smltp_b2-gsimltp_b1-ltr_4.csv'],
             case_17.__file__)
         ids = self.calc.datastore['source_info']['source_id']
-        numpy.testing.assert_equal(ids, ['A;0', 'A;1', 'B'])
+        numpy.testing.assert_equal(ids, ['A;0', 'B', 'A;1'])
 
     def test_case_18(self):  # GMPEtable
         self.assert_curves_ok(
@@ -359,17 +359,17 @@ hazard_uhs-std.csv
             'hazard_curve-smltp_sm1_sg2_cog2_char_simple-gsimltp_Sad1997.csv'],
             case_20.__file__, delta=1E-7)
         # there are 3 sources x 12 sm_rlzs
-        [sg] = self.calc.csm.src_groups  # 1 source group with 7 sources
-        self.assertEqual(len(sg), 7)
-        dupl = sum(len(src.grp_ids) - 1 for src in sg)
+        sgs = self.calc.csm.src_groups  # 7 source groups with 1 source each
+        self.assertEqual(len(sgs), 7)
+        dupl = sum(len(sg.sources[0].grp_ids) - 1 for sg in sgs)
         self.assertEqual(dupl, 29)  # there are 29 duplicated sources
 
         # another way to look at the duplicated sources; protects against
         # future refactorings breaking the pandas readability of source_info
         df = self.calc.datastore.read_df('source_info', 'source_id')
         numpy.testing.assert_equal(
-            list(df.index), ['CHAR1;0', 'CHAR1;1', 'CHAR1;2', 'COMFLT1;0',
-                             'COMFLT1;1', 'SFLT1;0', 'SFLT1;1'])
+            list(df.index), ['SFLT1;0', 'COMFLT1;0', 'CHAR1;0', 'CHAR1;1',
+                             'CHAR1;2', 'COMFLT1;1', 'SFLT1;1'])
 
         # check pandas readability of hcurves-rlzs and hcurves-stats
         df = self.calc.datastore.read_df('hcurves-rlzs', 'lvl')

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -736,8 +736,7 @@ def get_composite_source_model(oqparam, h5=None):
             ns += 1
             src.gidx = gidx[tuple(src.grp_ids)]
             row = [src.source_id, src.gidx, src.code,
-                   0, 0, 0, src.serial or ns,
-                   full_lt.trti[src.tectonic_region_type]]
+                   0, 0, 0, ns, full_lt.trti[src.tectonic_region_type]]
             wkts.append(src._wkt)  # this is a bit slow but okay
             data[src.source_id] = row
             if hasattr(src, 'mags'):  # UCERF

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -718,14 +718,13 @@ def get_composite_source_model(oqparam, h5=None):
          an open hdf5.File where to store the source info
     """
     full_lt = get_full_lt(oqparam)
+    full_lt.ses_seed = oqparam.ses_seed if oqparam.is_event_based() else 0
     if oqparam.cachedir and not oqparam.is_ucerf():
         csm = _get_cachedir(oqparam, full_lt, h5)
     else:
         csm = get_csm(oqparam, full_lt,  h5)
     grp_ids = csm.get_grp_ids()
     gidx = {tuple(arr): i for i, arr in enumerate(grp_ids)}
-    if oqparam.is_event_based():
-        csm.init_serials(oqparam.ses_seed)
     data = {}  # src_id -> row
     mags = AccumDict(accum=set())  # trt -> mags
     wkts = []

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -718,7 +718,6 @@ def get_composite_source_model(oqparam, h5=None):
          an open hdf5.File where to store the source info
     """
     full_lt = get_full_lt(oqparam)
-    full_lt.ses_seed = oqparam.ses_seed if oqparam.is_event_based() else 0
     if oqparam.cachedir and not oqparam.is_ucerf():
         csm = _get_cachedir(oqparam, full_lt, h5)
     else:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -746,8 +746,9 @@ def get_composite_source_model(oqparam, h5=None):
                 srcmags = ['%.2f' % item[0] for item in
                            src.get_annual_occurrence_rates()]
             mags[sg.trt].update(srcmags)
-    logging.info('There are %d sources with len(grp_ids)=%.1f',
-                 sum(len(sg) for sg in csm.src_groups), numpy.mean(lens))
+    logging.info('There are %d groups and %d sources with len(grp_ids)=%.1f',
+                 len(csm.src_groups), sum(len(sg) for sg in csm.src_groups),
+                 numpy.mean(lens))
     if h5:
         attrs = dict(atomic=any(grp.atomic for grp in csm.src_groups))
         # avoid hdf5 damned bug by creating source_info in advance

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -728,15 +728,15 @@ def get_composite_source_model(oqparam, h5=None):
     data = {}  # src_id -> row
     mags = AccumDict(accum=set())  # trt -> mags
     wkts = []
-    ns = -1
+    lens = []
     for sg in csm.src_groups:
         if hasattr(sg, 'mags'):  # UCERF
             mags[sg.trt].update('%.2f' % mag for mag in sg.mags)
         for src in sg:
-            ns += 1
+            lens.append(len(src.grp_ids))
             src.gidx = gidx[tuple(src.grp_ids)]
             row = [src.source_id, src.gidx, src.code,
-                   0, 0, 0, ns, full_lt.trti[src.tectonic_region_type]]
+                   0, 0, 0, src.id, full_lt.trti[src.tectonic_region_type]]
             wkts.append(src._wkt)  # this is a bit slow but okay
             data[src.source_id] = row
             if hasattr(src, 'mags'):  # UCERF
@@ -747,7 +747,8 @@ def get_composite_source_model(oqparam, h5=None):
                 srcmags = ['%.2f' % item[0] for item in
                            src.get_annual_occurrence_rates()]
             mags[sg.trt].update(srcmags)
-    logging.info('There are %d sources', ns + 1)
+    logging.info('There are %d sources with len(grp_ids)=%.1f',
+                 sum(len(sg) for sg in csm.src_groups), numpy.mean(lens))
     if h5:
         attrs = dict(atomic=any(grp.atomic for grp in csm.src_groups))
         # avoid hdf5 damned bug by creating source_info in advance

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -281,6 +281,7 @@ class CompositeSourceModel:
         self.src_groups = src_groups
         idx = 0
         for sg in src_groups:
+            assert len(sg)  # sanity check
             for src in sg:
                 src.id = idx
                 idx += 1

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -238,12 +238,13 @@ def _get_csm(full_lt, groups):
                 src._wkt = src.wkt()
                 idx += 1
                 lst.append(src)
-        if serial:  # only for event based
+        if full_lt.ses_seed:  # only for event based
             serial = init_serials(lst, serial)
         for grp in general.groupby(lst, grp_ids).values():
             src_groups.append(sourceconverter.SourceGroup(trt, grp))
     for ag in atomic:
-        serial = init_serials(ag.sources, serial)
+        if full_lt.ses_seed:  # only for event based
+            serial = init_serials(ag.sources, serial)
         for src in ag:
             src.id = idx
             src._wkt = src.wkt()

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -243,6 +243,7 @@ def _get_csm(full_lt, groups):
         for grp in general.groupby(lst, grp_ids).values():
             src_groups.append(sourceconverter.SourceGroup(trt, grp))
     for ag in atomic:
+        serial = init_serials(ag.sources, serial)
         for src in ag:
             src.id = idx
             src._wkt = src.wkt()

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -100,6 +100,7 @@ def get_csm(oq, full_lt, h5=None):
     logging.info('%d effective smlt realization(s)', len(full_lt.sm_rlzs))
     classical = not oq.is_event_based()
     if oq.is_ucerf():
+        serial = full_lt.ses_seed
         [grp] = nrml.to_python(oq.inputs["source_model"], converter)
         src_groups = []
         for grp_id, sm_rlz in enumerate(full_lt.sm_rlzs):
@@ -117,6 +118,7 @@ def get_csm(oq, full_lt, h5=None):
                 sg.sources.extend(src.get_background_sources())
             else:  # event_based, use one source
                 sg.sources = [src]
+                serial = init_serials(sg, serial)
         return CompositeSourceModel(full_lt, src_groups)
 
     logging.info('Reading the source model(s) in parallel')
@@ -225,7 +227,6 @@ def _get_csm(full_lt, groups):
         elif grp:
             acc[grp.trt].extend(grp)
     key = operator.attrgetter('source_id', 'code')
-    idx = 0
     src_groups = []
     serial = full_lt.ses_seed
     for trt in acc:
@@ -234,9 +235,7 @@ def _get_csm(full_lt, groups):
             if len(srcs) > 1:
                 srcs = reduce_sources(srcs)
             for src in srcs:
-                src.id = idx
                 src._wkt = src.wkt()
-                idx += 1
                 lst.append(src)
         if full_lt.ses_seed:  # only for event based
             serial = init_serials(lst, serial)
@@ -246,9 +245,7 @@ def _get_csm(full_lt, groups):
         if full_lt.ses_seed:  # only for event based
             serial = init_serials(ag.sources, serial)
         for src in ag:
-            src.id = idx
             src._wkt = src.wkt()
-            idx += 1
     src_groups.extend(atomic)
     _check_dupl_ids(src_groups)
     return CompositeSourceModel(full_lt, src_groups)
@@ -281,6 +278,11 @@ class CompositeSourceModel:
         self.sm_rlzs = full_lt.sm_rlzs
         self.full_lt = full_lt
         self.src_groups = src_groups
+        idx = 0
+        for sg in src_groups:
+            for src in sg:
+                src.id = idx
+                idx += 1
 
     def get_grp_ids(self):
         """

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -99,6 +99,7 @@ def get_csm(oq, full_lt, h5=None):
         not spinning_off, oq.source_id, discard_trts=oq.discard_trts)
     logging.info('%d effective smlt realization(s)', len(full_lt.sm_rlzs))
     classical = not oq.is_event_based()
+    full_lt.ses_seed = 0 if classical else oq.ses_seed
     if oq.is_ucerf():
         serial = full_lt.ses_seed
         [grp] = nrml.to_python(oq.inputs["source_model"], converter)

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -32,6 +32,10 @@ TWO16 = 2 ** 16  # 65,536
 by_id = operator.attrgetter('source_id')
 
 
+def grp_ids(src):
+    return tuple(src.grp_ids)
+
+
 def random_filtered_sources(sources, srcfilter, seed):
     """
     :param sources: a list of sources
@@ -233,7 +237,8 @@ def _get_csm(full_lt, groups):
                 src._wkt = src.wkt()
                 idx += 1
                 lst.append(src)
-        src_groups.append(sourceconverter.SourceGroup(trt, lst))
+        for grp in general.groupby(lst, grp_ids).values():
+            src_groups.append(sourceconverter.SourceGroup(trt, grp))
     for ag in atomic:
         for src in ag:
             src.id = idx

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -733,13 +733,15 @@ Subduction Interface,b3,[SadighEtAl1997],w=1.0>''')
         oqparam.number_of_logic_tree_samples = 0
         csm = readinput.get_composite_source_model(oqparam)
         self.assertEqual(len(csm.sm_rlzs), 9)  # example with 1 x 3 x 3 paths
-        # there are 2 distinct tectonic region types, so 2 src_groups
-        self.assertEqual(sum(1 for tm in csm.src_groups), 2)
+        # there are 2 distinct tectonic region types and 18 src_groups
+        self.assertEqual(sum(1 for tm in csm.src_groups), 18)
 
         rlzs = csm.full_lt.get_realizations()
         self.assertEqual(len(rlzs), 18)  # the gsimlt has 1 x 2 paths
         # counting the sources in each TRT model (after splitting)
-        self.assertEqual([9, 18], list(map(len, csm.src_groups)))
+        self.assertEqual(
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+            list(map(len, csm.src_groups)))
 
     def test_oversampling(self):
         from openquake.qa_tests_data.classical import case_17

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -113,10 +113,11 @@ def classical(group, src_filter, gsims, param, monitor=Monitor()):
     extra['task_no'] = getattr(monitor, 'task_no', 0)
     extra['trt'] = trt
     extra['source_id'] = src.source_id
+    extra['grp_ids'] = src.grp_ids
     extra['maxradius'] = maxradius
     group_probability = getattr(group, 'grp_probability', None)
     if src_mutex and group_probability:
-        pmap[src.grp_id] *= group_probability
+        pmap *= group_probability
 
     if cluster:
         tom = getattr(group, 'temporal_occurrence_model')

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -199,8 +199,7 @@ def calc_hazard_curves(
                 classical, (group.sources, srcfilter, [gsim], param),
                 weight=operator.attrgetter('weight'))
         for dic in it:
-            for grp_id, pval in dic['pmap'].items():
-                pmap |= pval
+            pmap |= dic['pmap']
     sitecol = getattr(srcfilter, 'sitecol', srcfilter)
     return pmap.convert(imtls, len(sitecol.complete))
 
@@ -218,7 +217,6 @@ def calc_hazard_curve(site1, src, gsims_by_trt, oqparam):
     gsims = gsims_by_trt['*'] if '*' in gsims_by_trt else gsims_by_trt[trt]
     cmaker = ContextMaker(trt, gsims, vars(oqparam))
     srcfilter = SourceFilter(site1, oqparam.maximum_distance)
-    pmap_by_grp, rup_data, calc_times, extra = PmapMaker(
+    pmap, rup_data, calc_times, extra = PmapMaker(
         cmaker, srcfilter, [src]).make()
-    pmap = pmap_by_grp[src.grp_ids[0]]
     return pmap[0]  # pcurve with shape (L, G)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -45,7 +45,7 @@ the engine manages all the realizations at once.
 import operator
 from openquake.baselib.performance import Monitor
 from openquake.baselib.parallel import sequential_apply
-from openquake.baselib.general import DictArray, groupby, AccumDict
+from openquake.baselib.general import DictArray, groupby
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.gsim.base import ContextMaker, PmapMaker
 from openquake.hazardlib.calc.filters import SourceFilter
@@ -58,7 +58,7 @@ def _cluster(imtls, tom, gsims, pmap):
     Computes the probability map in case of a cluster group
     """
     L, G = len(imtls.array), len(gsims)
-    pmapclu = AccumDict(accum=ProbabilityMap(L, G))
+    pmapclu = ProbabilityMap(L, G)
     # Get temporal occurrence model
     # Number of occurrences for the cluster
     first = True
@@ -68,10 +68,10 @@ def _cluster(imtls, tom, gsims, pmap):
         ocr = tom.occurrence_rate
         prob_n_occ = tom.get_probability_n_occurrences(ocr, nocc)
         if first:
-            pmapclu = prob_n_occ * (~pmap)**nocc
+            pmapclu = (~pmap)**nocc * prob_n_occ
             first = False
         else:
-            pmapclu += prob_n_occ * (~pmap)**nocc
+            pmapclu += (~pmap)**nocc * prob_n_occ
     pmap = ~pmapclu
     return pmap
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -353,7 +353,6 @@ class ContextMaker(object):
             ctx.sids = r_sites.sids
             for par in self.REQUIRES_DISTANCES | {'rrup'}:
                 setattr(ctx, par, getattr(dctx, par))
-            ctx.grp_ids = grp_ids
             ctx.gidx = gidx
             if fewsites:
                 closest = rup.surface.get_closest_points(sites.complete)

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -60,8 +60,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
                 self.hypocenter_distribution.data)
         else:
             rescale = 1
-        g = len(self.grp_ids)
-        return self.num_ruptures * self.ngsims * nsites_factor * g / rescale
+        return self.num_ruptures * self.ngsims * nsites_factor / rescale
 
     @property
     def grp_ids(self):

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -106,7 +106,7 @@ class HazardCurvesTestCase01(unittest.TestCase):
                                     self.gsim_by_trt,
                                     truncation_level=None)
         crv = curves[0][0]
-        self.assertAlmostEqual(0.3, crv[0])
+        npt.assert_almost_equal([0.30000, 0.2646, 0.0625], crv, decimal=4)
 
     def test_hazard_curve_A(self):
         # Test back-compatibility
@@ -116,8 +116,8 @@ class HazardCurvesTestCase01(unittest.TestCase):
                                     self.imtls,
                                     self.gsim_by_trt,
                                     truncation_level=None)
-        crv = curves[0][0]
-        npt.assert_almost_equal(numpy.array([0.30000, 0.2646, 0.0625]),
+        crv = list(curves[0][0])
+        npt.assert_almost_equal([0.30000, 0.2646, 0.0625],
                                 crv, decimal=4)
 
     def test_hazard_curve_B(self):
@@ -158,7 +158,7 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
                      grp_probability=group.grp_probability)
         crv = classical(group, self.sites, gsim_by_trt, param)['pmap'][0]
         npt.assert_almost_equal(numpy.array([0.35000, 0.32497, 0.10398]),
-                                crv[0].array[:, 0], decimal=4)
+                                crv.array[:, 0], decimal=4)
 
     def test_raise_error_non_uniform_group(self):
         # Test that the uniformity of a group (in terms of tectonic region)

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -97,9 +97,8 @@ class CollapseTestCase(unittest.TestCase):
                              collapse_level=2))
         pmap = res['pmap']
         effrups = sum(nr for nr, ns, dt in res['calc_times'].values())
-        curves = [pmap[grp_id].array(N)[0, :, 0] for grp_id in sorted(pmap)]
-        mean = numpy.average(curves, axis=0, weights=weights)
-        return mean, srcs, effrups, weights
+        curve = pmap.array(N)[0, :, 0]
+        return curve, srcs, effrups, weights
 
     # this tests also the collapsing of the ruptures happening in contexts.py
     def test_point_source_full_enum(self):

--- a/openquake/qa_tests_data/event_based/case_15/expected/ruptures.csv
+++ b/openquake/qa_tests_data/event_based/case_15/expected/ruptures.csv
@@ -1,4 +1,4 @@
-#,,,,,,,,,"generated_by='OpenQuake engine 3.8.0-git784eb9b41c', start_date='2019-11-21T05:37:52', checksum=2896463652, investigation_time=50.0, ses_per_logic_tree_path=1"
+#,,,,,,,,,"generated_by='OpenQuake engine 3.11.0-git62e51e85e5', start_date='2020-10-27T07:51:35', checksum=2710180929, investigation_time=50.0, ses_per_logic_tree_path=1"
 rup_id,multiplicity,mag,centroid_lon,centroid_lat,centroid_depth,trt,strike,dip,rake
 0,1,5.100000E+00,1.459040E+02,4.339700E+01,5.200000E+01,Subduction Interface - North East Correction,2.417376E+02,3.441956E+01,9.000000E+01
 1,1,7.900000E+00,1.460250E+02,4.289000E+01,2.580000E+01,Subduction Interface - North East Correction,NAN,NAN,9.000000E+01


### PR DESCRIPTION
For ZAF we are using 370x less memory and the speed in "composing poes" increases by 42x. This is expected to improve also models like EUR, CAN, AUS etc (the improvement will be very small if the number of sources with src_multiplicity>1 is small).
```
# before
operation-duration     outputs mean    stddev min     max    
classical1             931     294     66%    1.88434 954    
classical_split_filter 186     200     90%    3.44867 881    
calc_355                     time_sec memory_mb counts   
============================ ======== ========= =========
total classical1             274_293  776       931      
composing pnes               268_100  0.0       6_844_546
total classical_split_filter 37_216   786       1_117    
get_poes                     19_695   0.0       6_844_546
computing mean_std           14_076   0.0       6_844_546
make_contexts                5_365    0.0       208_558  
ClassicalCalculator.run      3_598    4_830     1      
aggregate curves             651      505       1_117    
saving probability maps      474      0.0       1       

# after
operation-duration     outputs mean    stddev min     max
classical1             916     47      38%    5.03281 160
classical_split_filter 98      33      49%    4.28577 67
calc_361                     time_sec memory_mb counts   
============================ ======== ========= =========
total classical1             43_842   16        916      
get_poes                     19_073   0.0       6_844_546
computing mean_std           12_893   0.0       6_844_546
composing pnes               6_286    0.0       6_844_546
make_contexts                5_388    0.0       208_558  
total classical_split_filter 3_277    10        1_014    
ClassicalCalculator.run      959      3_860     1        
saving probability maps      479      1.98438   1         
aggregate curves             377      209       1_014    
```