### PR TITLE
Perform prefiltering even in event_based

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -912,15 +912,6 @@ class HazardCalculator(BaseCalculator):
                 srcs[row[SERIAL]].num_ruptures = int(arr[0])
                 srcs[row[SERIAL]].nsites = int(arr[1])
 
-    def store_source_info(self, calc_times, nsites=False):
-        """
-        Save (eff_ruptures, num_sites, calc_time) inside the source_info
-        """
-        self.update_source_info(calc_times, nsites)
-        recs = [tuple(row) for row in self.csm.source_info.values()]
-        hdf5.extend(self.datastore['source_info'],
-                    numpy.array(recs, readinput.source_info_dt))
-
     def post_process(self):
         """For compatibility with the engine"""
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -932,16 +932,20 @@ class HazardCalculator(BaseCalculator):
         """
         Update (eff_ruptures, num_sites, calc_time) inside the source_info
         """
-        srcs = self.csm.get_sources()
-        for src_id, arr in calc_times.items():
-            src_id = re.sub(r':\d+$', '', src_id)
+        for src in self.csm.get_sources():
+            try:
+                nr, ns, dt = calc_times[src.source_id]
+            except KeyError:  # discarded source
+                continue
+            src_id = re.sub(r':\d+$', '', src.source_id)
             row = self.csm.source_info[src_id]
-            row[CALC_TIME] += arr[2]
+            row[CALC_TIME] += dt
             if nsites:
-                row[EFF_RUPTURES] += arr[0]
-                row[NUM_SITES] += arr[1]
-                srcs[row[SERIAL]].num_ruptures = int(arr[0])
-                srcs[row[SERIAL]].nsites = int(arr[1])
+                row[EFF_RUPTURES] += nr
+                row[NUM_SITES] += nr
+                row[SERIAL] = src.serial
+                src.num_ruptures = int(nr)
+                src.nsites = int(ns)
 
     def post_process(self):
         """For compatibility with the engine"""

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -527,12 +527,13 @@ class ClassicalCalculator(base.HazardCalculator):
         pgetter = getters.PmapGetter(
             self.datastore, weights, self.sitecol.sids, oq.imtls)
         logging.info('Saving _poes')
+        srcidx = {src_id: i for i, src_id in enumerate(self.csm.source_info)}
         with self.monitor('saving probability maps'):
             for key, pmap in pmap_by_key.items():
                 if isinstance(key, str):  # disagg_by_src
-                    serial = self.csm.source_info[key][readinput.SERIAL]
+                    idx = srcidx[self.csm.source_info[key][0]]
                     rlzs_by_gsim = rlzs_by_gsim_list[pmap.grp_id]
-                    self.datastore['disagg_by_src'][..., serial] = (
+                    self.datastore['disagg_by_src'][..., idx] = (
                         pgetter.get_hcurves(pmap, rlzs_by_gsim))
                 elif pmap:  # pmap can be missing if the group is filtered away
                     # key is the group ID

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -18,7 +18,6 @@
 import io
 import os
 import re
-import time
 import copy
 import pprint
 import logging

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -120,7 +120,8 @@ class EventBasedCalculator(base.HazardCalculator):
             srcfilter = nofilter  # otherwise it would be ultra-slow
         else:
             srcfilter = self.srcfilter
-        self.prefilter_csm()
+        self.prefilter_csm()  # NB: must go go before init_serials
+        self.csm.init_serials(self.oqparam.ses_seed)  # must go after
         maxweight = sum(sg.weight for sg in self.csm.src_groups) / (
             self.oqparam.concurrent_tasks or 1)
         for sg in self.csm.src_groups:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -159,7 +159,10 @@ class EventBasedCalculator(base.HazardCalculator):
         # must be called before storing the events
         self.store_rlz_info(eff_ruptures)  # store full_lt
         with self.monitor('store source_info'):
-            self.store_source_info(calc_times)
+            self.update_source_info(calc_times)
+            recs = [tuple(row) for row in self.csm.source_info.values()]
+            hdf5.extend(self.datastore['source_info'],
+                        numpy.array(recs, readinput.source_info_dt))
         imp = calc.RuptureImporter(self.datastore)
         with self.monitor('saving ruptures and events'):
             imp.import_rups(self.datastore.getitem('ruptures')[()])

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -120,8 +120,7 @@ class EventBasedCalculator(base.HazardCalculator):
             srcfilter = nofilter  # otherwise it would be ultra-slow
         else:
             srcfilter = self.srcfilter
-        self.prefilter_csm()  # NB: must go go before init_serials
-        self.csm.init_serials(self.oqparam.ses_seed)  # must go after
+        self.prefilter_csm()
         maxweight = sum(sg.weight for sg in self.csm.src_groups) / (
             self.oqparam.concurrent_tasks or 1)
         for sg in self.csm.src_groups:

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -270,14 +270,6 @@ class CompositeSourceModel:
         self.full_lt = full_lt
         self.src_groups = src_groups
 
-    def init_serials(self, serial):
-        """
-        Called always but used only in event based calculations
-        """
-        for src in sorted(self.get_sources(), key=operator.attrgetter('id')):
-            src.serial = serial
-            serial += src.num_ruptures * len(src.et_ids)
-
     def get_et_ids(self):
         """
         :returns: an array of et_ids (to be stored as an hdf5.vuint32 array)


### PR DESCRIPTION
That means that `.count_ruptures()` is now parallelized. In event_based_risk/case_4 there is a PointSource which is discarded by the prefiltering, so the seeds are different.