### PR TITLE
Optimized get_poes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Introduced an early memory check in classical calculations
   * Reduced the memory occupation in classical calculations
   * Implemented AvgPoeGMPE
   * Forbidded the usage of `aggregate_by` except in ebrisk calculations

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -568,8 +568,10 @@ class ClassicalCalculator(base.HazardCalculator):
                     # key is the group ID
                     trt = self.full_lt.trt_by_et[et_ids[key][0]]
                     # avoid saving PoEs == 1
-                    arr = base.fix_ones(pmap).array(self.N)
-                    self.datastore['_poes'][:, :, slice_by_g[key]] = arr
+                    base.fix_ones(pmap)
+                    sids = sorted(pmap)
+                    arr = numpy.array([pmap[sid].array for sid in sids])
+                    self.datastore['_poes'][sids, :, slice_by_g[key]] = arr
                     extreme = max(
                         get_extreme_poe(pmap[sid].array, oq.imtls)
                         for sid in pmap)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -20,6 +20,7 @@ import os
 import re
 import time
 import copy
+import psutil
 import pprint
 import logging
 import operator
@@ -323,6 +324,10 @@ class ClassicalCalculator(base.HazardCalculator):
         size = numpy.prod(poes_shape) * 8
         logging.info('Requiring %s for ProbabilityMap of shape %s',
                      humansize(size), poes_shape)
+        avail = psutil.virtual_memory().available
+        if avail < 2 * size:
+            raise MemoryError(
+                'You have only %s of free RAM' % humansize(avail))
         self.datastore.create_dset('_poes', F64, poes_shape)
 
     def execute(self):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -212,7 +212,7 @@ class ContextMaker(object):
 
         # instantiate monitors
         self.gmf_mon = monitor('computing mean_std', measuremem=False)
-        self.poe_mon = monitor('get_poes', measuremem=not self.split_sources)
+        self.poe_mon = monitor('get_poes', measuremem=False)
 
     def gen_ctx_poes(self, ctxs):
         """

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -225,18 +225,17 @@ class ContextMaker(object):
         for g, gsim in enumerate(self.gsims):
             with self.gmf_mon:
                 mean_std = numpy.zeros(shp)
-                start = 0
+                s = 0
                 for n, ctx in zip(nsites, ctxs):
-                    mean_std[:, start:start+n] = gsim.get_mean_std(
-                        ctx, self.imts)
-                    start += n
+                    mean_std[:, s:s+n] = gsim.get_mean_std(ctx, self.imts)
+                    s += n
             with self.poe_mon:
                 poes[:, :, g] = gsim.get_poes(
                     mean_std, self.loglevels, self.trunclevel, self.af, ctxs)
-        start = 0
+        s = 0
         for ctx, n in zip(ctxs, nsites):
-            yield ctx, poes[start:start+n]
-            start += n
+            yield ctx, poes[s:s+n]
+            s += n
 
     def get_ctx_params(self):
         """

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -221,15 +221,12 @@ class ContextMaker(object):
         """
         nsites = [len(ctx.sids) for ctx in ctxs]
         N = sum(nsites)
-        shp = (2, N, len(self.loglevels))
         poes = numpy.zeros((N, len(self.loglevels.array), len(self.gsims)))
         for g, gsim in enumerate(self.gsims):
             with self.gmf_mon:
-                mean_std = numpy.zeros(shp)
-                s = 0
-                for n, ctx in zip(nsites, ctxs):
-                    mean_std[:, s:s+n] = gsim.get_mean_std(ctx, self.imts)
-                    s += n
+                # shape (2, N, M)
+                mean_std = numpy.concatenate([gsim.get_mean_std(ctx, self.imts)
+                                              for ctx in ctxs], axis=1)
             with self.poe_mon:
                 poes[:, :, g] = gsim.get_poes(
                     mean_std, self.loglevels, self.trunclevel, self.af, ctxs)

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -147,7 +147,7 @@ def _get_poes_site(mean_std, loglevels, truncation_level, ampfun, ctxs):
 
         # Get the values of ground-motion used to compute the probability
         # of exceedance on soil.
-        soillevels = loglevels[imt]  # shape S
+        soillevels = loglevels[imt]  # shape L1
 
         # Here we set automatically the IMLs that will be used to compute
         # the probability of occurrence of GM on rock within discrete
@@ -187,11 +187,11 @@ def _get_poes_site(mean_std, loglevels, truncation_level, ampfun, ctxs):
 
             # Computing the probability of exceedance of the levels of
             # ground-motion loglevels on soil
-            logaf = numpy.log(numpy.exp(soillevels) / iml_mid)  # shape S
-            for c in range(C):
+            logaf = numpy.log(numpy.exp(soillevels) / iml_mid)  # shape L1
+            for l in range(L1):
                 poex_af = 1. - norm.cdf(
-                    logaf, numpy.log(median_af[c]), std_af[c])  # shape S
-                out_s[c, m * L1: (m + 1) * L1] += poex_af * pocc_rock[c]  # S
+                    logaf[l], numpy.log(median_af), std_af)  # shape C
+                out_s[:, m * L1 + l] += poex_af * pocc_rock  # shape C
 
     return out_s
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -126,7 +126,8 @@ def _get_poes_site(mean_std, loglevels, truncation_level, ampfun, ctxs):
     # L - Number of intensity measure levels
     mean, stddev = mean_std  # shape (C, M)
     C, L = len(mean), len(loglevels.array)
-    assert C == len(ctxs), C
+    for ctx in ctxs:
+        assert len(ctx.sids) == 1  # 1 site
     M = len(loglevels)
     L1 = L // M
 

--- a/openquake/hazardlib/site_amplification.py
+++ b/openquake/hazardlib/site_amplification.py
@@ -17,7 +17,6 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import copy
 import numpy
 import pandas as pd
 
@@ -105,6 +104,7 @@ class AmplFunction():
         median = numpy.zeros(len(mags))
         std = numpy.zeros(len(mags))
 
+        # TODO: figure out a way to vectorize this
         for i, (mag, dst) in enumerate(zip(mags, dsts)):
 
             # Filtering magnitude

--- a/openquake/hazardlib/tests/site_amplification_function_test.py
+++ b/openquake/hazardlib/tests/site_amplification_function_test.py
@@ -19,9 +19,8 @@
 import numpy
 import unittest
 
-from openquake.baselib import InvalidFile
 from openquake.baselib.hdf5 import read_csv
-from openquake.baselib.general import gettemp, DictArray
+from openquake.baselib.general import gettemp
 from openquake.hazardlib.site import ampcode_dt
 from openquake.hazardlib.site_amplification import AmplFunction
 
@@ -96,10 +95,10 @@ class AmplificationFunctionTestCase(unittest.TestCase):
     def test_get_median_std(self):
         """ Calculation of median amplification + std """
         site = b'A'
-        mag = 4.5
+        mags = [4.5]
         imt = 'PGA'
         imls = 0.12
-        rrups = 10.
-        med, std = self.af.get_mean_std(site, imt, imls, mag, rrups)
+        rrups = [10.]
+        med, std = self.af.get_mean_std(site, imt, imls, mags, rrups)
         self.assertEqual(med, 1.305, 'wrong median af')
         self.assertEqual(std, 0.3, 'wrong std af')


### PR DESCRIPTION
By using long arrays instead of short arrays the speed of `get_poes` can be tripled; this fixes the slowdown introduced by https://github.com/gem/oq-engine/pull/6212.
Here are the figures for a reduced SHARE calculation:
```
   calc_40203, maxmem=1.0 GB    time_sec memory_mb counts    # master
   ============================ ======== ========= ==========
   total classical              856_617  64        1_192     
   get_poes                     571_438  0.0       65_377_848
   computing mean_std           285_023  0.0       65_377_848
   calc_40204, maxmem=1.0 GB    time_sec memory_mb counts    # this branch
   ============================ ======== ========= ==========
   total classical              507_155  120       1_192     
   computing mean_std           277_385  0.0       1_765_402 
   get_poes                     179_401  0.0       1_765_402 
```
Also, I am adding an early check on the memory occupation and fixing `split_sources` to be honored also inside the ContextMaker. Finally, I am optimizing the saving of the poes and changing the API of `_get_poes_site` to pave the way for future vectorization.