### PR TITLE
Fixed the GMF exporter for secondary perils

### DIFF
--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -450,13 +450,13 @@ def _expand_gmv(array, imts):
         if name == 'gmv':
             for imt in imts:
                 dtlist.append(('gmv_' + imt, F32))
-        else:
+        elif name in ('sid', 'eid'):
             dtlist.append((name, dt))
     new = numpy.zeros(len(array), dtlist)
-    for name in dtype.names:
-        if name == 'gmv':
+    for name, _dt in dtlist:
+        if name.startswith('gmv_'):
             for i, imt in enumerate(imts):
-                new['gmv_' + imt] = array['gmv'][:, i]
+                new[name] = array['gmv'][:, i]
         else:
             new[name] = array[name]
     return new

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -23,6 +23,7 @@ import math
 
 import numpy.testing
 
+from openquake.baselib.hdf5 import read_csv
 from openquake.baselib.general import countby, gettemp
 from openquake.baselib.datastore import read
 from openquake.hazardlib import nrml, InvalidFile
@@ -478,6 +479,9 @@ class EventBasedTestCase(CalculatorTestCase):
         nd_mean = df[df.newmark_disp > 0].newmark_disp.mean()
         self.assertGreater(pd_mean, 0)
         self.assertGreater(nd_mean, 0)
+        [fname, _, _] = export(('gmf_data', 'csv'), self.calc.datastore)
+        arr = read_csv(fname)[:2]
+        self.assertEqual(arr.dtype.names, ('site_id', 'event_id', 'gmv_PGA'))
 
     def test_case_26_liq(self):
         # cali liquefaction simplified
@@ -486,7 +490,7 @@ class EventBasedTestCase(CalculatorTestCase):
         pd_mean = df[df.liq_prob > 0].liq_prob.mean()
         lat_spread_mean = df.lat_spread.mean()
         vert_settle_mean = df.vert_settlement.mean()
-        self.assertGreater(pd_mean, 0.) 
+        self.assertGreater(pd_mean, 0.)
         self.assertGreater(lat_spread_mean, 0.)
         self.assertGreater(vert_settle_mean, 0.)
 


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6204. Now the secondary perils fields are not exported. This is on purpose, I do not want to expose them for the moment being.