### PR TITLE
Moved UCERF point sources in a different group

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -366,10 +366,12 @@ class ClassicalCalculator(base.HazardCalculator):
         # if OQ_SAMPLE_SOURCES is set extract one source for group
         ss = os.environ.get('OQ_SAMPLE_SOURCES')
         if ss:
+            logging.info('Reducing the number of sources')
             for sg in self.csm.src_groups:
                 if not sg.atomic:
-                    srcs = [src for src in sg if src.nsites]
-                    sg.sources = [srcs[0]]
+                    src = max(
+                        sg, key=operator.attrgetter('nsites', 'source_id'))
+                    sg.sources = [src]
 
         mags = self.datastore['source_mags']  # by TRT
         if len(mags) == 0:  # everything was discarded

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -115,7 +115,9 @@ def get_csm(oq, full_lt, h5=None):
                 src.ruptures_per_block = oq.ruptures_per_block
                 sg.sources = list(src)
                 # add background point sources
-                sg.sources.extend(src.get_background_sources())
+                sg = copy.copy(grp)
+                src_groups.append(sg)
+                sg.sources = src.get_background_sources()
             else:  # event_based, use one source
                 sg.sources = [src]
             serial = init_serials(sg, serial)


### PR DESCRIPTION
So that OQ_SAMPLE_SOURCES will always sample at least one UCERSource. Moreover, the contribution from the fault sources and from the background will be automatically visible.