### PR TITLE
Raised an error for soil_intensities with amplification_method != convolution

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -902,6 +902,15 @@ class OqParam(valid.ParamSet):
             ('classical', 'disaggregation'))
         return not invalid
 
+    def is_valid_soil_intensities(self):
+        """
+        soil_intensities can be set only if amplification_method=convolution
+        """
+        if self.amplification_method == 'convolution':
+            return len(self.soil_intensities) > 1
+        else:
+            return self.soil_intensities is None
+
     def is_valid_sites_disagg(self):
         """
         The option `sites_disagg` (when given) requires `specific_assets` to


### PR DESCRIPTION
As discussed with @mmpagani . Avoids the error in the Popoyan calculation
```python
  File "/opt/openquake/oq-engine/openquake/calculators/classical.py", line 597, in post_execute
    self.calc_stats()
  File "/opt/openquake/oq-engine/openquake/calculators/classical.py", line 649, in calc_stats
    parallel.Starmap(
  File "/opt/openquake/oq-engine/openquake/baselib/parallel.py", line 825, in reduce
    return self.submit_all().reduce(agg, acc)
  File "/opt/openquake/oq-engine/openquake/baselib/parallel.py", line 589, in reduce
    acc = agg(acc, result)
  File "/opt/openquake/oq-engine/openquake/calculators/classical.py", line 551, in save_hazard
    dset[s, r] = pmap[s].array.reshape(self.M, self.L1)
ValueError: cannot reshape array of size 800 into shape (16,14)
```