### PR TITLE
Add two methods to the modifiable GMPE

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -39,6 +39,8 @@
   * Added a method to create a TruncatedGRMFD from a value of scalar seismic
     moment
   * Added a method to the modifiable GMPE to add (or subtract) a delta std
+  * Added a method to the modifiable GMPE to set the total std as the sum of 
+	tau plus a delta
 
 python3-oq-engine (3.10.1-1~xenial01) xenial; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -38,6 +38,7 @@
   * Added a check on DEFINED_FOR_REFERENCE_VELOCITY when using amplification
   * Added a method to create a TruncatedGRMFD from a value of scalar seismic
     moment
+  * Added a method to the modifiable GMPE to add (or subtract) a delta std
 
 python3-oq-engine (3.10.1-1~xenial01) xenial; urgency=low
 

--- a/openquake/hazardlib/gsim/mgmpe/modifiable_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/modifiable_gmpe.py
@@ -187,6 +187,15 @@ class ModifiableGMPE(GMPE):
         shp = getattr(self, const.StdDev.TOTAL).shape
         setattr(self, const.StdDev.TOTAL, C["total_sigma"] + np.zeros(shp))
 
+    def add_delta_std_to_total_std(self, sites, rup, dists, imt, delta):
+        """
+        :param delta:
+            A delta std e.g. a phi S2S to be removed from total
+        """
+        total_stddev = getattr(self, const.StdDev.TOTAL)
+        total_stddev = (total_stddev**2 + np.sign(delta) * delta**2)**0.5
+        setattr(self, const.StdDev.TOTAL, total_stddev)
+
     @staticmethod
     def _dict_to_coeffs_table(input_dict, name):
         """

--- a/openquake/hazardlib/gsim/mgmpe/modifiable_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/modifiable_gmpe.py
@@ -82,7 +82,8 @@ class ModifiableGMPE(GMPE):
         """
         working_std_types = copy.copy(stddev_types)
 
-        if 'set_between_epsilon' in self.params:
+        if ('set_between_epsilon' in self.params or
+                'set_total_std_as_tau_plus_delta' in self.params):
             if (const.StdDev.INTER_EVENT not in
                     self.gmpe.DEFINED_FOR_STANDARD_DEVIATION_TYPES):
                 raise ValueError('The GMPE does not have between event std')
@@ -194,6 +195,15 @@ class ModifiableGMPE(GMPE):
         """
         total_stddev = getattr(self, const.StdDev.TOTAL)
         total_stddev = (total_stddev**2 + np.sign(delta) * delta**2)**0.5
+        setattr(self, const.StdDev.TOTAL, total_stddev)
+
+    def set_total_std_as_tau_plus_delta(self, sites, rup, dists, imt, delta):
+        """
+        :param delta:
+            A delta std e.g. a phi SS to be combined with between std, tau.
+        """
+        tau = getattr(self, const.StdDev.INTER_EVENT)
+        total_stddev = (tau**2 + np.sign(delta) * delta**2)**0.5
         setattr(self, const.StdDev.TOTAL, total_stddev)
 
     @staticmethod

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -175,6 +175,22 @@ class ModifiableGMPETest(unittest.TestCase):
                                            sfact * np.ones(stddev.shape))
 
 
+    def test_add_delta(self):
+        """Check adding/removing a delta std to the total std"""
+        gmpe_name = 'AkkarEtAlRjb2014'
+        stddevs = [const.StdDev.TOTAL]
+
+        gmm = ModifiableGMPE(
+            gmpe={gmpe_name: {}},
+            add_delta_std_to_total_std={"delta": -0.20})
+        imt = PGA()
+        [stddev] = gmm.get_mean_and_stddevs(self.sites, self.rup,
+                                            self.dists, imt, stddevs)[1]
+
+        # Original total std for PGA is 0.6201
+        np.testing.assert_almost_equal(stddev[0], 0.68344277, decimal=6)
+
+
 class ModifiableGMPETestSwissAmpl(unittest.TestCase):
     """
     Tests the implementation of a correction factor for intensity

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -187,7 +187,7 @@ class ModifiableGMPETest(unittest.TestCase):
         [stddev] = gmm.get_mean_and_stddevs(self.sites, self.rup,
                                             self.dists, imt, stddevs)[1]
 
-        # Original total std for PGA is 0.6201
+        # Original total std for PGA is 0.7121
         np.testing.assert_almost_equal(stddev[0], 0.68344277, decimal=6)
 
 
@@ -203,7 +203,7 @@ class ModifiableGMPETest(unittest.TestCase):
         [stddev] = gmm.get_mean_and_stddevs(self.sites, self.rup,
                                             self.dists, imt, stddevs)[1]
 
-        # Original total std for PGA is 0.6201
+        # Original tau for PGA is 0.6201
         np.testing.assert_almost_equal(stddev[0], 0.5701491121, decimal=6)
 
 

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -191,6 +191,22 @@ class ModifiableGMPETest(unittest.TestCase):
         np.testing.assert_almost_equal(stddev[0], 0.68344277, decimal=6)
 
 
+    def test_set_total_std_as_tau_plus_phi(self):
+        """Check set total std as between plus phi SS"""
+        gmpe_name = 'AkkarEtAlRjb2014'
+        stddevs = [const.StdDev.TOTAL]
+
+        gmm = ModifiableGMPE(
+            gmpe={gmpe_name: {}},
+            set_total_std_as_tau_plus_delta={"delta": 0.45})
+        imt = PGA()
+        [stddev] = gmm.get_mean_and_stddevs(self.sites, self.rup,
+                                            self.dists, imt, stddevs)[1]
+
+        # Original total std for PGA is 0.6201
+        np.testing.assert_almost_equal(stddev[0], 0.5701491121, decimal=6)
+
+
 class ModifiableGMPETestSwissAmpl(unittest.TestCase):
     """
     Tests the implementation of a correction factor for intensity


### PR DESCRIPTION
This PR adds to methods to the modifiable GMPE that help in to define the total standard deviation in case of site specific studies. Note that the same behaviour can be achieved by extending more traditional GMPEs with a different table of coefficients.