### PR TITLE
Avoided reading data from the workers in UCERF classical

### DIFF
--- a/openquake/calculators/ucerf_base.py
+++ b/openquake/calculators/ucerf_base.py
@@ -243,10 +243,13 @@ class UCERFSource(BaseSeismicSource):
         """
         :returns: min_lon, min_lat, max_lon, max_lat
         """
-        with h5py.File(self.source_file, 'r') as hdf5:
-            locations = hdf5["Grid/Locations"][()]
-        lons, lats = locations[:, 0], locations[:, 1]
-        bbox = lons.min(), lats.min(), lons.max(), lats.max()
+        lons, lats = [], []
+        sections = set(sec for sections in self.sections for sec in sections)
+        for sec in sections:
+            plane = self.planes[sec]
+            lons.extend(plane[:, 0].flat)
+            lats.extend(plane[:, 1].flat)
+        bbox = min(lons), min(lats), max(lons), max(lats)
         a1 = min(maxdist * KM_TO_DEGREES, 90)
         a2 = angular_distance(maxdist, bbox[1], bbox[3])
         return bbox[0] - a2, bbox[1] - a1, bbox[2] + a2, bbox[3] + a1

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -111,13 +111,14 @@ def get_csm(oq, full_lt, h5=None):
             del src.__dict__['mags']  # remove cache
             src.checksum = src.et_id = src.id = et_id
             src.samples = sm_rlz.samples
-            logging.info('Reading rupture planes for %s', src)
+            logging.info('Reading sections and rupture planes for %s', src)
             planes = src.get_planes()
             if classical:
                 src.ruptures_per_block = oq.ruptures_per_block
                 sg.sources = list(src)
                 for s in sg:
                     s.planes = planes
+                    s.sections = s.get_sections()
                 # add background point sources
                 sg = copy.copy(grp)
                 src_groups.append(sg)
@@ -125,6 +126,7 @@ def get_csm(oq, full_lt, h5=None):
             else:  # event_based, use one source
                 sg.sources = [src]
                 src.planes = planes
+                src.sections = src.get_sections()
             serial = init_serials(sg, serial)
         return CompositeSourceModel(full_lt, src_groups)
 

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -111,15 +111,20 @@ def get_csm(oq, full_lt, h5=None):
             del src.__dict__['mags']  # remove cache
             src.checksum = src.et_id = src.id = et_id
             src.samples = sm_rlz.samples
+            logging.info('Reading rupture planes for %s', src)
+            planes = src.get_planes()
             if classical:
                 src.ruptures_per_block = oq.ruptures_per_block
                 sg.sources = list(src)
+                for s in sg:
+                    s.planes = planes
                 # add background point sources
                 sg = copy.copy(grp)
                 src_groups.append(sg)
                 sg.sources = src.get_background_sources()
             else:  # event_based, use one source
                 sg.sources = [src]
+                src.planes = planes
             serial = init_serials(sg, serial)
         return CompositeSourceModel(full_lt, src_groups)
 


### PR DESCRIPTION
This also improves a lot the performance in `iter_ruptures`. Here are the figures in a calculation with 92 sites and 1 realization:
```
calc_40218, maxmem=1.3 GB time_sec memory_mb counts   # new
========================= ======== ========= =========
total classical           850_257  363       1_792
make_contexts             569_850  0.0       10_905
iter_ruptures             232_455  0.0       10_905
computing mean_std        43_286   0.0       10_905
ClassicalCalculator.run   4_329    1_223     1

calc_40217, maxmem=0.2 GB time_sec memory_mb counts   # old
========================= ======== ========= =========
total classical           924_918  356       1_792    
make_contexts             569_088  0.0       10_905   
iter_ruptures             306_764  0.0       10_905   
computing mean_std        44_243   0.0       10_905   
ClassicalCalculator.run   4_532    81        1        
```
Part of https://github.com/gem/oq-engine/issues/6218. The event based part is still reading from the workers, though.