### PR TITLE
Changed `gsim.get_mean_std` to accept multiple contexts

### DIFF
--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -178,7 +178,7 @@ def disaggregate(ctxs, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
 
 def set_mean_std(ctxs, imts, gsims):
     for u, ctx in enumerate(ctxs):
-        ctx.mean_std = [gsim.get_mean_std(ctx, imts) for gsim in gsims]
+        ctx.mean_std = [gsim.get_mean_std([ctx], imts) for gsim in gsims]
 
 
 def _disagg_eps(survival, bins, eps_bands, cum_bands):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -223,8 +223,7 @@ class ContextMaker(object):
         for g, gsim in enumerate(self.gsims):
             with self.gmf_mon:
                 # shape (2, N, M)
-                mean_std = numpy.concatenate([gsim.get_mean_std(ctx, self.imts)
-                                              for ctx in ctxs], axis=1)
+                mean_std = gsim.get_mean_std(ctxs, self.imts)
             with self.poe_mon:
                 poes[:, :, g] = gsim.get_poes(
                     mean_std, self.loglevels, self.trunclevel, self.af, ctxs)
@@ -419,7 +418,7 @@ class ContextMaker(object):
             means = []
             for gsim in self.gsims:
                 try:
-                    mean = gsim.get_mean_std(ctx, self.imts)[0, 0]
+                    mean = gsim.get_mean_std([ctx], self.imts)[0, 0]
                 except ValueError:  # magnitude outside of supported range
                     continue
                 means.append(mean.max())

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -112,13 +112,14 @@ class AvgPoeGMPE(GMPE):
             stds.append(std)
         return means, stds
 
-    def get_mean_std(self, ctx, imts):
+    def get_mean_std(self, ctxs, imts):
         """
         Call the underlying GMPEs and return an array of shape (2, N, M, G')
         """
-        res = numpy.zeros((2, len(ctx.sids), len(imts), len(self.gsims)))
+        N = sum(len(ctx.sids) for ctx in ctxs)
+        res = numpy.zeros((2, N, len(imts), len(self.gsims)))
         for g, gsim in enumerate(self.gsims):
-            res[:, :, :, g] = gsim.get_mean_std(ctx, imts)
+            res[:, :, :, g] = gsim.get_mean_std(ctxs, imts)
         return res
 
     def get_poes(self, mean_std, loglevels, trunclevel,


### PR DESCRIPTION
The dream would be to vectorize on the contexts in the future. As it is now the performance is the same but the call is more elegant and consistent with the logic used in `get_poes`.