### PR TITLE
Changed the classical rupture storage to be pandas-friendly

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,13 @@
   [Michele Simionato]
+  * Internal: made the classical ruptures pandas-friendly
+  * Internal: made the damage distributions pandas-friendly
+
+  [Marco Pagani]
+  * Added a new type of undertainty for the seismic source characterisation
+    logic tree called `TruncatedGRFromSlipAbsolute`
+  * Added a get_fault_surface_area method to sources
+
+  [Michele Simionato]
   * Changed the source seed algorithm in event based calculations
   * Added an estimate of the portfolio damage error due to the seed dependency
   * Stored the damage distributions in a pandas-friendly way and extended
@@ -55,9 +64,6 @@
   * Added a method to the modifiable GMPE to add (or subtract) a delta std
   * Added a method to the modifiable GMPE to set the total std as the sum of
 	tau plus a delta
-  * Added a get_fault_surface_area method to sources
-  * Added a new type of undertainty for the seismic source characterisation 
-    logic tree called `TruncatedGRFromSlipAbsolute`
 
 python3-oq-engine (3.10.1-1~xenial01) xenial; urgency=low
 

--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -488,7 +488,10 @@ class DataStore(collections.abc.MutableMapping):
         elif '__pdcolumns__' in dset.attrs:
             columns = dset.attrs['__pdcolumns__'].split()
             dic = {col: dset[col][slc] for col in columns}
-            df = pandas.DataFrame(dic).set_index(index)
+            if index is None:
+                df = pandas.DataFrame(dic)
+            else:
+                df = pandas.DataFrame(dic).set_index(index)
             return df
         dtlist = []
         for name in dset.dtype.names:

--- a/openquake/baselib/tests/datastore_test.py
+++ b/openquake/baselib/tests/datastore_test.py
@@ -136,3 +136,12 @@ class DataStoreTestCase(unittest.TestCase):
         print(df)
         df = self.dstore.read_df('df', 'eid')
         print(df)
+
+    def test_pandas_vlen(self):
+        self.dstore['test/val'] = [.2, .3]
+        self.dstore.hdf5.save_vlen(
+            'test/val_', [numpy.array([1]), numpy.array([2, 3])])
+        self.dstore.getitem('test').attrs['__pdcolumns__'] = 'val val_'
+        df = self.dstore.read_df('test')
+        numpy.testing.assert_equal(df['val_'].loc[0], [1])
+        numpy.testing.assert_equal(df['val_'].loc[1], [2, 3])

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -157,12 +157,14 @@ def store_ctxs(dstore, rupdata, grp_id):
     nr = len(rupdata['mag'])
     rupdata['nsites'] = numpy.array([len(s) for s in rupdata['sids_']])
     rupdata['grp_id'] = numpy.array([grp_id] * nr)
-    for name in dstore[magstr]:
-        n = '%s/%s' % (magstr, name)
-        if name.endswith('_'):
-            dstore.hdf5.save_vlen(n, rupdata[name])
+    for par in dstore[magstr]:
+        n = '%s/%s' % (magstr, par)
+        if par not in rupdata:  # when not requiring the parameter
+            hdf5.extend(dstore[n], numpy.array([numpy.nan] * nr))
+        elif par.endswith('_'):
+            dstore.hdf5.save_vlen(n, rupdata[par])
         else:
-            hdf5.extend(dstore[n], rupdata[name])
+            hdf5.extend(dstore[n], rupdata[par])
 
 
 @base.calculators.add('classical', 'preclassical', 'ucerf_classical')

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -149,31 +149,20 @@ def preclassical(srcs, srcfilter, monitor):
     return calc_times
 
 
-def store_ctxs(dstore, rdt, rupdata, grp_id):
+def store_ctxs(dstore, rupdata, grp_id):
     """
     Store contexts with the same magnitude in the datastore
     """
-    magstr = '%.2f' % rupdata['mag'][0]
-    rctx = dstore['mag_%s/rctx' % magstr]
+    magstr = 'mag_%.2f' % rupdata['mag'][0]
     nr = len(rupdata['mag'])
-    rdata = numpy.zeros(nr, rdt)
-    rdata['nsites'] = [len(s) for s in rupdata['sids_']]
-    rdata['grp_id'] = grp_id
-    rdt_names = set(rupdata) & set(n[0] for n in rdt)
-    for name in rdt_names:
-        if name == 'probs_occur':
-            rdata[name] = list(rupdata[name])
-        else:
-            rdata[name] = rupdata[name]
-    hdf5.extend(rctx, rdata)
-    for name in dstore['mag_%s' % magstr]:
+    rupdata['nsites'] = numpy.array([len(s) for s in rupdata['sids_']])
+    rupdata['grp_id'] = numpy.array([grp_id] * nr)
+    for name in dstore[magstr]:
+        n = '%s/%s' % (magstr, name)
         if name.endswith('_'):
-            n = 'mag_%s/%s' % (magstr, name)
-            if name in rupdata:
-                dstore.hdf5.save_vlen(n, rupdata[name])
-            else:
-                zs = [numpy.zeros(0, numpy.float32)] * nr
-                dstore.hdf5.save_vlen(n, zs)
+            dstore.hdf5.save_vlen(n, rupdata[name])
+        else:
+            hdf5.extend(dstore[n], rupdata[name])
 
 
 @base.calculators.add('classical', 'preclassical', 'ucerf_classical')
@@ -229,7 +218,7 @@ class ClassicalCalculator(base.HazardCalculator):
 
             # store rup_data if there are few sites
             for mag, c in dic['rup_data'].items():
-                store_ctxs(self.datastore, self.rdt, c, grp_id)
+                store_ctxs(self.datastore, c, grp_id)
         return acc
 
     def acc0(self):
@@ -237,7 +226,8 @@ class ClassicalCalculator(base.HazardCalculator):
         Initial accumulator, a dict et_id -> ProbabilityMap(L, G)
         """
         zd = AccumDict()
-        rparams = {'grp_id', 'occurrence_rate', 'clon_', 'clat_', 'rrup_'}
+        rparams = {'grp_id', 'occurrence_rate', 'clon_', 'clat_', 'rrup_',
+                   'nsites', 'probs_occur_', 'sids_'}
         gsims_by_trt = self.full_lt.get_gsims_by_trt()
         for trt, gsims in gsims_by_trt.items():
             cm = ContextMaker(trt, gsims)
@@ -250,23 +240,18 @@ class ClassicalCalculator(base.HazardCalculator):
             mags.update(dset[:])
         mags = sorted(mags)
         if self.few_sites:
-            self.rdt = [('nsites', U16)]
-            dparams = ['sids_']
-            for rparam in rparams:
-                if rparam.endswith('_'):
-                    dparams.append(rparam)
-                elif rparam == 'grp_id':
-                    self.rdt.append((rparam, U32))
-                else:
-                    self.rdt.append((rparam, F32))
-            self.rdt.append(('probs_occur', hdf5.vfloat64))
             for mag in mags:
                 name = 'mag_%s/' % mag
-                self.datastore.create_dset(name + 'rctx', self.rdt, (None,),
-                                           compression='gzip')
-                for dparam in dparams:
-                    dt = hdf5.vuint32 if dparam == 'sids_' else hdf5.vfloat32
-                    self.datastore.create_dset(name + dparam, dt, (None,),
+                for param in rparams:
+                    if param == 'sids_':
+                        dt = hdf5.vuint16
+                    elif param.endswith('_'):
+                        dt = hdf5.vfloat64
+                    elif param in {'nsites', 'grp_id'}:
+                        dt = U32
+                    else:
+                        dt = F64
+                    self.datastore.create_dset(name + param, dt, (None,),
                                                compression='gzip')
         self.by_task = {}  # task_no => src_ids
         self.totrups = 0  # total number of ruptures before collapsing

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -228,14 +228,14 @@ class ClassicalCalculator(base.HazardCalculator):
         Initial accumulator, a dict et_id -> ProbabilityMap(L, G)
         """
         zd = AccumDict()
-        rparams = {'grp_id', 'occurrence_rate', 'clon_', 'clat_', 'rrup_',
-                   'nsites', 'probs_occur_', 'sids_'}
+        params = {'grp_id', 'occurrence_rate', 'clon_', 'clat_', 'rrup_',
+                  'nsites', 'probs_occur_', 'sids_'}
         gsims_by_trt = self.full_lt.get_gsims_by_trt()
         for trt, gsims in gsims_by_trt.items():
             cm = ContextMaker(trt, gsims)
-            rparams.update(cm.REQUIRES_RUPTURE_PARAMETERS)
+            params.update(cm.REQUIRES_RUPTURE_PARAMETERS)
             for dparam in cm.REQUIRES_DISTANCES:
-                rparams.add(dparam + '_')
+                params.add(dparam + '_')
         zd.eff_ruptures = AccumDict(accum=0)  # trt -> eff_ruptures
         mags = set()
         for trt, dset in self.datastore['source_mags'].items():
@@ -244,7 +244,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if self.few_sites:
             for mag in mags:
                 name = 'mag_%s/' % mag
-                for param in rparams:
+                for param in params:
                     if param == 'sids_':
                         dt = hdf5.vuint16
                     elif param.endswith('_'):
@@ -255,6 +255,8 @@ class ClassicalCalculator(base.HazardCalculator):
                         dt = F64
                     self.datastore.create_dset(name + param, dt, (None,),
                                                compression='gzip')
+                dset = self.datastore.getitem(name)
+                dset.attrs['__pdcolumns__'] = ' '.join(params)
         self.by_task = {}  # task_no => src_ids
         self.totrups = 0  # total number of ruptures before collapsing
         self.maxradius = 0

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -313,8 +313,8 @@ class DisaggregationCalculator(base.HazardCalculator):
             mags.update(dset[:])
         mags = sorted(mags)
         allargs = []
-        totweight = sum(d['rctx']['nsites'].sum() for n, d in dstore.items()
-                        if n.startswith('mag_') and len(d['rctx']))
+        totweight = sum(d['nsites'][:].sum() for n, d in dstore.items()
+                        if n.startswith('mag_'))
         et_ids = dstore['et_ids'][:]
         rlzs_by_gsim = self.full_lt.get_rlzs_by_gsim_list(et_ids)
         G = max(len(rbg) for rbg in rlzs_by_gsim)
@@ -326,13 +326,13 @@ class DisaggregationCalculator(base.HazardCalculator):
         U = 0
         totrups = 0
         for mag in mags:
-            rctx = dstore['mag_%s/rctx' % mag][:]
-            totrups += len(rctx)
+            grp_ids = dstore['mag_%s/grp_id' % mag][:]
+            totrups += len(grp_ids)
             for grp_id, gids in enumerate(et_ids):
-                idxs, = numpy.where(rctx['grp_id'] == grp_id)
+                idxs, = numpy.where(grp_ids == grp_id)
                 if len(idxs) == 0:
                     continue
-                nsites = rctx['nsites'][idxs]
+                nsites = dstore['mag_%s/nsites' % mag][idxs]
                 trti = gids[0] // num_eff_rlzs
                 trt = self.trts[trti]
                 cmaker = ContextMaker(

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -436,7 +436,7 @@ hazard_uhs-std.csv
             'hazard_curve-SA(2.0).csv', 'hazard_uhs.csv'], case_24.__file__)
         # test that the number of ruptures is at max 1/3 of the the total
         # due to the collapsing of the hypocenters (rjb is depth-independent)
-        self.assertEqual(len(self.calc.datastore['mag_5.25/rctx']), 34)
+        self.assertEqual(len(self.calc.datastore['mag_5.25/mag']), 34)
         self.assertEqual(self.calc.totrups, 780)
 
     def test_case_25(self):  # negative depths
@@ -449,7 +449,7 @@ hazard_uhs-std.csv
     def test_case_27(self):  # Nankai mutex model
         self.assert_curves_ok(['hazard_curve.csv'], case_27.__file__)
         # make sure probs_occur are stored as expected
-        probs_occur = self.calc.datastore['mag_8.20/rctx']['probs_occur']
+        probs_occur = self.calc.datastore['mag_8.20/probs_occur_']
         tot_probs_occur = sum(len(po) for po in probs_occur)
         self.assertEqual(tot_probs_occur, 4)  # 2 nonparam rups x 2
 
@@ -487,7 +487,7 @@ hazard_uhs-std.csv
                                    'hazard_curve-SA(1.0).csv'],
                                   case_30.__file__)
             # check rupdata
-            nruptures = len(self.calc.datastore['mag_5.05/rctx'])
+            nruptures = len(self.calc.datastore['mag_5.05/mag'])
             self.assertEqual(nruptures, 28)
 
     def test_case_30_sampling(self):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -119,26 +119,23 @@ def read_ctxs(dstore, magstr, idxs=slice(None), req_site_params=None):
     Use it as `read_ctxs(dstore, 'mag_5.50')`.
     :returns: a pair (contexts, [contexts close to site for each site])
     """
-    sitecol = dstore['sitecol']
+    sitecol = dstore['sitecol'].complete
     site_params = {par: sitecol[par]
                    for par in req_site_params or sitecol.array.dtype.names}
-    rctx = dstore[magstr]['rctx'][idxs]
     if h5py.version.version_tuple >= (2, 10, 0):
         # this version is spectacularly better in cluster1; for
         # Colombia with 1.2M ruptures I measured a speedup of 8.5x
-        grp = {n: d[idxs] for n, d in dstore[magstr].items()
-               if n.endswith('_')}
+        params = {n: d[idxs] for n, d in dstore[magstr].items()}
     else:
         # for old h5py read the whole array and then filter on the indices
-        grp = {n: d[:][idxs] for n, d in dstore[magstr].items()
-               if n.endswith('_')}
+        params = {n: d[:][idxs] for n, d in dstore[magstr].items()}
     ctxs = []
-    for u, rec in enumerate(rctx):
+    for u in range(len(params['mag'])):
         ctx = RuptureContext()
-        for par in rctx.dtype.names:
-            setattr(ctx, par, rec[par])
-        for par, arr in grp.items():
-            setattr(ctx, par[:-1], arr[u])
+        for par, arr in params.items():
+            if par.endswith('_'):
+                par = par[:-1]
+            setattr(ctx, par, arr[u])
         for par, arr in site_params.items():
             setattr(ctx, par, arr[ctx.sids])
         ctx.idx = {sid: idx for idx, sid in enumerate(ctx.sids)}
@@ -231,7 +228,7 @@ class ContextMaker(object):
         :returns: the interesting attributes of the context
         """
         params = {'occurrence_rate', 'sids_',
-                  'probs_occur', 'clon_', 'clat_', 'rrup_'}
+                  'probs_occur_', 'clon_', 'clat_', 'rrup_'}
         params.update(self.REQUIRES_RUPTURE_PARAMETERS)
         for dparam in self.REQUIRES_DISTANCES:
             params.add(dparam + '_')


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/6239. The performance of the SGC calculation is a little bit better than before:
```
   calc_533, maxmem=350.8 GB    time_sec memory_mb counts   
   ============================ ======== ========= =========
   total classical              355_789  1_941     618      
   total compute_disagg         293_963  2_276     719      
   get_poes                     252_141  0.0       49_506   
   disaggregate                 205_176  0.0       527_766  
   disagg mean_std              86_253   2_052     719      
   computing mean_std           79_855   0.0       49_506   
   composing pnes               40_793   0.0       5_935_905
   total classical_split_filter 33_511   1_905     693      
   make_contexts                12_273   0.0       693      
   DisaggregationCalculator.run 7_458    6_229     1        
   ClassicalCalculator.run      3_944    2_594     1        
   iter_ruptures                2_432    0.0       1_226_427
   reading contexts             2_171    306       719
   
   operation-duration     counts mean    stddev min     max    
   classical              618    575     132%   0.59772 3_403  
   classical_split_filter 75     446     165%   1.69990 3_161  
   compute_disagg         719    408     74%    0.12588 1_456  
```