### PR TITLE
Upgraded to h5py 2.10.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Internal: required h5py == 2.10.0
   * Internal: made the classical ruptures pandas-friendly
   * Internal: made the damage distributions pandas-friendly
 

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -332,7 +332,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                 idxs, = numpy.where(grp_ids == grp_id)
                 if len(idxs) == 0:
                     continue
-                nsites = dstore['mag_%s/nsites' % mag][:][idxs]
+                nsites = dstore['mag_%s/nsites' % mag][idxs]
                 trti = gids[0] // num_eff_rlzs
                 trt = self.trts[trti]
                 cmaker = ContextMaker(

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -122,13 +122,7 @@ def read_ctxs(dstore, magstr, idxs=slice(None), req_site_params=None):
     sitecol = dstore['sitecol'].complete
     site_params = {par: sitecol[par]
                    for par in req_site_params or sitecol.array.dtype.names}
-    if h5py.version.version_tuple >= (2, 10, 0):
-        # this version is spectacularly better in cluster1; for
-        # Colombia with 1.2M ruptures I measured a speedup of 8.5x
-        params = {n: d[idxs] for n, d in dstore[magstr].items()}
-    else:
-        # for old h5py read the whole array and then filter on the indices
-        params = {n: d[:][idxs] for n, d in dstore[magstr].items()}
+    params = {n: d[idxs] for n, d in dstore[magstr].items()}
     ctxs = []
     for u in range(len(params['mag'])):
         ctx = RuptureContext()

--- a/requirements-py36-linux64.txt
+++ b/requirements-py36-linux64.txt
@@ -8,7 +8,7 @@
 
 https://wheelhouse.openquake.org/v2/linux/py/pytz-2018.3-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py/setuptools-39.0.1-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/linux/py36/h5py-2.9.0-cp36-cp36m-manylinux1_x86_64.whl
+https://wheelhouse.openquake.org/v2/linux/py36/h5py-2.10.0-cp36-cp36m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v2/linux/py/nose-1.3.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/linux/py36/numpy-1.16.5-cp36-cp36m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v2/linux/py36/scipy-1.3.1-cp36-cp36m-manylinux1_x86_64.whl

--- a/requirements-py36-macos.txt
+++ b/requirements-py36-macos.txt
@@ -8,7 +8,7 @@
 
 https://wheelhouse.openquake.org/v2/macos/py/pytz-2018.3-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py/setuptools-39.0.1-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/macos/py36/h5py-2.9.0-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+https://wheelhouse.openquake.org/v2/macos/py36/h5py-2.10.0-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 https://wheelhouse.openquake.org/v2/macos/py/nose-1.3.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/macos/py36/numpy-1.16.5-cp36-cp36m-macosx_10_9_x86_64.whl
 https://wheelhouse.openquake.org/v2/macos/py36/scipy-1.3.1-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl

--- a/requirements-py36-win64.txt
+++ b/requirements-py36-win64.txt
@@ -8,7 +8,7 @@
 
 https://wheelhouse.openquake.org/v2/windows/py/pytz-2018.3-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py/setuptools-39.0.1-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v2/windows/py36/h5py-2.9.0-cp36-cp36m-win_amd64.whl
+https://wheelhouse.openquake.org/v2/windows/py36/h5py-2.10.0-cp36-cp36m-win_amd64.whl
 https://wheelhouse.openquake.org/v2/windows/py/nose-1.3.7-py3-none-any.whl
 https://wheelhouse.openquake.org/v2/windows/py36/numpy-1.16.5-cp36-cp36m-win_amd64.whl
 https://wheelhouse.openquake.org/v2/windows/py36/scipy-1.3.1-cp36-cp36m-win_amd64.whl

--- a/requirements-py37-linux64.txt
+++ b/requirements-py37-linux64.txt
@@ -7,7 +7,7 @@
 
 https://wheelhouse.openquake.org/v3/linux/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/setuptools-41.0.1-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v3/linux/py37/h5py-2.9.0-cp37-cp37m-manylinux1_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py37/h5py-2.10.0-cp37-cp37m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py37/numpy-1.16.5-cp37-cp37m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py37/scipy-1.3.1-cp37-cp37m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py37/pandas-0.25.3-cp37-cp37m-manylinux1_x86_64.whl

--- a/requirements-py37-macos.txt
+++ b/requirements-py37-macos.txt
@@ -7,7 +7,7 @@
 
 https://wheelhouse.openquake.org/v3/macos/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/setuptools-41.0.1-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v3/macos/py37/h5py-2.9.0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+https://wheelhouse.openquake.org/v3/macos/py37/h5py-2.10.0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 https://wheelhouse.openquake.org/v3/macos/py37/numpy-1.16.5-cp37-cp37m-macosx_10_9_x86_64.whl
 https://wheelhouse.openquake.org/v3/macos/py37/scipy-1.3.1-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
 https://wheelhouse.openquake.org/v3/macos/py37/pandas-0.25.3-cp37-cp37m-macosx_10_9_x86_64.whl

--- a/requirements-py37-win64.txt
+++ b/requirements-py37-win64.txt
@@ -7,7 +7,7 @@
 
 https://wheelhouse.openquake.org/v3/windows/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py/setuptools-41.0.1-py2.py3-none-any.whl
-https://wheelhouse.openquake.org/v3/windows/py37/h5py-2.9.0-cp37-cp37m-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py37/h5py-2.10.0-cp37-cp37m-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py37/numpy-1.16.5-cp37-cp37m-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py37/scipy-1.3.1-cp37-cp37m-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py37/pandas-0.25.3-cp37-cp37m-win_amd64.whl

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ PY_MODULES = ['openquake.commands.__main__']
 
 install_requires = [
     'setuptools',
-    'h5py >=2.9, <2.11',
+    'h5py >=2.10, <2.11',
     'numpy >=1.16, <1.19',
     'scipy >=1.3, <1.5',
     'pandas >=0.25, <1.1',


### PR DESCRIPTION
To avoid breaking the oq-risk-tests for disaggregation all the time, and to have consistent performance.