### PR TITLE
Reduced the data storage in classical ruptures

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -249,12 +249,14 @@ class ClassicalCalculator(base.HazardCalculator):
                 for param in params:
                     if param == 'sids_':
                         dt = hdf5.vuint16
-                    elif param.endswith('_'):
+                    elif param == 'probs_occur_':
                         dt = hdf5.vfloat64
+                    elif param.endswith('_'):
+                        dt = hdf5.vfloat32
                     elif param in {'nsites', 'grp_id'}:
                         dt = U32
                     else:
-                        dt = F64
+                        dt = F32
                     self.datastore.create_dset(name + param, dt, (None,),
                                                compression='gzip')
                 dset = self.datastore.getitem(name)


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/6245. We are now better than engine 3.10 in disk space but using 2x more memory in the tasks:
```
   calc_12, maxmem=69.7 GB      time_sec memory_mb counts   
   ============================ ======== ========= =========
   total classical_             33_501   389       1_114    
   make_contexts                11_703   0.0       150_163  
   composing pnes               8_700    0.0       6_256_047
   computing mean_std           7_107    0.0       6_256_047
   get_poes                     5_303    0.0       6_256_047
   total classical_split_filter 2_566    406       1_255    
   ClassicalCalculator.run      773      3_377     1        
   aggregate curves             482      1_272     1_255    
   /mnt/sdd/users/michele/oqdata/calc_12.hdf5 : 55.93 GB  # engine 3.10

   calc_14, maxmem=205.3 GB     time_sec memory_mb counts   
   ============================ ======== ========= =========
   total classical              33_470   1_848     618      
   make_contexts                12_521   0.0       693      
   get_poes                     7_461    0.0       4_977    
   computing mean_std           6_683    0.0       4_977    
   composing pnes               6_417    0.0       5_935_905
   total classical_split_filter 3_219    1_859     693      
   iter_ruptures                2_504    0.0       1_226_427
   ClassicalCalculator.run      711      3_321     1        
   aggregate curves             343      3_023     692      
   /mnt/sdd/users/michele/oqdata/calc_14.hdf5 : 51.27 GB  # this branch
```