### PR TITLE
Pandas-friendly classical rupture storage

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -153,12 +153,12 @@ def store_ctxs(dstore, rupdata, grp_id):
     """
     Store contexts with the same magnitude in the datastore
     """
-    magstr = 'mag_%.2f' % rupdata['mag'][0]
+    grp = 'grp-%02d' % grp_id
     nr = len(rupdata['mag'])
     rupdata['nsites'] = numpy.array([len(s) for s in rupdata['sids_']])
     rupdata['grp_id'] = numpy.array([grp_id] * nr)
-    for par in dstore[magstr]:
-        n = '%s/%s' % (magstr, par)
+    for par in dstore[grp]:
+        n = '%s/%s' % (grp, par)
         if par not in rupdata:  # when not requiring the parameter
             hdf5.extend(dstore[n], numpy.array([numpy.nan] * nr))
         elif par.endswith('_'):
@@ -219,8 +219,7 @@ class ClassicalCalculator(base.HazardCalculator):
             acc.eff_ruptures[trt] += eff_rups
 
             # store rup_data if there are few sites
-            for mag, c in dic['rup_data'].items():
-                store_ctxs(self.datastore, c, grp_id)
+            store_ctxs(self.datastore, dic['rup_data'], grp_id)
         return acc
 
     def acc0(self):
@@ -241,9 +240,10 @@ class ClassicalCalculator(base.HazardCalculator):
         for trt, dset in self.datastore['source_mags'].items():
             mags.update(dset[:])
         mags = sorted(mags)
+        G = len(self.datastore['et_ids'])
         if self.few_sites:
-            for mag in mags:
-                name = 'mag_%s/' % mag
+            for grp_id in range(G):
+                name = 'grp-%02d/' % grp_id
                 for param in params:
                     if param == 'sids_':
                         dt = hdf5.vuint16

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -220,7 +220,8 @@ class ClassicalCalculator(base.HazardCalculator):
             acc.eff_ruptures[trt] += eff_rups
 
             # store rup_data if there are few sites
-            store_ctxs(self.datastore, dic['rup_data'], grp_id)
+            if self.few_sites:
+                store_ctxs(self.datastore, dic['rup_data'], grp_id)
 
         return acc
 

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -341,7 +341,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                  'investigation_time': oq.investigation_time,
                  'imtls': oq.imtls})
             U = max(U, block.weight)
-            idxs = numpy.array(sorted(rec['idx'] for rec in block))
+            idxs = numpy.sort([rec['idx'] for rec in block])
             allargs.append((dstore, magi, idxs, cmaker,
                             self.hmap4, trti, self.bin_edges))
             task_inputs.append((trti, magi, len(idxs)))

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -341,6 +341,8 @@ class DisaggregationCalculator(base.HazardCalculator):
                  'maximum_distance': oq.maximum_distance,
                  'collapse_level': oq.collapse_level,
                  'imtls': oq.imtls})
+            logging.info('%d ruptures in grp_id=%d split in %d mag bins',
+                         nr, grp_id, len(numpy.unique(arr['magi'])))
             for block in block_splitter(arr, maxweight,
                                         operator.itemgetter('nsites'),
                                         operator.itemgetter('magi'),
@@ -351,7 +353,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                 allargs.append((dstore, magi, blk, cmaker,
                                 self.hmap4, grp_id, trti, self.bin_edges, oq))
                 task_inputs.append((trti, magi, len(blk)))
-        logging.info('Found {:_d} ruptures'.format(totrups))
+        logging.info('Total {:_d} ruptures'.format(totrups))
         nbytes, msg = get_nbytes_msg(dict(M=self.M, G=G, U=U, F=2))
         logging.info('Maximum mean_std per task:\n%s', msg)
 
@@ -367,10 +369,10 @@ class DisaggregationCalculator(base.HazardCalculator):
         logging.info('Estimated data transfer:\n%s', msg)
 
         sd.pop('tasks')
-        sd['mags_trt'] = sum(len(mags) for mags in
-                             self.datastore['source_mags'].values())
-        nbytes, msg = get_nbytes_msg(sd)
-        logging.info('Estimated memory on the master:\n%s', msg)
+        #sd['mags_trt'] = sum(len(mags) for mags in
+        #                     self.datastore['source_mags'].values())
+        #nbytes, msg = get_nbytes_msg(sd)
+        #logging.info('Estimated memory on the master:\n%s', msg)
 
         dt = numpy.dtype([('trti', U8), ('mag', '|S4'), ('nrups', U32)])
         self.datastore['disagg_task'] = numpy.array(task_inputs, dt)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -307,7 +307,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         magi = numpy.searchsorted(self.bin_edges[0], dstore['rup/mag'][:]) - 1
         magi[magi == -1] = 0  # when the magnitude is on the edge
         totrups = len(magi)
-        logging.info('Read {:_d} ruptures'.format(totrups))
+        logging.info('Reading {:_d} ruptures'.format(totrups))
         rdt = [('grp_id', U16), ('magi', U8), ('nsites', U16), ('idx', U32)]
         rdata = numpy.zeros(totrups, rdt)
         rdata['magi'] = magi

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -347,7 +347,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                                         sort=True):
                 magi = block[0]['magi']
                 U = max(U, block.weight)
-                blk = numpy.array([rec['idx'] for rec in block])
+                blk = numpy.array(sorted(rec['idx'] for rec in block))
                 allargs.append((dstore, magi, blk, cmaker,
                                 self.hmap4, grp_id, trti, self.bin_edges, oq))
                 task_inputs.append((trti, magi, len(blk)))

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -326,6 +326,12 @@ class DisaggregationCalculator(base.HazardCalculator):
         U = 0
         self.datastore.swmr_on()
         smap = parallel.Starmap(compute_disagg, h5=self.datastore.hdf5)
+        # ABSURDLY IMPORTANT!! we rely on the fact that the classical part
+        # of the calculation stores the ruptures in chunks of constant
+        # grp_id, therefore it is possible to build (start, stop) slices;
+        # we are NOT grouping by operator.itemgetter('grp_id', 'magi'):
+        # that would break the ordering of the indices causing an incredibly
+        # worse performance, but visible only in extra-large calculations!
         for block in block_splitter(rdata, maxweight,
                                     operator.itemgetter('nsites'),
                                     operator.itemgetter('grp_id')):

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -314,6 +314,8 @@ class DisaggregationCalculator(base.HazardCalculator):
         rdata['grp_id'] = dstore['rup/grp_id'][:]
         rdata['nsites'] = dstore['rup/nsites'][:]
         rdata.sort(order=['grp_id', 'magi'])
+        blocks = len(numpy.unique(rdata[['grp_id', 'magi']]))
+        logging.info('There are %d combinations (grp_id, magi)', blocks)
         allargs = []
         totweight = rdata['nsites'].sum()
         et_ids = dstore['et_ids'][:]

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -341,10 +341,10 @@ class DisaggregationCalculator(base.HazardCalculator):
                  'investigation_time': oq.investigation_time,
                  'imtls': oq.imtls})
             U = max(U, block.weight)
-            idxs = numpy.sort([rec['idx'] for rec in block])
-            smap.submit((dstore, idxs, cmaker, self.hmap4, trti, magi[idxs],
+            slc = slice(block[0]['idx'], block[-1]['idx'] + 1)
+            smap.submit((dstore, slc, cmaker, self.hmap4, trti, magi[slc],
                          self.bin_edges))
-            task_inputs.append((trti, len(idxs)))
+            task_inputs.append((trti, slc.stop-slc.start))
 
         nbytes, msg = get_nbytes_msg(dict(M=self.M, G=G, U=U, F=2))
         logging.info('Maximum mean_std per task:\n%s', msg)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -324,6 +324,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         num_eff_rlzs = len(self.full_lt.sm_rlzs)
         task_inputs = []
         U = 0
+        self.datastore.swmr_on()
         smap = parallel.Starmap(compute_disagg, h5=self.datastore.hdf5)
         for block in block_splitter(rdata, maxweight,
                                     operator.itemgetter('nsites'),

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -124,7 +124,7 @@ def compute_disagg(dstore, magi, rup_df, cmaker, hmap4, trti, bin_edges,
         cmaker.investigation_time)
     with monitor('reading contexts', measuremem=True):
         dstore.open('r')
-        ctxs, close_ctxs = read_ctxs(
+        ctxs = read_ctxs(
             dstore, rup_df, req_site_params=cmaker.REQUIRES_SITES_PARAMETERS)
 
     dis_mon = monitor('disaggregate', measuremem=False)
@@ -145,7 +145,8 @@ def compute_disagg(dstore, magi, rup_df, cmaker, hmap4, trti, bin_edges,
 
     # disaggregate by site, IMT
     for s, iml3 in enumerate(hmap4):
-        if not g_by_z[s] or not close_ctxs[s]:
+        close = [ctx for ctx in ctxs if s in ctx.idx]
+        if not g_by_z[s] or not close:
             # g_by_z[s] is empty in test case_7
             continue
         # dist_bins, lon_bins, lat_bins, eps_bins
@@ -155,7 +156,7 @@ def compute_disagg(dstore, magi, rup_df, cmaker, hmap4, trti, bin_edges,
         with dis_mon:
             # 7D-matrix #distbins, #lonbins, #latbins, #epsbins, M, P, Z
             matrix = disagg.disaggregate(
-                close_ctxs[s], g_by_z[s], iml2, eps3, s, bins)  # 7D-matrix
+                close, g_by_z[s], iml2, eps3, s, bins)  # 7D-matrix
             for m in range(M):
                 mat6 = matrix[..., m, :, :]
                 if mat6.any():

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -155,9 +155,8 @@ class DisaggregationTestCase(CalculatorTestCase):
     def test_case_7(self):
         # test with 7+2 ruptures of two source models, 1 GSIM, 1 site
         self.run_calc(case_7.__file__, 'job.ini')
-        ctxs, _close = read_ctxs(self.calc.datastore, 'mag_7.70')
-        ctxs0 = [ctx for ctx in ctxs if ctx.grp_id == 0]
-        ctxs1 = [ctx for ctx in ctxs if ctx.grp_id == 1]
+        ctxs0, _close = read_ctxs(self.calc.datastore, 0)
+        ctxs1, _close = read_ctxs(self.calc.datastore, 1)
         self.assertEqual(len(ctxs0), 7)  # rlz-0, the closest to the mean
         self.assertEqual(len(ctxs1), 2)  # rlz-1, the one to discard
         # checking that the wrong realization is indeed discarded

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -155,7 +155,7 @@ class DisaggregationTestCase(CalculatorTestCase):
     def test_case_7(self):
         # test with 7+2 ruptures of two source models, 1 GSIM, 1 site
         self.run_calc(case_7.__file__, 'job.ini')
-        ctxs, _close = read_ctxs(self.calc.datastore)
+        ctxs = read_ctxs(self.calc.datastore)
         ctxs0 = [ctx for ctx in ctxs if ctx.grp_id == 0]
         ctxs1 = [ctx for ctx in ctxs if ctx.grp_id == 1]
         self.assertEqual(len(ctxs0), 7)  # rlz-0, the closest to the mean

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -155,7 +155,7 @@ class DisaggregationTestCase(CalculatorTestCase):
     def test_case_7(self):
         # test with 7+2 ruptures of two source models, 1 GSIM, 1 site
         self.run_calc(case_7.__file__, 'job.ini')
-        ctxs = read_ctxs(self.calc.datastore)
+        ctxs, _ = read_ctxs(self.calc.datastore)
         ctxs0 = [ctx for ctx in ctxs if ctx.grp_id == 0]
         ctxs1 = [ctx for ctx in ctxs if ctx.grp_id == 1]
         self.assertEqual(len(ctxs0), 7)  # rlz-0, the closest to the mean

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -155,8 +155,9 @@ class DisaggregationTestCase(CalculatorTestCase):
     def test_case_7(self):
         # test with 7+2 ruptures of two source models, 1 GSIM, 1 site
         self.run_calc(case_7.__file__, 'job.ini')
-        ctxs0, _close = read_ctxs(self.calc.datastore, 0)
-        ctxs1, _close = read_ctxs(self.calc.datastore, 1)
+        ctxs, _close = read_ctxs(self.calc.datastore)
+        ctxs0 = [ctx for ctx in ctxs if ctx.grp_id == 0]
+        ctxs1 = [ctx for ctx in ctxs if ctx.grp_id == 1]
         self.assertEqual(len(ctxs0), 7)  # rlz-0, the closest to the mean
         self.assertEqual(len(ctxs1), 2)  # rlz-1, the one to discard
         # checking that the wrong realization is indeed discarded

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -113,15 +113,15 @@ def _make_pmap(ctxs, cmaker, investigation_time):
     return ~pmap
 
 
-def read_ctxs(dstore, grp_id, idxs=slice(None), req_site_params=None):
+def read_ctxs(dstore, idxs=slice(None), req_site_params=None):
     """
-    Use it as `read_ctxs(dstore, grp_id=0)`.
+    Use it as `read_ctxs(dstore)`.
     :returns: a pair (contexts, [contexts close to site for each site])
     """
     sitecol = dstore['sitecol'].complete
     site_params = {par: sitecol[par]
                    for par in req_site_params or sitecol.array.dtype.names}
-    params = {n: d[idxs] for n, d in dstore['grp-%02d' % grp_id].items()}
+    params = {n: d[idxs] for n, d in dstore['rup'].items()}
     ctxs = []
     for u in range(len(params['mag'])):
         ctx = RuptureContext()

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -102,8 +102,9 @@ def get_num_distances(gsims):
 
 
 # used only in contexts_test.py
-def _make_pmap(ctxs, cmaker, investigation_time):
-    RuptureContext.temporal_occurrence_model = PoissonTOM(investigation_time)
+def _make_pmap(ctxs, cmaker):
+    RuptureContext.temporal_occurrence_model = PoissonTOM(
+        cmaker.investigation_time)
     # easy case of independent ruptures, useful for debugging
     pmap = ProbabilityMap(len(cmaker.loglevels.array), len(cmaker.gsims))
     for ctx, poes in cmaker.gen_ctx_poes(ctxs):
@@ -159,7 +160,9 @@ class ContextMaker(object):
         self.gsims = gsims
         self.maximum_distance = (
             param.get('maximum_distance') or MagDepDistance({}))
+        self.investigation_time = param.get('investigation_time')
         self.trunclevel = param.get('truncation_level')
+        self.num_epsilon_bins = param.get('num_epsilon_bins', 1)
         self.effect = param.get('effect')
         for req in self.REQUIRES:
             reqset = set()

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -122,6 +122,7 @@ def read_ctxs(dstore, idxs=slice(None), req_site_params=None):
     sitecol = dstore['sitecol'].complete
     site_params = {par: sitecol[par]
                    for par in req_site_params or sitecol.array.dtype.names}
+    # this is the slow part, reading from a huge dataset
     params = {n: d[idxs] for n, d in dstore['rup'].items()}
     ctxs = []
     for u in range(len(params['mag'])):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -116,7 +116,7 @@ def _make_pmap(ctxs, cmaker):
 
 def read_ctxs(dstore, rup_df=None, req_site_params=None):
     """
-     :returns: a pair (contexts, [contexts close to site for each site])
+     :returns: a list of contexts
     """
     sitecol = dstore['sitecol'].complete
     site_params = {par: sitecol[par]
@@ -136,13 +136,7 @@ def read_ctxs(dstore, rup_df=None, req_site_params=None):
             setattr(ctx, par, arr[ctx.sids])
         ctx.idx = {sid: idx for idx, sid in enumerate(ctx.sids)}
         ctxs.append(ctx)
-    # sorting for debugging convenience
-    ctxs.sort(key=lambda ctx: ctx.occurrence_rate)
-    close_ctxs = [[] for sid in sitecol.sids]
-    for ctx in ctxs:
-        for sid in ctx.idx:
-            close_ctxs[sid].append(ctx)
-    return ctxs, close_ctxs
+    return ctxs
 
 
 class ContextMaker(object):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -114,16 +114,17 @@ def _make_pmap(ctxs, cmaker):
     return ~pmap
 
 
-def read_ctxs(dstore, idxs=slice(None), req_site_params=None):
+def read_ctxs(dstore, rup_df=None, req_site_params=None):
     """
-    Use it as `read_ctxs(dstore)`.
-    :returns: a pair (contexts, [contexts close to site for each site])
+     :returns: a pair (contexts, [contexts close to site for each site])
     """
     sitecol = dstore['sitecol'].complete
     site_params = {par: sitecol[par]
                    for par in req_site_params or sitecol.array.dtype.names}
-    # this is the slow part, reading from a huge dataset
-    params = {n: d[idxs] for n, d in dstore['rup'].items()}
+    if rup_df is None:  # in tests
+        params = {n: d[:] for n, d in dstore['rup'].items()}
+    else:  # in disaggregation
+        params = {n: rup_df[n].to_numpy() for n in rup_df.columns}
     ctxs = []
     for u in range(len(params['mag'])):
         ctx = RuptureContext()

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -26,7 +26,6 @@ import itertools
 import functools
 import collections
 import numpy
-import h5py
 from scipy.interpolate import interp1d
 
 from openquake.baselib import hdf5, parallel
@@ -114,15 +113,15 @@ def _make_pmap(ctxs, cmaker, investigation_time):
     return ~pmap
 
 
-def read_ctxs(dstore, magstr, idxs=slice(None), req_site_params=None):
+def read_ctxs(dstore, grp_id, idxs=slice(None), req_site_params=None):
     """
-    Use it as `read_ctxs(dstore, 'mag_5.50')`.
+    Use it as `read_ctxs(dstore, grp_id=0)`.
     :returns: a pair (contexts, [contexts close to site for each site])
     """
     sitecol = dstore['sitecol'].complete
     site_params = {par: sitecol[par]
                    for par in req_site_params or sitecol.array.dtype.names}
-    params = {n: d[idxs] for n, d in dstore[magstr].items()}
+    params = {n: d[idxs] for n, d in dstore['grp-%02d' % grp_id].items()}
     ctxs = []
     for u in range(len(params['mag'])):
         ctx = RuptureContext()
@@ -595,9 +594,7 @@ class PmapMaker(object):
             pmap = self._make_src_mutex()
         else:
             pmap = self._make_src_indep()
-        rupdata = groupby(self.rupdata, lambda ctx: '%.2f' % ctx.mag)
-        for mag, ctxs in rupdata.items():
-            rupdata[mag] = self.dictarray(ctxs)
+        rupdata = self.dictarray(self.rupdata)
         return (pmap, rupdata, self.calc_times, dict(totrups=self.totrups))
 
     def collapse_point_ruptures(self, rups, sites):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -114,13 +114,6 @@ def _make_pmap(ctxs, cmaker):
     return ~pmap
 
 
-def _get(dset, idxs):
-    if hasattr(idxs,  'start'):  # is a slice
-        return dset[idxs]
-    # fast access to the dataset by filtering a larger slice
-    return dset[idxs[0]:idxs[-1] + 1][idxs-idxs[0]]
-
-
 def read_ctxs(dstore, slc=slice(None), req_site_params=None):
     """
      :returns: a list of contexts
@@ -128,7 +121,7 @@ def read_ctxs(dstore, slc=slice(None), req_site_params=None):
     sitecol = dstore['sitecol'].complete
     site_params = {par: sitecol[par]
                    for par in req_site_params or sitecol.array.dtype.names}
-    params = {n: _get(dstore['rup/' + n], slc) for n in dstore['rup']}
+    params = {n: dstore['rup/' + n][slc] for n in dstore['rup']}
     ctxs = []
     for u in range(len(params['mag'])):
         ctx = RuptureContext()

--- a/openquake/hazardlib/tests/contexts_test.py
+++ b/openquake/hazardlib/tests/contexts_test.py
@@ -224,6 +224,7 @@ class CollapseTestCase(unittest.TestCase):
             ctx.rjb = numpy.array([99.])
             ctxs.append(ctx)
         cmaker = ContextMaker(
-            'TRT', gsims, dict(imtls=imtls, truncation_level=trunclevel))
-        pmap = _make_pmap(ctxs, cmaker, 50.)
+            'TRT', gsims, dict(imtls=imtls, truncation_level=trunclevel,
+                               investigation_time=50))
+        pmap = _make_pmap(ctxs, cmaker)
         numpy.testing.assert_almost_equal(pmap[0].array, 0.066381)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6239. Here are the figures for the SGC calculation with 1 IMT:
```
# master
calc_20, maxmem=233.3 GB     time_sec memory_mb counts   
============================ ======== ========= =========
total compute_disagg         44_754   952       369      
total classical              37_080   1_854     618      
disaggregate                 35_062   0.0       200_316  
make_contexts                12_450   0.0       693      
get_poes                     11_287   0.0       4_977    
disagg mean_std              7_928    411       369      
computing mean_std           6_650    0.0       4_977    
composing pnes               6_433    0.0       5_935_905
total classical_split_filter 3_358    1_857     693      
iter_ruptures                2_489    0.0       1_226_427
DisaggregationCalculator.run 1_471    3_989     1        
reading contexts             1_463    1_010     369      
ClassicalCalculator.run      835      3_968     1        
aggregate curves             455      3_429     692      

# this branch
calc_19, maxmem=232.0 GB     time_sec memory_mb counts
============================ ======== ========= =========
total compute_disagg         44_263   833       1_567    
disaggregate                 34_408   0.0       680_326  
total classical              33_694   1_857     618      
make_contexts                12_592   0.0       693      
get_poes                     7_601    0.0       4_977    
disagg mean_std              7_560    433       1_567    
computing mean_std           6_711    0.0       4_977    
composing pnes               6_418    0.0       5_935_905
total classical_split_filter 3_261    1_858     693      
iter_ruptures                2_523    0.0       1_226_427
DisaggregationCalculator.run 1_339    3_813     1        
reading contexts             723      840       354      
ClassicalCalculator.run      709      3_784     1        
aggregate curves             346      2_771     692      
```
Overall we are faster than master (709s vs 835s for classical, due to aggregate curves being faster).