### PR TITLE
Store `src_id` in the contexts

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -55,7 +55,7 @@ F32 = numpy.float32
 TWO16 = 2 ** 16
 TWO32 = 2 ** 32
 
-CALC_TIME, NUM_SITES, EFF_RUPTURES, SERIAL = 3, 4, 5, 6
+CALC_TIME, NUM_SITES, EFF_RUPTURES = 3, 4, 5
 
 stats_dt = numpy.dtype([('mean', F32), ('std', F32),
                         ('min', F32), ('max', F32), ('len', U16)])
@@ -901,14 +901,13 @@ class HazardCalculator(BaseCalculator):
         """
         srcs = self.csm.get_sources()
         for src_id, arr in calc_times.items():
-            src_id = re.sub(r':\d+$', '', src_id)
             row = self.csm.source_info[src_id]
             row[CALC_TIME] += arr[2]
             if nsites:
                 row[EFF_RUPTURES] += arr[0]
                 row[NUM_SITES] += arr[1]
-                srcs[row[SERIAL]].num_ruptures = int(arr[0])
-                srcs[row[SERIAL]].nsites = int(arr[1])
+                srcs[src_id].num_ruptures = int(arr[0])
+                srcs[src_id].nsites = int(arr[1])
 
     def store_source_info(self, calc_times, nsites=False):
         """
@@ -918,6 +917,7 @@ class HazardCalculator(BaseCalculator):
         recs = [tuple(row) for row in self.csm.source_info.values()]
         hdf5.extend(self.datastore['source_info'],
                     numpy.array(recs, readinput.source_info_dt))
+        return [rec[0] for rec in recs]  # return source_ids
 
     def post_process(self):
         """For compatibility with the engine"""

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -559,7 +559,8 @@ class ClassicalCalculator(base.HazardCalculator):
         pgetter = getters.PmapGetter(
             self.datastore, weights, self.sitecol.sids, oq.imtls)
         logging.info('Saving _poes')
-        srcid = {row[0]: srcid for srcid, row in self.csm.source_info.items()}
+        enum = enumerate(self.datastore['source_info']['source_id'])
+        srcid = {source_id: i for i, source_id in enum}
         with self.monitor('saving probability maps'):
             for key, pmap in pmap_by_key.items():
                 if isinstance(key, str):  # disagg_by_src

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -54,12 +54,11 @@ def check_disagg_by_src(dstore):
 
 def get_dists(dstore):
     dic = general.AccumDict(accum=[])  # site_id -> distances
-    for name, dset in dstore.items():
-        if name.startswith('mag_'):
-            for sids, dsts in zip(dset['sids_'], dset['rrup_']):
-                for sid, dst in zip(sids, dsts):
-                    dic[sid].append(int(round(dst)))
-    return dic
+    rup = dstore['rup']
+    for sids, dsts in zip(rup['sids_'], rup['rrup_']):
+        for sid, dst in zip(sids, dsts):
+            dic[sid].append(int(round(dst)))
+    return {sid: sorted(dsts, reverse=True) for sid, dsts in dic.items()}
 
 
 class ClassicalTestCase(CalculatorTestCase):
@@ -436,7 +435,7 @@ hazard_uhs-std.csv
             'hazard_curve-SA(2.0).csv', 'hazard_uhs.csv'], case_24.__file__)
         # test that the number of ruptures is at max 1/3 of the the total
         # due to the collapsing of the hypocenters (rjb is depth-independent)
-        self.assertEqual(len(self.calc.datastore['mag_5.25/mag']), 34)
+        self.assertEqual(len(self.calc.datastore['rup/mag']), 174)
         self.assertEqual(self.calc.totrups, 780)
 
     def test_case_25(self):  # negative depths
@@ -449,9 +448,9 @@ hazard_uhs-std.csv
     def test_case_27(self):  # Nankai mutex model
         self.assert_curves_ok(['hazard_curve.csv'], case_27.__file__)
         # make sure probs_occur are stored as expected
-        probs_occur = self.calc.datastore['mag_8.20/probs_occur_']
+        probs_occur = self.calc.datastore['rup/probs_occur_'][:]
         tot_probs_occur = sum(len(po) for po in probs_occur)
-        self.assertEqual(tot_probs_occur, 4)  # 2 nonparam rups x 2
+        self.assertEqual(tot_probs_occur, 28)  # 14 x 2
 
         # make sure there is an error when trying to disaggregate
         with self.assertRaises(NotImplementedError):
@@ -487,8 +486,8 @@ hazard_uhs-std.csv
                                    'hazard_curve-SA(1.0).csv'],
                                   case_30.__file__)
             # check rupdata
-            nruptures = len(self.calc.datastore['mag_5.05/mag'])
-            self.assertEqual(nruptures, 28)
+            nruptures = len(self.calc.datastore['rup/mag'])
+            self.assertEqual(nruptures, 3202)
 
     def test_case_30_sampling(self):
         # IMT-dependent weights with sampling by cheating

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -71,10 +71,8 @@ source_info_dt = numpy.dtype([
     ('calc_time', numpy.float32),      # 3
     ('num_sites', numpy.uint32),       # 4
     ('eff_ruptures', numpy.uint32),    # 5
-    ('serial', numpy.uint32),          # 6
-    ('trti', numpy.uint8),             # 7
+    ('trti', numpy.uint8),             # 6
 ])
-SERIAL = 6
 
 
 class DuplicatedPoint(Exception):
@@ -737,9 +735,9 @@ def get_composite_source_model(oqparam, h5=None):
             lens.append(len(src.et_ids))
             src.grp_id = grp_id[tuple(src.et_ids)]
             row = [src.source_id, src.grp_id, src.code,
-                   0, 0, 0, src.id, full_lt.trti[src.tectonic_region_type]]
+                   0, 0, 0, full_lt.trti[src.tectonic_region_type]]
             wkts.append(src._wkt)  # this is a bit slow but okay
-            data[src.source_id] = row
+            data[src.id] = row
             if hasattr(src, 'mags'):  # UCERF
                 continue  # already accounted for in sg.mags
             elif hasattr(src, 'data'):  # nonparametric

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -337,14 +337,13 @@ class SourceFilter(object):
         """
         :yields: pairs ([split], sites)
         """
-        for src in sources:
+        with mon:
+            split, dt = split_sources(sources)
+        for s in split:
             with mon:
-                split, dt = split_sources(src)
-            for s in split:
-                with mon:
-                    sites = self.get_close_sites(s)
-                if sites is not None:
-                    yield [s], sites
+                sites = self.get_close_sites(s)
+            if sites is not None:
+                yield [s], sites
 
     # used in the rupture prefiltering: it should not discard too much
     def close_sids(self, rec, trt):

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -199,7 +199,7 @@ def sample_cluster(sources, srcfilter, num_ses, param):
                     rup_counter[src.id][rup.idx] += 1
                 # Store info
                 dt = time.time() - t0
-                calc_times[src.source_id] += numpy.array(
+                calc_times[src.id] += numpy.array(
                     [len(rup_data[src.id]), src.nsites, dt])
         elif param['src_interdep'] == 'mutex':
             raise NotImplementedError('src_interdep == mutex')
@@ -266,7 +266,7 @@ def sample_ruptures(sources, srcfilter, param, monitor=Monitor()):
                 ebr = EBRupture(rup, src.source_id, et_id, n_occ)
                 eb_ruptures.append(ebr)
             dt = time.time() - t0
-            calc_times[src.source_id] += numpy.array([nr, src.nsites, dt])
+            calc_times[src.id] += numpy.array([nr, src.nsites, dt])
         rup_array = get_rup_array(eb_ruptures, srcfilter)
         yield AccumDict(dict(rup_array=rup_array, calc_times=calc_times,
                              eff_ruptures={trt: eff_ruptures}))


### PR DESCRIPTION
So that it is possible to know, for each rupture, which source generated it. Also, fixes some errors introduced by https://github.com/gem/oq-engine/pull/6247.