### PR TITLE
Exporting the secondary intensities

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Using pandas to export the GMF in CSV format
   * Internal: required h5py == 2.10.0
   * Internal: made the classical ruptures pandas-friendly
   * Internal: made the damage distributions pandas-friendly

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -398,10 +398,14 @@ def export_gmf_data_csv(ekey, dstore):
     df = dstore.read_df('gmf_data').sort_values(['eid', 'sid'])
     ren = {'sid': 'site_id', 'eid': 'event_id'}
     for m, imt in enumerate(imts):
-        ren[f'gmv_{m}'] = imt
+        ren[f'gmv_{m}'] = 'gmv_' + imt
     df.rename(columns=ren, inplace=True)
     event_id = dstore['events']['id']
     f = dstore.build_fname('sitemesh', '', 'csv')
+    arr = dstore['sitecol'][['lon', 'lat']]
+    sids = numpy.arange(len(arr), dtype=U32)
+    sites = util.compose_arrays(sids, arr, 'site_id')
+    writers.write_csv(f, sites)
     fname = dstore.build_fname('gmf', 'data', 'csv')
     df.to_csv(fname, index=False)
     if 'sigma_epsilon' in dstore['gmf_data']:

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -407,7 +407,7 @@ def export_gmf_data_csv(ekey, dstore):
     sites = util.compose_arrays(sids, arr, 'site_id')
     writers.write_csv(f, sites)
     fname = dstore.build_fname('gmf', 'data', 'csv')
-    df.to_csv(fname, index=False)
+    df.to_csv(fname, index=False, float_format=writers.FIVEDIGITS)
     if 'sigma_epsilon' in dstore['gmf_data']:
         sig_eps_csv = dstore.build_fname('sigma_epsilon', '', 'csv')
         sig_eps = dstore['gmf_data/sigma_epsilon'][()]

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -481,7 +481,9 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertGreater(nd_mean, 0)
         [fname, _, _] = export(('gmf_data', 'csv'), self.calc.datastore)
         arr = read_csv(fname)[:2]
-        self.assertEqual(arr.dtype.names, ('site_id', 'event_id', 'gmv_PGA'))
+        self.assertEqual(arr.dtype.names,
+                         ('site_id', 'event_id', 'gmv_PGA',
+                          'newmark_disp', 'prob_disp'))
 
     def test_case_26_liq(self):
         # cali liquefaction simplified


### PR DESCRIPTION
Useful for the implementation of https://github.com/gem/oq-engine/issues/6081. The idea is to export a CSV in the hazard phase than can be reimported in the risk phase, to generate meaning inputs for the tests.

While at it, I am also taking advantage of pandas to export the GMFs, with a huge performance benefit. Here is an example with 1 GB of GMFs (4.4x):
```
exporting 1GB before: 495s
exporting 1GB after:  112s
```
