### PR TITLE
Reverted the BooreAtkinson2008 refactoring in https://github.com/gem/oq-engine/pull/6265

### DIFF
--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -41,7 +41,7 @@ class BooreAtkinson2008(GMPE):
     #: Supported intensity measure types are spectral acceleration,
     #: peak ground velocity and peak ground acceleration, see table 3
     #: pag. 110
-   q
+
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = {PGA, PGV, SA}
 
     #: Supported intensity measure component is orientation-independent

--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -41,6 +41,7 @@ class BooreAtkinson2008(GMPE):
     #: Supported intensity measure types are spectral acceleration,
     #: peak ground velocity and peak ground acceleration, see table 3
     #: pag. 110
+   q
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = {PGA, PGV, SA}
 
     #: Supported intensity measure component is orientation-independent
@@ -50,8 +51,11 @@ class BooreAtkinson2008(GMPE):
 
     #: Supported standard deviation types are inter-event, intra-event
     #: and total, see equation 2, pag 106.
-    DEFINED_FOR_STANDARD_DEVIATION_TYPES = {
-        const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA_EVENT}
+    DEFINED_FOR_STANDARD_DEVIATION_TYPES = set([
+        const.StdDev.TOTAL,
+        const.StdDev.INTER_EVENT,
+        const.StdDev.INTRA_EVENT
+    ])
 
     #: Required site parameters is Vs30.
     #: See paragraph 'Predictor Variables', pag 103
@@ -68,34 +72,6 @@ class BooreAtkinson2008(GMPE):
     #: Shear-wave velocity for reference soil conditions in [m s-1]
     DEFINED_FOR_REFERENCE_VELOCITY = 760.
 
-    def get_mean_std1(self, ctx, imts):
-        """
-        :param ctx: a multi-RuptureContext of size U
-        :param imts: a list of M intensity measure types
-        :returns: means and total stddevs as an array of shape (2, U, M)
-        """
-        U = ctx.size()
-        res = np.zeros((2, U, len(imts)))
-        for m, imt in enumerate(imts):
-            C = self.COEFFS[imt]
-            C_SR = self.COEFFS_SOIL_RESPONSE[imt]
-            pga4nl = self._get_pga_on_rock(ctx, C)
-            if isinstance(imt, PGA):
-                mean = (np.log(pga4nl) +
-                        self._get_site_amplification_linear(ctx.vs30, C_SR) +
-                        self._get_site_amplification_non_linear(
-                            ctx.vs30, pga4nl, C_SR))
-            else:
-                mean = (self._compute_magnitude_scaling(ctx, C) +
-                        self._compute_distance_scaling(ctx, C) +
-                        self._get_site_amplification_linear(ctx.vs30, C_SR) +
-                        self._get_site_amplification_non_linear(
-                            ctx.vs30, pga4nl, C_SR))
-            [stddev] = self._get_stddevs(C, [const.StdDev.TOTAL], U)
-            res[0, :, m] = mean
-            res[1, :, m] = stddev
-        return res
-
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         See :meth:`superclass method
@@ -109,8 +85,7 @@ class BooreAtkinson2008(GMPE):
 
         # compute PGA on rock conditions - needed to compute non-linear
         # site amplification term
-        vars(rup).update(vars(dists))  # update RuptureContext with distances
-        pga4nl = self._get_pga_on_rock(rup, C)
+        pga4nl = self._get_pga_on_rock(rup, dists, C)
 
         # equation 1, pag 106, without sigma term, that is only the first 3
         # terms. The third term (site amplification) is computed as given in
@@ -125,7 +100,7 @@ class BooreAtkinson2008(GMPE):
                                                         C_SR)
         else:
             mean = self._compute_magnitude_scaling(rup, C) + \
-                self._compute_distance_scaling(rup, C) + \
+                self._compute_distance_scaling(rup, dists, C) + \
                 self._get_site_amplification_linear(sites.vs30, C_SR) + \
                 self._get_site_amplification_non_linear(sites.vs30, pga4nl,
                                                         C_SR)
@@ -149,41 +124,30 @@ class BooreAtkinson2008(GMPE):
                 stddevs.append(C['tau'] + np.zeros(num_sites))
         return stddevs
 
-    def _compute_distance_scaling(self, ctx, C):
+    def _compute_distance_scaling(self, rup, dists, C):
         """
         Compute distance-scaling term, equations (3) and (4), pag 107.
         """
         Mref = 4.5
         Rref = 1.0
-        R = np.sqrt(ctx.rjb ** 2 + C['h'] ** 2)
-        return (C['c1'] + C['c2'] * (ctx.mag - Mref)) * np.log(R / Rref) + \
+        R = np.sqrt(dists.rjb ** 2 + C['h'] ** 2)
+        return (C['c1'] + C['c2'] * (rup.mag - Mref)) * np.log(R / Rref) + \
             C['c3'] * (R - Rref)
 
-    def _compute_magnitude_scaling(self, ctx, C):
+    def _compute_magnitude_scaling(self, rup, C):
         """
         Compute magnitude-scaling term, equations (5a) and (5b), pag 107.
         """
-        U = ctx.size()
-        if U == 1:
-            return self._compute_ms(ctx, C)
-        else:
-            lst = [self._compute_ms(c, C) for c in ctx.ctxs]
-            return np.array(lst)
-
-    def _compute_ms(self, ctx, C):
-        """
-        Compute magnitude-scaling term, equations (5a) and (5b), pag 107.
-        """
-        U, SS, NS, RS = self._get_fault_type_dummy_variables(ctx)
-        if ctx.mag <= C['Mh']:
+        U, SS, NS, RS = self._get_fault_type_dummy_variables(rup)
+        if rup.mag <= C['Mh']:
             return C['e1'] * U + C['e2'] * SS + C['e3'] * NS + C['e4'] * RS + \
-                C['e5'] * (ctx.mag - C['Mh']) + \
-                C['e6'] * (ctx.mag - C['Mh']) ** 2
+                C['e5'] * (rup.mag - C['Mh']) + \
+                C['e6'] * (rup.mag - C['Mh']) ** 2
         else:
             return C['e1'] * U + C['e2'] * SS + C['e3'] * NS + C['e4'] * RS + \
-                C['e7'] * (ctx.mag - C['Mh'])
+                C['e7'] * (rup.mag - C['Mh'])
 
-    def _get_fault_type_dummy_variables(self, ctx):
+    def _get_fault_type_dummy_variables(self, rup):
         """
         Get fault type dummy variables, see Table 2, pag 107.
         Fault type (Strike-slip, Normal, Thrust/reverse) is
@@ -196,17 +160,18 @@ class BooreAtkinson2008(GMPE):
         because rake is always given.
         """
         U, SS, NS, RS = 0, 0, 0, 0
-        if ctx.rake == 'undefined':
+        if rup.rake == 'undefined':
             U = 1
-        elif np.abs(ctx.rake) <= 30.0 or (180.0 - np.abs(ctx.rake)) <= 30.0:
+        elif np.abs(rup.rake) <= 30.0 or (180.0 - np.abs(rup.rake)) <= 30.0:
             # strike-slip
             SS = 1
-        elif ctx.rake > 30.0 and ctx.rake < 150.0:
+        elif rup.rake > 30.0 and rup.rake < 150.0:
             # reverse
             RS = 1
         else:
             # normal
             NS = 1
+
         return U, SS, NS, RS
 
     def _get_site_amplification_linear(self, vs30, C):
@@ -216,7 +181,7 @@ class BooreAtkinson2008(GMPE):
         """
         return C['blin'] * np.log(vs30 / 760.0)
 
-    def _get_pga_on_rock(self, ctx, _C):
+    def _get_pga_on_rock(self, rup, dists, _C):
         """
         Compute and return PGA on rock conditions (that is vs30 = 760.0 m/s).
         This is needed to compute non-linear site amplification term
@@ -232,8 +197,8 @@ class BooreAtkinson2008(GMPE):
         # Table 6 should read "Distance-scaling coefficients (Mref=4.5 and
         # Rref=1.0 km for all periods)".
         C_pga = self.COEFFS[PGA()]
-        pga4nl = np.exp(self._compute_magnitude_scaling(ctx, C_pga) +
-                        self._compute_distance_scaling(ctx, C_pga))
+        pga4nl = np.exp(self._compute_magnitude_scaling(rup, C_pga) +
+                        self._compute_distance_scaling(rup, dists, C_pga))
 
         return pga4nl
 
@@ -266,7 +231,7 @@ class BooreAtkinson2008(GMPE):
         # equation (13b)
         idx = np.where((vs30 > V1) & (vs30 <= V2))
         bnl[idx] = (C['b1'] - C['b2']) * \
-            np.log(vs30[idx] / V2) / np.log(V1 / V2) + C['b2']
+                   np.log(vs30[idx] / V2) / np.log(V1 / V2) + C['b2']
 
         # equation (13c)
         idx = np.where((vs30 > V2) & (vs30 < Vref))
@@ -278,9 +243,8 @@ class BooreAtkinson2008(GMPE):
         Compute non-linear term,
         equation (8a) to (8c), pag 108.
         """
+
         fnl = np.zeros(pga4nl.shape)
-        if len(bnl) < len(fnl):  # single site case, fix shape
-            bnl = np.repeat(bnl[0], len(fnl))
         a1 = 0.03
         a2 = 0.09
         pga_low = 0.06

--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -163,24 +163,27 @@ class BooreAtkinson2008(GMPE):
         """
         Compute magnitude-scaling term, equations (5a) and (5b), pag 107.
         """
-        if ctx.size() == 1:  # single rupture
+        U = ctx.size()
+        if U == 1:
             return self._compute_ms(ctx, C)
-        return np.array([self._compute_ms(c, C) for c in ctx.ctxs])
+        else:
+            lst = [self._compute_ms(c, C) for c in ctx.ctxs]
+            return np.array(lst)
 
-    def _compute_ms(self, rup, C):
+    def _compute_ms(self, ctx, C):
         """
         Compute magnitude-scaling term, equations (5a) and (5b), pag 107.
         """
-        U, SS, NS, RS = self._get_fault_type_dummy_variables(rup)
-        if rup.mag <= C['Mh']:
+        U, SS, NS, RS = self._get_fault_type_dummy_variables(ctx)
+        if ctx.mag <= C['Mh']:
             return C['e1'] * U + C['e2'] * SS + C['e3'] * NS + C['e4'] * RS + \
-                C['e5'] * (rup.mag - C['Mh']) + \
-                C['e6'] * (rup.mag - C['Mh']) ** 2
+                C['e5'] * (ctx.mag - C['Mh']) + \
+                C['e6'] * (ctx.mag - C['Mh']) ** 2
         else:
             return C['e1'] * U + C['e2'] * SS + C['e3'] * NS + C['e4'] * RS + \
-                C['e7'] * (rup.mag - C['Mh'])
+                C['e7'] * (ctx.mag - C['Mh'])
 
-    def _get_fault_type_dummy_variables(self, rup):
+    def _get_fault_type_dummy_variables(self, ctx):
         """
         Get fault type dummy variables, see Table 2, pag 107.
         Fault type (Strike-slip, Normal, Thrust/reverse) is
@@ -193,12 +196,12 @@ class BooreAtkinson2008(GMPE):
         because rake is always given.
         """
         U, SS, NS, RS = 0, 0, 0, 0
-        if rup.rake == 'undefined':
+        if ctx.rake == 'undefined':
             U = 1
-        elif np.abs(rup.rake) <= 30.0 or (180.0 - np.abs(rup.rake)) <= 30.0:
+        elif np.abs(ctx.rake) <= 30.0 or (180.0 - np.abs(ctx.rake)) <= 30.0:
             # strike-slip
             SS = 1
-        elif rup.rake > 30.0 and rup.rake < 150.0:
+        elif ctx.rake > 30.0 and ctx.rake < 150.0:
             # reverse
             RS = 1
         else:
@@ -277,7 +280,7 @@ class BooreAtkinson2008(GMPE):
         """
         fnl = np.zeros(pga4nl.shape)
         if len(bnl) < len(fnl):  # single site case, fix shape
-            bnl = np.repeat(bnl, len(fnl))
+            bnl = np.repeat(bnl[0], len(fnl))
         a1 = 0.03
         a2 = 0.09
         pga_low = 0.06

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -257,9 +257,6 @@ class BaseRupture(metaclass=abc.ABCMeta):
         """Returns the code (integer in the range 0 .. 255) of the rupture"""
         return self._code[self.__class__, self.surface.__class__]
 
-    def size(self):
-        return 1
-
     get_probability_no_exceedance = (
         contexts.RuptureContext.get_probability_no_exceedance)
 

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -18,7 +18,7 @@ import numpy
 
 import openquake.hazardlib
 from openquake.baselib.parallel import Starmap, sequential_apply
-from openquake.hazardlib import const, nrml, valid
+from openquake.hazardlib import const
 from openquake.hazardlib.geo import Point, Line
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
@@ -31,9 +31,8 @@ from openquake.hazardlib.mfd import TruncatedGRMFD, ArbitraryMFD
 from openquake.hazardlib.source import PointSource, SimpleFaultSource
 from openquake.hazardlib.gsim.sadigh_1997 import SadighEtAl1997
 from openquake.hazardlib.gsim.akkar_bommer_2010 import AkkarBommer2010
-from openquake.hazardlib.gsim.boore_atkinson_2008 import BooreAtkinson2008
-from openquake.hazardlib.gsim.chiou_youngs_2014 import ChiouYoungs2014PEER
 from openquake.hazardlib.gsim.mgmpe.avg_gmpe import AvgGMPE
+from openquake.hazardlib.gsim.chiou_youngs_2014 import ChiouYoungs2014PEER
 
 
 class HazardCurvesFiltersTestCase(unittest.TestCase):
@@ -227,51 +226,3 @@ class MixtureModelGMPETestCase(unittest.TestCase):
         perc_diff = 100.0 * ((hcm_lnpga / expected) - 1.0)
         numpy.testing.assert_allclose(perc_diff, numpy.zeros(len(perc_diff)),
                                       atol=0.04)
-
-
-# an area source with 52 point sources
-asource = nrml.get('''\
-<areaSource
-  id="1"
-  name="Area Source"
-  tectonicRegion="Stable Continental Crust">
-  <areaGeometry>
-      <gml:Polygon>
-          <gml:exterior>
-              <gml:LinearRing>
-                  <gml:posList>
-                    -.5 -.5 -.3 -.1 .1 .2 .3 -.8
-                  </gml:posList>
-              </gml:LinearRing>
-          </gml:exterior>
-      </gml:Polygon>
-      <upperSeismoDepth>0</upperSeismoDepth>
-      <lowerSeismoDepth>10 </lowerSeismoDepth>
-  </areaGeometry>
-  <magScaleRel>WC1994</magScaleRel>
-  <ruptAspectRatio>1</ruptAspectRatio>
-  <truncGutenbergRichterMFD aValue="4.5" bValue="1" maxMag="7" minMag="5"/>
-  <nodalPlaneDist>
-    <nodalPlane dip="90" probability="1" rake="0" strike="0"/>
-  </nodalPlaneDist>
-  <hypoDepthDist>
-     <hypoDepth depth="5" probability="1"/>
-  </hypoDepthDist>
-</areaSource>''')
-
-
-class SingleSiteOptTestCase(unittest.TestCase):
-    """
-    Test the single site optimization for BooreAtkinson2008
-    """
-    def test(self):
-        site = Site(Point(0, 0), vs30=760., z1pt0=48.0, z2pt5=0.607,
-                    vs30measured=True)
-        sitecol = SiteCollection([site])
-        imtls = {"PGA": valid.logscale(.1, 1, 10)}
-        gsim = BooreAtkinson2008()
-        [hcurve] = calc_hazard_curves([asource], sitecol, imtls,
-                                      {"Stable Continental Crust": gsim})
-        exp = [0.879914, 0.747273, 0.566655, 0.376226, 0.217617,
-               0.110198, 0.049159, 0.019335, 0.006663, 0.001989]
-        numpy.testing.assert_allclose(hcurve['PGA'], exp, atol=1E-5)

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -39,7 +39,7 @@ class BaseGSIMTestCase(unittest.TestCase):
         if hasattr(gsim, 'DO_NOT_CHECK_DISTANCES'):
             d_att = d_att.difference(gsim.DO_NOT_CHECK_DISTANCES)
         self.assertEqual(gsim.REQUIRES_SITES_PARAMETERS, s_att)
-        self.assertGreater(r_att, gsim.REQUIRES_RUPTURE_PARAMETERS)
+        self.assertEqual(gsim.REQUIRES_RUPTURE_PARAMETERS, r_att)
         self.assertEqual(gsim.REQUIRES_DISTANCES, d_att)
         if errors:
             raise AssertionError(stats)

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -39,7 +39,7 @@ class BaseGSIMTestCase(unittest.TestCase):
         if hasattr(gsim, 'DO_NOT_CHECK_DISTANCES'):
             d_att = d_att.difference(gsim.DO_NOT_CHECK_DISTANCES)
         self.assertEqual(gsim.REQUIRES_SITES_PARAMETERS, s_att)
-        self.assertGreaterEqual(r_att, gsim.REQUIRES_RUPTURE_PARAMETERS)
+        self.assertGreater(r_att, gsim.REQUIRES_RUPTURE_PARAMETERS)
         self.assertEqual(gsim.REQUIRES_DISTANCES, d_att)
         if errors:
             raise AssertionError(stats)


### PR DESCRIPTION
It was breaking the Canada model. The reason is unknown, the only test sensitive to it is in oq-risk-tests and it did NOT break after the refactoring, but only after a totally unrelated change in https://github.com/gem/oq-engine/pull/6270: there must be some unholy commixtion there. Further investigation is required. The first thing to do is to simplify the test in oq-risk-tests and to move it inside the engine proper. It is the only one we have for real-life usage of the NRCan15SiteTerm.
