### PR TITLE
Restore single-site-approx for BooreAtksinson2008

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -818,6 +818,14 @@ class RuptureContext(BaseContext):
         for param, value in param_pairs:
             setattr(self, param, value)
 
+    def update_dists(self, ctx):
+        """
+        Update the distance parameters by reading them from another context
+        """
+        for name, value in vars(ctx).items():
+            if name in KNOWN_DISTANCES:
+                setattr(self, name, value)
+
     def size(self):
         """
         If the context is a multi rupture context, i.e. it contains an array

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -781,6 +781,16 @@ class DistancesContext(BaseContext):
         return ctx
 
 
+def get_dists(ctx):
+    """
+    Extract the distance parameters from a context.
+
+    :returns: a dictionary dist_name -> distances
+    """
+    return {par: dist for par, dist in vars(ctx).items()
+            if par in KNOWN_DISTANCES}
+
+
 # mock of a rupture used in the tests and in the SMTK
 class RuptureContext(BaseContext):
     """
@@ -817,14 +827,6 @@ class RuptureContext(BaseContext):
     def __init__(self, param_pairs=()):
         for param, value in param_pairs:
             setattr(self, param, value)
-
-    def update_dists(self, ctx):
-        """
-        Update the distance parameters by reading them from another context
-        """
-        for name, value in vars(ctx).items():
-            if name in KNOWN_DISTANCES:
-                setattr(self, name, value)
 
     def size(self):
         """

--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -22,7 +22,7 @@ Module exports :class:`BooreAtkinson2008`.
 import numpy as np
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable
-from openquake.hazardlib import const
+from openquake.hazardlib import const, contexts
 from openquake.hazardlib.imt import PGA, PGV, SA
 
 
@@ -110,7 +110,7 @@ class BooreAtkinson2008(GMPE):
 
         # compute PGA on rock conditions - needed to compute non-linear
         # site amplification term
-        rup.update_dists(dists)  # update RuptureContext with distances
+        vars(rup).update(contexts.get_dists(dists))  # update distances
         pga4nl = self._get_pga_on_rock(rup, C)
 
         # equation 1, pag 106, without sigma term, that is only the first 3

--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -19,6 +19,7 @@
 """
 Module exports :class:`BooreAtkinson2008`.
 """
+import copy
 import numpy as np
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable
@@ -51,11 +52,8 @@ class BooreAtkinson2008(GMPE):
 
     #: Supported standard deviation types are inter-event, intra-event
     #: and total, see equation 2, pag 106.
-    DEFINED_FOR_STANDARD_DEVIATION_TYPES = set([
-        const.StdDev.TOTAL,
-        const.StdDev.INTER_EVENT,
-        const.StdDev.INTRA_EVENT
-    ])
+    DEFINED_FOR_STANDARD_DEVIATION_TYPES = {
+        const.StdDev.TOTAL, const.StdDev.INTER_EVENT, const.StdDev.INTRA_EVENT}
 
     #: Required site parameters is Vs30.
     #: See paragraph 'Predictor Variables', pag 103
@@ -72,6 +70,34 @@ class BooreAtkinson2008(GMPE):
     #: Shear-wave velocity for reference soil conditions in [m s-1]
     DEFINED_FOR_REFERENCE_VELOCITY = 760.
 
+    def get_mean_std1(self, ctx, imts):
+        """
+        :param ctx: a multi-RuptureContext of size U
+        :param imts: a list of M intensity measure types
+        :returns: means and total stddevs as an array of shape (2, U, M)
+        """
+        U = ctx.size()
+        res = np.zeros((2, U, len(imts)))
+        for m, imt in enumerate(imts):
+            C = self.COEFFS[imt]
+            C_SR = self.COEFFS_SOIL_RESPONSE[imt]
+            pga4nl = self._get_pga_on_rock(ctx, C)
+            if isinstance(imt, PGA):
+                mean = (np.log(pga4nl) +
+                        self._get_site_amplification_linear(ctx.vs30, C_SR) +
+                        self._get_site_amplification_non_linear(
+                            ctx.vs30, pga4nl, C_SR))
+            else:
+                mean = (self._compute_magnitude_scaling(ctx, C) +
+                        self._compute_distance_scaling(ctx, C) +
+                        self._get_site_amplification_linear(ctx.vs30, C_SR) +
+                        self._get_site_amplification_non_linear(
+                            ctx.vs30, pga4nl, C_SR))
+            [stddev] = self._get_stddevs(C, [const.StdDev.TOTAL], U)
+            res[0, :, m] = mean
+            res[1, :, m] = stddev
+        return res
+
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         See :meth:`superclass method
@@ -85,7 +111,8 @@ class BooreAtkinson2008(GMPE):
 
         # compute PGA on rock conditions - needed to compute non-linear
         # site amplification term
-        pga4nl = self._get_pga_on_rock(rup, dists, C)
+        rup.update_dists(dists)  # update RuptureContext with distances
+        pga4nl = self._get_pga_on_rock(rup, C)
 
         # equation 1, pag 106, without sigma term, that is only the first 3
         # terms. The third term (site amplification) is computed as given in
@@ -100,7 +127,7 @@ class BooreAtkinson2008(GMPE):
                                                         C_SR)
         else:
             mean = self._compute_magnitude_scaling(rup, C) + \
-                self._compute_distance_scaling(rup, dists, C) + \
+                self._compute_distance_scaling(rup, C) + \
                 self._get_site_amplification_linear(sites.vs30, C_SR) + \
                 self._get_site_amplification_non_linear(sites.vs30, pga4nl,
                                                         C_SR)
@@ -124,20 +151,25 @@ class BooreAtkinson2008(GMPE):
                 stddevs.append(C['tau'] + np.zeros(num_sites))
         return stddevs
 
-    def _compute_distance_scaling(self, rup, dists, C):
+    def _compute_distance_scaling(self, ctx, C):
         """
         Compute distance-scaling term, equations (3) and (4), pag 107.
         """
         Mref = 4.5
         Rref = 1.0
-        R = np.sqrt(dists.rjb ** 2 + C['h'] ** 2)
-        return (C['c1'] + C['c2'] * (rup.mag - Mref)) * np.log(R / Rref) + \
+        R = np.sqrt(ctx.rjb ** 2 + C['h'] ** 2)
+        return (C['c1'] + C['c2'] * (ctx.mag - Mref)) * np.log(R / Rref) + \
             C['c3'] * (R - Rref)
 
-    def _compute_magnitude_scaling(self, rup, C):
+    def _compute_magnitude_scaling(self, ctx, C):
         """
         Compute magnitude-scaling term, equations (5a) and (5b), pag 107.
         """
+        if ctx.size() == 1:  # single rupture
+            return self._compute_ms(ctx, C)
+        return np.array([self._compute_ms(c, C) for c in ctx.ctxs])
+
+    def _compute_ms(self, rup, C):
         U, SS, NS, RS = self._get_fault_type_dummy_variables(rup)
         if rup.mag <= C['Mh']:
             return C['e1'] * U + C['e2'] * SS + C['e3'] * NS + C['e4'] * RS + \
@@ -181,7 +213,7 @@ class BooreAtkinson2008(GMPE):
         """
         return C['blin'] * np.log(vs30 / 760.0)
 
-    def _get_pga_on_rock(self, rup, dists, _C):
+    def _get_pga_on_rock(self, ctx, _C):
         """
         Compute and return PGA on rock conditions (that is vs30 = 760.0 m/s).
         This is needed to compute non-linear site amplification term
@@ -197,8 +229,8 @@ class BooreAtkinson2008(GMPE):
         # Table 6 should read "Distance-scaling coefficients (Mref=4.5 and
         # Rref=1.0 km for all periods)".
         C_pga = self.COEFFS[PGA()]
-        pga4nl = np.exp(self._compute_magnitude_scaling(rup, C_pga) +
-                        self._compute_distance_scaling(rup, dists, C_pga))
+        pga4nl = np.exp(self._compute_magnitude_scaling(ctx, C_pga) +
+                        self._compute_distance_scaling(ctx, C_pga))
 
         return pga4nl
 
@@ -230,8 +262,8 @@ class BooreAtkinson2008(GMPE):
 
         # equation (13b)
         idx = np.where((vs30 > V1) & (vs30 <= V2))
-        bnl[idx] = (C['b1'] - C['b2']) * \
-                   np.log(vs30[idx] / V2) / np.log(V1 / V2) + C['b2']
+        bnl[idx] = (C['b1'] - C['b2']) * (
+            np.log(vs30[idx] / V2) / np.log(V1 / V2) + C['b2'])
 
         # equation (13c)
         idx = np.where((vs30 > V2) & (vs30 < Vref))

--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -19,7 +19,6 @@
 """
 Module exports :class:`BooreAtkinson2008`.
 """
-import copy
 import numpy as np
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable

--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -256,13 +256,12 @@ class BooreAtkinson2008(GMPE):
         bnl = np.zeros(vs30.shape)
 
         # equation (13a)
-        idx = vs30 <= V1
-        bnl[idx] = C['b1']
+        bnl[vs30 <= V1] = C['b1']
 
         # equation (13b)
         idx = np.where((vs30 > V1) & (vs30 <= V2))
-        bnl[idx] = (C['b1'] - C['b2']) * (
-            np.log(vs30[idx] / V2) / np.log(V1 / V2) + C['b2'])
+        bnl[idx] = (C['b1'] - C['b2']) * \
+            np.log(vs30[idx] / V2) / np.log(V1 / V2) + C['b2']
 
         # equation (13c)
         idx = np.where((vs30 > V2) & (vs30 < Vref))

--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -245,6 +245,8 @@ class BooreAtkinson2008(GMPE):
         """
 
         fnl = np.zeros(pga4nl.shape)
+        if len(bnl) < len(fnl):  # single site case, fix shape
+            bnl = np.repeat(bnl, len(fnl))
         a1 = 0.03
         a2 = 0.09
         pga_low = 0.06

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -257,6 +257,14 @@ class BaseRupture(metaclass=abc.ABCMeta):
         """Returns the code (integer in the range 0 .. 255) of the rupture"""
         return self._code[self.__class__, self.surface.__class__]
 
+    def size(self):
+        """
+        Dummy method for compatibility with the RuptureContext.
+
+        :returns: 1
+        """
+        return 1
+
     get_probability_no_exceedance = (
         contexts.RuptureContext.get_probability_no_exceedance)
 


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/6278. The error was in the line `vars(rup).update(vars(dists))` that was also updating the rupture parameters, in particular the magnitude, but the effect was only visible in GMPEs like OceanicCan15Mid which are modifying the magnitude (there is a line `rupl.mag -= 0.5`).