### PR TITLE
Show all calculations when the authentication is off

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
   * Fixed a small bug of logic in the WebUI: if the authentication is
-    turned off, every one must be able to see all calculations
+    turned off, everyone must be able to see all calculations
   * Fixed a bug in the calculation of averages losses in scenario_risk
     calculations in presence of sites with zero hazard
   * Optimized the prefiltering by using a KDTree

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed a small bug of logic in the WebUI: if the authentication is
+    turned off, every one must be able to see all calculations
   * Fixed a bug in the calculation of averages losses in scenario_risk
     calculations in presence of sites with zero hazard
   * Optimized the prefiltering by using a KDTree

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -20,7 +20,6 @@ import getpass
 import requests
 import logging
 import django
-import numpy
 
 from time import sleep
 from django.conf import settings
@@ -32,10 +31,13 @@ if settings.LOCKDOWN:
 
 
 def is_superuser(request):
-    if settings.LOCKDOWN and hasattr(request, 'user'):
-        if request.user.is_superuser:
-            return True
-    return False
+    """
+    Without authentication (settings.LOCKDOW is false) every user is considered
+    a superuser, otherwise look at the attribute `request.user.is_superuser`.
+    """
+    if not settings.LOCKDOWN:
+        return True
+    return request.user.is_superuser if hasattr(request, 'user') else False
 
 
 def get_user(request):


### PR DESCRIPTION
BTW, we need to see how the WebUI works with the ansible installation. I expect that it will not be possible to download a calculation of user `pippo` because the user `openquake` has no access to `/home/pippo/oqdata`. This can be considered acceptable.