### PR TITLE
Exported the outputs of recompute_losses in the database

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -56,6 +56,10 @@ oq show exposed_values/agg_NAME_1
 oq show exposed_values/agg_taxonomy
 oq show exposed_values/agg
 
+# recompute losses
+oq recompute_losses -1 NAME_1
+oq engine --list-outputs -1
+
 # display the calculations
 oq db find %
 

--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -x
 if [ ! -d "$1" ]; then
     echo "Please specify the location of the folder containing the demos. Aborting." >&2
     exit 1
@@ -26,13 +26,13 @@ oq engine --eos -1 /tmp
 # extract disaggregation data
 oq extract "disagg_layer?" 14
 
-# do something with the generated data
+# do something with the generated data, 9 is the AreaSource demo
 oq engine --lhc
-MPLBACKEND=Agg oq plot 'hcurves?kind=stats&imt=PGA' 16
-MPLBACKEND=Agg oq plot 'hmaps?kind=mean&imt=PGA' 16
-MPLBACKEND=Agg oq plot 'uhs?kind=stats' 16
+MPLBACKEND=Agg oq plot 'hcurves?kind=stats&imt=PGA' 9
+MPLBACKEND=Agg oq plot 'hmaps?kind=mean&imt=PGA' 9
+MPLBACKEND=Agg oq plot 'uhs?kind=stats' 9
 MPLBACKEND=Agg oq plot 'disagg?kind=Mag&imt=PGA&poe_id=1&rlz=0' 14
-MPLBACKEND=Agg oq plot 'task_info?kind=classical_split_filter' 16
+MPLBACKEND=Agg oq plot 'task_info?kind=classical_split_filter' 9
 MPLBACKEND=Agg oq plot_sites -1
 MPLBACKEND=Agg oq plot memory?
 MPLBACKEND=Agg oq plot sources?

--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -34,8 +34,8 @@ MPLBACKEND=Agg oq plot 'uhs?kind=stats' 9
 MPLBACKEND=Agg oq plot 'disagg?kind=Mag&imt=PGA&poe_id=1&rlz=0' 14
 MPLBACKEND=Agg oq plot 'task_info?kind=classical_split_filter' 9
 MPLBACKEND=Agg oq plot_sites -1
-MPLBACKEND=Agg oq plot memory?
-MPLBACKEND=Agg oq plot sources?
+MPLBACKEND=Agg oq plot memory? -1
+MPLBACKEND=Agg oq plot sources? 9
 
 # fake a failed/executing calculation to check that it is not exported
 oq engine --run $1/hazard/AreaSourceClassicalPSHA/job.ini --config-file openquake/engine/openquake.cfg

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed `oq recompute_losses` to expose the outputs to the database
   * Fixed `oq engine --run --params` that was not working for
     the `pointsource_distance`
   * Fixed the strike, dip and rake parameters in PointRuptures when using

--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -46,7 +46,7 @@ def purge_all(user=None):
     if os.path.exists(datadir):
         for fname in os.listdir(datadir):
             if fname.endswith('.pik'):
-                os.remove(fname)
+                os.remove(os.path.join(datadir, fname))
             mo = re.match(r'(calc_|cache_)(\d+)\.hdf5', fname)
             if mo is not None:
                 calc_id = int(mo.group(2))

--- a/openquake/commands/recompute_losses.py
+++ b/openquake/commands/recompute_losses.py
@@ -21,7 +21,7 @@ import logging
 from openquake.baselib import sap, parallel
 from openquake.commonlib import logs, util
 from openquake.calculators.post_risk import PostRiskCalculator
-
+from openquake.engine import engine
 
 @sap.Script
 def recompute_losses(calc_id, aggregate_by):
@@ -41,6 +41,7 @@ def recompute_losses(calc_id, aggregate_by):
         prc = PostRiskCalculator(oqp, job_id)
         try:
             prc.run(aggregate_by=aggby)
+            engine.expose_outputs(prc.datastore)
         finally:
             parallel.Starmap.shutdown()
 

--- a/openquake/engine/tools/make_html_report.py
+++ b/openquake/engine/tools/make_html_report.py
@@ -17,8 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
-import cgi
+import html
 import time
 from datetime import date, datetime, timedelta
 import itertools
@@ -70,7 +69,7 @@ class HtmlTable(object):
     def render(self, dummy_ctxt=None):
         out = "\n%s\n" % "".join(list(self._gen_table()))
         if not self.rows:
-            out += '<em>%s</em>' % cgi.escape(self.empty_table, quote=True)
+            out += '<em>%s</em>' % html.escape(self.empty_table, quote=True)
         return out
 
     def _gen_table(self):
@@ -175,7 +174,7 @@ def make_report(isodate='today'):
             report = html_parts(txt)
         except Exception as exc:
             report = dict(
-                html_title='Could not generate report: %s' % cgi.escape(
+                html_title='Could not generate report: %s' % html.escape(
                     str(exc), quote=True),
                 fragment='')
         page = report['html_title']

--- a/openquake/engine/tools/make_html_report.py
+++ b/openquake/engine/tools/make_html_report.py
@@ -30,7 +30,7 @@ from openquake.commonlib.logs import dbcmd
 tablecounter = itertools.count(0)
 
 
-def html(header_rows):
+def htmltable(header_rows):
     """
     Convert a list of tuples describing a table into a HTML string
     """
@@ -178,7 +178,7 @@ def make_report(isodate='today'):
                     str(exc), quote=True),
                 fragment='')
         page = report['html_title']
-        page += html([stats._fields, stats])
+        page += htmltable([stats._fields, stats])
         page += report['fragment']
         tag_contents.append(page)
 


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6255. Also fixed `oq engine --make-html-report` which was broken in python 3.8.