### PR TITLE
Turned `CollapsedPointSource.point_ruptures` into a generator to save memory

### DIFF
--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -403,9 +403,9 @@ class CollapsedPointSource(ParametricSeismicSource):
 
     def count_ruptures(self):
         """
-        :returns: the number of underlying point sources * 2
+        :returns: the number of underlying point ruptures * 2
         """
-        return len(self.pointsources) * 2
+        return len(self.get_annual_occurrence_rates()) * 2
 
     def get_bounding_box(self, maxdist):
         """

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -371,14 +371,9 @@ class CollapsedPointSource(ParametricSeismicSource):
         self.location = Point(longitude=numpy.mean(lons),
                               latitude=numpy.mean(lats),
                               depth=numpy.average(depths, weights=weights))
-        strike = numpy.average(strikes, weights=np_weights)
-        dip = numpy.average(dips, weights=np_weights)
-        rake = numpy.average(rakes, weights=np_weights)
-        for mag, mag_occ_rate in self.get_annual_occurrence_rates():
-            pr = PointRupture(mag, self.tectonic_region_type, self.location,
-                              strike, dip, rake, mag_occ_rate,
-                              self.temporal_occurrence_model)
-            self.pointruptures.append(pr)
+        self.strike = numpy.average(strikes, weights=np_weights)
+        self.dip = numpy.average(dips, weights=np_weights)
+        self.rake = numpy.average(rakes, weights=np_weights)
 
     def get_annual_occurrence_rates(self):
         """
@@ -398,15 +393,19 @@ class CollapsedPointSource(ParametricSeismicSource):
 
     def point_ruptures(self):
         """
-        :returns: the underlying point ruptures
+        :yields: the underlying point ruptures
         """
-        return self.pointruptures
+        for mag, mag_occ_rate in self.get_annual_occurrence_rates():
+            pr = PointRupture(mag, self.tectonic_region_type, self.location,
+                              self.strike, self.dip, self.rake, mag_occ_rate,
+                              self.temporal_occurrence_model)
+            yield pr
 
     def count_ruptures(self):
         """
-        :returns: the number of underlying point ruptures * P
+        :returns: the number of underlying point sources * 2
         """
-        return len(self.pointruptures) * len(self.pointsources)
+        return len(self.pointsources) * 2
 
     def get_bounding_box(self, maxdist):
         """


### PR DESCRIPTION
Here are the figures for Canada with pointsource_distance=50km, ps_grid_spacing=50:
```
   calc_121, maxmem=37.1 GB     time_sec memory_mb counts    
   ============================ ======== ========= ==========
   total classical              271_927  144       229       
   computing mean_std           189_454  0.0       4_751_901 
   composing pnes               31_942   0.0       35_576_543
   get_poes                     20_657   0.0       4_751_901 
   total classical_split_filter 17_707   166       303       
   make_contexts                16_157   0.0       35_590_055
   total grid_point_sources     477      1.04297   23        
   ClassicalCalculator.run      5_670    3_520     1         
```
Here are the figures for Canada with pointsource_distance=50km, no gridding:
```
   calc_103, maxmem=49.0 GB     time_sec  memory_mb counts    
   ============================ ========= ========= ==========
   total classical              1_168_836 307       432       
   computing mean_std           390_997   0.0       39_501_081
   composing pnes               380_935   0.0       48_822_096
   get_poes                     237_725   0.0       39_501_081
   total build_hazard           117_246   5.82422   240       
   combine pmaps                109_429   0.0       138_284   
   total classical_split_filter 108_035   341       565       
   make_contexts                87_141    0.0       570_507   
   ClassicalCalculator.run      13_971    2_549     1
```
The gain is 4x (11x on get_poes) and the error is very small:
```
$ oq compare hmaps PGA 103 121
poe      rms-diff
======== =========
0.002105 9.213E-04
0.000404 0.00204
```