### PR TITLE
Moved the preclassical phase inside `get_composite_source_model`

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -54,8 +54,6 @@ F32 = numpy.float32
 TWO16 = 2 ** 16
 TWO32 = 2 ** 32
 
-CALC_TIME, NUM_SITES, EFF_RUPTURES, TASK_NO = 3, 4, 5, 7
-
 stats_dt = numpy.dtype([('mean', F32), ('std', F32),
                         ('min', F32), ('max', F32), ('len', U16)])
 
@@ -472,13 +470,11 @@ class HazardCalculator(BaseCalculator):
             with self.monitor('composite source model', measuremem=True):
                 self.csm = csm = readinput.get_composite_source_model(
                     oq, self.datastore.hdf5)
-                srcs = [src for sg in csm.src_groups for src in sg]
-                if not srcs:
-                    raise RuntimeError('All sources were discarded!?')
-                logging.info('Checking the sources bounding box')
-                sids = self.src_filter().within_bbox(srcs)
-                if len(sids) == 0:
-                    raise RuntimeError('All sources were discarded!?')
+                mags_by_trt = csm.get_mags_by_trt()
+                oq.maximum_distance.interp(mags_by_trt)
+                for trt in mags_by_trt:
+                    self.datastore['source_mags/' + trt] = numpy.array(
+                        mags_by_trt[trt])
                 self.full_lt = csm.full_lt
         self.init()  # do this at the end of pre-execute
 
@@ -893,24 +889,11 @@ class HazardCalculator(BaseCalculator):
                                                   oq.inputs['job_ini'])
             logging.warning(msg)
 
-    def update_source_info(self, calc_times, nsites=False):
-        """
-        Update (eff_ruptures, num_sites, calc_time) inside the source_info
-        """
-        for src_id, arr in calc_times.items():
-            row = self.csm.source_info[src_id]
-            row[CALC_TIME] += arr[2]
-            if len(arr) == 4:  # after preclassical
-                row[TASK_NO] = arr[3]
-            if nsites:
-                row[EFF_RUPTURES] += arr[0]
-                row[NUM_SITES] += arr[1]
-
     def store_source_info(self, calc_times, nsites=False):
         """
         Save (eff_ruptures, num_sites, calc_time) inside the source_info
         """
-        self.update_source_info(calc_times, nsites)
+        self.csm.update_source_info(calc_times, nsites)
         recs = [tuple(row) for row in self.csm.source_info.values()]
         hdf5.extend(self.datastore['source_info'],
                     numpy.array(recs, readinput.source_info_dt))

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -28,16 +28,14 @@ try:
     from PIL import Image
 except ImportError:
     Image = None
-from openquake.baselib import parallel, performance, hdf5
+from openquake.baselib import parallel, hdf5
 from openquake.baselib.python3compat import encode
 from openquake.baselib.general import (
     AccumDict, DictArray, block_splitter, groupby, humansize,
     get_nbytes_msg)
-from openquake.hazardlib.source.point import grid_point_sources
 from openquake.hazardlib.contexts import ContextMaker, get_effect
 from openquake.hazardlib.calc.hazard_curve import classical as hazclassical
 from openquake.hazardlib.probability_map import ProbabilityMap
-from openquake.hazardlib.sourceconverter import SourceGroup
 from openquake.commonlib import calc, util, logs
 from openquake.calculators import getters
 from openquake.calculators import base
@@ -104,28 +102,6 @@ def classical_split_filter(sources, rlzs_by_gsim, params, monitor):
             # a foreign key error in case of `oq run` is expected
             print(msg)
     yield classical(light, rlzs_by_gsim, params, monitor)
-
-
-def preclassical(srcs, params, monitor):
-    """
-    Prefilter and weight the sources. Also split if split_sources is true.
-    """
-    srcfilter = monitor.read('srcfilter')
-    # nrups, nsites, time, task_no
-    calc_times = AccumDict(accum=numpy.zeros(4, F32))
-    sources = []
-    for src in srcs:
-        t0 = time.time()
-        sources.extend(srcfilter.split_source(src, params['split_sources']))
-        dt = time.time() - t0
-        calc_times[src.id] += F32([src.num_ruptures, src.nsites, dt, 0])
-    for arr in calc_times.values():
-        arr[3] = monitor.task_no
-    dic = grid_point_sources(sources, params['ps_grid_spacing'])
-    dic['calc_times'] = calc_times
-    dic['before'] = len(sources)
-    dic['after'] = len(dic[sources[0].grp_id])
-    return dic
 
 
 def store_ctxs(dstore, rupdata, grp_id):
@@ -277,9 +253,10 @@ class ClassicalCalculator(base.HazardCalculator):
         super().init()
         if self.oqparam.hazard_calculation_id:
             full_lt = self.datastore.parent['full_lt']
+            et_ids = self.datastore.parent['et_ids'][:]
         else:
             full_lt = self.csm.full_lt
-        et_ids = self.datastore['et_ids'][:]
+            et_ids = self.csm.get_et_ids()
         rlzs_by_gsim_list = full_lt.get_rlzs_by_gsim_list(et_ids)
         rlzs_by_g = []
         for rlzs_by_gsim in rlzs_by_gsim_list:
@@ -315,38 +292,13 @@ class ClassicalCalculator(base.HazardCalculator):
         assert oq.max_sites_per_tile > oq.max_sites_disagg, (
             oq.max_sites_per_tile, oq.max_sites_disagg)
         psd = self.set_psd()
-        srcfilter = self.src_filter()
-        performance.Monitor.save(self.datastore, 'srcfilter', srcfilter)
-
-        # do nothing for atomic sources
-        for src in self.csm.get_sources(atomic=True):
-            src.num_ruptures = src.count_ruptures()
-            src.nsites = self.N
-
-        # run preclassical for non-atomic sources
-        sources_by_grp = groupby(
-            self.csm.get_sources(atomic=False), operator.attrgetter('grp_id'))
-        res = parallel.Starmap(
-            preclassical,
-            ((srcs, self.param) for srcs in sources_by_grp.values()),
-            h5=self.datastore.hdf5,
-            distribute=None if len(sources_by_grp) > 1 else 'no').reduce()
-        for grp_id, sources in sources_by_grp.items():
-            sg = SourceGroup(sources[0].tectonic_region_type)
-            sg.sources = res[grp_id]
-            self.csm.src_groups[grp_id] = sg
-        if res and res['before'] != res['after']:
-            logging.info('Reduced the number of sources from {:_d} -> {:_d}'.
-                         format(res['before'], res['after']))
 
         # exit early if we want to perform only a preclassical
         if oq.calculation_mode == 'preclassical':
-            self.store_source_info(res.get('calc_times', {}), nsites=True)
             self.datastore['full_lt'] = self.csm.full_lt
             self.datastore.swmr_on()  # fixes HDF5 error in build_hazard
             return
 
-        self.update_source_info(res.get('calc_times', {}), nsites=True)
         smap = parallel.Starmap(classical, h5=self.datastore.hdf5)
         self.submit_tasks(smap)
         acc0 = self.acc0()  # create the rup/ datasets BEFORE swmr_on()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -300,6 +300,7 @@ class ClassicalCalculator(base.HazardCalculator):
             return
 
         smap = parallel.Starmap(classical, h5=self.datastore.hdf5)
+        smap.monitor.save('srcfilter', self.src_filter())
         self.submit_tasks(smap)
         acc0 = self.acc0()  # create the rup/ datasets BEFORE swmr_on()
         self.datastore.swmr_on()

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -823,20 +823,20 @@ def get_composite_source_model(oqparam, h5=None):
         ((srcs, srcfilter, param) for srcs in sources_by_grp.values()), h5=h5,
         distribute=None if len(sources_by_grp) > 1 else 'no').reduce()
 
-    if res and res['before'] != res['after']:
-        logging.info('Reduced the number of sources from {:_d} -> {:_d}'.
-                     format(res['before'], res['after']))
+    if res and h5:
+        csm.update_source_info(res['calc_times'], nsites=True)
+        if oqparam.calculation_mode == 'preclassical':
+            recs = [tuple(row) for row in csm.source_info.values()]
+            hdf5.extend(h5['source_info'], numpy.array(recs, source_info_dt))
 
     for grp_id, sources in sources_by_grp.items():
         sg = SourceGroup(sources[0].tectonic_region_type)
         sg.sources = res[grp_id]
         csm.src_groups[grp_id] = sg
 
-    if h5:
-        csm.update_source_info(res['calc_times'], nsites=True)
-        if oqparam.calculation_mode == 'preclassical':
-            recs = [tuple(row) for row in csm.source_info.values()]
-            hdf5.extend(h5['source_info'], numpy.array(recs, source_info_dt))
+    if res and res['before'] != res['after']:
+        logging.info('Reduced the number of sources from {:_d} -> {:_d}'.
+                     format(res['before'], res['after']))
 
     if oqparam.cachedir:
         logging.info('Saving %s', fname)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -832,6 +832,11 @@ def get_composite_source_model(oqparam, h5=None):
         sg.sources = res[grp_id]
         csm.src_groups[grp_id] = sg
 
+    if h5:
+        csm.update_source_info(res['calc_times'], nsites=True)
+        recs = [tuple(row) for row in csm.source_info.values()]
+        hdf5.extend(h5['source_info'], numpy.array(recs, source_info_dt))
+
     if oqparam.cachedir:
         logging.info('Saving %s', fname)
         with open(fname, 'wb') as f:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -776,7 +776,7 @@ def get_composite_source_model(oqparam, h5=None):
     # then read the composite source model from the cache if possible
     if oqparam.cachedir and not os.path.exists(oqparam.cachedir):
         os.makedirs(oqparam.cachedir)
-    if oqparam.cachedir and not oqparam.is_ucerf():
+    if oqparam.cachedir:
         checksum = get_checksum32(oqparam, h5)
         fname = os.path.join(oqparam.cachedir, 'csm_%s.pik' % checksum)
         if os.path.exists(fname):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -19,6 +19,7 @@ import os
 import re
 import ast
 import csv
+import time
 import copy
 import json
 import zlib
@@ -26,6 +27,7 @@ import pickle
 import shutil
 import zipfile
 import logging
+import operator
 import tempfile
 import functools
 import configparser
@@ -34,18 +36,21 @@ import collections
 import numpy
 import requests
 
-from openquake.baselib import hdf5, parallel
+from openquake.baselib import hdf5, parallel, performance
 from openquake.baselib.general import (
-    random_filter, countby, group_array, get_duplicates)
+    AccumDict, random_filter, countby, groupby, group_array, get_duplicates)
 from openquake.baselib.python3compat import zip
 from openquake.baselib.node import Node
 from openquake.hazardlib.const import StdDev
+from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.calc.gmf import CorrelationButNoInterIntraStdDevs
 from openquake.hazardlib import (
     source, geo, site, imt, valid, sourceconverter, nrml, InvalidFile)
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib.calc.stochastic import rupture_dt
 from openquake.hazardlib.probability_map import ProbabilityMap
+from openquake.hazardlib.source.point import grid_point_sources
+from openquake.hazardlib.sourceconverter import SourceGroup
 from openquake.risklib import asset, riskmodels
 from openquake.risklib.riskmodels import get_risk_functions
 from openquake.commonlib.oqvalidation import OqParam
@@ -708,25 +713,49 @@ def get_full_lt(oqparam):
     return full_lt
 
 
-def _get_cachedir(oq, full_lt, h5=None):
-    # read the composite source model from the cache
-    if not os.path.exists(oq.cachedir):
-        os.makedirs(oq.cachedir)
-    checksum = get_checksum32(oq, h5)
-    fname = os.path.join(oq.cachedir, 'csm_%s.pik' % checksum)
-    if os.path.exists(fname):
-        logging.info('Reading %s', fname)
-        with open(fname, 'rb') as f:
-            csm = pickle.load(f)
-            csm.full_lt = full_lt
-            return csm
-    csm = get_csm(oq, full_lt, h5)
-    if not csm.src_groups:  # everything was filtered away
-        return csm
-    logging.info('Saving %s', fname)
-    with open(fname, 'wb') as f:
-        pickle.dump(csm, f)
-    return csm
+def preclassical(srcs, params, monitor):
+    """
+    Prefilter and weight the sources. Also split if split_sources is true.
+    """
+    srcfilter = monitor.read('srcfilter')
+    # nrups, nsites, time, task_no
+    calc_times = AccumDict(accum=numpy.zeros(4, F32))
+    sources = []
+    for src in srcs:
+        t0 = time.time()
+        sources.extend(srcfilter.split_source(src, params['split_sources']))
+        dt = time.time() - t0
+        calc_times[src.id] += F32([src.num_ruptures, src.nsites, dt, 0])
+    for arr in calc_times.values():
+        arr[3] = monitor.task_no
+    dic = grid_point_sources(sources, params['ps_grid_spacing'])
+    dic['calc_times'] = calc_times
+    dic['before'] = len(sources)
+    dic['after'] = len(dic[sources[0].grp_id])
+    return dic
+
+
+def save_source_info(csm, h5):
+    data = {}  # src_id -> row
+    wkts = []
+    lens = []
+    for sg in csm.src_groups:
+        for src in sg:
+            lens.append(len(src.et_ids))
+            row = [src.source_id, src.grp_id, src.code,
+                   0, 0, 0, csm.full_lt.trti[src.tectonic_region_type], 0]
+            wkts.append(src._wkt)
+            data[src.id] = row
+    logging.info('There are %d groups and %d sources with len(et_ids)=%.2f',
+                 len(csm.src_groups), sum(len(sg) for sg in csm.src_groups),
+                 numpy.mean(lens))
+    csm.source_info = data  # src_id -> row
+    if h5:
+        attrs = dict(atomic=any(grp.atomic for grp in csm.src_groups))
+        # avoid hdf5 damned bug by creating source_info in advance
+        hdf5.create(h5, 'source_info', source_info_dt, attrs=attrs)
+        h5['source_wkt'] = numpy.array(wkts, hdf5.vstr)
+        h5['et_ids'] = csm.get_et_ids()
 
 
 def get_composite_source_model(oqparam, h5=None):
@@ -738,41 +767,75 @@ def get_composite_source_model(oqparam, h5=None):
     :param h5:
          an open hdf5.File where to store the source info
     """
-    logging.info('Reading the CompositeSourceModel')
+    # first of all, read the sites and the logic tree
+    sitecol = get_site_collection(oqparam, h5)
     full_lt = get_full_lt(oqparam)
+    srcfilter = SourceFilter(sitecol, oqparam.maximum_distance)
+    performance.Monitor.save(h5, 'srcfilter', srcfilter)
+
+    # then read the composite source model from the cache if possible
+    if oqparam.cachedir and not os.path.exists(oqparam.cachedir):
+        os.makedirs(oqparam.cachedir)
     if oqparam.cachedir and not oqparam.is_ucerf():
-        csm = _get_cachedir(oqparam, full_lt, h5)
-    else:
-        csm = get_csm(oqparam, full_lt,  h5)
-    et_ids = csm.get_et_ids()
+        checksum = get_checksum32(oqparam, h5)
+        fname = os.path.join(oqparam.cachedir, 'csm_%s.pik' % checksum)
+        if os.path.exists(fname):
+            logging.info('Reading %s', fname)
+            with open(fname, 'rb') as f:
+                csm = pickle.load(f)
+                csm.full_lt = full_lt
+                save_source_info(csm, h5)
+                return csm
+
+    # else read and process the composite source model
+    csm = get_csm(oqparam, full_lt,  h5)
     logging.info('%d effective smlt realization(s)', len(full_lt.sm_rlzs))
-    data = {}  # src_id -> row
-    mags_by_trt = csm.get_mags_by_trt()
-    wkts = []
-    lens = []
-    for sg in csm.src_groups:
-        for src in sg:
-            lens.append(len(src.et_ids))
-            row = [src.source_id, src.grp_id, src.code,
-                   0, 0, 0, full_lt.trti[src.tectonic_region_type], 0]
-            wkts.append(src._wkt)
-            data[src.id] = row
-    logging.info('There are %d groups and %d sources with len(et_ids)=%.2f',
-                 len(csm.src_groups), sum(len(sg) for sg in csm.src_groups),
-                 numpy.mean(lens))
-    if h5:
-        attrs = dict(atomic=any(grp.atomic for grp in csm.src_groups))
-        # avoid hdf5 damned bug by creating source_info in advance
-        hdf5.create(h5, 'source_info', source_info_dt, attrs=attrs)
-        h5['source_wkt'] = numpy.array(wkts, hdf5.vstr)
-        h5['et_ids'] = et_ids
-        for trt in mags_by_trt:
-            h5['source_mags/' + trt] = numpy.array(mags_by_trt[trt])
-        oqparam.maximum_distance.interp(mags_by_trt)
+    save_source_info(csm, h5)
+
+    # checks
     csm.gsim_lt.check_imts(oqparam.imtls)
-    csm.source_info = data  # src_id -> row
+
+    srcs = csm.get_sources()
+    if not srcs:
+        raise RuntimeError('All sources were discarded!?')
+
     if os.environ.get('OQ_CHECK_INPUT'):
         source.check_complex_faults(csm.get_sources())
+
+    logging.info('Checking the sources bounding box')
+    sids = srcfilter.within_bbox(srcs)
+    if len(sids) == 0:
+        raise RuntimeError('All sources were discarded!?')
+
+    # do nothing for atomic sources except counting the ruptures
+    for src in csm.get_sources(atomic=True):
+        src.num_ruptures = src.count_ruptures()
+        src.nsites = len(sitecol)
+
+    # run preclassical for non-atomic sources
+    sources_by_grp = groupby(
+        csm.get_sources(atomic=False), operator.attrgetter('grp_id'))
+    param = dict(ps_grid_spacing=oqparam.ps_grid_spacing,
+                 split_sources=oqparam.split_sources)
+    res = parallel.Starmap(
+        preclassical,
+        ((srcs, param) for srcs in sources_by_grp.values()), h5=h5,
+        distribute=None if len(sources_by_grp) > 1 else 'no').reduce()
+
+    if res and res['before'] != res['after']:
+        logging.info('Reduced the number of sources from {:_d} -> {:_d}'.
+                     format(res['before'], res['after']))
+
+    for grp_id, sources in sources_by_grp.items():
+        sg = SourceGroup(sources[0].tectonic_region_type)
+        sg.sources = res[grp_id]
+        csm.src_groups[grp_id] = sg
+
+    if oqparam.cachedir:
+        logging.info('Saving %s', fname)
+        with open(fname, 'wb') as f:
+            pickle.dump(csm, f)
+
     return csm
 
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -713,11 +713,10 @@ def get_full_lt(oqparam):
     return full_lt
 
 
-def preclassical(srcs, params, monitor):
+def preclassical(srcs, srcfilter, params, monitor):
     """
     Prefilter and weight the sources. Also split if split_sources is true.
     """
-    srcfilter = monitor.read('srcfilter')
     # nrups, nsites, time, task_no
     calc_times = AccumDict(accum=numpy.zeros(4, F32))
     sources = []
@@ -771,7 +770,6 @@ def get_composite_source_model(oqparam, h5=None):
     sitecol = get_site_collection(oqparam, h5)
     full_lt = get_full_lt(oqparam)
     srcfilter = SourceFilter(sitecol, oqparam.maximum_distance)
-    performance.Monitor.save(h5, 'srcfilter', srcfilter)
 
     # then read the composite source model from the cache if possible
     if oqparam.cachedir and not os.path.exists(oqparam.cachedir):
@@ -819,7 +817,7 @@ def get_composite_source_model(oqparam, h5=None):
                  split_sources=oqparam.split_sources)
     res = parallel.Starmap(
         preclassical,
-        ((srcs, param) for srcs in sources_by_grp.values()), h5=h5,
+        ((srcs, srcfilter, param) for srcs in sources_by_grp.values()), h5=h5,
         distribute=None if len(sources_by_grp) > 1 else 'no').reduce()
 
     if res and res['before'] != res['after']:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -814,7 +814,8 @@ def get_composite_source_model(oqparam, h5=None):
     sources_by_grp = groupby(
         csm.get_sources(atomic=False), operator.attrgetter('grp_id'))
     param = dict(ps_grid_spacing=oqparam.ps_grid_spacing,
-                 split_sources=oqparam.split_sources)
+                 split_sources=False if oqparam.is_event_based()
+                 else oqparam.split_sources)
     res = parallel.Starmap(
         preclassical,
         ((srcs, srcfilter, param) for srcs in sources_by_grp.values()), h5=h5,

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -834,8 +834,9 @@ def get_composite_source_model(oqparam, h5=None):
 
     if h5:
         csm.update_source_info(res['calc_times'], nsites=True)
-        recs = [tuple(row) for row in csm.source_info.values()]
-        hdf5.extend(h5['source_info'], numpy.array(recs, source_info_dt))
+        if oqparam.calculation_mode == 'preclassical':
+            recs = [tuple(row) for row in csm.source_info.values()]
+            hdf5.extend(h5['source_info'], numpy.array(recs, source_info_dt))
 
     if oqparam.cachedir:
         logging.info('Saving %s', fname)

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -30,6 +30,8 @@ from openquake.hazardlib.lt import apply_uncertainties
 TWO16 = 2 ** 16  # 65,536
 by_id = operator.attrgetter('source_id')
 
+CALC_TIME, NUM_SITES, EFF_RUPTURES, TASK_NO = 3, 4, 5, 7
+
 
 def et_ids(src):
     return tuple(src.et_ids)
@@ -331,6 +333,19 @@ class CompositeSourceModel:
         if not data:
             return numpy.array([1, 1])
         return numpy.array(data).mean(axis=0)
+
+    def update_source_info(self, calc_times, nsites=False):
+        """
+        Update (eff_ruptures, num_sites, calc_time) inside the source_info
+        """
+        for src_id, arr in calc_times.items():
+            row = self.source_info[src_id]
+            row[CALC_TIME] += arr[2]
+            if len(arr) == 4:  # after preclassical
+                row[TASK_NO] = arr[3]
+            if nsites:
+                row[EFF_RUPTURES] += arr[0]
+                row[NUM_SITES] += arr[1]
 
     def __repr__(self):
         """

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -85,8 +85,6 @@ def get_csm(oq, full_lt, h5=None):
             sg = copy.copy(grp)
             src_groups.append(sg)
             src = sg[0].new(sm_rlz.ordinal, sm_rlz.value)  # one source
-            sg.mags = numpy.unique(numpy.round(src.mags, 2))
-            del src.__dict__['mags']  # remove cache
             src.checksum = src.et_id = src.id = et_id
             src.samples = sm_rlz.samples
             logging.info('Reading sections and rupture planes for %s', src)
@@ -306,11 +304,10 @@ class CompositeSourceModel:
         """
         mags = general.AccumDict(accum=set())  # trt -> mags
         for sg in self.src_groups:
-            if hasattr(sg, 'mags'):  # UCERF
-                mags[sg.trt].update('%.2f' % mag for mag in sg.mags)
             for src in sg:
                 if hasattr(src, 'mags'):  # UCERF
-                    continue  # already accounted for in sg.mags
+                    srcmags = ['%.2f' % mag for mag in numpy.unique(
+                        numpy.round(src.mags, 2))]
                 elif hasattr(src, 'data'):  # nonparametric
                     srcmags = ['%.2f' % item[0].mag for item in src.data]
                 else:

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -731,6 +731,7 @@ Subduction Interface,b3,[SadighEtAl1997],w=1.0>''')
     def test_many_rlzs(self):
         oqparam = tests.get_oqparam('classical_job.ini')
         oqparam.number_of_logic_tree_samples = 0
+        oqparam.split_sources = False
         csm = readinput.get_composite_source_model(oqparam)
         self.assertEqual(len(csm.sm_rlzs), 9)  # example with 1 x 3 x 3 paths
         # there are 2 distinct tectonic region types and 18 src_groups

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -18,7 +18,6 @@
 
 import ast
 import sys
-import logging
 import operator
 from contextlib import contextmanager
 import numpy
@@ -27,7 +26,7 @@ from scipy.spatial import cKDTree
 from openquake.baselib.python3compat import raise_
 from openquake.hazardlib import site
 from openquake.hazardlib.geo.utils import (
-    KM_TO_DEGREES, angular_distance, fix_lon, get_bounding_box, cross_idl,
+    KM_TO_DEGREES, angular_distance, fix_lon, get_bounding_box,
     get_longitudinal_extent, BBoxError, spherical_to_cartesian)
 
 U32 = numpy.uint32
@@ -399,36 +398,6 @@ class SourceFilter(object):
             if len(sids):
                 src.nsites = len(sids)
                 yield src, sids
-
-    def within_bbox(self, srcs):
-        """
-        :param srcs: a list of source objects
-        :returns: the site IDs within the enlarged bounding box of the sources
-        """
-        if self.sitecol is None:  # for test_case_1_ruptures
-            return [0]
-        lons = []
-        lats = []
-        for src in srcs:
-            try:
-                box = self.integration_distance.get_enlarged_box(src)
-            except BBoxError as exc:
-                logging.error(exc)
-                continue
-            lons.append(box[0])
-            lats.append(box[1])
-            lons.append(box[2])
-            lats.append(box[3])
-        if cross_idl(*(list(self.sitecol.lons) + lons)):
-            lons = numpy.array(lons) % 360
-        else:
-            lons = numpy.array(lons)
-        bbox = (lons.min(), min(lats), lons.max(), max(lats))
-        if bbox[2] - bbox[0] > 180:
-            raise BBoxError(
-                'The bounding box of the sources is larger than half '
-                'the globe: %d degrees' % (bbox[2] - bbox[0]))
-        return self.sitecol.within_bbox(bbox)
 
     def __getitem__(self, slc):
         if slc.start is None and slc.stop is None:

--- a/openquake/qa_tests_data/ucerf/job_classical_redux.ini
+++ b/openquake/qa_tests_data/ucerf/job_classical_redux.ini
@@ -26,7 +26,8 @@ source_model_logic_tree_file = ucerf_true_mean_smlt.xml
 source_model_file = ucerf_true_mean_source.xml
 gsim_logic_tree_file = gmpe_logic_tree_ucerf_mean.xml
 investigation_time = 1.0
-intensity_measure_types_and_levels = {"PGA": [0.01, 0.04, 0.1, 0.4, 0.6], "SA(0.1)": [0.01, 0.04, 0.1, 0.4, 0.6]}
+intensity_measure_types_and_levels = {
+  "PGA": [0.01, 0.04, 0.1, 0.4, 0.6], "SA(0.1)": [0.01, 0.04, 0.1, 0.4, 0.6]}
 maximum_distance = {'Active Shallow Crust': 300.0}
 
 [output]


### PR DESCRIPTION
The advantage is that the processed model (i.e. with collapsed point sources) can be cached. I am also implementing  the reduced site collection trick mentioned in https://github.com/gem/oq-engine/pull/6302.