### PR TITLE
Reduced the slow tasks due to point sources in classical calculations

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -21,7 +21,6 @@ import psutil
 import pprint
 import logging
 import operator
-from datetime import datetime
 import numpy
 try:
     from PIL import Image
@@ -303,7 +302,7 @@ class ClassicalCalculator(base.HazardCalculator):
             self.numrups = sum(arr[0] for arr in self.calc_times.values())
             numsites = sum(arr[1] for arr in self.calc_times.values())
             logging.info('Effective number of ruptures: {:_d}/{:_d}'.format(
-                int(self.numrups), self.totrups))
+                int(self.numrups), int(self.totrups)))
             logging.info('Effective number of sites per rupture: %d',
                          numsites / self.numrups)
         if psd:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -48,7 +48,7 @@ from openquake.hazardlib import (
 from openquake.hazardlib.source import point, rupture
 from openquake.hazardlib.calc.stochastic import rupture_dt
 from openquake.hazardlib.probability_map import ProbabilityMap
-from openquake.hazardlib.source.point import grid_point_sources
+from openquake.hazardlib.source.point import PointSource, grid_point_sources
 from openquake.hazardlib.sourceconverter import SourceGroup
 from openquake.hazardlib.geo.utils import BBoxError, cross_idl
 from openquake.risklib import asset, riskmodels
@@ -57,8 +57,6 @@ from openquake.commonlib.oqvalidation import OqParam
 from openquake.commonlib.source_reader import get_csm
 from openquake.commonlib import logictree
 
-# the following is quite arbitrary, it gives output weights that I like (MS)
-NORMALIZATION_FACTOR = 1E-2
 F32 = numpy.float32
 F64 = numpy.float64
 U8 = numpy.uint8
@@ -731,7 +729,7 @@ def weight_sources(srcs, srcfilter, params, monitor):
         for split in splits:
             split.nsites = len(srcfilter.close_sids(split)) or .01
             split.num_ruptures = split.count_ruptures()
-            if pd and hasattr(split, 'nodal_plane_distribution'):
+            if pd and isinstance(split, PointSource):
                 nphc = split.count_nphc()
                 if nphc > 1:
                     close, far = srcfilter.count_close_far(

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -735,7 +735,6 @@ def weight_sources(srcs, srcfilter, params, monitor):
                     close, far = srcfilter.count_close_far(
                         split.location, pd, md)
                     factor = (nphc * close + far) / (close + far)
-                    print(split, split.num_ruptures, factor)
                     split.num_ruptures /= factor
             sources.append(split)
         dt = time.time() - t0

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -726,22 +726,21 @@ def weight_sources(srcs, srcfilter, params, monitor):
         md = params['maximum_distance'](trt)
         pd = psd(trt)
         splits = split_source(src) if params['split_sources'] else [src]
-        for split in splits:
-            split.nsites = len(srcfilter.close_sids(split)) or .01
-            split.num_ruptures = split.count_ruptures()
-            if pd and isinstance(split, PointSource):
-                nphc = split.count_nphc()
-                if nphc > 1:
-                    close, far = srcfilter.count_close_far(
-                        split.location, pd, md)
-                    factor = (nphc * close + far) / (close + far)
-                    split.num_ruptures /= factor
-            sources.append(split)
+        sources.extend(splits)
         dt = time.time() - t0
         calc_times[src.id] += F32([src.num_ruptures, src.nsites, dt, 0])
     for arr in calc_times.values():
         arr[3] = monitor.task_no
     dic = grid_point_sources(sources, grp_id, params['ps_grid_spacing'])
+    for src in dic[grp_id]:
+        src.nsites = len(srcfilter.close_sids(src)) or .01
+        src.num_ruptures = src.count_ruptures()
+        if pd and isinstance(src, PointSource):
+            nphc = src.count_nphc()
+            if nphc > 1:
+                close, far = srcfilter.count_close_far(src.location, pd, md)
+                factor = (nphc * close + far) / (close + far)
+                src.num_ruptures /= factor
     dic['calc_times'] = calc_times
     dic['before'] = len(sources)
     dic['after'] = len(dic[grp_id])

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -727,8 +727,9 @@ def weight_sources(srcs, srcfilter, params, monitor):
         pd = psd(trt)
         splits = split_source(src) if params['split_sources'] else [src]
         sources.extend(splits)
+        nrups = src.count_ruptures()
         dt = time.time() - t0
-        calc_times[src.id] += F32([src.num_ruptures, src.nsites, dt, 0])
+        calc_times[src.id] += F32([nrups, src.nsites, dt, 0])
     for arr in calc_times.values():
         arr[3] = monitor.task_no
     dic = grid_point_sources(sources, grp_id, params['ps_grid_spacing'])

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -41,7 +41,7 @@ from openquake.baselib.general import (
 from openquake.baselib.python3compat import zip
 from openquake.baselib.node import Node
 from openquake.hazardlib.const import StdDev
-from openquake.hazardlib.calc.filters import SourceFilter
+from openquake.hazardlib.calc.filters import SourceFilter, split_source
 from openquake.hazardlib.calc.gmf import CorrelationButNoInterIntraStdDevs
 from openquake.hazardlib import (
     source, geo, site, imt, valid, sourceconverter, nrml, InvalidFile)
@@ -721,9 +721,25 @@ def weight_sources(srcs, srcfilter, params, monitor):
     calc_times = AccumDict(accum=numpy.zeros(4, F32))
     sources = []
     grp_id = srcs[0].grp_id
+    psd = params['pointsource_distance'] or (lambda src: None)
     for src in srcs:
         t0 = time.time()
-        sources.extend(srcfilter.split_source(src, params['split_sources']))
+        trt = src.tectonic_region_type
+        md = params['maximum_distance'](trt)
+        pd = psd(trt)
+        splits = split_source(src) if params['split_sources'] else [src]
+        for split in splits:
+            split.nsites = len(srcfilter.close_sids(split)) or .01
+            split.num_ruptures = split.count_ruptures()
+            if pd and hasattr(split, 'nodal_plane_distribution'):
+                nphc = split.count_nphc()
+                if nphc > 1:
+                    close, far = srcfilter.count_close_far(
+                        split.location, pd, md)
+                    factor = (nphc * close + far) / (close + far)
+                    print(split, split.num_ruptures, factor)
+                    split.num_ruptures /= factor
+            sources.append(split)
         dt = time.time() - t0
         calc_times[src.id] += F32([src.num_ruptures, src.nsites, dt, 0])
     for arr in calc_times.values():
@@ -786,7 +802,7 @@ def _check_csm(csm, oqparam, h5):
         lats = []
         for src in srcs:
             try:
-                box = srcfilter.integration_distance.get_enlarged_box(src)
+                box = srcfilter.get_enlarged_box(src)
             except BBoxError as exc:
                 logging.error(exc)
                 continue
@@ -821,7 +837,9 @@ def _weight_sources(csm, srcfilter, oqparam, h5):
     sources_by_grp = groupby(
         csm.get_sources(atomic=False),
         lambda src: (src.grp_id, point.msr_name(src)))
-    param = dict(ps_grid_spacing=oqparam.ps_grid_spacing,
+    param = dict(maximum_distance=oqparam.maximum_distance,
+                 pointsource_distance=oqparam.pointsource_distance,
+                 ps_grid_spacing=oqparam.ps_grid_spacing,
                  split_sources=oqparam.split_sources)
 
     res = parallel.Starmap(

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -786,11 +786,11 @@ def _check_csm(csm, oqparam, h5):
     sitecol = get_site_collection(oqparam, h5)
     if sitecol is None:
         fewsites = None
-    elif len(sitecol) <= oqparam.max_sites_disagg:
+    elif len(sitecol) <= 50:
         fewsites = sitecol
     else:  # long sitecol
-        fewsites = sitecol.filter(sitecol.sids % 10 == 0)
-    # performance hack: use 1 site over 10 when weighting the sources!
+        fewsites = sitecol.filter(sitecol.sids % 50 == 0)
+    # performance hack: use 1 site over 50 when weighting the sources!
     srcfilter = SourceFilter(fewsites, oqparam.maximum_distance)
 
     if sitecol:  # missing in test_case_1_ruptures

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -335,6 +335,7 @@ class CompositeSourceModel:
         """
         Update (eff_ruptures, num_sites, calc_time) inside the source_info
         """
+        print(calc_times)
         for src_id, arr in calc_times.items():
             row = self.source_info[src_id]
             row[CALC_TIME] += arr[2]

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -335,7 +335,6 @@ class CompositeSourceModel:
         """
         Update (eff_ruptures, num_sites, calc_time) inside the source_info
         """
-        print(calc_times)
         for src_id, arr in calc_times.items():
             row = self.source_info[src_id]
             row[CALC_TIME] += arr[2]

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -372,9 +372,12 @@ class SourceFilter(object):
         return sids
 
     def count_close_far(self, location, distance1, distance2):
+        if distance1 == 0:
+            close2, far2 = self.sitecol.split(location, distance2)
+            return 0, len(close2 or [0])
         close1, far1 = self.sitecol.split(location, distance1)
         close2, far2 = self.sitecol.split(location, distance2)
-        return len(close1), len(close2) - len(close1)
+        return len(close1 or [0]), len(close2 or [0]) - len(close1 or [0])
 
     def filter(self, sources):
         """

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -666,7 +666,7 @@ class PmapMaker(object):
         if loc and self.pointsource_distance == 0:
             # all finite size effects are ignored
             yield from rups(src.point_ruptures(), sites)
-        elif loc and self.pointsource_distance:
+        elif loc and self.pointsource_distance and src.count_nphc() > 1:
             # finite site effects are ignored only for sites over the
             # pointsource_distance from the rupture (if any)
             for pr in src.point_ruptures():

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -56,12 +56,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         if not self.num_ruptures:
             self.num_ruptures = self.count_ruptures()
         nsites_factor = min(self.nsites, 1)
-        if hasattr(self, 'nodal_plane_distribution'):
-            rescale = len(self.nodal_plane_distribution.data) * len(
-                self.hypocenter_distribution.data)
-        else:
-            rescale = 1
-        return self.num_ruptures * self.ngsims * nsites_factor / rescale
+        return self.num_ruptures * self.ngsims * nsites_factor
 
     @property
     def et_ids(self):

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -410,6 +410,12 @@ class CollapsedPointSource(PointSource):
             acc += dict(psource.get_annual_occurrence_rates())
         return sorted(acc.items())
 
+    def count_nphc(self):
+        """
+        :returns: always 1
+        """
+        return 1
+
     def iter_ruptures(self, **kwargs):
         """
         :returns: an iterator over the underlying ruptures

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -89,7 +89,7 @@ def calc_average(pointsources):
     """
     acc = dict(lon=[], lat=[], dep=[], strike=[], dip=[], rake=[],
                upper_seismogenic_depth=[], lower_seismogenic_depth=[],
-               rupture_aspect_ratio=[])
+               rupture_aspect_ratio=[], nphc=[])
     rates = []
     trt = pointsources[0].tectonic_region_type
     msr = msr_name(pointsources[0])
@@ -112,6 +112,7 @@ def calc_average(pointsources):
         acc['upper_seismogenic_depth'].append(src.upper_seismogenic_depth)
         acc['lower_seismogenic_depth'].append(src.lower_seismogenic_depth)
         acc['rupture_aspect_ratio'].append(src.rupture_aspect_ratio)
+        acc['nphc'].append(src.count_nphc())
     return {key: numpy.average(acc[key], weights=rates) for key in acc}
 
 
@@ -412,9 +413,9 @@ class CollapsedPointSource(PointSource):
 
     def count_nphc(self):
         """
-        :returns: always 1
+        :returns: the average number of nodal planes and hypocenters
         """
-        return 1
+        return self.nphc
 
     def iter_ruptures(self, **kwargs):
         """
@@ -493,11 +494,9 @@ def grid_point_sources(sources, grp_id, ps_grid_spacing):
     grid = groupby_grid(coords[:, 0], coords[:, 1], deltax, deltay)
     for idxs in grid.values():
         cps = CollapsedPointSource(ps[idxs])
-        cps.num_ruptures = cps.count_ruptures()
         cps.id = ps[0].id
         cps.grp_id = ps[0].grp_id
         cps.et_id = ps[0].et_id
-        cps.nsites = sum(p.nsites for p in ps)
         out.append(cps)
     return {grp_id: out}
 

--- a/openquake/qa_tests_data/classical/case_2/expected/hcurve.csv
+++ b/openquake/qa_tests_data/classical/case_2/expected/hcurve.csv
@@ -1,3 +1,3 @@
-#,,,,,,"generated_by='OpenQuake engine 3.11.0-git56486270cb', start_date='2020-11-28T07:22:51', checksum=1989732488, kind='mean', investigation_time=1.0, imt='PGA'"
+#,,,,,,"generated_by='OpenQuake engine 3.11.0-git95cf59e94a', start_date='2020-11-30T11:39:24', checksum=1743396429, kind='mean', investigation_time=1.0, imt='PGA'"
 lon,lat,depth,poe-0.1000000,poe-0.4000000,poe-0.6000000,poe-1.0000000
-0.10000,0.00000,0.00000,1.214438E-02,4.958536E-05,0.000000E+00,0.000000E+00
+0.10000,0.00000,0.00000,1.218549E-02,5.375316E-04,6.943041E-05,0.000000E+00


### PR DESCRIPTION
By introducing a concept of effective number of ruptures, depending on the `pointsource_distance`.
Here the figures for a SHARE model containing only area sources, for pointsource_distance=50:
```
operation-duration counts mean    stddev min     max   
classical          605    20      47%    0.97021 52     # old
classical          606    20      37%    0.79250 47     # new
```
The situation is even better if there is a ps_grid_spacing:
```
operation-duration counts mean    stddev min     max
classical          621    10      90%    0.01089 38     # old
classical          618    10      56%    0.38381 24     # new
```