### PR TITLE
Implemented minimum_asset_loss in scenario_risk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Implemented `minimum_asset_loss` in scenario_risk for consistency
+    with the `ebrisk` calculator
   * Added a command `oq plot gridded_sources?`
   * Fixed `oq recompute_losses` to expose the outputs to the database
   * Fixed `oq engine --run --params` that was not working for

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -32,10 +32,9 @@ from openquake.baselib import (
 from openquake.baselib import parallel
 from openquake.baselib.performance import Monitor, init_performance
 from openquake.hazardlib import InvalidFile, site
-
 from openquake.hazardlib.site_amplification import Amplifier
 from openquake.hazardlib.site_amplification import AmplFunction
-from openquake.hazardlib.calc.filters import SourceFilter
+from openquake.hazardlib.calc.filters import SourceFilter, getdefault
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap import get_sitecol_shakemap, to_gmfs
 from openquake.risklib import riskinput, riskmodels
@@ -831,6 +830,9 @@ class HazardCalculator(BaseCalculator):
         for sp in sec_perils:
             sp.prepare(self.sitecol)  # add columns as needed
 
+        mal = {lt: getdefault(oq.minimum_asset_loss, lt)
+               for lt in oq.loss_names}
+        logging.info('minimum_asset_loss=%s', mal)
         self.param = dict(individual_curves=oq.individual_curves,
                           ps_grid_spacing=oq.ps_grid_spacing,
                           collapse_level=oq.collapse_level,
@@ -838,7 +840,8 @@ class HazardCalculator(BaseCalculator):
                           avg_losses=oq.avg_losses,
                           amplifier=self.amplifier,
                           sec_perils=sec_perils,
-                          ses_seed=oq.ses_seed)
+                          ses_seed=oq.ses_seed,
+                          minimum_asset_loss=mal)
 
         # compute exposure stats
         if hasattr(self, 'assetcol'):

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -23,7 +23,6 @@ import numpy
 
 from openquake.baselib import datastore, hdf5, parallel, general
 from openquake.baselib.python3compat import zip
-from openquake.hazardlib.calc.filters import getdefault
 from openquake.risklib.scientific import LossesByAsset
 from openquake.risklib.riskinput import (
     cache_epsilons, get_assets_by_taxo, get_output)
@@ -193,15 +192,11 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.A = A = len(self.assetcol)
         self.L = L = len(lba.loss_names)
         self.check_number_loss_curves()
-        mal = {lt: getdefault(oq.minimum_asset_loss, lt)
-               for lt in oq.loss_names}
-        logging.info('minimum_asset_loss=%s', mal)
+        mal = self.param['minimum_asset_loss']
         if (oq.aggregate_by and self.E * A > oq.max_potential_gmfs and
-                any(val == 0 for val in mal.values()) and not
-                sum(oq.minimum_asset_loss.values())):
+                any(val == 0 for val in mal.values())):
             logging.warning('The calculation is really big; you should set '
                             'minimum_asset_loss')
-        self.param['minimum_asset_loss'] = mal
 
         elt_dt = [('event_id', U32), ('loss', (F32, (L,)))]
         for idxs, attrs in gen_indices(self.assetcol.tagcol, oq.aggregate_by):

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -195,7 +195,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         mal = self.param['minimum_asset_loss']
         if (oq.aggregate_by and self.E * A > oq.max_potential_gmfs and
                 any(val == 0 for val in mal.values())):
-            logging.warning('The calculation is really big; you should set '
+            logging.warning('The calculation is really big; consider setting '
                             'minimum_asset_loss')
 
         elt_dt = [('event_id', U32), ('loss', (F32, (L,)))]

--- a/openquake/qa_tests_data/scenario_risk/case_1/expected/agg.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_1/expected/agg.csv
@@ -1,3 +1,3 @@
-#,,,,"generated_by='OpenQuake engine 3.7.0-git5e91b20b88', start_date='2019-09-05T06:18:32', checksum=1296573449"
+#,,,,"generated_by='OpenQuake engine 3.11.0-git33085e4c00', start_date='2020-12-04T08:30:53', checksum=3590982611"
 rlz_id,loss_type,unit,mean,stddev
-0,structural,USD,4.322254E+02,1.868645E+02
+0,structural,USD,4.123671E+02,2.217485E+02

--- a/openquake/qa_tests_data/scenario_risk/case_1/expected/losses_by_event.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_1/expected/losses_by_event.csv
@@ -1,4 +1,4 @@
-#,,"generated_by='OpenQuake engine 3.7.0-git2cf1ae85ae', start_date='2019-09-05T18:14:35', checksum=1296573449, investigation_time=None, risk_investigation_time=None"
+#,,"generated_by='OpenQuake engine 3.11.0-git33085e4c00', start_date='2020-12-04T08:30:53', checksum=3590982611"
 event_id,structural,rlz_id
 0,8.51288E+02,0
 1,3.28829E+02,0
@@ -7,6 +7,5 @@ event_id,structural,rlz_id
 4,3.42458E+02,0
 5,2.52500E+02,0
 6,4.81053E+02,0
-7,1.98583E+02,0
 8,5.79551E+02,0
 9,5.03661E+02,0

--- a/openquake/qa_tests_data/scenario_risk/case_1/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_1/job_risk.ini
@@ -6,7 +6,7 @@ sites_csv = sites.csv
 structural_vulnerability_file = vulnerability.xml
 exposure_file = exposure_model.xml
 gmfs_file = gmf_scenario.csv
-
+minimum_asset_loss = {"structural": 200.0}
 region =  15.48 38.30, 15.63 38.30,  15.63 38.01,  15.48 38.01
 export_dir = /tmp/
 asset_loss_table = true


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/6320. This is not the end since we need to make more consistent the behavior of `minimum_asset_loss` in ebrisk (currently losses are discarded when computing the average asset losses but not when computing the total portfolio losses, thus resulting in discrepancies when comparing the two).