### PR TITLE
Fixed the bug with the disappearing log

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -670,10 +670,14 @@ class ClassicalCalculator(base.HazardCalculator):
             build_hazard, allargs, distribute=dist, h5=self.datastore.hdf5
         ).reduce(self.save_hazard)
         task_info = self.datastore.read_df('task_info', 'taskname')
-        dur = task_info.loc[b'classical'].duration
-        slow_tasks = len(dur[dur > 3 * dur.mean()])
-        if slow_tasks:
-            logging.info('There were %d slow tasks', slow_tasks)
+        try:
+            dur = task_info.loc[b'classical'].duration
+        except KeyError:  # no data
+            pass
+        else:
+            slow_tasks = len(dur[dur > 3 * dur.mean()])
+            if slow_tasks:
+                logging.info('There were %d slow tasks', slow_tasks)
         if 'hmaps-stats' in self.datastore:
             hmaps = self.datastore.sel('hmaps-stats', stat='mean')  # NSMP
             maxhaz = hmaps.max(axis=(0, 1, 3))

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -485,6 +485,11 @@ class EngineRunJobTestCase(unittest.TestCase):
         self.assertEqual(r1.hazard_calculation_id, r1.id)
         self.assertEqual(r2.hazard_calculation_id, r1.id)
 
+    def test_OQ_REDUCE(self):
+        with mock.patch.dict(os.environ, OQ_REDUCE='10'):
+            job_ini = os.path.join(os.path.dirname(case_4.__file__), 'job.ini')
+            run_jobs([job_ini])
+
     def test_sensitivity(self):
         job_ini = gettemp('''[general]
 description = sensitivity test

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -258,30 +258,8 @@ class OqParam(valid.ParamSet):
                 for key, value in self.inputs['reqv'].items()}
 
     def __init__(self, **names_vals):
-        if '_job_id' in names_vals:
-            # assume most attributes already validated
-            vars(self).update(names_vals)
-            if 'hazard_calculation_id' in names_vals:
-                self.hazard_calculation_id = int(
-                    names_vals['hazard_calculation_id'])
-            if 'maximum_distance' in names_vals:
-                self.maximum_distance = valid.MagDepDistance.new(
-                            str(names_vals['maximum_distance']))
-            if 'pointsource_distance' in names_vals:
-                self.pointsource_distance = valid.MagDepDistance.new(
-                    str(names_vals['pointsource_distance']))
-            if 'region_constraint' in names_vals:
-                self.region = valid.wkt_polygon(
-                    names_vals['region_constraint'])
-            if 'minimum_magnitude' in names_vals:
-                self.minimum_magnitude = valid.floatdict(
-                    str(names_vals['minimum_magnitude']))
-            if 'minimum_intensity' in names_vals:
-                self.minimum_intensity = valid.floatdict(
-                    str(names_vals['minimum_intensity']))
-            if 'sites' in names_vals:
-                self.sites = valid.coordinates(names_vals['sites'])
-            return
+        if '_job_id' in names_vals:  # called from engine
+            del names_vals['_job_id']
 
         # support legacy names
         for name in list(names_vals):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -19,7 +19,6 @@ import os
 import re
 import ast
 import csv
-import time
 import copy
 import json
 import zlib
@@ -207,6 +206,8 @@ def _update(params, items, base_path):
         params['pointsource_distance'] = '0'
 
 
+# NB: this function must NOT log, since it is called when the logging
+# is not configured yet
 def get_params(job_ini, **kw):
     """
     Parse a .ini file or a .zip archive
@@ -289,7 +290,7 @@ def get_oqparam(job_ini, pkg=None, calculators=None, hc_id=None, validate=1):
         # reduce the ses by a factor of `re`
         # set save_disk_space = true
         os.environ['OQ_SAMPLE_SITES'] = str(1 / float(re))
-        job_ini['number_of_logic_tree_samples'] = 1
+        job_ini['number_of_logic_tree_samples'] = '1'
         ses = job_ini.get('ses_per_logic_tree_path')
         if ses:
             ses = str(int(numpy.ceil(int(ses) / float(re))))
@@ -300,7 +301,7 @@ def get_oqparam(job_ini, pkg=None, calculators=None, hc_id=None, validate=1):
             imt = next(iter(imtls))
             job_ini['intensity_measure_types_and_levels'] = repr(
                 {imt: imtls[imt]})
-        job_ini['save_disk_space'] = True
+        job_ini['save_disk_space'] = 'true'
     oqparam = OqParam(**job_ini)
     if validate and '_job_id' not in job_ini:
         oqparam.check_source_model()


### PR DESCRIPTION
This was happening in presence of an unknown parameter in the `job.ini` (typically because of a mispelling): the log was disappearing since `get_oqparam` was called before the log was initialized. As a consequence the logging module was using the Python defaults (i.e. not logging on the database, and logging on screen only the warnings). The fix also simplifies/unifies the logic and allows to remove 20+ lines of code.