### PR TITLE
Now setting `ps_grid_spacing` also sets `pointsource_distance`

### DIFF
--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -115,8 +115,7 @@ class CalculatorTestCase(unittest.TestCase):
         """
         self.testdir = os.path.dirname(testfile) if os.path.isfile(testfile) \
             else testfile
-        params = readinput.get_params(
-            os.path.join(self.testdir, job_ini), **kw)
+        params = readinput.get_params(os.path.join(self.testdir, job_ini), kw)
 
         oqvalidation.OqParam.calculation_mode.validator.choices = tuple(
             base.calculators)

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -21,7 +21,7 @@ import getpass
 from openquake.baselib import sap, config, datastore
 from openquake.baselib.general import safeprint
 from openquake.hazardlib import valid
-from openquake.commonlib import logs, oqvalidation
+from openquake.commonlib import logs
 from openquake.engine.engine import run_jobs
 from openquake.engine.export import core
 from openquake.engine.utils import confirm
@@ -140,7 +140,6 @@ def engine(log_file, no_distribute, yes, config_file, make_html_report,
             pars['cachedir'] = datadir
         if hc_id:
             pars['hazard_calculation_id'] = str(hc_id)
-        pars = oqvalidation.OqParam.check(pars)
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
         job_inis = [os.path.expanduser(f) for f in run]

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -77,23 +77,24 @@ def run2(job_haz, job_risk, calc_id, concurrent_tasks, pdb, reuse_input,
     """
     Run both hazard and risk, one after the other
     """
-    hcalc = base.calculators(readinput.get_oqparam(job_haz), calc_id)
-    hcalc.run(concurrent_tasks=concurrent_tasks, pdb=pdb,
-              exports=exports, **params)
+    oq = readinput.get_oqparam(job_haz, kw=params)
+    hcalc = base.calculators(oq, calc_id)
+    hcalc.run(concurrent_tasks=concurrent_tasks, pdb=pdb, exports=exports)
     hcalc.datastore.close()
     hc_id = hcalc.datastore.calc_id
     rcalc_id = logs.init(level=getattr(logging, loglevel.upper()))
-    oq = readinput.get_oqparam(job_risk, hc_id=hc_id)
+    params['hazard_calculation_id'] = str(hc_id)
+    oq = readinput.get_oqparam(job_risk, kw=params)
+    rcalc = base.calculators(oq, rcalc_id)
     if reuse_input:  # enable caching
         oq.cachedir = datastore.get_datadir()
-    rcalc = base.calculators(oq, rcalc_id)
-    rcalc.run(pdb=pdb, exports=exports, **params)
+    rcalc.run(pdb=pdb, exports=exports)
     return rcalc
 
 
 # run with processpool unless OQ_DISTRIBUTE is set to something else
 def _run(job_inis, concurrent_tasks, calc_id, pdb, reuse_input, loglevel,
-         hc, exports, params):
+         exports, params):
     global calc_path
     assert len(job_inis) in (1, 2), job_inis
     # set the logs first of all
@@ -104,27 +105,24 @@ def _run(job_inis, concurrent_tasks, calc_id, pdb, reuse_input, loglevel,
         if os.environ.get('OQ_DISTRIBUTE') not in ('no', 'processpool'):
             os.environ['OQ_DISTRIBUTE'] = 'processpool'
         if len(job_inis) == 1:  # run hazard or risk
-            if hc:
-                hc_id = hc[0]
-                rlz_ids = hc[1:]
+            if 'hazard_calculation_id' in params:
+                hc_id = int(params['hazard_calculation_id'])
             else:
                 hc_id = None
-                rlz_ids = ()
-            oqparam = readinput.get_oqparam(job_inis[0], hc_id=hc_id)
-            vars(oqparam).update(params)  # params already checked
-            if reuse_input:  # enable caching
-                oqparam.cachedir = datastore.get_datadir()
             if hc_id and hc_id < 0:  # interpret negative calculation ids
                 calc_ids = datastore.get_calc_ids()
                 try:
-                    hc_id = calc_ids[hc_id]
+                    params['hazard_calculation_id'] = str(calc_ids[hc_id])
                 except IndexError:
                     raise SystemExit(
                         'There are %d old calculations, cannot '
                         'retrieve the %s' % (len(calc_ids), hc_id))
+            oqparam = readinput.get_oqparam(job_inis[0], kw=params)
             calc = base.calculators(oqparam, calc_id)
+            if reuse_input:  # enable caching
+                oqparam.cachedir = datastore.get_datadir()
             calc.run(concurrent_tasks=concurrent_tasks, pdb=pdb,
-                     exports=exports, rlz_ids=rlz_ids)
+                     exports=exports)
         else:  # run hazard + risk
             calc = run2(
                 job_inis[0], job_inis[1], calc_id, concurrent_tasks, pdb,
@@ -146,10 +144,11 @@ def run(job_ini, slowest=False, hc=None, param='', concurrent_tasks=None,
     """
     dbserver.ensure_on()
     if param:
-        params = oqvalidation.OqParam.check(
-            dict(p.split('=', 1) for p in param.split(',')))
+        params = dict(p.split('=', 1) for p in param.split(','))
     else:
         params = {}
+    if hc:
+        params['hazard_calculation_id'] = str(hc)
     if slowest:
         prof = cProfile.Profile()
         stmt = ('_run(job_ini, concurrent_tasks, calc_id, pdb, reuse_input, '
@@ -162,7 +161,7 @@ def run(job_ini, slowest=False, hc=None, param='', concurrent_tasks=None,
         return
     try:
         return _run(job_ini, concurrent_tasks, calc_id, pdb,
-                    reuse_input, loglevel, hc, exports, params)
+                    reuse_input, loglevel, exports, params)
     finally:
         parallel.Starmap.shutdown()
 

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -247,7 +247,7 @@ class RunShowExportTestCase(unittest.TestCase):
         job_ini = os.path.join(os.path.dirname(case_1.__file__), 'job.ini')
         with Print.patch() as cls.p:
             calc = run._run([job_ini], 0, 'nojob', False,
-                            False, 'info', None, '', {})
+                            False, 'info', '', {})
         cls.calc_id = calc.datastore.calc_id
 
     def test_run_calc(self):
@@ -584,7 +584,7 @@ class ReduceSourceModelTestCase(unittest.TestCase):
         job_ini = os.path.join(temp_dir, 'data', 'job.ini')
         with Print.patch():
             calc = run._run([job_ini], 0, 'nojob', False, False,
-                            'info', None, '', {})
+                            'info', '', {})
         calc_id = calc.datastore.calc_id
         with mock.patch('logging.info') as info:
             reduce_sm(calc_id)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -319,6 +319,11 @@ class OqParam(valid.ParamSet):
                     i2 = calc.filters.getdefault(self.maximum_intensity, imt)
                     self.hazard_imtls[imt] = list(valid.logscale(i1, i2, 20))
             delattr(self, 'intensity_measure_types')
+        if ('ps_grid_spacing' in names_vals and
+                'pointsource_distance' not in names_vals):
+            self.pointsource_distance = valid.MagDepDistance.new(
+                    names_vals['ps_grid_spacing'])
+
         self._risk_files = get_risk_files(self.inputs)
 
         if self.hazard_precomputed() and self.job_type == 'risk':

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -250,7 +250,7 @@ def get_params(job_ini, kw):
     return params
 
 
-def get_oqparam(job_ini, pkg=None, calculators=None, kw=(), validate=1):
+def get_oqparam(job_ini, pkg=None, calculators=None, kw={}, validate=1):
     """
     Parse a dictionary of parameters from an INI-style config file.
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -208,7 +208,7 @@ def _update(params, items, base_path):
 
 # NB: this function must NOT log, since it is called when the logging
 # is not configured yet
-def get_params(job_ini, **kw):
+def get_params(job_ini, kw):
     """
     Parse a .ini file or a .zip archive
 
@@ -250,7 +250,7 @@ def get_params(job_ini, **kw):
     return params
 
 
-def get_oqparam(job_ini, pkg=None, calculators=None, hc_id=None, validate=1):
+def get_oqparam(job_ini, pkg=None, calculators=None, kw=(), validate=1):
     """
     Parse a dictionary of parameters from an INI-style config file.
 
@@ -261,8 +261,8 @@ def get_oqparam(job_ini, pkg=None, calculators=None, hc_id=None, validate=1):
     :param calculators:
         Sequence of calculator names (optional) used to restrict the
         valid choices for `calculation_mode`
-    :param hc_id:
-        Not None only when called from a post calculation
+    :param kw:
+        Dictionary of strings to override the job parameters
     :param validate:
         Flag. By default it is true and the parameters are validated
     :returns:
@@ -279,9 +279,7 @@ def get_oqparam(job_ini, pkg=None, calculators=None, hc_id=None, validate=1):
         calculators or base.calculators)
     if not isinstance(job_ini, dict):
         basedir = os.path.dirname(pkg.__file__) if pkg else ''
-        job_ini = get_params(os.path.join(basedir, job_ini))
-    if hc_id:
-        job_ini.update(hazard_calculation_id=str(hc_id))
+        job_ini = get_params(os.path.join(basedir, job_ini), kw)
     re = os.environ.get('OQ_REDUCE')  # debugging facility
     if re:
         # reduce the imtls to the first imt

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -62,7 +62,7 @@ investigation_time = 50
 export_dir = %s
         """ % (site_model_input, TMP))
         with self.assertRaises(ValueError) as ctx:
-            readinput.get_params(job_config)
+            readinput.get_params(job_config, {})
         self.assertIn('is an absolute path', str(ctx.exception))
 
     def test_get_oqparam_with_sites_csv(self):


### PR DESCRIPTION
If it is not already set. This saves the day in case one forgets to set the pointsource_distance and then all the speedup is lost.
Closes https://github.com/gem/oq-engine/issues/6263.