### PR TITLE
Refactored the aggregation of losses in ebrisk

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -98,8 +98,8 @@ def calc_risk(gmfs, param, monitor):
     acc['alt'] = alt = {}
     for key, k in aggkey.items():
         s = ','.join(map(str, key)) + ','
-        alt[s] = numpy.array([(eid, arr[k]) for eid, arr in lba.alt.items()],
-                             elt_dt)
+        alt[s] = numpy.array([(eid, arr[k]) for eid, arr in lba.alt.items()
+                              if arr.sum()], elt_dt)
     if param['avg_losses']:
         acc['losses_by_A'] = param['lba'].losses_by_A * param['ses_ratio']
         # without resetting the cache the sequential avg_losses would be wrong!

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -154,16 +154,20 @@ def ebrisk(rupgetter, param, monitor):
     return res
 
 
-def get_pairs(tagcol, aggby):
-    pairs = [((), {})]
+def get_aggkey_attrs(tagcol, aggby):
+    aggkey = {(): 0}
+    attrs = [{}]
     if not aggby:
-        return pairs
+        return aggkey, attrs
     alltags = [getattr(tagcol, tagname) for tagname in aggby]
     ranges = [range(1, len(tags)) for tags in alltags]
+    i = 1
     for idxs in itertools.product(*ranges):
         d = {name: tags[idx] for idx, name, tags in zip(idxs, aggby, alltags)}
-        pairs.append((idxs, d))
-    return pairs
+        aggkey[idxs] = i
+        attrs.append(d)
+        i += 1
+    return aggkey, attrs
 
 
 @base.calculators.add('ebrisk')
@@ -197,10 +201,13 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                             'minimum_asset_loss')
 
         elt_dt = [('event_id', U32), ('loss', (F32, (L,)))]
-        for idxs, attrs in get_pairs(self.assetcol.tagcol, oq.aggregate_by):
+        self.aggkey, attrs = get_aggkey_attrs(
+            self.assetcol.tagcol, oq.aggregate_by)
+        for idxs, attr in zip(self.aggkey, attrs):
             idx = ','.join(map(str, idxs)) + ','
             self.datastore.create_dset('event_loss_table/' + idx, elt_dt,
-                                       attrs=attrs)
+                                       attrs=attr)
+        self.param['aggkey'] = self.aggkey
         self.param.pop('oqparam', None)  # unneeded
         self.datastore.create_dset('avg_losses-stats', F32, (A, 1, L))  # mean
         elt_nbytes = 4 * self.E * L

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1496,7 +1496,7 @@ class LossesByAsset(object):
                         losses[a], ded * avalues[a], lim * avalues[a])
                 yield self.lni[lt + '_ins'], ins_losses
 
-    def aggregate(self, out, eids, minimum_loss, tagidxs, ws):
+    def aggregate(self, out, eids, minimum_loss, aggkey, tagidxs, ws):
         """
         Populate .losses_by_A and .alt
         """
@@ -1506,7 +1506,7 @@ class LossesByAsset(object):
                 aids = out.assets['ordinal']
                 self.losses_by_A[aids, lni] += losses @ ws
             for eid, loss in zip(eids, losses.sum(axis=0)):
-                self.alt[','][eid][lni] += loss
+                self.alt[eid][0, lni] += loss
             if tagidxs is not None:
                 # this is the slow part, depending on minimum_loss
                 for a, asset in enumerate(out.assets):
@@ -1514,10 +1514,10 @@ class LossesByAsset(object):
                     ok = ls > minimum_loss[lni]
                     if not ok.sum():
                         continue
-                    idx = ','.join(map(str, tagidxs[a])) + ','
+                    idx = aggkey[tuple(tagidxs[a])]
                     kept = 0
                     for loss, eid in zip(ls[ok], out.eids[ok]):
-                        self.alt[idx][eid][lni] += loss
+                        self.alt[eid][idx, lni] += loss
                         kept += 1
                     numlosses += numpy.array([kept, len(losses[a])])
         return numlosses


### PR DESCRIPTION
The pandas idea behing https://github.com/gem/oq-engine/issues/6335 was a complete failure, with aggregating losses 70x slower than before. This is a plan B approach:
```
   calc_23, maxmem=85.1 GB                     time_sec memory_mb counts # before
   =========================================== ======== ========= =======
   total start_ebrisk                          12_644   222       194    
   getting assets                              3_524    402       194    
   computing risk                              1_704    0.0       130_103
   aggregating losses                          677      0.0       130_103
   getting hazard                              544      12        194    
   EbriskCalculator.run                        331      1_614     1      

   calc_27, maxmem=84.3 GB                     time_sec memory_mb counts # after
   =========================================== ======== ========= =======
   total start_ebrisk                          12_223   221       194    
   getting assets                              3_405    402       194    
   computing risk                              1_625    0.0       130_103
   aggregating losses                          620      0.0       130_103
   getting hazard                              535      12        194    
   EbriskCalculator.run                        324      1_616     1      
```
We are only slightly faster, but it is better than before and it paves the way for further refactorings.