### PR TITLE
Implemented InsuredLosses as SecondaryLosses

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -90,6 +90,8 @@ def calc_risk(gmfs, param, monitor):
         s = ','.join(map(str, key)) + ','
         alt[s] = numpy.array([(eid, arr[k]) for eid, arr in lba.alt.items()
                               if arr[k].sum()], elt_dt)
+        # in the demo there are 264/1694 nonzero events, i.e. arr[k].sum()
+        # is zero most of the time
     if param['avg_losses']:
         acc['losses_by_A'] = param['lba'].losses_by_A * param['ses_ratio']
         # without resetting the cache the sequential avg_losses would be wrong!

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -59,12 +59,10 @@ def calc_risk(gmfs, param, monitor):
         crmodel = monitor.read('crmodel')
         weights = dstore['weights'][()]
     L = len(param['agg'].loss_names)
-    K = len(param['aggkey'])
     aggkey = param['aggkey']
     elt_dt = [('event_id', U32), ('loss', (F32, (L,)))]
     acc = dict(events_per_sid=0)
     agg = param['agg']
-    agg.alt = general.AccumDict(accum=numpy.zeros((K, L), F32))  # eid->loss
     tempname = param['tempname']
     aggby = param['aggregate_by']
     haz_by_sid = general.group_array(gmfs, 'sid')
@@ -81,11 +79,12 @@ def calc_risk(gmfs, param, monitor):
             out = get_output(crmodel, assets_by_taxo, haz)  # slow
         with mon_agg:
             agg.aggregate(out, param['minimum_asset_loss'], aggby)
+            # NB: after the aggregation out contains losses, not loss_ratios
         if param['avg_losses']:
             with mon_avg:
                 ws = weights[haz['rlz']]
                 for lni, ln in enumerate(agg.loss_names):
-                    losses_by_A[out.assets['ordinal'], lni] += out[ln] @ ws
+                    losses_by_A[assets['ordinal'], lni] += out[ln] @ ws
     if len(gmfs):
         acc['events_per_sid'] /= len(gmfs)
     acc['alt'] = alt = {}

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -82,11 +82,7 @@ def calc_risk(gmfs, param, monitor):
             assets_by_taxo = get_assets_by_taxo(assets, tempname)  # fast
             out = get_output(crmodel, assets_by_taxo, haz)  # slow
         with mon_agg:
-            if aggby:
-                tagidxs = [aggkey[tuple(key)] for key in out.assets[aggby]]
-            else:
-                tagidxs = [0 for _ in out.assets]
-            lba.aggregate(out, param['minimum_asset_loss'], tagidxs, ws)
+            lba.aggregate(out, param['minimum_asset_loss'], aggby, ws)
     if len(gmfs):
         acc['events_per_sid'] /= len(gmfs)
     acc['alt'] = alt = {}
@@ -202,6 +198,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         elt_dt = [('event_id', U32), ('loss', (F32, (L,)))]
         self.aggkey, attrs = get_aggkey_attrs(
             self.assetcol.tagcol, oq.aggregate_by)
+        lba.aggkey = self.aggkey
         for idxs, attr in zip(self.aggkey, attrs):
             idx = ','.join(map(str, idxs)) + ','
             self.datastore.create_dset('event_loss_table/' + idx, elt_dt,

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -90,11 +90,11 @@ def calc_risk(gmfs, param, monitor):
             assets_by_taxo = get_assets_by_taxo(assets, tempname)  # fast
             out = get_output(crmodel, assets_by_taxo, haz)  # slow
         with mon_agg:
-            for a, asset in enumerate(out.assets):
-                dic = {lt: out[lt][a] for lt in out.loss_types}
-                dic['eid'] = out.eids
-                idx = aggkey[tuple(asset[aggby])] if aggby else 0
-                lba.aggregate(asset, dic, minimum_loss, idx, ws)
+            if aggby:
+                tagidxs = [aggkey[tuple(key)] for key in out.assets[aggby]]
+            else:
+                tagidxs = [0 for _ in out.assets]
+            lba.aggregate(out, minimum_loss, tagidxs, ws)
     if len(gmfs):
         acc['events_per_sid'] /= len(gmfs)
     acc['alt'] = alt = {}

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -90,9 +90,11 @@ def calc_risk(gmfs, param, monitor):
             assets_by_taxo = get_assets_by_taxo(assets, tempname)  # fast
             out = get_output(crmodel, assets_by_taxo, haz)  # slow
         with mon_agg:
-            tagidxs = assets[aggby] if aggby else None
-            acc['numlosses'] += lba.aggregate(
-                out, haz['eid'], minimum_loss, aggkey, tagidxs, ws)
+            for a, asset in enumerate(out.assets):
+                dic = {lt: out[lt][a] for lt in out.loss_types}
+                dic['eid'] = out.eids
+                idx = aggkey[tuple(asset[aggby])] if aggby else 0
+                lba.aggregate(asset, dic, minimum_loss, idx, ws)
     if len(gmfs):
         acc['events_per_sid'] /= len(gmfs)
     acc['alt'] = alt = {}

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -23,7 +23,7 @@ import numpy
 
 from openquake.baselib import datastore, hdf5, parallel, general
 from openquake.baselib.python3compat import zip
-from openquake.risklib.scientific import LossesByAsset, InsuredLosses
+from openquake.risklib.scientific import LossAggregator, InsuredLosses
 from openquake.risklib.riskinput import (
     cache_epsilons, get_assets_by_taxo, get_output)
 from openquake.commonlib import logs
@@ -51,22 +51,24 @@ def calc_risk(gmfs, param, monitor):
     """
     mon_risk = monitor('computing risk', measuremem=False)
     mon_agg = monitor('aggregating losses', measuremem=False)
+    mon_avg = monitor('averaging losses', measuremem=False)
     dstore = datastore.read(param['hdf5path'])
     with monitor('getting assets'):
         assets_df = dstore.read_df('assetcol/array', 'ordinal')
     with monitor('getting crmodel'):
         crmodel = monitor.read('crmodel')
         weights = dstore['weights'][()]
-    L = len(param['lba'].loss_names)
+    L = len(param['agg'].loss_names)
     K = len(param['aggkey'])
     aggkey = param['aggkey']
     elt_dt = [('event_id', U32), ('loss', (F32, (L,)))]
     acc = dict(events_per_sid=0)
-    lba = param['lba']
-    lba.alt = general.AccumDict(accum=numpy.zeros((K, L), F32))  # eid->loss
+    agg = param['agg']
+    agg.alt = general.AccumDict(accum=numpy.zeros((K, L), F32))  # eid->loss
     tempname = param['tempname']
     aggby = param['aggregate_by']
     haz_by_sid = general.group_array(gmfs, 'sid')
+    losses_by_A = numpy.zeros((len(assets_df), len(agg.loss_names)), F32)
     for sid, asset_df in assets_df.groupby('site_id'):
         try:
             haz = haz_by_sid[sid]
@@ -75,27 +77,26 @@ def calc_risk(gmfs, param, monitor):
         with mon_risk:
             assets = asset_df.to_records()  # fast
             acc['events_per_sid'] += len(haz)
-            if param['avg_losses']:
-                ws = weights[haz['rlz']]
-            else:
-                ws = None
             assets_by_taxo = get_assets_by_taxo(assets, tempname)  # fast
             out = get_output(crmodel, assets_by_taxo, haz)  # slow
         with mon_agg:
-            lba.aggregate(out, param['minimum_asset_loss'], aggby, ws)
+            agg.aggregate(out, param['minimum_asset_loss'], aggby)
+        if param['avg_losses']:
+            with mon_avg:
+                ws = weights[haz['rlz']]
+                for lni, ln in enumerate(agg.loss_names):
+                    losses_by_A[out.assets['ordinal'], lni] += out[ln] @ ws
     if len(gmfs):
         acc['events_per_sid'] /= len(gmfs)
     acc['alt'] = alt = {}
     for key, k in aggkey.items():
         s = ','.join(map(str, key)) + ','
-        alt[s] = numpy.array([(eid, arr[k]) for eid, arr in lba.alt.items()
+        alt[s] = numpy.array([(eid, arr[k]) for eid, arr in agg.alt.items()
                               if arr[k].sum()], elt_dt)
         # in the demo there are 264/1694 nonzero events, i.e. arr[k].sum()
         # is zero most of the time
     if param['avg_losses']:
-        acc['losses_by_A'] = param['lba'].losses_by_A * param['ses_ratio']
-        # without resetting the cache the sequential avg_losses would be wrong!
-        del param['lba'].__dict__['losses_by_A']
+        acc['losses_by_A'] = losses_by_A * param['ses_ratio']
     return acc
 
 
@@ -182,14 +183,16 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         if self.policy_dict:
             sec_losses.append(
                 InsuredLosses(self.policy_name, self.policy_dict))
-        self.param['lba'] = lba = LossesByAsset(
-            self.assetcol, oq.loss_dt().names, sec_losses)
+        self.aggkey, attrs = get_aggkey_attrs(
+            self.assetcol.tagcol, oq.aggregate_by)
+        self.param['agg'] = agg = LossAggregator(
+            self.aggkey, oq.loss_dt().names, sec_losses)
         self.param['ses_ratio'] = oq.ses_ratio
         self.param['aggregate_by'] = oq.aggregate_by
         ct = oq.concurrent_tasks or 1
         self.param['maxweight'] = int(oq.ebrisk_maxsize / ct)
         self.A = A = len(self.assetcol)
-        self.L = L = len(lba.loss_names)
+        self.L = L = len(agg.loss_names)
         self.check_number_loss_curves()
         mal = self.param['minimum_asset_loss']
         if (oq.aggregate_by and self.E * A > oq.max_potential_gmfs and
@@ -198,9 +201,6 @@ class EbriskCalculator(event_based.EventBasedCalculator):
                             'minimum_asset_loss')
 
         elt_dt = [('event_id', U32), ('loss', (F32, (L,)))]
-        self.aggkey, attrs = get_aggkey_attrs(
-            self.assetcol.tagcol, oq.aggregate_by)
-        lba.aggkey = self.aggkey
         for idxs, attr in zip(self.aggkey, attrs):
             idx = ','.join(map(str, idxs)) + ','
             self.datastore.create_dset('event_loss_table/' + idx, elt_dt,

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -89,7 +89,7 @@ def calc_risk(gmfs, param, monitor):
     for key, k in aggkey.items():
         s = ','.join(map(str, key)) + ','
         alt[s] = numpy.array([(eid, arr[k]) for eid, arr in lba.alt.items()
-                              if arr.sum()], elt_dt)
+                              if arr[k].sum()], elt_dt)
     if param['avg_losses']:
         acc['losses_by_A'] = param['lba'].losses_by_A * param['ses_ratio']
         # without resetting the cache the sequential avg_losses would be wrong!

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -221,7 +221,7 @@ class OqParam(valid.ParamSet):
     spatial_correlation = valid.Param(valid.Choice('yes', 'no', 'full'), 'yes')
     specific_assets = valid.Param(valid.namelist, [])
     split_sources = valid.Param(valid.boolean, True)
-    ebrisk_maxsize = valid.Param(valid.positivefloat, 5E9)  # used in ebrisk
+    ebrisk_maxsize = valid.Param(valid.positivefloat, 1E10)  # used in ebrisk
     # NB: you cannot increase too much min_weight otherwise too few tasks will
     # be generated in cases like Ecuador inside full South America
     min_weight = valid.Param(valid.positiveint, 200)  # used in classical

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -221,7 +221,7 @@ class OqParam(valid.ParamSet):
     spatial_correlation = valid.Param(valid.Choice('yes', 'no', 'full'), 'yes')
     specific_assets = valid.Param(valid.namelist, [])
     split_sources = valid.Param(valid.boolean, True)
-    ebrisk_maxsize = valid.Param(valid.positivefloat, 1E10)  # used in ebrisk
+    ebrisk_maxsize = valid.Param(valid.positivefloat, 2E10)  # used in ebrisk
     # NB: you cannot increase too much min_weight otherwise too few tasks will
     # be generated in cases like Ecuador inside full South America
     min_weight = valid.Param(valid.positiveint, 200)  # used in classical

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -30,7 +30,7 @@ import numpy
 from numpy.testing import assert_equal
 from scipy import interpolate, stats, random
 
-from openquake.baselib.general import CallableDict
+from openquake.baselib.general import CallableDict, AccumDict
 from openquake.hazardlib.stats import compute_stats2
 
 F64 = numpy.float64
@@ -1468,6 +1468,8 @@ class LossAggregator(object):
         self.sec_losses = sec_losses
         for sec_loss in sec_losses:
             self.loss_names.extend(sec_loss.outputs)
+        KL = len(aggkey), len(self.loss_names)
+        self.alt = AccumDict(accum=numpy.zeros(KL, F32))  # eid->loss
 
     def aggregate(self, out, minimum_loss, aggby):
         """

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1491,7 +1491,8 @@ class LossesByAsset(object):
                 avalue = avalues[a]
                 ls = out[lt][a]
                 ls *= avalue
-                ls[ls < minimum_loss[lti]] = 0
+                if minimum_loss[lti]:
+                    ls[ls < minimum_loss[lti]] = 0
                 if lt in self.policy_dict:
                     ded, lim = self.policy_dict[lt][asset[self.policy_name]]
                     out[lt + '_ins'][a] = insured_losses(

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1457,8 +1457,12 @@ class LossAggregator(object):
     A class to aggregate losses.
 
     :param aggkey: a dictionary tuple -> integer
-    :param loss_type: a list of loss types
+    :param loss_types: a list of primary loss types
     :param sec_losses: a list of SecondaryLosses (can be empty)
+
+    Works by populating a dictionary of matrices of shape (K, L') .alt,
+    with K the number of aggregation keys and L' the number of primary
+    loss types plus secondary loss types.
     """
     alt = None  # set by the ebrisk calculator
 

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1482,9 +1482,13 @@ class LossesByAsset(object):
         """
         eids = out.eids
         assets = out.assets
+
+        # initialize secondary losses outputs, if any
         for sec_loss in self.sec_losses:
             for k in sec_loss.outputs:
                 setattr(out, k, numpy.zeros((len(assets), len(eids))))
+
+        # populate outputs
         for a, asset in enumerate(out.assets):
             for lti, lt in enumerate(out.loss_types):
                 avalue = (asset['occupants_None'] if lt == 'occupants'
@@ -1496,7 +1500,8 @@ class LossesByAsset(object):
                 for sec_loss in self.sec_losses:
                     for k, o in sec_loss.compute(asset, lt, ls).items():
                         out[k][a] = o
-        # vectorize on the assets too, this can double the performance
+
+        # vectorize on the assets, this can double the performance
         for lni, ln in enumerate(self.loss_names):
             if ws is not None:
                 self.losses_by_A[assets['ordinal'], lni] += out[ln] @ ws
@@ -1508,6 +1513,7 @@ class LossesByAsset(object):
                     for eid, loss in zip(eids, losses):
                         if loss:
                             self.alt[eid][idx, lni] += loss
+
 
 # must have attribute .outputs and method .compute(asset, losses, loss_type)
 # returning a dictionary sec_key -> sec_losses


### PR DESCRIPTION
First step towards https://github.com/gem/oq-engine/issues/6341. This also fixes the issue described in https://github.com/gem/oq-engine/pull/6326, i.e. the losses below `minimum_asset_loss` being not discarded in the basic event loss table. I am also monitoring the time to average the losses separately (before it was included in the aggregation time).