### PR TITLE
Fixed the WebUI tests

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -396,7 +396,7 @@ def run_jobs(job_inis, log_level='info', log_file=None, exports='',
     multi = kw.pop('multi', None)
     loglvl = getattr(logging, log_level.upper())
     jobs = create_jobs(job_inis, loglvl, kw)  # inizialize the logs
-    if 'hazard_calculation_id' in kw:
+    if kw.get('hazard_calculation_id'):
         hc_id = int(kw['hazard_calculation_id'])
     else:
         hc_id = None
@@ -404,11 +404,12 @@ def run_jobs(job_inis, log_level='info', log_file=None, exports='',
         job_id = job['_job_id']
         with logs.handle(job_id, log_level, log_file):
             oqparam = readinput.get_oqparam(job)
-        logs.dbcmd('update_job', job_id,
-                   dict(calculation_mode=oqparam.calculation_mode,
-                        description=oqparam.description,
-                        user_name=username,
-                        hazard_calculation_id=hc_id))
+        dic = dict(calculation_mode=oqparam.calculation_mode,
+                   description=oqparam.description,
+                   user_name=username, is_running=1)
+        if hc_id:
+            dic['hazard_calculation_id'] = hc_id
+        logs.dbcmd('update_job', job_id, dic)
         if (not jobparams and not multi and 'hazard_calculation_id' not in kw
                 and 'sensitivity_analysis' not in job):
             hc_id = job_id

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -98,7 +98,7 @@ def create_job(db, datadir):
         the job ID
     """
     calc_id = get_calc_id(db, datadir) + 1
-    job = dict(id=calc_id, is_running=1, description='just created',
+    job = dict(id=calc_id, is_running=0, description='just created',
                user_name=getpass.getuser(), calculation_mode='to be set',
                ds_calc_dir=os.path.join('%s/calc_%s' % (datadir, calc_id)))
     return db('INSERT INTO job (?S) VALUES (?X)',

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -66,7 +66,8 @@ class EngineServerTestCase(unittest.TestCase):
         resp = cls.c.get('/v1/calc/%s' % path, data,
                          HTTP_HOST='127.0.0.1')
         if hasattr(resp, 'content'):
-            assert resp.content, 'No content from /v1/calc/%s' % path
+            assert resp.content, (
+                'No content from http://localhost:8800/v1/calc/%s' % path)
             js = resp.content.decode('utf8')
         else:
             js = bytes(loadnpz(resp.streaming_content)['json'])
@@ -91,8 +92,9 @@ class EngineServerTestCase(unittest.TestCase):
     def wait(cls):
         # wait until all calculations stop
         for i in range(40):  # 20 seconds of timeout
-            time.sleep(0.5)
+            time.sleep(2)
             running_calcs = cls.get('list', is_running='true')
+            print(running_calcs)
             if not running_calcs:
                 return
         # to avoid issues on Jenkins

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -99,7 +99,6 @@ class EngineServerTestCase(unittest.TestCase):
         raise unittest.SkipTest('Timeout waiting for %s' % running_calcs)
 
     def postzip(self, archive):
-        config.distribution['log_level'] = 'warning'
         with open(os.path.join(self.datadir, archive), 'rb') as a:
             resp = self.post('run', dict(archive=a))
         try:

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -563,14 +563,16 @@ def submit_job(job_ini, username, hazard_calculation_id=None):
     and run it in a new process. Returns a PID.
     """
     # errors in validating oqparam are reported immediately
-    params = vars(readinput.get_oqparam(job_ini))
+    params = readinput.get_params(job_ini)
     job_id = logs.init('job')
     params['_job_id'] = job_id
     # errors in the calculation are not reported but are visible in the log
+    kw = {'hazard_calculation_id': hazard_calculation_id} \
+        if hazard_calculation_id else {}
     proc = Process(target=engine.run_jobs,
                    args=([params], config.distribution.log_level, None,
                          '', username),
-                   kwargs={'hazard_calculation_id': hazard_calculation_id})
+                   kwargs=kw)
     proc.start()
     return job_id
 


### PR DESCRIPTION
A recent change (https://github.com/gem/oq-engine/pull/6332/) broke the WebUI since  openquake/server/views.py was not changed accordingly. This fixes Jenkins and also take care of the rare case of invalid calculations being considered running when they are just in the "created" state.