### PR TITLE
Replaced precision error with a warning in scenario_risk

### DIFF
--- a/openquake/calculators/tests/scenario_risk_test.py
+++ b/openquake/calculators/tests/scenario_risk_test.py
@@ -35,7 +35,7 @@ aac = numpy.testing.assert_allclose
 
 
 def tot_loss(dstore):
-    return dstore['loss_data/data']['loss'].sum(axis=0)
+    return dstore['agglosses']['mean'].sum(axis=0)
 
 
 class ScenarioRiskTestCase(CalculatorTestCase):


### PR DESCRIPTION
This is the situation for a calculation submitted by Tiegan:
```
contents, rlz=0: the total loss 5081017300.0 is different from the sum of the average losses 5082001400.0
nonstructural, rlz=0: the total loss 20744374000.0 is different from the sum of the average losses 20750260000.0
structural, rlz=0: the total loss 12590438000.0 is different from the sum of the average losses 12595606000.0
contents, rlz=1: the total loss 3064805600.0 is different from the sum of the average losses 3065075500.0
nonstructural, rlz=1: the total loss 12845446000.0 is different from the sum of the average losses 12846527000.0
structural, rlz=1: the total loss 10020832000.0 is different from the sum of the average losses 10024958000.0
contents, rlz=2: the total loss 2873817000.0 is different from the sum of the average losses 2874055000.0
nonstructural, rlz=2: the total loss 11840939000.0 is different from the sum of the average losses 11841935000.0
structural, rlz=2: the total loss 7489864000.0 is different from the sum of the average losses 7492084700.0
contents, rlz=3: the total loss 7935585300.0 is different from the sum of the average losses 7936358400.0
nonstructural, rlz=3: the total loss 32679322000.0 is different from the sum of the average losses 32683532000.0
structural, rlz=3: the total loss 21422592000.0 is different from the sum of the average losses 21431732000.0
```