### PR TITLE
Fixed the behavior for ignore_covs=true

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Bug fix: ignore_covs=true now sets the coefficient of variations to zero
+
   [Anirudh Rao]
   * Improved error handling of bad or zero coefficients of variation
     for the Beta distribution for vulnerability

--- a/openquake/qa_tests_data/scenario_risk/case_2/expected/agg.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_2/expected/agg.csv
@@ -1,3 +1,3 @@
-#,,,,"generated_by='OpenQuake engine 3.7.0-git5e91b20b88', start_date='2019-09-05T06:18:33', checksum=743756135"
+#,,,,"generated_by='OpenQuake engine 3.11.0-gitda41eb964a', start_date='2020-12-15T12:24:54', checksum=3590982611"
 rlz_id,loss_type,unit,mean,stddev
-0,structural,USD,4.738466E+02,2.286447E+02
+0,structural,USD,5.108213E+02,2.599641E+02

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -310,7 +310,7 @@ class RiskModel(object):
         means, covs, idxs = vf.interpolate(gmvs)
         if len(means) == 0:  # all gmvs are below the minimum imls, 0 ratios
             pass
-        elif self.ignore_covs or covs.sum() == 0 or len(epsilons) == 0:
+        elif covs.sum() == 0 or len(epsilons) == 0:
             # the ratios are equal for all assets
             ratios = vf.sample(means, covs, idxs, None)  # right shape
             for a in range(A):
@@ -462,7 +462,6 @@ def get_riskmodel(taxonomy, oqparam, **extra):
     extra['risk_investigation_time'] = oqparam.risk_investigation_time
     extra['lrem_steps_per_interval'] = oqparam.lrem_steps_per_interval
     extra['steps_per_interval'] = oqparam.steps_per_interval
-    extra['ignore_covs'] = oqparam.ignore_covs
     extra['time_event'] = oqparam.time_event
     if oqparam.calculation_mode == 'classical_bcr':
         extra['interest_rate'] = oqparam.interest_rate
@@ -617,6 +616,8 @@ class CompositeRiskModel(collections.abc.Mapping):
                     self.distributions.add(rf.distribution_name)
                 if hasattr(rf, 'init'):  # vulnerability function
                     rf.seed = oq.master_seed  # setting the seed
+                    if oq.ignore_covs:
+                        rf.covs = numpy.zeros_like(rf.covs)
                     rf.init()
                 # save the number of nonzero coefficients of variation
                 if hasattr(rf, 'covs') and rf.covs.any():

--- a/openquake/risklib/tests/riskmodels_test.py
+++ b/openquake/risklib/tests/riskmodels_test.py
@@ -325,8 +325,7 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
                nrml.to_python(vuln_model)['PGA', 'RC/A']}
         vfs['structural', 'vulnerability'].seed = 42
         vfs['structural', 'vulnerability'].init()
-        rm = riskmodels.RiskModel('event_based_risk', "RC/A", vfs,
-                                  ignore_covs=False)
+        rm = riskmodels.RiskModel('event_based_risk', "RC/A", vfs)
         assets = [0, 1]
         eids = numpy.array([1, 2, 3, 4, 5])
         gmvs = numpy.array([.1, .2, .3, .4, .5])


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6105. @raoanirudh I have changed the test oq-risk-tests/test/event_based_risk/inputs/case_1e to use ignore_covs=true with the beta distribution. The DegenerateDistribution is used, as wanted.