### PR TITLE
Adding rupture spacing to the function building non-parametric sources

### DIFF
--- a/openquake/hazardlib/geo/surface/kite_fault.py
+++ b/openquake/hazardlib/geo/surface/kite_fault.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from pyproj import Geod
 from openquake.baselib.node import Node
-from openquake.hazardlib.geo.mesh import Mesh, RectangularMesh
+from openquake.hazardlib.geo.mesh import RectangularMesh
 from openquake.hazardlib.geo import Point, Line
 from openquake.hazardlib.geo.surface.base import BaseSurface
 from openquake.hazardlib.geo.geodetic import npoints_towards
@@ -117,7 +117,6 @@ class KiteSurface(BaseSurface):
                 tlo = np.fliplr(self.mesh.lons)
                 tla = np.fliplr(self.mesh.lats)
                 tde = np.fliplr(self.mesh.depths)
-                # mesh = Mesh(tlo, tla, tde)
                 mesh = RectangularMesh(tlo, tla, tde)
                 self.mesh = mesh
         else:
@@ -291,7 +290,6 @@ class KiteSurface(BaseSurface):
         # Convert from profiles to edges
         msh = msh.swapaxes(0, 1)
         msh = fix_mesh(msh)
-        # return cls(Mesh(msh[:, :, 0], msh[:, :, 1], msh[:, :, 2]), profiles)
         return cls(RectangularMesh(msh[:, :, 0], msh[:, :, 1], msh[:, :, 2]), 
                    profiles)
 

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -207,7 +207,7 @@ class NonParametricSeismicSource(BaseSeismicSource):
 
         points = numpy.zeros(len(lons), [('lon', F32), ('lat', F32)])
         numpy.around(numpy.squeeze(lons), 5, points['lon'])
-        numpy.around(numpy.squeeze(lons), 5, points['lat'])
+        numpy.around(numpy.squeeze(lats), 5, points['lat'])
         points = numpy.unique(points)
         mesh = Mesh(points['lon'], points['lat'])
         return mesh.get_convex_hull()

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -187,11 +187,32 @@ class NonParametricSeismicSource(BaseSeismicSource):
         """
         The convex hull of the underlying mesh of points
         """
+
+        lons = []
+        lats = []
+        for rup, pmf in self.data:
+            for lo in rup.surface.mesh.lons:
+                lons.extend(list(lo))
+            for la in rup.surface.mesh.lats:
+                lats.extend(list(la))
+
+            #if isinstance(lo[0], numpy.ndarray):
+            #    lo = numpy.concatenate([a for a in lo[0]])
+            #   la = numpy.concatenate([a for a in la[0]])
+            #lons.extend(lo)
+            #lats.extend(la)
+        #lons = numpy.array(lons)
+        #lats = numpy.array(lats)
+
+        """
         lons = numpy.concatenate(
             [rup.surface.mesh.lons.flatten() for rup, pmf in self.data])
         lats = numpy.concatenate(
             [rup.surface.mesh.lats.flatten() for rup, pmf in self.data])
+        """
+
         points = numpy.zeros(len(lons), [('lon', F32), ('lat', F32)])
+
         points['lon'] = numpy.round(lons, 5)
         points['lat'] = numpy.round(lats, 5)
         points = numpy.unique(points)

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -202,26 +202,12 @@ class NonParametricSeismicSource(BaseSeismicSource):
                 except:
                     lats.append(la)
 
-            #if isinstance(lo[0], numpy.ndarray):
-            #    lo = numpy.concatenate([a for a in lo[0]])
-            #   la = numpy.concatenate([a for a in la[0]])
-            #lons.extend(lo)
-            #lats.extend(la)
-
         lons = numpy.array(lons)
         lats = numpy.array(lats)
 
-        """
-        lons = numpy.concatenate(
-            [rup.surface.mesh.lons.flatten() for rup, pmf in self.data])
-        lats = numpy.concatenate(
-            [rup.surface.mesh.lats.flatten() for rup, pmf in self.data])
-        """
-
         points = numpy.zeros(len(lons), [('lon', F32), ('lat', F32)])
         numpy.around(numpy.squeeze(lons), 5, points['lon'])
-        #points['lon'] = numpy.round(lons, 5)
-        points['lat'] = numpy.round(lats, 5)
+        numpy.around(numpy.squeeze(lons), 5, points['lat'])
         points = numpy.unique(points)
         mesh = Mesh(points['lon'], points['lat'])
         return mesh.get_convex_hull()

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -192,17 +192,24 @@ class NonParametricSeismicSource(BaseSeismicSource):
         lats = []
         for rup, pmf in self.data:
             for lo in rup.surface.mesh.lons:
-                lons.extend(list(lo))
+                try:
+                    lons.extend(list(lo))
+                except:
+                    lons.append(lo)
             for la in rup.surface.mesh.lats:
-                lats.extend(list(la))
+                try:
+                    lats.extend(list(la))
+                except:
+                    lats.append(la)
 
             #if isinstance(lo[0], numpy.ndarray):
             #    lo = numpy.concatenate([a for a in lo[0]])
             #   la = numpy.concatenate([a for a in la[0]])
             #lons.extend(lo)
             #lats.extend(la)
-        #lons = numpy.array(lons)
-        #lats = numpy.array(lats)
+
+        lons = numpy.array(lons)
+        lats = numpy.array(lats)
 
         """
         lons = numpy.concatenate(
@@ -212,8 +219,8 @@ class NonParametricSeismicSource(BaseSeismicSource):
         """
 
         points = numpy.zeros(len(lons), [('lon', F32), ('lat', F32)])
-
-        points['lon'] = numpy.round(lons, 5)
+        numpy.around(numpy.squeeze(lons), 5, points['lon'])
+        #points['lon'] = numpy.round(lons, 5)
         points['lat'] = numpy.round(lats, 5)
         points = numpy.unique(points)
         mesh = Mesh(points['lon'], points['lat'])

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -338,7 +338,7 @@ def split_coords_3d(seq):
     return list(zip(lons, lats, depths))
 
 
-def convert_nonParametricSeismicSource(fname, node):
+def convert_nonParametricSeismicSource(fname, node, rup_spacing=5.0):
     """
     Convert the given node into a non parametric source object.
 
@@ -346,6 +346,8 @@ def convert_nonParametricSeismicSource(fname, node):
         full pathname to the XML file associated to the node
     :param node:
         a Node object coming from an XML file
+    :param rup_spacing:
+        Rupture spacing [km]
     :returns:
         a :class:`openquake.hazardlib.source.NonParametricSeismicSource`
         instance
@@ -377,7 +379,7 @@ def convert_nonParametricSeismicSource(fname, node):
                 raise ValueError(
                     'prob_occurs=%s has %d elements, expected %s'
                     % (po, len(probs.data), num_probs))
-            rup = RuptureConverter(5.).convert_node(rupnode)
+            rup = RuptureConverter(rup_spacing).convert_node(rupnode)
             rup.tectonic_region_type = trt
             rup.weight = None if rups_weights is None else rups_weights[i]
             nps.data.append((rup, probs))
@@ -942,7 +944,8 @@ class SourceConverter(RuptureConverter):
             a :class:`openquake.hazardlib.source.NonParametricSeismicSource`
             instance
         """
-        return convert_nonParametricSeismicSource(self.fname, node)
+        return convert_nonParametricSeismicSource(self.fname, node,
+                                                  self.rupture_mesh_spacing)
 
     def convert_sourceModel(self, node):
         return [self.convert_node(subnode) for subnode in node]

--- a/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
@@ -277,7 +277,9 @@ class IdealisedSimpleDisalignedMeshTest(unittest.TestCase):
         self.assertTrue(np.all(tmp < 0.02))
 
         if PLOTTING:
-            ppp(self.profiles, srfc)
+            title = 'Simple case: top alignment '
+            title += '(IdealisedSimpleDisalignedMeshTest)'
+            ppp(self.profiles, srfc, title)
 
     def test__spacing(self):
         """ Check v-spacing: two misaligned profiles - no top alignment """
@@ -315,7 +317,8 @@ class IdealisedAsimmetricMeshTest(unittest.TestCase):
         self.assertTrue(np.all(~np.isnan(smsh.lons[0, :])))
 
         if PLOTTING:
-            title = 'Simple case: No top alignment'
+            title = 'Simple case: No top alignment '
+            title += '(IdealisedAsimmetricMeshTest)'
             ppp(self.profiles, srfc, title)
 
     def test_mesh_creation_with_alignment(self):
@@ -330,7 +333,19 @@ class IdealisedAsimmetricMeshTest(unittest.TestCase):
 
         if PLOTTING:
             title = 'Simple case: Top alignment'
+            title += '(IdealisedAsimmetricMeshTest)'
             ppp(self.profiles, srfc, title)
+
+    def test_get_width(self):
+        """ Test the calculation of the width """
+        h_sampl = 2.5
+        v_sampl = 2.5
+        idl = False
+        alg = True
+        srfc = KiteSurface.from_profiles(self.profiles, v_sampl, h_sampl,
+                                         idl, alg)
+        width = srfc.get_width()
+        np.testing.assert_almost_equal(37.2982758, width)
 
 
 class IdealizedATest(unittest.TestCase):

--- a/openquake/qa_tests_data/classical/case_29/job.ini
+++ b/openquake/qa_tests_data/classical/case_29/job.ini
@@ -14,7 +14,7 @@ number_of_logic_tree_samples = 0
 
 [erf]
 
-rupture_mesh_spacing = 2.
+rupture_mesh_spacing = 5.
 width_of_mfd_bin = 0.1
 area_source_discretization = 5.0
 


### PR DESCRIPTION
Ruptures in non-parametric sources were instantiated using a fixed sampling distance of 5km. Now the are discretised using the `rupture_mesh_spacing`. In a future PR we will consider adding to the `.ini` file ad hoc parameters for discretising kite surfaces.