### PR TITLE
Fixed the case of all zero covs for the beta distribution

### DIFF
--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -121,6 +121,7 @@ class VulnerabilityFunction(object):
         else:
             self.covs = numpy.zeros(self.imls.shape)
 
+        anycovs = self.covs.any()
         for lr, cov in zip(self.mean_loss_ratios, self.covs):
             if lr == 0 and cov > 0:
                 msg = ("It is not valid to define a mean loss ratio = 0 "
@@ -135,7 +136,7 @@ class VulnerabilityFunction(object):
                     pass
                 elif lr > 1:
                     raise ValueError('The meanLRs must be ≤ 1, got %s' % lr)
-                elif cov == 0:
+                elif cov == 0 and anycovs:
                     raise ValueError(
                         'Found a zero coefficient of variation in %s' %
                         self.covs)

--- a/openquake/risklib/tests/scientific_test.py
+++ b/openquake/risklib/tests/scientific_test.py
@@ -72,6 +72,11 @@ class BetaDistributionTestCase(unittest.TestCase):
         self.assertIn('zero coefficient of variation in [0.  0.2 0.3]',
                       str(ctx.exception))
 
+    def test_all_zero_covs(self):
+        # this is correct, must use the DegenerateDistribution
+        scientific.VulnerabilityFunction(
+            'v1', 'PGA', [.1, .2, .3], [.3, .1, .2], [0, 0, 0], 'BT')
+
 
 epsilons = scientific.make_epsilons(
     numpy.zeros((1, 3)), seed=3, correlation=0)[0]


### PR DESCRIPTION
It was incorrectly flagged as an error; in reality it is correct and it corresponds simply to using the DegenerateDistribution. This affects Jamal's calculation for Europe.