### PR TITLE
Fully restored the functionality of `oq reaggregate`

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -211,8 +211,7 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         """
         Raise an error for too many loss curves (> max_num_loss_curves)
         """
-        shp = self.assetcol.tagcol.agg_shape(
-            (self.L,), aggregate_by=self.oqparam.aggregate_by)
+        shp = self.assetcol.tagcol.agg_shape(self.oqparam.aggregate_by, self.L)
         if numpy.prod(shp) > self.oqparam.max_num_loss_curves:
             dic = dict(loss_types=self.L)
             for aggby in self.oqparam.aggregate_by:

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -452,7 +452,6 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/agg_losses.csv', fname, delta=1E-5)
         [fname] = out['agg_curves-rlzs', 'csv']
         self.assertEqualFiles('expected/agg_curves.csv', fname, delta=1E-5)
-        raise SkipTest('oq reaggregate is partially working')
         parent = self.calc.datastore
         # the parent has aggregate_by = NAME_1, NAME_2, taxonomy
         oq = parent['oqparam']

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -329,10 +329,12 @@ class TagCollection(object):
         for tagvalue in getattr(self, tagname):
             yield '%s=%s' % (tagname, decode(tagvalue))
 
-    def agg_shape(self, shp, aggregate_by):
+    def agg_shape(self, aggregate_by=None, *shp):
         """
         :returns: a shape shp + (T, ...) depending on the tagnames
         """
+        if aggregate_by is None:
+            aggregate_by = self.tagnames
         return shp + tuple(
             len(getattr(self, tagname)) - 1 for tagname in aggregate_by)
 


### PR DESCRIPTION
While working at https://github.com/gem/oq-engine/issues/6357 I had temporarily removed the ability to reaggregate losses in the case of less tagnames of the parent tagnames. It is now fully restored.