### PR TITLE
Fixed the event loss table exporter

### DIFF
--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -202,8 +202,9 @@ def export_losses_by_event(ekey, dstore):
         md.update(dict(investigation_time=oq.investigation_time,
                        risk_investigation_time=oq.risk_investigation_time))
     events = dstore['events'][()]
+    K = dstore.get_attr('agg_loss_table', 'K', 0)
     try:
-        df = dstore.read_df('agg_loss_table', 'agg_id', dict(agg_id=0))
+        df = dstore.read_df('agg_loss_table', 'agg_id', dict(agg_id=K))
     except KeyError:  # scenario_damage + consequences
         df = dstore.read_df('losses_by_event')
         ren = {'loss_%d' % l: ln for l, ln in enumerate(oq.loss_names)}

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -145,11 +145,8 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/agg_curves4.csv', tmp)
 
     def test_insured_losses(self):
-        # TODO: fix extract agg_curves for insured types
-
         # extract agg_curves with tags
-        self.run_calc(case_1.__file__, 'job_eb.ini',
-                      aggregate_by='policy,taxonomy')
+        self.run_calc(case_1.__file__, 'job_eb.ini')
 
         aw = extract(self.calc.datastore, 'agg_curves?kind=stats&'
                      'loss_type=structural&absolute=1&policy=A&taxonomy=RC')

--- a/openquake/qa_tests_data/event_based_risk/case_1/job_eb.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1/job_eb.ini
@@ -3,6 +3,7 @@ random_seed = 23
 master_seed = 42
 description = Event Based Risk QA Test 1
 calculation_mode = ebrisk
+aggregate_by = policy, taxonomy
 structural_vulnerability_file = vulnerability_model_stco.xml
 nonstructural_vulnerability_file = vulnerability_model_nonstco.xml
 insurance_csv = {'structural': 'policy.csv'}


### PR DESCRIPTION
There was a leftover `agg_id=0` instead of `agg_id=K` from the refactoring in https://github.com/gem/oq-engine/issues/6357