### PR TITLE
Making event_based_risk and scenario_risk more similar

### DIFF
--- a/openquake/baselib/datastore.py
+++ b/openquake/baselib/datastore.py
@@ -423,7 +423,7 @@ class DataStore(collections.abc.MutableMapping):
         """
         if isinstance(nametypes, pandas.DataFrame):
             nametypes = {name: nametypes[name].to_numpy()
-                         for name in nametypes.columns}
+                         for name in nametypes.columns}.items()
         names = []
         for name, value in nametypes:
             is_array = isinstance(value, numpy.ndarray)

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -83,7 +83,7 @@ def calc_risk(gmfs, param, monitor):
             assets_by_taxo = get_assets_by_taxo(assets, tempname)  # fast
             out = get_output(crmodel, assets_by_taxo, haz)  # slow
         with mon_agg:
-            alt.aggregate(out, mal, aggby, to_losses=True)
+            alt.aggregate(out, mal, aggby)
             # NB: after the aggregation out contains losses, not loss_ratios
         ws = weights[haz['rlz']]
         for col in gmfs.dtype.names:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -161,7 +161,6 @@ class EbrCalculator(base.RiskCalculator):
         self.param['avg_losses'] = oq.avg_losses
         self.param['ses_ratio'] = oq.ses_ratio
         self.param['stats'] = list(oq.hazard_stats().items())
-        self.param['conditional_loss_poes'] = oq.conditional_loss_poes
         self.taskno = 0
         self.start = 0
         avg_losses = oq.avg_losses

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -75,21 +75,20 @@ def event_based_risk(riskinputs, param, monitor):
             r = out.rlzi
             agglosses = numpy.zeros((len(out.eids), L), F32)
             for l, loss_type in enumerate(crmodel.loss_types):
-                loss_ratios = out[loss_type]
-                if loss_ratios is None:  # for GMFs below the minimum_intensity
+                losses = out[loss_type]
+                if losses is None:  # for GMFs below the minimum_intensity
                     continue
                 avalues = riskmodels.get_values(loss_type, ri.assets)
                 for a, asset in enumerate(ri.assets):
                     aval = avalues[a]
                     aid = asset['ordinal']
                     idx = aid2idx[aid]
-                    ratios = loss_ratios[a]  # length E
+                    ratios = losses[a] / aval  # length E
 
                     # average losses
-                    avg[idx, r, l] = (
-                        ratios.sum(axis=0) * param['ses_ratio'] * aval)
+                    avg[idx, r, l] = losses[a].sum(axis=0) * param['ses_ratio']
                     # agglosses
-                    agglosses[:, l] += ratios * aval
+                    agglosses[:, l] += losses[a]
                     if 'builder' in param:
                         with mon:  # this is the heaviest part
                             try:

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -18,10 +18,9 @@
 
 import numpy
 
-from openquake.baselib import general
 from openquake.hazardlib.stats import set_rlzs_stats
 from openquake.risklib import scientific, riskinput
-from openquake.calculators import base, post_risk
+from openquake.calculators import base
 
 U16 = numpy.uint16
 U32 = numpy.uint32
@@ -57,8 +56,6 @@ def scenario_risk(riskinputs, param, monitor):
                 out, param['minimum_asset_loss'], param['aggregate_by'])
             for l, loss_type in enumerate(crmodel.loss_types):
                 losses = out[loss_type]
-                if numpy.product(losses.shape) == 0:  # happens for all NaNs
-                    continue
                 avg = numpy.zeros(len(ri.assets), F64)
                 for a, asset in enumerate(ri.assets):
                     aid = asset['ordinal']

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -98,7 +98,7 @@ def write_csv(dest, data, sep=',', fmt='%.6E', header=None, comment=None,
 
 
 class CalculatorTestCase(unittest.TestCase):
-    OVERWRITE_EXPECTED = True
+    OVERWRITE_EXPECTED = False
     edir = None  # will be set to a temporary directory
 
     @classmethod

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -98,7 +98,7 @@ def write_csv(dest, data, sep=',', fmt='%.6E', header=None, comment=None,
 
 
 class CalculatorTestCase(unittest.TestCase):
-    OVERWRITE_EXPECTED = False
+    OVERWRITE_EXPECTED = True
     edir = None  # will be set to a temporary directory
 
     @classmethod

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/src_loss_table.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/src_loss_table.csv
@@ -1,6 +1,6 @@
-#,,"generated_by='OpenQuake engine 3.11.0-git194b1f9bdf', start_date='2020-12-18T08:42:27', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
+#,,"generated_by='OpenQuake engine 3.11.0-git8938981e82', start_date='2020-12-24T06:13:08', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
 source,loss_type,loss_value
-1,nonstructural,1.87880E+03
+1,nonstructural,1.87881E+03
 1,structural,5.33615E+03
 2,nonstructural,9.23934E+02
 2,structural,1.68834E+03

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -330,56 +330,11 @@ class RiskModel(object):
             for i, asset in enumerate(assets)]
         return list(zip(eal_original, eal_retrofitted, bcr_results))
 
-    def event_based_risk(self, loss_type, assets, gmvs, eids, epsilons):
-        """
-        :param str loss_type:
-            the loss type considered
-        :param assets:
-           a list of assets on the same site and with the same taxonomy
-        :param gmvs_eids:
-           a pair (gmvs, eids) with E values each
-        :param epsilons:
-           a matrix of epsilons of shape (A, E) (or an empty tuple)
-        :returns:
-            an array of losses of shape (A, E)
-        """
-        E = len(gmvs)
-        A = len(assets)
-        values = get_values(loss_type, assets)  # shape A
-        losses = numpy.zeros((A, E), F32)
-        vf = self.risk_functions[loss_type, 'vulnerability']
-        means, covs, idxs = vf.interpolate(gmvs)
-        if len(means) == 0:  # all gmvs are below the minimum imls, 0 ratios
-            pass
-        elif covs.sum() == 0 or len(epsilons) == 0:
-            # the ratios are equal for all assets
-            ratios = vf.sample(means, covs, idxs, None)  # right shape
-            for a in range(A):
-                losses[a, idxs] = ratios * values[a]
-        else:
-            # take into account the epsilons
-            for a, asset in enumerate(assets):
-                losses[a, idxs] = vf.sample(
-                    means, covs, idxs, epsilons[a]) * values[a]
-        return losses
-
-    ebrisk = event_based_risk
-
     def scenario_risk(self, loss_type, assets, gmvs, eids, epsilons):
         """
         :returns: an array of shape (A, E)
         """
         values = get_values(loss_type, assets, self.time_event)
-        ok = ~numpy.isnan(values)
-        if not ok.any():
-            # there are no assets with a value
-            return numpy.zeros(0)
-        # there may be assets without a value
-        missing_value = not ok.all()
-        if missing_value:
-            assets = assets[ok]
-            epsilons = epsilons[ok]
-
         E = len(eids)
 
         # a matrix of A x E elements
@@ -399,7 +354,7 @@ class RiskModel(object):
         loss_matrix[:, :] = (loss_ratio_matrix.T * values).T
         return loss_matrix
 
-    scenario = scenario_risk
+    scenario = ebrisk = event_based_risk = scenario_risk
 
     def scenario_damage(self, loss_type, assets, gmvs, eids=None, eps=None):
         """

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -895,13 +895,13 @@ class DiscreteDistribution(Distribution):
     seed = None  # to be set
 
     def sample(self, loss_ratios, probs):
-        ret = []
+        ret = numpy.zeros(probs.shape[1])
         r = numpy.arange(len(loss_ratios))
         for i in range(probs.shape[1]):
             random.seed(self.seed + i)
             # the seed is set inside the loop to avoid block-size dependency
             pmf = stats.rv_discrete(name='pmf', values=(r, probs[:, i])).rvs()
-            ret.append(loss_ratios[pmf])
+            ret[i] = loss_ratios[pmf]
         return ret
 
     def survival(self, loss_ratios, probs):
@@ -1477,7 +1477,7 @@ class AggLossTable(AccumDict):
         self.accum = numpy.zeros(KL, F32)
         return self
 
-    def aggregate(self, out, minimum_loss, aggby, to_losses=False):
+    def aggregate(self, out, minimum_loss, aggby):
         """
         Populate the event loss table
         """
@@ -1498,8 +1498,6 @@ class AggLossTable(AccumDict):
             lt_losses = []
             for lti, lt in enumerate(out.loss_types):
                 ls = out[lt][a]
-                if to_losses:  # convert ratios to losses
-                    ls *= asset['value-' + lt]
                 if minimum_loss[lt]:
                     ls[ls < minimum_loss[lt]] = 0
                 lt_losses.append((lt, ls))

--- a/openquake/risklib/tests/riskmodels_test.py
+++ b/openquake/risklib/tests/riskmodels_test.py
@@ -296,12 +296,12 @@ lossCategory="contents">
 
 
 class ProbabilisticEventBasedTestCase(unittest.TestCase):
-    expected_ratios = numpy.array([   # shape (2, 5)
+    expected_losses = numpy.array([   # shape (2, 5)
         [0.3458312, 0.34684792, 0.3478676, 0.3488903, 0.34991604],
         [0.3449187, 0.34501997, 0.34512126, 0.3452226, 0.34532395]])
 
     def test_splittable_events(self):
-        # split the events in two blocks and check that the ratios are
+        # split the events in two blocks and check that the losses are
         # same: there is no randomness in VulnerabilityFunction.sample
         vuln_model = gettemp("""\
 <?xml version='1.0' encoding='utf-8'?>
@@ -326,15 +326,15 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
         vfs['structural', 'vulnerability'].seed = 42
         vfs['structural', 'vulnerability'].init()
         rm = riskmodels.RiskModel('event_based_risk', "RC/A", vfs)
-        assets = [0, 1]
+        assets = numpy.array([1, 1], [('value-structural', float)])
         eids = numpy.array([1, 2, 3, 4, 5])
         gmvs = numpy.array([.1, .2, .3, .4, .5])
         epsilons = numpy.array(
             [[.01, .02, .03, .04, .05], [.001, .002, .003, .004, .005]])
 
-        # compute the ratios by considering all the events
-        ratios = rm('structural', assets, gmvs, eids, epsilons)
-        numpy.testing.assert_allclose(ratios, self.expected_ratios)
+        # compute the losses by considering all the events
+        losses = rm('structural', assets, gmvs, eids, epsilons)
+        numpy.testing.assert_allclose(losses, self.expected_losses)
 
         # split the events in two blocks
         eids1 = numpy.array([1, 2])
@@ -343,7 +343,7 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
         gmvs2 = numpy.array([.3, .4, .5])
         eps1 = numpy.array([[.01, .02], [.001, .002]])
         eps2 = numpy.array([[.03, .04, .05], [.003, .004, .005]])
-        ratios1 = rm('structural', assets, gmvs1, eids1, eps1)
-        ratios2 = rm('structural', assets, gmvs2, eids2, eps2)
-        numpy.testing.assert_allclose(ratios1, self.expected_ratios[:, :2])
-        numpy.testing.assert_allclose(ratios2, self.expected_ratios[:, 2:])
+        losses1 = rm('structural', assets, gmvs1, eids1, eps1)
+        losses2 = rm('structural', assets, gmvs2, eids2, eps2)
+        numpy.testing.assert_allclose(losses1, self.expected_losses[:, :2])
+        numpy.testing.assert_allclose(losses2, self.expected_losses[:, 2:])


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/6392. Now occupancy is managed the same in event_based_risk/ebrisk as in scenario_risk and 55 lines of code have been removed.