### PR TITLE
Using sparse matrices in the AggLossTable dictionary

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1056,6 +1056,7 @@ class RiskCalculator(HazardCalculator):
             return
         ct = self.oqparam.concurrent_tasks or 1
         maxw = sum(ri.weight for ri in self.riskinputs) / ct
+        self.datastore.swmr_on()
         smap = parallel.Starmap(
             self.core_task.__func__, h5=self.datastore.hdf5)
         smap.monitor.save('crmodel', self.crmodel)

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import copy
 import logging
 import numpy
 from openquake.hazardlib.stats import set_rlzs_stats
@@ -45,10 +46,11 @@ def scenario_risk(riskinputs, param, monitor):
         (lt_idx, rlz_idx, asset_ordinal, totloss)}
     """
     crmodel = monitor.read('crmodel')
-    result = dict(losses_by_asset=[], alt=param['alt'])
+    alt = copy.copy(param['alt'])
+    result = dict(losses_by_asset=[], alt=alt)
     for ri in riskinputs:
         for out in ri.gen_outputs(crmodel, monitor, param['tempname']):
-            param['alt'].aggregate(
+            alt.aggregate(
                 out, param['minimum_asset_loss'], param['aggregate_by'])
             for l, loss_type in enumerate(crmodel.loss_types):
                 losses = out[loss_type]

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -100,9 +100,10 @@ class ScenarioRiskCalculator(base.RiskCalculator):
     def combine(self, acc, res):
         if res is None:
             raise MemoryError('You ran out of memory!')
-        self.acc += res['alt']
-        for (l, r, aid, lba) in res['losses_by_asset']:
-            self.avglosses[aid, r, l] = lba * self.avg_ratio[r]
+        with self.monitor('aggregating losses', measuremem=False):
+            self.acc += res['alt']
+            for (l, r, aid, lba) in res['losses_by_asset']:
+                self.avglosses[aid, r, l] = lba * self.avg_ratio[r]
         return acc
 
     def post_execute(self, result):

--- a/openquake/risklib/riskinput.py
+++ b/openquake/risklib/riskinput.py
@@ -73,7 +73,7 @@ def get_output(crmodel, assets_by_taxo, haz, rlzi=None):
             # sample method would receive the means in random
             # order and produce random results even if the
             # seed is set correctly; very tricky indeed! (MS)
-            haz.sort_values('eid', inplace=True)
+            haz = haz.sort_values('eid')
             eids = haz.eid.to_numpy()
             data = haz
         else:  # ZeroGetter for this site (event based)

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -29,7 +29,7 @@ from functools import lru_cache
 import numpy
 import pandas
 from numpy.testing import assert_equal
-from scipy import interpolate, stats, random
+from scipy import interpolate, stats, random, sparse
 
 from openquake.baselib.general import CallableDict, AccumDict
 from openquake.hazardlib.stats import compute_stats2
@@ -1474,7 +1474,7 @@ class AggLossTable(AccumDict):
         for sec_loss in sec_losses:
             self.loss_names.extend(sec_loss.outputs)
         KL = len(self.aggkey), len(self.loss_names)
-        self.accum = numpy.zeros(KL, F32)
+        self.accum = sparse.dok_matrix(KL, dtype=F32)
         return self
 
     def aggregate(self, out, minimum_loss, aggby):
@@ -1528,7 +1528,8 @@ class AggLossTable(AccumDict):
         """
         out = AccumDict(accum=[])  # col -> values
         rangeK = numpy.arange(len(self.aggkey))
-        for eid, arr in self.items():
+        for eid, spar in self.items():
+            arr = spar.toarray()
             ok = arr.sum(axis=1) > 0
             out['event_id'].extend([eid] * ok.sum())
             out['agg_id'].extend(rangeK[ok])


### PR DESCRIPTION
Essential for https://github.com/gem/oq-engine/issues/6357: uses 640 times less memory on cluster1 and makes it possible to aggregate by site_id without running immediately out of memory.