### PR TITLE
Implemented deformation_component in secondary perils

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Introduced `deformation_component` parameter in the secondary perils
   * Optimized the storage of the risk model with a speedup of 60x
     for a calculation with ~50,000 fragility functions (2 minutes->2seconds)
     and a 3x reduction on disk space

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -478,23 +478,22 @@ class EventBasedTestCase(CalculatorTestCase):
         # cali landslide simplified
         self.run_calc(case_26.__file__, 'job_land.ini')
         df = self.calc.datastore.read_df('gmf_data', 'sid')
-        pd_mean = df[df.prob_disp > 0].prob_disp.mean()
-        nd_mean = df[df.newmark_disp > 0].newmark_disp.mean()
+        pd_mean = df[df.DispProb > 0].DispProb.mean()
+        nd_mean = df[df.Disp > 0].Disp.mean()
         self.assertGreater(pd_mean, 0)
         self.assertGreater(nd_mean, 0)
         [fname, _, _] = export(('gmf_data', 'csv'), self.calc.datastore)
         arr = read_csv(fname)[:2]
         self.assertEqual(arr.dtype.names,
                          ('site_id', 'event_id', 'gmv_PGA',
-                          'newmark_disp', 'prob_disp'))
+                          'Disp', 'DispProb'))
 
     def test_case_26_liq(self):
         # cali liquefaction simplified
         self.run_calc(case_26.__file__, 'job_liq.ini')
         df = view('avg_gmf', self.calc.datastore)
-        aae(df.liq_prob.max(), 0.27772662)
-        aae(df.lat_spread.max(), 0.51429284)
-        aae(df.vert_settlement.max(), 1.1649456)
+        aae(df.LiqProb.max(), 0.27772662)
+        aae(df.PGDGeomMean.max(), 0.55390346)
 
     def test_overflow(self):
         too_many_imts = {'SA(%s)' % period: [0.1, 0.2, 0.3]

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -23,6 +23,7 @@ types.
 import ast
 import operator
 import functools
+import numpy
 
 # NB: (MS) the management of the IMTs implemented here is complex, it would
 # be better to have a single IMT class, but it is as it is for legacy reasons
@@ -112,6 +113,8 @@ class IMT(tuple, metaclass=IMTMeta):
         return tuple(getattr(self, field) for field, check in self._fields)
 
     def __lt__(self, other):
+        if not self._fields:
+            return self[0] < other[0]  # ordered by name
         return (self[0], self[1] or 0, self[2] or 0) < (
             other[0], other[1] or 0, other[2] or 0)
 
@@ -230,32 +233,6 @@ class JMA(IMT):
     and on humans and their structures.
     """
 
-# geotechnical IMTs
-
-
-class PGDfLatSpread(IMT):
-    """
-    Permanent ground defomation (m) from lateral spread
-    """
-
-
-class PGDfSettle(IMT):
-    """
-    Permanent ground defomation (m) from settlement
-    """
-
-
-class PGDfSlope(IMT):
-    """
-    Permanent ground deformation (m) from slope failure
-    """
-
-
-class PGDfRupture(IMT):
-    """
-    Permanent ground deformation (m) from co-seismic rupture
-    """
-
 
 # Volcanic IMTs
 
@@ -263,3 +240,51 @@ class ASH(IMT):
     """
     Level of the ash fall in millimeters
     """
+
+
+# secondary perils
+
+class Disp(IMT):
+    """
+    Displacement
+    """
+
+
+class DispProb(IMT):
+    """
+    Displacement probability
+    """
+
+
+class LiqProb(IMT):
+    """
+    Liquefaction probability
+    """
+
+
+class PGDSettle(IMT):
+    """
+    Peak ground deformation as vertical settlement
+    """
+
+
+class PGDSpread(IMT):
+    """
+    Peak ground deformation as lateral spreading
+    """
+
+
+class PGDMax(IMT):
+    """
+    Maximum between vert_settlement and lat_spread
+    """
+    def __call__(self, vert_settlement, lat_spread):
+        return max(vert_settlement, lat_spread)
+
+
+class PGDGeomMean(IMT):
+    """
+    Geometric mean between vert_settlement and lat_spread
+    """
+    def __call__(cls, vert_settlement, lat_spread):
+        return numpy.sqrt(vert_settlement * lat_spread)

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -262,18 +262,6 @@ class LiqProb(IMT):
     """
 
 
-class PGDSettle(IMT):
-    """
-    Peak ground deformation as vertical settlement
-    """
-
-
-class PGDSpread(IMT):
-    """
-    Peak ground deformation as lateral spreading
-    """
-
-
 class PGDMax(IMT):
     """
     Maximum between vert_settlement and lat_spread

--- a/openquake/qa_tests_data/event_based/case_26/job_liq.ini
+++ b/openquake/qa_tests_data/event_based/case_26/job_liq.ini
@@ -27,5 +27,6 @@ truncation_level = 0
 maximum_distance = 200
 
 # liquefaction with default parameters
-secondary_perils = HazusLiquefaction, HazusLateralSpreading, HazusVerticalSettlement
-sec_peril_params = {'map_proportion_flag': 1}
+secondary_perils = HazusLiquefaction, HazusDeformation
+sec_peril_params = {
+  'map_proportion_flag': 1, 'deformation_component': "PGDGeomMean"}

--- a/openquake/sep/classes.py
+++ b/openquake/sep/classes.py
@@ -17,6 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import abc
 import inspect
+from openquake.hazardlib import imt
 from openquake.sep.landslide.common import static_factor_of_safety
 from openquake.sep.landslide.newmark import (
     newmark_critical_accel, newmark_displ_from_pga_M,
@@ -45,19 +46,25 @@ class SecondaryPeril(metaclass=abc.ABCMeta):
     The ``compute`` method will return a tuple with ``O`` arrays where ``O``
     is the number of outputs.
     """
+    outputs = []
+
+    @classmethod
+    def __init_subclass__(cls):
+        # make sure the name of the outputs are valid IMTs
+        for out in cls.outputs:
+            imt.from_string(out)
+
     @classmethod
     def instantiate(cls, secondary_perils, sec_peril_params):
         inst = []
         for clsname in secondary_perils:
             c = globals()[clsname]
-            lst = []
+            kw = {}
             for param in inspect.signature(c).parameters:
                 if param in sec_peril_params:
-                    lst.append(sec_peril_params[param])
-            inst.append(c(*lst))
+                    kw[param] = sec_peril_params[param]
+            inst.append(c(**kw))
         return inst
-
-    outputs = abc.abstractproperty()
 
     @abc.abstractmethod
     def prepare(self, sites):
@@ -75,20 +82,8 @@ class SecondaryPeril(metaclass=abc.ABCMeta):
         return '<%s>' % self.__class__.__name__
 
 
-class _FakePeril(SecondaryPeril):
-    # useful to test the framework
-    outputs = ['fake']
-
-    def prepare(self, sites):
-        pass
-
-    def compute(self, mag, imt_gmf, sites):
-        # gmv is an array with (N, M) elements
-        return [imt_gmf[0][1] * .1]  # fake formula
-
-
 class NewmarkDisplacement(SecondaryPeril):
-    outputs = ['newmark_disp', 'prob_disp']
+    outputs = ["Disp", "DispProb"]
 
     def __init__(self, c1=-2.71, c2=2.335, c3=-1.478, c4=0.424,
                  crit_accel_threshold=0.05):
@@ -110,8 +105,8 @@ class NewmarkDisplacement(SecondaryPeril):
 
     def compute(self, mag, imt_gmf, sites):
         out = []
-        for imt, gmf in imt_gmf:
-            if imt.name == 'PGA':
+        for im, gmf in imt_gmf:
+            if im.name == 'PGA':
                 nd = newmark_displ_from_pga_M(
                     gmf, sites.crit_accel, mag,
                     self.c1, self.c2, self.c3, self.c4,
@@ -122,7 +117,7 @@ class NewmarkDisplacement(SecondaryPeril):
 
 
 class HazusLiquefaction(SecondaryPeril):
-    outputs = ['liq_prob']
+    outputs = ["LiqProb"]
 
     def __init__(self, map_proportion_flag=True):
         self.map_proportion_flag = map_proportion_flag
@@ -132,8 +127,8 @@ class HazusLiquefaction(SecondaryPeril):
 
     def compute(self, mag, imt_gmf, sites):
         out = []
-        for imt, gmf in imt_gmf:
-            if imt.name == 'PGA':
+        for im, gmf in imt_gmf:
+            if im.name == 'PGA':
                 out.append(hazus_liquefaction_probability(
                     pga=gmf, mag=mag, liq_susc_cat=sites.liq_susc_cat,
                     groundwater_depth=sites.gwd,
@@ -141,41 +136,36 @@ class HazusLiquefaction(SecondaryPeril):
         return out
 
 
-class HazusLateralSpreading(SecondaryPeril):
-    outputs = ['lat_spread']
-
-    def __init__(self, return_unit='m'):
+class HazusDeformation(SecondaryPeril):
+    """
+    Computes PGDMax or PGDGeomMean from PGA
+    """
+    def __init__(self, return_unit='m', deformation_component='PGDMax'):
         self.return_unit = return_unit
+        self.deformation_component = imt.from_string(deformation_component)
+        self.outputs = [deformation_component]
 
     def prepare(self, sites):
         pass
 
     def compute(self, mag, imt_gmf, sites):
         out = []
-        for imt, gmf in imt_gmf:
-            if imt.name == 'PGA':
-                out.append(hazus_lateral_spreading_displacement(
+        for im, gmf in imt_gmf:
+            if im.name == 'PGA':
+                ls = hazus_lateral_spreading_displacement(
                     mag=mag, pga=gmf, liq_susc_cat=sites.liq_susc_cat,
-                    return_unit=self.return_unit))
+                    return_unit=self.return_unit)
+                vs = hazus_vertical_settlement(
+                    sites.liq_susc_cat, return_unit=self.return_unit)
+                out.append(self.deformation_component(ls, vs))
         return out
 
 
-class HazusVerticalSettlement(SecondaryPeril):
-    outputs = ['vert_settlement']
-
-    def __init__(self, return_unit='m'):
-        self.return_unit = return_unit
-
-    def prepare(self, sites):
-        pass
-
-    def compute(self, mag, imt_gmf, sites):
-        return [hazus_vertical_settlement(sites.liq_susc_cat,
-                return_unit=self.return_unit)]
-
-
 class ZhuLiquefactionGeneral(SecondaryPeril):
-    outputs = ['liq_prob']
+    """
+    Computes the liquefaction probability from PGA
+    """
+    outputs = ["LiqProb"]
 
     def __init__(self, intercept=24.1, cti_coeff=0.355, vs30_coeff=-4.784):
         self.intercept = intercept
@@ -187,10 +177,11 @@ class ZhuLiquefactionGeneral(SecondaryPeril):
 
     def compute(self, mag, imt_gmf, sites):
         out = []
-        for imt, gmf in imt_gmf:
-            if imt.name == 'PGA':
+        for im, gmf in imt_gmf:
+            if im.name == 'PGA':
                 out.append(zhu_liquefaction_probability_general(
                     pga=gmf, mag=mag, cti=sites.cti, vs30=sites.vs30))
         return out
+
 
 supported = [cls.__name__ for cls in SecondaryPeril.__subclasses__()]

--- a/openquake/sep/liquefaction/lateral_spreading.py
+++ b/openquake/sep/liquefaction/lateral_spreading.py
@@ -15,10 +15,9 @@ def hazus_lateral_spreading_displacement(
         pga: Union[float, np.ndarray],
         liq_susc_cat: Union[str, List[str]],
         thresh_table: dict = LIQUEFACTION_PGA_THRESHOLD_TABLE,
-        return_unit: str ='m'
-    )->Union[float, np.ndarray]:
+        return_unit: str = 'm') -> Union[float, np.ndarray]:
     """
-    Distance of lateral spreading from Hazus 
+    Distance of lateral spreading from Hazus
     (https://www.hsdl.org/?view&did=12760)
 
     :param mag:
@@ -36,7 +35,7 @@ def hazus_lateral_spreading_displacement(
             `m` : Medium
             `l` : Low
             `vl`: Very low
-            `n` : No suceptibility.
+            `n` : No susceptibility.
 
     :returns:
         Displacements from lateral spreading in meters or inches.
@@ -45,11 +44,9 @@ def hazus_lateral_spreading_displacement(
         pga_threshold = thresh_table[liq_susc_cat]
     else:
         pga_threshold = np.array(
-            [thresh_table[susc_cat] for susc_cat in liq_susc_cat]
-        )
-    
-    disp_inch = hazus_lateral_spreading_displacement_fn(mag, pga, pga_threshold)
-
+            [thresh_table[susc_cat] for susc_cat in liq_susc_cat])
+    disp_inch = hazus_lateral_spreading_displacement_fn(
+        mag, pga, pga_threshold)
     if return_unit == 'm':
         disp_m = disp_inch / (INCH_PER_M)
         return disp_m
@@ -59,7 +56,8 @@ def hazus_lateral_spreading_displacement(
     elif return_unit == 'in':
         return disp_inch
     else:
-        raise ValueError("Please choose 'm' or 'in' for return_unit.")
+        raise ValueError("Please choose 'm' or 'in' for return_unit, got %s"
+                         % return_unit)
 
 
 def hazus_lateral_spreading_displacement_fn(


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/6081. As request in @VSilva comment, you can now specify the deformation component (PGDMax or PGDGeomMean, default PGDMax) in the hazard part of the calculations, in the section `sec_peril_params` of the job.ini (see the liquefaction test).
Moreover, the classes HazusLateralSpreading and HazusVerticalSettlement have been unified in a single class HazusDeformation. I am also removing some old geotechnical IMTs that were never used.