### PR TITLE
Extended ArrayWrapper.to_dframe

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -592,6 +592,11 @@ class ArrayWrapper(object):
         1       RC       IND  5000.0
         2     WOOD       RES   500.0
         """
+        if hasattr(self, 'array'):
+            names = self.array.dtype.names
+            if names:  # wrapper over a structured array
+                return pandas.DataFrame({n: self[n] for n in names})
+
         if hasattr(self, 'json'):
             vars(self).update(json.loads(self.json))
         shape = self.shape

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -747,5 +747,4 @@ class CompositeRiskModel(collections.abc.Mapping):
 
     def __repr__(self):
         lines = ['%s: %s' % item for item in sorted(self.items())]
-        return '<%s(%d, %d)\n%s>' % (
-            self.__class__.__name__, len(lines), self.covs, '\n'.join(lines))
+        return '<%s\n%s>' % (self.__class__.__name__, '\n'.join(lines))


### PR DESCRIPTION
To the case when the ArrayWrapper contains a structured array (for instance coming from read_csv). Also, simplified `CompositeRiskModel.__repr__`.