### PR TITLE
Added a check on get_mean_std1

### DIFF
--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -212,7 +212,12 @@ class MetaGSIM(abc.ABCMeta):
                     if missing:
                         raise ValueError('Unknown distance %s in %s' %
                                          (missing, name))
-        return super().__new__(meta, name, bases, dic)
+        cls = super().__new__(meta, name, bases, dic)
+        ancestors = [vars(ancestor) for ancestor in cls.mro()[1:-1]]
+        if any('get_mean_std1' in ancestor for ancestor in ancestors):
+            if 'get_mean_and_stddevs' in dic and 'get_mean_std1' not in dic:
+                raise TypeError('%s.get_mean_std1 is not defined!' % name)
+        return cls
 
 
 @functools.total_ordering

--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -69,10 +69,8 @@ class BooreAtkinson2008(GMPE):
     #: Shear-wave velocity for reference soil conditions in [m s-1]
     DEFINED_FOR_REFERENCE_VELOCITY = 760.
 
-    # NB: this is NEVER called; if it were, the KOR model would fail
-    # since there is no corresponding AtkinsonBoore2006.get_mean_std1,
-    # so it would get inherited and it would try to use the rjb distance
-    # (and it would be wrong anyway); fixing AtkinsonBoore2006 is hard
+    # NB: there is an underscore in front of get_mean_std1 to disable the
+    # single site approximation that would fail the check in MetaGSIM
     def _get_mean_std1(self, ctx, imts):
         """
         :param ctx: a multi-RuptureContext of size U


### PR DESCRIPTION
To make sure that we do not forget to override needed methods. For instance defining `BooreAtkinson2008.get_mean_std1` requires to override 17 other methods (see https://github.com/gem/oq-engine/pull/6318)