### PR TITLE
Support for input URLs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Support for input URLs associated to an input archive
   * Introduced `deformation_component` parameter in the secondary perils
   * Optimized the storage of the risk model with a speedup of 60x
     for a calculation with ~50,000 fragility functions (2 minutes->2seconds)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -36,7 +36,7 @@ import requests
 
 from openquake.baselib import hdf5, parallel
 from openquake.baselib.general import (
-    random_filter, countby, group_array, get_duplicates)
+    random_filter, countby, group_array, get_duplicates, gettemp)
 from openquake.baselib.python3compat import zip
 from openquake.baselib.node import Node
 from openquake.hazardlib.const import StdDev
@@ -213,12 +213,17 @@ def get_params(job_ini, kw={}):
     Parse a .ini file or a .zip archive
 
     :param job_ini:
-        Configuration file or zip archive
+        Configuration file | zip archive | URL
     :param kw:
         Optionally override some parameters
     :returns:
         A dictionary of parameters
     """
+    if job_ini.startswith(('http://', 'https://')):
+        resp = requests.get(job_ini)
+        job_ini = gettemp(suffix='.zip')
+        with open(job_ini, 'wb') as f:
+            f.write(resp.content)
     # directory containing the config files we're parsing
     job_ini = os.path.abspath(job_ini)
     base_path = os.path.dirname(job_ini)


### PR DESCRIPTION
Works for zip archives containing a job.ini file. Example:
```
$ oq engine --run "https://github.com/gem/oq-engine/blob/master/openquake/server/tests/data/classical.zip?raw=true"
```
This is convenient for many purposes.