### PR TITLE
Honor `individual_curves` in risk results too

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Honored the `individual_curves` parameter in avg_losses, agg_losses and
+    and agg_curves (i.e. by default only expose the statistical results)
   * Refactored the `oq commands` and removed the redundant `oq help` since
     there is `oq --help` instead
   * Support for input URLs associated to an input archive

--- a/demos/risk/EventBasedRisk/job_eb.ini
+++ b/demos/risk/EventBasedRisk/job_eb.ini
@@ -36,7 +36,7 @@ exposure_file = exposure_model.xml
 
 [risk_calculation]
 asset_hazard_distance = 20
-individual_curves = true
+individual_curves = false
 minimum_asset_loss = {'structural': 1000, 'nonstructural': 1000}
 
 [outputs]

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -196,8 +196,10 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.datastore.create_dframe(
             'agg_loss_table', descr, K=len(self.aggkey))
         self.param.pop('oqparam', None)  # unneeded
-        self.datastore.create_dset('avg_losses-stats', F32, (A, 1, L),
-                                   attrs=dict(stat=[b'mean']))  # mean
+        self.datastore.create_dset('avg_losses-stats', F32, (A, 1, L))
+        self.datastore.set_shape_descr(
+            'avg_losses-stats', asset_id=self.assetcol['id'], stat='mean',
+            loss_type=oq.loss_names)
         alt_nbytes = 4 * self.E * L
         if alt_nbytes / (oq.concurrent_tasks or 1) > TWO32:
             raise RuntimeError('The event loss table is too big to be transfer'

--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -260,4 +260,4 @@ class EbriskCalculator(event_based.EventBasedCalculator):
         self.datastore.create_dframe('avg_gmf', self.avg_gmf.items())
         prc = PostRiskCalculator(oq, self.datastore.calc_id)
         prc.datastore.parent = self.datastore.parent
-        prc.run()
+        prc.run(exports='')

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -23,7 +23,6 @@ import numpy
 import pandas
 
 from openquake.baselib import hdf5
-from openquake.baselib.python3compat import decode
 from openquake.hazardlib.stats import compute_stats2
 from openquake.risklib import scientific
 from openquake.calculators.extract import (

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -821,10 +821,9 @@ def extract_losses_by_asset(dstore, what):
             data = util.compose_arrays(assets, losses)
             yield 'rlz-%03d' % rlz.ordinal, data
     elif 'avg_losses-stats' in dstore:
-        avg_losses = dstore['avg_losses-stats']
-        stats = decode(avg_losses.attrs['stat'])
-        for s, stat in enumerate(stats):
-            losses = cast(avg_losses[:, s], loss_dt)
+        aw = hdf5.ArrayWrapper.from_(dstore['avg_losses-stats'])
+        for s, stat in enumerate(aw.stat):
+            losses = cast(aw[:, s], loss_dt)
             data = util.compose_arrays(assets, losses)
             yield stat, data
     elif 'avg_losses-rlzs' in dstore:  # there is only one realization

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -163,7 +163,8 @@ class ScenarioRiskCalculator(base.RiskCalculator):
             set_rlzs_stats(self.datastore, 'agg_losses',
                            agg_id=K, loss_types=oq.loss_names, units=units)
         else:  # event_based_risk, run post_risk
-            post_risk.PostRiskCalculator(oq, self.datastore.calc_id).run()
+            prc = post_risk.PostRiskCalculator(oq, self.datastore.calc_id)
+            prc.run(exports='')
 
 
 @base.calculators.add('event_based_risk')

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -133,7 +133,8 @@ class CalculatorTestCase(unittest.TestCase):
         self.calc = self.get_calc(testfile, inis[0], **kw)
         self.edir = tempfile.mkdtemp()
         with self.calc._monitor:
-            result = self.calc.run(export_dir=self.edir)
+            result = self.calc.run(export_dir=self.edir,
+                                   exports=kw.get('exports', ''))
         self.calc.datastore.close()
         duration = {inis[0]: self.calc._monitor.duration}
         if len(inis) == 2:
@@ -141,7 +142,8 @@ class CalculatorTestCase(unittest.TestCase):
             calc = self.get_calc(
                 testfile, inis[1], hazard_calculation_id=str(hc_id), **kw)
             with calc._monitor:
-                exported = calc.run(export_dir=self.edir)
+                exported = calc.run(export_dir=self.edir,
+                                    exports=kw.get('exports', ''))
                 result.update(exported)
             duration[inis[1]] = calc._monitor.duration
             self.calc = calc


### PR DESCRIPTION
This happened to Luis: he ran a calculation with 100 realizations and then tried to export the `agg_curves-rlzs` from the WebUI. That was extra-slow (export time > calculation time). The engine is supposed to work for the risk curves as for the hazard curves: by default only the statistics must be exposed to the WebUI, unless the user sets the parameter `individual_curves=true`.
The right way to export the individual curves is via pandas anyway, using the WebUI is too slow unless there is 1 realization.
Also fix a small bug causing the curves to be exported twice when using the PostRiskCalculator.