### PR TITLE
Changed the logic in `oq workers`

### DIFF
--- a/openquake/commands/workers.py
+++ b/openquake/commands/workers.py
@@ -15,13 +15,15 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
 import sys
 import getpass
 from pprint import pprint
-from openquake.baselib import config
-from openquake.commonlib import logs
+from openquake.baselib import config, workerpool as w
 
 ro_commands = ('status', 'inspect')
+oqdist = os.environ.get('OQ_DISTRIBUTE', config.distribution.oq_distribute)
 
 
 def main(cmd):
@@ -31,7 +33,11 @@ def main(cmd):
     if (cmd not in ro_commands and config.dbserver.multi_user and
             getpass.getuser() not in 'openquake michele'):
         sys.exit('oq workers only works in single user mode')
-    pprint(logs.dbcmd('zmq_' + cmd))
+    if oqdist == 'zmq':
+        zmaster = w.WorkerMaster(**config.zworkers)
+        pprint(getattr(zmaster, cmd)())
+    else:
+        print('Nothing to do: oq_distribute=%s' % oqdist)
 
 
 main.cmd = dict(help='command',

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -70,11 +70,6 @@ class DbServer(object):
                 if cmd == 'getpid':
                     sock.send(self.pid)
                     continue
-                elif cmd.startswith('zmq_') and self.zmaster:
-                    msg = getattr(self.zmaster, cmd[4:])()
-                    logging.info(msg)
-                    sock.send(msg)
-                    continue
                 try:
                     func = getattr(actions, cmd)
                 except AttributeError:  # SQL string


### PR DESCRIPTION
Instead of sending commands to the DbServer to manage the zworkers, manage the zworkers directly. This will make debugging easier for @vot4anto . Also, paved the way for future extensions of the command to different distribution mechanisms.