### PR TITLE
Renamed scenario_risk -> event_based_risk in the RiskModel

### DIFF
--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -47,7 +47,7 @@ def run_sec_sims(out, loss_types, sec_sims, seed):
         out[lt][:] = numpy.mean(affected * out[lt], axis=0)  # shape E
 
 
-def scenario_risk(riskinputs, param, monitor):
+def event_based_risk(riskinputs, param, monitor):
     """
     Core function for a scenario_risk/event_based_risk computation.
 
@@ -90,7 +90,7 @@ class ScenarioRiskCalculator(base.RiskCalculator):
     """
     Run a scenario risk calculation
     """
-    core_task = scenario_risk
+    core_task = event_based_risk
     is_stochastic = True
     precalc = 'scenario'
     accept_precalc = ['scenario']

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -506,7 +506,7 @@ sensitivity_analysis = {
         # refactoring of the monitoring and it happened several times)
         with read(job_id) as dstore:
             perf = view('performance', dstore)
-            self.assertIn('total scenario_risk', perf)
+            self.assertIn('total event_based_risk', perf)
 
     def test_oqdata(self):
         # the that the environment variable OQ_DATADIR is honored

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -331,7 +331,7 @@ class RiskModel(object):
             for i, asset in enumerate(assets)]
         return list(zip(eal_original, eal_retrofitted, bcr_results))
 
-    def scenario_risk(self, loss_type, assets, gmvs, eids, epsilons):
+    def event_based_risk(self, loss_type, assets, gmvs, eids, epsilons):
         """
         :returns: an array of shape (A, E)
         """
@@ -355,7 +355,7 @@ class RiskModel(object):
         loss_matrix[:, :] = (loss_ratio_matrix.T * values).T
         return loss_matrix
 
-    scenario = ebrisk = event_based_risk = scenario_risk
+    scenario = ebrisk = scenario_risk = event_based_risk
 
     def scenario_damage(self, loss_type, assets, gmvs, eids=None, eps=None):
         """


### PR DESCRIPTION
As requested by Cata and Anirudh. Now a scenario_risk calculation will log as
```
  [INFO] event_based_risk   1% [214 submitted, 0 queued]
  [INFO] event_based_risk   2% [214 submitted, 0 queued]
  ...
```
since internally it is that.