### PR TITLE
Added a sanity check on suspicious zero losses

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -183,11 +183,12 @@ class EventBasedCalculator(base.HazardCalculator):
             return numpy.unique(self.datastore['gmf_data/eid'][:])
 
         logging.info('Computing avg_gmf')
+        avg_num_evs = len(self.datastore['events']) / self.R
         gmf_df = self.datastore.read_df('gmf_data', 'sid')
         for sid, df in gmf_df.groupby(gmf_df.index):
             weights = self.weights[self.rlzs[df.eid.to_numpy()]]
             for col in avg_gmf:
-                avg_gmf[col][sid] += df[col] @ weights
+                avg_gmf[col][sid] += df[col] @ weights / avg_num_evs
         return gmf_df.eid.unique()
 
     def agg_dicts(self, acc, result):
@@ -341,6 +342,7 @@ class EventBasedCalculator(base.HazardCalculator):
             with self.monitor('saving avg_gmf', measuremem=True):
                 self.weights = self.datastore['weights'][:]
                 self.rlzs = self.datastore['events']['rlz_id']
+                self.num_events = numpy.bincount(self.rlzs)  # events by rlz
                 avg_gmf = {imt: numpy.zeros(self.N, F32)
                            for imt in oq.all_imts()}
                 rel_events = self.save_avg_gmf(avg_gmf)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -186,7 +186,7 @@ class EventBasedCalculator(base.HazardCalculator):
         gmf_df = self.datastore.read_df('gmf_data', 'sid')
         for sid, df in gmf_df.groupby(gmf_df.index):
             rlzs = self.rlzs[df.eid.to_numpy()]
-            ws = self.weights[rlzs] / self.num_events[rlzs]
+            ws = 1 / self.num_events[rlzs] / self.R
             for col in avg_gmf:
                 avg_gmf[col][sid] += df[col].to_numpy() @ ws
         return gmf_df.eid.unique()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -183,12 +183,12 @@ class EventBasedCalculator(base.HazardCalculator):
             return numpy.unique(self.datastore['gmf_data/eid'][:])
 
         logging.info('Computing avg_gmf')
-        avg_num_evs = len(self.datastore['events']) / self.R
         gmf_df = self.datastore.read_df('gmf_data', 'sid')
         for sid, df in gmf_df.groupby(gmf_df.index):
-            weights = self.weights[self.rlzs[df.eid.to_numpy()]]
+            rlzs = self.rlzs[df.eid.to_numpy()]
+            ws = self.weights[rlzs] / self.num_events[rlzs]
             for col in avg_gmf:
-                avg_gmf[col][sid] += df[col] @ weights / avg_num_evs
+                avg_gmf[col][sid] += df[col].to_numpy() @ ws
         return gmf_df.eid.unique()
 
     def agg_dicts(self, acc, result):

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -196,8 +196,8 @@ class PostRiskCalculator(base.RiskCalculator):
         # NB: in the future we may use multiprocessing.shared_memory
         for (k, r), df in gb:
             arr = numpy.zeros((self.L, len(df)), F32)
-            for l, ln in enumerate(oq.loss_names):
-                arr[l] = df[ln].to_numpy()
+            for lni, ln in enumerate(oq.loss_names):
+                arr[lni] = df[ln].to_numpy()
             agg_losses[k, r] = arr.sum(axis=1)
             kr_losses.append((k, r, arr))
             if len(kr_losses) >= blocksize:

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -183,6 +183,7 @@ class EventBasedRiskCalculator(base.RiskCalculator):
         else:  # event_based_risk, run post_risk
             prc = post_risk.PostRiskCalculator(oq, self.datastore.calc_id)
             prc.run(exports='')
+            agglosses = self.datastore['agg_losses-rlzs'][K - 1]
 
         # sanity check on the agg_losses and sum_losses
         sumlosses = self.avglosses.sum(axis=0)

--- a/openquake/calculators/scenario_risk.py
+++ b/openquake/calculators/scenario_risk.py
@@ -205,6 +205,8 @@ class EventBasedRiskCalculator(base.RiskCalculator):
             gmf_df = self.datastore.read_df('avg_gmf')
         except KeyError:
             return
+        if not hasattr(self, 'sitecol'):  # FIXME: remove this
+            self.sitecol = self.datastore['sitecol']
         if self.sitecol is not self.sitecol.complete:
             gmf_df = gmf_df.loc[self.sitecol.sids]
         avglosses = self.avglosses.sum(axis=1) / self.R  # shape (A, L)

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -267,6 +267,9 @@ class EventBasedTestCase(CalculatorTestCase):
         [fname] = export(('realizations', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/realizations.csv', fname)
 
+        avg_gmf = self.calc.datastore.read_df('avg_gmf')
+        aae(avg_gmf.to_numpy(), 0.00996806)
+
     def test_case_7(self):
         # 2 models x 3 GMPEs, 1000 samples * 10 SES
         expected = [
@@ -492,8 +495,8 @@ class EventBasedTestCase(CalculatorTestCase):
         # cali liquefaction simplified
         self.run_calc(case_26.__file__, 'job_liq.ini')
         df = self.calc.datastore.read_df('avg_gmf')
-        aae(df.LiqProb.max(), 0.27772662)
-        aae(df.PGDGeomMean.max(), 0.55390346)
+        aae(df.LiqProb.max(), 0.03110679)
+        aae(df.PGDGeomMean.max(), 0.06230812)
 
     def test_overflow(self):
         too_many_imts = {'SA(%s)' % period: [0.1, 0.2, 0.3]

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -46,7 +46,7 @@ from openquake.qa_tests_data.event_based import (
 from openquake.qa_tests_data.event_based.spatial_correlation import (
     case_1 as sc1, case_2 as sc2, case_3 as sc3)
 
-aae = numpy.testing.assert_almost_equal
+aac = numpy.testing.assert_allclose
 
 
 def strip_calc_id(fname):
@@ -112,8 +112,8 @@ class EventBasedTestCase(CalculatorTestCase):
                 oq.ses_per_logic_tree_path)
 
             p05, p10 = expected[case]
-            aae(joint_prob_0_5, p05, decimal=1)
-            aae(joint_prob_1_0, p10, decimal=1)
+            aac(joint_prob_0_5, p05, atol=.1)
+            aac(joint_prob_1_0, p10, atol=.1)
 
     def test_blocksize(self):
         out = self.run_calc(blocksize.__file__, 'job.ini',
@@ -153,7 +153,7 @@ class EventBasedTestCase(CalculatorTestCase):
         oq = self.calc.datastore['oqparam']
         poes = gmvs_to_poes(df, oq.imtls, oq.ses_per_logic_tree_path)
         hcurve = self.calc.datastore['hcurves-stats'][0, 0]  # shape (M, L)
-        aae(poes, hcurve)
+        aac(poes, hcurve)
 
         # test gsim_by_imt
         out = self.run_calc(case_1.__file__, 'job.ini',
@@ -173,8 +173,8 @@ class EventBasedTestCase(CalculatorTestCase):
                          '[MultiGMPE."SA(0.1)".SadighEtAl1997]')
         self.assertEqual(einfo['rlzi'], 0)
         self.assertEqual(einfo['et_id'], 0)
-        aae(einfo['occurrence_rate'], 0.6)
-        aae(einfo['hypo'], [0., 0., 4.])
+        aac(einfo['occurrence_rate'], 0.6)
+        aac(einfo['hypo'], [0., 0., 4.])
 
         [fname, _, _] = out['gmf_data', 'csv']
         self.assertEqualFiles('expected/gsim_by_imt.csv', fname)
@@ -249,9 +249,9 @@ class EventBasedTestCase(CalculatorTestCase):
         # check MFD
         aw = extract(self.calc.datastore, 'event_based_mfd?kind=mean')
         self.assertEqual(aw.duration, 30)  # 30 years
-        aae(aw.magnitudes, [4.6, 4.7, 4.8, 4.9, 5.1, 5.3, 5.9], decimal=6)
-        aae(aw.mean_frequency, [0.02, 0.013333, 0.01, 0.053333, 0.006667,
-                                0.006667, 0.006667], decimal=6)
+        aac(aw.magnitudes, [4.6, 4.7, 4.8, 4.9, 5.1, 5.3, 5.9], atol=1E-6)
+        aac(aw.mean_frequency, [0.02, 0.013333, 0.01, 0.053333, 0.006667,
+                                0.006667, 0.006667], atol=1E-6)
 
     def test_case_6(self):
         # 2 models x 3 GMPEs, different weights
@@ -268,7 +268,7 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/realizations.csv', fname)
 
         avg_gmf = self.calc.datastore.read_df('avg_gmf')
-        aae(avg_gmf.to_numpy(), 0.00996806)
+        aac(avg_gmf.to_numpy(), 0.00996806)
 
     def test_case_7(self):
         # 2 models x 3 GMPEs, 1000 samples * 10 SES
@@ -495,8 +495,8 @@ class EventBasedTestCase(CalculatorTestCase):
         # cali liquefaction simplified
         self.run_calc(case_26.__file__, 'job_liq.ini')
         df = self.calc.datastore.read_df('avg_gmf')
-        aae(df.LiqProb.max(), 0.03110679)
-        aae(df.PGDGeomMean.max(), 0.06230812)
+        aac(df.LiqProb.max(), 0.031107, rtol=1E-3)
+        aac(df.PGDGeomMean.max(), 0.062308, rtol=1E-3)
 
     def test_overflow(self):
         too_many_imts = {'SA(%s)' % period: [0.1, 0.2, 0.3]

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -268,7 +268,7 @@ class EventBasedTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/realizations.csv', fname)
 
         avg_gmf = self.calc.datastore.read_df('avg_gmf')
-        aac(avg_gmf.to_numpy(), 0.00996806)
+        aac(avg_gmf.to_numpy(), 0.010628, atol=1E-5)
 
     def test_case_7(self):
         # 2 models x 3 GMPEs, 1000 samples * 10 SES
@@ -495,8 +495,8 @@ class EventBasedTestCase(CalculatorTestCase):
         # cali liquefaction simplified
         self.run_calc(case_26.__file__, 'job_liq.ini')
         df = self.calc.datastore.read_df('avg_gmf')
-        aac(df.LiqProb.max(), 0.031107, rtol=1E-3)
-        aac(df.PGDGeomMean.max(), 0.062308, rtol=1E-3)
+        aac(df.LiqProb.max(), 0.031107, rtol=1E-2)
+        aac(df.PGDGeomMean.max(), 0.062308, rtol=1E-2)
 
     def test_overflow(self):
         too_many_imts = {'SA(%s)' % period: [0.1, 0.2, 0.3]


### PR DESCRIPTION
Zero losses for nonzero GMFs are suspicious (see https://github.com/gem/oq-engine/pull/6431) and are now flagged. In particular a warning is printed for `scenario_risk/case_3` since the exposure contains a value structural of zero for asset "a4":
```xml
      <asset id="a4" taxonomy="W" number="800">
        <location lon="85.747" lat="27.90"/>
        <costs>
        </costs>
```
Should that be considered an error?