### PR TITLE
Saving memory in the classical calculator without splitting the calculation in bunches

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -242,7 +242,6 @@ class Hazard:
         Initialize the pmaps dictionary with zeros, if needed
         """
         if grp_id not in pmaps:
-            logging.debug('Initializing pmap#%d', grp_id)
             L, G = self.imtls.size, len(self.rlzs_by_gsim_list[grp_id])
             pmaps[grp_id] = ProbabilityMap.build(L, G, self.sids)
 
@@ -253,6 +252,7 @@ class Hazard:
         trt = self.full_lt.trt_by_et[self.et_ids[grp_id][0]]
         # avoid saving PoEs == 1
         base.fix_ones(pmap)
+        # perhaps the slow part is not the saving, is the line below
         arr = numpy.array([pmap[sid].array for sid in pmap])
         self.datastore['_poes'][:, :, self.slice_by_g[grp_id]] = arr
         extreme = max(
@@ -333,7 +333,7 @@ class ClassicalCalculator(base.HazardCalculator):
                     self.haz.store_poes(grp_id, acc.pop(grp_id))
 
         gc.collect()
-        logging.debug('Keeping %d pmaps(s) in memory', len(acc))
+        logging.info('Keeping %d pmaps(s) in memory', len(acc))
         return acc
 
     def create_dsets(self):
@@ -618,8 +618,6 @@ class ClassicalCalculator(base.HazardCalculator):
                     logging.debug('Sending %d source(s) with weight %d',
                                   len(block), sum(src.weight for src in block))
                     allargs.append((block, rlzs_by_gsim, self.params))
-        allargs.sort(key=lambda args: sum(src.weight for src in args[0]),
-                     reverse=True)
         return allargs
 
     def save_hazard(self, acc, pmap_by_kind):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -328,8 +328,6 @@ class ClassicalCalculator(base.HazardCalculator):
             with self.monitor('saving probability maps'):
                 if grp_id in acc:
                     self.haz.store_poes(grp_id, acc.pop(grp_id))
-
-        logging.info('Keeping %d pmaps(s) in memory', len(acc))
         return acc
 
     def create_dsets(self):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import io
+import gc
 import time
 import psutil
 import pprint
@@ -241,6 +242,7 @@ class Hazard:
         Initialize the pmaps dictionary with zeros, if needed
         """
         if grp_id not in pmaps:
+            logging.debug('Initializing pmap#%d', grp_id)
             L, G = self.imtls.size, len(self.rlzs_by_gsim_list[grp_id])
             pmaps[grp_id] = ProbabilityMap.build(L, G, self.sids)
 
@@ -330,6 +332,8 @@ class ClassicalCalculator(base.HazardCalculator):
                 if grp_id in acc:
                     self.haz.store_poes(grp_id, acc.pop(grp_id))
 
+        gc.collect()
+        logging.debug('Keeping %d pmaps(s) in memory', len(acc))
         return acc
 
     def create_dsets(self):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import io
-import gc
 import time
 import psutil
 import pprint
@@ -250,10 +249,8 @@ class Hazard:
         Store the pmap of the given group inside the _poes dataset
         """
         trt = self.full_lt.trt_by_et[self.et_ids[grp_id][0]]
-        # avoid saving PoEs == 1
-        base.fix_ones(pmap)  # fast
-        arr = numpy.array([pmap[sid].array for sid in pmap])  # fast
-        logging.info('Storing %s', humansize(arr.nbytes))
+        base.fix_ones(pmap)  # avoid saving PoEs == 1, fast
+        arr = numpy.array([pmap[sid].array for sid in pmap])  # shape NLG, fast
         self.datastore['_poes'][:, :, self.slice_by_g[grp_id]] = arr  # slow
         extreme = max(
             get_extreme_poe(pmap[sid].array, self.imtls)
@@ -332,7 +329,6 @@ class ClassicalCalculator(base.HazardCalculator):
                 if grp_id in acc:
                     self.haz.store_poes(grp_id, acc.pop(grp_id))
 
-        gc.collect()
         logging.info('Keeping %d pmaps(s) in memory', len(acc))
         return acc
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -251,14 +251,10 @@ class Hazard:
         """
         trt = self.full_lt.trt_by_et[self.et_ids[grp_id][0]]
         # avoid saving PoEs == 1
-        t0 = time.time()
-        base.fix_ones(pmap)
-        # perhaps the slow part is not the saving, is the line below
-        arr = numpy.array([pmap[sid].array for sid in pmap])
-        t1 = time.time()
-        self.datastore['_poes'][:, :, self.slice_by_g[grp_id]] = arr
-        t2 = time.time()
-        logging.info('grp_id=%d, time=%.1f,%.1f', grp_id,  t1-t0, t2-t1)
+        base.fix_ones(pmap)  # fast
+        arr = numpy.array([pmap[sid].array for sid in pmap])  # fast
+        logging.info('Storing %s', humansize(arr.nbytes))
+        self.datastore['_poes'][:, :, self.slice_by_g[grp_id]] = arr  # slow
         extreme = max(
             get_extreme_poe(pmap[sid].array, self.imtls)
             for sid in pmap)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -251,10 +251,14 @@ class Hazard:
         """
         trt = self.full_lt.trt_by_et[self.et_ids[grp_id][0]]
         # avoid saving PoEs == 1
+        t0 = time.time()
         base.fix_ones(pmap)
         # perhaps the slow part is not the saving, is the line below
         arr = numpy.array([pmap[sid].array for sid in pmap])
+        t1 = time.time()
         self.datastore['_poes'][:, :, self.slice_by_g[grp_id]] = arr
+        t2 = time.time()
+        logging.info('grp_id=%d, time=%.1f,%.1f', grp_id,  t1-t0, t2-t1)
         extreme = max(
             get_extreme_poe(pmap[sid].array, self.imtls)
             for sid in pmap)

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -24,8 +24,8 @@ log_level = info
 dask_scheduler= 127.0.0.1:8786
 
 [memory]
-# use at most 32 GB for the poes
-limit = 34_359_738_368
+# use at most 100 GiB for the poes
+limit = 100_000_000_000
 # above this quantity (in %) of memory used a warning will be printed
 soft_mem_limit = 90
 # above this quantity (in %) of memory used the job will be stopped


### PR DESCRIPTION
It is possible by releasing the memory in the accumulator dictionary when not needed and by initializing only the ProbabilityMaps that need to be kept in memory, not all of them. Refinement of https://github.com/gem/oq-engine/pull/6476.