### PR TITLE
Replace wget with curl in Mac installation instructions

### DIFF
--- a/doc/installing/macos.md
+++ b/doc/installing/macos.md
@@ -1,14 +1,15 @@
 # Installing the OpenQuake Engine on macOS
 
 The OpenQuake Engine can be installed on macOS with the universal installer,
-provided your system has a recent enough Python (>= 3.6).
+provided your system has a recent enough Python (3.6.x / 3.7.x / 3.8.x).
 
-If needed, you can install a recent version of Python (but Python 3.9 is **not supported**)
-by using the official installer provided by the Python Foundation (https://www.python.org/downloads/).
+If needed, you can install a recent version of Python (3.6.x / 3.7.x / 3.8.x)
+by using the official installers provided by the Python Foundation (https://www.python.org/downloads/).
+Python 3.9 is **not supported**.
 
 Make sure to run the script located under `/Applications/Python 3.X/Install Certificates.command`, after Python has been installed, to update the SSL certificates bundle [see FAQ](../faq.md#certificate-verification-on-macOS).
 
-Python from _Anaconda_ **is not supported**.
+Python from _Anaconda_ is **not supported**.
 
 ## Requirements
 
@@ -19,19 +20,19 @@ Requirements are:
 - 1.2 GB of free disk space
 - [Terminal](https://support.apple.com/guide/terminal/welcome) or [iTerm2](https://www.iterm2.com/) app
 
-*Big Sur* is not officially supported but some people manage to install the engine on it using the system Python (version 3.8). New macs with the M1 CPU are **unsupported**.
+macOS 11 (*Big Sur*) is not officially supported but some people have managed to install the engine on it using the system Python (version 3.8). New Macs with the M1 CPU are **unsupported**.
 
 ## Install packages from the OpenQuake website
 
 Download the installer script:
 
-```bash
-wget https://raw.githubusercontent.com/gem/oq-engine/master/install.py
+```zsh
+curl https://raw.githubusercontent.com/gem/oq-engine/master/install.py -O
 ```
 
 From the Terminal app (or using iTerm) run:
 
-```bash
+```zsh
 python3 install.py user
 ```
 
@@ -39,17 +40,23 @@ The code is installed in ~/openquake while the calculation data will be stored i
 
 ### Uninstall the OpenQuake engine
 
-You can just remove the ~/openquake directory
+You can just remove the ~/openquake directory:
 
-```bash
+```zsh
 rm -Rf ~/openquake
+```
+
+To also remove calculation data:
+
+```zsh
+rm -Rf ~/oqdata
 ```
 
 ## Run the OpenQuake Engine
 
 To load the OpenQuake Engine environment you must run:
 
-```bash
+```zsh
 # default is ~/openquake
 source ~/openquake/bin/activate
 ```
@@ -58,13 +65,13 @@ before the OpenQuake Engine can be properly used.
 
 To run the OpenQuake Engine via the command line, use:
 
-```bash
+```zsh
 oq engine --run </path/to/job.ini>
 ```
 
 To start the OpenQuake [WebUI](../running/server.md) use:
 
-```bash
+```zsh
 oq webui start
 ```
 The WebUI will be started and a new browser window will be opened.
@@ -75,5 +82,5 @@ More information is available at the pages [How to run the OpenQuake Engine](../
 
 ## Getting help
 If you need help or have questions/comments/feedback for us, you can:
-  * Subscribe to the OpenQuake users mailing list: https://groups.google.com/forum/#!forum/openquake-users
+  * Subscribe to the OpenQuake users mailing list: https://groups.google.com/u/0/g/openquake-users
   * Contact us on IRC: irc.freenode.net, channel #openquake


### PR DESCRIPTION
`wget` does not come installed by default on Macs; whereas `curl` is available by default. Thus, replacing the former with the latter in the instructions.