### PR TITLE
Fixed `oq plot hmaps`

### DIFF
--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -111,7 +111,9 @@ def make_figure_hmaps(extractors, what):
         itime = oq1.investigation_time
         assert oq2.investigation_time == itime
         sitecol = ex1.get('sitecol')
-        assert (ex2.get('sitecol').array == sitecol.array).all()
+        array2 = ex2.get('sitecol').array
+        for name in ('lon', 'lat'):
+            numpy.testing.assert_equal(array2[name], sitecol.array[name])
         hmaps1 = ex1.get(what)
         hmaps2 = ex2.get(what)
         [imt] = hmaps1.imt


### PR DESCRIPTION
It was failing for the SAM model due to NaNs and characters in the site collection. Now it is possible to produce maps like the following ones:
```
$ oq plot 'hmaps?kind=mean&imt=PGA' 40858 40808 -w
```
![SAM](https://user-images.githubusercontent.com/2463856/105960510-9dd39600-607d-11eb-856b-9a77abc542ed.png)
