### PR TITLE
Reduce by 10x the weight of point sources

### DIFF
--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -62,7 +62,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
             self.num_ruptures = self.count_ruptures()
         w = self.num_ruptures * self.ngsims * (.1 if self.nsites == EPS else 1)
         if hasattr(self, 'nodal_plane_distribution'):  # pointlike
-            w *= .2  # reduce weight of point sources compared to others
+            w *= .1  # reduce weight of point sources compared to others
         return w
 
     @property

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -60,8 +60,10 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         # pointsource_distance is set
         if not self.num_ruptures:
             self.num_ruptures = self.count_ruptures()
-        return self.num_ruptures * self.ngsims * (
-            .1 if self.nsites == EPS else 1)
+        w = self.num_ruptures * self.ngsims * (.1 if self.nsites == EPS else 1)
+        if hasattr(self, 'nodal_plane_distribution'):  # pointlike
+            w *= .2  # reduce weight of point sources compared to others
+        return w
 
     @property
     def et_ids(self):


### PR DESCRIPTION
That improves the task distribution in SAM and reduces by half the computation time:
```##
   operation-duration counts mean    stddev min     max    
   classical          407    812     85%    43      7_913  # before
   classical          414    823     90%    18      2_226  # after
   Mean time per core=4135s, std=1592.9s, min=2112s, max=10992s  # before
   Mean time per core=4262s, std=942.3s, min=2304s, max=5680s # after
```
