### PR TITLE
require soil_intensities when there is an amplification file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Robin Gee]
+  * Check soil_intensities in oqvalidation
+
   [Michele Simionato]
   * Documented all the parameters in a job.ini file, and removed some
     obsolete ones

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -949,6 +949,10 @@ class OqParam(valid.ParamSet):
                                           'disaggregation']):
             check_same_levels(self.imtls)
 
+        if ('amplification' in self.inputs and not self.soil_intensities):
+                raise InvalidFile('%s: The soil_intensities must be defined'
+                     % job_ini)
+
     def check_gsims(self, gsims):
         """
         :param gsims: a sequence of GSIM instances

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -949,7 +949,9 @@ class OqParam(valid.ParamSet):
                                           'disaggregation']):
             check_same_levels(self.imtls)
 
-        if ('amplification' in self.inputs and not self.soil_intensities):
+        if ('amplification' in self.inputs and
+            self.amplification_method == 'convolution' and
+            not self.soil_intensities):
                 raise InvalidFile('%s: The soil_intensities must be defined'
                      % job_ini)
 


### PR DESCRIPTION
If a hazard calculation is run using an `amplification_csv`  file, but the `soil_intensities` are not defined, then OQ breaks and with a TypeError (see [error.txt](https://github.com/gem/oq-engine/files/5919759/error.txt))

The message is not useful for a user, and occurs during the "Building hazard statistics" stage,  so I added a check earlier in oqvalidation that ensures the `soil_intensities` are defined when `amplification_csv` is specified.

