### PR TITLE
Fixed error reporting in config.read

### DIFF
--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -103,7 +103,7 @@ def read(*paths, **validators):
             try:
                 sec[k] = validators.get(k, lambda x: x)(v)
             except ValueError as err:
-                raise ValueError('%s for %s in %s' % (err, k, found[0]))
+                raise ValueError('%s for %s in %s' % (err, k, found[-1]))
 
 
 config.read = read


### PR DESCRIPTION
@vot4anto discovered that the engine was reporting the wrong path in case of errors.