### PR TITLE
Use shakemap from different sources than USGS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ demos/*/*.zip
 .tox
 venv
 *.whl
+*.vscode

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Nicolas Schmid]
+  * Added shakemap_url_grid and shakemap_url_uncertainty parameters to 
+    enable using shakemaps from http:// or file:// sources.
+  
   [Michele Simionato]
   * Extended the `collapse_logic_tree` feature to scenarios and event based
     calculations

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -522,6 +522,18 @@ shakemap_id:
   Example: *shakemap_id = usp000fjta*.
   Default: no default
 
+shakemap_url_grid:
+  Used in ShakeMap calculation to download a ShakeMap from another place than USGS.
+  Requires also shakemap_url_uncertainty to be defined.
+  Example: *shakemap_url_grid = https://another.site.org/shakemap.xml.
+  Default: None
+
+shakemap_url_uncertainty:
+  Used in ShakeMap calculation to download the uncertainty from another place than USGS.
+  Only works in combination with shakemap_url_grid.
+  Example: *shakemap_url_uncertainty = file://~/another/folder/shakemap.zip.
+  Default: None
+
 shift_hypo:
   Used in classical calculations to shift the rupture hypocenter.
   Example: *shift_hypo = true*.
@@ -1014,9 +1026,9 @@ class OqParam(valid.ParamSet):
 
         if ('amplification' in self.inputs and
             self.amplification_method == 'convolution' and
-            not self.soil_intensities):
-                raise InvalidFile('%s: The soil_intensities must be defined'
-                     % job_ini)
+                not self.soil_intensities):
+            raise InvalidFile('%s: The soil_intensities must be defined'
+                              % job_ini)
 
     def check_gsims(self, gsims):
         """

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -784,6 +784,8 @@ class OqParam(valid.ParamSet):
         valid.compose(valid.nonzero, valid.positiveint), 1)
     ses_seed = valid.Param(valid.positiveint, 42)
     shakemap_id = valid.Param(valid.nice_string, None)
+    shakemap_url_grid = valid.Param(valid.utf8, None)
+    shakemap_url_uncertainty = valid.Param(valid.utf8, None)
     shift_hypo = valid.Param(valid.boolean, False)
     site_effects = valid.Param(valid.boolean, False)  # shakemap amplification
     sites = valid.Param(valid.NoneOr(valid.coordinates), None)


### PR DESCRIPTION
Our swiss shakemaps have the same format as those from USGS. Therefore we would like to use those as an input for loss calculations.

I added two parameters + functionality, with which I can define custom URL's from where the shaking and uncertainty grids can be downloaded. (http(s):// for web, file:// for local).

