### PR TITLE
Remove checks on skip ci

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -5,7 +5,6 @@ on:
     branches: [ master ]
 jobs:
   demos:
-    if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-18.04
     env:
       GITHUB_PULL_REQUEST: ${{ github.event.number }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   engine:
-    if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +27,6 @@ jobs:
         pytest openquake/server openquake/commands openquake/commonlib --disable-warnings --color=yes && pytest openquake --doctest-modules -x -k "not gsim" --disable-warnings --color=yes --durations=10 && pytest doc/adv-manual/common-mistakes.rst doc/adv-manual/risk.rst doc/adv-manual/developing.rst doc/adv-manual/rupture-sampling.rst && oq dbserver stop
 
   hazardlib:
-    if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,6 @@ on:
 jobs:
 
   build_py36:
-    if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-latest
 
     steps:
@@ -39,7 +38,6 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
   build_py37:
-    if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-latest
 
     steps:
@@ -67,7 +65,6 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
   build_py38:
-    if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
From what we have seen while configuring CI for the IRMT plugin, it looks like github automatically skips CI if the commit message contains the string `[ci skip]`. On plugin side we tried to use the line of code that this PR removes, hoping that CI would be also skipped matching `skip CI`, but it did not work.