### PR TITLE
Removed redundant field e1 from ruptures dataset

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -19,7 +19,6 @@
 import os.path
 import logging
 import numpy
-import psutil
 
 from openquake.baselib import hdf5, parallel
 from openquake.baselib.general import AccumDict, copyobj, humansize

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -45,7 +45,6 @@ from unittest.mock import Mock
 import numpy
 
 from openquake.baselib import parallel
-from openquake.baselib.general import get_indices
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib import probability_map
 from openquake.hazardlib.source.rupture import EBRupture, events_dt
@@ -343,10 +342,9 @@ class RuptureImporter(object):
             extra['year'] = numpy.random.choice(itime, len(events)) + 1
         extra['ses_id'] = numpy.random.choice(nses, len(events)) + 1
         self.datastore['events'] = util.compose_arrays(events, extra)
-        eindices = get_indices(events['rup_id'])
-        arr = numpy.array(list(eindices.values()))[:, 0, :]
-        self.datastore['ruptures']['e0'] = arr[:, 0]
-        self.datastore['ruptures']['e1'] = arr[:, 1]
+        cumsum = self.datastore['ruptures']['n_occ'].cumsum()
+        rup_array['e0'][1:] = cumsum[:-1]
+        self.datastore['ruptures']['e0'] = rup_array['e0']
 
     def check_overflow(self, E):
         """

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -603,7 +603,7 @@ def get_ruptures(fname_csv):
         rate = dic.get('occurrence_rate', numpy.nan)
         tup = (u, row['seed'], 'no-source', trts.index(row['trt']),
                code[row['kind']], n_occ, row['mag'], row['rake'], rate,
-               minlon, minlat, maxlon, maxlat, hypo, u, 0, 0)
+               minlon, minlat, maxlon, maxlat, hypo, u, 0)
         rups.append(tup)
         points = mesh.flatten()  # lons + lats + deps
         # FIXME: extend to MultiSurfaces

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -90,7 +90,7 @@ rupture_dt = numpy.dtype([
     ('code', U8), ('n_occ', U32), ('mag', F32), ('rake', F32),
     ('occurrence_rate', F32),
     ('minlon', F32), ('minlat', F32), ('maxlon', F32), ('maxlat', F32),
-    ('hypo', (F32, 3)), ('geom_id', U32), ('e0', U32), ('e1', U32)])
+    ('hypo', (F32, 3)), ('geom_id', U32), ('e0', U32)])
 
 
 # this is really fast
@@ -140,7 +140,7 @@ def get_rup_array(ebruptures, srcfilter=nofilter):
         rate = getattr(rup, 'occurrence_rate', numpy.nan)
         tup = (0, ebrupture.rup_id, ebrupture.source_id, ebrupture.et_id,
                rup.code, ebrupture.n_occ, rup.mag, rup.rake, rate,
-               minlon, minlat, maxlon, maxlat, hypo, 0, 0, 0)
+               minlon, minlat, maxlon, maxlat, hypo, 0, 0)
         rups.append(tup)
         # we are storing the geometries as arrays of 32 bit floating points;
         # the first element is the number of surfaces, then there are


### PR DESCRIPTION
And removed usage of get_indices. Discovered while working at https://github.com/gem/oq-engine/issues/6544.