### PR TITLE
More refactoring of the risk calculators (6)

### DIFF
--- a/openquake/qa_tests_data/event_based_risk/case_1g/expected/avg_losses.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1g/expected/avg_losses.csv
@@ -1,4 +1,4 @@
-#,,,,"generated_by='OpenQuake engine 3.12.0-git6ca388b340', start_date='2021-03-10T04:35:42', checksum=3590982611, investigation_time=1.0, risk_investigation_time=1.0"
+#,,,,"generated_by='OpenQuake engine 3.12.0-gitee2f8747a6', start_date='2021-03-10T04:48:34', checksum=3590982611, investigation_time=1.0, risk_investigation_time=1.0"
 asset_id,taxonomy,lon,lat,structural
 a1,tax1,-122.00000,38.11300,8.50000E-01
-a2,tax1,-122.00000,38.11300,1.31500E+01
+a2,tax1,-122.00000,38.11300,1.70000E+00

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -230,7 +230,7 @@ class VulnerabilityFunction(object):
             cols = [col for col in ratio_df.columns if isinstance(col, int)]
             for eid, df in ratio_df.groupby('eid'):
                 pmf = []
-                for probs in df[cols].to_numpy():
+                for probs in df[cols].to_numpy():  # probs by asset
                     if probs.sum() == 0:  # oq-risk-tests/case_1g
                         # means are zeros for events below the threshold
                         continue

--- a/openquake/risklib/tests/riskmodels_test.py
+++ b/openquake/risklib/tests/riskmodels_test.py
@@ -328,7 +328,7 @@ class ProbabilisticEventBasedTestCase(unittest.TestCase):
         rm = riskmodels.RiskModel('event_based_risk', "RC/A", vfs,
                                   minimum_asset_loss=dict(structural=0))
         assets = pandas.DataFrame(
-            {'value-structural': numpy.array([1, 1])})
+            {'site_id': [0, 0], 'value-structural': numpy.array([1, 1])})
         eids = numpy.array([0, 1, 2, 3, 4])
         AE = len(assets), len(eids)
         gmvs = numpy.array([.1, .2, .3, .4, .5])


### PR DESCRIPTION
This is the last step. Now finally a VulnerabilityFunction can be called with two DataFrames `asset_df` and `gmf_df`, which paves the way to vectorization by asset, which in turns should reduce the performance penalty significantly. Currently we are over 500x times slower than with engine 3.11.

NB: the change of numbers is case_1g is correct due to the change to the logic in the seed generation.