### PR TITLE
Removed computation of `avg_gmf` unless ground_motion_fields=true

### DIFF
--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -95,9 +95,6 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         # this is a case with insured losses and tags
         self.run_calc(case_1.__file__, 'job_eb.ini', concurrent_tasks='4')
 
-        shp = self.calc.datastore['avg_gmf'].shape
-        self.assertEqual(shp, (2, 3, 5))  # 3 sites x 5 IMTs
-
         [fname] = export(('avg_losses-stats', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname,
                               delta=1E-5)

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -215,7 +215,7 @@ class VulnerabilityFunction(object):
                 means = df['mean'].to_numpy()
                 covs = df['cov'].to_numpy()
                 vals = df['val'].to_numpy()
-                if rng and self.covs.sum():
+                if self.covs.sum():
                     sigma = numpy.sqrt(numpy.log(1 + covs ** 2))
                     div = numpy.sqrt(1 + covs ** 2)
                     eps = rng.normal(eid, len(df))


### PR DESCRIPTION
This saves a lot of memory in large calculations (i.e. Europe).