### PR TITLE
Saving memory in event_based_risk

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -55,7 +55,7 @@ def event_based_risk(df, param, monitor):
     mon_agg = monitor('aggregating losses', measuremem=False)
     mon_avg = monitor('averaging losses', measuremem=False)
     dstore = datastore.read(param['hdf5path'])
-    with monitor('getting data'):
+    with monitor('reading data'):
         if hasattr(df, 'start'):  # it is actually a slice
             df = dstore.read_df('gmf_data', slc=df)
         assets_df = dstore.read_df('assetcol/array', 'ordinal')


### PR DESCRIPTION
By reading the GMFs from the workers and avoided pickling. This improves a lot the situation but not enough to run Europe.