### PR TITLE
Optimized again avglosses

### DIFF
--- a/openquake/calculators/ebrisk.py
+++ b/openquake/calculators/ebrisk.py
@@ -68,8 +68,7 @@ def event_based_risk(df, param, monitor):
     AE = len(assets_df), len(rlz_id)
     AR = len(assets_df), len(weights)
     EK1 = len(rlz_id), param['K'] + 1
-    losses_by_AR = {
-        ln: sparse.dok_matrix(AR) for ln in crmodel.oqparam.loss_names}
+    losses_by_AR = {ln: [] for ln in crmodel.oqparam.loss_names}
     losses_by_EK1 = {
         ln: sparse.dok_matrix(EK1) for ln in crmodel.oqparam.loss_names}
     rndgen = MultiEventRNG(
@@ -86,7 +85,6 @@ def event_based_risk(df, param, monitor):
             coo = out[ln].tocoo()  # shape (A, E)
             if coo.getnnz() == 0:
                 continue
-            lba = losses_by_AR[ln]
             lbe = losses_by_EK1[ln]
             with mon_agg:
                 ldf = pandas.DataFrame(dict(eid=coo.col, loss=coo.data))
@@ -104,11 +102,11 @@ def event_based_risk(df, param, monitor):
                         dict(aid=coo.row, loss=coo.data,
                              rlz=rlz_id[coo.col]))
                     tot = ldf.groupby(['aid', 'rlz']).loss.sum()
-                    for (aid, rlz), loss in zip(tot.index, tot.to_numpy()):
-                        lba[aid, rlz] = loss
+                    aids, rlzs = zip(*tot.index)
+                    losses_by_AR[ln].append(
+                        sparse.coo_matrix((tot.to_numpy(), (aids, rlzs)), AR))
+    yield losses_by_AR
     for lni, ln in enumerate(crmodel.oqparam.loss_names):
-        if param['avg_losses']:
-            yield {ln: losses_by_AR[ln].tocoo()}
         lbe = losses_by_EK1[ln].tocoo()
         nnz = lbe.getnnz()
         if nnz:
@@ -302,7 +300,8 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                         dset = self.datastore['agg_loss_table/' + name]
                         hdf5.extend(dset, ls[name].to_numpy())
                 else:  # summing avg_losses, fast
-                    self.avg_losses[ls.row, ls.col, lti[ln]] += ls.data
+                    for coo in ls:
+                        self.avg_losses[coo.row, coo.col, lti[ln]] += coo.data
 
     def post_execute(self, dummy):
         """

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -212,13 +212,13 @@ class EventBasedRiskTestCase(CalculatorTestCase):
         [fname] = export(
             ('aggregate_by/avg_losses?tag=taxonomy&kind=rlz-0', 'csv'),
             self.calc.datastore)
-        self.assertEqualFiles('expected/losses_by_tag.csv', fname)
+        self.assertEqualFiles('expected/losses_by_tag.csv', fname, delta=1E-5)
 
         # losses by taxonomy for loss_type=structural
         [fname] = export(
             ('aggregate_by/avg_losses?tag=taxonomy&kind=rlz-0&'
              'loss_type=structural', 'csv'), self.calc.datastore)
-        self.assertEqualFiles('expected/losses_by_taxo.csv', fname)
+        self.assertEqualFiles('expected/losses_by_taxo.csv', fname, delta=1E-5)
 
     def test_missing_taxonomy(self):
         with self.assertRaises(RuntimeError) as ctx:


### PR DESCRIPTION
Before:
```
calc_181, maxmem=297.7 GB    time_sec memory_mb counts 
============================ ======== ========= =======
total event_based_risk       108_855  514       960    
averaging losses             70_021   0.0       413_864
aggregating losses           22_824   0.0       413_864
computing risk               4_414    0.0       206_932
reading data                 2_906    441       240    
EventBasedRiskCalculator.run 1_749    3_778     1      
saving agg_loss_table        124      459       960    
```
After:
```
calc_183, maxmem=176.3 GB    time_sec memory_mb counts 
============================ ======== ========= =======
total event_based_risk       53_606   1_281     720    
aggregating losses           21_551   0.0       413_864
averaging losses             15_494   0.0       413_864
computing risk               4_678    0.0       206_932
reading data                 3_639    441       240    
EventBasedRiskCalculator.run 867      4_015     1      
saving agg_loss_table        172      1_217     720    
```