### PR TITLE
Optimized event_based_risk for covs != 0

### DIFF
--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -757,11 +757,11 @@ class MultiEventRNG(object):
 
     >>> rng = MultiEventRNG(
     ...     master_seed=42, eids=[0, 1, 2], asset_correlation=1)
-    >>> eids = [1] * 3
+    >>> eids = numpy.array([1] * 3)
     >>> means = numpy.array([.5] * 3)
     >>> covs = numpy.array([.1] * 3)
     >>> rng.normal(eids, means, covs)
-    array([-2.46861114, -2.46861114, -2.46861114])
+    array([0.38892466, 0.38892466, 0.38892466])
     >>> rng.beta(eids, means, covs)
     array([0.4372343 , 0.57308132, 0.56392573])
     """

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -806,9 +806,9 @@ class MultiEventRNG(object):
         becomes extremelyn peaked. It also works properly when some one or
         all of the means are zero, returning zero in that case.
         """
-        # NB: you should not expect a smooth limit for the case of stddev->0
+        # NB: you should not expect a smooth limit for the case of on cov->0
         # since the random number generator will advance of a different number
-        # of steps with stddev == 0 and stddev != 0
+        # of steps with cov == 0 and cov != 0
         res = numpy.array(means)
         ok = (means != 0) & (covs != 0)  # nonsingular values
         alpha, beta = _alpha_beta(means[ok], means[ok] * covs[ok])

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -81,28 +81,33 @@ class Sampler(object):
         self.lratios = lratios  # for the PM distribution
         self.cols = cols  # for the PM distribution
         self.minloss = minloss
-        self.get_losses = getattr(self, 'sample' + distname)
 
-    def cutoff(self, losses):
+    def get_losses(self, df, covs):
+        vals = df['val'].to_numpy()
+        if not covs:  # fast lane for zero CoVs
+            losses = vals * df['mean'].to_numpy()
+        else:  # slow lane
+            losses = vals * getattr(self, 'sample' + self.distname)(df)
         losses[losses < self.minloss] = 0
         return losses
 
-    def sampleLN(self, eid, df):
+    def sampleLN(self, df):
         means = df['mean'].to_numpy()
-        vals = df['val'].to_numpy()
         covs = df['cov'].to_numpy()
-        return self.cutoff(vals * self.rng.normal(eid, means, covs))
+        eids = df['eid'].to_numpy()
+        return self.rng.normal(eids, means, covs)
 
-    def sampleBT(self, eid, df):
+    def sampleBT(self, df):
         means = df['mean'].to_numpy()
-        vals = df['val'].to_numpy()
         covs = df['cov'].to_numpy()
-        return self.cutoff(vals * self.rng.beta(eid, means, covs))
+        eids = df['eid'].to_numpy()
+        return self.rng.beta(eids, means, covs)
 
-    def samplePM(self, eid, df):
-        vals = df['val'].to_numpy()
+    def samplePM(self, df):
+        eids = df['eid'].to_numpy()
+        allprobs = df[self.cols].to_numpy()
         pmf = []
-        for probs in df[self.cols].to_numpy():  # probs by asset
+        for eid, probs in zip(eids, allprobs):  # probs by asset
             if probs.sum() == 0:  # oq-risk-tests/case_1g
                 # means are zeros for events below the threshold
                 continue
@@ -110,7 +115,7 @@ class Sampler(object):
                 name='pmf', values=(self.arange, probs),
                 seed=self.rng.master_seed + eid).rvs())
         if pmf:
-            return self.cutoff(self.lratios[pmf] * vals)
+            return self.lratios[pmf]
         else:
             return numpy.zeros(len(df.aid))
 
@@ -263,23 +268,11 @@ class VulnerabilityFunction(object):
         else:
             lratios = ()
             cols = None
+        df = ratio_df.join(asset_df, how='inner')
         sampler = Sampler(self.distribution_name, rng, lratios, cols, minloss)
-        if not hasattr(self, 'covs') or self.covs.any():  # slow lane
-            loss_matrix = sparse.dok_matrix(AE)
-            df = asset_df.join(ratio_df)
-            # print(df.memory_usage().sum())
-            for eid, df in df.groupby('eid'):
-                loss_matrix[df.aid, eid] = sampler.get_losses(eid, df)
-            loss_matrix = loss_matrix.tocoo()
-        else:  # fast lane for zero CoVs
-            df = ratio_df.join(asset_df, how='inner')
-            # print(df.memory_usage().sum())
-            aids = df['aid'].to_numpy()
-            eids = df['eid'].to_numpy()
-            means = df['mean'].to_numpy()
-            vals = df['val'].to_numpy()
-            losses = sampler.cutoff(means * vals)
-            loss_matrix = sparse.coo_matrix((losses, (aids, eids)), AE)
+        covs = not hasattr(self, 'covs') or self.covs.any()
+        losses = sampler.get_losses(df, covs)
+        loss_matrix = sparse.coo_matrix((losses, (df.aid, df.eid)), AE)
         if testmode:
             loss_matrix = loss_matrix.todense()
         return loss_matrix
@@ -764,9 +757,12 @@ class MultiEventRNG(object):
 
     >>> rng = MultiEventRNG(
     ...     master_seed=42, eids=[0, 1, 2], asset_correlation=1)
-    >>> rng.normal(eid=1, size=3)
+    >>> eids = [1] * 3
+    >>> means = numpy.array([.5] * 3)
+    >>> covs = numpy.array([.1] * 3)
+    >>> rng.normal(eids, means, covs)
     array([-2.46861114, -2.46861114, -2.46861114])
-    >>> rng.beta(1, means=numpy.array([.5]*3), stddevs=numpy.array([.05]*3))
+    >>> rng.beta(eids, means, covs)
     array([0.4372343 , 0.57308132, 0.56392573])
     """
     def __init__(self, master_seed, eids, asset_correlation=0):
@@ -777,33 +773,38 @@ class MultiEventRNG(object):
             ph = numpy.random.Philox(self.master_seed + eid)
             self.rng[eid] = numpy.random.Generator(ph)
 
-    def normal(self, eid, means, covs):
+    def normal(self, eids, means, covs):
         """
-        :param eid: event ID
+        :param eids: event IDs
         :param means: array of floats in the range 0..1
         :param covs: array of floats with the same shape
         :returns: array of floats
         """
-        size = len(means)
-        rng = self.rng[eid]
-        if self.asset_correlation:
-            eps = numpy.ones(size) * rng.normal()
-        else:
-            eps = rng.normal(size=size)
+        corrcache = {}
+        eps = numpy.array([self._get_eps(eid, corrcache) for eid in eids])
         sigma = numpy.sqrt(numpy.log(1 + covs ** 2))
         div = numpy.sqrt(1 + covs ** 2)
         return means * numpy.exp(eps * sigma) / div
 
-    def beta(self, eid, means, covs):
+    def _get_eps(self, eid, corrcache):
+        if self.asset_correlation:
+            try:
+                return corrcache[eid]
+            except KeyError:
+                corrcache[eid] = eps = self.rng[eid].normal()
+                return eps
+        return self.rng[eid].normal()
+
+    def beta(self, eids, means, covs):
         """
-        :param eid: event ID
+        :param eids: event IDs
         :param means: array of floats in the range 0..1
         :param covs: array of floats with the same shape
         :returns: array of floats following the beta distribution
 
         This function works properly even when some or all of the stddevs
         are zero: in that case it returns the means since the distribution
-        becomes extremelyn peaked. It also works properly when some one or
+        becomes extremely peaked. It also works properly when some one or
         all of the means are zero, returning zero in that case.
         """
         # NB: you should not expect a smooth limit for the case of on cov->0
@@ -812,7 +813,8 @@ class MultiEventRNG(object):
         res = numpy.array(means)
         ok = (means != 0) & (covs != 0)  # nonsingular values
         alpha, beta = _alpha_beta(means[ok], means[ok] * covs[ok])
-        res[ok] = self.rng[eid].beta(alpha, beta)
+        res[ok] = [self.rng[eid].beta(alpha[i], beta[i])
+                   for i, eid in enumerate(eids[ok])]
         return res
 
 


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/6607. Here are the figures for Miriam's island with no correlation:
```
# master
calc_13579, maxmem=4.7 GB    time_sec memory_mb counts
============================ ======== ========= ======
total event_based_risk       534      88        40    
computing risk               504      0.0       240   
EventBasedRiskCalculator.run 67       86        1     
aggregating losses           12       0.0       240   
averaging losses             6.39794  0.0       240   

# this branch
calc_13578, maxmem=3.4 GB    time_sec memory_mb counts
============================ ======== ========= ======
total event_based_risk       84       117       40    
computing risk               53       0.0       240   
aggregating losses           14       0.0       240   
EventBasedRiskCalculator.run 12       86        1     
averaging losses             5.11174  0.0       240   
```
The speedup in "computing risk" is 9.5x. We are also using a lot less memory. We have now finally beaten engine-3.11:
```
# engine 3.11
calc_13581, maxmem=3.0 GB    time_sec memory_mb counts
============================ ======== ========= ======
total event_based_risk       76       97        21    
computing risk               76       0.0       512   
EventBasedRiskCalculator.run 27       405       1      
aggregating losses           1.95674  0.0       21   
```
(tthe total runtimes is 12 s vs 27s having saved a lot of time not generating the epsilon matrix). There is still room for improvement in "aggregating losses".