### PR TITLE
Added parameter cholesky_limit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Added a `cholesky_limit` to forbid large Cholesky decompositions in ShakeMap
+    calculations
   * Weighted the heavy sources in parallel in event based calculations
   * Suppported zero coefficient of variations with the beta distribution
   * Fixed a bug in the agg_curves exporter with aggregate_by=id

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -123,6 +123,15 @@ float_dmg_dist:
   Example: *float_dmg_dist = true*.
   Default: False
 
+cholesky_limit:
+  When generating the GMFs from a ShakeMap the engine needs to perform a
+  Cholesky decomposition of a matrix of size (M x N)^2, being M the number
+  of intensity measure types and N the number of sites. The decomposition
+  can become ultra-slow, run out of memory, or produce bogus negative
+  eigenvalues, therefore there is a limit on the maximum size of M x N.
+  Example: *cholesky_limit = 1000*.
+  Default: 10,000
+
 continuous_fragility_discretization:
   Used when discretizing continuuos fragility functions.
   Example: *continuous_fragility_discretization = 10*.
@@ -694,6 +703,7 @@ class OqParam(valid.ParamSet):
     conditional_loss_poes = valid.Param(valid.probabilities, [])
     continuous_fragility_discretization = valid.Param(valid.positiveint, 20)
     cross_correlation = valid.Param(valid.Choice('yes', 'no', 'full'), 'yes')
+    cholesky_limit = valid.Param(valid.positiveint, 10_000)
     cachedir = valid.Param(valid.utf8, '')
     description = valid.Param(valid.utf8_not_empty)
     disagg_by_src = valid.Param(valid.boolean, False)

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -295,8 +295,7 @@ def to_gmfs(shakemap, spatialcorr, crosscorr, site_effects, trunclevel,
     cross_corr = cross_correlation_matrix(imts_, crosscorr)
     mu = numpy.array([numpy.ones(num_gmfs) * val[str(imt)][j]
                       for imt in imts_ for j in range(N)])
-    dmatrix = geo.geodetic.distance_matrix(
-        shakemap['lon'], shakemap['lat'])
+    dmatrix = geo.geodetic.distance_matrix(shakemap['lon'], shakemap['lat'])
     spatial_corr = spatial_correlation_array(dmatrix, imts_, spatialcorr)
     stddev = [std[str(imt)] for imt in imts_]
     for im, std in zip(imts_, stddev):


### PR DESCRIPTION
To stop users for running ShakeMap calculations which are too large and send the engine out of memory (or are absurdly slow, or produce negative eigenvalues).