### PR TITLE
fix(shakemap): correct logic in get_sitecol_shakemap to handle imts

### DIFF
--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -110,20 +110,23 @@ def get_sitecol_shakemap(array_or_id, imts, sitecol=None,
                'please change the risk model otherwise you will have '
                'incorrect zero losses for the associated taxonomies' %
                (missing.pop(), ', '.join(available_imts)))
-        if discard_assets:
+
+        imts = available_imts.intersection(imts)
+
+        if discard_assets and imts:
             logging.error(msg)
         else:
             raise RuntimeError(msg)
 
     # build a copy of the ShakeMap with only the relevant IMTs
-    dt = [(imt, F32) for imt in sorted(available_imts)]
+    dt = [(imt, F32) for imt in sorted(imts)]
     dtlist = [('lon', F32), ('lat', F32), ('vs30', F32),
               ('val', dt), ('std', dt)]
     data = numpy.zeros(len(array), dtlist)
     for name in ('lon',  'lat', 'vs30'):
         data[name] = array[name]
     for name in ('val', 'std'):
-        for im in available_imts:
+        for im in imts:
             data[name][im] = array[name][im]
 
     if sitecol is None:  # extract the sites from the shakemap


### PR DESCRIPTION
Problems fixed:
1. If oq.discard_assets is True, but there is no intersection between available_imts and oq.imtls, the program crashes later on when computing the gmfs.
2. line 118/121 says, that a copy of the Shakemap with only the relevant IMTs is made, but actually it makes an exact copy since it iterates over available_imts

Problem which is not fixed:
If discard_assets is true, no gmfs are made for the "missing" IMT. My test shows, that openquake crashes in that case. See log: [error.txt](https://github.com/gem/oq-engine/files/6157670/error.txt)

I would also be open to remove the if/else for discard assets and always raise an runtime error if imts are missing.