### PR TITLE
Added a generic shakemap.get_array

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1172,10 +1172,14 @@ def read_shakemap(calc, haz_sitecol, assetcol):
         # [8, 9, 10, 11, 13, 15, 16, 17, 18];
         # the total assetcol has 26 assets on the total sites
         # and the reduced assetcol has 9 assets on the reduced sites
-        smap = oq.shakemap_id if oq.shakemap_id else numpy.load(
-            oq.inputs['shakemap'])
+        if oq.shakemap_id:
+            uridict = {'kind': 'usgs_id', 'id': oq.shakemap_id}
+        elif 'shakemap' in oq.inputs:
+            uridict = {'kind': 'file_npy', 'fname': oq.inputs['shakemap']}
+        else:
+            uridict = oq.shakemap_uri
         sitecol, shakemap, discarded = get_sitecol_shakemap(
-            smap, oq.imtls, haz_sitecol,
+            uridict, oq.imtls, haz_sitecol,
             oq.asset_hazard_distance['default'])
         if len(discarded):
             calc.datastore['discarded'] = discarded

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -754,7 +754,7 @@ class HazardCalculator(BaseCalculator):
             if oq.region:
                 region = wkt.loads(oq.region)
                 self.sitecol = haz_sitecol.within(region)
-            if oq.shakemap_id or 'shakemap' in oq.inputs:
+            if oq.shakemap_id or 'shakemap' in oq.inputs or oq.shakemap_uri:
                 self.sitecol, self.assetcol = read_shakemap(
                     self, haz_sitecol, assetcol)
                 self.datastore['sitecol'] = self.sitecol

--- a/openquake/commands/download_shakemap.py
+++ b/openquake/commands/download_shakemap.py
@@ -18,7 +18,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import numpy
 from openquake.baselib import performance
-from openquake.hazardlib.shakemap import download_array
+from openquake.hazardlib.shakemap import get_array
 
 
 def main(id):
@@ -27,6 +27,6 @@ def main(id):
     """
     with performance.Monitor('shakemap', measuremem=True) as mon:
         dest = '%s.npy' % id
-        numpy.save(dest, download_array(id))
+        numpy.save(dest, get_array("usgs_id", id))
     print(mon)
     print('Saved %s' % dest)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -531,6 +531,15 @@ shakemap_id:
   Example: *shakemap_id = usp000fjta*.
   Default: no default
 
+shakemap_uri:
+  Dictionary used in ShakeMap calculations to specify a ShakeMap. Must contain
+  a key named "kind" with values "usgs_id", "usgs_xml" or "file_npy".
+  Example: *shakemap_uri = {
+     "kind": "usgs_xml",
+     "grid_url": "file:///home/michele/usp000fjta/grid.xml",
+     "uncertainty_url": "file:///home/michele/usp000fjta/uncertainty.xml"*.
+  Default: empty dictionary
+
 shift_hypo:
   Used in classical calculations to shift the rupture hypocenter.
   Example: *shift_hypo = true*.
@@ -794,6 +803,7 @@ class OqParam(valid.ParamSet):
         valid.compose(valid.nonzero, valid.positiveint), 1)
     ses_seed = valid.Param(valid.positiveint, 42)
     shakemap_id = valid.Param(valid.nice_string, None)
+    shakemap_uri = valid.Param(valid.dictionary, {})
     shift_hypo = valid.Param(valid.boolean, False)
     site_effects = valid.Param(valid.boolean, False)  # shakemap amplification
     sites = valid.Param(valid.NoneOr(valid.coordinates), None)

--- a/openquake/hazardlib/shakemap.py
+++ b/openquake/hazardlib/shakemap.py
@@ -82,8 +82,8 @@ def get_array_usgs_xml(kind, grid_url, uncertainty_url=None):
 
 
 @get_array.add('usgs_id')
-def get_array_usgs_id(kind, shakemap_id):
-    url = SHAKEMAP_URL.format(shakemap_id)
+def get_array_usgs_id(kind, id):
+    url = SHAKEMAP_URL.format(id)
     logging.info('Downloading %s', url)
     contents = json.loads(urlopen(url).read())[
         'properties']['products']['shakemap'][-1]['contents']

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -3,7 +3,7 @@ import unittest
 import numpy
 from openquake.hazardlib import geo, imt
 from openquake.hazardlib.shakemap import (
-    get_shakemap_array, get_sitecol_shakemap, to_gmfs, amplify_ground_shaking,
+    get_sitecol_shakemap, to_gmfs, amplify_ground_shaking,
     spatial_correlation_array, spatial_covariance_array,
     cross_correlation_matrix, cholesky)
 

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -26,10 +26,10 @@ def mean_std(shakemap, site_effects):
 class ShakemapTestCase(unittest.TestCase):
 
     def test_gmfs(self):
-        f1 = os.path.join(CDIR, 'ghorka_grid.xml')
-        f2 = os.path.join(CDIR, 'ghorka_uncertainty.xml')
-        array = get_shakemap_array(f1, f2)
-        sitecol, shakemap = get_sitecol_shakemap(array, imt_dt.names)
+        f1 = 'file://' + os.path.join(CDIR, 'ghorka_grid.xml')
+        f2 = 'file://' + os.path.join(CDIR, 'ghorka_uncertainty.xml')
+        uridict = dict(kind='usgs_xml', grid_url=f1, uncertainty_url=f2)
+        sitecol, shakemap = get_sitecol_shakemap(uridict, imt_dt.names)
         n = 4  # number of sites
         self.assertEqual(len(sitecol), n)
         gmf_by_imt, _ = mean_std(shakemap, site_effects=True)
@@ -116,10 +116,10 @@ class ShakemapTestCase(unittest.TestCase):
 
     def test_from_files(self):
         # files provided by Vitor Silva, without site amplification
-        f1 = os.path.join(CDIR, 'test_shaking.xml')
-        f2 = os.path.join(CDIR, 'test_uncertainty.xml')
-        array = get_shakemap_array(f1, f2)
-        sitecol, shakemap = get_sitecol_shakemap(array, imt_dt.names)
+        f1 = 'file://' + os.path.join(CDIR, 'test_shaking.xml')
+        f2 = 'file://' + os.path.join(CDIR, 'test_uncertainty.xml')
+        uridict = dict(kind='usgs_xml', grid_url=f1, uncertainty_url=f2)
+        sitecol, shakemap = get_sitecol_shakemap(uridict, imt_dt.names)
         n = 4  # number of sites
         self.assertEqual(len(sitecol), n)
         gmf_by_imt, std_by_imt = mean_std(shakemap, site_effects=False)


### PR DESCRIPTION
And added a `shakemap_uri` dictionary to the job.ini to describe non-USGS ShakeMaps. The following are valid shakemap_uris:
```python
shakemap_uri = {
     "kind": "usgs_id",
     "id": "usp000fjta"}
shakemap_uri = {
     "kind": "usgs_xml",
     "grid_url": "file:///home/michele/usp000fjta/grid.xml",
     "uncertainty_url": "file:///home/michele/usp000fjta/uncertainty.xml"}
shakemap_uri = {
    "kind": "file_npy",
    "fname": "/home/michele/usp000fjta.npy"}
```
This PR is totally backward-compatible.