### PR TITLE
Raised an error for aValue=-Inf

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check for the case of `aValue=-Inf` in the truncatedGR MFD
   * Extended the engine to read XML ShakeMaps from arbitrary sources (in
     particular local path names and web sites different from the USGS site)
   * Fixed hdf5.dumps that was generating invalid JSON for Windows pathnames,

--- a/openquake/hazardlib/mfd/truncated_gr.py
+++ b/openquake/hazardlib/mfd/truncated_gr.py
@@ -68,7 +68,6 @@ class TruncatedGRMFD(BaseMFD):
         self.bin_width = bin_width
         self.a_val = a_val
         self.b_val = b_val
-
         self.check_constraints()
 
     def check_constraints(self):
@@ -94,8 +93,10 @@ class TruncatedGRMFD(BaseMFD):
                              'bin width %g at least'
                              % (self.max_mag, self.min_mag, self.bin_width))
 
-        if not 0 < self.b_val:
+        if self.b_val <= 0:
             raise ValueError('b-value %g must be non-negative' % self.b_val)
+        if not np.isfinite(self.a_val):
+            raise ValueError(self.a_val)
 
     def _get_rate(self, mag):
         """

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -700,6 +700,7 @@ class SourceConverter(RuptureConverter):
         with context(self.fname, node):
             [mfd_node] = [subnode for subnode in node
                           if subnode.tag.endswith(KNOWN_MFDS)]
+        with context(self.fname, mfd_node):
             if mfd_node.tag.endswith('incrementalMFD'):
                 return mfd.EvenlyDiscretizedMFD(
                     min_mag=mfd_node['minMag'], bin_width=mfd_node['binWidth'],

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -710,11 +710,11 @@ class SourceConverter(RuptureConverter):
                 rigidity = mfd_node.get('rigidity')
                 if slip_rate:
                     assert rigidity
-                    # instantiate with a NaN area, to be fixed later on
+                    # instantiate with an area of 1, to be fixed later on
                     gr_mfd = mfd.TruncatedGRMFD.from_slip_rate(
                         mfd_node['minMag'], mfd_node['maxMag'],
                         self.width_of_mfd_bin, mfd_node['bValue'],
-                        slip_rate, rigidity, area=numpy.nan)
+                        slip_rate, rigidity, area=1)
                 else:
                     gr_mfd = mfd.TruncatedGRMFD(
                         a_val=mfd_node['aValue'], b_val=mfd_node['bValue'],

--- a/openquake/hazardlib/tests/mfd/truncated_gr_test.py
+++ b/openquake/hazardlib/tests/mfd/truncated_gr_test.py
@@ -38,6 +38,10 @@ class TruncatedGRMFDFromMomentTestCase(unittest.TestCase):
         msg = "Scalar Mo rate from MFD does not match the original one"
         self.assertAlmostEqual(moment_rate, computed, msg=msg, delta=1e14)
 
+        # test for a_val = -inf
+        with self.assertRaises(ValueError):
+            TruncatedGRMFD(min_mag, max_mag, bin_width, -np.inf, b_val)
+
 
 class TruncatedGRMFDConstraintsTestCase(BaseMFDTestCase):
     def test_negative_min_mag(self):


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6644. Now the computation by Celine has a nice error message:
```python
  File "/home/michele/oq-engine/openquake/hazardlib/mfd/truncated_gr.py", line 100, in check_constraints
    raise ValueError(self.a_val)
ValueError: node truncGutenbergRichterMFD: -inf, line 1252 of /home/michele/Downloads/envoi/modeleSHAREC2M32.xml
```