### PR TITLE
Refactor get_sitecol_shakemap

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1182,7 +1182,7 @@ def read_shakemap(calc, haz_sitecol, assetcol):
         else:
             uridict = oq.shakemap_uri
         sitecol, shakemap, discarded = get_sitecol_shakemap(
-            uridict, oq.imtls, haz_sitecol,
+            uridict.pop('kind'), uridict, oq.imtls, haz_sitecol,
             oq.asset_hazard_distance['default'])
         if len(discarded):
             calc.datastore['discarded'] = discarded

--- a/openquake/hazardlib/shakemap/maps.py
+++ b/openquake/hazardlib/shakemap/maps.py
@@ -25,16 +25,12 @@ from openquake.hazardlib.shakemap.parsers import get_array
 
 F32 = numpy.float32
 
-# Here is the explanation of USGS for the units they are using:
-# PGA = peak ground acceleration (percent-g)
-# PSA03 = spectral acceleration at 0.3 s period, 5% damping (percent-g)
-# PSA10 = spectral acceleration at 1.0 s period, 5% damping (percent-g)
-# PSA30 = spectral acceleration at 3.0 s period, 5% damping (percent-g)
-# STDPGA = the standard deviation of PGA (natural log of percent-g)
+get_sitecol_shakemap = CallableDict()
 
 
-def get_sitecol_shakemap(uridict, required_imts, sitecol=None,
-                         assoc_dist=None, mode='warn'):
+@get_sitecol_shakemap.add('usgs_xml', 'usgs_id', 'file_npy')
+def get_sitecol_usgs(kind, uridict, required_imts, sitecol=None,
+                     assoc_dist=None, mode='warn'):
     """
     :param uridict: a dictionary specifying the ShakeMap resource
     :param imts: required IMTs as a list of strings
@@ -43,78 +39,51 @@ def get_sitecol_shakemap(uridict, required_imts, sitecol=None,
     :param mode: 'strict', 'warn' or 'filter'
     :returns: filtered site collection, filtered shakemap, discarded
     """
-    kind = uridict.pop('kind')
-    array = get_array(kind, **uridict)
+    shakemap = get_array(kind, **uridict)
 
-    imts, bbox, shakemap = \
-        read_shakemap(kind, required_imts, array)
-
-    missing = set(required_imts) - imts
-    if missing:
-        msg = ('The IMT %s is required but not in the available set %s, '
-               'please change the risk model otherwise you will have '
-               'incorrect zero losses for the associated taxonomies' %
-               (missing.pop(), ', '.join(imts)))
-        raise RuntimeError(msg)
-
-    if sitecol is None:  # extract the sites from the shakemap
-        return create_site_collection(kind, shakemap), shakemap, []
-
-    indices = sitecol.within_bbox(bbox)
-
-    if len(indices) == 0:
-        raise RuntimeError('There are no sites within '
-                           'the bounding box %s' % str(bbox))
-    sitecol = sitecol.filtered(indices)
-    logging.info('Associating %d GMVs to %d sites',
-                 len(shakemap), len(sitecol))
-
-    return associate_to_usgs_shakemap(
-        kind, shakemap, sitecol, assoc_dist, mode)
-
-
-# read and filter parsed shakemap depending on type
-read_shakemap = CallableDict()
-
-
-@read_shakemap.add('usgs_xml', 'usgs_id', 'file_npy')
-def read_shakemap_usgs(kind, imts, shakemap):
-    """
-    :param imts: list of imts required
-    :param shakemap: shakemap data
-    """
     available_imts = set(shakemap['val'].dtype.names)
 
     bbox = (shakemap['lon'].min(), shakemap['lat'].min(),
             shakemap['lon'].max(), shakemap['lat'].max())
 
     # build a copy of the ShakeMap with only the relevant IMTs
-    dt = [(imt, F32) for imt in sorted(imts)]
+    dt = [(imt, F32) for imt in sorted(required_imts)]
     dtlist = [('lon', F32), ('lat', F32), ('vs30', F32),
               ('val', dt), ('std', dt)]
     data = numpy.zeros(len(shakemap), dtlist)
     for name in ('lon', 'lat', 'vs30'):
         data[name] = shakemap[name]
     for name in ('val', 'std'):
-        for im in imts:
+        for im in required_imts:
             data[name][im] = shakemap[name][im]
 
-    return available_imts, bbox, data
+    check_required_imts(required_imts, available_imts)
 
+    if sitecol is None:
+        return site.SiteCollection.from_usgs_shakemap(shakemap), shakemap, []
 
-# if no site collection was passed ro function, generate one from the shakemap
-create_site_collection = CallableDict()
+    sitecol = apply_bounding_box(sitecol, bbox)
 
+    logging.info('Associating %d GMVs to %d sites',
+                 len(shakemap), len(sitecol))
 
-@create_site_collection.add('usgs_xml')
-def from_usgs_shakemap(kind, shakemap):
-    return site.SiteCollection.from_usgs_shakemap(shakemap)
-
-
-# associate shakemap to site collection
-associate_sites = CallableDict()
-
-
-@associate_sites.add('usgs_xml')
-def associate_to_usgs_shakemap(kind, shakemap, sitecol, assoc_dist, mode):
     return geo.utils.assoc(shakemap, sitecol, assoc_dist, mode)
+
+
+def check_required_imts(required_imts, available_imts):
+    missing = set(required_imts) - available_imts
+    if missing:
+        msg = ('The IMT %s is required but not in the available set %s, '
+               'please change the risk model otherwise you will have '
+               'incorrect zero losses for the associated taxonomies' %
+               (missing.pop(), ', '.join(available_imts)))
+        raise RuntimeError(msg)
+
+
+def apply_bounding_box(sitecol, bbox):
+    indices = sitecol.within_bbox(bbox)
+
+    if len(indices) == 0:
+        raise RuntimeError('There are no sites within '
+                           'the bounding box %s' % str(bbox))
+    return sitecol.filtered(indices)

--- a/openquake/hazardlib/shakemap/maps.py
+++ b/openquake/hazardlib/shakemap/maps.py
@@ -79,6 +79,10 @@ read_shakemap = CallableDict()
 
 @read_shakemap.add('usgs_xml', 'usgs_id', 'file_npy')
 def read_shakemap_usgs(kind, imts, shakemap):
+    """
+    :param imts: list of imts required
+    :param shakemap: shakemap data
+    """
     available_imts = set(shakemap['val'].dtype.names)
 
     bbox = (shakemap['lon'].min(), shakemap['lat'].min(),
@@ -98,7 +102,7 @@ def read_shakemap_usgs(kind, imts, shakemap):
     return available_imts, bbox, data
 
 
-# if no site collection was passed generate one from the shakemap
+# if no site collection was passed ro function, generate one from the shakemap
 create_site_collection = CallableDict()
 
 

--- a/openquake/hazardlib/shakemap/maps.py
+++ b/openquake/hazardlib/shakemap/maps.py
@@ -19,56 +19,11 @@
 import logging
 import numpy
 
+from openquake.baselib.general import CallableDict
 from openquake.hazardlib import geo, site
 from openquake.hazardlib.shakemap.parsers import get_array
 
 F32 = numpy.float32
-
-
-def get_sitecol_shakemap(uridict, imts, sitecol=None,
-                         assoc_dist=None):
-    """
-    :param uridict: a dictionary specifying the ShakeMap resource
-    :param imts: required IMTs as a list of strings
-    :param sitecol: SiteCollection used to reduce the shakemap
-    :param assoc_dist: association distance
-    :returns: filtered site collection, filtered shakemap, discarded
-    """
-    array = get_array(uridict.pop('kind'), **uridict)
-    available_imts = set(array['val'].dtype.names)
-    missing = set(imts) - available_imts
-    if missing:
-        msg = ('The IMT %s is required but not in the available set %s, '
-               'please change the risk model otherwise you will have '
-               'incorrect zero losses for the associated taxonomies' %
-               (missing.pop(), ', '.join(available_imts)))
-        raise RuntimeError(msg)
-
-    # build a copy of the ShakeMap with only the relevant IMTs
-    dt = [(imt, F32) for imt in sorted(imts)]
-    dtlist = [('lon', F32), ('lat', F32), ('vs30', F32),
-              ('val', dt), ('std', dt)]
-    data = numpy.zeros(len(array), dtlist)
-    for name in ('lon', 'lat', 'vs30'):
-        data[name] = array[name]
-    for name in ('val', 'std'):
-        for im in imts:
-            data[name][im] = array[name][im]
-
-    if sitecol is None:  # extract the sites from the shakemap
-        return site.SiteCollection.from_shakemap(data), data, []
-
-    # associate the shakemap to the (filtered) site collection
-    bbox = (data['lon'].min(), data['lat'].min(),
-            data['lon'].max(), data['lat'].max())
-    indices = sitecol.within_bbox(bbox)
-    if len(indices) == 0:
-        raise RuntimeError('There are no sites within the boundind box %s'
-                           % str(bbox))
-    sites = sitecol.filtered(indices)
-    logging.info('Associating %d GMVs to %d sites', len(data), len(sites))
-    return geo.utils.assoc(data, sites, assoc_dist, 'warn')
-
 
 # Here is the explanation of USGS for the units they are using:
 # PGA = peak ground acceleration (percent-g)
@@ -76,3 +31,86 @@ def get_sitecol_shakemap(uridict, imts, sitecol=None,
 # PSA10 = spectral acceleration at 1.0 s period, 5% damping (percent-g)
 # PSA30 = spectral acceleration at 3.0 s period, 5% damping (percent-g)
 # STDPGA = the standard deviation of PGA (natural log of percent-g)
+
+
+def get_sitecol_shakemap(uridict, required_imts, sitecol=None,
+                         assoc_dist=None, mode='warn'):
+    """
+    :param uridict: a dictionary specifying the ShakeMap resource
+    :param imts: required IMTs as a list of strings
+    :param sitecol: SiteCollection used to reduce the shakemap
+    :param assoc_dist: the maximum distance for association
+    :param mode: 'strict', 'warn' or 'filter'
+    :returns: filtered site collection, filtered shakemap, discarded
+    """
+    kind = uridict.pop('kind')
+    array = get_array(kind, **uridict)
+
+    imts, bbox, shakemap = \
+        read_shakemap(kind, required_imts, array)
+
+    missing = set(required_imts) - imts
+    if missing:
+        msg = ('The IMT %s is required but not in the available set %s, '
+               'please change the risk model otherwise you will have '
+               'incorrect zero losses for the associated taxonomies' %
+               (missing.pop(), ', '.join(imts)))
+        raise RuntimeError(msg)
+
+    if sitecol is None:  # extract the sites from the shakemap
+        return create_site_collection(kind, shakemap), shakemap, []
+
+    indices = sitecol.within_bbox(bbox)
+
+    if len(indices) == 0:
+        raise RuntimeError('There are no sites within '
+                           'the bounding box %s' % str(bbox))
+    sitecol = sitecol.filtered(indices)
+    logging.info('Associating %d GMVs to %d sites',
+                 len(shakemap), len(sitecol))
+
+    return associate_to_usgs_shakemap(
+        kind, shakemap, sitecol, assoc_dist, mode)
+
+
+# read and filter parsed shakemap depending on type
+read_shakemap = CallableDict()
+
+
+@read_shakemap.add('usgs_xml', 'usgs_id', 'file_npy')
+def read_shakemap_usgs(kind, imts, shakemap):
+    available_imts = set(shakemap['val'].dtype.names)
+
+    bbox = (shakemap['lon'].min(), shakemap['lat'].min(),
+            shakemap['lon'].max(), shakemap['lat'].max())
+
+    # build a copy of the ShakeMap with only the relevant IMTs
+    dt = [(imt, F32) for imt in sorted(imts)]
+    dtlist = [('lon', F32), ('lat', F32), ('vs30', F32),
+              ('val', dt), ('std', dt)]
+    data = numpy.zeros(len(shakemap), dtlist)
+    for name in ('lon', 'lat', 'vs30'):
+        data[name] = shakemap[name]
+    for name in ('val', 'std'):
+        for im in imts:
+            data[name][im] = shakemap[name][im]
+
+    return available_imts, bbox, data
+
+
+# if no site collection was passed generate one from the shakemap
+create_site_collection = CallableDict()
+
+
+@create_site_collection.add('usgs_xml')
+def from_usgs_shakemap(kind, shakemap):
+    return site.SiteCollection.from_usgs_shakemap(shakemap)
+
+
+# associate shakemap to site collection
+associate_sites = CallableDict()
+
+
+@associate_sites.add('usgs_xml')
+def associate_to_usgs_shakemap(kind, shakemap, sitecol, assoc_dist, mode):
+    return geo.utils.assoc(shakemap, sitecol, assoc_dist, mode)

--- a/openquake/hazardlib/shakemap/maps.py
+++ b/openquake/hazardlib/shakemap/maps.py
@@ -71,6 +71,13 @@ def get_sitecol_usgs(kind, uridict, required_imts, sitecol=None,
 
 
 def check_required_imts(required_imts, available_imts):
+    """
+    Check if the list of required imts is present in the list of available imts
+
+    :param required_imts: list of strings of required imts
+    :param available_imts: set of available imts
+    :raises RuntimeError: if required imts are not present
+    """
     missing = set(required_imts) - available_imts
     if missing:
         msg = ('The IMT %s is required but not in the available set %s, '
@@ -81,6 +88,13 @@ def check_required_imts(required_imts, available_imts):
 
 
 def apply_bounding_box(sitecol, bbox):
+    """
+    Filter out sites which are not in the bounding box.
+
+    :param sitecol: SiteCollection of sites from exposed assets
+    :param bbox: Bounding Box (lon.min, lat.min, lon.max, lat.max)
+    :raises RuntimeError: if no sites are found within the Bounding Box
+    """
     indices = sitecol.within_bbox(bbox)
 
     if len(indices) == 0:

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -28,6 +28,8 @@ from openquake.hazardlib.geo.utils import (
     fix_lon, cross_idl, _GeographicObjects, geohash, spherical_to_cartesian)
 from openquake.hazardlib.geo.mesh import Mesh
 
+from openquake.baselib.general import CallableDict
+
 U32LIMIT = 2 ** 32
 ampcode_dt = (numpy.string_, 4)
 
@@ -56,6 +58,7 @@ class Site(object):
 
         :class:`Sites <Site>` are pickleable
     """
+
     def __init__(self, location, vs30=numpy.nan,
                  z1pt0=numpy.nan, z2pt5=numpy.nan, **extras):
         if not numpy.isnan(vs30) and vs30 <= 0:
@@ -187,7 +190,7 @@ class SiteCollection(object):
                     if item[0] not in ('lon', 'lat'))
 
     @classmethod
-    def from_shakemap(cls, shakemap_array):
+    def from_usgs_shakemap(cls, shakemap_array):
         """
         Build a site collection from a shakemap array
         """

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -28,8 +28,6 @@ from openquake.hazardlib.geo.utils import (
     fix_lon, cross_idl, _GeographicObjects, geohash, spherical_to_cartesian)
 from openquake.hazardlib.geo.mesh import Mesh
 
-from openquake.baselib.general import CallableDict
-
 U32LIMIT = 2 ** 32
 ampcode_dt = (numpy.string_, 4)
 

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -31,8 +31,8 @@ class ShakemapTestCase(unittest.TestCase):
         f1 = 'file://' + os.path.join(CDIR, 'ghorka_grid.xml')
         f2 = 'file://' + os.path.join(CDIR, 'ghorka_uncertainty.xml')
         uridict = dict(kind='usgs_xml', grid_url=f1, uncertainty_url=f2)
-        sitecol, shakemap, *_ = get_sitecol_shakemap(
-            uridict, imt_dt.names)
+        sitecol, shakemap, *_ = get_sitecol_shakemap(uridict.pop('kind'),
+                                                     uridict, imt_dt.names)
         n = 4  # number of sites
         self.assertEqual(len(sitecol), n)
         gmf_by_imt, _ = mean_std(shakemap, site_effects=True)
@@ -122,8 +122,8 @@ class ShakemapTestCase(unittest.TestCase):
         f1 = 'file://' + os.path.join(CDIR, 'test_shaking.xml')
         f2 = 'file://' + os.path.join(CDIR, 'test_uncertainty.xml')
         uridict = dict(kind='usgs_xml', grid_url=f1, uncertainty_url=f2)
-        sitecol, shakemap, *_ = get_sitecol_shakemap(
-            uridict, imt_dt.names)
+        sitecol, shakemap, *_ = get_sitecol_shakemap(uridict.pop('kind'),
+                                                     uridict, imt_dt.names)
         n = 4  # number of sites
         self.assertEqual(len(sitecol), n)
         gmf_by_imt, std_by_imt = mean_std(shakemap, site_effects=False)


### PR DESCRIPTION
As requested, instead of using an abstract class which contains the global logic, and defining abstract methods which define the implementation logic, I used a CallableDict.

Using the CallableDict to parse the input files is very intuitive and more elegant than using classes/inheritance. 

In this usecase however I'd still prefer a solution using a class ([example](https://github.com/swiss-seismological-service/sed-oq-engine/blob/e0616fe4578f205c099d71dc988d1f89a9a2af4f/openquake/hazardlib/shakemap/maps.py)) but we can go forward with this CallableDict of course.