### PR TITLE
Refactor to_gmfs and faster calculation method

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Nicolas Schmid]
+  * Improve performance for ShakeMap calculations when spatialcorr and crosscorr
+    are both set to 'no'
+
   [Michele Simionato]
   * Supported exposures with generic CSV fields thanks to the `exposureFields`
     mapping

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -141,13 +141,6 @@ def set_array(longarray, shortarray):
     longarray[len(shortarray):] = numpy.nan
 
 
-MAXSITES = 1000
-CORRELATION_MATRIX_TOO_LARGE = '''\
-You have a correlation matrix which is too large: %s > %d.
-To avoid that, set a proper `region_grid_spacing` so that your exposure
-involves less sites.'''
-
-
 class BaseCalculator(metaclass=abc.ABCMeta):
     """
     Abstract base class for all calculators.
@@ -1188,25 +1181,21 @@ def read_shakemap(calc, haz_sitecol, assetcol):
             calc.datastore['discarded'] = discarded
         assetcol.reduce_also(sitecol)
 
-    # checks
-    M = len(oq.imtls)
-    N = len(sitecol)
-    A = len(assetcol)
-    logging.info('Extracted %d assets', A)
-    if oq.spatial_correlation != 'no' and N > MAXSITES:
-        # hard-coded, heuristic
-        raise ValueError(CORRELATION_MATRIX_TOO_LARGE %
-                         (N, MAXSITES))
-    elif oq.spatial_correlation == 'no' and N * M > oq.cholesky_limit:
-        raise ValueError(CORRELATION_MATRIX_TOO_LARGE % (
-            '%d x %d' % (M, N), oq.cholesky_limit))
+    # assemble dictionary to decide on the calculation method for the gmfs
+    if oq.spatial_correlation != 'no' or oq.cross_correlation != 'no':
+        # cross correlation and/or spatial correlation after S&H
+        gmf_dict = {'kind': 'Silva&Horspool',
+                    'spatialcorr': oq.spatial_correlation,
+                    'crosscorr': oq.cross_correlation,
+                    'cholesky_limit': oq.cholesky_limit}
+    else:
+        # no correlation required, basic calculation is faster
+        gmf_dict = {'kind': 'basic'}
 
     logging.info('Building GMFs')
     with calc.monitor('building/saving GMFs'):
-        imts, gmfs = to_gmfs(
-            shakemap, oq.spatial_correlation, oq.cross_correlation,
-            oq.site_effects, oq.truncation_level, E, oq.random_seed,
-            oq.imtls)
+        imts, gmfs = to_gmfs(shakemap, gmf_dict, oq.site_effects,
+                             oq.truncation_level, E, oq.random_seed, oq.imtls)
         N, E, M = gmfs.shape
         events = numpy.zeros(E, rupture.events_dt)
         events['id'] = numpy.arange(E, dtype=U32)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1215,7 +1215,7 @@ def read_shakemap(calc, haz_sitecol, assetcol):
         lst = [(sitecol.sids[s], ei) + tuple(gmfs[s, ei])
                for s in numpy.arange(N, dtype=U32)
                for ei, event in enumerate(events)]
-        oq.hazard_imtls = {imt: [0] for imt in imts}
+        oq.hazard_imtls = {str(imt): [0] for imt in imts}
         data = numpy.array(lst, oq.gmf_data_dt())
         create_gmf_data(calc.datastore, len(imts), data=data)
     return sitecol, assetcol

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1180,6 +1180,7 @@ def read_shakemap(calc, haz_sitecol, assetcol):
         if len(discarded):
             calc.datastore['discarded'] = discarded
         assetcol.reduce_also(sitecol)
+        logging.info('Extracted %d assets', len(assetcol))
 
     # assemble dictionary to decide on the calculation method for the gmfs
     if oq.spatial_correlation != 'no' or oq.cross_correlation != 'no':

--- a/openquake/hazardlib/shakemap/gmfs.py
+++ b/openquake/hazardlib/shakemap/gmfs.py
@@ -203,11 +203,11 @@ def gmfs_calculation_methods_SH(kind, shakemap, imts, spatialcorr,
     L = cholesky(spatial_cov, cross_corr)  # shape (M * N, M * N)
 
     # mu has unit (pctg), L has unit ln(pctg)
-    def generate_gmfs(Z, mu):
+    def calculate_gmfs(Z, mu):
         mu = numpy.log(mu)
         return numpy.exp(L @ Z + mu) / PCTG
 
-    return generate_gmfs
+    return calculate_gmfs
 
 
 @gmfs_calculation_methods.add('basic')
@@ -217,26 +217,30 @@ def gmfs_calculation_methods_basic(kind, shakemap, imts):
 
     :param shakemap: site coordinates with shakemap values
     :param imts: list of required imts
-    :param spatialcorr: 'no', 'yes' or 'full'
-    :param crosscorr: 'no', 'yes' or 'full' 
     :returns: F(Z, mu) to calculate gmfs
     """
     # create diag matrix with std values
     std = numpy.array([shakemap['std'][str(im)] for im in imts])
     sig = numpy.diag(std.flatten())  # shape (M*N, M*N)
 
-    # mu has unit (pctg), L has unit ln(pctg)
-    def generate_gmfs(Z, mu):
+    # mu has unit (pctg), sig has unit ln(pctg)
+    def calculate_gmfs(Z, mu):
         mu = numpy.log(mu)
         return numpy.exp(sig @ Z + mu) / PCTG
 
-    return generate_gmfs
+    return calculate_gmfs
 
 
 def to_gmfs(shakemap, gmf_dict, site_effects, trunclevel,
             num_gmfs, seed, imts=None):
     """
-    :returns: IMT-strings, array of GMFs of shape (R, N, E, M)
+    :param shakemap: site coordinates with shakemap values
+    :param gmf_dict: dictionary with info about the gmf calculation method
+    :param site_effects: whether to apply site effects or not
+    :param num_gmfs: E, amount of gmfs to generate
+    :param seed: seed for generating numbers
+    :param imts: list of IMT-strings for which gmfs are generated
+    :returns: list of IMT-objects, array of GMFs of shape (R, N, E, M)
     """
     # create list of imts
     if imts is None or len(imts) == 0:

--- a/openquake/hazardlib/shakemap/gmfs.py
+++ b/openquake/hazardlib/shakemap/gmfs.py
@@ -259,13 +259,11 @@ def to_gmfs(shakemap, gmf_dict, site_effects, trunclevel,
     mu = numpy.array([numpy.ones(num_gmfs) * shakemap['val'][str(imt)][j]
                       for imt in imts for j in range(N)])
 
-    # assemble dictionary to decide on the calculation method for the gmfs
+    # assemble dictionary for the calculation of the gmfs
     gmf_dict.update({'shakemap': shakemap, 'imts': imts, 'Z': Z, 'mu': mu})
 
-    # returns calculation method
-    gmfs = calculate_gmfs(gmf_dict.pop('kind'), **gmf_dict)
-
     # execute the calculation
+    gmfs = calculate_gmfs(gmf_dict.pop('kind'), **gmf_dict)
 
     # apply site effects
     if site_effects:


### PR DESCRIPTION
Refactoring with the purpose of making the code extendable.
- some simple refactoring of the method to make it more readable
- added docstrings
- created CallableDict "gmfs_calculation_methods" which returns a function. This function contains the specific implementation how the gmfs are calculated, when given the matrix of mu (mean) and Z (random variables).
I could, instead of returning a function, also just return the finished result, but this way the "calculation method" and the actual "calculation" are clearly separated.

Improvement:
I also added new calculation method, which directly calculates the sampling in case no correlation is needed. Until now Cholesky was computed every time, which is pointless, if the correlation matrixes are identity matrices.