### PR TITLE
Fixed `pandas.read_csv`

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -708,7 +708,8 @@ def _read_csv(fileobj, compositedt):
         dic[name] = dt = compositedt[name]
         if dt.kind == 'S':  # limit of the length of byte-fields
             conv[name] = check_length(name, dt.itemsize)
-    df = pandas.read_csv(fileobj, names=compositedt.names, converters=conv)
+    df = pandas.read_csv(fileobj, names=compositedt.names, converters=conv,
+                         dtype=dic)
     arr = numpy.zeros(len(df), compositedt)
     for col in df.columns:
         arr[col] = df[col].to_numpy()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -472,26 +472,27 @@ class ClassicalCalculator(base.HazardCalculator):
         weights = [rlz.weight for rlz in self.realizations]
         pgetter = getters.PmapGetter(
             self.datastore, weights, self.sitecol.sids, oq.imtls)
-        srcidx = {rec[0]: i for i, rec in enumerate(
-            self.csm.source_info.values())}
+        srcidx = {
+            rec[0]: i for i, rec in enumerate(self.csm.source_info.values())}
         self.haz = Hazard(self.datastore, self.full_lt, pgetter, srcidx)
-        blocks = list(block_splitter(grp_ids, len(self.grp_ids)))
-        for b, block in enumerate(blocks, 1):
-            args = self.get_args(block, self.haz)
-            logging.info('Sending %d tasks', len(args))
-            smap = parallel.Starmap(classical, args, h5=self.datastore.hdf5)
-            smap.monitor.save('srcfilter', self.src_filter())
-            self.datastore.swmr_on()
-            smap.h5 = self.datastore.hdf5
-            pmaps = smap.reduce(self.agg_dicts)
-            logging.debug("busy time: %s", smap.busytime)
-            self.haz.store_disagg(pmaps)
+        args = self.get_args(grp_ids, self.haz)
+        logging.info('Sending %d tasks', len(args))
+        smap = parallel.Starmap(classical, args, h5=self.datastore.hdf5)
+        smap.monitor.save('srcfilter', self.src_filter())
+        self.datastore.swmr_on()
+        smap.h5 = self.datastore.hdf5
+        pmaps = smap.reduce(self.agg_dicts)
+        logging.debug("busy time: %s", smap.busytime)
+        self.haz.store_disagg(pmaps)
         if not oq.hazard_calculation_id:
             self.haz.store_disagg()
         self.store_info(psd)
         return True
 
     def store_info(self, psd):
+        """
+        Store full_lt, source_info and by_task
+        """
         self.store_rlz_info(self.rel_ruptures)
         source_ids = self.store_source_info(self.calc_times)
         if self.by_task:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -165,12 +165,12 @@ class PmapGetter(object):
                 pcurves[rlzi] |= c
         return pcurves
 
-    def get_hcurves(self, pmap, rlzs_by_gsim):  # in disagg_by_src
+    def get_hcurves(self, pmap, rlzs_by_gsim):  # used in in disagg_by_src
         """
-        :param pmap_by_et_id: a dictionary of ProbabilityMaps by group ID
+        :param pmap: a ProbabilityMap
+        :param rlzs_by_gsim: a dictionary gsim -> rlz IDs
         :returns: an array of PoEs of shape (N, R, M, L)
         """
-        self.init()
         res = numpy.zeros((self.N, self.R, self.L))
         for sid, pc in pmap.items():
             for gsim_idx, rlzis in enumerate(rlzs_by_gsim.values()):


### PR DESCRIPTION
Setting `dtype=dic` is necessary even if a warning in pandas 0.25 says that it is not used :-(
Also, some cleanup of unused code.