### PR TITLE
shakemaps: use relative paths

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -84,7 +84,7 @@ def urlextract(url, fname):
                 raise
 
 
-def parse_url_path(url):
+def path2url(url):
     """
     If a relative path is given for the file, parse it so it can be
     read with 'urlopen'.
@@ -95,7 +95,7 @@ def parse_url_path(url):
         if file.is_file():
             return 'file:{}'.format(pathname2url(str(file.absolute())))
         else:
-            raise RuntimeError(
+            raise FileNotFoundError(
                 'The following path could not be found: %s' % url)
     return url
 
@@ -106,14 +106,14 @@ get_array = CallableDict()
 @get_array.add('usgs_xml')
 def get_array_usgs_xml(kind, grid_url, uncertainty_url=None):
 
-    grid_url = parse_url_path(grid_url)
+    grid_url = path2url(grid_url)
 
     if uncertainty_url is None:
         with urlopen(grid_url) as f:
             return get_shakemap_array(f)
     else:
         with urlopen(grid_url) as f1, urlextract(
-                parse_url_path(uncertainty_url), 'uncertainty.xml') as f2:
+                path2url(uncertainty_url), 'uncertainty.xml') as f2:
             return get_shakemap_array(f1, f2)
 
 

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -21,8 +21,9 @@ https://earthquake.usgs.gov/scenario/product/shakemap-scenario/sclegacyshakeout2
 to numpy composite arrays.
 """
 
-from urllib.request import urlopen
+from urllib.request import urlopen, pathname2url
 import io
+import pathlib
 import logging
 import json
 import zipfile
@@ -83,17 +84,36 @@ def urlextract(url, fname):
                 raise
 
 
+def parse_url_path(url):
+    """
+    If a relative path is given for the file, parse it so it can be
+    read with 'urlopen'.
+    :param url: path/url to be parsed
+    """
+    if not url.startswith('file:') and not url.startswith('http'):
+        file = pathlib.Path(url)
+        if file.is_file():
+            return 'file:{}'.format(pathname2url(str(file.absolute())))
+        else:
+            raise RuntimeError(
+                'The following path could not be found: %s' % url)
+    return url
+
+
 get_array = CallableDict()
 
 
 @get_array.add('usgs_xml')
 def get_array_usgs_xml(kind, grid_url, uncertainty_url=None):
+
+    grid_url = parse_url_path(grid_url)
+
     if uncertainty_url is None:
         with urlopen(grid_url) as f:
             return get_shakemap_array(f)
     else:
         with urlopen(grid_url) as f1, urlextract(
-                uncertainty_url, 'uncertainty.xml') as f2:
+                parse_url_path(uncertainty_url), 'uncertainty.xml') as f2:
             return get_shakemap_array(f1, f2)
 
 


### PR DESCRIPTION
With this method it is possible to use different local pathnames for the shakemap files:

```
"grid_url": "shakemap_files/grid.xml"
"grid_url": "grid.xml"
"grid_url": /home/user/calculation/grid.xml
"grid_url": file:/home/user/calculation/grid.xml
```

`pathlib.Path` accepts relative and absolute paths, `pathname2url` makes sure it is converted into the right form to be used by `urlopen` independently from OS. 