### PR TITLE
Fixed bug in scenario_damage for few events

### DIFF
--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -175,8 +175,10 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         self.param['asset_damage_dt'] = self.crmodel.asset_damage_dt(
             oq.float_dmg_dist or num_floats)
         self.param['master_seed'] = oq.master_seed
-        self.param['num_events'] = numpy.bincount(  # events by rlz
-            self.datastore['events']['rlz_id'])
+        self.param['num_events'] = ne = numpy.bincount(  # events by rlz
+            self.datastore['events']['rlz_id'], minlength=self.R)
+        if (ne == 0).any():
+            logging.warning('There are realizations with zero events')
         self.datastore.create_dframe(
             'dd_data', self.param['asset_damage_dt'], 'gzip')
         self.riskinputs = self.build_riskinputs('gmf')


### PR DESCRIPTION
Was causing errors like the following:
```python
     File "/home/michele/oq-engine/openquake/calculators/scenario_damage.py", line 109, in scenario_damage
       ne = num_events[r]  # total number of events
   IndexError: index 87 is out of bounds for axis 0 with size 87
```