### PR TITLE
Fixed event_based_damage in absence of value-fields

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1217,8 +1217,10 @@ def save_agg_values(dstore, assetcol, lossnames, aggby):
     agg_number[K] = assetcol['number'].sum()
     dstore['agg_number'] = agg_number
     lst.append('*total*')
-    dstore['agg_values'] = assetcol.get_agg_values(lossnames, aggby)
-    dstore.set_shape_descr('agg_values', aggregation=lst, loss_type=lossnames)
+    if assetcol.get_value_fields():
+        dstore['agg_values'] = assetcol.get_agg_values(lossnames, aggby)
+        dstore.set_shape_descr(
+            'agg_values', aggregation=lst, loss_type=lossnames)
     return aggkey if aggby else {}
 
 

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import numpy
 import pandas
 
@@ -153,6 +154,7 @@ class DamageCalculator(EventBasedRiskCalculator):
 
     def post_execute(self, dummy):
         oq = self.oqparam
+        logging.info('Building aggregated curves')
         builder = get_loss_builder(self.datastore)
         alt_df = self.datastore.read_df('agg_loss_table')
         del alt_df['event_id']

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -489,6 +489,12 @@ class AssetCollection(object):
                 aval[array['ordinal'], lti] = array['value-' + lt]
         return aval
 
+    def get_value_fields(self):
+        """
+        :returns: list of fields starting with value-
+        """
+        return [f for f in self.array.dtype.names if f.startswith('value-')]
+
     def get_agg_values(self, loss_names, tagnames):
         """
         :param loss_names:


### PR DESCRIPTION
Avoids the error
```python
     File "/opt/openquake2/oq-engine/openquake/calculators/base.py", line 1220, in save_agg_values
       dstore['agg_values'] = assetcol.get_agg_values(lossnames, aggby)
     File "/opt/openquake2/oq-engine/openquake/risklib/asset.py", line 521, in get_agg_values
       agg_values[aggkey[key], :] = numpy.array(grp.sum())
   ValueError: could not broadcast input array from shape (0) into shape (1)
```
in the calculation for Cali with aggregate_by.