### PR TITLE
Made sure `oq zip` works with shapefiles

### DIFF
--- a/doc/adv-manual/risk-features.rst
+++ b/doc/adv-manual/risk-features.rst
@@ -207,15 +207,18 @@ instead of a `shakemap_id`::
          "uncertainty_url": "https://url.to/uncertainty.xml"
          }
 
-It is also possible to define absolute paths with`"file://absolute/path/to/file.xml"`, even if it is a BAD idea, since using absolute paths will make your calculation not portable across different machines.
+It is also possible to define absolute paths with
+``file://absolute/path/to/file.xml``, even if it is a BAD idea,
+since using absolute paths will make your calculation not portable
+across different machines.
 The files still have to be in the USGS ShakeMap format and either `*.xml` or 
 a `*.zip` file containing a valid xml file.
 
-Also starting from version 3.12 it is possible to use ESRI Shapefiles in the same
-manner as ShakeMaps. Polygons define areas with the same intensity levels and 
-assets/sites will be associated to a polygon if contained by the latter. Sites
-outside of a polygon will be discarded. Shapefile inputs can be specified similar
-to ShakeMaps::
+Also starting from version 3.12 it is possible to use ESRI Shapefiles
+in the same manner as ShakeMaps. Polygons define areas with the same
+intensity levels and assets/sites will be associated to a polygon if
+contained by the latter. Sites outside of a polygon will be
+discarded. Shapefile inputs can be specified similar to ShakeMaps::
 
    shakemap_uri = {
       "kind": "shapefile",

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -42,6 +42,7 @@ from openquake.qa_tests_data.event_based import (
     case_2, case_5, case_16, case_21)
 from openquake.qa_tests_data.event_based_risk import (
     case_master, case_1 as case_eb)
+from openquake.qa_tests_data.scenario_risk import case_shapefile
 from openquake.qa_tests_data.gmf_ebrisk import case_1 as ebrisk
 from openquake.server import manage, dbapi, dbserver
 from openquake.server.tests import data as test_data
@@ -399,6 +400,19 @@ class ZipTestCase(unittest.TestCase):
         dtemp = os.path.join(tempfile.mkdtemp(), 'inp')
         shutil.copytree(os.path.dirname(case_21.__file__), dtemp)
         sap.runline(f'openquake.commands zip {dtemp}')
+        shutil.rmtree(dtemp)
+
+    def test_shapefile(self):
+        # zipping shapefiles used for ShakeMaps
+        dtemp = os.path.join(tempfile.mkdtemp(), 'inp')
+        shutil.copytree(os.path.dirname(case_shapefile.__file__), dtemp)
+        sap.runline(f'openquake.commands zip {dtemp}')
+        job_zip = os.path.join(dtemp, 'job.zip')
+        names = sorted(zipfile.ZipFile(job_zip).namelist())
+        self.assertIn('shp/output.dbf', names)
+        self.assertIn('shp/output.prj', names)
+        self.assertIn('shp/output.shp', names)
+        self.assertIn('shp/output.shx', names)
         shutil.rmtree(dtemp)
 
 

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -406,7 +406,7 @@ class ZipTestCase(unittest.TestCase):
         # zipping shapefiles used for ShakeMaps
         dtemp = os.path.join(tempfile.mkdtemp(), 'inp')
         shutil.copytree(os.path.dirname(case_shapefile.__file__), dtemp)
-        sap.runline(f'openquake.commands zip {dtemp}')
+        sap.runline(f'openquake.commands zip {dtemp}/job.ini {dtemp}/job.zip')
         job_zip = os.path.join(dtemp, 'job.zip')
         names = sorted(zipfile.ZipFile(job_zip).namelist())
         self.assertIn('shp/output.dbf', names)

--- a/openquake/commonlib/oqzip.py
+++ b/openquake/commonlib/oqzip.py
@@ -97,9 +97,10 @@ def zip_job(job_ini, archive_zip='', risk_ini='', oq=None, log=logging.info):
     oq = oq or readinput.get_oqparam(job_ini, validate=False)
     if risk_ini:
         risk_ini = os.path.normpath(os.path.abspath(risk_ini))
-        risk_inputs = readinput.get_params(risk_ini)['inputs']
-        del risk_inputs['job_ini']
-        oq.inputs.update(risk_inputs)
+        oqr = readinput.get_oqparam(risk_ini)
+        del oqr.inputs['job_ini']
+        oq.inputs.update(oqr.inputs)
+        oq.shakemap_uri.update(oqr.shakemap_uri)
     files = readinput.get_input_files(oq)
     if risk_ini:
         files = [risk_ini] + files

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1158,9 +1158,14 @@ def get_input_files(oqparam, hazard=False):
     :returns: input path names in a specific order
     """
     fnames = set()  # files entering in the checksum
-    for key, fname in oqparam.shakemap_uri.items():
-        if key == 'fname':
-            fnames.update(get_shapefiles(os.path.dirname(fname)))
+    uri = oqparam.shakemap_uri
+    if isinstance(uri, dict) and uri:
+        if uri['kind'] == 'shapefile':
+            fnames.update(get_shapefiles(os.path.dirname(uri['fname'])))
+        else:  # xml local files
+            for key, val in uri.items():
+                if key.endswith('_url') and os.path.exists(val):
+                    fnames.add(val)
     for key in oqparam.inputs:
         fname = oqparam.inputs[key]
         if hazard and key not in ('source_model_logic_tree',

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1138,6 +1138,19 @@ def reduce_source_model(smlt_file, source_ids, remove=True):
     return good, total
 
 
+def get_shapefiles(dirname):
+    """
+    :param dirname: directory containing the shapefiles
+    :returns: list of shapefiles
+    """
+    out = []
+    extensions = ('.shp', '.dbf', '.prj', '.shx')
+    for fname in os.listdir(dirname):
+        if fname.endswith(extensions):
+            out.append(os.path.join(dirname, fname))
+    return out
+
+
 def get_input_files(oqparam, hazard=False):
     """
     :param oqparam: an OqParam instance
@@ -1145,6 +1158,9 @@ def get_input_files(oqparam, hazard=False):
     :returns: input path names in a specific order
     """
     fnames = set()  # files entering in the checksum
+    for key, fname in oqparam.shakemap_uri.items():
+        if key == 'fname':
+            fnames.update(get_shapefiles(os.path.dirname(fname)))
     for key in oqparam.inputs:
         fname = oqparam.inputs[key]
         if hazard and key not in ('source_model_logic_tree',

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1165,10 +1165,11 @@ def get_input_files(oqparam, hazard=False):
             fnames.update(get_shapefiles(os.path.dirname(fname)))
         else:  # xml local files
             for key, val in uri.items():
-                if key == 'fname':
-                    fnames.add(val)
-                elif key.endswith('_url') and os.path.exists(val):
-                    fnames.add(val)
+                if key == 'fname' or (
+                        key.endswith('_url') and os.path.exists(val)):
+                    fname = os.path.join(oqparam.base_path, val)
+                    uri[key] = fname
+                    fnames.add(fname)
     for key in oqparam.inputs:
         fname = oqparam.inputs[key]
         if hazard and key not in ('source_model_logic_tree',

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1161,7 +1161,8 @@ def get_input_files(oqparam, hazard=False):
     uri = oqparam.shakemap_uri
     if isinstance(uri, dict) and uri:
         if uri['kind'] == 'shapefile':
-            fnames.update(get_shapefiles(os.path.dirname(uri['fname'])))
+            fname = os.path.join(oqparam.base_path, uri['fname'])
+            fnames.update(get_shapefiles(os.path.dirname(fname)))
         else:  # xml local files
             for key, val in uri.items():
                 if key == 'fname':

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1164,7 +1164,9 @@ def get_input_files(oqparam, hazard=False):
             fnames.update(get_shapefiles(os.path.dirname(uri['fname'])))
         else:  # xml local files
             for key, val in uri.items():
-                if key.endswith('_url') and os.path.exists(val):
+                if key == 'fname':
+                    fnames.add(val)
+                elif key.endswith('_url') and os.path.exists(val):
                     fnames.add(val)
     for key in oqparam.inputs:
         fname = oqparam.inputs[key]

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -110,7 +110,6 @@ def get_array_shapefile(kind, fname):
     either a zip or the location of one of the files,
     *.shp and *.dbf are necessary, *.prj and *.shx optional
     """
-
     fname = path2url(fname)
 
     extensions = ['shp', 'dbf', 'prj', 'shx']
@@ -158,7 +157,9 @@ def get_array_shapefile(kind, fname):
 
 @get_array.add('usgs_xml')
 def get_array_usgs_xml(kind, grid_url, uncertainty_url=None):
-
+    """
+    Read a ShakeMap in XML format from the local file system
+    """
     grid_url = path2url(grid_url)
 
     if uncertainty_url is None:
@@ -172,7 +173,9 @@ def get_array_usgs_xml(kind, grid_url, uncertainty_url=None):
 
 @get_array.add('usgs_id')
 def get_array_usgs_id(kind, usgs_id):
-
+    """
+    Download a ShakeMap from the USGS site
+    """
     url = SHAKEMAP_URL.format(usgs_id)
     logging.info('Downloading %s', url)
     contents = json.loads(urlopen(url).read())[
@@ -188,7 +191,9 @@ def get_array_usgs_id(kind, usgs_id):
 
 @get_array.add('file_npy')
 def get_array_file_npy(kind, fname):
-
+    """
+    Read a ShakeMap in .npy format from the local file system
+    """
     return numpy.load(fname)
 
 

--- a/openquake/qa_tests_data/scenario_risk/case_shakemap/job.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_shakemap/job.ini
@@ -3,5 +3,5 @@ description = Download ShakeMap and prepare GMFs
 calculation_mode = scenario_risk
 random_seed = 152
 number_of_ground_motion_fields = 3
-shakemap_file = usp000fjta.npy
+shakemap_uri = {"kind": "file_npy", "fname": "usp000fjta.npy"}
 asset_hazard_distance = 20


### PR DESCRIPTION
`oq zip` was broken by https://github.com/gem/oq-engine/pull/6700 by @schmidni 

NB: a test with local files
```
   shakemap_uri = {
         "kind": "usgs_xml",
         "grid_url": "relative/path/file.xml",
         "uncertainty_url": "relative/path/file.xml"
      }
```
is still missing. Also is missing a test with

```python
   shakemap_uri = {
         "kind": "file_npy",
         "fname": "relative/path/file.npy",
      }
```
as well as tests with `file:///`