### PR TITLE
Stopped pandas from converting nan in numpy.nan

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -802,7 +802,7 @@ def _read_csv(fileobj, compositedt):
         if dt.kind == 'S':  # limit of the length of byte-fields
             conv[name] = check_length(name, dt.itemsize)
     df = pandas.read_csv(fileobj, names=compositedt.names, converters=conv,
-                         dtype=dic)
+                         dtype=dic, keep_default_na=False)
     arr = numpy.zeros(len(df), compositedt)
     for col in df.columns:
         arr[col] = df[col].to_numpy()

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -802,7 +802,7 @@ def _read_csv(fileobj, compositedt):
         if dt.kind == 'S':  # limit of the length of byte-fields
             conv[name] = check_length(name, dt.itemsize)
     df = pandas.read_csv(fileobj, names=compositedt.names, converters=conv,
-                         dtype=dic, keep_default_na=False)
+                         dtype=dic, keep_default_na=False, na_filter=False)
     arr = numpy.zeros(len(df), compositedt)
     for col in df.columns:
         arr[col] = df[col].to_numpy()


### PR DESCRIPTION
Even in string fields! Fortunately, engine < 3.12 used csv.reader and not pandas, so the bug is only in current master.