### PR TITLE
Added an utility csm2rup

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -31,7 +31,7 @@ import pandas
 from openquake.baselib import (
     general, hdf5, __version__ as engine_version)
 from openquake.baselib import parallel, python3compat
-from openquake.baselib.performance import Monitor, init_performance
+from openquake.baselib.performance import Monitor
 from openquake.hazardlib import InvalidFile, site, stats
 from openquake.hazardlib.site_amplification import Amplifier
 from openquake.hazardlib.site_amplification import AmplFunction
@@ -158,7 +158,6 @@ class BaseCalculator(metaclass=abc.ABCMeta):
     def __init__(self, oqparam, calc_id):
         oqparam.validate()
         self.datastore = datastore.new(calc_id)
-        init_performance(self.datastore.hdf5)
         self._monitor = Monitor(
             '%s.run' % self.__class__.__name__, measuremem=True,
             h5=self.datastore)

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -265,6 +265,7 @@ class DataStore(collections.abc.MutableMapping):
             raise IOError('File not found: %s' % self.filename)
         self.hdf5 = ()  # so that `key in self.hdf5` is valid
         self.open(self.mode)
+        performance.init_performance(self.hdf5)
 
     def open(self, mode):
         """

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -175,7 +175,7 @@ cross_correlation:
 description:
   A string describing the calculation.
   Example: *description = Test calculation*.
-  Default: no default
+  Default: "no description"
 
 disagg_by_src:
   Flag used to enable disaggregation by source when possible.
@@ -723,7 +723,7 @@ class OqParam(valid.ParamSet):
     cross_correlation = valid.Param(valid.Choice('yes', 'no', 'full'), 'yes')
     cholesky_limit = valid.Param(valid.positiveint, 10_000)
     cachedir = valid.Param(valid.utf8, '')
-    description = valid.Param(valid.utf8_not_empty)
+    description = valid.Param(valid.utf8_not_empty, "no description")
     disagg_by_src = valid.Param(valid.boolean, False)
     disagg_outputs = valid.Param(valid.disagg_outputs,
                                  list(calc.disagg.pmf_map))

--- a/utils/csm2rup
+++ b/utils/csm2rup
@@ -7,7 +7,7 @@ import pandas
 from openquake.baselib import sap, parallel, general, hdf5
 from openquake.commonlib import readinput, datastore, logs
 
-MAX_RUPS_PER_SOURCE = 1_000_000
+MAX_RUPS_PER_SOURCE = 1_000_000_000
 rupfields = dict(
     mag=numpy.float32,
     occurrence_rate=numpy.float32,
@@ -64,10 +64,14 @@ def main(job_ini):
     """
     Convert a composite source model into a DataFrame of ruptures
     """
-    dstore = datastore.new("job")
-    dstore["oqparam"] = oq = readinput.get_oqparam(job_ini)
+    job_id = datastore.init("job")
+    oq = readinput.get_oqparam(job_ini)
+    dstore = datastore.new(job_id, oq)
     csm = readinput.get_composite_source_model(oq)
-    csm2rup(csm, dstore)
+    try:
+        csm2rup(csm, dstore)
+    finally:
+        parallel.Starmap.shutdown()
     nrups = len(dstore['rup/mag'])
     size = general.humansize(os.path.getsize(dstore.filename))
     logging.info('Stored {:_d} ruptures [{}] inside {}'.format(

--- a/utils/csm2rup
+++ b/utils/csm2rup
@@ -35,7 +35,8 @@ def build_rupdict(srcs, mon):
             dic['hypo_dep'].append(rup.hypocenter.z)
             dic['grp_id'].append(src.grp_id)
             dic['rup_id'].append(src.id * TWO32 + rupno)
-    return dic
+    return {k: rupfields[k](v) for k, v in dic.items()}
+
 
 
 def csm2rup(csm, dstore):
@@ -49,14 +50,18 @@ def csm2rup(csm, dstore):
         else:
             return 1
     sources = csm.get_sources()
-    dic = parallel.Starmap.apply(
+    rupdicts = parallel.Starmap.apply(
         build_rupdict, (sources,), weight=src_weight,
         key=operator.attrgetter('grp_id'), h5=dstore,
-        concurrent_tasks=1000,
-    ).reduce()
-    df = pandas.DataFrame(
-        {k: rupfields[k](v) for k, v in dic.items()})
-    dstore.create_df('rup', df, compression='gzip')  # 10x gain!
+        concurrent_tasks=1000)
+    dic = {}
+    for rupdict in rupdicts:
+        for k, v in rupdict.items():
+            if k in dic:
+                dic[k] = numpy.concatenate([dic[k], v])
+            else:
+                dic[k] = v
+    dstore.create_df('rup', dic.items(), compression='gzip')  # 10x gain!
 
 
 def main(job_ini):

--- a/utils/csm2rup
+++ b/utils/csm2rup
@@ -68,7 +68,8 @@ def main(job_ini):
     csm2rup(csm, dstore)
     nrups = len(dstore['rup/mag'])
     size = general.humansize(os.path.getsize(dstore.filename))
-    logging.info('Stored %d ruptures [%s] inside %s', nrups, size, dstore)
+    logging.info('Stored {:_d} ruptures [{}] inside {}'.format(
+        nrups, size, dstore.filename))
 
 
 if __name__ == '__main__':

--- a/utils/csm2rup
+++ b/utils/csm2rup
@@ -4,10 +4,10 @@ import logging
 import operator
 import numpy
 import pandas
-from openquake.baselib import sap, parallel, general
+from openquake.baselib import sap, parallel, general, hdf5
 from openquake.commonlib import readinput, datastore, logs
 
-TWO32 = 2 ** 32
+MAX_RUPS_PER_SOURCE = 1_000_000
 rupfields = dict(
     mag=numpy.float32,
     occurrence_rate=numpy.float32,
@@ -28,13 +28,14 @@ def build_rupdict(srcs, mon):
     dic = {f: [] for f in rupfields}
     for src in srcs:
         for rupno, rup in enumerate(src.iter_ruptures()):
+            assert rupno < MAX_RUPS_PER_SOURCE
             dic['mag'].append(rup.mag)
             dic['occurrence_rate'].append(rup.occurrence_rate)
             dic['hypo_lon'].append(rup.hypocenter.x)
             dic['hypo_lat'].append(rup.hypocenter.y)
             dic['hypo_dep'].append(rup.hypocenter.z)
             dic['grp_id'].append(src.grp_id)
-            dic['rup_id'].append(src.id * TWO32 + rupno)
+            dic['rup_id'].append(src.id * MAX_RUPS_PER_SOURCE + rupno)
     return {k: rupfields[k](v) for k, v in dic.items()}
 
 
@@ -50,18 +51,13 @@ def csm2rup(csm, dstore):
         else:
             return 1
     sources = csm.get_sources()
-    rupdicts = parallel.Starmap.apply(
-        build_rupdict, (sources,), weight=src_weight,
-        key=operator.attrgetter('grp_id'), h5=dstore,
-        concurrent_tasks=1000)
-    dic = {}
-    for rupdict in rupdicts:
+    dstore.create_df('rup', rupfields.items(), compression='gzip')  # 10x gain!
+    for rupdict in parallel.Starmap.apply(
+            build_rupdict, (sources,), weight=src_weight,
+            key=operator.attrgetter('grp_id'), h5=dstore,
+            concurrent_tasks=1000):
         for k, v in rupdict.items():
-            if k in dic:
-                dic[k] = numpy.concatenate([dic[k], v])
-            else:
-                dic[k] = v
-    dstore.create_df('rup', dic.items(), compression='gzip')  # 10x gain!
+            hdf5.extend(dstore[f'rup/{k}'], v)
 
 
 def main(job_ini):

--- a/utils/csm2rup
+++ b/utils/csm2rup
@@ -51,7 +51,8 @@ def csm2rup(csm, dstore):
     sources = csm.get_sources()
     dic = parallel.Starmap.apply(
         build_rupdict, (sources,), weight=src_weight,
-        key=operator.attrgetter('grp_id'), h5=dstore
+        key=operator.attrgetter('grp_id'), h5=dstore,
+        concurrent_tasks=1000,
     ).reduce()
     df = pandas.DataFrame(
         {k: rupfields[k](v) for k, v in dic.items()})

--- a/utils/csm2rup
+++ b/utils/csm2rup
@@ -5,7 +5,7 @@ import operator
 import numpy
 import pandas
 from openquake.baselib import sap, parallel, general
-from openquake.commonlib import readinput, datastore
+from openquake.commonlib import readinput, datastore, logs
 
 TWO32 = 2 ** 32
 rupfields = dict(
@@ -21,6 +21,10 @@ rupfields = dict(
 
 
 def build_rupdict(srcs, mon):
+    """
+    :param srcs: a list of sources of the same source group
+    :param mon: a Monitor instance (used to save performance info)
+    """
     dic = {f: [] for f in rupfields}
     for src in srcs:
         for rupno, rup in enumerate(src.iter_ruptures()):
@@ -58,15 +62,14 @@ def main(job_ini):
     """
     Convert a composite source model into a DataFrame of ruptures
     """
-    oq = readinput.get_oqparam(job_ini)
+    dstore = datastore.new("job")
+    dstore["oqparam"] = oq = readinput.get_oqparam(job_ini)
     csm = readinput.get_composite_source_model(oq)
-    with datastore.new('job', oq) as dstore:
-        csm2rup(csm, dstore)
-        nrups = len(dstore['rup/mag'])
+    csm2rup(csm, dstore)
+    nrups = len(dstore['rup/mag'])
     size = general.humansize(os.path.getsize(dstore.filename))
     logging.info('Stored %d ruptures [%s] inside %s', nrups, size, dstore)
 
 
 if __name__ == '__main__':
-    # example: python csm2rup2.py classical/case_20/job.ini
     sap.run(main)

--- a/utils/csm2rup
+++ b/utils/csm2rup
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+import os
+import logging
+import operator
+import numpy
+import pandas
+from openquake.baselib import sap, parallel, general
+from openquake.commonlib import readinput, datastore
+
+TWO32 = 2 ** 32
+rupfields = dict(
+    mag=numpy.float32,
+    occurrence_rate=numpy.float32,
+    hypo_lon=numpy.float32,
+    hypo_lat=numpy.float32,
+    hypo_dep=numpy.float32,
+    grp_id=numpy.uint16,
+    rup_id=numpy.uint64,
+    # add more if you like
+)
+
+
+def build_rupdict(srcs, mon):
+    dic = {f: [] for f in rupfields}
+    for src in srcs:
+        for rupno, rup in enumerate(src.iter_ruptures()):
+            dic['mag'].append(rup.mag)
+            dic['occurrence_rate'].append(rup.occurrence_rate)
+            dic['hypo_lon'].append(rup.hypocenter.x)
+            dic['hypo_lat'].append(rup.hypocenter.y)
+            dic['hypo_dep'].append(rup.hypocenter.z)
+            dic['grp_id'].append(src.grp_id)
+            dic['rup_id'].append(src.id * TWO32 + rupno)
+    return dic
+
+
+def csm2rup(csm, dstore):
+    """
+    :param csm: CompositeSourceModel instance
+    :param dstore: DataStore where to save the ruptures
+    """
+    def src_weight(src):  # make point sources 100x lighter
+        if src.code == b'P':
+            return .01
+        else:
+            return 1
+    sources = csm.get_sources()
+    dic = parallel.Starmap.apply(
+        build_rupdict, (sources,), weight=src_weight,
+        key=operator.attrgetter('grp_id'), h5=dstore
+    ).reduce()
+    df = pandas.DataFrame(
+        {k: rupfields[k](v) for k, v in dic.items()})
+    dstore.create_df('rup', df, compression='gzip')  # 10x gain!
+
+
+def main(job_ini):
+    """
+    Convert a composite source model into a DataFrame of ruptures
+    """
+    oq = readinput.get_oqparam(job_ini)
+    csm = readinput.get_composite_source_model(oq)
+    with datastore.new('job', oq) as dstore:
+        csm2rup(csm, dstore)
+        nrups = len(dstore['rup/mag'])
+    size = general.humansize(os.path.getsize(dstore.filename))
+    logging.info('Stored %d ruptures [%s] inside %s', nrups, size, dstore)
+
+
+if __name__ == '__main__':
+    # example: python csm2rup2.py classical/case_20/job.ini
+    sap.run(main)


### PR DESCRIPTION
And a couple of minor improvements to the codebase. On my workstation I can process SHARE in 16 minutes, storing 51 MB of ruptures (vs 476 MB without compression). The number of ruptures is only 16_595_393 and geometries are not stored at all, only the hypocenters. The situation is a lot worse for Australia, that requires a cluster having 806_872_819 ruptures; it runs in ~3 hours. The good news is the compressed .hdf5 file requires only 2.28 GB.

The way to run the script on the cluster is
```
$ oq1 shell /opt/openquake/oq-engine/utils/csm2rup /path/to/job.ini 
```
NB: the script here has slow tasks, but it is good enough for experimentation purposes.