### PR TITLE
Fixed bug in ShakeMaps: the GMFs were stored in the wrong order

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -40,7 +40,7 @@ from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap.maps import get_sitecol_shakemap
 from openquake.hazardlib.shakemap.gmfs import to_gmfs
 from openquake.risklib import riskinput, riskmodels
-from openquake.commonlib import readinput, logictree, datastore, logs
+from openquake.commonlib import readinput, logictree, datastore
 from openquake.calculators.export import export as exp
 from openquake.calculators import getters
 
@@ -1283,8 +1283,8 @@ def read_shakemap(calc, haz_sitecol, assetcol):
         calc.datastore['events'] = events
         # convert into an array of dtype gmv_data_dt
         lst = [(sitecol.sids[s], ei) + tuple(gmfs[s, ei])
-               for s in numpy.arange(N, dtype=U32)
-               for ei, event in enumerate(events)]
+               for ei, event in enumerate(events)
+               for s in numpy.arange(N, dtype=U32)]
         oq.hazard_imtls = {str(imt): [0] for imt in imts}
         data = numpy.array(lst, oq.gmf_data_dt())
         create_gmf_data(calc.datastore, imts, data=data)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -382,7 +382,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         K = self.datastore['agg_loss_table'].attrs.get('K', 0)
         upper_limit = self.E * self.L * (K + 1)
         size = len(alt)
-        # assert size <= upper_limit, (size, upper_limit)
+        assert size <= upper_limit, (size, upper_limit)
         if oq.avg_losses:
             for r in range(self.R):
                 self.avg_losses[:, r] *= self.avg_ratio[r]


### PR DESCRIPTION
Discovered by @schmidni here: https://groups.google.com/g/openquake-users/c/zz5oaW7sV7I/m/SeIadfLdAwAJ
Added a sanity check to discover the issue immediately. The bug is minor since it does not affect engine 3.11.