### PR TITLE
Added a view over the branch IDs

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1051,3 +1051,17 @@ def view_composite_source_model(token, dstore):
         trts, sm_rlzs = numpy.divmod(trt_smrs[grp_id], n)
         lst.append((str(grp_id), to_str(trts), to_str(sm_rlzs), srcs))
     return numpy.array(lst, dt('grp_id trt smrs sources'))
+
+
+@view.add('branch_ids')
+def view_branch_ids(token, dstore):
+    """
+    Show the branch IDs
+    """
+    full_lt = dstore['full_lt']
+    tbl = []
+    for k, v in full_lt.source_model_lt.shortener.items():
+        tbl.append(('source_model_lt', k, v))
+    for k, v in full_lt.gsim_lt.shortener.items():
+        tbl.append(('gsim_lt', k, v))
+    return text_table(tbl, ['logic_tree', 'abbrev', 'branch_id'])

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1061,7 +1061,7 @@ def view_branch_ids(token, dstore):
     full_lt = dstore['full_lt']
     tbl = []
     for k, v in full_lt.source_model_lt.shortener.items():
-        tbl.append(('source_model_lt', k, v))
+        tbl.append(('source_model_lt', v, k))
     for k, v in full_lt.gsim_lt.shortener.items():
-        tbl.append(('gsim_lt', k, v))
+        tbl.append(('gsim_lt', v, k))
     return text_table(tbl, ['logic_tree', 'abbrev', 'branch_id'])


### PR DESCRIPTION
Requested by Peter Pazak. For instance for Canada one gets
```
$ oq show branch_ids
+-----------------+--------+-----------+
| logic_tree      | abbrev | branch_id |
+-----------------+--------+-----------+
| source_model_lt | 0      | b0        |
| source_model_lt | 1      | b1        |
| source_model_lt | 2      | b2        |
| source_model_lt | 3      | b3        |
| source_model_lt | 4      | b4        |
| source_model_lt | 5      | b5        |
| gsim_lt         | 0      | b31       |
| gsim_lt         | 1      | b32       |
| gsim_lt         | 2      | b33       |
| gsim_lt         | 3      | b11       |
| gsim_lt         | 4      | b12       |
| gsim_lt         | 5      | b13       |
| gsim_lt         | 6      | b61       |
| gsim_lt         | 7      | b62       |
| gsim_lt         | 8      | b63       |
| gsim_lt         | 9      | b71       |
| gsim_lt         | A      | b72       |
| gsim_lt         | B      | b73       |
| gsim_lt         | C      | b21       |
| gsim_lt         | D      | b22       |
| gsim_lt         | E      | b23       |
| gsim_lt         | F      | b41       |
| gsim_lt         | G      | b42       |
| gsim_lt         | H      | b43       |
| gsim_lt         | I      | b51       |
| gsim_lt         | J      | b52       |
| gsim_lt         | K      | b53       |
+-----------------+--------+-----------+
```