### PR TITLE
Fixed event_based_damage exporter

### DIFF
--- a/openquake/calculators/tests/event_based_damage_test.py
+++ b/openquake/calculators/tests/event_based_damage_test.py
@@ -20,7 +20,7 @@ import numpy
 
 from openquake.baselib.general import gettemp
 from openquake.qa_tests_data.event_based_damage import (
-    case_12, case_13, case_14)
+    case_11, case_12, case_13, case_14)
 from openquake.calculators.tests import CalculatorTestCase, strip_calc_id
 from openquake.calculators.export import export
 
@@ -38,6 +38,13 @@ class EventBasedDamageTestCase(CalculatorTestCase):
         for col in df.columns:
             df[col] = numpy.around(df[col])
         self.assertEqualFiles('expected/' + f2, gettemp(str(df)))
+
+    def test_case_11(self):
+        # test with double aggregate_by by Catalina
+        self.run_calc(case_11.__file__, 'job.ini')
+        [f1, f2] = export(('aggcurves', 'csv'), self.calc.datastore)
+        self.assertEqualFiles('expected/' + strip_calc_id(f1), f1, delta=1E-5)
+        self.assertEqualFiles('expected/' + strip_calc_id(f2), f2, delta=1E-5)
 
     def test_case_12a(self):
         # test event_based_damage, no aggregate_by

--- a/openquake/qa_tests_data/event_based_damage/case_11/assets.csv
+++ b/openquake/qa_tests_data/event_based_damage/case_11/assets.csv
@@ -1,0 +1,8 @@
+﻿id,lon,lat,taxonomy,number,structural,nonstructural,contents,day,night,transit,state,county,tract,city,zip
+a1,-122.000,38.113,tax1,7,10000,15000,5000,2000,4,6,California,Solano,252702,Suisun,94585
+a2,-122.114,38.113,tax2,6,20000,15000,5000,2000,4,6,California,Solano,252102,Benicia,94510
+a3,-122.570,38.113,tax1,5,30000,15000,5000,2000,4,6,California,Marin,102203,Novato,94945
+a4,-122.000,38.000,tax3,4,40000,15000,5000,2000,4,6,California,Contra Costa,355200,Concord,94519
+a5,-122.000,37.910,tax1,3,50000,15000,5000,2000,4,6,California,Contra Costa,338302,Walnut Creek,94598
+a6,-122.000,38.225,tax2,2,60000,15000,5000,2000,4,6,California,Solano,252702,Suisun,94585
+a7,-121.886,38.113,tax1,1,70000,15000,5000,2000,4,6,California,Solano,253500,Birds Landing,94512

--- a/openquake/qa_tests_data/event_based_damage/case_11/expected/aggcurves.csv
+++ b/openquake/qa_tests_data/event_based_damage/case_11/expected/aggcurves.csv
@@ -1,0 +1,20 @@
+#,,,,,,,,"generated_by='OpenQuake engine 3.12.0-git49693837bc', start_date='2021-05-12T16:24:41', checksum=1445836419, risk_investigation_time=1.0, num_events=4, effective_time=200.0, limit_states='ds1 ds2 ds3 ds4'"
+return_period,ds1,ds2,ds3,ds4,losses,county,taxonomy,loss_type
+50,3.90515E-02,0.00000E+00,0.00000E+00,7.59852E-02,8.78371E+02,Solano,tax1,structural
+100,1.81137E-01,0.00000E+00,0.00000E+00,1.12160E-01,1.16672E+03,Solano,tax1,structural
+200,2.92480E+00,4.07909E-02,0.00000E+00,3.38403E-01,3.77741E+03,Solano,tax1,structural
+50,4.84003E-01,1.80193E-01,2.75315E-02,3.46011E-03,1.77647E+03,Solano,tax2,structural
+100,4.84003E-01,1.80193E-01,2.75315E-02,3.46011E-03,1.77647E+03,Solano,tax2,structural
+200,7.93283E-01,4.92802E-01,1.55303E-01,4.67417E-02,9.63500E+03,Solano,tax2,structural
+50,2.44072E-02,0.00000E+00,0.00000E+00,4.74908E-02,9.41111E+02,Marin,tax1,structural
+100,2.44072E-02,0.00000E+00,0.00000E+00,4.74908E-02,9.41111E+02,Marin,tax1,structural
+200,2.44072E-02,0.00000E+00,0.00000E+00,4.74908E-02,9.41111E+02,Marin,tax1,structural
+50,1.46443E-02,0.00000E+00,0.00000E+00,2.84945E-02,9.41111E+02,Contra Costa,tax1,structural
+100,1.46443E-02,0.00000E+00,0.00000E+00,2.84945E-02,9.41111E+02,Contra Costa,tax1,structural
+200,1.46443E-02,0.00000E+00,0.00000E+00,2.84945E-02,9.41111E+02,Contra Costa,tax1,structural
+50,9.26098E-02,6.97632E-02,8.82354E-04,6.96218E-05,6.07736E+02,Contra Costa,tax3,structural
+100,9.26098E-02,6.97632E-02,8.82354E-04,6.96218E-05,6.07736E+02,Contra Costa,tax3,structural
+200,8.25671E-01,1.18986E+00,3.08145E-01,8.61940E-02,1.50870E+04,Contra Costa,tax3,structural
+50,6.54716E-01,2.49956E-01,2.84138E-02,1.55500E-01,5.14480E+03,*total*,*total*,structural
+100,1.52986E+00,6.03356E-01,1.56185E-01,2.77800E-01,1.59024E+04,*total*,*total*,structural
+200,3.84974E+00,1.37006E+00,3.35676E-01,4.61200E-01,1.99124E+04,*total*,*total*,structural

--- a/openquake/qa_tests_data/event_based_damage/case_11/expected/dmgcsq.csv
+++ b/openquake/qa_tests_data/event_based_damage/case_11/expected/dmgcsq.csv
@@ -1,0 +1,8 @@
+#,,,,,,,,,"generated_by='OpenQuake engine 3.12.0-git49693837bc', start_date='2021-05-12T16:24:41', checksum=1445836419, risk_investigation_time=1.0, num_events=4, effective_time=200.0, limit_states='ds1 ds2 ds3 ds4'"
+number,nodamage,ds1,ds2,ds3,ds4,losses,county,taxonomy,loss_type
+8,1.40863E-01,1.59202E-02,2.03955E-04,0.00000E+00,3.01267E-03,3.35044E+01,Solano,tax1,structural
+8,1.42132E-01,1.12265E-02,5.16691E-03,1.18948E-03,2.85610E-04,7.48220E+01,Solano,tax2,structural
+5,9.85620E-02,4.88144E-04,0.00000E+00,0.00000E+00,9.49815E-04,1.88222E+01,Marin,tax1,structural
+3,5.91372E-02,2.92886E-04,0.00000E+00,0.00000E+00,5.69889E-04,1.88222E+01,Contra Costa,tax1,structural
+4,6.55008E-02,5.51750E-03,6.99577E-03,1.55396E-03,4.32014E-04,8.45511E+01,Contra Costa,tax3,structural
+28,5.06195E-01,3.34452E-02,1.23666E-02,2.74344E-03,5.25000E-03,2.30522E+02,*total*,*total*,structural

--- a/openquake/qa_tests_data/event_based_damage/case_11/exposure_model.xml
+++ b/openquake/qa_tests_data/event_based_damage/case_11/exposure_model.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<nrml xmlns:gml="http://www.opengis.net/gml" 
+      xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<exposureModel id="exp1" category="buildings">
+  <description>Multiple assets example</description>
+  <conversions>
+    <area type="per_asset" unit="SQM" />
+    <costTypes>
+      <costType name="structural" type="per_asset" unit="USD" />
+      <costType name="nonstructural" type="per_asset" unit="USD" />
+      <costType name="contents" type="per_asset" unit="USD" />
+    </costTypes>
+  </conversions>
+  <tagNames>state county tract city zip</tagNames>
+  
+  <assets>
+    assets.csv
+  </assets>
+</exposureModel>
+
+</nrml>

--- a/openquake/qa_tests_data/event_based_damage/case_11/gsim_logic_tree.xml
+++ b/openquake/qa_tests_data/event_based_damage/case_11/gsim_logic_tree.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<logicTree logicTreeID='lt1'>
+  <logicTreeBranchingLevel branchingLevelID="bl1">
+    <logicTreeBranchSet uncertaintyType="gmpeModel" 
+                        branchSetID="bs1" 
+                        applyToTectonicRegionType="Active Shallow Crust">
+
+      <logicTreeBranch branchID="b1">
+        <uncertaintyModel>BooreAtkinson2008</uncertaintyModel>
+        <uncertaintyWeight>1.0</uncertaintyWeight>
+      </logicTreeBranch>
+
+  </logicTreeBranchSet>
+  </logicTreeBranchingLevel>
+</logicTree>
+
+</nrml>

--- a/openquake/qa_tests_data/event_based_damage/case_11/job.ini
+++ b/openquake/qa_tests_data/event_based_damage/case_11/job.ini
@@ -1,0 +1,53 @@
+[general]
+description = event based damage Case_1b
+calculation_mode = event_based_damage
+random_seed = 24
+
+[sites]
+exposure_file = exposure_model.xml
+
+[site_params]
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 5.0
+reference_depth_to_1pt0km_per_sec = 100.0
+
+[erf]
+width_of_mfd_bin = 0.1
+rupture_mesh_spacing = 2.0
+area_source_discretization = 10
+
+[logic_trees]
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gsim_logic_tree.xml
+
+[correlation]
+ground_motion_correlation_model = JB2009
+ground_motion_correlation_params = {"vs30_clustering": True}
+
+[hazard_calculation]
+truncation_level = 3
+maximum_distance = 200.0
+investigation_time = 1
+number_of_logic_tree_samples = 0
+ses_per_logic_tree_path = 200
+
+[hazard_outputs]
+mean = False
+quantiles = 0.50
+intensity_measure_types_and_levels = {
+    'PGA': logscale(0.005, 2.0, 20),
+    'SA(0.1)': logscale(0.005, 2.0, 20),
+    'SA(0.3)': logscale(0.005, 2.0, 20),
+    'SA(0.6)': logscale(0.005, 2.0, 20),}
+
+[fragility]
+structural_fragility_file = structural_fragility_model.xml
+
+[consequence]
+structural_consequence_file = structural_consequence_model.xml
+
+[risk_calculation]
+risk_investigation_time = 1
+asset_correlation = 0
+aggregate_by = county, taxonomy

--- a/openquake/qa_tests_data/event_based_damage/case_11/source_model.xml
+++ b/openquake/qa_tests_data/event_based_damage/case_11/source_model.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+
+<sourceModel name="source1">
+  <simpleFaultSource id="1" name="simple fault, trunc gr mfd" tectonicRegion="Active Shallow Crust">
+    <simpleFaultGeometry>
+     
+      <gml:LineString>
+        <gml:posList>
+          -122.0000 38.0000
+          -122.0000 38.2248
+        </gml:posList>
+      </gml:LineString>
+      
+      <dip>90.0</dip>
+      <upperSeismoDepth>0.0</upperSeismoDepth>
+      <lowerSeismoDepth>12.0</lowerSeismoDepth>
+    </simpleFaultGeometry>
+    
+    <magScaleRel>WC1994</magScaleRel>
+    <ruptAspectRatio>2.0</ruptAspectRatio>
+    <truncGutenbergRichterMFD aValue="3.1292" bValue="0.9" minMag="5.0" maxMag="6.5" />
+    <rake>0.0</rake>
+
+  </simpleFaultSource>
+</sourceModel>
+
+</nrml>

--- a/openquake/qa_tests_data/event_based_damage/case_11/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/event_based_damage/case_11/source_model_logic_tree.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<logicTree logicTreeID="lt1">
+  <logicTreeBranchingLevel branchingLevelID="bl1">
+    <logicTreeBranchSet uncertaintyType="sourceModel"
+						branchSetID="bs1">
+      <logicTreeBranch branchID="b1">
+		<uncertaintyModel>source_model.xml</uncertaintyModel>
+		<uncertaintyWeight>1.0</uncertaintyWeight>
+      </logicTreeBranch>
+	</logicTreeBranchSet>
+  </logicTreeBranchingLevel>
+</logicTree>
+
+</nrml>

--- a/openquake/qa_tests_data/event_based_damage/case_11/structural_consequence_model.xml
+++ b/openquake/qa_tests_data/event_based_damage/case_11/structural_consequence_model.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<consequenceModel id="example" assetCategory="buildings" lossCategory="structural">
+
+  <description>ln cf | tax3 | zcov</description>
+  <limitStates>ds1 ds2 ds3 ds4</limitStates>
+
+  <consequenceFunction id="tax1" dist="LN">
+    <params ls="ds1" mean="0.04" stddev="0.00"/>
+    <params ls="ds2" mean="0.16" stddev="0.00"/>
+    <params ls="ds3" mean="0.32" stddev="0.00"/>
+    <params ls="ds4" mean="0.64" stddev="0.00"/>
+  </consequenceFunction>
+
+  <consequenceFunction id="tax2" dist="LN">
+    <params ls="ds1" mean="0.04" stddev="0.00"/>
+    <params ls="ds2" mean="0.16" stddev="0.00"/>
+    <params ls="ds3" mean="0.32" stddev="0.00"/>
+    <params ls="ds4" mean="0.64" stddev="0.00"/>
+  </consequenceFunction>
+
+  <consequenceFunction id="tax3" dist="LN">
+    <params ls="ds1" mean="0.04" stddev="0.00"/>
+    <params ls="ds2" mean="0.16" stddev="0.00"/>
+    <params ls="ds3" mean="0.32" stddev="0.00"/>
+    <params ls="ds4" mean="0.64" stddev="0.00"/>
+  </consequenceFunction>
+
+</consequenceModel>
+
+</nrml>

--- a/openquake/qa_tests_data/event_based_damage/case_11/structural_fragility_model.xml
+++ b/openquake/qa_tests_data/event_based_damage/case_11/structural_fragility_model.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5">
+
+<fragilityModel id="fm1" assetCategory="buildings" lossCategory="structural">
+
+  <description>cont ff | tax3 | imt3 | nonzero miniml</description>
+  <limitStates>ds1 ds2 ds3 ds4</limitStates>
+
+  <fragilityFunction id="tax1" format="continuous" shape="logncdf">
+    <imls imt="PGA" noDamageLimit="0.0" minIML="0.3" maxIML="5.0"/>
+    <params ls="ds1" mean="0.50" stddev="0.10"/>
+    <params ls="ds2" mean="1.00" stddev="0.40"/>
+    <params ls="ds3" mean="1.50" stddev="0.90"/>
+    <params ls="ds4" mean="2.00" stddev="1.60"/>
+  </fragilityFunction>
+
+  <fragilityFunction id="tax2" format="continuous" shape="logncdf">
+    <imls imt="SA(0.1)" noDamageLimit="0.0" minIML="0.3" maxIML="5.0"/>
+    <params ls="ds1" mean="1.00" stddev="0.80"/>
+    <params ls="ds2" mean="1.50" stddev="1.20"/>
+    <params ls="ds3" mean="2.50" stddev="2.00"/>
+    <params ls="ds4" mean="4.00" stddev="3.20"/>
+  </fragilityFunction>
+
+  <fragilityFunction id="tax3" format="continuous" shape="logncdf">
+    <imls imt="SA(0.3)" noDamageLimit="0.0" minIML="0.3" maxIML="5.0"/>
+    <params ls="ds1" mean="1.20" stddev="0.90"/>
+    <params ls="ds2" mean="1.80" stddev="1.50"/>
+    <params ls="ds3" mean="3.00" stddev="2.00"/>
+    <params ls="ds4" mean="5.00" stddev="3.50"/>
+  </fragilityFunction>
+
+</fragilityModel>
+
+</nrml>


### PR DESCRIPTION
@CatalinaYepes signaled this error, happening for aggregations with zero damages:
```python
  File "/home/michele/oq-engine/openquake/calculators/export/risk.py", line 596, in export_aggcurves_csv
    dmg0 = agg_number * E * oq.time_ratio - dmgcsq[dmgs].to_numpy().sum(axis=1)
operands could not be broadcast together with shapes (10,) (6,) 
```
This is now fixed.