### PR TITLE
Fixed event_based_damage with no ruptures

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -51,10 +51,6 @@ SOURCE_ID = stochastic.rupture_dt['source_id']
 memoized = lru_cache()
 
 
-class NotFound(Exception):
-    pass
-
-
 def lit_eval(string):
     """
     `ast.literal_eval` the string if possible, otherwise returns it unchanged
@@ -521,12 +517,14 @@ def extract_sources(dstore, what):
         logging.info('Extracting sources with ids: %s', source_ids)
         info = info[numpy.isin(info['source_id'], source_ids)]
         if len(info) == 0:
-            raise NotFound('There is no source with id %s' % source_ids)
+            raise getters.NotFound(
+                'There is no source with id %s' % source_ids)
     if codes is not None:
         logging.info('Extracting sources with codes: %s', codes)
         info = info[numpy.isin(info['code'], codes)]
         if len(info) == 0:
-            raise NotFound('There is no source with code in %s' % codes)
+            raise getters.NotFound(
+                'There is no source with code in %s' % codes)
     for code, rows in general.group_array(info, 'code').items():
         if limit < len(rows):
             logging.info('Code %s: extracting %d sources out of %s',

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -478,7 +478,7 @@ class RuptureGetter(object):
     def num_ruptures(self):
         return len(self.proxies)
 
-    def get_rupdict(self):  # used in extract_rupture_info
+    def get_rupdict(self):  # used in extract_event_info and show rupture
         """
         :returns: a dictionary with the parameters of the rupture
         """
@@ -488,6 +488,7 @@ class RuptureGetter(object):
             rupgeoms = dstore['rupgeoms']
             rec = self.proxies[0].rec
             geom = rupgeoms[rec['id']]
+            # duplicating rupture._get_rupture
             num_surfaces = int(geom[0])
             start = 2 * num_surfaces + 1
             dic['lons'], dic['lats'], dic['deps'] = [], [], []

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -35,6 +35,10 @@ code2cls = BaseRupture.init()
 weight = operator.attrgetter('weight')
 
 
+class NotFound(Exception):
+    pass
+
+
 def build_stat_curve(poes, imtls, stat, weights):
     """
     Build statistics by taking into account IMT-dependent weights
@@ -402,6 +406,8 @@ def get_rupture_getters(dstore, ct=0, slc=slice(None), srcfilter='infer'):
     full_lt = dstore['full_lt']
     rlzs_by_gsim = full_lt.get_rlzs_by_gsim()
     rup_array = dstore['ruptures'][slc]
+    if len(rup_array) == 0:
+        raise NotFound('There are no ruptures in %s' % dstore)
     rup_array.sort(order='trt_smr')  # avoid generating too many tasks
     scenario = 'scenario' in dstore['oqparam'].calculation_mode
     if srcfilter is None:

--- a/openquake/calculators/tests/event_based_damage_test.py
+++ b/openquake/calculators/tests/event_based_damage_test.py
@@ -22,6 +22,7 @@ from openquake.baselib.general import gettemp
 from openquake.qa_tests_data.event_based_damage import (
     case_11, case_12, case_13, case_14)
 from openquake.calculators.tests import CalculatorTestCase, strip_calc_id
+from openquake.calculators.getters import NotFound
 from openquake.calculators.export import export
 
 
@@ -50,6 +51,10 @@ class EventBasedDamageTestCase(CalculatorTestCase):
         # test event_based_damage, no aggregate_by
         self.run_calc(case_12.__file__, 'job_a.ini')
         self.check_damages('a_damage_table.txt', 'a_damages.txt')
+
+        # since there are not ruptures, exporting the ruptures is an error
+        with self.assertRaises(NotFound):
+            export(('ruptures', 'csv'), self.calc.datastore)
 
     def test_case_12b(self):
         # test event_based_damage, aggregate_by=taxonomy

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-import io
 import ast
 import os.path
 import numbers
@@ -36,8 +35,7 @@ from openquake.baselib.python3compat import encode, decode
 from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.commonlib import util
 from openquake.risklib.scientific import losses_by_period, return_periods
-from openquake.commonlib.writers import (
-    build_header, scientificformat, write_csv)
+from openquake.commonlib.writers import build_header, scientificformat
 from openquake.calculators.extract import extract
 
 F32 = numpy.float32
@@ -1064,4 +1062,4 @@ def view_branch_ids(token, dstore):
         tbl.append(('source_model_lt', v, k))
     for k, v in full_lt.gsim_lt.shortener.items():
         tbl.append(('gsim_lt', v, k))
-    return text_table(tbl, ['logic_tree', 'abbrev', 'branch_id'])
+    return numpy.array(tbl, dt('logic_tree abbrev branch_id'))

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -140,8 +140,9 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
         try:
             size_mb = dstore.getsize(key) / MB
         except (KeyError, AttributeError):
-            size_mb = None
-        keysize.append((key, size_mb))
+            size_mb = '?'
+        if size_mb:
+            keysize.append((key, size_mb))
     ds_size = dstore.getsize() / MB
     logs.dbcmd('create_outputs', dstore.calc_id, keysize, ds_size)
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -140,7 +140,7 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
         try:
             size_mb = dstore.getsize(key) / MB
         except (KeyError, AttributeError):
-            size_mb = '?'
+            size_mb = -1
         if size_mb:
             keysize.append((key, size_mb))
     ds_size = dstore.getsize() / MB


### PR DESCRIPTION
The ruptures output was exported even if empty and then an error was raised at export time.