### PR TITLE
Fixed extract/rupture_info

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1293,7 +1293,7 @@ def extract_rupture_info(dstore, what):
               ('strike', F32), ('dip', F32), ('rake', F32)]
     rows = []
     boundaries = []
-    for rgetter in getters.get_rupture_getters(dstore):
+    for rgetter in getters.get_rupture_getters(dstore, srcfilter=None):
         proxies = rgetter.get_proxies(min_mag)
         rup_data = RuptureData(rgetter.trt, rgetter.rlzs_by_gsim)
         for r in rup_data.to_array(proxies):


### PR DESCRIPTION
Fixes this error breaking QGIS:
```python
$ oq extract rupture_info -l
INFO:root:GET http://localhost:8800/v1/calc/8059/extract/oqparam
INFO:root:GET http://localhost:8800/v1/calc/8059/extract/rupture_info
Traceback (most recent call last):
  File "/home/michele/openquake/bin/oq", line 11, in <module>
    load_entry_point('openquake.engine', 'console_scripts', 'oq')()
  File "/home/michele/oq-engine/openquake/commands/__main__.py", line 50, in oq
    sap.run(commands, prog='oq')
  File "/home/michele/oq-engine/openquake/baselib/sap.py", line 225, in run
    return _run(parser(funcdict, **parserkw), argv)
  File "/home/michele/oq-engine/openquake/baselib/sap.py", line 216, in _run
    return func(**dic)
  File "/home/michele/oq-engine/openquake/commands/extract.py", line 39, in main
    aw = WebExtractor(calc_id, 'http://localhost:8800', '').get(what)
  File "/home/michele/oq-engine/openquake/calculators/extract.py", line 1452, in get
    raise WebAPIError(resp.text)
openquake.calculators.extract.WebAPIError: ValueError: signal only works in main thread in /v1/calc/8059/extract/rupture_info
  File "/home/michele/oq-engine/openquake/server/views.py", line 725, in extract
    obj = _extract(ds, what + query_string)
  File "/home/michele/oq-engine/openquake/calculators/extract.py", line 185, in __call__
    data = self[key](dstore, '')
  File "/home/michele/oq-engine/openquake/calculators/extract.py", line 1296, in extract_rupture_info
    for rgetter in getters.get_rupture_getters(dstore, srcfilter=None):
  File "/home/michele/oq-engine/openquake/calculators/getters.py", line 420, in get_rupture_getters
    proxies = parallel.Starmap.apply(
  File "/home/michele/oq-engine/openquake/baselib/parallel.py", line 718, in apply
    return cls(task, taskargs, distribute, progress, h5)
  File "/home/michele/oq-engine/openquake/baselib/parallel.py", line 722, in __init__
    self.__class__.init(distribute=distribute)
  File "/home/michele/oq-engine/openquake/baselib/parallel.py", line 657, in init
    term_handler = signal.signal(signal.SIGTERM, signal.SIG_DFL)
  File "/usr/lib/python3.8/signal.py", line 47, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
```