### PR TITLE
Do not store losses in the DamageCalculator

### DIFF
--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -127,6 +127,11 @@ class DamageCalculator(EventBasedRiskCalculator):
     accept_precalc = ['scenario', 'event_based',
                       'event_based_risk', 'event_based_damage']
 
+    def save_avg_losses(self):
+        """
+        Do nothing: there are no losses in the DamageCalculator
+        """
+
     def execute(self):
         """
         Compute risk from GMFs or ruptures depending on what is stored

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -290,7 +290,6 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             self.datastore.create_df(
                 'agg_loss_table', descr,
                 K=len(self.aggkey), L=len(oq.loss_names), limit_states=dmgs)
-        ws = self.datastore['weights']
         self.rlzs = self.datastore['events']['rlz_id']
         self.num_events = numpy.bincount(self.rlzs)  # events by rlz
         if oq.avg_losses:
@@ -303,6 +302,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
 
     def save_avg_losses(self):
         oq = self.oqparam
+        ws = self.datastore['weights']
         R = 1 if oq.collect_rlzs else len(ws)
         if oq.collect_rlzs:
             if oq.investigation_time:  # event_based
@@ -314,8 +314,8 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                 self.avg_ratio = numpy.array([oq.time_ratio] * len(ws))
             else:  # scenario
                 self.avg_ratio = 1. / self.num_events
-        self.avg_losses = numpy.zeros((A, R, L), F32)
-        self.datastore.create_dset('avg_losses-rlzs', F32, (A, R, L))
+        self.avg_losses = numpy.zeros((self.A, R, self.L), F32)
+        self.datastore.create_dset('avg_losses-rlzs', F32, (self.A, R, self.L))
         self.datastore.set_shape_descr(
             'avg_losses-rlzs', asset_id=self.assetcol['id'], rlz=R,
             loss_type=oq.loss_names)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -291,30 +291,34 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                 'agg_loss_table', descr,
                 K=len(self.aggkey), L=len(oq.loss_names), limit_states=dmgs)
         ws = self.datastore['weights']
-        R = 1 if oq.collect_rlzs else len(ws)
         self.rlzs = self.datastore['events']['rlz_id']
         self.num_events = numpy.bincount(self.rlzs)  # events by rlz
         if oq.avg_losses:
-            if oq.collect_rlzs:
-                if oq.investigation_time:  # event_based
-                    self.avg_ratio = numpy.array([oq.time_ratio / len(ws)])
-                else:  # scenario
-                    self.avg_ratio = numpy.array([1. / self.num_events.sum()])
-            else:
-                if oq.investigation_time:  # event_based
-                    self.avg_ratio = numpy.array([oq.time_ratio] * len(ws))
-                else:  # scenario
-                    self.avg_ratio = 1. / self.num_events
-            self.avg_losses = numpy.zeros((A, R, L), F32)
-            self.datastore.create_dset('avg_losses-rlzs', F32, (A, R, L))
-            self.datastore.set_shape_descr(
-                'avg_losses-rlzs', asset_id=self.assetcol['id'], rlz=R,
-                loss_type=oq.loss_names)
+            self.save_avg_losses()
         alt_nbytes = 4 * self.E * L
         if alt_nbytes / (oq.concurrent_tasks or 1) > TWO32:
-            raise RuntimeError('The event loss table is too big to be transfer'
-                               'red with %d tasks' % oq.concurrent_tasks)
+            raise RuntimeError('The agg_loss_table is too big to be transfer'
+                               'ed with %d tasks' % oq.concurrent_tasks)
         self.datastore.create_dset('gmf_info', gmf_info_dt)
+
+    def save_avg_losses(self):
+        oq = self.oqparam
+        R = 1 if oq.collect_rlzs else len(ws)
+        if oq.collect_rlzs:
+            if oq.investigation_time:  # event_based
+                self.avg_ratio = numpy.array([oq.time_ratio / len(ws)])
+            else:  # scenario
+                self.avg_ratio = numpy.array([1. / self.num_events.sum()])
+        else:
+            if oq.investigation_time:  # event_based
+                self.avg_ratio = numpy.array([oq.time_ratio] * len(ws))
+            else:  # scenario
+                self.avg_ratio = 1. / self.num_events
+        self.avg_losses = numpy.zeros((A, R, L), F32)
+        self.datastore.create_dset('avg_losses-rlzs', F32, (A, R, L))
+        self.datastore.set_shape_descr(
+            'avg_losses-rlzs', asset_id=self.assetcol['id'], rlz=R,
+            loss_type=oq.loss_names)
 
     def execute(self):
         """

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import os
-import logging
 from unittest import mock
 import numpy
 


### PR DESCRIPTION
Since there are no losses! Discovered by @CatalinaYepes, the engine was storing a dataset full of zeros. An accident of inheritance.