### PR TITLE
Changed the definition of average damage in event_based_damage

### DIFF
--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -214,10 +214,7 @@ class ScenarioDamageCalculator(base.RiskCalculator):
 
         # avg_ratio = ratio used when computing the averages
         oq = self.oqparam
-        if oq.investigation_time:  # event_based_damage
-            avg_ratio = numpy.array([oq.ses_ratio] * R)
-        else:  # scenario_damage
-            avg_ratio = 1. / self.param['num_events']
+        avg_ratio = 1. / self.param['num_events']
 
         # damage by asset
         d_asset = numpy.zeros((A, R, L, D), F32)

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-rlz-000.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-rlz-000.csv
@@ -1,6 +1,6 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.11.0-git6f08fb75b7', start_date='2021-02-04T05:32:27', checksum=3100364614, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.11.3-gitb8bc2e4a91', start_date='2021-05-19T05:47:24', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,policy,taxonomy,lon,lat,structural~no_damage,structural~LS1,structural~LS2
-a0,A,RM,81.29850,29.10980,1.850000E+00,5.000000E-01,5.000000E-01
-a1,A,RC,83.08230,27.90060,4.423000E+02,2.070000E+01,1.200000E+01
-a2,B,W,85.74770,27.90150,6.787000E+02,1.195000E+02,1.518000E+02
-a3,B,RM,85.74770,27.90150,6.350000E+00,1.400000E+00,1.750000E+00
+a0,A,RM,81.29850,29.10980,1.947368E+00,5.263158E-01,5.263158E-01
+a1,A,RC,83.08230,27.90060,4.655789E+02,2.178947E+01,1.263158E+01
+a2,B,W,85.74770,27.90150,7.144211E+02,1.257895E+02,1.597895E+02
+a3,B,RM,85.74770,27.90150,6.684210E+00,1.473684E+00,1.842105E+00

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-rlz-001.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-rlz-001.csv
@@ -1,6 +1,6 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.11.0-git6f08fb75b7', start_date='2021-02-04T05:32:27', checksum=3100364614, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.11.3-gitb8bc2e4a91', start_date='2021-05-19T05:47:24', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,policy,taxonomy,lon,lat,structural~no_damage,structural~LS1,structural~LS2
-a0,A,RM,81.29850,29.10980,2.950000E+00,4.000000E-01,1.000000E-01
-a1,A,RC,83.08230,27.90060,4.687500E+02,6.285000E+01,4.340000E+01
-a2,B,W,85.74770,27.90150,9.147000E+02,1.168000E+02,1.185000E+02
-a3,B,RM,85.74770,27.90150,8.850000E+00,1.450000E+00,1.200000E+00
+a0,A,RM,81.29850,29.10980,2.565217E+00,3.478261E-01,8.695652E-02
+a1,A,RC,83.08230,27.90060,4.076087E+02,5.465217E+01,3.773913E+01
+a2,B,W,85.74770,27.90150,7.953913E+02,1.015652E+02,1.030435E+02
+a3,B,RM,85.74770,27.90150,7.695652E+00,1.260870E+00,1.043478E+00


### PR DESCRIPTION
Currently when computing the average damage we multiply by `risk_investigation_time/effective_investigation_time`, similarly to what we do for event_based_risk when computing the average loss. But then the check

`sum of all damage states = number of buildings`

fails miserably. For instance for event_based_risk/case_1/job_damage.ini one gets for `avg_damages-rlz-001.csv`:
```
| asset |           ND |          LS1 |          LS2 |  number |
|-------+--------------+--------------+--------------+---------|
| a0    | 2.950000E+00 | 4.000000E-01 | 1.000000E-01 |    3.45 |
| a1    | 4.687500E+02 | 6.285000E+01 | 4.340000E+01 |    575. |
| a2    | 9.147000E+02 | 1.168000E+02 | 1.185000E+02 |   1150. |
| a3    | 8.850000E+00 | 1.450000E+00 | 1.200000E+00 |    11.5 |
| total |      1395.25 |        181.5 |        163.2 | 1739.95 |
```
The solution is to use the same definition we use for scenario_damage, i.e. divide by the number of events.
The trick is that different realizations have different number of events and then we can recapture the number of buildings which is lost if we divide by a global number for all realizations. After the change one gets
```
| asset |           ND |          LS1 |          LS2 |    number |
|-------+--------------+--------------+--------------+-----------|
| a0    | 2.565217E+00 | 3.478261E-01 | 8.695652E-02 |        3. |
| a1    | 4.076087E+02 | 5.465217E+01 | 3.773913E+01 |      500. |
| a2    | 7.953913E+02 | 1.015652E+02 | 1.030435E+02 |     1000. |
| a3    | 7.695652E+00 | 1.260870E+00 | 1.043478E+00 |       10. |
| total |    1213.2609 |    157.82607 |    141.91306 | 1513.0000 |
```
which is correct since a0, a1, a2 and a3 have respectively 3, 500, 1000 and 10 buildings each, as seen from the exposure.