### PR TITLE
Speedup by 14x the SURA calculation

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -84,7 +84,7 @@ def average_losses(ln, alt, rlz_id, AR, collect_rlzs):
     else:
         ldf = pandas.DataFrame(
             dict(aid=alt.aid.to_numpy(), loss=alt.loss.to_numpy(),
-                 rlz=rlz_id[alt.eid.to_numpy()]))
+                 rlz=rlz_id[U32(alt.eid)]))
         tot = ldf.groupby(['aid', 'rlz']).loss.sum()
         aids, rlzs = zip(*tot.index)
         return sparse.coo_matrix((tot.to_numpy(), (aids, rlzs)), AR)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -90,7 +90,7 @@ def average_losses(ln, alt, rlz_id, AR, collect_rlzs):
         return sparse.coo_matrix((tot.to_numpy(), (aids, rlzs)), AR)
 
 
-def split_df(df, cond, maxsize=1000):
+def split_df(df, cond=True, maxsize=1000):
     """
     :param df: a large dataframe
     :param cond: boolean condition for splitting

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -148,8 +148,7 @@ def event_based_risk(df, param, monitor):
                 yield crmodel.get_output(
                     taxo, asset_df, gmf_df, param['sec_losses'], rndgen)
             else:
-                yield from crmodel.gen_outputs(
-                    taxo, asset_df, gmf_df, param['sec_losses'])
+                yield from crmodel.gen_outputs(taxo, asset_df, gmf_df, param)
 
     return aggreg(outputs(), crmodel, AR, kids, rlz_id, param, monitor)
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -160,7 +160,8 @@ def event_based_risk(df, param, monitor):
             if len(gmf_df) == 0:
                 continue
             if rndgen:
-                yield ebr_slow(taxo, asset_df, gmf_df, crmodel, rndgen, param)
+                yield crmodel.get_output(
+                    taxo, asset_df, gmf_df, param['sec_losses'], rndgen)
             else:
                 ratios = crmodel.get_interp_ratios(taxo, gmf_df)  # fast
                 mal = crmodel.oqparam.minimum_asset_loss
@@ -168,16 +169,6 @@ def event_based_risk(df, param, monitor):
                     yield ebr_fast(adf, ratios, mal, param)
 
     return aggreg(outputs(), crmodel, AR, kids, rlz_id, param, monitor)
-
-
-def ebr_slow(taxo, asset_df, gmf_df, crmodel, rnd, param):
-    out = crmodel.get_output(taxo, asset_df, gmf_df, param['sec_losses'], rnd)
-    dic = {}
-    for ln in crmodel.oqparam.loss_names:
-        if ln not in out or len(out[ln]) == 0:
-            continue
-        dic[ln] = out[ln]
-    return dic
 
 
 def ebr_fast(asset_df, ratios, minimum_asset_loss, param):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -135,8 +135,7 @@ def event_based_risk(df, param, monitor):
         rndgen = None
     else:
         rndgen = MultiEventRNG(
-            param['master_seed'], numpy.unique(df.eid),
-            param['asset_correlation'])
+            param['master_seed'], df.eid.unique(), param['asset_correlation'])
 
     def outputs():
         for taxo, asset_df in assets_df.groupby('taxonomy'):

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -723,7 +723,8 @@ class CompositeRiskModel(collections.abc.Mapping):
             outs = []
             for rm in rmodels:
                 imt = rm.imt_by_lt[lt]
-                out = rm.interpolate(gmf_df, alias.get(imt, imt))
+                rf = rm.risk_functions[lt, 'vulnerability']
+                out = rf.interpolate(gmf_df, alias.get(imt, imt))
                 outs.append(out)
             dic[lt] = stats.average_df(outs, weights)
         return dic

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -728,7 +728,15 @@ class CompositeRiskModel(collections.abc.Mapping):
                 sec_loss.update(lt, dic, assets)
         return dic
 
+    # called by event_based_risk fast
     def gen_outputs(self, taxo, asset_df, gmf_df, param):
+        """
+        :param taxo: a taxonomy index
+        :param asset_df: a DataFrame of assets of the given taxonomy
+        :param gmf_df: a DataFrame of GMVs on the sites
+        :param param: a dictionary of extra parameters
+        :yields: dictionaries keyed by the loss type
+        """
         ratios = self.get_interp_ratios(taxo, gmf_df)  # fast
         minimum_asset_loss = self.oqparam.minimum_asset_loss
         for adf in split_df(asset_df):


### PR DESCRIPTION
Second part of https://github.com/gem/oq-engine/pull/6810. This solves the performance issue in current master in the case of many assets on the same site. It also reduces the memory occupation even more. The penalty in the case of few assets per site is minor. Here are the figures for the SURA calculation on cluster2:
```
# current master
| calc_41843, maxmem=10.7 GB   | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total event_based_risk       | 289_151  | 1_229     | 160     |
| averaging losses             | 8_671    | 0.0       | 197_465 |
| aggregating losses           | 3_033    | 0.0       | 197_465 |

# this branch
| calc_41851, maxmem=12.1 GB   | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total event_based_risk       | 20_849   | 671       | 160     |
| averaging losses             | 7_946    | 0.0       | 196_825 |
| aggregating losses           | 2_742    | 0.0       | 196_825 |
```
