### PR TITLE
Fixed bug in the average damages in 3.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a bug in event_based_damage producing slightly wrong average damages
   * Fixed the sanity check in event_based_damage giving false warnings
   * Fixed the corner case when there are zero events per realization in
     scenario_damage

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -315,6 +315,7 @@ def export_damages_csv(ekey, dstore):
         rit = oq.risk_investigation_time or oq.investigation_time
         md.update(dict(investigation_time=oq.investigation_time,
                        risk_investigation_time=rit))
+    if oq.calculation_mode == 'event_based_damage':
         rate = len(dstore['events']) * oq.ses_ratio / len(rlzs)
     else:
         rate = 1

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -23,11 +23,10 @@ import numpy
 import pandas
 
 from openquake.baselib import hdf5
-from openquake.hazardlib.stats import compute_stats, compute_stats2
+from openquake.hazardlib.stats import compute_stats2
 from openquake.risklib import scientific
 from openquake.calculators.extract import (
     extract, build_damage_dt, build_damage_array, sanitize)
-from openquake.calculators.views import view
 from openquake.calculators.export import export, loss_curves
 from openquake.calculators.export.hazard import savez
 from openquake.commonlib import writers
@@ -308,20 +307,17 @@ def export_damages_csv(ekey, dstore):
     oq = dstore['oqparam']
     dmg_dt = build_damage_dt(dstore)
     rlzs = dstore['full_lt'].get_realizations()
-    data = dstore['damages-rlzs']  # shape (A, R, L, D)
+    orig = dstore[ekey[0]]  # shape (A, R, L, D)
     writer = writers.CsvWriter(fmt='%.6E')
     assets = get_assets(dstore)
     md = dstore.metadata
     if oq.investigation_time:
+        rit = oq.risk_investigation_time or oq.investigation_time
         md.update(dict(investigation_time=oq.investigation_time,
-                       risk_investigation_time=oq.risk_investigation_time))
-    event_rates = view('event_rates', dstore)
-    data = numpy.array(
-        [data[:, r] * event_rates[r] for r in range(len(rlzs))])  # shape RALD
+                       risk_investigation_time=rit))
+    rate = len(dstore['events']) * oq.ses_ratio / len(rlzs)
     if ekey[0].endswith('stats'):
         rlzs_or_stats = oq.hazard_stats()
-        ws = dstore['weights'][:]
-        data = compute_stats(data, rlzs_or_stats.values(), ws)
     else:
         rlzs_or_stats = ['rlz-%03d' % r for r in range(len(rlzs))]
     name = ekey[0].split('-')[0]
@@ -329,9 +325,9 @@ def export_damages_csv(ekey, dstore):
         name = 'avg_' + name
     for i, ros in enumerate(rlzs_or_stats):
         if oq.modal_damage_state:
-            damages = modal_damage_array(data[i], dmg_dt)
+            damages = modal_damage_array(orig[:, i] * rate, dmg_dt)
         else:
-            damages = build_damage_array(data[i], dmg_dt)
+            damages = build_damage_array(orig[:, i] * rate, dmg_dt)
         fname = dstore.build_fname(name, ros, ekey[1])
         writer.save(compose_arrays(assets, damages), fname,
                     comment=md, renamedict=dict(id='asset_id'))

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -315,7 +315,9 @@ def export_damages_csv(ekey, dstore):
         rit = oq.risk_investigation_time or oq.investigation_time
         md.update(dict(investigation_time=oq.investigation_time,
                        risk_investigation_time=rit))
-    rate = len(dstore['events']) * oq.ses_ratio / len(rlzs)
+        rate = len(dstore['events']) * oq.ses_ratio / len(rlzs)
+    else:
+        rate = 1
     if ekey[0].endswith('stats'):
         rlzs_or_stats = oq.hazard_stats()
     else:

--- a/openquake/calculators/scenario_damage.py
+++ b/openquake/calculators/scenario_damage.py
@@ -271,7 +271,6 @@ class ScenarioDamageCalculator(base.RiskCalculator):
         """
         Sanity check on the total number of buildings
         """
-        E0 = self.param['num_events'][0]
         avg0 = self.datastore['damages-rlzs'][:, 0].sum(axis=0)  # (L, D)
         if not len(self.datastore['dd_data/aid']):
             logging.warning('There is no damage at all!')
@@ -281,9 +280,6 @@ class ScenarioDamageCalculator(base.RiskCalculator):
             rst = views.rst_table(df)
             logging.info('Portfolio damage\n%s' % rst)
         num_buildings = avg0.sum(axis=1)
-        if self.oqparam.investigation_time:  # event_based_damage
-            # N = avg * T / E
-            num_buildings /= self.oqparam.ses_ratio * E0
         expected = self.assetcol['number'].sum()
         nums = set(num_buildings) | {expected}
         if len(nums) > 1:

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -957,7 +957,7 @@ def view_event_rates(token, dstore):
     """
     Show the number of events per realization multiplied by risk_time/eff_time
     """
-    oq = dstore['oqparam']    
+    oq = dstore['oqparam']
     R = dstore['full_lt'].get_num_rlzs()
     if oq.calculation_mode != 'event_based_damage':
         return numpy.ones(R)
@@ -965,3 +965,21 @@ def view_event_rates(token, dstore):
         oq.ses_per_logic_tree_path * oq.investigation_time)
     rlzs = dstore['events']['rlz_id']
     return numpy.bincount(rlzs, minlength=R) * time_ratio
+
+
+@view.add('sum')
+def view_sum(token, dstore):
+    """
+    Show the sum of an array on the first axis; used to debug the damages
+    """
+    _, arrayname = token.split(':')  # called as sum:damages-rlzs
+    dset = dstore[arrayname]
+    A, R, L, *D = dset.shape
+    cols = ['RL', 'sum']
+    arr = dset[:].sum(axis=(0, 3))  # shape R, L
+    z = numpy.zeros(R * L, [('RL', object), ('sum', object)])
+    for r, ar in enumerate(arr):
+        for li, a in enumerate(ar):
+            for c, col in enumerate(cols):
+                z[r * L + li][col] = a if c > 0 else (r, li)
+    return rst_table(z, fmt='%f')

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-mean.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-mean.csv
@@ -1,6 +1,6 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.11.3-gitcebb035e92', start_date='2021-05-26T14:15:33', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.11.3-gitfcf1859084', start_date='2021-05-27T09:00:31', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,policy,taxonomy,lon,lat,structural~no_damage,structural~LS1,structural~LS2
-a0,A,RM,81.29850,29.10980,2.400000E+00,4.500000E-01,3.000000E-01
-a1,A,RC,83.08230,27.90060,4.555250E+02,4.177500E+01,2.770000E+01
-a2,B,W,85.74770,27.90150,7.967000E+02,1.181500E+02,1.351500E+02
-a3,B,RM,85.74770,27.90150,7.600000E+00,1.425000E+00,1.475000E+00
+a0,A,RM,81.29850,29.10980,2.369107E+00,4.589245E-01,3.219680E-01
+a1,A,RC,83.08230,27.90060,4.584235E+02,4.013187E+01,2.644462E+01
+a2,B,W,85.74770,27.90150,7.926515E+02,1.193612E+02,1.379873E+02
+a3,B,RM,85.74770,27.90150,7.549427E+00,1.435641E+00,1.514931E+00

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-quantile-0.25.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-quantile-0.25.csv
@@ -1,6 +1,6 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.11.3-gitcebb035e92', start_date='2021-05-26T14:15:33', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.11.3-gitfcf1859084', start_date='2021-05-27T09:00:31', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,policy,taxonomy,lon,lat,structural~no_damage,structural~LS1,structural~LS2
-a0,A,RM,81.29850,29.10980,1.850000E+00,4.000000E-01,1.000000E-01
-a1,A,RC,83.08230,27.90060,4.423000E+02,2.070000E+01,1.200000E+01
-a2,B,W,85.74770,27.90150,6.787000E+02,1.168000E+02,1.185000E+02
-a3,B,RM,85.74770,27.90150,6.350000E+00,1.400000E+00,1.200000E+00
+a0,A,RM,81.29850,29.10980,2.044737E+00,3.652174E-01,9.130435E-02
+a1,A,RC,83.08230,27.90060,4.279891E+02,2.287895E+01,1.326316E+01
+a2,B,W,85.74770,27.90150,7.501421E+02,1.066435E+02,1.081956E+02
+a3,B,RM,85.74770,27.90150,7.018421E+00,1.323913E+00,1.095652E+00

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-rlz-000.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-rlz-000.csv
@@ -1,6 +1,6 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.11.0-git6f08fb75b7', start_date='2021-02-04T05:32:27', checksum=3100364614, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.11.3-gitfcf1859084', start_date='2021-05-27T09:00:31', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,policy,taxonomy,lon,lat,structural~no_damage,structural~LS1,structural~LS2
-a0,A,RM,81.29850,29.10980,1.850000E+00,5.000000E-01,5.000000E-01
-a1,A,RC,83.08230,27.90060,4.423000E+02,2.070000E+01,1.200000E+01
-a2,B,W,85.74770,27.90150,6.787000E+02,1.195000E+02,1.518000E+02
-a3,B,RM,85.74770,27.90150,6.350000E+00,1.400000E+00,1.750000E+00
+a0,A,RM,81.29850,29.10980,2.044737E+00,5.526316E-01,5.526316E-01
+a1,A,RC,83.08230,27.90060,4.888579E+02,2.287895E+01,1.326316E+01
+a2,B,W,85.74770,27.90150,7.501421E+02,1.320789E+02,1.677789E+02
+a3,B,RM,85.74770,27.90150,7.018421E+00,1.547368E+00,1.934210E+00

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-rlz-001.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/avg_damages-rlz-001.csv
@@ -1,6 +1,6 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.11.0-git6f08fb75b7', start_date='2021-02-04T05:32:27', checksum=3100364614, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,"generated_by='OpenQuake engine 3.11.3-gitfcf1859084', start_date='2021-05-27T09:00:31', checksum=4077124359, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,policy,taxonomy,lon,lat,structural~no_damage,structural~LS1,structural~LS2
-a0,A,RM,81.29850,29.10980,2.950000E+00,4.000000E-01,1.000000E-01
-a1,A,RC,83.08230,27.90060,4.687500E+02,6.285000E+01,4.340000E+01
-a2,B,W,85.74770,27.90150,9.147000E+02,1.168000E+02,1.185000E+02
-a3,B,RM,85.74770,27.90150,8.850000E+00,1.450000E+00,1.200000E+00
+a0,A,RM,81.29850,29.10980,2.693478E+00,3.652174E-01,9.130435E-02
+a1,A,RC,83.08230,27.90060,4.279891E+02,5.738478E+01,3.962609E+01
+a2,B,W,85.74770,27.90150,8.351608E+02,1.066435E+02,1.081956E+02
+a3,B,RM,85.74770,27.90150,8.080434E+00,1.323913E+00,1.095652E+00

--- a/openquake/qa_tests_data/event_based_risk/case_1/job_damage.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1/job_damage.ini
@@ -11,11 +11,9 @@ asset_hazard_distance = 20
 sites = 81.2985 29.1098, 83.082298 27.9006, 85.747703 27.9015
 
 [logic_tree]
-
 number_of_logic_tree_samples = 0
 
 [erf]
-
 # km
 rupture_mesh_spacing = 5
 width_of_mfd_bin = 0.3
@@ -23,7 +21,6 @@ width_of_mfd_bin = 0.3
 area_source_discretization = 10
 
 [site_params]
-
 reference_vs30_type = measured
 reference_vs30_value = 760.0
 reference_depth_to_2pt5km_per_sec = 5.0
@@ -40,4 +37,5 @@ truncation_level = 3
 maximum_distance = 100.0
 
 [output]
+quantiles = .25
 export_dir = /tmp


### PR DESCRIPTION
The numbers where slightly off. Now the sums of the damage states are consistently going to event_rate * num_buildings for each realization and also for the mean. For the quantiles it is impossible to get that.