### PR TITLE
Some support to fix latin1 files

### DIFF
--- a/openquake/commands/shell.py
+++ b/openquake/commands/shell.py
@@ -75,12 +75,20 @@ class OpenQuake(object):
             ex.close()
 
     def read_ruptures(self, calc_id, field):
-        dstore = read(calc_id)
+        dstore = datastore.read(calc_id)
         lst = []
         for name, dset in dstore.items():
             if name.startswith('rup_'):
                 lst.append(dset[field][:])
         return numpy.concatenate(lst)
+
+    def fix_latin1(self, fname):
+        "Try to convert from latin1 to utf8"
+        with open(fname, encoding='latin1') as f:
+            data = f.read()
+        with open(fname, 'w', encoding='utf-8-sig', newline='') as f:
+            f.write(data)
+        print('Converted %s: WARNING: it may still be wrong' % fname)
 
 
 def main(script=None, args=()):

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -973,7 +973,12 @@ class Exposure(object):
         strfields = self.tagcol.tagnames + self.occupancy_periods.split()
         for fname in self.datafiles:
             with open(fname, encoding='utf-8-sig') as f:
-                fields = next(csv.reader(f))
+                try:
+                    fields = next(csv.reader(f))
+                except UnicodeDecodeError:
+                    msg = ("%s is not encoded as UTF-8\ntry oq shell "
+                           "and then o.fix_latin1('%s')" % (fname, fname))
+                    raise RuntimeError(msg)
                 header = set(self.fieldmap.get(f, f) for f in fields)
                 for field in fields:
                     if field not in strfields:
@@ -1016,7 +1021,8 @@ class Exposure(object):
             # check_dupl is False only in oq prepare_site_model since
             # in that case we are only interested in the asset locations
             if check_dupl and asset_id in asset_refs:
-                raise nrml.DuplicatedID(asset_id)
+                raise nrml.DuplicatedID('asset_id=%s while processing %s' % (
+                    asset_id, param['fname']))
             asset_refs.add(param['asset_prefix'] + asset_id)
             self._add_asset(idx, asset, param)
 


### PR DESCRIPTION
This happened to an exposure of Maria Camilla. Unfortunately, it is not enough, since often the exposure is build from different Excel files with different encodings, so assuming latin-1 is not the solution. Another possibility would be to open the files with errors="ignore", then the names of the places in the exposure would have missing characters but everything would work.