### PR TITLE
Removed 50 lines of code

### DIFF
--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -766,7 +766,7 @@ class CoeffsTable(object):
         if 'table' not in kwargs:
             raise TypeError('CoeffsTable requires "table" kwarg')
         self._coeffs = {}  # cache
-        self.logratio = kwargs.pop('logratio', None)
+        self.logratio = kwargs.pop('logratio', True)
         table = kwargs.pop('table')
         self.sa_coeffs = {}
         self.non_sa_coeffs = {}
@@ -854,13 +854,13 @@ class CoeffsTable(object):
         if max_below is None or min_above is None:
             raise KeyError(imt)
 
-        if self.logratio:  # in the ACME project
-            ratio = ((math.log(imt.period) - math.log(max_below.period)) /
-                     (math.log(min_above.period) - math.log(max_below.period)))
-        else:  # regular case
+        if self.logratio:  # regular case
             # ratio tends to 1 when target period tends to a minimum
             # known period above and to 0 if target period is close
             # to maximum period below.
+            ratio = ((math.log(imt.period) - math.log(max_below.period)) /
+                     (math.log(min_above.period) - math.log(max_below.period)))
+        else:  # in the ACME project
             ratio = ((imt.period - max_below.period) /
                      (min_above.period - max_below.period))
         max_below = self.sa_coeffs[max_below]

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -766,6 +766,7 @@ class CoeffsTable(object):
         if 'table' not in kwargs:
             raise TypeError('CoeffsTable requires "table" kwarg')
         self._coeffs = {}  # cache
+        self.logratio = kwargs.pop('logratio', None)
         table = kwargs.pop('table')
         self.sa_coeffs = {}
         self.non_sa_coeffs = {}
@@ -853,11 +854,15 @@ class CoeffsTable(object):
         if max_below is None or min_above is None:
             raise KeyError(imt)
 
-        # ratio tends to 1 when target period tends to a minimum
-        # known period above and to 0 if target period is close
-        # to maximum period below.
-        ratio = ((math.log(imt.period) - math.log(max_below.period))
-                 / (math.log(min_above.period) - math.log(max_below.period)))
+        if self.logratio:  # in the ACME project
+            ratio = ((math.log(imt.period) - math.log(max_below.period)) /
+                     (math.log(min_above.period) - math.log(max_below.period)))
+        else:  # regular case
+            # ratio tends to 1 when target period tends to a minimum
+            # known period above and to 0 if target period is close
+            # to maximum period below.
+            ratio = ((imt.period - max_below.period) /
+                     (min_above.period - max_below.period))
         max_below = self.sa_coeffs[max_below]
         min_above = self.sa_coeffs[min_above]
         self._coeffs[imt] = c = {

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -894,11 +894,10 @@ class NGAEastGMPETotalSigma(NGAEastGMPE):
         if self.ergodic:
             # IMT list should be taken from the PHI_S2SS_MODEL
             imt_list = list(
-                PHI_S2SS_MODEL[self.phi_s2ss_model].non_sa_coeffs.keys())
-            imt_list += \
-                list(PHI_S2SS_MODEL[self.phi_s2ss_model].sa_coeffs.keys())
+                PHI_S2SS_MODEL[self.phi_s2ss_model].non_sa_coeffs)
+            imt_list += list(PHI_S2SS_MODEL[self.phi_s2ss_model].sa_coeffs)
         else:
-            imt_list = phi_std.keys()
+            imt_list = list(phi_std)
         phi_std = CoeffsTable(sa_damping=5, table=phi_std)
         tau_bar, tau_std = self._get_tau_vector(self.TAU, tau_std, imt_list)
         phi_bar, phi_std = self._get_phi_vector(self.PHI_SS, phi_std, imt_list)

--- a/openquake/hazardlib/gsim/projects/acme_2019.py
+++ b/openquake/hazardlib/gsim/projects/acme_2019.py
@@ -23,7 +23,7 @@ import numpy as np
 from openquake.hazardlib import const
 from openquake.hazardlib.gsim.base import GMPE, registry, CoeffsTable
 from openquake.hazardlib.gsim.projects.acme_base import (
-    CoeffsTableACME, get_phi_ss_at_quantile_ACME)
+    get_phi_ss_at_quantile_ACME)
 from openquake.hazardlib.imt import SA, PGA
 from openquake.hazardlib.contexts import DistancesContext
 from openquake.hazardlib.gsim.chiou_youngs_2014 import ChiouYoungs2014
@@ -534,7 +534,7 @@ class AlAtikSigmaModel(GMPE):
         return phi
 
 # PHI_SS2S coefficients, table 2.2 HID
-PHI_S2SS_BRB = CoeffsTableACME(sa_damping=5., table="""\
+PHI_S2SS_BRB = CoeffsTable(logratio=True, sa_damping=5., table="""\
     imt   phi_s2ss  
     PGA     0.0000 
     0.001   0.0000
@@ -547,8 +547,8 @@ PHI_S2SS_BRB = CoeffsTableACME(sa_damping=5., table="""\
     """)
 
 # Phi_ss coefficients for the global model
-PHI_SS_GLOBAL_LINEAR = CoeffsTableACME(sa_damping=5., table="""\
-imt     mean_a   var_a  mean_b  var_b
+PHI_SS_GLOBAL_LINEAR = CoeffsTable(logratio=True, sa_damping=5., table="""\
+imt     mean_a   var_a  mean_b  var_bs
 pgv     0.5034  0.0609  0.3585  0.0316
 pga     0.5477  0.0731  0.3505  0.0412
 0.010   0.5477  0.0731  0.3505  0.0412

--- a/openquake/hazardlib/gsim/projects/acme_2019.py
+++ b/openquake/hazardlib/gsim/projects/acme_2019.py
@@ -534,7 +534,7 @@ class AlAtikSigmaModel(GMPE):
         return phi
 
 # PHI_SS2S coefficients, table 2.2 HID
-PHI_S2SS_BRB = CoeffsTable(logratio=True, sa_damping=5., table="""\
+PHI_S2SS_BRB = CoeffsTable(logratio=False, sa_damping=5., table="""\
     imt   phi_s2ss  
     PGA     0.0000 
     0.001   0.0000
@@ -547,7 +547,7 @@ PHI_S2SS_BRB = CoeffsTable(logratio=True, sa_damping=5., table="""\
     """)
 
 # Phi_ss coefficients for the global model
-PHI_SS_GLOBAL_LINEAR = CoeffsTable(logratio=True, sa_damping=5., table="""\
+PHI_SS_GLOBAL_LINEAR = CoeffsTable(logratio=False, sa_damping=5., table="""\
 imt     mean_a   var_a  mean_b  var_bs
 pgv     0.5034  0.0609  0.3585  0.0316
 pga     0.5477  0.0731  0.3505  0.0412

--- a/openquake/hazardlib/gsim/projects/acme_base.py
+++ b/openquake/hazardlib/gsim/projects/acme_base.py
@@ -42,4 +42,4 @@ def get_phi_ss_at_quantile_ACME(phi_model, quantile):
                 "b": _at_percentile(phi_model[imt]["mean_b"],
                                     phi_model[imt]["var_b"],
                                     quantile)}
-    return CoeffsTable(sa_damping=5., table=coeffs, logratio=True)
+    return CoeffsTable(logratio=False, sa_damping=5., table=coeffs)

--- a/openquake/hazardlib/gsim/projects/acme_base.py
+++ b/openquake/hazardlib/gsim/projects/acme_base.py
@@ -17,62 +17,8 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from copy import deepcopy
-
 from openquake.hazardlib.gsim.base import CoeffsTable
-
 from openquake.hazardlib.gsim.nga_east import _at_percentile
-
-class CoeffsTableACME(CoeffsTable):
-
-    def __getitem__(self, imt):
-        """
-        Return a dictionary of coefficients corresponding to ``imt``
-        from this table (if there is a line for requested IMT in it),
-        or the dictionary of interpolated coefficients, if ``imt`` is
-        of type :class:`~openquake.hazardlib.imt.SA` and interpolation
-        is possible.
-
-        :raises KeyError:
-            If ``imt`` is not available in the table and no interpolation
-            can be done.
-        """
-        try:
-            return self._coeffs[imt]
-        except KeyError:
-            pass
-        if imt.name != 'SA':
-            self._coeffs[imt] = c = self.non_sa_coeffs[imt]
-            return c
-        try:
-            self._coeffs[imt] = c = self.sa_coeffs[imt]
-            return c
-        except KeyError:
-            pass
-
-        max_below = min_above = None
-        for unscaled_imt in list(self.sa_coeffs):
-            if unscaled_imt.damping != imt.damping:
-                continue
-            if unscaled_imt.period > imt.period:
-                if min_above is None or unscaled_imt.period < min_above.period:
-                    min_above = unscaled_imt
-            elif unscaled_imt.period < imt.period:
-                if max_below is None or unscaled_imt.period > max_below.period:
-                    max_below = unscaled_imt
-        if max_below is None or min_above is None:
-            raise KeyError(imt)
-
-        # ratio tends to 1 when target period tends to a minimum
-        # known period above and to 0 if target period is close
-        # to maximum period below.
-        ratio = (((imt.period) - (max_below.period))
-                 / ((min_above.period) - (max_below.period)))
-        max_below = self.sa_coeffs[max_below]
-        min_above = self.sa_coeffs[min_above]
-        self._coeffs[imt] = c = {
-            co: (min_above[co] - max_below[co]) * ratio + max_below[co]
-            for co in max_below}
-        return c
 
 
 def get_phi_ss_at_quantile_ACME(phi_model, quantile):
@@ -95,6 +41,5 @@ def get_phi_ss_at_quantile_ACME(phi_model, quantile):
                                     quantile),
                 "b": _at_percentile(phi_model[imt]["mean_b"],
                                     phi_model[imt]["var_b"],
-                                    quantile)
-                }
-    return CoeffsTableACME(sa_damping=5., table=coeffs)
+                                    quantile)}
+    return CoeffsTable(sa_damping=5., table=coeffs, logratio=True)

--- a/openquake/hazardlib/tests/gsim/raghukanth_iyengar_2007_test.py
+++ b/openquake/hazardlib/tests/gsim/raghukanth_iyengar_2007_test.py
@@ -77,7 +77,7 @@ class RaghukanthIyengar2007TestCase(BaseGSIMTestCase):
         gmpe = self.GSIM_CLASS()
         rctx.mag = np.array([6.5])
         dctx.rhypo = np.array([100.])
-        im_type = sorted(gmpe.COEFFS_BEDROCK.sa_coeffs.keys())[0]
+        im_type = sorted(gmpe.COEFFS_BEDROCK.sa_coeffs)[0]
         std_types = list(gmpe.DEFINED_FOR_STANDARD_DEVIATION_TYPES)
 
         # set critical value to trigger warning


### PR DESCRIPTION
The class `CoeffsTableACME` was useless, since its functionality can be implemented in the regular `CoeffsTable` class in two lines. Part of the work for refactoring hazardlib.