### PR TITLE
Added a limit of 12 characters to IMT names

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a limit of 12 characters to IMT names
   * Forbidded multiple inheritance in GMPE hierarchies
   * Added parameter `ignore_encoding_errors` to the job.ini
   * Extended the damage calculators to generic consequences

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -73,8 +73,7 @@ class IMTMeta(type):
     """
     def __new__(mcs, name, bases, dct):
         if len(name) > 12:
-            raise NameError(
-                'An IMT class name must be shorter than 12 chars: %s' % name)
+            raise NameError('IMT class name longer than 12 chars: %s' % name)
         dct['__slots__'] = ()
         cls = type.__new__(mcs, name, bases, dct)
         fields = ''

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -72,6 +72,9 @@ class IMTMeta(type):
     Metaclass setting __slots__, __new__ and the properties of IMT classes
     """
     def __new__(mcs, name, bases, dct):
+        if len(name) > 12:
+            raise NameError(
+                'An IMT class name must be shorter than 12 chars: %s' % name)
         dct['__slots__'] = ()
         cls = type.__new__(mcs, name, bases, dct)
         fields = ''


### PR DESCRIPTION
So that they can be easily passed into numpy arrays. Part of the refactoring for https://github.com/gem/oq-engine/blob/master/doc/breaking-hazardlib.md
