### PR TITLE
Improved SingleSiteOptTestCase

### DIFF
--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -213,18 +213,19 @@ def calc_hazard_curves(
     return pmap.convert(imtls, len(sitecol.complete))
 
 
-# called in adv-manual/developing.rst
-def calc_hazard_curve(site1, src, gsims, oqparam):
+# called in adv-manual/developing.rst and in SingleSiteOptTestCase
+def calc_hazard_curve(site1, src, gsims, oqparam, monitor=Monitor()):
     """
     :param site1: site collection with a single site
     :param src: a seismic source object
     :param gsims: a list of GSIM objects
     :param oqparam: an object with attributes .maximum_distance, .imtls
+    :param monitor: a Monitor instance (optional)
     :returns: a ProbabilityCurve object
     """
     assert len(site1) == 1, site1
     trt = src.tectonic_region_type
-    cmaker = ContextMaker(trt, gsims, vars(oqparam))
+    cmaker = ContextMaker(trt, gsims, vars(oqparam), monitor)
     cmaker.tom = src.temporal_occurrence_model
     srcfilter = SourceFilter(site1, oqparam.maximum_distance)
     pmap, rup_data, calc_times = PmapMaker(cmaker, srcfilter, [src]).make()

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -145,13 +145,14 @@ def get_pmap(ctxs, cmaker, probmap=None):
         pmap = probmap
     for ctx, poes in zip(ctxs, gen_poes(ctxs, cmaker)):
         # pnes and poes of shape (N, L, G)
-        pnes = ctx.get_probability_no_exceedance(poes, tom)
-        for sid, pne in zip(ctx.sids, pnes):
-            probs = pmap.setdefault(sid, cmaker.rup_indep).array
-            if rup_indep:
-                probs *= pne
-            else:  # rup_mutex
-                probs += (1. - pne) * ctx.weight
+        with cmaker.pne_mon:
+            pnes = ctx.get_probability_no_exceedance(poes, tom)
+            for sid, pne in zip(ctx.sids, pnes):
+                probs = pmap.setdefault(sid, cmaker.rup_indep).array
+                if rup_indep:
+                    probs *= pne
+                else:  # rup_mutex
+                    probs += (1. - pne) * ctx.weight
     if probmap is None:  # return the new pmap
         return ~pmap if rup_indep else pmap
 
@@ -244,6 +245,7 @@ class ContextMaker(object):
         # instantiate monitors
         self.gmf_mon = monitor('computing mean_std', measuremem=False)
         self.poe_mon = monitor('get_poes', measuremem=False)
+        self.pne_mon = monitor('composing pnes', measuremem=False)
 
     def read_ctxs(self, dstore, slc=None):
         """
@@ -565,7 +567,6 @@ class PmapMaker(object):
         self.src_mutex = getattr(group, 'src_interdep', None) == 'mutex'
         self.cmaker.rup_indep = getattr(group, 'rup_interdep', None) != 'mutex'
         self.fewsites = self.N <= cmaker.max_sites_disagg
-        self.pne_mon = cmaker.mon('composing pnes', measuremem=False)
         # NB: if maxsites is too big or too small the performance of
         # get_poes can easily become 2-3 times worse!
         self.maxsites = 512000 / len(self.gsims) / self.imtls.size
@@ -587,10 +588,9 @@ class PmapMaker(object):
         # compute PoEs and update pmap
         # splitting in blocks makes sure that the maximum poes array
         # generated has size N x L x G x 8 = 4 MB
-        with self.pne_mon:
-            for block in block_splitter(
-                    ctxs, self.maxsites, lambda ctx: len(ctx.sids)):
-                get_pmap(block, self.cmaker, pmap)
+        for block in block_splitter(
+                ctxs, self.maxsites, lambda ctx: len(ctx.sids)):
+            get_pmap(block, self.cmaker, pmap)
 
     def _ruptures(self, src, filtermag=None):
         return src.iter_ruptures(

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -287,6 +287,6 @@ class SingleSiteOptTestCase(unittest.TestCase):
             print(child)
         got = hcurve.array[:, 0]
         exp = [0.103379, 0.468937, 0.403896, 0.278772, 0.213645, 0.142985,
-               0.103438, 0.079094, 0.062861, 0.051344, 0.04066 , 0.031589,
+               0.103438, 0.079094, 0.062861, 0.051344, 0.04066, 0.031589,
                0.024935]
         numpy.testing.assert_allclose(got, exp, atol=1E-5)

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -17,11 +17,13 @@ import unittest
 import numpy
 
 import openquake.hazardlib
-from openquake.baselib.parallel import Starmap, sequential_apply
-from openquake.hazardlib import nrml, valid
+from openquake.baselib.general import DictArray
+from openquake.baselib.parallel import Starmap, sequential_apply, Monitor
+from openquake.hazardlib import nrml
 from openquake.hazardlib.geo import Point, Line
 from openquake.hazardlib.tom import PoissonTOM
-from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
+from openquake.hazardlib.calc.hazard_curve import (
+    calc_hazard_curve, calc_hazard_curves)
 from openquake.hazardlib.calc.filters import SourceFilter, MagDepDistance
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.pmf import PMF
@@ -31,7 +33,7 @@ from openquake.hazardlib.mfd import TruncatedGRMFD, ArbitraryMFD
 from openquake.hazardlib.source import PointSource, SimpleFaultSource
 from openquake.hazardlib.gsim.sadigh_1997 import SadighEtAl1997
 from openquake.hazardlib.gsim.akkar_bommer_2010 import AkkarBommer2010
-from openquake.hazardlib.gsim.boore_atkinson_2008 import BooreAtkinson2008
+from openquake.hazardlib.gsim.toro_2002 import ToroEtAl2002
 from openquake.hazardlib.gsim.chiou_youngs_2014 import ChiouYoungs2014PEER
 from openquake.hazardlib.gsim.mgmpe.avg_gmpe import AvgGMPE
 
@@ -229,7 +231,7 @@ class MixtureModelGMPETestCase(unittest.TestCase):
                                       atol=0.04)
 
 
-# an area source with 52 point sources
+# an area source with 388 point sources and 4656 ruptures
 asource = nrml.get('''\
 <areaSource
   id="1"
@@ -240,7 +242,7 @@ asource = nrml.get('''\
           <gml:exterior>
               <gml:LinearRing>
                   <gml:posList>
-                    -.5 -.5 -.3 -.1 .1 .2 .3 -.8
+                    -1.5 -1.5 -1.3 -1.1 1.1 .2 1.3 -1.8
                   </gml:posList>
               </gml:LinearRing>
           </gml:exterior>
@@ -252,10 +254,13 @@ asource = nrml.get('''\
   <ruptAspectRatio>1</ruptAspectRatio>
   <truncGutenbergRichterMFD aValue="4.5" bValue="1" maxMag="7" minMag="5"/>
   <nodalPlaneDist>
-    <nodalPlane dip="90" probability="1" rake="0" strike="0"/>
+    <nodalPlane dip="90" probability=".33" rake="0" strike="0"/>
+    <nodalPlane dip="60" probability=".33" rake="0" strike="0"/>
+    <nodalPlane dip="30" probability=".34" rake="0" strike="0"/>
   </nodalPlaneDist>
   <hypoDepthDist>
-     <hypoDepth depth="5" probability="1"/>
+     <hypoDepth depth="5" probability=".5"/>
+     <hypoDepth depth="10" probability=".5"/>
   </hypoDepthDist>
 </areaSource>''')
 
@@ -268,10 +273,20 @@ class SingleSiteOptTestCase(unittest.TestCase):
         site = Site(Point(0, 0), vs30=760., z1pt0=48.0, z2pt5=0.607,
                     vs30measured=True)
         sitecol = SiteCollection([site])
-        imtls = {"PGA": valid.logscale(.1, 1, 10)}
-        gsim = BooreAtkinson2008()
-        [hcurve] = calc_hazard_curves([asource], sitecol, imtls,
-                                      {"Stable Continental Crust": gsim})
-        exp = [0.879914, 0.747273, 0.566655, 0.376226, 0.217617,
-               0.110198, 0.049159, 0.019335, 0.006663, 0.001989]
-        numpy.testing.assert_allclose(hcurve['PGA'], exp, atol=1E-5)
+        imtls = {"PGA": [.123]}
+        for period in numpy.arange(.1, 1.3, .1):
+            imtls['SA(%.2f)' % period] = [.123]
+        assert len(imtls) == 13  # 13 periods
+        mon = Monitor()
+        oq = unittest.mock.Mock(
+            imtls=DictArray(imtls),
+            maximum_distance=MagDepDistance.new('300'))
+        hcurve = calc_hazard_curve(
+            sitecol, asource, [ToroEtAl2002()], oq, mon)
+        for child in mon.children:
+            print(child)
+        got = hcurve.array[:, 0]
+        exp = [0.103379, 0.468937, 0.403896, 0.278772, 0.213645, 0.142985,
+               0.103438, 0.079094, 0.062861, 0.051344, 0.04066 , 0.031589,
+               0.024935]
+        numpy.testing.assert_allclose(got, exp, atol=1E-5)


### PR DESCRIPTION
And fixed the monitoring (pne_mon was measuring the wrong thing).
Running the test on my laptop gives the following figures:
```
<Monitor make_contexts[michele], duration=3.504476308822632s, counts=4656>
<Monitor computing mean_std[michele], duration=2.919656991958618s, counts=388>
<Monitor get_poes[michele], duration=0.05186915397644043s, counts=388>
<Monitor composing pnes[michele], duration=0.04806876182556152s, counts=4656>
```
The program in https://github.com/gem/oq-engine/issues/6850 could help a little, but not too much in this case, since most of the time is spent in `make_contexts`.