### PR TITLE
Vectorized by gsim in `get_mean_stdt`

### DIFF
--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -34,8 +34,8 @@ from openquake.hazardlib.geo.utils import get_longitudinal_extent
 from openquake.hazardlib.geo.utils import (angular_distance, KM_TO_DEGREES,
                                            cross_idl)
 from openquake.hazardlib.site import SiteCollection
-from openquake.hazardlib.gsim.base import (
-    ContextMaker, to_distribution_values)
+from openquake.hazardlib.gsim.base import to_distribution_values
+from openquake.hazardlib.contexts import ContextMaker, get_mean_stdt
 
 BIN_NAMES = 'mag', 'dist', 'lon', 'lat', 'eps', 'trt'
 BinData = collections.namedtuple('BinData', 'dists, lons, lats, pnes')
@@ -175,8 +175,8 @@ def disaggregate(ctxs, tom, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
 
 def set_mean_std(ctxs, cmaker):
     for u, ctx in enumerate(ctxs):
-        ctx.mean_std = [gsim.get_mean_std([ctx], cmaker, g)
-                        for g, gsim in enumerate(cmaker.gsims)]
+        ms = get_mean_stdt([ctx], cmaker)  # shape (2, N, M, G)
+        ctx.mean_std = ms.transpose(3, 0, 1, 2)
 
 
 def _disagg_eps(survival, bins, eps_bands, cum_bands):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -174,8 +174,8 @@ def get_mean_stdt(orig_ctxs, cmaker):
             if all(len(ctx) == 1 for ctx in ctxs):  # single-site-optimization
                 ctxs = [cmaker.multi(ctxs)]
             for param, sites, clist, slc in cmaker.gen_params(g, ctxs):
-                calc_mean(arr[0, slc, g], param, sites, *clist)
-                calc_stdt(arr[1, slc, g], param, sites, *clist)
+                calc_mean(arr[0, slc, :, g], param, sites, *clist)
+                calc_stdt(arr[1, slc, :, g], param, sites, *clist)
         else:  # slow lane
             start = 0
             for ctx in ctxs:

--- a/openquake/hazardlib/gsim/mgmpe/avg_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_gmpe.py
@@ -99,6 +99,7 @@ class AvgGMPE(GMPE):
             self.DEFINED_FOR_STANDARD_DEVIATION_TYPES = def_for_stddevs[0]
         self.weights = numpy.array(weights)
 
+    # TODO: fix this to work with the numpy-oriented API
     def get_mean_and_stddevs(self, sctx, rctx, dctx, imt, stddev_types):
         """
         Call the underlying GMPEs and return the weighted mean and stddev

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -104,7 +104,7 @@ class AvgPoeGMPE(GMPE):
     def calc_mean(out, param, sites):
         """Do nothing: the work is done in get_poes"""
 
-    def calc_std(out, param, sites):
+    def calc_stdt(out, param, sites):
         """Do nothing: the work is done in get_poes"""
 
     def get_poes(self, mean_std, cmaker, ctxs):

--- a/openquake/hazardlib/gsim/test_2021.py
+++ b/openquake/hazardlib/gsim/test_2021.py
@@ -33,9 +33,9 @@ def _compute_term1(C, mag):
 def _compute_term2(C, mag, rjb):
     RM = np.sqrt(rjb ** 2 + (C['c7'] ** 2) *
                  np.exp(-1.25 + 0.227 * mag) ** 2)
-
-    return (-C['c4'] * np.log(RM) - (C['c5'] - C['c4']) *
-            np.maximum(np.log(RM / 100), 0) - C['c6'] * RM)
+    res = (-C['c4'] * np.log(RM) - (C['c5'] - C['c4']) *
+           np.maximum(np.log(RM / 100), 0) - C['c6'] * RM)
+    return res
 
 
 class Test2021(GMPE):

--- a/openquake/hazardlib/tests/gsim/base_site_test.py
+++ b/openquake/hazardlib/tests/gsim/base_site_test.py
@@ -23,10 +23,10 @@ from openquake.baselib.hdf5 import read_csv
 from openquake.hazardlib.imt import PGA, SA
 from openquake.hazardlib.gsim.base import _get_poes_site, _get_poes
 from openquake.baselib.general import gettemp, DictArray
-from openquake.hazardlib.contexts import RuptureContext, ContextMaker
+from openquake.hazardlib.contexts import (
+    RuptureContext, ContextMaker, get_mean_stdt)
 from openquake.hazardlib.tests.gsim.mgmpe.dummy import Dummy
 from openquake.hazardlib.gsim.boore_atkinson_2008 import BooreAtkinson2008
-from openquake.hazardlib.gsim.boore_2014 import BooreEtAl2014
 
 from openquake.hazardlib.site import ampcode_dt
 from openquake.hazardlib.site_amplification import AmplFunction
@@ -47,7 +47,6 @@ class GetPoesSiteTestCase(unittest.TestCase):
 
         # Set GMMs
         gmmA = BooreAtkinson2008()
-        gmmB = BooreEtAl2014()
 
         # Set parameters
         dsts = [10., 15., 20., 30., 40.]
@@ -64,7 +63,7 @@ class GetPoesSiteTestCase(unittest.TestCase):
         # Compute GM on rock
         cmaker = ContextMaker(
             'TRT', [gmmA], dict(imtls={str(im): [0] for im in imts}))
-        self.meastd = gmmA.get_mean_std([ctx], cmaker, 0)  # shp(2, N=1, M=2)
+        self.meastd = get_mean_stdt([ctx], cmaker)[..., 0]  # shp(2, N=1, M=2)
 
     def test01(self):
 


### PR DESCRIPTION
As a matter of elegance and performance. The improvement is very minor in the case of many sites, but still there. For instance for a small SHARE calculation on cluster2:
```
# before
| calc_41920, maxmem=7.0 GB | time_sec | memory_mb | counts     |
|---------------------------+----------+-----------+------------|
| total classical           | 82_303   | 124.4     | 420        |
| computing mean_std        | 52_270   | 0.0       | 1_654_532  |
| get_poes                  | 11_008   | 0.0       | 1_654_532  |
| make_contexts             | 9_761    | 0.0       | 10_177_127 |
| composing pnes            | 3_226    | 0.0       | 10_160_959 |
| total build_hazard        | 2_566    | 26.9      | 159        |
| combine pmaps             | 2_083    | 0.0       | 10_000     |
| ClassicalCalculator.run   | 1_549    | 1_398     | 1          |

# after
| calc_41921, maxmem=7.0 GB | time_sec | memory_mb | counts     |
|---------------------------+----------+-----------+------------|
| total classical           | 80_626   | 124.7     | 420        |
| computing mean_std        | 51_346   | 0.0       | 378_053    |
| get_poes                  | 10_616   | 0.0       | 378_053    |
| make_contexts             | 9_577    | 0.0       | 10_177_127 |
| composing pnes            | 3_145    | 0.0       | 10_160_959 |
| total build_hazard        | 2_818    | 26.9      | 159        |
| combine pmaps             | 2_011    | 0.0       | 10_000     |
| ClassicalCalculator.run   | 1_514    | 1_434     | 1          |
```
Part of https://github.com/gem/oq-engine/issues/6850.