### PR TITLE
Compiling and caching the jittable function when instantiating the ContextMaker

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -26,10 +26,14 @@ from datetime import datetime
 import psutil
 import numpy
 try:
-    from numba import njit as jittable
+    from numba import njit
+
+    def jittable(func):
+        """Calls numba.njit with a cache"""
+        return njit(func, cache=True)
 except ImportError:
     def jittable(func):
-        "Do nothing decorator, used if numba is missing"
+        """Do nothing decorator, used if numba is missing"""
         return func
 
 from openquake.baselib.general import humansize

--- a/openquake/hazardlib/gsim/example_a_2021.py
+++ b/openquake/hazardlib/gsim/example_a_2021.py
@@ -26,15 +26,15 @@ from openquake.hazardlib.imt import PGA, SA
 @jittable
 def _compute_term1(C, mag):
     mag_diff = mag - 6
-    return C['c2'] * mag_diff + C['c3'] * mag_diff ** 2
+    return C.c2 * mag_diff + C.c3 * mag_diff ** 2
 
 
 @jittable
 def _compute_term2(C, mag, rjb):
-    RM = np.sqrt(rjb ** 2 + (C['c7'] ** 2) *
+    RM = np.sqrt(rjb ** 2 + (C.c7 ** 2) *
                  np.exp(-1.25 + 0.227 * mag) ** 2)
-    res = (-C['c4'] * np.log(RM) - (C['c5'] - C['c4']) *
-           np.maximum(np.log(RM / 100), 0) - C['c6'] * RM)
+    res = (-C.c4 * np.log(RM) - (C.c5 - C.c4) *
+           np.maximum(np.log(RM / 100), 0) - C.c6 * RM)
     return res
 
 
@@ -68,11 +68,11 @@ class ExampleA2021(GMPE):
     def calc_mean(out, ctx, coeffs):
         mag, rjb = ctx.mag, ctx.rjb
         for m, C in enumerate(coeffs):
-            out[:, m] = (C['c1'] + _compute_term1(C, mag) +
+            out[:, m] = (C.c1 + _compute_term1(C, mag) +
                          _compute_term2(C, mag, rjb))
-            if C['period'] == 3.0:
+            if C.period == 3.0:
                 out[:, m] /= 0.612
-            elif C['period'] == 4.0:
+            elif C.period == 4.0:
                 out[:, m] /= 0.559
 
     @jittable
@@ -80,11 +80,9 @@ class ExampleA2021(GMPE):
         mag, rjb = ctx.mag, ctx.rjb
         for m, C in enumerate(coeffs):
             sigma_ale_m = np.interp(
-                mag, [5.0, 5.5, 8.0],
-                [C['m50'], C['m55'], C['m80']])
-            sigma_ale_rjb = np.interp(
-                rjb, [5.0, 20.0], [C['r5'], C['r20']])
+                mag, [5.0, 5.5, 8.0], [C.m50, C.m55, C.m80])
+            sigma_ale_rjb = np.interp(rjb, [5.0, 20.0], [C.r5, C.r20])
             sigma_ale = np.sqrt(sigma_ale_m ** 2 + sigma_ale_rjb ** 2)
-            sigma_epi = (0.36 + 0.07 * (mag - 6) if C["period"] < 1
+            sigma_epi = (0.36 + 0.07 * (mag - 6) if C.period < 1
                          else 0.34 + 0.06 * (mag - 6))
             out[:, m] = np.sqrt(sigma_ale ** 2 + sigma_epi ** 2)

--- a/openquake/hazardlib/gsim/example_a_2021.py
+++ b/openquake/hazardlib/gsim/example_a_2021.py
@@ -26,15 +26,15 @@ from openquake.hazardlib.imt import PGA, SA
 @jittable
 def _compute_term1(C, mag):
     mag_diff = mag - 6
-    return C.c2 * mag_diff + C.c3 * mag_diff ** 2
+    return C['c2'] * mag_diff + C['c3'] * mag_diff ** 2
 
 
 @jittable
 def _compute_term2(C, mag, rjb):
-    RM = np.sqrt(rjb ** 2 + (C.c7 ** 2) *
+    RM = np.sqrt(rjb ** 2 + (C['c7'] ** 2) *
                  np.exp(-1.25 + 0.227 * mag) ** 2)
-    res = (-C.c4 * np.log(RM) - (C.c5 - C.c4) *
-           np.maximum(np.log(RM / 100), 0) - C.c6 * RM)
+    res = (-C['c4'] * np.log(RM) - (C['c5'] - C['c4']) *
+           np.maximum(np.log(RM / 100), 0) - C['c6'] * RM)
     return res
 
 
@@ -66,23 +66,25 @@ class ExampleA2021(GMPE):
 
     @jittable
     def calc_mean(out, ctx, coeffs):
-        mag, rjb = ctx.mag, ctx.rjb
+        mag, rjb = ctx['mag'], ctx['rjb']
         for m, C in enumerate(coeffs):
-            out[:, m] = (C.c1 + _compute_term1(C, mag) +
+            out[:, m] = (C['c1'] + _compute_term1(C, mag) +
                          _compute_term2(C, mag, rjb))
-            if C.period == 3.0:
+            if C['period'] == 3.0:
                 out[:, m] /= 0.612
-            elif C.period == 4.0:
+            elif C['period'] == 4.0:
                 out[:, m] /= 0.559
 
     @jittable
     def calc_stdt(out, ctx, coeffs):
-        mag, rjb = ctx.mag, ctx.rjb
+        mag, rjb = ctx['mag'], ctx['rjb']
         for m, C in enumerate(coeffs):
             sigma_ale_m = np.interp(
-                mag, [5.0, 5.5, 8.0], [C.m50, C.m55, C.m80])
-            sigma_ale_rjb = np.interp(rjb, [5.0, 20.0], [C.r5, C.r20])
+                mag, [5.0, 5.5, 8.0],
+                [C['m50'], C['m55'], C['m80']])
+            sigma_ale_rjb = np.interp(
+                rjb, [5.0, 20.0], [C['r5'], C['r20']])
             sigma_ale = np.sqrt(sigma_ale_m ** 2 + sigma_ale_rjb ** 2)
-            sigma_epi = (0.36 + 0.07 * (mag - 6) if C.period < 1
+            sigma_epi = (0.36 + 0.07 * (mag - 6) if C["period"] < 1
                          else 0.34 + 0.06 * (mag - 6))
             out[:, m] = np.sqrt(sigma_ale ** 2 + sigma_epi ** 2)

--- a/openquake/hazardlib/gsim/example_a_2021.py
+++ b/openquake/hazardlib/gsim/example_a_2021.py
@@ -65,8 +65,8 @@ class ExampleA2021(GMPE):
     """)
 
     @jittable
-    def calc_mean(out, param, sites, coeffs):
-        mag, rjb = param['mag'], sites['rjb']
+    def calc_mean(out, ctx, coeffs):
+        mag, rjb = ctx.mag, ctx.rjb
         for m, C in enumerate(coeffs):
             out[:, m] = (C['c1'] + _compute_term1(C, mag) +
                          _compute_term2(C, mag, rjb))
@@ -76,8 +76,8 @@ class ExampleA2021(GMPE):
                 out[:, m] /= 0.559
 
     @jittable
-    def calc_stdt(out, param, sites, coeffs):
-        mag, rjb = param['mag'], sites['rjb']
+    def calc_stdt(out, ctx, coeffs):
+        mag, rjb = ctx.mag, ctx.rjb
         for m, C in enumerate(coeffs):
             sigma_ale_m = np.interp(
                 mag, [5.0, 5.5, 8.0],

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -101,10 +101,10 @@ class AvgPoeGMPE(GMPE):
             self.DEFINED_FOR_STANDARD_DEVIATION_TYPES = def_for_stddevs[0]
         self.weights = numpy.array(weights)
 
-    def calc_mean(out, param, sites):
+    def calc_mean(out, ctx):
         """Do nothing: the work is done in get_poes"""
 
-    def calc_stdt(out, param, sites):
+    def calc_stdt(out, ctx):
         """Do nothing: the work is done in get_poes"""
 
     def get_poes(self, mean_std, cmaker, ctxs):

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -280,10 +280,6 @@ class NewApiTestCase(unittest.TestCase):
         oq = unittest.mock.Mock(
             imtls=DictArray(imtls),
             maximum_distance=MagDepDistance.new('300'))
-        # first call to compile the jittable functions
-        hcurve = calc_hazard_curve(
-            sitecol, asource, [ExampleA2021()], oq)
-        # now measure the performance
         mon = Monitor()
         hcurve = calc_hazard_curve(
             sitecol, asource, [ExampleA2021()], oq, mon)


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/6850. Also changed the API again, now `calc_mean` and `calc_stdt` accept a single structured array in one-to-one correspondence with a Context instance, in accordance with an idea of 3 years ago (when the module `contexts.py` was introduced).
