### PR TITLE
Made visible the warning on non-contributing TRTs for all calculators

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made visible the warning on non-contributing TRTs for all calculators
   * Fixed a bug in scenarios from CSV ruptures with wrong TRTs
   * Added a limit of 12 characters to IMT names
   * Forbidded multiple inheritance in GMPE hierarchies

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -884,7 +884,7 @@ class HazardCalculator(BaseCalculator):
         # check for gsim logic tree reduction
         discard_trts = []
         for trt in self.full_lt.gsim_lt.values:
-            if rel_ruptures.get(trt, 0) == 0:
+            if trt != '*' and rel_ruptures.get(trt, 0) == 0:
                 discard_trts.append(trt)
         if discard_trts:
             msg = ('No sources for some TRTs: you should set\n'

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -886,10 +886,7 @@ class HazardCalculator(BaseCalculator):
         for trt in self.full_lt.gsim_lt.values:
             if rel_ruptures.get(trt, 0) == 0:
                 discard_trts.append(trt)
-        if (discard_trts and 'scenario' not in oq.calculation_mode
-                and 'event_based' not in oq.calculation_mode
-                and 'ebrisk' not in oq.calculation_mode
-                and not oq.is_ucerf()):
+        if discard_trts:
             msg = ('No sources for some TRTs: you should set\n'
                    'discard_trts = %s\nin %s') % (', '.join(discard_trts),
                                                   oq.inputs['job_ini'])


### PR DESCRIPTION
The warning was working only for classical calculations.