### PR TITLE
Forced a name convention on the coefficient tables

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Forced a name convention on the coefficient tables (must start with COEFFS)
   * Replaced IMT classes with factory functions
   * Changed the `minimum_distance` from a parameter of the GMPE to a
     parameter in the job.ini

--- a/openquake/hazardlib/gsim/armenia_2016.py
+++ b/openquake/hazardlib/gsim/armenia_2016.py
@@ -42,7 +42,7 @@ class AkkarEtAlRjb2014Armenia(AkkarEtAlRjb2014):
     """
     A
     """
-    ADJUST = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_ADJUST = CoeffsTable(sa_damping=5, table="""\
     IMT            a          b        tau_adj        sig_adj
     pga     -4.41108    0.67245    1.237606958    1.382804565
     0.01    -4.41108    0.67245    1.237606958    1.382804565
@@ -63,7 +63,7 @@ class AkkarEtAlRjb2014Armenia(AkkarEtAlRjb2014):
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         """
-        C_ADJ = self.ADJUST[imt]
+        C_ADJ = self.COEFFS_ADJUST[imt]
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, [const.StdDev.INTER_EVENT,
                                      const.StdDev.INTRA_EVENT])
@@ -87,7 +87,7 @@ class BindiEtAl2014RjbArmenia(BindiEtAl2014Rjb):
     """
     Adjustment of Bindi et al based on Armenian data
     """
-    ADJUST = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_ADJUST = CoeffsTable(sa_damping=5, table="""\
     IMT              a          b      tau_adj       sig_adj
     pga       -3.53175    0.51121  1.148988194   1.339231170
     0.01      -3.53175    0.51121  1.148988194   1.339231170
@@ -108,7 +108,7 @@ class BindiEtAl2014RjbArmenia(BindiEtAl2014Rjb):
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         """
-        C_ADJ = self.ADJUST[imt]
+        C_ADJ = self.COEFFS_ADJUST[imt]
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, [const.StdDev.INTER_EVENT,
                                      const.StdDev.INTRA_EVENT])
@@ -131,7 +131,7 @@ class BooreEtAl2014LowQArmenia(BooreEtAl2014LowQ):
     """
     Adjustment of Boore et al for Low Q regions - adjusted for Armenian data
     """
-    ADJUST = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_ADJUST = CoeffsTable(sa_damping=5, table="""\
     IMT             a          b        tau_adj        sig_adj
     pga      -5.45458    0.84260    1.633057382    1.315998086
     0.01     -5.45458    0.84260    1.633057382    1.315998086
@@ -152,7 +152,7 @@ class BooreEtAl2014LowQArmenia(BooreEtAl2014LowQ):
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         """
-        C_ADJ = self.ADJUST[imt]
+        C_ADJ = self.COEFFS_ADJUST[imt]
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, [const.StdDev.INTER_EVENT,
                                      const.StdDev.INTRA_EVENT])
@@ -175,7 +175,7 @@ class CauzziEtAl2014Armenia(CauzziEtAl2014):
     """
     Adjustment of Cauzzi et al. (2014) for Armenia
     """
-    ADJUST = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_ADJUST = CoeffsTable(sa_damping=5, table="""\
     IMT               a          b       tau_adj        sig_adj
     pga        -4.01091    0.54155   1.182557898    1.336230261
     0.01       -4.01091    0.54155   1.182557898    1.336230261
@@ -196,7 +196,7 @@ class CauzziEtAl2014Armenia(CauzziEtAl2014):
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         """
-        C_ADJ = self.ADJUST[imt]
+        C_ADJ = self.COEFFS_ADJUST[imt]
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, [const.StdDev.INTER_EVENT,
                                      const.StdDev.INTRA_EVENT])
@@ -219,7 +219,7 @@ class KaleEtAl2015Armenia(KaleEtAl2015Turkey):
     """
     Adjustment of Kale et al (2015) - Turkish version, for use in Armenia
     """
-    ADJUST = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_ADJUST = CoeffsTable(sa_damping=5, table="""\
     IMT             a          b       tau_adj        sig_adj
     pga       -3.81210   0.60842   1.211930412    1.380035424
     0.01      -3.81210   0.60842   1.211930412    1.380035424
@@ -240,7 +240,7 @@ class KaleEtAl2015Armenia(KaleEtAl2015Turkey):
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         """
-        C_ADJ = self.ADJUST[imt]
+        C_ADJ = self.COEFFS_ADJUST[imt]
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, [const.StdDev.INTER_EVENT,
                                      const.StdDev.INTRA_EVENT])
@@ -264,7 +264,7 @@ class KothaEtAl2016Armenia(KothaEtAl2016Turkey):
     Adaptation of Kotha et al. (2016) - Turkey Regionalisation - for use in
     Armenia
     """
-    ADJUST = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_ADJUST = CoeffsTable(sa_damping=5, table="""\
     IMT             a          b       tau_adj       sig_adj
     pga      -4.69043    0.75333   1.309083043   1.468617949
     0.01     -4.69043    0.75333   1.309083043   1.468617949
@@ -285,7 +285,7 @@ class KothaEtAl2016Armenia(KothaEtAl2016Turkey):
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         """
-        C_ADJ = self.ADJUST[imt]
+        C_ADJ = self.COEFFS_ADJUST[imt]
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, [const.StdDev.INTER_EVENT,
                                      const.StdDev.INTRA_EVENT])
@@ -308,7 +308,7 @@ class ChiouYoungs2014Armenia(ChiouYoungs2014):
     """
     Adaptation of Chiou & Youngs (2014) for use in Armenia
     """
-    ADJUST = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_ADJUST = CoeffsTable(sa_damping=5, table="""\
     IMT             a          b       tau_adj        sig_adj
     pga      -4.51489    0.57803   1.647935626    1.331572905
     0.01     -4.51489    0.57803   1.647935626    1.331572905
@@ -329,7 +329,7 @@ class ChiouYoungs2014Armenia(ChiouYoungs2014):
     def get_mean_and_stddevs(self, sites, rup, dists, imt, stddev_types):
         """
         """
-        C_ADJ = self.ADJUST[imt]
+        C_ADJ = self.COEFFS_ADJUST[imt]
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, [const.StdDev.INTER_EVENT,
                                      const.StdDev.INTRA_EVENT])

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -25,7 +25,6 @@ import abc
 import math
 import warnings
 import functools
-import collections
 import numpy
 from scipy.special import ndtr
 from scipy.stats import norm
@@ -541,6 +540,8 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
         params.update(cls.__base__.REQUIRES_ATTRIBUTES)
         for attr, ctable in vars(cls).items():
             if isinstance(ctable, CoeffsTable):
+                if not attr.startswith('COEFFS'):
+                    raise NameError('%s does not start with COEFFS' % attr)
                 params[attr] = ctable.dt.dtype
         names = sorted(params)
         cls.dType = DType(names, [params[p] for p in names])

--- a/openquake/hazardlib/gsim/bindi_2011.py
+++ b/openquake/hazardlib/gsim/bindi_2011.py
@@ -279,11 +279,11 @@ class BindiEtAl2011Ita19Low(BindiEtAl2011):
 
     def _get_delta(self, imt, mag):
         # Get the coefficients needed to compute the delta used for scaling
-        coeffs = self.DELTACOEFF[imt]
+        coeffs = self.COEFFS_DELTA[imt]
         tmp = coeffs['a']*mag**2. + coeffs['b']*mag + coeffs['c']
         return tmp
 
-    DELTACOEFF = CoeffsTable(sa_damping=5, table="""
+    COEFFS_DELTA = CoeffsTable(sa_damping=5, table="""
     imt   a      b     c
     pga   0.101 -1.136 3.555
     pgv   0.066 -0.741 2.400

--- a/openquake/hazardlib/gsim/boore_atkinson_2011.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2011.py
@@ -75,12 +75,12 @@ class Atkinson2008prime(BooreAtkinson2011):
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, stddev_types)
 
-        A08 = self.A08_COEFFS[imt]
+        A08 = self.COEFFS_A08[imt]
         f_ena = 10.0 ** (A08["c"] + A08["d"] * dists.rjb)
 
         return np.log(np.exp(mean)*f_ena), stddevs
 
-    A08_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_A08 = CoeffsTable(sa_damping=5, table="""\
     IMT         c         d
     pgv     0.450   0.00211
     pga     0.419   0.00039

--- a/openquake/hazardlib/gsim/can15/eastern.py
+++ b/openquake/hazardlib/gsim/can15/eastern.py
@@ -73,7 +73,7 @@ class EasternCan15Mid(PezeshkEtAl2011):
         """
         """
         if imt.period:
-            cff = self.SITE_COEFFS[imt]
+            cff = self.COEFFS_SITE[imt]
             tmp = cff['mf']
         elif imt in [PGA()]:
             tmp = -0.3+0.15*np.log10(dists.repi)
@@ -152,7 +152,7 @@ class EasternCan15Mid(PezeshkEtAl2011):
         #
         return mean_adj, stds_adj
 
-    SITE_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_SITE = CoeffsTable(sa_damping=5, table="""\
     IMT        mf
     0.05    -0.10
     0.10     0.03

--- a/openquake/hazardlib/gsim/can15/sinter.py
+++ b/openquake/hazardlib/gsim/can15/sinter.py
@@ -82,13 +82,13 @@ class SInterCan15Mid(ZhaoEtAl2006SInter):
         mean_ga14, stds4 = g[2].get_mean_and_stddevs(
             sites, rup, dists, imt,  stddev_types)
         # Computing adjusted mean and stds
-        cff = self.SITE_COEFFS[imt]
+        cff = self.COEFFS_SITE[imt]
         mean_adj = (np.log(np.exp(mean_zh06)*cff['mf'])*0.1 +
                     mean_am09*0.5 + mean_ab15*0.2 +
                     np.log(np.exp(mean_ga14)*cff['mf'])*0.2)
         return mean_adj
 
-    SITE_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_SITE = CoeffsTable(sa_damping=5, table="""\
     IMT        mf
     pgv     1.000
     pga     0.500

--- a/openquake/hazardlib/gsim/can15/sslab.py
+++ b/openquake/hazardlib/gsim/can15/sslab.py
@@ -57,14 +57,14 @@ class SSlabCan15Mid(ZhaoEtAl2006SSlab):
         dists.rrup = rrup
         mean, stddevs = super().get_mean_and_stddevs(sites, rup, dists, imt,
                                                      stddev_types)
-        cff = self.SITE_COEFFS[imt]
+        cff = self.COEFFS_SITE[imt]
         mean_adj = np.log(np.exp(mean) * 10**cff['mf'])
         stddevs = [np.ones(len(dists.rrup))*get_sigma(imt)]
         return mean_adj, stddevs
 
     # These are the coefficients included in Table 1 of Atkinson and Adams
     # (2013)
-    SITE_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_SITE = CoeffsTable(sa_damping=5, table="""\
     IMT        mf
     pgv     1.000
     pga    -0.301

--- a/openquake/hazardlib/gsim/douglas_stochastic_2013.py
+++ b/openquake/hazardlib/gsim/douglas_stochastic_2013.py
@@ -189,7 +189,7 @@ class DouglasEtAl2013StochasticSD001Q200K005(GMPE):
         for spec of input and result values.
         """
         C = self.COEFFS[imt]
-        C_SIG = self.SIGMA_COEFFS[imt]
+        C_SIG = self.COEFFS_SIGMA[imt]
 
         mean = (get_magnitude_scaling_term(C, rup.mag) +
                 get_distance_scaling_term(C, dists.rhypo))
@@ -225,7 +225,7 @@ class DouglasEtAl2013StochasticSD001Q200K005(GMPE):
           0.500000    1.238325   2.390165   -0.382327   -0.030766   -1.110481   -0.009430   0.000000   0.107816
          """)
 
-    SIGMA_COEFFS = CoeffsTable(sa_damping=5, table="""
+    COEFFS_SIGMA = CoeffsTable(sa_damping=5, table="""
                                IMT         phi       tau_s       tau_b
                                pgv  0.53545879  0.65762034  0.55823845
                                pga  0.57602321  0.90206692  0.63679205

--- a/openquake/hazardlib/gsim/eshm20_craton.py
+++ b/openquake/hazardlib/gsim/eshm20_craton.py
@@ -212,9 +212,9 @@ class ESHM20Craton(GMPE):
         (Hashash et al., 2019) amplification terms
         """
         # Get the coefficients for the IMT
-        C_LIN = NGAEastGMPE.LINEAR_COEFFS[imt]
-        C_F760 = NGAEastGMPE.F760[imt]
-        C_NL = NGAEastGMPE.NONLINEAR_COEFFS[imt]
+        C_LIN = NGAEastGMPE.COEFFS_LINEAR[imt]
+        C_F760 = NGAEastGMPE.COEFFS_F760[imt]
+        C_NL = NGAEastGMPE.COEFFS_NONLINEAR[imt]
         if str(imt).startswith("PGA"):
             period = 0.01
         elif str(imt).startswith("PGV"):

--- a/openquake/hazardlib/gsim/hong_goda_2007.py
+++ b/openquake/hazardlib/gsim/hong_goda_2007.py
@@ -171,7 +171,7 @@ class HongGoda2007(GMPE):
         """
         C = self.COEFFS[imt]
         C_PGA = self.COEFFS[PGA()]
-        C_AMP = self.AMP_COEFFS[imt]
+        C_AMP = self.COEFFS_AMP[imt]
 
         # Gets the PGA on rock - need to convert from g to cm/s/s
         pga_rock = _compute_pga_rock(C_PGA, rup.mag, dists.rjb) * 980.665
@@ -217,7 +217,7 @@ class HongGoda2007(GMPE):
     3.00   -0.955    1.027   -0.265   -0.677   -0.029   2.3   0.420   0.594   0.728
     """)
 
-    AMP_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_AMP = CoeffsTable(sa_damping=5, table="""\
     imt           blin       b1sa       b2sa
     pgv       -0.60000   -0.49500   -0.06000
     pga       -0.36100   -0.64100   -0.14400

--- a/openquake/hazardlib/gsim/mcverry_2006_chch.py
+++ b/openquake/hazardlib/gsim/mcverry_2006_chch.py
@@ -52,7 +52,7 @@ class McVerry2006Chch(McVerry2006AscSC):
         C = self.COEFFS_PRIMED[imt]
         C_PGA = self.COEFFS_PRIMED[PGA()]
         C_PGA_unprimed = self.COEFFS_UNPRIMED[PGA()]
-        SC = self.STRESS_COEFFS[imt]
+        SC = self.COEFFS_STRESS[imt]
 
         # Get S term to determine if consider site term is applied
         S = self._get_site_class(sites)
@@ -178,7 +178,7 @@ class McVerry2006Chch(McVerry2006AscSC):
         return in_cshm
 
     #: Coefficient table (Atkinson and Boore, 2006, table 7, page 2201)
-    STRESS_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_STRESS = CoeffsTable(sa_damping=5, table="""\
     IMT    delta  M1    Mh
     pga    0.15   0.50  5.50
     0.025  0.15   0.00  5.00

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -640,9 +640,9 @@ class NGAEastGMPE(GMPETable):
         (Hashash et al., 2019) amplification terms
         """
         # Get the coefficients for the IMT
-        C_LIN = self.LINEAR_COEFFS[imt]
-        C_F760 = self.F760[imt]
-        C_NL = self.NONLINEAR_COEFFS[imt]
+        C_LIN = self.COEFFS_LINEAR[imt]
+        C_F760 = self.COEFFS_F760[imt]
+        C_NL = self.COEFFS_NONLINEAR[imt]
         if str(imt).startswith("PGA"):
             period = 0.01
         elif str(imt).startswith("PGV"):
@@ -725,7 +725,7 @@ class NGAEastGMPE(GMPETable):
 
     # Coefficients for the linear model, taken from the electronic supplement
     # to Stewart et al., (2017)
-    LINEAR_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_LINEAR = CoeffsTable(sa_damping=5, table="""\
     imt           c      v1       v2      vf  sigma_vc  sigma_L  sigma_U
     pgv      -0.449   331.0    760.0   314.0     0.251    0.306    0.334
     pga      -0.290   319.0    760.0   345.0     0.300    0.345    0.480
@@ -754,7 +754,7 @@ class NGAEastGMPE(GMPETable):
 
     # Coefficients for the nonlinear model, taken from Table 2.1 of
     # Hashash et al., (2017)
-    NONLINEAR_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_NONLINEAR = CoeffsTable(sa_damping=5, table="""\
     imt          f3         f4         f5     Vc   sigma_c
     pgv     0.06089   -0.08344   -0.00667   2257.0   0.120
     pga     0.07520   -0.43755   -0.00131   2990.0   0.120
@@ -785,7 +785,7 @@ class NGAEastGMPE(GMPETable):
     # to those needed in order to reproduce Figure 5 of Petersen et al. (2019)
     # The original f760i was 0.674 +/- 0.366, and the values below are taken
     # from the US NSHMP software
-    F760 = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_F760 = CoeffsTable(sa_damping=5, table="""\
     imt       f760i     f760g   f760is   f760gs
     pgv      0.3753     0.297    0.313    0.117
     pga      0.1850     0.121    0.434    0.248

--- a/openquake/hazardlib/gsim/nshmp_2014.py
+++ b/openquake/hazardlib/gsim/nshmp_2014.py
@@ -50,7 +50,7 @@ class AtkinsonMacias2009NSHMP2014(AtkinsonMacias2009):
         # Get original mean and standard deviations
         mean, stddevs = super().get_mean_and_stddevs(
             sctx, rctx, dctx, imt, stddev_types)
-        mean += np.log(SInterCan15Mid.SITE_COEFFS[imt]['mf'])
+        mean += np.log(SInterCan15Mid.COEFFS_SITE[imt]['mf'])
         return mean, stddevs
 
 

--- a/openquake/hazardlib/gsim/pezeshk_2011.py
+++ b/openquake/hazardlib/gsim/pezeshk_2011.py
@@ -217,13 +217,13 @@ class  PezeshkEtAl2011NEHRPBC(PezeshkEtAl2011):
         <.base.GroundShakingIntensityModel.get_mean_and_stddevs>`
         for spec of input and result values.
         """
-        C_AMP = self.SITE_COEFFS[imt]
+        C_AMP = self.COEFFS_SITE[imt]
         # Get method from superclass
         mean, stddevs = super().get_mean_and_stddevs(
             sites, rup, dists, imt, stddev_types)
         return mean + C_AMP["F"]*np.log(10.), stddevs
 
-    SITE_COEFFS = CoeffsTable(sa_damping=5, table="""
+    COEFFS_SITE = CoeffsTable(sa_damping=5, table="""
     IMT         F
     pga         -0.10
     0.010       -0.10

--- a/openquake/hazardlib/gsim/projects/acme_2019.py
+++ b/openquake/hazardlib/gsim/projects/acme_2019.py
@@ -251,7 +251,7 @@ class AlAtikSigmaModel(GMPE):
                                        TAU_SETUP[self.tau_model]["STD"],
                                        self.tau_quantile)
         # setup phi
-        PHI_SETUP['global_linear'] = self.PHI_SS_GLOBAL_LINEAR
+        PHI_SETUP['global_linear'] = self.COEFFS_PHI_SS_GLOBAL_LINEAR
         self.PHI_SS = get_phi_ss_at_quantile_ACME(PHI_SETUP[self.phi_model],
                                                   self.phi_ss_quantile)
         # if required setup phis2ss
@@ -261,7 +261,7 @@ class AlAtikSigmaModel(GMPE):
                     PHI_S2SS_MODEL[self.phi_s2ss_model],
                     self.phi_s2ss_quantile)
             elif self.phi_s2ss_model == 'brb':
-                self.PHI_S2SS = self.PHI_S2SS_BRB
+                self.PHI_S2SS = self.COEFFS_PHI_S2SS_BRB
             else:
                 opts = "'cena', 'brb', or 'None'"
                 raise ValueError('phi_s2ss_model can be {}'.format(opts))
@@ -297,7 +297,7 @@ class AlAtikSigmaModel(GMPE):
             else:
                 set_highest = periods
         except AttributeError:
-            coeffs = gmpe.TAB2.sa_coeffs
+            coeffs = gmpe.COEFFS_TAB2.sa_coeffs
             imts = [*coeffs]
             periods = [imt.period for imt in imts]
             if gmpe.__class__.__name__ == 'BindiEtAl2014Rjb':
@@ -463,7 +463,7 @@ class AlAtikSigmaModel(GMPE):
         return phi
 
     # PHI_SS2S coefficients, table 2.2 HID
-    PHI_S2SS_BRB = CoeffsTable(logratio=False, sa_damping=5., table="""\
+    COEFFS_PHI_S2SS_BRB = CoeffsTable(logratio=False, sa_damping=5., table="""\
         imt   phi_s2ss
         PGA     0.0000
         0.001   0.0000
@@ -476,7 +476,7 @@ class AlAtikSigmaModel(GMPE):
         """)
 
     # Phi_ss coefficients for the global model
-    PHI_SS_GLOBAL_LINEAR = CoeffsTable(logratio=False, sa_damping=5., table="""\
+    COEFFS_PHI_SS_GLOBAL_LINEAR = CoeffsTable(logratio=False, sa_damping=5., table="""\
     imt     mean_a   var_a  mean_b  var_bs
     pgv     0.5034  0.0609  0.3585  0.0316
     pga     0.5477  0.0731  0.3505  0.0412

--- a/openquake/hazardlib/gsim/usgs_ceus_2019.py
+++ b/openquake/hazardlib/gsim/usgs_ceus_2019.py
@@ -198,9 +198,9 @@ class NGAEastUSGSGMPE(NGAEastGMPE):
             imean = np.copy(pga_r)
 
         # Get the coefficients for the IMT
-        C_LIN = self.LINEAR_COEFFS[imt]
-        C_F760 = self.F760[imt]
-        C_NL = self.NONLINEAR_COEFFS[imt]
+        C_LIN = self.COEFFS_LINEAR[imt]
+        C_F760 = self.COEFFS_F760[imt]
+        C_NL = self.COEFFS_NONLINEAR[imt]
 
         site_amp = self.get_site_amplification(imt, np.exp(pga_r), sctx)
 

--- a/openquake/hazardlib/gsim/yenier_atkinson_2015.py
+++ b/openquake/hazardlib/gsim/yenier_atkinson_2015.py
@@ -149,9 +149,9 @@ class YenierAtkinson2015BSSA(GMPE):
 
     def _get_mean_on_rock(self, sctx, rctx, dctx, imt, stddev_types):
         # Get coefficients
-        C2 = self.TAB2[imt]
-        C3 = self.TAB3[imt]
-        C4 = self.TAB4[imt]
+        C2 = self.COEFFS_TAB2[imt]
+        C3 = self.COEFFS_TAB3[imt]
+        C4 = self.COEFFS_TAB4[imt]
         # Magnitude effect
         f_m = self._get_f_m(C2, imt, rctx.mag)
         # Stress adjustment
@@ -319,7 +319,7 @@ class YenierAtkinson2015BSSA(GMPE):
             msg = fmt.format(region)
             raise ValueError(msg)
 
-    TAB2 = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_TAB2 = CoeffsTable(sa_damping=5, table="""\
    imt    Mh        e0      e1       e2      e3      b3        b4
   0.01  5.85  2.227000  0.6874 -0.13630  0.7643 -0.6209  0.060570
  0.013  5.90  2.281000  0.6855 -0.12900  0.7617 -0.6259  0.061290
@@ -356,7 +356,7 @@ class YenierAtkinson2015BSSA(GMPE):
    PGV  5.90  5.960000  1.0300 -0.16510  1.0790 -0.5785  0.057370
 """)
 
-    TAB3 = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_TAB3 = CoeffsTable(sa_damping=5, table="""\
    imt      s0      s1       s2        s3        s4        s5       s6       s7        s8        s9
   0.01 -2.0480  1.8810 -0.49010  0.056680 -0.002433 -1.437000  1.24200 -0.28920  0.030880 -0.001252
  0.013 -1.9220  1.8020 -0.47130  0.054710 -0.002357 -1.348000  1.19500 -0.27990  0.030060 -0.001225
@@ -393,7 +393,7 @@ class YenierAtkinson2015BSSA(GMPE):
    PGV -2.2460  1.9510 -0.51810  0.061390 -0.002725 -1.758000  1.37900 -0.32560  0.035000 -0.001425
 """)
 
-    TAB4 = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_TAB4 = CoeffsTable(sa_damping=5, table="""\
    imt     gCENA  gCalifornia
   0.01 -0.004661    -0.009823
  0.013 -0.004693    -0.009833

--- a/openquake/hazardlib/gsim/zhao_2016.py
+++ b/openquake/hazardlib/gsim/zhao_2016.py
@@ -491,7 +491,7 @@ class ZhaoEtAl2016Asc(GMPE):
         # extracting dictionary of coefficients specific to required
         # intensity measure type.
         C = self.COEFFS[imt]
-        C_SITE = self.SITE_COEFFS[imt]
+        C_SITE = self.COEFFS_SITE[imt]
         trt = self.DEFINED_FOR_TECTONIC_REGION_TYPE
         s_c, idx = _get_site_classification(sites.vs30)
         sa_rock = (get_magnitude_scaling_term(trt, C, rup) +
@@ -555,7 +555,7 @@ class ZhaoEtAl2016Asc(GMPE):
     """)
 
     # Coefficients specific to the site amplification
-    SITE_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_SITE = CoeffsTable(sa_damping=5, table="""\
     imt    LnAmax1D1   LnAmax1D2   LnAmax1D3   LnAmax1D4     Src1D1     Src1D2     Src1D3     Src1D4      fsr1      fsr2      fsr3      fsr4
     pga     0.650220    0.709730    0.644340    0.404280   8.429000   1.913680   1.117140   0.836440  1.000000  1.000000  1.000000  1.000000
     0.005   0.650220    0.709730    0.644340    0.404280   8.429000   1.913680   1.117140   0.836440  1.000000  1.000000  1.000000  1.000000
@@ -614,7 +614,7 @@ class ZhaoEtAl2016UpperMantle(ZhaoEtAl2016Asc):
     DEFINED_FOR_TECTONIC_REGION_TYPE = const.TRT.UPPER_MANTLE
 
     # For Upper Mantle
-    SITE_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_SITE = CoeffsTable(sa_damping=5, table="""\
     imt    LnAmax1D1   LnAmax1D2   LnAmax1D3   LnAmax1D4     Src1D1     Src1D2     Src1D3     Src1D4      fsr1      fsr2      fsr3      fsr4
     pga     0.650220    0.709730    0.644340    0.404280   8.429000   1.913680   1.117140   0.836440  1.000000  1.000000  1.000000  1.000000
     0.005   0.650220    0.709730    0.644340    0.404280   8.429000   1.913680   1.117140   0.836440  1.000000  1.000000  1.000000  1.000000
@@ -727,7 +727,7 @@ class ZhaoEtAl2016SInter(ZhaoEtAl2016Asc):
     """)
 
     # Coefficients specific to the site amplification
-    SITE_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_SITE = CoeffsTable(sa_damping=5, table="""\
     imt    LnAmax1D1   LnAmax1D2   LnAmax1D3   LnAmax1D4     Src1D1     Src1D2     Src1D3     Src1D4     fsr1    fsr2    fsr3    fsr4
     pga     0.650220    0.709730    0.644340    0.404280   8.429000   1.913680   1.117140   0.836440   1.0000  1.0000  1.1650  1.0000
     0.005   0.650220    0.709730    0.644340    0.404280   8.429000   1.913680   1.117140   0.836440   1.0000  1.0000  1.1650  1.0000
@@ -841,7 +841,7 @@ pga    -5.30118903954448  1.151  1.44758  0.37625  0.42646  0.01825668401347  -1
     """)
 
     # Coefficients specific to the site amplification
-    SITE_COEFFS = CoeffsTable(sa_damping=5, table="""\
+    COEFFS_SITE = CoeffsTable(sa_damping=5, table="""\
     imt    LnAmax1D1   LnAmax1D2   LnAmax1D3   LnAmax1D4     Src1D1     Src1D2     Src1D3     Src1D4     fsr1    fsr2    fsr3    fsr4
     pga     0.650220    0.709730    0.644340    0.404280   8.429000   1.913680   1.117140   0.836440   1.0000  1.0000  1.0000  1.0000
     0.005   0.650220    0.709730    0.644340    0.404280   8.429000   1.913680   1.117140   0.836440   1.0000  1.0000  1.0000  1.0000


### PR DESCRIPTION
The name must start with COEFFS. Right now there is too much anarchy that it is hindering further refactoring. Part of #6850 .
An user using a wrong name (like SITE_COEFFS instead of the right COEFFS_SITE) will get an error at class definition time.