### PR TITLE
Modify pga_threshold_table from job.ini for HAZUS lateral spreading

### DIFF
--- a/openquake/sep/classes.py
+++ b/openquake/sep/classes.py
@@ -23,7 +23,8 @@ from openquake.sep.landslide.newmark import (
     newmark_critical_accel, newmark_displ_from_pga_M,
     prob_failure_given_displacement)
 from openquake.sep.liquefaction.liquefaction import (
-    hazus_liquefaction_probability, zhu_liquefaction_probability_general)
+    hazus_liquefaction_probability, zhu_liquefaction_probability_general,
+    LIQUEFACTION_PGA_THRESHOLD_TABLE)
 from openquake.sep.liquefaction.lateral_spreading import (
     hazus_lateral_spreading_displacement)
 from openquake.sep.liquefaction.vertical_settlement import (
@@ -140,10 +141,16 @@ class HazusDeformation(SecondaryPeril):
     """
     Computes PGDMax or PGDGeomMean from PGA
     """
-    def __init__(self, return_unit='m', deformation_component='PGDMax'):
+    def __init__(self, return_unit='m', deformation_component='PGDMax',
+        pga_threshold_table=LIQUEFACTION_PGA_THRESHOLD_TABLE):
         self.return_unit = return_unit
         self.deformation_component = getattr(imt, deformation_component)
         self.outputs = [deformation_component]
+
+        if pga_threshold_table != LIQUEFACTION_PGA_THRESHOLD_TABLE:
+            pga_threshold_table = {bytes(str(k), 'utf-8'): v
+                for k, v in pga_threshold_table.items()}
+        self.pga_threshold_table=pga_threshold_table
 
     def prepare(self, sites):
         pass
@@ -154,6 +161,7 @@ class HazusDeformation(SecondaryPeril):
             if im.name == 'PGA':
                 ls = hazus_lateral_spreading_displacement(
                     mag=mag, pga=gmf, liq_susc_cat=sites.liq_susc_cat,
+                    pga_threshold_table=self.pga_threshold_table,
                     return_unit=self.return_unit)
                 vs = hazus_vertical_settlement(
                     sites.liq_susc_cat, return_unit=self.return_unit)

--- a/openquake/sep/liquefaction/lateral_spreading.py
+++ b/openquake/sep/liquefaction/lateral_spreading.py
@@ -14,7 +14,7 @@ def hazus_lateral_spreading_displacement(
         mag: Union[float, np.ndarray],
         pga: Union[float, np.ndarray],
         liq_susc_cat: Union[str, List[str]],
-        thresh_table: dict = LIQUEFACTION_PGA_THRESHOLD_TABLE,
+        pga_threshold_table: dict = LIQUEFACTION_PGA_THRESHOLD_TABLE,
         return_unit: str = 'm') -> Union[float, np.ndarray]:
     """
     Distance of lateral spreading from Hazus
@@ -41,10 +41,10 @@ def hazus_lateral_spreading_displacement(
         Displacements from lateral spreading in meters or inches.
     """
     if isinstance(liq_susc_cat, str):
-        pga_threshold = thresh_table[liq_susc_cat]
+        pga_threshold = pga_threshold_table[liq_susc_cat]
     else:
         pga_threshold = np.array(
-            [thresh_table[susc_cat] for susc_cat in liq_susc_cat])
+            [pga_threshold_table[susc_cat] for susc_cat in liq_susc_cat])
     disp_inch = hazus_lateral_spreading_displacement_fn(
         mag, pga, pga_threshold)
     if return_unit == 'm':


### PR DESCRIPTION
This PR lets the user pass a dictionary specifying the threshold at which liquefaction displacements will occur for the `hazus_lateral_spreading_displacement` function.

The dictionary is passed in the `sec_peril_params` section of the `job.ini` file:
```
sec_peril_params = {'pga_threshold_table': {
                        'vh': 0.4,
                        'h': 0.6,
                        'm': 0.8,
                        'l': 1.0,
                        'vl': 1.5,
                        'n': 15.0,
                        }
}
```

It is optional, and if it is not specified then the default dictionary is used (as was previously the case).