### PR TITLE
From numba objects to structured arrays/1

### DIFF
--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -311,9 +311,10 @@ def export_hcurves_xml(ekey, dstore):
             fname = name[:-len_ext] + '-' + im + '.' + fmt
             data = [HazardCurve(Location(site), poes[0])
                     for site, poes in zip(sitemesh, hcurves)]
+            imt_name = 'SA' if im.startswith('SA') else im
             writer = writercls(fname,
                                investigation_time=oq.investigation_time,
-                               imls=oq.imtls[im], imt=imt.name,
+                               imls=oq.imtls[im], imt=imt_name,
                                sa_period=getattr(imt, 'period', None) or None,
                                sa_damping=getattr(imt, 'damping', None),
                                smlt_path=smlt_path, gsimlt_path=gsimlt_path)
@@ -499,8 +500,9 @@ def export_disagg_csv_xml(ekey, dstore):
             'rlz-%d-%s-sid-%d-poe-%d.xml' % (r, imt, s, p))
         lon, lat = sitecol.lons[s], sitecol.lats[s]
         metadata = dstore.metadata
+        imt_name = 'SA' if imt.string.startswith('SA') else imt.string
         metadata.update(investigation_time=oq.investigation_time,
-                        imt=imt.name,
+                        imt=imt_name,
                         smlt_path='_'.join(rlz.sm_lt_path),
                         gsimlt_path=rlz.gsim_rlz.pid, lon=lon, lat=lat,
                         mag_bin_edges=bins['Mag'].tolist(),

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1089,7 +1089,10 @@ class OqParam(valid.ParamSet):
         """
         :param gsims: a sequence of GSIM instances
         """
-        imts = set(from_string(imt).name for imt in self.imtls)
+        imts = set()
+        for imt in self.imtls:
+            im = from_string(imt)
+            imts.add("SA" if imt.startswith("SA") else im.string)
         for gsim in gsims:
             if hasattr(gsim, 'weight'):  # disable the check
                 continue

--- a/openquake/hazardlib/gsim/abrahamson_2014.py
+++ b/openquake/hazardlib/gsim/abrahamson_2014.py
@@ -342,7 +342,7 @@ def _get_vs30star(vs30, imt):
     This computes equations 8 and 9 at page 1034
     """
     # compute the v1 value (see eq. 9, page 1034)
-    if imt.name == "SA":
+    if imt.string[:2] == "SA":
         t = imt.period
         if t <= 0.50:
             v1 = 1500.0
@@ -350,7 +350,7 @@ def _get_vs30star(vs30, imt):
             v1 = np.exp(-0.35 * np.log(t / 0.5) + np.log(1500.))
         else:
             v1 = 800.0
-    elif imt.name == "PGA":
+    elif imt.string == "PGA":
         v1 = 1500.0
     else:
         # This covers the PGV case

--- a/openquake/hazardlib/gsim/abrahamson_silva_2008.py
+++ b/openquake/hazardlib/gsim/abrahamson_silva_2008.py
@@ -363,7 +363,7 @@ def _compute_v1_factor(imt):
     """
     Compute and return v1 factor, equation 6, page 77.
     """
-    if imt.name == "SA":
+    if imt.string[:2] == "SA":
         t = imt.period
         if t <= 0.50:
             v1 = 1500.0
@@ -373,7 +373,7 @@ def _compute_v1_factor(imt):
             v1 = np.exp(6.76 - 0.297 * np.log(t))
         else:
             v1 = 700.0
-    elif imt.name == "PGA":
+    elif imt.string == "PGA":
         v1 = 1500.0
     else:
         # this is for PGV
@@ -388,9 +388,9 @@ def _compute_e2_factor(imt, vs30):
     """
     e2 = np.zeros_like(vs30)
 
-    if imt.name == "PGV":
+    if imt.string == "PGV":
         period = 1
-    elif imt.name == "PGA":
+    elif imt.string == "PGA":
         period = 0
     else:
         period = imt.period
@@ -427,7 +427,7 @@ def _compute_a22_factor(imt):
     """
     Compute and return the a22 factor, equation 20, page 80.
     """
-    if imt.name == 'PGV':
+    if imt.string == 'PGV':
         return 0.0
     period = imt.period
     if period < 2.0:

--- a/openquake/hazardlib/gsim/akkar_bommer_2010.py
+++ b/openquake/hazardlib/gsim/akkar_bommer_2010.py
@@ -191,14 +191,14 @@ class AkkarBommer2010(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.name in 'PGA SA':
+        if imt.string.startswith(("SA", "PGA")):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:
             mean = np.log(10.0 ** imean)
 
         # apply scaling factor for SA at 4 s
-        if imt.name == 'SA' and imt.period == 4.0:
+        if imt.string[:2] == 'SA' and imt.period == 4.0:
             mean /= 0.8
 
         istddevs = _get_stddevs(

--- a/openquake/hazardlib/gsim/akkar_cagnan_2010.py
+++ b/openquake/hazardlib/gsim/akkar_cagnan_2010.py
@@ -168,7 +168,7 @@ class AkkarCagnan2010(BooreAtkinson2008):
 
         # compute full mean value by adding site amplification terms
         # (but avoiding recomputing mean on rock for PGA)
-        if imt.name == "PGA":
+        if imt.string == "PGA":
             mean = (np.log(pga4nl) +
                     _get_site_amplification_linear(sites.vs30, C_SR) +
                     _get_site_amplification_non_linear(sites.vs30, pga4nl,
@@ -181,7 +181,7 @@ class AkkarCagnan2010(BooreAtkinson2008):
                                                        C_SR))
 
         # convert from cm/s**2 to g for SA (PGA is already computed in g)
-        if imt.name == "SA":
+        if imt.string[:2] == "SA":
             mean = np.log(np.exp(mean) * 1e-2 / g)
 
         stddevs = _get_stddevs(C, stddev_types, num_sites=len(sites.vs30))

--- a/openquake/hazardlib/gsim/atkinson_2015.py
+++ b/openquake/hazardlib/gsim/atkinson_2015.py
@@ -119,7 +119,7 @@ class Atkinson2015(GMPE):
         imean = (_get_magnitude_term(C, rup.mag) +
                  _get_distance_term(C, dists.rhypo, rup.mag))
         # Convert mean from cm/s and cm/s/s
-        if imt.name in "SA PGA":
+        if imt.string.startswith(('PGA', 'SA')):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log(10.0 ** imean)

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -402,9 +402,10 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
         """
         names = set(f.__name__
                     for f in self.DEFINED_FOR_INTENSITY_MEASURE_TYPES)
-        if imt.name not in names:
+        name = "SA" if imt.string[:2] == "SA" else imt.string
+        if name not in names:
             raise ValueError('imt %s is not supported by %s' %
-                             (imt.name, type(self).__name__))
+                             (name, type(self).__name__))
 
     def __lt__(self, other):
         """

--- a/openquake/hazardlib/gsim/bindi_2011.py
+++ b/openquake/hazardlib/gsim/bindi_2011.py
@@ -223,7 +223,7 @@ class BindiEtAl2011(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.name in "SA PGA":
+        if imt.string.startswith(('PGA', 'SA')):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/bindi_2014.py
+++ b/openquake/hazardlib/gsim/bindi_2014.py
@@ -208,7 +208,7 @@ class BindiEtAl2014Rjb(GMPE):
         C = self.COEFFS[imt]
         imean = _get_mean(self.kind, self.sof, C, rup,
                           getattr(dists, self.dist_type), sites)
-        if imt.name in "SA PGA":
+        if imt.string.startswith(('PGA', 'SA')):
             # Convert units to g,
             # but only for PGA and SA (not PGV):
             mean = np.log((10.0 ** (imean - 2.0)) / g)

--- a/openquake/hazardlib/gsim/boore_2014.py
+++ b/openquake/hazardlib/gsim/boore_2014.py
@@ -329,7 +329,7 @@ class BooreEtAl2014(GMPE):
         # intensity measure type.
         C = self.COEFFS[imt]
         C_PGA = self.COEFFS[PGA()]
-        imt_per = 0 if imt.name == 'PGV' else imt.period
+        imt_per = 0 if imt.string == 'PGV' else imt.period
         pga_rock = _get_pga_on_rock(
             self.kind, self.region, self.sof, C_PGA, rup, dists)
         mean = (_get_magnitude_scaling_term(self.sof, C, rup) +

--- a/openquake/hazardlib/gsim/bozorgnia_campbell_2016.py
+++ b/openquake/hazardlib/gsim/bozorgnia_campbell_2016.py
@@ -102,7 +102,7 @@ class BozorgniaCampbell2016(GMPE):
         C_PGA = self.COEFFS[PGA()]
         # Get mean and standard deviations for IMT
         mean = self.get_mean_values(C, sites, rup, dists)
-        if imt.name == "SA" and imt.period < 0.25:
+        if imt.string[:2] == "SA" and imt.period < 0.25:
             # If Sa (T) < PGA for T < 0.25 then set mean Sa(T) to mean PGA
             # Get PGA on given sites
             pga = self.get_mean_values(C_PGA, sites, rup, dists)

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
@@ -96,7 +96,7 @@ class CampbellBozorgnia2008(GMPE):
         # For spectral accelerations at periods between 0.0 and 0.25 s, Sa (T)
         # cannot be less than PGA on soil, therefore if the IMT is in this
         # period range it is necessary to calculate PGA on soil
-        if imt.name == 'SA' and imt.period > 0.0 and imt.period < 0.25:
+        if imt.string[:2] == 'SA' and imt.period > 0.0 and imt.period < 0.25:
             get_pga_site = True
         else:
             get_pga_site = False

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
@@ -103,7 +103,7 @@ class CampbellBozorgnia2014(GMPE):
         pga1100 = np.exp(self.get_mean_values(C_PGA, sites, rup, dists, None))
         # Get mean and standard deviations for IMT
         mean = self.get_mean_values(C, sites, rup, dists, pga1100)
-        if imt.name == "SA" and imt.period <= 0.25:
+        if imt.string[:2] == "SA" and imt.period <= 0.25:
             # According to Campbell & Bozorgnia (2013) [NGA West 2 Report]
             # If Sa (T) < PGA for T < 0.25 then set mean Sa(T) to mean PGA
             # Get PGA on soil

--- a/openquake/hazardlib/gsim/cauzzi_2014.py
+++ b/openquake/hazardlib/gsim/cauzzi_2014.py
@@ -56,10 +56,10 @@ def _compute_mean(clsname, sof, adjustment_factor, C, rup, dists, sites, imt):
                 clsname, sof, C, sites.vs30))
     # convert from cm/s**2 to g for SA and from cm/s**2 to g for PGA (PGV
     # is already in cm/s) and also convert from base 10 to base e.
-    if imt.name == "PGA":
+    if imt.string == "PGA":
         mean = np.log((10 ** mean) * ((2 * np.pi / 0.01) ** 2) *
                       1e-2 / g)
-    elif imt.name == "SA":
+    elif imt.string[:2] == "SA":
         mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                       1e-2 / g)
     else:

--- a/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
+++ b/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
@@ -163,9 +163,9 @@ class CauzziFaccioli2008(GMPE):
 
         # convert from cm/s**2 to g for SA and from m/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if imt.name == "PGA":
+        if imt.string == "PGA":
             mean = np.log((10 ** mean) / g)
-        elif imt.name == "SA":
+        elif imt.string[:2] == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
         else:

--- a/openquake/hazardlib/gsim/chao_2020.py
+++ b/openquake/hazardlib/gsim/chao_2020.py
@@ -38,7 +38,7 @@ def _fc(C, imt, vs30, sa1180):
     C value factor [23].
     """
     s = CONSTANTS
-    if imt.name in ["PGD", "PGV"]:
+    if imt.string in ["PGD", "PGV"]:
         c = 2400
     else:
         c = 2.4

--- a/openquake/hazardlib/gsim/climent_1994.py
+++ b/openquake/hazardlib/gsim/climent_1994.py
@@ -93,7 +93,7 @@ def _compute_mean(C, rup, dists, sites, imt):
 
     # convert from m/s**2 to g for PGA and from m/s to g for PSV
     # and divided this value for the ratio(SA_larger/SA_geo_mean)
-    if imt.name == "PGA":
+    if imt.string == "PGA":
         mean = (np.exp(mean) / g) / C['r_SA']
     else:
         W = (2. * np.pi)/imt.period

--- a/openquake/hazardlib/gsim/coeffs_table.py
+++ b/openquake/hazardlib/gsim/coeffs_table.py
@@ -175,12 +175,12 @@ class CoeffsTable(object):
     @property
     def sa_coeffs(self):
         return {imt: self._coeffs[imt] for imt in self._coeffs
-                if imt.name == 'SA'}
+                if imt.string[:2] == 'SA'}
 
     @property
     def non_sa_coeffs(self):
         return {imt: self._coeffs[imt] for imt in self._coeffs
-                if imt.name != 'SA'}
+                if imt.string[:2] != 'SA'}
 
     def __getitem__(self, imt):
         """

--- a/openquake/hazardlib/gsim/derras_2014.py
+++ b/openquake/hazardlib/gsim/derras_2014.py
@@ -249,7 +249,7 @@ class DerrasEtAl2014(GMPE):
         # Get the mean
         mean = get_mean(self.region, self.W_1, self.B_1,
                         C, rup, sites, dists)
-        if imt.name == "PGV":
+        if imt.string == "PGV":
             # Convert from log10 m/s to ln cm/s
             mean = np.log((10.0 ** mean) * 100.)
         else:
@@ -374,7 +374,7 @@ class DerrasEtAl2014RhypoGermany(DerrasEtAl2014):
         # Get the mean
         mean = get_mean(self.region, self.W_1, self.B_1,
                         C, rup, sites, dists)
-        if imt.name == "PGV":
+        if imt.string == "PGV":
             # Convert from log10 m/s to ln cm/s
             mean = np.log((10.0 ** mean) * 100.)
         else:

--- a/openquake/hazardlib/gsim/dost_2004.py
+++ b/openquake/hazardlib/gsim/dost_2004.py
@@ -136,7 +136,7 @@ class DostEtAl2004(GMPE):
         imean = (_compute_magnitude_term(self.kind, C, rup.mag) +
                  _compute_distance_term(C, dists.rhypo))
         # Convert mean from cm/s and cm/s/s
-        if imt.name == "PGA":
+        if imt.string == "PGA":
             mean = np.log((10.0 ** (imean)) / g)
         else:
             mean = np.log(10.0 ** imean)

--- a/openquake/hazardlib/gsim/douglas_stochastic_2013.py
+++ b/openquake/hazardlib/gsim/douglas_stochastic_2013.py
@@ -198,7 +198,7 @@ class DouglasEtAl2013StochasticSD001Q200K005(GMPE):
 
         #: Mean ground motions initially returned in cm/s/s (for PGA, SA)
         #: and cm/s for PGV
-        if not imt.name == "PGV":
+        if not imt.string == "PGV":
             # Convert mean from log(cm/s/s) to g
             mean = np.log(np.exp(mean) / (100. * g))
 

--- a/openquake/hazardlib/gsim/drouet_2015_brazil.py
+++ b/openquake/hazardlib/gsim/drouet_2015_brazil.py
@@ -128,9 +128,9 @@ class DrouetBrazil2015(GMPE):
         C = self.COEFFS[imt]
         depth = "hypo_depth" in self.REQUIRES_RUPTURE_PARAMETERS
         mean = _compute_mean(depth, C, rup, dists.rjb)
-        if imt.name in "SA PGA":  # Convert from m/s**2 to g
+        if imt.string.startswith(('PGA', 'SA')):  # Convert from m/s**2 to g
             mean -= np.log(g)
-        elif imt.name == "PGV":  # Convert from m/s to cm/s
+        elif imt.string == "PGV":  # Convert from m/s to cm/s
             mean += np.log(100.0)
         stddevs = _get_stddevs(C, stddev_types, rup.mag, dists.rjb.shape)
 

--- a/openquake/hazardlib/gsim/drouet_alpes_2015.py
+++ b/openquake/hazardlib/gsim/drouet_alpes_2015.py
@@ -137,10 +137,10 @@ class DrouetAlpes2015Rjb(GMPE):
         """
         C = self.COEFFS[imt]
         mean = _compute_mean(C, rup.mag, dists.rjb)
-        if imt.name in 'SA PGA':
+        if imt.string.startswith(("PGA", "SA")):
             # Convert from m/s**2 to g
             mean = mean - np.log(g)
-        elif imt.name == 'PGV':  # Convert from m/s to cm/s
+        elif imt.string == 'PGV':  # Convert from m/s to cm/s
             mean = mean + np.log(100.0)
         stddevs = _get_stddevs(C, stddev_types, rup.mag,
                                dists.rjb.shape[0])
@@ -193,10 +193,10 @@ class DrouetAlpes2015Rrup(DrouetAlpes2015Rjb):
         """
         C = self.COEFFS[imt]
         mean = _compute_mean(C, rup.mag, dists.rrup)
-        if imt.name in 'SA PGA':
+        if imt.string.startswith(("PGA", "SA")):
             # Convert from m/s**2 to g
             mean = mean - np.log(g)
-        elif imt.name == 'PGV':  # Convert from m/s to cm/s
+        elif imt.string == 'PGV':  # Convert from m/s to cm/s
             mean = mean + np.log(100.0)
         stddevs = _get_stddevs(C, stddev_types, rup.mag,
                                dists.rrup.shape[0])
@@ -249,13 +249,13 @@ class DrouetAlpes2015Repi(DrouetAlpes2015Rjb):
         """
         C = self.COEFFS[imt]
         mean = _compute_mean(C, rup.mag, dists.repi)
-        if imt.name in 'SA PGA':
+        if imt.string.startswith(("PGA", "SA")):
             # Convert from m/s**2 to g
             mean = mean - np.log(g)
-        elif imt.name == 'PGV':  # Convert from m/s to cm/s
+        elif imt.string == 'PGV':  # Convert from m/s to cm/s
             mean = mean + np.log(100.0)
         stddevs = _get_stddevs(C, stddev_types, rup.mag,
-                                    dists.repi.shape[0])
+                               dists.repi.shape[0])
         return mean, stddevs
 
     #: Coefficient tables are constructed from the electronic suplements of
@@ -305,9 +305,9 @@ class DrouetAlpes2015Rhyp(DrouetAlpes2015Rjb):
         """
         C = self.COEFFS[imt]
         mean = _compute_mean(C, rup.mag, dists.rhyp)
-        if imt.name in 'SA PGA':  # Convert from m/s**2 to g
+        if imt.string.startswith(('PGA', 'SA')):  # Convert from m/s**2 to g
             mean = mean - np.log(g)
-        elif imt.name == 'PGV':  # Convert from m/s to cm/s
+        elif imt.string == 'PGV':  # Convert from m/s to cm/s
             mean = mean + np.log(100.0)
         stddevs = _get_stddevs(C, stddev_types, rup.mag,
                                dists.rhyp.shape[0])

--- a/openquake/hazardlib/gsim/edwards_fah_2013a.py
+++ b/openquake/hazardlib/gsim/edwards_fah_2013a.py
@@ -207,7 +207,7 @@ class EdwardsFah2013Alpine10Bars(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.name in "SA PGA":
+        if imt.string.startswith(("SA", "PGA")):
             mean = np.log(mean / (g*100.))
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/edwards_fah_2013f.py
+++ b/openquake/hazardlib/gsim/edwards_fah_2013f.py
@@ -91,7 +91,7 @@ class EdwardsFah2013Foreland10Bars(EdwardsFah2013Alpine10Bars):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.name in "SA PGA":
+        if imt.string.startswith(('PGA', 'SA')):
             mean = np.log(mean / (g*100.))
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/faccioli_2010.py
+++ b/openquake/hazardlib/gsim/faccioli_2010.py
@@ -74,9 +74,9 @@ class FaccioliEtAl2010(CauzziFaccioli2008):
 
         # convert from cm/s**2 to g for SA and from m/s**2 to g for PGA,
         # and also convert from base 10 to base e.
-        if imt.name == "PGA":
+        if imt.string == "PGA":
             mean = np.log((10 ** mean) / g)
-        elif imt.name == "SA":
+        elif imt.string[:2] == "SA":
             mean = np.log((10 ** mean) * ((2 * np.pi / imt.period) ** 2) *
                           1e-2 / g)
 

--- a/openquake/hazardlib/gsim/ghofrani_atkinson_2014.py
+++ b/openquake/hazardlib/gsim/ghofrani_atkinson_2014.py
@@ -192,7 +192,7 @@ class GhofraniAtkinson2014(GMPE):
                  _get_scaling_term(self.kind, C, dists.rrup))
         # Convert mean from cm/s and cm/s/s and from common logarithm to
         # natural logarithm
-        if imt.name in "SA PGA":
+        if imt.string.startswith(('PGA', 'SA')):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log((10.0 ** (imean)))

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -210,9 +210,9 @@ class AmplificationTable(object):
             Number Levels]
         """
         # Levels by Distances
-        if imt.name in 'PGA PGV':
+        if imt.string in 'PGA PGV':
             interpolator = interp1d(self.magnitudes,
-                                    numpy.log10(self.mean[imt.name]), axis=2)
+                                    numpy.log10(self.mean[imt.string]), axis=2)
             output_table = 10.0 ** (
                 interpolator(rctx.mag).reshape(self.shape[0], self.shape[3]))
         else:
@@ -240,9 +240,9 @@ class AmplificationTable(object):
         output_tables = []
         for stddev_type in stddev_types:
             # For PGA and PGV only needs to apply magnitude interpolation
-            if imt.name in 'PGA PGV':
+            if imt.string in 'PGA PGV':
                 interpolator = interp1d(self.magnitudes,
-                                        self.sigma[stddev_type][imt.name],
+                                        self.sigma[stddev_type][imt.string],
                                         axis=2)
                 output_tables.append(
                     interpolator(rctx.mag).reshape(self.shape[0],
@@ -470,12 +470,12 @@ class GMPETable(GMPE):
         :param val_type:
             String indicating the type of data {"IMLs", "Total", "Inter" etc}
         """
-        if imt.name in 'PGA PGV':
+        if imt.string in 'PGA PGV':
             # Get scalar imt
             if val_type == "IMLs":
-                iml_table = self.imls[imt.name][:]
+                iml_table = self.imls[imt.string][:]
             else:
-                iml_table = self.stddevs[val_type][imt.name][:]
+                iml_table = self.stddevs[val_type][imt.string][:]
             n_d, n_s, n_m = iml_table.shape
             iml_table = iml_table.reshape([n_d, n_m])
         else:

--- a/openquake/hazardlib/gsim/hassani_atkinson_2020.py
+++ b/openquake/hazardlib/gsim/hassani_atkinson_2020.py
@@ -78,7 +78,7 @@ def _ffpeak(C, imt, fpeak):
     """
     Fpeak factor.
     """
-    if not imt.name == "SA" or max(fpeak) <= 0:
+    if imt.string[:2] != "SA" or max(fpeak) <= 0:
         # pgv, pga or unknown fpeak
         return 0
 
@@ -304,7 +304,7 @@ class HassaniAtkinson2020SInter(GMPE):
         mean = 10 ** (fm + fdsigma + fz + fkappa + fgamma
                       + self.CONST_REGION['cc'] + clf + C['chf']
                       + C['amp_cr'] + fvs30 + fz2pt5 + ffpeak + fsnonlin)
-        if imt.name != "PGV":
+        if imt.string != "PGV":
             # pgv in cm/s
             # sa and psa in cm/s^2
             mean = mean / 981

--- a/openquake/hazardlib/gsim/idriss_2014.py
+++ b/openquake/hazardlib/gsim/idriss_2014.py
@@ -88,7 +88,7 @@ def _get_stddevs(imt, mag, n_sites, stddev_types):
     else:
         stddev_mag = mag
 
-    if imt.name == "PGA" or imt.period < 0.05:
+    if imt.string == "PGA" or imt.period < 0.05:
         total_sigma = 1.18 + 0.035 * np.log(0.05) - 0.06 * stddev_mag
     elif imt.period > 3.0:
         total_sigma = 1.18 + 0.035 * np.log(3.0) - 0.06 * stddev_mag

--- a/openquake/hazardlib/gsim/kanno_2006.py
+++ b/openquake/hazardlib/gsim/kanno_2006.py
@@ -187,7 +187,7 @@ class Kanno2006Shallow(GMPE):
         ln_stddevs = np.array(log_stddevs)*LOG10
 
         # convert accelerations from cm/s^2 to g
-        if not imt.name == "PGV":
+        if not imt.string == "PGV":
             ln_mean -= np.log(100*g)
 
         return ln_mean, ln_stddevs

--- a/openquake/hazardlib/gsim/kotha_2016.py
+++ b/openquake/hazardlib/gsim/kotha_2016.py
@@ -83,7 +83,7 @@ class KothaEtAl2016(GMPE):
 
         # Units of GMPE are in terms of m/s (corrected in an Erratum)
         # Convert to g
-        if imt.name in "SA PGA":
+        if imt.string.startswith(('PGA', 'SA')):
             mean = np.log(np.exp(mean) / g)
         else:
             # For PGV convert from m/s to cm/s/s

--- a/openquake/hazardlib/gsim/kotha_2020.py
+++ b/openquake/hazardlib/gsim/kotha_2020.py
@@ -215,7 +215,7 @@ class KothaEtAl2020(GMPE):
                 self.get_distance_term(C, rup, dists.rjb, imt, sites) +
                 self.get_site_amplification(C, sites, imt))
         # GMPE originally in cm/s/s - convert to g
-        if imt.name in "PGA SA":
+        if imt.string.startswith(('PGA', 'SA')):
             mean -= np.log(100.0 * g)
         stddevs = self.get_stddevs(C, dists.rjb.shape, stddev_types,
                                    sites, imt, rup.mag)

--- a/openquake/hazardlib/gsim/lanzano_2016.py
+++ b/openquake/hazardlib/gsim/lanzano_2016.py
@@ -247,7 +247,7 @@ class LanzanoEtAl2016_RJB(GMPE):
         istddevs = _get_stddevs(C, stddev_types, num_sites=len(sites.vs30))
 
         # Convert units to g, but only for PGA and SA (not PGV):
-        if imt.name in "SA PGA":
+        if imt.string.startswith(("SA", "PGA")):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/lanzano_2019.py
+++ b/openquake/hazardlib/gsim/lanzano_2019.py
@@ -173,7 +173,7 @@ class LanzanoEtAl2019_RJB_OMO(GMPE):
         istddevs = _get_stddevs(C, stddev_types, num_sites=len(sites.vs30))
 
         # Convert units to g, but only for PGA and SA (not PGV):
-        if imt.name in "SA PGA":
+        if imt.string.startswith(("SA", "PGA")):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/lanzano_luzi_2019.py
+++ b/openquake/hazardlib/gsim/lanzano_luzi_2019.py
@@ -160,7 +160,7 @@ class LanzanoLuzi2019shallow(GMPE):
         istddevs = _get_stddevs(C, stddev_types, sites.vs30.size)
 
         # Convert units to g, but only for PGA and SA (not PGV)
-        if imt.name in "SA PGA":
+        if imt.string.startswith(("SA", "PGA")):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:  # PGV:
             mean = np.log(10.0 ** imean)

--- a/openquake/hazardlib/gsim/megawati_2003.py
+++ b/openquake/hazardlib/gsim/megawati_2003.py
@@ -79,7 +79,7 @@ class MegawatiEtAl2003(GMPE):
                 self._get_distance_scaling(coe, dists.rhypo) +
                 self._get_azimuth_correction(coe, dists.azimuth))
         # Convert to g
-        if imt.name in "SA PGA":
+        if imt.string.startswith(("PGA", "SA")):
             mean = np.log(np.exp(mean) / (100.0 * g))
         # Compute std
         stddevs = self._compute_std(coe, stddev_types, dists.azimuth.shape)

--- a/openquake/hazardlib/gsim/megawati_pan_2010.py
+++ b/openquake/hazardlib/gsim/megawati_pan_2010.py
@@ -101,7 +101,7 @@ class MegawatiPan2010(GMPE):
         C = self.COEFFS[imt]
         mean = (_get_magnitude_scaling(C, rup.mag) +
                 _get_distance_scaling(C, rup.mag, dists.rhypo))
-        if imt.name in "SA PGA":
+        if imt.string.startswith(('PGA', 'SA')):
             mean = np.log(np.exp(mean) / (100.0 * g))
         stddevs = _compute_std(C, stddev_types, len(dists.rhypo))
         return mean, stddevs

--- a/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/nrcan15_site_term.py
@@ -185,7 +185,7 @@ class NRCan15SiteTerm(GMPE):
         # compute mean and standard deviation
         mean, stddvs = self.gmpe.get_mean_and_stddevs(sites_rock, rup, dists,
                                                       imt, stds_types)
-        if imt.name != 'PGA':
+        if imt.string != 'PGA':
             # compute mean and standard deviation on rock
             mean_rock, stddvs_rock = self.gmpe.get_mean_and_stddevs(
                 sites_rock, rup, dists, imt, stds_types)

--- a/openquake/hazardlib/gsim/multi.py
+++ b/openquake/hazardlib/gsim/multi.py
@@ -73,7 +73,8 @@ class MultiGMPE(GMPE):
         for imt, gsim_dic in self.kwargs.items():
             [(gsim_name, kw)] = gsim_dic.items()
             self.kwargs[imt] = gsim = registry[gsim_name](**kw)
-            imt_factory = getattr(imt_module, imt_module.from_string(imt).name)
+            name = "SA" if imt.startswith("SA") else imt
+            imt_factory = getattr(imt_module, name)
             if imt_factory not in gsim.DEFINED_FOR_INTENSITY_MEASURE_TYPES:
                 raise ValueError("IMT %s not supported by %s" % (imt, gsim))
             for name in uppernames:

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -104,7 +104,7 @@ def global_tau(imt, mag, params):
     'Global' model of inter-event variability, as presented in equation 5.6
     (p103)
     """
-    if imt.name == "PGV":
+    if imt.string == "PGV":
         C = params["PGV"]
     else:
         C = params["SA"]
@@ -124,7 +124,7 @@ def cena_constant_tau(imt, mag, params):
     """
     Returns the inter-event tau for the constant tau case
     """
-    if imt.name == "PGV":
+    if imt.string == "PGV":
         return params["PGV"]["tau"]
     else:
         return params["SA"]["tau"]
@@ -134,7 +134,7 @@ def cena_tau(imt, mag, params):
     """
     Returns the inter-event standard deviation, tau, for the CENA case
     """
-    if imt.name == "PGV":
+    if imt.string == "PGV":
         C = params["PGV"]
     else:
         C = params["SA"]
@@ -606,7 +606,7 @@ class NGAEastGMPE(GMPETable):
         pga_r = self.get_hard_rock_mean(rctx, dctx, rock_imt, stddev_types)
 
         # Get the desired spectral acceleration on rock
-        if imt.name != "PGA":
+        if imt.string != "PGA":
             # Calculate the ground motion at required spectral period for
             # the reference rock
             mean = self.get_hard_rock_mean(rctx, dctx, imt, stddev_types)

--- a/openquake/hazardlib/gsim/rietbrock_2013.py
+++ b/openquake/hazardlib/gsim/rietbrock_2013.py
@@ -154,7 +154,7 @@ class RietbrockEtAl2013SelfSimilar(GMPE):
                  _get_distance_scaling_term(C, dists.rjb, rup.mag))
         # convert from cm/s**2 to g for SA and from cm/s**2 to g for PGA (PGV
         # is already in cm/s) and also convert from base 10 to base e.
-        if imt.name in "SA PGA":
+        if imt.string.startswith(('PGA', 'SA')):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             mean = np.log(10 ** imean)

--- a/openquake/hazardlib/gsim/rietbrock_edwards_2019.py
+++ b/openquake/hazardlib/gsim/rietbrock_edwards_2019.py
@@ -137,7 +137,7 @@ class RietbrockEdwards2019Mean(GMPE):
         imean = C["c1"] + (_get_magnitude_term(C, rup.mag) +
                            _get_distance_term(C, dists.rjb, rup.mag))
         # Converting from log10 to log
-        if imt.name in "SA PGA":
+        if imt.string.startswith(("SA", "PGA")):
             mean = np.log(10.0**(imean) / 980.665)
         else:
             mean = np.log(10 ** imean)

--- a/openquake/hazardlib/gsim/shahjouei_pezeshk_2016.py
+++ b/openquake/hazardlib/gsim/shahjouei_pezeshk_2016.py
@@ -96,7 +96,7 @@ def _compute_standard_dev(rup, imt, C):
     described on page 744, eq. 4
     """
     sigma_mean = 0.
-    if imt.name in "SA PGA":
+    if imt.string.startswith(('PGA', 'SA')):
         psi = -6.898E-3
     else:
         psi = -3.054E-5

--- a/openquake/hazardlib/gsim/si_midorikawa_1999.py
+++ b/openquake/hazardlib/gsim/si_midorikawa_1999.py
@@ -115,7 +115,7 @@ def _apply_subduction_trench_correction(mean, x_tr, H, rrup, imt):
     equation 3.5.2-1, page 3-148 of "Technical Reports on National Seismic
     Hazard Maps for Japan"
     """
-    if imt.name == 'PGV':
+    if imt.string == 'PGV':
         V1 = 10 ** ((-4.021e-5 * x_tr + 9.905e-3) * (H - 30))
         V2 = np.maximum(1., (10 ** (-0.012)) * ((rrup / 300.) ** 2.064))
         corr = V2
@@ -137,7 +137,7 @@ def _apply_volcanic_front_correction(mean, x_vf, H, imt):
     Hazard Maps for Japan"
     """
     V1 = np.zeros_like(x_vf)
-    if imt.name == 'PGV':
+    if imt.string == 'PGV':
         idx = x_vf <= 75
         V1[idx] = 4.28e-5 * x_vf[idx] * (H - 30)
         idx = x_vf > 75
@@ -181,7 +181,7 @@ def _get_mean(imt, mag, hypo_depth, rrup, d):
     # clip magnitude at 8.3 as per note at page 3-36 in table Table 3.3.2-6
     # in "Technical Reports on National Seismic Hazard Maps for Japan"
     mag = min(mag, 8.3)
-    if imt.name == 'PGV':
+    if imt.string == 'PGV':
         mean = (
             0.58 * mag +
             0.0038 * hypo_depth +
@@ -313,7 +313,7 @@ class SiMidorikawa1999SInter(SiMidorikawa1999Asc):
         <.base.GroundShakingIntensityModel.get_mean_and_stddevs>`
         for spec of input and result values.
         """
-        if imt.name == 'PGV':
+        if imt.string == 'PGV':
             d = -0.02
         else:
             d = 0.01
@@ -393,7 +393,7 @@ class SiMidorikawa1999SSlab(SiMidorikawa1999SInter):
         <.base.GroundShakingIntensityModel.get_mean_and_stddevs>`
         for spec of input and result values.
         """
-        if imt.name == 'PGV':
+        if imt.string == 'PGV':
             d = 0.12
         else:
             d = 0.22

--- a/openquake/hazardlib/gsim/skarlatoudis_2013.py
+++ b/openquake/hazardlib/gsim/skarlatoudis_2013.py
@@ -204,7 +204,7 @@ class SkarlatoudisEtAlSSlab2013(GMPE):
 
         # Convert units to g,
         # but only for PGA and SA (not PGV):
-        if imt.name in "SA PGA":
+        if imt.string.startswith(("SA", "PGA")):
             mean = np.log((10.0 ** (imean - 2.0)) / g)
         else:
             # PGV:

--- a/openquake/hazardlib/gsim/yenier_atkinson_2015.py
+++ b/openquake/hazardlib/gsim/yenier_atkinson_2015.py
@@ -38,11 +38,12 @@ def get_sof_adjustment(rake, imt):
     :return:
         The adjustment factor
     """
-    if imt.name == 'PGA' or (imt.name == 'SA' and imt.period <= 0.4):
+    im2 = imt.string[:2]
+    if imt.string == 'PGA' or (im2 == 'SA' and imt.period <= 0.4):
         f_r_ss = 1.2
-    elif imt.name == 'SA' and imt.period > 0.4 and imt.period < 3.0:
+    elif im2 == 'SA' and imt.period > 0.4 and imt.period < 3.0:
         f_r_ss = 1.2 - (0.3/np.log10(3.0/0.4))*np.log10(imt.period/0.4)
-    elif imt.name == 'SA' and imt.period >= 3.0:
+    elif im2 == 'SA' and imt.period >= 3.0:
         f_r_ss = 1.2 - (0.3/np.log10(3.0/0.4))*np.log10(3.0/0.4)
     else:
         raise ValueError('Unsupported IMT')
@@ -71,9 +72,9 @@ def _get_c_e(region, imt):
     """
     if region == 'CENA':
         # See equation 23 page 2003 of Yenier and Atkinson
-        if imt.name == 'PGA':
+        if imt.string == 'PGA':
             return -0.25
-        elif imt.name == 'PGV':
+        elif imt.string == 'PGV':
             return -0.21
         elif imt.period <= 10.:
             return -0.25 + np.max([0, 0.39*np.log(imt.period/2)])
@@ -93,9 +94,9 @@ def _get_c_p(region, imt, rrup, m):
     """
     if region == 'CENA':
         # See equations 24 and 25 page 2003 of Yenier and Atkinson
-        if imt.name == 'PGA':
+        if imt.string == 'PGA':
             delta_b3 = 0.030
-        elif imt.name == 'PGV':
+        elif imt.string == 'PGV':
             delta_b3 = 0.052
         elif imt.period <= 10.:
             tmp = 0.095*np.log(imt.period/0.065)

--- a/openquake/hazardlib/gsim/yu_2013.py
+++ b/openquake/hazardlib/gsim/yu_2013.py
@@ -226,9 +226,9 @@ class YuEtAl2013Ms(GMPE):
         x = (mean1 * np.sin(np.radians(dists.azimuth)))**2
         y = (mean2 * np.cos(np.radians(dists.azimuth)))**2
         mean = mean1 * mean2 / np.sqrt(x+y)
-        if imt.name == "PGA":
+        if imt.string == "PGA":
             mean = np.exp(mean)/g/100
-        elif imt.name == "PGV":
+        elif imt.string == "PGV":
             mean = np.exp(mean)
         else:
             raise ValueError('Unsupported IMT')
@@ -333,9 +333,9 @@ class YuEtAl2013Mw(YuEtAl2013Ms):
         x = (mean1 * np.sin(np.radians(dists.azimuth)))**2
         y = (mean2 * np.cos(np.radians(dists.azimuth)))**2
         mean = mean1 * mean2 / np.sqrt(x+y)
-        if imt.name == "PGA":
+        if imt.string == "PGA":
             mean = np.exp(mean)/g/100
-        elif imt.name == "PGV":
+        elif imt.string == "PGV":
             mean = np.exp(mean)
         else:
             raise ValueError('Unsupported IMT')

--- a/openquake/hazardlib/gsim/zalachoris_rathje_2019.py
+++ b/openquake/hazardlib/gsim/zalachoris_rathje_2019.py
@@ -109,7 +109,7 @@ def get_FENA(Cadj, rup, dists, imt):
              _get_C3_term(Cadj, dists.rjb))
 
     # Convert from log10 to ln
-    if imt.name in "SA PGA":
+    if imt.string.startswith(("SA", "PGA")):
         FENA = np.log(10.0 ** imean)
     else:
         FENA = np.log(10.0 ** imean)
@@ -170,7 +170,7 @@ class ZalachorisRathje2019(BooreEtAl2014):
         Cadj = self.COEFFS_HA15[imt]
         C_ZR19 = self.COEFFS_ZR19[imt]
 
-        imt_per = 0 if imt.name == 'PGV' else imt.period
+        imt_per = 0 if imt.string == 'PGV' else imt.period
         pga_rock = _get_pga_on_rock(self.kind, self.region, self.sof,
                                     C_PGA, rup, dists)
         mean_BSSA14 = (

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -21,7 +21,6 @@ Module :mod:`openquake.hazardlib.imt` defines different intensity measure
 types.
 """
 import re
-import ast
 import collections
 import numpy
 
@@ -54,7 +53,8 @@ def imt2tup(string):
             raise ValueError('Missing period in SA')
         # no parenthesis, PGA is considered the same as PGA()
         return (s,)
-    return (name, float(rest[0][:-1]))
+    period = float(rest[0][:-1])
+    return ('SA(%s)' % period, period)
 
 
 def from_string(imt, _damping=5.0):
@@ -70,15 +70,12 @@ def from_string(imt, _damping=5.0):
 
 
 def repr(self):
-    if self.period:
-        if self.damping == 5.0:
-            return '%s(%s)' % (self.name, self.period)
-        else:
-            return '%s(%s, %s)' % (self.name, self.period, self.damping)
-    return self.name
+    if self.period and self.damping != 5.0:
+        return 'SA(%s, %s)' % (self.period, self.damping)
+    return self.string
 
 
-IMT = collections.namedtuple('IMT', 'name period damping')
+IMT = collections.namedtuple('IMT', 'string period damping')
 IMT.__new__.__defaults__ = (0., 5.0)
 IMT.__repr__ = repr
 
@@ -111,7 +108,8 @@ def SA(period, damping=5.0):
     single-degree-of-freedom harmonic oscillator. Units are ``g``, times
     of gravitational acceleration.
     """
-    return IMT('SA', float(period), damping)
+    period = float(period)
+    return IMT('SA(%s)' % period, period, damping)
 
 
 def AvgSA():

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -38,9 +38,9 @@ def imt2tup(string):
     >>> imt2tup('PGA')
     ('PGA',)
     >>> imt2tup('SA(1.0)')
-    ('SA', 1.0)
+    ('SA(1.0)', 1.0)
     >>> imt2tup('SA(1)')
-    ('SA', 1.0)
+    ('SA(1.0)', 1.0)
     """
     s = string.strip()
     name, *rest = s.split('(')

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -77,6 +77,10 @@ def repr(self):
 
 IMT = collections.namedtuple('IMT', 'string period damping')
 IMT.__new__.__defaults__ = (0., 5.0)
+IMT.__lt__ = lambda self, other: self[1] < other[1]
+IMT.__gt__ = lambda self, other: self[1] > other[1]
+IMT.__le__ = lambda self, other: self[1] <= other[1]
+IMT.__ge__ = lambda self, other: self[1] >= other[1]
 IMT.__repr__ = repr
 
 

--- a/openquake/hazardlib/shakemap/gmfs.py
+++ b/openquake/hazardlib/shakemap/gmfs.py
@@ -194,7 +194,7 @@ def calculate_gmfs_sh(kind, shakemap, imts, Z, mu, spatialcorr,
     for im, std in zip(imts, stddev):
         if std.sum() == 0:
             raise ValueError('Cannot decompose the spatial covariance '
-                             'because stddev==0 for IMT=%s' % im.name)
+                             'because stddev==0 for IMT=%s' % im.string)
     spatial_cov = spatial_covariance_array(stddev, spatial_corr)
 
     # Cholesky Decomposition

--- a/openquake/hazardlib/tests/imt_test.py
+++ b/openquake/hazardlib/tests/imt_test.py
@@ -38,7 +38,7 @@ class ImtOrderingTestCase(unittest.TestCase):
 
     def test_from_string(self):
         sa = imt_module.from_string('SA(0.1)')
-        self.assertEqual(sa, ('SA', 0.1, 5.0))
+        self.assertEqual(sa, ('SA(0.1)', 0.1, 5.0))
         pga = imt_module.from_string('PGA')
         self.assertEqual(pga, ('PGA', 0, 5.0))
         with self.assertRaises(KeyError):

--- a/openquake/hazardlib/tests/valid_test.py
+++ b/openquake/hazardlib/tests/valid_test.py
@@ -109,9 +109,9 @@ class ValidationTestCase(unittest.TestCase):
             valid.probability('-0.1')
 
     def test_IMTstr(self):
-        self.assertEqual(imt.from_string('SA(1)'), ('SA', 1, 5))
-        self.assertEqual(imt.from_string('SA(1.)'), ('SA', 1, 5))
-        self.assertEqual(imt.from_string('SA(0.5)'), ('SA', 0.5, 5))
+        self.assertEqual(imt.from_string('SA(1)'), ('SA(1.0)', 1, 5))
+        self.assertEqual(imt.from_string('SA(1.)'), ('SA(1.0)', 1, 5))
+        self.assertEqual(imt.from_string('SA(0.5)'), ('SA(0.5)', 0.5, 5))
         self.assertEqual(imt.from_string('PGV'), ('PGV', 0., 5))
         with self.assertRaises(KeyError):
             imt.from_string('S(1)')

--- a/openquake/sep/classes.py
+++ b/openquake/sep/classes.py
@@ -106,7 +106,7 @@ class NewmarkDisplacement(SecondaryPeril):
     def compute(self, mag, imt_gmf, sites):
         out = []
         for im, gmf in imt_gmf:
-            if im.name == 'PGA':
+            if im.string == 'PGA':
                 nd = newmark_displ_from_pga_M(
                     gmf, sites.crit_accel, mag,
                     self.c1, self.c2, self.c3, self.c4,
@@ -128,7 +128,7 @@ class HazusLiquefaction(SecondaryPeril):
     def compute(self, mag, imt_gmf, sites):
         out = []
         for im, gmf in imt_gmf:
-            if im.name == 'PGA':
+            if im.string == 'PGA':
                 out.append(hazus_liquefaction_probability(
                     pga=gmf, mag=mag, liq_susc_cat=sites.liq_susc_cat,
                     groundwater_depth=sites.gwd,
@@ -151,7 +151,7 @@ class HazusDeformation(SecondaryPeril):
     def compute(self, mag, imt_gmf, sites):
         out = []
         for im, gmf in imt_gmf:
-            if im.name == 'PGA':
+            if im.string == 'PGA':
                 ls = hazus_lateral_spreading_displacement(
                     mag=mag, pga=gmf, liq_susc_cat=sites.liq_susc_cat,
                     return_unit=self.return_unit)
@@ -178,7 +178,7 @@ class ZhuLiquefactionGeneral(SecondaryPeril):
     def compute(self, mag, imt_gmf, sites):
         out = []
         for im, gmf in imt_gmf:
-            if im.name == 'PGA':
+            if im.string == 'PGA':
                 out.append(zhu_liquefaction_probability_general(
                     pga=gmf, mag=mag, cti=sites.cti, vs30=sites.vs30))
         return out


### PR DESCRIPTION
Numba objects (i.e. instances of a `jitclass`) are not pickleable, so are not usable in parallel computations. Instead we can use structured array. In particular we need to convert CoeffsTables into structured arrays keyed by the IMT. Then we need access from numba to the IMT string, not the IMT name.