### PR TITLE
Fixing the SMTK

### DIFF
--- a/openquake/hazardlib/const.py
+++ b/openquake/hazardlib/const.py
@@ -82,6 +82,7 @@ class IMC(Enum):
     VERTICAL_TO_HORIZONTAL_RATIO = 'Vertical-to-Horizontal Ratio'
 
 
+# NB: cannot be an enum because it would break the Strong Motion Toolkit :-(
 class StdDev(object):
     """
     GSIM standard deviation represents ground shaking variability at a site.

--- a/openquake/hazardlib/const.py
+++ b/openquake/hazardlib/const.py
@@ -82,7 +82,7 @@ class IMC(Enum):
     VERTICAL_TO_HORIZONTAL_RATIO = 'Vertical-to-Horizontal Ratio'
 
 
-class StdDev(Enum):
+class StdDev(object):
     """
     GSIM standard deviation represents ground shaking variability at a site.
     """

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -162,7 +162,7 @@ class AmplificationTable(object):
         for stddev_type in [const.StdDev.TOTAL, const.StdDev.INTER_EVENT,
                             const.StdDev.INTRA_EVENT]:
             level = next(iter(amplification_group))
-            if stddev_type.value in amplification_group[level]:
+            if stddev_type in amplification_group[level]:
                 self.sigma[stddev_type] = deepcopy(self.mean)
 
         for iloc, (level, amp_model) in enumerate(amplification_group.items()):
@@ -178,7 +178,7 @@ class AmplificationTable(object):
                     for stddev_type in self.sigma:
                         self.sigma[stddev_type][imt][
                             :, :, :, self.argrp_id[iloc]] = \
-                            amp_model["/".join([stddev_type.value, imt])][:]
+                            amp_model["/".join([stddev_type, imt])][:]
         self.shape = (n_d, n_p, n_m, n_levels)
 
     def get_set(self):
@@ -489,9 +489,9 @@ class GMPETable(GMPE):
                 self.DEFINED_FOR_STANDARD_DEVIATION_TYPES)
             for stddev_type in [const.StdDev.INTER_EVENT,
                                 const.StdDev.INTRA_EVENT]:
-                if stddev_type.value in fle:
+                if stddev_type in fle:
                     self.stddevs[stddev_type] = hdf_arrays_to_dict(
-                        fle[stddev_type.value])
+                        fle[stddev_type])
                     self.DEFINED_FOR_STANDARD_DEVIATION_TYPES.add(stddev_type)
 
             if "Amplification" in fle:

--- a/openquake/hazardlib/gsim/mgmpe/modifiable_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/modifiable_gmpe.py
@@ -211,7 +211,7 @@ class ModifiableGMPE(GMPE):
 
         # Save the stds
         for key, val in zip(working_std_types, ostds):
-            setattr(self, key.name, val)
+            setattr(self, key, val)
         self.mean = omean
 
         # Apply sequentially the modifications
@@ -222,6 +222,6 @@ class ModifiableGMPE(GMPE):
         # Return the standard deviation types as originally requested
         outs = []
         for key in stddev_types:
-            outs.append(getattr(self, key.name))
+            outs.append(getattr(self, key))
 
         return self.mean, outs

--- a/openquake/hazardlib/gsim/mgmpe/modifiable_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/modifiable_gmpe.py
@@ -42,15 +42,15 @@ def set_between_epsilon(self, sites, rup, dists, imt, epsilon_tau):
         the epsilon value used to constrain the between event variability
     """
     # Index for the between event standard deviation
-    key = const.StdDev.INTER_EVENT.name
+    key = const.StdDev.INTER_EVENT
     self.mean = self.mean + epsilon_tau * getattr(self, key)
 
     # Set between event variability to 0
-    keya = const.StdDev.TOTAL.name
+    keya = const.StdDev.TOTAL
     setattr(self, key, np.zeros_like(getattr(self, keya)))
 
     # Set total variability equal to the within-event one
-    keyb = const.StdDev.INTRA_EVENT.name
+    keyb = const.StdDev.INTRA_EVENT
     setattr(self, keya, getattr(self, keyb))
 
 
@@ -80,9 +80,9 @@ def set_scale_total_sigma_scalar(self, sites, rup, dists, imt,
     :param scaling_factor:
         Factor to scale the standard deviations
     """
-    total_stddev = getattr(self, const.StdDev.TOTAL.name)
+    total_stddev = getattr(self, const.StdDev.TOTAL)
     total_stddev *= scaling_factor
-    setattr(self, const.StdDev.TOTAL.name, total_stddev)
+    setattr(self, const.StdDev.TOTAL, total_stddev)
 
 
 def set_scale_total_sigma_vector(self, sites, rup, dists, imt,
@@ -94,9 +94,9 @@ def set_scale_total_sigma_vector(self, sites, rup, dists, imt,
         CoeffsTable
     """
     C = scaling_factor[imt]
-    total_stddev = getattr(self, const.StdDev.TOTAL.name)
+    total_stddev = getattr(self, const.StdDev.TOTAL)
     total_stddev *= C["scaling_factor"]
-    setattr(self, const.StdDev.TOTAL.name, total_stddev)
+    setattr(self, const.StdDev.TOTAL, total_stddev)
 
 
 def set_fixed_total_sigma(self, sites, rup, dists, imt, total_sigma):
@@ -106,9 +106,8 @@ def set_fixed_total_sigma(self, sites, rup, dists, imt, total_sigma):
         IMT-dependent total standard deviation as a CoeffsTable
     """
     C = total_sigma[imt]
-    shp = getattr(self, const.StdDev.TOTAL.name).shape
-    setattr(self, const.StdDev.TOTAL.name,
-            C["total_sigma"] + np.zeros(shp))
+    shp = getattr(self, const.StdDev.TOTAL).shape
+    setattr(self, const.StdDev.TOTAL, C["total_sigma"] + np.zeros(shp))
 
 
 def add_delta_std_to_total_std(self, sites, rup, dists, imt, delta):
@@ -116,9 +115,9 @@ def add_delta_std_to_total_std(self, sites, rup, dists, imt, delta):
     :param delta:
         A delta std e.g. a phi S2S to be removed from total
     """
-    total_stddev = getattr(self, const.StdDev.TOTAL.name)
+    total_stddev = getattr(self, const.StdDev.TOTAL)
     total_stddev = (total_stddev**2 + np.sign(delta) * delta**2)**0.5
-    setattr(self, const.StdDev.TOTAL.name, total_stddev)
+    setattr(self, const.StdDev.TOTAL, total_stddev)
 
 
 def set_total_std_as_tau_plus_delta(self, sites, rup, dists, imt, delta):
@@ -126,9 +125,9 @@ def set_total_std_as_tau_plus_delta(self, sites, rup, dists, imt, delta):
     :param delta:
         A delta std e.g. a phi SS to be combined with between std, tau.
     """
-    tau = getattr(self, const.StdDev.INTER_EVENT.name)
+    tau = getattr(self, const.StdDev.INTER_EVENT)
     total_stddev = (tau**2 + np.sign(delta) * delta**2)**0.5
-    setattr(self, const.StdDev.TOTAL.name, total_stddev)
+    setattr(self, const.StdDev.TOTAL, total_stddev)
 
 
 def _dict_to_coeffs_table(input_dict, name):

--- a/openquake/hazardlib/tests/gsim/gmpe_table_test.py
+++ b/openquake/hazardlib/tests/gsim/gmpe_table_test.py
@@ -563,8 +563,7 @@ class GSIMTableGoodTestCase(unittest.TestCase):
         with self.assertRaises(KeyError) as ve:
             gsim.get_mean_and_stddevs(sctx, rctx, dctx, imt_module.PGA(),
                                       stddevs)
-        self.assertEqual(str(ve.exception),
-                         "<StdDev.INTER_EVENT: 'Inter event'>")
+        self.assertEqual(str(ve.exception), "'Inter event'")
 
     def tearDown(self):
         """


### PR DESCRIPTION
One month ago (see https://github.com/gem/oq-engine/pull/6848) I turned `const.StdDev` into a subclass of `enum`, since numba supports `enum` objects but not ordinary Python objects. However now we have the `compute` API that does not pass around the stddev_types, so I can revert that change and fix the Strong Motion Toolkit. Part of #6850.
