### PR TITLE
54x speedup when computing the mean hazard curves

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * There is now a huge speedup when computing the hazard curve statistics
+    if numba is available
   * Made it possible to compute consequences in presence of a taxonomy mapping
   * Fixed a bug in `get_available_gsims`: GSIM aliases were not considered
   * Optimized the single site case by splitting the sources less


### PR DESCRIPTION
Measured for the Europe model: "combine pmaps" goes down from 94_131 -> 1_737 seconds, thanks to numba :-)
Unfortunately, the statistics are normally not the dominant part of the calculation :-(