### PR TITLE
Vectorized the GMPEs for Europe

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -511,7 +511,17 @@ def count_old_style(gsim_lt):
             old += 'get_mean_and_stddevs' in gsim.__class__.__dict__
     return old
 
-    
+
+def count_no_vect(gsim_lt):
+    # count the number of not vectorize GMPEs
+    no = 0
+    for gsims in gsim_lt.values.values():
+        for gsim in gsims:
+            compute = getattr(gsim.__class__, 'compute')
+            no += 'ctx' not in compute.__annotations__
+    return no
+
+
 def get_site_collection(oqparam, h5=None):
     """
     Returns a SiteCollection instance by looking at the points and the
@@ -595,7 +605,9 @@ def get_gsim_lt(oqparam, trts=('*',)):
     gsim_lt_cache[key] = gsim_lt
 
     old_style = count_old_style(gsim_lt)
+    no_vect = count_no_vect(gsim_lt)
     logging.info('There are %d old style GMPEs', old_style)
+    logging.info('There are %d not vectorized GMPEs', no_vect)
     return gsim_lt
 
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -39,6 +39,7 @@ from openquake.baselib.performance import Monitor
 from openquake.hazardlib import imt as imt_module
 from openquake.hazardlib.const import StdDev
 from openquake.hazardlib.tom import registry
+from openquake.hazardlib.site import site_param_dt
 from openquake.hazardlib.calc.filters import MagDepDistance
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.geo.surface import PlanarSurface
@@ -193,8 +194,13 @@ class ContextMaker(object):
         reqs = (sorted(self.REQUIRES_RUPTURE_PARAMETERS) +
                 sorted(self.REQUIRES_SITES_PARAMETERS) +
                 sorted(self.REQUIRES_DISTANCES))
-        dic = {req: 0. for req in reqs}
-        dic['sids'] = numpy.uint32([0])
+        dic = {}
+        for req in reqs:
+            if req in site_param_dt:
+                dic[req] = site_param_dt[req](0)
+            else:
+                dic[req] = 0.
+        dic['sids'] = numpy.uint32(0)
         self.ctx_builder = RecordBuilder(**dic)
         self.loglevels = DictArray(self.imtls) if self.imtls else {}
         self.shift_hypo = param.get('shift_hypo')

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -197,7 +197,11 @@ class ContextMaker(object):
         dic = {}
         for req in reqs:
             if req in site_param_dt:
-                dic[req] = site_param_dt[req](0)
+                dt = site_param_dt[req]
+                if isinstance(dt, tuple):  # (string_, size)
+                    dic[req] = b''
+                else:
+                    dic[req] = dt(0)
             else:
                 dic[req] = 0.
         dic['sids'] = numpy.uint32(0)

--- a/openquake/hazardlib/gsim/abrahamson_2015.py
+++ b/openquake/hazardlib/gsim/abrahamson_2015.py
@@ -54,10 +54,9 @@ def _compute_magterm(C1, theta1, theta4, theta5, theta13, dc1, mag):
     """
     base = theta1 + theta4 * dc1
     dmag = C1 + dc1
-    if mag > dmag:
-        f_mag = theta5 * (mag - dmag) + theta13 * (10. - mag) ** 2.
-    else:
-        f_mag = theta4 * (mag - dmag) + theta13 * (10. - mag) ** 2.
+    f_mag = np.where(mag > dmag,
+                     theta5 * (mag - dmag) + theta13 * (10. - mag) ** 2.,
+                     theta4 * (mag - dmag) + theta13 * (10. - mag) ** 2.)
     return base + f_mag
 
 

--- a/openquake/hazardlib/gsim/akkar_bommer_2010.py
+++ b/openquake/hazardlib/gsim/akkar_bommer_2010.py
@@ -60,14 +60,8 @@ def _get_fault_type_dummy_variables(ctx, imt):
     on Akkar and Bommer 2007b; read Strong-Motion Dataset and Record
     Processing on p. 514 (Akkar and Bommer 2007b).
     """
-
-    Fn, Fr = 0, 0
-    if ctx.rake >= -135 and ctx.rake <= -45:
-        # normal
-        Fn = 1
-    elif ctx.rake >= 45 and ctx.rake <= 135:
-        # reverse
-        Fr = 1
+    Fn = (ctx.rake >= -135) & (ctx.rake <= -45)  # normal fault
+    Fr = (ctx.rake >= 45) & (ctx.rake <= 135)  # reverse fault
     return Fn, Fr
 
 
@@ -159,7 +153,7 @@ class AkkarBommer2010(GMPE):
     #: Reference Vs30. See page 2983 (top or right column)
     DEFINED_FOR_REFERENCE_VELOCITY = 760.0
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`
@@ -299,7 +293,7 @@ class AkkarBommer2010SWISS01(AkkarBommer2010):
     #: confirmed by the Swiss GMPE group
     DEFINED_FOR_REFERENCE_VELOCITY = 1105.
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`

--- a/openquake/hazardlib/gsim/atkinson_boore_2003.py
+++ b/openquake/hazardlib/gsim/atkinson_boore_2003.py
@@ -219,7 +219,7 @@ class AtkinsonBoore2003SInter(GMPE):
 
     kind = 'SInter'
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`
@@ -304,7 +304,7 @@ class AtkinsonBoore2003SSlab(AtkinsonBoore2003SInter):
     #: Supported tectonic region type is subduction interface
     DEFINED_FOR_TECTONIC_REGION_TYPE = const.TRT.SUBDUCTION_INTRASLAB
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`

--- a/openquake/hazardlib/gsim/atkinson_boore_2003.py
+++ b/openquake/hazardlib/gsim/atkinson_boore_2003.py
@@ -41,8 +41,7 @@ def _compute_mean(kind, C, g, mag, hypo_depth, rrup, vs30, pga_rock, imt):
     """
     Compute mean according to equation 1, page 1706.
     """
-    if hypo_depth > 100:
-        hypo_depth = 100
+    hypo_depth = np.clip(hypo_depth, 0, 100.)
     delta = 0.00724 * 10 ** (0.507 * mag)
     R = np.sqrt(rrup ** 2 + delta ** 2)
 

--- a/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
+++ b/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
@@ -33,12 +33,10 @@ def _compute_faulting_style_term(C, rake):
     Compute faulting style term as a function of rake angle value as given
     in equation 5 page 465.
     """
-    if rake > -120.0 and rake <= -60.0:
-        return C['aN']
-    elif rake > 30.0 and rake <= 150.0:
-        return C['aR']
-    else:
-        return C['aS']
+    term = np.full_like(rake, C['aS'])
+    term[(rake > -120.0) & (rake <= -60.0)] = C['aN']
+    term[(rake > 30.0) & (rake <= 150.0)] = C['aR']
+    return term
 
 
 def _compute_mean(kind, C, mag, ctx, vs30, rake, imt):

--- a/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
+++ b/openquake/hazardlib/gsim/cauzzi_faccioli_2008.py
@@ -163,7 +163,7 @@ class CauzziFaccioli2008(GMPE):
 
     kind = "2008"
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`

--- a/openquake/hazardlib/gsim/faccioli_cauzzi_2006.py
+++ b/openquake/hazardlib/gsim/faccioli_cauzzi_2006.py
@@ -53,7 +53,7 @@ class FaccioliCauzzi2006(GMPE):
 
     REQUIRES_DISTANCES = {'repi'}
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`

--- a/openquake/hazardlib/gsim/lin_lee_2008.py
+++ b/openquake/hazardlib/gsim/lin_lee_2008.py
@@ -30,10 +30,10 @@ def _compute_mean(C, mag, rhypo, hypo_depth, mean, idx):
     """
     Compute mean value according to equations 10 and 11 page 226.
     """
-    mag = mag[idx]
-    rhypo = rhypo[idx]
-    hypo_depth = hypo_depth[idx]
-    mean[idx] = (C['C1'] + C['C2'] * mag + C['C3'] * np.log(rhypo +
+    if isinstance(mag, np.ndarray):
+        mag = mag[idx]
+        hypo_depth = hypo_depth[idx]
+    mean[idx] = (C['C1'] + C['C2'] * mag + C['C3'] * np.log(rhypo[idx] +
                  C['C4'] * np.exp(C['C5'] * mag)) + C['C6'] * hypo_depth)
 
 

--- a/openquake/hazardlib/gsim/lin_lee_2008.py
+++ b/openquake/hazardlib/gsim/lin_lee_2008.py
@@ -30,7 +30,10 @@ def _compute_mean(C, mag, rhypo, hypo_depth, mean, idx):
     """
     Compute mean value according to equations 10 and 11 page 226.
     """
-    mean[idx] = (C['C1'] + C['C2'] * mag + C['C3'] * np.log(rhypo[idx] +
+    mag = mag[idx]
+    rhypo = rhypo[idx]
+    hypo_depth = hypo_depth[idx]
+    mean[idx] = (C['C1'] + C['C2'] * mag + C['C3'] * np.log(rhypo +
                  C['C4'] * np.exp(C['C5'] * mag)) + C['C6'] * hypo_depth)
 
 
@@ -75,7 +78,7 @@ class LinLee2008SInter(GMPE):
     #: Vs30 threshold value between rock ctx (B, C) and soil ctx (C, D).
     ROCK_VS30 = 360
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`

--- a/openquake/hazardlib/gsim/toro_2002.py
+++ b/openquake/hazardlib/gsim/toro_2002.py
@@ -105,7 +105,7 @@ class ToroEtAl2002(GMPE):
     #: no fault style adjustement in the base class
     CONSTS_FS = {}
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`

--- a/openquake/hazardlib/gsim/youngs_1997.py
+++ b/openquake/hazardlib/gsim/youngs_1997.py
@@ -52,12 +52,16 @@ def _compute_mean(C, A1, A2, A3, A4, A5, A6, mag, hypo_depth,
     Compute mean for subduction interface events, as explained in table 2,
     page 67.
     """
-    mag = mag[idx]
-    rrup = rrup[idx]
-    hypo_depth = hypo_depth[idx]
+    if isinstance(mag, np.ndarray):
+        mag = mag[idx]
+        hypo_depth = hypo_depth[idx]
     mean[idx] = (A1 + A2 * mag + C['C1'] + C['C2'] * (A3 - mag) ** 3 +
-                 C['C3'] * np.log(rrup + A4 * np.exp(A5 * mag)) +
+                 C['C3'] * np.log(rrup[idx] + A4 * np.exp(A5 * mag)) +
                  A6 * hypo_depth)
+
+
+def get(array, idx):
+    return array[idx] if isinstance(array, np.ndarray) else array
 
 
 class YoungsEtAl1997SInter(GMPE):
@@ -131,7 +135,7 @@ class YoungsEtAl1997SInter(GMPE):
                               CONSTS['A6_rock'], ctx.mag, ctx.hypo_depth,
                               ctx.rrup, mean[m], idx_rock)
                 sig[m, idx_rock] += C['C4'] + C['C5'] * np.clip(
-                    ctx.mag[idx_rock], 0, 8.)
+                    get(ctx.mag, idx_rock), 0, 8.)
 
                 if imt == SA(period=4.0, damping=5.0):
                     mean[m] /= 0.399
@@ -144,7 +148,7 @@ class YoungsEtAl1997SInter(GMPE):
                               CONSTS['A6_soil'], ctx.mag, ctx.hypo_depth,
                               ctx.rrup, mean[m], idx_soil)
                 sig[m, idx_soil] += C['C4'] + C['C5'] * np.clip(
-                    ctx.mag[idx_soil], 0, 8.)
+                    get(ctx.mag, idx_soil), 0, 8.)
 
             if (self.DEFINED_FOR_TECTONIC_REGION_TYPE ==
                     const.TRT.SUBDUCTION_INTRASLAB):  # sslab correction

--- a/openquake/hazardlib/gsim/youngs_1997.py
+++ b/openquake/hazardlib/gsim/youngs_1997.py
@@ -52,8 +52,11 @@ def _compute_mean(C, A1, A2, A3, A4, A5, A6, mag, hypo_depth,
     Compute mean for subduction interface events, as explained in table 2,
     page 67.
     """
+    mag = mag[idx]
+    rrup = rrup[idx]
+    hypo_depth = hypo_depth[idx]
     mean[idx] = (A1 + A2 * mag + C['C1'] + C['C2'] * (A3 - mag) ** 3 +
-                 C['C3'] * np.log(rrup[idx] + A4 * np.exp(A5 * mag)) +
+                 C['C3'] * np.log(rrup + A4 * np.exp(A5 * mag)) +
                  A6 * hypo_depth)
 
 
@@ -106,7 +109,7 @@ class YoungsEtAl1997SInter(GMPE):
 
     delta = 0  # changed in subclasses
 
-    def compute(self, ctx, imts, mean, sig, tau, phi):
+    def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
         <.base.GroundShakingIntensityModel.compute>`
@@ -127,7 +130,8 @@ class YoungsEtAl1997SInter(GMPE):
                               CONSTS['A4_rock'], CONSTS['A5_rock'],
                               CONSTS['A6_rock'], ctx.mag, ctx.hypo_depth,
                               ctx.rrup, mean[m], idx_rock)
-                sig[m, idx_rock] += C['C4'] + C['C5'] * np.clip(ctx.mag, 0, 8.)
+                sig[m, idx_rock] += C['C4'] + C['C5'] * np.clip(
+                    ctx.mag[idx_rock], 0, 8.)
 
                 if imt == SA(period=4.0, damping=5.0):
                     mean[m] /= 0.399
@@ -139,7 +143,8 @@ class YoungsEtAl1997SInter(GMPE):
                               CONSTS['A4_soil'], CONSTS['A5_soil'],
                               CONSTS['A6_soil'], ctx.mag, ctx.hypo_depth,
                               ctx.rrup, mean[m], idx_soil)
-                sig[m, idx_soil] += C['C4'] + C['C5'] * np.clip(ctx.mag, 0, 8.)
+                sig[m, idx_soil] += C['C4'] + C['C5'] * np.clip(
+                    ctx.mag[idx_soil], 0, 8.)
 
             if (self.DEFINED_FOR_TECTONIC_REGION_TYPE ==
                     const.TRT.SUBDUCTION_INTRASLAB):  # sslab correction


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/6973. This gives a huge speedup (over 4x) in "computing mean_std". Here are the figures on the spot machine:
```
# master
| calc_21, maxmem=73.7 GB | time_sec | memory_mb | counts    |
|-------------------------+----------+-----------+-----------|
| total classical         | 65_426   | 321.6     | 628       |
| computing mean_std      | 31_275   | 0.0       | 19_457    |
| get_poes                | 14_501   | 0.0       | 19_457    |
| composing pnes          | 7_555    | 0.0       | 9_099_194 |
| make_contexts           | 7_390    | 0.0       | 9_160_616 |

# this branch
| calc_22, maxmem=86.2 GB | time_sec | memory_mb | counts    |
|-------------------------+----------+-----------+-----------|
| total classical         | 43_612   | 367.8     | 628       |
| get_poes                | 16_086   | 0.0       | 19_457    |
| composing pnes          | 7_842    | 0.0       | 9_099_194 |
| make_contexts           | 7_542    | 0.0       | 9_160_616 |
| computing mean_std      | 7_264    | 0.0       | 19_457    |
```