### PR TITLE
Improved the compatibility of the compute API with get_means_and_stddevs

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -895,7 +895,7 @@ class RuptureContext(BaseContext):
         'hypo_depth', 'width', 'hypo_loc')
 
     @classmethod
-    def full(cls, rup, sites, dctx=None):
+    def from_(cls, sites, rup, dctx=None):
         """
         :returns: a full context with all the relevant attributes
         """

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -34,7 +34,7 @@ except ImportError:
     numba = None
 from openquake.baselib import hdf5, parallel
 from openquake.baselib.general import (
-    AccumDict, DictArray, groupby, block_splitter, RecordBuilder)
+    AccumDict, DictArray, groupby, RecordBuilder)
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import imt as imt_module
 from openquake.hazardlib.const import StdDev
@@ -877,6 +877,21 @@ def get_dists(ctx):
             if par in KNOWN_DISTANCES}
 
 
+def full_context(sites, rup, dctx=None):
+    """
+    :returns: a full RuptureContext with all the relevant attributes
+    """
+    self = RuptureContext()
+    for par, val in vars(rup).items():
+        setattr(self, par, val)
+    for par in sites.array.dtype.names:
+        setattr(self, par, sites[par])
+    if dctx:
+        for par, val in vars(dctx).items():
+            setattr(self, par, val)
+    return self
+
+
 # mock of a rupture used in the tests and in the SMTK
 class RuptureContext(BaseContext):
     """
@@ -893,21 +908,6 @@ class RuptureContext(BaseContext):
     _slots_ = (
         'mag', 'strike', 'dip', 'rake', 'ztor', 'hypo_lon', 'hypo_lat',
         'hypo_depth', 'width', 'hypo_loc')
-
-    @classmethod
-    def from_(cls, sites, rup, dctx=None):
-        """
-        :returns: a full context with all the relevant attributes
-        """
-        self = cls()
-        for par, val in vars(rup).items():
-            setattr(self, par, val)
-        for par in sites.array.dtype.names:
-            setattr(self, par, sites[par])
-        if dctx:
-            for par, val in vars(dctx).items():
-                setattr(self, par, val)
-        return self
 
     def __init__(self, param_pairs=()):
         for param, value in param_pairs:

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -33,7 +33,8 @@ from openquake.baselib.performance import compile, numba
 from openquake.hazardlib import const
 from openquake.hazardlib.stats import _truncnorm_sf
 from openquake.hazardlib.gsim.coeffs_table import CoeffsTable
-from openquake.hazardlib.contexts import KNOWN_DISTANCES, RuptureContext
+from openquake.hazardlib.contexts import (
+    KNOWN_DISTANCES, RuptureContext, full_context)
 from openquake.hazardlib.contexts import *  # for backward compatibility
 
 
@@ -363,10 +364,10 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
         sig = numpy.zeros((1, N))
         tau = numpy.zeros((1, N))
         phi = numpy.zeros((1, N))
-        if not isinstance(rup, RuptureContext):
-            ctx = RuptureContext.from_(sites, rup, dists)
+        if isinstance(rup, (RuptureContext, numpy.ndarray)):
+            ctx = rup  # rup is already a good object
         else:
-            ctx = rup
+            ctx = full_context(sites, rup, dists)
         self.compute(ctx, [imt], mean, sig, tau, phi)
         stddevs = []
         for stddev_type in stddev_types:

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -364,13 +364,10 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
         tau = numpy.zeros((1, N))
         phi = numpy.zeros((1, N))
         if not isinstance(rup, RuptureContext):
-            ctx = RuptureContext()
-            vars(ctx).update(vars(rup))
-            vars(ctx).update(vars(sites))
-            vars(ctx).update(vars(dists))
+            ctx = RuptureContext.from_(sites, rup, dists)
         else:
             ctx = rup
-        self.compute(rup, [imt], mean, sig, tau, phi)
+        self.compute(ctx, [imt], mean, sig, tau, phi)
         stddevs = []
         for stddev_type in stddev_types:
             if stddev_type == const.StdDev.TOTAL:

--- a/openquake/hazardlib/tests/gsim/base_site_test.py
+++ b/openquake/hazardlib/tests/gsim/base_site_test.py
@@ -55,7 +55,7 @@ class GetPoesSiteTestCase(unittest.TestCase):
         sites = Dummy.get_site_collection(len(dsts), vs30=760.0)
         self.mag = 5.5
         rup = Dummy.get_rupture(mag=self.mag)
-        ctx = RuptureContext.full(rup, sites)
+        ctx = RuptureContext.from_(sites, rup)
         ctx.rjb = numpy.array(dsts)
         ctx.rrup = numpy.array(dsts)
         self.rrup = ctx.rrup

--- a/openquake/hazardlib/tests/gsim/base_site_test.py
+++ b/openquake/hazardlib/tests/gsim/base_site_test.py
@@ -24,7 +24,7 @@ from openquake.hazardlib import const
 from openquake.hazardlib.imt import PGA, SA
 from openquake.hazardlib.gsim.base import _get_poes
 from openquake.baselib.general import gettemp, DictArray
-from openquake.hazardlib.contexts import RuptureContext, ContextMaker
+from openquake.hazardlib.contexts import ContextMaker, full_context
 from openquake.hazardlib.tests.gsim.mgmpe.dummy import Dummy
 from openquake.hazardlib.gsim.boore_atkinson_2008 import BooreAtkinson2008
 
@@ -55,7 +55,7 @@ class GetPoesSiteTestCase(unittest.TestCase):
         sites = Dummy.get_site_collection(len(dsts), vs30=760.0)
         self.mag = 5.5
         rup = Dummy.get_rupture(mag=self.mag)
-        ctx = RuptureContext.from_(sites, rup)
+        ctx = full_context(sites, rup)
         ctx.rjb = numpy.array(dsts)
         ctx.rrup = numpy.array(dsts)
         self.rrup = ctx.rrup


### PR DESCRIPTION
Should address https://github.com/gem/oq-engine/issues/7018, at least partially. Just use `full_context(sites, rup, dists)`.