### PR TITLE
Fixed the ContextMaker API

### DIFF
--- a/doc/adv-manual/developing.rst
+++ b/doc/adv-manual/developing.rst
@@ -224,7 +224,7 @@ a dictionary of parameters:
 >>> param = dict(maximum_distance=oq.maximum_distance, imtls=oq.imtls,
 ...              truncation_level=oq.truncation_level,
 ...              investigation_time=oq.investigation_time)
->>> cmaker = ContextMaker(src.tectonic_region_type, gsims, param)
+>>> cmaker = ContextMaker(gsims, param)
 
 Then you can use the ``ContextMaker`` to generate context objects
 from the sources:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -340,7 +340,7 @@ class ClassicalCalculator(base.HazardCalculator):
                   'probs_occur_', 'sids_', 'src_id'}
         gsims_by_trt = self.full_lt.get_gsims_by_trt()
         for trt, gsims in gsims_by_trt.items():
-            cm = ContextMaker(trt, gsims, dict(imtls=self.oqparam.imtls))
+            cm = ContextMaker(gsims, dict(imtls=self.oqparam.imtls))
             params.update(cm.REQUIRES_RUPTURE_PARAMETERS)
             for dparam in cm.REQUIRES_DISTANCES:
                 params.add(dparam + '_')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -268,10 +268,10 @@ class EventBasedCalculator(base.HazardCalculator):
         if oq.inputs['rupture_model'].endswith('.xml'):
             self.gsims = [gsim_rlz.value[0] for gsim_rlz in gsim_lt]
             self.cmaker = ContextMaker(
-                '*', self.gsims, {'maximum_distance': oq.maximum_distance,
-                                  'minimum_distance': oq.minimum_distance,
-                                  'truncation_level': oq.truncation_level,
-                                  'imtls': oq.imtls})
+                self.gsims, {'maximum_distance': oq.maximum_distance,
+                             'minimum_distance': oq.minimum_distance,
+                             'truncation_level': oq.truncation_level,
+                             'imtls': oq.imtls})
             rup = readinput.get_rupture(oq)
             if self.N > oq.max_sites_disagg:  # many sites, split rupture
                 ebrs = [EBRupture(copyobj(rup, rup_id=rup.rup_id + i),

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1287,7 +1287,7 @@ class RuptureData(object):
     """
     def __init__(self, trt, gsims):
         self.trt = trt
-        self.cmaker = ContextMaker(trt, gsims)
+        self.cmaker = ContextMaker(gsims)
         self.params = sorted(self.cmaker.REQUIRES_RUPTURE_PARAMETERS -
                              set('mag strike dip rake hypo_depth'.split()))
         self.dt = numpy.dtype([

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -265,8 +265,7 @@ class GmfGetter(object):
         param = {'imtls': oqparam.imtls, 'maximum_distance': md,
                  'minimum_distance': oqparam.minimum_distance,
                  'truncation_level': oqparam.truncation_level}
-        self.cmaker = ContextMaker(
-            rupgetter.trt, rupgetter.rlzs_by_gsim, param)
+        self.cmaker = ContextMaker(rupgetter.rlzs_by_gsim, param)
         self.correl_model = oqparam.correl_model
 
     def gen_computers(self, mon):

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -568,7 +568,7 @@ def view_required_params_per_trt(token, dstore):
     tbl = []
     for trt in full_lt.trts:
         gsims = full_lt.gsim_lt.get_gsims(trt)
-        maker = ContextMaker(trt, gsims)
+        maker = ContextMaker(gsims)
         distances = sorted(maker.REQUIRES_DISTANCES)
         siteparams = sorted(maker.REQUIRES_SITES_PARAMETERS)
         ruptparams = sorted(maker.REQUIRES_RUPTURE_PARAMETERS)

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -369,7 +369,7 @@ def disaggregation(
     for trt, srcs in by_trt.items():
         tom = srcs[0].temporal_occurrence_model
         cmaker[trt] = ContextMaker(
-            trt, rlzs_by_gsim,
+            rlzs_by_gsim,
             {'truncation_level': truncation_level,
              'maximum_distance': source_filter.integration_distance,
              'imtls': {str(imt): [iml]}})

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -333,9 +333,8 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
         for all sites in the collection. First dimension represents
         sites and second one is for realizations.
     """
-    cmaker = ContextMaker(rupture.tectonic_region_type, [gsim],
-                          dict(truncation_level=truncation_level,
-                               imtls={str(imt): [1] for imt in imts}))
+    cmaker = ContextMaker([gsim], dict(truncation_level=truncation_level,
+                                       imtls={str(imt): [1] for imt in imts}))
     rupture.rup_id = seed
     gc = GmfComputer(rupture, sites, cmaker, correlation_model)
     [mean_stds] = cmaker.get_mean_stds([gc.ctx], StdDev.EVENT)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -196,7 +196,7 @@ def calc_hazard_curves(
     mon = Monitor()
     for group in groups:
         trt = group.trt
-        cmaker = ContextMaker(trt, [gsim_by_trt[trt]], param, mon)
+        cmaker = ContextMaker([gsim_by_trt[trt]], param, mon)
         for src in group:
             if not src.nsites:  # not set
                 src.nsites = 1
@@ -223,8 +223,7 @@ def calc_hazard_curve(site1, src, gsims, oqparam, monitor=Monitor()):
     :returns: a ProbabilityCurve object
     """
     assert len(site1) == 1, site1
-    trt = src.tectonic_region_type
-    cmaker = ContextMaker(trt, gsims, vars(oqparam), monitor)
+    cmaker = ContextMaker(gsims, vars(oqparam), monitor)
     cmaker.tom = src.temporal_occurrence_model
     srcfilter = SourceFilter(site1, oqparam.maximum_distance)
     pmap, rup_data, calc_times = PmapMaker(cmaker, srcfilter, [src]).make()

--- a/openquake/hazardlib/gsim/can15/eastern.py
+++ b/openquake/hazardlib/gsim/can15/eastern.py
@@ -119,9 +119,7 @@ class EasternCan15Mid(GMPE):
         imtls = {imt.string: [0] for imt in imts}
         mean_stds = []  # 5 arrays of shape (2, M, N)
         for gsim in self.gsims:
-            cmaker = contexts.ContextMaker(
-                self.DEFINED_FOR_TECTONIC_REGION_TYPE,
-                [gsim], {'imtls': imtls})
+            cmaker = contexts.ContextMaker([gsim], {'imtls': imtls})
             # add equivalent distances
             if isinstance(gsim, AtkinsonBoore2006Modified2011):
                 c = utils.add_distances_east(ctx, ab06=True)

--- a/openquake/hazardlib/gsim/can15/sinter.py
+++ b/openquake/hazardlib/gsim/can15/sinter.py
@@ -123,9 +123,7 @@ class SInterCan15Mid(GMPE):
         for spec of input and result values.
         """
         imtls = {imt.string: [0] for imt in imts}
-        cmaker = contexts.ContextMaker(
-            self.DEFINED_FOR_TECTONIC_REGION_TYPE,
-            self.gsims, {'imtls': imtls})
+        cmaker = contexts.ContextMaker(self.gsims, {'imtls': imtls})
         mean_zh06, mean_am09, mean_ab15, mean_ga14 = cmaker.get_mean_stds(
             [ctx], None)  # 4 arrays of shape (1, M, N)
 

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -157,7 +157,7 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
                      src_interdep=group.src_interdep,
                      rup_interdep=group.rup_interdep,
                      grp_probability=group.grp_probability)
-        cmaker = ContextMaker(src.tectonic_region_type, gsim_by_trt, param)
+        cmaker = ContextMaker(gsim_by_trt, param)
         crv = classical(group, self.sites, cmaker)['pmap'][0]
         npt.assert_almost_equal(numpy.array([0.35000, 0.32497, 0.10398]),
                                 crv.array[:, 0], decimal=4)

--- a/openquake/hazardlib/tests/contexts_test.py
+++ b/openquake/hazardlib/tests/contexts_test.py
@@ -221,7 +221,7 @@ class CollapseTestCase(unittest.TestCase):
             ctx.rjb = numpy.array([99.])
             ctxs.append(ctx)
         cmaker = ContextMaker(
-            'TRT', gsims, dict(imtls=imtls, truncation_level=trunclevel))
+            gsims, dict(imtls=imtls, truncation_level=trunclevel))
         cmaker.tom = PoissonTOM(time_span=50)
         pmap = cmaker.get_pmap(ctxs)
         numpy.testing.assert_almost_equal(pmap[0].array, 0.066381)

--- a/openquake/hazardlib/tests/gsim/base_site_test.py
+++ b/openquake/hazardlib/tests/gsim/base_site_test.py
@@ -62,7 +62,7 @@ class GetPoesSiteTestCase(unittest.TestCase):
 
         # Compute GM on rock
         self.cmaker = ContextMaker(
-            'TRT', [gmmA], dict(imtls={str(im): [0] for im in imts}))
+            [gmmA], dict(imtls={str(im): [0] for im in imts}))
         [self.meastd] = self.cmaker.get_mean_stds([ctx], const.StdDev.TOTAL)
         # shp(2, N=1, M=2)
 

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -24,7 +24,7 @@ import numpy
 
 from openquake.hazardlib import const, valid
 from openquake.hazardlib.gsim.base import (
-    GMPE, CoeffsTable, gsim_aliases, SitesContext, RuptureContext,
+    GMPE, gsim_aliases, SitesContext, RuptureContext,
     NotVerifiedWarning, DeprecationWarning)
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.imt import PGA
@@ -56,7 +56,7 @@ class _FakeGSIMTestCase(unittest.TestCase):
         super().setUp()
         self.gsim_class = FakeGSIM
         self.gsim = self.gsim_class()
-        self.cmaker = ContextMaker('faketrt', [self.gsim])
+        self.cmaker = ContextMaker([self.gsim])
         self.gsim.DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = \
             self.DEFAULT_COMPONENT
         self.gsim.DEFINED_FOR_INTENSITY_MEASURE_TYPES = frozenset(
@@ -159,7 +159,7 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
         self.fake_surface = FakeSurface
 
     def make_contexts(self, site_collection, rupture):
-        return ContextMaker('faketrt', [self.gsim_class]).make_contexts(
+        return ContextMaker([self.gsim_class]).make_contexts(
             site_collection, rupture)
 
     def test_unknown_distance_error(self):

--- a/openquake/hazardlib/tests/gsim/check_gsim.py
+++ b/openquake/hazardlib/tests/gsim/check_gsim.py
@@ -76,7 +76,7 @@ def check_gsim(gsim, datafile, max_discrep_percentage,
         ctx, stddev_type, expected_results, result_type = testcase
         set_read_only(ctx)
         imtls = {str(imt): [] for imt in expected_results}
-        cmaker = ContextMaker('*', [gsim], dict(imtls=imtls))
+        cmaker = ContextMaker([gsim], dict(imtls=imtls))
         [ms] = cmaker.get_mean_stds([ctx], stddev_type)
         for m, imt in enumerate(expected_results):
             expected_result = expected_results[imt]

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -98,8 +98,7 @@ class CollapseTestCase(unittest.TestCase):
         time_span = srcs[0].temporal_occurrence_model.time_span
         params = dict(imtls=self.imtls, truncation_level2=2,
                       collapse_level=2, investigation_time=time_span)
-        cmaker = contexts.ContextMaker(
-            srcs[0].tectonic_region_type, self.gsims, params)
+        cmaker = contexts.ContextMaker(self.gsims, params)
         res = classical(srcs, self.srcfilter, cmaker)
         pmap = res['pmap']
         effrups = sum(nr for nr, ns, dt in res['calc_times'].values())


### PR DESCRIPTION
The ContextMaker wants a TRT in input, but that parameter is useless since it can be inferred from the GSIMs. The reason is historical since originally the ContextMaker did not depend on the GSIMs as it was used solely to build the contexts. This is now fixed.