### PR TITLE
Printing a warning when the GMPEs are used in TRTs they are not defined for

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,17 @@
+  [Michele Simionato]
+  * Printing a warning when the GMPEs are used in TRTs they are not defined for
+
   [Graeme Weatherill]
-  * Implements Abrahamson & Gulerce (2020) NGA Subduction GMPE
+  * Implemented Abrahamson & Gulerce (2020) NGA Subduction GMPE
   
   [Nico Kuehn/Graeme Weatherill]
-  * Implements Kuehn et al. (2020) NGA Subduction GMPE
+  * Implemented Kuehn et al. (2020) NGA Subduction GMPE
 
   [Chung-Han Chan/Jia-Cian Gao]
-  * Implements Lin et al. (2011)
+  * Implemented Lin et al. (2011)
 
   [Graeme Weatherill/Nico Kuehn]
-  * Implements Si et al. (2020) NGA Subduction GMPE
+  * Implemented Si et al. (2020) NGA Subduction GMPE
 
   [Michele Simionato]
   * There is now a huge speedup when computing the hazard curve statistics

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -583,6 +583,10 @@ def get_gsim_lt(oqparam, trts=('*',)):
     gmfcorr = oqparam.correl_model
     for trt, gsims in gsim_lt.values.items():
         for gsim in gsims:
+            if gsim.DEFINED_FOR_TECTONIC_REGION_TYPE.value != trt:
+                raise ValueError(
+                    '%r is defined for %s, not %s!' %
+                    (gsim, gsim.DEFINED_FOR_TECTONIC_REGION_TYPE, trt))
             if gmfcorr and (gsim.DEFINED_FOR_STANDARD_DEVIATION_TYPES ==
                             {StdDev.TOTAL}):
                 raise CorrelationButNoInterIntraStdDevs(gmfcorr, gsim)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -584,9 +584,8 @@ def get_gsim_lt(oqparam, trts=('*',)):
     for trt, gsims in gsim_lt.values.items():
         for gsim in gsims:
             if gsim.DEFINED_FOR_TECTONIC_REGION_TYPE.value != trt:
-                raise ValueError(
-                    '%r is defined for %s, not %s!' %
-                    (gsim, gsim.DEFINED_FOR_TECTONIC_REGION_TYPE, trt))
+                logging.info('%r is defined for %s, not %s',
+                             gsim, gsim.DEFINED_FOR_TECTONIC_REGION_TYPE, trt)
             if gmfcorr and (gsim.DEFINED_FOR_STANDARD_DEVIATION_TYPES ==
                             {StdDev.TOTAL}):
                 raise CorrelationButNoInterIntraStdDevs(gmfcorr, gsim)


### PR DESCRIPTION
The warning is printed when the gsim logic tree is read.