### PR TITLE
Saved memory in gen_poes

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -571,21 +571,21 @@ class ContextMaker(object):
         """
         from openquake.hazardlib.site_amplification import get_poes_site
         nsites = numpy.array([len(ctx.sids) for ctx in ctxs])
-        N = nsites.sum()
-        poes = numpy.zeros((N, self.loglevels.size, len(self.gsims)))
         with self.gmf_mon:
             mean_stdt = self.get_mean_stds(ctxs, StdDev.TOTAL)
-        with self.poe_mon:
-            for g, gsim in enumerate(self.gsims):
-                # builds poes of shape (N, L, G)
-                if self.af:  # kernel amplification method
-                    poes[:, :, g] = get_poes_site(mean_stdt[g], self, ctxs)
-                else:  # regular case
-                    poes[:, :, g] = gsim.get_poes(mean_stdt[g], self, ctxs)
         s = 0
-        for n in nsites:
-            yield poes[s:s+n]
-            s += n
+        with self.poe_mon:
+            for n in nsites:
+                poes = numpy.zeros((n, self.loglevels.size, len(self.gsims)))
+                for g, gsim in enumerate(self.gsims):
+                    ms = mean_stdt[g][:, :, s:s+n]
+                    # builds poes of shape (n, L, G)
+                    if self.af:  # kernel amplification method
+                        poes[:, :, g] = get_poes_site(ms, self, ctxs)
+                    else:  # regular case
+                        poes[:, :, g] = gsim.get_poes(ms, self, ctxs)
+                yield poes
+                s += n
 
 
 # see contexts_tests.py for examples of collapse


### PR DESCRIPTION
Solves the out-of-memory issue in the Taiwan model discovered by @mmpagani .
Here is the memory occupation of model on the Azure machine:
```
| calc_25, maxmem=97.3 GB | time_sec | memory_mb | counts    |
|-------------------------+----------+-----------+-----------|
| total classical         | 218_679  | 504.8     | 621       |
| get_poes                | 194_217  | 0.0       | 15_868    |
| composing pnes          | 69_756   | 0.0       | 7_883_838 |
| computing mean_std      | 15_753   | 0.0       | 15_868    |
| make_contexts           | 5_071    | 0.0       | 7_883_838 |
| ClassicalCalculator.run | 2_069    | 190.2     | 1         |
```
Part of https://github.com/gem/oq-engine/issues/6973.

It should be noticed that with pointsource_distance=100 one gets essentially *identical numbers* with half the memory occupation and 5 times less time:
```
| calc_24, maxmem=58.5 GB | time_sec | memory_mb | counts    |
|-------------------------+----------+-----------+-----------|
| total classical         | 44_171   | 331.9     | 594       |
| get_poes                | 35_213   | 0.0       | 15_868    |
| composing pnes          | 13_913   | 0.0       | 8_194_180 |
| computing mean_std      | 2_575    | 0.0       | 15_868    |
| make_contexts           | 2_385    | 0.0       | 8_194_180 |
| ClassicalCalculator.run | 465.8    | 190.9     | 1         |
```