### PR TITLE
Abrahamson & Gulerce (2020) - backwards compatibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Jason Motha/Tom Son]
+  * Implemented backwards compatibility to Abrahamson & Gulerce (2020)
+
   [Michele Simionato]
   * `oq info gsim_logic_tree.xml` now displays the logic tree
   * Fixed a bug in the adjustment term in NSHMP2014 breaking the USA model

--- a/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
+++ b/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
@@ -237,7 +237,7 @@ def get_rupture_depth_scaling_term(C, trt, ctx):
 
 def get_site_amplification_term(C, region, vs30, pga1000):
     """
-    Returns the shallow site amplification term as descrbied in Equation 3.7,
+    Returns the shallow site amplification term as described in Equation 3.7,
     and corrected in the Erratum
 
     :param numpy.ndarray vs30:

--- a/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
+++ b/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
@@ -230,10 +230,8 @@ def get_rupture_depth_scaling_term(C, trt, ctx):
     if trt == const.TRT.SUBDUCTION_INTERFACE:
         # Not defined for interface events
         return 0.0
-    f_dep = C["a11"] * (ctx.ztor - 50.0)
+    f_dep = np.where(ctx.ztor <= 50.0, C["a8"] * (ctx.ztor - 50.0), C["a11"] * (ctx.ztor - 50.0))
     f_dep[ctx.ztor > 200.0] = C["a11"] * 150.0
-    idx = ctx.ztor <= 50.0
-    f_dep[idx] = C["a8"] * (ctx.ztor[idx] - 50.0)
     return f_dep
 
 


### PR DESCRIPTION
# Abrahamson & Gulerce (2020) - backwards compatibility

This PR is related to this issue - #7067 

We noticed this error by passing either a float or the length of 1 numpy.ndarry for `ztor` argument.
(But as the docstring said, within `get_rupture_depth_scaling_term()`, we should always pass a numpy.ndarray instead of a float.)

As a comment was left in the specified issue, implemented backwards compatibility.

