### PR TITLE
Fixed MultiFaultSources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3018,7 +3018,7 @@ python-oq-engine (2.0.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]
   * Another export fix: made sure it is run by the current user
-  * Fixed the export: if the export directory does not exists, it is created
+  * Fixed the export: if the export directory does not exist, it is created
   * Introduced the configuration variable `multi_user`, false for source
     installations and true for package installations
   * Fixed the WebUI export

--- a/doc/adv-manual/index.rst
+++ b/doc/adv-manual/index.rst
@@ -28,6 +28,7 @@ Contents:
    pandas
    parametric-gmpes
    multipoint
+   multifault
    parallelization
    special-features
    point-source-gridding

--- a/doc/adv-manual/multifault.rst
+++ b/doc/adv-manual/multifault.rst
@@ -8,14 +8,14 @@ Unlike regular sources, MultiFaultSources *are not self-consistent*:
 they exist only in relation to a *geometryModel* which is a list of
 surfaces (only *planarSurfaces* and *kiteSurfaces* are supported),
 each one with an ID. MultiFaultSources are lists of nonparametric ruptures
-with values mag, rake, probs_occur and IDs (sectionIndexes) taken from
-the geometryModel.
+with values mag, rake, probs_occur and IDs (called *sectionIndexes*)
+taken from the geometryModel.
 
-The example to study to understand MultiFaultSources, is in the directory
-``qa_tests_data/classical/case_65`` in the engine repo. In this example
-the geometryModel (the file sections.xml) contains two kiteSurfaces
-with IDs ``s1`` and ``s2`` respectively; there is a single single
-MultiFaultSource with the following content:
+In order to understand MultiFaultSources, The example to study is in
+the directory ``qa_tests_data/classical/case_65`` in the engine
+repository. In this example the geometryModel (the file sections.xml)
+contains two kiteSurfaces with IDs ``s1`` and ``s2`` respectively;
+there is a single MultiFaultSource with the following content:
 
 .. code-block:: xml
       <multiFaultSource id="1" name="Test1">
@@ -37,8 +37,8 @@ MultiFaultSource with the following content:
       </multiFaultSource>
 
 The ``probs_occur`` must sum up to 1 and the number of probabilities must
-be uniform across the MultiFaultSource (in this example there always two
-``probs_occur``) for each rupture.
+be uniform across the MultiFaultSource; in this example there always two
+``probs_occur`` for each rupture.
 
 When the engine reads a multiFaultSource XML file, a ``MultiFaultSource``
 object is instantiated. Such object cannot be used until the method

--- a/doc/adv-manual/multifault.rst
+++ b/doc/adv-manual/multifault.rst
@@ -1,4 +1,4 @@
-MultiPointSources
+MultiFaultSources
 =============================
 
 Starting from version 3.2, the OpenQuake Engine is able to manage
@@ -7,8 +7,8 @@ MultiFaultSources, which are special sources used for UCERF-like models.
 Unlike regular sources, MultiFaultSources *are not self-consistent*:
 they exist only in relation to a *geometryModel* which is a list of
 surfaces (only *planarSurfaces* and *kiteSurfaces* are supported),
-each one with an ID. MultiFaultSources are lists of ruptures with
-parameters mag, rake, probs_occur and IDs (sectionIndexes) taken from
+each one with an ID. MultiFaultSources are lists of nonparametric ruptures
+with values mag, rake, probs_occur and IDs (sectionIndexes) taken from
 the geometryModel.
 
 The example to study to understand MultiFaultSources, is in the directory

--- a/doc/adv-manual/multifault.rst
+++ b/doc/adv-manual/multifault.rst
@@ -1,0 +1,66 @@
+MultiPointSources
+=============================
+
+Starting from version 3.2, the OpenQuake Engine is able to manage
+MultiFaultSources, which are special sources used for UCERF-like models.
+
+Unlike regular sources, MultiFaultSources *are not self-consistent*:
+they exist only in relation to a *geometryModel* which is a list of
+surfaces (only *planarSurfaces* and *kiteSurfaces* are supported),
+each one with an ID. MultiFaultSources are lists of ruptures with
+parameters mag, rake, probs_occur and IDs (sectionIndexes) taken from
+the geometryModel.
+
+The example to study to understand MultiFaultSources, is in the directory
+``qa_tests_data/classical/case_65`` in the engine repo. In this example
+the geometryModel (the file sections.xml) contains two kiteSurfaces
+with IDs ``s1`` and ``s2`` respectively; there is a single single
+MultiFaultSource with the following content:
+
+.. code-block:: xml
+      <multiFaultSource id="1" name="Test1">
+	<multiPlanesRupture probs_occur="0.8 0.2">
+	  <magnitude>5.0</magnitude>
+	  <sectionIndexes indexes="s1"/>
+	  <rake>90</rake>
+	</multiPlanesRupture>
+	<multiPlanesRupture probs_occur="0.7 0.3">
+	  <magnitude>6.0</magnitude>
+	  <sectionIndexes indexes="s1,s2"/>
+	  <rake>90</rake>
+	</multiPlanesRupture>
+	<multiPlanesRupture probs_occur="0.9 0.1">
+	  <magnitude>5.2</magnitude>
+	  <sectionIndexes indexes="s2"/>
+	  <rake>90</rake>
+	</multiPlanesRupture>
+      </multiFaultSource>
+
+The ``probs_occur`` must sum up to 1 and the number of probabilities must
+be uniform across the MultiFaultSource (in this example there always two
+``probs_occur``) for each rupture.
+
+When the engine reads a multiFaultSource XML file, a ``MultiFaultSource``
+object is instantiated. Such object cannot be used until the method
+``.create_inverted_index(sections)`` is called. That is the essential
+method associating the sectionIndices to the section objects. The reading
+happens in three steps:
+
+1. read and instantiate all MultiFaultSources
+2. read the geometryFile and instantiate a dictionary of sections
+   section_id -> surface
+3. call ``src.set_sections(sections)`` for each MultiFaultSource: this
+   will create an attribute .sections pointing to the sections dictionary
+
+Only *after the .sections dictionary has been set*
+it is possible to call ``.iter_ruptures`` and to instantiate the underlying
+*NonParametricProbabilisticRupture* objects. Each rupture will have a
+surface; if the rupture contains a single section index the
+surface will be the surface in the geometryModel; if the ruptures contains
+multiple section indexes the surface will be a MultiSurface built from
+the corresponding surfaces in the geometryModel.
+
+In our example the first rupture will be associated to the KiteSurface ``s1``,
+the third rupture to the KiteSurface ``s2`` and the second rupture will
+be associated to the MultiSurface obtained from the KiteSurfaces ``s1`` and
+``s2``.

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -23,6 +23,7 @@ import numpy
 from openquake.baselib import parallel, general, config
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import lt, contexts
+from openquake.hazardlib.sourcewriter import write_source_model
 from openquake.commonlib import readinput
 from openquake.calculators.views import view, text_table
 from openquake.calculators.export import export
@@ -877,8 +878,17 @@ hazard_uhs-std.csv
         self.assertEqualFiles('expected/hcurve-mean.csv', f)
 
     def test_case_65(self):
-        # Multi fault source
+        # reading/writing a multiFaultSource
+        oq = readinput.get_oqparam('job.ini', pkg=case_65)
+        csm = readinput.get_composite_source_model(oq)
+        tmpname = general.gettemp()
+        out = write_source_model(tmpname, csm.src_groups)
+        self.assertEqual(out[0], tmpname)
+        self.assertEqual(out[1], tmpname[:-4] + '_sections.xml')
+
+        # running the calculation
         self.run_calc(case_65.__file__, 'job.ini')
+
         [f] = export(('hcurves/mean', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/hcurve-mean.csv', f, delta=1E-4)
 

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -145,21 +145,21 @@ def fix_geometry_sections(smdict):
         else:
             raise RuntimeError('Unknown model %s' % mod)
 
-    # merge the sections
-    sections = []
+    # merge and reorder the sections
+    sections = {}
     for gmod in gmodels:
-        sections.extend(gmod.sections)
-    sections.sort(key=operator.attrgetter('sec_id'))
-    nrml.check_unique([sec.sec_id for sec in sections])
+        sections.update(gmod.sections)
+    sections = {sid: sections[sid] for sid in sorted(sections)}
+    nrml.check_unique(sections)
 
     # fix the MultiFaultSources
     for smod in smodels:
         for sg in smod.src_groups:
             for src in sg:
-                if hasattr(src, 'create_inverted_index'):
+                if hasattr(src, 'set_sections'):
                     if not sections:
                         raise RuntimeError('Missing geometryModel files!')
-                    src.create_inverted_index(sections)
+                    src.set_sections(sections)
 
 
 def _build_groups(full_lt, smdict):

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -159,10 +159,10 @@ class SourceModel(collections.abc.Sequence):
 
 class GeometryModel(object):
     """
-    Contains a list of sections
+    Contains a dictionary of sections
     """
     def __init__(self, sections):
-        check_unique([sec.sec_id for sec in sections])
+        check_unique(sections)
         self.sections = sections
         self.src_groups = []
 

--- a/openquake/hazardlib/nrml_to.py
+++ b/openquake/hazardlib/nrml_to.py
@@ -140,7 +140,7 @@ def convert_to(fmt, fnames, chatty=False, *, outdir='.', geometry=''):
     t0 = time.time()
     if geometry:
         fnames = [geometry] + fnames
-    sections = []
+    sections = {}
     for fname in fnames:
         logging.info('Reading %s', fname)
         converter.fname = fname
@@ -149,7 +149,9 @@ def convert_to(fmt, fnames, chatty=False, *, outdir='.', geometry=''):
         srcs = collections.defaultdict(list)  # geom_index -> rows
         if fname == geometry:
             for srcnode in root.geometryModel:
-                sections.append(converter.convert_node(srcnode))
+                sec = converter.convert_node(srcnode)
+                sections[sec.sec_id] = sec
+            sections = {sid: sections[sid] for sid in sections}
         elif 'nrml/0.4' in root['xmlns']:
             for srcnode in root.sourceModel:
                 appendrow(converter.convert_node(srcnode),

--- a/openquake/hazardlib/nrml_to.py
+++ b/openquake/hazardlib/nrml_to.py
@@ -99,7 +99,7 @@ def to_wkt(geom, coords):
 # https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry
 def appendrow(row, rows, chatty, sections=()):
     if row.code == 'F':  # row.coords is a multiFaultSource
-        row.coords.create_inverted_index(sections)
+        row.coords.set_sections(sections)
         row.coords = [row.coords.polygon.coords]
     row.wkt = wkt = to_wkt(row.geom, row.coords)
     if wkt.startswith('POINT'):

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -92,24 +92,18 @@ class MultiFaultSource(BaseSeismicSource):
         self.rakes = rakes
         super().__init__(source_id, name, tectonic_region_type)
 
-    def create_inverted_index(self, sections):
+    def set_sections(self, sections):
         """
-        Check sections and sreates an inverted index structure, i.e. a
+        Check sections and creates an inverted index structure, i.e. a
         dictionary sec_id->index
         """
         assert sections
         self.sections = sections
-        section_idxs = [s.sec_id for s in sections]
         msg = 'Rupture #{:d}: section "{:s}" does not exists'
         for i in range(len(self.mags)):
             for idx in self.rupture_idxs[i]:
-                if idx not in section_idxs:
+                if idx not in sections:
                     raise ValueError(msg.format(i, idx))
-
-        # create the inverted index
-        self.invx = {}
-        for i, sec in enumerate(self.sections):
-            self.invx[sec.sec_id] = i
 
     def iter_ruptures(self, fromidx=0, untilidx=None, **kwargs):
         """
@@ -119,21 +113,20 @@ class MultiFaultSource(BaseSeismicSource):
         :param untilidx: stop
         """
         # check
-        if 'invx' not in self.__dict__:
-            raise RuntimeError(
-                'You forgot to call create_inverted_index in %s!' % self)
+        if 'sections' not in self.__dict__:
+            raise RuntimeError('You forgot to call set_sections in %s!' % self)
 
         # iter on the ruptures
         untilidx = len(self.mags) if untilidx is None else untilidx
         for i in range(fromidx, untilidx):
             idxs = self.rupture_idxs[i]
-            if len(idxs) < 2:
-                sfc = self.sections[self.invx[idxs[0]]].surface
+            if len(idxs) == 1:
+                sfc = self.sections[idxs[0]].surface
             else:
                 s = self.sections
-                sfc = MultiSurface([s[self.invx[j]].surface for j in idxs])
+                sfc = MultiSurface([s[j].surface for j in idxs])
             rake = self.rakes[i]
-            hypo = self.sections[self.invx[idxs[0]]].surface.get_middle_point()
+            hypo = self.sections[idxs[0]].surface.get_middle_point()
             yield NonParametricProbabilisticRupture(
                 self.mags[i], rake, self.tectonic_region_type, hypo, sfc,
                 self.pmfs[i])
@@ -155,7 +148,7 @@ class MultiFaultSource(BaseSeismicSource):
 
     @property
     def data(self):  # compatibility with NonParametricSeismicSource
-        for sec, pmf in zip(self.sections, self.pmfs):
+        for sec, pmf in zip(self.sections.values(), self.pmfs):
             yield sec, pmf
 
     polygon = NP.polygon

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -119,13 +119,13 @@ class MultiFaultSource(BaseSeismicSource):
 
         # iter on the ruptures
         untilidx = len(self.mags) if untilidx is None else untilidx
+        s = self.sections
         for i in range(fromidx, untilidx):
             idxs = self.rupture_idxs[i]
             if len(idxs) == 1:
                 sfc = self.sections[idxs[0]].surface
             else:
-                s = self.sections
-                sfc = MultiSurface([s[j].surface for j in idxs])
+                sfc = MultiSurface([s[idx].surface for idx in idxs])
             rake = self.rakes[i]
             hypo = self.sections[idxs[0]].surface.get_middle_point()
             yield NonParametricProbabilisticRupture(

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -100,7 +100,7 @@ class MultiFaultSource(BaseSeismicSource):
         """
         assert sections
         self.sections = sections
-        msg = 'Rupture #{:d}: section "{:s}" does not exists'
+        msg = 'Rupture #{:d}: section "{:s}" does not exist'
         for i in range(len(self.mags)):
             for idx in self.rupture_idxs[i]:
                 if idx not in sections:

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -94,8 +94,9 @@ class MultiFaultSource(BaseSeismicSource):
 
     def set_sections(self, sections):
         """
-        Check sections and creates an inverted index structure, i.e. a
-        dictionary sec_id->index
+        :param sections: a dictionary sec_id -> FaultSection
+
+        Set the attribute .sections to the passed dictionary
         """
         assert sections
         self.sections = sections
@@ -148,8 +149,8 @@ class MultiFaultSource(BaseSeismicSource):
 
     @property
     def data(self):  # compatibility with NonParametricSeismicSource
-        for sec, pmf in zip(self.sections.values(), self.pmfs):
-            yield sec, pmf
+        for i, rup in enumerate(self.iter_ruptures()):
+            yield rup, self.pmfs[i]
 
     polygon = NP.polygon
     wkt = NP.wkt

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -480,13 +480,12 @@ class RuptureConverter(object):
            :class:`openquake.hazardlib.geo.complexFaultSurface` instance
         3. there is a single griddedSurface node; returns a
            :class:`openquake.hazardlib.geo.GriddedSurface` instance
-        4. there is a list of PlanarSurface nodes; returns a
-           :class:`openquake.hazardlib.geo.MultiSurface` instance
+        5. there is either a single planarSurface or a list of planarSurface
+           nodes; returns a :class:`openquake.hazardlib.geo.PlanarSurface`
+           instance or a :class:`openquake.hazardlib.geo.MultiSurface` instance
         5. there is either a single kiteSurface or a list of kiteSurface
-           nodes; returns a
-           :class:`openquake.hazardlib.geo.KiteSurface` instance
-           or a :class:`openquake.hazardlib.geo.MultiSurface` instance,
-           respectively
+           nodes; returns a :class:`openquake.hazardlib.geo.KiteSurface`
+           instance or a :class:`openquake.hazardlib.geo.MultiSurface` instance
 
         :param surface_nodes: surface nodes as just described
         """
@@ -524,6 +523,8 @@ class RuptureConverter(object):
                         self.rupture_mesh_spacing))
                 surface = geo.MultiSurface(surfaces)
         else:  # a collection of planar surfaces
+            if len(surface_nodes) == 1:
+                return self.geo_planar(surface_nodes[0])
             planar_surfaces = list(map(self.geo_planar, surface_nodes))
             surface = geo.MultiSurface(planar_surfaces)
         return surface

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -684,9 +684,10 @@ class SourceConverter(RuptureConverter):
     def convert_geometryModel(self, node):
         """
         :param node: a geometryModel node
-        :returns: a list of sections
+        :returns: a dictionary sec_id -> section
         """
-        sections = [self.convert_node(secnode) for secnode in node]
+        sections = {secnode["id"]: self.convert_node(secnode)
+                    for secnode in node}
         return sections
 
     def convert_section(self, node):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -944,7 +944,7 @@ class SourceConverter(RuptureConverter):
             fault_trace = self.geo_line(geom)
             as_kite = False
         except Exception:
-            geom = node.kiteFaultGeometry
+            geom = node.kiteSurface
             profiles = self.geo_lines(geom)
 
         msr = valid.SCALEREL[~node.magScaleRel]()

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -699,7 +699,6 @@ def build_source_model_node(source_model):
     return Node('sourceModel', attrs, nodes=nodes)
 
 
-# usage: hdf5write(datastore.hdf5, csm)
 @obj_to_node.add('CompositeSourceModel')
 def build_source_model(csm):
     nodes = [obj_to_node(sg) for sg in csm.src_groups]

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -155,22 +155,22 @@ def build_complex_fault_geometry(fault_source):
     return Node("complexFaultGeometry", nodes=edge_nodes)
 
 
-def build_kite_fault_geometry(fault_source):
+@obj_to_node.add('KiteSurface')
+def build_kite_surface(ksurface):
     """
-    Returns the complex fault source geometry as a Node
-    :param fault_source:
+    Returns the KiteSurface instance as a Node
+
+    :param ksurface:
         Kite fault source model as an instance of the :class:
         `openquake.hazardlib.source.kite_fault.KiteFaultSource`
     :returns:
         Instance of :class:`openquake.baselib.node.Node`
     """
-    num_profiles = len(fault_source.profiles)
     profile_nodes = []
-    for iloc, profile in enumerate(fault_source.profiles):
-        profile_nodes.append(
-            Node("profile", nodes=[build_linestring_node(profile, with_depth=True)]))
-    return Node("kiteFaultGeometry", nodes=profile_nodes)
-
+    for profile in ksurface.profiles:
+        node = build_linestring_node(profile, with_depth=True)
+        profile_nodes.append(Node("profile", nodes=[node]))
+    return Node("kiteSurface", nodes=profile_nodes)
 
 
 @obj_to_node.add('EvenlyDiscretizedMFD')
@@ -624,7 +624,7 @@ def build_kite_fault_source_node(fault_source):
     """
 
     # Parse geometry
-    source_nodes = [build_kite_fault_geometry(fault_source)]
+    source_nodes = [build_kite_surface(fault_source)]
     # Parse common fault source attributes
     source_nodes.extend(get_fault_source_nodes(fault_source))
     return Node("kiteFaultSource",
@@ -659,6 +659,20 @@ def build_multi_fault_source_node(multi_fault_source):
     return Node("multiFaultSource",
                 get_source_attributes(multi_fault_source),
                 nodes=rup_nodes)
+
+
+@obj_to_node.add('FaultSection')
+def build_section(section):
+    """
+    Parses a FaultSection instance to a Node class
+
+    :param section:
+        A FaultSection instance
+    :returns:
+        Instance of :class:`openquake.baselib.node.Node`
+    """
+    nodes = [obj_to_node(section.surface)]
+    return Node("section", {'id': section.sec_id}, nodes=nodes)
 
 
 @obj_to_node.add('SourceGroup')
@@ -730,6 +744,8 @@ def write_source_model(dest, sources_or_groups, name=None,
         Source model in different formats
     :param name:
         Name of the source model (if missing, extracted from the filename)
+    :returns:
+        the list of generated filenames
     """
     if isinstance(sources_or_groups, nrml.SourceModel):
         groups = sources_or_groups.src_groups
@@ -750,6 +766,7 @@ def write_source_model(dest, sources_or_groups, name=None,
         del attrs['investigation_time']
     nodes = list(map(obj_to_node, groups))
     ddict = extract_ddict(groups)
+    out = [dest]
     if ddict:
         # remove duplicate content from nodes
         for grp_node in nodes:
@@ -769,14 +786,25 @@ def write_source_model(dest, sources_or_groups, name=None,
                         h[key][:] = v
                     else:
                         h[key] = v
+        out.append(dest5)
 
-    source_model = Node("sourceModel", attrs, nodes=nodes)
+    # produce a geometryModel if there are MultiFaultSources
+    sections = {}
+    for group in groups:
+        for src in group:
+            if hasattr(src, 'sections'):
+                sections.update(src.sections)
+    sections = {sid: sections[sid] for sid in sections}
+    smodel = Node("sourceModel", attrs, nodes=nodes)
     with open(dest, 'wb') as f:
-        nrml.write([source_model], f, '%s')
-    if ddict:
-        return [dest, dest5]
-    else:
-        return [dest]
+        nrml.write([smodel], f, '%s')
+    if sections:
+        secnodes = [obj_to_node(sec) for sec in sections.values()]
+        gmodel = Node("geometryModel", attrs, nodes=secnodes)
+        with open(dest[:-4] + '_sections.xml', 'wb') as f:
+            nrml.write([gmodel], f, '%s')
+            out.append(f.name)
+    return out
 
 
 def tomldump(obj, fileobj=None):

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -50,9 +50,9 @@ class MultiFaultTestCase(unittest.TestCase):
         sfc_c = KiteSurface.from_profiles(prf, vsmpl, hsmpl, idl, alg)
 
         # Sections list
-        sections = [FaultSection('0', sfc_a),
-                    FaultSection('1', sfc_b),
-                    FaultSection('2', sfc_c)]
+        sections = {"0": FaultSection('0', sfc_a),
+                    "1": FaultSection('1', sfc_b),
+                    "2": FaultSection('2', sfc_c)}
 
         # Rupture indexes
         rup_idxs = [['0'], ['1'], ['2'], ['0', '1'], ['0', '2'],
@@ -92,5 +92,5 @@ class MultiFaultTestCase(unittest.TestCase):
                                self.pmfs, self.mags, self.rakes)
         with self.assertRaises(ValueError) as ctx:
             mfs.set_sections(self.sections)
-        self.assertEqual('Rupture #2: section "3" does not exists',
-                         str(ctx.exception))
+        expected = 'Rupture #2: section "3" does not exist'
+        self.assertEqual(expected, str(ctx.exception))

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -81,16 +81,16 @@ class MultiFaultTestCase(unittest.TestCase):
         # test instantiation and rupture generation
         src = MultiFaultSource("01", "test", "Moon Crust",
                                self.rup_idxs, self.pmfs, self.mags, self.rakes)
-        src.create_inverted_index(self.sections)
+        src.set_sections(self.sections)
         rups = list(src.iter_ruptures())
         self.assertEqual(7, len(rups))
 
     def test02(self):
-        # test create_inverted_index, '3' is not a known section ID
+        # test set_sections, '3' is not a known section ID
         rup_idxs = [['0'], ['1'], ['3'], ['0'], ['1'], ['3'], ['0']]
         mfs = MultiFaultSource("01", "test", "Moon Crust", rup_idxs,
                                self.pmfs, self.mags, self.rakes)
         with self.assertRaises(ValueError) as ctx:
-            mfs.create_inverted_index(self.sections)
+            mfs.set_sections(self.sections)
         self.assertEqual('Rupture #2: section "3" does not exists',
                          str(ctx.exception))

--- a/openquake/hazardlib/tests/source_model/kite-fault-source.xml
+++ b/openquake/hazardlib/tests/source_model/kite-fault-source.xml
@@ -15,7 +15,7 @@ xmlns:gml="http://www.opengis.net/gml"
             id="100"
             name="100"
             >
-                <kiteFaultGeometry>
+                <kiteSurface>
                     <profile>
                         <gml:LineString>
                             <gml:posList>
@@ -30,7 +30,7 @@ xmlns:gml="http://www.opengis.net/gml"
                             </gml:posList>
                         </gml:LineString>
                     </profile>
-                </kiteFaultGeometry>
+                </kiteSurface>
                 <magScaleRel>
                     WC1994
                 </magScaleRel>

--- a/openquake/hazardlib/tests/sourceconverter_test.py
+++ b/openquake/hazardlib/tests/sourceconverter_test.py
@@ -288,15 +288,14 @@ class MultiFaultSourceModelTestCase(unittest.TestCase):
         sec_xml = os.path.join(datadir, 'sections_kite.xml')
         src_xml = os.path.join(datadir, 'sources.xml')
         conv = SourceConverter()
-        sec = nrml.to_python(sec_xml, conv).sections
+        sec = nrml.to_python(sec_xml, conv).sections  # s1 and s2
         expected = [Point(11, 45, 0), Point(11, 45.5, 10)]
         # Check geometry info
-        self.assertEqual(expected[0], sec[1].surface.profiles[0].points[0])
-        self.assertEqual(expected[1], sec[1].surface.profiles[0].points[1])
-        self.assertEqual(sec[1].sec_id, 's2')
+        self.assertEqual(expected[0], sec['s2'].surface.profiles[0].points[0])
+        self.assertEqual(expected[1], sec['s2'].surface.profiles[0].points[1])
         ssm = nrml.to_python(src_xml, conv)
         self.assertIsInstance(ssm, nrml.SourceModel)
-        ssm[0][0].create_inverted_index(sec)   # fix sections
+        ssm[0][0].set_sections(sec)   # fix sections
         rups = list(ssm[0][0].iter_ruptures())
 
         # Check data for the second rupture

--- a/openquake/hazardlib/tests/sourcewriter_test.py
+++ b/openquake/hazardlib/tests/sourcewriter_test.py
@@ -53,7 +53,7 @@ GRIDDED = os.path.join(os.path.dirname(__file__),
                        'source_model/gridded.xml')
 
 KITEFAULT = os.path.join(os.path.dirname(__file__),
-                       'source_model/kite-fault-source.xml')
+                         'source_model/kite-fault-source.xml')
 
 TOML = os.path.join(os.path.dirname(__file__), 'expected_sources.toml')
 


### PR DESCRIPTION
There were many issues.

1. Each MultiFaultSource had a dictionary `.invx` which was useless and wasting memory
2. KiteSurfaces were incorrectly called KiteFaultGeometry
3. We were missing serialization of KiteSurfaces
4. We were missing serialization of the GeometryModel
5. We were missing documentation of MultiFaultSources
6. the property MultiFaultSource.data was implemented incorrectly
7. SourceConverter.convert_surfaces was buggy in the case of a single PlanarSurface

Closes https://github.com/gem/oq-engine/issues/7073.