### PR TITLE
Extended the multi-rupture scenario calculator to multiple TRTs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,5 @@
   [Michele Simionato]
-  * Fixed the number of generated events in multi-rupture scenario
-    calculations with multiple TRTs
+  * Extended the multi-rupture scenario calculator to multiple TRTs
   * Removed the experimental feature `pointsource_distance=?`
   * Refactored the GMPE tests, with a speedup of 1-14 times
   * Added a script `utils/build_vtable` to build verification tables

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed the number of generated events in multi-rupture scenario
+    calculations with multiple TRTs
   * Removed the experimental feature `pointsource_distance=?`
   * Refactored the GMPE tests, with a speedup of 1-14 times
   * Added a script `utils/build_vtable` to build verification tables

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -297,14 +297,9 @@ class EventBasedCalculator(base.HazardCalculator):
                     'maximum_distance and the position of the rupture')
         elif oq.inputs['rupture_model'].endswith('.csv'):
             aw = get_ruptures(oq.inputs['rupture_model'])
-            if list(gsim_lt.values) == ['*']:
-                num_gsims = numpy.array([len(gsim_lt.values['*'])], U32)
-            else:
-                num_gsims = numpy.array(
-                    [len(gsim_lt.values.get(trt, [])) for trt in aw.trts], U32)
             if oq.calculation_mode.startswith('scenario'):
-                # rescale n_occ
-                aw['n_occ'] *= ngmfs * num_gsims[aw['trt_smr']]
+                # rescale n_occ by ngmfs and nrlzs
+                aw['n_occ'] *= ngmfs * gsim_lt.get_num_paths()
         else:
             raise InvalidFile("Something wrong in %s" % oq.inputs['job_ini'])
         rup_array = aw.array

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -139,9 +139,15 @@ class ScenarioTestCase(CalculatorTestCase):
         self.assertEqualFiles('sig_eps.csv', sig_eps)
 
     def test_case_13(self):
-        # multi-rupture scenario
+        # multi-rupture scenario with 2 ruptures, 10 rlzs, 10 gmfs, 100 sites
         self.run_calc(case_13.__file__, 'job.ini')
-        self.assertEqual(len(self.calc.datastore['gmf_data/eid']), 380)
+        gmf_df = self.calc.datastore.read_df('gmf_data')
+        counts_by_eid = gmf_df[['eid', 'sid']].groupby('eid').count()
+        self.assertEqual(len(counts_by_eid), 200)  # there are 2x10x10 events
+        # the first rupture touches 6 sites, the second 4 sites, so
+        # there are 600+400 = 1000 GMVs
+        self.assertEqual(4*(counts_by_eid.sid == 4).sum(), 400)
+        self.assertEqual(6*(counts_by_eid.sid == 6).sum(), 600)
 
     def test_case_14(self):
         # new Swiss GMPEs

--- a/openquake/hazardlib/__init__.py
+++ b/openquake/hazardlib/__init__.py
@@ -181,13 +181,13 @@ def read_input(hparams):
     for trt, rlzs_by_gsim in lt.get_rlzs_by_gsim_trt().items():
         cmaker[trt] = contexts.ContextMaker(trt, rlzs_by_gsim, hparams)
     if rmfname:
-        # for instance for 2 TRTs with 5x1 GSIMs and ngmfs=10, then the
-        # numbers of occupation are 50 and 10 respectively, for a total
-        # of 60 events, see scenario/case_13
+        # for instance for 2 TRTs with 5x2 GSIMs and ngmfs=10, then the
+        # number of occupation is 100 for each rupture, for a total
+        # of 200 events, see scenario/case_13
+        nrlzs = lt.get_num_paths()
         for grp in groups:
-            ngsims = len(cmaker[grp.trt].gsims)
             for ebr in grp:
-                ebr.n_occ = ngmfs * ngsims
+                ebr.n_occ = ngmfs * nrlzs
 
     sitecol = _get_sitecol(hparams, lt.req_site_params)
     return Input(groups, sitecol, lt, cmaker)


### PR DESCRIPTION
This was missing in engine v3.11 and implemented incorrectly in master until now.