### PR TITLE
Printing a warning in case of extreme GMVs

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -416,8 +416,7 @@ class EventBasedCalculator(base.HazardCalculator):
         L = oq.imtls.size
         L1 = L // (M or 1)
         # check seed dependency unless the number of GMFs is huge
-        if ('gmf_data' in self.datastore and
-                self.datastore.getsize('gmf_data') < 1E9):
+        if 'gmf_data' in self.datastore:
             logging.info('Checking stored GMFs')
             msg = views.view('extreme_gmvs', self.datastore)
             logging.warning(msg)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -416,7 +416,8 @@ class EventBasedCalculator(base.HazardCalculator):
         L = oq.imtls.size
         L1 = L // (M or 1)
         # check seed dependency unless the number of GMFs is huge
-        if 'gmf_data' in self.datastore:
+        if 'gmf_data' in self.datastore and self.datastore.getsize(
+                'gmf_data/gmv_0') < 4E9:
             logging.info('Checking stored GMFs')
             msg = views.view('extreme_gmvs', self.datastore)
             logging.warning(msg)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -418,11 +418,9 @@ class EventBasedCalculator(base.HazardCalculator):
         # check seed dependency unless the number of GMFs is huge
         if ('gmf_data' in self.datastore and
                 self.datastore.getsize('gmf_data') < 1E9):
-            logging.info('Checking seed dependency')
-            err = views.view('gmf_error', self.datastore)
-            if err > .05:
-                logging.warning('Your results are expected to have a large '
-                                'dependency from ses_seed')
+            logging.info('Checking stored GMFs')
+            msg = views.view('extreme_gmvs', self.datastore)
+            logging.warning(msg)
         if oq.hazard_curves_from_gmfs:
             rlzs = self.datastore['full_lt'].get_realizations()
             # compute and save statistics; this is done in process and can

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -725,15 +725,6 @@ def view_gmf(token, dstore):
     return str(gmf)
 
 
-def get_gmv0(dstore):
-    # returns dict gmf_error, extreme_ruptures
-    eids = dstore['gmf_data/eid'][:]
-    gmvs = dstore['gmf_data/gmv_0'][:]
-    sids = dstore['gmf_data/sid'][:]
-    df = pandas.DataFrame({'gmv_0': gmvs, 'sid': sids}, eids)
-    return df
-
-
 def binning_error(values, eids, nbins=10):
     """
     :param values: E values
@@ -746,15 +737,6 @@ def binning_error(values, eids, nbins=10):
     df = pandas.DataFrame({'val': values}, eids)
     res = df.groupby(eids % nbins).val.sum()
     return res.std() / res.mean()
-
-
-@view.add('gmf_error')
-def view_gmf_error(token, dstore):
-    """
-    Display a gmf relative error for seed dependency
-    """
-    return binning_error(
-        dstore['gmf_data/gmv_0'][:], dstore['gmf_data/eid'][:])
 
 
 class GmpeExtractor(object):
@@ -782,17 +764,29 @@ def view_extreme_gmvs(token, dstore):
     else:
         maxgmv = 10  # 10g is default value defining extreme GMVs
     imt0 = list(dstore['oqparam'].imtls)[0]
+
+    eids = dstore['gmf_data/eid'][:]
+    gmvs = dstore['gmf_data/gmv_0'][:]
+    sids = dstore['gmf_data/sid'][:]
+    msg = ''
+    err = binning_error(gmvs, eids)
+    if err > .05:
+        msg += ('Your results are expected to have a large dependency '
+                'from ses_seed')
     if imt0.startswith(('PGA', 'SA(')):
         gmpe = GmpeExtractor(dstore)
-        df = get_gmv0(dstore)
+        df = pandas.DataFrame({'gmv_0': gmvs, 'sid': sids}, eids)
         extreme_df = df[df.gmv_0 > maxgmv].copy()
         ev = dstore['events'][()][extreme_df.index]
         extreme_df['rlz'] = ev['rlz_id']
         extreme_df['rup'] = ev['rup_id']
         trt_smrs = dstore['ruptures']['trt_smr'][extreme_df.rup]
         extreme_df['gmpe'] = gmpe.extract(trt_smrs, ev['rlz_id'])
-        return extreme_df.sort_values('gmv_0').groupby('sid').head(1)
-    return 'Could not do anything for ' + imt0
+        exdf = extreme_df.sort_values('gmv_0').groupby('sid').head(1)
+        if len(exdf):
+            msg += '\nThere are extreme GMVs\n%s' % exdf
+        return msg
+    return msg + '\nCould not extract extreme GMVs for ' + imt0
 
 
 @view.add('mean_disagg')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -784,7 +784,7 @@ def view_extreme_gmvs(token, dstore):
         extreme_df['gmpe'] = gmpe.extract(trt_smrs, ev['rlz_id'])
         exdf = extreme_df.sort_values('gmv_0').groupby('sid').head(1)
         if len(exdf):
-            msg += '\nThere are extreme GMVs\n%s' % exdf
+            msg += '\nThere are extreme GMVs\n%s' % exdf.set_index('rup')
         return msg
     return msg + '\nCould not extract extreme GMVs for ' + imt0
 


### PR DESCRIPTION
Unfortunately this was enabled only for small calculations. I have raised the limit to 4 GB. One also can perform the analysis manually with the command `oq show extreme_gmvs`. Here is an example for Ecuador:
```
$ oq2 show extreme_gmvs 42402
There are extreme GMVs
            gmv_0   sid  rlz                            gmpe
rup
380760  10.006863   662   16        [MontalvaEtAl2016SInter]
380756  10.042521   526   23        [MontalvaEtAl2016SInter]
380758  10.110134   155    4        [MontalvaEtAl2016SInter]
312795  10.113150  2522    9              [BindiEtAl2014Rjb]
589348  10.115601   316    4        [MontalvaEtAl2016SInter]
380743  10.162351   670    3  [AbrahamsonEtAl2015SInterHigh]
494975  10.185571  3235   15              [BindiEtAl2014Rjb]
388422  10.185790  2535   15              [BindiEtAl2014Rjb]
343401  10.198751   951   21              [BindiEtAl2014Rjb]
380743  10.255490   943    3  [AbrahamsonEtAl2015SInterHigh]
380757  10.369276  1050   12        [MontalvaEtAl2016SInter]
380757  10.419384   519    7        [MontalvaEtAl2016SInter]
589355  10.444461   124    4        [MontalvaEtAl2016SInter]
589354  10.452167   177    4        [MontalvaEtAl2016SInter]
134669  10.480486  2466   14              [BindiEtAl2014Rjb]
88290   10.486018  2004   23              [BindiEtAl2014Rjb]
...
380758  12.610123   960    5        [MontalvaEtAl2016SInter]
589350  12.659808   152   18  [AbrahamsonEtAl2015SInterHigh]
577811  12.931211   469   14              [BindiEtAl2014Rjb]
380756  13.579221   133   11        [MontalvaEtAl2016SInter]
380757  13.581605   937   12        [MontalvaEtAl2016SInter]
589352  13.823578   238   12        [MontalvaEtAl2016SInter]
589351  14.282530   168   23        [MontalvaEtAl2016SInter]
589348  15.100355   216    4        [MontalvaEtAl2016SInter]
134669  15.291298  3012   14              [BindiEtAl2014Rjb]
```