### PR TITLE
Check number_of_logic_tree_samples with collect_rlzs and hazard_calculation_id

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1620,15 +1620,15 @@ class OqParam(valid.ParamSet):
         sampling_method must be early_weights, only the mean is available,
         and number_of_logic_tree_samples must be greater than 1.
         """
-        if self.collect_rlzs is False:
-            return True
-        elif self.calculation_mode == 'event_based_damage':
+        if self.calculation_mode == 'event_based_damage':
             if not self.investigation_time:
                 ini = self.inputs['job_ini']
                 raise InvalidFile('Missing investigation_time in %s' % ini)
             self.collect_rlzs = True
             return True
-        if self.hazard_calculation_id:
+        elif self.collect_rlzs is False:
+            return True
+        elif self.hazard_calculation_id:
             n = self._parent.number_of_logic_tree_samples
             if n == 0:
                 raise ValueError('collect_rlzs=true can only be specified if '

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1064,15 +1064,18 @@ class OqParam(valid.ParamSet):
         Set self.loss_names
         """
         from openquake.commonlib import datastore  # avoid circular import
+        if self.hazard_calculation_id:
+            with datastore.read(self.hazard_calculation_id) as ds:
+                self._parent = ds['oqparam']
+        else:
+            self._parent = None
         # set all_cost_types
         # rt has the form 'vulnerability/structural', 'fragility/...', ...
         costtypes = set(rt.rsplit('/')[1] for rt in self.risk_files)
         if not costtypes and self.hazard_calculation_id:
             try:
-                with datastore.read(self.hazard_calculation_id) as ds:
-                    parent = ds['oqparam']
-                    self._risk_files = rfs = get_risk_files(parent.inputs)
-                    costtypes = set(rt.rsplit('/')[1] for rt in rfs)
+                self._risk_files = rfs = get_risk_files(self._parent.inputs)
+                costtypes = set(rt.rsplit('/')[1] for rt in rfs)
             except OSError:  # FileNotFound for wrong hazard_calculation_id
                 pass
         self.all_cost_types = sorted(costtypes)
@@ -1617,14 +1620,19 @@ class OqParam(valid.ParamSet):
         sampling_method must be early_weights, only the mean is available,
         and number_of_logic_tree_samples must be greater than 1.
         """
-        if self.calculation_mode == 'event_based_damage':
+        if self.collect_rlzs is False:
+            return True
+        elif self.calculation_mode == 'event_based_damage':
             if not self.investigation_time:
                 ini = self.inputs['job_ini']
                 raise InvalidFile('Missing investigation_time in %s' % ini)
             self.collect_rlzs = True
             return True
-        if self.collect_rlzs is False or self.hazard_calculation_id:
-            return True
+        if self.hazard_calculation_id:
+            n = self._parent.number_of_logic_tree_samples
+            if n != self.number_of_logic_tree_samples:
+                raise ValueError('Please specify number_of_logic_tree_samples'
+                                 '=%d' % n)
         hstats = list(self.hazard_stats())
         nostats = not hstats or hstats == ['mean']
         return nostats and self.number_of_logic_tree_samples > 1 and (

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1630,7 +1630,10 @@ class OqParam(valid.ParamSet):
             return True
         if self.hazard_calculation_id:
             n = self._parent.number_of_logic_tree_samples
-            if n != self.number_of_logic_tree_samples:
+            if n == 0:
+                raise ValueError('collect_rlzs=true can only be specified if '
+                                 'the parent hazard calculation used sampling')
+            elif n != self.number_of_logic_tree_samples:
                 raise ValueError('Please specify number_of_logic_tree_samples'
                                  '=%d' % n)
         hstats = list(self.hazard_stats())


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6914. Now one gets the nice error
```
$ oq2 engine --run job_ebr_Chile_closedform_collectrlzs.ini --hc 42061
2021-09-02T03:45:53.40,CRITICAL,MainProcess/16207,Traceback (most recent call last):
  File "/opt/openquake2/oq-engine/openquake/engine/engine.py", line 240, in run_calc
    oqparam = log.get_oqparam()
  File "/opt/openquake2/oq-engine/openquake/commonlib/logs.py", line 186, in get_oqparam
    return readinput.get_oqparam(self.params)
  File "/opt/openquake2/oq-engine/openquake/commonlib/readinput.py", line 320, in get_oqparam
    oqparam.validate()
  File "/opt/openquake2/oq-engine/openquake/commonlib/oqvalidation.py", line 1088, in validate
    super().validate()
  File "/opt/openquake2/oq-engine/openquake/hazardlib/valid.py", line 1241, in validate
    if not is_valid():
  File "/opt/openquake2/oq-engine/openquake/commonlib/oqvalidation.py", line 1634, in is_valid_collect_rlzs
    raise ValueError('Please specify number_of_logic_tree_samples'
ValueError: Please specify number_of_logic_tree_samples=40
```
which is also displayed by the WebUI.