### PR TITLE
Trying to reproduce the extreme GMVs

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1541,3 +1541,15 @@ def clusterize(hmaps, rlzs, k):
         paths = [encode(path) for path in grp['path']]
         tbl.append((label, logictree.collect_paths(paths), centroid[label]))
     return numpy.array(tbl, dt), labels
+
+
+def read_ebrupture(dstore, rup_id):
+    """
+    :param dstore: a DataStore instance
+    :param rup_id: an integer rupture ID
+    :returns: an EBRupture instance
+    """
+    [getter] = getters.get_rupture_getters(
+        dstore, slc=slice(rup_id, rup_id + 1))
+    [proxy] = getter.get_proxies()
+    return proxy.to_ebr(getter.trt)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1264,3 +1264,35 @@ def read_cmakers(dstore, full_lt=None):
         start += len(rlzs_by_gsim)
         cmakers.append(cmaker)
     return cmakers
+
+
+def read_cmaker(dstore, trt_smr):
+    """
+    :param dstore: a DataStore-like object
+    :returns: a ContextMaker instance
+    """
+    oq = dstore['oqparam']
+    full_lt = dstore['full_lt']
+    trts = list(full_lt.gsim_lt.values)
+    trt = trts[trt_smr // len(full_lt.sm_rlzs)]
+    rlzs_by_gsim = full_lt.get_rlzs_by_gsim()[trt_smr]
+    mags = dstore['source_mags']
+    md = MagDepDistance.new(str(oq.maximum_distance))
+    md.interp({trt: mags[trt][:] for trt in mags})
+    cmaker = ContextMaker(
+        trt, rlzs_by_gsim,
+        {'truncation_level': oq.truncation_level,
+         'collapse_level': int(oq.collapse_level),
+         'num_epsilon_bins': oq.num_epsilon_bins,
+         'investigation_time': oq.investigation_time,
+         'maximum_distance': md,
+         'minimum_distance': oq.minimum_distance,
+         'ses_seed': oq.ses_seed,
+         'ses_per_logic_tree_path': oq.ses_per_logic_tree_path,
+         'max_sites_disagg': oq.max_sites_disagg,
+         'disagg_by_src': oq.disagg_by_src,
+         'min_iml': oq.min_iml,
+         'imtls': oq.imtls,
+         'reqv': oq.get_reqv(),
+         'shift_hypo': oq.shift_hypo})
+    return cmaker

--- a/utils/max_gmv0
+++ b/utils/max_gmv0
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from openquake.baselib import sap
-from openquake.hazardlib.contexts import ContextMaker
+from openquake.hazardlib.contexts import read_cmaker
 from openquake.hazardlib.calc.gmf import GmfComputer
 from openquake.commonlib.datastore import read
 from openquake.calculators.extract import read_ebrupture
@@ -8,14 +8,11 @@ from openquake.calculators.extract import read_ebrupture
 
 def max_gmv0(calc_id: int, rup_id: int):
     dstore = read(-1)
-    oq = dstore['oqparam']
     rlzs_by_gsim = dstore['full_lt'].get_rlzs_by_gsim()
     sitecol = dstore['sitecol']
-    ebr = read_ebrupture(dstore, 359)
+    ebr = read_ebrupture(dstore, rup_id)
     trt = ebr.tectonic_region_type
-    param = dict(imtls=oq.imtls, min_iml=oq.min_iml,
-                 truncation_level=oq.truncation_level)
-    cmaker = ContextMaker(trt, rlzs_by_gsim[ebr.trt_smr], param)
+    cmaker = read_cmaker(dstore, ebr.trt_smr)
     gc = GmfComputer(ebr, sitecol, cmaker)
     dic, dt = gc.compute_all()
     return max(dic['gmv_0'])

--- a/utils/max_gmv0
+++ b/utils/max_gmv0
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import pandas
 from openquake.baselib import sap
 from openquake.hazardlib.contexts import read_cmaker
 from openquake.hazardlib.calc.gmf import GmfComputer
@@ -12,7 +13,8 @@ def max_gmv0(calc_id: int, rup_id: int):
     ebr = read_ebrupture(dstore, rup_id)
     cmaker = read_cmaker(dstore, ebr.trt_smr)
     dic, dt = GmfComputer(ebr, sitecol, cmaker).compute_all()
-    return max(dic['gmv_0'])
+    df = pandas.DataFrame(dic).sort_values('gmv_0').groupby('sid').head(1)
+    return df
 
 
 if __name__ == '__main__':

--- a/utils/max_gmv0
+++ b/utils/max_gmv0
@@ -7,7 +7,7 @@ from openquake.calculators.extract import read_ebrupture
 
 
 def max_gmv0(calc_id: int, rup_id: int):
-    dstore = read(-1)
+    dstore = read(calc_id)
     rlzs_by_gsim = dstore['full_lt'].get_rlzs_by_gsim()
     sitecol = dstore['sitecol']
     ebr = read_ebrupture(dstore, rup_id)

--- a/utils/max_gmv0
+++ b/utils/max_gmv0
@@ -8,13 +8,10 @@ from openquake.calculators.extract import read_ebrupture
 
 def max_gmv0(calc_id: int, rup_id: int):
     dstore = read(calc_id)
-    rlzs_by_gsim = dstore['full_lt'].get_rlzs_by_gsim()
     sitecol = dstore['sitecol']
     ebr = read_ebrupture(dstore, rup_id)
-    trt = ebr.tectonic_region_type
     cmaker = read_cmaker(dstore, ebr.trt_smr)
-    gc = GmfComputer(ebr, sitecol, cmaker)
-    dic, dt = gc.compute_all()
+    dic, dt = GmfComputer(ebr, sitecol, cmaker).compute_all()
     return max(dic['gmv_0'])
 
 

--- a/utils/max_gmv0
+++ b/utils/max_gmv0
@@ -9,14 +9,13 @@ from openquake.calculators.extract import read_ebrupture
 def max_gmv0(calc_id: int, rup_id: int):
     dstore = read(-1)
     oq = dstore['oqparam']
-    gsim_lt = dstore['full_lt'].gsim_lt
+    rlzs_by_gsim = dstore['full_lt'].get_rlzs_by_gsim()
     sitecol = dstore['sitecol']
     ebr = read_ebrupture(dstore, 359)
     trt = ebr.tectonic_region_type
-    rlzs_by_gsim = gsim_lt.get_rlzs_by_gsim_trt()[trt]
     param = dict(imtls=oq.imtls, min_iml=oq.min_iml,
                  truncation_level=oq.truncation_level)
-    cmaker = ContextMaker(trt, rlzs_by_gsim, param)
+    cmaker = ContextMaker(trt, rlzs_by_gsim[ebr.trt_smr], param)
     gc = GmfComputer(ebr, sitecol, cmaker)
     dic, dt = gc.compute_all()
     return max(dic['gmv_0'])

--- a/utils/max_gmv0
+++ b/utils/max_gmv0
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+from openquake.baselib import sap
+from openquake.hazardlib.contexts import ContextMaker
+from openquake.hazardlib.calc.gmf import GmfComputer
+from openquake.commonlib.datastore import read
+from openquake.calculators.extract import read_ebrupture
+
+
+def max_gmv0(calc_id: int, rup_id: int):
+    dstore = read(-1)
+    oq = dstore['oqparam']
+    gsim_lt = dstore['full_lt'].gsim_lt
+    sitecol = dstore['sitecol']
+    ebr = read_ebrupture(dstore, 359)
+    trt = ebr.tectonic_region_type
+    rlzs_by_gsim = gsim_lt.get_rlzs_by_gsim_trt()[trt]
+    param = dict(imtls=oq.imtls, min_iml=oq.min_iml,
+                 truncation_level=oq.truncation_level)
+    cmaker = ContextMaker(trt, rlzs_by_gsim, param)
+    gc = GmfComputer(ebr, sitecol, cmaker)
+    dic, dt = gc.compute_all()
+    return max(dic['gmv_0'])
+
+
+if __name__ == '__main__':
+    print(sap.run(max_gmv0))


### PR DESCRIPTION
Here is the procedure to follow:
1. identify the problematic calculation by looking at the log (for instance #42462 on cluster2 for China)
2. copy the .hdf5 file to your $HOME/oqdata directory
3. print the extreme GMVs; from that you can get the rupture ID associated to the worst case (632502)
```
$ oq2 show extreme_gmvs:10 42462
              PGA    sid  rlz          gmpe
rup                                        
802066  10.203302  80328    4  [Idriss2014]
24236   10.291706  42162    9  [Idriss2014]
885409  10.296491  49979   19  [Idriss2014]
437083  10.569878  43869   14  [Idriss2014]
239966  10.674121  10242   19  [Idriss2014]
49926   10.678889  37613   14  [Idriss2014]
20214   10.842021  22075   14  [Idriss2014]
75873   10.961108  37971    9  [Idriss2014]
415397  11.003898  42669    4  [Idriss2014]
632502  12.207060  45014   14  [Idriss2014]
```
4. reproduce the calculation with `oq shell` by copying the following lines:
```python
import pandas
from openquake.hazardlib.contexts import read_cmaker
from openquake.hazardlib.calc.gmf import GmfComputer
from openquake.commonlib.datastore import read
from openquake.calculators.extract import read_ebrupture

calc_id = 42462
rup_id = 632502
dstore = read(calc_id)
sitecol = dstore['sitecol']
ebr = read_ebrupture(dstore, rup_id)
cmaker = read_cmaker(dstore, ebr.trt_smr)
gc = GmfComputer(ebr, sitecol, cmaker)
out, dt = gc.compute_all()
df = pandas.DataFrame(out).sort_values('gmv_0').set_index('sid')
site_id = df.index[-1]
print('seed =', ebr.rup_id)
arr = cmaker.recarray([gc.ctx])
arr = arr[arr.sids == site_id]
for name, value in zip(arr.dtype.names, arr[0]):
    print('%s = %s' % (name, value))
``` 
This will print out the following values (notice rrup=.49 km!)
```
dip = 45.0001174855747
hypo_depth = 15.0
mag = 7.550000190734863
rake = 90.0
width = 42.37628477594936
ztor = 0.0
vs30 = 209.55900000000003
vs30measured = False
z1pt0 = 506.586
z2pt5 = 2.6489999999999996
rjb = 0.4909803613369115
rrup = 0.49096965609247817
rx = -0.4909803613369115
ry0 = 0.0
sids = 45014
```
The debugging can progress by setting a breakpoint in the line `mean + total_residual` in hazardlib.calc.gmf and then printing mean and total_residual for the current site (sid=45014, idx=2210). Then one gets the reason for the 12g value: both mean and sigma are large.
```python
(Pdb++) idx = list(self.ctx.sids).index(45014)
(Pdb++) mean[idx]
array([1.00385968])
(Pdb++) total_residual[idx]
array([1.49815477])
(Pdb++) numpy.exp(mean[idx] + total_residual[idx])
array([12.20705971])
```