### PR TITLE
Relaxed the type of backarc

### DIFF
--- a/openquake/hazardlib/gsim/abrahamson_2015.py
+++ b/openquake/hazardlib/gsim/abrahamson_2015.py
@@ -118,6 +118,7 @@ def _compute_disterm(trt, C1, theta2, theta14, theta3, ctx, c4, theta9,
 
 
 def _compute_forearc_backarc_term(trt, faba_model, C, ctx):
+    backarc = np.bool_(ctx.backarc)
     if trt == const.TRT.SUBDUCTION_INTERFACE:
         dists = ctx.rrup
         a, b = C['theta15'], C['theta16']
@@ -131,9 +132,9 @@ def _compute_forearc_backarc_term(trt, faba_model, C, ctx):
     if faba_model is None:
         f_faba = np.zeros_like(dists)
         # Term only applies to backarc ctx (F_FABA = 0. for forearc)
-        fixed_dists = dists[ctx.backarc]
+        fixed_dists = dists[backarc]
         fixed_dists[fixed_dists < min_dist] = min_dist
-        f_faba[ctx.backarc] = a + b * np.log(fixed_dists / 40.)
+        f_faba[backarc] = a + b * np.log(fixed_dists / 40.)
         return f_faba
 
     # in BCHydro subclasses
@@ -274,7 +275,6 @@ class AbrahamsonEtAl2015SInter(GMPE):
     #: subduction interface, or on the backarc. This boolean is a vector
     #: containing True for a backarc site or False for a forearc or
     #: unknown site.
-
     REQUIRES_SITES_PARAMETERS = {'vs30', 'backarc'}
 
     #: Required rupture parameters are magnitude for the interface model

--- a/openquake/hazardlib/gsim/abrahamson_2015.py
+++ b/openquake/hazardlib/gsim/abrahamson_2015.py
@@ -118,7 +118,6 @@ def _compute_disterm(trt, C1, theta2, theta14, theta3, ctx, c4, theta9,
 
 
 def _compute_forearc_backarc_term(trt, faba_model, C, ctx):
-    backarc = np.bool_(ctx.backarc)
     if trt == const.TRT.SUBDUCTION_INTERFACE:
         dists = ctx.rrup
         a, b = C['theta15'], C['theta16']
@@ -130,6 +129,7 @@ def _compute_forearc_backarc_term(trt, faba_model, C, ctx):
     else:
         raise NotImplementedError(trt)
     if faba_model is None:
+        backarc = np.bool_(ctx.backarc)
         f_faba = np.zeros_like(dists)
         # Term only applies to backarc ctx (F_FABA = 0. for forearc)
         fixed_dists = dists[backarc]

--- a/openquake/hazardlib/gsim/ghofrani_atkinson_2014.py
+++ b/openquake/hazardlib/gsim/ghofrani_atkinson_2014.py
@@ -169,7 +169,7 @@ class GhofraniAtkinson2014(GMPE):
             C = self.COEFFS[imt]
 
             imean = (_get_magnitude_term(C, ctx.mag) +
-                     _get_distance_term(C, ctx.rrup, ctx.backarc) +
+                     _get_distance_term(C, ctx.rrup, np.bool_(ctx.backarc)) +
                      _get_site_term(C, ctx.vs30) +
                      _get_scaling_term(self.kind, C, ctx.rrup))
             # Convert mean from cm/s and cm/s/s and from common logarithm to

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -129,7 +129,7 @@ site_param_dt = {
     'z2pt5': numpy.float64,
     'siteclass': (numpy.string_, 1),
     'z1pt4': numpy.float64,
-    'backarc': numpy.bool,
+    'backarc': numpy.uint8,
     'xvf': numpy.float64,
     'soiltype': numpy.uint32,
     'bas': numpy.bool,

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -129,7 +129,7 @@ site_param_dt = {
     'z2pt5': numpy.float64,
     'siteclass': (numpy.string_, 1),
     'z1pt4': numpy.float64,
-    'backarc': numpy.uint8,
+    'backarc': numpy.uint8,  # 0=forearc,1=backarc,2=alongarc
     'xvf': numpy.float64,
     'soiltype': numpy.uint32,
     'bas': numpy.bool,

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -227,4 +227,5 @@ class BaseGSIMTestCase(unittest.TestCase):
                             msg[par] = getattr(ctx, par)[idx]
                         for par in cmaker.REQUIRES_RUPTURE_PARAMETERS:
                             msg[par] = getattr(ctx, par)
+                        import pdb; pdb.set_trace()
                         raise ValueError(msg)

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -227,5 +227,4 @@ class BaseGSIMTestCase(unittest.TestCase):
                             msg[par] = getattr(ctx, par)[idx]
                         for par in cmaker.REQUIRES_RUPTURE_PARAMETERS:
                             msg[par] = getattr(ctx, par)
-                        import pdb; pdb.set_trace()
                         raise ValueError(msg)

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -131,9 +131,8 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
         for arr in (cll.vs30, cll.z1pt0, cll.z2pt5):
             self.assertIsInstance(arr, numpy.ndarray)
             self.assertEqual(arr.dtype, float)
-        for arr in (cll.vs30measured, cll.backarc):
-            self.assertIsInstance(arr, numpy.ndarray)
-            self.assertEqual(arr.dtype, bool)
+        self.assertEqual(cll.vs30measured.dtype, numpy.bool_)
+        self.assertEqual(cll.backarc.dtype, numpy.uint8)
         self.assertEqual(len(cll), 2)
 
         # test split_in_tiles


### PR DESCRIPTION
This is needed for https://github.com/gem/oq-engine/pull/7118. Instead of a boolean the backarc site parameter can become of type uint8 with the following conventions:

backarc = 0 => fore arc
backarc = 1 => back arc
backarc = 2 => along arc

There is full backward compatibility.