### PR TITLE
TimeoutError for the DbServer commands

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -207,7 +207,7 @@ except ImportError:
 
 from openquake.baselib import config, hdf5, workerpool, version
 from openquake.baselib.python3compat import decode
-from openquake.baselib.zeromq import zmq, Socket
+from openquake.baselib.zeromq import zmq, Socket, TimeoutError
 from openquake.baselib.performance import (
     Monitor, memory_rss, init_performance)
 from openquake.baselib.general import (

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -33,10 +33,6 @@ except ImportError:
         "Do nothing"
 
 
-class TimeoutError(RuntimeError):
-    pass
-
-
 def _streamer():
     # streamer for zmq workers running on the master node
     port = int(config.zworkers.ctrl_port)

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -28,6 +28,10 @@ SOCKTYPE = {zmq.REQ: 'REQ', zmq.REP: 'REP',
             zmq.ROUTER: 'ROUTER', zmq.DEALER: 'DEALER'}
 
 
+class TimeoutError(RuntimeError):
+    pass
+
+
 def bind(end_point, socket_type):
     """
     Bind to a zmq URL; raise a proper error if the URL is invalid; return
@@ -155,6 +159,9 @@ class Socket(object):
             raise exc.__class__('%s: %r' % (exc, obj))
         self.num_sent += 1
         if self.socket_type == zmq.REQ:
+            ok = self.zsocket.poll(500)  # half second
+            if not ok:
+                raise TimeoutError('Probably the DbServer is not started')
             return self.zsocket.recv_pyobj()
 
     def __repr__(self):


### PR DESCRIPTION
If the DbServer is not started, DbServer commands should raise a TimeoutError, as requested by @pslh . Here is an example:
```bash
$ oq show performance -1
Traceback (most recent call last):
  File "/home/michele/openquake/bin/oq", line 33, in <module>
    sys.exit(load_entry_point('openquake.engine', 'console_scripts', 'oq')())
  File "/home/michele/oq-engine/openquake/commands/__main__.py", line 50, in oq
    sap.run(commands, prog='oq')
  File "/home/michele/oq-engine/openquake/baselib/sap.py", line 225, in run
    return _run(parser(funcdict, **parserkw), argv)
  File "/home/michele/oq-engine/openquake/baselib/sap.py", line 216, in _run
    return func(**dic)
  File "/home/michele/oq-engine/openquake/commands/show.py", line 81, in main
    ds = datastore.read(calc_id)
  File "/home/michele/oq-engine/openquake/commonlib/datastore.py", line 113, in read
    dstore = _read(calc_id, datadir, mode)
  File "/home/michele/oq-engine/openquake/commonlib/datastore.py", line 86, in _read
    job = dbcmd('get_job', jid)
  File "/home/michele/oq-engine/openquake/commonlib/logs.py", line 51, in dbcmd
    res = sock.send((action,) + args)
  File "/home/michele/oq-engine/openquake/baselib/zeromq.py", line 164, in send
    raise TimeoutError('Probably the DbServer is not started')
openquake.baselib.zeromq.TimeoutError: Probably the DbServer is not started
```
Notice that the command still hangs, but at least the error is clear.