### PR TITLE
Renamed individual_curves->individual_rlzs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Renamed the parameter `individual_curves` -> `individual_rlzs`
   * Reduced the number of disaggregation outputs and removed the long-time
     deprecated XML exporters
   * Fixed the ShakeMap calculator failing with a TypeError:

--- a/demos/hazard/Disaggregation/job.ini
+++ b/demos/hazard/Disaggregation/job.ini
@@ -44,5 +44,5 @@ num_epsilon_bins = 3
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp

--- a/demos/hazard/LogicTreeCase1ClassicalPSHA/job.ini
+++ b/demos/hazard/LogicTreeCase1ClassicalPSHA/job.ini
@@ -37,7 +37,7 @@ maximum_distance = 200.0
 [output]
 
 export_dir = /tmp
-individual_curves = true
+individual_rlzs = true
 mean = true
 quantiles = 0.05 0.5 0.95
 hazard_maps = true

--- a/demos/risk/EventBasedRisk/job.ini
+++ b/demos/risk/EventBasedRisk/job.ini
@@ -37,7 +37,7 @@ exposure_file = exposure_model.xml
 
 [risk_calculation]
 asset_hazard_distance = 20
-individual_curves = true
+individual_rlzs = true
 
 [outputs]
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -825,7 +825,7 @@ class HazardCalculator(BaseCalculator):
                for lt in oq.loss_names}
         if mal:
             logging.info('minimum_asset_loss=%s', mal)
-        self.param = dict(individual_curves=oq.individual_curves,
+        self.param = dict(individual_rlzs=oq.individual_rlzs,
                           ps_grid_spacing=oq.ps_grid_spacing,
                           minimum_distance=oq.minimum_distance,
                           min_iml=oq.min_iml,

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -427,7 +427,7 @@ class EventBasedCalculator(base.HazardCalculator):
             # be very slow if there are thousands of realizations
             weights = [rlz.weight for rlz in rlzs]
             # NB: in the future we may want to save to individual hazard
-            # curves if oq.individual_curves is set; for the moment we
+            # curves if oq.individual_rlzs is set; for the moment we
             # save the statistical curves only
             hstats = oq.hazard_stats()
             S = len(hstats)
@@ -438,7 +438,7 @@ class EventBasedCalculator(base.HazardCalculator):
                 # logic tree reduction mechanism during refactoring
                 raise AssertionError('Expected %d pmaps, got %d' %
                                      (len(weights), len(pmaps)))
-            if oq.individual_curves:
+            if oq.individual_rlzs:
                 logging.info('Saving individual hazard curves')
                 self.datastore.create_dset('hcurves-rlzs', F32, (N, R, M, L1))
                 self.datastore.set_shape_descr(

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -300,7 +300,7 @@ hazard_uhs-std.csv
                 case_16.__file__)
 
         # test that the single realization export fails because
-        # individual_curves was false
+        # individual_rlzs was false
         with self.assertRaises(KeyError) as ctx:
             export(('hcurves/rlz-3', 'csv'), self.calc.datastore)
         self.assertIn('hcurves-rlzs', str(ctx.exception))

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -303,6 +303,11 @@ individual_rlzs:
   Example: *individual_rlzs = true*.
   Default: False
 
+individual_curves:
+  Legacy name for `individual_rlzs`, it should not be used.
+  Example: *individual_curves = true*.
+  Default: False
+
 inputs:
   INTERNAL. Dictionary with the input files paths.
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -297,11 +297,10 @@ imt_ref:
   Example: *imt_ref = SA(0.15)*.
   Default: no default
 
-
-individual_curves:
+individual_rlzs:
   When set, store the individual hazard curves and/or individual risk curves
   for each realization.
-  Example: *individual_curves = true*.
+  Example: *individual_rlzs = true*.
   Default: False
 
 inputs:
@@ -776,7 +775,7 @@ class OqParam(valid.ParamSet):
     iml_disagg = valid.Param(valid.floatdict, {})  # IMT -> IML
     imls_ref = valid.Param(valid.positivefloats, [])
     imt_ref = valid.Param(valid.intensity_measure_type)
-    individual_curves = valid.Param(valid.boolean, None)
+    individual_rlzs = individual_curves = valid.Param(valid.boolean, None)
     inputs = valid.Param(dict, {})
     ash_wet_amplification_factor = valid.Param(valid.positivefloat, 1.0)
     intensity_measure_types = valid.Param(valid.intensity_measure_types, '')
@@ -1415,7 +1414,7 @@ class OqParam(valid.ParamSet):
             yield kind
             return
         # default: yield stats (and realizations if required)
-        if R > 1 and self.individual_curves or not stats:
+        if R > 1 and self.individual_rlzs or not stats:
             for r in range(R):
                 yield 'rlz-%03d' % r
         yield from stats

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -109,13 +109,13 @@ def expose_outputs(dstore, owner=getpass.getuser(), status='complete'):
         dskeys.add('realizations')
     hdf5 = dstore.hdf5
     if 'hcurves-stats' in hdf5 or 'hcurves-rlzs' in hdf5:
-        if oq.hazard_stats() or oq.individual_curves or len(rlzs) == 1:
+        if oq.hazard_stats() or oq.individual_rlzs or len(rlzs) == 1:
             dskeys.add('hcurves')
         if oq.uniform_hazard_spectra:
             dskeys.add('uhs')  # export them
         if oq.hazard_maps:
             dskeys.add('hmaps')  # export them
-    if len(rlzs) > 1 and not oq.individual_curves and not oq.collect_rlzs:
+    if len(rlzs) > 1 and not oq.individual_rlzs and not oq.collect_rlzs:
         for out in ['avg_losses-rlzs', 'agg_losses-rlzs', 'agg_curves-rlzs']:
             if out in dskeys:
                 dskeys.remove(out)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -30,7 +30,7 @@ than 20 lines of code:
    def main(job_ini):
        with logs.init('job', job_ini) as log:
            calc = calculators(log.get_oqparam(), log.calc_id)
-           calc.run(individual_curves='true', shutdown=True)
+           calc.run(individual_rlzs='true', shutdown=True)
            print('The hazard curves are in %s::/hcurves-rlzs'
                 % calc.datastore.filename)
 

--- a/openquake/qa_tests_data/classical/case_10/job.ini
+++ b/openquake/qa_tests_data/classical/case_10/job.ini
@@ -41,7 +41,7 @@ maximum_distance = 200.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 mean = false
 quantile_hazard_curves =
 poes =

--- a/openquake/qa_tests_data/classical/case_11/job.ini
+++ b/openquake/qa_tests_data/classical/case_11/job.ini
@@ -42,7 +42,7 @@ maximum_distance = 200.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 mean = true
 quantile_hazard_curves = 0.1 0.9
 poes =

--- a/openquake/qa_tests_data/classical/case_14/job.ini
+++ b/openquake/qa_tests_data/classical/case_14/job.ini
@@ -43,7 +43,7 @@ maximum_distance = 200.0
 [output]
 
 export_dir = /tmp
-individual_curves = true
+individual_rlzs = true
 mean = false
 quantile_hazard_curves =
 hazard_maps = false

--- a/openquake/qa_tests_data/classical/case_16/job.ini
+++ b/openquake/qa_tests_data/classical/case_16/job.ini
@@ -42,5 +42,5 @@ mean = true
 quantile_hazard_curves = 0.1, 0.9
 hazard_maps = false
 uniform_hazard_spectra = false
-individual_curves = false
+individual_rlzs = false
 poes =

--- a/openquake/qa_tests_data/classical/case_17/job.ini
+++ b/openquake/qa_tests_data/classical/case_17/job.ini
@@ -42,6 +42,6 @@ mean = false
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp
 

--- a/openquake/qa_tests_data/classical/case_18/job.ini
+++ b/openquake/qa_tests_data/classical/case_18/job.ini
@@ -37,7 +37,7 @@ minimum_intensity = .002
 [output]
 
 export_dir = /tmp
-individual_curves = true
+individual_rlzs = true
 mean = true
 quantile_hazard_curves =
 hazard_maps = true

--- a/openquake/qa_tests_data/classical/case_20/job.ini
+++ b/openquake/qa_tests_data/classical/case_20/job.ini
@@ -43,5 +43,5 @@ mean = true
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp

--- a/openquake/qa_tests_data/classical/case_21/job.ini
+++ b/openquake/qa_tests_data/classical/case_21/job.ini
@@ -41,6 +41,6 @@ maximum_distance = 200.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 mean = false
 export_dir = /tmp

--- a/openquake/qa_tests_data/classical/case_28/job.ini
+++ b/openquake/qa_tests_data/classical/case_28/job.ini
@@ -47,7 +47,7 @@ truncation_level = 3
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 uniform_hazard_spectra = true
 poes = .00005
 export_dir = /tmp

--- a/openquake/qa_tests_data/classical/case_52/job.ini
+++ b/openquake/qa_tests_data/classical/case_52/job.ini
@@ -32,4 +32,4 @@ investigation_time = 1.0
 intensity_measure_types_and_levels = {"PGA": logscale(1E-2, 1, 20)}
 truncation_level = 2.0
 maximum_distance = 200.0
-individual_curves = true
+individual_rlzs = true

--- a/openquake/qa_tests_data/classical/case_58/job.ini
+++ b/openquake/qa_tests_data/classical/case_58/job.ini
@@ -36,5 +36,5 @@ maximum_distance = 400.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp

--- a/openquake/qa_tests_data/classical/case_58/job_case01.ini
+++ b/openquake/qa_tests_data/classical/case_58/job_case01.ini
@@ -36,5 +36,5 @@ maximum_distance = 400.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp

--- a/openquake/qa_tests_data/classical/case_58/job_case02.ini
+++ b/openquake/qa_tests_data/classical/case_58/job_case02.ini
@@ -36,5 +36,5 @@ maximum_distance = 400.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp

--- a/openquake/qa_tests_data/classical/case_59/job.ini
+++ b/openquake/qa_tests_data/classical/case_59/job.ini
@@ -28,5 +28,5 @@ maximum_distance = {"Active Shallow Offshore": 600}
 minimum_magnitude = {"Active Shallow Offshore": 5.5}
 intensity_measure_types_and_levels = {'SA(0.3)': logscale(1E-2, 1, 20)}
 investigation_time = 20
-individual_curves = true
+individual_rlzs = true
 

--- a/openquake/qa_tests_data/classical/case_61/job.ini
+++ b/openquake/qa_tests_data/classical/case_61/job.ini
@@ -37,5 +37,5 @@ maximum_distance = 200.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp

--- a/openquake/qa_tests_data/classical/case_7/job.ini
+++ b/openquake/qa_tests_data/classical/case_7/job.ini
@@ -42,6 +42,6 @@ maximum_distance = 200.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 mean = true
 poes = .5

--- a/openquake/qa_tests_data/classical/case_73/job.ini
+++ b/openquake/qa_tests_data/classical/case_73/job.ini
@@ -36,5 +36,5 @@ maximum_distance = 400.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp

--- a/openquake/qa_tests_data/classical/case_8/job.ini
+++ b/openquake/qa_tests_data/classical/case_8/job.ini
@@ -41,7 +41,7 @@ maximum_distance = 200.0
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 mean = false
 quantile_hazard_curves =
 poes =

--- a/openquake/qa_tests_data/disagg/case_2/job.ini
+++ b/openquake/qa_tests_data/disagg/case_2/job.ini
@@ -41,4 +41,4 @@ rlz_index = 0 1 2 3
 [output]
 
 export_dir = /tmp
-individual_curves = true
+individual_rlzs = true

--- a/openquake/qa_tests_data/disagg/case_3/job.ini
+++ b/openquake/qa_tests_data/disagg/case_3/job.ini
@@ -46,4 +46,4 @@ maximum_distance = {'Stable Shallow Crust': 200.0, 'Active Shallow Crust': 200.0
 [output]
 
 export_dir = /tmp
-individual_curves = true
+individual_rlzs = true

--- a/openquake/qa_tests_data/disagg/case_6/job.ini
+++ b/openquake/qa_tests_data/disagg/case_6/job.ini
@@ -52,5 +52,5 @@ coordinate_bin_width = 0.5
 num_epsilon_bins = 1
 disagg_outputs = Lon_Lat
 disagg_by_src = true
-individual_curves = true
+individual_rlzs = true
 num_rlzs_disagg = 3

--- a/openquake/qa_tests_data/disagg/case_7/job.ini
+++ b/openquake/qa_tests_data/disagg/case_7/job.ini
@@ -32,4 +32,4 @@ coordinate_bin_width = 0.5
 export_dir = /tmp
 disagg_outputs = TRT
 hazard_maps = true
-individual_curves = true
+individual_rlzs = true

--- a/openquake/qa_tests_data/event_based/case_2/job_2.ini
+++ b/openquake/qa_tests_data/event_based/case_2/job_2.ini
@@ -48,7 +48,7 @@ ground_motion_correlation_params =
 
 [output]
 
-individual_curves = true
+individual_rlzs = true
 hazard_curves_from_gmfs = true
 quantiles =
 poes =

--- a/openquake/qa_tests_data/event_based/case_25/job.ini
+++ b/openquake/qa_tests_data/event_based/case_25/job.ini
@@ -3,7 +3,7 @@
 description = common + extra
 calculation_mode = event_based
 compare_with_classical = true
-individual_curves = true
+individual_rlzs = true
 
 [geometry]
 

--- a/openquake/qa_tests_data/event_based/case_25/job2.ini
+++ b/openquake/qa_tests_data/event_based/case_25/job2.ini
@@ -3,7 +3,7 @@
 description = common + extra
 calculation_mode = event_based
 compare_with_classical = true
-individual_curves = true
+individual_rlzs = true
 
 [geometry]
 

--- a/openquake/qa_tests_data/event_based_risk/case_1/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1/job.ini
@@ -49,7 +49,7 @@ truncation_level = 3
 # km
 maximum_distance = 100.0
 return_periods = [30, 60, 120, 240, 480, 960]
-individual_curves = true
+individual_rlzs = true
 
 [output]
 export_dir = /tmp

--- a/openquake/qa_tests_data/event_based_risk/case_1/job_eb.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1/job_eb.ini
@@ -51,7 +51,7 @@ truncation_level = 3
 # km
 maximum_distance = 100.0
 return_periods = [30, 60, 120, 240, 480, 960]
-individual_curves = true
+individual_rlzs = true
 
 [output]
 export_dir = /tmp

--- a/openquake/qa_tests_data/event_based_risk/case_2/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_2/job.ini
@@ -48,4 +48,4 @@ ses_per_logic_tree_path = 20
 truncation_level = 3
 # km
 maximum_distance = 100.0
-individual_curves = true
+individual_rlzs = true

--- a/openquake/qa_tests_data/event_based_risk/case_2/job_loss.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_2/job_loss.ini
@@ -47,5 +47,5 @@ region = 81.1 26, 88 26, 88 30, 81.1 30
 risk_investigation_time = 50.0
 
 [export]
-individual_curves = true
+individual_rlzs = true
 export_dir = /tmp

--- a/openquake/qa_tests_data/event_based_risk/case_4/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_4/job.ini
@@ -45,7 +45,7 @@ ses_per_logic_tree_path = 1
 
 [output]
 hazard_curves_from_gmfs = true
-individual_curves = false
+individual_rlzs = false
 mean = true
 uniform_hazard_spectra = false
 poes = 0.1 0.2

--- a/openquake/qa_tests_data/event_based_risk/case_7a/job_r.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_7a/job_r.ini
@@ -14,7 +14,7 @@ asset_hazard_distance = 20.0
 
 [calculation]
 risk_investigation_time = 1
-individual_curves = true
+individual_rlzs = true
 
 [export]
 mean = false

--- a/openquake/qa_tests_data/event_based_risk/case_master/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_master/job.ini
@@ -63,7 +63,7 @@ asset_correlation = 0
 
 [risk_outputs]
 avg_losses = true
-individual_curves = true
+individual_rlzs = true
 
 [export]
 export_dir = /tmp

--- a/openquake/qa_tests_data/event_based_risk/case_miriam/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_miriam/job.ini
@@ -62,5 +62,5 @@ exposure_file = exposure_model.xml
 structural_vulnerability_file = vulnerability_model.xml
 # conditional_loss_poes = 0.1, 0.01, 0.02
 avg_losses = true
-individual_curves = true
+individual_rlzs = true
 asset_loss_table = true

--- a/openquake/qa_tests_data/event_based_risk/occupants/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/occupants/job.ini
@@ -49,4 +49,4 @@ asset_hazard_distance = 20.0
 risk_investigation_time = 1
 asset_correlation = 0
 conditional_loss_poes = 0.01 0.02
-individual_curves = true
+individual_rlzs = true

--- a/openquake/qa_tests_data/scenario/case_15/job.ini
+++ b/openquake/qa_tests_data/scenario/case_15/job.ini
@@ -26,5 +26,5 @@ ground_motion_correlation_params = {"vs30_clustering": False}
 number_of_ground_motion_fields = 1
 
 [output]
-individual_curves = True
+individual_rlzs = True
 poes = 0.0001


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/6552. The old name `individual_curves` is still valid and it is an alias of `individual_rlzs`.