### PR TITLE
Added a check for invalid consequence files

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -859,6 +859,7 @@ def get_crmodel(oqparam):
             arrays = []
             for fname in fnames:
                 arr = hdf5.read_csv(fname, dtypedict).array
+                arrays.append(arr)
                 for no, row in enumerate(arr, 2):
                     if row['loss_type'] not in loss_types:
                         msg = '%s: %s is not a recognized loss type, line=%d'


### PR DESCRIPTION
This happened to Maria Camilla with the following file:
```
taxonomy,consequence,loss_type,slight,moderate,extensive,complete
CR_LDUAL-DUH_H1,losses,occupants,0,0,0,0.015
CR_LDUAL-DUH_H10,losses,occupants,0,0,0,0.005
CR_LDUAL-DUH_H11,losses,occupants,0,0,0,0.005
```
Now one gets a clear error message:
```python
openquake.baselib.InvalidFile: /home/michele/ebd/Vulnerability/fragility_consequence/consequence_fatalities.csv:
occupants is not a recognized loss type, line=2
```