### PR TITLE
Improved error checking when reading the taxonomy mapping file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved error checking when reading the taxonomy mapping file
   * Renamed conversion -> risk_id in the header of the taxonomy mapping file
 
   [Antonio Ettorre]

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -997,7 +997,10 @@ def taxonomy_mapping(oqparam, taxonomies):
 
 
 def _taxonomy_mapping(filename, taxonomies):
-    tmap_df = pandas.read_csv(filename)
+    try:
+        tmap_df = pandas.read_csv(filename, converters=dict(weight=float))
+    except Exception as e:
+        raise e.__class__('%s while reading %s' % (e, filename))
     if 'weight' not in tmap_df:
         tmap_df['weight'] = 1.
 

--- a/openquake/qa_tests_data/scenario_risk/case_master/taxonomy_mapping.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_master/taxonomy_mapping.csv
@@ -1,4 +1,4 @@
-taxonomy,conversion,weight
+taxonomy,risk_id,weight
 tax1,tax1,1
 tax2,tax2,1
 tax3,tax3,1


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/7072. Now you get:
```
ValueError: could not convert string to float: 'weight' while reading
/home/michele/oq-engine/openquake/qa_tests_data/scenario_risk/case_master/taxonomy_mapping.csv
```
and then you can open the file and search for the offending string.