### PR TITLE
Made sure the latest commit of a branch is downloaded

### DIFF
--- a/install.py
+++ b/install.py
@@ -340,7 +340,7 @@ def install(inst, version):
         commit = latest_commit(version)
         print('Installing commit', commit)
         subprocess.check_call([pycmd, '-m', 'pip', 'install',
-                               '--upgrade', GITBRANCH % version])
+                               '--upgrade', GITBRANCH % commit])
         fix_version(commit, inst.VENV)
 
     install_standalone(inst.VENV)


### PR DESCRIPTION
`pip install  https://github.com/gem/oq-engine/archive/master.zip` should install the latest code: however, both in oq-risk-tests and mosaic repositories this is not working and we are installing outdated code (a bug in GitHub? some cache issue in docker/GitLab/whatever?). So I am changing the installation script to manually download the latest commit of a branch. We will see if it works. In any case it is the right thing to do since the approach used in current master is subject to race conditions if in the milliseconds between getting the latest commit and getting the .zip somebody pushes a new commit.
