### PR TITLE
Add intensity_measure_types_and_levels to classical_risk example

### DIFF
--- a/doc/manual/oqum/risk/verbatim/config_classical_hazard.ini
+++ b/doc/manual/oqum/risk/verbatim/config_classical_hazard.ini
@@ -24,3 +24,6 @@ random_seed = 42
 investigation_time = 1
 truncation_level = 3.0
 maximum_distance = 200.0
+intensity_measure_types_and_levels = {
+ "PGA": logscale(0.05, 3.0, 30),
+ "SA(1.0)": logscale(0.05, 3.0, 30)}


### PR DESCRIPTION
Update listings in manual affected by https://github.com/gem/oq-engine/pull/5473. 
Reported on the user forum: https://groups.google.com/g/openquake-users/c/83fVNUSV7Og/m/tTaKz2VeAQAJ