### PR TITLE
Deprecated consequence models in XML format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Deprecated XML models in XML format
+
   [Elena Manea, Laurentiu Danciu]
   * Added the GMPE Manea (2021)
 

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -129,6 +129,10 @@ def get_risk_functions(oqparam, kind='vulnerability fragility consequence '
                 loss_type = mo.group(1)  # the cost_type in the key
                 # can be occupants, structural, nonstructural, ...
                 rmodel = nrml.to_python(oqparam.inputs[key])
+                if kind == 'consequence':
+                    logging.warning('Consequence models in XML format are '
+                                    'deprecated, please replace %s',
+                                    oqparam.inputs[key])
                 if len(rmodel) == 0:
                     raise InvalidFile('%s is empty!' % oqparam.inputs[key])
                 rmodels[loss_type, kind] = rmodel


### PR DESCRIPTION
The plan is to NEVER remove the support, because we want to be able to run old calculations, but I want to annoy users with a warning. It must be clear that the format to use for the consequence models is CSV. In the next PR I am going to fix the ScenarioDamage demo that was still using a consequence model in XML format.