### PR TITLE
Added parameter `discrete_damage_distribution`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Added parameter `discrete_damage_distribution` in scenario damage
+    calculations
   * Deprecated consequence models in XML format
   * Event based damage calculations now explicitly require to specify
     `number_of_logic_tree_samples` (before it assumed a default of 1)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -142,13 +142,6 @@ conditional_loss_poes:
   Example: *conditional_loss_poes = 0.01 0.02*.
   Default: empty list
 
-float_dmg_dist:
-  Flag used in scenario_damage calculations to specify that the damage
-  distributions should be stored as floating point numbers (float32)
-  and not as integers (uint32).
-  Example: *float_dmg_dist = true*.
-  Default: False
-
 cholesky_limit:
   When generating the GMFs from a ShakeMap the engine needs to perform a
   Cholesky decomposition of a matrix of size (M x N)^2, being M the number
@@ -201,6 +194,12 @@ discard_trts:
   Used to discard tectonic region types that do not contribute to the hazard.
   Example: *discard_trts = Volcanic*.
   Default: empty list
+
+discrete_damage_distribution
+  Make sure the damage distribution contain only integers (require the "number"
+  field in the exposure to be integer).
+  Example: *discrete_damage_distribution = true*
+  Default: None
 
 distance_bin_width:
   In km, used in disaggregation calculations to specify the distance bins.
@@ -760,8 +759,8 @@ class OqParam(valid.ParamSet):
                                  list(calc.disagg.pmf_map))
     discard_assets = valid.Param(valid.boolean, False)
     discard_trts = valid.Param(str, '')  # tested in the cariboo example
+    discrete_damage_distribution = valid.Param(valid.boolean, None)
     distance_bin_width = valid.Param(valid.positivefloat)
-    float_dmg_dist = valid.Param(valid.boolean, False)
     mag_bin_width = valid.Param(valid.positivefloat)
     ignore_encoding_errors = valid.Param(valid.boolean, False)
     ignore_master_seed = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -195,7 +195,7 @@ discard_trts:
   Example: *discard_trts = Volcanic*.
   Default: empty list
 
-discrete_damage_distribution
+discrete_damage_distribution:
   Make sure the damage distribution contain only integers (require the "number"
   field in the exposure to be integer).
   Example: *discrete_damage_distribution = true*

--- a/openquake/qa_tests_data/scenario_damage/case_11/job.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_11/job.ini
@@ -7,4 +7,4 @@ sites = 0 0, 0 1, 0 2
 structural_fragility_file = fragility.xml
 exposure_file = exposure.xml
 secondary_perils = HazusLiquefaction, HazusDeformation
-float_dmg_dist = true
+discrete_damage_distribution = false


### PR DESCRIPTION
This is totally compatible with the past. If not specified the engine will use the discrete (slow) method if the exposure has integer "number" and the float (fast) method otherwise. Removed the old parameter `float_dmg_dist` which was less clear.

Another option (which I like more) is to change the behavior of the engine and to use the fast method unless otherwise specified, but that will change the numbers for all scenario_damage calculations. What do you think?

NB: I ran the ScenarioDamage demo with `discrete_damage_distribution` True and False respectively and got the following: `discrete_damage_distribution=false` *we are over 4x faster and produce essentially the same portfolio distribution:*
```
$ oq show portfolio_damage  # ddd
| loss_type  | no_damage | slight  | moderate | extreme | complete |
|------------+-----------+---------+----------+---------+----------|
| structural | 4_029_140 | 248_630 | 343_603  | 246_656 | 497_734  |

$ oq show portfolio_damage  # fdd
| loss_type  | no_damage | slight  | moderate | extreme | complete |
|------------+-----------+---------+----------+---------+----------|
| structural | 4_029_108 | 248_684 | 343_595  | 246_634 | 497_735  |

| calc_4863, maxmem=1.3 GB     | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total scenario_damage        | 281.0    | 68.8      | 9      | #ddd
| total scenario_damage        | 72.9     | 66.1      | 9      | #fdd
```