### PR TITLE
Changed the algorithm to compute risk_by_event to use DataFrames and not arrays

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -76,29 +76,33 @@ def save_curve_stats(dstore):
     dstore.set_attrs('agg_curves-stats', units=units)
 
 
-def aggregate_losses(alt, K, kids, correl):
+def aggregate_losses(alt, K, kids, correl, loss_id):
     """
     Aggregate losses and variances for each event by using the formulae
 
     sigma^2 = sum(sigma_i)^2 for correl=1
     sigma^2 = sum(sigma_i^2) for correl=0
     """
-    lbe = general.AccumDict(accum=numpy.zeros(2, F32))
-    x = numpy.sqrt(alt.variance) if correl else alt.variance
-    ldf = pandas.DataFrame(dict(eid=alt.eid, loss=alt.loss, x=x))
-    if len(kids):
-        ldf['kid'] = kids[alt.aid.to_numpy()]
-        tot = ldf.groupby(['eid', 'kid']).sum()
-        for (eid, kid), loss, x in zip(
-                tot.index, tot.loss, tot.x):
-            lbe[eid, kid] += F32([loss, x])
-    tot = ldf.groupby('eid').sum()
-    for eid, loss, x in zip(tot.index, tot.loss, tot.x):
-        lbe[eid, K] += F32([loss, x])
+    if 'index' in alt.columns:
+        del alt['index']
+    if correl:
+        alt['variance'] = numpy.sqrt(alt.variance)
+    tot2 = alt.groupby('eid').sum().reset_index()
+    tot2['kid'] = K
+    tot2['loss_id'] = loss_id
+    del tot2['aid']
+    tot2 = tot2.set_index(['eid', 'kid', 'loss_id'])
+    if len(kids) == 0:
+        if correl:  # restore the variances
+            tot2['variance'] = tot2.variance ** 2
+        return tot2
+    alt['kid'] = kids[alt.pop('aid').to_numpy()]
+    tot1 = alt.groupby(['eid', 'kid']).sum()
+    tot1['loss_id'] = loss_id
+    tot1 = tot1.reset_index().set_index(['eid', 'kid', 'loss_id'])
     if correl:  # restore the variances
-        for ek in lbe:
-            lbe[ek][1] = lbe[ek][1] ** 2
-    return lbe
+        tot1['variance'] = tot1.variance ** 2
+    return tot1.add(tot2, fill_value=0.)
 
 
 def average_losses(ln, alt, rlz_id, AR, collect_rlzs):
@@ -129,23 +133,27 @@ def aggreg(outputs, crmodel, AR, kids, rlz_id, param, monitor):
     mon_agg = monitor('aggregating losses', measuremem=False)
     mon_avg = monitor('averaging losses', measuremem=False)
     loss_by_AR = {ln: [] for ln in crmodel.oqparam.loss_names}
-    loss_by_EK1 = {ln: general.AccumDict(accum=numpy.zeros(2, F32))
-                   for ln in crmodel.oqparam.loss_names}
     collect_rlzs = param['collect_rlzs']
+    df = None
     for out in outputs:
         for lni, ln in enumerate(crmodel.oqparam.loss_names):
             if ln not in out or len(out[ln]) == 0:
                 continue
-            alt = out[ln]
-            with mon_agg:
-                alt = alt.reset_index()
-                loss_by_EK1[ln] += aggregate_losses(
-                    alt, param['K'], kids, param['asset_correlation'])
+            alt = out[ln].reset_index()
             if param['avg_losses']:
                 with mon_avg:
                     coo = average_losses(ln, alt, rlz_id, AR, collect_rlzs)
                     loss_by_AR[ln].append(coo)
-    return dict(avg=loss_by_AR, alt=_build_risk_by_event(loss_by_EK1))
+            with mon_agg:
+                df_ = aggregate_losses(
+                    alt, param['K'], kids, param['asset_correlation'], lni)
+                if df is None:
+                    df = df_
+                else:
+                    df = df.add(df_, fill_value=0.)
+    if df is not None:
+        df = df.reset_index().rename(columns=dict(eid='event_id', kid='agg_id'))
+    return dict(avg=loss_by_AR, alt=df)
 
 
 def event_based_risk(df, param, monitor):
@@ -184,27 +192,6 @@ def event_based_risk(df, param, monitor):
                 yield from crmodel.gen_outputs(taxo, asset_df, gmf_df, param)
 
     return aggreg(outputs(), crmodel, AR, kids, rlz_id, param, monitor)
-
-
-def _build_risk_by_event(loss_by_EK1):
-    alt = {}
-    for lni, ln in enumerate(loss_by_EK1):
-        nnz = len(loss_by_EK1[ln])
-        if nnz:
-            eid = numpy.zeros(nnz, U32)
-            kid = numpy.zeros(nnz, U16)
-            loss = numpy.zeros(nnz, F32)
-            var = numpy.zeros(nnz, F32)
-            lid = numpy.ones(nnz, U8) * lni
-            for i, ((e, k), lv) in enumerate(loss_by_EK1[ln].items()):
-                eid[i] = e
-                kid[i] = k
-                loss[i] = lv[0]
-                var[i] = lv[1]
-            alt[ln] = pandas.DataFrame(
-                dict(event_id=eid, agg_id=kid, loss=loss, variance=var,
-                     loss_id=lid))
-    return alt
 
 
 def start_ebrisk(rgetter, param, monitor):
@@ -401,10 +388,11 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         lti = self.oqparam.lti
         self.oqparam.ground_motion_fields = False  # hack
         with self.monitor('saving risk_by_event'):
-            for ln, ls in dic['alt'].items():
-                for name in ls.columns:
+            alt = dic['alt']
+            if alt is not None:
+                for name in alt.columns:
                     dset = self.datastore['risk_by_event/' + name]
-                    hdf5.extend(dset, ls[name].to_numpy())
+                    hdf5.extend(dset, alt[name].to_numpy())
             for ln, ls in dic['avg'].items():
                 for coo in ls:
                     self.avg_losses[coo.row, coo.col, lti[ln]] += coo.data

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -100,9 +100,10 @@ def aggregate_losses(alt, K, kids, correl, loss_id):
     tot1 = alt.groupby(['eid', 'kid']).sum()
     tot1['loss_id'] = loss_id
     tot1 = tot1.reset_index().set_index(['eid', 'kid', 'loss_id'])
+    tot = tot1.add(tot2, fill_value=0.)
     if correl:  # restore the variances
-        tot1['variance'] = tot1.variance ** 2
-    return tot1.add(tot2, fill_value=0.)
+        tot['variance'] = tot.variance ** 2
+    return tot
 
 
 def average_losses(ln, alt, rlz_id, AR, collect_rlzs):


### PR DESCRIPTION
Crucial steps toward unifying risk and damage calculators. Right now this has a large performance penalty that may not be important (if it becomes important it will be addressed in the future). Here are the figures for the bc.zip test on my workstation
```
# master
| calc_804, maxmem=5.4 GB      | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total start_ebrisk           | 247.3    | 278.1     | 44     |
| aggregating losses           | 79.1     | 0.0       | 12_034 |
# this branch
| calc_805, maxmem=5.7 GB      | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total start_ebrisk           | 387.5    | 284.8     | 44     |
| aggregating losses           | 205.5    | 0.0       | 12_034 |
```
For Jamal's calculation for Europe "aggregating losses" become 4 times slower, but it is not significant compared to  "total event_based_risk" that increases only a little (from 19_658s to 22_512s).