### PR TITLE
Optimized the aggregation of losses in event_based_risk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Optimized the aggregation of losses in event_based_risk and made it possible
+    to aggregate by site_id for more than 65,536 sites
   * Fixed the calculation of average insured losses with a nontrivial taxonomy
     mapping: now the insured losses are computed before the average procedure,
     not after

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -137,21 +137,20 @@ def aggreg(outputs, crmodel, ARKD, kids, rlz_id, monitor):
                 if len(kids):
                     aids = alt.aid.to_numpy()
                     fast_agg(eids + kids[aids], values, correl, lni, acc)
-    if acc:
-        with mon_df:
-            dic = general.AccumDict(accum=[])
-            for ukey, arr in acc.items():
-                eid, kid = divmod(ukey, TWO32)
-                for li in range(L):
+    with mon_df:
+        dic = general.AccumDict(accum=[])
+        for ukey, arr in acc.items():
+            eid, kid = divmod(ukey, TWO32)
+            for li in range(L):
+                if arr[li].any():
                     dic['event_id'].append(eid)
                     dic['agg_id'].append(kid)
                     dic['loss_id'].append(li)
                     for c, col in enumerate(value_cols):
                         dic[col].append(arr[li, c])
-            fix_dtypes(dic)
-            df = pandas.DataFrame(dic)
-            return dict(avg=loss_by_AR, alt=df)
-    return dict(avg=loss_by_AR, alt=pandas.DataFrame())
+        fix_dtypes(dic)
+        df = pandas.DataFrame(dic)
+    return dict(avg=loss_by_AR, alt=df)
 
 
 def event_based_risk(df, param, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -35,10 +35,11 @@ from openquake.calculators.post_risk import PostRiskCalculator, fix_dtypes
 U8 = numpy.uint8
 U16 = numpy.uint16
 U32 = numpy.uint32
+U64 = numpy.uint64
 F32 = numpy.float32
 F64 = numpy.float64
 TWO16 = 2 ** 16
-TWO32 = 2 ** 32
+TWO32 = U64(2 ** 32)
 get_n_occ = operator.itemgetter(1)
 
 gmf_info_dt = numpy.dtype([('rup_id', U32), ('task_no', U16),
@@ -131,12 +132,12 @@ def aggreg(outputs, crmodel, ARKD, kids, rlz_id, monitor):
             with mon_agg:
                 if correl:  # use sigma^2 = (sum sigma_i)^2
                     alt['variance'] = numpy.sqrt(alt.variance)
-                eids = alt.eid.to_numpy() * TWO32
+                eids = alt.eid.to_numpy() * TWO32  # U64
                 values = numpy.array([alt[col] for col in value_cols]).T
-                fast_agg(eids + K, values, correl, lni, acc)
+                fast_agg(eids + U64(K), values, correl, lni, acc)
                 if len(kids):
                     aids = alt.aid.to_numpy()
-                    fast_agg(eids + kids[aids], values, correl, lni, acc)
+                    fast_agg(eids + U64(kids[aids]), values, correl, lni, acc)
     with mon_df:
         dic = general.AccumDict(accum=[])
         for ukey, arr in acc.items():


### PR DESCRIPTION
After the recent unification the aggregation procedure has become a lot slower (https://github.com/gem/oq-engine/pull/7232). This is now fixed. In the case of Europe the aggregation by site_id is now over 100x faster and the total time spent in event_based_risk is 29x less than before. There is a 30% improvement even with respect to engine 3.12:
```
# engine-3.12
| calc_130, maxmem=160.0 GB    | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total event_based_risk       | 34_742   | 836.4     | 240     |
| aggregating losses           | 18_467   | 0.0       | 312_300 |
| reading data                 | 3_231    | 409.9     | 240     |
| averaging losses             | 616.2    | 0.0       | 312_300 |

# this branch
| calc_128, maxmem=142.8 GB    | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total event_based_risk       | 24_480   | 585.6     | 240     |
| aggregating losses           | 5_639    | 0.0       | 312_300 |
| computing risk               | 4_892    | 0.0       | 199_902 |
| reading data                 | 3_445    | 410.1     | 240     |
| building dataframe           | 1_478    | 5.63672   | 240     |
| averaging losses             | 585.9    | 0.0       | 312_300 |
```