### PR TITLE
Added a warning in case of global duplicated branch IDs in the gsim logic tree

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Added a warning in case of global duplicated branch IDs in the gsim logic
+    tree file
   * Optimized the aggregation of losses in event_based_risk and made it possible
     to aggregate by site_id for more than 65,536 sites
   * Fixed the calculation of average insured losses with a nontrivial taxonomy

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -28,7 +28,6 @@ import pickle
 import socket
 import random
 import atexit
-import pprint
 import zipfile
 import builtins
 import operator
@@ -37,6 +36,7 @@ import tempfile
 import importlib
 import itertools
 import subprocess
+import collections
 import multiprocessing
 from contextlib import contextmanager
 from collections.abc import Mapping, Container, MutableSequence
@@ -55,9 +55,10 @@ mp = multiprocessing.get_context('spawn')
 
 def duplicated(items):
     """
-    :returns: True if the items are duplicated, False otherwise
+    :returns: the list of duplicated keys, possibly empty
     """
-    return len(items) > len(set(items))
+    counter = collections.Counter(items)
+    return [key for key, counts in counter.items() if counts > 1]
 
 
 def cached_property(method):

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -20,6 +20,7 @@ import io
 import os
 import json
 import string
+import logging
 import operator
 import itertools
 from collections import namedtuple, defaultdict
@@ -398,6 +399,7 @@ class GsimLogicTree(object):
         # do the parsing, called at instantiation time to populate .values
         trts = []
         branches = []
+        branchids = []
         branchsetids = set()
         basedir = os.path.dirname(self.filename)
         no = 0
@@ -454,10 +456,16 @@ class GsimLogicTree(object):
                 raise InvalidLogicTree(
                     'There where duplicated branchIDs in %s' %
                     self.filename)
+            branchids.extend(branch_ids)
+
         if len(trts) > len(set(trts)):
             raise InvalidLogicTree(
                 '%s: Found duplicated applyToTectonicRegionType=%s' %
                 (self.filename, trts))
+        dupl = duplicated(branchids)
+        if dupl:
+            logging.warning(
+                'There are duplicated branchIDs %s in %s', dupl, self.filename)
         branches.sort(key=lambda b: (b.trt, b.id))
         # TODO: add an .idx to each GSIM ?
         return branches


### PR DESCRIPTION
Discovered by Anne, see https://groups.google.com/g/openquake-users/c/7TSs3waTpcg/m/bZ6uvrzCDQAJ
