### PR TITLE
Added a command `oq info cfg` to show the configuration file paths

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -5,6 +5,9 @@ if [ ! -d "$1" ]; then
     exit 1
 fi
 
+oq info venv
+oq info cfg
+
 # run demos with job_hazard.ini and job_risk.ini
 for demo_dir in $(find "$1" -type d | sort); do
    if [ -f $demo_dir/job_hazard.ini ]; then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a command `oq info cfg` to show the configuration file paths
   * Added a check on the intensity measure levels with `--hc` is used
   * Bug fix: pointsource_distance = 0 was not honored
   * Added a warning in case of global duplicated branch IDs in the gsim logic

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -25,6 +25,7 @@ import operator
 import collections
 import numpy
 from decorator import FunctionMaker
+from openquake.baselib import config
 from openquake.baselib.general import groupby, gen_subclasses
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import gsim, nrml, imt
@@ -155,6 +156,10 @@ def main(what, report=False):
             print(cls.__name__)
     elif what == 'venv':
         print(sys.prefix)
+    elif what == 'cfg':
+        print('Looking at the following paths (the last wins)')
+        for path in config.paths:
+            print(path)
     elif what == 'sources':
         for cls in gen_subclasses(BaseSeismicSource):
             print(cls.__name__)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -120,6 +120,12 @@ class InfoTestCase(unittest.TestCase):
         lines = str(p).split()
         self.assertGreaterEqual(len(lines), 5)
 
+    def test_cfg(self):
+        with Print.patch() as p:
+            sap.runline('openquake.commands info cfg')
+        lines = str(p).split('\n')
+        self.assertGreaterEqual(len(lines), 2)
+
     def test_sources(self):
         with Print.patch() as p:
             sap.runline('openquake.commands info sources')


### PR DESCRIPTION
Useful for @vot4anto since it is impossible to remember the configuration paths for all the platforms and installation methods we have.