### PR TITLE
Restored the performance in get_poes

### DIFF
--- a/openquake/hazardlib/tests/gsim/mgmpe/generic_gmpe_avgsa_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/generic_gmpe_avgsa_test.py
@@ -55,6 +55,7 @@ class GenericGmpeAvgSATestCase(unittest.TestCase):
         ctx = self.ctx(4, vs30=760.)
         ctx.hypo_depth = 10.
         ctx.rrup = np.array([1., 10., 30., 70.])
+        ctx.occurrence_rate = 0.0001
         imtype = PGA()
         stdt = [const.StdDev.TOTAL]
         # Computes results

--- a/openquake/hazardlib/tests/gsim/mgmpe/split_sigma_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/split_sigma_gmpe_test.py
@@ -39,6 +39,7 @@ class SplitSigmaGMPETest(unittest.TestCase):
         ctx.sids = [0, 1, 2, 3]
         ctx.vs30 = [760.] * 4
         ctx.rrup = np.array([1., 10., 30., 70.])
+        ctx.occurrence_rate = .0001
         imt = PGA()
         stds_types = [const.StdDev.TOTAL, const.StdDev.INTER_EVENT,
                       const.StdDev.INTRA_EVENT]

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -203,9 +203,7 @@ class BaseGSIMTestCase(unittest.TestCase):
 
         cmaker, df = read_cmaker_df(gsim, fnames)
         for ctx in gen_ctxs(df):
-            if cmaker.use_recarray:
-                ctx.occurrence_rate = 0.
-                ctx = cmaker.recarray([ctx])
+            ctx.occurrence_rate = 0
             out = cmaker.get_mean_stds([ctx])[:, 0]
             for o, out_type in enumerate(out_types):
                 if not hasattr(ctx, out_type):


### PR DESCRIPTION
The latest pull requests improved the memory consumption but a big performance price. Here the performance is restored with an even better memory benefit. Here are the figures for a small yufang-like calculation on my workstation:
```
# before
| calc_7, maxmem=2.7 GB      | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total classical            | 500.5    | 112.5     | 22     |
| composing pnes             | 202.3    | 0.0       | 677    |
| get_poes                   | 110.5    | 0.0       | 677    |
| make_contexts              | 96.2     | 0.0       | 87_862 |
| ClassicalCalculator.run    | 79.7     | 184.4     | 1      |
| computing mean_std         | 29.2     | 0.0       | 677    |
# after
| calc_8, maxmem=2.1 GB      | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total classical            | 418.7    | 42.2      | 22     |
| get_poes                   | 147.5    | 0.0       | 86_770 |
| make_contexts              | 95.4     | 0.0       | 87_862 |
| composing pnes             | 83.8     | 0.0       | 86_770 |
| ClassicalCalculator.run    | 72.8     | 177.1     | 1      |
| computing mean_std         | 38.1     | 0.0       | 1_656  |
```
The big speedup is in "composing pnes".