### PR TITLE
Saving memory by skipping the zeros in the ProbabilityMaps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,9 @@
   [Claudia Mascandola]
-  * Added the computation of tau and phi stdevs to the sgobba_2020 gmm.
-  * Added the corresponding tests and Verification Tables.
-  
-  [Claudia Mascandola]
+  * Added the computation of tau and phi stdevs to the sgobba_2020 GMPE
   * Added a new class to the lanzano_2019 gmm.
-  
+
   [Michele Simionato]
-  * Reduced the memory consumption in `get_poes` in classical calculations
+  * Reduced the memory (and disk) consumption in classical calculations
   * Changed the behavior of `sites_slice`
   * Changed `custom_site_id` to an ASCII string up to 6 characters
   * Fixed the error raised in presence of a mag-dep distance for a tectonic

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,7 @@
   * Added a new class to the lanzano_2019 gmm.
 
   [Michele Simionato]
-  * Reduced the memory (and disk) consumption in classical calculations
+  * Reduced the memory consumption in classical calculations
   * Changed the behavior of `sites_slice`
   * Changed `custom_site_id` to an ASCII string up to 6 characters
   * Fixed the error raised in presence of a mag-dep distance for a tectonic

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -295,8 +295,8 @@ class ClassicalCalculator(base.HazardCalculator):
         avail = min(psutil.virtual_memory().available, config.memory.limit)
         logging.info('Requiring %s for full ProbabilityMap of shape %s',
                      humansize(size), (G, N, L))
-        maxsize = 20_000 * max(num_gs) * self.oqparam.imtls.size * 8
-        logging.info('Requiring at max %s for gen_poes', humansize(maxsize))
+        maxsize = max(num_gs) * self.oqparam.imtls.size * 8
+        logging.info('Requiring at max %s per site', humansize(maxsize))
         if avail < bytes_per_grp:
             raise MemoryError(
                 'You have only %s of free RAM' % humansize(avail))

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -190,6 +190,9 @@ class ClassicalCalculator(base.HazardCalculator):
             acc[source_id.split(':')[0]] = pmap
         if pmap:
             acc[grp_id] |= pmap
+        self.counts[grp_id] -= 1
+        if self.counts[grp_id] == 0:  # no other tasks for this grp_id
+            self.haz.store_poes(grp_id, acc.pop(grp_id))
         return acc
 
     def create_dsets(self):
@@ -347,10 +350,6 @@ class ClassicalCalculator(base.HazardCalculator):
         smap.reduce(self.agg_dicts, acc)
         logging.debug("busy time: %s", smap.busytime)
         self.store_info(psd)
-        logging.info('Saving _poes')
-        for grp_id in list(acc):
-            if isinstance(grp_id, int):
-                self.haz.store_poes(grp_id, acc.pop(grp_id))
         self.haz.store_disagg(acc)
         return True
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -330,14 +330,12 @@ class ClassicalCalculator(base.HazardCalculator):
         self.haz = Hazard(self.datastore, self.full_lt, pgetter, srcidx,
                           self.monitor('storing _poes', measuremem=True))
         args = self.get_args(grp_ids, self.haz.cmakers)
-        self.counts = collections.Counter(arg[0][0].grp_id for arg in args)
+        self.counts = collections.Counter(arg[1].grp_id for arg in args)
         logging.info('grp_id->ntasks: %s', list(self.counts.values()))
         L = oq.imtls.size
         # only groups generating more than 1 task preallocate memory
-        num_gs = [len(cm.gsims) for grp, cm in enumerate(self.haz.cmakers)
-                  if self.counts[grp] > 1]
-        if num_gs:
-            self.check_memory(self.N, L, num_gs)
+        num_gs = [len(cm.gsims) for grp, cm in enumerate(self.haz.cmakers)]
+        self.check_memory(self.N, L, num_gs)
         h5 = self.datastore.hdf5
         smap = parallel.Starmap(classical, args, h5=h5)
         smap.monitor.save('sitecol', self.sitecol)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -282,8 +282,8 @@ class ClassicalCalculator(base.HazardCalculator):
         self.ct = self.oqparam.concurrent_tasks * 1.5 or 1
         # NB: it is CRITICAL for performance to have shape GNL and not NLG
         # dset[g, :, :] = XXX is fast, dset[:, :, g] = XXX is ultra-slow
-        self.datastore.create_dset('_poes', F64, poes_shape,
-                                   compression='gzip')  # huge improvement
+        self.datastore.create_dset('_poes', F64, poes_shape)
+        # NB: compressing the dataset causes a big slowdown in writing :-(
         if not self.oqparam.hazard_calculation_id:
             self.datastore.swmr_on()
 


### PR DESCRIPTION
This saves memory on the master node. By distributing `store_poes` along the calculation we keep under control the saving time. Compressing the dataset is not possible (21x slowdown, everything is blocked while writing the poes)