### PR TITLE
Removed a warning in newer versions of h5py

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -291,11 +291,11 @@ class File(h5py.File):
         """Raised when reading an empty dataset"""
 
     def __init__(self, name, mode='r', driver=None, libver='latest',
-                 userblock_size=None, swmr=True, rdcc_nslots=None,
+                 userblock_size=None, rdcc_nslots=None,
                  rdcc_nbytes=None, rdcc_w0=None, track_order=None,
                  **kwds):
         super().__init__(name, mode, driver, libver,
-                         userblock_size, swmr, rdcc_nslots,
+                         userblock_size, mode == 'r', rdcc_nslots,
                          rdcc_nbytes, rdcc_w0, track_order, **kwds)
 
     @classmethod

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -122,7 +122,7 @@ class StarmapTestCase(unittest.TestCase):
         numchars = sum(len(arg) for arg, in allargs)  # 61
         tmpdir = tempfile.mkdtemp()
         tmp = os.path.join(tmpdir, 'calc_1.hdf5')
-        performance.init_performance(tmp, swmr=True)
+        performance.init_performance(tmp)
         smap = parallel.Starmap(supertask, allargs, h5=hdf5.File(tmp, 'a'))
         res = smap.reduce()
         smap.h5.close()
@@ -185,7 +185,7 @@ class SWMRTestCase(unittest.TestCase):
         cls.tmp = os.path.join(tmpdir, 'calc_1.hdf5')
         with hdf5.File(cls.tmp, 'w') as h:
             h['array'] = numpy.arange(100)
-        performance.init_performance(cls.tmp, swmr=True)
+        performance.init_performance(cls.tmp)
 
     def test(self):
         allargs = []


### PR DESCRIPTION
There is a warning saying that the swmr_mode can be true only in 'r' mode.