### PR TITLE
Restored tiling again

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -516,9 +516,11 @@ class ClassicalCalculator(base.HazardCalculator):
 
         if self.N > oq.max_sites_per_tile:
             ntiles = numpy.ceil(self.N / oq.max_sites_per_tile)
+            tiles = self.sitecol.split_in_tiles(ntiles)
+            logging.info('There are %d tiles', len(tiles))
         else:
-            ntiles = 1
-        for tile in self.sitecol.split_in_tiles(ntiles):
+            tiles = [self.sitecol]
+        for tile in tiles:
             for grp_id in grp_ids:
                 sg = src_groups[grp_id]
                 if sg.atomic:
@@ -650,6 +652,8 @@ class ClassicalCalculator(base.HazardCalculator):
         # {0: [(0, 3), (6, 9)], 1: [(3, 6), (9, 12)]}
         slicedic = performance.get_slices(
             dstore['_poes/sid'][:] // sites_per_task)
+        nslices = sum(len(slices) for slices in slicedic.values())
+        logging.info('There are %d slices of poes', nslices)
         allargs = [
             (getters.PmapGetter(dstore, ws, slices, oq.imtls, oq.poes),
              N, hstats, individual, oq.max_sites_disagg, self.amplifier)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -84,6 +84,8 @@ def classical(srcs, tile, cmaker, monitor):
     """
     cmaker.init_monitoring(monitor)
     if tile is None:
+        # read from the temporary storage, this avoids sending the
+        # same sitecol hundreds of times
         tile = monitor.read('sitecol')
     return hazclassical(srcs, tile, cmaker)
 
@@ -444,7 +446,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.check_memory(max(self.tile_sizes), L, num_gs)
         self.datastore.swmr_on()  # must come before the Starmap
         smap = parallel.Starmap(classical, sg_tl_cm, h5=self.datastore.hdf5)
-        smap.monitor.save('sitecol', self.sitecol)  # possibly in postclassical
+        smap.monitor.save('sitecol', self.sitecol)
         smap.h5 = self.datastore.hdf5
         acc = {cm.grp_id: ProbabilityMap.build(L, len(cm.gsims))
                for cm in self.haz.cmakers}

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -394,6 +394,9 @@ max_sites_per_gmf:
   Example: *max_sites_per_gmf = 100_000*.
   Default: 65536
 
+max_sites_per_tile:
+  INTERNAL
+
 max_weight:
   INTERNAL
 
@@ -809,6 +812,7 @@ class OqParam(valid.ParamSet):
     max_potential_gmfs = valid.Param(valid.positiveint, 2E11)
     max_potential_paths = valid.Param(valid.positiveint, 15_000)
     max_sites_per_gmf = valid.Param(valid.positiveint, 65536)
+    max_sites_per_tile = valid.Param(valid.positiveint, 500_000)
     max_sites_disagg = valid.Param(valid.positiveint, 10)
     mean_hazard_curves = mean = valid.Param(valid.boolean, True)
     std = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1033,6 +1033,12 @@ class OqParam(valid.ParamSet):
             # store input files, mandatory for the QGIS plugin
             self.save_disk_space = False
 
+        # check for tiling
+        if self.max_sites_disagg > self.max_sites_per_tile:
+            raise ValueError(
+                'max_sites_disagg is larger than max_sites_per_tile! (%d>%d)'
+                % (self.max_sites_disagg, self.max_sites_per_tile))
+
         # checks for disaggregation
         if self.calculation_mode == 'disaggregation':
             if not self.poes_disagg and self.poes:


### PR DESCRIPTION
The approach used in https://github.com/gem/oq-engine/pull/7132/ was elegant on the surface (yielding multiple pmaps from the same task) but tricky in the details. In particular it was difficult to decide when we got all the results coming from a given source group and when to store the aggregated poes: to avoid that issue we kept everything in memory, thus making large calculations impossible :-(. Even worse (in terms of internal logic) was the fact that `store_poes` was called multiple times for the same group and it was difficult to compute the quantities to be stored in `disagg_by_grp`. For these reasons we had to remove tiling in https://github.com/gem/oq-engine/pull/7319. 
Unfortunately, having removed tit, a calculation like ESHM20 that requires up to 5 GB per core cannot be run on cluster1. Here we restore tiling, but with a naive approach, such that the same sources are sent multiple times: that makes understanding when we can store the poes trivial (it is the same as in absence of tiling) so we need to keep in memory the same amount of data as before. Tiling also solves the potential issue of returning more than 4GB of data (i.e. the well known pickling error).