### PR TITLE
Restored smart tiling

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -687,7 +687,7 @@ class ClassicalCalculator(base.HazardCalculator):
             postclassical, allargs,
             distribute='no' if self.few_sites else None,
             h5=self.datastore.hdf5,
-            slowdown=1 if N > 20_000 and ct > 256 else 0
+            slowdown=.5 if N > 20_000 and ct > 256 else 0
         ).reduce(self.collect_hazard)
         for kind in sorted(self.hazard):
             logging.info('Saving %s', kind)  # very fast

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -86,8 +86,12 @@ def classical(srcs, tile, cmaker, monitor):
     if tile is None:
         # read from the temporary storage, this avoids sending the
         # same sitecol hundreds of times
-        tile = monitor.read('sitecol')
-    return hazclassical(srcs, tile, cmaker)
+        tiles = monitor.read('sitecol').split_in_tiles(
+            cmaker.max_sites_per_tile)
+        for tile in tiles:
+            yield hazclassical(srcs, tile, cmaker)
+    else:
+        yield hazclassical(srcs, tile, cmaker)
 
 
 def postclassical(pgetter, N, hstats, individual_rlzs,
@@ -301,8 +305,8 @@ class ClassicalCalculator(base.HazardCalculator):
             acc[source_id.split(':')[0]] = pmap
         if pmap:
             acc[grp_id] |= pmap
-        self.ntasks[grp_id] -= 1
-        if self.ntasks[grp_id] == 0:  # no other tasks for this grp_id
+        self.n_outs[grp_id] -= 1
+        if self.n_outs[grp_id] == 0:  # no other tasks for this grp_id
             with self.monitor('storing PoEs', measuremem=True):
                 self.haz.store_poes(grp_id, acc.pop(grp_id))
         return acc
@@ -438,8 +442,6 @@ class ClassicalCalculator(base.HazardCalculator):
             rec[0]: i for i, rec in enumerate(self.csm.source_info.values())}
         self.haz = Hazard(self.datastore, self.full_lt, srcidx)
         sg_tl_cm = self.get_sg_tl_cm(grp_ids, self.haz.cmakers)
-        self.ntasks = collections.Counter(arg[2].grp_id for arg in sg_tl_cm)
-        logging.info('grp_id->ntasks: %s', list(self.ntasks.values()))
         L = oq.imtls.size
         # only groups generating more than 1 task preallocate memory
         num_gs = [len(cm.gsims) for grp, cm in enumerate(self.haz.cmakers)]
@@ -520,34 +522,34 @@ class ClassicalCalculator(base.HazardCalculator):
 
         tiling = self.N > oq.max_sites_per_tile
         if tiling:
-            ntiles = numpy.ceil(self.N / oq.max_sites_per_tile)
-            tiles = self.sitecol.split_in_tiles(ntiles)
-        else:
-            tiles = [self.sitecol]
-        self.tile_sizes = []
-        for tile in tiles:
-            self.tile_sizes.append(len(tile))
-            if not tiling:
-                tile = None
-            for grp_id in grp_ids:
-                sg = src_groups[grp_id]
-                if sg.atomic:
-                    # do not split atomic groups
-                    triples.append((sg, tile, cmakers[grp_id]))
-                else:  # regroup the sources in blocks
-                    blks = (groupby(sg, get_source_id).values()
-                            if oq.disagg_by_src else
-                            block_splitter(
-                                sg, max_weight, get_weight, sort=True))
-                    blocks = list(blks)
-                    for block in blocks:
-                        logging.debug(
-                            'Sending %d source(s) with weight %d',
-                            len(block), sum(src.weight for src in block))
-                        triples.append((block, tile, cmakers[grp_id]))
-        if tiling:
+            tiles = self.sitecol.split_in_tiles(oq.max_sites_per_tile)
+            self.tile_sizes = [len(tile) for tile in tiles]
+            ntiles = len(tiles)
             logging.info('There are %d tiles of sizes %s',
-                         len(tiles), self.tile_sizes)
+                         ntiles, self.tile_sizes)
+        else:
+            self.tile_sizes = [self.N]
+            ntiles = 1
+        for grp_id in grp_ids:
+            sg = src_groups[grp_id]
+            if sg.atomic:
+                # do not split atomic groups
+                triples.append((sg, None, cmakers[grp_id]))
+            else:  # regroup the sources in blocks
+                blks = (groupby(sg, get_source_id).values()
+                        if oq.disagg_by_src else
+                        block_splitter(
+                            sg, max_weight, get_weight, sort=True))
+                blocks = list(blks)
+                for block in blocks:
+                    logging.debug(
+                        'Sending %d source(s) with weight %d',
+                        len(block), sum(src.weight for src in block))
+                    triples.append((block, None, cmakers[grp_id]))
+        self.n_outs = collections.Counter(t[2].grp_id for t in triples)
+        for grp_id in grp_ids:
+            self.n_outs[grp_id] *= ntiles
+        logging.info('grp_id->n_outs: %s', list(self.n_outs.values()))
         return triples
 
     def collect_hazard(self, acc, pmap_by_kind):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -663,6 +663,12 @@ time_event:
   Example: *time_event = day*.
   Default: None
 
+time_per_tile:
+  Used in classical calculatins with tiling. If running a tile takes longer
+  then time_per_tile seconds, use subtasks for the other tiles in the task.
+  Example: *time_per_tile=300*
+  Default: 60
+
 truncation_level:
   Truncation level used in the GMPEs.
   Example: *truncation_level = 0* to compute median GMFs.
@@ -877,6 +883,7 @@ class OqParam(valid.ParamSet):
     min_weight = valid.Param(valid.positiveint, 200)  # used in classical
     max_weight = valid.Param(valid.positiveint, 1E6)  # used in classical
     time_event = valid.Param(str, None)
+    time_per_tile = valid.Param(str, 60)
     truncation_level = valid.Param(valid.NoneOr(valid.positivefloat), None)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)
     vs30_tolerance = valid.Param(valid.positiveint, 0)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -191,6 +191,7 @@ class ContextMaker(object):
         param = param
         self.af = param.get('af', None)
         self.max_sites_disagg = param.get('max_sites_disagg', 10)
+        self.max_sites_per_tile = param.get('max_sites_per_tile', 50_000)
         self.disagg_by_src = param.get('disagg_by_src')
         self.collapse_level = param.get('collapse_level', False)
         self.disagg_by_src = param.get('disagg_by_src', False)
@@ -1263,6 +1264,7 @@ def read_cmakers(dstore, full_lt=None):
              'ses_seed': oq.ses_seed,
              'ses_per_logic_tree_path': oq.ses_per_logic_tree_path,
              'max_sites_disagg': oq.max_sites_disagg,
+             'max_sites_per_tile': oq.max_sites_per_tile,
              'disagg_by_src': oq.disagg_by_src,
              'min_iml': oq.min_iml,
              'imtls': oq.imtls,

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -421,10 +421,12 @@ class SiteCollection(object):
         """
         Split a SiteCollection into a set of tiles (SiteCollection instances).
 
-        :param hint: hint for how many tiles to generate
+        :param hint: hint for how many tiles to generate (> 0)
         """
+        if hint < 2:
+            return [self]
         tiles = []
-        for seq in split_in_blocks(range(len(self)), hint or 1):
+        for seq in split_in_blocks(range(len(self)), hint):
             sc = SiteCollection.__new__(SiteCollection)
             sc.array = self.array[numpy.array(seq, int)]
             sc.complete = self

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -416,17 +416,17 @@ class SiteCollection(object):
         """True if all depths are zero"""
         return (self.depths == 0).all()
 
-    # used in the engine when computing the hazard statistics
-    def split_in_tiles(self, hint):
+    # used in the engine
+    def split_in_tiles(self, max_sites_per_tile):
         """
         Split a SiteCollection into a set of tiles (SiteCollection instances).
-
-        :param hint: hint for how many tiles to generate (> 0)
         """
-        if hint < 2:
+        N = len(self)
+        if N < max_sites_per_tile:  # do not split
             return [self]
+        hint = int(numpy.ceil(N / max_sites_per_tile))
         tiles = []
-        for seq in split_in_blocks(range(len(self)), hint):
+        for seq in split_in_blocks(range(N), hint):
             sc = SiteCollection.__new__(SiteCollection)
             sc.array = self.array[numpy.array(seq, int)]
             sc.complete = self

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -136,13 +136,10 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
         self.assertEqual(len(cll), 2)
 
         # test split_in_tiles
-        tiles = cll.split_in_tiles(0)
+        tiles = cll.split_in_tiles(2)  # there are 2 sites, 1 tile
         self.assertEqual(len(tiles), 1)
 
-        tiles = cll.split_in_tiles(1)
-        self.assertEqual(len(tiles), 1)
-
-        tiles = cll.split_in_tiles(2)
+        tiles = cll.split_in_tiles(1)  # 2 tiles of 1 site each
         self.assertEqual(len(tiles), 2)
 
         # test geohash


### PR DESCRIPTION
We are back to the idea first implemented in https://github.com/gem/oq-engine/pull/7132 (i.e. do not increase the number of tasks, just the number of outputs) but in a smarter way, so that we can keep storing the data continuously, as soon as possible, and not at the end of the entire calculation, thus saving memory and time. This has the *huge* benefit of solving the slow tasks issue of https://github.com/gem/oq-engine/pull/7334, so that now we are as bad as without tiling and not worse.
Here are some figures for the Canada model with OQ_SAMPLE_SOURCES=.01:
```
| operation-duration | counts | mean    | stddev | min     | max     |
|--------------------+--------+---------+--------+---------+---------|
| before             | 2_040  | 80.8    | 78%    | 0.00438 | 277.2   | # 43215
| after              | 680    | 250.6   | 37%    | 1.08788 | 434.2   | # 43216
```
The rate slowest_task/mean_task goes down from 3.43 to 1.73, i.e. effectively the slow tasks disappear. The performance
and the memory occupation are the same as before while the data transfer in sources and sites goes down from 13+ GB to essentially zero.
```
| operation | time_sec | memory_mb | counts  |
|-----------+----------+-----------+---------|
| before    | 164_890  | 194.9     | 2_040   |
| after     | 170_436  | 208.1     | 2_040   |
```
Despite producing 3 times less tasks the task distribution is much better and the calculation is significantly faster, from 1001s to 829s.

I am also adding a new parameter `time_per_tile` that will turn useful in the future.