### PR TITLE
Improved the slow tasks with tiling

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -667,7 +667,7 @@ time_per_tile:
   Used in classical calculatins with tiling. If running a tile takes longer
   then time_per_tile seconds, use subtasks for the other tiles in the task.
   Example: *time_per_tile=300*
-  Default: 60
+  Default: 600
 
 truncation_level:
   Truncation level used in the GMPEs.
@@ -883,7 +883,7 @@ class OqParam(valid.ParamSet):
     min_weight = valid.Param(valid.positiveint, 200)  # used in classical
     max_weight = valid.Param(valid.positiveint, 1E6)  # used in classical
     time_event = valid.Param(str, None)
-    time_per_tile = valid.Param(valid.positivefloat, 60)
+    time_per_tile = valid.Param(valid.positivefloat, 600)
     truncation_level = valid.Param(valid.NoneOr(valid.positivefloat), None)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)
     vs30_tolerance = valid.Param(valid.positiveint, 0)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -883,7 +883,7 @@ class OqParam(valid.ParamSet):
     min_weight = valid.Param(valid.positiveint, 200)  # used in classical
     max_weight = valid.Param(valid.positiveint, 1E6)  # used in classical
     time_event = valid.Param(str, None)
-    time_per_tile = valid.Param(str, 60)
+    time_per_tile = valid.Param(valid.positivefloat, 60)
     truncation_level = valid.Param(valid.NoneOr(valid.positivefloat), None)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)
     vs30_tolerance = valid.Param(valid.positiveint, 0)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -192,6 +192,7 @@ class ContextMaker(object):
         self.af = param.get('af', None)
         self.max_sites_disagg = param.get('max_sites_disagg', 10)
         self.max_sites_per_tile = param.get('max_sites_per_tile', 50_000)
+        self.time_per_tile = param.get('time_per_tile', 60)
         self.disagg_by_src = param.get('disagg_by_src')
         self.collapse_level = param.get('collapse_level', False)
         self.disagg_by_src = param.get('disagg_by_src', False)
@@ -1265,6 +1266,7 @@ def read_cmakers(dstore, full_lt=None):
              'ses_per_logic_tree_path': oq.ses_per_logic_tree_path,
              'max_sites_disagg': oq.max_sites_disagg,
              'max_sites_per_tile': oq.max_sites_per_tile,
+             'time_per_tile': oq.time_per_tile,
              'disagg_by_src': oq.disagg_by_src,
              'min_iml': oq.min_iml,
              'imtls': oq.imtls,
@@ -1305,6 +1307,8 @@ def read_cmaker(dstore, trt_smr):
          'ses_seed': oq.ses_seed,
          'ses_per_logic_tree_path': oq.ses_per_logic_tree_path,
          'max_sites_disagg': oq.max_sites_disagg,
+         'max_sites_per_tile': oq.max_sites_per_tile,
+         'time_per_tile': oq.time_per_tile,
          'disagg_by_src': oq.disagg_by_src,
          'min_iml': oq.min_iml,
          'imtls': oq.imtls,

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -426,9 +426,10 @@ class SiteCollection(object):
             return [self]
         hint = int(numpy.ceil(N / max_sites_per_tile))
         tiles = []
-        for seq in split_in_blocks(range(N), hint):
+        for i in range(hint):
             sc = SiteCollection.__new__(SiteCollection)
-            sc.array = self.array[numpy.array(seq, int)]
+            # smart trick to split in "homogenous" tiles
+            sc.array = self.array[self.sids % hint == i]
             sc.complete = self
             tiles.append(sc)
         return tiles

--- a/openquake/qa_tests_data/classical/case_14/job.ini
+++ b/openquake/qa_tests_data/classical/case_14/job.ini
@@ -4,6 +4,7 @@ description = Classical PSHA QA test with sites_csv
 calculation_mode = classical
 random_seed = 23
 max_sites_per_tile = 5
+time_per_tile = .1
 max_sites_disagg = 1
 
 [geometry]


### PR DESCRIPTION
Thanks to https://github.com/gem/oq-engine/pull/7344, slow tasks with tiling are no worse than without tiling. With this PR we aim to make slow tasks with tiling *better* than without tiling, i.e. tiling can be used as a trick to solve the issue of slow tasks, at the cost of a performance penalty. Here is an example for Canada with 3 tiles:
```
| operation-duration | counts |  mean | stddev |     min |   max |  kind   |
|--------------------+--------+-------+--------+---------+-------+---------|
| classical          |    258 | 189.7 |    41% | 0.01046 | 296.3 | no tiles|
| classical          |    258 | 214.5 |    40% | 0.31863 | 329.3 | 3 tiles |
| classical          |    688 | 125.5 |    22% | 0.01600 | 169.0 | 3 new   |
```
The stddev is half than before! But the cost is high:
```
# 3 tiles, master
| calc_39, maxmem=52.9 GB    | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 55_334   | 173.9     | 774     |
| computing mean_std         | 29_433   | 0.0       | 75_330  |
| get_poes                   | 14_548   | 0.0       | 662_707 |
| composing pnes             | 9_719    | 0.0       | 662_707 |
| total postclassical        | 7_178    | 29.7      | 240     |
| combine pmaps              | 5_061    | 0.0       | 138_284 |
| make_contexts              | 1_359    | 40.5      | 11_787  |
| compute stats              | 1_343    | 0.0       | 138_284 |
| ClassicalCalculator.run    | 1_083    | 2_481     | 1       |
| read PoEs                  | 376.3    | 18.1      | 240     |

# 3 tiles, this branch
| calc_41, maxmem=47.4 GB    | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 86_346   | 161.0     | 1_204     |
| computing mean_std         | 59_636   | 0.0       | 69_140    |
| get_poes                   | 14_623   | 0.0       | 1_471_789 |
| composing pnes             | 9_694    | 0.0       | 1_471_789 |
| total postclassical        | 7_158    | 37.1      | 240       |
| combine pmaps              | 5_045    | 0.0       | 138_284   |
| make_contexts              | 2_179    | 15.4      | 17_157    |
| compute stats              | 1_337    | 0.0       | 138_284   |
| ClassicalCalculator.run    | 1_231    | 4_987     | 1         |
| read PoEs                  | 377.1    | 38.0      | 240       |
```
However the penalty is much smaller with 2 tasks (*total classical=68_874s*) and the task distribution is still a lot better (*stddev=28%*).