### PR TITLE
Fixed the issue of falsely failed jobs with kubernets

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -210,19 +210,14 @@ def poll_queue(job_id, poll_time):
     if offset >= 0:
         first_time = True
         while True:
-            jobs = logs.dbcmd(GET_JOBS)
-            failed = [job.id for job in jobs if not psutil.pid_exists(job.pid)]
-            if failed:
-                for job in failed:
-                    logs.dbcmd('update_job', job,
-                               {'status': 'failed', 'is_running': 0})
-            elif any(j.id < job_id - offset for j in jobs):
+            running = logs.dbcmd(GET_JOBS)
+            previous = [job for job in running if job.id < job_id - offset]
+            if previous:
                 if first_time:
-                    print('Waiting for jobs %s' % [j.id for j in jobs
-                                                   if j.id < job_id - offset])
                     logs.dbcmd('update_job', job_id,
                                {'status': 'submitted', 'pid': _PID})
                     first_time = False
+                    logging.info('Waiting for jobs %s', previous)
                 time.sleep(poll_time)
             else:
                 break


### PR DESCRIPTION
Missing PIDs were considered failed, but this logic makes sense only on a single machine, it has to be removed in a multi-machine situation.