### PR TITLE
Improved the rupture weights

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -219,6 +219,7 @@ def ebrisk(rupgetter, param, monitor):
     :returns: a dictionary of arrays
     """
     mon_rup = monitor('getting ruptures', measuremem=False)
+    mon_fil = monitor('filtering ruptures', measuremem=False)
     mon_haz = monitor('getting hazard', measuremem=True)
     alldata = general.AccumDict(accum=[])
     gmf_info = []
@@ -227,7 +228,7 @@ def ebrisk(rupgetter, param, monitor):
     gg = getters.GmfGetter(rupgetter, srcfilter, param['oqparam'],
                            param['amplifier'])
     with mon_haz:
-        for c in gg.gen_computers(mon_rup):
+        for c in gg.gen_computers(mon_rup, mon_fil):
             data, time_by_rup = c.compute_all()
             if len(data):
                 for key, val in data.items():

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -362,7 +362,7 @@ class GmfGetter(object):
         """
         oq = self.oqparam
         rmon = monitor('getting ruptures', measuremem=True)
-        fmon = monitor('filtering ruptures', measuremem=True)
+        fmon = monitor('filtering ruptures', measuremem=False)
         hcurves = {}  # key -> poes
         if oq.hazard_curves_from_gmfs:
             hc_mon = monitor('building hazard curves', measuremem=False)

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -129,10 +129,8 @@ class GmfComputer(object):
         self.ctx = ctxs[0]
         if correlation_model:  # store the filtered sitecol
             self.sites = sitecol.complete.filtered(self.ctx.sids)
-        if cross_correl is None:
-            self.cross_correl = NoCrossCorrelation(cmaker.trunclevel)
-        else:
-            self.cross_correl = cross_correl
+        self.cross_correl = cross_correl or NoCrossCorrelation(
+            cmaker.trunclevel)
 
     def compute_all(self, sig_eps=None):
         """

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -781,7 +781,7 @@ class RuptureProxy(object):
             number of occurrences and number of presumably affected sites
         """
         return self['n_occ'] * (
-            10 if self.nsites is None else numpy.clip(self.nsites, 10, 1000))
+            10 if self.nsites is None else numpy.clip(self.nsites, 100, 2000))
 
     def __getitem__(self, name):
         return self.rec[name]

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -781,7 +781,7 @@ class RuptureProxy(object):
             number of occurrences and number of presumably affected sites
         """
         return self['n_occ'] * (
-            10 if self.nsites is None else max(self.nsites, 10))
+            10 if self.nsites is None else numpy.clip(self.nsites, 10, 1000))
 
     def __getitem__(self, name):
         return self.rec[name]
@@ -797,6 +797,10 @@ class RuptureProxy(object):
                         self.rec['n_occ'], self.rec['id'], self.rec['e0'],
                         self.scenario)
         return ebr
+
+    def __repr__(self):
+        src = self.rec['source_id'].decode('ascii')
+        return '<%s[%s], w=%d>' % (self.__class__.__name__, src, self.weight)
 
 
 def get_ruptures(fname_csv):


### PR DESCRIPTION
To improve the situation with slow tasks in China. Here is an example reducing by half the slowest task:
```
| operation-duration | counts |  mean | stddev |     min |   max | slowfac |
|--------------------+--------+-------+--------+---------+-------+---------|
| compute_gmfs       | 287    | 106.7 | 66%    | 0.45983 | 542.6 | 5.08717 |
| compute_gmfs       | 278    | 109.3 | 58%    | 0.20009 | 288.1 | 2.63469 |
```


