### PR TITLE
Made sure `valid.gsim` instantiates the GSIM

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made sure `valid.gsim` instantiates the GSIM
   * ShakeMap calculations failing with a nonpositive definite correlation
     matrix now point out to the manual for the solution of the problem
   * Introduced the GodaAtkinson2009 cross correlation between event model

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -261,16 +261,16 @@ class GsimLogicTree(object):
         self.branches = []
         self.shortener = {}
         self.values = defaultdict(list)
+        dirname = os.path.dirname(dic['filename'])
         for bsno, branches in enumerate(group_array(array, 'trt').values()):
             for brno, branch in enumerate(branches):
                 branch = fix_bytes(branch)
                 br_id = branch['branch']
-                gsim = valid.gsim(branch['uncertainty'])
+                gsim = valid.gsim(branch['uncertainty'], dirname)
                 for k, v in gsim.kwargs.items():
                     if k.endswith(('_file', '_table')):
                         arr = numpy.asarray(dic[os.path.basename(v)][()])
                         gsim.kwargs[k] = io.BytesIO(bytes(arr))
-                gsim.__init__(**gsim.kwargs)
                 self.values[branch['trt']].append(gsim)
                 weight = object.__new__(ImtWeight)
                 # branch dtype ('trt', 'branch', 'uncertainty', 'weight', ...)

--- a/openquake/hazardlib/tests/valid_test.py
+++ b/openquake/hazardlib/tests/valid_test.py
@@ -135,6 +135,11 @@ class ValidationTestCase(unittest.TestCase):
         self.assertEqual(validator(''), None)
         self.assertEqual(validator('1'), 1)
 
+    def test_full_instantiation(self):
+        # test for https://github.com/gem/oq-engine/issues/7363
+        abr = valid.gsim("AbrahamsonEtAl2014")
+        self.assertIsNone(abr.region)
+
     def test_gsim(self):
         class FakeGsim(object):
             def __init__(self, arg):

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -134,11 +134,7 @@ def gsim(value, basedir=''):
         gsim_class = registry[gsim_name]
     except KeyError:
         raise ValueError('Unknown GSIM: %s' % gsim_name)
-    if basedir:
-        gs = gsim_class(**kwargs)
-    else:
-        gs = object.__new__(gsim_class)
-        gs.kwargs = kwargs
+    gs = gsim_class(**kwargs)
     gs._toml = '\n'.join(line.strip() for line in value.splitlines())
     return gs
 


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/7363. Notice that the ``__new__`` was not a leftover as I thought, but it was still used and needed in the case of gsims of kind ``GMPETable``. With the current refactoring it should not be needed anymore. Then the usage becomes more predictable: now `valid.gsim` returns a correctly instantiated GSIM or fails, not a partially instantiated GSIM that has to be post-initialized later on.