### PR TITLE
numpy 1.20.0

### DIFF
--- a/requirements-py37-linux64.txt
+++ b/requirements-py37-linux64.txt
@@ -8,7 +8,7 @@ https://wheelhouse.openquake.org/v3/linux/py/setuptools-56.0.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py37/h5py-3.1.0-cp37-cp37m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py37/setproctitle-1.2.2-cp37-cp37m-manylinux1_x86_64.whl
-https://wheelhouse.openquake.org/v3/linux/py37/numpy-1.18.2-cp37-cp37m-manylinux1_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py37/numpy-1.20.0-cp37-cp37m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py37/scipy-1.4.1-cp37-cp37m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py37/pandas-1.1.5-cp37-cp37m-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py37/pyzmq-19.0.0-cp37-cp37m-manylinux1_x86_64.whl

--- a/requirements-py37-macos.txt
+++ b/requirements-py37-macos.txt
@@ -7,7 +7,7 @@
 https://wheelhouse.openquake.org/v3/linux/py/setuptools-56.0.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py37/h5py-3.1.0-cp37-cp37m-macosx_10_9_x86_64.whl
-https://wheelhouse.openquake.org/v3/macos/py37/numpy-1.18.2-cp37-cp37m-macosx_10_9_x86_64.whl
+https://wheelhouse.openquake.org/v3/macos/py37/numpy-1.20.0-cp37-cp37m-macosx_10_9_x86_64.whl
 https://wheelhouse.openquake.org/v3/macos/py37/scipy-1.4.1-cp37-cp37m-macosx_10_6_intel.whl
 https://wheelhouse.openquake.org/v3/macos/py37/pandas-1.1.5-cp37-cp37m-macosx_10_9_x86_64.whl
 https://wheelhouse.openquake.org/v3/macos/py37/pyzmq-19.0.0-cp37-cp37m-macosx_10_9_x86_64.whl

--- a/requirements-py37-win64.txt
+++ b/requirements-py37-win64.txt
@@ -8,7 +8,7 @@ https://wheelhouse.openquake.org/v3/linux/py/setuptools-56.0.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py37/h5py-3.1.0-cp37-cp37m-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py37/setproctitle-1.2.2-cp37-cp37m-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py37/numpy-1.18.2-cp37-cp37m-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py37/numpy-1.20.0-cp37-cp37m-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py37/scipy-1.4.1-cp37-cp37m-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py37/pandas-1.1.5-cp37-cp37m-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py37/pyzmq-19.0.0-cp37-cp37m-win_amd64.whl

--- a/requirements-py38-linux64.txt
+++ b/requirements-py38-linux64.txt
@@ -8,7 +8,7 @@ https://wheelhouse.openquake.org/v3/linux/py/setuptools-56.0.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/linux/py38/h5py-3.1.0-cp38-cp38-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py38/setproctitle-1.2.2-cp38-cp38-manylinux1_x86_64.whl
-https://wheelhouse.openquake.org/v3/linux/py38/numpy-1.18.2-cp38-cp38-manylinux1_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py38/numpy-1.20.0-cp38-cp38-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py38/scipy-1.4.1-cp38-cp38-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py38/pandas-1.1.5-cp38-cp38-manylinux1_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py38/pyzmq-19.0.0-cp38-cp38-manylinux1_x86_64.whl

--- a/requirements-py38-macos.txt
+++ b/requirements-py38-macos.txt
@@ -7,7 +7,7 @@
 https://wheelhouse.openquake.org/v3/linux/py/setuptools-56.0.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/macos/py38/h5py-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl
-#https://wheelhouse.openquake.org/v3/macos/py38/numpy-1.18.2-cp38-cp38-macosx_10_9_x86_64.whl
+#https://wheelhouse.openquake.org/v3/macos/py38/numpy-1.20.0-cp38-cp38-macosx_10_9_x86_64.whl
 https://wheelhouse.openquake.org/v3/macos/py38/scipy-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl
 https://wheelhouse.openquake.org/v3/macos/py38/pandas-1.1.5-cp38-cp38-macosx_10_9_x86_64.whl
 https://wheelhouse.openquake.org/v3/macos/py38/pyzmq-19.0.0-cp38-cp38-macosx_10_9_x86_64.whl

--- a/requirements-py38-win64.txt
+++ b/requirements-py38-win64.txt
@@ -8,7 +8,7 @@ https://wheelhouse.openquake.org/v3/windows/py/setuptools-56.0.0-py3-none-any.wh
 https://wheelhouse.openquake.org/v3/windows/py/pytz-2019.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/windows/py38/setproctitle-1.2.2-cp38-cp38-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py38/h5py-3.1.0-cp38-cp38-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py38/numpy-1.18.2-cp38-cp38-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py38/numpy-1.20.0-cp38-cp38-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py38/scipy-1.4.1-cp38-cp38-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py38/pandas-1.1.5-cp38-cp38-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py38/pyzmq-19.0.0-cp38-cp38-win_amd64.whl

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ PY_MODULES = ['openquake.commands.__main__']
 install_requires = [
     'setuptools',
     'h5py >=2.10',
-    'numpy >=1.18, <1.20',
+    'numpy >=1.20',
     'scipy >=1.3, <1.7',
     'pandas >=0.25, <1.3',
     'pyzmq <20.0',


### PR DESCRIPTION
Set version of numpy for python3.7 and 3.8 to 1.20.0. Part of https://github.com/gem/oq-engine/issues/7374.