### PR TITLE
4x speedup of the postclassical calculator

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -269,15 +269,19 @@ def extract_cols(datagrp, sel, slc, columns):
         slcs = [slc]
     acc = general.AccumDict(accum=[])  # col -> arrays
     for slc in slcs:
-        ok = slice(None)
-        dic = {col: datagrp[col][slc] for col in sel}
-        for col in sel:
-            if isinstance(ok, slice):  # first selection
-                ok = is_ok(dic[col], sel[col])
-            else:  # other selections
-                ok &= is_ok(dic[col], sel[col])
-        for col in columns:
-            acc[col].append(datagrp[col][slc][ok])
+        if sel:
+            ok = slice(None)
+            dic = {col: datagrp[col][slc] for col in sel}
+            for col in sel:
+                if isinstance(ok, slice):  # first selection
+                    ok = is_ok(dic[col], sel[col])
+                else:  # other selections
+                    ok &= is_ok(dic[col], sel[col])
+            for col in columns:
+                acc[col].append(datagrp[col][slc][ok])
+        else:  # avoid making unneeded copies
+            for col in columns:
+                acc[col].append(datagrp[col][slc])
     return {k: numpy.concatenate(vs) for k, vs in acc.items()}
 
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -723,7 +723,7 @@ class Starmap(object):
                          maxweight, weight, key, distribute, progress, h5)
 
     def __init__(self, task_func, task_args=(), distribute=None,
-                 progress=logging.info, h5=None, slowdown=0):
+                 progress=logging.info, h5=None):
         self.__class__.init(distribute=distribute)
         self.task_func = task_func
         if h5:
@@ -740,7 +740,6 @@ class Starmap(object):
         self.task_args = task_args
         self.progress = progress
         self.h5 = h5
-        self.slowdown = slowdown
         self.task_queue = []
         try:
             self.num_tasks = len(self.task_args)
@@ -864,9 +863,6 @@ class Starmap(object):
             first_args = self.task_queue[:self.num_cores]
             self.task_queue[:] = self.task_queue[self.num_cores:]
             for func, args in first_args:
-                # possibly slow down the sending of the tasks
-                # to give time to the workers
-                time.sleep(self.slowdown)
                 self.submit(args, func=func)
         if not hasattr(self, 'socket'):  # no submit was ever made
             return ()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -683,7 +683,6 @@ class ClassicalCalculator(base.HazardCalculator):
             postclassical, allargs,
             distribute='no' if self.few_sites else None,
             h5=self.datastore.hdf5,
-            slowdown=.5 if N > 20_000 and ct > 256 else 0
         ).reduce(self.collect_hazard)
         for kind in sorted(self.hazard):
             logging.info('Saving %s', kind)  # very fast


### PR DESCRIPTION
This are the figures for the ESHM20 model on cluster1:
```
before
| calc_43518, maxmem=40.7 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total postclassical        | 414_525  | 677.0     | 399    |
| read PoEs                  | 390_871  | 682.6     | 399    |
| combine pmaps              | 18_086   | 0.0       | 94_909 |
| compute stats              | 4_285    | 0.0       | 94_909 |
| ClassicalCalculator.run    | 2_132    | 41_378    | 1      |

after
| calc_43562, maxmem=40.6 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total postclassical        | 130_184  | 679.9     | 399    |
| read PoEs                  | 108_363  | 684.1     | 399    |
| combine pmaps              | 17_018   | 0.0       | 94_909 |
| compute stats              | 3_703    | 0.0       | 94_909 |
| ClassicalCalculator.run    | 1_368    | 41_358    | 1      |
```