### PR TITLE
Adding support for Ray

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -657,11 +657,11 @@ class Starmap(object):
             except ImportError:
                 cls.pool = multiprocessing.get_context('spawn').Pool(
                     cls.num_cores, init_workers)
+                cls.pids = [proc.pid for proc in cls.pool._pool]
             # after spawning the processes restore the original handlers
             # i.e. the ones defined in openquake.engine.engine
             signal.signal(signal.SIGTERM, term_handler)
             signal.signal(signal.SIGINT, int_handler)
-            cls.pids = [proc.pid for proc in cls.pool._pool]
         elif cls.distribute == 'threadpool' and not hasattr(cls, 'pool'):
             cls.pool = multiprocessing.dummy.Pool(cls.num_cores)
         elif cls.distribute == 'dask':

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -651,8 +651,12 @@ class Starmap(object):
             # we use spawn here to avoid deadlocks with logging, see
             # https://github.com/gem/oq-engine/pull/3923 and
             # https://codewithoutrules.com/2018/09/04/python-multiprocessing/
-            cls.pool = multiprocessing.get_context('spawn').Pool(
-                cls.num_cores, init_workers)
+            try:
+                from ray.util.multiprocessing import Pool
+                cls.pool = Pool(cls.num_cores, init_workers)
+            except ImportError:
+                cls.pool = multiprocessing.get_context('spawn').Pool(
+                    cls.num_cores, init_workers)
             # after spawning the processes restore the original handlers
             # i.e. the ones defined in openquake.engine.engine
             signal.signal(signal.SIGTERM, term_handler)


### PR DESCRIPTION
[Ray](https://docs.ray.io/en/latest/index.html) is a competitor of Dask. It has the advantage of being compatible with multiprocessing.Pool, so supporting it in the engine is the work of one minute, at least for single machine situations.
Unfortunately the first test showed a slowdown of over 2x for the ESHM20 calculation on the spot machine.
```
without ray
| calc_43404, maxmem=59.5 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total split_task           | 176_852  | 136.1     | 1_770      |
| computing mean_std         | 82_568   | 0.0       | 354_806    |
| get_poes                   | 65_387   | 0.0       | 30_379_024 |
| total classical            | 43_863   | 80.8      | 192        |
| make_contexts              | 40_796   | 19.2      | 230_298    |
| composing pnes             | 29_695   | 0.0       | 30_379_024 |
| ClassicalCalculator.run    | 2_564    | 7_576     | 1          |
with ray (not measuring the memory on the ray workers)

| calc_43407, maxmem=8.3 GB  | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total split_task           | 172_193  | 109.1     | 1_770      |
| computing mean_std         | 77_402   | 0.0       | 354_806    |
| get_poes                   | 60_031   | 0.0       | 30_379_024 |
| make_contexts              | 37_187   | 20.9      | 230_298    |
| total classical            | 31_289   | 136.7     | 112        |
| composing pnes             | 26_798   | 0.0       | 30_379_024 |
| ClassicalCalculator.run    | 5_413    | 8_267     | 1          |
```
The effect is that most cores are doing nothing most of the time, and therefore the total runtime doubles (5_413s >> 2_564s).