### PR TITLE
Supporting ipyparallel

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -675,7 +675,7 @@ class Starmap(object):
             cls.pool = multiprocessing.dummy.Pool(cls.num_cores)
         elif cls.distribute == 'dask':
             cls.dask_client = Client(config.distribution.dask_scheduler)
-        elif cls.distribute == 'ipp':
+        elif cls.distribute == 'ipp' and not hasattr(cls, 'executor'):
             rc = Cluster(n=cls.num_cores).start_and_connect_sync()
             cls.executor = rc.executor()
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -73,7 +73,7 @@ def set_concurrent_tasks_default(calc):
     OqParam.concurrent_tasks.default. Abort the calculations if no
     workers are available. Do nothing for trivial distributions.
     """
-    if OQ_DISTRIBUTE in 'no processpool':  # do nothing
+    if OQ_DISTRIBUTE in 'no processpool ipp':  # do nothing
         num_workers = 0 if OQ_DISTRIBUTE == 'no' else parallel.Starmap.CT // 2
         logging.warning('Using %d cores on %s', num_workers, platform.node())
         return


### PR DESCRIPTION
Yet another distribution mechanism. It is worse than what we have now but not so bad. Here are the figures for ESHM20 on the spot machine (10% slower):
```
with processpool
| calc_43404, maxmem=59.5 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total split_task           | 176_852  | 136.1     | 1_770      |
| computing mean_std         | 82_568   | 0.0       | 354_806    |
| get_poes                   | 65_387   | 0.0       | 30_379_024 |
| total classical            | 43_863   | 80.8      | 192        |
| make_contexts              | 40_796   | 19.2      | 230_298    |
| composing pnes             | 29_695   | 0.0       | 30_379_024 |
| ClassicalCalculator.run    | 2_564    | 7_576     | 1          |
with ipyparallel (not measuring the memory on the workers)
| calc_43410, maxmem=12.6 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total split_task           | 174_397  | 111.8     | 1_770      |
| computing mean_std         | 81_501   | 0.0       | 354_806    |
| get_poes                   | 64_429   | 0.0       | 30_379_024 |
| total classical            | 42_912   | 83.0      | 192        |
| make_contexts              | 40_106   | 18.5      | 230_298    |
| composing pnes             | 29_048   | 0.0       | 30_379_024 |
| ClassicalCalculator.run    | 2_751    | 12_617    | 1          |
```