### PR TITLE
Using the parentdir in datastore.read

### DIFF
--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -119,7 +119,10 @@ def read(calc_id, mode='r', datadir=None, parentdir=None):
         hc_id = dstore['oqparam'].hazard_calculation_id
     except KeyError:  # no oqparam
         hc_id = None
-    if hc_id:
+    if hc_id and parentdir:
+        dstore.ppath = os.path.join(parentdir, 'calc_%d.hdf5' % hc_id)
+        dstore.parent = DataStore(dstore.ppath, mode='r')
+    elif hc_id:
         dstore.parent = _read(hc_id, datadir, 'r')
         dstore.ppath = dstore.parent.filename
     return dstore.open(mode)


### PR DESCRIPTION
Removes all calls to the DbServer from event_based_risk tasks. That should solve @CatalinaYepes problem with the SEA calculation.
```python
  File "/opt/openquake/oq-engine/openquake/calculators/event_based_risk.py", line 168, in event_based_risk
    dstore = datastore.read(oqparam.hdf5path, parentdir=oqparam.parentdir)
  File "/opt/openquake/oq-engine/openquake/commonlib/datastore.py", line 123, in read
    dstore.parent = _read(hc_id, datadir, 'r')
  File "/opt/openquake/oq-engine/openquake/commonlib/datastore.py", line 86, in _read
    job = dbcmd('get_job', jid)
  File "/opt/openquake/oq-engine/openquake/commonlib/logs.py", line 52, in dbcmd
    res = sock.send((action,) + args)
  File "/opt/openquake/oq-engine/openquake/baselib/zeromq.py", line 164, in send
    raise TimeoutError(
TimeoutError: While sending ('get_job', 43669); probably the DbServer is off
```