### PR TITLE
Refined source weights

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -536,14 +536,17 @@ class ClassicalCalculator(base.HazardCalculator):
                     logging.debug(
                         'Sending %d source(s) with weight %d',
                         len(block), sum(src.weight for src in block))
-                    trip = (block, sids, cmakers[grp_id])
-                    triples.append(trip)
                     if len(block) >= split_level and not oq.disagg_by_src:
+                        trip = (block, sids, cmakers[grp_id])
+                        triples.append(trip)
                         smap.submit_split(trip, oq.time_per_task, split_level)
                         self.n_outs[grp_id] += split_level
                     else:
-                        smap.submit(trip)
-                        self.n_outs[grp_id] += 1
+                        for src in block:
+                            trip = ([src], sids, cmakers[grp_id])
+                            triples.append(trip)
+                            smap.submit(trip)
+                            self.n_outs[grp_id] += 1
         logging.info('grp_id->n_outs: %s', list(self.n_outs.values()))
         return smap
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -536,17 +536,14 @@ class ClassicalCalculator(base.HazardCalculator):
                     logging.debug(
                         'Sending %d source(s) with weight %d',
                         len(block), sum(src.weight for src in block))
+                    trip = (block, sids, cmakers[grp_id])
+                    triples.append(trip)
                     if len(block) >= split_level and not oq.disagg_by_src:
-                        trip = (block, sids, cmakers[grp_id])
-                        triples.append(trip)
                         smap.submit_split(trip, oq.time_per_task, split_level)
                         self.n_outs[grp_id] += split_level
                     else:
-                        for src in block:
-                            trip = ([src], sids, cmakers[grp_id])
-                            triples.append(trip)
-                            smap.submit(trip)
-                            self.n_outs[grp_id] += 1
+                        smap.submit(trip)
+                        self.n_outs[grp_id] += 1
         logging.info('grp_id->n_outs: %s', list(self.n_outs.values()))
         return smap
 

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -459,9 +459,13 @@ class SourceFilter(object):
                 idist = self.integration_distance(
                     src.tectonic_region_type, rup.mag)
                 src.weight += (dists <= idist).sum()
+        for src in sources:
             if hasattr(src, 'pointsources'):
                 # make CollapsedPointSource heavier
                 src.weight *= 3
+            elif not hasattr(src, 'location'):
+                # make non point sources even heavier
+                src.weight *= 10
 
     def get_nsites(self, rup):
         """


### PR DESCRIPTION
Here is an example for the calculation job_share_small.ini where the slowest tasks gets 2x-7x faster:
```
# before
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 7      | 421.8   | 53%    | 84.8    | 708.5   | 1.67977 |
| split_task         | 190    | 85.0    | 80%    | 0.00533 | 702.1   | 8.25481 |

# after
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 13     | 46.5    | 108%   | 0.00210 | 109.7   | 2.35781 |
| split_task         | 179    | 106.3   | 69%    | 0.07454 | 351.4   | 3.30692 |
```