### PR TITLE
Edit an error message regarding taxonomy strings in base.py

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -823,13 +823,13 @@ class HazardCalculator(BaseCalculator):
                     for taxo, weight in items:
                         if taxo != '?':
                             taxonomies.add(taxo)
-            # check that we are covering all the taxonomies in the exposure
+            # check that we are covering all the taxonomy strings in the exposure
             missing = taxonomies - set(self.crmodel.taxonomies)
             if self.crmodel and missing:
-                raise RuntimeError('The exposure contains the taxonomies %s '
+                raise RuntimeError('The exposure contains the taxonomy strings %s '
                                    'which are not in the risk model' % missing)
             if len(self.crmodel.taxonomies) > len(taxonomies):
-                logging.info('Reducing risk model from %d to %d taxonomies',
+                logging.info('Reducing risk model from %d to %d taxonomy strings',
                              len(self.crmodel.taxonomies), len(taxonomies))
                 self.crmodel = self.crmodel.reduce(taxonomies)
                 self.crmodel.tmap = tmap

--- a/openquake/hazardlib/shakemap/maps.py
+++ b/openquake/hazardlib/shakemap/maps.py
@@ -137,7 +137,7 @@ def check_required_imts(required_imts, available_imts):
     if missing:
         msg = ('The IMT %s is required but not in the available set %s, '
                'please change the risk model otherwise you will have '
-               'incorrect zero losses for the associated taxonomies' %
+               'incorrect zero losses for the associated taxonomy strings' %
                (missing.pop(), ', '.join(available_imts)))
         raise RuntimeError(msg)
 


### PR DESCRIPTION
'taxonomies' would imply different building classification systems like the GEM Taxonomy and HAZUS Taxonomy. Instead, the phrase 'taxonomy strings' might be more apt for these logging/error messages.