### PR TITLE
Added a check on the mesh size of MultiFaultSources and NonParametricSources

### DIFF
--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -298,6 +298,11 @@ def _get_csm(full_lt, groups):
         for sources in general.groupby(lst, trt_smrs).values():
             # set ._wkt attribute (for later storage in the source_wkt dataset)
             for src in sources:
+                # check on MultiFaultSources and NonParametricSources
+                mesh_size = getattr(src, 'mesh_size', 0)
+                if mesh_size > 1E6:
+                    msg = '{} has an underlying mesh with {:_d} points!'
+                    logging.warning(msg.format(src.source_id, mesh_size))
                 src._wkt = src.wkt()
             src_groups.append(sourceconverter.SourceGroup(trt, sources))
     for ag in atomic:

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -301,7 +301,7 @@ def _get_csm(full_lt, groups):
                 # check on MultiFaultSources and NonParametricSources
                 mesh_size = getattr(src, 'mesh_size', 0)
                 if mesh_size > 1E6:
-                    msg = '{} has an underlying mesh with {:_d} points!'
+                    msg = 'src "{}" has an underlying mesh with {:_d} points!'
                     logging.warning(msg.format(src.source_id, mesh_size))
                 src._wkt = src.wkt()
             src_groups.append(sourceconverter.SourceGroup(trt, sources))

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -154,3 +154,4 @@ class MultiFaultSource(BaseSeismicSource):
 
     polygon = NP.polygon
     wkt = NP.wkt
+    mesh_size = NP.mesh_size

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -183,6 +183,20 @@ class NonParametricSeismicSource(BaseSeismicSource):
             self.__class__.__name__, self.source_id, self.is_gridded())
 
     @property
+    def mesh_size(self):
+        """
+        :returns: the number of points in the underlying mesh
+        """
+        n = 0
+        for rup, pmf in self.data:
+            if isinstance(rup.surface, MultiSurface):
+                for sfc in rup.surface.surfaces:
+                    n += len(sfc.mesh)
+            else:
+                n += len(rup.surface.mesh)
+        return n
+
+    @property
     def polygon(self):
         """
         The convex hull of the underlying mesh of points


### PR DESCRIPTION
I see that most sources in the CHN model have underlying sources with over 1 million points. This is a performance killer and I strongly doubt that we really need so many points. Here are warnings that you will get now (all of them):
```
[#3217 INFO] Received {'tot': '183.6 MB'} in 133 seconds from read_source_model
[#3217 WARNING] 0 has an underlying mesh with 11_915_449 points!
[#3217 WARNING] 1 has an underlying mesh with 8_030_973 points!
[#3217 WARNING] 10 has an underlying mesh with 4_376_905 points!
[#3217 WARNING] 2 has an underlying mesh with 11_760_527 points!
[#3217 WARNING] 3 has an underlying mesh with 3_827_682 points!
[#3217 WARNING] 4 has an underlying mesh with 2_982_465 points!
[#3217 WARNING] 5 has an underlying mesh with 3_716_208 points!
[#3217 WARNING] 6 has an underlying mesh with 3_928_594 points!
[#3217 WARNING] 7 has an underlying mesh with 2_915_630 points!
[#3217 WARNING] 8 has an underlying mesh with 4_695_673 points!
[#3217 WARNING] 9 has an underlying mesh with 4_859_073 points!
```
It will probably be a good idea to turn such warnings into errors once the model is fixed. Such ultra-large meshes are also memory hogs.