### PR TITLE
Fixed the task names when using task_splitting

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -480,7 +480,7 @@ def safely_call(func, args, task_no=0, mon=dummy_mon):
         assert not isgenfunc, func
         return Result.new(func, args, mon)
 
-    if mon.operation.startswith(func.__name__):
+    if mon.operation.endswith('_split'):
         name = mon.operation
     else:
         name = func.__name__

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -479,7 +479,12 @@ def safely_call(func, args, task_no=0, mon=dummy_mon):
     if mon is dummy_mon:  # in the DbServer
         assert not isgenfunc, func
         return Result.new(func, args, mon)
-    mon = mon.new(operation='total ' + mon.operation, measuremem=True)
+
+    if mon.operation.startswith(func.__name__):
+        name = mon.operation
+    else:
+        name = func.__name__
+    mon = mon.new(operation='total ' + name, measuremem=True)
     mon.weight = getattr(args[0], 'weight', 1.)  # used in task_info
     mon.task_no = task_no
     if mon.inject:

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -184,7 +184,6 @@ import os
 import re
 import ast
 import sys
-import copy
 import time
 import socket
 import signal


### PR DESCRIPTION
The info in `oq show task_info` and `oq show performance` was wrong since the same task name (`split_task`) was used for different kinds of tasks (in the classical and preclassical phases, respectively). The issue was due to the confusion between task name and monitor operation. Also, avoided passing a non-used monitor.