### PR TITLE
Many small improvements to the source weights

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Enforced ps_grid_spacing <= pointsource_distance
   * Internal: added command `oq plot source_data?`
   * The engine is now splitting the MultiFaultSources, thus improving the task
     distribution

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -421,7 +421,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 self.csm = parent['_csm']
                 self.full_lt = parent['full_lt']
                 self.datastore['source_info'] = parent['source_info'][:]
-                tot, max_weight = self.csm.get_tot_max(oq)
+                max_weight = self.csm.get_max_weight(oq)
         else:
             max_weight = self.max_weight
         self.create_dsets()  # create the rup/ datasets BEFORE swmr_on()

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -509,7 +509,7 @@ def extract_source_data(dstore, what):
         sel = {'taskno': int(qdict['taskno'][0])}
     else:
         sel = {}
-    df = dstore.read_df('source_data', 'srcids', sel=sel).sort_values('ctimes')
+    df = dstore.read_df('source_data', 'src_id', sel=sel).sort_values('ctimes')
     dic = {col: df[col].to_numpy() for col in df.columns}
     return ArrayWrapper(df.index.to_numpy(), dic)
 

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -40,7 +40,7 @@ TWO32 = 2 ** 32
 def zero_times(sources):
     source_data = AccumDict(accum=[])
     for src in sources:
-        source_data['srcids'].append(src.source_id)
+        source_data['src_id'].append(src.source_id)
         source_data['nsites'].append(src.nsites)
         source_data['nrupts'].append(src.num_ruptures)
         source_data['weight'].append(src.weight)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -110,8 +110,7 @@ def run_preclassical(calc):
     for sg in csm.src_groups:
         grp_id = sg.sources[0].grp_id
         if sg.atomic:
-            sf = SourceFilter(sites, cmakers[grp_id].maximum_distance)
-            cmakers[grp_id].set_weight(sg, sf)
+            cmakers[grp_id].set_weight(sg, sites)
             atomic_sources.extend(sg)
         else:
             normal_sources.extend(sg)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -244,7 +244,7 @@ class PreClassicalCalculator(base.HazardCalculator):
         tectonic region type.
         """
         run_preclassical(self)
-        tot, self.max_weight = self.csm.get_tot_max(self.oqparam)
+        self.max_weight = self.csm.get_max_weight(self.oqparam)
         return self.csm
 
     def post_execute(self, csm):

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -64,7 +64,7 @@ def get_dists(dstore):
     rup = dstore['rup']
     for sids, dsts in zip(rup['sids_'], rup['rrup_']):
         for sid, dst in zip(sids, dsts):
-            dic[sid].append(int(round(dst)))
+            dic[sid].append(round(dst, 1))
     return {sid: sorted(dsts, reverse=True) for sid, dsts in dic.items()}
 
 
@@ -654,67 +654,50 @@ hazard_uhs-std.csv
         # (even if their true distances are around 109 km!)
         self.run_calc(case_48.__file__, 'job.ini')
         # 20 exact rrup distances for site 0 and site 1 respectively
-        exact = numpy.array([[54.1249, 109.704],
-                             [54.2632, 109.753],
-                             [53.7378, 109.321],
-                             [53.8517, 109.357],
-                             [53.2577, 108.842],
-                             [53.3404, 108.863],
-                             [52.6774, 108.255],
-                             [52.7076, 108.245],
-                             [51.9595, 107.525],
-                             [51.9044, 107.461],
-                             [50.5455, 106.076],
-                             [50.4445, 105.979],
-                             [47.7896, 103.201],
-                             [47.6827, 103.101],
-                             [43.7002, 98.7525],
-                             [43.5834, 98.6488],
-                             [38.1556, 92.0187],
-                             [38.0217, 91.9073],
-                             [32.9537, 82.3458],
-                             [32.7986, 82.2214]])
+        expect = numpy.array([[54.3, 109.8],
+                             [54.1, 109.7],
+                             [53.9, 109.4],
+                             [53.7, 109.3],
+                             [53.3, 108.9],
+                             [53.3, 108.8],
+                             [52.7, 108.3],
+                             [52.7, 108.2],
+                             [52.0, 107.5],
+                             [51.9, 107.5],
+                             [50.5, 106.1],
+                             [50.4, 106.0],
+                             [47.8, 103.2],
+                             [47.7, 103.1],
+                             [43.7, 98.8],
+                             [43.6, 98.6],
+                             [38.2, 92.0],
+                             [38.0, 91.9],
+                             [33.0, 82.3],
+                             [32.8, 82.2]])
         dst = get_dists(self.calc.datastore)
-        aac(dst[0], exact[:, 0], atol=.5)  # site 0
-        aac(dst[1], exact[:, 1], atol=.5)  # site 1
+        aac(dst[0], expect[:, 0], atol=.05)  # site 0
+        aac(dst[1], expect[:, 1], atol=.05)  # site 1
 
-        # This test shows in detail what happens to the distances in presence
-        # of a magnitude-dependent pointsource_distance.
-        self.run_calc(
-            case_48.__file__, 'job.ini', pointsource_distance=
-            '{"default": [(5.1, 42), (5.3, 47), (5.5, 52), (5.7, 58), '
-            '(5.9, 65), (6.1, 72), (6.3, 80), (6.5, 89), (6.7, 99), '
-            '(6.900001, 110)]}')
+        # This test shows in detail what happens to the distances
+        # in presence of a pointsource_distance
+        self.run_calc(case_48.__file__, 'job.ini', pointsource_distance='50')
 
-        psdist = self.calc.oqparam.pointsource_distance('default')
-        rup_df = self.calc.datastore.read_df('rup')
-        mags = rup_df.mag.unique()
-        dists = psdist(mags)
-        aac(dists, [42, 47, 52, 58, 65, 72, 80, 89, 99, 110], rtol=1E-6)
-
-        # 17 approx rrup distances for site 0 and site 1 respectively
-        approx = numpy.array([[54.1525, 109.711],
-                              [53.7572, 109.324],
-                              [53.2665, 108.84],
-                              [52.6774, 108.255],
-                              [52.7076, 108.245],
-                              [51.9595, 107.525],
-                              [51.9044, 107.461],
-                              [50.5455, 106.076],
-                              [50.4445, 105.979],
-                              [47.7896, 103.201],
-                              [47.6827, 103.101],
-                              [43.7002, 98.7525],
-                              [43.5834, 98.6488],
-                              [38.1556, 92.0187],
-                              [38.0217, 91.9073],
-                              [32.9537, 82.3458],
-                              [32.7986, 82.2214]])
+        # 10 approx rrup distances for site 0 and site 1 respectively
+        approx = numpy.array([[54.2, 109.7],
+                              [53.8, 109.3],
+                              [53.3, 108.8],
+                              [52.7, 108.2],
+                              [51.9, 107.5],
+                              [50.5, 106.0],
+                              [47.8, 103.2],
+                              [43.7, 98.7],
+                              [38.1, 92.0],
+                              [32.9, 82.3]])
 
         # approx distances from site 0 and site 1 respectively
         dst = get_dists(self.calc.datastore)
-        aac(dst[0], approx[:, 0], atol=.5)  # site 0
-        aac(dst[1], approx[:, 1], atol=.5)  # site 1
+        aac(dst[0], approx[:, 0], atol=.05)  # site 0
+        aac(dst[1], approx[:, 1], atol=.05)  # site 1
 
     def test_case_49(self):
         # serious test of amplification + uhs

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -174,11 +174,12 @@ def view_worst_sources(token, dstore):
         step = int(token.split(':')[1])
     else:
         step = 1
-    data = dstore.read_df('source_data', 'srcids')
+    data = dstore.read_df('source_data', 'src_id')
     ser = data.groupby('taskno').ctimes.sum().sort_values().tail(1)
     [[taskno, maxtime]] = ser.to_dict().items()
-    print('Sources in the slowest task (%d seconds)' % maxtime)
     data = data[data.taskno == taskno]
+    print('Sources in the slowest task (%d seconds, weight=%d)'
+          % (maxtime, data['weight'].sum()))
     data['slow_rate'] = data.ctimes / data.weight
     df = data.sort_values('slow_rate', ascending=False)
     return df[slice(None, None, step)]
@@ -683,12 +684,12 @@ def view_source_data(token, dstore):
      $ oq show source_data:42
     """
     if ':' not in token:
-        return dstore.read_df(token, 'srcids')
+        return dstore.read_df(token, 'src_id')
     _, taskno = token.split(':')
     taskno = int(taskno)
     if 'source_data' not in dstore:
         return 'Missing source_data'
-    df = dstore.read_df('source_data', 'srcids', sel={'taskno': taskno})
+    df = dstore.read_df('source_data', 'src_id', sel={'taskno': taskno})
     del df['taskno']
     df['slowrate'] = df['ctimes'] / df['weight']
     return df.sort_values('ctimes')

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -896,7 +896,6 @@ class OqParam(valid.ParamSet):
     split_sources = valid.Param(valid.boolean, True)
     split_level = valid.Param(valid.positiveint, 4)
     ebrisk_maxsize = valid.Param(valid.positivefloat, 2E10)  # used in ebrisk
-    min_weight = valid.Param(valid.positiveint, 1)  # used in classical
     time_event = valid.Param(str, None)
     time_per_task = valid.Param(valid.positivefloat, 600)
     truncation_level = valid.Param(valid.NoneOr(valid.positivefloat), None)

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -242,8 +242,8 @@ def _build_groups(full_lt, smdict):
 
         # check applyToSources
         sm_branch = rlz.lt_path[0]
-        srcids = full_lt.source_model_lt.info.applytosources[sm_branch]
-        for srcid in srcids:
+        src_id = full_lt.source_model_lt.info.applytosources[sm_branch]
+        for srcid in src_id:
             if srcid not in source_ids:
                 raise ValueError(
                     "The source %s is not in the source model,"
@@ -419,7 +419,7 @@ class CompositeSourceModel:
         Update (eff_ruptures, num_sites, calc_time) inside the source_info
         """
         for src_id, nsites, nrupts, weight, ctimes in zip(
-                source_data['srcids'], source_data['nsites'],
+                source_data['src_id'], source_data['nsites'],
                 source_data['nrupts'], source_data['weight'],
                 source_data['ctimes']):
             row = self.source_info[src_id.split(':')[0]]

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -215,7 +215,7 @@ def sample_cluster(sources, srcfilter, num_ses, param):
                     rup_counter[src_id][rup.idx] += 1
                 # Store info
                 dt = time.time() - t0
-                source_data['srcids'].append(src.source_id)
+                source_data['src_id'].append(src.source_id)
                 source_data['nsites'].append(src.nsites)
                 source_data['nrups'].append(len(rup_data[src_id]))
                 source_data['ctimes'].append(dt)
@@ -285,7 +285,7 @@ def sample_ruptures(sources, cmaker, sitecol=None, monitor=Monitor()):
                 ebr = EBRupture(rup, src.source_id, trt_smr, n_occ)
                 eb_ruptures.append(ebr)
             dt = time.time() - t0
-            source_data['srcids'].append(src.source_id)
+            source_data['src_id'].append(src.source_id)
             source_data['nsites'].append(src.nsites)
             source_data['nrups'].append(nr)
             source_data['ctimes'].append(dt)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -42,7 +42,8 @@ from openquake.hazardlib.tom import registry
 from openquake.hazardlib.site import site_param_dt
 from openquake.hazardlib.stats import _truncnorm_sf
 from openquake.hazardlib.calc.filters import (
-    IntegrationDistance, magdepdist, get_distances, getdefault, MINMAG, MAXMAG)
+    SourceFilter, IntegrationDistance, magdepdist, get_distances, getdefault,
+    MINMAG, MAXMAG)
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.geo.surface import PlanarSurface
 
@@ -727,6 +728,8 @@ class ContextMaker(object):
         """
         Set the weight attribute on each prefiltered source
         """
+        if hasattr(srcfilter, 'array'):  # a SiteCollection was passed
+            srcfilter = SourceFilter(srcfilter, self.maximum_distance)
         for src in sources:
             src.num_ruptures = src.count_ruptures()
             if src.nsites == 0:  # was discarded by the prefiltering

--- a/openquake/hazardlib/tests/contexts_test.py
+++ b/openquake/hazardlib/tests/contexts_test.py
@@ -16,11 +16,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import unittest
 import numpy
+from openquake.baselib.general import DictArray
+from openquake.hazardlib import read_input
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.const import TRT
-from openquake.baselib.general import DictArray
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.contexts import (
     Effect, RuptureContext, _collapse, ContextMaker, get_distances,
@@ -45,6 +47,7 @@ intensities = {
     '5.5': numpy.array([1.5, 1.2, .89, .85, .82, .6]),
     '6.0': numpy.array([2.0, 1.5, .9, .85, .81, .6])}
 tom = PoissonTOM(50.)
+JOB = os.path.join(os.path.dirname(__file__), 'data/context/job.ini')
 
 
 class ClosestPointOnTheRuptureTestCase(unittest.TestCase):
@@ -225,3 +228,9 @@ class CollapseTestCase(unittest.TestCase):
         cmaker.tom = PoissonTOM(time_span=50)
         pmap = cmaker.get_pmap(ctxs)
         numpy.testing.assert_almost_equal(pmap[0].array, 0.066381)
+
+
+class CountEffRupsTextCase(unittest.TestCase):
+    def test(self):
+        read_input()
+        

--- a/openquake/hazardlib/tests/contexts_test.py
+++ b/openquake/hazardlib/tests/contexts_test.py
@@ -230,7 +230,12 @@ class CollapseTestCase(unittest.TestCase):
         numpy.testing.assert_almost_equal(pmap[0].array, 0.066381)
 
 
-class CountEffRupsTextCase(unittest.TestCase):
+class SetWeightTestCase(unittest.TestCase):
     def test(self):
-        read_input()
-        
+        inp = read_input(JOB)
+        [[trt, cmaker]] = inp.cmakerdict.items()
+        [[area]] = inp.groups  # there is a single AreaSource
+        srcs = list(area)  # split in 3+3 PointSources
+        cmaker.set_weight(srcs, inp.sitecol)
+        weights = [src.weight for src in srcs]  # 3 within, 3 outside
+        self.assertEqual(weights, [10.1, 10.1, 10.1, 0.1, 0.1, 0.1])

--- a/openquake/hazardlib/tests/data/context/job.ini
+++ b/openquake/hazardlib/tests/data/context/job.ini
@@ -6,7 +6,7 @@ random_seed = 23
 
 [geometry]
 
-sites = 0.0 0.0
+sites = 0.0 1.0
 
 [logic_tree]
 
@@ -14,7 +14,6 @@ number_of_logic_tree_samples = 0
 
 [erf]
 
-rupture_mesh_spacing = 2
 width_of_mfd_bin = 0.2
 area_source_discretization = 10.0
 shift_hypo = true
@@ -28,12 +27,13 @@ reference_depth_to_1pt0km_per_sec = 100.0
 
 [calculation]
 
-source_model_logic_tree_file = source_model_logic_tree.xml
+source_model_file = source_model.xml
 gsim_logic_tree_file = gmpe_logic_tree.xml
 investigation_time = 50.0
 intensity_measure_types_and_levels = {"PGA": logscale(0.005, 2.13, 20)}
 truncation_level = 3
-maximum_distance = 200.0
+maximum_distance = 115
+pointsource_distance = {'default': 50}
 
 [output]
 

--- a/openquake/hazardlib/tests/data/context/source_model.xml
+++ b/openquake/hazardlib/tests/data/context/source_model.xml
@@ -11,7 +11,7 @@ xmlns:gml="http://www.opengis.net/gml"
                         <gml:exterior>
                             <gml:LinearRing>
                                 <gml:posList>
-                                    -0.1 -0.1 0.1 -0.1 0.1 0.1 -0.1 0.1
+                                    -0.2 -0.1 0.1 -0.1 0.1 0.1 -0.2 0.1
                                 </gml:posList>
                             </gml:LinearRing>
                         </gml:exterior>


### PR DESCRIPTION
- extended `hazardlib.read_input` to read simple job.ini files
- added a test for `ContextMaker.set_weight`
- some renaming
- reduced number of tasks when there are many cores
- improved view `worst_sources`
- made the `pointsource_distance` mag-independent
- added the constraint `ps_grid_spacing <= pointsource_distance`