### PR TITLE
Fixed slow tasks in the China model

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -705,7 +705,7 @@ class ContextMaker(object):
             return nrups if N == 1 else 0
         nsites = numpy.array([len(ctx) for ctx in ctxs])
         mesh_size = getattr(src, 'mesh_size', 0)  # for NP and MF sources
-        return (nrups + mesh_size / 1000) * numpy.mean(nsites / N + .001)
+        return (nrups + mesh_size / 500) * numpy.mean(nsites / N + .001)
 
     def set_weight(self, sources, srcfilter):
         """
@@ -719,7 +719,7 @@ class ContextMaker(object):
                 src.weight = .001
             else:
                 src.weight = .1 + self.estimate_weight(src, srcfilter)
-            if src.code in b'CSF':
+            if src.code in b'CS':
                 src.weight += 2
 
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -704,7 +704,8 @@ class ContextMaker(object):
         if not ctxs:
             return nrups if N == 1 else 0
         nsites = numpy.array([len(ctx) for ctx in ctxs])
-        return nrups * numpy.mean(nsites / N + .001)
+        mesh_size = getattr(src, 'mesh_size', 0)  # for NP and MF sources
+        return (nrups + mesh_size / 1000) * numpy.mean(nsites / N + .001)
 
     def set_weight(self, sources, srcfilter):
         """

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -140,7 +140,7 @@ class MultiFaultSource(BaseSeismicSource):
         Fast version of iter_ruptures used in estimate_weight
         """
         s = self.sections
-        for i in range(0, len(self.mags), BLOCKSIZE // 2):
+        for i in range(0, len(self.mags), BLOCKSIZE // 5):
             idxs = self.rupture_idxs[i]
             if len(idxs) == 1:
                 sfc = self.sections[idxs[0]].surface

--- a/openquake/hazardlib/tests/contexts_test.py
+++ b/openquake/hazardlib/tests/contexts_test.py
@@ -239,4 +239,4 @@ class SetWeightTestCase(unittest.TestCase):
         cmaker.set_weight(srcs, inp.sitecol)
         weights = [src.weight for src in srcs]  # 3 within, 3 outside
         numpy.testing.assert_allclose(
-            weights, [10.11, 10.11, 10.11, 0.1, 0.1, 0.1])
+            weights, [2.102, 2.102, 2.102, 0.1, 0.1, 0.1])


### PR DESCRIPTION
By changing the weight of MultiFaultSources and NonParametricSources. Also, made faster the computation of the weight for CollapsedPointSources. This is the situation on the spot machine:
```
| operation-duration | counts |    mean | stddev |       min |     max | slowfac |
|--------------------+--------+---------+--------+-----------+---------+---------|
| classical          |    578 |   660.2 |    24% |     231.5 |   1_218 | 1.84510 |
| preclassical       |     24 |    87.6 |   153% | 1.805E-04 |   399.6 | 4.56189 |
```