### PR TITLE
Fixed property MultiSurface.mesh

### DIFF
--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -121,17 +121,16 @@ class MultiSurface(BaseSurface):
         """
         :returns: mesh corresponding to the whole multi surface
         """
-        meshes = [surface.mesh for surface in self.surfaces]
         lons = []
         lats = []
         deps = []
-        for m in meshes:
-            for lo, la, de in zip(m.lons, m.lats, m.depths):
-                if numpy.isfinite(lo) and numpy.isfinite(la):
-                    lons.append(lo)
-                    lats.append(la)
-                    deps.append(de)
-        return Mesh(numpy.array(lons), numpy.array(lats), numpy.array(deps))
+        for m in [surface.mesh for surface in self.surfaces]:
+            ok = numpy.isfinite(m.lons) & numpy.isfinite(m.lats)
+            lons.append(m.lons[ok])
+            lats.append(m.lats[ok])
+            deps.append(m.depths[ok])
+        return Mesh(numpy.concatenate(lons), numpy.concatenate(lats),
+                    numpy.concatenate(deps))
 
     def __init__(self, surfaces, tol=0.1):
         """


### PR DESCRIPTION
The "and" was wrong in case of a RectangularMesh which contains 2D arrays. Also, this is the clean (vectorized) way to do it.