### PR TITLE
Improved task splitting in classical calculations

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -502,7 +502,7 @@ class ClassicalCalculator(base.HazardCalculator):
                     split_level = (oq.split_level
                                    if len(block) >= oq.split_level
                                    else len(block))
-                    if oq.disagg_by_src:
+                    if split_level > 1 and not oq.disagg_by_src:
                         smap.submit_split(trip, oq.time_per_task, split_level)
                         self.n_outs[grp_id] += split_level
                     else:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -479,7 +479,6 @@ class ClassicalCalculator(base.HazardCalculator):
         smap = parallel.Starmap(classical, h5=self.datastore.hdf5)
         smap.monitor.save('sitecol', self.sitecol)
         triples = []
-        split_level = oq.split_level
         for grp_id in self.grp_ids:
             sg = self.csm.src_groups[grp_id]
             if sg.atomic:
@@ -500,7 +499,10 @@ class ClassicalCalculator(base.HazardCalculator):
                         len(block), sum(src.weight for src in block))
                     trip = (block, sids, cmakers[grp_id])
                     triples.append(trip)
-                    if len(block) >= split_level and not oq.disagg_by_src:
+                    split_level = (oq.split_level
+                                   if len(block) >= oq.split_level
+                                   else len(block))
+                    if oq.disagg_by_src:
                         smap.submit_split(trip, oq.time_per_task, split_level)
                         self.n_outs[grp_id] += split_level
                     else:

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -657,7 +657,7 @@ split_sources:
 split_level:
   How many outputs per task to generate (honored in some calculators)
   Example: *split_level = 3*
-  Default: 5
+  Default: 4
 
 std:
   Compute the standard deviation  across realizations. Akin to mean and max.
@@ -890,7 +890,7 @@ class OqParam(valid.ParamSet):
     spatial_correlation = valid.Param(valid.Choice('yes', 'no', 'full'), 'yes')
     specific_assets = valid.Param(valid.namelist, [])
     split_sources = valid.Param(valid.boolean, True)
-    split_level = valid.Param(valid.positiveint, 5)
+    split_level = valid.Param(valid.positiveint, 4)
     ebrisk_maxsize = valid.Param(valid.positivefloat, 2E10)  # used in ebrisk
     time_event = valid.Param(str, None)
     time_per_task = valid.Param(valid.positivefloat, 600)


### PR DESCRIPTION
Tasks with few large sources were not split. This is solved now. Here is the difference for the Georgia calculation before and after:
```
| operation-duration | counts | mean    | stddev | min       | max     | slowfac |
|--------------------+--------+---------+--------+-----------+---------+---------|
| classical          | 675    | 691.6   | 65%    | 0.00810   | 3_930   | 5.68273 |
| classical          | 647    | 716.6   | 29%    | 0.00721   | 1_946   | 2.71606 |
```