### PR TITLE
Fixed datadir for the user openquake to /opt/openquake/oqdata

### DIFF
--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -63,7 +63,11 @@ def get_datadir():
     if not datadir:
         shared_dir = config.directory.shared_dir
         if shared_dir:
-            datadir = os.path.join(shared_dir, getpass.getuser(), 'oqdata')
+            user = getpass.getuser()
+            if user == 'openquake':  # use /opt/openquake/oqdata
+                datadir = os.path.join(shared_dir, 'oqdata')
+            else:
+                datadir = os.path.join(shared_dir, user, 'oqdata')
         else:  # use the home of the user
             datadir = os.path.join(os.path.expanduser('~'), 'oqdata')
     return datadir


### PR DESCRIPTION
It was creating `/opt/openquake/openquake/oqdata` instead.