### PR TITLE
Extended `oq postzip` to multiple files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Extended `oq postzip` to multiple files
   * Internal: changed install.py to install the venv in /opt/openquake/venv
   * Fixed a BOM issue on Windows when reading job.ini files
 


### PR DESCRIPTION
So that we can use the one-liner `find mosaic -name \*.ini | xargs oq postzip`