### PR TITLE
Speeding up `MultiFaultSource.get_bounding_box`

### DIFF
--- a/.github/workflows/engine_test.yml
+++ b/.github/workflows/engine_test.yml
@@ -25,6 +25,7 @@ jobs:
         pip install pytest
         pip install fiona
         pip install -r requirements-py39-linux64.txt && pip install -e .
+        python -c'import shapely as s; print("shapely=%s" % s.__version__)'
     - name: Test with pytest
       run: |
         oq dbserver start

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -24,8 +24,7 @@ from openquake.hazardlib.geo.surface.gridded import GriddedSurface
 from openquake.hazardlib.geo.surface.multi import MultiSurface
 from openquake.hazardlib.source.rupture import \
     NonParametricProbabilisticRupture
-from openquake.hazardlib.geo.utils import (angular_distance, KM_TO_DEGREES,
-                                           get_spherical_bounding_box)
+from openquake.hazardlib.geo.utils import angular_distance, KM_TO_DEGREES
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.pmf import PMF


### PR DESCRIPTION
By not calling .iter_ruptures implicitly. Part of https://github.com/gem/oq-engine/issues/7523. The improvement on UCERF3 is spectacular (calculations #45262 vs #45263 on cluster1, effect of fixing the bounding box,  `.polygon` and `.mesh_size`):

PreClassicalCalculator.run before: 108_308s
PreClassicalCalculator.run after: 8_789s
speedup: 12x, from 30 hours to 2.5 hours