### PR TITLE
Optimizing gmpe_table._get_mean

### DIFF
--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -50,11 +50,8 @@ def _get_mean_(kind, data, dists, table_dists):
     :return:
         The mean intensity measure level from the tables.
     """
-    # For values outside of the interpolation range use -999. to ensure
     # value is identifiable and outside of potential real values
-    interpolator_mean = interp1d(
-        table_dists, data, bounds_error=False, fill_value=-999.)
-    mean = interpolator_mean(dists)
+    mean = numpy.interp(dists, table_dists, data)
     # For those distances less than or equal to the shortest distance
     # extrapolate the shortest distance value
     mean[dists < (table_dists[0] + 1.0E-3)] = data[0]


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/7153. The calculation for Canada is a lot faster now (computing mean_std = 0.63 times as before, i.e. 37% faster).
```
| calc_44674, maxmem=87.5 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 628_846  | 370.4     | 1_174      |
| computing mean_std         | 371_381  | 0.0       | 714_752    |
| get_poes                   | 132_252  | 0.0       | 35_566_874 |
| composing pnes             | 87_693   | 0.0       | 35_566_874 |
| make_contexts              | 36_023   | 187.6     | 40_030     |
| total postclassical        | 7_884    | 25.3      | 240        |
| ClassicalCalculator.run    | 6_147    | 5_227     | 1          |
```