### PR TITLE
Collapsing the contexts/3

### DIFF
--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -612,7 +612,7 @@ hazard_uhs-std.csv
         self.run_calc(case_43.__file__, 'job.ini',
                       hazard_calculation_id=hc_id)
         data = self.calc.datastore.read_df('source_data')
-        self.assertEqual(data.nrupts.sum(), 538)  # number of contexts
+        self.assertEqual(data.nrupts.sum(), 164)  # number of contexts
         [fname] = export(('hcurves/mean', 'csv'), self.calc.datastore)
         self.assertEqualFiles("expected/hazard_curve-mean-PGA.csv", fname)
         [fname] = export(('hmaps/mean', 'csv'), self.calc.datastore)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -877,7 +877,8 @@ class PmapMaker(object):
             ctxs = self._get_ctxs(cm._gen_rups(src, sites), sites, src.id)
             nctxs = len(ctxs)
             nsites = sum(len(ctx) for ctx in ctxs)
-            cm.get_pmap(ctxs, pmap)
+            if nsites:
+                cm.get_pmap(ctxs, pmap)
             dt = time.time() - t0
             self.source_data['src_id'].append(src.source_id)
             self.source_data['nsites'].append(nsites)
@@ -897,7 +898,8 @@ class PmapMaker(object):
             ctxs = self._get_ctxs(cm._ruptures(src), sites, src.id)
             nctxs = len(ctxs)
             nsites = sum(len(ctx) for ctx in ctxs)
-            cm.get_pmap(ctxs, pm)
+            if nsites:
+                cm.get_pmap(ctxs, pm)
             p = pm
             if cm.rup_indep:
                 p = ~p

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -252,6 +252,7 @@ class ContextMaker(object):
                 gsim.set_tables(self.mags, self.imtls)
         self.maximum_distance = _interp(param, 'maximum_distance', trt)
         self.dist_bins = valid.sqrscale(0, self.maximum_distance(10), 100)
+        self.cfactor = numpy.zeros(2)  # used to compute the collapse factor
         if 'pointsource_distance' not in param:
             self.pointsource_distance = 1000.
         else:

--- a/openquake/hazardlib/tests/data/context/job.ini
+++ b/openquake/hazardlib/tests/data/context/job.ini
@@ -15,7 +15,7 @@ number_of_logic_tree_samples = 0
 [erf]
 
 width_of_mfd_bin = 0.2
-area_source_discretization = 1.0
+area_source_discretization = 10.
 shift_hypo = true
 
 [site_params]

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -112,7 +112,7 @@ class CollapseTestCase(unittest.TestCase):
         mean, srcs, effctxs, weights = self.full_enum()
         assert weights == [.2, .2, .6]
         assert scaling_rates(srcs) == [1, 1, 1]
-        self.assertEqual(effctxs, 7)
+        self.assertEqual(effctxs, 3)
 
         # compute the partially collapsed curve
         self.bs1.collapsed = True
@@ -120,7 +120,7 @@ class CollapseTestCase(unittest.TestCase):
         assert weights == [.4, .6]  # two rlzs
         # self.plot(mean, coll1)
         assert scaling_rates(srcs) == [1.0, 0.5, 0.5, 1.0]
-        self.assertEqual(effctxs, 9)
+        self.assertEqual(effctxs, 4)
         numpy.testing.assert_allclose(mean, coll1, atol=.1)
 
         # compute the fully collapsed curve
@@ -130,7 +130,7 @@ class CollapseTestCase(unittest.TestCase):
         assert weights == [1]  # one rlz
         # self.plot(mean, coll2)
         assert scaling_rates(srcs) == [0.4, 0.6, 0.5, 0.5]
-        self.assertEqual(effctxs, 9)
+        self.assertEqual(effctxs, 4)
         numpy.testing.assert_allclose(mean, coll2, atol=.21)  # big diff
 
     def plot(self, mean, coll):


### PR DESCRIPTION
Here is the improvement on a calculation on my workstation:
```
# master
| calc_47434, maxmem=3.0 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 3_136    | 20.4      | 84      |
| composing pnes             | 1_429    | 0.0       | 383_818 |
| get_poes                   | 701.5    | 0.0       | 191_909 |
| make_contexts              | 580.9    | 142.1     | 13_000  |
| computing mean_std         | 389.0    | 0.0       | 191_909 |
| ClassicalCalculator.run    | 379.3    | 179.6     | 1       |
# this branch
| calc_47447, maxmem=3.1 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 2_934    | 65.5      | 84      |
| composing pnes             | 1_395    | 0.0       | 114_326 |
| get_poes                   | 693.9    | 0.0       | 57_163  |
| make_contexts              | 577.6    | 107.8     | 13_000  |
| ClassicalCalculator.run    | 337.9    | 179.5     | 1       |
| computing mean_std         | 233.5    | 0.0       | 13_000  |
```
The trick is to reduce the number of calls by not calling split_by_mag unless necessary.