### PR TITLE
Collapsing the contexts/8

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1033,7 +1033,7 @@ def fast_agg3(structured_array, kfield, vfields=None, factor=None):
     return res
 
 
-def kmean(structured_array, kfield):
+def kmean(structured_array, kfield, uniq_indices_counts=()):
     """
     Given a structured array of N elements with a discrete kfield with
     K <= N unique values, returns a structured array of K elements
@@ -1041,8 +1041,11 @@ def kmean(structured_array, kfield):
     """
     allnames = structured_array.dtype.names
     assert kfield in allnames, kfield
-    uniq, indices, counts = numpy.unique(
-        structured_array[kfield], return_inverse=True, return_counts=True)
+    if uniq_indices_counts:
+        uniq, indices, counts = uniq_indices_counts
+    else:
+        uniq, indices, counts = numpy.unique(
+            structured_array[kfield], return_inverse=True, return_counts=True)
     dic = {}
     dtlist = []
     for name in allnames:

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1041,18 +1041,19 @@ def kmean(structured_array, kfield):
     """
     allnames = structured_array.dtype.names
     assert kfield in allnames, kfield
-    vfields = [name for name in allnames if name != kfield]
     uniq, indices, counts = numpy.unique(
         structured_array[kfield], return_inverse=True, return_counts=True)
     dic = {}
-    dtlist = [(kfield, structured_array.dtype[kfield])]
-    for name in vfields:
-        dic[name] = fast_agg(indices, structured_array[name])
+    dtlist = []
+    for name in allnames:
+        if name == kfield:
+            dic[kfield] = uniq
+        else:
+            dic[name] = fast_agg(indices, structured_array[name]) / counts
         dtlist.append((name, structured_array.dtype[name]))
     res = numpy.zeros(len(uniq), dtlist)
-    res[kfield] = uniq
     for name in dic:
-        res[name] = dic[name] / counts
+        res[name] = dic[name]
     return res
 
 

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1033,6 +1033,7 @@ def fast_agg3(structured_array, kfield, vfields=None, factor=None):
     return res
 
 
+# this is fast
 def kmean(structured_array, kfield, uniq_indices_counts=()):
     """
     Given a structured array of N elements with a discrete kfield with

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -380,23 +380,6 @@ def _idx_start_stop(integers):
     return numpy.array(out)
 
 
-def split_array(arr, ordered_indices):
-    """
-    :param arr: an array with N elements
-    :param indices: a set of ordered integers with repetitions
-    :returns: a list of K arrays, split on the integers
-
-    >>> arr = numpy.array([.1, .2, .3, .4, .5])
-    >>> idx = numpy.array([1, 1, 2, 2, 3])
-    >>> split_array(arr, idx)
-    [array([0.1, 0.2]), array([0.3, 0.4]), array([0.5])]
-    """
-    out = []
-    for idx, start, stop in _idx_start_stop(ordered_indices):
-        out.append(arr[start:stop])
-    return out
-
-
 # this is absurdly fast if you have numba
 def get_slices(uint32s):
     """
@@ -429,13 +412,20 @@ def _split3(uint32s, indices, counts, cumcounts):
     return out
 
 
-def split_array3(uint32s, indices, counts):
+def split_array(arr, indices, counts=None):
     """
-    :param uint32s: an array of N integers of kind uint32
-    :param indices: array of indices extracted from numpy.unique (size N)
-    :param counts: array of counts extracted from numpy.unique (size K)
-    :returns: a list of K arrays of integers of kind uint32
+    :param arr: an array with N elements
+    :param indices: a set of integers with repetitions
+    :param counts: if None the indices MUST be ordered
+    :returns: a list of K arrays, split on the integers
+
+    >>> arr = numpy.array([.1, .2, .3, .4, .5])
+    >>> idx = numpy.array([1, 1, 2, 2, 3])
+    >>> split_array(arr, idx)
+    [array([0.1, 0.2]), array([0.3, 0.4]), array([0.5])]
     """
+    if counts is None:  # ordered indices
+        return [arr[s1:s2] for i, s1, s2 in _idx_start_stop(indices)]
     cumcounts = counts.cumsum()
-    out = _split3(uint32s, indices, counts, cumcounts)
+    out = _split3(arr, indices, counts, cumcounts)
     return [out[s1:s2] for s1, s2 in zip(cumcounts, cumcounts + counts)]

--- a/openquake/baselib/tests/general_test.py
+++ b/openquake/baselib/tests/general_test.py
@@ -19,13 +19,14 @@
 """
 Test related to code in openquake/utils/general.py
 """
+import time
 import unittest.mock as mock
 import unittest
 import numpy
 from operator import attrgetter
 from collections import namedtuple
 from openquake.baselib.general import (
-    block_splitter, split_in_blocks, assert_close,
+    block_splitter, split_in_blocks, assert_close, kmean,
     deprecated, DeprecationWarning, cached_property, compress, decompress)
 
 
@@ -203,3 +204,41 @@ class CompressTestCase(unittest.TestCase):
     def test(self):
         a = dict(a=numpy.array([9999.]))
         self.assertEqual(a, decompress(compress(a)))
+
+
+class KmeanTestCase(unittest.TestCase):
+    def test_small(self):
+        # build a small structured array
+        dtlist = [('mdvbin', numpy.uint32), ('rake', numpy.float64),
+                  ('sids', numpy.uint32)]
+        N = 10
+        arr = numpy.zeros(N, dtlist)
+        rng = numpy.random.default_rng(42)
+        arr['mdvbin'] = rng.integers(50, size=N)
+        arr['rake'] = rng.random(N) * 360
+        arr['sids'] = rng.integers(1000, size=N)
+        sids = []
+        for rec in kmean(arr, 'mdvbin'):
+            sids.append(arr['sids'][arr['mdvbin'] == rec['mdvbin']])
+        expected_sids = [[450, 858, 631], [276], [554, 887], [92],
+                         [827], [227], [63]]
+        numpy.testing.assert_equal(sids, expected_sids)
+
+    def test_big(self):
+        # build a very large structured array
+        dtlist = [('mdvbin', numpy.uint32), ('rake', numpy.float64),
+                  ('sids', numpy.uint32)]
+        N = 10_000_000
+        arr = numpy.zeros(N, dtlist)
+        rng = numpy.random.default_rng(42)
+        arr['mdvbin'] = rng.integers(50, size=N)
+        arr['rake'] = rng.random(N) * 360
+        arr['sids'] = rng.integers(1000, size=N)
+        t0 = time.time()
+        mean = kmean(arr, 'mdvbin')
+        sids = []
+        for mdvbin in mean['mdvbin']:
+            sids.append(arr['sids'][arr['mdvbin'] == mdvbin])
+        print([len(s) for s in sids])
+        dt = time.time() - t0
+        print('Grouped %d elements in %.1f seconds' % (N, dt))

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -19,7 +19,7 @@ import time
 import unittest
 import pickle
 import numpy
-from openquake.baselib.performance import Monitor, split_array3
+from openquake.baselib.performance import Monitor, split_array
 
 
 class MonitorTestCase(unittest.TestCase):
@@ -75,7 +75,7 @@ class SplitArray3TestCase(unittest.TestCase):
         arr['sids'] = rng.integers(1000, size=N)
         uniq, indices, counts = numpy.unique(
             arr['mdvbin'], return_inverse=True, return_counts=True)
-        sids = split_array3(arr['sids'], indices, counts)
+        sids = split_array(arr['sids'], indices, counts)
         expected_sids = [[631, 858, 450], [276], [887, 554], [92],
                          [827], [227], [63]]
         numpy.testing.assert_equal(sids, expected_sids)

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -19,7 +19,7 @@ import time
 import unittest
 import pickle
 import numpy
-from openquake.baselib.performance import Monitor
+from openquake.baselib.performance import Monitor, split_array3
 
 
 class MonitorTestCase(unittest.TestCase):
@@ -60,3 +60,22 @@ class MonitorTestCase(unittest.TestCase):
 
     def test_pickleable(self):
         pickle.loads(pickle.dumps(self.mon))
+
+
+class SplitArray3TestCase(unittest.TestCase):
+    def test(self):
+        # build a small structured array
+        dtlist = [('mdvbin', numpy.uint32), ('rake', numpy.float64),
+                  ('sids', numpy.uint32)]
+        N = 10
+        arr = numpy.zeros(N, dtlist)
+        rng = numpy.random.default_rng(42)
+        arr['mdvbin'] = rng.integers(50, size=N)
+        arr['rake'] = rng.random(N) * 360
+        arr['sids'] = rng.integers(1000, size=N)
+        uniq, indices, counts = numpy.unique(
+            arr['mdvbin'], return_inverse=True, return_counts=True)
+        sids = split_array3(arr['sids'], indices, counts)
+        expected_sids = [[631, 858, 450], [276], [887, 554], [92],
+                         [827], [227], [63]]
+        numpy.testing.assert_equal(sids, expected_sids)

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -62,7 +62,7 @@ class MonitorTestCase(unittest.TestCase):
         pickle.loads(pickle.dumps(self.mon))
 
 
-class SplitArray3TestCase(unittest.TestCase):
+class SplitArrayTestCase(unittest.TestCase):
     def test(self):
         # build a small structured array
         dtlist = [('mdvbin', numpy.uint32), ('rake', numpy.float64),

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -19,7 +19,6 @@ import time
 import unittest
 import pickle
 import numpy
-from openquake.baselib.general import kmean
 from openquake.baselib.performance import Monitor
 
 
@@ -61,41 +60,3 @@ class MonitorTestCase(unittest.TestCase):
 
     def test_pickleable(self):
         pickle.loads(pickle.dumps(self.mon))
-
-
-class GroupArrayTestCase(unittest.TestCase):
-    def test_small(self):
-        # build a small structured array
-        dtlist = [('mdvbin', numpy.uint32), ('rake', numpy.float64),
-                  ('sids', numpy.uint32)]
-        N = 10
-        arr = numpy.zeros(N, dtlist)
-        rng = numpy.random.default_rng(42)
-        arr['mdvbin'] = rng.integers(50, size=N)
-        arr['rake'] = rng.random(N) * 360
-        arr['sids'] = rng.integers(1000, size=N)
-        sids = []
-        for rec in kmean(arr, 'mdvbin'):
-            sids.append(arr['sids'][arr['mdvbin'] == rec['mdvbin']])
-        expected_sids = [[450, 858, 631], [276], [554, 887], [92],
-                         [827], [227], [63]]
-        numpy.testing.assert_equal(sids, expected_sids)
-
-    def test_big(self):
-        # build a very large structured array
-        dtlist = [('mdvbin', numpy.uint32), ('rake', numpy.float64),
-                  ('sids', numpy.uint32)]
-        N = 10_000_000
-        arr = numpy.zeros(N, dtlist)
-        rng = numpy.random.default_rng(42)
-        arr['mdvbin'] = rng.integers(50, size=N)
-        arr['rake'] = rng.random(N) * 360
-        arr['sids'] = rng.integers(1000, size=N)
-        t0 = time.time()
-        mean = kmean(arr, 'mdvbin')
-        sids = []
-        for mdvbin in mean['mdvbin']:
-            sids.append(arr['sids'][arr['mdvbin'] == mdvbin])
-        print([len(s) for s in sids])
-        dt = time.time() - t0
-        print('Grouped %d elements in %.1f seconds' % (N, dt))

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -120,36 +120,37 @@ def get_num_distances(gsims):
     return len(dists)
 
 
-def collapse_array(array, cfactor):
+def collapse_array(array, cfactor, mon):
     """
     Collapse a structured array with uniform magnitude
     """
-    # i.e. mag, rake, vs30, rjb, mdvbin, sids, occurrence_rate
-    names = array.dtype.names
-    if 'rake' not in names or len(numpy.unique(array['rake'])) == 1:
-        # collapse all
-        far = array
-        close = numpy.zeros(0, array.dtype)
-    else:
-        # collapse far away ruptures
-        tocollapse = array['rrup'] >= array['mag'] * 10
-        far = array[tocollapse]
-        close = array[~tocollapse]
-    C = len(close)
-    if len(far):
-        mean = kmean(far, 'mdvbin')
-    else:
-        mean = numpy.zeros(0, array.dtype)
-    cfactor[0] += len(close) + len(mean)
-    cfactor[1] += len(array)
-    out = numpy.zeros(len(close) + len(mean), array.dtype)
-    out[:C] = close
-    out[C:] = mean
-    allsids = [U32([sid]) for sid in close['sids']]
-    sids = array['sids']
-    mdvbins = array['mdvbin']
-    for mdvbin in mean['mdvbin']:
-        allsids.append(sids[mdvbins == mdvbin])
+    with mon:
+        # i.e. mag, rake, vs30, rjb, mdvbin, sids, occurrence_rate
+        names = array.dtype.names
+        if 'rake' not in names or len(numpy.unique(array['rake'])) == 1:
+            # collapse all
+            far = array
+            close = numpy.zeros(0, array.dtype)
+        else:
+            # collapse far away ruptures
+            tocollapse = array['rrup'] >= array['mag'] * 10
+            far = array[tocollapse]
+            close = array[~tocollapse]
+        C = len(close)
+        if len(far):
+            mean = kmean(far, 'mdvbin')
+        else:
+            mean = numpy.zeros(0, array.dtype)
+        cfactor[0] += len(close) + len(mean)
+        cfactor[1] += len(array)
+        out = numpy.zeros(len(close) + len(mean), array.dtype)
+        out[:C] = close
+        out[C:] = mean
+
+        allsids = [[sid] for sid in close['sids']]
+        df = pandas.DataFrame({'sids': array['sids']}, index=array['mdvbin'])
+        for _, rows in df.groupby(df.index):
+            allsids.append(rows['sids'])
     return out.view(numpy.recarray), allsids
 
 
@@ -742,9 +743,7 @@ class ContextMaker(object):
 
         # collapse if possible
         if isarray and self.collapse_level:
-            with self.col_mon:
-                ctx.sort(order='mdvbin')
-                ctx, allsids = collapse_array(ctx, self.cfactor)
+            ctx, allsids = collapse_array(ctx, self.cfactor, self.col_mon)
         else:  # no collapse
             self.cfactor[0] += len(ctx)
             self.cfactor[1] += len(ctx)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -35,7 +35,7 @@ except ImportError:
     numba = None
 from openquake.baselib.general import (
     AccumDict, DictArray, RecordBuilder, gen_slices, kmean)
-from openquake.baselib.performance import Monitor, split_array, split_array3
+from openquake.baselib.performance import Monitor, split_array
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import valid, imt as imt_module
 from openquake.hazardlib.const import StdDev
@@ -138,7 +138,7 @@ def collapse_array(array, cfactor, mon):
             close = array[~tocollapse]
         C = len(close)
         if len(far):
-            uic = numpy.unique(
+            uic = numpy.unique(  # this is fast
                 far['mdvbin'], return_inverse=True, return_counts=True)
             mean = kmean(far, 'mdvbin', uic)
         else:
@@ -149,8 +149,8 @@ def collapse_array(array, cfactor, mon):
         out[:C] = close
         out[C:] = mean
         allsids = [[sid] for sid in close['sids']]
-        if len(far):
-            allsids.extend(split_array3(far['sids'], uic[1], uic[2]))
+        if len(far):  # this is slow
+            allsids.extend(split_array(far['sids'], uic[1], uic[2]))
     return out.view(numpy.recarray), allsids
 
 


### PR DESCRIPTION
Improving the performance of the collapsing. Here is an example for EUR on the spot machine:
```
# yesterday, 20,000 sites, no source splitting, collapse
# Collapse factor = 658510003/5133620292 = 0.1283
| calc_44797, maxmem=184.7 GB | time_sec | memory_mb | counts  |
|-----------------------------+----------+-----------+---------|
| total classical             | 166_733  | 3_838     | 797     |
| collapsing contexts         | 101_499  | 0.0       | 183_673 |
| make_contexts               | 26_362   | 7_039     | 193_477 |
| get_poes                    | 12_335   | 0.0       | 188_333 |
| computing pnes              | 9_013    | 13_281    | 188_333 |
| computing mean_std          | 5_366    | 0.0       | 188_333 |
| ClassicalCalculator.run     | 2_514    | 2_663     | 1       |

# this branch
| calc_44808, maxmem=184.1 GB | time_sec | memory_mb | counts  |
|-----------------------------+----------+-----------+---------|
| total classical             | 73_766   | 3_856     | 659     |
| make_contexts               | 26_546   | 7_151     | 193_477 |
| get_poes                    | 11_327   | 0.0       | 187_054 |
| collapsing contexts         | 10_717   | 0.0       | 183_673 |
| computing pnes              | 8_187    | 13_157    | 187_054 |
| computing mean_std          | 4_969    | 0.0       | 187_054 |
| ClassicalCalculator.run     | 1_819    | 2_847     | 1       |
```
There is a 9x speedup on "collapsing contexts". Overall, "total classical" is 4x faster than without collapse.