### PR TITLE
Fixed passing of the parent_dir in event_based_damage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed parentdir bug in event_based_damage
   * Fixed sorting bug in the `/v1/calc/run` web API
   * Internal: introduced limited unique rupture IDs in classical calculations
     with few sites

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import os.path
 import logging
 import numpy
 import pandas
@@ -185,8 +186,7 @@ class DamageCalculator(EventBasedRiskCalculator):
         oq.R = self.R  # 1 if collect_rlzs
         oq.float_dmg_dist = not oq.discrete_damage_distribution
         if oq.hazard_calculation_id:
-            oq.parentdir = self.datastore.ppath
-            import pdb; pdb.set_trace()
+            oq.parentdir = os.path.dirname(self.datastore.ppath)
         if oq.investigation_time:  # event based
             self.builder = get_loss_builder(self.datastore)  # check
         eids = self.datastore['gmf_data/eid'][:]

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -53,7 +53,7 @@ def event_based_damage(df, oqparam, monitor):
     :returns: (damages (eid, kid) -> LDc plus damages (A, Dc))
     """
     mon_risk = monitor('computing risk', measuremem=False)
-    dstore = datastore.read(oqparam.hdf5path)
+    dstore = datastore.read(oqparam.hdf5path, parentdir=oqparam.parentdir)
     K = oqparam.K
     with monitor('reading gmf_data'):
         if hasattr(df, 'start'):  # it is actually a slice
@@ -184,6 +184,9 @@ class DamageCalculator(EventBasedRiskCalculator):
                 'you cannot use dicrete_damage_distribution=true' % num_floats)
         oq.R = self.R  # 1 if collect_rlzs
         oq.float_dmg_dist = not oq.discrete_damage_distribution
+        if oq.hazard_calculation_id:
+            oq.parentdir = self.datastore.ppath
+            import pdb; pdb.set_trace()
         if oq.investigation_time:  # event based
             self.builder = get_loss_builder(self.datastore)  # check
         eids = self.datastore['gmf_data/eid'][:]

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -139,9 +139,10 @@ def new(calc_id, oqparam, datadir=None, mode=None):
     :returns:
         a DataStore instance associated to the given calc_id
     """
-    haz_id = None if oqparam is None else oqparam.hazard_calculation_id
-    dstore = _read(calc_id, datadir, mode, haz_id)
+    dstore = _read(calc_id, mode, datadir)
     dstore['oqparam'] = oqparam
+    if oqparam.hazard_calculation_id:
+        dstore.ppath = read(calc_id, 'r', datadir).ppath
     return dstore
 
 


### PR DESCRIPTION
Reported by Catarina. The error was
```python
File "/opt/openquake/oq-engine/openquake/calculators/event_based_damage.py", line 56, in event_based_damage
    dstore = datastore.read(oqparam.hdf5path)
  File "/opt/openquake/oq-engine/openquake/commonlib/datastore.py", line 127, in read
    dstore.parent = _read(hc_id, datadir, 'r')
  File "/opt/openquake/oq-engine/openquake/commonlib/datastore.py", line 73, in _read
    raise OSError(ddir)
OSError: /home/oqdata
```