### PR TITLE
Make the amplification compatible with the vectorization

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -134,10 +134,10 @@ def run_preclassical(calc):
             if pointsources or pointlike:
                 smap.submit((pointsources + pointlike, sites, cmakers[grp_id]))
         else:
-            smap.submit_split((pointsources, sites, cmakers[grp_id]), 10, 100)
+            smap.submit_split((pointsources, sites, cmakers[grp_id]), 10, 320)
             for src in pointlike:  # area, multipoint
                 smap.submit(([src], sites, cmakers[grp_id]))
-        smap.submit_split((others, sites, cmakers[grp_id]), 10, 100)
+        smap.submit_split((others, sites, cmakers[grp_id]), 10, 320)
     normal = smap.reduce()
     if atomic_sources:  # case_35
         n = len(atomic_sources)

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -112,7 +112,7 @@ class AvgPoeGMPE(GMPE):
         cm.poe_mon = performance.Monitor()  # avoid double counts
         cm.gsims = self.gsims
         avgs = []
-        for poes, pnes, allsids, ctx in cm.gen_poes(ctx):
+        for poes, pnes, allsids, ctx in cm.gen_poes(ctx, [[]], [len(ctx)]):
             # poes has shape N, L, G
             avgs.append(poes @ self.weights)
         return np.concatenate(avgs)

--- a/openquake/hazardlib/site_amplification.py
+++ b/openquake/hazardlib/site_amplification.py
@@ -111,7 +111,7 @@ class AmplFunction():
         median = numpy.zeros(len(mags))
         std = numpy.zeros(len(mags))
 
-        # TODO: figure out a way to vectorize this
+        # TODO: figure out a way to do the following better
         for i, (mag, dst) in enumerate(zip(mags, dsts)):
 
             # Filtering magnitude
@@ -416,7 +416,7 @@ def get_poes_site(mean_std, cmaker, ctx):
     truncation_level = cmaker.truncation_level
     mean, stddev = mean_std  # shape (C, M)
     C, L = mean.shape[1], loglevels.size
-    assert len(ctx.sids) == 1  # 1 site
+    assert len(numpy.unique(ctx.sids)) == 1  # 1 site
     M = len(loglevels)
     L1 = L // M
 
@@ -430,9 +430,9 @@ def get_poes_site(mean_std, cmaker, ctx):
     # Compute the probability of exceedance for each in intensity
     # measure type IMT
     sigma = cmaker.af.get_max_sigma()
-    mags = [ctx.mag]
+    mags = ctx.mag
     rrups = ctx.rrup
-    [ampcode] = ctx.sites['ampcode']
+    [ampcode] = numpy.unique(ctx.ampcode)
     for m, imt in enumerate(loglevels):
 
         # Get the values of ground-motion used to compute the probability

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -31,7 +31,7 @@ from openquake.hazardlib.geo.utils import angular_distance, KM_TO_DEGREES
 from openquake.hazardlib.source.base import BaseSeismicSource
 
 F32 = np.float32
-BLOCKSIZE = 500
+BLOCKSIZE = 1000
 
 
 class FaultSection(object):
@@ -150,8 +150,8 @@ class MultiFaultSource(BaseSeismicSource):
         """
         Fast version of iter_ruptures used in estimate_weight
         """
-        s = self.sections
-        for i in range(0, len(self.mags), BLOCKSIZE // 5):
+        s = self.sections  # use one rupture every 500
+        for i in range(0, len(self.mags), BLOCKSIZE // 2):
             idxs = self.rupture_idxs[i]
             if len(idxs) == 1:
                 sfc = self.sections[idxs[0]].surface


### PR DESCRIPTION
Instead of disabling the vectorization in presence of amplification, which was defeating the purpose of vectorization (remember: amplification with the convolution method is defined only for single-site situations, exactly the ones that benefit from vectorization). This closes the loop.

NB: I am also adding two non-related functionalities that will become useful in the future, the final goal is to enable vectorization also for nonparametric ruptures.