### PR TITLE
Made amplification compatible with vectorization

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -321,6 +321,8 @@ class ContextMaker(object):
             reqset = set()
             for gsim in gsims:
                 reqset.update(getattr(gsim, 'REQUIRES_' + req))
+                if self.af and req == 'SITES_PARAMETERS':
+                    reqset.add('ampcode')
                 if hasattr(gsim, 'gmpe') and hasattr(gsim, 'params'):
                     # ModifiableGMPE
                     if (req == 'SITES_PARAMETERS' and
@@ -672,7 +674,7 @@ class ContextMaker(object):
             pmap = probmap
         poissonian, other = [], []
         for ctx in ctxs:
-            if not hasattr(ctx, 'probs_occur') and not self.af:
+            if not hasattr(ctx, 'probs_occur'):
                 poissonian.append(ctx)
             else:
                 other.append(ctx)

--- a/openquake/hazardlib/site_amplification.py
+++ b/openquake/hazardlib/site_amplification.py
@@ -111,7 +111,7 @@ class AmplFunction():
         median = numpy.zeros(len(mags))
         std = numpy.zeros(len(mags))
 
-        # TODO: figure out a way to vectorize this
+        # TODO: figure out a way to do the following better
         for i, (mag, dst) in enumerate(zip(mags, dsts)):
 
             # Filtering magnitude
@@ -416,7 +416,7 @@ def get_poes_site(mean_std, cmaker, ctx):
     truncation_level = cmaker.truncation_level
     mean, stddev = mean_std  # shape (C, M)
     C, L = mean.shape[1], loglevels.size
-    assert len(ctx.sids) == 1  # 1 site
+    assert len(numpy.unique(ctx.sids)) == 1  # 1 site
     M = len(loglevels)
     L1 = L // M
 
@@ -430,9 +430,9 @@ def get_poes_site(mean_std, cmaker, ctx):
     # Compute the probability of exceedance for each in intensity
     # measure type IMT
     sigma = cmaker.af.get_max_sigma()
-    mags = [ctx.mag]
+    mags = ctx.mag
     rrups = ctx.rrup
-    [ampcode] = ctx.sites['ampcode']
+    [ampcode] = numpy.unique(ctx.ampcode)
     for m, imt in enumerate(loglevels):
 
         # Get the values of ground-motion used to compute the probability

--- a/openquake/hazardlib/tests/gsim/base_site_test.py
+++ b/openquake/hazardlib/tests/gsim/base_site_test.py
@@ -83,8 +83,8 @@ class GetPoesSiteTestCase(unittest.TestCase):
         tmp = _get_poes(self.meastd, ll, tl)
 
         # This function is rather slow at the moment
-        ctx = unittest.mock.Mock(mag=self.mag, rrup=self.rrup, sids=[0],
-                                 sites=dict(ampcode=[sitecode]))
+        ctx = unittest.mock.Mock(mag=[self.mag], rrup=self.rrup, sids=[0],
+                                 ampcode=[sitecode])
         res = get_poes_site(self.meastd, self.cmaker, ctx)
 
         if False:


### PR DESCRIPTION
Instead of disabling the vectorization in presence of amplification, which was defeating the purpose of vectorization (remember: amplification with the convolution method is defined only for single-site situations, exactly the ones that benefit from vectorization). This closes a loose end.