### PR TITLE
Reducing the preclassical for UCERF to <1 seconds

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -114,7 +114,11 @@ def run_preclassical(calc):
             cmakers[grp_id].set_weight(sg, sites)
             atomic_sources.extend(sg)
         else:
-            normal_sources.extend(sg)
+            for src in sg.sources:
+                if src.__class__.__name__.startswith('Multi'):
+                    normal_sources.extend(split_source(src))
+                else:
+                    normal_sources.append(src)
     # run preclassical for non-atomic sources
     sources_by_grp = groupby(
         normal_sources, lambda src: (src.grp_id, msr_name(src)))
@@ -134,10 +138,10 @@ def run_preclassical(calc):
             if pointsources or pointlike:
                 smap.submit((pointsources + pointlike, sites, cmakers[grp_id]))
         else:
-            smap.submit_split((pointsources, sites, cmakers[grp_id]), 10, 100)
+            smap.submit_split((pointsources, sites, cmakers[grp_id]), 10, 320)
             for src in pointlike:  # area, multipoint
                 smap.submit(([src], sites, cmakers[grp_id]))
-        smap.submit_split((others, sites, cmakers[grp_id]), 10, 100)
+        smap.submit_split((others, sites, cmakers[grp_id]), 10, 320)
     normal = smap.reduce()
     if atomic_sources:  # case_35
         n = len(atomic_sources)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -144,7 +144,7 @@ def run_preclassical(calc):
                 smap.submit(([src], sites, cmakers[grp_id]))
         if others:
             smap.submit_split((others, sites, cmakers[grp_id]), 10, 320)
-    normal = smap.reduce(acc=multifaults)
+    normal = smap.reduce() + multifaults
     if atomic_sources:  # case_35
         n = len(atomic_sources)
         atomic = AccumDict({'before': n, 'after': n})

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -130,7 +130,8 @@ def run_preclassical(calc):
             elif hasattr(src, 'nodal_plane_distribution'):
                 pointlike.append(src)
             elif hasattr(src, 'sections'):  # MultiFaultSource
-                smap.submit(([src], sites, cmakers[grp_id]))
+                for ss in split_source(src):
+                    smap.submit(([ss], sites, cmakers[grp_id]))
             else:
                 others.append(src)
         if calc.oqparam.ps_grid_spacing:

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -132,7 +132,9 @@ def run_preclassical(calc):
                 pointlike.append(src)
             elif hasattr(src, 'sections'):  # multifault
                 # this is essential to make the preclassical in UCERF fast
-                multifaults[grp_id].extend(split_source(src))
+                for ss in split_source(src):
+                    ss.num_ruptures = ss.count_ruptures()
+                    multifaults[grp_id].append(ss)
             else:
                 others.append(src)
         if calc.oqparam.ps_grid_spacing:

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -132,7 +132,9 @@ def run_preclassical(calc):
                 pointlike.append(src)
             elif hasattr(src, 'sections'):  # multifault
                 # this is essential to make the preclassical in UCERF fast
-                for ss in split_source(src):
+                splits = (split_source(src) if calc.oqparam.split_sources else
+                          [src])
+                for ss in splits:
                     ss.num_ruptures = ss.count_ruptures()
                     multifaults[grp_id].append(ss)
             else:

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -31,7 +31,7 @@ from openquake.hazardlib.geo.utils import angular_distance, KM_TO_DEGREES
 from openquake.hazardlib.source.base import BaseSeismicSource
 
 F32 = np.float32
-BLOCKSIZE = 1000
+BLOCKSIZE = 500
 
 
 class FaultSection(object):
@@ -150,7 +150,7 @@ class MultiFaultSource(BaseSeismicSource):
         """
         Fast version of iter_ruptures used in estimate_weight
         """
-        s = self.sections  # use one rupture every 500
+        s = self.sections  # use one rupture every 250
         for i in range(0, len(self.mags), BLOCKSIZE // 2):
             idxs = self.rupture_idxs[i]
             if len(idxs) == 1:

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -31,7 +31,9 @@ from openquake.hazardlib.geo.utils import angular_distance, KM_TO_DEGREES
 from openquake.hazardlib.source.base import BaseSeismicSource
 
 F32 = np.float32
-BLOCKSIZE = 500
+BLOCKSIZE = 1000
+# the BLOCKSIZE has to be large to reduce the number of sources and
+# therefore the redundant data transfer in the .sections attribute
 
 
 class FaultSection(object):
@@ -150,7 +152,7 @@ class MultiFaultSource(BaseSeismicSource):
         """
         Fast version of iter_ruptures used in estimate_weight
         """
-        s = self.sections  # use one rupture every 250
+        s = self.sections  # use one rupture every 500
         for i in range(0, len(self.mags), BLOCKSIZE // 2):
             idxs = self.rupture_idxs[i]
             if len(idxs) == 1:


### PR DESCRIPTION
By splitting the multi-sources in-core. This reduces to zero the time spent in preclassical for UCERF.