### PR TITLE
Changed /extract/events to return events sorted by ID to make the QGIS plugin happy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed /extract/events to return events sorted by ID
   * Changed the default amplification method to "convolution"
   * Fixed a bug with discard_trts sometimes discarding too much
   * Raised a helpful error message when ensurepip is missing

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1035,11 +1035,14 @@ def extract_relevant_events(dstore, dummy=None):
     Example:
     http://127.0.0.1:8800/v1/calc/30/extract/events
     """
-    events = dstore['events'][:]
+    all_events = dstore['events'][:]
     if 'relevant_events' not in dstore:
-        return events
+        all_events.sort(order='id')
+        return all_events
     rel_events = dstore['relevant_events'][:]
-    return events[rel_events]
+    events = all_events[rel_events]
+    events.sort(order='id')
+    return events
 
 
 @extract.add('event_info')

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -161,6 +161,8 @@ class EngineServerTestCase(unittest.TestCase):
         # check eids_by_gsim
         resp = self.c.get(extract_url + 'eids_by_gsim')
         dic = dict(loadnpz(resp.streaming_content))
+        for gsim, eids in dic.items():
+            numpy.testing.assert_equal(eids, numpy.sort(eids)), gsim
         self.assertEqual(len(dic['[AtkinsonBoore2003SInter]']), 7)
 
         # check extract/composite_risk_model.attrs


### PR DESCRIPTION
Affects Robin who is using engine 3.13.