### PR TITLE
Changed the signature of get_poes

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -746,18 +746,18 @@ class ContextMaker(object):
         if any(hasattr(gsim, 'gmpe_table') for gsim in self.gsims):
             assert len(recarrays) == 1, len(recarrays)
             recarrays = split_array(recarrays[0], U32(recarrays[0].mag*100))
-        self.adj = [[] for g in range(G)]  # NSHM2014 adjustments
+        self.adj = {gsim: [] for gsim in self.gsims}  # NSHM2014 adjustments
         for g, gsim in enumerate(self.gsims):
             compute = gsim.__class__.compute
             start = 0
             for ctx in recarrays:
                 slc = slice(start, start + len(ctx))
-                compute(gsim, ctx, self.imts, *out[:, g, :, slc])
-                if hasattr(gsim, 'adjustment'):
-                    self.adj[g].append(gsim.adjustment)
+                adj = compute(gsim, ctx, self.imts, *out[:, g, :, slc])
+                if adj is not None:
+                    self.adj[gsim].append(adj)
                 start = slc.stop
-        self.adj = [numpy.concatenate(adj) if len(adj) else []
-                    for adj in self.adj]
+            if self.adj[gsim]:
+                self.adj[gsim] = numpy.concatenate(self.adj[gsim])
         return out
 
     # http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.845.163&rep=rep1&type=pdf
@@ -849,13 +849,12 @@ class ContextMaker(object):
             with self.poe_mon:
                 poes = numpy.zeros((len(ctxt), L, G))
                 for g, gsim in enumerate(self.gsims):
-                    adj = self.adj[g]  # NSHM14, case_72
                     ms = mean_stdt[:2, g]
                     # builds poes of shape (n, L, G)
                     if self.af:  # kernel amplification method for single site
                         poes[:, :, g] = get_poes_site(ms, self, ctxt)
                     else:  # regular case
-                        poes[:, :, g] = gsim.get_poes(ms, self, ctxt, adj)
+                        poes[:, :, g] = gsim.get_poes(ms, self, ctxt, npdata)
             with self.pne_mon:
                 if npdata is None:  # parametric
                     probs_or_tom = self.tom

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -465,8 +465,7 @@ class GMPE(GroundShakingIntensityModel):
         """
         raise NotImplementedError
 
-    # the ctxs are used in avg_poe_gmpe
-    def get_poes(self, mean_std, cmaker, ctx, adj):
+    def get_poes(self, mean_std, cmaker, ctx, npdata=None):
         """
         Calculate and return probabilities of exceedance (PoEs) of one or more
         intensity measure levels (IMLs) of one intensity measure type (IMT)
@@ -476,11 +475,11 @@ class GMPE(GroundShakingIntensityModel):
             An array of shape (2, M, N) with mean and standard deviations
             for the sites and intensity measure types
         :param cmaker:
-            A ContextMaker instance, used only in avg_poe_gmpe
+            A ContextMaker instance, used only in nhsm_2014
         :param ctx:
-            Context objects used to compute mean_std
-        :param adj:
-            Adjustment vector (None except for NSHMP14)
+            A recarray used only in  avg_poe_gmpe
+        :param npdata:
+            A recarray used only in  avg_poe_gmpe
         :returns:
             array of PoEs of shape (N, L)
         :raises ValueError:
@@ -497,13 +496,13 @@ class GMPE(GroundShakingIntensityModel):
         if truncation_level is not None and truncation_level < 0:
             raise ValueError('truncation level must be zero, positive number '
                              'or None')
-        if hasattr(self, 'weights_signs'):  # for nshmp_2014
+        if hasattr(self, 'weights_signs'):  # for nshmp_2014, case_72
             outs = []
             weights, signs = zip(*self.weights_signs)
             for s in signs:
                 ms = numpy.array(mean_std)  # make a copy
                 for m in range(len(loglevels)):
-                    ms[0, m] += s * adj
+                    ms[0, m] += s * cmaker.adj[self]
                 outs.append(_get_poes(ms, loglevels, truncation_level))
             arr[:] = numpy.average(outs, weights=weights, axis=0)
         elif hasattr(self, "mixture_model"):

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -104,15 +104,16 @@ class AvgPoeGMPE(GMPE):
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """Do nothing: the work is done in get_poes"""
 
-    def get_poes(self, mean_std, cmaker, ctx, adj):
+    def get_poes(self, mean_std, cmaker, ctx, npdata=None):
         """
         :returns: an array of shape (N, L)
         """
         cm = copy.copy(cmaker)
         cm.poe_mon = performance.Monitor()  # avoid double counts
+        cm.pne_mon = performance.Monitor()  # avoid double counts
         cm.gsims = self.gsims
         avgs = []
-        for poes, pnes, allsids, ctx in cm.gen_poes(ctx):
+        for poes, pnes, allsids, ctx in cm.gen_poes(ctx, npdata):
             # poes has shape N, L, G
             avgs.append(poes @ self.weights)
         return np.concatenate(avgs)

--- a/openquake/hazardlib/gsim/nshmp_2014.py
+++ b/openquake/hazardlib/gsim/nshmp_2014.py
@@ -78,14 +78,12 @@ class NSHMP2014(base.GMPE):
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
-        See :meth:`superclass method
-        <.base.GroundShakingIntensityModel.compute>`
-        for spec of input and result values.
+        Compute mean, sig, tau, phi and returns the so called adjustment
         """
         self.gsim.compute(ctx, imts, mean, sig, tau, phi)
-        self.adjustment = nga_west2_epistemic_adjustment(ctx.mag, ctx.rrup)
-        mean[:] += self.sgn * self.adjustment
-
+        adjustment = nga_west2_epistemic_adjustment(ctx.mag, ctx.rrup)
+        mean[:] += self.sgn * adjustment
+        return adjustment
 
 # populate gsim_aliases
 # for instance "AbrahamsonEtAl2014NSHMPMean" is associated to the TOML string


### PR DESCRIPTION
By passing npdata (required by avg_poe_gmpe, which was broken in presence of nonparametric ruptures) instead of the adjustment (which is inside the cmaker already and therefore not required).