### PR TITLE
Fix a typo in Kuehn et al. (2020) model

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Tom Son]
+  * Fixed a typo within Kuehn et al. (2020) model to include Z2.5 when the given
+    region is JAPAN while converting CTX context to `numpy.recarray`.
+
   [Michele Simionato]
   * Changed /extract/events to return events sorted by ID
   * Changed the default amplification method to "convolution"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
   [Tom Son]
   * Fixed a typo within Kuehn et al. (2020) model to include Z2.5 when the given
-    region is JAPAN while converting CTX context to `numpy.recarray`.
+    region is JAPAN while converting CTX(a new style full RuptureContext)
+    to `numpy.recarray`.
 
   [Michele Simionato]
   * Changed /extract/events to return events sorted by ID

--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -567,7 +567,7 @@ class KuehnEtAl2020SInter(GMPE):
     - Alaska (USA-AK)
     - Cascadia (CAS)
     - Central America & Mexico (CAM)
-    - Japan (JPM)
+    - Japan (JPN)
     - New Zealand (NZL)
     - South America (SAM)
     - Taiwan (TWN)

--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -639,8 +639,8 @@ class KuehnEtAl2020SInter(GMPE):
         self.region = region
 
         # For some regions a basin depth term is defined
-        if self.region in ("CAS", "JAP"):
-            # If region is CAS or JAP then the GMPE needs Z2.5
+        if self.region in ("CAS", "JPN"):
+            # If region is CAS or JPN then the GMPE needs Z2.5
             self.REQUIRES_SITES_PARAMETERS = \
                  self.REQUIRES_SITES_PARAMETERS.union({"z2pt5", })
         elif self.region in ("NZL", "TWN"):


### PR DESCRIPTION
# Fix a typo in Kuehn et al. (2020) model

- Fixed a typo, from JAP and JPM to JPN.

Based on the Kuehn model, these are the supported regions for this model
```python
SUPPORTED_REGIONS = ["GLO", "USA-AK", "CAS", "CAM", "JPN", "NZL", "SAM", "TWN"]
```

However with the existing typo, what happened was,
```python
# Within your scratch
model = K_20.KuehnEtAl2020SInter(region="JPN")
model.get_mean_and_stddevs(some args...)

# within base.py after the conversion to new-style context
if self.compute.__annotations__.get("ctx") is numpy.recarray:
    # The class `ContextMaker` is where the typo triggered an issue
    cmaker = ContextMaker('*', [self], {'imtls': {imt: [0]}})

# within ContextMaker's __init__ part
for req in self.REQUIRES:
    reqset = set()
    for gsim in gsims:
        reqset.update(getattr(gsim, 'REQUIRES_' + req))
        if self.af and req == 'SITES_PARAMETERS':
            reqset.add('ampcode')
        if hasattr(gsim, 'gmpe') and hasattr(gsim, 'params'):
            # ModifiableGMPE
            if (req == 'SITES_PARAMETERS' and
                    'apply_swiss_amplification' in gsim.params):
                reqset.add('amplfactor')
    setattr(self, 'REQUIRES_' + req, reqset)

# within Kuehn model
"""Cascadia and Japan regions need Z2.5 as specified and we need to add this to 
`self.REQUIRES_SITES_PARAMETERS` so that way, ContextMaker class above does the right job.
However, the input region is JPN but the conditions check whether it's CAS or JAP instead of JPN.
"""
if self.region in ("CAS", "JAP"):
    # If region is CAS or JPN then the GMPE needs Z2.5
    self.REQUIRES_SITES_PARAMETERS = \
         self.REQUIRES_SITES_PARAMETERS.union({"z2pt5", })
```

Hence, with the existing code, even if you pass the `z2pt5`(Z2.5) for the Site Context, this will never be included as with the region JPN, will never be included in the if statement due to the typo.

## Demonstration
### Common Site object
```python
# WIth the following site
oq_site = Site(
        location=Point(0.0, 0.0, 0.0),
        vs30=np.array([vs30]),
        z1pt0=np.array([0.000000001]),
        z2pt5=np.array([0.000000001]),
    )
```
### Before fixing the typo
```python
Traceback (most recent call last):
  File "/home/tom/Documents/QuakeCoRE/oq-engine/venv/lib/python3.8/site-packages/numpy/core/records.py", line 463, in __getattribute__
    res = fielddict[attr][:2]
KeyError: 'z2pt5'

## Conversion didn't work as we expected
>>> ctx.mag
array([9.])
>>> ctx.z2pt5
Traceback (most recent call last):
  File "/snap/pycharm-community/267/plugins/python-ce/helpers/pydev/_pydevd_bundle/pydevd_exec2.py", line 3, in Exec
    exec(exp, global_vars, local_vars)
  File "<input>", line 1, in <module>
  File "/home/tom/Documents/QuakeCoRE/oq-engine/venv/lib/python3.8/site-packages/numpy/core/records.py", line 465, in __getattribute__
    raise AttributeError("recarray has no attribute %s" % attr) from e
AttributeError: recarray has no attribute z2pt5
```

### After fixing the typo
```python
## Conversion worked as we expected to include Z2.5 for JAPAN region
>>> ctx.mag
array([9.])
>>> ctx.z2pt5
array([1.e-09])
```

