### PR TITLE
Storing the correct occurrence rate in the ruptures dataset

### DIFF
--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -239,6 +239,7 @@ def _build_groups(full_lt, smdict):
             sg = apply_uncertainties(bset_values, src_group)
             for src in sg:
                 src.trt_smr = trt_smr
+                src.smweight = rlz.weight
                 if rlz.samples > 1:
                     src.samples = rlz.samples
             groups.append(sg)

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -265,7 +265,7 @@ def reduce_sources(sources_with_same_id):
     out = []
     for src in sources_with_same_id:
         dic = {k: v for k, v in vars(src).items()
-               if k not in 'source_id trt_smr samples'}
+               if k not in 'source_id trt_smr smweight samples'}
         src.checksum = zlib.adler32(pickle.dumps(dic, protocol=4))
     for srcs in general.groupby(
             sources_with_same_id, operator.attrgetter('checksum')).values():

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -132,6 +132,7 @@ def get_csm(oq, full_lt, h5=None):
             src = sg[0].new(sm_rlz.ordinal, sm_rlz.value[0])  # one source
             src.checksum = src.grp_id = src.trt_smr = grp_id
             src.samples = sm_rlz.samples
+            src.smweight = sm_rlz.weight
             logging.info('Reading sections and rupture planes for %s', src)
             planes = src.get_planes()
             if classical:

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -114,6 +114,9 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         for trt_smr in self.trt_smrs:
             for rup, num_occ in self._sample_ruptures(eff_num_ses):
                 rup.rup_id = seed
+                if hasattr(rup, 'occurrence_rate'):
+                    # defined only for poissonian sources
+                    rup.occurrence_rate *= self.smweight
                 rup.occurrence_rate *= self.smweight
                 seed += 1
                 yield rup, trt_smr, num_occ

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -117,7 +117,6 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
                 if hasattr(rup, 'occurrence_rate'):
                     # defined only for poissonian sources
                     rup.occurrence_rate *= self.smweight
-                rup.occurrence_rate *= self.smweight
                 seed += 1
                 yield rup, trt_smr, num_occ
 

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -114,6 +114,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         for trt_smr in self.trt_smrs:
             for rup, num_occ in self._sample_ruptures(eff_num_ses):
                 rup.rup_id = seed
+                rup.occurrence_rate *= self.smweight
                 seed += 1
                 yield rup, trt_smr, num_occ
 


### PR DESCRIPTION
If a rupture comes from a source model with weight W, its occurrence rate must be multiplied by W before storing it. This fixes an inconsistency when comparing `n_occ` with `occurrence_rate * eff_time`. There is no effect on the numbers produced by the engine.