### PR TITLE
Proposal - Relocate the setting mag within Kuehn 2020

### DIFF
--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -688,7 +688,7 @@ class KuehnEtAl2020SInter(GMPE):
                 pga_soil = get_mean_values(C_PGA, self.region, trt, m_b,
                                            ctx, pga1100)
                 break
-        [mag] = np.unique(np.round(ctx.mag, 6))
+
         for m, imt in enumerate(imts):
             # Get coefficinets for imt
             C = self.COEFFS[imt]
@@ -709,6 +709,7 @@ class KuehnEtAl2020SInter(GMPE):
                                           ctx, pga1100)
             # Apply the sigma mu adjustment if necessary
             if self.sigma_mu_epsilon:
+                [mag] = np.unique(np.round(ctx.mag, 6))
                 sigma_mu_adjust = get_sigma_mu_adjustment(
                     self.sigma_mu_model, imt, mag, ctx.rrup)
                 mean[m] += self.sigma_mu_epsilon * sigma_mu_adjust


### PR DESCRIPTION
# Relocate the setting mag code within Kuehn 2020

This PR is more about the proposal.

Based on this [commit](https://github.com/gem/oq-engine/commit/ab6145bfa76b7c561a8423a5a63413179bf111b2) which is vectorized Kuehn model.

This made our team be able to compute multiple ruptures.

However, 
```python
[mag] = np.unique(np.round(ctx.mag, 6))
```
this line causes an issue as we deal with multiple ruptures which makes this `ctx.mag` to be an array of N number of magnitudes information. Then `[mag]` cannot be handled as there are more than one element inside `np.unique()`.

Hence, I prose pose to move this code to just before the following code block where `mag` value is actually used.
```python
sigma_mu_adjust = get_sigma_mu_adjustment(
                    self.sigma_mu_model, imt, mag, ctx.rrup)
```

As `mag` variable does not need anywhere else and with our usage, we don't get to that point so we do not have to worry about the different sizes of array from `np.unique` 

Ideally, we might be able to make that function `get_sigma_mu_adjustment()` work with an array of mag instead of a single variable. However, when I checked that function, `get_sigma_mu_adjustment()`, it didn't mention whether it was from Kuehn's paper. For instance, function `_get_ln_z_ref()`, says this is Equation 4.11 which I can check the paper to see what is happening. but `get_sigma_mu_adjustment()` did not have one, so I couldn't investigate further and this might be a big change, hence I propose to move `[mag] = np.unique(np.round(ctx.mag, 6))` to just before the function call, `get_sigma_mu_adjustment()`
