### PR TITLE
Reduced tolerance in kuehn2020_test

### DIFF
--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -690,14 +690,14 @@ class KuehnEtAl2020SInter(GMPE):
                 break
         [mag] = np.unique(np.round(ctx.mag, 6))
         for m, imt in enumerate(imts):
-            # Get coefficinets for imt
+            # Get coefficients for imt
             C = self.COEFFS[imt]
-            m_break = m_b + C["dm_b"] if trt == const.TRT.SUBDUCTION_INTERFACE and\
-                self.region in ("JPN", "SAM") else m_b
-
+            m_break = m_b + C["dm_b"] if (
+                trt == const.TRT.SUBDUCTION_INTERFACE and
+                self.region in ("JPN", "SAM")) else m_b
             if imt.string == "PGA":
                 mean[m] = pga_soil
-            elif ("SA" in imt.string) and (imt.period <= 0.1):
+            elif "SA" in imt.string and imt.period <= 0.1:
                 # If Sa (T) < PGA for T <= 0.1 then set mean Sa(T) to mean PGA
                 mean[m] = get_mean_values(C, self.region, trt, m_break,
                                           ctx, pga1100)

--- a/openquake/hazardlib/tests/gsim/kuehn_2020_test.py
+++ b/openquake/hazardlib/tests/gsim/kuehn_2020_test.py
@@ -141,6 +141,6 @@ class KuehnEtAl2020RegionTestCase(BaseGSIMTestCase):
             for region, files in self.FILES.items():
                 mean_file, *std_files = [f.format(trt) for f in files]
                 self.check(mean_file,
-                           max_discrep_percentage=0.1, region=region)
+                           max_discrep_percentage=0.03, region=region)
                 self.check(*std_files,
                            max_discrep_percentage=0.1, region=region)


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/7654. The test was there but the tolerance was too high, so the error was invisible.