### PR TITLE
Fixed equivalent distance approximation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Slightly changed the collapsing of nodal planes and hypocenters in
+    presence of the equivalent distance approximation (`reqv`)
   * Extended `oq reduce_sm` to multiFaultSources
   * Fixed the check on unique section IDs for multiFaultSources
   * Implemented multi-aggregation with a syntax like

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -140,8 +140,7 @@ def get_csm(oq, full_lt, h5=None):
         oq.source_id,
         discard_trts=[s.strip() for s in oq.discard_trts.split(',')],
         floating_x_step=oq.floating_x_step,
-        floating_y_step=oq.floating_y_step,
-        collapse_nphc='reqv' in oq.inputs)
+        floating_y_step=oq.floating_y_step)
     classical = not oq.is_event_based()
     full_lt.ses_seed = oq.ses_seed
     if oq.is_ucerf():

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -114,6 +114,9 @@ def get_csm(oq, full_lt, h5=None):
     Build source models from the logic tree and to store
     them inside the `source_full_lt` dataset.
     """
+    if 'reqv' in oq.inputs:
+        logging.warning('Using equivalent distance approximation and ignoring '
+                        'finite size effects in point sources')
     converter = sourceconverter.SourceConverter(
         oq.investigation_time, oq.rupture_mesh_spacing,
         oq.complex_fault_mesh_spacing, oq.width_of_mfd_bin,
@@ -121,7 +124,8 @@ def get_csm(oq, full_lt, h5=None):
         oq.source_id,
         discard_trts=[s.strip() for s in oq.discard_trts.split(',')],
         floating_x_step=oq.floating_x_step,
-        floating_y_step=oq.floating_y_step)
+        floating_y_step=oq.floating_y_step,
+        collapse_nphc='reqv' in oq.inputs)
     classical = not oq.is_event_based()
     full_lt.ses_seed = oq.ses_seed
     if oq.is_ucerf():

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -775,7 +775,7 @@ class ContextMaker(object):
     # called by gen_poes and by the GmfComputer
     def get_mean_stds(self, ctxs):
         """
-        :param ctxs: a list of contexts
+        :param ctxs: a list of contexts with N=sum(len(ctx) for ctx in ctxs)
         :returns: an array of shape (4, G, M, N) with mean and stddevs
         """
         if not hasattr(self, 'imts'):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -110,6 +110,25 @@ def rounded_unique(mags, idxs):
     return mags
 
 
+def collapse_nphc(src):
+    """
+    Collapse the nodal_plane_distribution and hypocenter_distribution.
+    """
+    if (hasattr(src, 'nodal_plane_distribution') and
+            hasattr(src, 'hypocenter_distribution')):
+        if len(src.nodal_plane_distribution.data) > 1:
+            ws, nps = zip(*src.nodal_plane_distribution.data)
+            strike = numpy.average([np.strike for np in nps], weights=ws)
+            dip = numpy.average([np.dip for np in nps], weights=ws)
+            rake = numpy.average([np.rake for np in nps], weights=ws)
+            val = geo.NodalPlane(strike, dip, rake)
+            src.nodal_plane_distribution = pmf.PMF([(1., val)])
+        if len(src.hypocenter_distribution.data) > 1:
+            ws, vals = zip(*src.hypocenter_distribution.data)
+            val = numpy.average(vals, weights=ws)
+            src.hypocenter_distribution = pmf.PMF([(1., val)])
+
+
 class SourceGroup(collections.abc.Sequence):
     """
     A container for the following parameters:
@@ -675,13 +694,15 @@ class SourceConverter(RuptureConverter):
                  area_source_discretization=None,
                  minimum_magnitude={'default': 0},
                  source_id=None, discard_trts=(),
-                 floating_x_step=0, floating_y_step=0):
+                 floating_x_step=0, floating_y_step=0,
+                 collapse_nphc=False):
         self.investigation_time = investigation_time
         self.area_source_discretization = area_source_discretization
         self.minimum_magnitude = minimum_magnitude
         self.rupture_mesh_spacing = rupture_mesh_spacing
         self.complex_fault_mesh_spacing = (
             complex_fault_mesh_spacing or rupture_mesh_spacing)
+        self.collapse_nphc = collapse_nphc
         self.width_of_mfd_bin = width_of_mfd_bin
         self.source_id = source_id
         self.discard_trts = discard_trts
@@ -1188,6 +1209,10 @@ class SourceConverter(RuptureConverter):
             msg = 'The Source Group is a cluster but does not have a '
             msg += 'temporal occurrence model'
             raise ValueError(msg)
+
+        if self.collapse_nphc:
+            for src in sg.sources:
+                collapse_nphc(src)
         return sg
 
 

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -110,25 +110,6 @@ def rounded_unique(mags, idxs):
     return mags
 
 
-def collapse_nphc(src):
-    """
-    Collapse the nodal_plane_distribution and hypocenter_distribution.
-    """
-    if (hasattr(src, 'nodal_plane_distribution') and
-            hasattr(src, 'hypocenter_distribution')):
-        if len(src.nodal_plane_distribution.data) > 1:
-            ws, nps = zip(*src.nodal_plane_distribution.data)
-            strike = numpy.average([np.strike for np in nps], weights=ws)
-            dip = numpy.average([np.dip for np in nps], weights=ws)
-            rake = numpy.average([np.rake for np in nps], weights=ws)
-            val = geo.NodalPlane(strike, dip, rake)
-            src.nodal_plane_distribution = pmf.PMF([(1., val)])
-        if len(src.hypocenter_distribution.data) > 1:
-            ws, vals = zip(*src.hypocenter_distribution.data)
-            val = numpy.average(vals, weights=ws)
-            src.hypocenter_distribution = pmf.PMF([(1., val)])
-
-
 class SourceGroup(collections.abc.Sequence):
     """
     A container for the following parameters:
@@ -1209,10 +1190,6 @@ class SourceConverter(RuptureConverter):
             msg = 'The Source Group is a cluster but does not have a '
             msg += 'temporal occurrence model'
             raise ValueError(msg)
-
-        if self.collapse_nphc:
-            for src in sg.sources:
-                collapse_nphc(src)
         return sg
 
 

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -675,15 +675,13 @@ class SourceConverter(RuptureConverter):
                  area_source_discretization=None,
                  minimum_magnitude={'default': 0},
                  source_id=None, discard_trts=(),
-                 floating_x_step=0, floating_y_step=0,
-                 collapse_nphc=False):
+                 floating_x_step=0, floating_y_step=0):
         self.investigation_time = investigation_time
         self.area_source_discretization = area_source_discretization
         self.minimum_magnitude = minimum_magnitude
         self.rupture_mesh_spacing = rupture_mesh_spacing
         self.complex_fault_mesh_spacing = (
             complex_fault_mesh_spacing or rupture_mesh_spacing)
-        self.collapse_nphc = collapse_nphc
         self.width_of_mfd_bin = width_of_mfd_bin
         self.source_id = source_id
         self.discard_trts = discard_trts


### PR DESCRIPTION
In engine <=3.13 having 'reqv' in the job.ini meant collapsing the nodal plane and hypocenter distributions. We lost this feature in master and this is the reason why the USA model is much slower than before. With this fix we get 3.4 times faster:
```
# USA before the fix
| calc_44928, maxmem=246.2 GB | time_sec  | memory_mb | counts  |
|-----------------------------+-----------+-----------+---------|
| total classical             | 1_260_318 | 1_271     | 270     |
| get_poes                    | 712_060   | 0.0       | 175_747 |
| computing mean_std          | 236_622   | 0.0       | 175_747 |
| computing pnes              | 156_245   | 0.0       | 175_747 |
| make_contexts               | 92_061    | 961.9     | 10_643  |
| ClassicalCalculator.run     | 16_657    | 6_728     | 1       |

# USA after the fix
| calc_44941, maxmem=196.8 GB | time_sec | memory_mb | counts |
|-----------------------------+----------+-----------+--------|
| total classical             | 371_938  | 1_390     | 274    |
| get_poes                    | 185_005  | 0.0       | 84_459 |
| computing mean_std          | 66_193   | 0.0       | 84_459 |
| computing pnes              | 64_368   | 0.0       | 84_459 |
| make_contexts               | 30_129   | 358.8     | 10_658 |
| ClassicalCalculator.run     | 7_434    | 6_732     | 1      |
```