### PR TITLE
Optimized "computing pnes"

### DIFF
--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -240,8 +240,9 @@ def get_probability_no_exceedance(ctx, poes, probs_or_tom):
     pnes = numpy.zeros_like(poes)
     if hasattr(probs_or_tom, 'get_probability_no_exceedance'):  # poissonian
         time_span = probs_or_tom.time_span
+        # NB: this is performance critical, using the out= trick
         for i, rate in enumerate(ctx.occurrence_rate):
-            pnes[i] = -rate * time_span * poes[i]
+            numpy.multiply(-rate * time_span, poes[i], out=pnes[i])
         numpy.exp(pnes, out=pnes)
         return pnes
     else:  # nonpoissonian

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -23,6 +23,7 @@ density functions for earthquake temporal occurrence modeling.
 import abc
 import numpy
 import scipy.stats
+from openquake.baselib.performance import compile
 
 registry = {}
 F64 = numpy.float64
@@ -184,15 +185,7 @@ class PoissonTOM(BaseTOM):
 
         The probability is computed as exp(-occurrence_rate * time_span * poes)
         """
-        try:
-            n = len(occurrence_rate)
-        except TypeError:  # float' has no len()
-            eff_time = occurrence_rate * self.time_span * poes
-        else:
-            eff_time = numpy.zeros((n,) + poes.shape)
-            for i in range(n):
-                eff_time[i] = occurrence_rate[i] * self.time_span * poes[i]
-        return numpy.exp(- eff_time)
+        return numpy.exp(- occurrence_rate * self.time_span * poes)
 
 
 # use in calc.disagg
@@ -227,6 +220,17 @@ def get_probability_no_exceedance_rup(rup, poes, tom):
         return tom.get_probability_no_exceedance(rup.occurrence_rate, poes)
 
 
+@compile("(float64[:], float64[:,:,:], float64, float64[:,:,:])")
+def calc_poisson(rates, poes, time_span, out):
+    """
+    Compute probabilities of no exceedance by using the poisson distribution
+    (fast). Works by populating the "out" array.
+    """
+    for i, rate in enumerate(rates):
+        out[i] = -rate * time_span * poes[i]
+    numpy.exp(out, out)
+
+
 def get_probability_no_exceedance(ctx, poes, probs_or_tom):
     """
     Vectorized version of :func:`get_probability_no_exceedance_rup`.
@@ -239,11 +243,7 @@ def get_probability_no_exceedance(ctx, poes, probs_or_tom):
     """
     pnes = numpy.zeros_like(poes)
     if hasattr(probs_or_tom, 'get_probability_no_exceedance'):  # poissonian
-        time_span = probs_or_tom.time_span
-        # NB: this is performance critical, using the out= trick
-        for i, rate in enumerate(ctx.occurrence_rate):
-            numpy.multiply(-rate * time_span, poes[i], out=pnes[i])
-        numpy.exp(pnes, out=pnes)
+        calc_poisson(ctx.occurrence_rate, poes, probs_or_tom.time_span, pnes)
         return pnes
     else:  # nonpoissonian
         for i, probs_occur in enumerate(probs_or_tom):

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -242,13 +242,15 @@ def get_probability_no_exceedance(ctx, poes, probs_or_tom):
         list of N probability mass functions otherwise
     """
     pnes = numpy.zeros_like(poes)
-    if hasattr(probs_or_tom, 'get_probability_no_exceedance'):  # poissonian
+    if isinstance(probs_or_tom, FatedTOM):
+        for i, rate in enumerate(ctx.occurrence_rate):
+            pnes[i] = probs_or_tom.get_probability_no_exceedance(rate, poes[i])
+    elif isinstance(probs_or_tom, PoissonTOM):
         calc_pnes(ctx.occurrence_rate, poes, probs_or_tom.time_span, pnes)
-        return pnes
     else:  # nonpoissonian
         for i, probs_occur in enumerate(probs_or_tom):
             pnes[i] = get_probability_no_exceedance_np(probs_occur, poes[i])
-        return pnes
+    return pnes
 
 
 def get_probability_no_exceedance_np(probs_occur, poes):

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -239,9 +239,10 @@ def get_probability_no_exceedance(ctx, poes, probs_or_tom):
     """
     pnes = numpy.zeros_like(poes)
     if hasattr(probs_or_tom, 'get_probability_no_exceedance'):  # poissonian
+        time_span = probs_or_tom.time_span
         for i, rate in enumerate(ctx.occurrence_rate):
-            pnes[i] = probs_or_tom.get_probability_no_exceedance(
-                rate, poes[i])
+            pnes[i] = -rate * time_span * poes[i]
+        numpy.exp(pnes, out=pnes)
         return pnes
     else:  # nonpoissonian
         for i, probs_occur in enumerate(probs_or_tom):

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -221,7 +221,7 @@ def get_probability_no_exceedance_rup(rup, poes, tom):
 
 
 @compile("(float64[:], float64[:,:,:], float64, float64[:,:,:])")
-def calc_poisson(rates, poes, time_span, out):
+def calc_pnes(rates, poes, time_span, out):
     """
     Compute probabilities of no exceedance by using the poisson distribution
     (fast). Works by populating the "out" array.
@@ -243,7 +243,7 @@ def get_probability_no_exceedance(ctx, poes, probs_or_tom):
     """
     pnes = numpy.zeros_like(poes)
     if hasattr(probs_or_tom, 'get_probability_no_exceedance'):  # poissonian
-        calc_poisson(ctx.occurrence_rate, poes, probs_or_tom.time_span, pnes)
+        calc_pnes(ctx.occurrence_rate, poes, probs_or_tom.time_span, pnes)
         return pnes
     else:  # nonpoissonian
         for i, probs_occur in enumerate(probs_or_tom):


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/7701. This time it works. Here is the difference for a calculation on my workstation: computing pnes  447.6s -> 108.9s (4x speedup). Here is the difference for the SAM model on the spot machine (2.5x speedup):
```
# before
| calc_44964, maxmem=53.2 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 246_537  | 513.2     | 244       |
| computing pnes             | 129_942  | 0.0       | 1_466_402 |
| make_contexts              | 46_491   | 479.8     | 97_514    |
# after
| calc_44966, maxmem=53.1 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 170_730  | 548.1     | 244       |
| computing pnes             | 52_955   | 0.0       | 1_466_402 |
| make_contexts              | 47_037   | 508.2     | 97_514    |
```
