### PR TITLE
Optimized "computing pnes"/3

### DIFF
--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -249,15 +249,16 @@ def get_probability_no_exceedance(ctx, poes, probs_or_tom):
         calc_pnes(ctx.occurrence_rate, poes, probs_or_tom.time_span, pnes)
     else:  # nonpoissonian
         for i, probs_occur in enumerate(probs_or_tom):
-            pnes[i] = get_probability_no_exceedance_np(probs_occur, poes[i])
+            set_probability_no_exceedance_np(probs_occur, poes[i], pnes[i])
     return pnes
 
 
-def get_probability_no_exceedance_np(probs_occur, poes):
+@compile("(float64[:], float64[:,:], float64[:,:])")
+def set_probability_no_exceedance_np(probs_occur, poes, pnes):
     """
     :param probs_occur: an array of probabilities
     :param poes: an array of PoEs
-    :returns: an array of PNEs computed as ∑ p(k|T) * p(X<x|rup)^k
+    :paran pnes: set an array of PNEs computed as ∑ p(k|T) * p(X<x|rup)^k
     """
     # Uses the formula
     #
@@ -270,5 +271,8 @@ def get_probability_no_exceedance_np(probs_occur, poes):
     #
     # `p(k|T)` is given by the attribute probs_occur and
     # `p(X<x|rup)` is computed as ``1 - poes``.
-    pnes = F64([v * (1 - poes) ** p for p, v in enumerate(probs_occur)])
-    return numpy.clip(pnes.sum(axis=0), 0., 1.)  # avoid numeric issues
+    P = len(probs_occur)
+    arr = numpy.zeros((P,) + poes.shape)
+    for p, v in enumerate(probs_occur):
+        arr[p] = v * (1 - poes) ** p
+    pnes[:] = numpy.clip(arr.sum(axis=0), 0., 1.)  # avoid numeric issues

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -215,7 +215,9 @@ def get_probability_no_exceedance_rup(rup, poes, tom):
         temporal occurrence model (not used if the rupture is nonparametric)
     """
     if numpy.isnan(rup.occurrence_rate):  # nonparametric
-        return get_probability_no_exceedance_np(rup.probs_occur, poes)
+        pnes = numpy.zeros_like(poes)
+        set_probability_no_exceedance_np(rup.probs_occur, poes, pnes)
+        return pnes
     else:  # parametric
         return tom.get_probability_no_exceedance(rup.occurrence_rate, poes)
 

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -271,7 +271,7 @@ def set_probability_no_exceedance_np(probs_occur, poes, pnes):
     #
     # `p(k|T)` is given by the attribute probs_occur and
     # `p(X<x|rup)` is computed as ``1 - poes``.
-    arr = numpy.zeros_like(poes)
-    for p, v in enumerate(probs_occur):
+    arr = numpy.full_like(poes, probs_occur[0])
+    for p, v in enumerate(probs_occur[1:], 1):
         arr += v * (1 - poes) ** p
     pnes[:] = numpy.clip(arr, 0., 1.)  # avoid numeric issues

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -271,8 +271,7 @@ def set_probability_no_exceedance_np(probs_occur, poes, pnes):
     #
     # `p(k|T)` is given by the attribute probs_occur and
     # `p(X<x|rup)` is computed as ``1 - poes``.
-    P = len(probs_occur)
-    arr = numpy.zeros((P,) + poes.shape)
+    arr = numpy.zeros_like(poes)
     for p, v in enumerate(probs_occur):
-        arr[p] = v * (1 - poes) ** p
-    pnes[:] = numpy.clip(arr.sum(axis=0), 0., 1.)  # avoid numeric issues
+        arr += v * (1 - poes) ** p
+    pnes[:] = numpy.clip(arr, 0., 1.)  # avoid numeric issues


### PR DESCRIPTION
Optimizing with numba also nonparametric occurrence rates. Here is an example with a source from SAM (speedup 9x in "computing pnes"):
```
# before
| calc_53715, maxmem=4.0 GB | time_sec | memory_mb | counts |
|---------------------------+----------+-----------+--------|
| total classical           | 394.9    | 90.4      | 23     |
| computing pnes            | 279.3    | 0.0       | 626    |
| ClassicalCalculator.run   | 70.7     | 206.4     | 1      |
| get_poes                  | 59.6     | 0.0       | 626    |
| computing mean_std        | 18.9     | 0.0       | 626    |
| make_contexts             | 14.2     | 24.4      | 23     |
# after
| calc_53738, maxmem=4.1 GB | time_sec | memory_mb | counts |
|---------------------------+----------+-----------+--------|
| total classical           | 151.7    | 90.7      | 23     |
| get_poes                  | 62.3     | 0.0       | 626    |
| ClassicalCalculator.run   | 39.7     | 198.9     | 1      |
| computing pnes            | 31.5     | 0.0       | 626    |
| computing mean_std        | 19.6     | 0.0       | 626    |
| make_contexts             | 14.6     | 24.2      | 23     |
```