### PR TITLE
Reducing the memory stress on the CPU

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-
+  * Reduced the stress on the memory in classical calculations
   * Setting the truncation_level to the empty string is now forbidden;
     some GMFs calculations not setting truncation_level can now give
     different results since truncation_level=None is now replaced with

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -33,7 +33,7 @@ from openquake.hazardlib.calc import filters
 from openquake.hazardlib.geo.utils import get_longitudinal_extent
 from openquake.hazardlib.geo.utils import (angular_distance, KM_TO_DEGREES,
                                            cross_idl)
-from openquake.hazardlib.tom import get_probability_no_exceedance_rup
+from openquake.hazardlib.tom import get_pnes
 from openquake.hazardlib.site import SiteCollection
 from openquake.hazardlib.gsim.base import to_distribution_values
 from openquake.hazardlib.contexts import ContextMaker
@@ -165,7 +165,8 @@ def disaggregate(ctxs, tom, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
         poes[:, :, m, p, z] = _disagg_eps(
             truncnorm.sf(lvls), idxs, eps_bands, cum_bands)
     for u, ctx in enumerate(ctxs):
-        pnes[u] *= get_probability_no_exceedance_rup(ctx, poes[u], tom)  # slow
+        pnes[u] *= get_pnes(ctx.occurrence_rate, ctx.probs_occur, poes[u],
+                            tom.time_span)  # slow
     bindata = BinData(dists, lons, lats, pnes)
     DEBUG[idx].append(pnes.mean())
     if not bin_edges:

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -166,7 +166,7 @@ def disaggregate(ctxs, tom, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
             truncnorm.sf(lvls), idxs, eps_bands, cum_bands)
     for u, ctx in enumerate(ctxs):
         pnes[u] *= get_pnes(ctx.occurrence_rate, ctx.probs_occur, poes[u],
-                            tom.time_span)  # slow
+                            tom.time_span)
     bindata = BinData(dists, lons, lats, pnes)
     DEBUG[idx].append(pnes.mean())
     if not bin_edges:

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -164,9 +164,11 @@ def disaggregate(ctxs, tom, g_by_z, iml2dict, eps3, sid=0, bin_edges=()):
         idxs = numpy.searchsorted(epsilons, lvls)
         poes[:, :, m, p, z] = _disagg_eps(
             truncnorm.sf(lvls), idxs, eps_bands, cum_bands)
+    z0 = numpy.zeros(0)
     for u, ctx in enumerate(ctxs):
-        pnes[u] *= get_pnes(ctx.occurrence_rate, ctx.probs_occur, poes[u],
-                            tom.time_span)
+        pnes[u] *= get_pnes(ctx.occurrence_rate,
+                            getattr(ctx, 'probs_occur', z0),
+                            poes[u], tom.time_span)
     bindata = BinData(dists, lons, lats, pnes)
     DEBUG[idx].append(pnes.mean())
     if not bin_edges:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -766,7 +766,12 @@ class ContextMaker(object):
             pmap = ProbabilityMap(size(self.imtls), len(self.gsims))
         else:  # update passed probmap
             pmap = probmap
-        itime = 0. if isinstance(self.tom, FatedTOM) else self.tom.time_span
+        if self.tom is None:
+            itime = -1.  # not used
+        elif isinstance(self.tom, FatedTOM):
+            itime = 0.
+        else:
+            itime = self.tom.time_span
         for ctx in self.recarrays(ctxs):
             # allocating pmap in advance
             dic = {}  # sid -> array of shape (L, G)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -41,7 +41,7 @@ from openquake.baselib.performance import Monitor, split_array
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import valid, imt as imt_module
 from openquake.hazardlib.const import StdDev
-from openquake.hazardlib.tom import registry, get_probability_no_exceedance
+from openquake.hazardlib.tom import registry, get_pnes, FatedTOM
 from openquake.hazardlib.site import site_param_dt
 from openquake.hazardlib.stats import _truncnorm_sf
 from openquake.hazardlib.calc.filters import (
@@ -766,31 +766,34 @@ class ContextMaker(object):
             pmap = ProbabilityMap(size(self.imtls), len(self.gsims))
         else:  # update passed probmap
             pmap = probmap
+        itime = 0. if isinstance(self.tom, FatedTOM) else self.tom.time_span
         for ctx in self.recarrays(ctxs):
             # allocating pmap in advance
             dic = {}  # sid -> array of shape (L, G)
             for sid in numpy.unique(ctx.sids):
                 dic[sid] = pmap.setdefault(sid, self.rup_indep).array
             for poes, ctxt, slcsids in self.gen_poes(ctx):
-                probs_or_tom = getattr(ctxt, 'probs_occur', self.tom)
+                probs_occur = getattr(ctxt, 'probs_occur',
+                                      numpy.zeros((len(ctxt), 0)))
+                rates = getattr(ctxt, 'occurrence_rate',
+                                numpy.zeros(len(ctxt)))
                 with self.pne_mon:
-                    # the following is slow
-                    pnes = get_probability_no_exceedance(
-                        ctxt, poes, probs_or_tom)
-
-                    # the following is relatively fast
                     if isinstance(slcsids, numpy.ndarray):
                         # no collapse: avoiding an inner loop can give a 25%
                         if self.rup_indep:
-                            for poe, pne, sid in zip(poes, pnes, ctxt.sids):
-                                dic[sid] *= pne
+                            z = zip(poes, rates, probs_occur, ctxt.sids)
+                            for poe, rate, probs, sid in z:
+                                dic[sid] *= get_pnes(rate, probs, poe, itime)
                         else:  # USAmodel, New Madrid cluster
-                            w = getattr(ctxt, 'weight', numpy.zeros(len(ctxt)))
-                            for poe, pne, wei, sid in zip(
-                                    poes, pnes, w, ctxt.sids):
+                            z = zip(poes, rates, probs_occur,
+                                    ctxt.weight, ctxt.sids)
+                            for poe, rate, probs, wei, sid in z:
+                                pne = get_pnes(rate, probs, poe, itime)
                                 dic[sid] += (1. - pne) * wei
                     else:  # collapse is possible only for rup_indep
-                        for poe, pne, sids in zip(poes, pnes, slcsids):
+                        z = zip(poes, rates, probs_occur, slcsids)
+                        for poe, rate, probs, sids in z:
+                            pne = get_pnes(rate, probs, poe, itime)
                             for sid in sids:
                                 dic[sid] *= pne
 

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -35,7 +35,8 @@ except ImportError:
     from scipy.special import ndtr
 
 
-@compile("float64[:,:](float64, float64[:,:])")
+@compile(["float64[:,:](float64, float64[:,:])",
+          "float64[:](float64, float64[:])"])
 def _truncnorm_sf(truncation_level, values):
     """
     Survival function for truncated normal distribution.


### PR DESCRIPTION
cole is particulary bad at allocating memory. Let's help it but not allocating the pnes array.
```
# before the cure
| calc_153, maxmem=57.7 GB   | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total classical            | 6_342    | 209.6     | 252    |
| get_poes                   | 3_722    | 0.0       | 10_824 |
| composing pnes             | 1_763    | 0.0       | 10_824 |
| computing mean_std         | 532.4    | 0.0       | 10_824 |
| make_contexts              | 192.6    | 43.8      | 2_617  |
| ClassicalCalculator.run    | 114.3    | 1_684     | 1      |

# after the cure
| calc_154, maxmem=52.4 GB   | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total classical            | 4_741    | 200.6     | 252    |
| get_poes                   | 2_762    | 0.0       | 10_824 |
| composing pnes             | 1_098    | 0.0       | 10_824 |
| computing mean_std         | 554.3    | 0.0       | 10_824 |
| make_contexts              | 190.4    | 44.1      | 2_617  |
| ClassicalCalculator.run    | 99.0     | 1_648     | 1      |
```
The improvement  6_342 -> 4_741 (25%) is major on cole, minor on the spot machine: 3_684 -> 3_555 (3.5%)