### PR TITLE
Avoided double counting with `ps_grid_spacing`

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -85,8 +85,6 @@ def preclassical(srcs, sites, cmaker, monitor):
     cmaker.set_weight(dic[grp_id], sf, mon)
     dic['before'] = len(split_sources)
     dic['after'] = len(dic[grp_id])
-    if spacing:
-        dic['ps_grid/%02d' % monitor.task_no] = dic[grp_id]
     return dic
 
 
@@ -179,20 +177,7 @@ def run_preclassical(calc):
     for val, key in sorted((val, key) for key, val in acc.items()):
         cls = code2cls[key].__name__
         logging.info('{} ruptures: {:_d}'.format(cls, val))
-
     calc.store_source_info(source_data(csm.get_sources()))
-    # store ps_grid data, if any
-    for key, sources in res.items():
-        if isinstance(key, str) and key.startswith('ps_grid/'):
-            arrays = []
-            for ps in sources:
-                if hasattr(ps, 'location'):
-                    lonlats = [ps.location.x, ps.location.y]
-                    for src in getattr(ps, 'pointsources', []):
-                        lonlats.extend([src.location.x, src.location.y])
-                    arrays.append(F32(lonlats))
-            h5[key] = arrays
-
     h5['full_lt'] = csm.full_lt
     return res
 


### PR DESCRIPTION
Storing the ps_grid information was causing double counting of simple fault ruptures in some models (like EUR), already at the preclassical level.