### PR TITLE
Reducing the memory stress on the CPU/3

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -99,9 +99,9 @@ def run_preclassical(calc):
     calc.datastore['toms'] = numpy.array(
         [sg.tom_name for sg in csm.src_groups], hdf5.vstr)
     cmakers = read_cmakers(calc.datastore, csm.full_lt)
-    L = calc.oqparam.imtls.size
+    M = len(calc.oqparam.imtls)
     G = max(len(cm.gsims) for cm in cmakers)
-    logging.info('Max NLG={:.1f} MB'.format(MEDSIZE * L * G * 8 / 1024**2))
+    logging.info('Max 4NMG={:.1f} MB'.format(4*MEDSIZE*M*G*8 / 1024**2))
     h5 = calc.datastore.hdf5
     calc.sitecol = sites = csm.sitecol if csm.sitecol else None
     # do nothing for atomic sources except counting the ruptures

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -101,7 +101,7 @@ def run_preclassical(calc):
     cmakers = read_cmakers(calc.datastore, csm.full_lt)
     M = len(calc.oqparam.imtls)
     G = max(len(cm.gsims) for cm in cmakers)
-    logging.info('Max 4NMG={:.1f} MB'.format(4*MEDSIZE*M*G*8 / 1024**2))
+    logging.info('Max 4GMN={:.1f} MB'.format(4*MEDSIZE*M*G*8 / 1024**2))
     h5 = calc.datastore.hdf5
     calc.sitecol = sites = csm.sitecol if csm.sitecol else None
     # do nothing for atomic sources except counting the ruptures

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -918,7 +918,7 @@ class ContextMaker(object):
         """
         from openquake.hazardlib.site_amplification import get_poes_site
         L, G = self.loglevels.size, len(self.gsims)
-        # F is the MEDSIZE reduction factor such that the NLG arrays have
+        # L1 is the MEDSIZE reduction factor such that the NLG arrays have
         # the same size as the GMN array and fit in the CPU cache
         L1 = L // len(self.loglevels)
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -49,7 +49,7 @@ from openquake.hazardlib.geo.surface.multi import get_distdic, MultiSurface
 U32 = numpy.uint32
 F64 = numpy.float64
 MAXSIZE = 500_000  # used when collapsing
-MEDSIZE = 10_000  # crucial so that the arrays NLG fit in the CPU cache
+MEDSIZE = 5_000  # crucial so that the arrays NLG fit in the CPU cache
 TWO16 = 2**16
 TWO24 = 2**24
 TWO32 = 2**32

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -49,7 +49,7 @@ from openquake.hazardlib.geo.surface.multi import get_distdic, MultiSurface
 U32 = numpy.uint32
 F64 = numpy.float64
 MAXSIZE = 500_000  # used when collapsing
-MEDSIZE = 1000  # crucial so that the arrays NLG fit in the CPU cache
+MEDSIZE = 10_000  # crucial so that the arrays NLG fit in the CPU cache
 TWO16 = 2**16
 TWO24 = 2**24
 TWO32 = 2**32


### PR DESCRIPTION
Carefully crafting the lengths of the arrays `mean_stds` and `poes`. Now cole is faster than the spot machine. For instance for EUR:
```
# EUR on cole
| calc_70, maxmem=71.3 GB    | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 83_409   | 689.6     | 269       |
| get_poes                   | 38_647   | 0.0       | 9_039_982 |
| computing mean_std         | 16_692   | 0.0       | 453_822   |
| composing pnes             | 13_993   | 0.0       | 9_039_982 |
| make_contexts              | 11_815   | 154.2     | 22_083    |
| ClassicalCalculator.run    | 1_433    | 5_282     | 1         |
# EUR on spot
| calc_45009, maxmem=68.6 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 94_978   | 664.9     | 254       |
| get_poes                   | 44_549   | 0.0       | 9_039_983 |
| computing mean_std         | 17_409   | 0.0       | 453_816   |
| composing pnes             | 16_028   | 0.0       | 9_039_983 |
| make_contexts              | 14_461   | 160.3     | 22_083    |
| ClassicalCalculator.run    | 1_496    | 5_333     | 1         |
```