### PR TITLE
Supporting h5py >=3.4

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -185,7 +185,6 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                 self.oqparam, self.datastore.hdf5)
             logging.info(f'Checksum of the inputs: {check} '
                          f'(total size {general.humansize(size)})')
-        self.datastore.flush()
 
     def check_precalc(self, precalc_mode):
         """


### PR DESCRIPTION
Removing the flush avoids the error in case_1g ``RuntimeError: Can't decrement id ref count (slist already enabled?)``
Related to https://github.com/gem/oq-engine/pull/7702.