### PR TITLE
Fixed NaNs in disaggregation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed disaggregation returning NaNs in some situations with
+    nonParametric/multiFaultSources
   * Bug fix: not storing far away ruptures coming from multiFaultSources
   * Implemented CScalingMSR
   * Optimized context collapsing in classical calculations

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1161,9 +1161,7 @@ class PmapMaker(object):
         ctx = ctxs[0]
         for par in self.cmaker.get_ctx_params():
             pa = par[:-1] if par.endswith('_') else par
-            if pa not in vars(ctx):
-                continue
-            elif par.endswith('_'):
+            if par.endswith('_'):
                 if par == 'probs_occur_':
                     lst = [getattr(ctx, pa, []) for ctx in ctxs]
                 else:


### PR DESCRIPTION
Discovered by our friends in New Zealand. A test has been added in oq-risk-tests. Already backported to engine-3.14.