### PR TITLE
Better vectorization of get_poes

### DIFF
--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -92,17 +92,18 @@ def _get_poes(mean_std, loglevels, truncation_level):
     # returns a matrix of shape (N, L)
     N = mean_std.shape[2]  # shape (2, M, N)
     L1 = loglevels.size // len(loglevels)
-    out = numpy.zeros((N, loglevels.size))  # shape (N, L)
+    out = numpy.zeros((loglevels.size, N))  # shape (L, N)
     for m, levels in enumerate(loglevels):
         mL1 = m * L1
         iml = numpy.zeros((L1, 1))  # trick to vectorize better
-        iml[:, 0] = levels
+        iml[:, 0] = levels  # numba is not happy with reshape
+        mea, sig = mean_std[:, m]  # shape N
         if truncation_level == 0.:
-            out[:, mL1:mL1 + L1] = (iml <= mean_std[0, m]).T  # (N, L1)
+            out[mL1:mL1 + L1] = (iml <= mea)  # shape (L1, N)
         else:
-            out[:, mL1:mL1 + L1] = _truncnorm_sf(
-                truncation_level, (iml - mean_std[0, m]) / mean_std[1, m]).T
-    return out
+            out[mL1:mL1 + L1] = _truncnorm_sf(  # shape (L1, N)
+                truncation_level, (iml - mea) / sig)
+    return out.T
 
 
 OK_METHODS = 'compute get_mean_and_stddevs get_poes set_parameters set_tables'

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -92,15 +92,16 @@ def _get_poes(mean_std, loglevels, truncation_level):
     # returns a matrix of shape (N, L)
     N = mean_std.shape[2]  # shape (2, M, N)
     L1 = loglevels.size // len(loglevels)
-    out = numpy.zeros((N, loglevels.size))  # shape (N, L)
+    out = numpy.zeros((N, loglevels.size))  # shape (N, L1)
     for m, levels in enumerate(loglevels):
         mL1 = m * L1
-        for li, iml in enumerate(levels):
-            if truncation_level == 0.:
-                out[:, mL1 + li] = iml <= mean_std[0, m]
-            else:
-                out[:, mL1 + li] = _truncnorm_sf(
-                    truncation_level, (iml - mean_std[0, m]) / mean_std[1, m])
+        iml = numpy.zeros((L1, 1))  # trick to vectorize better
+        iml[:, 0] = levels
+        if truncation_level == 0.:
+            out[:, mL1:mL1 + L1] = (iml <= mean_std[0, m]).T  # (N, L1)
+        else:
+            out[:, mL1:mL1 + L1] = _truncnorm_sf(
+                truncation_level, (iml - mean_std[0, m]) / mean_std[1, m]).T
     return out
 
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -92,7 +92,7 @@ def _get_poes(mean_std, loglevels, truncation_level):
     # returns a matrix of shape (N, L)
     N = mean_std.shape[2]  # shape (2, M, N)
     L1 = loglevels.size // len(loglevels)
-    out = numpy.zeros((N, loglevels.size))  # shape (N, L1)
+    out = numpy.zeros((N, loglevels.size))  # shape (N, L)
     for m, levels in enumerate(loglevels):
         mL1 = m * L1
         iml = numpy.zeros((L1, 1))  # trick to vectorize better


### PR DESCRIPTION
Without numba `get_poes` was 11 times slower. Now it is only 1.2 times slower and in any case faster than before. Here are some figures for the tiling test:
```
# before
| calc_358, maxmem=2.5 GB    | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 4_965    | 75.8      | 54      |
| get_poes                   | 4_453    | 0.0       | 721_887 |
| ClassicalCalculator.run    | 721.2    | 145.1     | 1       |
# now
| calc_443, maxmem=2.5 GB    | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 924.9    | 75.9      | 54      |
| get_poes                   | 417.2    | 0.0       | 721_887 |
| ClassicalCalculator.run    | 140.1    | 183.0     | 1       |
```