### PR TITLE
Fixed bug for empty probs_occur

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1159,11 +1159,12 @@ class PmapMaker(object):
         if not ctxs:
             return dic
         ctx = ctxs[0]
+        z0 = numpy.zeros(0)
         for par in self.cmaker.get_ctx_params():
             pa = par[:-1] if par.endswith('_') else par
             if par.endswith('_'):
                 if par == 'probs_occur_':
-                    lst = [getattr(ctx, pa, []) for ctx in ctxs]
+                    lst = [getattr(ctx, pa, z0) for ctx in ctxs]
                 else:
                     lst = [getattr(ctx, pa) for ctx in ctxs]
                 dic[par] = numpy.array(lst, dtype=object)


### PR DESCRIPTION
The disaggregation fix https://github.com/gem/oq-engine/pull/7740 broke the KOR model:
```python
  File "/home/openquake/openquake/lib/python3.8/site-packages/openquake/calculators/classical.py", line 293, in agg_dicts
    store_ctxs(self.datastore, dic['rup_data'], grp_id)
  File "/home/openquake/openquake/lib/python3.8/site-packages/openquake/calculators/classical.py", line 76, in store_ctxs
    dstore.hdf5.save_vlen(n, rupdata[par])
  File "/home/openquake/openquake/lib/python3.8/site-packages/openquake/baselib/hdf5.py", line 420, in save_vlen
    shape = (None,) + data[0].shape[:-1]
AttributeError: 'list' object has no attribute 'shape'
```
Fixing it.