### PR TITLE
Huge speedup of the classical calculator for few sites

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1101,6 +1101,7 @@ class PmapMaker(object):
                 else self.srcfilter.split)
         cm = self.cmaker
         allctxs = []
+        totlen = 0
         for src, sites in filt(self.group):
             t0 = time.time()
             if self.fewsites:
@@ -1109,7 +1110,8 @@ class PmapMaker(object):
             allctxs.extend(ctxs)
             nctxs = len(ctxs)
             nsites = sum(len(ctx) for ctx in ctxs)
-            if nsites and sum(len(ctx) for ctx in allctxs) > MAXSIZE:
+            totlen += nsites
+            if nsites and totlen > MAXSIZE:
                 cm.get_pmap(allctxs, pmap)
                 allctxs.clear()
             dt = time.time() - t0


### PR DESCRIPTION
While working at https://github.com/gem/oq-engine/issues/7745 I discovered that a *huge* amount of time was wasted in computing `len(ctx)` millions of time.
```
$ OQ_SAMPLE_SITES=.001 oq run GLD.zip -c0 -s100 && oq show performance

# master
| calc_55097, maxmem=0.4 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| ClassicalCalculator.run    | 134.1    | 128.6     | 1      |
| total classical            | 126.6    | 204.8     | 1      |
| make_contexts              | 56.4     | 187.6     | 2_516  |

# this branch, double speed
| calc_55098, maxmem=0.4 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| ClassicalCalculator.run    | 70.7     | 129.1     | 1      |
| total classical            | 63.4     | 203.8     | 1      |
| make_contexts              | 54.4     | 187.8     | 2_516  |
```
The effect is huge in the case of few sites, but visible also in the case of many sites.