### PR TITLE
make_contexts/6

### DIFF
--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -114,7 +114,7 @@ class PlanarSurface(BaseSurface):
             bottom_left.latitude, bottom_right.latitude], [
                 top_left.depth, top_right.depth,
                 bottom_left.depth, bottom_right.depth]])  # shape (3, 4)
-        # now set the attributes normal, d, uv1, uv2, zero_zero
+        # now set the attributes normal, d, uv1, uv2, tl
         self._init_plane(check)
 
     @classmethod
@@ -258,7 +258,7 @@ class PlanarSurface(BaseSurface):
         # corners. see :meth:`_project`.
         self.uv1 = geo_utils.normalized(tr - tl)
         self.uv2 = numpy.cross(self.normal, self.uv1)
-        self.zero_zero = tl
+        self.tl = tl
 
         # now we can check surface for validity
         dists, xx, yy = self._project(self.mesh.xyz)
@@ -359,7 +359,7 @@ class PlanarSurface(BaseSurface):
         # uses method from http://www.9math.com/book/projection-point-plane
         dists = points @ self.normal + self.d
         # translate projected points to surface coordinate space, shape (N, 3)
-        vectors2d = points - self.normal * dists[:, None] - self.zero_zero
+        vectors2d = points - self.normal * dists[:, None] - self.tl
         return dists, vectors2d @ self.uv1, vectors2d @ self.uv2
 
     def _project_back(self, dists, xx, yy):
@@ -373,7 +373,7 @@ class PlanarSurface(BaseSurface):
         :return:
             Tuple of longitudes, latitudes and depths numpy arrays.
         """
-        vectors = (self.zero_zero +
+        vectors = (self.tl +
                    self.uv1 * xx.reshape(xx.shape + (1, )) +
                    self.uv2 * yy.reshape(yy.shape + (1, )) +
                    self.normal * dists.reshape(dists.shape + (1, )))

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -243,8 +243,7 @@ class PlanarSurface(BaseSurface):
         Prepare everything needed for projecting arbitrary points on a plane
         containing the surface.
         """
-        tl, tr, bl, br = geo_utils.spherical_to_cartesian(
-            self.corner_lons, self.corner_lats, self.corner_depths)
+        tl, tr, bl, br = xyz = self.mesh.xyz
         # these two parameters define the plane that contains the surface
         # (in 3d Cartesian space): a normal unit vector,
         self.normal = geo_utils.normalized(numpy.cross(tl - tr, tl - bl))
@@ -261,7 +260,7 @@ class PlanarSurface(BaseSurface):
         self.tl = tl
 
         # now we can check surface for validity
-        dists, xx, yy = self._project(self.mesh.xyz)
+        dists, xx, yy = self._project(xyz)
         # "length" of the rupture is measured along the top edge
         length1, length2 = xx[1] - xx[0], xx[3] - xx[2]
         # "width" of the rupture is measured along downdip direction

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -21,7 +21,6 @@ from unittest.mock import Mock
 import numpy
 from openquake.baselib.general import AccumDict, groupby_grid
 from openquake.baselib.performance import Monitor
-from openquake.hazardlib.scalerel import PointMSR
 from openquake.hazardlib.geo import Point, geodetic
 from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib.source.base import (
@@ -43,6 +42,14 @@ surfin_dt = numpy.dtype([
     ('lat', float),
     ('dep', float),
     ('dims', (float, 3)),
+])
+
+surfout_dt = numpy.dtype([
+    ('zero', float),
+    ('normal', float),
+    ('uv1', float),
+    ('uv2', float),
+    ('wld', float),
 ])
 
 

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -44,14 +44,6 @@ surfin_dt = numpy.dtype([
     ('dims', (float, 3)),
 ])
 
-surfout_dt = numpy.dtype([
-    ('zero', float),
-    ('normal', float),
-    ('uv1', float),
-    ('uv2', float),
-    ('wld', float),
-])
-
 
 def _get_rupture_dimensions(surfin):
     """

--- a/openquake/hazardlib/tests/geo/utils_test.py
+++ b/openquake/hazardlib/tests/geo/utils_test.py
@@ -262,7 +262,7 @@ class SphericalToCartesianAndBackTestCase(unittest.TestCase):
                          numpy.array([lons, lats, depths]).shape)
         aac([lons, lats, depths], res_sphe)
 
-    def test_zero_zero_zero(self):
+    def test_tl_zero(self):
         self._test((0, 0, 0), (6371, 0, 0))
         self._test((0, 0, None), (6371, 0, 0))
         self._test(([0], [0], [0]), [(6371, 0, 0)])


### PR DESCRIPTION
Part of #7745. Removing the redundant call to `spherical_to_cartesian`, with some improvement:
```
$ OQ_SAMPLE_SITES=.01 oq run GLD.zip && oq show performance
# with double spherical_to_cartesian
| calc_55324, maxmem=2.7 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total classical            | 215.0    | 7.77734   | 254    |
| make_contexts              | 122.9    | 0.95703   | 2_617  |
| ClassicalCalculator.run    | 48.6     | 55.7      | 1      |
| iter_ruptures              | 45.0     | 0.0       | 2_617  |
| get_poes                   | 37.7     | 0.0       | 4_285  |

# with single spherical_to_cartesian
| calc_55323, maxmem=2.7 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total classical            | 195.2    | 7.62500   | 254    |
| make_contexts              | 110.9    | 0.95312   | 2_617  |
| ClassicalCalculator.run    | 41.5     | 54.8      | 1      |
| iter_ruptures              | 38.4     | 0.0       | 2_617  |
| get_poes                   | 34.2     | 0.0       | 4_285  |
```
Plus some renaming.