### PR TITLE
WIP on (un)limiting the max number of source branches

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -50,6 +50,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 BASE94 = ''.join(chr(i) for i in range(65, 127)) + ''.join(
     chr(i) for i in range(33, 65))
+BASE8836 = [''.join(x) for x in itertools.product(BASE94, BASE94)] #CBC allow for larger source_logic_trees
 mp = multiprocessing.get_context('spawn')
 
 

--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -47,6 +47,7 @@ from openquake.hazardlib.gsim_lt import (
 from openquake.hazardlib.lt import (
     Branch, BranchSet, Realization, CompositeLogicTree, dummy_branchset,
     LogicTreeError, parse_uncertainty, random, attach_to_branches)
+from openquake.baselib.general import BASE8836, BASE94
 
 TRT_REGEX = re.compile(r'tectonicRegion="([^"]+?)"')
 ID_REGEX = re.compile(r'Source\s+id="([^"]+?)"')
@@ -319,7 +320,7 @@ class SourceModelLogicTree(object):
                 root, self.filename, "missing logicTree node")
         self.shortener = {}
         self.branchsets = []
-        self.parse_tree(tree)
+        self.parse_tree(tree) #!CBC
 
         # determine if the logic tree is source specific
         dicts = list(self.bsetdict.values())[1:]
@@ -350,7 +351,7 @@ class SourceModelLogicTree(object):
         t0 = time.time()
         for depth, blnode in enumerate(tree_node.nodes):
             [bsnode] = bsnodes(self.filename, blnode)
-            self.parse_branchset(bsnode, depth)
+            self.parse_branchset(bsnode, depth) #!CBC
         dt = time.time() - t0
         bname = os.path.basename(self.filename)
         logging.info('Validated %s in %.2f seconds', bname, dt)
@@ -386,7 +387,7 @@ class SourceModelLogicTree(object):
             raise nrml.DuplicatedID('%s in %s' % (bsid, self.filename))
         self.bsetdict[bsid] = attrs
         self.validate_branchset(branchset_node, depth, branchset)
-        self.parse_branches(branchset_node, branchset)
+        self.parse_branches(branchset_node, branchset) #!CBC
         dummies = []  # dummy branches in case of applyToBranches
         if self.root_branchset is None:  # not set yet
             self.num_paths = 1
@@ -463,8 +464,10 @@ class SourceModelLogicTree(object):
                     branchnode, self.filename,
                     "branchID '%s' is not unique" % branch_id)
             self.branches[branch_id] = branch
+            shortener_chars = BASE8836 if len(branches) > 94 else BASE94
+            #shortener_chars = BASE94
             self.shortener[branch_id] = keyno(
-                branch_id, bsno, brno, self.filename)
+                branch_id, bsno, brno, self.filename, shortener_chars)
             branchset.branches.append(branch)
         if abs(weight_sum - 1.0) > pmf.PRECISION:
             raise LogicTreeError(

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -25,9 +25,10 @@ min_input_size = 1_000_000
 
 [memory]
 # use at most 1 TiB for the poes
-limit = 1_000_000_000_000
+#20 GB
+limit = 20_000_000_000
 # above this quantity (in %) of memory used a warning will be printed
-soft_mem_limit = 90
+soft_mem_limit = 10
 # above this quantity (in %) of memory used the job will be stopped
 # use a lower value to protect against loss of control when OOM occurs
 hard_mem_limit = 99
@@ -53,7 +54,7 @@ listen = 127.0.0.1
 host = localhost
 # port 1908 has a good reputation:
 # https://isc.sans.edu/port.html?port=1908
-port = 1908
+port = 1909
 # receiver host; if missing use hostname
 receiver_host = 
 # port range used by workers to send back results

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -137,8 +137,9 @@ def keyno(branch_id, bsno, brno, fname='', chars=BASE94):
     :param brno: number of the branch in the branchset (starting from 0)
     :returns: a short unique alias for the branch_id
     """
-    if not set(branch_id) <= set(chars):
-        raise ValueError('%s %s' % (ex, fname))
+    #!CBC this check is not making sense, and `ex` is out of scope!
+    #if not set(branch_id) <= set(chars):
+    #     raise ValueError('%s %s' % (ex, fname))
     return chars[brno] + str(bsno)
 
 


### PR DESCRIPTION
resolves #7757 

This is not an ideal fix, but as I'm new to the project I thought I'd submit as is and garner feedback. Possible improvements...
 - [ ] make shortener a class and encapsulate the character-set management (choose max-size in __init__)
 - [ ] then call `shortener.keyno()`
 - [ ] figure out what the exception in keyno fn is meant to do. It doesn't work as expected now.