### PR TITLE
make_contexts/8

### DIFF
--- a/openquake/hazardlib/geo/surface/complex_fault.py
+++ b/openquake/hazardlib/geo/surface/complex_fault.py
@@ -28,7 +28,7 @@ from openquake.baselib.node import Node
 from openquake.hazardlib.geo.line import Line
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo.surface.base import BaseSurface
-from openquake.hazardlib.geo.surface.planar import PlanarSurface, _project
+from openquake.hazardlib.geo.surface.planar import PlanarSurface
 from openquake.hazardlib.geo.mesh import Mesh, RectangularMesh
 from openquake.hazardlib.geo.utils import spherical_to_cartesian
 
@@ -222,8 +222,8 @@ class ComplexFaultSurface(BaseSurface):
         # project surface boundary to reference plane and check for
         # validity.
         ref_plane = PlanarSurface.from_corner_points(ul, ur, br, bl)
-        _, xx, yy = _project(ref_plane,
-                             spherical_to_cartesian(lons, lats, depths))
+        _, xx, yy = ref_plane._project(
+            spherical_to_cartesian(lons, lats, depths))
         coords = [(x, y) for x, y in zip(xx, yy)]
         p = shapely.geometry.Polygon(coords)
         if not p.is_valid:

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -52,9 +52,9 @@ def build_surfout(array, hypo=(), check=False):
     """
     :returns: a surfout array of length 3
     """
-    surfout = numpy.zeros(3, surfout_dt).view(numpy.recarray)
+    surfout = numpy.zeros(array.shape[:-1], surfout_dt).view(numpy.recarray)
     surfout['corners'] = array
-    if len(hypo):
+    if isinstance(hypo, numpy.ndarray):
         surfout['hypo'] = hypo
     tl, tr, bl, br = xyz = geo_utils.spherical_to_cartesian(*array)
     surfout['xyz'] = xyz.T

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -48,12 +48,14 @@ surfout_dt = numpy.dtype([
     ('hypo', float)])
 
 
-def build_surfout(array, check=False):
+def build_surfout(array, hypo=(), check=False):
     """
     :returns: a surfout array of length 3
     """
     surfout = numpy.zeros(3, surfout_dt).view(numpy.recarray)
     surfout['corners'] = array
+    if len(hypo):
+        surfout['hypo'] = hypo
     tl, tr, bl, br = xyz = geo_utils.spherical_to_cartesian(*array)
     surfout['xyz'] = xyz.T
     # these two parameters define the plane that contains the surface
@@ -302,7 +304,7 @@ class PlanarSurface(BaseSurface):
         Prepare everything needed for projecting arbitrary points on a plane
         containing the surface.
         """
-        surfout = build_surfout(self.corners, check)
+        surfout = build_surfout(self.corners, check=check)
         for par in surfout.dtype.names:
             setattr(self, par, surfout[par])
 

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -101,9 +101,8 @@ class AreaSource(ParametricSeismicSource):
         np_probs, nplanes = zip(*self.nodal_plane_distribution.data)
         hc_probs, depths = zip(*self.hypocenter_distribution.data)
         surfin = PointSource.get_surfin(self, mags, nplanes)
-        points = [geo.Point(epicenter0.x, epicenter0.y, depth)
-                  for depth in depths]
-        surfaces = build_planar_surfaces(surfin, points, shift_hypo)
+        surfaces = build_planar_surfaces(
+            surfin, epicenter0.x, epicenter0.y, depths, shift_hypo)
         for m, mag in enumerate(mags):
             for n, np in enumerate(nplanes):
                 for d, hc_depth in enumerate(depths):

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -113,7 +113,8 @@ def _surfout(surfin, clon, clat, cdepths):
                 array[:2] = geodetic.point_at(clon, clat, azimuths, hor_dist)
                 array[2, 0:2] = cdep - half_height
                 array[2, 2:4] = cdep + half_height
-                out[m, n, d] = build_surfout(array, [clon, clat, cdep])
+                hypo = numpy.array([clon, clat, cdep])
+                out[m, n, d] = build_surfout(array, hypo, check=False)
     return out
 
 

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -298,14 +298,12 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         for num_occ, args, rate in zip(occurs, rup_args, rates):
             if num_occ:
                 mag_occ_rate, np_prob, hc_prob, mag, np, hc_depth, src = args
-                hc = Point(latitude=src.location.latitude,
-                           longitude=src.location.longitude,
-                           depth=hc_depth)
+                lon, lat = src.location.x, src.location.y
                 [[[surface]]] = build_planar_surfaces(
-                    src.get_surfin([mag], [np]), [hc])
+                    src.get_surfin([mag], [np]), lon, lat, [hc_depth])
                 rup = ParametricProbabilisticRupture(
-                    mag, np.rake, src.tectonic_region_type, hc,
-                    surface, rate, tom)
+                    mag, np.rake, src.tectonic_region_type,
+                    surface.hc, surface, rate, tom)
                 yield rup, num_occ
 
     @abc.abstractmethod

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -106,31 +106,34 @@ def _surfout(usd, lsd, mag, dims, strike, dip, clon, clat, cdep):
     return out
 
 
-def build_planar_surfaces(surfin, hypos, shift_hypo=False):
+def build_planar_surfaces(surfin, lon, lat, depths, shift_hypo=False):
     """
     :param surfin:
         Surface input parameters as an array of shape (M, N)
-    :param hypos:
-        A list of hypocenters with different depths
+    :param lon:
+        Hypocenter longitude
+    :param lat:
+        Hypocenter latitude
+    :param depths:
+        An array of hypocentral depths
     :param shift_hypo:
         If true, change .hc to the shifted hypocenter
     :return:
         an array of PlanarSurfaces of shape (M, N, D)
     """
-    out = numpy.zeros(surfin.shape + (len(hypos),), object)  # shape (M, N, D)
-    hypo_arr = numpy.array([(h.x, h.y, h.z) for h in hypos])  # shape (D, 3)
+    out = numpy.zeros(surfin.shape + (len(depths),), object)  # shape (M, N, D)
     M, N, D = out.shape
     for m in range(M):
         for n in range(N):
-            for d in range(D):
+            for d, dep in enumerate(depths):
                 rec = surfin[m, n]
                 surfout = _surfout(rec.usd, rec.lsd, rec.mag, rec.dims,
-                                   rec.strike, rec.dip, *hypo_arr[d])
+                                   rec.strike, rec.dip, lon, lat, dep)
                 surface = PlanarSurface.from_(surfout, rec.strike, rec.dip)
                 if shift_hypo:
                     surface.hc = Point(*surfout['hypo'])
                 else:
-                    surface.hc = hypos[d]
+                    surface.hc = Point(lon, lat, dep)
                 out[m, n, d] = surface
     return out
 

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -106,12 +106,12 @@ def _surfout(usd, lsd, mag, dims, strike, dip, clon, clat, cdep):
     return out
 
 
-def build_planar_array(surfin, hypos, shift_hypo=False):
+def build_planar_array(surfin, hypos, shift_hypo):
     """
     :param surfin:
         Surface input parameters as an array of shape (M, N)
     :param hypos:
-        A list of hypocenters with different depths
+        Array of hypocenters with shape (D, 3)
     :param shift_hypo:
         If true, change .hc to the shifted hypocenter
     :return:
@@ -123,10 +123,8 @@ def build_planar_array(surfin, hypos, shift_hypo=False):
         for n in range(N):
             rec = surfin[m, n]
             for d in range(D):
-                hypo = hypos[d]
                 out[m, n, d] = _surfout(rec.usd, rec.lsd, rec.mag, rec.dims,
-                                        rec.strike, rec.dip,
-                                        hypo.x, hypo.y, hypo.z)
+                                        rec.strike, rec.dip, *hypos[d])
     return out
 
 
@@ -142,7 +140,8 @@ def build_planar_surfaces(surfin, hypos, shift_hypo=False):
         an array of PlanarSurfaces of shape (M, N, D)
     """
     out = numpy.zeros(surfin.shape + (len(hypos),), object)  # shape (M, N, D)
-    surfout = build_planar_array(surfin, hypos, shift_hypo)
+    hypo_arr = numpy.array([(h.x, h.y, h.z) for h in hypos])  # shape (D, 3)
+    surfout = build_planar_array(surfin, hypo_arr, shift_hypo)
     M, N, D = surfout.shape[:-1]
     for m in range(M):
         for n in range(N):

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -139,18 +139,18 @@ def _gen_ruptures(src, nplanes=(), hypos=(), filtermag=None, shift_hypo=False):
         np_probs = [1.]
     if not hypos:
         hc_probs, depths = zip(*src.hypocenter_distribution.data)
-        hypos = [Point(src.location.x, src.location.y, dep) for dep in depths]
     else:
-        hc_probs = [1.]
+        hc_probs, depths = [1.], [h.z for h in hypos]
     surfin = src.get_surfin(mags, nplanes)
-    surfaces = build_planar_surfaces(surfin, hypos, shift_hypo)
+    x, y = src.location.x, src.location.y
+    surfaces = build_planar_surfaces(surfin, x, y, depths, shift_hypo)
     for m, mag in enumerate(mags):
         for n, np in enumerate(nplanes):
-            for d, hypo in enumerate(hypos):
+            for d, hc_prob in enumerate(hc_probs):
                 surface = surfaces[m, n, d]
                 yield ParametricProbabilisticRupture(
                     mag, np.rake, src.tectonic_region_type,
-                    surface.hc, surface, rates[m] * np_probs[n] * hc_probs[d],
+                    surface.hc, surface, rates[m] * np_probs[n] * hc_prob,
                     src.temporal_occurrence_model)
 
 

--- a/openquake/hazardlib/tests/geo/surface/planar_test.py
+++ b/openquake/hazardlib/tests/geo/surface/planar_test.py
@@ -19,7 +19,7 @@ import numpy
 from openquake.hazardlib.geo import Point
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.geo import utils as geo_utils
-from openquake.hazardlib.geo.surface.planar import PlanarSurface, _project
+from openquake.hazardlib.geo.surface.planar import PlanarSurface
 from openquake.hazardlib.tests.geo.surface import _planar_test_data as tdata
 from openquake.hazardlib.scalerel import WC1994
 
@@ -183,7 +183,7 @@ class PlanarSurfaceProjectTestCase(unittest.TestCase):
         xyz = numpy.array([[60, -10, -10], [59, 0, 0], [70, -11, -10]])
         plons, plats, pdepths = geo_utils.cartesian_to_spherical(xyz)
 
-        dists, xx, yy = _project(surface, xyz)
+        dists, xx, yy = surface._project(xyz)
         aaae(xx, [0, 10, 0])
         aaae(yy, [0, 10, -1])
         aaae(dists, [0, 1, -10])
@@ -201,7 +201,7 @@ class PlanarSurfaceProjectTestCase(unittest.TestCase):
         plons, plats, pdepths = [[4., 4.3, 3.1], [1.5, 1.7, 3.5],
                                  [11., 12., 13.]]
         xyz = geo_utils.spherical_to_cartesian(plons, plats, pdepths)
-        dists, xx, yy = _project(surface, xyz)
+        dists, xx, yy = surface._project(xyz)
         lons, lats, depths = surface._project_back(dists, xx, yy)
         aaae = numpy.testing.assert_array_almost_equal
         aaae(lons, plons)

--- a/openquake/hazardlib/tests/source/point_test.py
+++ b/openquake/hazardlib/tests/source/point_test.py
@@ -163,8 +163,8 @@ class PointSourceIterRupturesTestCase(unittest.TestCase):
         width_right = surface.top_right.distance(surface.bottom_right)
         self.assertAlmostEqual(width_left, width_right, delta=delta)
         self.assertAlmostEqual(width_right, width, delta=delta)
-        self.assertAlmostEqual(width, surface.width, delta=delta)
-        self.assertAlmostEqual(length, surface.length, delta=delta)
+        self.assertAlmostEqual(width, surface.wld[0], delta=delta)
+        self.assertAlmostEqual(length, surface.wld[1], delta=delta)
 
     def test_1_rupture_is_inside(self):
         rupture = self._get_rupture(min_mag=5, max_mag=6, hypocenter_depth=8,


### PR DESCRIPTION
More refactoring for #7745. `_project` is back to being a method. It is also faster since the useless term `self.normal * dists[:, None]` has been removed (it is parallel to the normal,  so not contributing when projecting with uv1 and uv2). Here are the figures:
```
$ OQ_SAMPLE_SITES=.001 oq run GLD.zip -c0 && oq show performance
# master
| calc_5427, maxmem=0.4 GB   | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| ClassicalCalculator.run    | 41.0     | 221.2     | 1      |
| total classical            | 33.0     | 184.1     | 1      |
| make_contexts              | 28.8     | 167.7     | 2_516  |
| iter_ruptures              | 12.3     | 0.0       | 2_516  |
# surfout
| calc_5425, maxmem=0.5 GB   | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| ClassicalCalculator.run    | 38.0     | 228.3     | 1      |
| total classical            | 30.1     | 191.5     | 1      |
| make_contexts              | 26.0     | 175.6     | 2_516  |
| iter_ruptures              | 10.2     | 0.0       | 2_516  |
```