### PR TITLE
Made test_shapefile skippable

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -31,13 +31,7 @@ import pathlib
 import logging
 import json
 import zipfile
-
 from shapely.geometry import Polygon
-try:
-    import shapefile  # optional dependency
-except ImportError:
-    pass
-
 import numpy
 from openquake.baselib.general import CallableDict
 from openquake.baselib.node import node_from_xml
@@ -113,6 +107,7 @@ def get_array_shapefile(kind, fname):
     either a zip or the location of one of the files,
     *.shp and *.dbf are necessary, *.prj and *.shx optional
     """
+    import shapefile  # optional dependency
     fname = path2url(fname)
 
     extensions = ['shp', 'dbf', 'prj', 'shx']

--- a/openquake/hazardlib/tests/shakemap/shakemapconverter_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemapconverter_test.py
@@ -1,6 +1,11 @@
 import os.path
 import unittest
 import numpy
+try:
+    import shapefile  # optional dependency
+except ImportError:
+    shapefile = None
+
 from openquake.baselib.general import gettemp
 from openquake.hazardlib.shakemap.parsers import \
     get_shakemap_array, get_array_shapefile
@@ -66,6 +71,7 @@ class ShakemapConverterTestCase(unittest.TestCase):
         array = get_shakemap_array(grid_file, uncertainty_file)
         aae(array['std']['SA(0.3)'], [0.57, 0.55, 0.56, 0.52])
 
+    @unittest.skipUnless(shapefile, 'Missing dependency pyshp')
     def test_shapefile(self):
         dt = sorted((imt[1], F32)
                     for key, imt in FIELDMAP.items() if imt[0] == 'val')

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ extras_require = {
         'flake8 >=3.5',
         'pdbpp',
         'ipython',
-        'silx == 0.10',
+        'silx',
     ]
 }
 


### PR DESCRIPTION
If `pyshp` is not installed. Closes https://github.com/gem/oq-engine/issues/7773.