### PR TITLE
make_contexts/11

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -724,9 +724,9 @@ class ContextMaker(object):
         with self.ir_mon:
             allrups = numpy.array(
                 list(src.iter_ruptures(shift_hypo=self.shift_hypo, step=step)))
-        ms = numpy.array([rup.m for rup in allrups])
+        m_idx = numpy.array([rup.m for rup in allrups])
         for m, rup in enumerate(src.iruptures(step)):
-            rups = allrups[ms == m]
+            rups = allrups[m_idx == m]  # ruptures with magnitude index `m`
             psdist = self.pointsource_distance + src.get_radius(rup)
             close = sites.filter(cdist <= psdist)
             far = sites.filter(cdist > psdist)
@@ -979,6 +979,7 @@ class ContextMaker(object):
                             poes[:, :, g] = gsim.get_poes(ms, self, ctxt)
                 yield poes, ctxt, slcsids
 
+    # tested in test_collapse_small
     def estimate_weight(self, src, srcfilter):
         """
         :param src: a source object
@@ -997,7 +998,7 @@ class ContextMaker(object):
         nsites = numpy.array([len(ctx) for ctx in ctxs])
         if (hasattr(src, 'location') and src.count_nphc() > 1 and
                 self.pointsource_distance < 1000):
-            eff_rups = src.num_ruptures / 5  # heuristic
+            eff_rups = src.num_ruptures / 6  # heuristic
         else:
             eff_rups = src.num_ruptures
         weight = eff_rups * (nsites.mean() / N + .02)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -721,8 +721,9 @@ class ContextMaker(object):
     def _cps_rups(self, src, sites, step):
         fewsites = len(sites) <= self.max_sites_disagg
         cdist = sites.get_cdist(src.location)
-        allrups = numpy.array(
-            list(src.iter_ruptures(shift_hypo=self.shift_hypo, step=step)))
+        with self.ir_mon:
+            allrups = numpy.array(
+                list(src.iter_ruptures(shift_hypo=self.shift_hypo, step=step)))
         ms = numpy.array([rup.m for rup in allrups])
         for m, rup in enumerate(src.iruptures(step)):
             rups = allrups[ms == m]


### PR DESCRIPTION
Reimplemented https://github.com/gem/oq-engine/pull/7752/ in a fast way. Now the time spent in `iter_ruptures` is sometimes reduced, like in the case of GLD with ps_grid_spacing=35:
```
# master
| calc_56386, maxmem=3.8 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 1_761    | 60.6      | 275     |
| get_poes                   | 857.1    | 0.0       | 199_166 |
| computing mean_std         | 404.0    | 0.0       | 10_085  |
| composing pnes             | 275.0    | 0.0       | 199_166 |
| ClassicalCalculator.run    | 207.3    | 382.6     | 1       |
| make_contexts              | 155.9    | 10.1      | 1_134   |
| iter_ruptures              | 30.8     | 0.0       | 15_147  |

# filtermag is faster since iter_ruptures goes down
| calc_56389, maxmem=3.8 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 1_704    | 54.5      | 275     |
| get_poes                   | 841.2    | 0.0       | 199_158 |
| computing mean_std         | 394.2    | 0.0       | 10_086  |
| composing pnes             | 270.6    | 0.0       | 199_158 |
| ClassicalCalculator.run    | 192.7    | 395.8     | 1       |
| make_contexts              | 130.7    | 10.1      | 1_134   |
| iter_ruptures              | 10.2     | 0.0       | 1_134   |
```