### PR TITLE
Simple performance improvement of Kuehn et al. 2020 model

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Tom Son, Claudio Schill]
+  * Simple performance improvement of Kuehn et al. 2020 model
+
   [Michele Simionato]
   * Fixed the field `source_info.trti` in the datastore to point to the
     correct tectonic region type index and not to zero

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -837,9 +837,7 @@ class ContextMaker(object):
             recarrays = [self.recarray(ctxs)]
         if any(hasattr(gsim, 'gmpe_table') for gsim in self.gsims):
             assert len(recarrays) == 1, len(recarrays)
-            recarrays = split_array(
-                recarrays[0], U32(numpy.round(recarrays[0].mag * 100).astype(int))
-            )
+            recarrays = split_array(recarrays[0], U32(recarrays[0].mag*100))
         self.adj = {gsim: [] for gsim in self.gsims}  # NSHM2014 adjustments
         for g, gsim in enumerate(self.gsims):
             compute = gsim.__class__.compute

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -837,7 +837,9 @@ class ContextMaker(object):
             recarrays = [self.recarray(ctxs)]
         if any(hasattr(gsim, 'gmpe_table') for gsim in self.gsims):
             assert len(recarrays) == 1, len(recarrays)
-            recarrays = split_array(recarrays[0], U32(recarrays[0].mag*100))
+            recarrays = split_array(
+                recarrays[0], numpy.round(recarrays[0].mag * 100).astype(int)
+            )
         self.adj = {gsim: [] for gsim in self.gsims}  # NSHM2014 adjustments
         for g, gsim in enumerate(self.gsims):
             compute = gsim.__class__.compute

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -838,7 +838,7 @@ class ContextMaker(object):
         if any(hasattr(gsim, 'gmpe_table') for gsim in self.gsims):
             assert len(recarrays) == 1, len(recarrays)
             recarrays = split_array(
-                recarrays[0], numpy.round(recarrays[0].mag * 100).astype(int)
+                recarrays[0], U32(numpy.round(recarrays[0].mag * 100).astype(int))
             )
         self.adj = {gsim: [] for gsim in self.gsims}  # NSHM2014 adjustments
         for g, gsim in enumerate(self.gsims):

--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -600,7 +600,6 @@ class KuehnEtAl2020SInter(GMPE):
                       interpolated to the magnitude and distances required
     """
     experimental = True
-    gmpe_table = True  # enable split by mag
 
     #: Supported tectonic region type is subduction interface
     DEFINED_FOR_TECTONIC_REGION_TYPE = const.TRT.SUBDUCTION_INTERFACE
@@ -654,6 +653,7 @@ class KuehnEtAl2020SInter(GMPE):
         # epsilon for epistemic uncertainty
         self.sigma_mu_epsilon = sigma_mu_epsilon
         if self.sigma_mu_epsilon:
+            self.gmpe_table = True  # enable split by mag
             self.sigma_mu_model = _retrieve_sigma_mu_data(
                 self.DEFINED_FOR_TECTONIC_REGION_TYPE, self.region)
         else:
@@ -688,7 +688,7 @@ class KuehnEtAl2020SInter(GMPE):
                 pga_soil = get_mean_values(C_PGA, self.region, trt, m_b,
                                            ctx, pga1100)
                 break
-        [mag] = np.unique(np.round(ctx.mag, 6))
+
         for m, imt in enumerate(imts):
             # Get coefficients for imt
             C = self.COEFFS[imt]
@@ -709,6 +709,7 @@ class KuehnEtAl2020SInter(GMPE):
                                           ctx, pga1100)
             # Apply the sigma mu adjustment if necessary
             if self.sigma_mu_epsilon:
+                [mag] = np.unique(np.round(ctx.mag, 6))
                 sigma_mu_adjust = get_sigma_mu_adjustment(
                     self.sigma_mu_model, imt, mag, ctx.rrup)
                 mean[m] += self.sigma_mu_epsilon * sigma_mu_adjust

--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -709,7 +709,7 @@ class KuehnEtAl2020SInter(GMPE):
                                           ctx, pga1100)
             # Apply the sigma mu adjustment if necessary
             if self.sigma_mu_epsilon:
-                [mag] = np.unique(np.round(ctx.mag, 6))
+                [mag] = np.unique(np.round(ctx.mag, 2))
                 sigma_mu_adjust = get_sigma_mu_adjustment(
                     self.sigma_mu_model, imt, mag, ctx.rrup)
                 mean[m] += self.sigma_mu_epsilon * sigma_mu_adjust


### PR DESCRIPTION
# Simple performance improvement of Kuehn et al. 2020 model

### Kuehn 2020 proposed workflow on splitting recarrays

As proposed(#7785), we only split `recarrays` into sub-arrays if a user specifies a `sigma_mu_epsilon`

### Minor updates on the way of using `split_array`
In the current workflow, the given magnitudes must be in 2dp. 
To be slightly more robust, we modified a little bit and now, magnitudes can have more than 2dp.