### PR TITLE
Numbified cartesian_to_spherical

### DIFF
--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -32,6 +32,7 @@ import shapely.geometry
 from shapely.strtree import STRtree
 
 from openquake.baselib.hdf5 import vstr
+from openquake.baselib.performance import compile
 from openquake.hazardlib.geo import geodetic
 
 U32 = numpy.uint32
@@ -570,25 +571,26 @@ def get_middle_point(lon1, lat1, lon2, lat2):
     return geodetic.point_at(lon1, lat1, azimuth, dist / 2.0)
 
 
-def cartesian_to_spherical(vectors):
+@compile("f8[:,:](f8[:,:])")
+def cartesian_to_spherical(arrayN3):
     """
     Return the spherical coordinates for coordinates in Cartesian space.
 
     This function does an opposite to :func:`spherical_to_cartesian`.
 
-    :param vectors:
-        Array of 3d vectors in Cartesian space of shape (..., 3)
+    :param arrayN3:
+        Array of cartesian coordinates of shape (N, 3)
     :returns:
-        Tuple of three arrays of the same shape as ``vectors`` representing
-        longitude (decimal degrees), latitude (decimal degrees) and depth (km)
-        in specified order.
+        Array of shape (3, N) representing longitude (decimal degrees),
+        latitude (decimal degrees) and depth (km) in specified order.
     """
-    rr = numpy.sqrt(numpy.sum(vectors * vectors, axis=-1))
-    xx, yy, zz = vectors.T
-    lats = numpy.degrees(numpy.arcsin((zz / rr).clip(-1., 1.)))
-    lons = numpy.degrees(numpy.arctan2(yy, xx))
-    depths = EARTH_RADIUS - rr
-    return lons.T, lats.T, depths
+    out = numpy.zeros_like(arrayN3)
+    rr = numpy.sqrt(numpy.sum(arrayN3 * arrayN3, axis=-1))
+    xx, yy, zz = arrayN3.T
+    out[:, 0] = numpy.degrees(numpy.arcsin((zz / rr).clip(-1., 1.)))
+    out[:, 1] = numpy.degrees(numpy.arctan2(yy, xx))
+    out[:, 2] = EARTH_RADIUS - rr
+    return out.T  # shape (3, N)
 
 
 def triangle_area(e1, e2, e3):

--- a/openquake/hazardlib/tests/geo/point_test.py
+++ b/openquake/hazardlib/tests/geo/point_test.py
@@ -148,13 +148,6 @@ class PointCreationTestCase(unittest.TestCase):
         geo.Point(0.0, 90.0, EARTH_ELEVATION + 0.1)
 
 
-class PointFromVectorTestCase(unittest.TestCase):
-    def test_from_vector(self):
-        point = geo.Point(12.34, -56.78, 91.011)
-        vector = spherical_to_cartesian(point.x, point.y, point.z)
-        self.assertEqual(point, geo.Point.from_vector(vector))
-
-
 class PointToPolygonTestCase(unittest.TestCase):
     def test(self):
         point = geo.Point(10.43, -35.1)

--- a/openquake/hazardlib/tests/geo/surface/planar_test.py
+++ b/openquake/hazardlib/tests/geo/surface/planar_test.py
@@ -180,7 +180,8 @@ class PlanarSurfaceProjectTestCase(unittest.TestCase):
         surface = PlanarSurface(20, 30, *Mesh(lons, lats, depths))
         aaae = numpy.testing.assert_array_almost_equal
 
-        xyz = numpy.array([[60, -10, -10], [59, 0, 0], [70, -11, -10]])
+        xyz = numpy.array(
+            [[60., -10., -10.], [59., 0., 0.], [70., -11., -10.]])
         plons, plats, pdepths = geo_utils.cartesian_to_spherical(xyz)
 
         dists, xx, yy = _project(surface, xyz)

--- a/openquake/hazardlib/tests/geo/utils_test.py
+++ b/openquake/hazardlib/tests/geo/utils_test.py
@@ -262,23 +262,17 @@ class SphericalToCartesianAndBackTestCase(unittest.TestCase):
         aac([lons, lats, depths], res_sphe)
 
     def test_tl_zero(self):
-        self._test((0, 0, 0), (6371, 0, 0))
-        self._test((0, 0, None), (6371, 0, 0))
         self._test(([0], [0], [0]), [(6371, 0, 0)])
         self._test(([0], [0], None), [(6371, 0, 0)])
 
     def test_north_pole(self):
-        self._test((0, 90, 0), (0, 0, 6371))
-        self._test((0, 90, None), (0, 0, 6371))
         self._test(([0], [90], [0]), [(0, 0, 6371)])
         self._test(([0], [90], None), [(0, 0, 6371)])
 
     def test_north_pole_10_km_depth(self):
-        self._test((0, 90, 10), (0, 0, 6361))
         self._test(([0], [90], [10]), [(0, 0, 6361)])
 
     def test_topo(self):
-        self._test((0, 0, -10), (6381, 0, 0))
         self._test(([0], [0], [-10]), [(6381, 0, 0)])
 
     def test_arrays(self):


### PR DESCRIPTION
The performance improvement is marginal (the bottlenecks are others), but it is needed to numbify `PlanarSurface.get_closest_points`, which is part of the program described in https://github.com/gem/oq-engine/issues/7745. 