### PR TITLE
Rewritten disaggregation in terms of context arrays

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -116,8 +116,6 @@ def compute_disagg(dstore, slc, cmaker, hmap4, magi, bin_edges, monitor):
     with monitor('reading contexts', measuremem=True):
         dstore.open('r')
         allctxs = cmaker.read_ctxs(dstore, slc)
-        for magidx, ctx in zip(magi, allctxs):
-            ctx.magi = magidx
     # Set epsstar boolean variable
     epsstar = dstore['oqparam'].epsilon_star
     dis_mon = monitor('disaggregate', measuremem=False)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -116,6 +116,8 @@ def compute_disagg(dstore, slc, cmaker, hmap4, magi, bin_edges, monitor):
     with monitor('reading contexts', measuremem=True):
         dstore.open('r')
         allctxs = cmaker.read_ctxs(dstore, slc)
+        for magidx, ctx in zip(magi, allctxs):
+            ctx.magi = magidx
     # Set epsstar boolean variable
     epsstar = dstore['oqparam'].epsilon_star
     dis_mon = monitor('disaggregate', measuremem=False)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -478,13 +478,17 @@ class ContextMaker(object):
         # ctxs.sort(key=operator.attrgetter('mag'))
         return ctxs
 
-    def recarray(self, ctxs):
+    def recarray(self, ctxs, magi=None):
         """
         :params ctxs: a non-empty list of homogeneous contexts
         :returns: a recarray, possibly collapsed
         """
         assert ctxs
         dd = self.defaultdict.copy()
+        if magi is not None:  # magnitude bin used in disaggregation
+            dd['magi'] = numpy.uint8(0)
+            dd['clon'] = numpy.float64(0.)
+            dd['clat'] = numpy.float64(0.)
         if hasattr(ctxs[0], 'weight'):
             dd['weight'] = numpy.float64(0.)
             noweight = False

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -515,7 +515,9 @@ class ContextMaker(object):
                 gsim.set_parameters(ctx)
             slc = slice(start, start + len(ctx))
             for par in dd:
-                if par == 'mdvbin':
+                if par == 'magi':  # in disaggregation
+                    val = magi
+                elif par == 'mdvbin':
                     val = self.collapser.calc_mdvbin(ctx)
                 elif par == 'weight' and noweight:
                     val = 0.


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/7745. This is a huge improvement: next is to store directly the context arrays, then it will be possible to return arrays directly from `get_ctxs`, and then for point sources the arrays can be build directly in a vectorized way, with a huge speedup. Notice also that we are *removing* lines of code.