### PR TITLE
make_ctxs/18

### DIFF
--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -213,6 +213,7 @@ def _reshape(array, orig_shape):
     return array[0]  # scalar array
 
 
+@compile("f8[:, :](f8[:], f8[:], f8[:])")
 def spherical_to_cartesian(lons, lats, depths):
     """
     Return the position vectors (in Cartesian coordinates) of list of spherical

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -213,7 +213,7 @@ def _reshape(array, orig_shape):
     return array[0]  # scalar array
 
 
-def spherical_to_cartesian(lons, lats, depths=None):
+def spherical_to_cartesian(lons, lats, depths):
     """
     Return the position vectors (in Cartesian coordinates) of list of spherical
     coordinates.
@@ -235,19 +235,9 @@ def spherical_to_cartesian(lons, lats, depths=None):
     """
     phi = np.radians(lons)
     theta = np.radians(lats)
-    if depths is None:
-        rr = EARTH_RADIUS
-    else:
-        rr = EARTH_RADIUS - np.array(depths)
+    rr = EARTH_RADIUS - np.array(depths)
     cos_theta_r = rr * np.cos(theta)
-    try:
-        shape = lons.shape
-    except AttributeError:  # a list/tuple was passed
-        try:
-            shape = (len(lons),)
-        except TypeError:  # a scalar was passed
-            shape = ()
-    arr = np.zeros(shape + (3,))
+    arr = np.zeros(phi.shape + (3,))
     arr[..., 0] = cos_theta_r * np.cos(phi)
     arr[..., 1] = cos_theta_r * np.sin(phi)
     arr[..., 2] = rr * np.sin(theta)

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -26,7 +26,7 @@ from scipy.spatial.distance import cdist
 from openquake.baselib.node import Node
 from openquake.baselib.performance import numba, compile
 from openquake.hazardlib.geo.geodetic import (
-    point_at, spherical_to_cartesian)
+    point_at, spherical_to_cartesian, fast_spherical_to_cartesian)
 from openquake.hazardlib.geo import Point
 from openquake.hazardlib.geo.surface.base import BaseSurface
 from openquake.hazardlib.geo.mesh import Mesh
@@ -290,8 +290,7 @@ def get_rjb(planar, points):
         # distances from all the target points to each of surface's
         # corners' projections (we might not need all of those but it's
         # better to do that calculation once for all).
-        corners = spherical_to_cartesian(
-            corners[0], corners[1], numpy.zeros_like(corners[0]))
+        corners = fast_spherical_to_cartesian(corners[0], corners[1])
         # shape (4, 3) and (N, 3) -> (4, N) -> N
         dists_to_corners = cdist(corners, points).min(axis=0)  # shape N
 

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -290,7 +290,8 @@ def get_rjb(planar, points):
         # distances from all the target points to each of surface's
         # corners' projections (we might not need all of those but it's
         # better to do that calculation once for all).
-        corners = spherical_to_cartesian(corners[0], corners[1])
+        corners = spherical_to_cartesian(
+            corners[0], corners[1], numpy.zeros_like(corners[0]))
         # shape (4, 3) and (N, 3) -> (4, N) -> N
         dists_to_corners = cdist(corners, points).min(axis=0)  # shape N
 

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -176,7 +176,7 @@ def project(planar, points):
             ],
             # case "III": abscissa doesn't have an effect on a distance
             # to the rectangle
-            default=0
+            default=0.
         )
         # for ordinate we do the same operation (again three cases):
         #
@@ -278,31 +278,35 @@ def get_rjb(planar, points):
         strike, dip, rake = pla['sdr']
         downdip = (strike + 90) % 360
         corners = pla.corners
+        clons, clats = numpy.zeros(4), numpy.zeros(4)
+        clons[:], clats[:] = corners[0], corners[1]
         dists_to_arcs = numpy.zeros((len(lons), 4))  # shape (N, 4)
         # calculate distances from all the target points to all four arcs
         dists_to_arcs[:, 0] = geodetic.distances_to_arc(
-            corners[0, 2], corners[1, 2], strike, lons, lats)
+            clons[2], clats[2], strike, lons, lats)
         dists_to_arcs[:, 1] = geodetic.distances_to_arc(
-            corners[0, 0], corners[1, 0], strike, lons, lats)
+            clons[0], clats[0], strike, lons, lats)
         dists_to_arcs[:, 2] = geodetic.distances_to_arc(
-            corners[0, 0], corners[1, 0], downdip, lons, lats)
+            clons[0], clats[0], downdip, lons, lats)
         dists_to_arcs[:, 3] = geodetic.distances_to_arc(
-            corners[0, 1], corners[1, 1], downdip, lons, lats)
+            clons[1], clats[1], downdip, lons, lats)
 
         # distances from all the target points to each of surface's
         # corners' projections (we might not need all of those but it's
         # better to do that calculation once for all).
-        corners = fast_spherical_to_cartesian(corners[0], corners[1])
+        corners = fast_spherical_to_cartesian(clons, clats)
         # shape (4, 3) and (N, 3) -> (4, N) -> N
-        dists_to_corners = [geo_utils.min_distance(point, corners)
-                            for point in points]
+        dists_to_corners = numpy.array([geo_utils.min_distance(point, corners)
+                                        for point in points])
 
         # extract from ``dists_to_arcs`` signs (represent relative positions
         # of an arc and a point: +1 means on the left hand side, 0 means
         # on arc and -1 means on the right hand side) and minimum absolute
         # values of distances to each pair of parallel arcs.
         ds1, ds2, ds3, ds4 = numpy.sign(dists_to_arcs).transpose()
-        dists_to_arcs = numpy.abs(dists_to_arcs).reshape(-1, 2, 2).min(axis=-1)
+        dta = numpy.abs(dists_to_arcs).reshape(-1, 2, 2)
+        dists_to_arcs0 = numpy.array([d2[0].min() for d2 in dta])
+        dists_to_arcs1 = numpy.array([d2[1].min() for d2 in dta])
 
         out[u] = numpy.select(
             # consider four possible relative positions of point and arcs:
@@ -323,14 +327,14 @@ def get_rjb(planar, points):
                 dists_to_corners,
                 # case "II": closest distance is distance to arc "1" or "2",
                 # whichever is closer
-                dists_to_arcs[:, 0],
+                dists_to_arcs0,
                 # case "III": closest distance is distance to either
                 # arc "3" or "4"
-                dists_to_arcs[:, 1]
+                dists_to_arcs1
             ],
 
             # default -- case "IV"
-            default=0)
+            default=0.)
     return out
 
 
@@ -345,11 +349,10 @@ if numba:
         numba.float64[:, :],
         numba.float64[:, :]
     ))(project_back)
-    # need to numbify spherical_to_cartesian
-    #get_rjb = compile(numba.float64[:, :](
-    #    planar_nt[:, :],
-    #    numba.float64[:, :],
-    #))(get_rjb)
+    get_rjb = compile(numba.float64[:, :](
+        planar_nt[:, :],
+        numba.float64[:, :],
+    ))(get_rjb)
 
 
 class PlanarSurface(BaseSurface):

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -593,6 +593,15 @@ def cartesian_to_spherical(arrayN3):
     return out.T  # shape (3, N)
 
 
+@compile("f8(f8[:], f8[:, :])")
+def min_distance(point, points):
+    x0, y0, z0 = point
+    d2 = numpy.zeros(len(points))
+    for i, (x, y, z) in enumerate(points):
+        d2[i] = (x-x0)**2 + (y-y0)**2 + (z-z0)**2
+    return math.sqrt(d2.min())
+
+
 def triangle_area(e1, e2, e3):
     """
     Get the area of triangle formed by three vectors.


### PR DESCRIPTION
Used numba inside get_rjb. This gives some speedup. Here is the test share_small in oq-risk-tests:
```
# master
| calc_16897, maxmem=4.9 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 2_456    | 89.5      | 250     |
| make_contexts              | 2_098    | 84.3      | 18_865  |
| iter_ruptures              | 461.3    | 0.0       | 18_865  |
| ClassicalCalculator.run    | 355.7    | 1_101     | 1       |

# rjb
| calc_16834, maxmem=4.9 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 1_789    | 84.0      | 250     |
| make_contexts              | 1_403    | 80.0      | 18_865  |
| iter_ruptures              | 492.3    | 0.0       | 18_865  |
| ClassicalCalculator.run    | 273.6    | 1_117     | 1       |
```
