### PR TITLE
Fixed bug introduced in https://github.com/gem/oq-engine/pull/7795

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -130,28 +130,28 @@ def compute_disagg(dstore, slc, cmaker, hmap4, magi, bin_edges, monitor):
     eps3 = disagg._eps3(cmaker.truncation_level, cmaker.num_epsilon_bins)
     imts = [from_string(im) for im in cmaker.imtls]
     for magi, ctxs in groupby(allctxs, operator.attrgetter('magi')).items():
-        ctx = cmaker.recarray(ctxs, magi)
-        res = {'trti': cmaker.trti, 'magi': magi}
-        # disaggregate by site, IMT
-        for s, iml3 in enumerate(hmap4):
-            close = ctx[(ctx.sids == s) & (ctx.magi == magi)]
-            if len(g_by_z[s]) == 0 or len(close) == 0:
-                # g_by_z[s] is empty in test case_7
-                continue
-            # dist_bins, lon_bins, lat_bins, eps_bins
-            bins = (bin_edges[1], bin_edges[2][s], bin_edges[3][s],
-                    bin_edges[4])
-            iml2 = dict(zip(imts, iml3))
-            with dis_mon:
-                # 7D-matrix #distbins, #lonbins, #latbins, #epsbins, M, P, Z
-                matrix = disagg.disaggregate(close, cmaker, g_by_z[s],
-                                             iml2, eps3, s, bins,
-                                             epsstar=epsstar)  # 7D-matrix
-                for m in range(M):
-                    mat6 = matrix[..., m, :, :]
-                    if mat6.any():
-                        res[s, m] = output(mat6)
-        yield res
+        for ctx in cmaker.recarrays(ctxs, magi):
+            res = {'trti': cmaker.trti, 'magi': magi}
+            # disaggregate by site, IMT
+            for s, iml3 in enumerate(hmap4):
+                close = ctx[(ctx.sids == s) & (ctx.magi == magi)]
+                if len(g_by_z[s]) == 0 or len(close) == 0:
+                    # g_by_z[s] is empty in test case_7
+                    continue
+                # dist_bins, lon_bins, lat_bins, eps_bins
+                bins = (bin_edges[1], bin_edges[2][s], bin_edges[3][s],
+                        bin_edges[4])
+                iml2 = dict(zip(imts, iml3))
+                with dis_mon:
+                    # 7D-matrix #disbins, #lonbins, #latbins, #epsbins, M, P, Z
+                    matrix = disagg.disaggregate(close, cmaker, g_by_z[s],
+                                                 iml2, eps3, s, bins,
+                                                 epsstar=epsstar)  # 7D-matrix
+                    for m in range(M):
+                        mat6 = matrix[..., m, :, :]
+                        if mat6.any():
+                            res[s, m] = output(mat6)
+            yield res
     # NB: compressing the results is not worth it since the aggregation of
     # the matrices is fast and the data are not queuing up
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -525,11 +525,7 @@ class ContextMaker(object):
                     val = numpy.nan
                 else:  # never missing
                     val = getattr(ctx, par)
-                try:
-                    getattr(ra, par)[slc] = val
-                except:
-                    import pdb; pdb.set_trace()
-                pass
+                getattr(ra, par)[slc] = val
             ra.sids[slc] = ctx.sids
             start = slc.stop
         return ra

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -749,7 +749,7 @@ class ContextMaker(object):
         with patch.object(self.collapser, 'collapse_level', collapse_level):
             return self.get_pmap(ctxs).array(len(sitecol))
 
-    def recarrays(self, ctxs):
+    def recarrays(self, ctxs, magi=None):
         """
         :returns: a list of one or two recarrays
         """
@@ -761,9 +761,9 @@ class ContextMaker(object):
             else:
                 parametric.append(ctx)
         if parametric:
-            out.append(self.recarray(parametric))
+            out.append(self.recarray(parametric, magi))
         if nonparametric:
-            out.append(self.recarray(nonparametric))
+            out.append(self.recarray(nonparametric, magi))
         return out
 
     def get_pmap(self, ctxs, probmap=None):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -525,7 +525,11 @@ class ContextMaker(object):
                     val = numpy.nan
                 else:  # never missing
                     val = getattr(ctx, par)
-                getattr(ra, par)[slc] = val
+                try:
+                    getattr(ra, par)[slc] = val
+                except:
+                    import pdb; pdb.set_trace()
+                pass
             ra.sids[slc] = ctx.sids
             start = slc.stop
         return ra
@@ -756,7 +760,7 @@ class ContextMaker(object):
         parametric, nonparametric, out = [], [], []
         for ctx in ctxs:
             assert not isinstance(ctx, numpy.recarray), ctx
-            if hasattr(ctx, 'probs_occur'):
+            if numpy.isnan(getattr(ctx, 'occurrence_rate', numpy.nan)):
                 nonparametric.append(ctx)
             else:
                 parametric.append(ctx)


### PR DESCRIPTION
The NZ disaggregation was failing with
```python
  File "/home/michele/oq-engine/openquake/calculators/disaggregation.py", line 133, in compute_disagg
    ctx = cmaker.recarray(ctxs, magi)
  File "/home/michele/oq-engine/openquake/hazardlib/contexts.py", line 528, in recarray
    getattr(ra, par)[slc] = val
ValueError: could not broadcast input array from shape (0,) into shape (1,2)
```