### PR TITLE
Fixed `oq compare rups` after the change in the rupture storage

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -322,7 +322,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if self.few_sites:
             # self.oqparam.time_per_task = 1_000_000  # disable task splitting
             descr = []  # (param, dt)
-            for param in params:
+            for param in sorted(params):
                 if param == 'sids':
                     dt = U16  # storing only for few sites
                 elif param == 'probs_occur':

--- a/openquake/commands/compare.py
+++ b/openquake/commands/compare.py
@@ -18,7 +18,6 @@
 import sys
 import collections
 import numpy
-from openquake.baselib.general import rmsdiff
 from openquake.commonlib import datastore
 from openquake.calculators.extract import Extractor
 from openquake.calculators import views
@@ -37,20 +36,6 @@ def get_diff_idxs(array, rtol, atol):
             if not numpy.allclose(array[c, n], array[0, n], rtol, atol):
                 diff_idxs.add(n)
     return numpy.fromiter(diff_idxs, int)
-
-
-def _print_diff(a1, a2, idx1, idx2, col):
-    if col.endswith('_'):
-        for i, (v1, v2) in enumerate(zip(a1, a2)):
-            idx = numpy.where(numpy.abs(v1-v2) > 1e-5)
-            if len(idx[0]):
-                print(col, v1[idx], v2[idx])
-                break
-    else:
-        i, = numpy.where(numpy.abs(a1-a2) > 1e-5)
-        if len(i):
-            print(col, idx1[i], a1[i])
-            print(col, idx2[i], a2[i])
 
 
 def get_mean(extractor, what, sids, imtls, p):
@@ -190,15 +175,9 @@ def compare_rups(calc_1: int, calc_2: int):
     Compare the ruptures of two calculations as pandas DataFrames
     """
     with datastore.read(calc_1) as ds1, datastore.read(calc_2) as ds2:
-        df1 = ds1.read_df('rup', 'id').sort_index()
-        df2 = ds2.read_df('rup', 'id').sort_index()
-    cols = [col for col in df1.columns if col not in
-            {'probs_occur_', 'clon_', 'clat_'}]
-    for col in cols:
-        a1 = df1[col].to_numpy()
-        a2 = df2[col].to_numpy()
-        assert len(a1) == len(a2), (len(a1), len(a2))
-        _print_diff(a1, a2, df1.index, df2.index, col)
+        df1 = ds1.read_df('rup')
+        df2 = ds2.read_df('rup')
+    print(df1.compare(df2))
 
 
 def compare_cumtime(calc1: int, calc2: int):


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/7803, part of #7745 