### PR TITLE
Avoid logging the generic name split_task

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -756,10 +756,13 @@ class Starmap(object):
             self.calc_id = None
             h5 = hdf5.File(gettemp(suffix='.hdf5'), 'w')
             init_performance(h5)
-        self.monitor = Monitor(task_func.__name__)
+        if task_func is split_task:
+            self.name = task_args[0][1].__name__
+        else:
+            self.name = task_func.__name__
+        self.monitor = Monitor(self.name)
         self.monitor.filename = h5.filename
         self.monitor.calc_id = self.calc_id
-        self.name = self.monitor.operation
         self.task_args = task_args
         self.progress = progress
         self.h5 = h5


### PR DESCRIPTION
Instead log the name of the real task being run.