### PR TITLE
make_contexts/30

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -41,7 +41,8 @@ from openquake.hazardlib.calc.filters import (
     SourceFilter, IntegrationDistance, magdepdist, get_distances, getdefault,
     MINMAG, MAXMAG)
 from openquake.hazardlib.probability_map import ProbabilityMap
-from openquake.hazardlib.geo.surface.planar import project, project_back
+from openquake.hazardlib.geo.surface.planar import (
+    project, project_back, get_distances_planar)
 
 U32 = numpy.uint32
 F64 = numpy.float64
@@ -694,8 +695,7 @@ class ContextMaker(object):
                 umask = rrup <= self.maximum_distance(rups[0].mag)  # (U, N)
                 dists = {'rrup': rrup}
                 for par in self.REQUIRES_DISTANCES - {'rrup'}:
-                    dists[par] = numpy.array([
-                        get_distances(rup, sites, par) for rup in rups])
+                    dists[par] = get_distances_planar(planar, sites, par)
 
             for u, rup in enumerate(rups):
                 mask = umask[u]

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -87,6 +87,22 @@ def geodetic_distance(lons1, lats1, lons2, lats2, diameter=2*EARTH_RADIUS):
     return diameter * distance
 
 
+@compile("f8[:](f8, f8, f8[:], f8[:])")
+def fast_azimuth(lon, lat, lons, lats):
+    """
+    Calculate the azimuths of a collection of points with respect to a
+    reference point.
+    """
+    lon, lat = math.radians(lon), math.radians(lat)
+    lons, lats = np.radians(lons), np.radians(lats)
+    cos_lats = np.cos(lats)
+    true_course = np.arctan2(
+        np.sin(lon - lons) * cos_lats,
+        math.cos(lat) * np.sin(lats) -
+        math.sin(lat) * cos_lats * np.cos(lon - lons))
+    return - np.degrees(true_course)
+
+
 def azimuth(lons1, lats1, lons2, lats2):
     """
     Calculate the azimuth between two points or two collections of points.

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -260,10 +260,9 @@ class PointSource(ParametricSeismicSource):
                 surface = PlanarSurface.from_(pla)
                 strike, dip, rake = pla.sdr
                 rate = pla.wlr[2]
-                if shift_hypo:
-                    hc = Point(*pla.hypo)
-                else:
-                    hc = Point(clon, clat, inp.dep)
+                if not shift_hypo:
+                    pla.hypo[2] = inp.dep
+                hc = Point(*pla.hypo)
                 rup = ParametricProbabilisticRupture(
                     magd[m][1], rake, self.tectonic_region_type,
                     hc, surface, rate,  self.temporal_occurrence_model)

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -260,8 +260,8 @@ class PointSource(ParametricSeismicSource):
                 surface = PlanarSurface.from_(pla)
                 strike, dip, rake = pla.sdr
                 rate = pla.wlr[2]
-                if not shift_hypo:
-                    pla.hypo[2] = inp.dep
+                if not shift_hypo:  # use the original hypocenter
+                    pla.hypo[:] = [clon, clat, inp.dep]
                 hc = Point(*pla.hypo)
                 rup = ParametricProbabilisticRupture(
                     magd[m][1], rake, self.tectonic_region_type,


### PR DESCRIPTION
Finally  vectorized the distance computations. There is a 3x speedup in "computing distances" in the share_small calculation:
```
# master
| calc_57582, maxmem=4.6 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 2_418    | 10.6      | 251     |
| make_contexts              | 2_259    | 9.53906   | 18_865  |
| iter_ruptures              | 878.5    | 0.0       | 18_865  |
| computing distances        | 424.1    | 0.0       | 311_440 |
| ClassicalCalculator.run    | 314.3    | 1_337     | 1       |

# vectorize
| calc_57583, maxmem=4.6 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 2_225    | 7.03516   | 251     |
| make_contexts              | 2_067    | 6.51953   | 18_865  |
| iter_ruptures              | 955.5    | 0.0       | 18_865  |
| ClassicalCalculator.run    | 296.1    | 1_279     | 1       |
| computing distances        | 157.1    | 0.0       | 311_440 |
```
This seems nearly useless, since the calculation is dominated by iter_ruptures, but the next PR will drastically drop the time spent in iter_ruptures and then the improvement in the distances will become quite significant ;-)
