### PR TITLE
make_contexts/33

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -453,7 +453,7 @@ class ContextMaker(object):
         # instantiating child monitors, may be called in the workers
         self.ctx_mon = monitor('make_contexts', measuremem=True)
         self.col_mon = monitor('collapsing contexts', measuremem=False)
-        self.gmf_mon = monitor('computing mean_std', measuremem=True)
+        self.gmf_mon = monitor('computing mean_std', measuremem=False)
         self.poe_mon = monitor('get_poes', measuremem=False)
         self.pne_mon = monitor('composing pnes', measuremem=False)
         self.ir_mon = monitor('iter_ruptures', measuremem=False)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -453,7 +453,7 @@ class ContextMaker(object):
         # instantiating child monitors, may be called in the workers
         self.ctx_mon = monitor('make_contexts', measuremem=True)
         self.col_mon = monitor('collapsing contexts', measuremem=False)
-        self.gmf_mon = monitor('computing mean_std', measuremem=False)
+        self.gmf_mon = monitor('computing mean_std', measuremem=True)
         self.poe_mon = monitor('get_poes', measuremem=False)
         self.pne_mon = monitor('composing pnes', measuremem=False)
         self.ir_mon = monitor('iter_ruptures', measuremem=False)
@@ -735,7 +735,9 @@ class ContextMaker(object):
                 if len(ctxt):
                     ctxt['mdvbin'] = self.collapser.calc_mdvbin(ctxt)
                     ctxs.append(ctxt)
-        return ctxs
+        if not ctxs:
+            return []
+        return [numpy.concatenate(ctxs).view(numpy.recarray)]
 
     def _triples(self, src, sitecol, planardict):
         # splitting by magnitude


### PR DESCRIPTION
Restored long context arrays even for planar ruptures. Here is the improvement for GLD.zip on tiny:
```
# before
| calc_24283, maxmem=3.6 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 2_139    | 178.5     | 17      |
| get_poes                   | 881.3    | 0.0       | 321_029 |
| computing mean_std         | 538.8    | 0.0       | 54_957  |
| composing pnes             | 348.7    | 0.0       | 321_029 |
| ClassicalCalculator.run    | 290.6    | 357.5     | 1       |

# now
| calc_24292, maxmem=3.6 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 1_786    | 178.7     | 17      |
| get_poes                   | 858.3    | 0.0       | 428_707 |
| computing mean_std         | 405.5    | 0.0       | 22_677  |
| composing pnes             | 342.8    | 0.0       | 428_707 |
| ClassicalCalculator.run    | 245.2    | 351.7     | 1       |
```