### PR TITLE
Doubled the speed in `iter_ruptures`

### DIFF
--- a/openquake/hazardlib/scalerel/point.py
+++ b/openquake/hazardlib/scalerel/point.py
@@ -19,6 +19,7 @@
 """
 Module :mod:`openquake.hazardlib.scalerel.point` implements :class:`PointMSR`.
 """
+import numpy
 from openquake.hazardlib.scalerel.base import BaseMSR
 
 
@@ -46,4 +47,4 @@ class PointMSR(BaseMSR):
         >>> 1e-4 == point_msr.get_median_area(9.0, 0)
         True
         """
-        return 1e-4
+        return numpy.full_like(mag, 1e-4)

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -65,10 +65,10 @@ def _get_rupdims(planin, width, rar):
 
 def msr_name(src):
     """
-    :returns: the name of MSR class or "Undefined" if not applicable
+    :returns: string representation of the MSR or "Undefined" if not applicable
     """
     try:
-        return src.magnitude_scaling_relationship.__class__.__name__
+        return str(src.magnitude_scaling_relationship)
     except AttributeError:   # no MSR for nonparametric sources
         return 'Undefined'
 


### PR DESCRIPTION
By vectorizing by magnitude `get_median_area` and `get_rupdims`. Still part of #7745 . Here are the figures for Guillaume's calculation:
```
# before
| calc_25181, maxmem=2.8 GB | time_sec  | memory_mb | counts  |
|---------------------------+-----------+-----------+---------|
| total classical           | 318.9     | 6.53906   | 95      |
| iter_ruptures             | 149.3     | 0.0       | 30_645  |
| ClassicalCalculator.run   | 54.3      | 361.7     | 1       |
# after
| calc_25299, maxmem=2.8 GB | time_sec  | memory_mb | counts  |
|---------------------------+-----------+-----------+---------|
| total classical           | 228.5     | 6.57031   | 95      |
| iter_ruptures             | 61.4      | 0.0       | 30_645  |
| ClassicalCalculator.run   | 38.2      | 360.9     | 1       |
```