### PR TITLE
Introduced the concept of split sources at the XML level

### DIFF
--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -358,7 +358,7 @@ POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
         with self.assertRaises(ValueError) as ctx:
             readinput.get_exposure(oqparam)
         self.assertIn("Invalid ID 'a 1': the only accepted chars are "
-                      "a-zA-Z0-9_-, line 11", str(ctx.exception))
+                      "a-zA-Z0-9_-:, line 11", str(ctx.exception))
 
     def test_no_assets(self):
         oqparam = mock.Mock()

--- a/openquake/hazardlib/tests/valid_test.py
+++ b/openquake/hazardlib/tests/valid_test.py
@@ -32,7 +32,7 @@ class ValidationTestCase(unittest.TestCase):
             valid.simple_id('a x')
         self.assertEqual(
             str(ctx.exception),
-            "Invalid ID 'a x': the only accepted chars are a-zA-Z0-9_-")
+            "Invalid ID 'a x': the only accepted chars are a-zA-Z0-9_-:")
         with self.assertRaises(ValueError):
             valid.simple_id('0|1')
         with self.assertRaises(ValueError):

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -262,7 +262,7 @@ class SimpleId(object):
     :param length: maximum length of the ID
     :param regex: accepted characters
     """
-    def __init__(self, length, regex=r'^[\w_\-]+$'):
+    def __init__(self, length, regex=r'^[\w_\-:]+$'):
         self.length = length
         self.regex = regex
         self.__name__ = 'SimpleId(%d, %s)' % (length, regex)
@@ -270,7 +270,7 @@ class SimpleId(object):
     def __call__(self, value):
         if max(map(ord, value)) > 127:
             raise ValueError(
-                'Invalid ID %r: the only accepted chars are a-zA-Z0-9_-'
+                'Invalid ID %r: the only accepted chars are a-zA-Z0-9_-:'
                 % value)
         elif len(value) > self.length:
             raise ValueError("The ID '%s' is longer than %d character" %
@@ -278,7 +278,7 @@ class SimpleId(object):
         elif re.match(self.regex, value):
             return value
         raise ValueError(
-            "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-" % value)
+            "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-:" % value)
 
 
 MAX_ID_LENGTH = 75  # length required for some sources in US14 collapsed model


### PR DESCRIPTION
Sources that are fragments of the same total source can be recognized by using colons in the ID. For instance
```
src_cot:6pt45
src_cot:6pt55
src_cot:6pt65
src_cot:6pt75
```
When using `disagg_by_src` the engine will collect the resuls under the total source `src_cot`.
This in theory. We need a test.