### PR TITLE
Fixed type error in get_mean_and_stddevs

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import abc
 import copy
 import time
@@ -26,7 +25,6 @@ import collections
 from unittest.mock import patch
 
 import numpy
-import pandas
 from scipy.interpolate import interp1d
 from openquake.baselib.general import (
     AccumDict, DictArray, RecordBuilder, gen_slices, kmean)
@@ -324,6 +322,9 @@ class ContextMaker(object):
             except KeyError:  # missing TRT but there is only one
                 [(_, self.mags)] = oq.mags_by_trt.items()
         if 'imtls' in param:
+            for imt in param['imtls']:
+                if not isinstance(imt, str):
+                    raise TypeError('Expected string, got %s' % type(imt))
             self.imtls = param['imtls']
         elif 'hazard_imtls' in param:
             self.imtls = DictArray(param['hazard_imtls'])

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -356,7 +356,7 @@ class GroundShakingIntensityModel(metaclass=MetaGSIM):
         else:
             ctx = rup  # rup is already a good object
         if self.compute.__annotations__.get("ctx") is numpy.recarray:
-            cmaker = ContextMaker('*', [self], {'imtls': {imt: [0]}})
+            cmaker = ContextMaker('*', [self], {'imtls': {imt.string: [0]}})
             if not isinstance(ctx, numpy.ndarray):
                 ctx = cmaker.recarray([ctx])
         self.compute(ctx, [imt], mean, sig, tau, phi)

--- a/openquake/hazardlib/tests/gsim/mgmpe/generic_gmpe_avgsa_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/generic_gmpe_avgsa_test.py
@@ -130,7 +130,7 @@ class GenericGmpeAvgSATestCase(unittest.TestCase):
 
         ctx = gsim.base.RuptureContext()
         ctx.sids = [0]
-        P = imt.AvgSA
+        P = imt.AvgSA()
         S = [const.StdDev.TOTAL]
 
         with open(DATA_FILE, 'r') as f:
@@ -166,7 +166,7 @@ class GenericGmpeAvgSATestCase(unittest.TestCase):
 
         ctx = RuptureContext()
         ctx.sids = [0]
-        P = imt.AvgSA
+        P = imt.AvgSA()
         S = [const.StdDev.TOTAL]
 
         with open(DATA_FILE, 'r') as f:


### PR DESCRIPTION
The IMT has to be passed as a string, not as an instance. Also added some type checks in the ContextMaker.