### PR TITLE
Improved slow tasks more

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -175,7 +175,7 @@ def view_worst_sources(token, dstore):
     else:
         step = 1
     data = dstore.read_df('source_data', 'src_id')
-    del data['nsites']
+    del data['impact']
     ser = data.groupby('taskno').ctimes.sum().sort_values().tail(1)
     [[taskno, maxtime]] = ser.to_dict().items()
     data = data[data.taskno == taskno]

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1139,7 +1139,7 @@ def print_finite_size(rups):
     print(c)
     print('total finite size ruptures = ', sum(c.values()))
 
-    
+
 class PmapMaker(object):
     """
     A class to compute the PoEs from a given source

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1100,8 +1100,9 @@ class ContextMaker(object):
             else:
                 with mon:
                     src.esites = 0  # overridden inside estimate_weight
-                    src.weight = self.estimate_weight(src, srcfilter)
-                    src.weight += .1 if src.code in b'pP' else 1.
+                    src.weight = .1 + self.estimate_weight(src, srcfilter)
+                    if src.code not in b'pP':
+                        src.weight *= 5
 
 
 # see contexts_tests.py for examples of collapse

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1078,7 +1078,7 @@ class ContextMaker(object):
             if not ctxs:
                 return src.num_ruptures if N == 1 else 0
             esites = len(ctxs[0]) * src.num_ruptures / self.num_rups
-        weight = esites / N
+        weight = esites / N  # the weight is the effective number of ruptures
         src.esites = int(esites)
         return weight
 
@@ -1100,7 +1100,8 @@ class ContextMaker(object):
             else:
                 with mon:
                     src.esites = 0  # overridden inside estimate_weight
-                    src.weight = .1 + self.estimate_weight(src, srcfilter)
+                    src.weight = self.estimate_weight(src, srcfilter)
+                    src.weight += .1 if src.code in b'pP' else 1.
 
 
 # see contexts_tests.py for examples of collapse

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1051,9 +1051,10 @@ class ContextMaker(object):
         planardict = src.get_planar(iruptures=True)
         esites = 0
         for m, (mag, [planar]) in enumerate(planardict.items()):
-            rrup = project(planar, sites.xyz)[0, 0]  # shape N
+            dists = project(planar, sites.xyz)[0, 0]  # shape N
+            rrup = dists[dists < self.maximum_distance(mag)]
             nclose = (rrup < self.pointsource_distance + src.radius[m]).sum()
-            nfar = len(sites) - nclose
+            nfar = len(rrup) - nclose
             esites += nclose * nphc + nfar
         return esites
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1101,8 +1101,8 @@ class ContextMaker(object):
                 with mon:
                     src.esites = 0  # overridden inside estimate_weight
                     src.weight = .1 + self.estimate_weight(src, srcfilter)
-                    if src.code not in b'pP':
-                        src.weight *= 5
+                    if src.code == b'C':
+                        src.weight += 4.9
 
 
 # see contexts_tests.py for examples of collapse

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -58,6 +58,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
     splittable = True
     checksum = 0  # set in source_reader
     weight = 1  # set in contexts
+    esites = 0  # updated in estimate_weight
 
     @abc.abstractproperty
     def MODIFICATIONS(self):

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -149,6 +149,7 @@ class PointSource(ParametricSeismicSource):
     code = b'P'
     MODIFICATIONS = set()
     ps_grid_spacing = 0  # updated in CollapsedPointSource
+    esites = 0  # updated in estimate_weight
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -26,6 +26,7 @@ from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib.geo.surface.planar import (
     build_planar, PlanarSurface, planin_dt)
 from openquake.hazardlib.pmf import PMF
+from openquake.hazardlib.scalerel.point import PointMSR
 from openquake.hazardlib.source.base import ParametricSeismicSource
 from openquake.hazardlib.source.rupture import (
     ParametricProbabilisticRupture, PointRupture)
@@ -224,6 +225,10 @@ class PointSource(ParametricSeismicSource):
         """
         if hasattr(self, 'radius'):
             return self.radius[-1]  # max radius
+        if isinstance(self.magnitude_scaling_relationship, PointMSR):
+            M = len(self.get_annual_occurrence_rates())
+            self.radius = numpy.full(M, self.ps_grid_spacing * 0.707)
+            return self.radius[-1]
         magd = [(r, mag) for mag, r in self.get_annual_occurrence_rates()]
         npd = self.nodal_plane_distribution.data
         self.radius = numpy.zeros(len(magd))

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -150,7 +150,6 @@ class PointSource(ParametricSeismicSource):
     code = b'P'
     MODIFICATIONS = set()
     ps_grid_spacing = 0  # updated in CollapsedPointSource
-    esites = 0  # updated in estimate_weight
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/hazardlib/tests/contexts_test.py
+++ b/openquake/hazardlib/tests/contexts_test.py
@@ -193,7 +193,7 @@ class CollapseTestCase(unittest.TestCase):
         cmaker.set_weight(srcs, inp.sitecol)
         weights = [src.weight for src in srcs]  # 3 within, 3 outside
         numpy.testing.assert_allclose(
-            weights, [6.766667, 6.766667, 6.766667, 0.1, 0.1, 0.1])
+            weights, [10.1, 10.1, 10.1, 0.1, 0.1, 0.1])
 
         # set different vs30s on the two sites
         inp.sitecol.array['vs30'] = [600., 700.]

--- a/openquake/hazardlib/tests/contexts_test.py
+++ b/openquake/hazardlib/tests/contexts_test.py
@@ -193,7 +193,7 @@ class CollapseTestCase(unittest.TestCase):
         cmaker.set_weight(srcs, inp.sitecol)
         weights = [src.weight for src in srcs]  # 3 within, 3 outside
         numpy.testing.assert_allclose(
-            weights, [8.01, 8.01, 8.01, 0.01, 0.01, 0.01])
+            weights, [6.766667, 6.766667, 6.766667, 0.1, 0.1, 0.1])
 
         # set different vs30s on the two sites
         inp.sitecol.array['vs30'] = [600., 700.]


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/7868.
```
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 568    | 275.1   | 84%    | 0.22629 | 1_478   | 5.37256 | # before
| classical          | 568    | 277.1   | 67%    | 0.22824 | 1_074   | 3.87676 | # after
```
The total runtime went down from 39m to 32m.