### PR TITLE
Solved slow tasks in EUR

### DIFF
--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -474,7 +474,7 @@ class CompositeSourceModel:
         if not heavy:
             maxsrc = max(srcs, key=lambda s: s.weight)
             logging.info('Heaviest: %s', maxsrc)
-        return max_weight / 2 if oq.ps_grid_spacing else max_weight
+        return max_weight
 
     def __toh5__(self):
         data = gzip.compress(pickle.dumps(self, pickle.HIGHEST_PROTOCOL))

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1094,6 +1094,7 @@ class ContextMaker(object):
         if hasattr(srcfilter, 'array'):  # a SiteCollection was passed
             srcfilter = SourceFilter(srcfilter, self.maximum_distance)
         N = len(srcfilter.sitecol)
+        G = len(self.gsims)
         for src in sources:
             src.num_ruptures = src.count_ruptures()
             if src.nsites == 0:  # was discarded by the prefiltering
@@ -1105,9 +1106,11 @@ class ContextMaker(object):
             else:
                 with mon:
                     src.esites = 0  # overridden inside estimate_weight
-                    src.weight = .1 + self.estimate_weight(src, srcfilter)
-                    if src.code == b'C':
-                        src.weight += 4.9
+                    src.weight = .1 + self.estimate_weight(src, srcfilter) * G
+                    if src.code == b'F':
+                        src.weight += .9
+                    elif src.code == b'C':
+                        src.weight += 9.9
 
 
 # see contexts_tests.py for examples of collapse


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/7868. The trick was to multiply by the number of GSIMs. Here are the figures, the total runtime is 29 minutes.
```
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 318    | 498.4   | 44%    | 0.22751 | 768.0   | 1.54088 |
```