### PR TITLE
Removed `set_parameters` from Bradley and McVerry

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -789,7 +789,7 @@ class ContextMaker(object):
         self.fewsites = len(sitecol.complete) <= self.max_sites_disagg
         ctxs = []
         if getattr(src, 'location', None) and step == 1:
-            return self.fix(self.get_ctxs_planar(src, sitecol))
+            return self.update_ctx(self.get_ctxs_planar(src, sitecol))
         elif hasattr(src, 'source_id'):  # other source
             with self.ir_mon:
                 allrups = numpy.array(list(src.iter_ruptures(
@@ -820,15 +820,16 @@ class ContextMaker(object):
                         c = rup.surface.get_closest_points(sites.complete)
                         ctx.clon = c.lons[ctx.sids]
                         ctx.clat = c.lats[ctx.sids]
-        return self.fix([] if not ctxs else [self.recarray(ctxs)])
+        return self.update_ctx([] if not ctxs else [self.recarray(ctxs)])
 
-    def fix(self, ctxs):
+    def update_ctx(self, ctxs):
         """
-        Call gsim.set_parameters and fix the contexts
+        Call gsim.update_ctx and fix the contexts
         """
         for ctx in ctxs:
             for gsim in self.gsims:
-                gsim.set_parameters(ctx)
+                if hasattr(gsim, 'update_ctx'):
+                    gsim.update_ctx(ctx)
         return ctxs
 
     def max_intensity(self, sitecol1, mags, dists):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -587,8 +587,12 @@ class ContextMaker(object):
                 value = rup.surface.get_width()
             elif param == 'in_cshm':  # computed in McVerry2006Chch
                 value = False
-            elif param == 'zbot':  # needed for width estimation in CampbellBozorgnia2014
-                value = rup.zbot
+            elif param == 'zbot':
+                # needed for width estimation in CampbellBozorgnia2014
+                if rup.surface:
+                    value = rup.surface.mesh.depths.max()
+                else:
+                    value = rup.hypocenter.depth
             else:
                 raise ValueError('%s requires unknown rupture parameter %r' %
                                  (type(self).__name__, param))

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -106,7 +106,8 @@ def _get_poes(mean_std, loglevels, truncation_level):
     return out.T
 
 
-OK_METHODS = 'compute get_mean_and_stddevs get_poes set_parameters set_tables'
+OK_METHODS = ('compute', 'get_mean_and_stddevs', 'get_poes',
+              'set_parameters', 'set_tables', 'update_ctx')
 
 
 def bad_methods(clsdict):
@@ -419,20 +420,21 @@ class GMPE(GroundShakingIntensityModel):
     of actual GMPE implementations is supposed to return the mean
     value as a natural logarithm of intensity.
     """
-    def set_parameters(self, rup=None):
+    def set_parameters(self):
         """
         Combines the parameters of the GMPE provided at the construction level
         with the ones originally assigned to the backbone modified GMPE.
+
+        :param ctx: if given, a context recarray to be updated
         """
-        if rup is None:   # in gulerce_abrahamson, split_sigma, etc
-            for key in (ADMITTED_STR_PARAMETERS + ADMITTED_FLOAT_PARAMETERS +
-                        ADMITTED_SET_PARAMETERS):
-                try:
-                    val = getattr(self.gmpe, key)
-                except AttributeError:
-                    pass
-                else:
-                    setattr(self, key, val)
+        for key in (ADMITTED_STR_PARAMETERS + ADMITTED_FLOAT_PARAMETERS +
+                    ADMITTED_SET_PARAMETERS):
+            try:
+                val = getattr(self.gmpe, key)
+            except AttributeError:
+                pass
+            else:
+                setattr(self, key, val)
 
     def compute(self, ctx: numpy.recarray, imts, mean, sig, tau, phi):
         """

--- a/openquake/hazardlib/gsim/bradley_2013.py
+++ b/openquake/hazardlib/gsim/bradley_2013.py
@@ -814,18 +814,16 @@ class Bradley2013bChchMaps(Bradley2013bChchCBD):
     #: not have code that can be made available.
     non_verified = True
 
-    def set_parameters(self, rup):
+    def set_parameters(self, ctx):
         """
         Checks if any part of the rupture surface mesh is located within the
         intended boundaries of the Canterbury Seismic Hazard Model in
         Gerstenberger et al. (2014), Seismic hazard modelling for the recovery
         of Christchurch, Earthquake Spectra, 30(1), 17-29.
         """
-        lons = np.ravel(rup.surface.mesh.array[0])
-        lats = np.ravel(rup.surface.mesh.array[1])
         points_in_polygon = [
-            shapely.geometry.Point(lons[i], lats[i]).within(cshm_polygon)
-            for i in np.arange(len(lons))]
+            shapely.geometry.Point(rec.clon, rec.clat).within(cshm_polygon)
+            for rec in ctx]
         self.in_cshm = any(points_in_polygon)
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):

--- a/openquake/hazardlib/gsim/bradley_2013.py
+++ b/openquake/hazardlib/gsim/bradley_2013.py
@@ -38,11 +38,6 @@ from openquake.hazardlib import const
 from openquake.hazardlib.imt import PGA, SA
 
 
-# These coordinates are provided by M Gerstenberger (personal
-# communication, 10 August 2018)
-cshm_polygon = shapely.geometry.Polygon([(171.6, -43.3), (173.2, -43.3),
-                                         (173.2, -43.9), (171.6, -43.9)])
-
 cbd_polygon = shapely.geometry.Polygon(
     [(172.6259, -43.5209), (172.6505, -43.5209),
      (172.6505, -43.5399), (172.6124, -43.5400),
@@ -54,8 +49,8 @@ def _adjust_mean_model(region, in_cshm, in_cbd, imt_per, b13_mean):
     dL2L = dS2S = np.array(np.zeros(np.shape(b13_mean)))
     # If the site is in the CBD polygon, get dL2L and dS2S terms
     # Only apply the dL2L term only to sites located in the CBD.
-    dL2L[in_cbd & in_cshm] = _get_dL2L(imt_per)
-    dS2S[in_cbd & in_cshm] = _get_dS2S(region, imt_per)
+    dL2L[in_cbd == 1] = _get_dL2L(imt_per)
+    dS2S[in_cbd == 1] = _get_dS2S(region, imt_per)
     return b13_mean + dL2L + dS2S
 
 
@@ -68,7 +63,7 @@ def _check_in_cbd_polygon(lons, lats):
     """
     points = [shapely.geometry.Point(lons[ind], lats[ind])
               for ind in np.arange(len(lons))]
-    in_cbd = np.array([cbd_polygon.contains(point) for point in points])
+    in_cbd = np.asarray([cbd_polygon.contains(point) for point in points])
     return in_cbd
 
 
@@ -156,10 +151,11 @@ def set_adjusted_stddevs(
         srf_sigma = np.array(np.ones(np.shape(in_cbd)))
         srf_phi = np.array(np.ones(np.shape(in_cbd)))
         srf_tau = np.array(np.ones(np.shape(in_cbd)))
-        srf_sigma[in_cshm & in_cbd] = _get_SRF_sigma(imt_per)
-        srf_phi[in_cshm & in_cbd] = _get_SRF_phi(imt_per)
-        # The tau reduction term is not used in this implementation
-        # srf_tau[in_cbd == True] = _get_SRF_tau(imt_per)
+        if in_cshm == 1:
+            srf_sigma[in_cbd == 1] = _get_SRF_sigma(imt_per)
+            srf_phi[in_cbd == 1] = _get_SRF_phi(imt_per)
+            # The tau reduction term is not used in this implementation
+            # srf_tau[in_cbd == True] = _get_SRF_tau(imt_per)
 
         # Add 'additional sigma' specified in the Canterbury Seismic
         # Hazard Model to total sigma, eq. 21
@@ -812,20 +808,6 @@ class Bradley2013bChchMaps(Bradley2013bChchCBD):
     #: not have code that can be made available.
     non_verified = True
 
-    def set_parameters(self, rup):
-        """
-        Checks if any part of the rupture surface mesh is located within the
-        intended boundaries of the Canterbury Seismic Hazard Model in
-        Gerstenberger et al. (2014), Seismic hazard modelling for the recovery
-        of Christchurch, Earthquake Spectra, 30(1), 17-29.
-        """
-        lons = rup.surface.mesh.lons.flatten()
-        lats = rup.surface.mesh.lats.flatten()
-        points_in_polygon = [
-            shapely.geometry.Point(lons[i], lats[i]).within(cshm_polygon)
-            for i in np.arange(len(lons))]
-        rup.in_cshm = any(points_in_polygon)
-
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
         See :meth:`superclass method
@@ -838,9 +820,8 @@ class Bradley2013bChchMaps(Bradley2013bChchCBD):
         # Check if the sites are located in the CBD polygon
         in_cbd = _check_in_cbd_polygon(ctx.lon, ctx.lat)
         # Fix CBD site terms before dS2S modification.
-        ctx.vs30[in_cbd] = 250
-        ctx.z1pt0[in_cbd] = 330
-        in_cshm = ctx.in_cshm
+        ctx.vs30[in_cbd == 1] = 250
+        ctx.z1pt0[in_cbd == 1] = 330
         for m, imt in enumerate(imts):
             C = self.COEFFS[imt]
             imt_per = imt.period
@@ -857,11 +838,11 @@ class Bradley2013bChchMaps(Bradley2013bChchCBD):
             b13_mean = _get_mean(ctx, C, ln_y_ref, exp1, exp2, v1)
             # Adjust mean and standard deviation
             mean[m] = _adjust_mean_model(
-                self.region, in_cshm, in_cbd, imt_per, b13_mean)
+                self.region, ctx.in_cshm, in_cbd, imt_per, b13_mean)
             mean[m] += convert_to_LHC(imt)
             set_adjusted_stddevs(
                 name, self.additional_sigma, ctx, C, ln_y_ref, exp1, exp2,
-                in_cshm, in_cbd, imt_per, sig[m], tau[m], phi[m])
+                ctx.in_cshm, in_cbd, imt_per, sig[m], tau[m], phi[m])
 
 
 class Bradley2013bChchMapsAdditionalSigma(Bradley2013bChchMaps):

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
@@ -364,10 +364,9 @@ class CampbellBozorgnia2014(GMPE):
 
         if self.estimate_width:
             # To estimate a width, the GMPE needs Zbot
-            self.REQUIRES_RUPTURE_PARAMETERS = \
-                self.REQUIRES_RUPTURE_PARAMETERS.union({"zbot", })
+            self.REQUIRES_RUPTURE_PARAMETERS |= {"zbot"}
 
-    def set_parameters(self, ctx):
+    def update_ctx(self, ctx):
         """
         Use the ztor, width and hypo_depth formula to estimate
         if the estimate attribute is set.

--- a/openquake/hazardlib/gsim/mcverry_2006.py
+++ b/openquake/hazardlib/gsim/mcverry_2006.py
@@ -691,20 +691,17 @@ class McVerry2006Chch(McVerry2006AscSC):
     REQUIRES_RUPTURE_PARAMETERS = (
         McVerry2006AscSC.REQUIRES_RUPTURE_PARAMETERS | {"in_cshm"})
 
-    # this is meant for non-point ruptures
-    def set_parameters(self, rup):
+    def set_parameters(self, ctx):
         """
         Checks if any part of the rupture surface mesh is located within the
         intended boundaries of the Canterbury Seismic Hazard Model in
         Gerstenberger et al. (2014), Seismic hazard modelling for the recovery
         of Christchurch, Earthquake Spectra, 30(1), 17-29.
         """
-        lons = np.ravel(rup.surface.mesh.array[0])
-        lats = np.ravel(rup.surface.mesh.array[1])
         points_in_polygon = [
-            shapely.geometry.Point(lons[i], lats[i]).within(cshm_polygon)
-            for i in np.arange(len(lons))]
-        rup.in_cshm = any(points_in_polygon)
+            shapely.geometry.Point(rec.clon, rec.clat).within(cshm_polygon)
+            for rec in ctx]
+        ctx.in_cshm = any(points_in_polygon)
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """

--- a/openquake/hazardlib/gsim/mcverry_2006.py
+++ b/openquake/hazardlib/gsim/mcverry_2006.py
@@ -23,18 +23,10 @@ Module exports :class:`McVerry2006Asc`, :class:`McVerry2006SInter`,
 :class:`McVerry2006SSlabSC`, :class:`McVerry2006VolcSC`.
 """
 import numpy as np
-import shapely
-
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable
 from openquake.hazardlib import const
 from openquake.hazardlib.imt import PGA, SA
 from openquake.baselib.general import CallableDict
-
-
-# These coordinates were provided by M Gerstenberger (personal
-# communication, 10 August 2018)
-cshm_polygon = shapely.geometry.Polygon([(171.6, -43.3), (173.2, -43.3),
-                                         (173.2, -43.9), (171.6, -43.9)])
 
 
 def _compute_f4(C, mag, rrup):
@@ -690,21 +682,6 @@ class McVerry2006Chch(McVerry2006AscSC):
     additional_sigma = 0
     REQUIRES_RUPTURE_PARAMETERS = (
         McVerry2006AscSC.REQUIRES_RUPTURE_PARAMETERS | {"in_cshm"})
-
-    # this is meant for non-point ruptures
-    def set_parameters(self, rup):
-        """
-        Checks if any part of the rupture surface mesh is located within the
-        intended boundaries of the Canterbury Seismic Hazard Model in
-        Gerstenberger et al. (2014), Seismic hazard modelling for the recovery
-        of Christchurch, Earthquake Spectra, 30(1), 17-29.
-        """
-        lons = rup.surface.mesh.lons.flatten()
-        lats = rup.surface.mesh.lats.flatten()
-        points_in_polygon = [
-            shapely.geometry.Point(lons[i], lats[i]).within(cshm_polygon)
-            for i in np.arange(len(lons))]
-        rup.in_cshm = any(points_in_polygon)
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """

--- a/openquake/hazardlib/gsim/mcverry_2006.py
+++ b/openquake/hazardlib/gsim/mcverry_2006.py
@@ -701,7 +701,8 @@ class McVerry2006Chch(McVerry2006AscSC):
         points_in_polygon = [
             shapely.geometry.Point(rec.clon, rec.clat).within(cshm_polygon)
             for rec in ctx]
-        ctx.in_cshm = any(points_in_polygon)
+        ctx.in_cshm = np.array(points_in_polygon)
+        print(ctx.in_cshm)
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """

--- a/openquake/qa_tests_data/classical/case_71/expected/hcurves.csv
+++ b/openquake/qa_tests_data/classical/case_71/expected/hcurves.csv
@@ -1,3 +1,3 @@
-#,,,,,,,,,,"generated_by='OpenQuake engine 3.15.0-git26b9c2dc2f', start_date='2022-05-27T14:56:54', checksum=2179507265, kind='mean', investigation_time=50.0, imt='PGA'"
+#,,,,,,,,,,"generated_by='OpenQuake engine 3.15.0-git056d8fc5ba', start_date='2022-06-01T09:46:07', checksum=2828904858, kind='mean', investigation_time=50.0, imt='PGA'"
 lon,lat,depth,poe-0.0098000,poe-0.0137000,poe-0.0192000,poe-0.0527000,poe-0.5560000,poe-0.7780000,poe-1.0900000,poe-1.5200000
-0.00000,0.00000,0.00000,8.348926E-01,7.832218E-01,7.227613E-01,4.067545E-01,3.178857E-02,1.155776E-02,2.992375E-03,4.293816E-04
+0.00000,0.00000,0.00000,9.283215E-01,8.829470E-01,8.089448E-01,4.163229E-01,3.178857E-02,1.155776E-02,2.992375E-03,4.293816E-04

--- a/openquake/qa_tests_data/classical/case_71/source_model2.xml
+++ b/openquake/qa_tests_data/classical/case_71/source_model2.xml
@@ -93,5 +93,37 @@
             </hypoDepthDist>
         </areaSource>
 
+        <simpleFaultSource
+            id="3"
+            name="Simple Fault Source"
+            tectonicRegion="Active Shallow Crust"
+            >
+                <simpleFaultGeometry>
+                    <gml:LineString>
+                        <gml:posList>
+                            1 -0.2 1.4 0.0 1.7 0.0
+                        </gml:posList>
+                    </gml:LineString>
+                    <dip>
+                        3.0000000E+01
+                    </dip>
+                    <upperSeismoDepth>
+                        5.0000000E+00
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        1.5000000E+01
+                    </lowerSeismoDepth>
+                </simpleFaultGeometry>
+                <magScaleRel>
+                    WC1994
+                </magScaleRel>
+                <ruptAspectRatio>
+                    2.0000000E+00
+                </ruptAspectRatio>
+                <truncGutenbergRichterMFD aValue="4.2000000E+00" bValue="9.0000000E-01" maxMag="7.0000000E+00" minMag="6.5000000E+00"/>
+                <rake>
+                    9.0000000E+01
+                </rake>
+        </simpleFaultSource>
     </sourceModel>
 </nrml>


### PR DESCRIPTION
The right place were to put that logic is in `make_rctx`. This change finally closes #7878 by removing lines of code.
The test case_71 has been extended to contain a fault source too.