### PR TITLE
Enabled sequential mode to save memory

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Added early check on the minimum available memory
+  * Entered automatically in sequential mode if there is not enough memory
   * Raised an early error for missing risk IDs in the vulnerability files
   * Changed the definition of `aggrisk` again to ensure consistency with the
     average losses

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -457,9 +457,12 @@ class HazardCalculator(BaseCalculator):
         required = .5 * (1 if parallel.oq_distribute() == 'no'
                          else parallel.Starmap.num_cores)
         if avail < required:
-            raise MemoryError('You have %.1f GB available, but at least %.1f '
-                              'GB are required: see https://github.com/gem/oq-engine/blob/master/doc/faq.md'
-                              % (avail, required))
+            logging.warning(
+                'Entering SLOW MODE. You have %.1f GB available, but the '
+                'engine would like at least 0.5 GB per core, i.e. %.1f GB. See'
+                ' https://github.com/gem/oq-engine/blob/master/doc/faq.md',
+                avail, required)
+            oq.concurrent_tasks = 0
         self._read_risk_data()
         self.check_overflow()  # check if self.sitecol is too large
 

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -457,12 +457,15 @@ class HazardCalculator(BaseCalculator):
         required = .5 * (1 if parallel.oq_distribute() == 'no'
                          else parallel.Starmap.num_cores)
         if avail < required:
-            logging.warning(
-                'Entering SLOW MODE. You have %.1f GB available, but the '
-                'engine would like at least 0.5 GB per core, i.e. %.1f GB. See'
-                ' https://github.com/gem/oq-engine/blob/master/doc/faq.md',
-                avail, required)
-            oq.concurrent_tasks = 0
+            msg = ('Entering SLOW MODE. You have %.1f GB available, but the '
+                   'engine would like at least 0.5 GB per core, i.e. %.1f GB: '
+                   'https://github.com/gem/oq-engine/blob/master/doc/faq.md'
+                   ) % (avail, required)
+            if oq.concurrent_tasks:
+                oq.concurrent_tasks = 0
+                logging.warning(msg)
+            else:
+                raise MemoryError('You have only %.1f GB available' % avail)
         self._read_risk_data()
         self.check_overflow()  # check if self.sitecol is too large
 


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/7884. The approach could be improved to use more than 1 core, but this extension is left for the future since it requires some testing on Windows. Here we want to be as conservative as possible.