### PR TITLE
Implemented direct database access

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Internal: implemented direct database access with OQ_DATABASE=local
+
   [Julián Santiago Montejo Espitia]
   * Implemented the Arteta et al. (2021) subduction model for Colombia
 

--- a/doc/sphinx/openquake.commonlib.rst
+++ b/doc/sphinx/openquake.commonlib.rst
@@ -9,6 +9,14 @@ openquake.commonlib.datastore module
     :undoc-members:
     :show-inheritance:
 
+openquake.commonlib.dbapi module
+-----------------------------
+
+.. automodule:: openquake.commonlib.dbapi
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 calc module
 ---------------------------------
 

--- a/doc/sphinx/openquake.server.rst
+++ b/doc/sphinx/openquake.server.rst
@@ -12,14 +12,6 @@ Subpackages
 Submodules
 ----------
 
-openquake.server.dbapi module
------------------------------
-
-.. automodule:: openquake.server.dbapi
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 openquake.server.dbserver module
 --------------------------------
 

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -108,6 +108,7 @@ class CalculatorTestCase(unittest.TestCase):
         cls.duration = general.AccumDict()
         if OQ_CALC_OUTPUTS:
             writers.write_csv = write_csv
+        os.environ['OQ_DATABASE'] = 'local'
 
     def get_calc(self, testfile, job_ini, **kw):
         """

--- a/openquake/commands/restore.py
+++ b/openquake/commands/restore.py
@@ -25,7 +25,7 @@ import zipfile
 import sqlite3
 import requests
 from openquake.baselib.general import safeprint
-from openquake.server.dbapi import Db
+from openquake.commonlib.dbapi import Db
 
 
 def main(archive, oqdata):

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -31,6 +31,7 @@ from openquake.baselib import parallel, sap
 from openquake.baselib.hdf5 import read_csv
 from openquake.hazardlib import tests
 from openquake import commonlib
+from openquake.commonlib import dbapi
 from openquake.commonlib.datastore import read
 from openquake.commonlib.readinput import get_params
 from openquake.engine.engine import create_jobs, run_jobs
@@ -45,7 +46,7 @@ from openquake.qa_tests_data.event_based_risk import (
     case_master, case_1 as case_eb)
 from openquake.qa_tests_data.scenario_risk import case_shapefile, case_shakemap
 from openquake.qa_tests_data.gmf_ebrisk import case_1 as ebrisk
-from openquake.server import manage, dbapi, dbserver
+from openquake.server import manage, dbserver
 from openquake.server.tests import data as test_data
 
 DATADIR = os.path.join(commonlib.__path__[0], 'tests', 'data')

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -390,8 +390,8 @@ class Table(list):
 
 
 # we cannot use a namedtuple here because one would get a PicklingError:
-# Can't pickle <class 'openquake.server.dbapi.Row'>: attribute lookup
-# openquake.server.dbapi.Row failed
+# Can't pickle <class 'openquake.commonlib.dbapi.Row'>: attribute lookup
+# openquake.commonlib.dbapi.Row failed
 class Row(collections.abc.Sequence):
     """
     A pickleable row, working both as a tuple and an object:

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -26,7 +26,7 @@ import traceback
 from datetime import datetime
 from openquake.baselib import config, zeromq, parallel
 from openquake.hazardlib import valid
-from openquake.commonlib import readinput
+from openquake.commonlib import readinput, dbapi
 
 LEVELS = {'debug': logging.DEBUG,
           'info': logging.INFO,
@@ -44,6 +44,9 @@ def dbcmd(action, *args):
     :param string action: database action to perform
     :param tuple args: arguments
     """
+    if os.environ.get('OQ_DATABASE') == 'local':
+        from openquake.server.db import actions
+        return getattr(actions, action)(dbapi.db, *args)
     sock = zeromq.Socket('tcp://' + DATABASE, zeromq.zmq.REQ, 'connect')
     with sock:
         res = sock.send((action,) + args)

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -24,7 +24,7 @@ from openquake.hazardlib import valid
 from openquake.server import __file__ as server_path
 from openquake.server.db.schema.upgrades import upgrader
 from openquake.server.db import upgrade_manager
-from openquake.server.dbapi import NotFound
+from openquake.commonlib.dbapi import NotFound
 
 JOB_TYPE = '''CASE
 WHEN calculation_mode LIKE '%risk'
@@ -40,7 +40,7 @@ def check_outdated(db):
     """
     Check if the db is outdated, called before starting anything
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     """
     return upgrader.check_versions(db.conn)
 
@@ -51,7 +51,7 @@ def reset_is_running(db):
     DbServer is restarted: the idea is that it is restarted only when
     all computations are completed.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     """
     db("UPDATE job SET is_running=0, status='failed'"
        "WHERE is_running=1 OR status='executing'")
@@ -62,7 +62,7 @@ def set_status(db, job_id, status):
     Set the status 'created', 'executing', 'complete', 'failed', 'aborted'
     consistently with `is_running`.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id: ID of the current job
     :param status: status string
     """
@@ -90,7 +90,7 @@ def create_job(db, datadir, calculation_mode='to be set',
     Create job for the given user, return it.
 
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param datadir:
         data directory of the user who owns/started this job.
     :param calculation_mode:
@@ -138,7 +138,7 @@ def delete_uncompleted_calculations(db, user):
     """
     Delete the uncompleted calculations of the given user.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param user: user name
     """
     db("UPDATE job SET status = 'deleted' "
@@ -150,7 +150,7 @@ def get_job(db, job_id, username=None):
     If job_id is negative, return the last calculation of the current
     user, otherwise returns the job_id unchanged.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id: a job ID (can be negative and can be nonexisting)
     :param username: an user name (if None, ignore it)
     :returns: a valid job or None if the original job ID was invalid
@@ -185,7 +185,7 @@ def get_calc_id(db, datadir, job_id=None):
     Return the latest calc_id by looking both at the datastore
     and the database.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param datadir: the directory containing the datastores
     :param job_id: a job ID; if None, returns the latest job ID
     """
@@ -205,7 +205,7 @@ def get_weight(db, job_id):
     """
     Return information about the total weight of the source model.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id: a job ID
     """
     rows = db("SELECT description, message FROM log, job "
@@ -220,7 +220,7 @@ def list_calculations(db, job_type, user_name):
     """
     Yield a summary of past calculations.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_type: 'hazard' or 'risk'
     :param user_name: an user name
     """
@@ -247,7 +247,7 @@ def list_outputs(db, job_id, full=True):
     :class:`~openquake.server.db.models.OqJob`.
 
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         ID of a calculation.
     :param bool full:
@@ -275,7 +275,7 @@ def list_outputs(db, job_id, full=True):
 def get_outputs(db, job_id):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         ID of a calculation.
     :returns:
@@ -324,7 +324,7 @@ def create_outputs(db, job_id, keysize, ds_size):
     Build a correspondence between the outputs in the datastore and the
     ones in the database. Also, update the datastore size in the job table.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id: ID of the current job
     :param keysize: a list of pairs (key, size_mb)
     :param ds_size: total datastore size in MB
@@ -340,7 +340,7 @@ def finish(db, job_id, status):
     Set the job columns `is_running`, `status`, and `stop_time`.
 
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         ID of the current job
     :param status:
@@ -355,7 +355,7 @@ def del_calc(db, job_id, user, force=False):
     """
     Delete a calculation and all associated outputs, if possible.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id: job ID, can be an integer or a string
     :param user: username
     :param force: delete even if there are dependent calculations
@@ -406,7 +406,7 @@ def log(db, job_id, timestamp, level, process, message):
     Write a log record in the database.
 
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         a job ID
     :param timestamp:
@@ -426,7 +426,7 @@ def get_log(db, job_id):
     """
     Extract the logs as a big string
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id: a job ID
     """
     logs = db('SELECT * FROM log WHERE job_id=?x ORDER BY id', job_id)
@@ -439,7 +439,7 @@ def get_log(db, job_id):
 
 def get_output(db, output_id):
     """
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param output_id: ID of an Output object
     :returns: (ds_key, calc_id, dirname)
     """
@@ -454,7 +454,7 @@ def fetch(db, templ, *args):
     Run generic queries directly on the database. See the documentation
     of the dbapi module.
 
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param templ: a SQL query template
     :param args: arguments to pass to the template
     """
@@ -464,7 +464,7 @@ def fetch(db, templ, *args):
 def get_path(db):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :returns: the full path to the dbserver codebase
     """
     return server_path
@@ -472,7 +472,7 @@ def get_path(db):
 
 def get_dbpath(db):
     """
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :returns: the path to the database file.
     """
     rows = db('PRAGMA database_list')
@@ -484,7 +484,7 @@ def get_dbpath(db):
 
 def what_if_I_upgrade(db, extract_scripts):
     """
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param extract_scripts: scripts to extract
     """
     return upgrade_manager.what_if_I_upgrade(
@@ -493,14 +493,14 @@ def what_if_I_upgrade(db, extract_scripts):
 
 def db_version(db):
     """
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     """
     return upgrade_manager.db_version(db.conn)
 
 
 def upgrade_db(db):
     """
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     """
     return upgrade_manager.upgrade_db(db.conn)
 
@@ -509,7 +509,7 @@ def upgrade_db(db):
 
 def calc_info(db, calc_id):
     """
-    :param db: a :class:`openquake.server.dbapi.Db` instance
+    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param calc_id: calculation ID
     :returns: dictionary of info about the given calculation
     """
@@ -526,7 +526,7 @@ def calc_info(db, calc_id):
 def get_calcs(db, request_get_dict, allowed_users, user_acl_on=False, id=None):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param request_get_dict:
         a dictionary
     :param allowed_users:
@@ -582,7 +582,7 @@ def update_job(db, job_id, dic):
     Update the given calculation record.
 
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         a job ID
     :param dic:
@@ -604,7 +604,7 @@ def get_log_slice(db, job_id, start, stop):
     Get a slice of the calculation log as a JSON list of rows
 
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         a job ID
     :param start:
@@ -629,7 +629,7 @@ def get_log_size(db, job_id):
     Get a slice of the calculation log as a JSON list of rows.
 
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         a job ID
     """
@@ -643,7 +643,7 @@ def get_traceback(db, job_id):
     The list is empty if the calculation was successful.
 
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         a job ID
     """
@@ -659,7 +659,7 @@ def get_traceback(db, job_id):
 def get_result(db, result_id):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param result_id:
         a result ID
     :returns: (job_id, job_status, datadir, datastore_key)
@@ -673,7 +673,7 @@ def get_result(db, result_id):
 def get_results(db, job_id):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         a job ID
     :returns: (datadir, datastore_keys)
@@ -693,7 +693,7 @@ class List(list):
 def get_executing_jobs(db):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :returns:
         (id, user_name, start_time) tuples
     """
@@ -718,7 +718,7 @@ def get_calc_ids(db, user):
 def get_longest_jobs(db):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :returns:
         (id, user_name, days) tuples
     """
@@ -731,7 +731,7 @@ FROM job WHERE status='complete' AND days > 0.04 ORDER BY days desc'''
 def find(db, description):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param description:
         job description, used in a case-insensitive LIKE clause
     """
@@ -748,7 +748,7 @@ ORDER BY julianday(stop_time) - julianday(start_time)'''
 def add_checksum(db, job_id, value):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         job ID
     :param value:
@@ -760,7 +760,7 @@ def add_checksum(db, job_id, value):
 def update_job_checksum(db, job_id, checksum):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         job ID
     :param checksum:
@@ -773,7 +773,7 @@ def update_job_checksum(db, job_id, checksum):
 def get_checksum_from_job(db, job_id):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         job ID
     :returns:
@@ -787,7 +787,7 @@ def get_checksum_from_job(db, job_id):
 def get_job_from_checksum(db, checksum):
     """
     :param db:
-        a :class:`openquake.server.dbapi.Db` instance
+        a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id:
         job ID
     :returns:

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -32,7 +32,7 @@ from openquake.hazardlib import valid
 from openquake.commonlib import logs
 from openquake.engine import __version__
 from openquake.server.db import actions
-from openquake.server.dbapi import db
+from openquake.commonlib.dbapi import db
 from openquake.server import __file__ as server_path
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -44,7 +44,7 @@ from django.shortcuts import render
 from openquake.baselib import hdf5, config
 from openquake.baselib.general import groupby, gettemp, zipfiles
 from openquake.hazardlib import nrml, gsim, valid
-from openquake.commonlib import readinput, oqvalidation, logs, datastore
+from openquake.commonlib import readinput, oqvalidation, logs, datastore, dbapi
 from openquake.calculators import base
 from openquake.calculators.getters import NotFound
 from openquake.calculators.export import export
@@ -53,7 +53,7 @@ from openquake.engine import __version__ as oqversion
 from openquake.engine.export import core
 from openquake.engine import engine
 from openquake.engine.export.core import DataStoreExportError
-from openquake.server import utils, dbapi
+from openquake.server import utils
 
 from django.conf import settings
 from django.http import FileResponse


### PR DESCRIPTION
This is quite useful when debugging queries. It can be enabled by setting the environment variable OQ_DATABASE=local. It is automatically set in the calculators tests which now are slightly faster (399s instead of 408s). Moved server.dbapi -> commonlib.dbapi.