### PR TITLE
Added a check for site parameters not passed correctly

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check for required site parameters not passed correctly
   * Fixed `ps_grid_spacing` approximation when the grid is degenerate
   * Logging a warning when starting from an old hazard calculation
   * The extra fields of the site collection were lost when using --hc

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -561,6 +561,13 @@ def get_site_collection(oqparam, h5=None):
     if ('vs30' in sitecol.array.dtype.names and
             not numpy.isnan(sitecol.vs30).any()):
         assert sitecol.vs30.max() < 32767, sitecol.vs30.max()
+
+    # sanity check on the site parameters
+    for param in req_site_params:
+        dt = site.site_param_dt[param]
+        if dt is F64 and (sitecol.array[param] == 0.).all():
+            raise ValueError('The site parameter %s is always zero: please '
+                             'check the site nodel' % param)
     return sitecol
 
 

--- a/openquake/hazardlib/gsim/kotha_2020.py
+++ b/openquake/hazardlib/gsim/kotha_2020.py
@@ -481,7 +481,7 @@ class KothaEtAl2020Site(KothaEtAl2020):
     a polynomial site amplification function dependent on Vs30 (m/s)
     """
     #: Required site parameter is not set
-    REQUIRES_SITES_PARAMETERS = set(("vs30",))
+    REQUIRES_SITES_PARAMETERS = {"vs30"}
 
     kind = "site"
 

--- a/openquake/qa_tests_data/classical/case_34/job.ini
+++ b/openquake/qa_tests_data/classical/case_34/job.ini
@@ -1,12 +1,12 @@
 [general]
 
-description = Classical PSHA — using GMPE specrtal averaging
+description = Classical PSHA — using GMPE spectral averaging
 calculation_mode = classical
 random_seed = 23
 
 [geometry]
 
-sites = 13.248049 42.553045
+site_model_file = site_model.csv
 
 [logic_tree]
 
@@ -17,13 +17,6 @@ number_of_logic_tree_samples = 0
 rupture_mesh_spacing = 2
 width_of_mfd_bin = 0.2
 area_source_discretization = 10.0
-
-[site_params]
-
-reference_vs30_type = measured
-reference_vs30_value = 600.0
-reference_depth_to_2pt5km_per_sec = 5.0
-reference_depth_to_1pt0km_per_sec = 100.0
 
 [calculation]
 

--- a/openquake/qa_tests_data/classical/case_34/site_model.csv
+++ b/openquake/qa_tests_data/classical/case_34/site_model.csv
@@ -1,0 +1,2 @@
+lon,lat,vs30,slope,geology,region
+13.248049,42.553045,600,.0001,0,0


### PR DESCRIPTION
Currently the engine is too forgiving: if you set `sites = lon lat` in the job.ini the required site parameters are assumed to be zero. This is too error prone as @Shreyasvi91 discovered (she did not pass the parameter `xvf`). Instead we must force to users to use a site model file, even if there is a single site, then the checks already in place will ensure that all required parameters are present.

NB: the test case_34 was broken, so I had to fix it.