### PR TITLE
Reduced multi_fault.BLOCKSIZE

### DIFF
--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -31,7 +31,7 @@ from openquake.hazardlib.geo.utils import angular_distance, KM_TO_DEGREES
 from openquake.hazardlib.source.base import BaseSeismicSource
 
 F32 = np.float32
-BLOCKSIZE = 1000
+BLOCKSIZE = 100
 # the BLOCKSIZE has to be large to reduce the number of sources and
 # therefore the redundant data transfer in the .sections attribute
 


### PR DESCRIPTION
Changing BLOCKSIZE=1000 -> 100 gives a 8.58x speedup in the slowest task in the reference calculation in https://github.com/gem/oq-engine/issues/7916. This will hugely increases the data transfer but it will not be a problem since the master plan includes storing the sections in the datastore.
```
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 223    | 103.4   | 385%   | 7.36974 | 2_832   | 27.4    
| classical          | 295    | 74.9    | 120%   | 11.3    | 330.2   | 4.40979 |
```
Here is the improvement on cole (7.4x):
```
# before
| calc_47918, maxmem=61.2 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 23_054   | 774.3     | 223     |
| make_contexts              | 16_414   | 0.0       | 26_949  |
| computing mean_std         | 2_208    | 0.0       | 46_016  |
| get_poes                   | 2_089    | 0.0       | 964_072 |
| total preclassical         | 1_603    | 122.2     | 22      |
| ClassicalCalculator.run    | 3_297    | 386.4     | 1       |
```
```
# after
| calc_47917, maxmem=62.6 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 22_092   | 113.4     | 295     |
| make_contexts              | 15_353   | 0.0       | 26_949  |
| computing mean_std         | 2_238    | 0.0       | 46_054  |
| get_poes                   | 2_117    | 0.0       | 964_073 |
| total preclassical         | 1_653    | 58.8      | 210     |
| ClassicalCalculator.run    | 444.3    | 753.2     | 1       |
```