### PR TITLE
Storing multi_fault_sections

### DIFF
--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -907,19 +907,18 @@ hazard_uhs-std.csv
         self.assertEqualFiles('expected/hcurve-mean.csv', f)
 
     def test_case_65(self):
-        # reading/writing a multiFaultSource
-        oq = readinput.get_oqparam('job.ini', pkg=case_65)
-        csm = readinput.get_composite_source_model(oq)
-        tmpname = general.gettemp()
-        out = write_source_model(tmpname, csm.src_groups)
-        self.assertEqual(out[0], tmpname)
-        self.assertEqual(out[1], tmpname[:-4] + '_sections.xml')
-
         # running the calculation
         self.run_calc(case_65.__file__, 'job.ini')
 
         [f] = export(('hcurves/mean', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/hcurve-mean.csv', f, delta=1E-5)
+
+        # reading/writing a multiFaultSource
+        csm = self.calc.datastore['_csm']
+        tmpname = general.gettemp()
+        out = write_source_model(tmpname, csm.src_groups)
+        self.assertEqual(out[0], tmpname)
+        # self.assertEqual(out[1], tmpname[:-4] + '_sections.xml')
 
         # make sure we are not breaking event_based
         self.run_calc(case_65.__file__, 'job_eb.ini')

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -180,7 +180,7 @@ def fix_geometry_sections(smdict, h5):
     sections = [sections[suid] for suid in sorted(sections)]
     for idx, sec in enumerate(sections):
         sec.suid = idx
-    if h5:
+    if h5 and sections:
         h5.save_vlen('multi_fault_sections',
                      [kite_to_geom(sec) for sec in sections])
 

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -178,6 +178,8 @@ def fix_geometry_sections(smdict, h5):
         sec_ids, 'section ID in files ' + ' '.join(gfiles))
     s2i = {suid: i for i, suid in enumerate(sorted(sections))}
     sections = [sections[suid] for suid in sorted(sections)]
+    for idx, sec in enumerate(sections):
+        sec.suid = idx
     if h5:
         h5.save_vlen('multi_fault_sections',
                      [kite_to_geom(sec) for sec in sections])
@@ -193,7 +195,6 @@ def fix_geometry_sections(smdict, h5):
                         src.hdf5path = h5.filename
                     src.rupture_idxs = [tuple(s2i[idx] for idx in idxs)
                                         for idxs in src.rupture_idxs]
-                    src.set_sections(sections)
 
 
 def _groups_ids(smlt_dir, smdict, fnames):

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -29,6 +29,7 @@ from openquake.hazardlib import nrml, sourceconverter, InvalidFile
 from openquake.hazardlib.contexts import basename
 from openquake.hazardlib.calc.filters import magstr
 from openquake.hazardlib.lt import apply_uncertainties
+from openquake.hazardlib.geo.surface.kite_fault import kite_to_geom
 
 TWO16 = 2 ** 16  # 65,536
 by_id = operator.attrgetter('source_id')
@@ -138,7 +139,7 @@ def get_csm(oq, full_lt, h5=None):
                               h5=h5 if h5 else None).reduce()
     if len(smdict) > 1:  # really parallel
         parallel.Starmap.shutdown()  # save memory
-    fix_geometry_sections(smdict)
+    fix_geometry_sections(smdict, h5)
     logging.info('Applying uncertainties')
     groups = _build_groups(full_lt, smdict)
 
@@ -150,7 +151,7 @@ def get_csm(oq, full_lt, h5=None):
     return _get_csm(full_lt, groups)
 
 
-def fix_geometry_sections(smdict):
+def fix_geometry_sections(smdict, h5):
     """
     If there are MultiFaultSources, fix the sections according to the
     GeometryModels (if any).
@@ -177,7 +178,9 @@ def fix_geometry_sections(smdict):
         sec_ids, 'section ID in files ' + ' '.join(gfiles))
     s2i = {suid: i for i, suid in enumerate(sorted(sections))}
     sections = [sections[suid] for suid in sorted(sections)]
-    # section_arrays = [geom(surf) for surf in sections]
+    if h5:
+        h5.save_vlen('multi_fault_sections',
+                     [kite_to_geom(sec) for sec in sections])
 
     # fix the MultiFaultSources
     for smod in smodels:

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -189,6 +189,8 @@ def fix_geometry_sections(smdict, h5):
                 if hasattr(src, 'set_sections'):
                     if not sections:
                         raise RuntimeError('Missing geometryModel files!')
+                    if h5:
+                        src.hdf5path = h5.filename
                     src.rupture_idxs = [tuple(s2i[idx] for idx in idxs)
                                         for idxs in src.rupture_idxs]
                     src.set_sections(sections)

--- a/openquake/hazardlib/geo/surface/kite_fault.py
+++ b/openquake/hazardlib/geo/surface/kite_fault.py
@@ -1368,3 +1368,21 @@ def fix_mesh(msh):
             if not (check_row and check_col):
                 msh[i, j, :] = np.nan
     return msh
+
+
+def kite_to_geom(surface):
+    """
+    :returns: the geometry array describing the KiteSurface
+    """
+    shape_y, shape_z = surface.mesh.array.shape[1:]
+    coords = np.float32(surface.mesh.array.flat)
+    return np.concatenate([np.float32([1, shape_y, shape_z]), coords])
+
+
+def geom_to_kite(geom):
+    """
+    :returns: KiteSurface described by the given geometry array
+    """
+    shape_y, shape_z = int(geom[1]), int(geom[2])
+    array = geom[3:].astype(np.float64).reshape(3, shape_y, shape_z)
+    return KiteSurface(RectangularMesh(*array))

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -65,6 +65,8 @@ class MultiFaultSource(BaseSeismicSource):
     """
     code = b'F'
     MODIFICATIONS = {}
+    hdf5path = ''
+    offset = 0
 
     def __init__(self, source_id: str, name: str, tectonic_region_type: str,
                  rupture_idxs: list, occurrence_probs: Union[list, np.ndarray],
@@ -133,6 +135,7 @@ class MultiFaultSource(BaseSeismicSource):
                 self.pmfs[slc],
                 self.mags[slc],
                 self.rakes[slc])
+            src.offset = i * BLOCKSIZE
             src.set_sections(self.sections)
             src.num_ruptures = src.count_ruptures()
             yield src

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -162,7 +162,7 @@ def _get_rupture(rec, geom=None, trt=None):
                 geo.PlanarSurface.from_array(array[:, 0, :])
                 for array in arrays])
         else:
-            # assume KyteSurfaces
+            # assume KiteSurfaces
             surface.__init__([geo.KiteSurface(RectangularMesh(*array))
                               for array in arrays])
 

--- a/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
@@ -24,7 +24,8 @@ from openquake.hazardlib.geo import geodetic
 from openquake.hazardlib.geo import Point, Line
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.geo.geodetic import distance
-from openquake.hazardlib.geo.surface import KiteSurface
+from openquake.hazardlib.geo.surface.kite_fault import (
+    KiteSurface, kite_to_geom, geom_to_kite)
 from openquake.hazardlib.nrml import to_python
 from openquake.hazardlib.sourceconverter import SourceConverter
 
@@ -184,6 +185,14 @@ class KiteSurfaceFromMeshTest(unittest.TestCase):
         tlo, tla = self.ksfc.get_tor()
         aae(lons, tlo)
         aae(lats, tla)
+
+    def test_geom(self):
+        geom = kite_to_geom(self.ksfc)
+        ksfc = geom_to_kite(geom)
+        for par in ('lons', 'lats', 'depths'):
+            orig = getattr(self.ksfc.mesh, par)
+            copy = getattr(ksfc.mesh, par)
+            np.testing.assert_almost_equal(orig, copy)  # 32/64 bit mismatch
 
 
 class KiteSurfaceWithNaNs(unittest.TestCase):


### PR DESCRIPTION
This reduces by a factor of 10+ the data transfer in the reference calculation in https://github.com/gem/oq-engine/issues/7916.
```
$ oq show job_info 47920
| task              | sent                                         | received |
|-------------------+----------------------------------------------+----------|
| preclassical      | srcs=72.53 MB cmaker=53.89 MB sites=46.01 MB | 76.84 MB |
| classical         | cmaker=151.38 MB srcs=77 MB sids=1.15 KB     | 2.51 GB  |
$ oq show job_info 47944
| task              | sent                                        | received |
|-------------------+---------------------------------------------+----------|
| preclassical      | cmaker=53.89 MB sites=46.01 MB srcs=5.72 MB | 7.51 MB  |
| classical         | cmaker=151.38 MB srcs=7.78 MB sids=1.15 KB  | 2.51 GB  |
```
For the rest the performance is nearly the same, as expected:
```
| calc_47944, maxmem=61.2 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 22_153   | 116.2     | 295     |
| make_contexts              | 15_394   | 0.0       | 26_949  |
| computing mean_std         | 2_239    | 0.0       | 46_054  |
| get_poes                   | 2_116    | 0.0       | 964_073 |
| total preclassical         | 1_696    | 64.3      | 210     |
| ClassicalCalculator.run    | 438.3    | 373.3     | 1       |
```