### PR TITLE
Getting the engine version from the DbServer

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Internal: added command `oq db git_suffix`
+  * Internal: added command `oq db engine_version`
   * Added a check for required site parameters not passed correctly
   * Fixed `ps_grid_spacing` approximation when the grid is degenerate
   * Logging a warning when starting from an old hazard calculation

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Internal: added command `oq db git_suffix`
   * Added a check for required site parameters not passed correctly
   * Fixed `ps_grid_spacing` approximation when the grid is degenerate
   * Logging a warning when starting from an old hazard calculation

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -132,7 +132,7 @@ from openquake.baselib.general import git_suffix  # noqa: E402
 
 # the version is managed by packager.sh with a sed
 __version__ = '3.15.0'
-__version__ += git_suffix(__file__)
+__version__ += git_suffix()
 
 version = dict(python='%d.%d' % sys.version_info[:2],
                numpy=numpy.__version__,

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -128,11 +128,9 @@ else:  # linux
 import numpy
 import scipy
 import pandas
-from openquake.baselib.general import git_suffix  # noqa: E402
 
 # the version is managed by packager.sh with a sed
 __version__ = '3.15.0'
-__version__ += git_suffix()
 
 version = dict(python='%d.%d' % sys.version_info[:2],
                numpy=numpy.__version__,

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -41,6 +41,7 @@ import multiprocessing
 from collections.abc import Mapping, Container, MutableSequence
 import numpy
 from decorator import decorator
+from openquake.baselib import __version__
 from openquake.baselib.python3compat import decode
 
 U8 = numpy.uint8
@@ -415,9 +416,9 @@ def removetmp():
                 pass
 
 
-def git_suffix():
+def engine_version():
     """
-    :returns: `<short git hash>` if Git repository found
+    :returns: __version__ + `<short git hash>` if Git repository found
     """
     # we assume that the .git folder is two levels above any package
     # i.e. openquake/engine/../../.git
@@ -434,13 +435,12 @@ def git_suffix():
                 stderr=open(os.devnull, 'w'),
                 cwd=os.path.dirname(git_path)).strip()
             gh = "-git" + decode(gh) if gh else ''
-            return gh
         except Exception:
             # trapping everything on purpose; git may not be installed or it
             # may not work properly
-            pass
+            gh = ''
 
-    return ''
+    return __version__ + gh
 
 
 def run_in_process(code, *args):

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -415,13 +415,13 @@ def removetmp():
                 pass
 
 
-def git_suffix(fname):
+def git_suffix():
     """
     :returns: `<short git hash>` if Git repository found
     """
     # we assume that the .git folder is two levels above any package
     # i.e. openquake/engine/../../.git
-    git_path = os.path.join(os.path.dirname(fname), '..', '..', '.git')
+    git_path = os.path.join(os.path.dirname(__file__), '..', '..', '.git')
 
     # macOS complains if we try to execute git and it's not available.
     # Code will run, but a pop-up offering to install bloatware (Xcode)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -30,8 +30,7 @@ import h5py
 import numpy
 import pandas
 
-from openquake.baselib import (
-    general, hdf5, __version__ as engine_version)
+from openquake.baselib import general, hdf5
 from openquake.baselib import performance, parallel, python3compat
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import InvalidFile, site, stats
@@ -42,7 +41,8 @@ from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap.maps import get_sitecol_shakemap
 from openquake.hazardlib.shakemap.gmfs import to_gmfs
 from openquake.risklib import riskinput, riskmodels
-from openquake.commonlib import readinput, logictree, datastore, source_reader
+from openquake.commonlib import (
+    readinput, logictree, datastore, source_reader, logs)
 from openquake.calculators.export import export as exp
 from openquake.calculators import getters
 
@@ -178,7 +178,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
             # always except in case_shakemap
             self.datastore['oqparam'] = self.oqparam
         attrs = self.datastore['/'].attrs
-        attrs['engine_version'] = engine_version
+        attrs['engine_version'] = logs.dbcmd('engine_version')
         attrs['date'] = datetime.now().isoformat()[:19]
         if 'checksum32' not in attrs:
             attrs['input_size'] = size = self.oqparam.get_input_size()

--- a/openquake/commands/__main__.py
+++ b/openquake/commands/__main__.py
@@ -37,10 +37,6 @@ elif PY_VER == (3, 6):
     print('Python 3.6 (%s) is not supported; the engine may not work correctly'
           % sys.executable)
 
-# force cluster users to use `oq engine` so that we have centralized logs
-if os.environ['OQ_DISTRIBUTE'] == 'celery' and 'run' in sys.argv:
-    print('You are on a cluster and you are using oq run?? '
-          'Use oq engine --run instead!')
 
 # sanity check, all display name keys must be exportable
 dic = general.groupby(export.export, operator.itemgetter(0))

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -481,11 +481,11 @@ def get_dbpath(db):
     return rows[0].file
 
 
-def git_suffix(db):
+def engine_version(db):
     """
     :returns: git version as seen by the db
     """
-    return general.git_suffix()
+    return general.engine_version()
 
 
 # ########################## upgrade operations ########################## #

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -20,6 +20,7 @@ import getpass
 import operator
 from datetime import datetime
 
+from openquake.baselib import general
 from openquake.hazardlib import valid
 from openquake.server import __file__ as server_path
 from openquake.server.db.schema.upgrades import upgrader
@@ -478,6 +479,13 @@ def get_dbpath(db):
     rows = db('PRAGMA database_list')
     # return a row with fields (id, dbname, dbpath)
     return rows[0].file
+
+
+def git_suffix(db):
+    """
+    :returns: git version as seen by the db
+    """
+    return general.git_suffix()
 
 
 # ########################## upgrade operations ########################## #

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if sys.version_info < (3, 6):
     sys.exit('Sorry, Python < 3.6 is not supported')
 
 
-def engine_version():
+def get_version():
     version_re = r"^__version__\s+=\s+['\"]([^'\"]*)['\"]"
     version = None
 
@@ -47,7 +47,7 @@ def get_readme():
         return readme.read()
 
 
-version = engine_version()
+version = get_version()
 readme = get_readme()
 
 url = "https://github.com/gem/oq-engine"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if sys.version_info < (3, 6):
     sys.exit('Sorry, Python < 3.6 is not supported')
 
 
-def get_version():
+def engine_version():
     version_re = r"^__version__\s+=\s+['\"]([^'\"]*)['\"]"
     version = None
 
@@ -47,7 +47,7 @@ def get_readme():
         return readme.read()
 
 
-version = get_version()
+version = engine_version()
 readme = get_readme()
 
 url = "https://github.com/gem/oq-engine"


### PR DESCRIPTION
To avoid the git security fix that makes it impossible to get the version of repository if you are not the owner.

NB: `oq --version` will give the wrong version. We will live with that :-(