### PR TITLE
Fixed misleading error message

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed error message when trying to compute disagg_by_src with too many
+    sources: in some cases, it contained a misleading reference to point sources
   * Fixed disaggregation when a tectonic region type contains a single
     magnitude, thus breaking the magnitude binning formula
   * Reorganized the Advanced Manual; changed the theme to be consistent with

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -359,16 +359,9 @@ class ClassicalCalculator(base.HazardCalculator):
         sources = list(self.csm.source_info)
         size, msg = get_nbytes_msg(
             dict(N=self.N, R=self.R, M=self.M, L1=self.L1, Ns=self.Ns))
-        ps = any(src.code == b'P' for src in self.csm.get_sources())
-        if size > TWO32 and not ps:
+        if size > TWO32:
             raise RuntimeError('The matrix disagg_by_src is too large: %s'
                                % msg)
-        elif size > TWO32:
-            msg = ('The source model contains point sources: you cannot set '
-                   'disagg_by_src=true unless you convert them to multipoint '
-                   'sources with the command oq upgrade_nrml --multipoint %s'
-                   ) % oq.base_path
-            raise RuntimeError(msg)
         return sources
 
     def init_poes(self):

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -71,7 +71,10 @@ def create_source_info(csm, h5):
             mutex = getattr(src, 'mutex_weight', 0)
             srcid = basename(src)
             trti = csm.full_lt.trti.get(src.tectonic_region_type, -1)
-            code = csm.code.get(srcid, b'P')
+            if src.code == b'p':
+                code = b'p'
+            else:
+                code = csm.code.get(srcid, b'P')
             lens.append(len(src.trt_smrs))
             row = [srcid, src.grp_id, code, 0, 0, 0, src.weight, mutex, trti]
             wkts.append(getattr(src, '_wkt', ''))
@@ -354,7 +357,8 @@ class CompositeSourceModel:
             for src in sg:
                 src.grp_id = grp_id
                 if src.code != b'P':
-                    self.code[src.source_id] = src.code
+                    source_id = src.source_id.split(':')[0]
+                    self.code[source_id] = src.code
 
     # used for debugging; assume PoissonTOM; use read_cmakers instead
     def _get_cmakers(self, oq):


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/7939. Now the error message is clear:
```python
RuntimeError: The matrix disagg_by_src is too large: (N=1) * (R=5_500) * (M=3) * (L1=20) * (Ns=7_609) * 8 bytes = 18.71 GB
```
You need to put more colons in the source IDs, there are still Ns=7_609 independent sources, too many. Or reduce the number of realizations, 5_500 is too many,