### PR TITLE
Storing rupture IDs

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -237,6 +237,7 @@ class PreClassicalCalculator(base.HazardCalculator):
                     assert src.weight
                     assert src.num_ruptures
                     acc[src.code] += int(src.num_ruptures)
+        csm.fix_src_offset()
         for val, key in sorted((val, key) for key, val in acc.items()):
             cls = code2cls[key].__name__
             logging.info('{} ruptures: {:_d}'.format(cls, val))

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -35,7 +35,7 @@ from openquake.hazardlib.geo.surface.kite_fault import kite_to_geom
 TWO16 = 2 ** 16  # 65,536
 by_id = operator.attrgetter('source_id')
 
-CALC_TIME, NUM_SITES, EFF_RUPTURES, WEIGHT = 3, 4, 5, 6
+CALC_TIME, NUM_SITES, NUM_RUPTURES, WEIGHT = 3, 4, 5, 6
 
 source_info_dt = numpy.dtype([
     ('source_id', hdf5.vstr),          # 0
@@ -43,7 +43,7 @@ source_info_dt = numpy.dtype([
     ('code', (numpy.string_, 1)),      # 2
     ('calc_time', numpy.float32),      # 3
     ('num_sites', numpy.uint32),       # 4
-    ('eff_ruptures', numpy.uint32),    # 5
+    ('num_ruptures', numpy.uint32),    # 5
     ('weight', numpy.float32),         # 6
     ('mutex_weight', numpy.float64),   # 7
     ('trti', numpy.uint8),             # 8
@@ -467,10 +467,10 @@ class CompositeSourceModel:
                 source_data['src_id'], source_data['nsites'],
                 source_data['nrupts'], source_data['weight'],
                 source_data['ctimes']):
-            row = self.source_info[short_id(src_id)]
+            row = self.source_info[src_id.split(':')[0]]
             row[CALC_TIME] += ctimes
             row[WEIGHT] += weight
-            row[EFF_RUPTURES] += nrupts
+            row[NUM_RUPTURES] += nrupts
             row[NUM_SITES] += nsites
 
     def count_ruptures(self):

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -33,6 +33,7 @@ from openquake.hazardlib.lt import apply_uncertainties
 from openquake.hazardlib.geo.surface.kite_fault import kite_to_geom
 
 TWO16 = 2 ** 16  # 65,536
+TWO32 = 2 ** 32  # 4,294,967,296
 by_id = operator.attrgetter('source_id')
 
 CALC_TIME, NUM_SITES, NUM_RUPTURES, WEIGHT = 3, 4, 5, 6
@@ -463,6 +464,7 @@ class CompositeSourceModel:
         """
         Update (eff_ruptures, num_sites, calc_time) inside the source_info
         """
+        assert len(source_data) < TWO32, len(source_data)
         for src_id, nsites, nrupts, weight, ctimes in zip(
                 source_data['src_id'], source_data['nsites'],
                 source_data['nrupts'], source_data['weight'],
@@ -491,6 +493,9 @@ class CompositeSourceModel:
             for src in srcs:
                 src.offset = offset
                 offset += src.num_ruptures
+                if src.num_ruptures >= TWO32:
+                    raise ValueError(
+                        '%s contains more than 2**32 ruptures' % src)
                 # print(src, src.offset, offset)
 
     def get_max_weight(self, oq):  # used in preclassical

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -33,7 +33,8 @@ from openquake.baselib.performance import Monitor, split_array, compile, numba
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import valid, imt as imt_module
 from openquake.hazardlib.const import StdDev
-from openquake.hazardlib.tom import registry, get_pnes, FatedTOM, NegativeBinomialTOM
+from openquake.hazardlib.tom import (
+    registry, get_pnes, FatedTOM, NegativeBinomialTOM)
 from openquake.hazardlib.site import site_param_dt
 from openquake.hazardlib.stats import _truncnorm_sf
 from openquake.hazardlib.calc.filters import (

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -59,6 +59,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
     checksum = 0  # set in source_reader
     weight = 1  # set in contexts
     esites = 0  # updated in estimate_weight
+    offset = 0  # set in fix_src_offset
 
     @abc.abstractproperty
     def MODIFICATIONS(self):


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/7960. I am missing the tests. The performance penalty is acceptable. Here is the Guillaume's disaggregation calculation:
```
 src_offset
| calc_5977, maxmem=2.9 GB     | time_sec  | memory_mb | counts  |
|------------------------------+-----------+-----------+---------|
| total classical              | 159.4     | 13.2      | 99      |
| make_contexts                | 44.6      | 0.0       | 179_769 |

# master
| calc_5978, maxmem=2.8 GB     | time_sec  | memory_mb | counts  |
|------------------------------+-----------+-----------+---------|
| total classical              | 143.0     | 12.5      | 99      |
| make_contexts                | 29.5      | 0.0       | 179_769 |
```
`make_contexts` is much slower because of the loop
```python
 for u, rup_id in enumerate(rup_ids):
                ctx[u]['rup_id'] = rup_id
```
as expected.
