### PR TITLE
Fixed rup_id split-dependence

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -18,6 +18,7 @@
 from urllib.parse import parse_qs
 from unittest.mock import Mock
 from functools import lru_cache
+import operator
 import logging
 import json
 import gzip
@@ -533,6 +534,7 @@ def extract_mean_by_rup(dstore, what):
             # shape (4, G, M, U) => U
             means = cmaker.get_mean_stds([ctx])[0].mean(axis=(0, 1))
             out.extend(zip(ctx.src_id, ctx.rup_id, means))
+    out.sort(key=operator.itemgetter(0, 1))
     return numpy.array(out, [('src_id', U32), ('rup_id', U32), ('mean', F64)])
 
 

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -81,11 +81,14 @@ class ClassicalTestCase(CalculatorTestCase):
                                   delta=delta)
         return got
 
-    #def tearDown(self):
-    #    dstore = self.calc.datastore
-    #    if 'rup' in dstore:
-    #        mean_by_rup = extract(dstore, 'mean_by_rup?')
-    #        print(mean_by_rup.array)
+    def tearDown(self):
+        # sanity check on mean_by_rup on single-site tests
+        dstore = self.calc.datastore
+        if len(dstore['sitecol']) == 1:
+            mean_by_rup = extract(dstore, 'mean_by_rup?')
+            n = len(mean_by_rup.array)
+            uniq = numpy.unique(mean_by_rup.array[['src_id', 'rup_id']])
+            self.assertEqual(n, len(uniq))
 
     def test_case_1(self):
         self.assert_curves_ok(

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -81,15 +81,6 @@ class ClassicalTestCase(CalculatorTestCase):
                                   delta=delta)
         return got
 
-    def tearDown(self):
-        # sanity check on mean_by_rup on single-site tests
-        dstore = self.calc.datastore
-        if len(dstore['sitecol']) == 1:
-            mean_by_rup = extract(dstore, 'mean_by_rup?')
-            n = len(mean_by_rup.array)
-            uniq = numpy.unique(mean_by_rup.array[['src_id', 'rup_id']])
-            self.assertEqual(n, len(uniq))
-
     def test_case_1(self):
         self.assert_curves_ok(
             ['hazard_curve-PGA.csv', 'hazard_curve-SA(0.1).csv'],

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -483,6 +483,8 @@ class CompositeSourceModel:
         """
         for srcs in general.groupby(self.get_sources(), basename).values():
             offset = 0
+            if len(srcs) > 1:  # keep the ordering by split number
+                srcs.sort(key=lambda src: int(src.source_id.split(':')[1]))
             for src in srcs:
                 src.offset = offset
                 offset += src.num_ruptures

--- a/openquake/commonlib/source_reader.py
+++ b/openquake/commonlib/source_reader.py
@@ -483,7 +483,7 @@ class CompositeSourceModel:
         """
         for srcs in general.groupby(self.get_sources(), basename).values():
             offset = 0
-            if len(srcs) > 1:  # keep the ordering by split number
+            if len(srcs) > 1:  # order by split number
                 srcs.sort(key=lambda src: int(src.source_id.split(':')[1]))
             for src in srcs:
                 src.offset = offset

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -503,7 +503,9 @@ class ContextMaker(object):
         params = {n: dstore['rup/' + n][slc] for n in dstore['rup']}
         dtlist = []
         for par, val in params.items():
-            if par == 'probs_occur':
+            if len(val) == 0:
+                return []
+            elif par == 'probs_occur':
                 item = (par, object)
             elif par == 'occurrence_rate':
                 item = (par, F64)


### PR DESCRIPTION
There was an ordering issue. Closes https://github.com/gem/oq-engine/issues/7960 together with the test in https://gitlab.openquake.org/openquake/oq-risk-tests/-/merge_requests/64/diffs.