### PR TITLE
Optimized event_based_risk

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -99,7 +99,7 @@ def aggreg(outputs, crmodel, ARKD, aggids, rlz_id, monitor):
         for li, ln in enumerate(oq.ext_loss_types):
             if ln not in out or len(out[ln]) == 0:
                 continue
-            alt = out[ln].reset_index()
+            alt = out[ln]
             if oq.avg_losses:
                 with mon_avg:
                     coo = average_losses(
@@ -128,6 +128,9 @@ def aggreg(outputs, crmodel, ARKD, aggids, rlz_id, monitor):
                         dic[col].append(arr[li, c])
         fix_dtypes(dic)
         df = pandas.DataFrame(dic)
+        red = df[(df.loss_id == 9) & (df.agg_id == 0)]
+        if len(red):
+            print(red)
     return dict(avg=loss_by_AR, alt=df)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -128,9 +128,6 @@ def aggreg(outputs, crmodel, ARKD, aggids, rlz_id, monitor):
                         dic[col].append(arr[li, c])
         fix_dtypes(dic)
         df = pandas.DataFrame(dic)
-        red = df[(df.loss_id == 9) & (df.agg_id == 0)]
-        if len(red):
-            print(red)
     return dict(avg=loss_by_AR, alt=df)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -94,12 +94,12 @@ def aggreg(outputs, crmodel, ARKD, aggids, rlz_id, monitor):
     correl = int(oq.asset_correlation)
     (A, R, K, D), L = ARKD, len(xtypes)
     acc = general.AccumDict(accum=numpy.zeros((L, D)))  # u8idx->array
+    value_cols = ['variance', 'loss']
     for out in outputs:
         for li, ln in enumerate(oq.ext_loss_types):
             if ln not in out or len(out[ln]) == 0:
                 continue
             alt = out[ln].reset_index()
-            value_cols = alt.columns[2:]  # strip eid, aid
             if oq.avg_losses:
                 with mon_avg:
                     coo = average_losses(

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -359,7 +359,7 @@ class RiskModel(object):
         asset_df = pandas.DataFrame(dict(aid=assets.index, val=val), sid)
         vf = self.risk_functions[loss_type, 'vulnerability']
         return vf(asset_df, gmf_df, col, rndgen,
-                  self.minimum_asset_loss[loss_type]).set_index(['eid', 'aid'])
+                  self.minimum_asset_loss[loss_type])
 
     scenario = ebrisk = scenario_risk = event_based_risk
 

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1413,14 +1413,16 @@ def insurance_losses(asset_df, losses_by_rl, policy_df):
         if len(policy):
             new = out.copy()
             new['variance'] = 0.
-            for (eid, aid), ser in out.iterrows():
+            ins = numpy.zeros(len(out))
+            for i, (eid, aid, loss) in enumerate(
+                    zip(out.eid, out.aid, out.loss)):
                 asset = asset_df.loc[aid]  # aid==ordinal
                 avalue = asset['value-' + lt]
                 policy_idx = asset['policy']
                 ded = policy.loc[policy_idx].deductible
                 lim = policy.loc[policy_idx].insurance_limit
-                ins = insured_losses(ser.loss, ded * avalue, lim * avalue)
-                new.loc[eid, aid]['loss'] = ins
+                ins[i] = insured_losses(loss, ded * avalue, lim * avalue)
+            new['loss'] = ins
             losses_by_rl[riskid, lt + '_ins'] = new
 
 

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -32,8 +32,10 @@ from scipy import interpolate, stats
 F64 = numpy.float64
 F32 = numpy.float32
 U32 = numpy.uint32
+U64 = numpy.uint64
 U16 = numpy.uint16
 U8 = numpy.uint8
+TWO32 = 2 ** 32
 KNOWN_CONSEQUENCES = ['loss', 'ins_loss', 'losses', 'collapsed', 'injured',
                       'fatalities', 'homeless']
 
@@ -1482,6 +1484,30 @@ def get_agg_value(consequence, agg_values, agg_id, loss_type):
         return aval[loss_type]
     else:
         raise NotImplementedError(consequence)
+
+
+# ########################### u64_to_eal ################################# #
+
+def u64_to_eal(u64):
+    """
+    Convert an unit64 into a triple (eid, aid, lid)
+
+    >>> u64_to_eal(42949673216001)
+    (10000, 1000, 1)
+    """
+    eid, x = divmod(u64, TWO32)
+    aid, lid = divmod(x, 256)
+    return eid, aid, lid
+
+
+def eal_to_u64(eid, aid, lid):
+    """
+    Convert a triple (eid, aid, lid) into an uint64:
+
+    >>> eal_to_u64(10000, 1000, 1)
+    42949673216001
+    """
+    return U64(eid * TWO32) + U64(aid * 256) + U64(lid)
 
 
 if __name__ == '__main__':

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1407,13 +1407,13 @@ def insurance_losses(asset_df, losses_by_rl, policy_df):
         if len(policy):
             new = out.copy()
             new['variance'] = 0.
-            for (eid, aid), df in out.iterrows():
+            for (eid, aid), ser in out.iterrows():
                 asset = asset_df.loc[aid]  # aid==ordinal
                 avalue = asset['value-' + lt]
                 policy_idx = asset['policy']
                 ded = policy.loc[policy_idx].deductible
                 lim = policy.loc[policy_idx].insurance_limit
-                ins = insured_losses(df.loss, ded * avalue, lim * avalue)
+                ins = insured_losses(ser.loss, ded * avalue, lim * avalue)
                 new.loc[eid, aid]['loss'] = ins
             losses_by_rl[riskid, lt + '_ins'] = new
 

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1357,11 +1357,12 @@ class LossCurvesMapsBuilder(object):
             losses, self.return_periods, self.num_events[rlzi], self.eff_time)
 
 
-def avg(loss_dfs, weights):
+def _avg(loss_dfs, weights):
+    # average loss DataFrames with fields (eid, aid, variance, loss)
     for loss_df, w in zip(loss_dfs, weights):
         loss_df['variance'] *= w
         loss_df['loss'] *= w
-    return pandas.concat(loss_dfs).groupby(['eid', 'aid']).sum()
+    return pandas.concat(loss_dfs).groupby(['eid', 'aid']).sum().reset_index()
 
 
 class AvgRiskModel(dict):
@@ -1391,7 +1392,7 @@ class AvgRiskModel(dict):
                 continue
             elif len(outs) > 1 and hasattr(outs[0], 'loss'):
                 # computing the average dataframe for event_based_risk
-                out[lt] = avg(outs, weights).reset_index()
+                out[lt] = _avg(outs, weights)
             elif len(outs) > 1:
                 # for oq-risk-tests/test/event_based_damage/inputs/cali/job.ini
                 out[lt] = numpy.average(outs, weights=weights, axis=0)


### PR DESCRIPTION
By removing .set_index and .reset_index we get some speedup. For instance, for the slovenia calculation in oq-risk-tests:
```
# before
| calc_9419, maxmem=2.7 GB     | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total event_based_risk       | 33.3     | 33.4      | 16     |
| computing risk               | 19.0     | 0.0       | 2_096  |
| reading data                 | 3.32491  | 19.3      | 16     |
| averaging losses             | 2.79689  | 0.0       | 3_155  |
| aggregating losses           | 2.54641  | 0.0       | 3_155  |
# after
| calc_9378, maxmem=2.7 GB     | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total event_based_risk       | 26.7     | 33.1      | 16     |
| computing risk               | 14.8     | 0.0       | 2_096  |
| reading data                 | 3.25910  | 19.3      | 16     |
| averaging losses             | 2.80203  | 0.0       | 3_155  |
| aggregating losses           | 2.45717  | 0.0       | 3_155  |
```
Also improved a bit the calculation of the insurance losses and added two helper functions that might be useful in the future. Part of #7886 