### PR TITLE
add option for disagg_outputs that include mag, dist, and trt

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -483,6 +483,10 @@ class DisaggregationCalculator(base.HazardCalculator):
                         out[key][s, m, p, :] = pprod(mat4, axis=2)
                     elif key == 'Mag_Dist_Eps' and k == 0:
                         out[key][s, m, p, :] = mat4
+                    elif key == 'Mag_Dist_TRT' and k == 0:
+                        out[key][s, m, p, :] = pprod(mat5, axis=(3)).transpose(1, 2, 0, 3)  # T Mag Dist Z -> Mag Dist T Z
+                    elif key == 'Mag_Dist_TRT_Eps' and k == 0:
+                        out[key][s, m, p, :] = mat5.transpose(1, 2, 0, 3, 4)  # T Mag Dist Eps Z -> Mag Dist T Eps Z
                     elif key == 'Lon_Lat' and k == 1:
                         out[key][s, m, p, :] = pprod(mat4, axis=0)
                     elif key == 'Mag_Lon_Lat' and k == 1:

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -425,6 +425,10 @@ lon_lat_pmf = partial(pprod, axis=(DIS, MAG, EPS))
 mag_lon_lat_pmf = partial(pprod, axis=(DIS, EPS))
 trt_pmf = partial(pprod, axis=(1, 2, 3, 4, 5))
 # applied on matrix TRT MAG DIS LON LAT EPS
+mag_dist_trt_pmf = partial(pprod, axis=(3, 4, 5))
+# applied on matrix TRT MAG DIS LON LAT EPS
+mag_dist_trt_eps_pmf = partial(pprod, axis=(3, 4))
+# applied on matrix TRT MAG DIS LON LAT EPS
 
 
 def lon_lat_trt_pmf(matrices):
@@ -450,6 +454,8 @@ pmf_map = dict([
     ('TRT', trt_pmf),
     ('Mag_Dist', mag_dist_pmf),
     ('Mag_Dist_Eps', mag_dist_eps_pmf),
+	('Mag_Dist_TRT', mag_dist_trt_pmf),
+    ('Mag_Dist_TRT_Eps', mag_dist_trt_eps_pmf),
     ('Lon_Lat', lon_lat_pmf),
     ('Mag_Lon_Lat', mag_lon_lat_pmf),
     ('Lon_Lat_TRT', lon_lat_trt_pmf),


### PR DESCRIPTION
The NZ NSHM uses these custom combinations of disagg_outputs. This also addresses the feature request in this thread: https://groups.google.com/g/openquake-users/c/pnSGbii0F8A/m/78CrmW9wAwAJ

@micheles, you noted in that thread that this feature will produce too many output .csv files. If this is still a deterrent for adding it, @mmpagani had suggested that the extra disagg_outputs (Mag_Dist_TRT and Mag_Dist_TRT_Eps) could be run only when specifically called by the user.