### PR TITLE
Added some restrictions on risk IDs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added some restrictions on risk IDs
   * Extended `disagg_by_src` to mutually exclusive sources (i.e. Japan)
 
   [Anne Hulsey]

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -291,7 +291,8 @@ class SimpleId(object):
         elif re.match(self.regex, value):
             return value
         raise ValueError(
-            "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-:" % value)
+            "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-:"
+            % value)
 
 
 MAX_ID_LENGTH = 75  # length required for some sources in US14 collapsed model
@@ -303,6 +304,15 @@ asset_id = SimpleId(ASSET_ID_LENGTH)
 source_id = SimpleId(MAX_ID_LENGTH, r'^[\w\.\-_]+$')
 nice_string = SimpleId(  # nice for Windows, Linux, HDF5 and XML
     ASSET_ID_LENGTH, r'[a-zA-Z0-9\.`!#$%\(\)\+/,;@\[\]\^_{|}~-]+')
+
+
+def risk_id(value):
+    """
+    A valid risk ID cannot contain the characters #'"
+    """
+    if '#' in value or '"' in value or "'" in value:
+        raise ValueError('Invalid ID "%s" contains forbidden chars' % value)
+    return value
 
 
 class FloatRange(object):

--- a/openquake/risklib/read_nrml.py
+++ b/openquake/risklib/read_nrml.py
@@ -382,9 +382,9 @@ def update_validators():
     Call this to updade the global nrml.validators
     """
     validators.update({
-        'fragilityFunction.id': valid.utf8,  # taxonomy
-        'vulnerabilityFunction.id': valid.utf8,  # taxonomy
-        'consequenceFunction.id': valid.utf8,  # taxonomy
+        'fragilityFunction.id': valid.risk_id,  # taxonomy
+        'vulnerabilityFunction.id': valid.risk_id,  # taxonomy
+        'consequenceFunction.id': valid.risk_id,  # taxonomy
         'asset.id': valid.asset_id,
         'costType.name': valid.cost_type,
         'costType.type': valid.cost_type_type,

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -432,14 +432,14 @@ def get_riskcomputer(dic):
     rc.wdic = {}
     rfs = AccumDict(accum=[])
     for rlk, func in dic['risk_functions'].items():
-        riskid, lt, kind = rlk.split(':')
+        riskid, lt, kind = rlk.split('#')
         rf = hdf5.json_to_obj(json.dumps(func))
         rf.init()
         rf.loss_type = lt
         rfs[riskid].append(rf)
     mal = dic.get('minimum_asset_loss', {lt: 0. for lt in dic['loss_types']})
     for rlt, weight in dic['wdic'].items():
-        riskid, lt = rlt.split(':')
+        riskid, lt = rlt.split('#')
         rm = RiskModel(dic['calculation_mode'], 'taxonomy',
                        group_by_lt(rfs[riskid]),
                        minimum_asset_loss=mal)

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1515,12 +1515,12 @@ class RiskComputer(dict):
         for rlt, rm in self.items():
             for lt, rfs in rm.risk_functions.items():
                 for rf in rfs:
-                    rlk = '%s:%s:%s' % (rf.id, lt, rf.kind)
+                    rlk = '%s#%s#%s' % (rf.id, lt, rf.kind)
                     rfdic[rlk] = ast.literal_eval(hdf5.obj_to_json(rf))
         df = self.asset_df
         dic = dict(asset_df={col: df[col].tolist() for col in df.columns},
                    risk_functions=rfdic,
-                   wdic={'%s:%s' % k: v for k, v in self.wdic.items()},
+                   wdic={'%s#%s' % k: v for k, v in self.wdic.items()},
                    alias=self.alias,
                    loss_types=self.loss_types,
                    minimum_asset_loss=self.minimum_asset_loss,

--- a/openquake/risklib/tests/riskmodels_test.py
+++ b/openquake/risklib/tests/riskmodels_test.py
@@ -313,7 +313,7 @@ class RiskComputerTestCase(unittest.TestCase):
             'loss_types': ['structural'],
             'minimum_asset_loss': {'structural': 0},
             'risk_functions': {
-                'RC:structural:vulnerability':
+                'RC#structural#vulnerability':
                 {"openquake.risklib.scientific.VulnerabilityFunction":
                  {"id": "RC",
                   "loss_type": "structural",
@@ -322,7 +322,7 @@ class RiskComputerTestCase(unittest.TestCase):
                   "mean_loss_ratios": [0.0035, 0.07, 0.14, 0.28, 0.56],
                   "covs": [0.0, 0.0, 0.0, 0.0, 0.0],
                   "distribution_name": "LN"}}},
-            'wdic': {'RC:structural': 1}}
+            'wdic': {'RC#structural': 1}}
         gmfs = {'eid': [0, 1],
                 'sid': [0, 0],
                 'gmv_0': [.23, .31]}
@@ -351,7 +351,7 @@ class RiskComputerTestCase(unittest.TestCase):
                'calculation_mode': 'event_based_risk',
                'loss_types': ['nonstructural', 'structural'],
                'risk_functions': {
-                   'RM:nonstructural:vulnerability': {
+                   'RM#nonstructural#vulnerability': {
                        'openquake.risklib.scientific.VulnerabilityFunction': {
                            'covs': [0.0001, 0.0001, 0.0001, 0.0001, 0.0001],
                            'distribution_name': 'LN',
@@ -359,7 +359,7 @@ class RiskComputerTestCase(unittest.TestCase):
                            'imls': [0.1, 0.2, 0.4, 0.7, 1.0],
                            'imt': 'SA(1.0)',
                            'mean_loss_ratios': [0.1, 0.2, 0.35, 0.6, 0.9]}},
-                   'RM:structural:vulnerability': {
+                   'RM#structural#vulnerability': {
                        'openquake.risklib.scientific.VulnerabilityFunction': {
                            'covs': [0.0001, 0.0001, 0.0001, 0.0001, 0.0001],
                            'distribution_name': 'LN',
@@ -367,7 +367,7 @@ class RiskComputerTestCase(unittest.TestCase):
                            'imls': [0.02, 0.3, 0.5, 0.9, 1.2],
                            'imt': 'PGA',
                            'mean_loss_ratios': [0.05, 0.1, 0.2, 0.4, 0.8]}}},
-               'wdic': {'RM:nonstructural': 1, 'RM:structural': 1}}
+               'wdic': {'RM#nonstructural': 1, 'RM#structural': 1}}
 
         gmfs = {'eid': [0, 2],
                 'sid': [0, 0],


### PR DESCRIPTION
So that the RiskComputer serialization work. Part of #7886. For the moment the only restriction is to forbid the characters ``#"'`` but I want to add more restrictions in the future, like forbidding non-ascii characters. This is tricky since existing risk models must keep working.