### PR TITLE
Saving more memory when building the contexts

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -481,7 +481,6 @@ class ContextMaker(object):
         self.poe_mon = monitor('get_poes', measuremem=False)
         self.pne_mon = monitor('composing pnes', measuremem=False)
         self.ir_mon = monitor('iter_ruptures', measuremem=False)
-        self.col_mon = monitor('collecting contexts', measuremem=True)
         self.task_no = getattr(monitor, 'task_no', 0)
         self.out_no = getattr(monitor, 'out_no', self.task_no)
 
@@ -1322,7 +1321,6 @@ class PmapMaker(object):
         if allctxs:
             cm.get_pmap(concat(allctxs), pmap)
             allctxs.clear()
-        print('==================== contexts=%.1f MB' % ctxs_mb)
         dt = time.time() - t0
         nsrcs = len(self.sources)
         for src in self.sources:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -52,7 +52,7 @@ TWO16 = 2**16
 TWO24 = 2**24
 TWO32 = 2**32
 STD_TYPES = (StdDev.TOTAL, StdDev.INTER_EVENT, StdDev.INTRA_EVENT)
-MAX_MB = 1024
+MAX_MB = 512
 KNOWN_DISTANCES = frozenset(
     'rrup rx ry0 rjb rhypo repi rcdpp azimuth azimuth_cp rvolc closest_point'
     .split())

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -35,8 +35,8 @@ from openquake.hazardlib.source.base import BaseSeismicSource
 
 F32 = np.float32
 BLOCKSIZE = 200
-# the BLOCKSIZE has to be large to reduce the number of sources and
-# therefore the redundant data transfer in the .sections attribute
+# NB: we need enough sources for parallelization and not too
+# big to cause an out-of-memory when building the contexts
 
 
 class MultiFaultSource(BaseSeismicSource):


### PR DESCRIPTION
By using MAX_MB which is safer than the maxsize used before.