### PR TITLE
Fixed the installer to work outside of the oq-engine directory

### DIFF
--- a/install.py
+++ b/install.py
@@ -65,6 +65,8 @@ except ImportError:
             sys.exit('venv is missing! Please see the documentation of your '
                      'Operating System to install it')
 
+CDIR = os.path.dirname(__file__)
+
 
 class server:
     """
@@ -357,7 +359,7 @@ def install(inst, version):
     subprocess.check_call([pycmd, '-m', 'pip', 'install', '-r', req])
 
     if (inst is devel or inst is devel_server):  # install from the local repo
-        subprocess.check_call([pycmd, '-m', 'pip', 'install', '-e', '.'])
+        subprocess.check_call([pycmd, '-m', 'pip', 'install', '-e', CDIR])
     elif version is None:  # install the stable version
         subprocess.check_call([pycmd, '-m', 'pip', 'install',
                                '--upgrade', 'openquake.engine'])


### PR DESCRIPTION
Avoid the error
```python
  File "/Users/devops/oq-engine/install.py", line 360, in install
    subprocess.check_call([pycmd, '-m', 'pip', 'install', '-e', '.'])
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_3/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/Users/devops/openquake/bin/python3', '-m', 'pip', 'install', '-e', '.']' returned non-zero exit status 1.
```