### PR TITLE
Csm for xvf

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -536,7 +536,8 @@ def get_site_collection(oqparam, h5=None):
             req_site_params.add('ampcode')
         if h5 and 'site_model' in h5:  # comes from a site_model.csv
             sm = h5['site_model'][:]
-        elif 'site_model' in oqparam.inputs:
+        elif (not h5 and 'site_model' in oqparam.inputs and
+              'exposure' not in oqparam.inputs):
             # tested in test_with_site_model
             sm = get_site_model(oqparam)
         else:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -570,7 +570,7 @@ def get_site_collection(oqparam, h5=None):
         dt = site.site_param_dt[param]
         if dt is F64 and (sitecol.array[param] == 0.).all():
             raise ValueError('The site parameter %s is always zero: please '
-                             'check the site nodel' % param)
+                             'check the site model' % param)
     return sitecol
 
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -536,6 +536,9 @@ def get_site_collection(oqparam, h5=None):
             req_site_params.add('ampcode')
         if h5 and 'site_model' in h5:  # comes from a site_model.csv
             sm = h5['site_model'][:]
+        elif not h5 and ('site_model' in oqparam.inputs 
+                and not 'exposure' in oqparam.inputs):
+            sm = get_site_model(oqparam)
         else:
             sm = oqparam
         sitecol = site.SiteCollection.from_points(

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -536,8 +536,8 @@ def get_site_collection(oqparam, h5=None):
             req_site_params.add('ampcode')
         if h5 and 'site_model' in h5:  # comes from a site_model.csv
             sm = h5['site_model'][:]
-        elif not h5 and ('site_model' in oqparam.inputs 
-                and not 'exposure' in oqparam.inputs):
+        elif 'site_model' in oqparam.inputs:
+            # tested in test_with_site_model
             sm = get_site_model(oqparam)
         else:
             sm = oqparam

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -27,7 +27,8 @@ from openquake.hazardlib import InvalidFile, site_amplification, gsim_lt
 from openquake.hazardlib.calc.filters import MINMAG, MAXMAG
 from openquake.risklib import asset
 from openquake.commonlib import readinput, datastore
-from openquake.qa_tests_data.classical import case_2, case_15, case_21
+from openquake.qa_tests_data.classical import (case_2, case_15, 
+        case_21, case_34)
 from openquake.qa_tests_data.event_based import case_16
 from openquake.qa_tests_data.event_based_risk import (
     case_2 as ebr2, case_caracas)
@@ -497,6 +498,11 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
                 os.remove(h5.filename)
         self.assertEqual(
             error.call_args[0][0], 'source SFLT2: too large: 84 km')
+
+    def test_site_model_with_xvf(self):
+        oq = readinput.get_oqparam('job.ini', case_34)
+        ssclt = readinput.get_composite_source_model(oq)
+        self.assertEqual(ssclt.source_model_lt.source_ids['956'], ['b1']) 
 
 
 class SitecolAssetcolTestCase(unittest.TestCase):

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -27,8 +27,8 @@ from openquake.hazardlib import InvalidFile, site_amplification, gsim_lt
 from openquake.hazardlib.calc.filters import MINMAG, MAXMAG
 from openquake.risklib import asset
 from openquake.commonlib import readinput, datastore
-from openquake.qa_tests_data.classical import (case_2, case_15, 
-        case_21, case_34)
+from openquake.qa_tests_data.classical import (
+        case_2, case_15, case_21, case_34)
 from openquake.qa_tests_data.event_based import case_16
 from openquake.qa_tests_data.event_based_risk import (
     case_2 as ebr2, case_caracas)
@@ -502,7 +502,7 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
     def test_site_model_with_xvf(self):
         oq = readinput.get_oqparam('job.ini', case_34)
         ssclt = readinput.get_composite_source_model(oq)
-        self.assertEqual(ssclt.source_model_lt.source_ids['956'], ['b1']) 
+        self.assertEqual(ssclt.source_model_lt.source_ids['956'], ['b1'])
 
 
 class SitecolAssetcolTestCase(unittest.TestCase):

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -499,7 +499,7 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
         self.assertEqual(
             error.call_args[0][0], 'source SFLT2: too large: 84 km')
 
-    def test_site_model_with_xvf(self):
+    def test_with_site_model(self):
         oq = readinput.get_oqparam('job.ini', case_34)
         ssclt = readinput.get_composite_source_model(oq)
         self.assertEqual(ssclt.source_model_lt.source_ids['956'], ['b1'])


### PR DESCRIPTION
Called through a notebook, [get_composite_source_model](https://github.com/gem/oq-engine/blob/master/openquake/commonlib/readinput.py#L770) failed if the job.ini specifies a site_model_file with a field xvf unless h5 file != None, for example:

```
# Load oq parameters from the file
oqparam = get_oqparam(fname_ini)
ssc_lt = get_composite_source_model(oqparam)
```
 failed with
```
ValueError                                Traceback (most recent call last)
File ~/GEM/oq-engine/openquake/commonlib/readinput.py:736, in _check_csm(csm, oqparam, h5)
    735 try:
--> 736     sitecol = get_site_collection(oqparam, h5)
    737 except ValueError:   # already stored (case_66)

File ~/GEM/oq-engine/openquake/commonlib/readinput.py:570, in get_site_collection(oqparam, h5)
    569     if dt is F64 and (sitecol.array[param] == 0.).all():
--> 570         raise ValueError('The site parameter %s is always zero: please '
    571                          'check the site nodel' % param)
    572 return sitecol

ValueError: The site parameter xvf is always zero: please check the site nodel
```

 This PR corrects the issue.