### PR TITLE
Worked around a numpy.concatenate bug

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -549,9 +549,6 @@ class ContextMaker(object):
         """
         assert ctxs
         dd = self.defaultdict.copy()
-        if self.fewsites:
-            dd['clon'] = numpy.float64(0.)
-            dd['clat'] = numpy.float64(0.)
         if magi is not None:  # magnitude bin used in disaggregation
             dd['magi'] = numpy.uint8(0)
 
@@ -563,7 +560,9 @@ class ContextMaker(object):
             shps = [ctx.probs_occur.shape for ctx in ctxs]
             np = max(i[1] if len(i) > 1 else i[0] for i in shps)
         dd['probs_occur'] = numpy.zeros(np)
-
+        if self.fewsites:  # must be at the end
+            dd['clon'] = numpy.float64(0.)
+            dd['clat'] = numpy.float64(0.)
         C = sum(len(ctx) for ctx in ctxs)
         ra = RecordBuilder(**dd).zeros(C)
         start = 0


### PR DESCRIPTION
Should solve https://github.com/gem/oq-engine/issues/7842. The issue was that the contexts coming from the point sources had dtype `(..., clon, clat, probs_occur)` instead of `(..., probs_occur, clon, clat)` and numpy was silently filling some clon with zeros (?!)