### PR TITLE
Improve error messages for missing taxonomy string cases

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -866,7 +866,7 @@ class HazardCalculator(BaseCalculator):
             if self.crmodel and missing:
                 raise RuntimeError(
                     'The exposure contains the taxonomy strings '
-                    '%s which are not in the risk model' % missing)
+                    '%s which are not in the fragility/vulnerability/consequence model' % missing)
 
             self.crmodel.check_risk_ids(oq.inputs)
 

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -236,7 +236,7 @@ agg_id
     def test_missing_taxonomy(self):
         with self.assertRaises(RuntimeError) as ctx:
             self.run_calc(case_2.__file__, 'job_err.ini')
-        self.assertIn('not in the risk model', str(ctx.exception))
+        self.assertIn('not in the fragility/vulnerability/consequence model', str(ctx.exception))
 
     def test_case_3(self):
         # this is a test with statistics

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1013,8 +1013,8 @@ def _taxonomy_mapping(filename, taxonomies):
     taxonomies = taxonomies[1:]  # strip '?'
     missing = set(taxonomies) - set(dic)
     if missing:
-        raise InvalidFile('The taxonomies %s are in the exposure but not in '
-                          'the taxonomy mapping %s' % (missing, filename))
+        raise InvalidFile('The taxonomy strings %s are in the exposure but not in '
+                          'the taxonomy mapping file %s' % (missing, filename))
     lst = [[("?", 1)]]
     for taxo in taxonomies:
         recs = dic[taxo]


### PR DESCRIPTION
- Similar to #7441 but for taxonomy mapping files, and
- Improves the error message to clarify what 'risk model' means (see https://groups.google.com/g/openquake-users/c/QijCGK_qUW0/m/XAJceza-BgAJ)