### PR TITLE
Disabling DBHandler in "calc" mode

### DIFF
--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -46,7 +46,7 @@ from openquake.qa_tests_data.event_based_risk import (
     case_master, case_1 as case_eb)
 from openquake.qa_tests_data.scenario_risk import case_shapefile, case_shakemap
 from openquake.qa_tests_data.gmf_ebrisk import case_1 as ebrisk
-from openquake.server import manage, dbserver
+from openquake.server import dbserver
 from openquake.server.tests import data as test_data
 
 DATADIR = os.path.join(commonlib.__path__[0], 'tests', 'data')
@@ -448,18 +448,6 @@ class ZipTestCase(unittest.TestCase):
         names = sorted(zipfile.ZipFile(job_zip).namelist())
         self.assertIn('shakefile/usp000fjta.npy', names)
         shutil.rmtree(dtemp)
-
-
-class DbTestCase(unittest.TestCase):
-    def test_db(self):
-        # the some db commands bypassing the dbserver
-        with Print.patch(), mock.patch(
-                'openquake.commonlib.logs.dbcmd', manage.fakedbcmd):
-            sap.runline('openquake.commands db db_version')
-            try:
-                sap.runline('openquake.commands db calc_info 1')
-            except dbapi.NotFound:  # happens on an empty db
-                pass
 
 
 class EngineRunJobTestCase(unittest.TestCase):

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -236,7 +236,7 @@ class LogContext:
 
     def __getstate__(self):
         # ensure pickleability
-        return dict(calc_id=self.calc_id, params=self.params,
+        return dict(calc_id=self.calc_id, params=self.params, usedb=self.usedb,
                     log_level=self.log_level, log_file=self.log_file,
                     user_name=self.user_name, oqparam=self.oqparam)
 

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -186,12 +186,15 @@ class LogContext:
                 user_name,
                 hc_id,
                 host)
+            self.usedb = True
         elif calc_id == -1:
             # only works in single-user situations
             self.calc_id = get_last_calc_id() + 1
+            self.usedb = False
         else:
             # assume the calc_id was alreay created in the db
             self.calc_id = calc_id
+            self.usedb = True
 
     def get_oqparam(self):
         """
@@ -209,7 +212,7 @@ class LogContext:
         for handler in logging.root.handlers:
             fmt = logging.Formatter(f, datefmt='%Y-%m-%d %H:%M:%S')
             handler.setFormatter(fmt)
-        self.handlers = [LogDatabaseHandler(self.calc_id)]
+        self.handlers = [LogDatabaseHandler(self.calc_id)] if self.usedb else []
         if self.log_file is None:
             # add a StreamHandler if not already there
             if not any(h for h in logging.root.handlers


### PR DESCRIPTION
In 'calc' mode it makes no sense to log on the database.