### PR TITLE
Refactored management of treaties

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -715,12 +715,10 @@ class HazardCalculator(BaseCalculator):
         for loss_type, fname in lt_fnames:
             if 'reinsurance' in oq.inputs:
                 assert len(lt_fnames) == 1, lt_fnames
-                df, treaty_df, max_cession, fieldmap = reinsurance.parse(
-                    fname, policy_idx)
+                df, treaty_df, fieldmap = reinsurance.parse(fname, policy_idx)
                 treaties = set(treaty_df.id)
                 assert len(treaties) == len(treaty_df), 'Not unique treaties'
                 self.datastore.create_df('treaty_df', treaty_df,
-                                         max_cession=json.dumps(max_cession),
                                          field_map=json.dumps(fieldmap))
                 self.treaty_df = treaty_df.set_index('id')
             else:  # insurance

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -399,10 +399,8 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             agg_loss_table = alt[alt.loss_id == LOSSID[lt]]
             if len(agg_loss_table) == 0:
                 raise ValueError('No losses for reinsurance %s' % lt)
-            max_cession = self.datastore.get_attr('treaty_df', 'max_cession')
             rbp, rbe = reinsurance.by_policy_event(
-                agg_loss_table, self.policy_df,
-                json.loads(max_cession), self.treaty_df)
+                agg_loss_table, self.policy_df, self.treaty_df)
             self.datastore.create_df('reinsurance_by_policy', rbp)
             self.datastore.create_df('reinsurance_by_event', rbe)
 

--- a/openquake/risklib/reinsurance.py
+++ b/openquake/risklib/reinsurance.py
@@ -165,24 +165,9 @@ def claim_to_cessions(claim, policy, treaty_df):
     """
     :param claim: an array of claims
     :param policy: a dictionary corresponding to a specific policy
-    :param nonprops: dataframe with nonprop treaties of type wxlr
+    :param treaty_df: dataframe with treaties
 
-    Converts an array of claims into a dictionary of arrays
-
-    >>> df = pd.DataFrame({'id': ['prop1', 'nonprop1'],
-    ...                    'max_retention': [0, 100_000],
-    ...                    'limit': [1_000_000, 200_000],
-    ...                     type: ['prop', 'wxlr']}).set_index('id')
-    >>> pol1 = {'prop1': .3, 'prop2': .5, 'nonprop1': True}
-    >>> pol2 = {'prop1': .4, 'prop2': .4, 'nonprop1': True}
-    >>> claim_to_cessions(np.array([900_000]), pol1, df)
-    {'claim': array([900000]), 'retention': array([100000.]), 'prop1': array([270000.]), 'prop2': array([450000.]), 'nonprop1': array([80000.])}
-
-    >>> claim_to_cessions(np.array([1_800_000]), pol2, df)
-    {'claim': array([1800000]), 'retention': array([260000.]), 'prop1': array([720000.]), 'prop2': array([720000.]), 'nonprop1': array([100000.])}
-
-    >>> claim_to_cessions(np.array([80_000]), pol2, df)
-    {'claim': array([80000]), 'retention': array([16000.]), 'prop1': array([32000.]), 'prop2': array([32000.]), 'nonprop1': array([0.])}
+    Converts an array of claims into a dictionary of arrays.
     """
     # proportional cessions
     fractions = [policy[col] for col in policy if col.startswith('prop')]
@@ -192,11 +177,8 @@ def claim_to_cessions(claim, policy, treaty_df):
         cession = 'prop%d' % i
         out[cession] = claim * frac
 
-    wxl = treaty_df[treaty_df.type == 'wxlr']
-    if len(wxl) == 0:
-        return {k: np.round(v, 6) for k, v in out.items()}
-
     # wxlr cessions
+    wxl = treaty_df[treaty_df.type == 'wxlr']
     for col, nonprop in wxl.iterrows():
         out[col] = np.zeros(len(claim))
         if policy[col]:

--- a/openquake/risklib/reinsurance.py
+++ b/openquake/risklib/reinsurance.py
@@ -99,26 +99,29 @@ def parse(fname, policy_idx):
     :param policy_idx: dictionary policy name -> policy index
 
     Parse a reinsurance.xml file and returns
-    (policy_df, treaty_df, max_cession, field_map)
+    (policy_df, treaty_df, field_map)
     """
     rmodel = nrml.read(fname).reinsuranceModel
     fieldmap = {}
     reversemap = {} # propN->nameN
-    max_cession = {}  # propN->cessionN
-    nonprop = dict(id=[], type=[], max_retention=[], limit=[])
+    treaty = dict(id=[], type=[], max_retention=[], limit=[])
     for node in rmodel.fieldMap:
         fieldmap[node['input']] = col = node['oq']
         reversemap[col] = node['input']
-        mce = node.get('max_cession_event')
-        if mce:
-            max_cession[col] = mce
+        if col in ('policy', 'deductible', 'liability'):  # not a treaty
+            continue
         treaty_type = node.get('type', 'prop')
-        assert treaty_type in (None, 'prop','wxlr', 'catxl'), treaty_type
-        if treaty_type in ('wxlr', 'catxl'):
-            nonprop['id'].append(col)
-            nonprop['type'].append(treaty_type)
-            nonprop['max_retention'].append(node['max_retention'])
-            nonprop['limit'].append(node['limit'])
+        assert treaty_type in ('prop', 'wxlr', 'catxl'), treaty_type
+        if treaty_type == 'prop':
+            limit = node.get('max_cession_event', 1E100)
+            maxret = 0
+        else:
+            limit = node['limit']
+            maxret = node['max_retention']
+        treaty['id'].append(col)
+        treaty['type'].append(treaty_type)
+        treaty['max_retention'].append(maxret)
+        treaty['limit'].append(limit)
     for name, col in fieldmap.items():
         if col.startswith('prop'):
             reversemap['overspill' + col[4:]] = 'overspill_' + name
@@ -136,11 +139,11 @@ def parse(fname, policy_idx):
         if col.startswith('prop'):
             colnames.append(origname)
             colvalues.append(df[col].to_numpy())
-        elif col.startswith('nonprop'):
+        elif col.startswith('treaty'):
             df[col] = np.bool_(df[col])
     if colnames:
         check_fractions(colnames, colvalues, policyfname)
-    return df, pd.DataFrame(nonprop), max_cession, reversemap
+    return df, pd.DataFrame(treaty), reversemap
 
 
 @compile(["(float64[:],float64[:],float64,float64)",
@@ -158,7 +161,7 @@ def apply_nonprop(cession, retention, maxret, limit):
                 cession[i] = overmax
 
 
-def claim_to_cessions(claim, policy, nonprops=()):
+def claim_to_cessions(claim, policy, treaty_df):
     """
     :param claim: an array of claims
     :param policy: a dictionary corresponding to a specific policy
@@ -166,8 +169,10 @@ def claim_to_cessions(claim, policy, nonprops=()):
 
     Converts an array of claims into a dictionary of arrays
 
-    >>> df = pd.DataFrame({'id': ['nonprop1'], 'max_retention': [100_000],
-    ...                    'limit': [200_000], type: 'wxlr'}).set_index('id')
+    >>> df = pd.DataFrame({'id': ['prop1', 'nonprop1'],
+    ...                    'max_retention': [0, 100_000],
+    ...                    'limit': [1_000_000, 200_000],
+    ...                     type: ['prop', 'wxlr']}).set_index('id')
     >>> pol1 = {'prop1': .3, 'prop2': .5, 'nonprop1': True}
     >>> pol2 = {'prop1': .4, 'prop2': .4, 'nonprop1': True}
     >>> claim_to_cessions(np.array([900_000]), pol1, df)
@@ -186,22 +191,18 @@ def claim_to_cessions(claim, policy, nonprops=()):
     for i, frac in enumerate(fractions, 1):
         cession = 'prop%d' % i
         out[cession] = claim * frac
-    if len(nonprops) == 0:
+
+    wxl = treaty_df[treaty_df.type == 'wxlr']
+    if len(wxl) == 0:
         return {k: np.round(v, 6) for k, v in out.items()}
 
-    # nonproportional cessions
-    for col, nonprop in nonprops.iterrows():
+    # wxlr cessions
+    for col, nonprop in wxl.iterrows():
         out[col] = np.zeros(len(claim))
         if policy[col]:
             apply_nonprop(out[col], out['retention'],
                           nonprop['max_retention'], nonprop['limit'])
 
-    # sanity check, uncomment it in case of errors
-    tot = out['retention'].copy()
-    for col in out:
-        if col.startswith(('prop', 'nonprop')):
-            tot += out[col]
-    np.testing.assert_allclose(tot, out['claim'], rtol=1E-6)
     return {k: np.round(v, 6) for k, v in out.items()}
 
 
@@ -213,7 +214,7 @@ def by_policy(agglosses_df, pol_dict, treaty_df):
     :param dict pol_dict:
         Policy parameters, with pol_dict['policy'] being an integer >= 1
     :param DataFrame treaty_df:
-        Non-proportional treaties
+        All treaties
     :returns:
         DataFrame of reinsurance losses by event ID and policy ID
     '''
@@ -224,16 +225,14 @@ def by_policy(agglosses_df, pol_dict, treaty_df):
     claim = scientific.insured_losses(losses, ded, lim)
     out['event_id'] = df.event_id.to_numpy()
     out['policy_id'] = np.array([pol_dict['policy']] * len(df))
-    wxlr_df = treaty_df[treaty_df.type == 'wxlr']
-    out.update(claim_to_cessions(claim, pol_dict, wxlr_df))
+    out.update(claim_to_cessions(claim, pol_dict, treaty_df))
     nonzero = out['claim'] > 0  # discard zero claims
     return pd.DataFrame({k: out[k][nonzero] for k in out})
 
 
-def _by_event(by_policy_df, max_cession, treaty_df):
+def _by_event(by_policy_df, treaty_df):
     """
     :param DataFrame by_policy_df: output of `by_policy`
-    :param dict max_cession: maximum cession for proportional treaties
     :param DataFrame treaty_df: treaties
     """
     df = by_policy_df.groupby('event_id').sum()
@@ -243,7 +242,8 @@ def _by_event(by_policy_df, max_cession, treaty_df):
         dic[col] = df[col].to_numpy()
 
     # proportional overspill
-    for col, cession in max_cession.items():
+    prop = treaty_df[treaty_df.type == 'prop']
+    for col, cession in zip(prop.index, prop.limit):
         over = dic[col] > cession
         overspill = np.maximum(dic[col] - cession, 0)
         if overspill.any():
@@ -261,11 +261,10 @@ def _by_event(by_policy_df, max_cession, treaty_df):
     return pd.DataFrame(dic)
 
 
-def by_policy_event(agglosses_df, policy_df, max_cession, treaty_df):
+def by_policy_event(agglosses_df, policy_df, treaty_df):
     """
     :param DataFrame agglosses_df: losses aggregated by (agg_id, event_id)
     :param DataFrame policy_df: policies
-    :param dict max_cession: maximum cession for proportional treaties
     :param DataFrame treaty_df: treaties
     :returns: (by_policy_df, by_event_df)
     """
@@ -275,4 +274,4 @@ def by_policy_event(agglosses_df, policy_df, max_cession, treaty_df):
         dfs.append(df)
     df = pd.concat(dfs)
     # print(by_policy)  # when debugging
-    return df, _by_event(df, max_cession, treaty_df)
+    return df, _by_event(df, treaty_df)

--- a/openquake/risklib/tests/reinsurance_test.py
+++ b/openquake/risklib/tests/reinsurance_test.py
@@ -142,9 +142,8 @@ class ReinsuranceTestCase(unittest.TestCase):
     def setUpClass(cls):
         csvfname = general.gettemp(CSV_NP)
         xmlfname = general.gettemp(XML_NP.format(csvfname))
-        cls.policy_df, treaty_df, maxc, fmap = reinsurance.parse(
+        cls.policy_df, treaty_df, fmap = reinsurance.parse(
             xmlfname, policy_idx)
-        assert not maxc  # there are no proportional treaties
         print(cls.policy_df)
         print(treaty_df)
         print(fmap)
@@ -199,14 +198,14 @@ event_id,policy_id,claim,retention,nonprop1,nonprop2
 event_id,claim,retention,nonprop1,nonprop2,nonprop3
 25,      8500.0,   50.0,   3000.0,  4800.0,   650.0''', index_col='event_id')
         bypolicy, byevent = reinsurance.by_policy_event(
-            risk_by_event, self.policy_df, {}, self.treaty_df)
+            risk_by_event, self.policy_df, self.treaty_df)
         byevent = byevent[byevent.event_id == 25].set_index('event_id')
         assert_ok(byevent, expected)
 
     def test_max_cession(self):
-        max_cession = {'prop1': 5000}
         treaty_df = _df('''\
 id,type,max_retention,limit
+prop1,prop,      0,    5000
 nonprop1,wxlr, 200,    4000
 nonprop2,catxl,500,   10000
 ''').set_index('id')
@@ -226,7 +225,7 @@ event_id,agg_id,loss
 event_id,claim,retention,prop1,nonprop1,overspill1,nonprop2
        1,20000,    500.0,5000.0, 7600.0,    4800.0,6900.0''')
         bypolicy, byevent = reinsurance.by_policy_event(
-            risk_by_event, pol_df, max_cession, treaty_df)
+            risk_by_event, pol_df, treaty_df)
 
     def _test_many_levels(self):
         max_cession = {'prop1': 5000}

--- a/openquake/risklib/tests/reinsurance_test.py
+++ b/openquake/risklib/tests/reinsurance_test.py
@@ -227,3 +227,38 @@ event_id,claim,retention,prop1,nonprop1,overspill1,nonprop2
        1,20000,    500.0,5000.0, 7600.0,    4800.0,6900.0''')
         bypolicy, byevent = reinsurance.by_policy_event(
             risk_by_event, pol_df, max_cession, treaty_df)
+
+    def _test_many_levels(self):
+        max_cession = {'prop1': 5000}
+        treaty_df = _df('''\
+id,type,max_retention,limit
+cat1,catxl, 200,   4000
+cat2,catxl, 500,  10000
+cat3,catxl, 200,   4000
+cat4,catxl, 500,  10000
+cat5,catxl,1000,  50000
+''').set_index('id')
+        pol_df = _df('''\
+policy,liability,deductible,qshared,cat1,cat2,cat3,cat4,cat5
+1,     99000,        0,     .5,        1,   0,   0,   1,   1
+2,     99000,        0,     .4,        1,   0,   0,   1,   1
+3,     99000,        0,     .6,        0,   1,   0,   1,   1
+4,     99000,        0,     .6,        0,   1,   0,   1,   1
+5,     99000,        0,     .6,        0,   0,   1,   0,   1
+6,     99000,        0,     .6,        0,   0,   1,   0,   1
+''')
+        # catcomb = '10011', '01011', '00101' = 19, 11, 5
+        risk_by_event = _df('''\
+event_id,agg_id,loss
+1,     0,      12000
+1,     1,      5000
+1,     2,      3000
+1,     3,      12000
+1,     4,      5000
+1,     5,      3000
+''')
+        expected = _df('''\
+event_id,claim,retention,prop1,nonprop1,overspill1,nonprop2
+       1,20000,    500.0,5000.0, 7600.0,    4800.0,6900.0''')
+        bypolicy, byevent = reinsurance.by_policy_event(
+            risk_by_event, pol_df, max_cession, treaty_df)


### PR DESCRIPTION
Storing proportional and nonproportional treaties in the same DataFrame. Also added a (commented) test with 5 CatXLs. Part of #7886 