### PR TITLE
Multi-risk curves

### DIFF
--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1365,6 +1365,17 @@ def return_periods(eff_time, num_losses):
     return U32(periods)
 
 
+def maximum_probable_loss(losses, return_period, eff_time):
+    """
+    :returns: Maximum Probable Loss at the given return period
+
+    >>> losses = [1000., 0., 2000., 1500., 780., 900., 1700., 0., 100., 200.]
+    >>> maximum_probable_loss(losses, 2000, 10_000)
+    900.0
+    """
+    return losses_by_period(losses, [return_period], len(losses), eff_time)[0]
+
+
 def losses_by_period(losses, return_periods, num_events=None, eff_time=None):
     """
     :param losses: simulated losses

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1365,7 +1365,7 @@ def return_periods(eff_time, num_losses):
     return U32(periods)
 
 
-def maximum_probable_loss(losses, return_period, eff_time):
+def maximum_probable_loss(losses, return_period, eff_time, sorting_idxs=None):
     """
     :returns: Maximum Probable Loss at the given return period
 
@@ -1373,10 +1373,12 @@ def maximum_probable_loss(losses, return_period, eff_time):
     >>> maximum_probable_loss(losses, 2000, 10_000)
     900.0
     """
-    return losses_by_period(losses, [return_period], len(losses), eff_time)[0]
+    return losses_by_period(losses, [return_period], len(losses), eff_time,
+                            sorting_idxs)[0]
 
 
-def losses_by_period(losses, return_periods, num_events=None, eff_time=None):
+def losses_by_period(losses, return_periods, num_events=None, eff_time=None,
+                     sorting_idxs=None):
     """
     :param losses: simulated losses
     :param return_periods: return periods of interest
@@ -1409,7 +1411,10 @@ def losses_by_period(losses, return_periods, num_events=None, eff_time=None):
             % (num_events, num_losses))
     if eff_time is None:
         eff_time = return_periods[-1]
-    losses = numpy.sort(losses)
+    if sorting_idxs is None:
+        losses = numpy.sort(losses)
+    else:
+        losses = losses[sorting_idxs]
     # num_losses < num_events: just add zeros
     num_zeros = num_events - num_losses
     if num_zeros:

--- a/openquake/risklib/tests/scientific_test.py
+++ b/openquake/risklib/tests/scientific_test.py
@@ -565,14 +565,18 @@ class LossesByEventTestCase(unittest.TestCase):
         aae(mean, full, rtol=1E-2)  # converges only at 1%
 
     def test_maximum_probable_loss(self):
-        # MPL breaks summability
+        # checking that MPL does not break summability
         rng = numpy.random.default_rng(42)
-        claim = 1000 + rng.random(10) * 1000
-        cession = rng.random(10) * 1000
+        claim = numpy.round(1000 + rng.random(10) * 1000)
+        cession = numpy.round(rng.random(10) * 1000)
         period = 2000
         efftime = 10000
         retention = claim - cession
-        claim_mpl = scientific.maximum_probable_loss(claim, period, efftime)
-        cession_mpl = scientific.maximum_probable_loss(cession, period, efftime)
-        ret_mpl = scientific.maximum_probable_loss(retention, period, efftime)
-        print(claim_mpl, cession_mpl, ret_mpl)
+        idxs = numpy.argsort(cession)
+        claim_mpl = scientific.maximum_probable_loss(
+            claim, period, efftime, idxs)
+        cession_mpl = scientific.maximum_probable_loss(
+            cession, period, efftime, idxs)
+        ret_mpl = scientific.maximum_probable_loss(
+            retention, period, efftime, idxs)
+        self.assertEqual(claim_mpl, cession_mpl + ret_mpl)

--- a/openquake/risklib/tests/scientific_test.py
+++ b/openquake/risklib/tests/scientific_test.py
@@ -563,3 +563,16 @@ class LossesByEventTestCase(unittest.TestCase):
         full = scientific.losses_by_period(
             losses, periods, eff_time=2*eff_time)
         aae(mean, full, rtol=1E-2)  # converges only at 1%
+
+    def test_maximum_probable_loss(self):
+        # MPL breaks summability
+        rng = numpy.random.default_rng(42)
+        claim = 1000 + rng.random(10) * 1000
+        cession = rng.random(10) * 1000
+        period = 2000
+        efftime = 10000
+        retention = claim - cession
+        claim_mpl = scientific.maximum_probable_loss(claim, period, efftime)
+        cession_mpl = scientific.maximum_probable_loss(cession, period, efftime)
+        ret_mpl = scientific.maximum_probable_loss(retention, period, efftime)
+        print(claim_mpl, cession_mpl, ret_mpl)


### PR DESCRIPTION
Given losses with 3 components per event claim, cession and retention, with claim = cession + retention, the generated risk curves must keep the relation  claim = cession + retention. Currently this is NOT the case. Part of #7886 