### PR TITLE
minor fixes in functions implementing Stepp (1972) completeness analysis

### DIFF
--- a/openquake/hmtk/plotting/seismicity/completeness/plot_stepp_1972.py
+++ b/openquake/hmtk/plotting/seismicity/completeness/plot_stepp_1972.py
@@ -125,8 +125,7 @@ def create_stepp_plot(model, figure_size=(8, 6),
                   markerfacecolor='white',
                   markeredgecolor=colour)
 
-    ax.legend(loc='center left',
-              bbox_to_anchor=(1, 0.5), frameon=False, fontsize='small')
+    ax.legend(loc='lower left', frameon=False, fontsize='small')
     ax.set_xlabel('Time (years)')
     ax.set_ylabel("$\\sigma_{\\lambda} = \\sqrt{\\lambda} / \\sqrt{T}$")
     ax.autoscale(enable=True, axis='both', tight=True)

--- a/openquake/hmtk/seismicity/completeness/comp_stepp_1971.py
+++ b/openquake/hmtk/seismicity/completeness/comp_stepp_1971.py
@@ -292,7 +292,7 @@ class Stepp1971(BaseCatalogueCompleteness):
         if (max_mag - min_mag) < delta_m:
             raise ValueError('Bin width greater than magnitude range!')
 
-        mag_bins = np.arange(np.floor(min_mag), np.ceil(max_mag), delta_m)
+        mag_bins = np.arange(np.floor(min_mag), np.ceil(max_mag + delta_m), delta_m)
 
         # Check to see if there are magnitudes in lower and upper bins
         is_mag = np.logical_and(mag_bins - max_mag < delta_m,


### PR DESCRIPTION
Two changes:
1. added the highest magnitude bin in the analysis, which was missing
2. propose an improvement in the function to plot Stepp (1972) analysis: the legend was set outside the Axes and labels were consequently truncated on the right