### PR TITLE
Changed event_based_risk to transfer filtered GMFs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the event_based_risk calculator to transfer filtered GMFs
   * Increased `sys.recursionlimit` to 1500 to solve a rare pickling issue
   * Added a parameter `max_aggregations` with a default of 100,000
   * Changed the risk calculators to reuse the hazard exposure (if any)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed event_based_risk to transfer filtered GMFs
   * Fixed a performance issue in large event based risk calculations with a 4x
     speedup for Chile
   * Increased `sys.recursionlimit` to 1500 to solve a rare pickling issue

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -836,7 +836,8 @@ class HazardCalculator(BaseCalculator):
                     assetcol.tagcol.site_id.extend(range(self.N))
         else:  # no exposure
             if oq.hazard_calculation_id:  # read the sitecol of the child
-                self.sitecol = readinput.get_site_collection(oq, self.datastore)
+                self.sitecol = readinput.get_site_collection(
+                    oq, self.datastore)
                 self.datastore['sitecol'] = self.sitecol
             else:
                 self.sitecol = haz_sitecol

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -421,12 +421,14 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         ct = oq.concurrent_tasks or 1
         maxweight = len(eids) / ct
         start = stop = weight = 0
-        # IMPORTANT!! we rely on the fact that the hazard part
-        # of the calculation stores the GMFs in chunks of constant eid
 
         def read(start, stop):
+            #filtered = self.sitecol is not self.sitecol.complete
+            #import pdb; pdb.set_trace()
             return self.datastore.read_df('gmf_data', slc=slice(start, stop))
         sizes = []
+        # IMPORTANT!! we rely on the fact that the hazard part
+        # of the calculation stores the GMFs in chunks of constant eid
         for eid, group in itertools.groupby(eids):
             nsites = sum(1 for _ in group)
             stop += nsites

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import os.path
 import logging
 import operator
@@ -247,7 +246,9 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         oq.hdf5path = self.datastore.filename
         oq.parentdir = parentdir
         logging.info(
-            'There are {:_d} ruptures'.format(len(self.datastore['ruptures'])))
+            'There are {:_d} ruptures and {:_d} events'.format(
+                len(self.datastore['ruptures']),
+                len(self.datastore['events'])))
         self.events_per_sid = numpy.zeros(self.N, U32)
         try:
             K = len(self.datastore['agg_keys'])
@@ -264,8 +265,6 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         oq.M = len(oq.all_imts())
         oq.N = self.N
         oq.K = K
-        ct = oq.concurrent_tasks or 1
-        oq.maxweight = int(oq.ebrisk_maxsize / ct)
         self.A = A = len(self.assetcol)
         self.L = L = len(oq.loss_types)
         if (oq.aggregate_by and self.E * A > oq.max_potential_gmfs and

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -145,11 +145,6 @@ def event_based_risk(df, oqparam, dstore, monitor):
         dstore.parent.open('r')
     with dstore, monitor('reading data'):
         assetcol = dstore['assetcol']
-        if oqparam.K:
-            aggids, _ = assetcol.build_aggids(
-                oqparam.aggregate_by, oqparam.max_aggregations)
-        else:
-            aggids = ()
         crmodel = monitor.read('crmodel')
         rlz_id = monitor.read('rlz_id')
         weights = [1] if oqparam.collect_rlzs else dstore['weights'][()]

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -446,7 +446,8 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                 submit((pandas.concat(dfs), oq, self.datastore))
                 dfs.clear()
                 sizes.append(size)
-                sys.stderr.write('.')
+                logging.info('Sending {:_d} rows of GMFs'.format(size))
+
         # IMPORTANT!! we rely on the fact that the hazard part
         # of the calculation stores the GMFs in chunks of constant eid
         dfs = []
@@ -459,7 +460,6 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             df = pandas.concat(dfs)
             submit((df, oq, self.datastore))
             sizes.append(len(df))
-        sys.stderr.write('\n')
         taxonomies, num_assets_by_taxo = numpy.unique(
             self.assetcol.taxonomies, return_counts=1)
         max_assets = max(num_assets_by_taxo)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -180,7 +180,7 @@ def event_based_risk(df, oqparam, dstore, monitor):
         # can aggregate millions of asset by using few GBs of RAM
         for taxo, adf in assets.groupby('taxonomy'):  # fast
             with mon_filt:
-                # discard the GMFs not affecting the assets
+                # discard the GMFs not affecting the assets, crucial
                 gmf_sid = df.sid.to_numpy()
                 adf_sid = adf.site_id.to_numpy()
                 gmf_df = df[numpy.isin(gmf_sid, adf_sid)]
@@ -441,7 +441,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             if self.sitecol is not self.sitecol.complete:
                 df = df[numpy.isin(df.sid.to_numpy(), sids)]
             size = len(df)
-            sys.stdout.write('.')
+            sys.stderr.write('.')
             if size:
                 submit((df, oq, self.datastore))
             sizes.append(size)
@@ -457,6 +457,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                 start = stop
         if weight:
             read_filter(start, stop)
+        sys.stderr.write('\n')
         taxonomies, num_assets_by_taxo = numpy.unique(
             self.assetcol.taxonomies, return_counts=1)
         max_assets = max(num_assets_by_taxo)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -455,6 +455,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         for idx, start, stop in performance._idx_start_stop(eids // 1000):
             df = self.datastore.read_df('gmf_data', slc=slice(start, stop))
             if self.sitecol is not self.sitecol.complete:
+                # filter on the sites belonging to the asset collection
                 df = df[numpy.isin(df.sid.to_numpy(), sids)]
             send(df, dfs)
         if dfs:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -175,6 +175,11 @@ def event_based_risk(df, oqparam, dstore, monitor):
                 out = crmodel.get_output(adf, gmf_df, oqparam._sec_losses, rng)
             yield out
 
+    if oqparam.K:
+        aggids, _ = assetcol.build_aggids(
+            oqparam.aggregate_by, oqparam.max_aggregations)
+    else:
+        aggids = ()
     return aggreg(outputs(), crmodel, ARK, aggids, rlz_id, monitor)
 
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -37,7 +37,7 @@ import requests
 
 from openquake.baselib import config, hdf5, parallel, InvalidFile
 from openquake.baselib.general import (
-    random_filter, countby, group_array, get_duplicates, gettemp)
+    random_filter, countby, group_array, get_duplicates, gettemp, humansize)
 from openquake.baselib.python3compat import zip, decode
 from openquake.baselib.node import Node
 from openquake.hazardlib.const import StdDev
@@ -947,9 +947,9 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, cost_types=()):
         discarded = []
         logging.info('Read {:_d} sites and {:_d} assets from the exposure'.
                      format(len(sitecol), sum(len(a) for a in assets_by_site)))
-
     assetcol = asset.AssetCollection(
         exposure, assets_by_site, oqparam.time_event, oqparam.aggregate_by)
+    logging.info('There are %s of assets', humansize(assetcol.array.nbytes))
     if assetcol.occupancy_periods:
         missing = set(cost_types) - set(exposure.cost_types['name']) - set(
             ['occupants'])

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -444,7 +444,7 @@ def check_obsolete_version(calculation_mode='WebUI'):
         return
 
     version = logs.dbcmd('engine_version')
-    logging.info('Using engine version %s', version)
+    logging.info('Using DbServer version %s', version)
     headers = {'User-Agent': 'OpenQuake Engine %s;%s;%s;%s' %
                (version, calculation_mode, platform.platform(),
                 config.distribution.oq_distribute)}


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/8126. The improvement for the Chile calculation on the Thinkstation is from
```
# oq engine --run job_Chile.ini --hc 45126
| calc_46369, maxmem=27.8 GB   | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total event_based_risk       | 11_765   | 563.2     | 792    |
| computing risk               | 7_439    | 1_677     | 44_901 |
| EventBasedRiskCalculator.run | 1_640    | 2_120     | 1      |
| reading data                 | 1_081    | 725.0     | 792    |
| aggregating losses           | 578.6    | 0.0       | 43_568 |
```
to
```
| calc_45778, maxmem=34.9 GB   | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total event_based_risk       | 7_164    | 819.7     | 55     |
| computing risk               | 6_242    | 3_514     | 3_905  |
| EventBasedRiskCalculator.run | 1_226    | 2_088     | 1      |
| aggregating losses           | 594.1    | 0.0       | 4_837  |
| submitting gmf_data          | 152.4    | 780.4     | 1      |
| filtering GMFs for taxonomy  | 85.0     | 22.5      | 3_905  |
| averaging losses             | 78.7     | 0.0       | 4_837  |
| reading data                 | 66.5     | 724.7     | 55     |
```
but it is only due to the fact that there are less tasks (less tasks => more performance).
On the other hard the core starvation effect becomes stronger the bigger the calculation, so this may not be a good idea :-(
Also, `oq show performance` will not work for hours until all tasks are submitted. Another surprising things is that filtering
(by site) is faster than pickling, so it is faster to filter on the master node. There is another big benefit: the slow tasks
are reduced a lot.

