### PR TITLE
Reduced slow tasks in event_based_risk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Strongly reduced the slow tasks in event_based_risk calculations
   * Fixed a performance issue in event based risk calculations, due to the same
     aggregation IDs being computed for each task
   * Increased `sys.recursionlimit` to 1500 to solve a rare pickling issue

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -400,7 +400,7 @@ else:
 @compile(["int64[:, :](uint8[:])",
           "int64[:, :](uint32[:])",
           "int64[:, :](int64[:])"])
-def _idx_start_stop(integers):
+def idx_start_stop(integers):
     # given an array of integers returns an array int64 of shape (n, 3)
     out = []
     start = i = 0
@@ -427,7 +427,7 @@ def get_slices(uint32s):
     if len(uint32s) == 0:
         return {}
     indices = {}  # idx -> [(start, stop), ...]
-    for idx, start, stop in _idx_start_stop(uint32s):
+    for idx, start, stop in idx_start_stop(uint32s):
         if idx not in indices:
             indices[idx] = []
         indices[idx].append((start, stop))
@@ -462,7 +462,7 @@ def split_array(arr, indices, counts=None):
     [array([0.1, 0.2]), array([0.3, 0.4]), array([0.5])]
     """
     if counts is None:  # ordered indices
-        return [arr[s1:s2] for i, s1, s2 in _idx_start_stop(indices)]
+        return [arr[s1:s2] for i, s1, s2 in idx_start_stop(indices)]
     # indices and counts coming from numpy.unique(arr)
     # this part can be slow, but it is still 10x faster than pandas for EUR!
     cumcounts = counts.cumsum()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -105,7 +105,7 @@ def semicolon_aggregate(probs, source_ids):
     srcids = [srcid.split(';')[0] for srcid in source_ids]
     unique, indices = numpy.unique(srcids, return_inverse=True)
     new = numpy.zeros_like(probs)
-    for i, s1, s2 in performance._idx_start_stop(indices):
+    for i, s1, s2 in performance.idx_start_stop(indices):
         new[..., i] = pprod(probs[..., s1:s2], axis=-1)
     return new, unique
 

--- a/openquake/calculators/conditional_spectrum.py
+++ b/openquake/calculators/conditional_spectrum.py
@@ -116,7 +116,7 @@ class ConditionalSpectrumCalculator(base.HazardCalculator):
         # of the calculation stores the ruptures in chunks of constant
         # grp_id, therefore it is possible to build (start, stop) slices
         out = general.AccumDict()  # grp_id => dict
-        for gid, start, stop in performance._idx_start_stop(rdata['grp_id']):
+        for gid, start, stop in performance.idx_start_stop(rdata['grp_id']):
             cmaker = self.cmakers[gid]
             ctxs = cmaker.read_ctxs(dstore, slice(start, stop))
             for ctx in ctxs:

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -219,8 +219,6 @@ class DamageCalculator(EventBasedRiskCalculator):
         if oq.investigation_time:  # event based
             self.builder = get_loss_builder(self.datastore)  # check
         self.dmgcsq = zero_dmgcsq(len(self.assetcol), self.R, self.crmodel)
-
-        logging.info('Building GMF slices')
         with self.monitor('getting gmf_data slices', measuremem=True):
             slice_list = calc.build_gmfslices(
                 self.datastore, oq.concurrent_tasks or 1)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -352,7 +352,6 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             logging.info(
                 'Produced %s of GMFs', general.humansize(self.gmf_bytes))
         else:  # start from GMFs
-            logging.info('Building GMF slices')
             with self.monitor('getting gmf_data slices', measuremem=True):
                 slice_list = build_gmfslices(
                     self.datastore, oq.concurrent_tasks or 1)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -437,7 +437,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         allargs = []
         site_ids = self.sitecol.sids
         sizes = []
-        for idx, s1, s2 in performance._idx_start_stop(eids // 1000):
+        for idx, s1, s2 in performance.idx_start_stop(eids // 1000):
             stop += s2 - s1
             if self.sitecol is self.sitecol.complete:
                 size = s2 - s1

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -446,7 +446,8 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             sizes.append(size)
             weight += size
             if weight > minrows:
-                logging.info('Sending {:_d} rows'.format(size))
+                logging.info('Sending {:_d}({:_d}) rows'.format(
+                    s2-s1, size))
                 allargs.append((slice(start, stop), oq, self.datastore))
                 weight = 0
                 start = stop

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -436,19 +436,21 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         # of the calculation stores the GMFs in chunks of constant eid
         allargs = []
         site_ids = self.sitecol.sids
+        sizes = []
         for idx, s1, s2 in performance._idx_start_stop(eids):
             stop += s2 - s1
             if self.sitecol is self.sitecol.complete:
-                weight += s2 - s1
+                size = s2 - s1
             else:
-                weight += numpy.isin(sids[s1:s2], site_ids).sum()
+                size = numpy.isin(sids[s1:s2], site_ids).sum()
+            sizes.append(size)
+            weight += size
             if weight > maxweight:
                 allargs.append((slice(start, stop), oq, self.datastore))
                 weight = 0
                 start = stop
         if weight:
             allargs.append((slice(start, stop), oq, self.datastore))
-        sizes = [slc.stop - slc.start for slc, oq, ds in allargs]
         taxonomies, num_assets_by_taxo = numpy.unique(
             self.assetcol.taxonomies, return_counts=1)
         max_assets = max(num_assets_by_taxo)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -429,8 +429,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         eids = self.datastore['gmf_data/eid'][:]
         sids = self.datastore['gmf_data/sid'][:]
         self.log_info(eids)
-        ct = oq.concurrent_tasks or 1
-        minrows = len(eids) // ct
+        minrows = 10_000
         logging.info('minrows = {:_d}'.format(minrows))
         start = stop = weight = 0
         # IMPORTANT!! we rely on the fact that the hazard part
@@ -438,7 +437,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         allargs = []
         site_ids = self.sitecol.sids
         sizes = []
-        for idx, s1, s2 in performance._idx_start_stop(eids):
+        for idx, s1, s2 in performance._idx_start_stop(eids // 1000):
             stop += s2 - s1
             if self.sitecol is self.sitecol.complete:
                 size = s2 - s1

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -429,7 +429,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         eids = self.datastore['gmf_data/eid'][:]
         sids = self.datastore['gmf_data/sid'][:]
         self.log_info(eids)
-        minrows = 10_000
+        minrows = 100_000
         logging.info('minrows = {:_d}'.format(minrows))
         start = stop = weight = 0
         # IMPORTANT!! we rely on the fact that the hazard part

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -352,6 +352,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             logging.info(
                 'Produced %s of GMFs', general.humansize(self.gmf_bytes))
         else:  # start from GMFs
+            logging.info('Building GMF slices')
             with self.monitor('getting gmf_data slices', measuremem=True):
                 slice_list = build_gmfslices(
                     self.datastore, oq.concurrent_tasks or 1)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -19,7 +19,6 @@
 import os.path
 import logging
 import operator
-import itertools
 from functools import partial
 import numpy
 import pandas

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -358,6 +358,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                     self.datastore, oq.concurrent_tasks or 1)
                 allargs = [(arr, oq, self.datastore) for arr in slice_list]
             self.datastore.swmr_on()  # crucial!
+            logging.info('Starting ebr_from_gmfs')
             smap = parallel.Starmap(
                 ebr_from_gmfs, allargs, h5=self.datastore.hdf5)
             save_tmp(self, smap.monitor)

--- a/openquake/calculators/tests/scenario_damage_test.py
+++ b/openquake/calculators/tests/scenario_damage_test.py
@@ -194,8 +194,10 @@ class ScenarioDamageTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/aggrisk.csv', fname, delta=1E-4)
 
     def test_case_10(self):
-        self.run_calc(case_10.__file__, 'job.ini')
-        self.assertTrue(self.calc.nodamage)
+        # test with GMVs = 0 on the sites of the exposure
+        with self.assertRaises(ValueError) as ctx:
+            self.run_calc(case_10.__file__, 'job.ini')
+        self.assertIn('The sites in gmf_data are disjoint', str(ctx.exception))
 
     def test_case_11(self):
         # secondary perils without secondary simulations

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -31,7 +31,6 @@ from openquake.baselib import parallel, sap
 from openquake.baselib.hdf5 import read_csv
 from openquake.hazardlib import tests
 from openquake import commonlib
-from openquake.commonlib import dbapi
 from openquake.commonlib.datastore import read
 from openquake.commonlib.readinput import get_params
 from openquake.engine.engine import create_jobs, run_jobs
@@ -46,7 +45,6 @@ from openquake.qa_tests_data.event_based_risk import (
     case_master, case_1 as case_eb)
 from openquake.qa_tests_data.scenario_risk import case_shapefile, case_shakemap
 from openquake.qa_tests_data.gmf_ebrisk import case_1 as ebrisk
-from openquake.server import dbserver
 from openquake.server.tests import data as test_data
 
 DATADIR = os.path.join(commonlib.__path__[0], 'tests', 'data')
@@ -514,7 +512,7 @@ Source Loss Table'''.splitlines())
         # refactoring of the monitoring and it happened several times)
         with read(log.calc_id) as dstore:
             perf = str(view('performance', dstore))
-            self.assertIn('total event_based_risk', perf)
+            self.assertIn('total ebr_from_gmfs', perf)
 
     def test_oqdata(self):
         # the that the environment variable OQ_DATADIR is honored

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -450,6 +450,6 @@ def build_gmfslices(dstore, hint):
         arrayE3, max_weight, operator.itemgetter(WEIGHT))
     gmfslices = [compactify(numpy.array(block)) for block in blocks]
     ws = numpy.array([arr[:, WEIGHT].sum() for arr in gmfslices])
-    logging.info('Weights min, max, mean=%d, %d, %d',
-                 ws.min(), ws.max(), ws.mean())
+    logging.info('Weights min, mean, max {:_d}, {:_d}, {:_d}'.
+                 format(ws.min(), int(ws.mean()), ws.max()))
     return gmfslices

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -443,7 +443,7 @@ def build_gmfslices(dstore, hint):
         arrayE3[i, WEIGHT] = num_assets[oksids].sum()
     arrayE3 = arrayE3[arrayE3[:, WEIGHT] > 0]
     tot_weight = arrayE3[:, WEIGHT].sum()
-    max_weight = numpy.clip(tot_weight / hint, 1000, 10_000_000)
+    max_weight = numpy.clip(tot_weight / hint, 10_00, 100_000_000)
     blocks = general.block_splitter(
         arrayE3, max_weight, operator.itemgetter(WEIGHT))
     gmfslices = [compactify(numpy.array(block)) for block in blocks]

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -427,10 +427,12 @@ def build_gmfslices(dstore, hint):
     num_assets = numpy.zeros(len(sitecol.complete), int)
     sids, counts = numpy.unique(assetcol['site_id'], return_counts=True)
     num_assets[sids] = counts
+    logging.info('Reading gmf_data')
     eids = dstore['gmf_data/eid'][:]
     sids = dstore['gmf_data/sid'][:]
     if filtered:
         ok = numpy.isin(sids, sitecol.sids)
+    logging.info('Building GMF slices')
     arr = performance.idx_start_stop(eids)
     arrayE3 = numpy.zeros((len(arr), 3), int)  # start, stop, weight
     for i, (eid, start, stop) in enumerate(arr):

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -443,8 +443,11 @@ def build_gmfslices(dstore, hint):
         arrayE3[i, WEIGHT] = num_assets[oksids].sum()
     arrayE3 = arrayE3[arrayE3[:, WEIGHT] > 0]
     tot_weight = arrayE3[:, WEIGHT].sum()
-    max_weight = numpy.clip(tot_weight / hint, 1000, 10_000)
+    max_weight = numpy.clip(tot_weight / hint, 1000, 10_000_000)
     blocks = general.block_splitter(
         arrayE3, max_weight, operator.itemgetter(WEIGHT))
     gmfslices = [compactify(numpy.array(block)) for block in blocks]
+    ws = numpy.array([arr[:, WEIGHT].sum() for arr in gmfslices])
+    logging.info('Weights min, max, mean=%d, %d, %d',
+                 ws.min(), ws.max(), ws.mean())
     return gmfslices


### PR DESCRIPTION
Supersedes https://github.com/gem/oq-engine/pull/8128. Part of https://github.com/gem/oq-engine/issues/8126. Here is the improvement for Argentina with 10,000 years on my workstation (over 2x speedup with half the memory used in "computing risk", over 2x in "reading data"):
```
# before
| calc_22361, maxmem=18.7 GB   | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total event_based_risk       | 2_291    | 633.3     | 16     |
| computing risk               | 627.1    | 2_901     | 1_424  |
| EventBasedRiskCalculator.run | 462.9    | 1_837     | 1      |
| aggregating losses           | 128.0    | 0.0       | 1_936  |
| reading data                 | 49.3     | 736.4     | 16     |
| getting gmf_data slices      | 17.2     | 926.4     | 1      |

# after
| calc_22334, maxmem=16.6 GB   | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total ebr_from_gmfs          | 998.5    | 675.8     | 17     |
| computing risk               | 590.7    | 1_624     | 1_513  |
| EventBasedRiskCalculator.run | 267.5    | 1_924     | 1      |
| aggregating losses           | 116.8    | 0.0       | 2_052  |
| reading data                 | 26.4     | 350.2     | 34     |
| getting gmf_data slices      | 17.6     | 927.1     | 1      |
```
The slow task situation is much better:
```
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| event_based_risk   | 16     | 143.2   | 25%    | 104.7   | 221.8   | 1.54922 |
| ebr_from_gmfs      | 17     | 58.7    | 26%    | 2.96108 | 73.7    | 1.25450 |
```
The approach scales really well even for large calculations, such as Chile with 100,000y on the spot machine:
```
# oq engine --run job_Chile.ini --hc 45118
| calc_45153, maxmem=281.6 GB  | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total ebr_from_gmfs          | 83_102   | 736.6     | 1_010  |
| computing risk               | 66_592   | 1_921     | 71_710 |
| aggregating losses           | 7_088    | 0.0       | 88_329 |
| reading data                 | 3_354    | 718.9     | 2_020  |
| EventBasedRiskCalculator.run | 2_049    | 13_826    | 1      |
| averaging losses             | 962.7    | 0.0       | 88_329 |
| getting gmf_data slices      | 778.2    | 11_931    | 1      |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| ebr_from_gmfs      | 1_010  | 82.3    | 15%    | 51.1    | 125.5   | 1.52563 |
```
**We are using 10 times less memory than before in "computing risk"!**