### PR TITLE
Parallel filtering

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -358,7 +358,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             logging.info(
                 'Produced %s of GMFs', general.humansize(self.gmf_bytes))
         else:  # start from GMFs
-            with self.monitor('getting gmf_data slices', measuremem=True):
+            with self.monitor('building gmf_data slices', measuremem=True):
                 slice_list = build_gmfslices(
                     self.datastore, oq.concurrent_tasks or 1)
                 allargs = [(arr, oq, self.datastore) for arr in slice_list]

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -415,10 +415,12 @@ def compactify(arrayN3):
 
 def filter_sids(slices, risk_sids, dstore, monitor):
     dstore.open('r')
+    out = []
     for _, start, stop in slices:
         haz_sids = dstore['gmf_data/sid'][start:stop]
         oksids = haz_sids[numpy.isin(haz_sids, risk_sids)]
-        yield start, stop, oksids
+        out.append((start, stop, oksids))
+    return out
 
 
 def weighting(slices, sitecol, num_assets, dstore):

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -429,7 +429,8 @@ def weighting(slices, sitecol, num_assets, dstore):
         filter_sids, (slices, sitecol.sids, dstore.parent),
         concurrent_tasks=hint, distribute='processpool', h5=dstore.hdf5)
     arrayE3 = numpy.zeros((len(slices), 3), int)
-    for i, (start, stop, oksids) in enumerate(sorted(res)):
+    rows = sorted(sum(res, []))
+    for i, (start, stop, oksids) in enumerate(rows):
         arrayE3[i, START] = start
         arrayE3[i, STOP] = stop
         arrayE3[i, WEIGHT] = num_assets[oksids].sum()

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -425,7 +425,7 @@ def weighting(slices, sitecol, num_assets, dstore):
     hint = parallel.Starmap.num_cores
     res = parallel.Starmap.apply(
         filter_sids, (slices, sitecol.sids, dstore.parent),
-        concurrent_tasks=hint, h5=dstore.hdf5)
+        concurrent_tasks=hint, distribute='processpool', h5=dstore.hdf5)
     arrayE3 = numpy.zeros((len(slices), 3), int)
     for i, (start, stop, oksids) in enumerate(sorted(res)):
         arrayE3[i, START] = start


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/8126. Makes "building gmfslices" faster. For instance on the spot machine
the following script
```python
import logging
from openquake.baselib import performance
from openquake.commonlib import datastore, calc

if __name__ == '__main__':
    logging.basicConfig(level=logging.INFO)
    ds = datastore.read(45153)  # Chile
    with performance.Monitor(measuremem=True) as mon:
        calc.build_gmfslices(ds, 240)
    print(mon)
```
has an improvement from 596s to 78s.