### PR TITLE
Fixed export bug caused by policy IDs magically promoted from ints to floats

### DIFF
--- a/openquake/risklib/reinsurance.py
+++ b/openquake/risklib/reinsurance.py
@@ -286,7 +286,7 @@ def by_policy(agglosses_df, pol_dict, treaty_df):
     ded, lim = get_ded_lim(losses, pol_dict)
     claim = scientific.insured_losses(losses, ded, lim)
     out['event_id'] = df.event_id.to_numpy()
-    out['policy_id'] = np.array([pol_dict['policy']] * len(df))
+    out['policy_id'] = np.array([pol_dict['policy']] * len(df), int)
     out.update(claim_to_cessions(claim, pol_dict, treaty_df))
     nonzero = out['claim'] > 0  # discard zero claims
     out_df = pd.DataFrame({k: out[k][nonzero] for k in out})
@@ -297,7 +297,7 @@ def _by_event(rbp, treaty_df, mon=Monitor()):
     with mon('processing policy_loss_table', measuremem=True):
         tdf = treaty_df.set_index('code')
         inpcols = ['eid', 'claim'] + [t.id for _, t in tdf.iterrows()
-                                           if t.type != 'catxl']
+                                      if t.type != 'catxl']
         outcols = ['retention', 'claim'] + list(tdf.index)
         idx = {col: i for i, col in enumerate(outcols)}
         eids, idxs = np.unique(rbp.event_id.to_numpy(), return_inverse=True)


### PR DESCRIPTION
Maria Jose found this with 97,000+ policies. The error was
```python
  File "/home/michele/oq-engine/openquake/calculators/export/risk.py", line 624, in export_reinsurance
    df['policy_id'] = decode(policy_names[df['policy_id'].to_numpy() - 1])
arrays used as indices must be of integer (or boolean) type
```