### PR TITLE
Mitigated the slow tasks in event_based_risk

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -29,7 +29,7 @@ from openquake.hazardlib import stats, InvalidFile
 from openquake.hazardlib.source.rupture import RuptureProxy
 from openquake.risklib.scientific import (
     total_losses, insurance_losses, MultiEventRNG, LOSSID)
-from openquake.commonlib.calc import build_gmfslices
+from openquake.commonlib.calc import build_gmfslices, slc_weight
 from openquake.calculators import base, event_based
 from openquake.calculators.post_risk import (
     PostRiskCalculator, post_aggregate, fix_dtypes)
@@ -164,7 +164,7 @@ def ebr_from_gmfs(gmfslices, oqparam, dstore, monitor):
             slc = slice(gmfslice[0], gmfslice[1])
             dfs.append(dstore.read_df('gmf_data', slc=slc))
         df = pandas.concat(dfs)
-    # print(monitor.task_no, len(df), gmfslices[:, 2].sum())
+    # print(monitor.task_no, len(df), slc_weight(gmfslices))
     return event_based_risk(df, oqparam, monitor)
 
 
@@ -443,4 +443,3 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             prc.exported = self.exported
         with prc.datastore:
             prc.run(exports='')
-

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -400,6 +400,15 @@ START, STOP, WEIGHT = 0, 1, 2
 SLICE_BY_EVENT_NSITES = 1000
 
 
+def slc_weight(slc):
+    """
+    :returns: the weight a slice array
+    """
+    if len(slc.shape) == 1:
+        return slc[1] - slc[0] + slc[2]
+    return (slc[:, 1] - slc[:, 0] + slc[:, 2]).sum()
+
+
 def build_slice_by_event(eids, offset=0):
     arr = performance.idx_start_stop(eids)
     sbe = numpy.zeros(len(arr), slice_dt)
@@ -442,8 +451,6 @@ def compactify(arrayN3):
         # nothing to compactify
         return arrayN3
     out = numpy.array(functools.reduce(_concat, arrayN3, []))
-    # sanity check that the compactification preserves the weight
-    assert out[:, WEIGHT].sum() == arrayN3[:, WEIGHT].sum()
     return out
 
 
@@ -453,19 +460,18 @@ def ponder_slices(slice_by_event, num_assets, sids_risk, dstore, monitor):
     If `sids_risk` is not None, it is used to filter the hazard sites
     and in that case the rows with zero weight are discarded.
     """
-    slice_by_weight = numpy.zeros((len(slice_by_event), 3), int)
     start, stop = slice_by_event[0]['start'], slice_by_event[-1]['stop']
     with dstore.open('r'):
         haz_sids = dstore['gmf_data/sid'][start:stop]
-    for i, (s1, s2, _e) in enumerate(slice_by_event):
+    out = []
+    for s1, s2, _e in slice_by_event:
         sids = haz_sids[s1-start:s2-start]
         if sids_risk is not None:
             sids = sids[numpy.isin(sids, sids_risk)]
-        weight = num_assets[sids].sum()
-        slice_by_weight[i] = (s1, s2, weight)
-    if sids_risk is None:
-        return slice_by_weight
-    return slice_by_weight[slice_by_weight[:, WEIGHT] > 0]
+        na = num_assets[sids].sum()
+        if na:
+            out.append((s1, s2, na * .01))
+    return numpy.array(out, int)
 
 
 def build_gmfslices(dstore, hint=None):
@@ -532,10 +538,9 @@ def build_gmfslices(dstore, hint=None):
     # discrete_damage_distribution = true
     logging.info('Sorting and compactifying slices')
     slice_by_weight = numpy.sort(numpy.concatenate(slice_by_weight), axis=0)
-    tot_weight = slice_by_weight[:, WEIGHT].sum()
+    tot_weight = slc_weight(slice_by_weight)
     max_weight = numpy.clip(tot_weight / hint, 10_000, maxrows)
-    blocks = general.block_splitter(
-        slice_by_weight, max_weight, operator.itemgetter(WEIGHT))
+    blocks = general.block_splitter(slice_by_weight, max_weight, slc_weight)
     gmfslices = [compactify(numpy.array(block)) for block in blocks]
     ns = sum(len(arr) for arr in gmfslices)
     logging.info('Built {:d} GMF slices'.format(ns))
@@ -543,7 +548,7 @@ def build_gmfslices(dstore, hint=None):
     h = general.humansize(nbytes_per_row * nrows)
     htot = general.humansize(nbytes_per_row * tot_nrows)
     logging.info('Considering %s of %s of GMFs', h, htot)
-    ws = numpy.array([arr[:, WEIGHT].sum() for arr in gmfslices])
+    ws = numpy.array([slc_weight(arr) for arr in gmfslices])
     logging.info('Slice weights min, mean, max {:_d}, {:_d}, {:_d}'.
-                 format(ws.min(), int(ws.mean()), ws.max()))
+                 format(int(ws.min()), int(ws.mean()), int(ws.max())))
     return gmfslices

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -538,7 +538,7 @@ def build_gmfslices(dstore, hint=None):
     logging.info('Sorting and compactifying slices')
     slice_by_weight = numpy.sort(numpy.concatenate(slice_by_weight), axis=0)
     tot_weight = slc_weight(slice_by_weight)
-    max_weight = numpy.clip(tot_weight / hint, 10_000, 1_000_000)
+    max_weight = numpy.clip(tot_weight / hint, 1_000, 1_000_000)
     blocks = general.block_splitter(slice_by_weight, max_weight, slc_weight)
     gmfslices = [compactify(numpy.array(block)) for block in blocks]
     ns = sum(len(arr) for arr in gmfslices)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -21,7 +21,6 @@ import itertools
 import warnings
 import logging
 import functools
-import operator
 from unittest.mock import Mock
 import numpy
 
@@ -539,7 +538,7 @@ def build_gmfslices(dstore, hint=None):
     logging.info('Sorting and compactifying slices')
     slice_by_weight = numpy.sort(numpy.concatenate(slice_by_weight), axis=0)
     tot_weight = slc_weight(slice_by_weight)
-    max_weight = numpy.clip(tot_weight / hint, 10_000, maxrows)
+    max_weight = numpy.clip(tot_weight / hint, 10_000, 1_000_000)
     blocks = general.block_splitter(slice_by_weight, max_weight, slc_weight)
     gmfslices = [compactify(numpy.array(block)) for block in blocks]
     ns = sum(len(arr) for arr in gmfslices)


### PR DESCRIPTION
Spectacularly (the slowest task is 42x faster). Here are the numbers for Ecuador with 100k years on the spot machine (before vs after):
```
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| ebr_from_gmfs      | 642    | 68.6    | 371%   | 3.90483 | 6_244   | 91.1    |
| ebr_from_gmfs      | 833    | 54.4    | 48%    | 5.14592 | 150.3   | 2.75996 |
```