### PR TITLE
Saving memory in event_based_risk

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -154,7 +154,12 @@ def ebr_from_gmfs(gmfslices, oqparam, dstore, monitor):
         items = monitor.read('assets').groupby('taxonomy')
         taxo_assets = [(t, a.set_index('ordinal')) for t, a in items]
     # print(monitor.task_no, len(df), slc_weight(gmfslices))
-    return event_based_risk(df, oqparam, taxo_assets, monitor)
+    if len(df) > 500_000:
+        # split in 5 outputs to save memory
+        for _, grp in df.groupby(df.eid % 5):
+            yield event_based_risk(grp, oqparam, taxo_assets, monitor)
+    else:
+        yield event_based_risk(df, oqparam, taxo_assets, monitor)
 
 
 def event_based_risk(df, oqparam, taxo_assets, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -154,12 +154,12 @@ def ebr_from_gmfs(gmfslices, oqparam, dstore, monitor):
         items = monitor.read('assets').groupby('taxonomy')
         taxo_assets = [(t, a.set_index('ordinal')) for t, a in items]
     # print(monitor.task_no, len(df), slc_weight(gmfslices))
-    if len(df) > 500_000:
-        # split in 5 outputs to save memory
-        for _, grp in df.groupby(df.eid % 5):
-            yield event_based_risk(grp, oqparam, taxo_assets, monitor)
-    else:
+    n = len(df) // 200_000 + 1
+    if n == 1:  # do not split
         yield event_based_risk(df, oqparam, taxo_assets, monitor)
+    else:  # split in n blocks to save memory
+        for _, grp in df.groupby(df.eid % n):
+            yield event_based_risk(grp, oqparam, taxo_assets, monitor)
 
 
 def event_based_risk(df, oqparam, taxo_assets, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -232,6 +232,9 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
     accept_precalc = ['scenario', 'event_based', 'event_based_risk', 'ebrisk']
 
     def save_tmp(self, monitor, srcfilter=None):
+        """
+        Save some useful data in the file calc_XXX_tmp.hdf5
+        """
         oq = self.oqparam
         monitor.save('assets', self.assetcol.to_dframe())
         monitor.save('srcfilter', srcfilter)


### PR DESCRIPTION
By producing more outputs. Here are the figures for Chile with 100,000 years on the spot machine:
```
| calc_45273, maxmem=261.6 GB  | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total ebr_from_gmfs          | 81_514   | 2_415     | 2_585   |
| computing risk               | 66_897   | 1_665     | 183_498 |
| aggregating losses           | 6_808    | 0.0       | 216_107 |
| filtering GMFs               | 2_388    | 34.4      | 183_535 |
| reading assets               | 2_094    | 1_116     | 517     |
| reading crmodel              | 1_421    | 60.6      | 2_585   |
| EventBasedRiskCalculator.run | 1_412    | 1_916     | 1       |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| ebr_from_gmfs      | 517    | 157.7   | 86%    | 21.7    | 645.2   | 4.09228 |
```
Part of #8155 