### PR TITLE
Fast and simple event_based_risk

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -427,6 +427,24 @@ def idx_start_stop(integers):
     return numpy.array(out, I64)
 
 
+@compile("int64[:, :](uint32[:], uint32)")
+def split_slices(integers, size):
+    # given an array of integers returns an array int64 of shape (n, 2)
+    out = []
+    start = i = 0
+    prev = integers[0]
+    totsize = 1
+    for i, val in enumerate(integers[1:], 1):
+        totsize += 1
+        if val != prev and totsize >= size:
+            out.append((start, i))
+            totsize = 0
+            start = i
+        prev = val
+    out.append((start, i + 1))
+    return numpy.array(out, I64)
+
+
 # this is absurdly fast if you have numba
 def get_slices(uint32s):
     """

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -80,7 +80,7 @@ class Socket(object):
     :param mode: default 'bind', accepts also 'connect'
     :param timeout: default 15000 ms, used when polling the underlying socket
     """
-    def __init__(self, end_point, socket_type, mode, timeout=15000):
+    def __init__(self, end_point, socket_type, mode, timeout=15):
         assert socket_type in (zmq.REP, zmq.REQ, zmq.PULL, zmq.PUSH)
         assert mode in ('bind', 'connect'), mode
         if mode == 'bind':
@@ -88,7 +88,7 @@ class Socket(object):
         self.end_point = end_point
         self.socket_type = socket_type
         self.mode = mode
-        self.timeout = timeout
+        self.timeout = timeout * 1000  # milliseconds
         self.running = False
 
     def __enter__(self):
@@ -159,7 +159,7 @@ class Socket(object):
             raise exc.__class__('%s: %r' % (exc, obj))
         self.num_sent += 1
         if self.socket_type == zmq.REQ:
-            ok = self.zsocket.poll(30000)  # 30 seconds
+            ok = self.zsocket.poll(self.timeout)  # 30 seconds
             if not ok:
                 raise TimeoutError(
                     'While sending %s; probably the DbServer is off' %

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -248,11 +248,16 @@ class DamageCalculator(EventBasedRiskCalculator):
         Store damages-rlzs/stats, aggrisk and aggcurves
         """
         oq = self.oqparam
-        # no damage check
+        # no damage check, perhaps the sites where disjoint from gmf_data
         if self.dmgcsq[:, :, :, 1:].sum() == 0:
-            self.nodamage = True
-            logging.warning(
-                'There is no damage, perhaps the hazard is too small?')
+            haz_sids = self.datastore['gmf_data/sid'][:]
+            count = numpy.isin(haz_sids, self.sitecol.sids).sum()
+            if count == 0:
+                raise ValueError('The sites in gmf_data are disjoint from the '
+                                 'site collection!?')
+            else:
+                logging.warning(
+                    'There is no damage, perhaps the hazard is too small?')
             return
 
         prc = PostRiskCalculator(oq, self.datastore.calc_id)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -55,27 +55,27 @@ def build_slice_by_event(eids, offset=0):
     return sbe
 
 
-def split(gmf_df, size):
+def split(df, size):
     """
     Split a dataframe chunks. For instance for
 
-    >>> eids = [1, 1, 1, 2, 2, 4, 5, 5, 6, 8, 8, 8]
+    >>> eids = U32([1, 1, 1, 2, 2, 4, 5, 5, 6, 8, 8, 8])
     >>> len(eids)
     12
     >>> dfs = split(pandas.DataFrame({'eid': eids}), size=3)
     >>> [len(df) for df in dfs]
-    [2, 4, 2, 3, 1]
+    [3, 3, 3, 3]
     >>> dfs = split(pandas.DataFrame({'eid': eids}), size=4)
     >>> [len(df) for df in dfs]
-    [4, 5, 3]
+    [3, 5, 4]
     >>> dfs = split(pandas.DataFrame({'eid': eids}), size=6)
     >>> [len(df) for df in dfs]
-    [1, 4, 7]
+    [5, 7]
     """
-    n = len(gmf_df) // size + 1
-    if n == 1:
-        return [gmf_df]
-    return [df for _, df in gmf_df.groupby(gmf_df.eid % n)]
+    if len(df) <= size:
+        return [df]
+    eids = df.eid.to_numpy()
+    return [df[s0:s1] for s0, s1 in performance.split_slices(eids, size)]
 
 
 def fast_agg(keys, values, correl, li, acc):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -154,12 +154,12 @@ def ebr_from_gmfs(gmfslices, oqparam, dstore, monitor):
         items = monitor.read('assets').groupby('taxonomy')
         taxo_assets = [(t, a.set_index('ordinal')) for t, a in items]
     # print(monitor.task_no, len(df), slc_weight(gmfslices))
-    n = len(df) // 200_000 + 1
-    if n == 1:  # do not split
-        yield event_based_risk(df, oqparam, taxo_assets, monitor)
-    else:  # split in n blocks to save memory
-        for _, grp in df.groupby(df.eid % n):
+    n = len(df) // 200_000 + 1  # split in n blocks to save memory
+    for i, grp in df.groupby(df.eid % n):
+        if i == 0:
             yield event_based_risk(grp, oqparam, taxo_assets, monitor)
+        else:
+            yield event_based_risk, grp, oqparam, taxo_assets
 
 
 def event_based_risk(df, oqparam, taxo_assets, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -150,7 +150,7 @@ def ebr_from_gmfs(gmfslices, oqparam, dstore, monitor):
             dfs.append(dstore.read_df('gmf_data', slc=slc))
         df = pandas.concat(dfs)
     # print(monitor.task_no, len(df), slc_weight(gmfslices))
-    n = len(df) // 200_000 + 1  # split in n blocks to save memory
+    n = len(df) // 500_000 + 1  # split in n blocks to save memory
     for i, grp in df.groupby(df.eid % n):
         if i == 0:
             yield event_based_risk(grp, oqparam, monitor)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -187,7 +187,7 @@ def ebr_from_gmfs(sbe, oqparam, dstore, monitor):
     idx, = numpy.where(numpy.isin(haz_sids, risk_sids))
     if len(idx) == 0:
         return {}
-    print('waiting %.1f' % dt)
+    # print('waiting %.1f' % dt)
     time.sleep(dt)
     with dstore, monitor('reading GMFs', measuremem=True):
         start, stop = idx.min(), idx.max() + 1
@@ -199,7 +199,7 @@ def ebr_from_gmfs(sbe, oqparam, dstore, monitor):
                 data = dstore['gmf_data/' + col][s0+start:s0+stop]
                 dic[col] = data[idx - start]
         df = pandas.DataFrame(dic)
-    if len(df) < 1_000_000:
+    if len(df) < 500_000:
         yield event_based_risk(df, oqparam, monitor)
     else:
         for grp in split(df, 1_000_000):
@@ -234,7 +234,6 @@ def event_based_risk(df, oqparam, monitor):
         mon_risk = monitor('computing risk', measuremem=True)
         fil_mon = monitor('filtering GMFs', measuremem=True)
         for grp in split(df, 200_000):
-            print('{:_d}'.format(len(grp)))
             for taxo, adf in taxo_assets:
                 with fil_mon:
                     # *crucial* for the performance

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -167,7 +167,7 @@ def ebr_from_gmfs(sbe, oqparam, dstore, monitor):
                 data = dstore['gmf_data/' + col][s0+start:s0+stop]
                 dic[col] = data[idx - start]
         df = pandas.DataFrame(dic)
-    if len(df) < 500_000:
+    if len(df) < 750_000:
         yield event_based_risk(df, oqparam, monitor)
     else:
         for s0, s1 in performance.split_slices(df.eid.to_numpy(), 1_000_000):
@@ -200,7 +200,7 @@ def event_based_risk(df, oqparam, monitor):
 
     def outputs():
         mon_risk = monitor('computing risk', measuremem=True)
-        fil_mon = monitor('filtering GMFs', measuremem=True)
+        fil_mon = monitor('filtering GMFs', measuremem=False)
         for s0, s1 in performance.split_slices(df.eid.to_numpy(), 200_000):
             grp = df[s0:s1]
             for taxo, adf in taxo_assets:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -151,10 +151,10 @@ def ebr_from_gmfs(gmfslices, oqparam, dstore, monitor):
         df = pandas.concat(dfs)
     # print(monitor.task_no, len(df), slc_weight(gmfslices))
     n = len(df) // 500_000 + 1  # split in n blocks to save memory
-    if n == 1:
-        yield event_based_risk(df, oqparam, monitor)
-    else:
-        for _, grp in df.groupby(df.eid % n):
+    for i, grp in df.groupby(df.eid % n):
+        if i == 0:
+            yield event_based_risk(grp, oqparam, monitor)
+        else:
             yield event_based_risk, grp, oqparam
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -151,10 +151,10 @@ def ebr_from_gmfs(gmfslices, oqparam, dstore, monitor):
         df = pandas.concat(dfs)
     # print(monitor.task_no, len(df), slc_weight(gmfslices))
     n = len(df) // 500_000 + 1  # split in n blocks to save memory
-    for i, grp in df.groupby(df.eid % n):
-        if i == 0:
-            yield event_based_risk(grp, oqparam, monitor)
-        else:
+    if n == 1:
+        yield event_based_risk(df, oqparam, monitor)
+    else:
+        for _, grp in df.groupby(df.eid % n):
             yield event_based_risk, grp, oqparam
 
 

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -16,19 +16,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import itertools
 import warnings
 import logging
-import functools
 from unittest.mock import Mock
 import numpy
 
-from openquake.baselib import performance, parallel, hdf5, general
+from openquake.baselib import performance, parallel, hdf5
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib import probability_map
 from openquake.hazardlib.source.rupture import EBRupture, events_dt
-from openquake.commonlib import util, datastore
+from openquake.commonlib import util
 
 TWO16 = 2 ** 16
 TWO32 = numpy.float64(2 ** 32)
@@ -394,18 +392,9 @@ class RuptureImporter(object):
 # logic for building the GMF slices used in event_based_risk #
 ##############################################################
 
-slice_dt = numpy.dtype([('start', int), ('stop', int), ('eid', U32)])
-START, STOP, WEIGHT = 0, 1, 2
 SLICE_BY_EVENT_NSITES = 1000
 
-
-def slc_weight(slc):
-    """
-    :returns: the weight a slice array
-    """
-    if len(slc.shape) == 1:
-        return slc[1] - slc[0] + slc[2]
-    return (slc[:, 1] - slc[:, 0] + slc[:, 2]).sum()
+slice_dt = numpy.dtype([('start', int), ('stop', int), ('eid', U32)])
 
 
 def build_slice_by_event(eids, offset=0):
@@ -417,137 +406,20 @@ def build_slice_by_event(eids, offset=0):
     return sbe
 
 
-def _concat(acc, slc2):
-    if len(acc) == 0:
-        return [slc2]
-    slc1 = acc[-1]  # last slice
-    if slc2[START] == slc1[STOP]:
-        new = numpy.zeros(3, int)
-        new[START] = slc1[START]
-        new[STOP] = slc2[STOP]
-        new[WEIGHT] = slc1[WEIGHT] + slc2[WEIGHT]
-        return acc[:-1] + [new]
-    return acc + [slc2]
-
-
-def compactify(arrayN3):
+def starmap_from_gmfs(task_func, oq, dstore):
     """
-    :param arrayN3: an array with columns (start, stop, weight)
-    :returns: a shorter array with the same structure
-
-    Here is how it works in an example where the first three slices
-    are compactified into one while the last slice stays as it is:
-
-    >>> arr = numpy.array([[84384702, 84385520, 1308],
-    ...                    [84385520, 84385770, 28],
-    ...                    [84385770, 84386062, 12],
-    ...                    [84387636, 84388028, 183]])
-    >>> compactify(arr)
-    array([[84384702, 84386062,     1348],
-           [84387636, 84388028,      183]])
+    :returns: a Starmap object useful for event based calculations
     """
-    if len(arrayN3) == 1:
-        # nothing to compactify
-        return arrayN3
-    out = numpy.array(functools.reduce(_concat, arrayN3, []))
-    return out
-
-
-def ponder_slices(slice_by_event, num_assets, sids_risk, dstore, monitor):
-    """
-    Convert an array `slice_by_event` into an array `slice_by_weight`.
-    If `sids_risk` is not None, it is used to filter the hazard sites
-    and in that case the rows with zero weight are discarded.
-    """
-    start, stop = slice_by_event[0]['start'], slice_by_event[-1]['stop']
-    with dstore.open('r'):
-        haz_sids = dstore['gmf_data/sid'][start:stop]
-    out = []
-    for s1, s2, _e in slice_by_event:
-        sids = haz_sids[s1-start:s2-start]
-        if sids_risk is not None:
-            sids = sids[numpy.isin(sids, sids_risk)]
-        na = num_assets[sids].sum()
-        if na:
-            out.append((s1, s2, 0))
-    return numpy.array(out, int)
-
-
-def build_gmfslices(dstore, hint=None):
-    """
-    :param dstore: a DataStore containing gmf_data in it or its parent
-    :param hint: hint for the number of arrays to generate
-    :returns: a list of slice arrays
-    """
-    df = dstore.read_df('gmf_data', slc=slice(0, 1))
-    nbytes_per_row = df.memory_usage(index=False).sum()
-    maxrows = MAX_NBYTES // nbytes_per_row
-    logging.info('Considering blocks of {:_d} rows'.format(maxrows))
-    tot_nrows = len(dstore['gmf_data/sid'])
-    parent = dstore.parent
-    Np = len(parent['sitecol']) if parent else 0
-    if hint is None:
-        hint = tot_nrows // maxrows or 1
+    data = dstore['gmf_data']
     try:
-        slice_by_event = dstore['gmf_data/slice_by_event'][:]
+        sbe = data['slice_by_event'][:]
     except KeyError:
-        # missing slice_by_event
-        logging.info('Reading the full gmf_data/eid')
-        eids = dstore['gmf_data/eid'][:]
-        if parent and Np >= SLICE_BY_EVENT_NSITES:
-            # try to fix the parent if there are many sites
-            parent.close()
-            with datastore.read(parent.filename, 'r+') as p:
-                slice_by_event = build_slice_by_event(eids)
-                p['gmf_data/slice_by_event'] = slice_by_event
-            parent.open('r')
-        else:
-            # no parent or few sites
-            slice_by_event = build_slice_by_event(eids)
-
-    logging.info('Reading sites and assets')
-    sitecol = dstore['sitecol']
-    assetcol = dstore['assetcol']
-    if parent:
-        # important for oq-risk-tests event_based_risk case_8e
-        filtered = len(sitecol) < Np
-    else:
-        filtered = (sitecol.sids != numpy.arange(len(sitecol))).any()
-    N = sitecol.sids.max() + 1 if filtered else len(sitecol)
-    num_assets = numpy.zeros(N, int)
-    sids_risk, counts = numpy.unique(assetcol['site_id'], return_counts=True)
-    num_assets[sids_risk] = counts
-    logging.info('Building slice_by_event')
-    slice_by_weight = []
-    if not filtered:
-        sids_risk = None
-    dstore.swmr_on()  # crucial!
-    dist = 'no' if os.environ.get('OQ_DISTRIBUTE') == 'no' else 'processpool'
-    smap = parallel.Starmap(ponder_slices, distribute=dist, h5=dstore.hdf5)
-    for sbe in numpy.array_split(slice_by_event, hint):
-        if len(sbe):
-            smap.submit((sbe, num_assets, sids_risk, dstore))
-    for sbw in smap:
-        if len(sbw):
-            slice_by_weight.append(sbw)
-    if not slice_by_weight:
-        raise ValueError('The sites in gmf_data are disjoint from the '
-                         'site collection!?')
-    # NB: the sort below is needed for scenario_damage case_12 with
-    # discrete_damage_distribution = true
-    logging.info('Sorting and compactifying slices')
-    slice_by_weight = numpy.sort(numpy.concatenate(slice_by_weight), axis=0)
-    tot_weight = slc_weight(slice_by_weight)
-    max_weight = numpy.clip(tot_weight / hint, 1_000, 1_000_000)
-    blocks = general.block_splitter(slice_by_weight, max_weight, slc_weight)
-    gmfslices = [compactify(numpy.array(block)) for block in blocks]
-    ns = sum(len(arr) for arr in gmfslices)
-    logging.info('Built {:d} GMF slices'.format(ns))
-    nrows = sum((arr[:, STOP]-arr[:, START]).sum() for arr in gmfslices)
-    h = general.humansize(nbytes_per_row * nrows)
-    htot = general.humansize(nbytes_per_row * tot_nrows)
-    logging.info('Considering %s of %s of GMFs', h, htot)
-    ws = numpy.array([slc_weight(arr) for arr in gmfslices])
-    logging.info('Slice weights min, mean, max {:_d}, {:_d}, {:_d}'.
-                 format(int(ws.min()), int(ws.mean()), int(ws.max())))
-    return gmfslices
+        sbe = build_slice_by_event(data['eid'][:])
+    maxweight = (sbe[-1]['stop']-sbe[0]['start']) // (oq.concurrent_tasks or 1)
+    dstore.swmr_on()  # before the Starmap
+    smap = parallel.Starmap.apply(
+        task_func, (sbe, oq, dstore),
+        weight=lambda rec: rec['stop']-rec['start'],
+        maxweight=numpy.clip(maxweight, 1000, 10_000_000),
+        h5=dstore.hdf5)
+    return smap

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -52,7 +52,8 @@ def dbcmd(action, *args):
             return dbapi.db(action, *args)
         else:
             return func(dbapi.db, *args)
-    sock = zeromq.Socket('tcp://' + DATABASE, zeromq.zmq.REQ, 'connect')
+    sock = zeromq.Socket('tcp://' + DATABASE, zeromq.zmq.REQ, 'connect',
+                         timeout=60)  # when the system is loaded 60 seconds
     with sock:
         res = sock.send((action,) + args)
         if isinstance(res, parallel.Result):


### PR DESCRIPTION
Finally closes https://github.com/gem/oq-engine/issues/8126 by implementing the following features:

- [x] calculations do not run out of memory, obtained by splitting the GMFs in chunks of suitable size
- [x] the chunk-splitting is smart enough to keep GMVs from the same event together
- [x] the number of generated tasks is kept under control (at most a few thousands even with 200+GB of GMFs)
- [x] subtasks are generated so that the big tasks are homogeneous in size and the not homogeneous tasks are small, i.e. there are few slow tasks
- [x] the data transfer is kept under control
- [x] in situation of big stress on the disks the calculation does not fail due to a timeout when writing on the db
- [x] there is no preprocessing phase and a lot of lines of code can be removed

As a consequence of this work, it is now possible to run all of South America with a single command. Here are the figures for Chile with half million years, which is the largest calculation seen so far:
```
| calc_45331, maxmem=305.8 GB  | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| computing risk               | 336_321  | 16_447    | 314_902 |
| total event_based_risk       | 329_458  | 941.1     | 815     |
| total ebr_from_gmfs          | 181_096  | 1_079     | 1_475   |
| reading GMFs                 | 50_853   | 366.7     | 1_047   |
| aggregating losses           | 36_646   | 0.0       | 379_030 |
| EventBasedRiskCalculator.run | 5_438    | 24_019    | 1       |
| reading assets/crmodel       | 4_885    | 1_191     | 1_475   |
| filtering GMFs               | 3_824    | 16.4      | 315_240 |

| operation-duration | counts | mean  | stddev | min     | max   | slowfac |
|--------------------+--------+-------+--------+---------+-------+---------|
| ebr_from_gmfs      | 1_072  | 169.9 | 47%    | 4.12812 | 737.7 | 4.34168 |
| event_based_risk   | 815    | 404.2 | 54%    | 7.05667 | 1_568 | 3.87983 |

| task             | sent                                           | received  |
|------------------+------------------------------------------------+-----------|
| ebr_from_gmfs    | sbe=245.5 MB oqparam=18.91 MB dstore=314.06 KB | 362.12 MB |
| event_based_risk | df=14.38 GB oqparam=14.12 MB                   | 984.37 MB |
```