### PR TITLE
Fixed AtkinsonBoore2006 with stress drop adjustment

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Fixed an indexing error breaking the GMPE AtkinsonBoore2006 with
+    stress drop adjustment
+
   [C. Bruce Worden]
   * Extended the AbrahamsonEtAl2014 GMPE to extrapolate the vs30
 

--- a/openquake/hazardlib/gsim/atkinson_boore_2006.py
+++ b/openquake/hazardlib/gsim/atkinson_boore_2006.py
@@ -113,8 +113,10 @@ def _compute_mean(C, f0, f1, f2, SC, mag, rrup, idxs, mean, scale_fac):
     """
     if idxs.sum() == 0:  # no effect
         return
+    if np.isinstance(scale_fac, np.ndarray):
+        scale_fac = scale_fac[idxs]
     mag = mag[idxs]
-    sda = _compute_stress_drop_adjustment(SC, mag, scale_fac[idxs])
+    sda = _compute_stress_drop_adjustment(SC, mag, scale_fac)
     mean[idxs] = (C['c1'] +
                   C['c2'] * mag +
                   C['c3'] * (mag ** 2) +

--- a/openquake/hazardlib/gsim/atkinson_boore_2006.py
+++ b/openquake/hazardlib/gsim/atkinson_boore_2006.py
@@ -106,8 +106,7 @@ def _compute_magnitude_scaling(ctx, C):
     return _compute_ms(ctx, C)
 
 
-def _compute_mean(C, f0, f1, f2, SC, mag, rrup, idxs, mean,
-                  scale_fac):
+def _compute_mean(C, f0, f1, f2, SC, mag, rrup, idxs, mean, scale_fac):
     """
     Compute mean value (for a set of indexes) without site amplification
     terms. This is equation (5), p. 2191, without S term.
@@ -115,14 +114,14 @@ def _compute_mean(C, f0, f1, f2, SC, mag, rrup, idxs, mean,
     if idxs.sum() == 0:  # no effect
         return
     mag = mag[idxs]
+    sda = _compute_stress_drop_adjustment(SC, mag, scale_fac[idxs])
     mean[idxs] = (C['c1'] +
                   C['c2'] * mag +
                   C['c3'] * (mag ** 2) +
                   (C['c4'] + C['c5'] * mag) * f1[idxs] +
                   (C['c6'] + C['c7'] * mag) * f2[idxs] +
                   (C['c8'] + C['c9'] * mag) * f0[idxs] +
-                  C['c10'] * rrup[idxs] +
-                  _compute_stress_drop_adjustment(SC, mag, scale_fac))
+                  C['c10'] * rrup[idxs] + sda)
 
 
 def _compute_ms(ctx, C):

--- a/openquake/hazardlib/gsim/atkinson_boore_2006.py
+++ b/openquake/hazardlib/gsim/atkinson_boore_2006.py
@@ -113,7 +113,7 @@ def _compute_mean(C, f0, f1, f2, SC, mag, rrup, idxs, mean, scale_fac):
     """
     if idxs.sum() == 0:  # no effect
         return
-    if np.isinstance(scale_fac, np.ndarray):
+    if isinstance(scale_fac, np.ndarray):
         scale_fac = scale_fac[idxs]
     mag = mag[idxs]
     sda = _compute_stress_drop_adjustment(SC, mag, scale_fac)


### PR DESCRIPTION
Discovered by @Shreyasvi91, the error was:
```python
  File "/opt/openquake/oq-engine/openquake/hazardlib/contexts.py", line 1039, in get_mean_stds
    adj = compute(gsim, ctx, self.imts, *out[:, g, :, slc])
  File "/opt/openquake/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2006.py", line 436, in compute
    mean[m] = _get_mean(
  File "/opt/openquake/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2006.py", line 262, in _get_mean
    pga_bc = _get_pga_bc(
  File "/opt/openquake/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2006.py", line 290, in _get_pga_bc
    _compute_mean(C_pga_bc, f0, f1, f2, SC, mag,
  File "/opt/openquake/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2006.py", line 125, in _compute_mean
    _compute_stress_drop_adjustment(SC, mag, scale_fac))
  File "/opt/openquake/oq-engine/openquake/hazardlib/gsim/atkinson_boore_2006.py", line 219, in _compute_stress_drop_adjustment
    return scale_fac * np.clip(
ValueError: operands could not be broadcast together with shapes (1337,) (1335,) 
```