### PR TITLE
Worked aroun the memory leak in the tiling calculator

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed memory leak in the tiling calculator by resetting the ProcessPool
   * Fixed an indexing error breaking the GMPE AtkinsonBoore2006 with
     stress drop adjustment
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -499,6 +499,7 @@ class ClassicalCalculator(base.HazardCalculator):
             smap.reduce(self.agg_dicts, acc)
             if len(tiles) > 1:
                 logging.info('Finished tile %d of %d', t, len(tiles))
+                parallel.Starmap.shutdown()
         self.store_info()
         self.haz.store_disagg(acc)
         if self.cfactor[0] == 0:


### PR DESCRIPTION
It is enough to reset the ProcessPool after each tile. This makes it possible to run the new AUS model.