### PR TITLE
Added some support for SharedMemory in the Starmap

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -645,6 +645,31 @@ def getargnames(task_func):
         return inspect.getfullargspec(task_func.__call__).args[1:]
 
 
+class SharedArray(object):
+    """
+    Wrapper over a SharedMemory object to be used as a context manager.
+    """
+    def __init__(self, shape, dtype, value):
+        nbytes = numpy.zeros(1, dtype).nbytes * numpy.prod(shape)
+        sm = shmem.SharedMemory(create=True, size=nbytes)
+        self.name = sm.name
+        self.shape = shape
+        self.dtype = dtype
+        # fill the SharedMemory buffer with the value
+        arr = numpy.ndarray(shape, dtype, buffer=sm.buf)
+        arr[:] = value
+
+    def __enter__(self):
+        self.sm = shmem.SharedMemory(self.name)
+        return numpy.ndarray(self.shape, self.dtype, buffer=self.sm.buf)
+
+    def __exit__(self, etype, exc, tb):
+        self.sm.close()
+
+    def unlink(self):
+        shmem.SharedMemory(self.name).unlink()
+
+
 class Starmap(object):
     pids = ()
     running_tasks = []  # currently running tasks
@@ -690,11 +715,11 @@ class Starmap(object):
 
     @classmethod
     def shutdown(cls):
+        for shared in cls.shared:
+            shmem.SharedMemory(shared.name).unlink()
         # shutting down the pool during the runtime causes mysterious
         # race conditions with errors inside atexit._run_exitfuncs
         if hasattr(cls, 'pool'):
-            for shared in cls.shared:
-                shmem.SharedMemory(shared.name).unlink()
             cls.pool.close()
             cls.pool.terminate()
             cls.pool.join()
@@ -940,7 +965,11 @@ class Starmap(object):
     def create_shared(self, shape, dtype=float, value=0.):
         """
         Create an array backed by a SharedMemory buffer.
-        :returns: an SharedArray instance
+
+        :param shape: shape of the array
+        :param dtype: dtype of the array (default float)
+        :param value: initialization value (default 0.)
+        :returns: a SharedArray instance
         """
         shared = SharedArray(shape, dtype, value)
         self.shared.append(shared)
@@ -1111,31 +1140,3 @@ def workers_wait(seconds=30):
         else:
             raise TimeoutError(status)
         return status
-
-
-class SharedArray(object):
-    """
-    Wrapper over a SharedMemory object to be used as a context manager:
-
-    with SharedArray(arr) as arr:
-      print(arr)
-    """
-    def __init__(self, shape, dtype, value):
-        nbytes = numpy.zeros(1, dtype).nbytes * numpy.prod(shape)
-        sm = shmem.SharedMemory(create=True, size=nbytes)
-        self.name = sm.name
-        self.shape = shape
-        self.dtype = dtype
-        # fill the SharedMemory buffer with the value
-        arr = numpy.ndarray(shape, dtype, buffer=sm.buf)
-        arr[:] = value
-
-    def __enter__(self):
-        self.sm = shmem.SharedMemory(self.name)
-        return numpy.ndarray(self.shape, self.dtype, buffer=self.sm.buf)
-
-    def __exit__(self, etype, exc, tb):
-        self.sm.close()
-
-    def unlink(self):
-        shmem.SharedMemory(self.name).unlink()

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -675,7 +675,7 @@ class Starmap(object):
                 cls.pool = multiprocessing.get_context('spawn').Pool(
                     cls.num_cores, init_workers)
                 cls.pids = [proc.pid for proc in cls.pool._pool]
-            cls.pool.shared = []
+            cls.shared = []
             # after spawning the processes restore the original handlers
             # i.e. the ones defined in openquake.engine.engine
             signal.signal(signal.SIGTERM, term_handler)
@@ -693,7 +693,7 @@ class Starmap(object):
         # shutting down the pool during the runtime causes mysterious
         # race conditions with errors inside atexit._run_exitfuncs
         if hasattr(cls, 'pool'):
-            for shared in cls.pool.shared:
+            for shared in cls.shared:
                 shmem.SharedMemory(shared.name).unlink()
             cls.pool.close()
             cls.pool.terminate()
@@ -943,7 +943,7 @@ class Starmap(object):
         :returns: an SharedArray instance
         """
         shared = SharedArray(numpy.full(shape, value, dtype))
-        self.pool.shared.append(shared)
+        self.shared.append(shared)
         return shared
 
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -942,7 +942,7 @@ class Starmap(object):
         Create an array backed by a SharedMemory buffer.
         :returns: an SharedArray instance
         """
-        shared = SharedArray(numpy.full(shape, value, dtype))
+        shared = SharedArray(shape, dtype, value)
         self.shared.append(shared)
         return shared
 
@@ -1120,14 +1120,15 @@ class SharedArray(object):
     with SharedArray(arr) as arr:
       print(arr)
     """
-    def __init__(self, array):
-        sm = shmem.SharedMemory(create=True, size=array.nbytes)
+    def __init__(self, shape, dtype, value):
+        nbytes = numpy.zeros(1, dtype).nbytes * numpy.prod(shape)
+        sm = shmem.SharedMemory(create=True, size=nbytes)
         self.name = sm.name
-        self.shape = array.shape
-        self.dtype = array.dtype
-        # fill the SharedMemory buffer with a copy of the array
-        arr = numpy.ndarray(array.shape, array.dtype, buffer=sm.buf)
-        arr[:] = array
+        self.shape = shape
+        self.dtype = dtype
+        # fill the SharedMemory buffer with the value
+        arr = numpy.ndarray(shape, dtype, buffer=sm.buf)
+        arr[:] = value
 
     def __enter__(self):
         self.sm = shmem.SharedMemory(self.name)

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -233,3 +233,24 @@ class SplitTaskTestCase(unittest.TestCase):
         self.assertAlmostEqual(res, 48.6718458266)
         """
         shutil.rmtree(tmpdir)
+
+
+def update_array(shared, index):
+    with shared as array:
+        for i in range(index):
+            for j in range(index):
+                array[i, j] *= .99
+
+
+class SharedMemoryTestCase(unittest.TestCase):
+    def test(self):
+        shape = 10, 10
+        smap = parallel.Starmap(update_array)
+        shared = smap.create_shared(shape, value=1.)
+        for i in range(shape[1]):
+            smap.submit((shared, i))
+        smap.reduce()
+        print()
+        with shared as array:
+            print(array)
+        parallel.Starmap.shutdown()

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -183,7 +183,7 @@ class LogContext:
                 'create_job',
                 get_datadir(),
                 self.params['calculation_mode'],
-                self.params['description'],
+                self.params.get('description', 'test'),
                 user_name,
                 hc_id,
                 host)


### PR DESCRIPTION
Here is an example script:
```python
import numpy
from openquake.baselib import parallel
from openquake.commonlib import logs, datastore

def update_array(shared, index, monitor):
    with shared as array:
        array[:, index] *= .99999

def update_array2(shape, index, monitor):
    array = numpy.ones(shape)
    array[:, index] *= .99999

def main_shared(*shape):
    log = logs.init('calc', {'calculation_mode': 'scenario'})
    with log, datastore.new(log.calc_id, log.get_oqparam(False)) as ds:
        smap = parallel.Starmap(update_array, h5=ds)
        shared = smap.create_shared(shape, value=1.)
        for i in range(shape[1]):
            smap.submit((shared, i))
        smap.reduce()
        print()
        with shared as array:
            print(array.mean())

def main_notshared(*shape):
    log = logs.init('calc', {'calculation_mode': 'scenario'})
    with log, datastore.new(log.calc_id, log.get_oqparam(False)) as ds:
        smap = parallel.Starmap(update_array2, h5=ds)
        for i in range(shape[1]):
            smap.submit((shape, i))
        smap.reduce()

if __name__ == '__main__':
    main_shared(1_000_000, 240)
    main_notshared(1_000_000, 240)
```
On the spot machine I get a significant memory reduction
```
| calc_48681, maxmem=154.0 GB | time_sec | memory_mb | counts |
|-----------------------------+----------+-----------+--------|
| total update_array2         | 353.0    | 0.35547   | 240    |

| calc_48680, maxmem=70.6 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total update_array         | 129.0    | 0.36328   | 240    |
```