### PR TITLE
More refactoring of the ProbabilityMaps

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -144,13 +144,16 @@ def classical(srcs, sids, cmaker, monitor):
     Read the sitecol and call the classical calculator in hazardlib
     """
     cmaker.init_monitoring(monitor)
+    cmaker.rup_indep = getattr(srcs, 'rup_interdep', None) != 'mutex'
     sitecol = monitor.read('sitecol')
     if sids is not None:  # tiling
         sitecol = sitecol.filter(numpy.isin(sitecol.sids, sids))
-    result = hazclassical(srcs, sitecol, cmaker)
+    pmap = ProbabilityMap(
+        sitecol.sids, cmaker.imtls.size, len(cmaker.gsims))
+    pmap.fill(cmaker.rup_indep)
+    result = hazclassical(srcs, sitecol, cmaker, pmap)
     if sids is None:  # single tile, save memory
         result['pmap'] = result['pmap'].remove_zeros()
-    # print(srcs, sum(src.weight for src in srcs))
     return result
 
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -144,13 +144,13 @@ def classical(srcs, sids, cmaker, monitor):
     Read the sitecol and call the classical calculator in hazardlib
     """
     cmaker.init_monitoring(monitor)
-    cmaker.rup_indep = getattr(srcs, 'rup_interdep', None) != 'mutex'
+    rup_indep = getattr(srcs, 'rup_interdep', None) != 'mutex'
     sitecol = monitor.read('sitecol')
     if sids is not None:  # tiling
         sitecol = sitecol.filter(numpy.isin(sitecol.sids, sids))
     pmap = ProbabilityMap(
         sitecol.sids, cmaker.imtls.size, len(cmaker.gsims))
-    pmap.fill(cmaker.rup_indep)
+    pmap.fill(rup_indep)
     result = hazclassical(srcs, sitecol, cmaker, pmap)
     if sids is None:  # single tile, save memory
         result['pmap'] = result['pmap'].remove_zeros()

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -65,7 +65,6 @@ def _cluster(sids, imtls, tom, gsims, pmap):
             pmapclu = pmap.new(numpy.full(pmap.shape, prob_n_occ))
         else:
             pmapclu.array += (1.-pmap.array)**nocc * prob_n_occ
-    print(pmapclu.array)
     return ~pmapclu
 
 
@@ -79,6 +78,7 @@ def classical(group, sitecol, cmaker, pmap=None):
     :returns:
         a dictionary with keys pmap, source_data, rup_data, extra
     """
+    not_passed_pmap = pmap is None
     src_filter = SourceFilter(sitecol, cmaker.maximum_distance)
     cluster = getattr(group, 'cluster', None)
     cmaker.rup_indep = getattr(group, 'rup_interdep', None) != 'mutex'
@@ -101,7 +101,7 @@ def classical(group, sitecol, cmaker, pmap=None):
         cmaker.tom = PoissonTOM(time_span) if time_span else None
     if cluster:
         cmaker.tom = FatedTOM(time_span=1)
-    if pmap is None:
+    if not_passed_pmap:
         pmap = ProbabilityMap(
             sitecol.sids, cmaker.imtls.size, len(cmaker.gsims))
         pmap.fill(cmaker.rup_indep)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -81,7 +81,7 @@ def classical(group, sitecol, cmaker, pmap=None):
     not_passed_pmap = pmap is None
     src_filter = SourceFilter(sitecol, cmaker.maximum_distance)
     cluster = getattr(group, 'cluster', None)
-    cmaker.rup_indep = getattr(group, 'rup_interdep', None) != 'mutex'
+    rup_indep = getattr(group, 'rup_interdep', None) != 'mutex'
     trts = set()
     for src in group:
         if not src.num_ruptures:
@@ -104,7 +104,7 @@ def classical(group, sitecol, cmaker, pmap=None):
     if not_passed_pmap:
         pmap = ProbabilityMap(
             sitecol.sids, cmaker.imtls.size, len(cmaker.gsims))
-        pmap.fill(cmaker.rup_indep)
+        pmap.fill(rup_indep)
 
     dic = PmapMaker(cmaker, src_filter, group).make(pmap)
     if cluster:

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -65,6 +65,7 @@ def _cluster(sids, imtls, tom, gsims, pmap):
             pmapclu = pmap.new(numpy.full(pmap.shape, prob_n_occ))
         else:
             pmapclu.array += (1.-pmap.array)**nocc * prob_n_occ
+    print(pmapclu.array)
     return ~pmapclu
 
 
@@ -80,6 +81,7 @@ def classical(group, sitecol, cmaker, pmap=None):
     """
     src_filter = SourceFilter(sitecol, cmaker.maximum_distance)
     cluster = getattr(group, 'cluster', None)
+    cmaker.rup_indep = getattr(group, 'rup_interdep', None) != 'mutex'
     trts = set()
     for src in group:
         if not src.num_ruptures:
@@ -102,6 +104,7 @@ def classical(group, sitecol, cmaker, pmap=None):
     if pmap is None:
         pmap = ProbabilityMap(
             sitecol.sids, cmaker.imtls.size, len(cmaker.gsims))
+        pmap.fill(cmaker.rup_indep)
 
     dic = PmapMaker(cmaker, src_filter, group).make(pmap)
     if cluster:
@@ -205,7 +208,7 @@ def calc_hazard_curve(site1, src, gsims, oqparam, monitor=Monitor()):
     cmaker = ContextMaker(trt, gsims, vars(oqparam), monitor)
     cmaker.tom = src.temporal_occurrence_model
     srcfilter = SourceFilter(site1, oqparam.maximum_distance)
-    pmap = ProbabilityMap(site1.sids, oqparam.imtls.size, 1).fill(0)
+    pmap = ProbabilityMap(site1.sids, oqparam.imtls.size, 1).fill(1)
     PmapMaker(cmaker, srcfilter, [src]).make(pmap)
     if not pmap:  # filtered away
         zero = numpy.zeros((oqparam.imtls.size, len(gsims)))

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1172,7 +1172,6 @@ class PmapMaker(object):
         except AttributeError:  # already a list of sources
             self.sources = group
         self.src_mutex = getattr(group, 'src_interdep', None) == 'mutex'
-        self.cmaker.rup_indep = getattr(group, 'rup_interdep', None) != 'mutex'
         self.fewsites = self.N <= cmaker.max_sites_disagg
 
     def count_bytes(self, ctxs):
@@ -1291,7 +1290,7 @@ class PmapMaker(object):
             for source_id, pm in pmap_by_src.items():
                 pmap.array += pm.array
         else:
-            pmap.fill(self.cmaker.rup_indep)
+            #pmap.fill(self.cmaker.rup_indep)
             self._make_src_indep(pmap)
         dic['pmap'] = pmap
         dic['cfactor'] = self.cmaker.collapser.cfactor


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/8177. Now the ProbabilityMap is passed from the engine and not created in hazardlib. Also, the magic attribute `rup_indep` has been removed from the ContextMaker (it was attached later).