### PR TITLE
Add a command `oq purge failed`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added command `oq purge failed`
   * Fixed memory leak in the tiling calculator by resetting the ProcessPool
   * Fixed an indexing error breaking the GMPE AtkinsonBoore2006 with
     stress drop adjustment

--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -55,12 +55,12 @@ def purge_all(user=None):
 
 def purge_failed():
     """
-    Remove all failed calculations older than 3 days
+    Remove all failed calculations older than 1 day
     """
     rows = logs.dbcmd(
         'SELECT id, ds_calc_dir || ".hdf5" FROM job '
         'WHERE status NOT IN ("complete", "running")'
-        "AND start_time> datetime('now', '-3 days')")
+        "AND start_time < datetime('now', '-1 days')")
     todelete = []
     totsize = 0
     for calc_id, fname in rows:

--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -53,7 +53,7 @@ def purge_all(user=None):
                 purge_one(calc_id, user, force=True)
 
 
-def purge_failed():
+def purge_failed(force):
     """
     Remove all failed calculations older than 1 day
     """
@@ -72,9 +72,11 @@ def purge_failed():
                 todelete.append(tname)
                 totsize += os.path.getsize(tname)
     size = humansize(totsize)
-    print('Deleting %d files .hdf5, %s' % (len(todelete), size))
     for fname in todelete:
-        os.remove(fname)
+        print(fname)
+        if force:
+            os.remove(fname)
+    print('Processed %d HDF5 files, %s' % (len(todelete), size))
 
     
 def main(what, force=False):
@@ -83,7 +85,7 @@ def main(what, force=False):
     If you want to remove everything,  use oq reset.
     """
     if what == 'failed':
-        purge_failed()
+        purge_failed(force)
         return
     calc_id = int(what)
     if calc_id < 0:

--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -66,11 +66,11 @@ def purge_failed():
     for calc_id, fname in rows:
         if os.path.exists(fname) and os.access(fname, os.W_OK):
             todelete.append(fname)
-            totsize += os.getsize(fname)
+            totsize += os.path.getsize(fname)
             tname = fname.replace('.hdf5', '_tmp.hdf5')
             if os.path.exists(tname) and os.access(tname, os.W_OK):
                 todelete.append(tname)
-                totsize += os.getsize(tname)
+                totsize += os.path.getsize(tname)
     size = humansize(totsize)
     print('Deleting %d files .hdf5, %s' % (len(todelete), size))
     for fname in todelete:


### PR DESCRIPTION
The command will purge nearly 1 TB of data on cole:
```
# oq purge --force failed
/home/aettorre/oqdata/calc_42478.hdf5
/home/aettorre/oqdata/calc_42479.hdf5
/home/yenshin.chen/oqdata/calc_43564.hdf5
/home/yenshin.chen/oqdata/calc_43567.hdf5
/home/acalderon/oqdata/calc_43783.hdf5
/home/arao/oqdata/calc_44006.hdf5
/home/arao/oqdata/calc_44009.hdf5
/home/arao/oqdata/calc_44013.hdf5
/home/arao/oqdata/calc_44191.hdf5
/home/arao/oqdata/calc_44193.hdf5
/home/ccosta/oqdata/calc_44641.hdf5
/home/ccosta/oqdata/calc_44642.hdf5
...
/home/kjohnson/oqdata/calc_48697.hdf5
/home/kjohnson/oqdata/calc_48700.hdf5
Processed 605 HDF5 files, 860.57 GB
```
Closes https://github.com/gem/oq-engine/issues/8196.