### PR TITLE
Fighting memory leaks with `maxtasksperchild`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed parallel.Starmap to use maxtasksperchild=1 to fight memory leaks
   * Added command `oq purge failed`
   * Fixed memory leak in the tiling calculator by resetting the ProcessPool
   * Fixed an indexing error breaking the GMPE AtkinsonBoore2006 with

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
   * Changed parallel.Starmap to use maxtasksperchild=1 to fight memory leaks
+    and introduced automatic tiling for extra-large calculations
   * Added command `oq purge failed`
   * Fixed memory leak in the tiling calculator by resetting the ProcessPool
   * Fixed an indexing error breaking the GMPE AtkinsonBoore2006 with

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -699,7 +699,7 @@ class Starmap(object):
                 cls.pool = Pool(cls.num_cores, init_workers)
             except ImportError:
                 cls.pool = multiprocessing.get_context('spawn').Pool(
-                    cls.num_cores, init_workers)
+                    cls.num_cores, init_workers, maxtasksperchild=1)
                 cls.pids = [proc.pid for proc in cls.pool._pool]
             cls.shared = []
             # after spawning the processes restore the original handlers

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -674,6 +674,7 @@ class Starmap(object):
     pids = ()
     running_tasks = []  # currently running tasks
     shared = []  # SharedArrays
+    maxtasksperchild = 1
     num_cores = int(config.distribution.get('num_cores', '0'))
     if not num_cores:
         # use only the "visible" cores, not the total system cores
@@ -699,7 +700,8 @@ class Starmap(object):
                 cls.pool = Pool(cls.num_cores, init_workers)
             except ImportError:
                 cls.pool = multiprocessing.get_context('spawn').Pool(
-                    cls.num_cores, init_workers, maxtasksperchild=1)
+                    cls.num_cores, init_workers,
+                    maxtasksperchild=cls.maxtasksperchild)
                 cls.pids = [proc.pid for proc in cls.pool._pool]
             cls.shared = []
             # after spawning the processes restore the original handlers

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -146,7 +146,10 @@ def memory_rss(pid):
     """
     :returns: the RSS memory allocated by a process
     """
-    return psutil.Process(pid).memory_info().rss
+    try:
+        return psutil.Process(pid).memory_info().rss
+    except psutil.NoSuchProcess:
+        return 0
 
 
 # this is not thread-safe

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -493,7 +493,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.haz = Hazard(self.datastore, self.full_lt, srcidx)
         num_gs = [len(cm.gsims) for cm in self.haz.cmakers]
         L = oq.imtls.size
-        max_gb = max(num_gs) * L * self.N * 8 // 1024**3
+        max_gb = max(num_gs) * L * self.N * 8 / 1024**3
         if max_gb > 1:  # split in tiles
             max_sites = min(numpy.ceil(self.N / max_gb), oq.max_sites_per_tile)
             tiles = self.sitecol.split_max(max_sites)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -504,6 +504,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if len(tiles) > 1:
             sizes = [len(tile) for tile in tiles]
             logging.info('There are %d tiles of sizes %s', len(tiles), sizes)
+            assert not oq.disagg_by_src, 'disagg_by_src with tiles'
             for size in sizes:
                 assert size > oq.max_sites_disagg, (size, oq.max_sites_disagg)
         self.source_data = AccumDict(accum=[])

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -502,6 +502,7 @@ class ClassicalCalculator(base.HazardCalculator):
         else:
             tiles = [self.sitecol]
         if len(tiles) > 1:
+            mw /= 2  # produce more tasks
             sizes = [len(tile) for tile in tiles]
             logging.info('There are %d tiles of sizes %s', len(tiles), sizes)
             assert not oq.disagg_by_src, 'disagg_by_src with tiles'

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -109,6 +109,7 @@ class CalculatorTestCase(unittest.TestCase):
         if OQ_CALC_OUTPUTS:
             writers.write_csv = write_csv
         os.environ['OQ_DATABASE'] = 'local'
+        parallel.Starmap.maxtasksperchild = None
 
     def get_calc(self, testfile, job_ini, **kw):
         """
@@ -255,6 +256,7 @@ class CalculatorTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         parallel.Starmap.shutdown()
+        parallel.Starmap.maxtasksperchild = 1
         builtins.open = orig_open
         export.sanity_check = False
         if OQ_CALC_OUTPUTS:


### PR DESCRIPTION
This essentially solves the leak in classical calculations discussed in https://github.com/gem/oq-engine/issues/8177, at least as much as feasible. Also, introduced automatic tiling for calculations exceeding 1 GB per ProbabilityMap.