### PR TITLE
Fixed OQ_REDUCE

### DIFF
--- a/openquake/commonlib/logictree.py
+++ b/openquake/commonlib/logictree.py
@@ -142,7 +142,7 @@ def collect_info(smltpath, branchID=None):
     except Exception:
         raise InvalidFile('%s is not a valid source_model_logic_tree_file'
                           % smltpath)
-    paths = set()
+    smpaths = set()
     h5paths = set()
     applytosources = collections.defaultdict(list)  # branchID -> source IDs
     for blevel in blevels:
@@ -156,12 +156,14 @@ def collect_info(smltpath, branchID=None):
                         continue
                     with context(smltpath, br):
                         fnames = unique(br.uncertaintyModel.text.split())
-                        paths.update(abs_paths(smltpath, fnames))
+                        smpaths.update(abs_paths(smltpath, fnames))
                         for fname in fnames:
                             hdf5file = os.path.splitext(fname)[0] + '.hdf5'
                             if os.path.exists(hdf5file):
                                 h5paths.add(os.path.abspath(hdf5file))
-    return Info(sorted(paths), sorted(h5paths), applytosources)
+                    if os.environ.get('OQ_REDUCE'):  # only take first branch
+                        break
+    return Info(sorted(smpaths), sorted(h5paths), applytosources)
 
 
 def read_source_groups(fname):
@@ -451,6 +453,9 @@ class SourceModelLogicTree(object):
         bs_id = branchset_node['branchSetID']
         weight_sum = 0
         branches = branchset_node.nodes
+        if os.environ.get('OQ_REDUCE'):  # only take first branch
+            branches = [branches[0]]
+            branches[0].uncertaintyWeight.text = 1.
         values = []
         bsno = len(self.branchsets)
         for brno, branchnode in enumerate(branches):

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -288,7 +288,6 @@ def get_oqparam(job_ini, pkg=None, kw={}, validate=True):
         # reduce the sites by a factor of `re`
         # reduce the ses by a factor of `re`
         os.environ['OQ_SAMPLE_SITES'] = re
-        job_ini['number_of_logic_tree_samples'] = '1'
         ses = job_ini.get('ses_per_logic_tree_path')
         if ses:
             ses = str(int(numpy.ceil(int(ses) * float(re))))

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -392,9 +392,10 @@ class ContextMaker(object):
                 reqset.update(getattr(gsim, 'REQUIRES_' + req))
                 if self.af and req == 'SITES_PARAMETERS':
                     reqset.add('ampcode')
-                if (is_modifiable(gsim) and req == 'SITES_PARAMETERS' and
-                        'apply_swiss_amplification' in gsim.params):
-                    reqset.add('amplfactor')
+                if is_modifiable(gsim) and req == 'SITES_PARAMETERS':
+                    reqset.update(gsim.gmpe.REQUIRES_SITES_PARAMETERS)
+                    if 'apply_swiss_amplification' in gsim.params:
+                        reqset.add('amplfactor')
             setattr(self, 'REQUIRES_' + req, reqset)
         try:
             self.min_iml = param['min_iml']

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -387,13 +387,13 @@ class ContextMaker(object):
         self.split_sources = param.get('split_sources')
         self.effect = param.get('effect')
         for req in self.REQUIRES:
-            # make the vs30 always required to make ModifiableGMPE happy
-            reqset = {'vs30'} if req == 'SITES_PARAMETERS' else set()
+            reqset = set()
             for gsim in gsims:
                 reqset.update(getattr(gsim, 'REQUIRES_' + req))
                 if self.af and req == 'SITES_PARAMETERS':
                     reqset.add('ampcode')
                 if is_modifiable(gsim) and req == 'SITES_PARAMETERS':
+                    reqset.add('vs30')  # required by the ModifiableGMPE
                     reqset.update(gsim.gmpe.REQUIRES_SITES_PARAMETERS)
                     if 'apply_swiss_amplification' in gsim.params:
                         reqset.add('amplfactor')

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -387,7 +387,8 @@ class ContextMaker(object):
         self.split_sources = param.get('split_sources')
         self.effect = param.get('effect')
         for req in self.REQUIRES:
-            reqset = set()
+            # make the vs30 always required to make ModifiableGMPE happy
+            reqset = {'vs30'} if req == 'SITES_PARAMETERS' else set()
             for gsim in gsims:
                 reqset.update(getattr(gsim, 'REQUIRES_' + req))
                 if self.af and req == 'SITES_PARAMETERS':

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -406,6 +406,9 @@ class GsimLogicTree(object):
                     branches.append(bt)
                     self.shortener[branch_id] = keyno(
                         branch_id, bsno, brno, self.filename)
+                if os.environ.get('OQ_REDUCE'):  # take the first branch only
+                    bt.weight.dic['weight'] = 1.
+                    break
             tot = sum(weights)
             assert tot.is_one(), '%s in branch %s' % (tot, branch_id)
             if duplicated(branch_ids):


### PR DESCRIPTION
When debugging, it is useful to reduce the logic trees to the first branch only. Before, we were reading all the source models, even the ones of the discarded branches, which is slow, particularly for the AUS model. I have also fixed a bug that made it impossible to use OQ_REDUCE with the ModifiableGMPE used in the new AUS model.