### PR TITLE
 Reduced memory consumption when using the ps_grid_spacing approximation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Added `spawn` distribution
+  * Reduced the memory consumption when using the ps_grid_spacing approximation
+  * Added `spawn` distribution mechanism for testing purposes
 
   [Marco Pagani]
   * Added the possibility to define the edges of disaggregation bins

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -495,7 +495,7 @@ class ClassicalCalculator(base.HazardCalculator):
         num_gs = [len(cm.gsims) for cm in self.haz.cmakers]
         L = oq.imtls.size
         max_gb = max(num_gs) * L * self.N * 8 / 1024**3
-        if max_gb > 0.5:  # split in tiles
+        if max_gb > 1:  # split in tiles
             max_sites = min(numpy.ceil(self.N / max_gb), oq.max_sites_per_tile)
             tiles = self.sitecol.split_max(max_sites)
         elif oq.max_sites_per_tile < self.N:


### PR DESCRIPTION
Nearly by half in this example for CHN (reduced):
```
# before
| calc_48849, maxmem=255.1 GB | time_sec | memory_mb | counts  |
|-----------------------------+----------+-----------+---------|
| total classical             | 67_267   | 1_409     | 252     |
| planar contexts             | 42_655   | 0.0       | 9_782   |
| computing mean_std          | 10_062   | 0.0       | 351_284 |
| collapsing contexts         | 5_911    | 523.9     | 3_695   |
| composing pnes              | 4_398    | 0.0       | 700_743 |
| get_poes                    | 2_128    | 0.0       | 700_743 |
| ClassicalCalculator.run     | 984.9    | 1_035     | 1       |
# after
| calc_48850, maxmem=143.4 GB | time_sec | memory_mb | counts  |
|-----------------------------+----------+-----------+---------|
| total classical             | 64_981   | 1_440     | 252     |
| nonplanar contexts          | 40_726   | 0.0       | 590_132 |
| computing mean_std          | 9_897    | 0.0       | 352_714 |
| collapsing contexts         | 5_724    | 107.3     | 7_150   |
| composing pnes              | 4_402    | 0.0       | 702_420 |
| get_poes                    | 2_118    | 0.0       | 702_420 |
| ClassicalCalculator.run     | 961.2    | 1_045     | 1       |
```
This should finally solve the memory problem for AUS (see https://github.com/gem/oq-engine/issues/8177).