### PR TITLE
Sending one multiFaultSource per task

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
   * Changed the distribution of multiFaultSources to send one fragment per task
+  * Mitigate the issue of ultra-long planar ruptures affecting many models
   * Forced the usage of `collect_rlzs` for large exposures when computing
     avg_losses with many realizations
   * Bug fix: min_mag and max_mag were not honored when using a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the distribution of multiFaultSources to send one fragment per task
   * Forced the usage of `collect_rlzs` for large exposures when computing
     avg_losses with many realizations
   * Bug fix: min_mag and max_mag were not honored when using a

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -548,17 +548,18 @@ class ClassicalCalculator(base.HazardCalculator):
                 acc[cm.grp_id] = ProbabilityMap(
                     tile.sids, oq.imtls.size, len(cm.gsims)).fill(1)
                 # send the multiFaultSources first
-                multifaults = [src for src in sg if src.code == b'F']
-                for src in multifaults:
-                    smap.submit(([src], tile, cm))
+                for src in sg:
+                    if src.code == b'F':
+                        self.n_outs[cm.grp_id] += 1
+                        smap.submit(([src], tile, cm))
                 srcs = [src for src in sg if src.code != b'F']
                 blks = (groupby(srcs, basename).values() if oq.disagg_by_src
                         else block_splitter(srcs, mw, get_weight, sort=True))
                 for block in blks:
                     logging.debug('Sending %d source(s) with weight %d',
                                   len(block), sg.weight)
-                    smap.submit((block, tile, cm))
                     self.n_outs[cm.grp_id] += 1
+                    smap.submit((block, tile, cm))
         smap.reduce(self.agg_dicts, acc)
 
     def store_info(self):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1118,7 +1118,6 @@ class ContextMaker(object):
         """
         if hasattr(srcfilter, 'array'):  # a SiteCollection was passed
             srcfilter = SourceFilter(srcfilter, self.maximum_distance)
-        N = len(srcfilter.sitecol)
         G = len(self.gsims)
         for src in sources:
             if src.nsites == 0:  # was discarded by the prefiltering
@@ -1129,9 +1128,7 @@ class ContextMaker(object):
                     src.esites = 0  # overridden inside estimate_weight
                     src.weight = .1 + self.estimate_weight(
                         src, srcfilter, multiplier) * G
-                    if src.code == b'F' and N <= self.max_sites_disagg:
-                        src.weight *= 20  # test ucerf
-                    elif src.code == b'S':
+                    if src.code == b'S':
                         src.weight += .9
                     elif src.code == b'C':
                         src.weight += 9.9


### PR DESCRIPTION
This is the most aggressive approach towards the reduction of the slow tasks. Needed for the CHN model. Here are some figures for the reduced version:
```
| calc_48868, maxmem=106.9 GB | time_sec | memory_mb | counts    |
|-----------------------------+----------+-----------+-----------|
| total classical             | 156_910  | 256.6     | 682       |
| nonplanar contexts          | 115_672  | 0.0       | 66_040    |
| planar contexts             | 13_193   | 0.0       | 578_587   |
| get_poes                    | 10_081   | 0.0       | 4_339_556 |
| composing pnes              | 6_436    | 0.0       | 4_339_556 |
| computing mean_std          | 5_528    | 0.0       | 168_763   |
| collapsing contexts         | 3_121    | 126.3     | 4_046     |
| ClassicalCalculator.run     | 1_816    | 1_172     | 1         |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 682    | 230.1   | 75%    | 7.07705 | 1_325   | 5.76099 |
```