### PR TITLE
Fixed the exporter of `avg_losses-stats`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the exporter of `avg_losses-stats` when using `collect_rlzs=true`
   * Changed the distribution of multiFaultSources to send one fragment per task
   * Mitigate the issue of ultra-long planar ruptures affecting many models
   * Forced the usage of `collect_rlzs` for large exposures when computing

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -177,6 +177,9 @@ def _get_data(dstore, dskey, loss_types, stats):
             rlzs_or_stats = list(stats)
             statfuncs = [stats[ros] for ros in stats]
             value = avglosses(dstore, loss_types, 'stats')  # shape (A, S, L)
+        elif dstore['oqparam'].collect_rlzs:
+            rlzs_or_stats = list(stats)
+            value = avglosses(dstore, loss_types, 'rlzs')
         else:  # compute on the fly
             rlzs_or_stats, statfuncs = zip(*stats.items())
             value = compute_stats2(

--- a/openquake/calculators/tests/event_risk_test.py
+++ b/openquake/calculators/tests/event_risk_test.py
@@ -86,6 +86,11 @@ class GmfEbRiskTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/' + strip_calc_id(fname), fname,
                               delta=1E-5)
 
+        # checking avg_losses-stats with collect_rlzs
+        [fname] = export(('avg_losses-stats', 'csv'), self.calc.datastore)
+        self.assertEqualFiles('expected/' + strip_calc_id(fname), fname,
+                              delta=1E-5)
+
         # checking aggrisk
         for fname in export(('aggrisk', 'csv'), self.calc.datastore):
             self.assertEqualFiles('expected/' + strip_calc_id(fname), fname,

--- a/openquake/commonlib/util.py
+++ b/openquake/commonlib/util.py
@@ -182,6 +182,8 @@ def get_assets(dstore):
     """
     assetcol = dstore['assetcol']
     tagnames = sorted(tn for tn in assetcol.tagnames if tn != 'id')
+    if 'site_id' in tagnames:  # special case, starts from 1 and not from 0
+        assetcol.array['site_id'] += 1
     tag = {t: getattr(assetcol.tagcol, t) for t in tagnames}
     dtlist = [('id', '<S100')]
     for tagname in tagnames:

--- a/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/aggcurves-.csv
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/aggcurves-.csv
@@ -1,4 +1,4 @@
-#,,,,"generated_by='OpenQuake engine 3.14.0-git64bb9b4d84', start_date='2022-03-25T09:26:16', checksum=1831259238, risk_investigation_time=50.0, num_events=3, effective_time=4.0, limit_states=''"
-return_period,loss_type,rlz_id,loss_value,loss_ratio
-1,structural,0,6.10171E+02,1.52543E-02
-2,structural,0,9.31775E+02,2.32944E-02
+#,,,"generated_by='OpenQuake engine 3.16.0-git480018e916', start_date='2022-11-09T03:05:43', checksum=2174348292, risk_investigation_time=50.0, num_events=3, effective_time=10.0, limit_states=''"
+return_period,loss_type,loss_value,loss_ratio
+5,structural,6.10171E+02,1.52543E-02
+10,structural,9.31775E+02,2.32944E-02

--- a/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/aggcurves-site_id.csv
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/aggcurves-site_id.csv
@@ -1,6 +1,6 @@
-#,,,,,"generated_by='OpenQuake engine 3.14.0-git64bb9b4d84', start_date='2022-03-25T09:23:54', checksum=1831259238, risk_investigation_time=50.0, num_events=3, effective_time=4.0, limit_states=''"
-site_id,return_period,loss_type,rlz_id,loss_value,loss_ratio
-0,1,structural,0,4.52851E+02,1.50950E-02
-0,2,structural,0,7.28594E+02,2.42865E-02
-1,1,structural,0,1.57320E+02,1.57320E-02
-1,2,structural,0,2.03181E+02,2.03181E-02
+#,,,,"generated_by='OpenQuake engine 3.16.0-git480018e916', start_date='2022-11-09T03:05:43', checksum=2174348292, risk_investigation_time=50.0, num_events=3, effective_time=10.0, limit_states=''"
+site_id,return_period,loss_type,loss_value,loss_ratio
+0,5,structural,4.52851E+02,1.50950E-02
+0,10,structural,7.28594E+02,2.42865E-02
+1,5,structural,1.57320E+02,1.57320E-02
+1,10,structural,2.03181E+02,2.03181E-02

--- a/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/aggrisk-.csv
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/aggrisk-.csv
@@ -1,3 +1,3 @@
-#,,"generated_by='OpenQuake engine 3.15.0-gite0efa39f20', start_date='2022-06-03T08:25:36', checksum=1831259238, investigation_time=1.0, risk_investigation_time=50.0"
+#,,"generated_by='OpenQuake engine 3.16.0-git480018e916', start_date='2022-11-09T03:05:43', checksum=2174348292, investigation_time=1.0, risk_investigation_time=50.0"
 loss_type,loss_value,loss_ratio
-structural,5.25042E+04,1.31261E+00
+structural,1.05008E+04,2.62521E-01

--- a/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/aggrisk-site_id.csv
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/aggrisk-site_id.csv
@@ -1,4 +1,4 @@
-#,,,"generated_by='OpenQuake engine 3.15.0-gite0efa39f20', start_date='2022-06-03T08:25:36', checksum=1831259238, investigation_time=1.0, risk_investigation_time=50.0"
+#,,,"generated_by='OpenQuake engine 3.16.0-git480018e916', start_date='2022-11-09T03:05:43', checksum=2174348292, investigation_time=1.0, risk_investigation_time=50.0"
 loss_type,site_id,loss_value,loss_ratio
-structural,0,3.98211E+04,1.32737E+00
-structural,1,1.26832E+04,1.26832E+00
+structural,0,7.96421E+03,2.65474E-01
+structural,1,2.53664E+03,2.53664E-01

--- a/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/avg_losses-mean.csv
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_4/expected/avg_losses-mean.csv
@@ -1,0 +1,5 @@
+#,,,,,,,"generated_by='OpenQuake engine 3.16.0-git480018e916', start_date='2022-11-09T03:15:06', checksum=2174348292, investigation_time=1.0, risk_investigation_time=50.0"
+asset_id,cresta,site_id,state,taxonomy,lon,lat,structural
+a2,0.11,0,01,tax1,-122.00000,38.10000,5.16733E+03
+a3,0.11,0,01,tax1,-122.00000,38.10000,2.79688E+03
+a1,0.11,1,01,tax1,-122.00000,38.11300,2.53664E+03

--- a/openquake/qa_tests_data/gmf_ebrisk/case_4/job_haz.ini
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_4/job_haz.ini
@@ -30,7 +30,7 @@ random_seed = 24
 truncation_level = 3
 maximum_distance = 200.0
 investigation_time = 1
-number_of_logic_tree_samples = 0
+number_of_logic_tree_samples = 5
 ses_per_logic_tree_path = 2
 
 [hazard_outputs]

--- a/openquake/qa_tests_data/gmf_ebrisk/case_4/job_risk.ini
+++ b/openquake/qa_tests_data/gmf_ebrisk/case_4/job_risk.ini
@@ -1,6 +1,8 @@
 [general]
 description = event_based_risk with two source models
 calculation_mode = event_based_risk
+collect_rlzs = true
+number_of_logic_tree_samples = 5
 
 [boundaries]
 region = -122.6 38.3, -121.5 38.3, -121.5 37.9, -122.6 37.9
@@ -10,7 +12,7 @@ aggregate_by = site_id
 structural_vulnerability_file = structural_vulnerability_model.xml
 risk_investigation_time = 50
 asset_correlation = 0
-avg_losses = false
+avg_losses = true
 
 [export]
 export_dir = /tmp


### PR DESCRIPTION
When using `collect_rlzs=true` was giving an error
```python
Traceback (most recent call last):
  File "/usr/bin/oq", line 33, in <module>
    sys.exit(load_entry_point('openquake.engine', 'console_scripts', 'oq')())
  File "/opt/openquake/oq-engine/openquake/commands/__main__.py", line 53, in oq
    sap.run(commands, prog='oq')
  File "/opt/openquake/oq-engine/openquake/baselib/sap.py", line 225, in run
    return _run(parser(funcdict, **parserkw), argv)
  File "/opt/openquake/oq-engine/openquake/baselib/sap.py", line 216, in _run
    return func(**dic)
  File "/opt/openquake/oq-engine/openquake/commands/export.py", line 38, in main
    fnames = export_((datastore_key, fmt), dstore)
  File "/opt/openquake/oq-engine/openquake/baselib/general.py", line 565, in __call__
    return self[key](obj, *args, **kw)
  File "/opt/openquake/oq-engine/openquake/calculators/export/risk.py", line 201, in export_avg_losses
    name, value, rlzs_or_stats = _get_data(
  File "/opt/openquake/oq-engine/openquake/calculators/export/risk.py", line 182, in _get_data
    value = compute_stats2(
  File "/opt/openquake/oq-engine/openquake/hazardlib/stats.py", line 331, in compute_stats2
    raise ValueError('Got %d weights but %d values!' %
ValueError: Got 1000 weights but 1 values!
```