### PR TITLE
Unskipped the breaking reinsurance_test

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -914,6 +914,7 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, cost_types=()):
     :param cost_types: the expected cost types
     :returns: (site collection, asset collection, discarded)
     """
+    global exposure
     asset_hazard_distance = max(oqparam.asset_hazard_distance.values())
     exposure = get_exposure(oqparam)
     if haz_sitecol is None:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -914,11 +914,8 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, cost_types=()):
     :param cost_types: the expected cost types
     :returns: (site collection, asset collection, discarded)
     """
-    global exposure
     asset_hazard_distance = max(oqparam.asset_hazard_distance.values())
-    if exposure is None:
-        # haz_sitecol not extracted from the exposure
-        exposure = get_exposure(oqparam)
+    exposure = get_exposure(oqparam)
     if haz_sitecol is None:
         haz_sitecol = get_site_collection(oqparam)
     if oqparam.region_grid_spacing:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -916,7 +916,9 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, cost_types=()):
     """
     global exposure
     asset_hazard_distance = max(oqparam.asset_hazard_distance.values())
-    exposure = get_exposure(oqparam)
+    if exposure is None:
+        # haz_sitecol not extracted from the exposure
+        exposure = get_exposure(oqparam)
     if haz_sitecol is None:
         haz_sitecol = get_site_collection(oqparam)
     if oqparam.region_grid_spacing:

--- a/openquake/commonlib/tests/reinsurance_test.py
+++ b/openquake/commonlib/tests/reinsurance_test.py
@@ -773,6 +773,7 @@ class WrongInputTestCase(unittest.TestCase):
             xml.write(REINSURANCE)
         with open(cls.policyfname, 'w') as csv:
             csv.write(POLICY)
+        readinput.exposure = None  # for independence from other tests
 
     # Checks in the policy file
 
@@ -972,8 +973,6 @@ rur_Ant_1,10000,100,.1,.2''')
                       str(ctx.exception))
 
     def test_correct_aggregate_by_policy_semicolon_taxonomy(self):
-        if os.environ.get('GITHUB_ACTION'):
-            raise unittest.SkipTest('Not working on GitHub')
         with open(self.jobfname, 'w') as job:
             job.write(JOB % dict(aggregate_by='policy; taxonomy'))
         oq = readinput.get_oqparam(self.jobfname)


### PR DESCRIPTION
It was due to the evil global `readinput.exposure` so that the exposure from the previous test was used,