### PR TITLE
Fixed zworkers

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -1053,26 +1053,13 @@ def split_task(elements, func, args, duration, outs_per_task, monitor):
 OQDIST = oq_distribute()
 
 
-def ssh_args(zworkers):
-    remote_python = zworkers.remote_python or sys.executable
-    remote_user = zworkers.remote_user or getpass.getuser()
-    if zworkers.host_cores.strip():
-        for hostcores in config.zworkers.host_cores.split(','):
-            host, cores = hostcores.split()
-            if host == '127.0.0.1':  # localhost
-                yield host, cores, [sys.executable]
-            else:
-                yield host, cores, [
-                    'ssh', '-f', '-T', remote_user + '@' + host, remote_python]
-
-
 def workers_start(zworkers):
     """
     Start the remote workers with ssh
     """
     if OQDIST in 'no processpool':
         return
-    for host, cores, args in ssh_args(zworkers):
+    for host, cores, args in workerpool.ssh_args(zworkers):
         if OQDIST == 'dask':
             sched = config.distribution.dask_scheduler
             args += ['-m', 'distributed.cli.dask_worker', sched,

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -52,7 +52,7 @@ def ssh_args(zworkers):
     remote_python = zworkers.remote_python or sys.executable
     remote_user = zworkers.remote_user or getpass.getuser()
     if zworkers.host_cores.strip():
-        for hostcores in config.zworkers.host_cores.split(','):
+        for hostcores in zworkers.host_cores.split(','):
             host, cores = hostcores.split()
             if host == '127.0.0.1':  # localhost
                 yield host, cores, [sys.executable]

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -29,7 +29,6 @@ from openquake.baselib import (
 from openquake.baselib.general import socket_ready, detach_process
 from openquake.hazardlib import valid
 from openquake.commonlib import logs
-from openquake.engine import __version__
 from openquake.server.db import actions
 from openquake.commonlib.dbapi import db
 from openquake.server import __file__ as server_path
@@ -45,10 +44,6 @@ class DbServer(object):
         self.backend = 'inproc://dbworkers'
         self.num_workers = num_workers
         self.pid = os.getpid()
-        if p.OQDIST == 'zmq':
-            self.zmaster = w.WorkerMaster(config.zworkers)
-        else:
-            self.zmaster = None
 
     def dworker(self, sock):
         # a database worker responding to commands
@@ -59,9 +54,9 @@ class DbServer(object):
                     sock.send(self.pid)
                     continue
                 elif cmd.startswith('workers_'):
-                    # engine.run_jobs calls logs.dbcmd(cmd)
+                    # call parallel.workers_start et similar routines
+                    logging.info('Calling %s', cmd_)
                     msg = getattr(p, cmd)(*args)
-                    logging.info(msg)
                     sock.send(msg)
                     continue
                 try:
@@ -90,9 +85,6 @@ class DbServer(object):
             threading.Thread(target=w._streamer, daemon=True).start()
             logging.warning('Task streamer started on port %d',
                             int(config.zworkers.ctrl_port) + 1)
-            if 'git' not in __version__:
-                # in production installations start the zworkers
-                self.zmaster.start()
         # start frontend->backend proxy for the database workers
         try:
             z.zmq.proxy(z.bind(self.frontend, z.zmq.ROUTER),
@@ -107,10 +99,9 @@ class DbServer(object):
             self.stop()
 
     def stop(self):
-        """Stop the DbServer and the zworkers if any"""
-        if p.OQDIST == 'zmq':
-            self.zmaster.stop()
-            z.context.term()
+        """
+        Stop the DbServer
+        """
         self.db.close()
 
 

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -55,7 +55,6 @@ class DbServer(object):
                     continue
                 elif cmd.startswith('workers_'):
                     # call parallel.workers_start et similar routines
-                    logging.info('Calling %s', cmd_)
                     msg = getattr(p, cmd)(*args)
                     sock.send(msg)
                     continue


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/8218.
The DbServer was incorrectly reading the zworkers dictionary from config.