### PR TITLE
Moved the zstreamer in `oq workers start`

### DIFF
--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -79,11 +79,6 @@ class DbServer(object):
             dworkers.append(sock)
         logging.warning('DB server started with %s on %s, pid %d',
                         sys.executable, self.frontend, self.pid)
-        if p.OQDIST == 'zmq':
-            # start task_in->task_server streamer thread
-            threading.Thread(target=w._streamer, daemon=True).start()
-            logging.warning('Task streamer started on port %d',
-                            int(config.zworkers.ctrl_port) + 1)
         # start frontend->backend proxy for the database workers
         try:
             z.zmq.proxy(z.bind(self.frontend, z.zmq.ROUTER),


### PR DESCRIPTION
So that it can receive the ctrl_port. Still not enough to have a second zmq cluster sharing the DbServer.