### PR TITLE
Sending the heavy tasks first

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -626,7 +626,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 srcs = [src for src in sg if src.code != b'F']
                 # NB: disagg_by_src is disabled in case of tiling
                 blks = (groupby(srcs, basename).values() if oq.disagg_by_src
-                        else block_splitter(srcs, maxw, get_weight))
+                        else block_splitter(srcs, maxw, get_weight, sort=True))
                 for block in blks:
                     logging.debug('Sending %d source(s) with weight %d',
                                   len(block), sg.weight)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -626,7 +626,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 srcs = [src for src in sg if src.code != b'F']
                 # NB: disagg_by_src is disabled in case of tiling
                 blks = (groupby(srcs, basename).values() if oq.disagg_by_src
-                        else block_splitter(srcs, maxw, get_weight, sort=True))
+                        else block_splitter(srcs, maxw, get_weight))
                 for block in blks:
                     logging.debug('Sending %d source(s) with weight %d',
                                   len(block), sg.weight)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -345,7 +345,7 @@ def decide_num_tasks(dstore, concurrent_tasks):
     """
     cmakers = read_cmakers(dstore)
     weights = [cm.weight for cm in cmakers]
-    maxw = sum(weights) / concurrent_tasks / 2
+    maxw = sum(weights) / concurrent_tasks
     dtlist = [('grp_id', U16), ('cmakers', U16), ('tiles', U16)]
     ntasks = []
     for cm in sorted(cmakers, key=lambda cm: weights[cm.grp_id], reverse=True):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -345,7 +345,7 @@ def decide_num_tasks(dstore, concurrent_tasks):
     """
     cmakers = read_cmakers(dstore)
     weights = [cm.weight for cm in cmakers]
-    maxw = sum(weights) / concurrent_tasks / 2.5
+    maxw = sum(weights) / concurrent_tasks / 2
     dtlist = [('grp_id', U16), ('cmakers', U16), ('tiles', U16)]
     ntasks = []
     for cm in sorted(cmakers, key=lambda cm: weights[cm.grp_id], reverse=True):
@@ -594,7 +594,7 @@ class ClassicalCalculator(base.HazardCalculator):
         for grp_id, num_cmakers, num_tiles in decide:
             cmaker = self.haz.cmakers[grp_id]
             grp = self.csm.src_groups[grp_id]
-            logging.info('Sending [%d] %s', num_cmakers * num_tiles, grp)
+            logging.info('Sending [%d*%d] %s', num_cmakers, num_tiles, grp)
             for tile in self.sitecol.split(num_tiles):
                 for cm in cmaker.split_by_gsim():
                     smap.submit((grp, tile, cm))

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -260,7 +260,7 @@ def view_eff_ruptures(token, dstore):
     info = dstore.read_df('source_info', 'source_id')
     df = info.groupby('code').sum()
     df['slow_factor'] = df.calc_time / df.weight
-    del df['grp_id'], df['trti']
+    del df['grp_id'], df['trti'], df['mutex_weight']
     return df
 
 


### PR DESCRIPTION
Some refinements to the task distribution for the classical calculator. Here are some figures for EUR with 10% sites and 10% sources on the spot machine.
```
# splitting the source groups before
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 718    | 38.4    | 33%    | 0.06196 | 55.3    | 1.44093 |
Received {'pnemap': '47.94 GB'} in 257 seconds from classical

# splitting the source groups after
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 719    | 38.1    | 27%    | 0.05819 | 55.1    | 1.44469 |
Received {'pnemap': '28.55 GB'} in 312 seconds from classical
```
It looks slower, but only because we submit the tasks all at once. The important thing is the better distribution.
```
# keeping the source groups before
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 2_389  | 20.4    | 61%    | 0.05552 | 36.2    | 1.77475 |
Received {'pnemap': '7.86 GB'} in 295 seconds from classical

# keeping the source groups after
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 1_484  | 24.2    | 82%    | 0.06251 | 56.4    | 2.33053 |
Received {'pnemap': '7.86 GB'} in 295 seconds from classical
````
We produce now less tasks but we are not losing in performance, actually improving.