### PR TITLE
Made preclassical faster in presence of big sources

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -179,9 +179,8 @@ class PreClassicalCalculator(base.HazardCalculator):
                     pointsources.append(src)
                 elif hasattr(src, 'nodal_plane_distribution'):
                     pointlike.append(src)
-                elif src.code in b'FN':  # split multifault, nonparametric
-                    others.extend(split_source(src)
-                                  if self.oqparam.split_sources else [src])
+                elif src.code in b'CFN':  # send the heavy sources
+                    smap.submit(([src], sites, cmakers[grp_id]))
                 else:
                     others.append(src)
             if pointsources or pointlike:


### PR DESCRIPTION
For instance for SAM the complex fault sources were causing a terrible slow task. This is now solved and the slowest task is 3.5x faster:
```
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| preclassical       | 321    | 2.13418 | 1345%  | 0.05925 | 511.6   | 239.7   |
| preclassical       | 41     | 17.9    | 189%   | 0.11890 | 145.1   | 8.10057 |
```
The total preclassical time goes down from 10 minutes to 4 minutes on my workstation.