### PR TITLE
Fixed the weight of non-point sources

### DIFF
--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -153,6 +153,11 @@ class ClassicalTestCase(CalculatorTestCase):
              'hazard_curve-smltp_b2-gsimltp_b1.csv'],
             case_7.__file__)
 
+        # check the weights of the sources, a simple fault and a complex fault
+        info = self.calc.datastore.read_df('source_info', 'source_id')
+        self.assertEqual(info.loc[b'1'].weight, 184)
+        self.assertEqual(info.loc[b'2'].weight, 118)
+
         # checking the individual hazard maps are nonzero
         iml = self.calc.datastore.sel(
             'hmaps-rlzs', imt="PGA", site_id=0).squeeze()

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1168,8 +1168,8 @@ class ContextMaker(object):
             ctxs = list(self.get_ctx_iter(src, sites, step=10))  # reduced
             if not ctxs:
                 return src.num_ruptures if N == 1 else 0, 0
-            esites = (len(ctxs[0]) * src.num_ruptures /
-                      self.num_rups * multiplier)
+            esites = (sum(len(ctx) for ctx in ctxs) * src.num_ruptures /
+                      self.num_rups * multiplier)  # num_rups from get_ctx_iter
         weight = esites / N  # the weight is the effective number of ruptures
         return weight, int(esites)
 


### PR DESCRIPTION
It was a regression, a change to `get_ctx_iter` broke the weighing algorithm causing slow tasks. For instance in the ALS model the estimated SimpleFaultSource weight was 3 times smaller than correct. Here are the figures on hendrix:
```
# before
| calc_49170, maxmem=51.8 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 54_512   | 270.6     | 135       |
| get_poes                   | 30_350   | 0.0       | 4_277_960 |
| composing pnes             | 10_275   | 0.0       | 4_277_960 |
| computing mean_std         | 6_909    | 0.0       | 203_860   |
| planar contexts            | 2_754    | 0.0       | 109_342   |
| nonplanar contexts         | 2_572    | 0.0       | 20_322    |
| ClassicalCalculator.run    | 1_829    | 906.9     | 1         |
| iter_ruptures              | 728.2    | 10.8      | 3_719     |
| total preclassical         | 401.6    | 129.9     | 15        |
| PreClassicalCalculator.run | 198.1    | 697.4     | 1         |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 135    | 403.8   | 42%    | 73.6    | 1_616   | 4.00316 |

# after
| calc_49182, maxmem=50.9 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 56_243   | 264.2     | 138       |
| get_poes                   | 31_130   | 0.0       | 4_277_976 |
| composing pnes             | 10_601   | 0.0       | 4_277_976 |
| computing mean_std         | 7_136    | 0.0       | 203_865   |
| nonplanar contexts         | 2_853    | 0.0       | 20_322    |
| planar contexts            | 2_777    | 0.0       | 109_342   |
| ClassicalCalculator.run    | 1_328    | 859.8     | 1         |
| iter_ruptures              | 744.8    | 10.0      | 3_719     |
| total preclassical         | 398.8    | 128.4     | 15        |
| PreClassicalCalculator.run | 197.0    | 699.5     | 1         |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 138    | 407.6   | 16%    | 68.2    | 573.7   | 1.40769 |
```
The total runtime went down from 30m to 22m and the slowest task from 27m to 10m.