### PR TITLE
Added `--venv` option to the universal installer

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
   [Michele Simionato]
-  * Bug fix: the `avg_losses-rlzs` output in classical risk was stored incorrectly
+  * Added `--venv` option to the universal installer to install in custom places
+  * Bug fix: the `avg_losses-rlzs` output in classical risk was stored
+    incorrectly
   * Speed up preclassical calculations in presence of complex fault sources and
     similar; for instance there is a 3x speedup for the SAM model
 
@@ -8,7 +10,8 @@
     based on Seyhan & Stewart (2014) amplification factors
   * Added classes SomervilleEtAl2009NonCratonic_SS14 and
     SomervilleEtAl2009YilgarnCraton_SS14 to Somerville et al (2009) GMM to
-    incorporate Vs30 scaling based on Seyhan & Stewart (2014) amplification factors
+    incorporate Vs30 scaling based on Seyhan & Stewart (2014) amplification
+    factors
   * Added Allen (2022) GMM for Banda Sea earthquakes observed in the North
     Australian Craton
 

--- a/install.py
+++ b/install.py
@@ -242,10 +242,12 @@ def install_standalone(venv):
             print('%s: could not install %s' % (exc, app))
 
 
-def before_checks(inst, port, remove, usage):
+def before_checks(inst, venv, port, remove, usage):
     """
     Checks to perform before the installation
     """
+    if venv:
+        inst.VENV = os.path.abspath(venv)
     if port:
         inst.DBPORT = int(port)
 
@@ -511,6 +513,7 @@ if __name__ == '__main__':
                         choices=['server', 'user', 'devel', 'devel_server'],
                         nargs='?',
                         help='the kind of installation you want')
+    parser.add_argument("--venv", help="venv directory")
     parser.add_argument("--remove",  action="store_true",
                         help="disinstall the engine")
     parser.add_argument("--version",
@@ -520,7 +523,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if args.inst:
         inst = globals()[args.inst]
-        before_checks(inst, args.dbport, args.remove, parser.format_usage())
+        before_checks(inst, args.venv, args.dbport, args.remove,
+                      parser.format_usage())
         if args.remove:
             remove(inst)
         else:


### PR DESCRIPTION
Then I can install old versions of the engine easily
```
$ /usr/bin/python3.8 install.py user --venv=~/oq38 --version=engine-3.8
```
