### PR TITLE
Reducing a bit the memory allocation in get_poes

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1123,7 +1123,7 @@ class ContextMaker(object):
                         if self.af:  # kernel amplification method
                             poes[:, :, g] = get_poes_site(ms, self, ctxt)
                         else:  # regular case
-                            poes[:, :, g] = gsim.get_poes(ms, self, ctxt)
+                            gsim.set_poes(ms, self, ctxt, poes[:, :, g])
                 yield poes, ctxt, slcsids
 
     def estimate_sites(self, src, sites):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -37,6 +37,7 @@ from openquake.hazardlib import valid, imt as imt_module
 from openquake.hazardlib.const import StdDev, OK_COMPONENTS
 from openquake.hazardlib.tom import (
     registry, get_pnes, FatedTOM, NegativeBinomialTOM)
+from openquake.hazardlib.stats import ndtr
 from openquake.hazardlib.site import site_param_dt
 from openquake.hazardlib.calc.filters import (
     SourceFilter, IntegrationDistance, magdepdist, get_distances, getdefault,
@@ -382,6 +383,7 @@ class ContextMaker(object):
         self.ses_seed = param.get('ses_seed', 42)
         self.ses_per_logic_tree_path = param.get('ses_per_logic_tree_path', 1)
         self.truncation_level = param.get('truncation_level', 99.)
+        self.phi_b = ndtr(self.truncation_level)
         self.num_epsilon_bins = param.get('num_epsilon_bins', 1)
         self.disagg_bin_edges = param.get('disagg_bin_edges', {})
         self.ps_grid_spacing = param.get('ps_grid_spacing')

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -106,7 +106,7 @@ def _get_poes(mean_std, loglevels, truncation_level):
     return out.T
 
 
-OK_METHODS = ('compute', 'get_mean_and_stddevs', 'get_poes',
+OK_METHODS = ('compute', 'get_mean_and_stddevs', 'set_poes',
               'set_parameters', 'set_tables')
 
 
@@ -448,7 +448,7 @@ class GMPE(GroundShakingIntensityModel):
         """
         raise NotImplementedError
 
-    def get_poes(self, mean_std, cmaker, ctx):
+    def set_poes(self, mean_std, cmaker, ctx, arr):
         """
         Calculate and return probabilities of exceedance (PoEs) of one or more
         intensity measure levels (IMLs) of one intensity measure type (IMT)
@@ -461,8 +461,8 @@ class GMPE(GroundShakingIntensityModel):
             A ContextMaker instance, used only in nhsm_2014
         :param ctx:
             A recarray used only in  avg_poe_gmpe
-        :returns:
-            array of PoEs of shape (N, L)
+        :param arr:
+            An array of PoEs of shape (N, L) to be filled
         :raises ValueError:
             If truncation level is not ``None`` and neither non-negative
             float number, and if ``imts`` dictionary contain wrong or
@@ -470,9 +470,7 @@ class GMPE(GroundShakingIntensityModel):
         """
         loglevels = cmaker.loglevels.array
         truncation_level = cmaker.truncation_level
-        N = mean_std.shape[2]  # 2, M, N
         M, L1 = loglevels.shape
-        arr = numpy.zeros((N, M*L1))
         if truncation_level is not None and truncation_level < 0:
             raise ValueError('truncation level must be zero, positive number '
                              'or None')
@@ -500,4 +498,3 @@ class GMPE(GroundShakingIntensityModel):
                 # set by the engine when parsing the gsim logictree
                 # when 0 ignore the contribution: see _build_trts_branches
                 arr[:, mL1:mL1 + L1] = 0
-        return arr

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -92,14 +92,13 @@ def _set_poes(mean_std, loglevels, truncation_level, out):
     L1 = loglevels.size // len(loglevels)
     for m, levels in enumerate(loglevels):
         mL1 = m * L1
-        iml = numpy.zeros((L1, 1))  # trick to vectorize better
-        iml[:, 0] = levels  # numba is not happy with reshape
-        mea, sig = mean_std[:, m]  # shape N
-        if truncation_level == 0.:
-            out[mL1:mL1 + L1] = (iml <= mea)  # shape (L1, N)
-        else:
-            out[mL1:mL1 + L1] = _truncnorm_sf(  # shape (L1, N)
-                truncation_level, (iml - mea) / sig)
+        mean, std = mean_std[:, m]  # shape N
+        for n, mea in enumerate(mean):
+            if truncation_level == 0.:
+                out[mL1:mL1 + L1, n] = levels <= mea  # shape L1
+            else:
+                out[mL1:mL1 + L1, n] = _truncnorm_sf(  # shape L1
+                    truncation_level, (levels - mea) / std[n])
 
 
 def _get_poes(mean_std, loglevels, truncation_level):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -92,13 +92,13 @@ def _set_poes(mean_std, loglevels, truncation_level, out):
     L1 = loglevels.size // len(loglevels)
     for m, levels in enumerate(loglevels):
         mL1 = m * L1
-        mean, std = mean_std[:, m]  # shape N
-        for n, mea in enumerate(mean):
+        mea, std = mean_std[:, m]  # shape N
+        for lvl, iml in enumerate(levels):
             if truncation_level == 0.:
-                out[mL1:mL1 + L1, n] = levels <= mea  # shape L1
+                out[mL1 + lvl] = iml <= mea  # shape N
             else:
-                out[mL1:mL1 + L1, n] = _truncnorm_sf(  # shape L1
-                    truncation_level, (levels - mea) / std[n])
+                out[mL1 + lvl] = _truncnorm_sf(  # shape N
+                    truncation_level, (iml - mea) / std)
 
 
 def _get_poes(mean_std, loglevels, truncation_level):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -98,8 +98,8 @@ def _set_poes(mean_std, loglevels, phi_b, out):
             if phi_b == 0.5:
                 out[mL1 + lvl] = iml <= mea  # shape N
             else:
-                truncnorm_sf = (phi_b - ndtr((iml - mea) / std)) / z
-                out[mL1 + lvl] = truncnorm_sf.clip(0, 1)
+                norm_sf = (phi_b - ndtr((iml - mea) / std)) / z
+                out[mL1 + lvl] = norm_sf.clip(0, 1)
 
 
 def _get_poes(mean_std, loglevels, phi_b):

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -105,7 +105,7 @@ class AvgPoeGMPE(GMPE):
         """Do nothing: the work is done in get_poes"""
         sig[:] = 1E-10  # to stop the error for zero sigma
 
-    def get_poes(self, mean_std, cmaker, ctx):
+    def set_poes(self, mean_std, cmaker, ctx, arr):
         """
         :returns: an array of shape (N, L)
         """
@@ -117,4 +117,4 @@ class AvgPoeGMPE(GMPE):
         for poes, ctxt, allsids in cm.gen_poes(ctx):
             # poes has shape N, L, G
             avgs.append(poes @ self.weights)
-        return np.concatenate(avgs)
+        arr[:] = np.concatenate(avgs)


### PR DESCRIPTION
Allocating less arrays gives a minor speedup. This is an example for a multipoint source and 100,000+ sites on hendrix:
```
# master
| calc_49389, maxmem=50.8 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 5_063    | 59.5      | 169     |
| get_poes                   | 2_274    | 0.0       | 311_399 |
| computing mean_std         | 1_224    | 0.0       | 12_059  |
| composing pnes             | 833.5    | 0.0       | 311_399 |
| planar contexts            | 274.4    | 0.0       | 19_752  |
| ClassicalCalculator.run    | 185.1    | 156.3     | 1       |
cfactor = 37_367_109/16_440_712 = 2.3
# set_poes2
| calc_49390, maxmem=50.6 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 5_083    | 64.3      | 169     |
| get_poes                   | 2_338    | 0.0       | 155_678 |
| computing mean_std         | 1_043    | 0.0       | 6_072   |
| composing pnes             | 848.1    | 0.0       | 155_678 |
| planar contexts            | 292.8    | 0.0       | 19_752  |
| ClassicalCalculator.run    | 148.9    | 191.4     | 1       |
```