### PR TITLE
Simplified the function truncnorm_sf

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -993,7 +993,8 @@ class OqParam(valid.ParamSet):
                      'structural+contents',
                      'nonstructural+contents',
                      'structural+nonstructural+contents'), None)
-    truncation_level = valid.Param(valid.positivefloat, 99.)
+    truncation_level = valid.Param(
+        lambda s: valid.positivefloat(s) or 1E-9, 99.)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)
     vs30_tolerance = valid.Param(valid.positiveint, 0)
     width_of_mfd_bin = valid.Param(valid.positivefloat, None)

--- a/openquake/hazardlib/calc/cond_spectra.py
+++ b/openquake/hazardlib/calc/cond_spectra.py
@@ -17,7 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy
-from openquake.hazardlib.stats import _truncnorm_sf
+from openquake.hazardlib.stats import truncnorm_sf
 
 
 def outdict(M, N, P, start, stop):
@@ -32,7 +32,7 @@ def outdict(M, N, P, start, stop):
 
 
 def _cs_out(mean_stds, probs, rho, imti, imls, cs_poes,
-            trunclevel, invtime, c, _c=None):
+            phi_b, invtime, c, _c=None):
     M, N, O, P = c.shape
     U = len(probs) // N
 
@@ -58,7 +58,7 @@ def _cs_out(mean_stds, probs, rho, imti, imls, cs_poes,
             # probability of occurrence for the reference IMT. Both
             # `eps` and `poes` have shape U
             eps = (numpy.log(iml) - mu[imti]) / sig[imti]
-            poes = _truncnorm_sf(trunclevel, eps)
+            poes = truncnorm_sf(phi_b, eps)
 
             # Converting to rates and dividing by the rate of
             # exceedance of the reference IMT and level
@@ -139,7 +139,7 @@ def get_cs_out(cmaker, ctx, imti, imls, _c=None):
     # For every GMM
     for g in range(G):
         _cs_out(mean_stds[:, g], probs, rho, imti, imls, cmaker.poes,
-                cmaker.truncation_level, cmaker.investigation_time,
+                cmaker.phi_b, cmaker.investigation_time,
                 out[cmaker.start + g], _c if _c is not None else None)
     return out
 

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -230,7 +230,7 @@ class GmfComputer(object):
         return result, sig, eps
 
     def _compute(self, mean_stds, imt, gsim, intra_eps, inter_eps):
-        if self.cmaker.truncation_level == 0:
+        if self.cmaker.truncation_level <= 1E-9:
             # for truncation_level = 0 there is only mean, no stds
             if self.correlation_model:
                 raise ValueError('truncation_level=0 requires '

--- a/openquake/hazardlib/site_amplification.py
+++ b/openquake/hazardlib/site_amplification.py
@@ -21,7 +21,7 @@ from scipy.stats import norm
 import pandas as pd
 
 from openquake.baselib import hdf5
-from openquake.hazardlib.stats import norm_cdf, _truncnorm_sf
+from openquake.hazardlib.stats import norm_cdf, truncnorm_sf
 from openquake.hazardlib.site import ampcode_dt
 from openquake.hazardlib.imt import from_string
 from openquake.hazardlib.probability_map import ProbabilityCurve
@@ -413,7 +413,7 @@ def get_poes_site(mean_std, cmaker, ctx):
     # C - Number of contexts
     # L - Number of intensity measure levels
     loglevels = cmaker.loglevels
-    truncation_level = cmaker.truncation_level
+    phi_b = cmaker.phi_b
     mean, stddev = mean_std  # shape (C, M)
     C, L = mean.shape[1], loglevels.size
     assert len(numpy.unique(ctx.sids)) == 1  # 1 site
@@ -452,16 +452,12 @@ def get_poes_site(mean_std, cmaker, ctx):
 
             # Set the arguments of the truncated normal distribution
             # function
-            if truncation_level == 0:
-                out_l = iml_l <= mean[m]
-                out_u = iml_u <= mean[m]
-            else:
-                out_l = (iml_l - mean[m]) / stddev[m]
-                out_u = (iml_u - mean[m]) / stddev[m]
+            out_l = (iml_l - mean[m]) / stddev[m]
+            out_u = (iml_u - mean[m]) / stddev[m]
 
             # Probability of occurrence on rock
-            pocc_rock = (_truncnorm_sf(truncation_level, out_l) -
-                         _truncnorm_sf(truncation_level, out_u))  # shape C
+            pocc_rock = (truncnorm_sf(phi_b, out_l) -
+                         truncnorm_sf(phi_b, out_u))  # shape C
 
             # Skipping cases where the pocc on rock is negligible
             if numpy.all(pocc_rock < 1e-10):

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -41,17 +41,16 @@ def truncnorm_sf(phi_b, values):
     """
     Fast survival function for truncated normal distribution.
     Assumes zero mean, standard deviation equal to one and symmetric
-    truncation. It is faster than using scipy.stats.truncnorm.sf:
-    
-    truncnorm_sf(sig, x) == truncnorm(-sig, sig).sf(x)
+    truncation. It is faster than using scipy.stats.truncnorm.sf.
     
     :param phi_b:
-         ndtr(truncation_level)
+         ndtr(truncation_level); assume phi_b > .5
     :param values:
          Numpy array of values as input to a survival function for the given
          distribution.
     :returns:
          Numpy array of survival function results in a range between 0 and 1.
+         For phi_b close to .5 returns a step function 1 1 1 1 .5 0 0 0 0 0.
     """
     # notation from http://en.wikipedia.org/wiki/Truncated_normal_distribution.
     # given that mu = 0 and sigma = 1, we have alpha = a and beta = b.

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -37,36 +37,28 @@ except ImportError:
 
 @compile(["float64[:,:](float64, float64[:,:])",
           "float64[:](float64, float64[:])"])
-def _truncnorm_sf(truncation_level, values):
-    # Fast survival function for truncated normal distribution.
-    # Assumes zero mean, standard deviation equal to one and symmetric
-    # truncation. It is faster than using scipy.stats.truncnorm.sf:
-    #
-    # _truncnorm_sf(sig, x) == truncnorm(-sig, sig).sf(x)
-    #
-    # :param truncation_level:
-    #     Positive float number representing the truncation on both sides
-    #     around the mean, in units of sigma, or None, for non-truncation
-    # :param values:
-    #     Numpy array of values as input to a survival function for the given
-    #     distribution.
-    # :returns:
-    #     Numpy array of survival function results in a range between 0 and 1.
-    if truncation_level == 0.:
-        return values
-
+def truncnorm_sf(phi_b, values):
+    """
+    Fast survival function for truncated normal distribution.
+    Assumes zero mean, standard deviation equal to one and symmetric
+    truncation. It is faster than using scipy.stats.truncnorm.sf:
+    
+    truncnorm_sf(sig, x) == truncnorm(-sig, sig).sf(x)
+    
+    :param phi_b:
+         ndtr(truncation_level)
+    :param values:
+         Numpy array of values as input to a survival function for the given
+         distribution.
+    :returns:
+         Numpy array of survival function results in a range between 0 and 1.
+    """
     # notation from http://en.wikipedia.org/wiki/Truncated_normal_distribution.
     # given that mu = 0 and sigma = 1, we have alpha = a and beta = b.
-
     # "CDF" in comments refers to cumulative distribution function
     # of non-truncated distribution with that mu and sigma values.
-
     # assume symmetric truncation, that is ``a = - truncation_level``
     # and ``b = + truncation_level``.
-
-    # calculate CDF of b
-    phi_b = ndtr(truncation_level)
-
     # calculate Z as ``Z = CDF(b) - CDF(a)``, here we assume that
     # ``CDF(a) == CDF(- truncation_level) == 1 - CDF(b)``
     z = phi_b * 2. - 1.


### PR DESCRIPTION
Now the engine internally converts truncation_level=0 into truncation_level=1E-9 so that now special cases are needed.
This closes https://github.com/gem/oq-engine/issues/8179.