### PR TITLE
Faster collapse

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -192,7 +192,7 @@ class Monitor(object):
         self.inner_loop = inner_loop
         self.h5 = h5
         self.version = version
-        self.mem = 0
+        self._mem = 0
         self.duration = 0
         self._start_time = self._stop_time = time.time()
         self.children = []
@@ -200,6 +200,11 @@ class Monitor(object):
         self.address = None
         self.username = getpass.getuser()
         self.task_no = -1  # overridden in parallel
+
+    @property
+    def mem(self):
+        """Mean memory allocation"""
+        return self._mem / self.counts
 
     @property
     def dt(self):
@@ -247,7 +252,7 @@ class Monitor(object):
         self.exc = exc
         if self.measuremem:
             self.stop_mem = self.measure_mem()
-            self.mem += self.stop_mem - self.start_mem
+            self._mem += self.stop_mem - self.start_mem
         self._stop_time = time.time()
         self.duration += self._stop_time - self._start_time
         self.counts += 1
@@ -274,7 +279,7 @@ class Monitor(object):
         Reset duration, mem, counts
         """
         self.duration = 0
-        self.mem = 0
+        self._mem = 0
         self.counts = 0
 
     def flush(self, h5):
@@ -349,7 +354,7 @@ class Monitor(object):
         """
         while True:
             try:
-                self.mem = 0
+                self._mem = 0
                 with self:
                     obj = next(genobj)
             except StopIteration:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -189,9 +189,16 @@ class Collapser(object):
             self.cfactor[1] += len(ctx)
             return ctx, ctx.sids.reshape(-1, 1)
 
-        out, allsids = kollapse(ctx, self.kfields, kround,
-                                mfields=['occurrence_rate', 'probs_occur'],
-                                afield='sids')
+        out, allsids = [], []
+        kfields = [k for k in self.kfields if k != 'mag']
+        for mag in numpy.unique(ctx.mag):
+            ctxt = ctx[ctx.mag == mag]
+            o, a = kollapse(ctxt, kfields, kround,
+                            mfields=['mag', 'occurrence_rate', 'probs_occur'],
+                            afield='sids')
+            out.append(o)
+            allsids.extend(a)
+        out = numpy.concatenate(out).view(numpy.recarray)
         self.cfactor[0] += len(out)
         self.cfactor[1] += len(ctx)
         print(self.kfields, len(ctx), len(out), '(%.1f)' % (len(ctx)/len(out)))


### PR DESCRIPTION
Here is an example for a reduced AUS computation on the spot machine (21% speedup on collapsing):
```
# before
| calc_847, maxmem=212.4 GB  | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 92_191   | 756.8     | 292        |
| collapsing contexts        | 32_771   | 9_704     | 3_389      |
| get_poes                   | 21_183   | 0.0       | 22_005_788 |
| composing pnes             | 21_111   | 0.0       | 22_005_788 |
| planar contexts            | 8_934    | 0.0       | 284_154    |
| computing mean_std         | 5_733    | 0.0       | 219_594    |
| ClassicalCalculator.run    | 1_489    | 3_129     | 1          |

# after
| calc_846, maxmem=211.7 GB  | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 86_722   | 878.7     | 292        |
| collapsing contexts        | 26_973   | 10_932    | 3_389      |
| get_poes                   | 21_252   | 0.0       | 22_005_788 |
| composing pnes             | 21_248   | 0.0       | 22_005_788 |
| planar contexts            | 8_965    | 0.0       | 284_154    |
| computing mean_std         | 5_782    | 0.0       | 219_594    |
| ClassicalCalculator.run    | 1_370    | 3_136     | 1          |
```