### PR TITLE
Remove split by gsim except when collapsing

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -198,9 +198,12 @@ def classical(srcs, sitecol, cmaker, monitor):
         with srcs:
             if sitecol is None:
                 sitecol = srcs['sitecol']
-            f = srcs.parent.hdf5 if srcs.parent else srcs.hdf5
-            arr = h5py.File.__getitem__(f, '_csm')[cmaker.grp_id]
-            srcs = pickle.loads(gzip.decompress(arr.tobytes()))
+            if srcs.parent:
+                h5 = srcs.parent.open('r').hdf5
+                dset = h5py.File.__getitem__(h5, '_csm')
+            else:
+                dset = h5py.File.__getitem__(srcs.hdf5, '_csm')
+            srcs =  pickle.loads(gzip.decompress(dset[cmaker.grp_id].tobytes()))
     rup_indep = getattr(srcs, 'rup_interdep', None) != 'mutex'
     pmap = ProbabilityMap(
         sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(rup_indep)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -387,6 +387,7 @@ class Hazard:
                         self.get_hcurves(pmap, rlzs_by_gsim))
             self.datastore['disagg_by_src'][:] = disagg_by_src
 
+
 def get_pmaps_size(dstore, ct):
     """
     :returns: memory required on the master node to keep the pmaps
@@ -406,7 +407,7 @@ def decide_num_tasks(dstore, concurrent_tasks):
     """
     cmakers = read_cmakers(dstore)
     weights = [cm.weight for cm in cmakers]
-    maxw = 1.5*sum(weights) / concurrent_tasks
+    maxw = sum(weights) / (concurrent_tasks / 2)
     dtlist = [('grp_id', U16), ('tiles', U16)]
     ntasks = []
     for cm in sorted(cmakers, key=lambda cm: weights[cm.grp_id], reverse=True):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -199,11 +199,11 @@ def classical(srcs, sitecol, cmaker, monitor):
             if sitecol is None:
                 sitecol = srcs['sitecol']
             if srcs.parent:
-                h5 = srcs.parent.open('r').hdf5
-                dset = h5py.File.__getitem__(h5, '_csm')
+                with srcs.parent.open('r').hdf5 as h5:
+                    arr = h5py.File.__getitem__(h5, '_csm')[cmaker.grp_id]
             else:
-                dset = h5py.File.__getitem__(srcs.hdf5, '_csm')
-            srcs =  pickle.loads(gzip.decompress(dset[cmaker.grp_id].tobytes()))
+                arr = h5py.File.__getitem__(srcs.hdf5, '_csm')[cmaker.grp_id]
+            srcs =  pickle.loads(gzip.decompress(arr.tobytes()))
     rup_indep = getattr(srcs, 'rup_interdep', None) != 'mutex'
     pmap = ProbabilityMap(
         sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(rup_indep)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -410,7 +410,7 @@ def decide_num_tasks(dstore, concurrent_tasks):
     """
     cmakers = read_cmakers(dstore)
     weights = [cm.weight for cm in cmakers]
-    maxw = sum(weights) / (concurrent_tasks / 2)
+    maxw = 1.5*sum(weights) / concurrent_tasks
     dtlist = [('grp_id', U16), ('tiles', U16)]
     ntasks = []
     for cm in sorted(cmakers, key=lambda cm: weights[cm.grp_id], reverse=True):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -407,7 +407,7 @@ def decide_num_tasks(dstore, concurrent_tasks):
     cmakers = read_cmakers(dstore)
     weights = [cm.weight for cm in cmakers]
     maxw = 2*sum(weights) / concurrent_tasks
-    dtlist = [('grp_id', U16), ('cmakers', U16), ('tiles', U16)]
+    dtlist = [('grp_id', U16), ('tiles', U16)]
     ntasks = []
     for cm in sorted(cmakers, key=lambda cm: weights[cm.grp_id], reverse=True):
         w = weights[cm.grp_id]


### PR DESCRIPTION
For instance for share_small in the oq-risk-tests with keep_source_groups I get
```
# before
| calc_47110, maxmem=9.2 GB  | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 2_254    | 716.0     | 54        |
| planar contexts            | 1_778    | 0.0       | 1_098_376 |
| iter_ruptures              | 1_163    | 0.01708   | 77_819    |
| ClassicalCalculator.run    | 403.2    | 1_169     | 1         |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 54     | 41.7    | 96%    | 0.06958 | 178.5   | 4.27647 

# after
| calc_47109, maxmem=7.2 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 807.9    | 679.0     | 17      |
| planar contexts            | 548.1    | 0.0       | 286_932 |
| iter_ruptures              | 342.9    | 0.01758   | 21_707  |
| ClassicalCalculator.run    | 263.0    | 1_164     | 1       |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 17     | 47.5    | 110%   | 0.06539 | 184.3   | 3.87813 |
```
The big advantage is sending the sources less times (3x). This is especially relevant when there are few cores (< num_gsims).
On the performance.zip file the improvement is on "get mean_stds" and "composing pnes" while "get_poes" gets slightly slower:
```
# before
Sending <SourceGroup Stable Shallow Crust, 396 source(s), weight=1427>, 3 gsims * 4 tiles
| calc_6636, maxmem=5.5 GB   | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 1_160    | 259.6     | 12      |
| get_poes                   | 405.4    | 0.0       | 604_691 |
| composing pnes             | 337.4    | 0.0       | 604_691 |
| planar contexts            | 209.7    | 0.0       | 234_141 |
| ClassicalCalculator.run    | 202.3    | 147.4     | 1       |
| computing mean_std         | 196.9    | 0.0       | 5_991   |

# after
Sending <SourceGroup Stable Shallow Crust, 396 source(s), weight=1427>, 11 tiles
| calc_6638, maxmem=6.2 GB   | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 1_082    | 260.0     | 11      |
| get_poes                   | 454.2    | 0.0       | 604_728 |
| planar contexts            | 204.5    | 0.0       | 210_566 |
| composing pnes             | 202.0    | 0.0       | 604_728 |
| ClassicalCalculator.run    | 201.1    | 141.2     | 1       |
| computing mean_std         | 178.1    | 0.0       | 6_004   |
```