### PR TITLE
Fixed the collapsing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed context collapsing in the multi-site case
   * Optimised postclassical, both in terms of memory in the master node
     and reading performance in the workers
   * Added `parallel.multispawn` facility in `oq engine --multi --run`

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -204,7 +204,7 @@ class Monitor(object):
     @property
     def mem(self):
         """Mean memory allocation"""
-        return self._mem / self.counts
+        return self._mem / (self.counts or 1)
 
     @property
     def dt(self):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1044,8 +1044,10 @@ class ContextMaker(object):
         """
         # collapse if possible
         self.collapser.mon = self.col_mon
-        poes = self.collapser.apply(calc_poes, ctx, self, rup_indep)
-        yield poes, ctx
+        for mag in numpy.unique(ctx.mag):
+            ctxt = ctx[ctx.mag == mag]
+            poes = self.collapser.apply(calc_poes, ctxt, self, rup_indep)
+            yield poes, ctxt
 
     def estimate_sites(self, src, sites):
         """

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -188,11 +188,13 @@ class Collapser(object):
             self.cfactor[1] += len(ctx)
             return ctx
 
-        out, inv = numpy.unique(ctx, return_inverse=True)
+        out, inv = numpy.unique(kround(ctx, self.kfields), return_inverse=True)
         self.cfactor[0] += len(out)
         self.cfactor[1] += len(ctx)
         print(self.kfields, len(ctx), len(out), '(%.1f)' % (len(ctx)/len(out)))
-        return out[inv].view(numpy.recarray)
+        for k in self.kfields:
+            ctx[k] = out[k][inv]
+        return ctx
 
 
 class FarAwayRupture(Exception):

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -114,7 +114,7 @@ class AvgPoeGMPE(GMPE):
         cm.pne_mon = performance.Monitor()  # avoid double counts
         cm.gsims = self.gsims
         avgs = []
-        for poes, ctxt, allsids in cm.gen_poes(ctx):
+        for poes, ctxt in cm.gen_poes(ctx):
             # poes has shape N, L, G
             avgs.append(poes @ self.weights)
         arr[:] = np.concatenate(avgs)

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -152,16 +152,6 @@ def update_pmap_m(arr, poes, rates, probs_occur, weights, idxs, itime):
 
 
 # numbified below
-def update_pmap_c(arr, poes, rates, probs_occur, idxs, sizes, itime):
-    start = 0
-    for poe, rate, probs, size in zip(poes, rates, probs_occur, sizes):
-        pne = get_pnes(rate, probs, poe, itime)
-        for idx in idxs[start:start + size]:
-            arr[idx] *= pne
-        start += size
-
-
-# numbified below
 def update_pnes(arr, idxs, pnes):
     for idx, pne in zip(idxs, pnes):
         arr[idx] *= pne
@@ -185,15 +175,6 @@ if numba:
                  t.uint32[:],                            # sids
                  t.float64)                              # itime
     update_pmap_m = compile(sig)(update_pmap_m)
-
-    sig = t.void(t.float64[:, :, :],                     # pmap
-                 t.float64[:, :, :],                     # poes
-                 t.float64[:],                           # rates
-                 t.float64[:, :],                        # probs_occur
-                 t.uint32[:],                            # allsids
-                 t.uint32[:],                            # sizes
-                 t.float64)                              # itime
-    update_pmap_c = compile(sig)(update_pmap_c)
 
     sig = t.void(t.float64[:, :, :],                     # pmap
                  t.uint32[:],                            # idxs
@@ -310,13 +291,6 @@ class ProbabilityMap(object):
         idxs = self.sidx[sids]
         update_pmap_m(self.array, poes, rates, probs_occur, weights, idxs,
                       itime)
-
-    def update_c(self, poes, rates, probs_occur, sids, sizes, itime):
-        """
-        Updating collapsed probabilities
-        """
-        update_pmap_c(self.array, poes, rates, probs_occur,
-                      self.sidx[sids], sizes, itime)
 
     def __invert__(self):
         return self.new(1. - self.array)


### PR DESCRIPTION
Finally we are getting the right numbers, i.e. the same as without collapsing with an extremely high precision. Also, the issue of collapsing causing slow tasks is solved. Here are some figures for ALS on the thinkstation:
```
# no collapse
| calc_47118, maxmem=24.7 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 21_482   | 308.3     | 22        |
| get_poes                   | 12_526   | 0.0       | 2_043_858 |
| composing pnes             | 4_238    | 0.0       | 4_102     |
| computing mean_std         | 2_660    | 0.0       | 4_102     |
| ClassicalCalculator.run    | 2_402    | 825.9     | 1         |
| planar contexts            | 886.4    | 0.0       | 109_342   |
| nonplanar contexts         | 871.2    | 0.0       | 20_322    |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 22     | 976.5   | 27%    | 69.3    | 1_249   | 1.27961 |

# with collapse
| calc_47117, maxmem=21.9 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 10_446   | 313.7     | 22        |
| composing pnes             | 4_241    | 0.0       | 4_102     |
| get_poes                   | 1_886    | 0.0       | 2_009_153 |
| collapsing contexts        | 1_553    | 71.9      | 4_102     |
| ClassicalCalculator.run    | 1_240    | 842.7     | 1         |
| planar contexts            | 883.7    | 0.0       | 109_342   |
| nonplanar contexts         | 867.8    | 0.0       | 20_322    |
| computing mean_std         | 280.1    | 0.0       | 4_102     |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 22     | 474.8   | 26%    | 35.7    | 604.7   | 1.27349 |
```
The speedup is over 2x.