### PR TITLE
Restored sequential tiling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -28,7 +28,6 @@
   * Optimized the parsing of XML files (35x for the Alaska model)
   * Bug fix: ModifiableGMPEs with underlying tables were not receiving a
     single magnitude when calling the `compute` method
-  * Introduced `keep_source_groups` mode in classical calculations
   * Rewritten ModifiableGMPE to avoid a subtle memory leak
 
   [Matteo Nastasi]

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -639,7 +639,7 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         assert self.N > self.oqparam.max_sites_disagg, self.N
         logging.info('Running %d tiles', ntiles)
-        for n, tile in enumerate(self.sitecol.split_in_tiles(ntiles)):
+        for n, tile in enumerate(self.sitecol.split(ntiles)):
             self.run_one(tile, maxw)
             logging.info('Finished tile %d of %d', n+1, ntiles)
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -663,7 +663,10 @@ class ClassicalCalculator(base.HazardCalculator):
             assert not (ntiles > 1 and oq.disagg_by_src)
             # NB: tiling only works with many sites
             assert ntiles == 1 or self.N > oq.max_sites_disagg * ntiles
-            tiles = sitecol.split(ntiles)
+            if sitecol is sitecol.complete:
+                tiles = sitecol.split(ntiles)
+            else:
+                tiles = [sitecol]  # do not split
 
             if sg.atomic or sg.weight <= maxw:
                 for tile in tiles:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -607,7 +607,8 @@ class ClassicalCalculator(base.HazardCalculator):
         t0 = time.time()
         max_gs = max(len(cm.gsims) for cm in self.haz.cmakers)
         req = self.check_memory(len(self.sitecol), oq.imtls.size, max_gs, maxw)
-        ntiles = 1 + int(req / oq.pmap_max_gb)
+        ntiles = 1 + int(req / (oq.pmap_max_gb * 30))  # 30 GB
+        self.n_outs = AccumDict(accum=0)
         if ntiles > 1:
             self.execute_seq(maxw, ntiles)
         else:
@@ -629,7 +630,6 @@ class ClassicalCalculator(base.HazardCalculator):
         Regular case
         """
         self.create_dsets()  # create the rup/ datasets BEFORE swmr_on()
-        self.n_outs = AccumDict(accum=0)
         acc = self.run_one(self.sitecol, maxw)
         self.haz.store_disagg(acc)
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -571,7 +571,6 @@ class ClassicalCalculator(base.HazardCalculator):
         if avail < size:
             raise MemoryError(
                 'You have only %s of free RAM' % humansize(avail))
-        return tot / 1024**3  # memory in GB
 
     def execute(self):
         """
@@ -659,13 +658,14 @@ class ClassicalCalculator(base.HazardCalculator):
             # maximum size of the pmap array in GB
             size_gb = G * L * self.N * 8 / 1024**3
             ntiles = numpy.ceil(size_gb / oq.pmap_max_gb)
-            # NB: disagg_by_src is disabled in case of tiling
-            assert not (ntiles > 1 and oq.disagg_by_src)
-            # NB: tiling only works with many sites
-            assert ntiles == 1 or self.N > oq.max_sites_disagg * ntiles
             if sitecol is sitecol.complete:
+                # NB: disagg_by_src is disabled in case of tiling
+                assert not (ntiles > 1 and oq.disagg_by_src)
+                # NB: tiling only works with many sites
                 tiles = sitecol.split(ntiles)
+                assert ntiles == 1 or self.N > oq.max_sites_disagg * ntiles
             else:
+                ntiles = 1
                 tiles = [sitecol]  # do not split
 
             if sg.atomic or sg.weight <= maxw:

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -42,7 +42,6 @@ from openquake.commonlib import util, logictree
 from openquake.risklib.scientific import (
     losses_by_period, return_periods, LOSSID, LOSSTYPE)
 from openquake.baselib.writers import build_header, scientificformat
-from openquake.calculators.classical import decide_num_tasks, get_pmaps_size
 from openquake.calculators.getters import get_rupture_getters
 from openquake.calculators.extract import extract
 
@@ -1364,25 +1363,6 @@ def view_mean_perils(token, dstore):
             weights = ev_weights[dstore['gmf_data/eid'][:]]
             out[peril] = fast_agg(sid, data * weights) / totw
     return out
-
-    
-@view.add('group_summary')
-def view_group_summary(token, dstore):
-    if ':' not in token:
-        ct = 1
-    else:
-        ct = int(token.split(':')[1])
-    L = dstore['oqparam'].imtls.size
-    N = len(dstore['sitecol'])
-    gb = L * N * 8
-    header = ['grp_id', 'ntasks', 'maxsize']
-    arr = decide_num_tasks(dstore, ct)
-    tbl = [(grp_id, gsims * tiles, humansize(gsims * gb))
-           for grp_id, gsims, tiles in arr]
-    totsize = arr['cmakers'].sum()
-    numtasks = (arr['cmakers'] * arr['tiles']).sum()
-    tbl.append(['tot', numtasks, humansize(totsize * gb)])
-    return text_table(tbl, header, ext='org')
 
 
 @view.add('pmaps_size')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1371,7 +1371,7 @@ def view_pmaps_size(token, dstore):
         ct = Starmap.num_cores * 2
     else:
         ct = int(token.split(':')[1])
-    return humansize(get_pmaps_size(dstore, ct))
+    return humansize(get_pmaps_gb(dstore, ct))
 
 
 @view.add('src_groups')

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -42,6 +42,7 @@ from openquake.commonlib import util, logictree
 from openquake.risklib.scientific import (
     losses_by_period, return_periods, LOSSID, LOSSTYPE)
 from openquake.baselib.writers import build_header, scientificformat
+from openquake.calculators.classical import get_pmaps_gb
 from openquake.calculators.getters import get_rupture_getters
 from openquake.calculators.extract import extract
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -619,13 +619,6 @@ sampling_method:
   Example: *sampling_method = early_latin*.
   Default: 'early_weights'
 
-keep_source_groups:
-   Set an approach that saves memory in large classical calculations, possibly
-   with a performance penalty. When left unspecified (None), the engine will
-   automatically decide when to use it (i.e. if there are enough gsims).
-   Example: *keep_source_groups = true*
-   Default: None
-
 sec_peril_params:
   INTERNAL
 
@@ -964,7 +957,6 @@ class OqParam(valid.ParamSet):
     sampling_method = valid.Param(
         valid.Choice('early_weights', 'late_weights',
                      'early_latin', 'late_latin'), 'early_weights')
-    keep_source_groups = valid.Param(valid.boolean, None)
     secondary_perils = valid.Param(valid.namelist, [])
     sec_peril_params = valid.Param(valid.dictionary, {})
     secondary_simulations = valid.Param(valid.dictionary, {})

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -340,6 +340,7 @@ class SourceFilter(object):
             self.integration_distance = default
         else:
             self.integration_distance = integration_distance
+            assert len(sitecol), sitecol
         self.slc = slice(None)
 
     def reduce(self, multiplier=5):

--- a/openquake/qa_tests_data/classical/case_22/job.ini
+++ b/openquake/qa_tests_data/classical/case_22/job.ini
@@ -2,7 +2,8 @@
 
 description = Classical PSHA using Alaska 2007 active shallow crust grid model
 calculation_mode = classical
-pmap_max_gb = 5E-5
+concurrent_tasks = 10
+pmap_max_gb = 2E-6
 max_sites_disagg = 5
 split_sources = false
 random_seed = 23

--- a/openquake/qa_tests_data/classical/case_25/job.ini
+++ b/openquake/qa_tests_data/classical/case_25/job.ini
@@ -5,7 +5,6 @@ calculation_mode = classical
 concurrent_tasks = 2
 random_seed = 23
 max_sites_disagg = 5
-keep_source_groups = true
 
 [geometry]
 


### PR DESCRIPTION
Since it is much better than the approach used in `keep_source_groups` which required processing the same sources too many times. Here are the numbers for the oq-risk-tests tiling test:
```
# 1 tile
| calc_47129, maxmem=15.9 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total classical            | 760.3    | 370.5     | 11     |
| get_poes                   | 484.0    | 0.0       | 51_726 |
| composing pnes             | 160.6    | 0.0       | 207    |
| ClassicalCalculator.run    | 95.3     | 202.3     | 1      |
| planar contexts            | 71.8     | 0.0       | 15_879 |
| computing mean_std         | 30.3     | 0.0       | 207    |

# 2 tiles
| calc_47128, maxmem=9.6 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 782.1    | 211.8     | 22      |
| get_poes                   | 489.3    | 0.0       | 103_381 |
| composing pnes             | 160.3    | 0.0       | 414     |
| ClassicalCalculator.run    | 100.0    | 209.4     | 1       |
| planar contexts            | 90.7     | 0.0       | 31_694  |
| computing mean_std         | 26.4     | 0.0       | 414     |
```
The penalty is very minor (5%) while the memory saving is huge. 