### PR TITLE
Produce the right number of postclassical tasks

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -815,7 +815,7 @@ class ClassicalCalculator(base.HazardCalculator):
         poes_gb = self.datastore.getsize('_poes') / 1024**3
         ct = int(poes_gb) + 1  # number of tasks =~ number of GB
         if ct > 1:
-            logging.info('Producing %d postclassical tasks')
+            logging.info('Producing %d postclassical tasks', ct)
         self.weights = ws = [rlz.weight for rlz in self.realizations]
         if '_poes' in set(self.datastore):
             dstore = self.datastore

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -241,7 +241,7 @@ def postclassical(pgetter, N, hstats, individual_rlzs,
     The "kind" is a string of the form 'rlz-XXX' or 'mean' of 'quantile-XXX'
     used to specify the kind of output.
     """
-    time.sleep(monitor.task_no)  # give time to the other tasks
+    time.sleep(monitor.task_no * 2)  # give time to the other tasks
     with monitor('read PoEs', measuremem=True):
         pgetter.init()
 
@@ -814,7 +814,7 @@ class ClassicalCalculator(base.HazardCalculator):
             return
         N, S, M, P, L1, individual = self._create_hcurves_maps()
         poes_gb = self.datastore.getsize('_poes') / 1024**3
-        ct = int(poes_gb) + 1  # number of tasks =~ number of GB
+        ct = 2 * int(poes_gb) + 1  # number of tasks = twice the number of GB
         if ct > 1:
             logging.info('Producing %d postclassical tasks', ct)
         self.weights = ws = [rlz.weight for rlz in self.realizations]

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -241,7 +241,8 @@ def postclassical(pgetter, N, hstats, individual_rlzs,
     The "kind" is a string of the form 'rlz-XXX' or 'mean' of 'quantile-XXX'
     used to specify the kind of output.
     """
-    time.sleep(monitor.task_no * 2)  # give time to the other tasks
+    if monitor.task_no > 32:
+        time.sleep(5)  # give time to the other tasks
     with monitor('read PoEs', measuremem=True):
         pgetter.init()
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -22,6 +22,7 @@ import gzip
 import time
 import pickle
 import psutil
+import random
 import logging
 import operator
 import functools
@@ -241,8 +242,8 @@ def postclassical(pgetter, N, hstats, individual_rlzs,
     The "kind" is a string of the form 'rlz-XXX' or 'mean' of 'quantile-XXX'
     used to specify the kind of output.
     """
-    if monitor.task_no > 32:
-        time.sleep(5)  # give time to the other tasks
+    if monitor.task_no > 60:
+        time.sleep(10 * random.random())  # give time to the other tasks
     with monitor('read PoEs', measuremem=True):
         pgetter.init()
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -812,9 +812,8 @@ class ClassicalCalculator(base.HazardCalculator):
         if not oq.hazard_curves:  # do nothing
             return
         N, S, M, P, L1, individual = self._create_hcurves_maps()
-        ct = oq.concurrent_tasks or 1
-        if 1 < ct < 80:  # saving memory on small machines
-            ct = 80
+        poes_gb = self.datastore.getsize('_poes') / 1024**3
+        ct = int(poes_gb) + 1  # number of tasks =~ number of GB
         self.weights = ws = [rlz.weight for rlz in self.realizations]
         if '_poes' in set(self.datastore):
             dstore = self.datastore

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -814,6 +814,8 @@ class ClassicalCalculator(base.HazardCalculator):
         N, S, M, P, L1, individual = self._create_hcurves_maps()
         poes_gb = self.datastore.getsize('_poes') / 1024**3
         ct = int(poes_gb) + 1  # number of tasks =~ number of GB
+        if ct > 1:
+            logging.info('Producing %d postclassical tasks')
         self.weights = ws = [rlz.weight for rlz in self.realizations]
         if '_poes' in set(self.datastore):
             dstore = self.datastore

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -241,6 +241,7 @@ def postclassical(pgetter, N, hstats, individual_rlzs,
     The "kind" is a string of the form 'rlz-XXX' or 'mean' of 'quantile-XXX'
     used to specify the kind of output.
     """
+    time.sleep(monitor.task_no)  # give time to the other tasks
     with monitor('read PoEs', measuremem=True):
         pgetter.init()
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -243,7 +243,7 @@ def postclassical(pgetter, N, hstats, individual_rlzs,
     used to specify the kind of output.
     """
     if monitor.task_no > 60:
-        time.sleep(10 * random.random())  # give time to the other tasks
+        time.sleep(100 * random.random())  # give time to the other tasks
     with monitor('read PoEs', measuremem=True):
         pgetter.init()
 


### PR DESCRIPTION
To fit within 2 GB per core. Also, added a time.sleep to avoid too much parallel readings.