### PR TITLE
Saving memory when collapsing the contexts

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -57,7 +57,7 @@ STD_TYPES = (StdDev.TOTAL, StdDev.INTER_EVENT, StdDev.INTRA_EVENT)
 KNOWN_DISTANCES = frozenset(
     'rrup rx ry0 rjb rhypo repi rcdpp azimuth azimuth_cp rvolc closest_point'
     .split())
-DIST_BINS = sqrscale(1, 1001, 1000)
+DIST_BINS = sqrscale(1, 1000, 1000)
 MULTIPLIER = 250  # len(mean_stds arrays) / len(poes arrays)
 MEA = 0
 STD = 1
@@ -1048,8 +1048,8 @@ class ContextMaker(object):
         # collapse if possible
         for mag in numpy.unique(ctx.mag):
             ctxt = ctx[ctx.mag == mag]
-            ctxt, invs = self.collapser.collapse(ctxt, rup_indep)
-            yield calc_poes(ctxt, self), ctxt, invs
+            kctx, invs = self.collapser.collapse(ctxt, rup_indep)
+            yield calc_poes(kctx, self), ctxt, invs
 
     def estimate_sites(self, src, sites):
         """

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -132,7 +132,7 @@ def trivial(ctx, name):
     return len(numpy.unique(numpy.float32(ctx[name]))) == 1
 
 
-def calc_poes(ctx, cmaker, rup_indep=True):
+def calc_poes(ctx, cmaker):
     """
     :param ctx: a vectorized context (recarray) of size N
     :returns: poes of shape (N, L, G)
@@ -215,14 +215,14 @@ class Collapser(object):
         self.cfactor = numpy.zeros(2)
         self.mon = mon
 
-    def apply(self, func, ctx, cmaker, rup_indep=True, collapse_level=None):
+    def collapse(self, ctx, rup_indep=True, collapse_level=None):
         """
         Collapse a context recarray if possible.
 
         :param ctx: a recarray with "sids"
         :param rup_indep: False if the ruptures are mutually exclusive
         :param collapse_level: if None, use .collapse_level
-        :returns: the collapsed array and a list of arrays with site IDs
+        :returns: the collapsed array and the inverting indices
         """
         clevel = (collapse_level if collapse_level is not None
                   else self.collapse_level)
@@ -230,14 +230,13 @@ class Collapser(object):
             # no collapse
             self.cfactor[0] += len(ctx)
             self.cfactor[1] += len(ctx)
-            return func(ctx, cmaker, rup_indep), numpy.arange(len(ctx))
+            return ctx, numpy.arange(len(ctx))
         with self.mon:
             krounded = kround[clevel](ctx, self.kfields)
             out, inv = numpy.unique(krounded, return_inverse=True)
         self.cfactor[0] += len(out)
         self.cfactor[1] += len(ctx)
-        res = func(out.view(numpy.recarray), cmaker, rup_indep)
-        return res, inv
+        return out.view(numpy.recarray), inv
 
 
 class FarAwayRupture(Exception):
@@ -1003,7 +1002,7 @@ class ContextMaker(object):
         else:
             itime = self.tom.time_span
         for ctx in ctxs:
-            for poes, invs, ctxt in self.gen_poes(ctx, rup_indep):
+            for poes, ctxt, invs in self.gen_poes(ctx, rup_indep):
                 with self.pne_mon:
                     pmap.update_(poes, invs, ctxt, itime, rup_indep)
 
@@ -1049,8 +1048,8 @@ class ContextMaker(object):
         # collapse if possible
         for mag in numpy.unique(ctx.mag):
             ctxt = ctx[ctx.mag == mag]
-            poes, invs = self.collapser.apply(calc_poes, ctxt, self, rup_indep)
-            yield poes, invs, ctxt
+            ctxt, invs = self.collapser.collapse(ctxt, rup_indep)
+            yield calc_poes(ctxt, self), ctxt, invs
 
     def estimate_sites(self, src, sites):
         """

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -114,7 +114,7 @@ class AvgPoeGMPE(GMPE):
         cm.pne_mon = performance.Monitor()  # avoid double counts
         cm.gsims = self.gsims
         avgs = []
-        for poes, ctxt in cm.gen_poes(ctx):
+        for poes, ctxt, invs in cm.gen_poes(ctx):
             # poes has shape N, L, G
             avgs.append(poes @ self.weights)
         arr[:] = np.concatenate(avgs)

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -138,16 +138,16 @@ class ProbabilityCurve(object):
 
 
 # numbified below
-def update_pmap_i(arr, poes, rates, probs_occur, idxs, itime):
-    for poe, rate, probs, idx in zip(poes, rates, probs_occur, idxs):
-        arr[idx] *= get_pnes(rate, probs, poe, itime)
+def update_pmap_i(arr, poes, invs, rates, probs_occur, idxs, itime):
+    for inv, rate, probs, idx in zip(invs, rates, probs_occur, idxs):
+        arr[idx] *= get_pnes(rate, probs, poes[inv], itime)
 
 
 # numbified below
-def update_pmap_m(arr, poes, rates, probs_occur, weights, idxs, itime):
-    for poe, rate, probs, wei, idx in zip(
-            poes, rates, probs_occur, weights, idxs):
-        pne = get_pnes(rate, probs, poe, itime)
+def update_pmap_m(arr, poes, invs, rates, probs_occur, weights, idxs, itime):
+    for inv, rate, probs, wei, idx in zip(
+            invs, rates, probs_occur, weights, idxs):
+        pne = get_pnes(rate, probs, poes[inv], itime)
         arr[idx] += (1. - pne) * wei
 
 
@@ -161,6 +161,7 @@ if numba:
     t = numba.types
     sig = t.void(t.float64[:, :, :],                     # pmap
                  t.float64[:, :, :],                     # poes
+                 t.int64[:],                             # invs
                  t.float64[:],                           # rates
                  t.float64[:, :],                        # probs_occur
                  t.uint32[:],                            # sids
@@ -169,6 +170,7 @@ if numba:
 
     sig = t.void(t.float64[:, :, :],                     # pmap
                  t.float64[:, :, :],                     # poes
+                 t.int64[:],                             # invs
                  t.float64[:],                           # rates
                  t.float64[:, :],                        # probs_occur
                  t.float64[:],                           # weights
@@ -281,19 +283,16 @@ class ProbabilityMap(object):
         """
         Update probabilities
         """
-        arr = self.array
         rates = ctxt.occurrence_rate
         probs_occur = getattr(ctxt, 'probs_occur',
                               numpy.zeros((len(ctxt), 0)))
         idxs = self.sidx[ctxt.sids]
         if rup_indep:
-            for inv, rate, probs, idx in zip(invs, rates, probs_occur, idxs):
-                arr[idx] *= get_pnes(rate, probs, poes[inv], itime)
+            update_pmap_i(self.array, poes, invs, rates,
+                          probs_occur, idxs, itime)
         else:  # mutex
-            for inv, rate, probs, wei, idx in zip(
-                    invs, rates, probs_occur, ctxt.weight, idxs):
-                pne = get_pnes(rate, probs, poes[inv], itime)
-                arr[idx] += (1. - pne) * wei
+            update_pmap_m(self.array, poes, invs, rates, probs_occur,
+                          ctxt.weight, idxs, itime)
 
     def __invert__(self):
         return self.new(1. - self.array)


### PR DESCRIPTION
Here is an example on the spot machine, considering ALS with collapse_level=0:
```
# master
| calc_11, maxmem=130.2 GB   | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 9_656    | 205.6     | 264       |
| composing pnes             | 3_612    | 0.0       | 9_349     |
| get_poes                   | 2_144    | 0.0       | 2_313_217 |
| collapsing contexts        | 1_281    | 147.3     | 9_349     |
| planar contexts            | 736.6    | 0.0       | 109_342   |
| nonplanar contexts         | 673.9    | 0.0       | 20_322    |
| computing mean_std         | 382.0    | 0.0       | 9_349     |
| iter_ruptures              | 203.2    | 7.89062   | 3_719     |
| ClassicalCalculator.run    | 172.0    | 963.8     | 1         |

# invs
| calc_12, maxmem=82.2 GB    | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 9_138    | 211.5     | 264       |
| composing pnes             | 3_825    | 0.0       | 9_349     |
| get_poes                   | 2_103    | 0.0       | 2_313_217 |
| collapsing contexts        | 1_207    | 142.8     | 9_349     |
| planar contexts            | 729.6    | 0.0       | 109_342   |
| nonplanar contexts         | 649.0    | 0.0       | 20_322    |
| computing mean_std         | 370.1    | 0.0       | 9_349     |
| iter_ruptures              | 201.3    | 7.67188   | 3_719     |
| ClassicalCalculator.run    | 166.1    | 962.0     | 1         |
```
We are using 40% less memory and we are a bit faster too.