### PR TITLE
Huge improvement of the task distribution when using zmq

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Huge improvement of the task distribution when using zmq; also, used
+    less memory on the master node
   * Fixed context collapsing in the multi-site case
   * Optimised postclassical, both in terms of memory in the master node
     and reading performance in the workers

--- a/doc/installing/cluster.md
+++ b/doc/installing/cluster.md
@@ -59,7 +59,6 @@ or firewall) so that external traffic is excluded.
 The following ports must be open on the **master node**:
 
 * 1908 for DbServer (or any other port allocated for the DbServer in the `openquake.cfg`)
-* 1910 for the ZeroMQ streamer
 * 1912-1920 for ZeroMQ receivers
 * 8800 for the API/WebUI (optional)
 

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -31,21 +31,6 @@ except ImportError:
         "Do nothing"
 
 
-def _streamer(ctrl_port):
-    # streamer for zmq workers running on the master node
-    task_input_url = 'tcp://0.0.0.0:%d' % (ctrl_port + 2)
-    task_output_url = 'tcp://%s:%s' % (config.dbserver.listen, ctrl_port + 1)
-    if (general.socket_ready(('0.0.0.0', ctrl_port + 1)) or
-            general.socket_ready(('0.0.0.0', ctrl_port + 2))):
-        return  # already started
-    sock_in = z.bind(task_input_url, z.zmq.PULL)
-    sock_out = z.bind(task_output_url, z.zmq.PUSH)
-    try:
-        z.zmq.proxy(sock_in, sock_out)
-    except (KeyboardInterrupt, z.zmq.ContextTerminated):
-        pass  # killed cleanly by SIGINT/SIGTERM
-
-
 def ssh_args(zworkers):
     """
     :yields: triples (hostIP, num_cores, [ssh remote python command])
@@ -227,7 +212,9 @@ class WorkerPool(object):
 
 
 def workerpool(worker_url='tcp://0.0.0.0:1909', *, num_workers: int = -1):
-    # start a workerpool without a streamer
+    """
+    Start a workerpool on the given URL with the given number of workers.
+    """
     WorkerPool(worker_url, num_workers).start()
 
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -697,7 +697,10 @@ class ClassicalCalculator(base.HazardCalculator):
         allargs.sort(key=lambda tup: sum(src.weight for src in tup[0]),
                      reverse=True)
         self.datastore.swmr_on()  # must come before the Starmap
-        smap = parallel.Starmap(classical, allargs, h5=self.datastore.hdf5)
+        smap = parallel.Starmap(classical, h5=self.datastore.hdf5)
+        for args in allargs:
+            # using submit avoids the .task_queue and thus core starvation
+            smap.submit(args)
         return smap.reduce(self.agg_dicts, acc)
 
     def store_info(self):


### PR DESCRIPTION
By removing the task streamer and using a regular REQ/REP socket talking with a normal process pool we can use all of the cluster (and not 60% of it as it was happening for the AUS model). Also, we can save a lot of memory in the master node.
Here is a 21% speedup for the Alaska calculation:
```
# before
| calc_49738, maxmem=14.4 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 14_460   | 305.0     | 480       |
| composing pnes             | 6_726    | 0.0       | 9_500     |
| collapsing contexts        | 3_004    | 232.8     | 9_500     |
| nonplanar contexts         | 1_907    | 0.0       | 46_638    |
| planar contexts            | 1_845    | 0.0       | 287_884   |
| iter_ruptures              | 500.6    | 0.92969   | 9_569     |
| ClassicalCalculator.run    | 436.9    | 722.4     | 1         |

# after
| calc_49737, maxmem=14.5 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 14_593   | 306.3     | 480       |
| composing pnes             | 6_773    | 0.0       | 9_500     |
| collapsing contexts        | 3_060    | 232.8     | 9_500     |
| nonplanar contexts         | 1_922    | 0.0       | 46_638    |
| planar contexts            | 1_872    | 0.0       | 287_884   |
| iter_ruptures              | 508.5    | 0.62891   | 9_569     |
| ClassicalCalculator.run    | 344.4    | 831.0     | 1         |
```