### PR TITLE
Avoid resending the sources when collapsing

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -585,7 +585,7 @@ class ClassicalCalculator(base.HazardCalculator):
 
         t0 = time.time()
         req = get_pmaps_gb(self.datastore)
-        ntiles = 1 + int(req / (oq.pmap_max_gb * 35))  # 35 GB
+        ntiles = 1 + int(req / (oq.pmap_max_gb * 40))  # 40 GB
         self.n_outs = AccumDict(accum=0)
         if ntiles > 1:
             self.execute_seq(maxw, ntiles)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -405,24 +405,6 @@ class Hazard:
             self.datastore['disagg_by_src'][:] = disagg_by_src
 
 
-def decide_num_tasks(dstore, concurrent_tasks):
-    """
-    :param dstore: DataStore
-    :param concurrent_tasks: hint for the number of tasks to generate
-    """
-    cmakers = read_cmakers(dstore)
-    weights = [cm.weight for cm in cmakers]
-    maxw = 1.5*sum(weights) / concurrent_tasks
-    dtlist = [('grp_id', U16), ('tiles', U16)]
-    ntasks = []
-    for cm in sorted(cmakers, key=lambda cm: weights[cm.grp_id], reverse=True):
-        w = weights[cm.grp_id]
-        nt = int(numpy.ceil(w / maxw))
-        assert nt
-        ntasks.append((cm.grp_id, nt))
-    return numpy.array(ntasks, dtlist)
-
-
 @base.calculators.add('classical', 'ucerf_classical')
 class ClassicalCalculator(base.HazardCalculator):
     """
@@ -637,7 +619,7 @@ class ClassicalCalculator(base.HazardCalculator):
         assert self.N > self.oqparam.max_sites_disagg, self.N
         logging.info('Running %d tiles', ntiles)
         for n, tile in enumerate(self.sitecol.split(ntiles)):
-            self.run_one(tile, maxw)
+            self.run_one(tile, maxw * .6)
             parallel.Starmap.shutdown()  # save memory
             logging.info('Finished tile %d of %d', n+1, ntiles)
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -457,7 +457,6 @@ class ClassicalCalculator(base.HazardCalculator):
 
         # store rup_data if there are few sites
         if self.few_sites and len(dic['rup_data']):
-            assert not self.cmakers_split
             with self.monitor('saving rup_data'):
                 store_ctxs(self.datastore, dic['rup_data'], grp_id)
 
@@ -600,12 +599,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if not performance.numba:
             logging.warning('numba is not installed: using the slow algorithm')
 
-        if oq.collapse_level >= 0:
-            self.cmakers = []
-            for cm in self.haz.cmakers:
-                self.cmakers.extend(cm.split_by_gsim())
-        else:
-            self.cmakers = self.haz.cmakers
+        self.cmakers = self.haz.cmakers
 
         t0 = time.time()
         req = get_pmaps_gb(self.datastore)
@@ -654,9 +648,6 @@ class ClassicalCalculator(base.HazardCalculator):
         acc = {}  # g -> pmap
         oq = self.oqparam
         L = oq.imtls.size
-        self.cmakers_split = len(self.cmakers) > len(self.haz.cmakers)
-        if oq.disagg_by_src and self.cmakers_split:
-            raise NotImplementedError('Cannot collapse with disagg_by_src')
         self.datastore.swmr_on()  # must come before the Starmap
         smap = parallel.Starmap(classical, h5=self.datastore.hdf5)
         for cm in self.cmakers:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -619,7 +619,7 @@ class ClassicalCalculator(base.HazardCalculator):
         assert self.N > self.oqparam.max_sites_disagg, self.N
         logging.info('Running %d tiles', ntiles)
         for n, tile in enumerate(self.sitecol.split(ntiles)):
-            self.run_one(tile, maxw * .6)
+            self.run_one(tile, maxw * .75)
             parallel.Starmap.shutdown()  # save memory
             logging.info('Finished tile %d of %d', n+1, ntiles)
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -59,7 +59,7 @@ KNOWN_DISTANCES = frozenset(
     .split())
 NUM_BINS = 256
 DIST_BINS = sqrscale(80, 1000, NUM_BINS)
-MULTIPLIER = 100  # len(mean_stds arrays) / len(poes arrays)
+MULTIPLIER = 150  # len(mean_stds arrays) / len(poes arrays)
 MEA = 0
 STD = 1
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -115,7 +115,7 @@ def get_maxsize(M, G):
     """
     :returns: an integer N such that arrays N*M*G fit in the CPU cache
     """
-    maxs = TWO20 // (4*M*G)
+    maxs = TWO20 // (M*G)
     assert maxs > 1, maxs
     return maxs * MULTIPLIER
 
@@ -980,7 +980,7 @@ class ContextMaker(object):
             ctxt = ctx[slc]
             self.slc = slc  # used in gsim/base.py
             with self.poe_mon:
-                # this is allocating at most 2MB of RAM
+                # this is allocating at most few MB of RAM
                 poes = numpy.zeros((len(ctxt), M*L1, G))
                 # NB: using .empty would break the MixtureModelGMPETestCase
                 for g, gsim in enumerate(self.gsims):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1159,7 +1159,7 @@ class ContextMaker(object):
         """
         Split the ContextMaker in multiple context makers, one per GSIM
         """
-        if len(self.gsims) == 1:
+        if self.collapse_level < 0 or len(self.gsims) == 1:
             return [self]
         cmakers = []
         for g, gsim in zip(self.gidx, self.gsims):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -59,7 +59,7 @@ KNOWN_DISTANCES = frozenset(
     .split())
 NUM_BINS = 256
 DIST_BINS = sqrscale(80, 1000, NUM_BINS)
-MULTIPLIER = 150  # len(mean_stds arrays) / len(poes arrays)
+MULTIPLIER = 100  # len(mean_stds arrays) / len(poes arrays)
 MEA = 0
 STD = 1
 
@@ -115,7 +115,7 @@ def get_maxsize(M, G):
     """
     :returns: an integer N such that arrays N*M*G fit in the CPU cache
     """
-    maxs = TWO20 // (M*G)
+    maxs = TWO20 // (2*M*G)
     assert maxs > 1, maxs
     return maxs * MULTIPLIER
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -59,7 +59,7 @@ KNOWN_DISTANCES = frozenset(
     .split())
 NUM_BINS = 256
 DIST_BINS = sqrscale(80, 1000, NUM_BINS)
-MULTIPLIER = 200  # len(mean_stds arrays) / len(poes arrays)
+MULTIPLIER = 150  # len(mean_stds arrays) / len(poes arrays)
 MEA = 0
 STD = 1
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1035,10 +1035,12 @@ class ContextMaker(object):
             itime = 0.
         else:
             itime = self.tom.time_span
-        for ctx in ctxs:
-            for poes, ctxt, invs in self.gen_poes(ctx, rup_indep):
-                with self.pne_mon:
-                    pmap.update_(poes, invs, ctxt, itime, rup_indep)
+        for cm in self.split_by_gsim():
+            idx = cm.gidx - self.gidx[0]
+            for ctx in ctxs:
+                for poes, ctxt, invs in cm.gen_poes(ctx, rup_indep):
+                    with self.pne_mon:
+                        pmap.update_(poes, invs, ctxt, itime, rup_indep, idx)
 
     # called by gen_poes and by the GmfComputer
     def get_mean_stds(self, ctxs):
@@ -1161,8 +1163,7 @@ class ContextMaker(object):
             cm = self.__class__(self.trt, gsims, self.oq)
             cm.gidx = numpy.array([gsim.g for gsim in gsims])
             cm.grp_id = self.grp_id
-            if len(dists) >= 3:  # don't collapse
-                cm.collapse_level = -1
+            cm.collapser.cfactor = self.collapser.cfactor
             cmakers.append(cm)
         return cmakers
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1164,6 +1164,9 @@ class ContextMaker(object):
             cm.gidx = numpy.array([gsim.g for gsim in gsims])
             cm.grp_id = self.grp_id
             cm.collapser.cfactor = self.collapser.cfactor
+            for attr in dir(self):
+                if attr.endswith('_mon'):
+                    setattr(cm, attr, getattr(self, attr))
             cmakers.append(cm)
         return cmakers
 

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -285,12 +285,12 @@ class ProbabilityMap(object):
         probs_occur = getattr(ctxt, 'probs_occur',
                               numpy.zeros((len(ctxt), 0)))
         idxs = self.sidx[ctxt.sids]
-        for g, i in enumerate(idx):
+        for i, x in enumerate(idx):
             if rup_indep:
-                update_pmap_i(self.array[:, :, i], poes[:, :, g], invs, rates,
+                update_pmap_i(self.array[:, :, x], poes[:, :, i], invs, rates,
                               probs_occur, idxs, itime)
             else:  # mutex
-                update_pmap_m(self.array[:, :, i], poes[:, :, g],
+                update_pmap_m(self.array[:, :, x], poes[:, :, i],
                               invs, rates, probs_occur, ctxt.weight,
                               idxs, itime)
 

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -138,17 +138,16 @@ class ProbabilityCurve(object):
 
 
 # numbified below
-def update_pmap_i(arr, poes, invs, rates, probs_occur, idxs, itime):
-    for inv, rate, probs, idx in zip(invs, rates, probs_occur, idxs):
-        arr[idx] *= get_pnes(rate, probs, poes[inv], itime)  # shape (L, G)
+def update_pmap_i(arr, poes, inv, rates, probs_occur, idxs, itime):
+    for i, rate, probs, idx in zip(inv, rates, probs_occur, idxs):
+        arr[idx] *= get_pnes(rate, probs, poes[i], itime)  # shape L
 
 
 # numbified below
-def update_pmap_m(arr, poes, invs, rates, probs_occur, weights, idxs, itime):
-    for inv, rate, probs, wei, idx in zip(
-            invs, rates, probs_occur, weights, idxs):
-        pne = get_pnes(rate, probs, poes[inv], itime)  # shape (L, G)
-        arr[idx] += (1. - pne) * wei
+def update_pmap_m(arr, poes, inv, rates, probs_occur, weights, idxs, itime):
+    for i, rate, probs, w, idx in zip(inv, rates, probs_occur, weights, idxs):
+        pne = get_pnes(rate, probs, poes[i], itime)  # shape L
+        arr[idx] += (1. - pne) * w
 
 
 # numbified below

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -197,7 +197,7 @@ class ClusterPoissonTOM(PoissonTOM):
         self.occurrence_rate = occurrence_rate
 
 
-@compile(["(float64, float64[:], float64[:,:], float64)",
+@compile(["(float64, float64[:], float64[:], float64)",
           "(float64, float64[:], float64[:,:,:,:], float64)"])
 def get_pnes(rate, probs, poes, time_span):
     """


### PR DESCRIPTION
Avoids recomputing the contexts and reduces slow tasks too. Here are some figures for reduced AUS on the thinkstation:
```
# before
| calc_47160, maxmem=20.7 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 14_597   | 466.5     | 66        |
| composing pnes             | 4_072    | 0.0       | 8_414     |
| get_poes                   | 3_526    | 0.0       | 1_654_487 |
| collapsing contexts        | 2_567    | 0.0       | 8_414     |
| planar contexts            | 2_536    | 0.0       | 778_887   |
| ClassicalCalculator.run    | 1_585    | 710.8     | 1         |
| computing mean_std         | 1_390    | 0.0       | 8_414     |
| iter_ruptures              | 678.2    | 0.37457   | 13_350    |

| operation-duration | counts | mean  | stddev | min  | max   | slowfac |
|--------------------+--------+-------+--------+------+-------+---------|
| classical          | 66     | 221.2 | 50%    | 27.9 | 464.8 | 2.10152 |

# after
| calc_47679, maxmem=9.4 GB | time_sec | memory_mb | counts    |
|---------------------------+----------+-----------+-----------|
| total classical           | 12_394   | 258.1     | 22        |
| get_poes                  | 3_813    | 0.0       | 2_210_719 |
| composing pnes            | 3_249    | 0.0       | 14_952    |
| collapsing contexts       | 2_289    | 0.0       | 14_952    |
| computing mean_std        | 1_436    | 0.0       | 14_952    |
| ClassicalCalculator.run   | 1_359    | 703.1     | 1         |
| planar contexts           | 1_088    | 0.0       | 259_629   |
| iter_ruptures             | 226.0    | 0.11392   | 4_450     |

| operation-duration | counts | mean  | stddev | min  | max   | slowfac |
|--------------------+--------+-------+--------+------+-------+---------|
| classical          | 22     | 563.4 | 31%    | 42.1 | 700.8 | 1.24405 |
```
Notice the big memory saving.