### PR TITLE
Added command `oq workers debug`

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -197,11 +197,6 @@ import multiprocessing.shared_memory as shmem
 from multiprocessing.connection import wait
 import psutil
 import numpy
-try:
-    from setproctitle import setproctitle
-except ImportError:
-    def setproctitle(title):
-        "Do nothing"
 
 from openquake.baselib import config, hdf5, workerpool
 from openquake.baselib.python3compat import decode
@@ -602,11 +597,6 @@ class IterResult(object):
         return res
 
 
-def init_workers():
-    """Waiting function, used to wake up the process pool"""
-    setproctitle('oq-worker')
-
-
 def getargnames(task_func):
     # a task can be a function, a method, a class or a callable instance
     if inspect.isfunction(task_func):
@@ -670,7 +660,7 @@ class Starmap(object):
             # https://github.com/gem/oq-engine/pull/3923 and
             # https://codewithoutrules.com/2018/09/04/python-multiprocessing/
             cls.pool = mp_context.Pool(
-                cls.num_cores, init_workers,
+                cls.num_cores, workerpool.init_workers,
                 maxtasksperchild=cls.maxtasksperchild)
             cls.pids = [proc.pid for proc in cls.pool._pool]
             cls.shared = []

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -464,6 +464,7 @@ def safely_call(func, args, task_no=0, mon=dummy_mon):
     if mon is dummy_mon:  # in the DbServer
         assert not isgenfunc, func
         return Result.new(func, args, mon)
+    # debug(f'{mon.backurl=}, {task_no=}')
     if mon.operation.endswith('_'):
         name = mon.operation[:-1]
     elif func is split_task:

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -219,13 +219,6 @@ GB = 1024 ** 3
 host_cores = config.zworkers.host_cores.split(',')
 
 
-def debug(msg, mon):
-    """
-    Trivial task useful for debugging
-    """
-    print(msg)
-
-
 @submit.add('no')
 def no_submit(self, func, args, monitor):
     return safely_call(func, args, self.task_no, monitor)
@@ -505,6 +498,7 @@ def safely_call(func, args, task_no=0, mon=dummy_mon):
             sentbytes += len(res.pik)
             if res.msg == 'TASK_ENDED':
                 break
+
 
 if oq_distribute() == 'ipp':
     from ipyparallel import Cluster

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -184,6 +184,7 @@ class Monitor(object):
     address = None
     authkey = None
     calc_id = None
+    inject = None
 
     def __init__(self, operation='', measuremem=False, inner_loop=False,
                  h5=None, version=None):

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -203,7 +203,6 @@ def debug(msg, mon):
 
 
 def call(func, args, taskno, mon, executing):
-    setproctitle('oq-zworker')
     fname = os.path.join(executing, '%s-%s' % (mon.calc_id, taskno))
     # NB: very hackish way of keeping track of the running tasks,
     # used in get_executing, could litter the file system
@@ -238,7 +237,8 @@ class WorkerPool(object):
         title = 'oq-zworkerpool %s' % self.ctrl_url[6:]  # strip tcp://
         print('Starting ' + title, file=sys.stderr)
         setproctitle(title)
-        self.pool = general.mp.Pool(self.num_workers)
+        self.pool = general.mp.Pool(
+            self.num_workers, lambda: setproctitle('oq-zworker'))
         # start control loop accepting the commands stop and kill
         with z.Socket(self.ctrl_url, z.zmq.REP, 'bind') as ctrlsock:
             for cmd in ctrlsock:

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -32,6 +32,11 @@ except ImportError:
         "Do nothing"
 
 
+def init_workers():
+    """Waiting function, used to wake up the process pool"""
+    setproctitle('oq-worker')
+
+
 def ssh_args(zworkers):
     """
     :yields: triples (hostIP, num_cores, [ssh remote python command])
@@ -237,8 +242,7 @@ class WorkerPool(object):
         title = 'oq-zworkerpool %s' % self.ctrl_url[6:]  # strip tcp://
         print('Starting ' + title, file=sys.stderr)
         setproctitle(title)
-        self.pool = general.mp.Pool(
-            self.num_workers, lambda: setproctitle('oq-zworker'))
+        self.pool = general.mp.Pool(self.num_workers, init_workers)
         # start control loop accepting the commands stop and kill
         with z.Socket(self.ctrl_url, z.zmq.REP, 'bind') as ctrlsock:
             for cmd in ctrlsock:

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -71,8 +71,8 @@ class WorkerMaster(object):
 
     def start(self):
         """
-        Start multiple workerpools, possibly on remote servers via ssh,
-        assuming there is an active streamer.
+        Start multiple workerpools on remote servers via ssh and/or a single
+        workerpool on localhost.
         """
         starting = []
         for host, cores, args in ssh_args(self.zworkers):

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -172,12 +172,12 @@ class WorkerMaster(object):
         self.start()
         try:
             mon = performance.Monitor('zmq-debug')
+            mon.inject = True
+            mon.config = config  # forget this and it will hang silently
             rec_host = config.dbserver.receiver_host or '127.0.0.1'
             receiver = 'tcp://%s:%s' % (
                 rec_host, config.dbserver.receiver_ports)
             with z.Socket(receiver, z.zmq.PULL, 'bind') as pull:
-                mon.inject = True
-                mon.config = config
                 mon.backurl = 'tcp://%s:%s' % (rec_host, pull.port)
                 for task_no, (host, _) in enumerate(self.host_cores):
                     url = 'tcp://%s:%d' % (host, self.ctrl_port)
@@ -188,7 +188,7 @@ class WorkerMaster(object):
                 isocket = iter(pull)
                 for _ in self.host_cores:
                     res = next(isocket)
-                    print('got', res.get())
+                    print('got result', res.get())
         finally:
             self.stop()
         return 'debugged'

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -186,7 +186,7 @@ class WorkerMaster(object):
             task_no = 0
             with z.Socket(receiver, z.zmq.PULL, 'bind') as pull:
                 mon.backurl = 'tcp://%s:%s' % (rec_host, pull.port)
-                for host, _ in enumerate(self.host_cores):
+                for host, _ in self.host_cores:
                     url = 'tcp://%s:%d' % (host, self.ctrl_port)
                     print('Sending to', url)
                     with z.Socket(url, z.zmq.REQ, 'connect') as sock:

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -19,6 +19,7 @@ import os
 import sys
 import time
 import shutil
+import socket
 import getpass
 import tempfile
 import subprocess
@@ -214,7 +215,7 @@ def debug_task(msg, mon):
     """
     Trivial task useful for debugging
     """
-    print(msg)
+    print(socket.gethostname(), msg)
     return mon.task_no
 
 

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -175,9 +175,8 @@ class Socket(object):
         if self.socket_type == zmq.REQ:
             ok = self.zsocket.poll(self.timeout)  # 30 seconds
             if not ok:
-                raise TimeoutError(
-                    'While sending %s; probably the DbServer is off' %
-                    repr(obj))
+                raise TimeoutError('While sending %r to %s' %
+                                   (obj, self.end_point))
             return self.zsocket.recv_pyobj()
 
     def __repr__(self):

--- a/openquake/commands/workers.py
+++ b/openquake/commands/workers.py
@@ -20,6 +20,8 @@ import sys
 import getpass
 from openquake.baselib import config, workerpool, parallel as p
 
+CHOICES = 'start stop status restart wait kill debug'.split()
+
 
 def main(cmd):
     """
@@ -36,5 +38,4 @@ def main(cmd):
         print('Nothing to do: oq_distribute=%s' % dist)
 
 
-main.cmd = dict(help='command', choices='start stop status restart wait kill'.
-                split())
+main.cmd = dict(help='command', choices=CHOICES)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -412,7 +412,7 @@ def run_jobs(jobctxs):
                           "AND status IN ('created', 'executing')", ids)
         for job_id, in rows:
             logs.dbcmd("set_status", job_id, 'failed')
-        cleanup('kill')
+        cleanup('stop')  # kill cause semaphore errors
         raise
     return jobctxs
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -412,7 +412,7 @@ def run_jobs(jobctxs):
                           "AND status IN ('created', 'executing')", ids)
         for job_id, in rows:
             logs.dbcmd("set_status", job_id, 'failed')
-        cleanup('stop')  # kill cause semaphore errors
+        cleanup('kill')
         raise
     return jobctxs
 


### PR DESCRIPTION
And generally improved the zmq distribution debugging experience. This is an example on wilson
```bash
$ oq workers debug  # as user openquake
ssh -f -T openquake@192.168.2.1 /opt/openquake/venv/bin/python3 -m openquake.baselib.workerpool tcp://0.0.0.0:1909 -n -1: if it hangs, check the ssh keys
ssh -f -T openquake@192.168.2.2 /opt/openquake/venv/bin/python3 -m openquake.baselib.workerpool tcp://0.0.0.0:1909 -n -1: if it hangs, check the ssh keys
ssh -f -T openquake@192.168.2.3 /opt/openquake/venv/bin/python3 -m openquake.baselib.workerpool tcp://0.0.0.0:1909 -n -1: if it hangs, check the ssh keys
ssh -f -T openquake@192.168.2.4 /opt/openquake/venv/bin/python3 -m openquake.baselib.workerpool tcp://0.0.0.0:1909 -n -1: if it hangs, check the ssh keys
ssh -f -T openquake@192.168.2.5 /opt/openquake/venv/bin/python3 -m openquake.baselib.workerpool tcp://0.0.0.0:1909 -n -1: if it hangs, check the ssh keys
Sending to tcp://192.168.2.1:1909
Starting oq-zworkerpool 0.0.0.0:1909
Starting oq-zworkerpool 0.0.0.0:1909
Starting oq-zworkerpool 0.0.0.0:1909
Starting oq-zworkerpool 0.0.0.0:1909
Starting oq-zworkerpool 0.0.0.0:1909
Sending to tcp://192.168.2.2:1909
Sending to tcp://192.168.2.3:1909
Sending to tcp://192.168.2.4:1909
Sending to tcp://192.168.2.5:1909
results=[8, 9, 3, 2, 0, 1, 5, 4, 6, 7]
mercury.gem.lan executing task #1
mercury.gem.lan executing task #0
marley.gem.lan executing task #2
marley.gem.lan executing task #3
dylan.gem.lan executing task #4
dylan.gem.lan executing task #5
cobain.gem.lan executing task #6
cobain.gem.lan executing task #7
hendrix.gem.lan executing task #8
hendrix.gem.lan executing task #9
debugged
```