### PR TITLE
Renamed rup_id -> seed in event_based calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Internal: renamed rup_id -> seed in event based calculations to avoid
+    confusion
   * Parallelized the reinsurance calculation
 
   [Marco Pagani]

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -320,11 +320,11 @@ class EventBasedCalculator(base.HazardCalculator):
             oq.mags_by_trt = {trt: ['%.2f' % rup.mag]}
             self.cmaker = ContextMaker(trt, rlzs_by_gsim, oq)
             if self.N > oq.max_sites_disagg:  # many sites, split rupture
-                ebrs = [EBRupture(copyobj(rup, rup_id=rup.rup_id + i),
+                ebrs = [EBRupture(copyobj(rup, seed=rup.seed + i),
                                   'NA', 0, G, e0=i * G, scenario=True)
                         for i in range(ngmfs)]
             else:  # keep a single rupture with a big occupation number
-                ebrs = [EBRupture(rup, 'NA', 0, G * ngmfs, rup.rup_id,
+                ebrs = [EBRupture(rup, 'NA', 0, G * ngmfs, rup.seed,
                                   scenario=True)]
             srcfilter = SourceFilter(self.sitecol, oq.maximum_distance(trt))
             aw = get_rup_array(ebrs, srcfilter)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -270,7 +270,7 @@ class RuptureImporter(object):
         eid_rlz = []
         for rup in proxies:
             ebr = EBRupture(
-                Mock(rup_id=rup['seed']), rup['source_id'],
+                Mock(seed=rup['seed']), rup['source_id'],
                 rup['trt_smr'], rup['n_occ'], e0=rup['e0'],
                 scenario='scenario' in self.oqparam.calculation_mode)
             for rlz_id, eids in ebr.get_eids_by_rlz(rlzs_by_gsim).items():

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -666,7 +666,7 @@ def get_rupture(oqparam):
     conv = sourceconverter.RuptureConverter(oqparam.rupture_mesh_spacing)
     rup = conv.convert_node(rup_node)
     rup.tectonic_region_type = '*'  # there is not TRT for scenario ruptures
-    rup.rup_id = oqparam.ses_seed
+    rup.seed = oqparam.ses_seed
     return rup
 
 

--- a/openquake/hazardlib/__init__.py
+++ b/openquake/hazardlib/__init__.py
@@ -113,8 +113,8 @@ def _get_ebruptures(fname, conv=None, ses_seed=None):
         [rup_node] = nrml.read(fname)
         rup = conv.convert_node(rup_node)
         rup.tectonic_region_type = '*'  # no TRT for scenario ruptures
-        rup.rup_id = ses_seed
-        ebrs = [EBRupture(rup, 'NA', 0, id=rup.rup_id, scenario=True)]
+        rup.seed = ses_seed
+        ebrs = [EBRupture(rup, 'NA', 0, id=rup.seed, scenario=True)]
         return ebrs
 
     assert fname.endswith('.csv'), fname

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -124,7 +124,7 @@ class GmfComputer(object):
             rupture = rupture.rupture  # the underlying rupture
         else:  # in the hazardlib tests
             self.source_id = '?'
-        self.seed = rupture.rup_id
+        self.seed = rupture.seed
         ctxs = list(cmaker.get_ctx_iter([rupture], sitecol))
         if not ctxs:
             raise FarAwayRupture
@@ -320,7 +320,7 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
     cmaker = ContextMaker(rupture.tectonic_region_type, [gsim],
                           dict(truncation_level=truncation_level,
                                imtls={str(imt): [1] for imt in imts}))
-    rupture.rup_id = seed
+    rupture.seed = seed
     gc = GmfComputer(rupture, sites, cmaker, correlation_model)
     mean_stds = cmaker.get_mean_stds([gc.ctx])[:, 0]
     res, _sig, _eps = gc.compute(gsim, realizations, mean_stds)

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -124,7 +124,7 @@ def get_rup_array(ebruptures, srcfilter=nofilter):
         shapes = U32(shapes)
         hypo = rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z
         rec = numpy.zeros(1, rupture_dt)[0]
-        rec['seed'] = rup.rup_id
+        rec['seed'] = rup.seed
         rec['minlon'] = minlon = numpy.nanmin(lons)  # NaNs are in KiteSurfaces
         rec['minlat'] = minlat = numpy.nanmin(lats)
         rec['maxlon'] = maxlon = numpy.nanmax(lons)
@@ -135,7 +135,7 @@ def get_rup_array(ebruptures, srcfilter=nofilter):
                 srcfilter.close_sids(rec, rup.tectonic_region_type)) == 0:
             continue
         rate = getattr(rup, 'occurrence_rate', numpy.nan)
-        tup = (0, ebrupture.rup_id, ebrupture.source_id, ebrupture.trt_smr,
+        tup = (0, ebrupture.seed, ebrupture.source_id, ebrupture.trt_smr,
                rup.code, ebrupture.n_occ, rup.mag, rup.rake, rate,
                minlon, minlat, maxlon, maxlat, hypo, 0, 0)
         rups.append(tup)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -880,7 +880,8 @@ class ContextMaker(object):
                     r_sites = sites.filter(mask)
                     rctx = self.get_rctx(rup, r_sites, dist[mask])
                     rctx.src_id = src_id
-                    rctx.rup_id = rup.rup_id
+                    if src_id:  # not event based
+                        rctx.rup_id = rup.rup_id
                     if self.fewsites:
                         c = rup.surface.get_closest_points(sites.complete)
                         rctx.clon = c.lons[rctx.sids]

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -114,7 +114,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         numpy.random.seed(seed)
         for trt_smr in self.trt_smrs:
             for rup, num_occ in self._sample_ruptures(eff_num_ses):
-                rup.rup_id = seed
+                rup.seed = seed
                 if hasattr(rup, 'occurrence_rate'):
                     # defined only for poissonian sources
                     rup.occurrence_rate *= self.smweight
@@ -364,7 +364,7 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
         for i, rup in enumerate(self.iter_ruptures()):
             if i == idx:
                 if hasattr(self, 'rup_id'):
-                    rup.rup_id = self.rup_id
+                    rup.seed = self.seed
                 rup.idx = idx
                 return rup
 

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -251,6 +251,6 @@ class NonParametricSeismicSource(BaseSeismicSource):
         serial = self.serial(ses_seed)
         for i, rup in enumerate(self.iter_ruptures()):
             if i == idx:
-                rup.rup_id = serial + i
+                rup.seed = serial + i
                 rup.idx = idx
                 return rup

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -98,7 +98,7 @@ def to_csv_array(ruptures):
     for rec, rup in zip(arr, ruptures):
         # s0=number of multi surfaces, s1=number of rows, s2=number of columns
         arrays = surface_to_arrays(rup.surface)  # shape (s0, 3, s1, s2)
-        rec['seed'] = rup.rup_id
+        rec['seed'] = rup.seed
         rec['mag'] = rup.mag
         rec['rake'] = rup.rake
         rec['lon'] = rup.hypocenter.x
@@ -177,7 +177,7 @@ def _get_rupture(rec, geom=None, trt=None):
 
     # build rupture
     rupture = object.__new__(rupture_cls)
-    rupture.rup_id = rec['seed']
+    rupture.seed = rec['seed']
     rupture.surface = surface
     rupture.mag = rec['mag']
     rupture.rake = rec['rake']
@@ -250,7 +250,7 @@ class BaseRupture(metaclass=abc.ABCMeta):
     NB: if you want to convert the rupture into XML, you should set the
     attribute surface_nodes to an appropriate value.
     """
-    rup_id = 0  # set to a value > 0 by the engine
+    seed = 0  # set to a value > 0 by the engine
     _code = {}
 
     @classmethod
@@ -697,7 +697,7 @@ class ExportedRupture(object):
     Simplified Rupture class with attributes rupid, events_by_ses, indices
     and others, used in export.
 
-    :param rupid: rupture rup_id ID
+    :param rupid: rupture.seed ID
     :param events_by_ses: dictionary ses_idx -> event records
     :param indices: site indices
     """
@@ -722,7 +722,7 @@ class EBRupture(object):
     """
     def __init__(self, rupture, source_id, trt_smr, n_occ=1,
                  id=None, e0=0, scenario=False):
-        assert rupture.rup_id > 0  # sanity check
+        assert rupture.seed > 0  # sanity check
         self.rupture = rupture
         self.source_id = source_id
         self.trt_smr = trt_smr
@@ -736,11 +736,11 @@ class EBRupture(object):
         return self.rupture.tectonic_region_type
 
     @property
-    def rup_id(self):
+    def seed(self):
         """
         Seed of the rupture
         """
-        return self.rupture.rup_id
+        return self.rupture.seed
 
     def get_eids_by_rlz(self, rlzs_by_gsim):
         """
@@ -756,8 +756,7 @@ class EBRupture(object):
                 dic[rlz_id] = eids
         else:  # event_based
             j = 0
-            histo = general.random_histogram(
-                self.n_occ, len(rlzs), self.rup_id)
+            histo = general.random_histogram(self.n_occ, len(rlzs), self.seed)
             for rlz, n in zip(rlzs, histo):
                 dic[rlz] = numpy.arange(j, j + n, dtype=U32) + self.e0
                 j += n
@@ -771,7 +770,7 @@ class EBRupture(object):
 
     def __repr__(self):
         return '<%s %d[%d]>' % (
-            self.__class__.__name__, self.rup_id, self.n_occ)
+            self.__class__.__name__, self.seed, self.n_occ)
 
 
 class RuptureProxy(object):


### PR DESCRIPTION
To avoid a big confusion with the .rup_id field in classical calculations.