### PR TITLE
removing multiple IM components

### DIFF
--- a/openquake/hazardlib/gsim/pankow_pechmann_2004.py
+++ b/openquake/hazardlib/gsim/pankow_pechmann_2004.py
@@ -44,9 +44,9 @@ class PankowPechmann2004(GMPE):
 
     #: Supported intensity measure component is VECTORIAL
     #: :attr:`~openquake.hazardlib.const.IMC.VECTORIAL`,
-    #: NOTE: The paper indicates it as Geometric mean (to check)
+    #: NOTE: The paper indicates it as Geometric mean
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = {
-        const.IMC.VECTORIAL, const.IMC.RANDOM_HORIZONTAL}
+        const.IMC.GEOMETRIC_MEAN}
 
     #: Supported standard deviation type is total
     DEFINED_FOR_STANDARD_DEVIATION_TYPES = {const.StdDev.TOTAL}

--- a/openquake/hazardlib/gsim/pankow_pechmann_2004.py
+++ b/openquake/hazardlib/gsim/pankow_pechmann_2004.py
@@ -45,8 +45,7 @@ class PankowPechmann2004(GMPE):
     #: Supported intensity measure component is VECTORIAL
     #: :attr:`~openquake.hazardlib.const.IMC.VECTORIAL`,
     #: NOTE: The paper indicates it as Geometric mean
-    DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = {
-        const.IMC.GEOMETRIC_MEAN}
+    DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.GEOMETRIC_MEAN
 
     #: Supported standard deviation type is total
     DEFINED_FOR_STANDARD_DEVIATION_TYPES = {const.StdDev.TOTAL}


### PR DESCRIPTION
The Pankow_Pechman_2004 gmpe is using multiple IMCs. The supporting paper suggests a geometric mean. Hence, the IMC has been changed accordingly. This issue came up while performing disaggregation for ARB model with `horiz_comp_to_geom_mean = true` specified in the job file. 