### PR TITLE
Removed celery from openquake.cfg

### DIFF
--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -14,7 +14,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 [distribution]
-# set zmq or celery if you have a cluster
+# set zmq if you have a cluster
 oq_distribute = processpool
 serialize_jobs = 1
 # num_cores = 1
@@ -31,15 +31,6 @@ soft_mem_limit = 90
 # above this quantity (in %) of memory used the job will be stopped
 # use a lower value to protect against loss of control when OOM occurs
 hard_mem_limit = 99
-
-[amqp]
-# RabbitMQ/celery, by default NOT USED and NOT RECOMMENDED
-host = localhost
-port = 5672
-user = openquake
-password = openquake
-vhost = openquake
-celery_queue = celery
 
 [dbserver]
 file = ~/oqdata/db.sqlite3


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/8281