### PR TITLE
Ignominiously defeated scipy: 100x speedup with our own truncnorm_sf

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Optimized the disaggregation by using our own truncnorm_sf function and not scipy
+
   [Anirudh Rao]
   * Implemented Conditioned GMFs as defined in Engler et al. (2022)
 


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/8346. Here are the figures for Kendra's calculation on my laptop:
```
# master vs truncnorm_sf
| calc_52346, maxmem=0.3 GB    | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| disaggregate                 | 10.0     | 0.0       | 11     |
| disaggregate                 | 0.38500  | 0.0       | 11     |
```
The speedup is 26x, but I have seen a 76x on a more realistic calculation and the larger the calculation the larger the speedup.