### PR TITLE
Fixed log in disaggregation calculations with num_disagg_rlzs=0

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -228,7 +228,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                 'The number of sites is to disaggregate is %d, but you have '
                 'max_sites_disagg=%d' % (self.N, few))
         all_edges, shapedic = disagg.get_edges_shapedic(
-            self.oqparam, self.sitecol, self.datastore['source_mags'])
+            self.oqparam, self.sitecol, self.datastore['source_mags'], self.R)
         *b, trts = all_edges
         T = len(trts)
         shape = [len(bin) - 1 for bin in
@@ -276,7 +276,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         if oq.rlz_index is None and oq.num_rlzs_disagg == 0:
             oq.num_rlzs_disagg = len(ws)  # 0 means all rlzs
         edges, self.shapedic = disagg.get_edges_shapedic(
-            oq, self.sitecol, self.datastore['source_mags'])
+            oq, self.sitecol, self.datastore['source_mags'], self.R)
         self.save_bin_edges(edges)
         self.full_lt = self.datastore['full_lt']
         self.poes_disagg = oq.poes_disagg or (None,)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -243,7 +243,6 @@ class DisaggregationCalculator(base.HazardCalculator):
 
     def execute(self):
         """Performs the disaggregation"""
-        self.pre_checks()
         return self.full_disaggregation()
 
     def get_curve(self, sid, rlzs):

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1219,11 +1219,11 @@ def extract_disagg_layer(dstore, what):
         kinds = oq.disagg_outputs
     sitecol = dstore['sitecol']
     poes_disagg = oq.poes_disagg or (None,)
+    realizations = numpy.array(dstore['full_lt'].get_realizations())
     edges, shapedic = disagg.get_edges_shapedic(
-        oq, sitecol, dstore['source_mags'])
+        oq, sitecol, dstore['source_mags'], len(realizations))
     dt = _disagg_output_dt(shapedic, kinds, oq.imtls, poes_disagg)
     out = numpy.zeros(len(sitecol), dt)
-    realizations = numpy.array(dstore['full_lt'].get_realizations())
     hmap4 = dstore['hmap4'][:]
     best_rlzs = dstore['best_rlzs'][:]
     arr = {kind: dstore['disagg/' + kind][:] for kind in kinds}

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -53,14 +53,14 @@ def assert_same_shape(arrays):
         assert arr.shape == shape, (arr.shape, shape)
 
 
-def get_edges_shapedic(oq, sitecol, mags_by_trt):
+def get_edges_shapedic(oq, sitecol, mags_by_trt, num_tot_rlzs):
     """
     :returns: (mag dist lon lat eps trt) edges and shape dictionary
     """
     assert mags_by_trt
     tl = oq.truncation_level
     if oq.rlz_index is None:
-        Z = oq.num_rlzs_disagg
+        Z = oq.num_rlzs_disagg or num_tot_rlzs
     else:
         Z = len(oq.rlz_index)
 


### PR DESCRIPTION
We were logging the line `Total output size: 0 B`; now we get the right number of bytes. I have also removed a redundant call to `.pre_checks()`.
