### PR TITLE
Reintroduce the duplication of tectonicRegion...

### DIFF
--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -678,15 +678,15 @@ class GPKG2NRMLTestCase(unittest.TestCase):
         expected_log_outputs = [
             'Skipping source of code "X" and attributes'
             ' "{\'id\': \'5\', \'name\': \'characteristic source,'
-            ' simple fault\'}"'
+            ' simple fault\', \'tectonicRegion\': \'Volcanic\'}"'
             ' (the converter is not implemented yet)',
             'Skipping source of code "X" and attributes'
             ' "{\'id\': \'6\', \'name\': \'characteristic source,'
-            ' complex fault\'}"'
+            ' complex fault\', \'tectonicRegion\': \'Volcanic\'}"'
             ' (the converter is not implemented yet)',
             'Skipping source of code "X" and attributes'
             ' "{\'id\': \'7\', \'name\': \'characteristic source,'
-            ' multi surface\'}"'
+            ' multi surface\', \'tectonicRegion\': \'Volcanic\'}"'
             ' (the converter is not implemented yet)']
         with mock.patch('logging.error') as error:
             sap.runline(f'openquake.commands nrml_from {gpkg_path} {out_path}')

--- a/openquake/commands/tests/data/expected_complex_fault_source_converted_nrml.xml
+++ b/openquake/commands/tests/data/expected_complex_fault_source_converted_nrml.xml
@@ -15,6 +15,7 @@ xmlns:gml="http://www.opengis.net/gml"
             <complexFaultSource
             id="1"
             name="Cascadia Megathrust"
+            tectonicRegion="Subduction Interface"
             >
                 <complexFaultGeometry>
                     <faultTopEdge>

--- a/openquake/commands/tests/data/expected_mixed_converted_nrml.xml
+++ b/openquake/commands/tests/data/expected_mixed_converted_nrml.xml
@@ -15,6 +15,7 @@ xmlns:gml="http://www.opengis.net/gml"
             <pointSource
             id="2"
             name="point"
+            tectonicRegion="Stable Continental Crust"
             >
                 <pointGeometry>
                     <gml:Point>
@@ -55,6 +56,7 @@ xmlns:gml="http://www.opengis.net/gml"
             <complexFaultSource
             id="4"
             name="Cascadia Megathrust"
+            tectonicRegion="Subduction Interface"
             >
                 <complexFaultGeometry>
                     <faultTopEdge>
@@ -107,6 +109,7 @@ xmlns:gml="http://www.opengis.net/gml"
             <areaSource
             id="1"
             name="Quito"
+            tectonicRegion="Active Shallow Crust"
             >
                 <areaGeometry>
                     <gml:Polygon>
@@ -151,6 +154,7 @@ xmlns:gml="http://www.opengis.net/gml"
             <simpleFaultSource
             id="3"
             name="Mount Diablo Thrust"
+            tectonicRegion="Active Shallow Crust"
             >
                 <simpleFaultGeometry>
                     <gml:LineString>

--- a/openquake/commands/tests/data/expected_multi_point_source_converted_nrml.xml
+++ b/openquake/commands/tests/data/expected_multi_point_source_converted_nrml.xml
@@ -15,6 +15,7 @@ xmlns:gml="http://www.opengis.net/gml"
             <multiPointSource
             id="mp1"
             name="multi point source"
+            tectonicRegion="Stable Continental Crust"
             >
                 <multiPointGeometry>
                     <gml:posList>
@@ -61,6 +62,7 @@ xmlns:gml="http://www.opengis.net/gml"
             <multiPointSource
             id="mp2"
             name="mps-with-GR"
+            tectonicRegion="Stable Continental Crust"
             >
                 <multiPointGeometry>
                     <gml:posList>

--- a/openquake/hazardlib/nrml_to.py
+++ b/openquake/hazardlib/nrml_to.py
@@ -183,8 +183,16 @@ def convert_to(fmt, fnames, chatty=False, *, outdir='.', geometry=''):
                             srcnode['groupname'] = srcgroup.attrib['name']
                         except KeyError:
                             srcnode['groupname'] = ''
-                        if (not srcnode['groupname'] and
-                                grp_trt and not srcnode.get('tectonicRegion')):
+
+                        # NOTE: the following condition would avoid duplicating
+                        # tectonicRegion into each source of a group for which
+                        # the tectonicRegion is already specified. We are
+                        # intentionally keeping the duplication in order to
+                        # make it possible to read the information directly
+                        # from the source section via old scripts.
+                        # if (not srcnode['groupname'] and
+                        #         grp_trt and not srcnode.get('tectonicRegion')):
+                        if grp_trt and not srcnode.get('tectonicRegion'):
                             srcnode['tectonicRegion'] = grp_trt
                         row = converter.convert_node(srcnode)
                         appendrow(row, srcs, chatty, sections, s2i)


### PR DESCRIPTION
 ...in all sources belonging to of a group for which the tectonicRegion is already specified.

This was explicitly requested by the hazard scientists in order to make it possible to read the information directly from each source via pre-existing scripts.

Fixes https://github.com/gem/oq-engine/issues/8319