### PR TITLE
Reducing the stress on the ZMQ receiver socket

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -447,7 +447,7 @@ dummy_mon.config = config
 dummy_mon.backurl = None
 
 
-def safely_call(func, args, task_no=0, mon=dummy_mon):
+def safely_call(func, args, task_no=0, mon=dummy_mon, backurl=None):
     """
     Call the given function with the given arguments safely, i.e.
     by trapping the exceptions. Return a pair (result, exc_type)
@@ -480,7 +480,7 @@ def safely_call(func, args, task_no=0, mon=dummy_mon):
     if mon.inject:
         args += (mon,)
     sentbytes = 0
-    with Socket(mon.backurl, zmq.PUSH, 'connect') as zsocket:
+    with Socket(backurl or mon.backurl, zmq.PUSH, 'connect') as zsocket:
         msg = check_mem_usage()  # warn if too much memory is used
         if msg:
             zsocket.send(Result(None, mon, msg=msg))

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -268,7 +268,7 @@ class WorkerPool(object):
         print('Starting ' + title, file=sys.stderr)
         setproctitle(title)
         self.pool = general.mp.Pool(self.num_workers, init_workers)
-        streamer_on = False
+        self.pool.apply_async(streamer)
         # start control loop accepting the commands stop and kill
         with z.Socket(self.ctrl_url, z.zmq.REP, 'bind') as ctrlsock:
             for cmd in ctrlsock:
@@ -286,9 +286,6 @@ class WorkerPool(object):
                 elif cmd == 'get_executing':
                     ctrlsock.send(' '.join(sorted(os.listdir(self.executing))))
                 elif isinstance(cmd, tuple):
-                    if not streamer_on:
-                        self.pool.apply_async(streamer)
-                        streamer_on = True
                     self.pool.apply_async(call, cmd + (self.executing,))
                     ctrlsock.send('submitted')
                 else:

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -231,7 +231,7 @@ def call(func, args, taskno, mon, executing):
     os.remove(fname)
 
 
-def streamer():
+def sendback():
     """
     Redirect from the WorkerPool to the backurl on the master
     """
@@ -268,7 +268,7 @@ class WorkerPool(object):
         print('Starting ' + title, file=sys.stderr)
         setproctitle(title)
         self.pool = general.mp.Pool(self.num_workers, init_workers)
-        self.pool.apply_async(streamer)
+        self.pool.apply_async(sendback)
         # start control loop accepting the commands stop and kill
         with z.Socket(self.ctrl_url, z.zmq.REP, 'bind') as ctrlsock:
             for cmd in ctrlsock:


### PR DESCRIPTION
On oq1 the receiver socket gets outputs from 320 cores and large calculations hangs (presumably there is a timeout on the workers, or something like that). The solution is to send the outputs from each worker pool to a single socket that then dispatches on the receiver, thus reducing the load from 320 to 5. Continuation of https://github.com/gem/oq-engine/pull/8312.