### PR TITLE
Sending small zmq messages in classical calculations

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -448,6 +448,7 @@ def check_mem_usage(soft_percent=None, hard_percent=None):
 dummy_mon = Monitor()
 dummy_mon.config = config
 dummy_mon.backurl = None
+DEBUG = False
 
 
 def sendback(res, zsocket, sentbytes):
@@ -458,12 +459,13 @@ def sendback(res, zsocket, sentbytes):
         calc_id = res.mon.calc_id
         task_no = res.mon.task_no
         size = humansize(len(res.pik))
-        if calc_id:  # None when building the png maps
+        if DEBUG and calc_id:  # None when building the png maps
             dblog('DEBUG', calc_id, task_no, 'sent back %s' % size)
     except Exception:  # like OverflowError
         _etype, exc, tb = sys.exc_info()
         tb_str = ''.join(traceback.format_tb(tb))
-        dblog('ERROR', calc_id, task_no, tb_str)
+        if DEBUG and calc_id:
+            dblog('ERROR', calc_id, task_no, tb_str)
         zsocket.send(Result(exc, res.mon, tb_str))
     return sentbytes + len(res.pik)
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -221,14 +221,13 @@ def classical(srcs, sitecol, cmaker, monitor):
     pmap = ProbabilityMap(
         sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(rup_indep)
     result = hazclassical(srcs, sitecol, cmaker, pmap)
-    pnemap = ~pmap.remove_zeros()
     if len(sitecol) > cmaker.max_sites_disagg:
-        for g, pne in zip(cmaker.gidx, pnemap.split()):
-            result['pnemap'] = pne
+        for g, pne in zip(cmaker.gidx, pmap.split()):
+            result['pnemap'] = ~pne.remove_zeros()
             result['pnemap'].gidx = [g]
             yield result
     else:
-        result['pnemap'] = pnemap
+        result['pnemap'] = ~pmap.remove_zeros()
         result['pnemap'].gidx = cmaker.gidx
         yield result
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -222,9 +222,14 @@ def classical(srcs, sitecol, cmaker, monitor):
         sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(rup_indep)
     result = hazclassical(srcs, sitecol, cmaker, pmap)
     pnemap = ~pmap.remove_zeros()
-    for g, pne in zip(cmaker.gidx, pnemap.split()):
-        result['pnemap'] = pne
-        result['pnemap'].gidx = [g]
+    if len(sitecol) > cmaker.max_sites_disagg:
+        for g, pne in zip(cmaker.gidx, pnemap.split()):
+            result['pnemap'] = pne
+            result['pnemap'].gidx = [g]
+            yield result
+    else:
+        result['pnemap'] = pnemap
+        result['pnemap'].gidx = cmaker.gidx
         yield result
 
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -221,9 +221,11 @@ def classical(srcs, sitecol, cmaker, monitor):
     pmap = ProbabilityMap(
         sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(rup_indep)
     result = hazclassical(srcs, sitecol, cmaker, pmap)
-    result['pnemap'] = ~pmap.remove_zeros()
-    result['pnemap'].gidx = cmaker.gidx
-    return result
+    pnemap = ~pmap.remove_zeros()
+    for g, pne in zip(cmaker.gidx, pnemap.split()):
+        result['pnemap'] = pne
+        result['pnemap'].gidx = [g]
+        yield result
 
 
 def postclassical(pgetter, N, hstats, individual_rlzs,

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -215,6 +215,14 @@ class ProbabilityMap(object):
         new.array = array
         return new
 
+    def split(self):
+        """
+        :yields: G ProbabilityMaps of shape (N, L, 1)
+        """
+        N, L, G = self.array.shape
+        for g in range(G):
+            yield self.__class__(self.sids, L, 1).new(self.array[:, :, [g]])
+
     def fill(self, value):
         """
         :param value: a scalar probability


### PR DESCRIPTION
It improves a bit the speed, but does not solve the hanging problem of oq1 :-(
Here are the numbers for a reduced EUR on oq2:
```
# master
| calc_50163, maxmem=32.2 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 41_613   | 294.9     | 229       |
# split_pmap
| calc_50161, maxmem=32.4 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 40_012   | 25.3      | 2_977     |
```