### PR TITLE
Optimized the rupture sampling for MultiFaultSources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Optimized the rupture sampling for MultiFaultSources
   * Supported `collect_rlzs` together with `disagg_by_src` to avoid running
     out of memory in models with many realizations and many sources
 

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -154,10 +154,11 @@ class MultiFaultSource(BaseSeismicSource):
                 sec.suid = idx
         else:
             s = self.sections
-        nrups = len(self.mags)
-        matrix = np.random.random((nrups, eff_num_ses))
+        # NB: np.random.random(eff_num_ses) called inside to save memory
+        # the seed is set before
         for i, probs in enumerate(self.probs_occur):
-            num_occ = np.digitize(matrix[i], np.cumsum(probs)).sum()
+            cdf = np.cumsum(probs)
+            num_occ = np.digitize(np.random.random(eff_num_ses), cdf).sum()
             if num_occ == 0:  # ignore non-occurring ruptures
                 continue
             idxs = self.rupture_idxs[i]

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -144,6 +144,33 @@ class MultiFaultSource(BaseSeismicSource):
                 self.mags[i], rake, self.tectonic_region_type, hypo, sfc,
                 PMF(data))
 
+    def _sample_ruptures(self, eff_num_ses):
+        # yields (rup, num_occur)
+        if self.hdf5path:
+            with hdf5.File(self.hdf5path, 'r') as f:
+                geoms = f['multi_fault_sections'][:]
+            s = [geom_to_kite(geom) for geom in geoms]
+            for idx, sec in enumerate(s):
+                sec.suid = idx
+        else:
+            s = self.sections
+        nrups = len(self.mags)
+        matrix = np.random.random((nrups, eff_num_ses))
+        for i, probs in enumerate(self.probs_occur):
+            num_occ = np.digitize(matrix[i], np.cumsum(probs)).sum()
+            if num_occ == 0:  # ignore non-occurring ruptures
+                continue
+            idxs = self.rupture_idxs[i]
+            if len(idxs) == 1:
+                sfc = s[idxs[0]]
+            else:
+                sfc = MultiSurface([s[idx] for idx in idxs])
+            hypo = s[idxs[0]].get_middle_point()
+            data = [(p, o) for o, p in enumerate(probs)]
+            yield (NonParametricProbabilisticRupture(
+                self.mags[i], self.rakes[i], self.tectonic_region_type, hypo,
+                sfc, PMF(data)), num_occ)
+
     def __iter__(self):
         if len(self.mags) <= BLOCKSIZE:  # already split
             yield self


### PR DESCRIPTION
Supersedes https://github.com/gem/oq-engine/pull/8380. Notice that test_case_65 does not break, so we have the same sampling as before, but we are faster since it is done **before** instantiating the ruptures.