### PR TITLE
Implemented output slowdown

### DIFF
--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -106,9 +106,11 @@ def read(*paths, **validators):
                 raise ValueError('%s for %s in %s' % (err, k, found[-1]))
 
 
+# NB: duplicated in commands/engine.py!!
 config.read = read
 config.read(limit=int, soft_mem_limit=int, hard_mem_limit=int, port=int,
-            serialize_jobs=positiveint, strict=positiveint, code=exec)
+            serialize_jobs=positiveint, strict=positiveint, code=exec,
+            slowdown_rate=float)
 
 if config.directory.custom_tmp:
     os.environ['TMPDIR'] = config.directory.custom_tmp

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -937,7 +937,7 @@ class Starmap(object):
                 self.todo -= 1
                 self._submit_many(1)
                 todo = set(range(self.task_no)) - finished
-                logging.debug('tasks todo %s', sorted(todo))
+                logging.debug('tasks todo %s', numpy.array(sorted(todo)))
                 yield res
             elif res.func:  # add subtask
                 self.task_queue.append((res.func, res.pik))

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -922,8 +922,8 @@ class Starmap(object):
                          self.name, humansize(nbytes), time.time() - self.t0)
 
         isocket = iter(self.socket)
-        self.todo = len(self.tasks)
         finished = set()
+        self.todo = len(self.tasks)
         while self.todo:
             self.log_percent()
             res = next(isocket)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -183,6 +183,7 @@ import re
 import ast
 import sys
 import time
+import random
 import socket
 import signal
 import pickle
@@ -474,7 +475,7 @@ def sendback(res, zsocket, sentbytes):
             dblog('ERROR', calc_id, task_no, tb_str)
         zsocket.send(Result(exc, res.mon, tb_str))
     # avoid output congestion by waiting a bit, if slowdown_rate is set
-    time.sleep(config.performance.slowdown_rate * nbytes)
+    time.sleep(config.performance.slowdown_rate * nbytes * random.random())
     return sentbytes + nbytes
 
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -226,8 +226,6 @@ def classical(srcs, sitecol, cmaker, monitor):
             result['pnemap'] = ~pne.remove_zeros()
             result['pnemap'].gidx = [g]
             yield result
-            # avoid output congestion by waiting a bit
-            time.sleep(config.performance.slowdown_rate * pne.array.nbytes)
     else:
         result['pnemap'] = ~pmap.remove_zeros()
         result['pnemap'].gidx = cmaker.gidx

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -615,7 +615,7 @@ class ClassicalCalculator(base.HazardCalculator):
 
         t0 = time.time()
         req = get_pmaps_gb(self.datastore)
-        ntiles = 1 + int(req / (oq.pmap_max_gb * 30))  # 30 GB
+        ntiles = 1 + int(req / (oq.pmap_max_gb * 40))  # 40 GB
         self.n_outs = AccumDict(accum=0)
         if ntiles > 1:
             self.execute_seq(maxw, ntiles)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -226,6 +226,8 @@ def classical(srcs, sitecol, cmaker, monitor):
             result['pnemap'] = ~pne.remove_zeros()
             result['pnemap'].gidx = [g]
             yield result
+            # avoid output congestion by waiting a bit
+            time.sleep(config.performance.slowdown_rate * pne.array.nbytes)
     else:
         result['pnemap'] = ~pmap.remove_zeros()
         result['pnemap'].gidx = cmaker.gidx

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -390,6 +390,9 @@ class Hazard:
         arr[arr == 1.] = .9999999999999999
         # arr[arr < 1E-5] = 0.  # minimum_poe
         idxs, lids = arr.nonzero()
+        nbytes = 4 + 2 + 2 + 8  # sid, gid, lid, poe
+        logging.debug('storing %s of PoEs for g=%d',
+                      humansize(len(idxs) * nbytes), g)
         gids = numpy.repeat(g, len(idxs))
         if len(idxs):
             sids = pmap.sids[idxs]
@@ -480,7 +483,6 @@ class ClassicalCalculator(base.HazardCalculator):
                 with self.monitor('storing PoEs', measuremem=True):
                     pmap = acc.pop(g)
                     size = humansize(pmap.array.nbytes)
-                    logging.debug('storing %s of PoEs for g=%d', size, g)
                     self.haz.store_poes(g, pmap)
         return acc
 

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -108,7 +108,7 @@ def main(
         config.read(os.path.abspath(os.path.expanduser(config_file)),
                     limit=int, soft_mem_limit=int, hard_mem_limit=int,
                     port=int, serialize_jobs=valid.boolean,
-                    strict=valid.boolean, code=exec)
+                    strict=valid.boolean, code=exec, slowdown_rate=float)
 
     if no_distribute:
         os.environ['OQ_DISTRIBUTE'] = 'no'

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -78,4 +78,4 @@ mosaic_dir =
 
 [performance]
 pointsource_distance = 1000
-slowdown_rate = 1E-7
+slowdown_rate = 0

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -78,3 +78,4 @@ mosaic_dir =
 
 [performance]
 pointsource_distance = 1000
+slowdown_rate = 1E-7


### PR DESCRIPTION
In presence of high inbound network traffic calculations on oq1 hangs. Adding a time.sleep is a workaround that works in many cases. This also reduces the task queue and therefore the memory consumption on the master node.