### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,10 @@ The OpenQuake Engine software provides calculation and assessment of seismic haz
 
 ## Visualizing outputs via QGIS
 
-![IRMT Logo](https://github.com/gem/oq-infrastructure/raw/master/icons/irmt_icon.png)
+<img src="https://github.com/gem/oq-infrastructure/raw/master/icons/irmt_icon.png" alt="IRMT Logo" width="50" >
 
-* [Installation](https://docs.openquake.org/oq-irmt-qgis/latest/00_installation.html)
-* [Driving the Engine](https://docs.openquake.org/oq-irmt-qgis/latest/14_driving_the_oqengine.html)
-* [Visualizing outputs](https://docs.openquake.org/oq-irmt-qgis/latest/15_viewer_dock.html)
-* [Repository](https://plugins.qgis.org/plugins/svir/)
-* [Source code](https://github.com/gem/oq-irmt-qgis)
-
+A [QGIS plug-in](https://plugins.qgis.org/plugins/svir/) is available for users that would like to visually explore the outputs from the engine. 
+Check the documentation for instructions on how to [drive the engine](https://docs.openquake.org/oq-irmt-qgis/latest/14_driving_the_oqengine.html) and [visualize outputs](https://docs.openquake.org/oq-irmt-qgis/latest/15_viewer_dock.html). [Source code](https://github.com/gem/oq-irmt-qgis) also available.
 
 ## For developers and contributors
 


### PR DESCRIPTION
I find that the installation instructions for the plugin are for developers instead of general users. The easiest way is to install it via the QGIS plugin manager.

I simplified the description, also to make sure that the word "installing" is only referring to the engine (to avoid confusion).