### PR TITLE
Fixed install.py: it must not set the shared_dir

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed install.py: it must not set the shared_dir
   * Optimized disaggregation, both in performance and memory consumption
 
 python3-oq-engine (3.16.0-1~xenial01) xenial; urgency=low

--- a/install.py
+++ b/install.py
@@ -83,7 +83,6 @@ class server:
     port = %d
     file = %s
     [directory]
-    shared_dir = /opt/openquake
     ''' % (DBPORT, DBPATH)
 
     @classmethod
@@ -111,7 +110,6 @@ class devel_server:
     port = %d
     file = %s
     [directory]
-    shared_dir = /opt/openquake
     ''' % (DBPORT, DBPATH)
     exit = server.exit
 


### PR DESCRIPTION
Otherwise users will try to write into `/opt/openquake/<user>/oqdata` which does not exist.