### PR TITLE
Reduced the number of tasks generated in disaggregation calculations/1

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -333,7 +333,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         grp_ids = rdata['grp_id']
         G = max(len(cmaker.gsims) for cmaker in cmakers)
         s = self.shapedic
-        nbytes = 0
+        n_outs = 0
         for grp_id, slices in performance.get_slices(grp_ids).items():
             cmaker = cmakers[grp_id]
             for start, stop in slices:
@@ -362,12 +362,13 @@ class DisaggregationCalculator(base.HazardCalculator):
                     U = max(U, n)
                     smap.submit((dis, triples))
                     task_inputs.append((grp_id, n))
-                    nbytes += len(triples) * s['mag'] * s['M'] * s['P'] * 8
+                    n_outs += len(triples)
 
         nbytes, msg = get_nbytes_msg(dict(M=self.M, G=G, U=U, F=2))
         logging.info('Maximum mean_std per task:\n%s', msg)
 
-        data_transfer = (s['dist'] * s['eps'] + s['lon'] * s['lat']) * nbytes
+        data_transfer = (s['dist'] * s['eps'] + s['lon'] * s['lat']) * \
+            s['mag'] * s['M'] * s['P'] * 8 * n_outs
         if data_transfer > oq.max_data_transfer:
             raise ValueError(
                 'Estimated data transfer too big\n%s > max_data_transfer=%s' %

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -459,13 +459,6 @@ class Disaggregator(object):
         if not self._ctxs:
             raise FarAwayRupture
 
-    @property
-    def num_rlzs(self):
-        """
-        :returns: the maximum number of relevant realizations
-        """
-        return len(self.g_by_rlz)
-
     def disagg6D(self, iml2, g):
         """
         Disaggregate a single realization.

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -425,60 +425,44 @@ class Disaggregator(object):
             magidx[magidx == -1] = 0  # when the magnitude is on the edge
             ctx.magi = magidx
 
-        mags = numpy.concatenate([ctx.mag for ctx in ctxs])
-        if len(mags) == 0:
+        ctx = numpy.concatenate(ctxs).view(numpy.recarray)
+        if len(ctx) == 0:
             raise FarAwayRupture('No ruptures affecting site #%d' % sid)
+        self.nbytes = ctx.nbytes
+        if cmaker.src_mutex:
+            # getting a context array and a weight for each source
+            # NB: relies on ctx.weight having all equal weights, being
+            # built as ctx['weight'] = src.mutex_weight in contexts.py
+            slices = get_slices(ctx.src_id).values()
+            self.ctxs = [ctx[s0:s1] for [(s0, s1)] in slices]
+            self.weights = [c.weight[0] for c in self.ctxs]
+        else:
+            self.ctxs = [ctx]
+            self.weights = [1.]
 
-        # populate dictionaries magi-> list
-        self.ctxs = {}
-        self.weights = {}
-        self.nbytes = 0
-        for magi in numpy.unique(magidx):
-            thectxs = [c[c.magi == magi] for c in ctxs]
-            ctx = numpy.concatenate(thectxs).view(numpy.recarray)
-            self.nbytes += ctx.nbytes
-            if self.cmaker.src_mutex:
-                # getting a context array and a weight for each source
-                # NB: relies on ctx.weight having all equal weights, being
-                # built as ctx['weight'] = src.mutex_weight in contexts.py
-                slices = get_slices(ctx.src_id).values()
-                self.ctxs[magi] = [ctx[s0:s1] for [(s0, s1)] in slices]
-                self.weights[magi] = [c.weight[0] for c in self.ctxs[magi]]
-            else:
-                self.ctxs[magi] = [ctx]
-                self.weights[magi] = [1.]
-
-    def init(self, monitor=Monitor()):
+    def init(self, magi, monitor=Monitor()):
+        self.magi = magi
         self.mon = monitor
-        # set .meas, .stds
-        self.meas = {}
-        self.stds = {}
-        for magi, ctxs in self.ctxs.items():
-            meas, stds = [], []
-            for ctx in ctxs:
+        self._ctxs = []
+        self._meas = []
+        self._stds = []
+        self._weights = []
+        for fullctx, weight in zip(self.ctxs, self.weights):
+            ctx = fullctx[fullctx.magi == magi]
+            if len(ctx):
                 mea, std = self.cmaker.get_mean_stds([ctx], split_by_mag=1)[:2]
-                meas.append(mea)
-                stds.append(std)
-            self.meas[magi] = meas
-            self.stds[magi] = stds
+                self._ctxs.append(ctx)
+                self._meas.append(mea)
+                self._stds.append(std)
+                self._weights.append(weight)
+        if not self._ctxs:
+            raise FarAwayRupture
 
     @property
     def num_rlzs(self):
         return len(self.g_by_rlz)
 
-    def split_by_magi(self):
-        """
-        :yields: pairs (magi, <Disaggregator>)
-        """
-        for magi in self.ctxs:
-            dis = copy.copy(self)
-            dis.nbytes = sum(c.nbytes for c in self.ctxs[magi])
-            dis.ctxs = {magi: self.ctxs[magi]}
-            dis.weights = {magi: self.weights[magi]}
-            if dis.nbytes:  # non-empty
-                yield magi, dis
-
-    def disagg6D(self, iml2, g, magi):
+    def disagg6D(self, iml2, g):
         """
         Disaggregate a single realization.
 
@@ -490,14 +474,13 @@ class Disaggregator(object):
             imlog2[m] = to_distribution_values(iml2[m], imt)
 
         mats = []
-        for ctx, mea, std in zip(
-                self.ctxs[magi], self.meas[magi], self.stds[magi]):
+        for ctx, mea, std in zip(self._ctxs, self._meas, self._stds):
             mat = _disaggregate(ctx, mea, std, self.cmaker, g, imlog2,
                                 self.bin_edges, self.epsstar, self.mon)
             mats.append(mat)
         if len(mats) == 1:
             return mat
-        return numpy.average(mats, weights=self.weights[magi], axis=0)
+        return numpy.average(mats, weights=self._weights, axis=0)
 
     def disagg_mag_dist_eps(self, iml2, rlzi):
         """
@@ -505,7 +488,7 @@ class Disaggregator(object):
         """
         mat5 = numpy.zeros((self.Ma, self.D, self.E) + iml2.shape)
         for magi in range(self.Ma):
-            mat6 = self.disagg6D(iml2, self.g_by_rlz[rlzi], magi)
+            mat6 = self.disagg6D(iml2, self.g_by_rlz[rlzi], self.magi)
             mat5[magi] = pprod(mat6, axis=(1, 2))
         return mat5
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -519,7 +519,6 @@ class ContextMaker(object):
             else:
                 item = (par, val[0].dtype)
             dtlist.append(item)
-        dtlist.append(('magi', numpy.uint8))
         for par in sitecol.dtype.names:
             if par != 'sids':
                 dtlist.append((par, sitecol.dtype[par]))

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -519,6 +519,7 @@ class ContextMaker(object):
             else:
                 item = (par, val[0].dtype)
             dtlist.append(item)
+        dtlist.append(('magi', numpy.uint8))
         for par in sitecol.dtype.names:
             if par != 'sids':
                 dtlist.append((par, sitecol.dtype[par]))

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -141,9 +141,6 @@ class DisaggregateTestCase(unittest.TestCase):
     def test_disaggregator(self):
         dis = disagg.Disaggregator([self.sources[0]], self.site, self.cmaker,
                                    self.bin_edges)
-        dis.init()
-        magi = list(dis.ctxs)
-        aac(magi, [0, 1, 2])  # magnitude bins
         iml2 = numpy.array([[.01]])
         mat3 = dis.disagg_mag_dist_eps(iml2, rlzi=0)[..., 0, 0]
         bymag = pprod(mat3, axis=(1, 2))


### PR DESCRIPTION
From 25,374 tasks to 4,710 tasks in the EUR calculation, by collecting together different magnitude bins. This is provisional and the plan is restore the splitting in magnitude bins in the future. Part of https://github.com/gem/oq-engine/issues/8326.