### PR TITLE
Managed the src_mutex case better in disaggregation

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -124,7 +124,7 @@ def compute_disagg(dis, triples, src_mutex, monitor):
         a dictionary s, z, m -> array5D
     """
     for magi in range(dis.Ma):
-        with monitor('building mean_std', measuremem=False):
+        with monitor('init disagg', measuremem=False):
             try:
                 dis.init(magi, src_mutex, monitor)
             except FarAwayRupture:
@@ -366,9 +366,6 @@ class DisaggregationCalculator(base.HazardCalculator):
                 smap.submit((dis, triples, src_mutex))
                 task_inputs.append((grp_id, n))
                 n_outs += len(triples)
-
-        nbytes, msg = get_nbytes_msg(dict(M=self.M, G=G, U=U, F=2))
-        logging.info('Maximum mean_std per task:\n%s', msg)
 
         data_transfer = s['dist'] * s['eps'] * s['lon'] * s['lat'] * \
             s['mag'] * s['M'] * s['P'] * 8 * n_outs

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -28,7 +28,8 @@ from openquake.baselib.general import (
 from openquake.baselib.python3compat import encode
 from openquake.hazardlib import stats
 from openquake.hazardlib.calc import disagg
-from openquake.hazardlib.contexts import read_cmakers, FarAwayRupture
+from openquake.hazardlib.contexts import (
+    read_cmakers, read_src_mutex, FarAwayRupture)
 from openquake.commonlib import util, calc
 from openquake.calculators import getters
 from openquake.calculators import base
@@ -107,7 +108,7 @@ def output(mat5):
     return pprod(mat5, axis=(1, 2)), pprod(mat5, axis=(0, 3))
 
 
-def compute_disagg(dis, triples, monitor):
+def compute_disagg(dis, triples, src_mutex, monitor):
     # see https://bugs.launchpad.net/oq-engine/+bug/1279247 for an explanation
     # of the algorithm used
     """
@@ -115,6 +116,8 @@ def compute_disagg(dis, triples, monitor):
         a Disaggregator instance
     :param triples:
         a list of triples (g, rlz, iml2)
+    :param src_mutex:
+        a dictionary {'src_id': [...], 'weight': [...]}
     :param monitor:
         monitor of the currently running job
     :returns:
@@ -123,7 +126,7 @@ def compute_disagg(dis, triples, monitor):
     for magi in range(dis.Ma):
         with monitor('building mean_std', measuremem=False):
             try:
-                dis.init(magi, monitor)
+                dis.init(magi, src_mutex, monitor)
             except FarAwayRupture:
                 continue
         res = {'trti': dis.cmaker.trti, 'magi': magi}
@@ -327,12 +330,14 @@ class DisaggregationCalculator(base.HazardCalculator):
         # that would break the ordering of the indices causing an incredibly
         # worse performance, but visible only in extra-large calculations!
         cmakers = read_cmakers(self.datastore)
+        src_mutex_by_grp = read_src_mutex(self.datastore)
         grp_ids = rdata['grp_id']
         G = max(len(cmaker.gsims) for cmaker in cmakers)
         s = self.shapedic
         n_outs = 0
         for grp_id, slices in performance.get_slices(grp_ids).items():
             cmaker = cmakers[grp_id]
+            src_mutex = src_mutex_by_grp.get(grp_id, {})
             ctxs = []
             for s0, s1 in slices:
                 ctxs.append(cmaker.read_ctxt(self.datastore, slice(s0, s1)))
@@ -356,9 +361,9 @@ class DisaggregationCalculator(base.HazardCalculator):
                     iml2 = iml3[:, :, z]
                     if iml2.any():
                         triples.append((g, rlz, iml2))
-                n = sum(len(ctx) for ctx in dis.ctxs)
+                n = len(dis.fullctx)
                 U = max(U, n)
-                smap.submit((dis, triples))
+                smap.submit((dis, triples, src_mutex))
                 task_inputs.append((grp_id, n))
                 n_outs += len(triples)
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -459,7 +459,7 @@ class Disaggregator(object):
             mats.append(mat)
         return numpy.average(mats, weights=self.weights, axis=0)
 
-    def disagg_mag_dist_eps(self, iml2, rlzi, src_mutex):
+    def disagg_mag_dist_eps(self, iml2, rlzi, src_mutex=None):
         """
         :returns: a 5D matrix of shape (Ma, D, E, M, P)
         """
@@ -573,9 +573,7 @@ def disaggregation(
               distance_bin_width=dist_bin_width,
               coordinate_bin_width=coord_bin_width,
               disagg_bin_edges=bin_edges)
-    for grp_id, (trt, srcs) in enumerate(by_trt.items()):
-        for src in srcs:
-            src.grp_id = grp_id
+    for trt, srcs in by_trt.items():
         cmaker[trt] = cm = ContextMaker(trt, rlzs_by_gsim, oq)
         cm.tom = srcs[0].temporal_occurrence_model
         ctxs[trt].extend(cm.from_srcs(srcs, sitecol))
@@ -592,11 +590,11 @@ def disaggregation(
     # Compute disaggregation per TRT
     matrix = numpy.zeros([dic['mag'], dic['dist'], dic['lon'], dic['lat'],
                           dic['eps'], len(trts)])
-    for grp_id, trt in enumerate(cmaker):
+    for trt in cmaker:
         dis = Disaggregator(ctxs[trt], sitecol, cmaker[trt], bin_edges)
         for magi in range(dis.Ma):
             try:
-                dis.init(magi, src_mutex={})
+                dis.init(magi, src_mutex={})  # src_mutex not implemented yet
             except FarAwayRupture:
                 continue                
             mat4 = dis.disagg6D([[iml]], 0)[..., 0, 0]

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -45,7 +45,6 @@ from openquake.hazardlib.contexts import (
 
 BIN_NAMES = 'mag', 'dist', 'lon', 'lat', 'eps', 'trt'
 BinData = collections.namedtuple('BinData', 'dists, lons, lats, pnes')
-aae = numpy.testing.assert_array_equal
 
 
 def assert_same_shape(arrays):
@@ -411,18 +410,16 @@ class Disaggregator(object):
             raise FarAwayRupture('No ruptures affecting site #%d' % sid)
 
         # build the magnitude bins
-        magidx = numpy.searchsorted(bin_edges[0], ctx.mag) - 1
-        magidx[magidx == -1] = 0  # when the magnitude is on the edge
+        self.fullmagi = numpy.searchsorted(bin_edges[0], ctx.mag) - 1
+        self.fullmagi[self.fullmagi == -1] = 0  # magnitude on the edge
 
         self.fullctx = ctx
-        self.magidx = magidx
-        self.nbytes = ctx.nbytes
 
     def init(self, magi, src_mutex, monitor=Monitor()):
         self.magi = magi
         self.src_mutex = src_mutex
         self.mon = monitor
-        self.ctx = self.fullctx[self.magidx == magi]
+        self.ctx = self.fullctx[self.fullmagi == magi]
         if len(self.ctx) == 0:
             raise FarAwayRupture
         self.mea, self.std = self.cmaker.get_mean_stds(
@@ -474,7 +471,7 @@ class Disaggregator(object):
         return mat5
 
     def __repr__(self):
-        return f'<{self.__class__.__name__} {humansize(self.nbytes)} >'
+        return f'<{self.__class__.__name__} {humansize(self.ctx.nbytes)} >'
 
 
 # this is used in the hazardlib tests, not in the engine


### PR DESCRIPTION
With this simplification in place I will be able to replace distribution by site with distribution by magbin in disaggregation, thus solving the issue of too many or too few tasks (part of https://github.com/gem/oq-engine/issues/8326). The performance is the same as before.