### PR TITLE
Computing the mean disaggregation on the workers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,8 @@
 
   [Michele Simionato]
   * Added an exporter for disagg_by_src
-  * Implemented statistical disaggregation outputs
+  * Implemented mean disaggregation outputs, with the means computed in terms
+    of rates, not probabilities
 
   [Kendra Johnson]
   * Corrected a bug when using the `reqv` feature: all sources were

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -99,7 +99,7 @@ def compute_disagg(dis_triples, magi, src_mutex, wdic, monitor):
     :param magi:
         an integer magnitude bin
     :param src_mutex:
-        a dictionary of weights (empty for independent sources)
+        dictionary src_id -> weight (empty for independent sources)
     :param wdic:
         dictionary rlz -> weight, empty for individual realizations
     :param monitor:

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -312,7 +312,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                 for rlzs in cmaker.gsims.values():
                     for rlz in rlzs:
                         wdic[rlz] = weights[rlz]
-            
+
             fullctx = numpy.concatenate(ctxs).view(numpy.recarray)
             magbins = numpy.searchsorted(self.bin_edges[0], fullctx.mag) - 1
             magbins[magbins == -1] = 0  # bins on the edge
@@ -450,7 +450,7 @@ class DisaggregationCalculator(base.HazardCalculator):
             mat7 = agg_probs(*mat8)  # shape (Ma, D, E, Lo, La, M, P)
             for key in oq.disagg_outputs:
                 if key == 'TRT':
-                    out[key][s, ..., z] = disagg.pmf_map[key](mat8)  # T,M,P
+                    out[key][s, ..., z] = disagg.pmf_map[key](mat8)  # (T,M,P)
                 elif key.startswith('TRT_'):
                     proj = disagg.pmf_map[key[4:]]
                     out[key][s, ..., z] = [proj(m7) for m7 in mat8]


### PR DESCRIPTION
Finally closes https://github.com/gem/oq-engine/issues/8326 in the most efficient possible way. Here are the figures for the EUR calculation with 43 sites, for reference purposes:
```
| calc_50569, maxmem=60.5 GB   | time_sec | memory_mb | counts    |
|------------------------------+----------+-----------+-----------|
| total compute_disagg         | 87_870   | 18.0      | 6_569     |
| init disagg                  | 57_889   | 0.0       | 6_569     |
| building disagg matrix       | 13_871   | 0.0       | 4_701_942 |
| composing pnes               | 13_012   | 0.0       | 4_701_942 |
| disagg by eps                | 2_642    | 0.0       | 4_701_942 |
| DisaggregationCalculator.run | 1_367    | 7_758     | 1         |
| aggregating disagg matrices  | 2.28237  | 3.28516   | 6_569     |
| saving disagg results        | 0.07963  | 0.0       | 1         |

| operation-duration | counts | mean | stddev | min     | max   | slowfac |
|--------------------+--------+------+--------+---------+-------+---------|
| compute_disagg     | 1_182  | 74.3 | 99%    | 0.14915 | 506.8 | 6.81704 |
| task           | sent                                            | received |
|----------------+-------------------------------------------------+----------|
| compute_disagg | dis_triples=2.35 GB wdic=29.37 MB magi=133.9 KB | 82.14 MB |
```
Instead of 300+ GB now the memory consumption is insignificant.