### PR TITLE
Reduced slow tasks in disaggregation

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -355,9 +355,7 @@ class DisaggregationCalculator(base.HazardCalculator):
                     # split by magbin
                     for c in disagg.split_by_magbin(
                             ctx, self.bin_edges[0]).values():
-                        sids = numpy.unique(c.sids)
-                        sites = tile.filter(numpy.isin(tile.sids, sids))
-                        submit(smap, self.datastore, c, sites, cmaker,
+                        submit(smap, self.datastore, c, tile, cmaker,
                                self.bin_edges, src_mutex, rwdic)
                 elif len(ctx):
                     submit(smap, self.datastore, ctx, tile, cmaker,

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -348,23 +348,19 @@ class DisaggregationCalculator(base.HazardCalculator):
                        self.bin_edges, src_mutex, rwdic)
                 continue
 
-            # submit tasks with splitting
-            for ctx in disagg.split_by_magbin(
-                    ctxt, self.bin_edges[0]).values():
-                sids = numpy.unique(ctx.sids)
-                sitecol = self.sitecol.filter(
-                    numpy.isin(self.sitecol.sids, sids))
-                ntasks = len(ctx) * cmaker.Z / maxsize
-                if len(sitecol) > ntasks:
-                    # split by magnitudes and tiles (test case_13)
-                    for tile in sitecol.split(ntasks):
-                        c = ctx[numpy.isin(ctx.sids, tile.sids)]
-                        if len(c):
-                            submit(smap, self.datastore, c, tile, cmaker,
-                                   self.bin_edges, src_mutex, rwdic)
-                else:
-                    # split by magnitude only (test case_1)
-                    submit(smap,self.datastore, ctx, sitecol, cmaker,
+            # split by tiles
+            for tile in self.sitecol.split(ntasks):
+                ctx = ctxt[numpy.isin(ctxt.sids, tile.sids)]
+                if len(ctx) * cmaker.Z > maxsize:
+                    # split by magbin
+                    for c in disagg.split_by_magbin(
+                            ctx, self.bin_edges[0]).values():
+                        sids = numpy.unique(c.sids)
+                        sites = tile.filter(numpy.isin(tile.sids, sids))
+                        submit(smap, self.datastore, c, sites, cmaker,
+                               self.bin_edges, src_mutex, rwdic)
+                elif len(ctx):
+                    submit(smap, self.datastore, ctx, tile, cmaker,
                            self.bin_edges, src_mutex, rwdic)
 
         shape8D = (s['trt'], s['mag'], s['dist'], s['lon'], s['lat'], s['eps'],

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -352,12 +352,13 @@ class DisaggregationCalculator(base.HazardCalculator):
             for tile in self.sitecol.split(ntasks):
                 ctx = ctxt[numpy.isin(ctxt.sids, tile.sids)]
                 if len(ctx) * cmaker.Z > maxsize:
-                    # split by magbin
+                    # split by magbin too
                     for c in disagg.split_by_magbin(
                             ctx, self.bin_edges[0]).values():
                         submit(smap, self.datastore, c, tile, cmaker,
                                self.bin_edges, src_mutex, rwdic)
                 elif len(ctx):
+                    # see case_multi in the oq-risk-tests
                     submit(smap, self.datastore, ctx, tile, cmaker,
                            self.bin_edges, src_mutex, rwdic)
 

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -431,6 +431,7 @@ class SiteCollection(object):
         :param ntiles: number of tiles to generate (rounded if float)
         :returns: self if there are <=1 tiles, otherwise the tiles
         """
+        # if ntiles > nsites produce N tiles with a single site each
         ntiles = min(int(numpy.ceil(ntiles)), len(self))
         if ntiles <= 1:
             return [self]

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -171,6 +171,12 @@ class SiteCollectionFilterTestCase(unittest.TestCase):
              z1pt0=22, z2pt5=11)
     ]
 
+    def test_split(self):
+        # splitting in more tiles than sites
+        col = SiteCollection(self.SITES)  # 4 sites
+        tiles = col.split(5)
+        self.assertEqual(len(tiles), 4)
+
     def test_filter(self):
         col = SiteCollection(self.SITES)
         filtered = col.filter(numpy.array([True, False, True, False]))


### PR DESCRIPTION
On oq1 we still had slow tasks and the EUR calculation with 43 sites took nearly one hour. Now it takes 10 minutes:
```
| operation-duration | counts |  mean | stddev |     min | max   | slowfac |
|--------------------+--------+-------+--------+---------+-------+---------|
| compute_disagg     | 782    | 119.1 |   101% | 1.20930 | 3_048 |    25.6 |
| compute_disagg     | 1_961  |  47.3 |    85% | 1.52212 | 538.3 |    11.4 |
```