### PR TITLE
Fixed BlockingIOError

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Sampling the ruptures was raising a BlockingIOError sometimes
+
   [Kendra Johnson]
   * Made it possible to use extendModel for multiple branchSets in the
     source model logic tree

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -259,7 +259,7 @@ class EventBasedCalculator(base.HazardCalculator):
             cmaker = ContextMaker(sg.trt, gsims_by_trt[sg.trt], oq)
             for src_group in sg.split(maxweight):
                 allargs.append((src_group, cmaker, srcfilter.sitecol))
-        # self.datastore.swmr_on() # removed to fix test_ebr[case_2b
+        self.datastore.swmr_on()
         smap = parallel.Starmap(
             sample_ruptures, allargs, h5=self.datastore.hdf5)
         mon = self.monitor('saving ruptures')


### PR DESCRIPTION
Sampling the UCERF ruptures caused
```python
BlockingIOError: [Errno 11] Unable to open file (unable to lock file, errno = 11,
error message = 'Resource temporarily unavailable')
```
Reported by @rcgee 