### PR TITLE
Fixed check on required site parameters

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Setting both `sites` and `site_model_file` now works also for models
+    with nonstandard site parameters, like EUR
+
   [Paolo Tormene]
   * Added AELO mode for the engine webui, providing a web form to insert input
     values and launch a calculation. Input values are validated and the

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -805,8 +805,7 @@ class HazardCalculator(BaseCalculator):
             if hasattr(self, 'rup'):
                 # for scenario we reduce the site collection to the sites
                 # within the maximum distance from the rupture
-                haz_sitecol, _dctx = self.cmaker.filter(
-                    haz_sitecol, self.rup)
+                haz_sitecol, _dctx = self.cmaker.filter(haz_sitecol, self.rup)
                 haz_sitecol.make_complete()
 
             if 'site_model' in oq.inputs:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -703,7 +703,7 @@ def get_full_lt(oqparam, branchID=None):
         logging.info('Considering {:_d} logic tree paths out of {:_d}'.format(
             oqparam.number_of_logic_tree_samples, p))
     else:  # full enumeration
-        logging.info('There are %d realization(s)', p)
+        logging.info('There are {:_d} logic tree paths(s)'.format(p))
         if oqparam.hazard_curves and p > oqparam.max_potential_paths:
             raise ValueError(
                 'There are too many potential logic tree paths (%d):'
@@ -715,7 +715,6 @@ def get_full_lt(oqparam, branchID=None):
             logging.warning(
                 'There are many potential logic tree paths (%d): '
                 'try to use sampling or reduce the source model' % p)
-        logging.info('Total number of logic tree paths = {:_d}'.format(p))
     if source_model_lt.is_source_specific:
         logging.info('There is a source specific logic tree')
     dupl = []

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -591,12 +591,6 @@ def get_site_collection(oqparam, h5=None):
             not numpy.isnan(sitecol.vs30).any()):
         assert sitecol.vs30.max() < 32767, sitecol.vs30.max()
 
-    # sanity check on the site parameters
-    for param in req_site_params:
-        dt = site.site_param_dt[param]
-        if dt is F64 and (sitecol.array[param] == 0.).all():
-            raise ValueError('The site parameter %s is always zero: please '
-                             'check the site model' % param)
     return sitecol
 
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1626,11 +1626,6 @@ def read_cmakers(dstore, full_lt=None):
     rlzs_by_gsim_list = full_lt.get_rlzs_by_gsim_list(trt_smrs)
     trts = list(full_lt.gsim_lt.values)
     num_eff_rlzs = len(full_lt.sm_rlzs)
-    if 'source_info' in dstore:
-        weight = dstore.read_df('source_info')[
-            ['grp_id', 'weight']].groupby('grp_id').sum().weight.to_numpy()
-    else:
-        weight = [1] * len(rlzs_by_gsim_list)
     start = 0
     aftershock = 'delta_rates' in dstore
     oq.mags_by_trt = {k: decode(v[:]) for k, v in dstore['source_mags'].items()}
@@ -1650,7 +1645,6 @@ def read_cmakers(dstore, full_lt=None):
         cmaker.trti = trti
         cmaker.gidx = numpy.arange(start, start + G)
         cmaker.grp_id = grp_id
-        cmaker.weight = weight[grp_id]
         start += G
         cmakers.append(cmaker)
     return cmakers

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -529,6 +529,8 @@ class SiteCollection(object):
 
         # sanity check
         for param in self.req_site_params:
+            if param in ignore:
+                continue
             dt = site_param_dt[param]
             if dt is numpy.float64 and (self.array[param] == 0.).all():
                 raise ValueError('The site parameter %s is always zero: please '

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -206,6 +206,7 @@ class SiteCollection(object):
     """ % '\n'.join('    - %s: %s' % item
                     for item in sorted(site_param_dt.items())
                     if item[0] not in ('lon', 'lat'))
+    req_site_params = ()
 
     @classmethod
     def from_usgs_shakemap(cls, shakemap_array):
@@ -249,6 +250,7 @@ class SiteCollection(object):
                                                        len(depths))
         self = object.__new__(cls)
         self.complete = self
+        self.req_site_params = req_site_params
         req = ['sids', 'lon', 'lat', 'depth'] + sorted(
             par for par in req_site_params if par not in ('lon', 'lat'))
         if 'vs30' in req and 'vs30measured' not in req:
@@ -524,6 +526,13 @@ class SiteCollection(object):
                 self._set(name, 0)  # default
                 # NB: by default reference_vs30_type == 'measured' is 1
                 # but vs30measured is 0 (the opposite!!)
+
+        # sanity check
+        for param in self.req_site_params:
+            dt = site_param_dt[param]
+            if dt is numpy.float64 and (self.array[param] == 0.).all():
+                raise ValueError('The site parameter %s is always zero: please '
+                                 'check the site model' % param)
         return site_model
 
     def within(self, region):


### PR DESCRIPTION
Avoids the error
```python
ValueError: The site parameter xvf is always zero: please check the site model
```
when running EUR in AELO mode. The trick is to move the check after the site model parameters association.