### PR TITLE
Some work on reducing logic trees

### DIFF
--- a/doc/adv-manual/logic_trees.rst
+++ b/doc/adv-manual/logic_trees.rst
@@ -162,7 +162,7 @@ attach the second ``extendModel`` to everything and get 8 paths:
  >>> logictree.get_all_paths()  # 3 * 2 + 2 paths
  ['ACF', 'ACG', 'ADF', 'ADG', 'AEF', 'AEG', 'B.F', 'B.G']
 
-The complete realizations can be obtained by not specifying ``applyToSources``:
+The complete realizations can be obtained by not specifying ``applyToBranches``:
 
 .. code-block:: python
 
@@ -302,7 +302,7 @@ branch IDs by using the command ``oq show branches``::
 The first character of the ``abbrev`` specifies the branch number ("A"
 means the first branch, "B" the second, etc) while the other characters
 are the branch set number starting from zero. The format works up to
-184 branches per branchset, bu using printable UTF8 characters.
+184 branches per branchset, using printable UTF8 characters.
 For instance the realization #322 has the following branch path in
 compact form::
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -850,7 +850,7 @@ class ClassicalCalculator(base.HazardCalculator):
         logging.info('There are %d slices of poes [%.1f per task]',
                      nslices, nslices / len(slicedic))
         allargs = [
-            (getters.PmapGetter(dstore, ws, slices, oq.imtls, oq.poes, ct),
+            (getters.PmapGetter(dstore, ws, slices, oq.imtls, oq.poes),
              N, hstats, individual, oq.max_sites_disagg, self.amplifier)
             for slices in allslices]
         self.hazard = {}  # kind -> array

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -139,7 +139,7 @@ class PmapGetter(object):
     :param dstore: a DataStore instance or file system path to it
     :param sids: the subset of sites to consider (if None, all sites)
     """
-    def __init__(self, dstore, weights, slices, imtls=(), poes=(), ntasks=1):
+    def __init__(self, dstore, weights, slices, imtls=(), poes=()):
         self.filename = dstore if isinstance(dstore, str) else dstore.filename
         if len(weights[0].dic) == 1:  # no weights by IMT
             self.weights = numpy.array([w['weight'] for w in weights])
@@ -147,7 +147,6 @@ class PmapGetter(object):
             self.weights = weights
         self.imtls = imtls
         self.poes = poes
-        self.ntasks = ntasks
         self.num_rlzs = len(weights)
         self.eids = None
         self.rlzs_by_g = dstore['rlzs_by_g'][()]

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -98,7 +98,7 @@ def write_csv(dest, data, sep=',', fmt='%.6E', header=None, comment=None,
 
 
 class CalculatorTestCase(unittest.TestCase):
-    OVERWRITE_EXPECTED = True
+    OVERWRITE_EXPECTED = False
     edir = None  # will be set to a temporary directory
 
     @classmethod

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -98,7 +98,7 @@ def write_csv(dest, data, sep=',', fmt='%.6E', header=None, comment=None,
 
 
 class CalculatorTestCase(unittest.TestCase):
-    OVERWRITE_EXPECTED = False
+    OVERWRITE_EXPECTED = True
     edir = None  # will be set to a temporary directory
 
     @classmethod

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -152,23 +152,20 @@ class ClassicalTestCase(CalculatorTestCase):
         self.assert_curves_ok(
             ['hazard_curve-mean.csv',
              'hazard_curve-smltp_b1-gsimltp_b1.csv',
-             'hazard_curve-smltp_b2-gsimltp_b1.csv'],
+             'hazard_curve-smltp_b2-gsimltp_b1.csv',
+             'hazard_curve-smltp_b3-gsimltp_b1.csv'],
             case_7.__file__)
 
-        # check the weights of the sources, a simple fault and a complex fault
+        # check the weights of the sources
         info = self.calc.datastore.read_df('source_info', 'source_id')
         self.assertEqual(info.loc[b'1'].weight, 184)
         self.assertEqual(info.loc[b'2'].weight, 118)
+        self.assertEqual(info.loc[b'3'].weight, 3914)
 
         # checking the individual hazard maps are nonzero
-        iml = self.calc.datastore.sel(
-            'hmaps-rlzs', imt="PGA", site_id=0).squeeze()
-        aac(iml, [0.167078, 0.134646], atol=.0001)  # for the two realizations
-
-        # exercise the warning for no output when mean='false'
-        self.run_calc(
-            case_7.__file__, 'job.ini', mean='false',
-            calculation_mode='preclassical',  poes='0.1')
+        imls = self.calc.datastore.sel(
+            'hmaps-rlzs', imt="PGA", site_id=0).squeeze()  # 3 rlzs
+        aac(imls, [0.167078, 0.134646, 0], atol=.0001)
 
     def test_case_8(self):
         self.assert_curves_ok(

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -614,10 +614,16 @@ hazard_uhs-std.csv
         self.run_calc(case_36.__file__, 'job.ini', hazard_calculation_id=hc_id,
                       calculation_mode='classical')
         self.assertEqual(self.calc.R, 9)  # there are 9 realizations
+        dstore = self.calc.datastore
 
-        tbl = general.gettemp(text_table(view('rlz:8', self.calc.datastore)))
+        # test `oq show rlz:`
+        tbl = general.gettemp(text_table(view('rlz:8', dstore)))
         self.assertEqualFiles('expected/show-rlz8.org', tbl)
 
+        # test `oq show branchsets`
+        tbl = general.gettemp(view('branchsets', dstore))
+        self.assertEqualFiles('expected/branchsets.org', tbl)
+        
     def test_case_37(self):
         # Christchurch
         self.assert_curves_ok(["hazard_curve-mean-PGA.csv",

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -35,9 +35,10 @@ from openquake.baselib.general import (
 from openquake.baselib.hdf5 import FLOAT, INT, get_shape_descr
 from openquake.baselib.performance import performance_view
 from openquake.baselib.python3compat import encode, decode
+from openquake.hazardlib import logictree
 from openquake.hazardlib.contexts import KNOWN_DISTANCES
 from openquake.hazardlib.gsim.base import ContextMaker, Collapser
-from openquake.commonlib import util, logictree
+from openquake.commonlib import util
 from openquake.risklib.scientific import (
     losses_by_period, return_periods, LOSSID, LOSSTYPE)
 from openquake.baselib.writers import build_header, scientificformat
@@ -1276,7 +1277,7 @@ def view_branchsets(token, dstore):
     Show the branchsets in the logic tree
     """
     flt = dstore['full_lt']
-    clt = logictree.compose(flt.gsim_lt, flt.source_model_lt)
+    clt = logictree.compose(flt.source_model_lt, flt.gsim_lt)
     return text_table(enumerate(map(repr, clt.branchsets)),
                       header=['bsno', 'bset'], ext='org')
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -703,8 +703,10 @@ def get_full_lt(oqparam, branchID=None):
     full_lt = logictree.FullLogicTree(source_model_lt, gsim_lt)
     p = full_lt.source_model_lt.num_paths * gsim_lt.get_num_paths()
     if oqparam.number_of_logic_tree_samples:
-        logging.info('Considering {:_d} logic tree paths out of {:_d}'.format(
-            oqparam.number_of_logic_tree_samples, p))
+        unique = numpy.unique(full_lt.rlzs['branch_path'])
+        logging.info('Considering {:_d} logic tree paths out of {:_d}, unique'
+                     ' {:_d}'.format(oqparam.number_of_logic_tree_samples, p,
+                                     len(unique)))
     else:  # full enumeration
         logging.info('There are {:_d} logic tree paths(s)'.format(p))
         if oqparam.hazard_curves and p > oqparam.max_potential_paths:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -723,8 +723,8 @@ def get_full_lt(oqparam, branchID=None):
     if source_model_lt.is_source_specific:
         logging.info('There is a source specific logic tree')
     dupl = []
-    for src_id, branchIDs in source_model_lt.source_ids.items():
-        if len(branchIDs) > 1:
+    for src_id, sms in source_model_lt.sms_by_src.items():
+        if len(sms) > 1:
             dupl.append(src_id)
     if dupl:
         logging.info('There are %d non-unique source IDs', len(dupl))

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -673,7 +673,10 @@ def get_source_model_lt(oqparam, branchID=None):
         a :class:`openquake.hazardlib.logictree.SourceModelLogicTree`
         instance
     """
-    return get_smlt(vars(oqparam), branchID)
+    smlt = get_smlt(vars(oqparam), branchID)
+    if len(oqparam.source_id) == 1:  # reduce to a single source
+        smlt.reduce(oqparam.source_id[0])
+    return smlt
 
 
 def get_full_lt(oqparam, branchID=None):

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -502,7 +502,7 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
     def test_with_site_model(self):
         oq = readinput.get_oqparam('job.ini', case_34)
         ssclt = readinput.get_composite_source_model(oq)
-        self.assertEqual(ssclt.source_model_lt.source_ids['956'], ['b1'])
+        self.assertEqual(ssclt.source_model_lt.sms_by_src['956'], ['b1'])
 
 
 class SitecolAssetcolTestCase(unittest.TestCase):

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -110,13 +110,13 @@ def get_effective_rlzs(rlzs):
     """
     Group together realizations with the same path
     and yield the first representative of each group.
+
+    :param rlzs: a list of Realization instances with a .pid property
     """
     effective = []
     ordinal = 0
     for group in groupby(rlzs, operator.attrgetter('pid')).values():
         rlz = group[0]
-        if all(path == '@' for path in rlz.lt_path):  # empty realization
-            continue
         effective.append(
             Realization(rlz.value, sum(r.weight for r in group),
                         ordinal, rlz.lt_path, len(group)))

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -387,6 +387,8 @@ class SourceModelLogicTree(object):
         Reduce the logic tree to a single source. Works by side effects.
         """
         self.tectonic_region_types = {self.trt_by_src[src_id]}
+        self.trt_by_src = {src_id: self.trt_by_src[src_id]}
+        self.sms_by_src = {src_id: self.sms_by_src[src_id]}
         for bset, dic in zip(self.branchsets, self.bsetdict.values()):
             ats = dic.get('applyToSources')
             if ats and src_id not in ats:
@@ -403,8 +405,11 @@ class SourceModelLogicTree(object):
         to the tree's root.
         """
         self.info = collect_info(self.filename, self.branchID)
-        self.sms_by_src = collections.defaultdict(list)  # src_id -> branchIDs
-        self.trt_by_src = {}  # src_id -> trt
+
+        # the following two dicts are populated in collect_source_model_data
+        self.sms_by_src = collections.defaultdict(list)
+        self.trt_by_src = {}
+
         t0 = time.time()
         for depth, blnode in enumerate(tree_node.nodes):
             [bsnode] = bsnodes(self.filename, blnode)

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -87,7 +87,7 @@ def get_trt_by_src(source_model_file):
     """
     pieces = TRT_REGEX.split(source_model_file.read())
     trt_by_src = {}
-    for text, trt in zip(pieces[0::2], pieces[1::2]):
+    for text, trt in zip(pieces[2::2], pieces[1::2]):
         for src_id in ID_REGEX.findall(text):
             trt_by_src[src_id] = trt
     return trt_by_src
@@ -380,12 +380,17 @@ class SourceModelLogicTree(object):
             self.num_paths = count_paths(self.root_branchset.branches)
 
     def reduce(self, src_id):
+        """
+        Reduce the logic tree to a single source. Works by side effects.
+        """
         self.tectonic_region_types = {self.trt_by_src[src_id]}
         for bset, dic in zip(self.branchsets, self.bsetdict.values()):
             ats = dic.get('applyToSources')
             if ats and src_id not in ats:
                 bset.collapsed = True
-                bset.branches = [bset.branches[0]]
+                b0 = bset.branches[0]
+                b0.branch_id = '.'
+                bset.branches = [b0]
                 del dic['applyToSources']
         self.num_paths = count_paths(self.root_branchset.branches)
 

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -386,16 +386,14 @@ class SourceModelLogicTree(object):
         """
         Reduce the logic tree to a single source. Works by side effects.
         """
-        self.tectonic_region_types = {self.trt_by_src[src_id]}
+        oksms = self.sms_by_src[src_id]
+        self.sms_by_src = {src_id: oksms}
         self.trt_by_src = {src_id: self.trt_by_src[src_id]}
-        self.sms_by_src = {src_id: self.sms_by_src[src_id]}
+        self.tectonic_region_types = {self.trt_by_src[src_id]}
         for bset, dic in zip(self.branchsets, self.bsetdict.values()):
             ats = dic.get('applyToSources')
             if ats and src_id not in ats:
-                bset.collapsed = True
-                b0 = bset.branches[0]
-                b0.branch_id = '.'
-                bset.branches = [b0]
+                bset.collapse()
                 del dic['applyToSources']
         self.num_paths = count_paths(self.root_branchset.branches)
 

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -85,9 +85,12 @@ def get_trt_by_src(source_model_file):
     """
     :returns: a dictionary source ID -> tectonic region type of the source
     """
-    pieces = TRT_REGEX.split(source_model_file.read())
+    xml = source_model_file.read()
+    pieces = TRT_REGEX.split(xml)
+    nrml05 = re.search('<sourceGroup', pieces[0])
+    start = 2 if nrml05 else 0  # trt before (start=2) or after src_id (start=0)
     trt_by_src = {}
-    for text, trt in zip(pieces[2::2], pieces[1::2]):
+    for text, trt in zip(pieces[start::2], pieces[1::2]):
         for src_id in ID_REGEX.findall(text):
             trt_by_src[src_id] = trt
     return trt_by_src

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -317,7 +317,8 @@ class SourceModelLogicTree(object):
                           branch_dt)
         dic = dict(filename='fake.xml', seed=0, num_samples=0,
                    sampling_method='early_weights', num_paths=1,
-                   sms_by_src=AccumDict(accum=[]), is_source_specific=0,
+                   sms_by_src=AccumDict(accum=[]), trt_by_src={},
+                   is_source_specific=0,
                    tectonic_region_types=set(),
                    bsetdict='{"bs0": {"uncertaintyType": "sourceModel"}}')
         self.__fromh5__(arr, dic)

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -317,7 +317,7 @@ class SourceModelLogicTree(object):
                           branch_dt)
         dic = dict(filename='fake.xml', seed=0, num_samples=0,
                    sampling_method='early_weights', num_paths=1,
-                   source_ids=AccumDict(accum=[]), is_source_specific=0,
+                   sms_by_src=AccumDict(accum=[]), is_source_specific=0,
                    tectonic_region_types=set(),
                    bsetdict='{"bs0": {"uncertaintyType": "sourceModel"}}')
         self.__fromh5__(arr, dic)
@@ -403,7 +403,7 @@ class SourceModelLogicTree(object):
         to the tree's root.
         """
         self.info = collect_info(self.filename, self.branchID)
-        self.source_ids = collections.defaultdict(list)  # src_id -> branchIDs
+        self.sms_by_src = collections.defaultdict(list)  # src_id -> branchIDs
         self.trt_by_src = {}  # src_id -> trt
         t0 = time.time()
         for depth, blnode in enumerate(tree_node.nodes):
@@ -632,7 +632,7 @@ class SourceModelLogicTree(object):
 
         if 'applyToSources' in f:
             for source_id in f['applyToSources'].split():
-                branchIDs = self.source_ids[source_id]
+                branchIDs = self.sms_by_src[source_id]
                 if not branchIDs:
                     raise LogicTreeError(
                         branchset_node, self.filename,
@@ -714,7 +714,7 @@ class SourceModelLogicTree(object):
         with self._get_source_model(source_model) as sm:
             trt_by_src = get_trt_by_src(sm)
         for src_id, trt in trt_by_src.items():
-            self.source_ids[src_id].append(branch_id)
+            self.sms_by_src[src_id].append(branch_id)
             self.trt_by_src[src_id] = trt
             self.tectonic_region_types.add(trt)
 

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -627,6 +627,7 @@ class BranchSet(object):
         """
         if self.collapsed:
             b0 = copy.copy(self.branches[0])
+            # b0.branch_id = '.'
             b0.weight = 1.0
             branches = [b0]
         else:

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -687,6 +687,16 @@ class BranchSet(object):
                 bset = br.bset
         return pairs
 
+    def collapse(self):
+        """
+        Collapse to the first branch (with side effects)
+        """
+        self.collapsed = True
+        b0 = self.branches[0]
+        b0.branch_id = '.'
+        b0.weight = 1.
+        self.branches = [b0]
+
     def to_list(self):
         """
         :returns: a literal list describing the branchset

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -703,7 +703,10 @@ class BranchSet(object):
         return repr(self.branches)
 
     def __repr__(self):
-        return '<%s(%d)>' % (self.uncertainty_type, len(self))
+        kvs = ', '.join('%s=%s' % item for item in self.filters.items())
+        if kvs:
+            kvs = ', ' + kvs
+        return '<%s(%d%s)>' % (self.uncertainty_type, len(self), kvs)
 
 
 # NB: this function cannot be used with monster logic trees like the one for

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -46,22 +46,6 @@ else:
             array[:, r] = (1. - (1. - array[:, r]) * (1. - other))
 
 
-def combine(pmap, rlz_groups):
-    """
-    Convert a ProbabilityMap with shape (N, L, G) into a ProbabilityMap
-    with shape (N, L, R), being G the number of realization groups, which
-    are list of integers in the range 0..R-1.
-    """
-    N, L, G = pmap.array.shape
-    R = max(max(rlzs) for rlzs in rlz_groups) + 1
-    out = ProbabilityMap(range(N), L, R).fill(0.)
-    for g, rlz_group in enumerate(rlz_groups):
-        rlzs = U32(rlz_group)
-        for sid in range(N):
-            combine_probs(out.array[sid], pmap.array[sid, :, g], rlzs)
-    return out
-
-
 def get_mean_curve(dstore, imt, site_id=0):
     """
     Extract the mean hazard curve from the datastore for the first site.
@@ -362,6 +346,22 @@ class ProbabilityMap(object):
         :returns: a new Pmap associated to a reshaped array
         """
         return self.new(self.array.reshape(N, M, P))
+
+    # used in calc/disagg_test.py
+    def expand(self, rlz_groups):
+        """
+        Convert a ProbabilityMap with shape (N, L, G) into a ProbabilityMap
+        with shape (N, L, R), being G the number of realization groups, which
+        are list of integers in the range 0..R-1.
+        """
+        N, L, G = self.array.shape
+        R = max(max(rlzs) for rlzs in rlz_groups) + 1
+        out = ProbabilityMap(range(N), L, R).fill(0.)
+        for g, rlz_group in enumerate(rlz_groups):
+            rlzs = U32(rlz_group)
+            for sid in range(N):
+                combine_probs(out.array[sid], self.array[sid, :, g], rlzs)
+        return out
 
     # used in calc_hazard_curves
     def convert(self, imtls, nsites, idx=0):

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -277,7 +277,7 @@ def test_single_source(job_ini):
     L = oq.imtls.size
     R = inp.full_lt.get_num_paths()
     G = sum(len(cm.gsims) for cm in inp.cmakers)
-    pmap = probability_map.ProbabilityCurve(numpy.zeros((1, L, G)))
+    pmap = probability_map.ProbabilityMap(inp.sitecol.sids, L, G).fill(0)
     rlzs_by_g = []
     for grp, cmaker in zip(inp.groups, inp.cmakers):
         for rlzs in cmaker.gsims.values():
@@ -286,10 +286,8 @@ def test_single_source(job_ini):
         pmap.array[:, :, cmaker.gidx] = cmaker.get_pmap(
             ctxs).array  # shape (L, G)
 
-    iml4 = probability_map.combine(pmap, rlzs_by_g).interp4D(
-        oq.imtls, oq.poes)
-
-    edges, shapedic = disagg.get_edges_shapedic(oq, inp.sitecol, R)
+    iml4 = pmap.expand(rlzs_by_g).interp4D(oq.imtls, oq.poes)
+    edges, shapedic = disagg.get_edges_shapedic(oq, inp.sitecol)
     dis = disagg.Disaggregator(grp, inp.sitecol, cmaker, edges)
     rlz = R - 1
     for magi in range(dis.Ma):

--- a/openquake/qa_tests_data/classical/README.md
+++ b/openquake/qa_tests_data/classical/README.md
@@ -59,7 +59,7 @@
 | case_57 | Test for sampling AvgPoeGMPE |
 | case_58 | Test for the truncatedGRFromSlipAbsolute epistemic uncertainty |
 | case_59 | Test for NRCan15SiteTerm |
-| case_60 | Test CampbellBozorgnia2003NSHMP2007|
+| case_60 | Test CampbellBozorgnia2003NSHMP2007 and no hazard|
 | case_61 | Test KiteFault source|
 | case_62 | Tests a sample model from SHERIFS |
 | case_63 | Test for GMM with soiltype |

--- a/openquake/qa_tests_data/classical/README.md
+++ b/openquake/qa_tests_data/classical/README.md
@@ -6,7 +6,7 @@
 | case_4  | Test SimpleFault, 1 rlz, 1 site|
 | case_5  | Test ComplexFault, 1 rlz, 1 site|
 | case_6  | Test 2 sources, 1 rlz, 1 site|
-| case_7  | Test 2 source models with a duplicate source, i.e. nontrivial trt_smrs|
+| case_7  | Test 3 source models with a duplicate source, i.e. nontrivial trt_smrs|
 | case_8  | Source Specific Logic Tree on 1 source, the other ignored|
 | case_9  | Source Specific Logic Tree on 1 source|
 | case_10 | Source Specific Logic Tree on 1 source|

--- a/openquake/qa_tests_data/classical/case_36/expected/branchsets.org
+++ b/openquake/qa_tests_data/classical/case_36/expected/branchsets.org
@@ -1,0 +1,15 @@
+| bsno | bset                                                                                 |
+|------+--------------------------------------------------------------------------------------|
+| 0    | <sourceModel(1)>                                                                     |
+| 1    | <maxMagGRRelative(3, applyToSources=['1', '2', '3', '4', '5', '6', '7', '8', '10'])> |
+| 2    | <maxMagGRRelative(3, applyToSources=['9'])>                                          |
+| 3    | <maxMagGRRelative(3, applyToSources=['11'])>                                         |
+| 4    | <abGRAbsolute(3, applyToSources=['1'])>                                              |
+| 5    | <abGRAbsolute(3, applyToSources=['2'])>                                              |
+| 6    | <abGRAbsolute(3, applyToSources=['5'])>                                              |
+| 7    | <abGRAbsolute(3, applyToSources=['9'])>                                              |
+| 8    | <abGRAbsolute(3, applyToSources=['10'])>                                             |
+| 9    | <abGRAbsolute(3, applyToSources=['11'])>                                             |
+| 10   | <gmpeModel(3)>                                                                       |
+| 11   | <gmpeModel(1)>                                                                       |
+| 12   | <gmpeModel(1)>                                                                       |

--- a/openquake/qa_tests_data/classical/case_7/expected/hazard_curve-mean.csv
+++ b/openquake/qa_tests_data/classical/case_7/expected/hazard_curve-mean.csv
@@ -1,3 +1,3 @@
-#,,,,,"generated_by='OpenQuake engine 3.9.0-git93fe51638e', start_date='2020-03-29T09:15:02', checksum=1870360642, kind='mean', investigation_time=1.0, imt='PGA'"
+#,,,,,"generated_by='OpenQuake engine 3.17.0-git5089c148d4', start_date='2023-02-27T06:52:04', checksum=47040888, kind='mean', investigation_time=1.0, imt='PGA'"
 lon,lat,depth,poe-0.1000000,poe-0.1200000,poe-0.2000000
-0.00000,0.00000,0.00000,7.949015E-01,7.580131E-01,3.440354E-01
+0.00000,0.00000,0.00000,5.820763E-01,5.478676E-01,2.411809E-01

--- a/openquake/qa_tests_data/classical/case_7/expected/hazard_curve-smltp_b3-gsimltp_b1.csv
+++ b/openquake/qa_tests_data/classical/case_7/expected/hazard_curve-smltp_b3-gsimltp_b1.csv
@@ -1,0 +1,3 @@
+#,,,,,"generated_by='OpenQuake engine 3.17.0-git5089c148d4', start_date='2023-02-27T06:52:04', checksum=47040888, kind='rlz-002', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.1000000,poe-0.1200000,poe-0.2000000
+0.00000,0.00000,0.00000,1.552476E-01,1.222277E-01,3.860128E-02

--- a/openquake/qa_tests_data/classical/case_7/job.ini
+++ b/openquake/qa_tests_data/classical/case_7/job.ini
@@ -43,5 +43,4 @@ maximum_distance = 200.0
 [output]
 
 individual_rlzs = true
-mean = true
 poes = .5

--- a/openquake/qa_tests_data/classical/case_7/source_model_3.xml
+++ b/openquake/qa_tests_data/classical/case_7/source_model_3.xml
@@ -2,7 +2,7 @@
 <nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
       xmlns:gml="http://www.opengis.net/gml">
     <sourceModel name="Classical Hazard QA Test, Case 7 source model 3">
-        <simpleFaultSource id="1" name="simple fault source" tectonicRegion="active shallow crust">
+        <simpleFaultSource id="3" name="fault3" tectonicRegion="active shallow crust">
             <simpleFaultGeometry>
                 <gml:LineString>
                     <gml:posList>

--- a/openquake/qa_tests_data/classical/case_7/source_model_3.xml
+++ b/openquake/qa_tests_data/classical/case_7/source_model_3.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+      xmlns:gml="http://www.opengis.net/gml">
+    <sourceModel name="Classical Hazard QA Test, Case 7 source model 3">
+        <simpleFaultSource id="1" name="simple fault source" tectonicRegion="active shallow crust">
+            <simpleFaultGeometry>
+                <gml:LineString>
+                    <gml:posList>
+                        -0.1449660802959 0
+                        0.449660802959 0
+                    </gml:posList>
+                </gml:LineString>
+
+                <dip>60.0</dip>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>1.0</lowerSeismoDepth>
+            </simpleFaultGeometry>
+
+            <magScaleRel>PeerMSR</magScaleRel>
+
+            <ruptAspectRatio>1.0</ruptAspectRatio>
+
+            <incrementalMFD minMag="4.0" binWidth="1.0">
+                <occurRates>1.0</occurRates>
+            </incrementalMFD>
+
+            <rake>0.0</rake>
+        </simpleFaultSource>
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_7/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/classical/case_7/source_model_logic_tree.xml
@@ -5,10 +5,14 @@
     <logicTreeBranchSet uncertaintyType="sourceModel" branchSetID="bs1">
       <logicTreeBranch branchID="b1">
         <uncertaintyModel>source_model_1.xml</uncertaintyModel>
-        <uncertaintyWeight>0.7</uncertaintyWeight>
+        <uncertaintyWeight>0.4</uncertaintyWeight>
       </logicTreeBranch>
       <logicTreeBranch branchID="b2">
         <uncertaintyModel>source_model_2.xml</uncertaintyModel>
+        <uncertaintyWeight>0.3</uncertaintyWeight>
+      </logicTreeBranch>
+      <logicTreeBranch branchID="b3">
+        <uncertaintyModel>source_model_3.xml</uncertaintyModel>
         <uncertaintyWeight>0.3</uncertaintyWeight>
       </logicTreeBranch>
     </logicTreeBranchSet>


### PR DESCRIPTION
Removed some code and fixed the view `oq show branchsets`. Added a function `get_trt_by_src` so that the tectonic type of each source is known without having to fully parse the source models. Added a method `ProbabilityMap.expand` and a method `BranchSet.collapse`. Expanded case_7 to 3 source models. Changed `get_source_model_lt` to collapse the logic tree to the given source, if specified in the job.ini (relevant for AELO). This is only the initial work.