### PR TITLE
Make sure we can run calculations on cole

### DIFF
--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -226,7 +226,8 @@ if APPLICATION_MODE.upper() in ('RESTRICTED', 'AELO'):
 
 STATIC_URL = '%s/static/' % WEBUI_PATHPREFIX
 
-if LOCKDOWN:
+if LOCKDOWN and APPLICATION_MODE == 'AELO':
+    # check essential constants are defined
     try:
         EMAIL_BACKEND  # noqa
     except NameError:
@@ -246,6 +247,7 @@ if LOCKDOWN:
                 f' EMAIL_<HOST|PORT|USE_TLS|HOST_USER|HOST_PASSWORD>'
                 f' must all be defined')
 
+if LOCKDOWN:
     AUTHENTICATION_BACKENDS += (
         'django.contrib.auth.backends.ModelBackend',
         # 'dpam.backends.PAMBackend',


### PR DESCRIPTION
It is currently impossible due to the AELO checks: any calculation produce an error
```python
  File "/opt/openquake/oq-engine/openquake/commands/webui.py", line 26, in <module>
    from openquake.server.utils import check_webserver_running
  File "/opt/openquake/oq-engine/openquake/server/utils.py", line 28, in <module>
    if settings.LOCKDOWN:
  File "/opt/openquake/venv/lib64/python3.8/site-packages/django/conf/__init__.py", line 82, in __getattr__
    self._setup(name)
  File "/opt/openquake/venv/lib64/python3.8/site-packages/django/conf/__init__.py", line 69, in _setup
    self._wrapped = Settings(settings_module)
  File "/opt/openquake/venv/lib64/python3.8/site-packages/django/conf/__init__.py", line 170, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/opt/openquake/oq-engine/openquake/server/settings.py", line 233, in <module>
    raise NameError(
NameError: If APPLICATION_MODE is public an email backend must be defined
```