### PR TITLE
Fixed event based running out of memory

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Fixed event based calculations running out of memory due to hazard curve
+    arrays being instantiated without need
+
   [Julián Santiago Montejo Espitia]
   * Contributed the GMPE Arteta et al. (2023) for crustal events on northern
     South America

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -218,14 +218,6 @@ class EventBasedCalculator(base.HazardCalculator):
             self.datastore.create_dset('ruptures', rupture_dt)
             self.datastore.create_dset('rupgeoms', hdf5.vfloat32)
 
-    def acc0(self):
-        """
-        Initial accumulator, a dictionary rlz -> ProbabilityMap
-        """
-        self.L = self.oqparam.imtls.size
-        return {r: ProbabilityMap(self.sitecol.sids, self.L, 1).fill(0)
-                for r in range(self.R)}
-
     def build_events_from_sources(self):
         """
         Prefilter the composite source model and store the source_info
@@ -462,7 +454,13 @@ class EventBasedCalculator(base.HazardCalculator):
             concurrent_tasks=oq.concurrent_tasks or 1,
             duration=oq.time_per_task,
             outs_per_task=oq.outs_per_task)
-        acc = smap.reduce(self.agg_dicts, self.acc0())
+        if oq.hazard_curves_from_gmfs:
+            self.L = oq.imtls.size
+            acc0 = {r: ProbabilityMap(self.sitecol.sids, self.L, 1).fill(0)
+                    for r in range(self.R)}
+        else:
+            acc0 = {}
+        acc = smap.reduce(self.agg_dicts, acc0)
         if 'gmf_data' not in dstore:
             return acc
         if oq.ground_motion_fields:


### PR DESCRIPTION
As discovered by @rcgee and friends. We were building empty hazard curves for 50,000 realizations even if `hazard_curves_from_gmfs` was false!