### PR TITLE
Implemented preclassical cache

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Enhanced --reuse-input to reuse preclassical calculations if possible
   * Normalized IMTs in the `minimum_intensity` dictionary (i.e. SA(1.)=>SA(1.0))
   * Fixed event based calculations running out of memory due to hazard curve
     arrays being instantiated without need

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -29,6 +29,7 @@ from openquake.hazardlib.source.base import get_code2cls
 from openquake.hazardlib.sourceconverter import SourceGroup
 from openquake.hazardlib.calc.filters import split_source, SourceFilter
 from openquake.hazardlib.scalerel.point import PointMSR
+from openquake.commonlib import readinput, datastore
 from openquake.calculators import base
 
 U16 = numpy.uint16
@@ -137,26 +138,30 @@ class PreClassicalCalculator(base.HazardCalculator):
     def init(self):
         super().init()
         if self.oqparam.hazard_calculation_id:
-            full_lt = self.datastore.parent['full_lt']
+            self.full_lt = self.datastore.parent['full_lt']
             trt_smrs = self.datastore.parent['trt_smrs'][:]
         else:
-            full_lt = self.csm.full_lt
+            self.full_lt = self.csm.full_lt
             trt_smrs = self.csm.get_trt_smrs()
         self.grp_ids = numpy.arange(len(trt_smrs))
         rlzs_by_g = []
         for t in trt_smrs:
-            for rlzs in full_lt.get_rlzs_by_gsim(t).values():
+            for rlzs in self.full_lt.get_rlzs_by_gsim(t).values():
                 rlzs_by_g.append(rlzs)
         self.datastore.hdf5.save_vlen(
             'rlzs_by_g', [U32(rlzs) for rlzs in rlzs_by_g])
 
-    def populate_csm(self):
-        # and store full_lt and source_info
-        csm = self.csm
-        self.datastore['trt_smrs'] = csm.get_trt_smrs()
+    def store(self):
+        # store full_lt, trt_smrs, toms
+        self.datastore['full_lt'] = self.csm.full_lt
+        self.datastore['trt_smrs'] = self.csm.get_trt_smrs()
         self.datastore['toms'] = numpy.array(
             [sg.get_tom_toml(self.oqparam.investigation_time)
-             for sg in csm.src_groups], hdf5.vstr)
+             for sg in self.csm.src_groups], hdf5.vstr)
+
+    def populate_csm(self):
+        csm = self.csm
+        self.store()
         cmakers = read_cmakers(self.datastore, csm.full_lt)
         self.sitecol = sites = csm.sitecol if csm.sitecol else None
         if sites is None:
@@ -186,7 +191,6 @@ class PreClassicalCalculator(base.HazardCalculator):
 
         # run preclassical for non-atomic sources
         sources_by_key = groupby(normal_sources, operator.attrgetter('grp_id'))
-        self.datastore.hdf5['full_lt'] = csm.full_lt
         logging.info('Starting preclassical with %d source groups',
                      len(sources_by_key))
         self.datastore.swmr_on()
@@ -262,7 +266,21 @@ class PreClassicalCalculator(base.HazardCalculator):
         parallelizing on the sources according to their weight and
         tectonic region type.
         """
-        self.populate_csm()
+        oq = self.oqparam
+        checksum = readinput.get_checksum32(oq, self.datastore.hdf5)
+        if oq.cachedir:
+            fname = os.path.join(oq.cachedir, 'csm_%d.hdf5' % checksum)
+            if os.path.exists(fname):
+                with datastore.read(os.path.realpath(fname)) as ds:
+                    self.csm = ds['_csm']
+                    self.csm.init()
+                    self.csm.full_lt = self.full_lt
+                self.store()
+            else:
+                self.populate_csm()
+                os.symlink(self.datastore.filename, fname)
+        else:
+            self.populate_csm()
         self.max_weight = self.csm.get_max_weight(self.oqparam)
         return self.csm
 

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -273,8 +273,7 @@ class PreClassicalCalculator(base.HazardCalculator):
             if os.path.exists(fname):
                 with datastore.read(os.path.realpath(fname)) as ds:
                     self.csm = ds['_csm']
-                    self.csm.init()
-                    self.csm.full_lt = self.full_lt
+                    self.csm.init(self.full_lt)
                 self.store()
             else:
                 self.populate_csm()

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -239,7 +239,7 @@ main.list_risk_calculations = dict(
 main.delete_uncompleted_calculations = dict(
     abbrev='--duc', help='Delete all the uncompleted calculations')
 main.multi = 'Run multiple job.inis in parallel'
-main.reuse_input = 'Read the sources|exposures from the cache (if any)'
+main.reuse_input = 'Read the CompositeSourceModel from the cache (if any)'
 
 # options
 main.log_file = dict(

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -809,8 +809,7 @@ def get_composite_source_model(oqparam, h5=None, branchID=None):
             from openquake.commonlib import datastore  # avoid circular import
             with datastore.read(os.path.realpath(fname)) as ds:
                 csm = ds['_csm']
-                csm.init()
-                csm.full_lt = full_lt
+                csm.init(full_lt)
         else:
             csm = source_reader.get_csm(oqparam, full_lt, h5)
             _check_csm(csm, oqparam, h5)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -50,6 +50,7 @@ from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.geo.utils import BBoxError, cross_idl
 from openquake.risklib import asset, riskmodels, scientific, reinsurance
 from openquake.risklib.riskmodels import get_risk_functions
+from openquake.commonlib import datastore
 from openquake.commonlib.oqvalidation import OqParam
 
 F32 = numpy.float32
@@ -801,31 +802,8 @@ def get_composite_source_model(oqparam, h5=None, branchID=None):
     :param h5:
          an open hdf5.File where to store the source info
     """
-    # first read the logic tree
     full_lt = get_full_lt(oqparam, branchID)
-
-    # then read the composite source model from the cache if possible
-    if oqparam.cachedir and not os.path.exists(oqparam.cachedir):
-        os.makedirs(oqparam.cachedir)
-    if oqparam.cachedir:
-        # for UCERF pickling the csm is slower
-        checksum = get_checksum32(oqparam, h5)
-        fname = os.path.join(oqparam.cachedir, 'csm_%s.pik' % checksum)
-        if os.path.exists(fname):
-            logging.info('Reading %s', fname)
-            with open(fname, 'rb') as f:
-                csm = pickle.load(f)
-                csm.full_lt = full_lt
-            _check_csm(csm, oqparam, h5)
-            return csm
-
-    # read and process the composite source model from the input files
     csm = source_reader.get_csm(oqparam, full_lt, h5)
-    if oqparam.cachedir:
-        logging.info('Saving %s', fname)
-        with open(fname, 'wb') as f:
-            pickle.dump(csm, f)
-
     _check_csm(csm, oqparam, h5)
     return csm
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -907,24 +907,12 @@ def get_exposure(oqparam):
     :returns:
         an :class:`Exposure` instance or a compatible AssetCollection
     """
-    if oqparam.cachedir and not os.path.exists(oqparam.cachedir):
-        os.makedirs(oqparam.cachedir)
-    checksum = _checksum(oqparam.inputs['exposure'])
-    fname = os.path.join(oqparam.cachedir, 'exp_%s.pik' % checksum)
-    if os.path.exists(fname):
-        logging.info('Reading %s', fname)
-        with open(fname, 'rb') as f:
-            return pickle.load(f)
     exposure = Global.exposure = asset.Exposure.read(
         oqparam.inputs['exposure'], oqparam.calculation_mode,
         oqparam.region, oqparam.ignore_missing_costs,
         by_country='country' in asset.tagset(oqparam.aggregate_by),
         errors='ignore' if oqparam.ignore_encoding_errors else None)
     exposure.mesh, exposure.assets_by_site = exposure.get_mesh_assets_by_site()
-    if oqparam.cachedir:
-        logging.info('Saving %s', fname)
-        with open(fname, 'wb') as f:
-            pickle.dump(exposure, f)
     return exposure
 
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -803,8 +803,20 @@ def get_composite_source_model(oqparam, h5=None, branchID=None):
          an open hdf5.File where to store the source info
     """
     full_lt = get_full_lt(oqparam, branchID)
-    csm = source_reader.get_csm(oqparam, full_lt, h5)
-    _check_csm(csm, oqparam, h5)
+    if oqparam.cachedir:
+        checksum = get_checksum32(oqparam, h5)
+        fname = os.path.join(oqparam.cachedir, 'csm_%d.hdf5' % checksum)
+        if os.path.exists(fname):
+            with datastore.read(os.path.realpath(fname)) as ds:
+                csm = ds['_csm']
+                csm.init()
+                csm.full_lt = full_lt
+        else:
+            csm = source_reader.get_csm(oqparam, full_lt, h5)
+            _check_csm(csm, oqparam, h5)
+    else:
+        csm = source_reader.get_csm(oqparam, full_lt, h5)
+        _check_csm(csm, oqparam, h5)
     return csm
 
 

--- a/openquake/engine/aelo.py
+++ b/openquake/engine/aelo.py
@@ -23,7 +23,7 @@ import sys
 import getpass
 from openquake.baselib import config, sap
 from openquake.hazardlib import valid
-from openquake.commonlib import readinput, mosaic
+from openquake.commonlib import datastore, readinput, mosaic
 from openquake.engine import engine
 
 CDIR = os.path.dirname(__file__)  # openquake/engine
@@ -46,6 +46,7 @@ def get_params_from(inputs):
     params['disagg_by_src'] = 'true'
     params['sites'] = '%(lon)s %(lat)s' % inputs
     params['override_vs30'] = '%(vs30)s' % inputs
+    params['cachedir'] = datastore.get_datadir()
     return params
 
 

--- a/openquake/engine/postproc/postproc_test.py
+++ b/openquake/engine/postproc/postproc_test.py
@@ -23,7 +23,7 @@ import numpy
 import pandas
 from openquake.baselib import general, hdf5
 from openquake.hazardlib.contexts import ContextMaker
-from openquake.commonlib import logs
+from openquake.commonlib import logs, datastore
 from openquake.engine.postproc.rupture_histogram import compute_histogram
 from openquake.engine.postproc import compute_mrd, disagg_by_rel_sources
 from openquake.calculators import base
@@ -85,6 +85,7 @@ def test_mosaic(model):
         log.params['ps_grid_spacing'] = '0.'
         log.params['pointsource_distance'] = '40.'
         log.params['sites'] = '%(lon)s %(lat)s' % sitedict
+        log.params['cachedir'] = datastore.get_datadir()
         calc = base.calculators(log.get_oqparam(), log.calc_id)
         calc.run()
         calc.datastore.close()

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -387,8 +387,12 @@ class CompositeSourceModel:
         self.sm_rlzs = full_lt.sm_rlzs
         self.full_lt = full_lt
         self.src_groups = src_groups
+        self.init()
+
+    def init(self):
+        # initialize the code dictionary
         self.code = {}  # srcid -> code
-        for grp_id, sg in enumerate(src_groups):
+        for grp_id, sg in enumerate(self.src_groups):
             assert len(sg)  # sanity check
             for src in sg:
                 src.grp_id = grp_id

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -382,14 +382,15 @@ class CompositeSourceModel:
         a flag True for event based calculations, flag otherwise
     """
     def __init__(self, full_lt, src_groups):
+        self.src_groups = src_groups
+        self.init(full_lt)
+
+    def init(self, full_lt):
+        self.full_lt = full_lt
         self.gsim_lt = full_lt.gsim_lt
         self.source_model_lt = full_lt.source_model_lt
         self.sm_rlzs = full_lt.sm_rlzs
-        self.full_lt = full_lt
-        self.src_groups = src_groups
-        self.init()
 
-    def init(self):
         # initialize the code dictionary
         self.code = {}  # srcid -> code
         for grp_id, sg in enumerate(self.src_groups):


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/8454. Here is the improvement for SAM:
```
# first run
| calc_65474, maxmem=10.2 GB | time_sec  | memory_mb | counts  |
|----------------------------+-----------+-----------+---------|
| ClassicalCalculator.run    | 227.6     | 4_462     | 1       |
| PreClassicalCalculator.run | 169.3     | 4_491     | 1       |
| composite source model     | 43.4      | 2_431     | 1       |

# second run
| calc_65475, maxmem=10.1 GB | time_sec  | memory_mb | counts  |
|----------------------------+-----------+-----------+---------|
| ClassicalCalculator.run    | 120.7     | 5_286     | 1       |
| PreClassicalCalculator.run | 61.2      | 5_233     | 1       |
| composite source model     | 15.3      | 3_090     | 1       |
```