### PR TITLE
Fixed Kendra fix for extendModel

### DIFF
--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -283,6 +283,8 @@ def _build_groups(full_lt, smdict):
                         '%s contains source(s) %s already present in %s' %
                         (value, common, rlz.value))
                 src_groups.extend(extra)
+            else:
+                break
         for src_group in src_groups:
             trt_smr = full_lt.get_trt_smr(src_group.trt, rlz.ordinal)
             sg = apply_uncertainties(bset_values, src_group)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -273,18 +273,15 @@ def _build_groups(full_lt, smdict):
         src_groups, source_ids = _groups_ids(
             smlt_dir, smdict, rlz.value[0].split())
         bset_values = full_lt.source_model_lt.bset_values(rlz.lt_path)
-        while bset_values:
-            if bset_values[0][0].uncertainty_type == 'extendModel':
-                (bset, value), *bset_values = bset_values
-                extra, extra_ids = _groups_ids(smlt_dir, smdict, value.split())
-                common = source_ids & extra_ids
-                if common:
-                    raise InvalidFile(
-                        '%s contains source(s) %s already present in %s' %
-                        (value, common, rlz.value))
-                src_groups.extend(extra)
-            else:
-                break
+        while bset_values and bset_values[0][0].uncertainty_type == 'extendModel':
+            (bset, value), *bset_values = bset_values
+            extra, extra_ids = _groups_ids(smlt_dir, smdict, value.split())
+            common = source_ids & extra_ids
+            if common:
+                raise InvalidFile(
+                    '%s contains source(s) %s already present in %s' %
+                    (value, common, rlz.value))
+            src_groups.extend(extra)
         for src_group in src_groups:
             trt_smr = full_lt.get_trt_smr(src_group.trt, rlz.ordinal)
             sg = apply_uncertainties(bset_values, src_group)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -273,8 +273,8 @@ def _build_groups(full_lt, smdict):
         src_groups, source_ids = _groups_ids(
             smlt_dir, smdict, rlz.value[0].split())
         bset_values = full_lt.source_model_lt.bset_values(rlz.lt_path)
-        if bset_values and bset_values[0][0].uncertainty_type == 'extendModel':
-            while len(bset_values):
+        while bset_values:
+            if bset_values[0][0].uncertainty_type == 'extendModel':
                 (bset, value), *bset_values = bset_values
                 extra, extra_ids = _groups_ids(smlt_dir, smdict, value.split())
                 common = source_ids & extra_ids


### PR DESCRIPTION
The fix https://github.com/gem/oq-engine/pull/8428 broke ARB:
```python
  File "/home/michele/oq-engine/openquake/commonlib/source_reader.py", line 263, in _build_groups
    extra, extra_ids = _groups_ids(smlt_dir, smdict, value.split())
AttributeError: 'float' object has no attribute 'split'
```
The reason is that there are non-extendModel branchsets after an extendModel branchset:
```xml
	<logicTreeBranchSet uncertaintyType="extendModel"
		branchSetID="mie">
            <logicTreeBranch branchID="m01">
                <uncertaintyModel>
                 ssm/mie_cut/ssm01.xml
                 </uncertaintyModel>
                <uncertaintyWeight>0.6</uncertaintyWeight>
            </logicTreeBranch>
            <logicTreeBranch branchID="m02">
                <uncertaintyModel>
                ssm/mie_cut/ssm02.xml
                </uncertaintyModel>
                <uncertaintyWeight>0.4</uncertaintyWeight>
            </logicTreeBranch>
        </logicTreeBranchSet>
	<logicTreeBranchSet uncertaintyType="maxMagGRRelative"
		branchSetID="mmax" applyToBranches="m01 m02"
		applyToSources="11 13 29 14 18 19 26 9 10 12 20 21 23 24 1 2 3 4 5 6 7 8 15 16 17 22 25 27 28">
            <logicTreeBranch branchID="m_m0.2">
                <uncertaintyModel>+0.2</uncertaintyModel>
                <uncertaintyWeight>0.2</uncertaintyWeight>
            </logicTreeBranch>
            <logicTreeBranch branchID="m_e0.0">
                <uncertaintyModel>0.0</uncertaintyModel>
                <uncertaintyWeight>0.6</uncertaintyWeight>
            </logicTreeBranch>
            <logicTreeBranch branchID="m_p0.2">
                <uncertaintyModel>-0.2</uncertaintyModel>
                <uncertaintyWeight>0.2</uncertaintyWeight>
            </logicTreeBranch>
        </logicTreeBranchSet>
```