### PR TITLE
Fixed disaggregation check

### DIFF
--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -463,18 +463,19 @@ class DisaggregationCalculator(base.HazardCalculator):
                     if m == 0 and poe == self.poes_disagg[-1]:
                         _disagg_trt[s] = tuple(
                             pprod(mat8[..., 0, 0], axis=(1, 2, 3, 4, 5)))
+                    poe_agg = pprod(mat6, axis=(0, 1, 2, 3, 4, 5))
+                    if poe and abs(1 - poe_agg/poe) > .1 and not count[s]:
+                        # warn only once per site
+                        msg = ('Site #%d, IMT=%s, rlz=#%d: poe_agg=%s is '
+                               'quite different from the expected poe=%s,'
+                               ' perhaps not enough levels')
+                        logging.warning(msg,  s, imt, best_rlzs[s, z],
+                                        poe_agg, poe)
+                        vcurves.append(self.curves[s])
+                        count[s] += 1
                     if name.endswith('-rlzs'):
-                        poe_agg = pprod(mat6, axis=(0, 1, 2, 3, 4, 5))
                         self.datastore['poe4'][s, m, p, z] = poe_agg
-                        if poe and abs(1 - poe_agg/poe) > .1 and not count[s]:
-                            # warn only once per site
-                            msg = ('Site #%d, IMT=%s, rlz=#%d: poe_agg=%s is '
-                                   'quite different from the expected poe=%s,'
-                                   ' perhaps not enough levels')
-                            logging.warning(msg,  s, imt, best_rlzs[s, z],
-                                            poe_agg, poe)
-                            vcurves.append(self.curves[s])
-                            count[s] += 1
+
         self.datastore[name] = out
         # below a dataset useful for debugging, at minimum IMT and maximum RP
         self.datastore['_disagg_trt'] = _disagg_trt

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -270,11 +270,9 @@ class DisaggregationCalculator(base.HazardCalculator):
         if oq.iml_disagg:
             # no hazard curves are needed
             self.poe_id = {None: 0}
-            curves = [[None for z in range(Z)] for s in range(self.N)]
         else:
             self.poe_id = {poe: i for i, poe in enumerate(oq.poes_disagg)}
-            curves = [self.get_curve(sid, rlzs[sid])
-                      for sid in self.sitecol.sids]
+        curves = [self.get_curve(sid, rlzs[sid]) for sid in self.sitecol.sids]
         s = self.shapedic
         logging.info('Building N * M * P * Z = {:_d} intensities'.format(
                      s['N'] * s['M'] * s['P'] * s['Z']))
@@ -465,17 +463,18 @@ class DisaggregationCalculator(base.HazardCalculator):
                     if m == 0 and poe == self.poes_disagg[-1]:
                         _disagg_trt[s] = tuple(
                             pprod(mat8[..., 0, 0], axis=(1, 2, 3, 4, 5)))
-                    poe_agg = pprod(mat6, axis=(0, 1, 2, 3, 4, 5))  # scalar
-                    self.datastore['poe4'][s, m, p, z] = poe_agg
-                    if poe and abs(1 - poe_agg/poe) > .1 and not count[s]:
-                        # warn only once per site
-                        msg = ('Site #%d, IMT=%s: poe_agg=%s is '
-                               'quite different from the expected poe=%s,'
-                               ' perhaps not enough levels')
-                        logging.warning(msg, s, imt, poe_agg, poe)
-                        vcurves.append(self.curves[s])
-                        count[s] += 1
-
+                    if name.endswith('-rlzs'):
+                        poe_agg = pprod(mat6, axis=(0, 1, 2, 3, 4, 5))
+                        self.datastore['poe4'][s, m, p, z] = poe_agg
+                        if poe and abs(1 - poe_agg/poe) > .1 and not count[s]:
+                            # warn only once per site
+                            msg = ('Site #%d, IMT=%s, rlz=#%d: poe_agg=%s is '
+                                   'quite different from the expected poe=%s,'
+                                   ' perhaps not enough levels')
+                            logging.warning(msg,  s, imt, best_rlzs[s, z],
+                                            poe_agg, poe)
+                            vcurves.append(self.curves[s])
+                            count[s] += 1
         self.datastore[name] = out
         # below a dataset useful for debugging, at minimum IMT and maximum RP
         self.datastore['_disagg_trt'] = _disagg_trt

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -151,7 +151,6 @@ class DisaggregationTestCase(CalculatorTestCase):
     def test_case_7(self):
         # test with 7+2 ruptures of two source models, 1 GSIM, 1 site
         self.run_calc(case_7.__file__, 'job.ini')
-        cmakers = read_cmakers(self.calc.datastore)
         ctx = read_ctx_by_grp(self.calc.datastore)
         self.assertEqual(len(ctx[0]), 7)  # rlz-0, the closest to the mean
         self.assertEqual(len(ctx[1]), 2)  # rlz-1, the one to discard


### PR DESCRIPTION
So that is printed even when `individual_rlzs` is false. Moreover, we are now logging the mean PoEs corresponding to the given `iml_disagg`, if any.