### PR TITLE
Fixed `logictree.get_trt_by_src`

### DIFF
--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -67,7 +67,7 @@ class _TestableSourceModelLogicTree(logictree.SourceModelLogicTree):
 def _make_nrml(content):
     return ("""<?xml version="1.0" encoding="UTF-8"?>
     <nrml xmlns:gml="http://www.opengis.net/gml"\
-          xmlns="http://openquake.org/xmlns/nrml/0.5">\
+          xmlns="http://openquake.org/xmlns/nrml/0.4">\
         %s
     </nrml>""" % content)
 


### PR DESCRIPTION
A regression broke the EUR model. The solution is to parse nrml/0.4 files instead of using the shortcut with regular expressions.