### PR TITLE
Fixed KeyError in calculations using the EasternCan15Mid with PGA

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed KeyError in calculations using the EasternCan15Mid with PGA
   * Replaced hard-coded limit to 25 levels in the MRD postprocessor
     with a simple warning
 

--- a/openquake/hazardlib/gsim/can15/eastern.py
+++ b/openquake/hazardlib/gsim/can15/eastern.py
@@ -126,7 +126,7 @@ class EasternCan15Mid(GMPE):
             mean_stds.append(contexts.get_mean_stds(gsim, c, imts))
 
         for m, imt in enumerate(imts):
-            cff = self.COEFFS_SITE[imt]
+            cff = None if imt == PGA() else self.COEFFS_SITE[imt]
 
             # Pezeshk et al. 2011 - Rrup
             mean1, stds1 = mean_stds[0][:2, m]


### PR DESCRIPTION
Reported here: https://groups.google.com/g/openquake-users/c/HNh2iGbH_Us/m/yYsrv52GBAAJ

I was a regression introduced by the vectorization refactoring that went unnoticed until now. We are missing a test for PGA.