### PR TITLE
Fixed IndexError in disagg.by_source

### DIFF
--- a/openquake/commands/onsite.py
+++ b/openquake/commands/onsite.py
@@ -23,7 +23,6 @@ from openquake.baselib import config, performance
 from openquake.hazardlib import valid
 from openquake.calculators import views
 from openquake.engine import engine
-#from openquake.engine.postproc import disagg_by_rel_sources
 from openquake.engine.aelo import get_params_from
 
 
@@ -54,7 +53,6 @@ def main(lon: valid.longitude, lat: valid.latitude, *,
             engine_profile(jobctx, slowest or 40)
         else:
             engine.run_jobs([jobctx])
-    #disagg_by_rel_sources.main(jobctx.calc_id)
 
 main.lon = 'longitude of the site to analyze'
 main.lat = 'latitude of the site to analyze'

--- a/openquake/engine/aelo.py
+++ b/openquake/engine/aelo.py
@@ -51,7 +51,7 @@ def get_params_from(inputs):
     params['sites'] = '%(lon)s %(lat)s' % inputs
     if 'vs30' in inputs:
         params['override_vs30'] = '%(vs30)s' % inputs
-    params['cachedir'] = datastore.get_datadir()
+    # params['cachedir'] = datastore.get_datadir()
     return params
 
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -682,6 +682,8 @@ def by_source(groups, sitecol, reduced_lt, edges_shapedic, oq,
         all_rlzs = list(cmaker.gsims.values())
         G = len(all_rlzs)
         ctxs = cmaker.from_srcs(groups[c], sitecol)
+        if not ctxs:
+            continue
         poes = cmaker.get_pmap(ctxs).array[0]  # shape (L, G)
         for c, g in enumerate(cmaker.gidx):
             i = c % G


### PR DESCRIPTION
It happens when the contexts are filtered away:
```python
  File "/home/michele/oq-engine/openquake/baselib/parallel.py", line 415, in new
    val = func(*args)
  File "/home/michele/oq-engine/openquake/hazardlib/calc/disagg.py", line 685, in by_source
    poes = cmaker.get_pmap(ctxs).array[0]  # shape (L, G)
  File "/home/michele/oq-engine/openquake/hazardlib/contexts.py", line 998, in get_pmap
    sids = numpy.unique(ctxs[0].sids)
IndexError: list index out of range
```
Also, removed the cache that apparently causes issues.