### PR TITLE
Better logging for mosaic models

### DIFF
--- a/openquake/commonlib/mosaic.py
+++ b/openquake/commonlib/mosaic.py
@@ -115,6 +115,11 @@ class MosaicGetter:
         logging.info(Counter(model_by_site.values()))
         return model_by_site
 
+try:
+    MODELS = MosaicGetter().get_models_list()
+except:  # missing fiona
+    MODELS = []
+
 
 def main(sites_csv_path, models_boundaries_shp_path):
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Since now the engine has information about the mosaic models we can use it when logging. Now one will see the name
of the model in the log lines:
```
[2023-03-15 07:52:56 #8967 EUR INFO] Checksum of the inputs: 500379091 (total size 68.45 MB)
```
