### PR TITLE
Fixed the error message for wrong weights in the gsim logic tree file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the error message for wrong weights in the gsim logic tree file
   * Fixed KeyError in calculations using the EasternCan15Mid with PGA
   * Replaced hard-coded limit to 25 levels in the MRD postprocessor
     with a simple warning

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -417,7 +417,8 @@ class GsimLogicTree(object):
                     bt.weight.dic['weight'] = 1.
                     break
             tot = sum(weights)
-            assert tot.is_one(), '%s in branch %s' % (tot, branch_id)
+            assert tot.is_one(), '%s in branchset %s' % (
+                tot, branchset.attrib['branchSetID'])
             if duplicated(branch_ids):
                 raise InvalidLogicTree(
                     'There where duplicated branchIDs in %s' %


### PR DESCRIPTION
It was not returning the branchset ID.