### PR TITLE
Fixed the source ID generation for CollapsedPointSources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the source ID generation for CollapsedPointSources
   * Fixed the error message for wrong weights in the gsim logic tree file
   * Fixed KeyError in calculations using the EasternCan15Mid with PGA
   * Replaced hard-coded limit to 25 levels in the MRD postprocessor

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -118,8 +118,10 @@ def preclassical(srcs, sites, cmaker, monitor):
         dic['after'] = len(split_sources)
         yield dic
     else:
+        cnt = 0
         for msr, block in groupby(split_sources, msr_name).items():
-            dic = grid_point_sources(block, spacing, msr, monitor)
+            dic = grid_point_sources(block, spacing, msr, cnt, monitor)
+            cnt = dic.pop('cnt')
             for src in dic[grp_id]:
                 src.num_ruptures = src.count_ruptures()
             # this is also prefiltering the split sources

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -40,7 +40,7 @@ from openquake.baselib import hdf5, node
 from openquake.baselib.python3compat import decode
 from openquake.baselib.node import node_from_elem, context, Node
 from openquake.baselib.general import groupby, group_array, AccumDict
-from openquake.hazardlib import nrml, InvalidFile, pmf
+from openquake.hazardlib import nrml, InvalidFile, pmf, valid
 from openquake.hazardlib.sourceconverter import SourceGroup
 from openquake.hazardlib.gsim_lt import (
     GsimLogicTree, bsnodes, fix_bytes, keyno, abs_paths, ImtWeight)
@@ -786,6 +786,11 @@ class SourceModelLogicTree(object):
         else:
             path = sm.name
         for src_id, trt in trt_by_src.items():
+            try:
+                valid.source_id(src_id)
+            except ValueError:
+                raise InvalidFile(
+                    '%s: contain invalid ID %s' % (sm.name, src_id))
             self.source_data.append((branch_id, trt, path, src_id))
             self.tectonic_region_types.add(trt)
 

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -21,6 +21,7 @@ import copy
 import numpy
 from openquake.baselib.general import AccumDict, groupby_grid
 from openquake.baselib.performance import Monitor
+from openquake.hazardlib import valid
 from openquake.hazardlib.geo import Point, geodetic
 from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib.geo.surface.planar import (
@@ -429,7 +430,7 @@ class CollapsedPointSource(PointSource):
         return sum(src.count_ruptures() for src in self.pointsources)
 
 
-def grid_point_sources(sources, ps_grid_spacing, msr, monitor=Monitor()):
+def grid_point_sources(sources, ps_grid_spacing, msr, cnt=0, monitor=Monitor()):
     """
     :param sources:
         a list of sources with the same grp_id (point sources and not)
@@ -437,6 +438,8 @@ def grid_point_sources(sources, ps_grid_spacing, msr, monitor=Monitor()):
         value of the point source grid spacing in km; if None, do nothing
     :param msr:
          magnitude scaling relationship as a string
+    :param cnt:
+         a counter starting from 0 used to produce distinct source IDs
     :returns:
         a dict grp_id -> list of non-point sources and collapsed point sources
     """
@@ -444,11 +447,11 @@ def grid_point_sources(sources, ps_grid_spacing, msr, monitor=Monitor()):
     for src in sources[1:]:
         assert src.grp_id == grp_id, (src.grp_id, grp_id)
     if not ps_grid_spacing:
-        return {grp_id: sources}
+        return {grp_id: sources, 'cnt': cnt}
     out = [src for src in sources if not hasattr(src, 'location')]
     ps = numpy.array([src for src in sources if hasattr(src, 'location')])
     if len(ps) < 2:  # nothing to collapse
-        return {grp_id: out + list(ps)}
+        return {grp_id: out + list(ps), 'cnt': cnt}
     coords = numpy.zeros((len(ps), 3))
     for p, psource in enumerate(ps):
         coords[p, 0] = psource.location.x
@@ -457,14 +460,15 @@ def grid_point_sources(sources, ps_grid_spacing, msr, monitor=Monitor()):
     if (len(numpy.unique(coords[:, 0])) == 1 or
             len(numpy.unique(coords[:, 1])) == 1):
         # degenerated rectangle, there is no grid, do not collapse
-        return {grp_id: out + list(ps)}
+        return {grp_id: out + list(ps), 'cnt': cnt}
     deltax = angular_distance(ps_grid_spacing, lat=coords[:, 1].mean())
     deltay = angular_distance(ps_grid_spacing)
     grid = groupby_grid(coords[:, 0], coords[:, 1], deltax, deltay)
     task_no = getattr(monitor, 'task_no', 0)
-    for i, idxs in enumerate(grid.values()):
+    for idxs in grid.values():
         if len(idxs) > 1:
-            name = 'cps-%s-%d-%d' % (msr, task_no, i)
+            cnt += 1
+            name = 'cps-%03d-%04d' % (task_no, cnt)
             cps = CollapsedPointSource(name, ps[idxs])
             cps.grp_id = ps[0].grp_id
             cps.trt_smr = ps[0].trt_smr
@@ -472,4 +476,4 @@ def grid_point_sources(sources, ps_grid_spacing, msr, monitor=Monitor()):
             out.append(cps)
         else:  # there is a single source
             out.append(ps[idxs[0]])
-    return {grp_id: out}
+    return {grp_id: out, 'cnt': cnt}

--- a/openquake/hazardlib/tests/valid_test.py
+++ b/openquake/hazardlib/tests/valid_test.py
@@ -43,7 +43,7 @@ class ValidationTestCase(unittest.TestCase):
             valid.simple_id('a' * 101)
 
     def test_source_id(self):
-        valid.source_id('ab_2.3_-27.0')
+        valid.source_id('ab_2:3_-27:0')
 
     def test_name(self):
         self.assertEqual(valid.name('x'), 'x')

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -345,7 +345,7 @@ ASSET_ID_LENGTH = 50  # length that makes Murray happy
 simple_id = SimpleId(MAX_ID_LENGTH)
 branch_id = SimpleId(MAX_ID_LENGTH, r'^[\w\:\#_\-\.]+$')
 asset_id = SimpleId(ASSET_ID_LENGTH)
-source_id = SimpleId(MAX_ID_LENGTH, r'^[\w\-_]+$')
+source_id = SimpleId(MAX_ID_LENGTH, r'^[\w\-_:]+$')
 nice_string = SimpleId(  # nice for Windows, Linux, HDF5 and XML
     ASSET_ID_LENGTH, r'[a-zA-Z0-9\.`!#$%\(\)\+/,;@\[\]\^_{|}~-]+')
 

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -345,7 +345,7 @@ ASSET_ID_LENGTH = 50  # length that makes Murray happy
 simple_id = SimpleId(MAX_ID_LENGTH)
 branch_id = SimpleId(MAX_ID_LENGTH, r'^[\w\:\#_\-\.]+$')
 asset_id = SimpleId(ASSET_ID_LENGTH)
-source_id = SimpleId(MAX_ID_LENGTH, r'^[\w\.\-_]+$')
+source_id = SimpleId(MAX_ID_LENGTH, r'^[\w\-_]+$')
 nice_string = SimpleId(  # nice for Windows, Linux, HDF5 and XML
     ASSET_ID_LENGTH, r'[a-zA-Z0-9\.`!#$%\(\)\+/,;@\[\]\^_{|}~-]+')
 


### PR DESCRIPTION
Was breaking the NZ model since the MSR contains a "." character. Also, added early validation of source IDs.
This case is now tested in the oq-risk-tests.