### PR TITLE
Fixing bug in the hinge function of Kuehn et al. (2020)

### DIFF
--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -315,6 +315,7 @@ def _log_hinge(x, x0, a, b0, b1, delta):
     terms, as described in Equation 4.3
     """
     xdiff = x - x0
+    xdiff = xdiff.astype('float64')
     return a + b0 * xdiff + (b1 - b0) * delta * np.log(1 + np.exp(xdiff /
                                                                   delta))
 
@@ -348,6 +349,7 @@ def get_depth_term(C, trt, ztor):
         z_b, zref = CONSTS["z_b_slab"], CONSTS["z_ref_slab"]
     z_break = z_b + dz_b
     ref_z = z_break - zref
+
     return _log_hinge(ztor, z_break, c_9 * ref_z, c_9,
                       CONSTS["c_10"], CONSTS["delta_z"])
 


### PR DESCRIPTION
The hinge function used to compute the depth term in simple precision generated an overflow. This PR fixes the problem by working in double precision.