### PR TITLE
Rejecting duplicated mutex sources

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -575,9 +575,6 @@ class ClassicalCalculator(base.HazardCalculator):
                 logging.debug('Producing %d inner tiles', ntiles)
 
             if oq.disagg_by_src:  # possible only with a single tile
-                if sg.src_interdep == 'mutex':
-                    raise RuntimeError(
-                        'You cannot use disagg_by_src with mutex sources')
                 blks = groupby(sg, basename).values()
             elif sg.atomic or sg.weight <= maxw:
                 blks = [sg]

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -221,7 +221,7 @@ def check_tricky_ids(smdict):
     found = []
     for srcid, srcs in acc.items():
         if len(srcs) > 1:  # duplicated ID
-            if any(src.mutex_weight for src in srcs):
+            if any(getattr(src, 'mutex_weight', 0) for src in srcs):
                 raise RuntimeError('Mutually exclusive sources cannot be '
                                    'duplicated: %s', srcid)
             add_checksums(srcs)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -221,6 +221,9 @@ def check_tricky_ids(smdict):
     found = []
     for srcid, srcs in acc.items():
         if len(srcs) > 1:  # duplicated ID
+            if any(src.mutex_weight for src in srcs):
+                raise RuntimeError('Mutually exclusive sources cannot be '
+                                   'duplicated: %s', srcid)
             add_checksums(srcs)
             if len(general.groupby(srcs, checksum)) > 1:
                 found.append(srcid)


### PR DESCRIPTION
Then I can remove the assertion forbidding `disagg_by_src` for mutex sources and then the JPN model will work for AELO purposes.