### PR TITLE
Forbidden duplicate sources in atomic groups

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Forbidden duplicate sources in atomic groups
+  * Forbidden duplicate mutually exclusive sources
   * Fixed conditional spectrum calculator with multiple sites and implemented
     parallelization
   * Fixed the source ID generation for CollapsedPointSources

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -214,13 +214,19 @@ def check_tricky_ids(smdict):
     Discriminated different sources with same ID by changing the ID
     """
     acc = general.AccumDict(accum=[])
+    atomic = set()
     for smodel in smdict.values():
         for sgroup in smodel.src_groups:
             for src in sgroup:
                 acc[src.source_id].append(src)
+                if sgroup.atomic:
+                    atomic.add(src.source_id)
     found = []
     for srcid, srcs in acc.items():
         if len(srcs) > 1:  # duplicated ID
+            if any(src.source_id in atomic for src in srcs):
+                raise RuntimeError('Sources in atomic groups cannot be '
+                                   'duplicated: %s', srcid)
             if any(getattr(src, 'mutex_weight', 0) for src in srcs):
                 raise RuntimeError('Mutually exclusive sources cannot be '
                                    'duplicated: %s', srcid)


### PR DESCRIPTION
To make it easier to reason about source models.