### PR TITLE
Reduced a bit the noise in case of critical exceptions

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -242,14 +242,13 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                 if self.result is not None:
                     self.post_execute(self.result)
                 self.export(kw.get('exports', ''))
-            except Exception:
+            except Exception as exc:
                 if kw.get('pdb'):  # post-mortem debug
                     tb = sys.exc_info()[2]
                     traceback.print_tb(tb)
                     pdb.post_mortem(tb)
                 else:
-                    logging.critical('', exc_info=True)
-                    raise
+                    raise exc from None
             finally:
                 if shutdown:
                     parallel.Starmap.shutdown()

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -144,7 +144,7 @@ class LogStreamHandler(logging.StreamHandler):
         super().__init__()
         self.job_id = job_id
 
-    def emit(self, record):  # pylint: disable=E0202
+    def emit(self, record):
         _update_log_record(self, record)
         super().emit(record)
 
@@ -158,7 +158,7 @@ class LogFileHandler(logging.FileHandler):
         self.job_id = job_id
         self.log_file = log_file
 
-    def emit(self, record):  # pylint: disable=E0202
+    def emit(self, record):
         _update_log_record(self, record)
         super().emit(record)
 


### PR DESCRIPTION
Now critical errors are stored once in the database, not twice; moreover they are printed twice and not three times. Still not perfect.

NB: the trick was to remove `logging.critical('', exc_info=True)` which is already done in the logging context manager.
Also, `raise exc from None` reduces a bit the verbosity.

Here is an example of the traceback one gets now:
```python
Traceback (most recent call last):
  File "/home/michele/oq-engine/openquake/commands/run.py", line 63, in _run
    calc.run(concurrent_tasks=concurrent_tasks, pdb=pdb, exports=exports)
  File "/home/michele/oq-engine/openquake/calculators/base.py", line 251, in run
    raise exc from None
  File "/home/michele/oq-engine/openquake/calculators/base.py", line 243, in run
    self.post_execute(self.result)
  File "/home/michele/oq-engine/openquake/calculators/classical.py", line 675, in post_execute
    triples = disagg_by_source(self.datastore, self.csm,
  File "/home/michele/oq-engine/openquake/calculators/classical.py", line 886, in disagg_by_source
    sanity_check(source_id, rates2D, parent['disagg_by_src'])
  File "/home/michele/oq-engine/openquake/calculators/classical.py", line 853, in sanity_check
    numpy.testing.assert_allclose(rates, expected_rates)
  File "/home/michele/openquake/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 1527, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
  File "/home/michele/openquake/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 844, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0
Mismatched elements: 1 / 1 (100%)
Max absolute difference: 0.00161556
Max relative difference: 1.
 x: array([[0.]])
 y: array([[0.001616]])
```