### PR TITLE
Distinguishing no sources from no ruptures

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -514,7 +514,7 @@ class ClassicalCalculator(base.HazardCalculator):
             self.execute_par(maxw)
         self.store_info()
         if self.cfactor[0] == 0:
-            raise RuntimeError('Filtered away all ruptures??')
+            raise RuntimeError('There are no ruptures close to the sites')
         logging.info('cfactor = {:_d}/{:_d} = {:.1f}'.format(
             int(self.cfactor[1]), int(self.cfactor[0]),
             self.cfactor[1] / self.cfactor[0]))

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -312,5 +312,8 @@ class PreClassicalCalculator(base.HazardCalculator):
 
     def post_execute(self, csm):
         """
-        Do nothing
+        Raise an error if the sources were all discarded
         """
+        num_sites = self.datastore['source_info']['num_sites']
+        if (num_sites == 0).all():
+            raise RuntimeError('There are no sources close to the site(s)')

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -26,7 +26,7 @@ import gzip
 import zlib
 import numpy
 
-from openquake.baselib import parallel, general, hdf5
+from openquake.baselib import parallel, general, hdf5, python3compat
 from openquake.hazardlib import nrml, sourceconverter, InvalidFile
 from openquake.hazardlib.contexts import basename
 from openquake.hazardlib.lt import apply_uncertainties
@@ -502,9 +502,8 @@ class CompositeSourceModel:
         Update (eff_ruptures, num_sites, calc_time) inside the source_info
         """
         assert len(source_data) < TWO32, len(source_data)
-        for src_id, grp_id, nsites, weight, ctimes in zip(
-                source_data['src_id'], source_data['grp_id'],
-                source_data['nsites'],
+        for src_id, nsites, weight, ctimes in python3compat.zip(
+                source_data['src_id'], source_data['nsites'],
                 source_data['weight'], source_data['ctimes']):
             baseid = basename(src_id)
             row = self.source_info[baseid]


### PR DESCRIPTION
The first is an error in preclassical, the second an error in classical.