### PR TITLE
Changed default to multi=True in create_jobs

### DIFF
--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -112,7 +112,7 @@ def main(job_ini,
         return _run(job_ini[0], concurrent_tasks, pdb, reuse_input,
                     loglevel, exports, params, user_name, host)
     jobs = create_jobs(job_ini, loglevel, hc_id=hc,
-                       user_name=user_name, host=host)
+                       user_name=user_name, host=host, multi=False)
     for job in jobs:
         job.params.update(params)
         job.params['exports'] = ','.join(exports)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -465,7 +465,7 @@ class ZipTestCase(unittest.TestCase):
 class EngineRunJobTestCase(unittest.TestCase):
     def test_multi_run(self):
         job_ini = os.path.join(os.path.dirname(case_4.__file__), 'job.ini')
-        jobs = create_jobs([job_ini, job_ini], 'error', multi=True)
+        jobs = create_jobs([job_ini, job_ini], 'error')
         run_jobs(jobs)
         with Print.patch():
             [r1, r2] = commonlib.logs.dbcmd(

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -294,7 +294,7 @@ def run_calc(log):
 
 
 def create_jobs(job_inis, log_level=logging.INFO, log_file=None,
-                user_name=USER, hc_id=None, multi=False, host=None):
+                user_name=USER, hc_id=None, multi=True, host=None):
     """
     Create job records on the database.
 

--- a/openquake/engine/multirun.py
+++ b/openquake/engine/multirun.py
@@ -43,7 +43,7 @@ def main(dirname, job_ini='job.ini', concurrent=0, **kw):
     dbserver.ensure_on()
     t0 = time.time()
     if concurrent:  # in parallel
-        ctxs = run_jobs(create_jobs(inis, multi=True), concurrent)
+        ctxs = run_jobs(create_jobs(inis), concurrent)
         out = [(ctx.calc_id, ini) for ctx, ini in zip(ctxs, inis)]
     else:  # sequentially
         out = []


### PR DESCRIPTION
Makes it easier to write parallel tests.