### PR TITLE
Fixed method /v1/ini_defaults returning NaNs for the site parameters

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed method '/v1/ini_defaults' returning NaNs for the site parameters
   * Added output `mean_disagg_bysrc` for single site calculations with use_rates
   * Added command `oq reduce_smlt`
   * Fixed reinsurance calculations when there is a single loss type

--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -356,6 +356,8 @@ class EngineServerTestCase(django.test.TestCase):
         resp = self.c.get('/v1/ini_defaults')
         self.assertEqual(resp.status_code, 200)
         # make sure an old name still works
+        dic = resp.json()
+        self.assertIsNone(dic['reference_depth_to_1pt0km_per_sec'])
         self.assertIn(b'individual_curves', resp.content)
 
     def test_validate_zip(self):

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -40,6 +40,7 @@ from django.core.mail import EmailMessage
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from django.shortcuts import render
+import numpy
 
 from openquake.baselib import hdf5, config
 from openquake.baselib.general import groupby, gettemp, zipfiles, mp
@@ -235,7 +236,10 @@ def get_ini_defaults(request):
         obj = getattr(oqvalidation.OqParam, newname)
         if (isinstance(obj, valid.Param)
                 and obj.default is not valid.Param.NODEFAULT):
-            ini_defs[name] = obj.default
+            if isinstance(obj.default, float) and numpy.isnan(obj.default):
+                ini_defs[name] = None
+            else:
+                ini_defs[name] = obj.default
     return HttpResponse(content=json.dumps(ini_defs), content_type=JSON)
 
 


### PR DESCRIPTION
The Python standard library json module by design returns invalid JSON: https://docs.python.org/3/library/json.html#encoders-and-decoders
I am converting the NaNs into nulls to get a valid JSON.
Discovered by @nastasi-oq 