### PR TITLE
Managed the case of empty branches in the source model logic tree

### DIFF
--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -569,10 +569,10 @@ hazard_uhs-std.csv
         # extendModel with sampling and reduction to single source
         self.run_calc(case_68.__file__, 'job1.ini')
 
-        # check the reduction from 10 to 3 realizations
+        # check the reduction from 10 to 2 realizations
         rlzs = extract(self.calc.datastore, 'realizations').array
-        ae(rlzs['branch_path'], [b'AA~A', b'AB~A', b'B.~A'])
-        aac(rlzs['weight'], [.4, .3, .3])
+        ae(rlzs['branch_path'], [b'AA~A', b'B.~A'])
+        aac(rlzs['weight'], [.7, .3])
 
         # check the hazard curves
         fnames = export(('hcurves', 'csv'), self.calc.datastore)

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -571,16 +571,18 @@ class SourceModelLogicTree(object):
                 raise LogicTreeError(
                     branchnode, self.filename,
                     "branchID '%s' is not unique" % branch_id)
-            if value != '':
+            if value == '':
+                # with logic tree reduction a branch can be empty
+                # see case_68_bis
+                zero_id = branch_id
+                zero_no = brno
+                zeros.append(weight)
+            else:
                 branch = Branch(bs_id, branch_id, weight, value)
                 self.branches[branch_id] = branch
                 self.shortener[branch_id] = keyno(
                     branch_id, bsno, brno, self.filename)
                 branchset.branches.append(branch)
-            else:
-                zero_id = branch_id
-                zero_no = brno
-                zeros.append(weight)
             weight_sum += weight
         if zeros:
             branch = Branch(bs_id, zero_id, sum(zeros), '')

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -1233,7 +1233,9 @@ class SourceConverter(RuptureConverter):
                 else:  # transmit as it is
                     setattr(src, attr, node[attr])
             sg.update(src)
-        if sg.src_interdep == 'mutex':
+        if sg and sg.src_interdep == 'mutex':
+            # sg can be empty if source_id is specified and it is different
+            # from any source in sg
             if len(node) and len(srcs_weights) != len(node):
                 raise ValueError(
                     'There are %d srcs_weights but %d source(s) in %s'

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-001-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-001-PGA.csv
@@ -1,3 +1,3 @@
-#,,,"generated_by='OpenQuake engine 3.17.0-git0c93570be6', start_date='2023-03-22T16:09:04', checksum=628017107, kind='rlz-001', investigation_time=1.0, imt='PGA'"
+#,,,"generated_by='OpenQuake engine 3.17.0-git00a1846f48', start_date='2023-03-29T05:59:43', checksum=628017107, kind='rlz-001', investigation_time=1.0, imt='PGA'"
 lon,lat,depth,poe-0.0010000
-0.00000,0.00000,0.00000,6.321205E-01
+0.00000,0.00000,0.00000,0.000000E+00

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-002-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-002-PGA.csv
@@ -1,3 +1,0 @@
-#,,,"generated_by='OpenQuake engine 3.17.0-git0c93570be6', start_date='2023-03-22T16:09:04', checksum=628017107, kind='rlz-002', investigation_time=1.0, imt='PGA'"
-lon,lat,depth,poe-0.0010000
-0.00000,0.00000,0.00000,0.000000E+00


### PR DESCRIPTION
This happens after logic tree reduction in the KOR model. With this fix we can reduce by 18x the number of realizations per source, from 864 to 48, with a 18x speedup.