### PR TITLE
Fixed extract_rates_by_src

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1209,7 +1209,7 @@ def extract_rates_by_src(dstore, what):
     lvl_id = get_lvl(mean, oq.imtls[imt], float(poe))
     imt_id = list(oq.imtls).index(imt)
     rates = dset[site_id, imt_id, lvl_id]  # shape Ns
-    arr = numpy.zeros(len(src_id), [('src_id', '<S16'), ('poe', '<f8')])
+    arr = numpy.zeros(len(src_id), [('src_id', hdf5.vstr), ('poe', '<f8')])
     arr['src_id'] = src_id
     arr['poe'] = rates
     arr.sort(order='poe')

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -177,7 +177,9 @@ class PreClassicalCalculator(base.HazardCalculator):
             arr = numpy.zeros((self.N, self.M, self.L1, len(sources)))
             dic = dict(shape_descr=['site_id', 'imt', 'lvl', 'src_id'],
                        site_id=self.N, imt=list(self.oqparam.imtls),
-                       lvl=self.L1, src_id=sources)
+                       lvl=self.L1, src_id=numpy.array(sources))
+            # NB: the array numpy.array(sources) is CRITICAL for JPN
+            # damn h5py breaking silently for long lists of strings!!
             self.datastore['rates_by_src'] = hdf5.ArrayWrapper(arr, dic)
 
     def populate_csm(self):


### PR DESCRIPTION
It was truncating the source ID, thus breaking the AELO calculation for NEA. I am also fixing the storage of `rates_by_src/src_id` breaking silently for JPN.