### PR TITLE
Provide more user-friendly URIs to AELO web users and api users

### DIFF
--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -32,13 +32,13 @@
               {% csrf_token %}
               <!-- FIXME: pre-filled with values that work for CCA (an example valid for EUR would be lon=11, lat=44) -->
               <!-- <label for"lon">Longitude:</label> -->
-              <input type="text" id="lon" name="lon" placeholder="Longitude" value="-86"/>
+              <input type="text" id="lon" name="lon" placeholder="Longitude"/>
               <!-- <label for"lat">Latitude:</label> -->
-              <input type="text" id="lat" name="lat" placeholder="Latitude" value="12"/>
+              <input type="text" id="lat" name="lat" placeholder="Latitude"/>
               <!-- <label for"vs30">Vs30:</label> -->
-              <input type="text" id="vs30" name="vs30" placeholder="vs30" value="800"/>
+              <input type="text" id="vs30" name="vs30" placeholder="vs30"/>
               <!-- <label for"siteid">Site ID:</label> -->
-              <input type="text" id="siteid" name="siteid" placeholder="Site ID" value="FIXME"/>
+              <input type="text" id="siteid" name="siteid" placeholder="Site ID"/>
               <button type="submit" class="btn">Submit</button>
               <!-- <input type="submit"> -->
             </form>

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -30,7 +30,6 @@
             {% endif %}
             <form id="aelo_run_form" method="post">
               {% csrf_token %}
-              <!-- FIXME: pre-filled with values that work for CCA (an example valid for EUR would be lon=11, lat=44) -->
               <!-- <label for"lon">Longitude:</label> -->
               <input type="text" id="lon" name="lon" placeholder="Longitude"/>
               <!-- <label for"lat">Latitude:</label> -->

--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -27,7 +27,7 @@ urlpatterns = [
     re_path(r'^(\d+)/abort$', views.calc_abort),
     re_path(r'^(\d+)/datastore$', views.calc_datastore),
     re_path(r'^(\d+)/extract/([-/_\.\w]+)$', views.extract),
-    re_path(r'^(\d+)/results$', views.calc_results),
+    re_path(r'^(\d+)/results$', views.calc_results, name="results"),
     re_path(r'^(\d+)/hmap_(\d+)_(\d+)$', views.hmap_png),
     re_path(r'^(\d+)/traceback$', views.calc_traceback, name="traceback"),
     re_path(r'^(\d+)/log/size$', views.calc_log_size),

--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     re_path(r'^(\d+)/hmap_(\d+)_(\d+)$', views.hmap_png),
     re_path(r'^(\d+)/traceback$', views.calc_traceback, name="traceback"),
     re_path(r'^(\d+)/log/size$', views.calc_log_size),
-    re_path(r'^(\d+)/log/(\d*):(\d*)$', views.calc_log),
+    re_path(r'^(\d+)/log/(\d*):(\d*)$', views.calc_log, name="log"),
     re_path(r'^(\d+)/remove$', views.calc_remove),
     re_path(r'^result/(\d+)$', views.calc_result),
     re_path(r'^validate_zip$', views.validate_zip),

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -617,14 +617,17 @@ def aelo_run(request):
         config.distribution.log_level, None, utils.get_user(request), None)
     job_id = jobctx.calc_id
 
-    outputs_uri = request.build_absolute_uri(
+    outputs_uri_web = request.build_absolute_uri(
         reverse('outputs', args=[job_id]))
+
+    outputs_uri_api = request.build_absolute_uri(
+        reverse('results', args=[job_id]))
 
     traceback_uri = request.build_absolute_uri(
         reverse('traceback', args=[job_id]))
 
     response_data = dict(
-        status='created', job_id=job_id, outputs_uri=outputs_uri,
+        status='created', job_id=job_id, outputs_uri=outputs_uri_api,
         traceback_uri=traceback_uri)
 
     job_owner_email = request.user.email
@@ -635,11 +638,11 @@ def aelo_run(request):
             ' the job completes, you can access its outputs at the following'
             ' link: %s. If the job fails, the error traceback will be'
             ' accessible at the following link: %s'
-            % (outputs_uri, traceback_uri))
+            % (outputs_uri_api, traceback_uri))
 
     # spawn the AELO main process
     mp.Process(target=aelo.main, args=(
-        lon, lat, vs30, siteid, job_owner_email, outputs_uri, jobctx,
+        lon, lat, vs30, siteid, job_owner_email, outputs_uri_web, jobctx,
         aelo_callback)).start()
     return HttpResponse(content=json.dumps(response_data), content_type=JSON,
                         status=200)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -623,12 +623,15 @@ def aelo_run(request):
     outputs_uri_api = request.build_absolute_uri(
         reverse('results', args=[job_id]))
 
+    log_uri = request.build_absolute_uri(
+        reverse('log', args=[job_id, '0', '']))
+
     traceback_uri = request.build_absolute_uri(
         reverse('traceback', args=[job_id]))
 
     response_data = dict(
         status='created', job_id=job_id, outputs_uri=outputs_uri_api,
-        traceback_uri=traceback_uri)
+        log_uri=log_uri, traceback_uri=traceback_uri)
 
     job_owner_email = request.user.email
     if not job_owner_email:


### PR DESCRIPTION
The link clickable in the email sent by the system when the calculation is completed will point to an html page that is more usable by the user via web. On the other hand, the link written in the initial response when the AELO calculation is started will be more api-friendly, returning a json with the list of outputs and the links to download each of them. In the same initial response, I am also adding a link to retrieve the log of the calculation while it is running or after its completion.
I've also removed pre-filled values from the AELO webform, that were useful only for debugging purposes.