### PR TITLE
Avoid breaking AELO logs when calling `get_params_from`

### DIFF
--- a/openquake/engine/aelo.py
+++ b/openquake/engine/aelo.py
@@ -21,6 +21,7 @@ Master script for running an AELO analysis
 import os
 import sys
 import getpass
+import logging
 from openquake.baselib import config, sap
 from openquake.hazardlib import valid
 from openquake.commonlib import readinput, mosaic
@@ -67,8 +68,8 @@ def main(lon: valid.longitude,
          lat: valid.latitude,
          vs30: valid.positivefloat,
          siteid: valid.simple_id,
-         job_owner_email,
-         outputs_uri,
+         job_owner_email=None,
+         outputs_uri=None,
          jobctx=None,
          callback=trivial_callback,
          ):
@@ -89,6 +90,7 @@ def main(lon: valid.longitude,
         sys.exit('mosaic_dir is not specified in openquake.cfg')
     try:
         jobctx.params.update(get_params_from(inputs))
+        logging.root.handlers = []  # avoid breaking the logs
     except Exception as exc:
         # This can happen for instance:
         # - if no model covers the given coordinates.

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -608,6 +608,7 @@ def aelo_run(request):
     try:
         params = get_params_from(
             dict(lon=lon, lat=lat, vs30=vs30, siteid=siteid))
+        logging.root.handlers = []  # avoid breaking the logs
     except ValueError as exc:
         response_data = {'status': 'failed', 'error_msg': str(exc)}
         return HttpResponse(


### PR DESCRIPTION
I've also set `job_owner_email=None` and `outputs_uri=None` in aelo.py `main` so it can be called from command line without those arguments.