### PR TITLE
Removed confusing modification of the occurrence rate

### DIFF
--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -118,9 +118,6 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         for trt_smr in self.trt_smrs:
             for rup, num_occ in self._sample_ruptures(eff_num_ses):
                 rup.seed = seed
-                if hasattr(rup, 'occurrence_rate'):
-                    # defined only for poissonian sources
-                    rup.occurrence_rate *= self.smweight
                 seed += 1
                 yield rup, trt_smr, num_occ
 


### PR DESCRIPTION
It is wrong because the weight is already accounted for; it was working because it had no practical effect.