### PR TITLE
Fixed get_src_loss_table and paved the pay for non-sequential rupture IDs

### DIFF
--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -158,15 +158,20 @@ def get_src_loss_table(dstore, loss_id):
                          dict(agg_id=K, loss_id=loss_id))
     if len(alt) == 0:  # no losses for this loss type
         return [], ()
+
+    ws = dstore['weights'][:]
+    srcs = dstore['source_info']['source_id']
+    events = dstore['events'][:]
+    ruptures = dstore['ruptures'][:]
     eids = alt.event_id.to_numpy()
-    evs = dstore['events'][:][eids]
+    evs = events[eids]
     rlz_ids = evs['rlz_id']
-    rup_ids = evs['rup_id']
-    source_id = python3compat.decode(dstore['ruptures']['source_id'][rup_ids])
-    w = dstore['weights'][:]
+    srcidx = dict(ruptures[['id', 'source_id']])
+    srcids = [srcidx[rup_id] for rup_id in evs['rup_id']]
+    source_id = python3compat.decode(srcs[srcids])
     acc = general.AccumDict(accum=0)
     for src, rlz_id, loss in zip(source_id, rlz_ids, alt.loss.to_numpy()):
-        acc[src] += loss * w[rlz_id]
+        acc[src] += loss * ws[rlz_id]
     return zip(*sorted(acc.items()))
 
 

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -160,17 +160,17 @@ def get_src_loss_table(dstore, loss_id):
         return [], ()
 
     ws = dstore['weights'][:]
-    srcs = dstore['source_info']['source_id']
     events = dstore['events'][:]
     ruptures = dstore['ruptures'][:]
+    source_id = dstore['source_info']['source_id']
     eids = alt.event_id.to_numpy()
     evs = events[eids]
     rlz_ids = evs['rlz_id']
     srcidx = dict(ruptures[['id', 'source_id']])
     srcids = [srcidx[rup_id] for rup_id in evs['rup_id']]
-    source_id = python3compat.decode(srcs[srcids])
+    srcs = python3compat.decode(source_id[srcids])
     acc = general.AccumDict(accum=0)
-    for src, rlz_id, loss in zip(source_id, rlz_ids, alt.loss.to_numpy()):
+    for src, rlz_id, loss in zip(srcs, rlz_ids, alt.loss.to_numpy()):
         acc[src] += loss * ws[rlz_id]
     return zip(*sorted(acc.items()))
 

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/src_loss_nonstructural.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/src_loss_nonstructural.csv
@@ -1,5 +1,5 @@
-#,"generated_by='OpenQuake engine 3.17.0-gitc6d5dee266', start_date='2023-04-20T04:09:07', checksum=2453527097, investigation_time=50.0, risk_investigation_time=50.0"
+#,"generated_by='OpenQuake engine 3.17.0-git4db4016d05', start_date='2023-04-20T06:13:22', checksum=2453527097, investigation_time=50.0, risk_investigation_time=50.0"
 source,value
-0,9.14390E+02
-1,3.99737E+02
-2,3.40663E+03
+1,9.14390E+02
+2,3.99737E+02
+3,3.40663E+03

--- a/openquake/qa_tests_data/event_based_risk/case_1/expected/src_loss_structural.csv
+++ b/openquake/qa_tests_data/event_based_risk/case_1/expected/src_loss_structural.csv
@@ -1,5 +1,5 @@
-#,"generated_by='OpenQuake engine 3.17.0-gitc6d5dee266', start_date='2023-04-20T04:09:07', checksum=2453527097, investigation_time=50.0, risk_investigation_time=50.0"
+#,"generated_by='OpenQuake engine 3.17.0-git4db4016d05', start_date='2023-04-20T06:13:22', checksum=2453527097, investigation_time=50.0, risk_investigation_time=50.0"
 source,value
-0,2.40759E+03
-1,2.14066E+03
-2,9.16178E+03
+1,2.40759E+03
+2,2.14066E+03
+3,9.16178E+03


### PR DESCRIPTION
It was broken by https://github.com/gem/oq-engine/pull/8649.
Part of https://github.com/gem/oq-engine/issues/8339.