### PR TITLE
Declassed repeated-values warning to info

### DIFF
--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -84,8 +84,8 @@ def fix_dupl(dist, fname=None, lineno=None):
         if fname is None:  # when called from the sourcewriter
             raise ValueError('There are repeated values in %s' % got)
         else:
-            logging.warning('There were repeated values %s in %s:%s',
-                            extract_dupl(got), fname, lineno)
+            logging.info('There were repeated values %s in %s:%s',
+                         extract_dupl(got), fname, lineno)
             assert abs(sum(values.values()) - 1) < EPSILON  # sanity check
             newdist = sorted([(p, v) for v, p in values.items()])
             if isinstance(newdist[0][1], tuple):  # nodal planes

--- a/openquake/hazardlib/tests/sourceconverter_test.py
+++ b/openquake/hazardlib/tests/sourceconverter_test.py
@@ -456,14 +456,14 @@ class SourceConverterTestCase(unittest.TestCase):
 
     def test_dupl_values_npdist(self):
         testfile = os.path.join(testdir, 'wrong-npdist.xml')
-        with unittest.mock.patch('logging.warning') as w:
+        with unittest.mock.patch('logging.info') as w:
             nrml.to_python(testfile)
         self.assertEqual(
             'There were repeated values %s in %s:%s', w.call_args[0][0])
 
     def test_dupl_values_hddist(self):
         testfile = os.path.join(testdir, 'wrong-hddist.xml')
-        with unittest.mock.patch('logging.warning') as w:
+        with unittest.mock.patch('logging.info') as w:
             nrml.to_python(testfile)
         self.assertEqual(
             'There were repeated values %s in %s:%s', w.call_args[0][0])


### PR DESCRIPTION
Since there is nothing that the user can do to fix it; also, it is a non-issue in practice.