### PR TITLE
Fully removed min_mag

### DIFF
--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -309,7 +309,7 @@ class EventBasedTestCase(CalculatorTestCase):
 
         # first check the number of generated ruptures
         num_rups = len(self.calc.datastore['ruptures'])
-        self.assertEqual(num_rups, 1942)
+        self.assertEqual(num_rups, 1906)
 
         fnames = out['hcurves', 'csv']
         expected = ['hazard_curve-mean.csv', 'quantile_curve-0.1.csv']

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -206,7 +206,6 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         self.trt_smr = -1  # set by the engine
         self.num_ruptures = 0  # set by the engine
         self.seed = None  # set by the engine
-        self.min_mag = 0  # FIXME: why this has effect on event_based/case_6??
 
     def is_gridded(self):
         """

--- a/openquake/qa_tests_data/event_based/case_6/expected/hazard_curve-mean.csv
+++ b/openquake/qa_tests_data/event_based/case_6/expected/hazard_curve-mean.csv
@@ -1,3 +1,3 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.17.0-gitc4d3047c05', start_date='2023-04-21T07:39:24', checksum=575548841, kind='mean', investigation_time=50.0, imt='PGA'"
+#,,,,,,,"generated_by='OpenQuake engine 3.17.0-git31e0f9f866', start_date='2023-04-21T18:14:37', checksum=575548841, kind='mean', investigation_time=50.0, imt='PGA'"
 lon,lat,depth,poe-0.0050000,poe-0.0070000,poe-0.0098000,poe-0.0137000,poe-0.0192000
-0.00000,0.00000,0.00000,9.473256E-01,9.230174E-01,8.879759E-01,8.334134E-01,7.855358E-01
+0.00000,0.00000,0.00000,9.626857E-01,9.365543E-01,8.986960E-01,8.490945E-01,8.000246E-01

--- a/openquake/qa_tests_data/event_based/case_6/expected/quantile_curve-0.1.csv
+++ b/openquake/qa_tests_data/event_based/case_6/expected/quantile_curve-0.1.csv
@@ -1,3 +1,3 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.17.0-git1804c540d0', start_date='2023-04-21T06:50:33', checksum=575548841, kind='quantile-0.1', investigation_time=50.0, imt='PGA'"
+#,,,,,,,"generated_by='OpenQuake engine 3.17.0-git31e0f9f866', start_date='2023-04-21T18:14:37', checksum=575548841, kind='quantile-0.1', investigation_time=50.0, imt='PGA'"
 lon,lat,depth,poe-0.0050000,poe-0.0070000,poe-0.0098000,poe-0.0137000,poe-0.0192000
-0.00000,0.00000,0.00000,7.892365E-01,7.139608E-01,5.766658E-01,4.412972E-01,3.195221E-01
+0.00000,0.00000,0.00000,8.507997E-01,7.682486E-01,6.820606E-01,5.562798E-01,4.547278E-01


### PR DESCRIPTION
There is an ABSURDLY SUBTLE issue here: the numbers in event_based/case_6 are different because this is a test with two different sources with the same ID; in master there is a `.min_mag` attribute, in this branch there is not, so the checksums are different and the checksums are used to order the sources, so the ordering is different => the seeds are different => the ruptures are different. This closes the last point of https://github.com/gem/oq-engine/pull/8644.
Part of #8631.