### PR TITLE
Passed the random number generator down to `sample_number_of_occurrences`

### DIFF
--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -152,7 +152,7 @@ def timedep_sample(src, eff_num_ses, seed):
     else:  # time-dependent nonparametric
         mutex_weight = getattr(src, 'mutex_weight', 1)
         for rup, rupid in zip(src.iter_ruptures(), rupids):
-            occurs = rup.sample_number_of_occurrences(eff_num_ses)
+            occurs = rup.sample_number_of_occurrences(eff_num_ses, rng)
             if mutex_weight < 1:
                 # consider only the occurrencies below the mutex_weight
                 occurs *= (rng.random(eff_num_ses) < mutex_weight)

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -305,7 +305,7 @@ class BaseRupture(metaclass=abc.ABCMeta):
         """
         return 1
 
-    def sample_number_of_occurrences(self, n=1):
+    def sample_number_of_occurrences(self, n, rng):
         """
         Randomly sample number of occurrences from temporal occurrence model
         probability distribution.
@@ -359,7 +359,7 @@ class NonParametricProbabilisticRupture(BaseRupture):
         if weight is not None:
             self.weight = weight
 
-    def sample_number_of_occurrences(self, n=1):
+    def sample_number_of_occurrences(self, n, rng):
         """
         See :meth:`superclass method
         <.rupture.BaseRupture.sample_number_of_occurrences>`
@@ -369,7 +369,7 @@ class NonParametricProbabilisticRupture(BaseRupture):
         """
         # compute cdf from pmf
         cdf = numpy.cumsum(self.probs_occur)
-        n_occ = numpy.digitize(numpy.random.random(n), cdf)
+        n_occ = numpy.digitize(rng.random(n), cdf)
         return n_occ
 
 
@@ -422,7 +422,7 @@ class ParametricProbabilisticRupture(BaseRupture):
         rate = self.occurrence_rate
         return tom.get_probability_n_occurrences(rate, 1)
 
-    def sample_number_of_occurrences(self, n=1):
+    def sample_number_of_occurrences(self, n, rng):
         """
         Draw a random sample from the distribution and return a number
         of events to occur as an array of integers of size n.
@@ -432,7 +432,7 @@ class ParametricProbabilisticRupture(BaseRupture):
         of an assigned temporal occurrence model.
         """
         r = self.occurrence_rate * self.temporal_occurrence_model.time_span
-        return numpy.random.poisson(r, n)
+        return rng.poisson(r, n)
 
     def get_dppvalue(self, site):
         """

--- a/openquake/qa_tests_data/event_based/case_8/expected/rup_data.csv
+++ b/openquake/qa_tests_data/event_based/case_8/expected/rup_data.csv
@@ -1,5 +1,5 @@
-#,,,,,,,,,"generated_by='OpenQuake engine 3.17.0-gitdd6242c941', start_date='2023-04-20T12:36:16', checksum=3170768143, investigation_time=50.0, ses_per_logic_tree_path=2"
+#,,,,,,,,,"generated_by='OpenQuake engine 3.17.0-git01ba5c2822', start_date='2023-04-26T14:33:40', checksum=3170768143, investigation_time=50.0, ses_per_logic_tree_path=2"
 rup_id,multiplicity,mag,centroid_lon,centroid_lat,centroid_depth,trt,strike,dip,rake
 0,1,8.300000E+00,1.430038E+02,4.072604E+01,2.610100E+01,Active Shallow Crust,1.561135E+02,1.995663E+01,9.000000E+01
-2,2,7.800000E+00,1.486679E+02,4.311786E+01,2.450000E+01,Active Shallow Crust,5.305690E+01,3.007044E+01,9.000000E+01
+2,1,7.800000E+00,1.486679E+02,4.311786E+01,2.450000E+01,Active Shallow Crust,5.305690E+01,3.007044E+01,9.000000E+01
 3,2,7.800000E+00,1.479987E+02,4.364543E+01,2.025000E+01,Active Shallow Crust,2.340425E+02,2.257265E+01,9.000000E+01


### PR DESCRIPTION
This was missing in https://github.com/gem/oq-engine/pull/8670. Part of #8631. Fixes oq-risk-test/cali