### PR TITLE
Minor improvements to the AELO GUI

### DIFF
--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -37,8 +37,8 @@
               <!-- <label for"vs30">Vs30:</label> -->
               <input type="text" id="vs30" name="vs30" placeholder="vs30"/>
               <!-- <label for"siteid">Site ID:</label> -->
-              <input type="text" id="siteid" name="siteid" placeholder="Site ID"/>
-              <button type="submit" class="btn">Submit</button>
+              <input type="text" id="siteid" name="siteid" placeholder="Site name"/>
+              <button id="submit_aelo_calc" type="submit" class="btn">Submit</button>
               <!-- <input type="submit"> -->
             </form>
           </div>

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -158,6 +158,7 @@
   <script>
     $(document).ready(function () {
       $("#aelo_run_form").submit(function (event) {
+        $('#submit_aelo_calc').prop('disabled', true);
         var formData = {
           lon: $("#lon").val(),
           lat: $("#lat").val(),
@@ -175,6 +176,8 @@
         }).error(function (data) {
           // TODO: replace with a better looking modal dialog with title
           window.alert(data.responseText);
+        }).always(function () {
+          $('#submit_aelo_calc').prop('disabled', false);
         });
         event.preventDefault();
       });


### PR DESCRIPTION
1. The "Submit" button becomes disabled after it is clicked and returns enabled after the corresponding request is finished (either completed successfully or raising an error). This is in order to avoid submitting by accident the same calculation twice, e.g. with a double-click
2. Following a suggestion by Nico, I changed the siteid placeholder in the form from "Site ID" to "Site name", in order to avoid confusion with respect to the calculation id and the output ids. I did not change the underlying variable name, that should probably be kept "siteid". Nico was suggesting something like "Calculation title", but then I think the discrepancy between that placeholder and the underlying variable name would be too much.