### PR TITLE
Fixed `minimum_magnitude` issue breaking AELO

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -507,19 +507,12 @@ class HazardCalculator(BaseCalculator):
                 self.csm = csm = readinput.get_composite_source_model(
                     oq, self.datastore)
                 self.datastore['full_lt'] = self.full_lt = csm.full_lt
-                oq.mags_by_trt = csm.get_mags_by_trt(oq.minimum_magnitude)
+                oq.mags_by_trt = csm.get_mags_by_trt(oq.maximum_distance)
                 assert oq.mags_by_trt, 'Filtered out all magnitudes!'
                 for trt in oq.mags_by_trt:
-                    mags = oq.mags_by_trt[trt]
-                    min_mag, max_mag = float(mags[0]), float(mags[-1])
-                    self.datastore['source_mags/' + trt] = numpy.array(mags)
+                    mags = numpy.array(oq.mags_by_trt[trt])
+                    self.datastore['source_mags/' + trt] = mags
                     interp = oq.maximum_distance(trt)
-                    if min_mag < interp.x[0]:
-                        logging.warning(
-                            '%s: discarding mags < %.2f', trt, interp.x[0])
-                    if max_mag > interp.x[-1]:
-                        logging.warning(
-                            '%s: discarding mags > %.2f', trt, interp.x[-1])
                     if len(interp.x) > 2:
                         md = '%s->%d, ... %s->%d, %s->%d' % (
                             interp.x[0], interp.y[0],

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -242,7 +242,7 @@ class IntegrationDistance(dict):
                 self[trt] = [(MINMAG, items), (MAXMAG, items)]
         return self
 
-    # tested in case_miriam
+    # tested in case_miriam and case_75
     def cut(self, min_mag_by_trt):
         """
         Cut the lower magnitudes. For instance
@@ -253,6 +253,10 @@ class IntegrationDistance(dict):
         {'default': [(5.0, 87.5), (8.0, 200.0)]}
         """
         all_trts = set(self) | set(min_mag_by_trt)
+        if 'default' not in self:
+            maxval = max(self.values(),
+                         key=lambda val: max(dist for mag, dist in val))
+            self['default'] = maxval
         for trt in all_trts:
             min_mag = getdefault(min_mag_by_trt, trt)
             if not min_mag:

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -482,8 +482,9 @@ class CompositeSourceModel:
             sources.add(basename(src, '!;:.'))
         return sorted(sources)
 
-    def get_mags_by_trt(self, minimum_magnitude):
+    def get_mags_by_trt(self, maximum_distance):
         """
+        :param maximum_distance: dictionary trt -> magdist interpolator
         :returns: a dictionary trt -> magnitudes in the sources as strings
         """
         mags = general.AccumDict(accum=set())  # trt -> mags
@@ -492,7 +493,7 @@ class CompositeSourceModel:
                 mags[sg.trt].update(src.get_magstrs())
         out = {}
         for trt in mags:
-            minmag = calc.filters.getdefault(minimum_magnitude, trt)
+            minmag = maximum_distance(trt).x[0]
             out[trt] = sorted(m for m in mags[trt] if float(m) >= minmag)
         return out
 

--- a/openquake/qa_tests_data/classical/case_75/job.ini
+++ b/openquake/qa_tests_data/classical/case_75/job.ini
@@ -34,6 +34,7 @@ investigation_time = 1.0
 intensity_measure_types_and_levels = {"PGA": logscale(0.005, 3.00, 20)}
 truncation_level = 3
 maximum_distance = {'Active Shallow Crust': 300}
+minimum_magnitude = 4.0
 pointsource_distance = 100.0
 cache_distances = true
 


### PR DESCRIPTION
Setting the `minimum_magnitude` was causing a missing 'default' error for PNG and AUS. This is another regression caused by https://github.com/gem/oq-engine/pull/8644. Added an additional test.