### PR TITLE
Refactored get_eids_by_rlz

### DIFF
--- a/openquake/commands/mosaic.py
+++ b/openquake/commands/mosaic.py
@@ -41,6 +41,8 @@ def engine_profile(jobctx, nrows):
                            ext='org'))
 
 
+# ########################## run_site ############################## #
+
 def from_file(fname, concurrent_jobs=8):
     """
     Run a PSHA analysis on the given sites
@@ -129,6 +131,8 @@ run_site.slowest = 'profile and show the slowest operations'
 run_site.concurrent_jobs = 'maximum number of concurrent jobs'
 
 
+# ########################## build_ses ############################## #
+
 def build_ses(model, *, slowest: int = None):
     """
     Generate the stochastic event set of the given model in the mosaic
@@ -150,6 +154,7 @@ def build_ses(model, *, slowest: int = None):
     params['ground_motion_fields'] = 'false'
     params['minimum_magnitude'] = '5.0'
     del params['inputs']['site_model']
+    print('ses_per_logic_tree_path = ' + params['ses_per_logic_tree_path'])
 
     logging.root.handlers = []  # avoid breaking the logs
     [jobctx] = engine.create_jobs([params], config.distribution.log_level,

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -189,9 +189,8 @@ class RuptureImporter(object):
                 rup['trt_smr'], rup['n_occ'], rupid, e0=rup['e0'],
                 scenario='scenario' in self.oqparam.calculation_mode)
             ebr.seed = rup['seed']
-            for rlz_id, eids in ebr.get_eids_by_rlz(rlzs_by_gsim).items():
-                for eid in eids:
-                    eid_rlz.append((eid, rup['id'], rlz_id))
+            for eid, rlz in ebr.get_eid_rlz(rlzs_by_gsim):
+                eid_rlz.append((eid, rup['id'], rlz))
         return {ordinal: numpy.array(eid_rlz, events_dt)}
 
     def import_rups_events(self, rup_array, get_rupture_getters):

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -183,7 +183,7 @@ class ConditionedGmfComputer(GmfComputer):
         min_iml = self.cmaker.min_iml
         rlzs_by_gsim = self.cmaker.gsims
         sids = self.target_sitecol.sids
-        eids_by_rlz = self.ebrupture.get_eids_by_rlz(rlzs_by_gsim)
+        eid_rlz = self.ebrupture.get_eid_rlz(rlzs_by_gsim)
         mag = self.ebrupture.rupture.mag
         data = AccumDict(accum=[])
         rng = numpy.random.default_rng(self.seed)
@@ -222,7 +222,7 @@ class ConditionedGmfComputer(GmfComputer):
             array = array.transpose(1, 0, 2)  # from M, N, E to N, M, E
             n = 0
             for rlz in rlzs:
-                eids = eids_by_rlz[rlz][0] + offsets
+                eids = eid_rlz[eid_rlz['rlz'] == rlz]['eid'][0] + offsets
                 for ei, eid in enumerate(eids):
                     gmfa = array[:, :, n + ei]  # shape (N, M)
                     if sig_eps is not None:

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -136,12 +136,12 @@ class GmfComputer(object):
         min_iml = self.cmaker.min_iml
         rlzs_by_gsim = self.cmaker.gsims
         sids = self.ctx.sids
-        eids_by_rlz = self.ebrupture.get_eids_by_rlz(rlzs_by_gsim)
+        eid_rlz = self.ebrupture.get_eid_rlz(rlzs_by_gsim)
         mag = self.ebrupture.rupture.mag
         data = AccumDict(accum=[])
         mean_stds = self.cmaker.get_mean_stds([self.ctx])  # (4, G, M, N)
         for g, (gs, rlzs) in enumerate(rlzs_by_gsim.items()):
-            num_events = sum(len(eids_by_rlz[rlz]) for rlz in rlzs)
+            num_events = numpy.isin(eid_rlz['rlz'], rlzs).sum()
             if num_events == 0:  # it may happen
                 continue
             # NB: the trick for performance is to keep the call to
@@ -167,7 +167,7 @@ class GmfComputer(object):
             array = array.transpose(1, 0, 2)  # from M, N, E to N, M, E
             n = 0
             for rlz in rlzs:
-                eids = eids_by_rlz[rlz]
+                eids = eid_rlz[eid_rlz['rlz'] == rlz]['eid']
                 for ei, eid in enumerate(eids):
                     gmfa = array[:, :, n + ei]  # shape (N, M)
                     if sig_eps is not None:

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -743,25 +743,27 @@ class EBRupture(object):
     def tectonic_region_type(self):
         return self.rupture.tectonic_region_type
 
-    def get_eids_by_rlz(self, rlzs_by_gsim):
+    def get_eid_rlz(self, rlzs_by_gsim):
         """
         :params rlzs_by_gsim: a dictionary gsims -> rlzs array
-        :returns: a dictionary rlz index -> eids array
+        :returns: an array with fields (eid, rlz)
         """
-        dic = {}
+        out = []
         rlzs = numpy.concatenate(list(rlzs_by_gsim.values()))
         if self.scenario:
             all_eids = numpy.arange(self.n_occ, dtype=U32) + self.e0
             splits = numpy.array_split(all_eids, len(rlzs))
-            for rlz_id, eids in zip(rlzs, splits):
-                dic[rlz_id] = eids
+            for rlz, eids in zip(rlzs, splits):
+                for eid in eids:
+                    out.append((eid, rlz))
         else:  # event_based
-            j = 0
+            e0 = self.e0
             histo = general.random_histogram(self.n_occ, len(rlzs), self.seed)
             for rlz, n in zip(rlzs, histo):
-                dic[rlz] = numpy.arange(j, j + n, dtype=U32) + self.e0
-                j += n
-        return dic
+                for eid in range(e0, e0 + n):
+                    out.append((eid, rlz))
+                e0 += n
+        return numpy.array(out, [('eid', U32), ('rlz', U32)])
 
     def get_eids(self):
         """


### PR DESCRIPTION
Part of #8631. "saving ruptures and events" becomes 3x faster. Here is JPN with 100,000 years on my workstation:
```
# events
| calc_33215, maxmem=3.1 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total sample_ruptures      | 312.5    | 5.40625   | 390    |
| EventBasedCalculator.run   | 178.0    | 513.7     | 1      |
| saving ruptures and events | 105.9    | 92.4      | 1      |

# master
| calc_33216, maxmem=3.1 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| EventBasedCalculator.run   | 524.0    | 512.5     | 1      |
| saving ruptures and events | 451.6    | 90.3      | 1      |
| total sample_ruptures      | 326.5    | 5.40625   | 390    |
```