### PR TITLE
Added source ID information when extracting a single rupture

### DIFF
--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -164,8 +164,10 @@ class EventBasedTestCase(CalculatorTestCase):
 
         # extracting a single rupture
         aw = extract(self.calc.datastore, 'ruptures?rup_id=0')
-        assert ('seed,mag,rake,lon,lat,dep,multiplicity,trt,kind,mesh,extra\r'
-                in aw.array) 
+        self.assertIn(
+            'seed,mag,rake,lon,lat,dep,multiplicity,trt,kind,mesh,extra\r',
+            aw.array)
+        self.assertIn("source_id=\'1\'", aw.array)
 
         # make sure ses_id >= 65536 is valid
         high_ses = (self.calc.datastore['events']['ses_id'] >= 65536).sum()


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/8005. The information is in the pre-header.