### PR TITLE
Huge helper for debugging GMPEs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Internal: added command `oq compare med_gmv <imt>`
   * Extended extract/ruptures to extract a single rupture given the `rup_id`
   * Fixed a bug in classical_damage causing a ValueError: could not broadcast
     input array from shape (X,Y) into shape (X,)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -997,7 +997,12 @@ class HazardCalculator(BaseCalculator):
         if oq.postproc_func:
             func = getattr(postproc, oq.postproc_func).main
             if 'csm' in inspect.getargspec(func).args:
-                oq.postproc_args['csm'] = self.csm
+                if hasattr(self, 'csm'):  # already there
+                    csm = self.csm
+                else:  # read the csm from the parent calculation
+                    csm = self.datastore.parent['_csm']
+                    csm.full_lt = self.datastore.parent['full_lt'].init()
+                oq.postproc_args['csm'] = csm
             func(self.datastore, **oq.postproc_args)
 
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1383,6 +1383,13 @@ def extract_risk_stats(dstore, what):
     return calc_stats(df, kfields, stats, weights)
 
 
+@extract.add('med_gmv')
+def extract_med_gmv(dstore, what):
+    """
+    Extract med_gmv array for the given source
+    """
+    return extract_(dstore, 'med_gmv/' + what)
+
 # #####################  extraction from the WebAPI ###################### #
 
 

--- a/openquake/calculators/postproc/med_gmv.py
+++ b/openquake/calculators/postproc/med_gmv.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2014-2023 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from openquake.baselib import parallel, python3compat
+from openquake.baselib.general import groupby
+from openquake.hazardlib.contexts import read_cmakers, basename
+from openquake.hazardlib.calc.gmf import exp
+
+
+def calc_med_gmv(src_frags, sitecol, cmaker, monitor):
+    cmaker.init_monitoring(monitor)
+    ctxs = cmaker.from_srcs(src_frags, sitecol)
+    mean = cmaker.get_mean_stds(ctxs)[0]  # shape (G, M, N)
+    for m, imt in enumerate(cmaker.imtls):
+        mean[:, m] = exp(mean[:, m], imt)
+    return src_frags[0].source_id, mean
+
+
+def main(dstore, csm):
+    oq = dstore['oqparam']
+    sitecol = dstore['sitecol']
+    cmakers = read_cmakers(dstore, csm)
+    oq.mags_by_trt = {
+        trt: python3compat.decode(dset[:])
+        for trt, dset in dstore['source_mags'].items()}
+
+    # send one task per source
+    allargs = []
+    for cm in cmakers:
+        sg = csm.src_groups[cm.grp_id]
+        for src_frags in groupby(sg, basename).values():
+            allargs.append((src_frags, sitecol, cm))
+    dstore.swmr_on()  # must come before the Starmap
+    smap = parallel.Starmap(calc_med_gmv, allargs, h5=dstore.hdf5)
+    n = 0
+    for src_id, gmvs in smap:
+        dset = dstore.create_dset(f'gmv/{src_id}', float, gmvs.shape)
+        dset[:] = gmvs
+        n += 1
+    logging.info('Stored %d sources', n)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -141,10 +141,10 @@ class PreClassicalCalculator(base.HazardCalculator):
     accept_precalc = []
 
     def init(self):
-        super().init()
         if self.oqparam.hazard_calculation_id:
-            self.full_lt = self.datastore.parent['full_lt']
+            self.full_lt = self.datastore.parent['full_lt'].init()
         else:
+            super().init()
             self.full_lt = self.csm.full_lt
         arr = numpy.zeros(self.full_lt.Gt, rlzs_by_g_dt)
         for g, rlzs in enumerate(self.full_lt.rlzs_by_g.values()):
@@ -269,6 +269,8 @@ class PreClassicalCalculator(base.HazardCalculator):
         parallelizing on the sources according to their weight and
         tectonic region type.
         """
+        if not hasattr(self, 'csm'):  # used only for post_process
+            return
         cachepath = readinput.get_cache_path(self.oqparam, self.datastore.hdf5)
         if os.path.exists(cachepath):
             realpath = os.path.realpath(cachepath)
@@ -300,5 +302,6 @@ class PreClassicalCalculator(base.HazardCalculator):
                 raise RuntimeError('There are no sources close to the site(s)')
 
     def post_process(self):
-        # needed, otherwise the parent method would be called too early
-        pass
+        if self.oqparam.calculation_mode == 'preclassical':
+            super().post_process()
+        # else do nothing, post_process will be called later on

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -109,7 +109,8 @@ class LogicTreeTestCase(CalculatorTestCase):
         self.run_calc(case_04.__file__, 'job.ini',
                       calculation_mode='preclassical')
         hc_id = str(self.calc.datastore.calc_id)
-        self.run_calc(case_04.__file__, 'job.ini', hazard_calculation_id=hc_id)
+        self.run_calc(case_04.__file__, 'job.ini', hazard_calculation_id=hc_id,
+                      postproc_func='disagg_by_rel_sources')
 
         [fname] = export(('hcurves', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/curve-mean.csv', fname)

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -39,7 +39,7 @@ from openquake.engine.engine import create_jobs, run_jobs
 from openquake.commands.tests.data import to_reduce
 from openquake.calculators.views import view
 from openquake.qa_tests_data.event_based_damage import case_15
-from openquake.qa_tests_data.logictree import case_09, case_56
+from openquake.qa_tests_data.logictree import case_09, case_13, case_56
 from openquake.qa_tests_data.classical import case_01, case_18
 from openquake.qa_tests_data.classical_risk import case_3
 from openquake.qa_tests_data.scenario import case_4
@@ -304,6 +304,16 @@ class RunShowExportTestCase(unittest.TestCase):
         self.assertIn(str(fnames[0]), str(p))
         shutil.rmtree(tempdir)
 
+class CompareTestCase(unittest.TestCase):
+    def test_med_gmv(self):
+        # testing the postprocessor med_gmv
+        ini = os.path.join(os.path.dirname(case_13.__file__), 'job_gmv.ini')
+        [job] = run_jobs(create_jobs([ini]))
+        id = job.calc_id
+        with Print.patch() as p:
+            sap.runline(f"openquake.commands compare med_gmv PGA {id} {id}")
+        self.assertIn('0_0!0: no differences within the tolerances', str(p))
+        
 
 class SampleSmTestCase(unittest.TestCase):
     TESTDIR = os.path.dirname(case_3.__file__)
@@ -598,7 +608,8 @@ class ReduceSourceModelTestCase(unittest.TestCase):
     def test_reduce_sm_with_duplicate_source_ids(self):
         # testing reduce_sm in case of two sources with the same ID and
         # different codes (false duplicates)
-        raise unittest.SkipTest('reduce_sm does not work with false duplicates!')
+        raise unittest.SkipTest(
+            'reduce_sm does not work with false duplicates!')
         temp_dir = tempfile.mkdtemp()
         calc_dir = os.path.dirname(to_reduce.__file__)
         shutil.copytree(calc_dir, os.path.join(temp_dir, 'data'))

--- a/openquake/qa_tests_data/logictree/case_04/job.ini
+++ b/openquake/qa_tests_data/logictree/case_04/job.ini
@@ -3,7 +3,6 @@
 description = Korean peninsula hazard model 
 calculation_mode = classical
 random_seed = 23
-postproc_func = disagg_by_rel_sources
 
 [geometry]
 

--- a/openquake/qa_tests_data/logictree/case_13/job_gmv.ini
+++ b/openquake/qa_tests_data/logictree/case_13/job_gmv.ini
@@ -1,0 +1,38 @@
+[general]
+
+description = Computing med_gmv
+calculation_mode = preclassical
+random_seed = 23
+
+[geometry]
+
+sites_csv = qa_sites.csv
+
+[logic_tree]
+
+number_of_logic_tree_samples = 0
+
+[erf]
+
+rupture_mesh_spacing = 4.0
+width_of_mfd_bin = 0.1
+area_source_discretization = 10.0
+
+[site_params]
+
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 2.0
+reference_depth_to_1pt0km_per_sec = 40.0
+
+[calculation]
+
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gmpe_logic_tree.xml
+investigation_time = 50.0
+intensity_measure_types_and_levels = {"PGA": [0.005, 0.007, 0.0098, 0.0137, 0.0192, 0.0269, 0.0376, 0.0527, 0.0738, 0.103, 0.145, 0.203, 0.284], "SA(0.2)": [0.005, 0.007, 0.0098, 0.0137, 0.0192, 0.0269, 0.0376, 0.0527, 0.0738, 0.103, 0.145, 0.203, 0.284]}
+truncation_level = 3
+maximum_distance = 100
+
+postproc_func = med_gmv
+postproc_args = {}


### PR DESCRIPTION
Implement a post-processor to compute ground motion values starting from a preclassical calculation, plus a a view to show discrepancies between different implementations of a set of GMPEs.  The view can also be used to debug the CanadaSHM6 model where adding an IMT changes the values of the original GMPE:
```
$ oq compare med_gmv PGA -1 -2
CAS: no differences within the tolerances atol=0.001, rtol=0%
DMFF: no differences within the tolerances atol=0.001, rtol=0%
DMFM: no differences within the tolerances atol=0.001, rtol=0%
DMFS: no differences within the tolerances atol=0.001, rtol=0%
GTPC[CanadaSHM6_InSlab_GarciaEtAl2005SSlab55]: 0.43629830752407495 vs 0.2526306418140307
GTPE[CanadaSHM6_InSlab_GarciaEtAl2005SSlab55]: 0.4206704134981445 vs 0.2504619174877016
GTPW[CanadaSHM6_InSlab_GarciaEtAl2005SSlab55]: 0.26851817534879097 vs 0.19519255901592228
LDFC: no differences within the tolerances atol=0.001, rtol=0%
LRFF: no differences within the tolerances atol=0.001, rtol=0%
LRFM: no differences within the tolerances atol=0.001, rtol=0%
LRFS: no differences within the tolerances atol=0.001, rtol=0%
OLM: no differences within the tolerances atol=0.001, rtol=0%
PGT: no differences within the tolerances atol=0.001, rtol=0%
VICM: no differences within the tolerances atol=0.001, rtol=0%
```
The view tells us the affected sources and GMPEs.