### PR TITLE
Deprecated the <area> conversion in the exposure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Deprecated the <area> conversion in the exposure
   * Added new loss types "area" and "number" for usage in risk calculations
   * Made the contexts immutable and fixed mutability bugs potentially
     affecting the modules akkar_bommer_2010, bindi_2011_ipe, can_shm6_inslab,

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -770,6 +770,9 @@ def _get_exposure(fname, stop=None):
         # about pickling dictionaries with empty strings:
         # https://github.com/numpy/numpy/pull/5475
         area = Node('area', dict(type='?'))
+    else:
+        logging.warning('The <area> conversion in the exposure is deprecated '
+                        'and will be removed in future versions of the engine')
     try:
         occupancy_periods = exposure.occupancyPeriods.text or ''
     except AttributeError:


### PR DESCRIPTION
As discussed with the risk team.