### PR TITLE
Restored `sites_csv = site_model.csv`

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -896,7 +896,7 @@ class HazardCalculator(BaseCalculator):
                 if oq.prefer_global_site_params:
                     self.sitecol.set_global_params(oq)
                 else:
-                    # use the site model parameters over the .ini parameters
+                    # use the site model parameters
                     self.sitecol.assoc(sm, assoc_dist)
                 if oq.override_vs30:
                     # override vs30, z1pt0 and z2pt5

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -893,7 +893,11 @@ class HazardCalculator(BaseCalculator):
                 assoc_dist = (oq.region_grid_spacing * 1.414
                               if oq.region_grid_spacing else 5)  # Graeme's 5km
                 sm = readinput.get_site_model(oq)
-                self.sitecol.assoc(sm, assoc_dist)
+                if oq.prefer_global_site_params:
+                    self.sitecol.set_global_params(oq)
+                else:
+                    # use the site model parameters over the .ini parameters
+                    self.sitecol.assoc(sm, assoc_dist)
                 if oq.override_vs30:
                     # override vs30, z1pt0 and z2pt5
                     names = self.sitecol.array.dtype.names

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -242,6 +242,12 @@ class ClassicalTestCase(CalculatorTestCase):
         self.assert_curves_ok([
             'hazard_curve-mean-AvgSA.csv'], case_34.__file__)
 
+        # test prefer_global_site_params
+        ae(self.calc.sitecol.vs30, [600])  # read vs30 from site_model.csv
+        self.run_calc(case_34.__file__, 'job.ini', sites_file='site_model.csv',
+                      site_model_file='', calculation_mode='preclassical')
+        ae(self.calc.sitecol.vs30, [700])  # read vs30 from the job.ini
+
     def test_case_35(self):
         # cluster
         self.assert_curves_ok(['hazard_curve-rlz-000-PGA.csv'],

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -863,6 +863,9 @@ def check_same_levels(imtls):
 
 class OqParam(valid.ParamSet):
     _input_files = ()  # set in get_oqparam
+
+    prefer_global_site_params = False
+
     KNOWN_INPUTS = {
         'rupture_model', 'exposure', 'site_model',
         'source_model', 'shakemap', 'gmfs', 'gsim_logic_tree',
@@ -1114,6 +1117,7 @@ class OqParam(valid.ParamSet):
                 raise NameError('Please remove sites, you should use '
                                 'only site_model')
             inp['site_model'] = [inp.pop('sites')]
+            self.prefer_global_site_params = False
 
     def __init__(self, **names_vals):
         if '_log' in names_vals:  # called from engine

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1113,11 +1113,11 @@ class OqParam(valid.ParamSet):
 
         inp = dic.get('inputs', {})
         if 'sites' in inp:
-            if 'site_model' in inp:
+            if inp.get('site_model'):
                 raise NameError('Please remove sites, you should use '
                                 'only site_model')
             inp['site_model'] = [inp.pop('sites')]
-            self.prefer_global_site_params = False
+            self.prefer_global_site_params = True
 
     def __init__(self, **names_vals):
         if '_log' in names_vals:  # called from engine

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -574,6 +574,9 @@ postproc_args:
   Example: *postproc_args = {'imt': 'PGA'}*
   Default: {} (no arguments)
 
+prefer_global_site_params:
+  INTERNAL. Automatically set by the engine.
+
 ps_grid_spacing:
   Used in classical calculations to grid the point sources. Requires the
   *pointsource_distance* to be set too.
@@ -997,6 +1000,7 @@ class OqParam(valid.ParamSet):
     pointsource_distance = valid.Param(valid.floatdict, {'default': PSDIST})
     postproc_func = valid.Param(valid.simple_id, '')
     postproc_args = valid.Param(valid.dictionary, {})
+    prefer_global_site_params = valid.Param(valid.boolean, None)
     ps_grid_spacing = valid.Param(valid.positivefloat, 0)
     quantile_hazard_curves = quantiles = valid.Param(valid.probabilities, [])
     random_seed = valid.Param(valid.positiveint, 42)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -867,8 +867,6 @@ def check_same_levels(imtls):
 class OqParam(valid.ParamSet):
     _input_files = ()  # set in get_oqparam
 
-    prefer_global_site_params = False
-
     KNOWN_INPUTS = {
         'rupture_model', 'exposure', 'site_model',
         'source_model', 'shakemap', 'gmfs', 'gsim_logic_tree',

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -295,16 +295,7 @@ class SiteCollection(object):
         if sitemodel is None:
             pass
         elif hasattr(sitemodel, 'reference_vs30_value'):
-            # sitemodel is actually an OqParam instance
-            self._set('vs30', sitemodel.reference_vs30_value)
-            self._set('vs30measured',
-                      sitemodel.reference_vs30_type == 'measured')
-            if 'z1pt0' in req_site_params:
-                self._set('z1pt0', sitemodel.reference_depth_to_1pt0km_per_sec)
-            if 'z2pt5' in req_site_params:
-                self._set('z2pt5', sitemodel.reference_depth_to_2pt5km_per_sec)
-            if 'backarc' in req_site_params:
-                self._set('backarc', sitemodel.reference_backarc)
+            self.set_global_params(sitemodel, req_site_params)
         else:
             for name in sitemodel.dtype.names:
                 if name not in ('lon', 'lat'):
@@ -327,6 +318,20 @@ class SiteCollection(object):
 
     xyz = Mesh.xyz
 
+    def set_global_params(self, oq, req_site_params=('z1pt0', 'z2pt5', 'backarc')):
+        """
+        Set the global site parameters (vs30, vs30measured, z1pt0, z2pt5, backarc)
+        """
+        self._set('vs30', oq.reference_vs30_value)
+        self._set('vs30measured',
+                  oq.reference_vs30_type == 'measured')
+        if 'z1pt0' in req_site_params:
+            self._set('z1pt0', oq.reference_depth_to_1pt0km_per_sec)
+        if 'z2pt5' in req_site_params:
+            self._set('z2pt5', oq.reference_depth_to_2pt5km_per_sec)
+        if 'backarc' in req_site_params:
+            self._set('backarc', oq.reference_backarc)
+        
     def filtered(self, indices):
         """
         :param indices:

--- a/openquake/qa_tests_data/classical/case_34/job.ini
+++ b/openquake/qa_tests_data/classical/case_34/job.ini
@@ -4,9 +4,11 @@ description = Classical PSHA — using GMPE spectral averaging
 calculation_mode = classical
 random_seed = 23
 
-[geometry]
+[site_params]
 
+# site_model.csv contains a vs30 of 600
 site_model_file = site_model.csv
+reference_vs30_value = 700.0
 
 [logic_tree]
 


### PR DESCRIPTION
Restore a feature needed by the hazard team and broken by https://github.com/gem/oq-engine/pull/8690.
When using  `sites_csv = site_model.csv` the global site parameters take precedence over the parameters in the
site model, i.e. the opposite of what happens when using  `site_model_csv = site_model.csv`.
