### PR TITLE
third fix to disaggregation with multifaults 

### DIFF
--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -20,6 +20,7 @@ Module :mod:`openquake.hazardlib.geo.surface.multi` defines
 :class:`MultiSurface`.
 """
 import numpy as np
+import logging
 from shapely.geometry import Polygon
 from openquake.hazardlib.geo.surface.base import BaseSurface
 from openquake.hazardlib.geo.mesh import Mesh
@@ -186,10 +187,11 @@ class MultiSurface(BaseSurface):
 
         # the centroid info for the sites must be evaluated and populated
         # one site at a time
+        rms_warning = False
         for jdx in idx.T:
-            i = int(np.where(jdx)[0])
+            i_all = np.where(jdx)[0]
+            i = int(i_all[0]) if len(i_all)>1 else int(i_all)
             surf = self.surfaces[i]
-
             cps = surf.get_closest_points(mesh)
             idx_i = idx[i, :]
             lons[idx_i] = cps.lons[idx_i]

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -20,7 +20,6 @@ Module :mod:`openquake.hazardlib.geo.surface.multi` defines
 :class:`MultiSurface`.
 """
 import numpy as np
-import logging
 from shapely.geometry import Polygon
 from openquake.hazardlib.geo.surface.base import BaseSurface
 from openquake.hazardlib.geo.mesh import Mesh
@@ -187,10 +186,8 @@ class MultiSurface(BaseSurface):
 
         # the centroid info for the sites must be evaluated and populated
         # one site at a time
-        rms_warning = False
         for jdx in idx.T:
-            i_all = np.where(jdx)[0]
-            i = int(i_all[0]) if len(i_all)>1 else int(i_all)
+            i = np.where(jdx)[0][0]
             surf = self.surfaces[i]
             cps = surf.get_closest_points(mesh)
             idx_i = idx[i, :]

--- a/openquake/hazardlib/tests/geo/surface/multi_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi_test.py
@@ -267,6 +267,31 @@ class MultiSurfaceTestCase(unittest.TestCase):
         assert (cpointsB_1.array.T[0] == cpointsB_12.array.T[0]).all()
 
 
+    def test_get_closest_point_v3(self):
+
+        # if two sections have the exact same point as the closest distance,
+        # then we can only choose one 
+        spc1 = 4.0
+        pro1 = Line([Point(174.693609, -41.234002, 0.0), Point(174.6937, -41.2337, 21.68)])
+        pro2 = Line([Point(174.6728, -41.2633, 0.0), Point(174.6729, -41.2629, 21.68)])
+        pro3 = Line([Point(174.6728, -41.2633, 0.0), Point(174.6729, -41.2629, 21.68)])
+        pro4 = Line([Point(174.645459, -41.285853, 0.0), Point(174.6455, -41.2855, 21.76)])
+        sfc1 = KiteSurface.from_profiles([pro1, pro2], spc1, spc1)
+        sfc2 = KiteSurface.from_profiles([pro3, pro4], spc1, spc1)
+        msurf1 = MultiSurface([sfc1, sfc2])
+
+        # Define the mesh of sites
+        pcoo = numpy.array([[174.777, -41.289]])
+        mesh = Mesh(pcoo[:, 0], pcoo[:, 1])
+        
+        # Compute closest distance between mesh points and surface
+        cpoints1 = msurf1.get_closest_points(mesh)
+
+        # checking cpoints
+        expected = [[174.6728], [-41.2633],[ 0.]]
+        assert (cpoints1.array == expected).all()
+
+
 def _plotting(surf, dst, mlons, mlats, lons=[], lats=[], label=''):
     """
     Plots mesh and surface


### PR DESCRIPTION
...and hopefully the last. 
[The second fix](https://github.com/gem/oq-engine/pull/8700/) broke disaggregation when there are sections with lengths shorter than the rupture mesh spacing. This is because then two adjacent sections in a rupture have a common coordinate, and if it coincides with the rupture point that has the minimum distance to the site, then two sections have the closest distance. This PR fixes that and adds a test. 

