### PR TITLE
Speeding up rupture sampling

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -242,7 +242,7 @@ class EventBasedCalculator(base.HazardCalculator):
         for src in sources:
             try:
                 src.num_ruptures = nrups[src.source_id]
-            except KeyError:
+            except KeyError:  # light source
                 src.num_ruptures = src.count_ruptures()
             src.weight = src.num_ruptures
         maxweight = sum(sg.weight for sg in self.csm.src_groups) / (

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -311,28 +311,30 @@ def split_source(src):
     from openquake.hazardlib.source import splittable  # avoid circular import
     if not splittable(src):
         return [src]
-    mag_a, mag_b = src.get_min_max_mag()
     splits = list(src)
+    if len(splits) == 1:
+        return [src]
     has_samples = hasattr(src, 'samples')
     has_smweight = hasattr(src, 'smweight')
     has_scaling_rate = hasattr(src, 'scaling_rate')
+    has_grp_id = hasattr(src, 'grp_id')
     grp_id = getattr(src, 'grp_id', 0)  # 0 in hazardlib
-    if len(splits) > 1:
-        offset = src.offset
-        for i, split in enumerate(splits):
-            split.offset = offset
-            split.source_id = '%s.%s' % (src.source_id, i)
-            split.trt_smr = src.trt_smr
-            split.grp_id = grp_id
-            split.id = src.id
-            if has_samples:
-                split.samples = src.samples
-            if has_smweight:
-                split.smweight = src.smweight
-            if has_scaling_rate:
-                split.scaling_rate = src.scaling_rate
-            offset += split.num_ruptures
-    for split in splits:
+    offset = src.offset
+    for i, split in enumerate(splits):
+        split.offset = offset
+        split.source_id = '%s.%s' % (src.source_id, i)
+        split.trt_smr = src.trt_smr
+        split.grp_id = grp_id
+        split.id = src.id
+        if has_samples:
+            split.samples = src.samples
+        if has_smweight:
+            split.smweight = src.smweight
+        if has_scaling_rate:
+            split.scaling_rate = src.scaling_rate
+        if has_grp_id:
+            split.grp_id = src.grp_id
+        offset += split.num_ruptures
         split.nsites = src.nsites
     return splits
 

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -314,6 +314,7 @@ def split_source(src):
     mag_a, mag_b = src.get_min_max_mag()
     splits = list(src)
     has_samples = hasattr(src, 'samples')
+    has_smweight = hasattr(src, 'smweight')
     has_scaling_rate = hasattr(src, 'scaling_rate')
     grp_id = getattr(src, 'grp_id', 0)  # 0 in hazardlib
     if len(splits) > 1:
@@ -326,19 +327,11 @@ def split_source(src):
             split.id = src.id
             if has_samples:
                 split.samples = src.samples
+            if has_smweight:
+                split.smweight = src.smweight
             if has_scaling_rate:
                 split.scaling_rate = src.scaling_rate
             offset += split.num_ruptures
-    elif splits:  # single source
-        [s] = splits
-        s.source_id = src.source_id
-        s.trt_smr = src.trt_smr
-        s.grp_id = grp_id
-        s.id = src.id
-        if has_samples:
-            s.samples = src.samples
-        if has_scaling_rate:
-            s.scaling_rate = src.scaling_rate
     for split in splits:
         split.nsites = src.nsites
     return splits

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -335,7 +335,7 @@ def split_source(src):
         if has_grp_id:
             split.grp_id = src.grp_id
         offset += split.num_ruptures
-        split.nsites = src.nsites
+        #split.nsites = src.nsites
     return splits
 
 

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -265,7 +265,9 @@ def sample_ruptures(sources, cmaker, sitecol=None, monitor=Monitor()):
             source_data['ctimes'].append(dt)
             source_data['weight'].append(src.weight)
             source_data['taskno'].append(monitor.task_no)
+        t0 = time.time()
         rup_array = get_rup_array(eb_ruptures, srcfilter)
+        dt = time.time() - t0
         if len(rup_array):
             yield AccumDict(dict(rup_array=rup_array, source_data=source_data,
                                  eff_ruptures={grp_id: eff_ruptures}))

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -98,6 +98,8 @@ def poisson_sample(src, eff_num_ses, seed):
     rup_args = []
     rates = []
     for ps in split_source(src):
+        if not hasattr(ps, 'location'):  # unsplit containing a single point source
+            [ps] = src
         lon, lat = ps.location.x, ps.location.y
         for mag, mag_occ_rate in ps.get_annual_occurrence_rates():
             for np_prob, np in ps.nodal_plane_distribution.data:

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -281,6 +281,7 @@ class SourceGroup(collections.abc.Sequence):
             print(src.weight)
         return self
 
+    # used only in event_based, where weight = num_ruptures
     def split(self, maxweight):
         """
         Split the group in subgroups with weight <= maxweight, unless it
@@ -289,7 +290,6 @@ class SourceGroup(collections.abc.Sequence):
         if self.atomic:
             return [self]
 
-        '''
         # split multipoint sources in avance
         sources = []
         for src in self:
@@ -297,10 +297,9 @@ class SourceGroup(collections.abc.Sequence):
                 sources.extend(split_source(src))
             else:
                 sources.append(src)
-        '''
         out = []
         for block in block_splitter(
-                self, maxweight, operator.attrgetter('weight')):
+                sources, maxweight, operator.attrgetter('num_ruptures')):
             sg = copy.copy(self)
             sg.sources = block
             out.append(sg)

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -25,14 +25,14 @@ import logging
 from dataclasses import dataclass
 import numpy
 
-from openquake.hazardlib.source.multi_fault import MultiFaultSource
 from openquake.baselib import hdf5
 from openquake.baselib.general import groupby, block_splitter
 from openquake.baselib.node import context, striptag, Node, node_to_dict
 from openquake.hazardlib import geo, mfd, pmf, source, tom, valid, InvalidFile
 from openquake.hazardlib.tom import PoissonTOM
+from openquake.hazardlib.calc.filters import split_source
 from openquake.hazardlib.source import NonParametricSeismicSource
-
+from openquake.hazardlib.source.multi_fault import MultiFaultSource
 
 U32 = numpy.uint32
 F32 = numpy.float32
@@ -288,6 +288,16 @@ class SourceGroup(collections.abc.Sequence):
         """
         if self.atomic:
             return [self]
+
+        '''
+        # split multipoint sources in avance
+        sources = []
+        for src in self:
+            if src.code == b'M':
+                sources.extend(split_source(src))
+            else:
+                sources.append(src)
+        '''
         out = []
         for block in block_splitter(
                 self, maxweight, operator.attrgetter('weight')):


### PR DESCRIPTION
By splitting multipoint sources. This has a huge effect on Alaska (45x):
```
Received {'rup_array': '356.03 MB'} in 1579 seconds from sample_ruptures  # before
Received {'rup_array': '357.37 MB'} in 35 seconds from sample_ruptures  # after
```