### PR TITLE
Removed ugly SkipTest in views_test.py

### DIFF
--- a/openquake/server/tests/views_test.py
+++ b/openquake/server/tests/views_test.py
@@ -80,5 +80,3 @@ class EngineServerTestCase(django.test.TestCase):
             running_calcs = cls.get('list', is_running='true')
             if not running_calcs:
                 return
-        # to avoid issues on Jenkins
-        raise django.test.SkipTest('Timeout waiting for %s' % running_calcs)


### PR DESCRIPTION
Let's see if it works, now that the engine is not tested on Jenkins anymore.