### PR TITLE
Splitting multiFaultSources before rupture sampling

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -255,7 +255,6 @@ class EventBasedCalculator(base.HazardCalculator):
         for sg in self.csm.src_groups:
             if not sg.sources:
                 continue
-            logging.info('Sending %s', sg)
             rgb = self.full_lt.get_rlzs_by_gsim(sg.sources[0].trt_smr)
             cmaker = ContextMaker(sg.trt, rgb, oq)
             for src_group in sg.split(maxweight):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -290,10 +290,10 @@ class SourceGroup(collections.abc.Sequence):
         if self.atomic:
             return [self]
 
-        # split multipoint sources in avance
+        # split multipoint/multifault in advance
         sources = []
         for src in self:
-            if src.code == b'M':
+            if src.code in b'MF':
                 sources.extend(split_source(src))
             else:
                 sources.append(src)

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -303,6 +303,7 @@ class SourceGroup(collections.abc.Sequence):
             sg = copy.copy(self)
             sg.sources = block
             out.append(sg)
+        logging.info('Produced %d subgroup(s) of %s', len(out), self)
         return out
 
     def get_tom_toml(self, time_span):


### PR DESCRIPTION
Because the USA model has a disastrous slow task:
```
| operation-duration | counts | mean    | stddev | min     | max   | slowfac |
|--------------------+--------+---------+--------+---------+-------+---------|
| sample_ruptures    | 265    | 36.6    | 1510%  | 0.00117 | 9_004 | 246.3   |
```
After this change the situation is a better (2x) but not enough :-(
```
| operation-duration | counts | mean    | stddev | min     | max   | slowfac |
|--------------------+--------+---------+--------+---------+-------+---------|
| sample_ruptures    | 265    | 46.3    | 950%   | 0.00115 | 5_705 | 123.2   |
```