### PR TITLE
Made `truncation_level` mandatory

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made the parameter `truncation_level` mandatory
   * Fixed the damage state header in the aggrisk outputs
   * Changed the order of the IMTs to be by period and not lexicographic
   * Fixed the realizations extractor for scenario calculations reading

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1772,6 +1772,9 @@ class OqParam(valid.ParamSet):
         """
         In presence of a correlation model the truncation level must be nonzero
         """
+        if ('hazard_curves' not in self.inputs and 'gmfs' not in self.inputs
+                and self.inputs['job_ini'] != '<in-memory>'):
+            self.truncation_level  # check mandatory attribute
         if self.ground_motion_correlation_model:
             return self.truncation_level != 0
         else:
@@ -1998,9 +2001,6 @@ class OqParam(valid.ParamSet):
                 'contain a single point')
 
     def check_source_model(self):
-        if ('hazard_curves' not in self.inputs and 'gmfs' not in self.inputs
-                and self.inputs['job_ini'] != '<in-memory>'):
-            self.truncation_level  # check mandatory attribute
         if ('hazard_curves' in self.inputs or 'gmfs' in self.inputs or
                 'multi_peril' in self.inputs or 'rupture_model' in self.inputs
                 or 'scenario' in self.calculation_mode

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1210,6 +1210,14 @@ class OqParam(valid.ParamSet):
 
         if self.job_type == 'risk':
             self.check_aggregate_by()
+        if ('hazard_curves' not in self.inputs and 'gmfs' not in self.inputs
+                and self.inputs['job_ini'] != '<in-memory>'
+                and self.calculation_mode != 'scenario'
+                and not self.hazard_calculation_id):
+            if not hasattr(self, 'truncation_level'):
+                raise InvalidFile("Missing truncation_level in %s" %
+                                  self.inputs['job_ini'])
+
         if 'reinsurance' in self.inputs:
             self.check_reinsurance()
 
@@ -1772,9 +1780,6 @@ class OqParam(valid.ParamSet):
         """
         In presence of a correlation model the truncation level must be nonzero
         """
-        if ('hazard_curves' not in self.inputs and 'gmfs' not in self.inputs
-                and self.inputs['job_ini'] != '<in-memory>'):
-            self.truncation_level  # check mandatory attribute
         if self.ground_motion_correlation_model:
             return self.truncation_level != 0
         else:

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1211,6 +1211,7 @@ class OqParam(valid.ParamSet):
         if self.job_type == 'risk':
             self.check_aggregate_by()
         if ('hazard_curves' not in self.inputs and 'gmfs' not in self.inputs
+                and 'multi_peril' not in self.inputs
                 and self.inputs['job_ini'] != '<in-memory>'
                 and self.calculation_mode != 'scenario'
                 and not self.hazard_calculation_id):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -784,7 +784,7 @@ total_losses:
 truncation_level:
   Truncation level used in the GMPEs.
   Example: *truncation_level = 0* to compute median GMFs.
-  Default: 99
+  Default: no default
 
 uniform_hazard_spectra:
   Flag used to generated uniform hazard specta for the given poes
@@ -1051,8 +1051,7 @@ class OqParam(valid.ParamSet):
                      'structural+contents',
                      'nonstructural+contents',
                      'structural+nonstructural+contents'), None)
-    truncation_level = valid.Param(
-        lambda s: valid.positivefloat(s) or 1E-9, 99.)
+    truncation_level = valid.Param(lambda s: valid.positivefloat(s) or 1E-9)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)
     use_rates = valid.Param(valid.boolean, False)
     vs30_tolerance = valid.Param(valid.positiveint, 0)
@@ -1999,6 +1998,9 @@ class OqParam(valid.ParamSet):
                 'contain a single point')
 
     def check_source_model(self):
+        if ('hazard_curves' not in self.inputs and 'gmfs' not in self.inputs
+                and self.inputs['job_ini'] != '<in-memory>'):
+            self.truncation_level  # check mandatory attribute
         if ('hazard_curves' in self.inputs or 'gmfs' in self.inputs or
                 'multi_peril' in self.inputs or 'rupture_model' in self.inputs
                 or 'scenario' in self.calculation_mode

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -710,8 +710,7 @@ def get_full_lt(oqparam, branchID=''):
         if trt in oqparam.discard_trts.split(','):
             continue
         elif trt.lower() not in trts_lower:
-            raise ValueError('Unknown TRT=%s in %s [reqv]' %
-                             (trt, oqparam.inputs['job_ini']))
+            logging.warning('Unknown TRT=%s in [reqv] section' % trt)
     gsim_lt = get_gsim_lt(oqparam, trts or ['*'])
     if len(oqparam.source_id) == 1:
         oversampling = 'reduce-rlzs'

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -56,6 +56,7 @@ class OqParamTestCase(unittest.TestCase):
                 hazard_calculation_id=None, hazard_output_id=None,
                 maximum_distance='10', sites='0.1 0.2',
                 reference_vs30_value='200',
+                truncation_level='3',
                 not_existing_param='XXX', export_dir=TMP,
                 intensity_measure_types_and_levels="{'PGA': [0.1, 0.2]}",
                 rupture_mesh_spacing='1.5').validate()
@@ -138,6 +139,7 @@ class OqParamTestCase(unittest.TestCase):
             calculation_mode='event_based', inputs=GST,
             intensity_measure_types_and_levels="{'PGA': [0.1, 0.2]}",
             intensity_measure_types='PGV', sites='0.1 0.2',
+            truncation_level='3',
             reference_vs30_value='200',
             maximum_distance='400')
         oq.validate()

--- a/openquake/commonlib/tests/oqvalidation_test.py
+++ b/openquake/commonlib/tests/oqvalidation_test.py
@@ -90,12 +90,14 @@ class OqParamTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             OqParam(
                 calculation_mode='classical_risk',
+                truncation_level='3',
                 hazard_calculation_id=None, hazard_output_id=None,
                 inputs=fakeinputs, maximum_distance='10', sites='',
                 hazard_maps='true',  poes='').validate()
         with self.assertRaises(ValueError):
             OqParam(
                 calculation_mode='classical_risk',
+                truncation_level='3',
                 hazard_calculation_id=None, hazard_output_id=None,
                 inputs=fakeinputs, maximum_distance='10', sites='',
                 uniform_hazard_spectra='true',  poes='').validate()
@@ -114,13 +116,14 @@ class OqParamTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             OqParam(
                 calculation_mode='classical', inputs=fakeinputs,
-                sites='0.1 0.2').validate()
+                truncation_level='3', sites='0.1 0.2').validate()
 
         oq = OqParam(
             calculation_mode='event_based', inputs=GST,
             intensity_measure_types_and_levels="{'PGA': [0.1, 0.2]}",
             intensity_measure_types='PGV', sites='0.1 0.2',
             reference_vs30_value='200',
+            truncation_level='3',
             maximum_distance='{"wrong TRT": 200}')
         oq.inputs['source_model_logic_tree'] = 'something'
 
@@ -180,6 +183,7 @@ class OqParamTestCase(unittest.TestCase):
                 calculation_mode='event_based', inputs=fakeinputs,
                 sites='0.1 0.2',
                 maximum_distance='400',
+                truncation_level='3',
                 ground_motion_correlation_model='JB2009',
                 intensity_measure_types_and_levels='{"PGV": [0.4, 0.5, 0.6]}',
             ).validate()
@@ -211,6 +215,7 @@ class OqParamTestCase(unittest.TestCase):
                 calculation_mode='classical', inputs=fakeinputs,
                 sites='0.1 0.2',
                 maximum_distance='400',
+                truncation_level='3',
                 intensity_measure_types='PGA',
             ).validate()
         self.assertIn('`intensity_measure_types_and_levels`',
@@ -222,6 +227,7 @@ class OqParamTestCase(unittest.TestCase):
                 calculation_mode='event_based', inputs=fakeinputs,
                 sites='0.1 0.2',
                 maximum_distance='400',
+                truncation_level='3',
                 intensity_measure_types='PGA',
                 hazard_curves_from_gmfs='true')
             oq.validate()
@@ -277,6 +283,7 @@ class OqParamTestCase(unittest.TestCase):
                 sites='0.1 0.2, 0.3 0.4',
                 poes='0.2',
                 maximum_distance='400',
+                truncation_level='3',
                 intensity_measure_types_and_levels="{'PGV': [0.1, 0.2, 0.3]}",
                 uniform_hazard_spectra='1',
                 inputs=fakeinputs,
@@ -293,6 +300,7 @@ class OqParamTestCase(unittest.TestCase):
                 sites='0.1 0.2, 0.3 0.4',
                 poes='0.2',
                 maximum_distance='400',
+                truncation_level='3',
                 intensity_measure_types_and_levels="{'PGA': [0.1, 0.2, 0.3]}",
                 uniform_hazard_spectra='1',
                 inputs=fakeinputs,
@@ -319,6 +327,7 @@ class OqParamTestCase(unittest.TestCase):
                 reference_vs30_value='200',
                 sites='0.1 0.2',
                 maximum_distance='400',
+                truncation_level='3',
                 intensity_measure_types_and_levels="{'PGV': [0.1, 0.2, 0.3]}",
                 uniform_hazard_spectra='1')
         self.assertIn("poes_disagg or iml_disagg must be set",
@@ -333,6 +342,7 @@ class OqParamTestCase(unittest.TestCase):
                 sites='0.1 0.2',
                 poes='0.2',
                 maximum_distance='400',
+                truncation_level='3',
                 iml_disagg="{'PGV': 0.1}",
                 poes_disagg="0.1",
                 uniform_hazard_spectra='1')

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -508,13 +508,13 @@ class GetCompositeSourceModelTestCase(unittest.TestCase):
                       str(c.exception))
 
     def test_wrong_trts_in_reqv(self):
-        # invalid TRT in job.ini [reqv]
+        # unknown TRT in job.ini [reqv]
         oq = readinput.get_oqparam('job.ini', case_02)
         fname = oq.inputs['reqv'].pop('active shallow crust')
         oq.inputs['reqv']['act shallow crust'] = fname
-        with self.assertRaises(ValueError) as ctx:
+        with mock.patch('logging.warning') as w:
             readinput.get_composite_source_model(oq)
-        self.assertIn('Unknown TRT=act shallow crust', str(ctx.exception))
+        self.assertIn('Unknown TRT=act shallow crust', w.call_args[0][0])
 
     def test_extra_large_source(self):
         raise unittest.SkipTest('Removed check on MAX_EXTENT')

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -447,6 +447,7 @@ POLYGON((78.0 31.5, 89.5 31.5, 89.5 25.5, 78.0 25.5, 78.0 31.5))'''
 [general]
 description = Exposure with missing cost_types
 calculation_mode = scenario_risk
+truncation_level = 5
 exposure_file = %s''' % os.path.basename(self.exposure4))
         oqparam = readinput.get_oqparam(job_ini)
         with self.assertRaises(InvalidFile) as ctx:

--- a/openquake/qa_tests_data/aftershock/case_1/pre_job.ini
+++ b/openquake/qa_tests_data/aftershock/case_1/pre_job.ini
@@ -13,4 +13,4 @@ rupture_mesh_spacing = 20
 area_source_discretization = 25
 investigation_time = 50
 maximum_distance = 300
-# split_sources = false
+truncation_level = 99

--- a/openquake/qa_tests_data/classical/case_27/job.ini
+++ b/openquake/qa_tests_data/classical/case_27/job.ini
@@ -36,3 +36,4 @@ investigation_time = 50.
 intensity_measure_types_and_levels = {"PGV": [20]}
 # km
 maximum_distance = 200.
+truncation_level = 99.

--- a/openquake/qa_tests_data/classical/case_47/job.ini
+++ b/openquake/qa_tests_data/classical/case_47/job.ini
@@ -31,6 +31,7 @@ gsim_logic_tree_file = gmpe_logic_tree.xml
 investigation_time = 1.0
 intensity_measure_types_and_levels = {"PGA": [0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 7.0]}
 maximum_distance = 200.0
+truncation_level = 99.
 
 [output]
 

--- a/openquake/qa_tests_data/classical/case_53/job.ini
+++ b/openquake/qa_tests_data/classical/case_53/job.ini
@@ -32,6 +32,7 @@ investigation_time = 1.0
 intensity_measure_types_and_levels = {"PGA": logscale(0.001, 1.0, 10),
                                       "SA(0.5)": logscale(0.001, 1.0, 10)}
 maximum_distance = 200.0
+truncation_level = 99.
 
 [output]
 

--- a/openquake/qa_tests_data/classical/case_54/job.ini
+++ b/openquake/qa_tests_data/classical/case_54/job.ini
@@ -32,6 +32,7 @@ investigation_time = 1.0
 intensity_measure_types_and_levels = {"PGA": logscale(0.001, 1.0, 10),
                                       "SA(0.5)": logscale(0.001, 1.0, 10)}
 maximum_distance = 200.0
+truncation_level = 99.
 
 [output]
 

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_1/job.ini
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_1/job.ini
@@ -37,7 +37,7 @@ investigation_time = 50.0
 intensity_measure_types = PGA
 # km
 maximum_distance = 200.0
-
+truncation_level = 99.
 
 [event_based_params]
 

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_2/job.ini
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_2/job.ini
@@ -37,7 +37,7 @@ investigation_time = 50.0
 intensity_measure_types = PGA
 # km
 maximum_distance = 200.0
-
+truncation_level = 99.
 
 [event_based_params]
 

--- a/openquake/qa_tests_data/event_based/spatial_correlation/case_3/job.ini
+++ b/openquake/qa_tests_data/event_based/spatial_correlation/case_3/job.ini
@@ -37,7 +37,7 @@ investigation_time = 50.0
 intensity_measure_types = PGA
 # km
 maximum_distance = 200.0
-
+truncation_level = 99.
 
 [event_based_params]
 

--- a/openquake/qa_tests_data/event_based_risk/case_miriam/job2.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_miriam/job2.ini
@@ -32,6 +32,7 @@ investigation_time = 1
 maximum_distance = 200.0
 asset_hazard_distance = 20.0
 structural_vulnerability_file = vulnerability_model.xml
+truncation_level = 99.
 
 [event_based_params]
 

--- a/openquake/qa_tests_data/logictree/case_12/job.ini
+++ b/openquake/qa_tests_data/logictree/case_12/job.ini
@@ -34,6 +34,7 @@ gsim_logic_tree_file = gmmLT.xml
 investigation_time = 1.0
 intensity_measure_types_and_levels = {"PGA": logscale(0.005, 3.00, 2)}
 maximum_distance = 100.0
+truncation_level = 99.
 horiz_comp_to_geom_mean = true
 pointsource_distance = 20.0
 

--- a/openquake/qa_tests_data/logictree/case_12/job_bis.ini
+++ b/openquake/qa_tests_data/logictree/case_12/job_bis.ini
@@ -34,6 +34,7 @@ gsim_logic_tree_file = gmmLT.xml
 investigation_time = 1.0
 intensity_measure_types_and_levels = {"PGA": logscale(0.005, 3.00, 2)}
 maximum_distance = 100.0
+truncation_level = 99.
 horiz_comp_to_geom_mean = true
 pointsource_distance = 20.0
 

--- a/openquake/qa_tests_data/logictree/case_36/job.ini
+++ b/openquake/qa_tests_data/logictree/case_36/job.ini
@@ -25,5 +25,6 @@ maximum_distance = {"Active Shallow Crust": 30.,
                     "Subduction Interface": 100.,
                     "Stable Continental Interior": 30.}
 investigation_time = 1.0
+truncation_level = 99.
 pointsource_distance = 0
 intensity_measure_types_and_levels = {"PGA": [.1, .2]}

--- a/openquake/qa_tests_data/scenario/case_5/job.ini
+++ b/openquake/qa_tests_data/scenario/case_5/job.ini
@@ -30,7 +30,7 @@ gsim = BooreAtkinson2008
 ground_motion_correlation_model = JB2009
 ground_motion_correlation_params = {"vs30_clustering": False}
 number_of_ground_motion_fields = 65000
-
+truncation_level = 2
 
 [output]
 

--- a/openquake/qa_tests_data/scenario/case_6/job.ini
+++ b/openquake/qa_tests_data/scenario/case_6/job.ini
@@ -30,7 +30,7 @@ gsim = BooreAtkinson2008
 ground_motion_correlation_model = JB2009
 ground_motion_correlation_params = {"vs30_clustering": True}
 number_of_ground_motion_fields = 20000
-
+truncation_level = 3
 
 [output]
 

--- a/openquake/qa_tests_data/scenario/case_8/job.ini
+++ b/openquake/qa_tests_data/scenario/case_8/job.ini
@@ -30,7 +30,7 @@ gsim = AtkinsonBoore2003SInter
 ground_motion_correlation_model =
 ground_motion_correlation_params =
 number_of_ground_motion_fields = 1000
-
+truncation_level = 3
 
 [output]
 

--- a/openquake/qa_tests_data/scenario_damage/case_4/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_4/job_risk.ini
@@ -3,6 +3,7 @@
 description = QA Scenario Risk
 calculation_mode = scenario_damage
 fragility_file = fragility_model.xml
+truncation_level = 3
 discrete_damage_distribution = true
 region = 78.0 31.5,89.5 31.5,89.5 25.5,78 25.5
 export_dir = /tmp

--- a/openquake/qa_tests_data/scenario_risk/case_1g/job_risk.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_1g/job_risk.ini
@@ -3,6 +3,7 @@ description = Scenario Risk
 calculation_mode = scenario_risk
 aggregate_by = id
 concurrent_tasks = 0
+truncation_level = 3
 
 [boundaries]
 region = -122.6 38.3, -121.5 38.3, -121.5 37.1, -122.6 37.1

--- a/openquake/qa_tests_data/scenario_risk/case_shakemap/expected/agglosses.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_shakemap/expected/agglosses.csv
@@ -1,3 +1,3 @@
-#,,"generated_by='OpenQuake engine 3.15.0-gitea8e84068a', start_date='2022-04-13T05:12:35', checksum=2236535684, investigation_time=None, risk_investigation_time=None"
+#,,"generated_by='OpenQuake engine 3.17.0-git5a0c6541e3', start_date='2023-05-17T05:56:46', checksum=2590104316, investigation_time=None, risk_investigation_time=None"
 loss_type,loss_value,loss_ratio
-structural,1.78341E+06,1.73463E-03
+structural,1.77770E+06,1.72908E-03

--- a/openquake/qa_tests_data/scenario_risk/case_shakemap/job.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_shakemap/job.ini
@@ -5,3 +5,4 @@ random_seed = 152
 number_of_ground_motion_fields = 3
 shakemap_uri = {"kind": "file_npy", "fname": "shakefile/usp000fjta.npy"}
 asset_hazard_distance = 20
+truncation_level = 3

--- a/openquake/qa_tests_data/scenario_risk/case_shapefile/expected/agglosses.csv
+++ b/openquake/qa_tests_data/scenario_risk/case_shapefile/expected/agglosses.csv
@@ -1,3 +1,3 @@
-#,,"generated_by='OpenQuake engine 3.15.0-gitea8e84068a', start_date='2022-04-13T05:12:36', checksum=407192687, investigation_time=None, risk_investigation_time=None"
+#,,"generated_by='OpenQuake engine 3.17.0-git5a0c6541e3', start_date='2023-05-17T05:57:31', checksum=1090210826, investigation_time=None, risk_investigation_time=None"
 loss_type,loss_value,loss_ratio
-structural,2.64362E+06,2.48367E-02
+structural,2.28944E+06,2.15091E-02

--- a/openquake/qa_tests_data/scenario_risk/case_shapefile/job.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_shapefile/job.ini
@@ -8,3 +8,4 @@ shakemap_uri = {
      "fname": "shp/output.shp"}
 spatial_correlation = no
 cross_correlation = no
+truncation_level = 2

--- a/openquake/qa_tests_data/scenario_risk/case_shapefile/job_zipped.ini
+++ b/openquake/qa_tests_data/scenario_risk/case_shapefile/job_zipped.ini
@@ -8,3 +8,4 @@ shakemap_uri = {
      "fname": "shp/shapefiles.zip"}
 spatial_correlation = no
 cross_correlation = no
+truncation_level = 3


### PR DESCRIPTION
This is dramatic: if somebody forgets to set it (as it happens in the USA model) the default of 99. is taken causing extreme ground motion values to appear affecting terribly the risk calculation. With this fix the parameter becomes mandatory, i.e. you get an error if you do not fix it.

Also removed the check on the TRTs in the [reqv] section (it is now just a warning) to make it possible to debug the UCERF source in the USA model.