### PR TITLE
Improved multiFault sampling more

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Optimized the rupture sampling for MultiFaultSources and improved
+    the parallelization for MultiFaultSources and MultiPointSources
   * Made the parameter `truncation_level` mandatory
   * Fixed the damage state header in the aggrisk outputs
   * Changed the order of the IMTs to be by period and not lexicographic

--- a/doc/adv-manual/general.rst
+++ b/doc/adv-manual/general.rst
@@ -442,6 +442,7 @@ Ground Accelation (PGA) of 0.1g by using the ToroEtAl2002SHARE GMPE:
 ... intensity_measure_types_and_levels="{'PGA': [0.1]}",
 ... investigation_time='50.0',
 ... gsim='ToroEtAl2002SHARE',
+... truncation_level='99.0',
 ... maximum_distance='200.0'))
 
 Then we need to specify the source:


### PR DESCRIPTION
By avoiding un-needed operations I can get a 3x speedup:
```
# before
| calc_549, maxmem=41.4 GB   | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total sample_ruptures      | 13_256   | 34.2      | 237    |
| EventBasedCalculator.run   | 238.8    | 1_389     | 1      |

# after
| calc_550, maxmem=41.5 GB   | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total sample_ruptures      | 4_318    | 34.3      | 237    |
| EventBasedCalculator.run   | 142.3    | 1_390     | 1      |
```