### PR TITLE
Replace url for menu help button

### DIFF
--- a/openquake/server/templates/engine/base.html
+++ b/openquake/server/templates/engine/base.html
@@ -55,7 +55,7 @@
                   </li>
                   {% endif %}
                   <li class="actions">
-                      <a href="https://github.com/gem/oq-engine" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
+                      <a href="https://www.globalquakemodel.org/openquake" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
Fixes https://github.com/gem/oq-engine/issues/8702

Now it points to https://www.globalquakemodel.org/openquake instead of https://github.com/gem/oq-engine