### PR TITLE
Replace help_url to point to the latest engine manual

### DIFF
--- a/openquake/server/templates/engine/base.html
+++ b/openquake/server/templates/engine/base.html
@@ -55,7 +55,7 @@
                   </li>
                   {% endif %}
                   <li class="actions">
-                      <a href="https://www.globalquakemodel.org/openquake" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
+                      <a href="https://docs.openquake.org/oq-engine/latest/manual/" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
Replaces https://github.com/gem/oq-engine/pull/8765

As soon as we have also a proper documentation for AELO, we may change the link in case of AELO application mode. But for now we can keep this link.