### PR TITLE
Storing the assets directly as a DataFrame

### DIFF
--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -620,6 +620,7 @@ class AssetCollection(object):
         :returns: the associated DataFrame
         """
         dic = {name: self.array[name] for name in self.array.dtype.names}
+        dic['id'] = decode(dic['id'])
         return pandas.DataFrame(dic, dic[indexfield])
 
     def __iter__(self):
@@ -931,8 +932,6 @@ class Exposure(object):
         for i, fname in enumerate(fnames, 1):
             if by_country and len(fnames) > 1:
                 prefix = prefix2cc['E%02d_' % i] + '_'
-            elif len(fnames) > 1:
-                prefix = 'E%02d_' % i
             else:
                 prefix = ''
             allargs.append((fname, calculation_mode, region_constraint,

--- a/openquake/risklib/connectivity.py
+++ b/openquake/risklib/connectivity.py
@@ -23,7 +23,7 @@ def analysis(dstore):
             tagname: {i: tag for i, tag in enumerate(tags[tagname])}
             for tagname in tagnames
         }
-    ).assign(id=lambda df: df.id.str.decode("utf-8")).set_index("id")
+    ).set_index("id")
 
     source_nodes = exposure_df.loc[
         exposure_df.supply_or_demand == "source"].index.to_list()

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1170,8 +1170,8 @@ def insurance_losses(asset_df, losses_by_lt, policy_df):
         lims = j.insurance_limit.to_numpy() * values
         ids_of_invalid_assets = aids[deds > lims]
         if len(ids_of_invalid_assets):
-            invalid_assets = set(asset_df['id'][aid].decode('utf8')
-                                 for aid in ids_of_invalid_assets)
+            invalid_assets = set(
+                asset_df['id'][aid] for aid in ids_of_invalid_assets)
             raise ValueError(
                 f"Please check deductible values. Values larger than the"
                 f" insurance limit were found for asset(s) {invalid_assets}.")


### PR DESCRIPTION
Should avoid the error
```python
  File "/opt/openquake/oq-engine/openquake/calculators/event_based_risk.py", line 273, in save_tmp
    monitor.save('assets', self.assetcol.to_dframe())
  File "/opt/openquake/oq-engine/openquake/baselib/performance.py", line 337, in save
    f[key] = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
  File "/opt/openquake/oq-engine/openquake/baselib/hdf5.py", line 481, in __setitem__
    self._set(path, numpy.void(obj))
numpy.core._exceptions._ArrayMemoryError: Unable to allocate -956. MiB for an array with shape () and data type |V-1002067604
```
affecting the USA model.

NB: also trying to remove the `prefix` feature.