### PR TITLE
Improve advanced manual about aggregation by multiple keys for reinsurance

### DIFF
--- a/doc/adv-manual/event_based.rst
+++ b/doc/adv-manual/event_based.rst
@@ -433,6 +433,8 @@ If you do not set the ``aggregate_by`` parameter
 you will still be able to compute the total loss curve 
 (for the entire portfolio of assets), and the total average losses.
 
+.. _aggregating_by_multiple_tags:
+
 Aggregating by multiple tags
 ----------------------------
 
@@ -2045,9 +2047,16 @@ calculations::
 
 **Additional comments:**
 
-- ``aggregate_by``: it is possible to define multiple aggregation keys.
+- ``aggregate_by``: it is possible to define multiple aggregation keys
+  (see :ref:`aggregating_by_multiple_tags`).
   However, for reinsurance calculations the ``policy`` key must be present,
   otherwise an error message will be raised.
+  In the following example, multiple aggregation keys are used:
+
+      ``aggregate_by = policy; tag1``
+
+  In this case, aggregated loss curves will be produced also for tag1 and policy,
+  while reinsurance outputs will only be produced for the policy.
 
 - ``reinsurance_file``: This dictionary associates the reinsurance information
   to a given the loss_type (the engine supports structural, nonstructural, 

--- a/doc/adv-manual/event_based.rst
+++ b/doc/adv-manual/event_based.rst
@@ -438,14 +438,20 @@ you will still be able to compute the total loss curve
 Aggregating by multiple tags
 ----------------------------
 
-The engine also supports aggregation my multiple tags. For instance
-the second event based risk demo (the file ``job_eb.ini``) has a line
+The engine also supports aggregation by multiple tags. 
+Multiple tags can be indicated as multi-tag and/or various single- aggregations.
+``aggregate_by = NAME_1, taxonomy
+aggregate_by = NAME_1; taxonomy``
 
-   ``aggregate_by = NAME_1, taxonomy``
+Comma ``,`` separated values will generate keys for all the possible 
+combinations of the indicated tag values, while semicolon ``;`` 
+will generate keys for the single tags.
 
+For instance the second event based risk demo 
+(the file ``job_eb.ini``) has a line ``aggregate_by = NAME_1, taxonomy`` 
 and it is able to aggregate both on geographic region (``NAME_1``) and
-on taxonomy. There are 25 possible combinations, that you can see with
-the command::
+on ``taxonomy``. There are 25 possible combinations, that you can see with
+the command `oq show agg_keys`::
 
    $ oq show agg_keys
    | NAME_1_ | taxonomy_ | NAME_1      | taxonomy                   |
@@ -481,15 +487,6 @@ The lines in this table are associated to the *generalized aggregation ID*,
 NAME_1=*Mid-Western* and taxonomy=*Wood*) to ``24`` (meaning aggregate assets
 with NAME_1=*Central* and taxonomy=*Concrete*); moreover ``agg_id=25`` means
 full aggregation.
-
-It is also possible to perform the aggregation by multiple tags in cascade,
-using the ';' separator instead of ','. For example, a line like
-
-   ``aggregate_by = NAME_1; taxonomy``
-
-would produce first the aggregation by geographic region (``NAME_1``), then
-by taxonomy. In this case, instead of producing 5 x 5 combinations, only
-5 + 5 outputs would be obtained.
 
 The ``agg_id`` field enters in ``risk_by_event`` and in outputs like
 the aggregate losses; for instance::
@@ -527,6 +524,15 @@ used. In the case of the demo actually only 20,877 rows are nonzero::
           event_id  agg_id  loss_id           loss      variance
    ...
    [20877 rows x 5 columns]
+
+It is also possible to perform the aggregation by various single- aggregations,
+using the ';' separator instead of ','. For example, a line like
+
+   ``aggregate_by = NAME_1; taxonomy``
+
+would produce first the aggregation by geographic region (``NAME_1``), then
+by ``taxonomy``. In this case, instead of producing 5 x 5 combinations, only
+5 + 5 outputs would be obtained.
 
 
 Rupture sampling: how does it work?

--- a/doc/adv-manual/event_based.rst
+++ b/doc/adv-manual/event_based.rst
@@ -439,9 +439,13 @@ Aggregating by multiple tags
 ----------------------------
 
 The engine also supports aggregation by multiple tags. 
-Multiple tags can be indicated as multi-tag and/or various single- aggregations.
-``aggregate_by = NAME_1, taxonomy
-aggregate_by = NAME_1; taxonomy``
+Multiple tags can be indicated as multi-tag and/or various single-tag aggregations:
+
+``aggregate_by = NAME_1, taxonomy``
+
+or
+
+``aggregate_by = NAME_1; taxonomy``
 
 Comma ``,`` separated values will generate keys for all the possible 
 combinations of the indicated tag values, while semicolon ``;`` 
@@ -525,8 +529,8 @@ used. In the case of the demo actually only 20,877 rows are nonzero::
    ...
    [20877 rows x 5 columns]
 
-It is also possible to perform the aggregation by various single- aggregations,
-using the ';' separator instead of ','. For example, a line like
+It is also possible to perform the aggregation by various single-tag aggregations,
+using the ``;`` separator instead of ``,``. For example, a line like
 
    ``aggregate_by = NAME_1; taxonomy``
 
@@ -2061,7 +2065,7 @@ calculations::
 
       ``aggregate_by = policy; tag1``
 
-  In this case, aggregated loss curves will be produced also for tag1 and policy,
+  In this case, aggregated loss curves will be produced also for ``tag1`` and ``policy``,
   while reinsurance outputs will only be produced for the policy.
 
 - ``reinsurance_file``: This dictionary associates the reinsurance information

--- a/doc/adv-manual/event_based.rst
+++ b/doc/adv-manual/event_based.rst
@@ -452,7 +452,10 @@ combinations of the indicated tag values, while semicolon ``;``
 will generate keys for the single tags.
 
 For instance the second event based risk demo 
-(the file ``job_eb.ini``) has a line ``aggregate_by = NAME_1, taxonomy`` 
+(the file ``job_eb.ini``) has a line
+
+``aggregate_by = NAME_1, taxonomy``
+
 and it is able to aggregate both on geographic region (``NAME_1``) and
 on ``taxonomy``. There are 25 possible combinations, that you can see with
 the command `oq show agg_keys`::


### PR DESCRIPTION
Fixes https://github.com/gem/oq-engine/issues/8750

I managed to build both the html and the pdf of the advanced manual and I checked that the cross-reference works as expected in both cases.
![Screenshot from 2023-05-18 10-15-34](https://github.com/gem/oq-engine/assets/350930/99068b6a-6a8c-4806-9532-53482498dda6)
