### PR TITLE
Speeding up processing the AssetCollection

### DIFF
--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -671,19 +671,14 @@ def build_asset_array(calc, sids, assets, area, tagnames=()):
              (str(name), F32) for name in float_fields] + int_fields)
     num_assets = len(assets)
     assetcol = numpy.zeros(num_assets, asset_dt)
-    asset_ordinal = 0
     fields = set(asset_dt.fields) - {'ordinal'}
-    for asset in assets:
-        record = assetcol[asset_ordinal]
-        asset_ordinal += 1
-        for field in fields:
-            if field == 'ideductible':
-                value = getattr(asset, 'ideductible', 0.)
-            elif field in tagnames:
-                value = asset['tagidxs'][tagi[field]]
-            else:
-                value = asset[field]
-            record[field] = value
+    tagidxs = assets['tagidxs']
+    for field in fields:
+        if field in tagnames:
+            idx = tagi[field]
+            assetcol[field] = [t[idx] for t in tagidxs]
+        elif field in assets.dtype.names:
+            assetcol[field] = assets[field]
     calc.update(assetcol)
     assetcol['ordinal'] = numpy.arange(num_assets)
     return assetcol, ' '.join(occupancy_periods)


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/8761. 50% speedup in building the site collection, but it makes little difference overall (222s-> 194s for 2.2 million assets):
```
# before
| ncalls   | cumtime | path                                   |
|----------+---------+----------------------------------------|
| 1        | 99.176  | readinput.py:919(get_exposure)         |
| 1        | 92.079  | asset.py:379(__init__)                 |
| 1        | 90.727  | asset.py:873(read)                     |
| 1        | 88.655  | asset.py:914(read_exp)                 |
| 3        | 72.458  | asset.py:1049(_populate_from)          |
| 2259098  | 60.485  | asset.py:1074(_update_asset)           |
| 2259102  | 49.875  | _internal.py:436(_promote_fields)      |
| 1        | 37.950  | asset.py:641(build_asset_array)        |
| 2259098  | 32.649  | asset.py:1076(<dictcomp>)              |
| 54218352 | 31.772  | records.py:281(__getitem__)            |
| 1        | 24.087  | site.py:602(geohash)                   |
| 1        | 24.048  | site.py:607(<listcomp>)                |
| 2259098  | 23.746  | asset.py:247(add_tags)                 |
| 1786861  | 23.662  | utils.py:755(geohash)                  |
| 4        | 11.921  | asset.py:995(_read_csv)                |
| 3        | 11.907  | hdf5.py:889(read_csv)                  |
| 3        | 10.282  | hdf5.py:871(_read_csv)                 |
| 22590980 | 8.186   | asset.py:233(add)                      |

# after
| ncalls   | cumtime | path                                   |
|----------+---------+----------------------------------------|
| 1        | 85.721  | base.py:676(read_exposure)             |
| 1        | 85.652  | readinput.py:977(get_sitecol_assetcol) |
| 3        | 76.641  | asset.py:1044(_populate_from)          |
| 2259098  | 64.030  | asset.py:1069(_update_asset)           |
| 1        | 59.162  | asset.py:379(__init__)                 |
| 2259102  | 50.967  | _internal.py:436(_promote_fields)      |
| 2259098  | 35.283  | asset.py:1071(<dictcomp>)              |
| 54218352 | 34.702  | records.py:281(__getitem__)            |
| 1        | 24.461  | site.py:602(geohash)                   |
| 2259098  | 24.423  | asset.py:247(add_tags)                 |
| 1        | 24.421  | site.py:607(<listcomp>)                |
| 1786861  | 24.005  | utils.py:755(geohash)                  |
| 4        | 11.925  | asset.py:990(_read_csv)                |
| 3        | 11.911  | hdf5.py:889(read_csv)                  |
| 3        | 10.306  | hdf5.py:871(_read_csv)                 |
| 22590980 | 8.658   | asset.py:233(add)                      |
```