### PR TITLE
Removed the ultra-slow `_promote_fields`

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -295,7 +295,7 @@ class Monitor(object):
             for child in self.children:
                 lst.append(child.get_data())
                 child.reset()
-            data = numpy.concatenate(lst)
+            data = numpy.concatenate(lst, dtype=perf_dt)
         if len(data) == 0:  # no information
             return
         hdf5.extend(h5['performance_data'], data)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1022,8 +1022,8 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, exp_types=()):
             assets.append(ass)
 
     array, occupancy_periods = asset.build_asset_array(
-        exp.tagcol, exp.cost_calculator, sitecol.sids, numpy.array(assets),
-        exp.area, exp.tagcol.tagnames)
+        exp.tagcol, exp.cost_calculator, sitecol.sids,
+        numpy.array(assets, ass.dtype), exp.area, exp.tagcol.tagnames)
     assetcol = asset.AssetCollection(
         exp, sitecol, array, occupancy_periods, oqparam.time_event,
         oqparam.aggregate_by)

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -914,7 +914,7 @@ class Exposure(object):
         if not asset_refs:
             raise RuntimeError('Could not find any asset within the region!')
 
-        exposure.assets = numpy.concatenate(all_assets)
+        exposure.assets = numpy.concatenate(all_assets, dtype=assets.dtype)
         exposure.param = param
         return exposure
 


### PR DESCRIPTION
Part of #8761.  This gives a huge speedup, such that we can finally beat version 3.16 of the engine. Here is the reduce exposure with 2.2 million events:
```
INFO:root:Total time spent: 89 s
| ncalls   | cumtime | path                                               |
|----------+---------+----------------------------------------------------|
| 1        | 25.510  | asset.py:867(read_exp)                             |
| 1        | 24.518  | site.py:602(geohash)                               |
| 1        | 24.479  | site.py:607(<listcomp>)                            |
| 1786861  | 24.072  | utils.py:755(geohash)                              |
| 1        | 14.040  | asset.py:1032(get_mesh_assets_by_site)             |
| 13       | 13.378  | arraysetops.py:138(unique)                         |
| 13       | 13.332  | arraysetops.py:323(_unique1d)                      |
| 1        | 11.941  | asset.py:601(build_asset_array)                    |
| 4        | 11.696  | asset.py:952(_read_csv)                            |
| 3        | 11.682  | hdf5.py:889(read_csv)                              |
| 1        | 11.372  | general.py:810(groupby)                            |
| 10       | 11.264  | asset.py:231(get_tagi)                             |
| 15813686 | 10.629  | records.py:281(__getitem__)                        |
| 3        | 10.078  | hdf5.py:871(_read_csv)                             |
| 3        | 9.463   | asset.py:1006(_populate_from)                      |
```
For the full USA exposure on Davis the runtime is 36 minutes (was 70 minutes this morning) of which 15 for the associations assets -> hazard sites.

Now the geohash is the slowest operation.