### PR TITLE
Using 2 digits for the magnitude

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed bug in disaggregation calculations associated to an error
+    in the line `[mag] = np.unique(np.round(ctx.mag, 6))`
   * Optimized the calculation of geohashes by using numba
 
   [Paolo Tormene]

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -27,7 +27,7 @@ from openquake.calculators.extract import extract
 from openquake.calculators.tests import CalculatorTestCase, strip_calc_id
 from openquake.qa_tests_data.disagg import (
     case_1, case_2, case_3, case_4, case_5, case_6, case_7, case_8, case_9,
-    case_10, case_11, case_12, case_13, case_master)
+    case_10, case_11, case_12, case_13, case_14, case_master)
 
 aae = numpy.testing.assert_almost_equal
 
@@ -226,6 +226,11 @@ class DisaggregationTestCase(CalculatorTestCase):
     def test_case_13(self):
         # check split_by_mag, essential with GMPETable
         self.run_calc(case_13.__file__, 'job.ini')
+
+    def test_case_14(self):
+        # check split_by_mag with NGAEastUSGS, see bug
+        # https://github.com/gem/oq-engine/issues/8780
+        self.run_calc(case_14.__file__, 'job.ini')
 
     def test_case_master(self):
         # this tests exercise the case of a complex logic tree

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1047,7 +1047,7 @@ class ContextMaker(object):
         if split_by_mag:
             recarr = numpy.concatenate(
                 recarrays, dtype=recarrays[0].dtype).view(numpy.recarray)
-            recarrays = split_array(recarr, U32(recarr.mag*100))
+            recarrays = split_array(recarr, U32(numpy.round(recarr.mag*100)))
         self.adj = {gsim: [] for gsim in self.gsims}  # NSHM2014P adjustments
         for g, gsim in enumerate(self.gsims):
             compute = gsim.__class__.compute

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1045,7 +1045,8 @@ class ContextMaker(object):
         else:  # vectorize the contexts
             recarrays = [self.recarray(ctxs)]
         if split_by_mag:
-            recarr = numpy.concatenate(recarrays).view(numpy.recarray)
+            recarr = numpy.concatenate(
+                recarrays, dtype=recarrays[0].dtype).view(numpy.recarray)
             recarrays = split_array(recarr, U32(recarr.mag*100))
         self.adj = {gsim: [] for gsim in self.gsims}  # NSHM2014P adjustments
         for g, gsim in enumerate(self.gsims):

--- a/openquake/hazardlib/gsim/can15/nbcc2015_aa13.py
+++ b/openquake/hazardlib/gsim/can15/nbcc2015_aa13.py
@@ -126,7 +126,7 @@ class NBCC2015_AA13(GMPETable):
         """
         Returns the mean and standard deviations
         """
-        [mag] = np.unique(np.round(ctx.mag, 6))
+        [mag] = np.unique(np.round(ctx.mag, 2))
         # get distance vector for the given magnitude
         idx = np.searchsorted(self.m_w, mag)
         dists = self.distances[:, 0, idx - 1]

--- a/openquake/hazardlib/gsim/can20/can_shm6_stable.py
+++ b/openquake/hazardlib/gsim/can20/can_shm6_stable.py
@@ -162,7 +162,7 @@ class CanadaSHM6_StableCrust_AA13(GMPETable):
         # Check input imts
         _check_imts(imts)
         # Magnitudes
-        [mag] = np.unique(np.round(ctx.mag, 6))
+        [mag] = np.unique(np.round(ctx.mag, 2))
 
         # Get distance vector for the given magnitude
         idx = np.searchsorted(self.m_w, mag)
@@ -487,7 +487,7 @@ class CanadaSHM6_StableCrust_NGAEast(GMPETable):
         _check_imts(imts)
 
         # Magnitudes
-        [mag] = np.unique(np.round(ctx.mag, 6))
+        [mag] = np.unique(np.round(ctx.mag, 2))
 
         # Get distance vector for the given magnitude
         idx = np.searchsorted(self.m_w, mag)

--- a/openquake/hazardlib/gsim/gmpe_table.py
+++ b/openquake/hazardlib/gsim/gmpe_table.py
@@ -219,7 +219,7 @@ class GMPETable(GMPE):
             self.stddev = todict(fle["Total"])
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
-        [mag] = np.unique(np.round(ctx.mag, 6))  # constructed unique
+        [mag] = np.unique(np.round(ctx.mag, 2))  # constructed unique
         idx = np.searchsorted(self.m_w, mag)
         table_dists = self.distances[:, 0, idx - 1]
         dists = getattr(ctx, self.distance_type)

--- a/openquake/hazardlib/gsim/hassani_atkinson_2020.py
+++ b/openquake/hazardlib/gsim/hassani_atkinson_2020.py
@@ -267,7 +267,7 @@ class HassaniAtkinson2020SInter(GMPE):
         <.base.GroundShakingIntensityModel.compute>`
         for spec of input and result values.
         """
-        mag = np.unique(np.round(ctx.mag, 6))
+        mag = np.unique(np.round(ctx.mag, 2))
         C_PGA = self.COEFFS[PGA()]
         dsigma = _dsigma(self.CONST_REGION, ctx.hypo_depth)
         fm_pga = _fm_ha18(C_PGA, mag)

--- a/openquake/hazardlib/gsim/nga_east.py
+++ b/openquake/hazardlib/gsim/nga_east.py
@@ -716,7 +716,7 @@ class NGAEastGMPE(GMPETable):
         """
         Returns the mean and standard deviations
         """
-        [mag] = np.unique(np.round(ctx.mag, 6))  # by construction
+        [mag] = np.unique(np.round(ctx.mag, 2))  # by construction
         for m, imt in enumerate(imts):
             mean[m], _, _ = get_mean_amp(self, mag, ctx, imt)
             # Get standard deviation model
@@ -912,7 +912,7 @@ def _get_total_sigma(self, imt, mag):
     Returns the estimated total standard deviation for a given intensity
     measure type and magnitude
     """
-    [mag] = np.unique(np.round(mag, 6))  # by construction
+    [mag] = np.unique(np.round(mag, 2))  # by construction
     C = self.SIGMA[imt]
     if mag <= self.magnitude_limits[0]:
         # The CENA constant model is always returned here

--- a/openquake/hazardlib/gsim/projects/acme_2019.py
+++ b/openquake/hazardlib/gsim/projects/acme_2019.py
@@ -306,7 +306,7 @@ class AlAtikSigmaModel(GMPE):
             self.KAPPATAB = CoeffsTable(table=data, sa_damping=5)
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
-        [mag] = np.unique(np.round(ctx.mag, 6))
+        [mag] = np.unique(np.round(ctx.mag, 2))
         for m, imt in enumerate(imts):
 
             cornerp = get_corner_period(mag)

--- a/openquake/hazardlib/gsim/usgs_ceus_2019.py
+++ b/openquake/hazardlib/gsim/usgs_ceus_2019.py
@@ -239,7 +239,10 @@ class NGAEastUSGSGMPE(NGAEastGMPE):
         """
         Returns the mean and standard deviations
         """
-        [mag] = np.unique(np.round(ctx.mag, 6))
+        try:
+            [mag] = np.unique(np.round(ctx.mag, 2))
+        except:
+            import pdb; pdb.set_trace()
         for m, imt in enumerate(imts):
             imean, site_amp, pga_r = get_mean_amp(self, mag, ctx, imt)
 

--- a/openquake/hazardlib/gsim/usgs_ceus_2019.py
+++ b/openquake/hazardlib/gsim/usgs_ceus_2019.py
@@ -239,10 +239,7 @@ class NGAEastUSGSGMPE(NGAEastGMPE):
         """
         Returns the mean and standard deviations
         """
-        try:
-            [mag] = np.unique(np.round(ctx.mag, 2))
-        except:
-            import pdb; pdb.set_trace()
+        [mag] = np.unique(np.round(ctx.mag, 2))
         for m, imt in enumerate(imts):
             imean, site_amp, pga_r = get_mean_amp(self, mag, ctx, imt)
 

--- a/openquake/qa_tests_data/disagg/case_14/CEUSFaultSources.xml
+++ b/openquake/qa_tests_data/disagg/case_14/CEUSFaultSources.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.4"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    name="Central and Eastern US - Fault Sources"
+    >
+        <characteristicFaultSource
+        id="Cheraw_USGS_full_2330__0_0"
+        name="Cheraw USGS full 2330 'Cheraw Char f 1 2 wt (0) (0)"
+        tectonicRegion="Stable Shallow Crust"
+        >
+            <surface>
+                <simpleFaultGeometry>
+                    <gml:LineString>
+                        <gml:posList>
+                            -103.2241 38.4309 -103.2393 38.402 -103.2637 38.3694 -103.3046 38.3321 -103.3631 38.2979 -103.436 38.2692 -103.4967 38.22879999999999 -103.5699 38.1596 -103.5848 38.1508
+                        </gml:posList>
+                    </gml:LineString>
+                    <dip>
+                        60.0
+                    </dip>
+                    <upperSeismoDepth>
+                        0.0
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        15.0
+                    </lowerSeismoDepth>
+                </simpleFaultGeometry>
+            </surface>
+            <arbitraryMFD>
+                <magnitudes>
+                    6.56 6.608 6.656 6.704 6.752 6.8 6.848 6.896 6.944 6.992 7.04
+                </magnitudes>
+                <occurRates>
+                    2.36530157909473e-07 4.859354117280643e-07 8.507137622323855e-07 1.2691158011215963e-06 1.613362383835298e-06 1.747734605882021e-06 1.613362383835298e-06 1.2691158011215963e-06 8.507137622323855e-07 4.859354117280643e-07 2.36530157909473e-07
+                </occurRates>
+            </arbitraryMFD>
+            <rake>
+                -90.0
+            </rake>
+        </characteristicFaultSource>
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/disagg/case_14/job.ini
+++ b/openquake/qa_tests_data/disagg/case_14/job.ini
@@ -1,0 +1,44 @@
+[general]
+description = disaggregation with NGAEast
+calculation_mode = disaggregation
+random_seed = 23
+
+[logic_tree]
+number_of_logic_tree_samples = 0
+
+[erf]
+rupture_mesh_spacing = 5
+complex_fault_mesh_spacing = 10
+width_of_mfd_bin = 0.1
+
+[site_params]
+reference_vs30_type = measured
+reference_vs30_value = 800.0
+reference_depth_to_1pt0km_per_sec = 30.0
+reference_depth_to_2pt5km_per_sec = 0.57
+
+[calculation]
+source_model_logic_tree_file = ssmLT_denver.xml
+gsim = NGAEastUSGSSeedB_bca10d
+investigation_time = 1.0
+intensity_measure_types_and_levels = {"PGA": [0.0001, 0.002]}
+truncation_level = 5.0
+maximum_distance = 200
+horiz_comp_to_geom_mean = true
+
+[geometry]
+sites_csv = sites_dsg.csv
+
+[disaggregation]
+poes_disagg = 0.002105 0.000404
+mag_bin_width = 0.5
+distance_bin_width = 25.0
+coordinate_bin_width = 100
+num_epsilon_bins = 10
+num_rlzs_disagg = 0
+disagg_outputs = Mag_Dist_Eps
+epsilon_star = true
+
+[output]
+poes = 0.002105 0.000404
+

--- a/openquake/qa_tests_data/disagg/case_14/reduced.xml
+++ b/openquake/qa_tests_data/disagg/case_14/reduced.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    name="reduced"
+    >
+        <sourceGroup
+        rup_interdep="indep"
+        src_interdep="indep"
+        tectonicRegion="Stable Shallow Crust"
+        >
+            <multiPointSource
+            id="sscn-8033-8013"
+            name="SSCn Craton [1,9,10] (adaptive)-M1"
+            >
+                <multiPointGeometry>
+                    <gml:posList>
+                        -105.69999694824219 39.79999923706055 -105.5999984741211 39.79999923706055
+                    </gml:posList>
+                    <upperSeismoDepth>
+                        0.0
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        22.0
+                    </lowerSeismoDepth>
+                </multiPointGeometry>
+                <magScaleRel>
+                    WC1994
+                </magScaleRel>
+                <ruptAspectRatio>
+                    1.0
+                </ruptAspectRatio>
+                <multiMFD
+                kind="incrementalMFD"
+                size="2"
+                >
+                    <bin_width>
+                        0.1
+                    </bin_width>
+                    <min_mag>
+                        4.7
+                    </min_mag>
+                    <occurRates>
+                        4.237767942161044e-05 3.3661787286679366e-05 2.6738508073092296e-05 2.1239151916860372e-05 1.6870858049160545e-05 1.340099889247365e-05 1.064479179380065e-05 8.4554586745772e-06 6.716409562761022e-06 5.335033751673252e-06 4.23776794216108e-06 3.3661787286679625e-06 2.6738508073092533e-06 2.1239151916860533e-06 1.6870858049160698e-06 1.3400998892473756e-06 1.0644791793800737e-06 8.455458674577267e-07 5.373127650208866e-07 4.2680270013386364e-07 4.0718213159997336e-05 3.2343626380507696e-05 2.5691455647410426e-05 2.0407448611904707e-05 1.621021263112078e-05 1.2876229583783415e-05 1.0227952715191271e-05 8.124351625101303e-06 6.45340188464607e-06 5.126119326997272e-06 4.0718213159997674e-06 3.2343626380507975e-06 2.5691455647410647e-06 2.0407448611904865e-06 1.62102126311209e-06 1.2876229583783531e-06 1.0227952715191347e-06 8.124351625101371e-07 5.162721507716898e-07 4.1008954615978507e-07
+                    </occurRates>
+                    <lengths>
+                        20 20
+                    </lengths>
+                </multiMFD>
+                <nodalPlaneDist>
+                    <nodalPlane dip="90.0" probability="0.25" rake="0.0" strike="0.0"/>
+                    <nodalPlane dip="90.0" probability="0.25" rake="0.0" strike="45.0"/>
+                    <nodalPlane dip="90.0" probability="0.25" rake="0.0" strike="90.0"/>
+                    <nodalPlane dip="90.0" probability="0.25" rake="0.0" strike="135.0"/>
+                </nodalPlaneDist>
+                <hypoDepthDist>
+                    <hypoDepth depth="5.0" probability="1.0"/>
+                </hypoDepthDist>
+            </multiPointSource>
+        </sourceGroup>
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/disagg/case_14/sites_dsg.csv
+++ b/openquake/qa_tests_data/disagg/case_14/sites_dsg.csv
@@ -1,0 +1,2 @@
+lon,lat,vs30,z1pt0,z2pt5,custom_site_id
+-104.870,39.770,800,31.07,0.57,Denver

--- a/openquake/qa_tests_data/disagg/case_14/ssmLT_denver.xml
+++ b/openquake/qa_tests_data/disagg/case_14/ssmLT_denver.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5"
+      xmlns:gml="http://www.opengis.net/gml">
+  <logicTree
+      logicTreeID="US18_all_excl_cali">
+    <logicTreeBranchSet
+        branchSetID="compressional" uncertaintyType="sourceModel">
+      <logicTreeBranch branchID="model">
+	<uncertaintyModel>reduced.xml CEUSFaultSources.xml</uncertaintyModel>
+	<uncertaintyWeight>1.0</uncertaintyWeight>
+      </logicTreeBranch>
+    </logicTreeBranchSet>
+    </logicTree>
+</nrml>


### PR DESCRIPTION
For legacy reasons we were still using 6 digits in many places. Closes https://github.com/gem/oq-engine/issues/8780.