### PR TITLE
Vectorized the association assets <-> sites

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Vectorized the association assets <-> hazard sites (up to 15x speedup)
   * Fixed bug in disaggregation calculations associated to an error
     in the line `[mag] = np.unique(np.round(ctx.mag, 6))`
   * Optimized the calculation of geohashes by using numba

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Vectorized the association assets <-> hazard sites (up to 15x speedup)
+  * Vectorized the association assets <-> hazard sites (up to 32x speedup)
   * Fixed bug in disaggregation calculations associated to an error
     in the line `[mag] = np.unique(np.round(ctx.mag, 6))`
   * Optimized the calculation of geohashes by using numba

--- a/openquake/commands/prepare_site_model.py
+++ b/openquake/commands/prepare_site_model.py
@@ -21,7 +21,7 @@ import logging
 import numpy
 from openquake.baselib import performance, writers, hdf5
 from openquake.hazardlib import site, valid
-from openquake.hazardlib.geo.utils import assoc
+from openquake.hazardlib.geo.utils import _GeographicObjects
 from openquake.risklib.asset import Exposure
 from openquake.commonlib import datastore
 
@@ -129,9 +129,9 @@ def main(
                 logging.info(
                     'Associating exposure grid with %d locations to %d '
                     'exposure sites', len(haz_sitecol), len(assets_by_site))
-                haz_sitecol, assets_by, discarded = assoc(
-                    assets_by_site, haz_sitecol,
-                    grid_spacing * SQRT2, 'filter')
+                haz_sitecol, assets_by, discarded = _GeographicObjects(
+                    haz_sitecol).assoc2(
+                        assets_by_site, grid_spacing * SQRT2, 'filter')
                 if len(discarded):
                     logging.info('Discarded %d sites with assets '
                                  '[use oq plot_assets]', len(discarded))

--- a/openquake/commands/prepare_site_model.py
+++ b/openquake/commands/prepare_site_model.py
@@ -131,7 +131,7 @@ def main(
                     'exposure sites', len(haz_sitecol), len(assets_by_site))
                 haz_sitecol, assets_by, discarded = _GeographicObjects(
                     haz_sitecol).assoc2(
-                        assets_by_site, grid_spacing * SQRT2, 'filter')
+                        mesh, assets_by_site, grid_spacing * SQRT2, 'filter')
                 if len(discarded):
                     logging.info('Discarded %d sites with assets '
                                  '[use oq plot_assets]', len(discarded))

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -998,14 +998,13 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, exp_types=()):
 
     if haz_sitecol.mesh != exp.mesh:
         # associate the assets to the hazard sites
-        t0 = time.time()
+        # this is absurdely fast: 10 million assets can be associated in <10s
         sitecol, assets_by, discarded = geo.utils._GeographicObjects(
-            haz_sitecol).assoc2(exp.mesh, exp.assets_by_site, haz_distance,
-                                'filter')
+            haz_sitecol).assoc2(
+                exp.mesh, exp.assets_by_site, haz_distance, 'filter')
         num_assets = sum(len(assets) for assets in assets_by)
-        dt = time.time() - t0
-        logging.info('Associated {:_d} assets to {:_d} sites in {:.1f}s'.
-                     format(num_assets, len(sitecol), dt))
+        logging.info('Associated {:_d} assets to {:_d} sites'.
+                     format(num_assets, len(sitecol)))
     else:
         # asset sites and hazard sites are the same
         sitecol = haz_sitecol

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -999,9 +999,9 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, exp_types=()):
     if haz_sitecol.mesh != exp.mesh:
         # associate the assets to the hazard sites
         t0 = time.time()
-        sitecol, assets_by, discarded = geo.utils.assoc(
-            exp.assets_by_site, haz_sitecol, haz_distance,
-            'filter')
+        sitecol, assets_by, discarded = geo.utils._GeographicObjects(
+            haz_sitecol).assoc2(exp.mesh, exp.assets_by_site, haz_distance,
+                                'filter')
         num_assets = sum(len(assets) for assets in assets_by)
         dt = time.time() - t0
         logging.info('Associated {:_d} assets to {:_d} sites in {:.1f}s'.

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -198,12 +198,11 @@ class _GeographicObjects(object):
         discarded = []
         objs, distances = self.get_closest(mesh.lons, mesh.lats)
         for obj, distance, assets in zip(objs, distances, assets_by_site):
-            lon, lat = assets[0]['lon'], assets[0]['lat']
-            obj, distance = self.get_closest(lon, lat)
             if distance <= assoc_dist:
                 # keep the assets, otherwise discard them
                 assets_by_sid[obj['sids']].extend(assets)
             elif mode == 'strict':
+                lon, lat = assets[0]['lon'], assets[0]['lat']
                 raise SiteAssociationError(
                     'There is nothing closer than %s km '
                     'to site (%s %s)' % (assoc_dist, lon, lat))

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -232,7 +232,7 @@ def assoc(objects, sitecol, assoc_dist, mode):
         if 'error' fail if all sites are not associated
     :returns: (filtered site collection, filtered objects)
     """
-    return _GeographicObjects(sitecol).assoc2(objects, assoc_dist, mode)
+    return _GeographicObjects(objects).assoc(sitecol, assoc_dist, mode)
 
 
 ERROR_OUTSIDE = 'The site (%.1f %.1f) is outside of any vs30 area.'

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -179,11 +179,12 @@ class _GeographicObjects(object):
         return (sitecol.filtered(sids), numpy.array([dic[s] for s in sids]),
                 discarded)
 
-    def assoc2(self, assets_by_site, assoc_dist, mode):
+    def assoc2(self, mesh, assets_by_site, assoc_dist, mode):
         """
         Associated a list of assets by site to the site collection used
         to instantiate GeographicObjects.
 
+        :param mesh: exposure mesh
         :param assets_by_sites: a list of lists of assets
         :param assoc_dist: the maximum distance for association
         :param mode: 'strict', 'warn' or 'filter'
@@ -195,7 +196,8 @@ class _GeographicObjects(object):
             [('asset_ref', vstr), ('lon', F32), ('lat', F32)])
         assets_by_sid = collections.defaultdict(list)
         discarded = []
-        for assets in assets_by_site:
+        objs, distances = self.get_closest(mesh.lons, mesh.lats)
+        for obj, distance, assets in zip(objs, distances, assets_by_site):
             lon, lat = assets[0]['lon'], assets[0]['lat']
             obj, distance = self.get_closest(lon, lat)
             if distance <= assoc_dist:
@@ -223,8 +225,7 @@ def assoc(objects, sitecol, assoc_dist, mode):
     Associate geographic objects to a site collection.
 
     :param objects:
-        something with .lons, .lats or ['lon'] ['lat'], or a list of lists
-        of objects with a .location attribute (i.e. assets_by_site)
+        something with .lons, .lats or ['lon'] ['lat']
     :param assoc_dist:
         the maximum distance for association
     :param mode:
@@ -232,12 +233,7 @@ def assoc(objects, sitecol, assoc_dist, mode):
         if 'error' fail if all sites are not associated
     :returns: (filtered site collection, filtered objects)
     """
-    if isinstance(objects, numpy.ndarray) or hasattr(objects, 'lons'):
-        # objects is a geo array with lon, lat fields; used for ShakeMaps
-        return _GeographicObjects(objects).assoc(sitecol, assoc_dist, mode)
-    else:  # objects is the list assets_by_site
-        return _GeographicObjects(sitecol).assoc2(
-            objects, assoc_dist, mode)
+    return _GeographicObjects(sitecol).assoc2(objects, assoc_dist, mode)
 
 
 ERROR_OUTSIDE = 'The site (%.1f %.1f) is outside of any vs30 area.'


### PR DESCRIPTION
With a 32x speedup in the USA model:
```
# master
| calc_57449               | time_sec | memory_mb | counts |
|--------------------------+----------+-----------+--------|
| EventBasedCalculator.run | 196.1    | 1_312     | 1      |
| importing inputs         | 192.1    | 3_195     | 1      |
| reading exposure         | 125.9    | 615.2     | 1      |
Associated 4_512_042 assets to 49_671 sites in 94.8s

# asset-site
| calc_57448               | time_sec | memory_mb | counts |
|--------------------------+----------+-----------+--------|
| EventBasedCalculator.run | 105.1    | 1_387     | 1      |
| importing inputs         | 101.0    | 3_266     | 1      |
| reading exposure         | 34.8     | 614.1     | 1      |
Associated 4_512_042 assets to 49_671 sites in 3.0s
```
We can import the USA exposure on davis in 17 minutes now (was 32 minutes) because now the association of
22_551_641 assets to 55_771 sites takes an incredible 16.7s.
