### PR TITLE
Fixed the sampling bug

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -60,6 +60,8 @@ F32 = numpy.float32
 TWO16 = 2 ** 16
 TWO32 = 2 ** 32
 
+rlzs_by_g_dt = numpy.dtype([('rlzs', hdf5.vuint32),
+                            ('weight', float)])
 stats_dt = numpy.dtype([('mean', F32), ('std', F32),
                         ('min', F32), ('max', F32),
                         ('len', U16)])
@@ -576,7 +578,8 @@ class HazardCalculator(BaseCalculator):
             self.datastore.create_df('_poes', readinput.Global.pmap.to_dframe())
             self.datastore['assetcol'] = self.assetcol
             self.datastore['full_lt'] = fake = logictree.FullLogicTree.fake()
-            self.datastore['rlzs_by_g'] = U32([[0]])
+            tup = (U32([[0]]), 1.)
+            self.datastore['rlzs_by_g'] = numpy.array([tup], rlzs_by_g_dt)
             self.realizations = fake.get_realizations()
             self.save_crmodel()
             self.datastore.swmr_on()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -57,11 +57,12 @@ def get_pmaps_gb(dstore):
     """
     :returns: memory required on the master node to keep the pmaps
     """
+    Gt = len(dstore['rlzs_by_g'])
     N = len(dstore['sitecol'])
     L = dstore['oqparam'].imtls.size
     full_lt = dstore['full_lt']
     full_lt.init()
-    return full_lt.Gt * N * L * 8 / 1024**3
+    return Gt * N * L * 8 / 1024**3
 
 
 def build_slice_by_sid(sids, offset=0):
@@ -485,7 +486,7 @@ class ClassicalCalculator(base.HazardCalculator):
         acc = {}  # src_id -> pmap
         oq = self.oqparam
         L = oq.imtls.size
-        Gt = self.full_lt.Gt
+        Gt = len(self.datastore['rlzs_by_g'])
         nbytes = 8 * len(sitecol) * L * Gt
         logging.info('Allocating %s for the global pmap', humansize(nbytes))
         self.pmap = ProbabilityMap(sitecol.sids, L, Gt).fill(1)

--- a/openquake/calculators/conditional_spectrum.py
+++ b/openquake/calculators/conditional_spectrum.py
@@ -92,6 +92,7 @@ class ConditionalSpectrumCalculator(base.HazardCalculator):
 
         oq = self.oqparam
         self.full_lt = self.datastore['full_lt'].init()
+        self.rlzs_by_g = self.datastore['rlzs_by_g']['rlzs']
         self.trts = list(self.full_lt.gsim_lt.values)
         self.imts = list(oq.imtls)
         imti = self.imts.index(oq.imt_ref)
@@ -180,7 +181,7 @@ class ConditionalSpectrumCalculator(base.HazardCalculator):
     def _apply_weights(self, acc):
         # build conditional spectra for each realization
         outdic = outdict(self.M, self.N, self.P, 0, self.R)
-        for g, rlzs in self.full_lt.rlzs_by_g.items():
+        for g, rlzs in enumerate(self.rlzs_by_g):
             for r in rlzs:
                 outdic[r] += acc[g]
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -150,7 +150,7 @@ class PmapGetter(object):
         self.use_rates = use_rates
         self.num_rlzs = len(full_lt.weights)
         self.eids = None
-        self.rlzs_by_g = full_lt.rlzs_by_g
+        self.rlzs_by_g = dstore['rlzs_by_g']['rlzs']
         self.slices = slices
         self._pmap = {}
 
@@ -223,7 +223,7 @@ class PmapGetter(object):
             numpy.zeros((self.L, self.num_rlzs)))
         if sid not in pmap:  # no hazard for sid
             return pc0
-        for g, rlzs in self.rlzs_by_g.items():
+        for g, rlzs in enumerate(self.rlzs_by_g):
             probability_map.combine_probs(
                 pc0.array, pmap[sid].array[:, g], rlzs)
         return pc0

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -39,8 +39,6 @@ F32 = numpy.float32
 F64 = numpy.float64
 TWO32 = 2 ** 32
 
-rlzs_by_g_dt = numpy.dtype([('rlzs', hdf5.vuint32), ('weight', float)])
-
 
 def source_data(sources):
     data = AccumDict(accum=[])
@@ -160,7 +158,7 @@ class PreClassicalCalculator(base.HazardCalculator):
         self.store()
         cmakers = read_cmakers(self.datastore, csm)
         Gt = sum(len(cm.gsims) for cm in cmakers)
-        arr = numpy.zeros(Gt, rlzs_by_g_dt)
+        arr = numpy.zeros(Gt, base.rlzs_by_g_dt)
         g = 0
         ws = numpy.array([r.weight['weight']
                           for r in self.full_lt.get_realizations()])
@@ -170,7 +168,7 @@ class PreClassicalCalculator(base.HazardCalculator):
                 arr[g]['weight'] = ws[rlzs].sum()
                 g += 1
         dset = self.datastore.create_dset(
-            'rlzs_by_g', rlzs_by_g_dt, (Gt,), fillvalue=None)
+            'rlzs_by_g', base.rlzs_by_g_dt, (Gt,), fillvalue=None)
         dset[:] = arr
         self.sitecol = sites = csm.sitecol if csm.sitecol else None
         if sites is None:

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -162,10 +162,12 @@ class PreClassicalCalculator(base.HazardCalculator):
         Gt = sum(len(cm.gsims) for cm in cmakers)
         arr = numpy.zeros(Gt, rlzs_by_g_dt)
         g = 0
+        ws = numpy.array([r.weight['weight']
+                          for r in self.full_lt.get_realizations()])
         for cm in cmakers:
             for rlzs in cm.gsims.values():
                 arr[g]['rlzs'] = U32(rlzs)
-                arr[g]['weight'] = self.full_lt.g_weights[g]['weight']
+                arr[g]['weight'] = ws[rlzs].sum()
                 g += 1
         dset = self.datastore.create_dset(
             'rlzs_by_g', rlzs_by_g_dt, (Gt,), fillvalue=None)

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -69,8 +69,10 @@ class LogicTreeTestCase(CalculatorTestCase):
             csm = self.calc.datastore['_csm']
             full_lt = self.calc.datastore['full_lt'].init()
             sitecol = self.calc.datastore['sitecol']
+            rlzs = self.calc.datastore['rlzs_by_g']['rlzs']
             rmap = calc_rmap(csm.src_groups, full_lt, sitecol, oq)[0]
-            mean_rates = calc_mean_rates(rmap, full_lt.g_weights, oq.imtls)
+            mean_rates = calc_mean_rates(
+                rmap, full_lt.g_weights(rlzs), oq.imtls)
             er = exp_rates[exp_rates < 1]
             mr = mean_rates[mean_rates < 1]
             aac(mr, er, atol=1e-6)

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -631,10 +631,14 @@ def disagg_source(groups, sitecol, reduced_lt, edges_shapedic, oq,
     rates5D = numpy.zeros((s['mag'], s['dist'], s['eps'], s['M'], s['P']))
     source_id = re.split('[:;.]', groups[0].sources[0].source_id)[0]
     rmap, ctxs, cmakers = calc_rmap(groups, reduced_lt, sitecol, oq)
-    iml3 = rmap.expand(reduced_lt).interp4D(oq.imtls, oq.poes)[0]  # (M, P, Z)
+    rlzs_by_g = [numpy.uint32(rlzs) for cm in cmakers
+                 for rlzs in cm.gsims.values()]
+    iml3 = rmap.expand(reduced_lt, rlzs_by_g).interp4D(
+        oq.imtls, oq.poes)[0]  # (M, P, Z)
     ws = reduced_lt.rlzs['weight']
     for ctx, cmaker in zip(ctxs, cmakers):
         dis = Disaggregator([ctx], sitecol, cmaker, edges)
         rates5D += dis.disagg_mag_dist_eps(iml3, ws)
-    rates2D = calc_mean_rates(rmap, reduced_lt.g_weights, oq.imtls)[0]
+    gws = reduced_lt.g_weights(rlzs_by_g)
+    rates2D = calc_mean_rates(rmap, gws, oq.imtls)[0]
     return source_id, rates5D, rates2D

--- a/openquake/hazardlib/calc/mean_rates.py
+++ b/openquake/hazardlib/calc/mean_rates.py
@@ -53,8 +53,11 @@ def calc_rmap(src_groups, full_lt, sitecol, oq):
     oq.use_rates = True
     oq.disagg_by_src = False
     L = oq.imtls.size
-    rmap = ProbabilityMap(sitecol.sids, L, full_lt.Gt).fill(0)
     cmakers = get_cmakers(src_groups, full_lt, oq)
+    Gt = sum(len(cm.gsims) for cm in cmakers)
+    logging.info('Computing rate map with N=%d, L=%d, Gt=%d',
+                 len(sitecol), oq.imtls.size, Gt)
+    rmap = ProbabilityMap(sitecol.sids, L, Gt).fill(0)
     ctxs = []
     for group, cmaker in zip(src_groups, cmakers):
         G = len(cmaker.gsims)
@@ -99,8 +102,6 @@ def main(job_ini):
         assoc_dist = (oq.region_grid_spacing * 1.414
                       if oq.region_grid_spacing else 5)  # Graeme's 5km
         sitecol.assoc(readinput.get_site_model(oq), assoc_dist)
-    logging.info('Computing rate map with N=%d, L=%d, Gt=%d',
-                 len(sitecol), oq.imtls.size, csm.full_lt.Gt)
     rmap, ctxs, cmakers = calc_rmap(csm.src_groups, csm.full_lt, sitecol, oq)
     rates = calc_mean_rates(rmap, csm.full_lt.g_weights, oq.imtls)
     N, M, L1 = rates.shape

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1640,17 +1640,20 @@ def get_cmakers(src_groups, full_lt, oq):
         all_trt_smrs.append(src.trt_smrs)
     trts = list(full_lt.gsim_lt.values)
     cmakers = []
+    g = 0
     for grp_id, trt_smrs in enumerate(all_trt_smrs):
         rlzs_by_gsim = full_lt.get_rlzs_by_gsim(trt_smrs)
         if not rlzs_by_gsim:  # happens for gsim_lt.reduce() on empty TRTs
             continue
+        G = len(rlzs_by_gsim)
         trti = trt_smrs[0] // TWO24
         cmaker = ContextMaker(trts[trti], rlzs_by_gsim, oq)
         cmaker.trti = trti
         cmaker.trt_smrs = trt_smrs
-        cmaker.gidx = full_lt.get_gidx(trt_smrs)
+        cmaker.gidx = numpy.arange(g, g + G)
         cmaker.grp_id = grp_id
         cmakers.append(cmaker)
+        g += G
     return cmakers
 
 

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1071,8 +1071,6 @@ class FullLogicTree(object):
         self.Gt = g
         self.rlzs_by_g = {g: U32(rlzs) for g, rlzs in enumerate(rlzs_by_g)}
         self.weights = [rlz.weight for rlz in self.get_realizations()]
-        ws = numpy.array(self.weights)
-        self.g_weights = [ws[rlzs].sum() for rlzs in rlzs_by_g]
 
         # sanity check on Gt
         if self.num_samples == 0:  # easy formula
@@ -1084,6 +1082,15 @@ class FullLogicTree(object):
             sum(len(rlzs) for rlzs in rlzs_by_g), RT)
 
         return self
+
+    def g_weights(self, rlzs_by_g):
+        """
+        :returns: a list of Gt weights
+        """
+        out = []
+        for g, rlzs in enumerate(rlzs_by_g):
+            out.append(sum(self.weights[r] for r in rlzs))
+        return out
 
     def get_gidx(self, trt_smrs):
         """

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1057,30 +1057,7 @@ class FullLogicTree(object):
         assert self.Re <= TWO24, len(self.sm_rlzs)
         self.trti = {trt: i for i, trt in enumerate(self.gsim_lt.values)}
         self.trts = list(self.gsim_lt.values)
-        self.gdict = {}
-        g = 0
-        rlzs_by_g = []
-        for trti, trt in enumerate(self.trts):
-            for smr in range(self.Re):
-                trt_smr = trti * TWO24 + smr
-                rgb = self.get_rlzs_by_gsim(trt_smr)
-                self.gdict[trt_smr] = numpy.arange(g, g + len(rgb)) 
-                for rlzs in rgb.values():
-                    rlzs_by_g.append(rlzs)
-                    g += 1
-        self.Gt = g
-        self.rlzs_by_g = {g: U32(rlzs) for g, rlzs in enumerate(rlzs_by_g)}
         self.weights = [rlz.weight for rlz in self.get_realizations()]
-
-        # sanity check on Gt
-        if self.num_samples == 0:  # easy formula
-            tot_gsims = sum(len(vals) for vals in self.gsim_lt.values.values())
-            assert self.Gt == len(self.sm_rlzs) * tot_gsims
-
-        RT = self.get_num_paths() * len(self.trts)
-        assert sum(len(rlzs) for rlzs in rlzs_by_g) == RT, (
-            sum(len(rlzs) for rlzs in rlzs_by_g), RT)
-
         return self
 
     def g_weights(self, rlzs_by_g):
@@ -1091,12 +1068,6 @@ class FullLogicTree(object):
         for g, rlzs in enumerate(rlzs_by_g):
             out.append(sum(self.weights[r] for r in rlzs))
         return out
-
-    def get_gidx(self, trt_smrs):
-        """
-        :returns: an array of g-indices
-        """
-        return numpy.concatenate([self.gdict[ts] for ts in trt_smrs])
 
     def get_smr_by_ltp(self):
         """
@@ -1352,18 +1323,6 @@ class FullLogicTree(object):
                               shorten(r.gsim_rlz.lt_path, sh2))
             tups.append((r.ordinal, path, r.weight['weight']))
         return numpy.array(tups, rlz_dt)
-
-    def get_sm_by_grp(self):
-        """
-        :returns: a dictionary trt_smr -> sm_id
-        """
-        dic = {}
-        for sm in self.sm_rlzs:
-            trt_smrs = sm.ordinal + numpy.arange(
-                len(self.gsim_lt.values)) * TWO24
-            for trt_smr in trt_smrs:
-                dic[trt_smr] = sm.ordinal
-        return dic
 
     def __repr__(self):
         info_by_model = {}

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -357,16 +357,16 @@ class ProbabilityMap(object):
         return self.new(self.array.reshape(N, M, P))
 
     # used in calc/disagg_test.py
-    def expand(self, full_lt):
+    def expand(self, full_lt, rlzs_by_g):
         """
         Convert a ProbabilityMap with shape (N, L, Gt) into a ProbabilityMap
         with shape (N, L, R): works only for rates
         """
-        N, L, G = self.array.shape
-        assert G == full_lt.Gt, (G, full_lt.Gt)
+        N, L, Gt = self.array.shape
+        assert Gt == len(rlzs_by_g), (Gt, len(rlzs_by_g))
         R = full_lt.get_num_paths()
         out = ProbabilityMap(range(N), L, R).fill(0.)
-        for g, rlzs in full_lt.rlzs_by_g.items():
+        for g, rlzs in enumerate(rlzs_by_g):
             for sid in range(N):
                 for rlz in rlzs:
                     out.array[sid, :, rlz] += self.array[sid, :, g]

--- a/openquake/qa_tests_data/logictree/case_18/expected/hazard_curve-mean.csv
+++ b/openquake/qa_tests_data/logictree/case_18/expected/hazard_curve-mean.csv
@@ -1,3 +1,3 @@
-#,,,"generated_by='OpenQuake engine 3.17.0-gita3e0aefbf5', start_date='2023-06-02T06:04:45', checksum=3385863026, kind='mean', investigation_time=50.0, imt='PGA'"
+#,,,"generated_by='OpenQuake engine 3.17.0-git4b6d4adc80', start_date='2023-06-02T06:06:48', checksum=3385863026, kind='mean', investigation_time=50.0, imt='PGA'"
 lon,lat,depth,poe-1.0900000
-0.50000,-0.50000,0.00000,9.895871E-05
+0.50000,-0.50000,0.00000,1.754468E-04


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/8827. I am reverting to the previous storage of the poes, so the explanation in https://github.com/gem/oq-engine/issues/8515 has to be updated. Here is the impact on a few sites in EUR:
```
$ oq compare hmaps PGA -1 -2
| site_id | calc_id | 0.002105 | 0.000404 |
|---------+---------+----------+----------|
| 2       | 590     | 0.35276  | 0.70406  |
| 2       | 589     | 0.35820  | 0.71791  |
| 3       | 590     | 0.03778  | 0.08731  |
| 3       | 589     | 0.03884  | 0.09179  |
| 4       | 590     | 0.04493  | 0.10073  |
| 4       | 589     | 0.04590  | 0.10413  |
| 5       | 590     | 0.48654  | 1.03863  |
| 5       | 589     | 0.49245  | 1.04783  |
| 6       | 590     | 0.02753  | 0.06046  |
| 6       | 589     | 0.02816  | 0.06267  |
| 7       | 590     | 0.03636  | 0.08503  |
| 7       | 589     | 0.03745  | 0.08982  |
| 8       | 590     | 0.00941  | 0.03246  |
| 8       | 589     | 0.01025  | 0.03497  |
| 9       | 590     | 0.00765  | 0.02508  |
| 9       | 589     | 0.00834  | 0.02738  |
| 10      | 590     | 0.00927  | 0.03388  |
| 10      | 589     | 0.00969  | 0.03629  |
| 11      | 590     | 0.00716  | 0.02403  |
| 11      | 589     | 0.00788  | 0.02647  |
| 12      | 590     | 0.01213  | 0.03604  |
| 12      | 589     | 0.01293  | 0.03936  |
| 13      | 590     | 0.01262  | 0.03960  |
| 13      | 589     | 0.01329  | 0.04362  |
| 14      | 590     | 0.03657  | 0.10859  |
| 14      | 589     | 0.03716  | 0.11045  |
| 15      | 590     | 0.02184  | 0.07679  |
| 15      | 589     | 0.02259  | 0.08258  |
| 23      | 590     | 0.02026  | 0.07203  |
| 23      | 589     | 0.02079  | 0.07311  |
...
| poe      | rms-diff | max-diff |
|----------+----------+----------|
| 0.002105 | 0.01354  | 0.09682  |
| 0.000404 | 0.03377  | 0.23333  |
```
Notice that case_18 is the only test sensitive to the bug.