### PR TITLE
Solved usual HDF5 bug

### DIFF
--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -263,6 +263,7 @@ def build_store_agg(dstore, rbe_df, num_events):
     loss_kinds = [col for col in columns if not col.startswith('dmg_')]
     if oq.investigation_time and loss_kinds:  # build aggcurves
         logging.info('Building aggcurves')
+        units = dstore['cost_calculator'].get_units(oq.loss_types)
         builder = get_loss_builder(dstore, num_events=num_events)
         items = []
         for (agg_id, rlz_id, loss_id), df in gb:
@@ -275,8 +276,7 @@ def build_store_agg(dstore, rbe_df, num_events):
         fix_dtypes(dic)
         dstore.create_df('aggcurves', pandas.DataFrame(dic),
                          limit_states=' '.join(oq.limit_states),
-                         units=dstore['cost_calculator'].get_units(
-                             oq.loss_types))
+                         units=units)
     return aggrisk
 
 

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -376,17 +376,16 @@ def starmap_from_gmfs(task_func, oq, dstore):
     :param dstore: DataStore instance where the GMFs are stored
     :returns: a Starmap object used for event based calculations
     """
-    data = dstore['gmf_data']
+    ds = dstore.parent or dstore
+    data = ds['gmf_data']
     try:
         sbe = data['slice_by_event'][:]
     except KeyError:
         sbe = build_slice_by_event(data['eid'][:])
     nrows = sbe[-1]['stop'] - sbe[0]['start']
     maxweight = numpy.ceil(nrows / (oq.concurrent_tasks or 1))
-    if oq.hazard_calculation_id is None:
-        dstore.swmr_on()  # before the Starmap
     smap = parallel.Starmap.apply(
-        task_func, (sbe, oq, dstore),
+        task_func, (sbe, oq, ds),
         weight=lambda rec: rec['stop']-rec['start'],
         maxweight=numpy.clip(maxweight, 1000, 10_000_000),
         h5=dstore.hdf5)


### PR DESCRIPTION
It is back for the 10th time. Discovered by @nicolepaul for Russia. The error is
```python

2023-06-10T11:07:45.66,CRITICAL,MainProcess/3096320,Traceback (most recent call last):
  File "/opt/openquake/oq-engine/openquake/calculators/base.py", line 253, in run
    raise exc from None
  File "/opt/openquake/oq-engine/openquake/calculators/base.py", line 242, in run
    self.result = self.execute()
  File "/opt/openquake/oq-engine/openquake/calculators/event_based_risk.py", line 440, in execute
    smap = starmap_from_gmfs(ebr_from_gmfs, oq, self.datastore)
  File "/opt/openquake/oq-engine/openquake/commonlib/calc.py", line 385, in starmap_from_gmfs
    dstore.swmr_on()  # before the Starmap
  File "/opt/openquake/oq-engine/openquake/commonlib/datastore.py", line 248, in swmr_on
    self.close()  # flush everything
  File "/opt/openquake/oq-engine/openquake/commonlib/datastore.py", line 377, in close
    self.hdf5.flush()
  File "/opt/openquake/venv/lib64/python3.9/site-packages/h5py/_hl/files.py", line 561, in flush
    h5f.flush(self.id)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5f.pyx", line 164, in h5py.h5f.flush
RuntimeError: Unable to flush file (slist not empty (2)?)
```