### PR TITLE
Ugly workaround for area unit of measure

### DIFF
--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -142,6 +142,8 @@ class CostCalculator(object):
                 lt = lt[:-4]
             elif lt == 'number':
                 unit = 'units'
+            elif lt == 'area':
+                unit = 'unknown'
             elif lt in ('occupants', 'residents'):
                 unit = 'people'
             else:


### PR DESCRIPTION
@ptormene will have to solve this. The area unit cannot be "unknown". The workaround is needed for the Global Risk Model (Russia and other countries).