### PR TITLE
Saving memory in store_poes

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -250,19 +250,19 @@ class Hazard:
         """
         Store 1-pnes inside the _poes dataset
         """
-        # Physically, an extremely small intensity measure level can have an
-        # extremely large probability of exceedence, however that probability
-        # cannot be exactly 1 unless the level is exactly 0. Numerically, the
-        # PoE can be 1 and this give issues when calculating the damage (there
-        # is a log(0) in
-        # :class:`openquake.risklib.scientific.annual_frequency_of_exceedence`).
-        # Here we solve the issue by replacing the unphysical probabilities 1
-        # with .9999999999999999 (the float64 closest to 1).
         avg_poe = 0
         nsites = 0
+        # store by IMT to save memory
         for imt in self.imtls:
             slc = self.imtls(imt)
             poes = 1. - pnes[:, slc]
+            # Physically, an extremely small intensity measure level can have an
+            # extremely large probability of exceedence,however that probability
+            # cannot be exactly 1 unless the level is exactly 0. Numerically,
+            # the PoE can be 1 and this give issues when calculating the damage:
+            # there is a log(0) in scientific.annual_frequency_of_exceedence.
+            # Here we solve the issue by replacing the unphysical probabilities
+            # 1 with .9999999999999999 (the float64 closest to 1).
             poes[poes == 1.] = .9999999999999999
             # poes[poes < 1E-5] = 0.  # minimum_poe
             idxs, lids, gids = poes.nonzero()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -273,6 +273,9 @@ class Hazard:
             hdf5.extend(self.datastore['_poes/gid'], gids)
             hdf5.extend(self.datastore['_poes/lid'], lids + slc.start)
             hdf5.extend(self.datastore['_poes/poe'], poes[idxs, lids, gids])
+
+            # slice_by_sid contains 3x6=18 slices in classical/case_22
+            # which has 6 IMTs each one with 20 levels
             sbs = build_slice_by_sid(sids, self.offset)
             hdf5.extend(self.datastore['_poes/slice_by_sid'], sbs)
             self.offset += len(sids)


### PR DESCRIPTION
By storing one IMT at the time. This reduces by 7 times the required memory in the master in the Global Hazard Model, with an insignificant penalty on `store_poes` and an actually faster `postclassical`:
```
# before
| calc_53976, maxmem=142.3 GB | time_sec | memory_mb | counts    |
|-----------------------------+----------+-----------+-----------|
| total classical             | 29_649   | 103.9     | 364       |
| get_poes                    | 16_404   | 0.0       | 1_625_769 |
| composing pnes              | 6_300    | 0.0       | 1_625_769 |
| computing mean_std          | 5_903    | 0.0       | 11_155    |
| total postclassical         | 572.3    | 1_054     | 29        |
| ClassicalCalculator.run     | 545.3    | 7_156     | 1         |
| read PoEs                   | 98.4     | 1_028     | 29        |
| storing PoEs                | 87.1     | 2_543     | 1         |

# after
| calc_53978, maxmem=142.3 GB | time_sec | memory_mb | counts    |
|-----------------------------+----------+-----------+-----------|
| total classical             | 29_748   | 105.4     | 364       |
| get_poes                    | 16_423   | 0.0       | 1_625_769 |
| composing pnes              | 6_358    | 0.0       | 1_625_769 |
| computing mean_std          | 5_929    | 0.0       | 11_155    |
| total postclassical         | 559.8    | 1_186     | 29        |
| ClassicalCalculator.run     | 558.8    | 4_612     | 1         |
| read PoEs                   | 94.6     | 1_186     | 29        |
| storing PoEs                | 93.6     | 0.07422   | 1         |
```