### PR TITLE
Add `SHOW_RUN_CALC_BTN` setting to display/hide the `Run a Calculation` button from the WebUI

### DIFF
--- a/openquake/server/local_settings.py.aelo
+++ b/openquake/server/local_settings.py.aelo
@@ -1,6 +1,7 @@
 import os
 
 APPLICATION_MODE = 'aelo'
+SHOW_RUN_CALC_BTN = False
 
 # # Static Folder
 # STATIC_ROOT = ''

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -179,6 +179,8 @@ APPLICATION_MODES = ['PUBLIC', 'RESTRICTED', 'AELO']
 # case insensitive
 APPLICATION_MODE = 'public'
 
+SHOW_RUN_CALC_BTN = True
+
 # Expose the WebUI interface, otherwise only the REST API will be available
 WEBUI = True
 

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -1,7 +1,7 @@
 {% extends "engine/base.html" %}
 
   {% block nav-items %}
-                {% if not aelo_mode %}
+                {% if show_run_calc_btn %}
                 <li class="calc">
                   <form class="calc-form form-horizontal"
                         enctype="multipart/form-data"

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -947,7 +947,7 @@ def calc_datastore(request, job_id):
 
 
 def web_engine(request, **kwargs):
-    params = {}
+    params = {'show_run_calc_btn': settings.SHOW_RUN_CALC_BTN}
     if settings.APPLICATION_MODE.upper() == 'AELO':
         params['aelo_mode'] = True
         params['aelo_form_placeholders'] = AELO_FORM_PLACEHOLDERS


### PR DESCRIPTION
By default, the button is displayed.
The new setting is independent from the aelo mode, but it is set to `False` in the `local_settings.py.aelo` template (so in principle it allows to enable it also in aelo mode, if desired).
When we update the current aelo machine, we must remember to set this new variable to `False` as it is in the updated local_settings template..