### PR TITLE
Removed section ordering in in the multiFaultSource reader

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Removed sorting of the sections in the multiFaultSource reader to keep
+    the rup_idxs consistent with the order in the files
   * GMFs too small to produce losses now give a warning rather than an error
   * Fixed bug in `get_ry0_distance` breaking conditioned GMFs
   * Made sure lon and lat are rounded to 5 digits in the site collection

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -273,14 +273,13 @@ def fix_geometry_sections(smdict, dstore):
         sections.update(gmod.sections)
     nrml.check_unique(
         sec_ids, 'section ID in files ' + ' '.join(gfiles))
-    s2i = {suid: i for i, suid in enumerate(sorted(sections))}
-    sections = [sections[suid] for suid in sorted(sections)]
-    for idx, sec in enumerate(sections):
+    s2i = {suid: i for i, suid in enumerate(sections)}
+    for idx, sec in enumerate(sections.values()):
         sec.suid = idx
     if dstore and sections:
         with hdf5.File(dstore.tempname, 'w') as h5:
             h5.save_vlen('multi_fault_sections',
-                         [kite_to_geom(sec) for sec in sections])
+                         [kite_to_geom(sec) for sec in sections.values()])
 
     # fix the MultiFaultSources
     section_idxs = []


### PR DESCRIPTION
Issue reported by @g-weatherill in https://groups.google.com/g/openquake-users/c/gKM8QPmacwo/m/b4o9w58hAwAJ.