### PR TITLE
Hide the `Continue` button while running the webui in aelo mode

### DIFF
--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -111,7 +111,7 @@
                 {% endif %}
                 <% if (calc.get('status') == 'complete') { %>
                   <a href="{% url "index" %}/<%= calc.get('id') %>/outputs" class="btn btn-sm" style="margin: 2px 0 2px 0">Outputs</a>
-                  {% if application_mode != 'READ_ONLY' %}
+                  {% if application_mode != 'AELO' and application_mode != 'READ_ONLY' %}
                   <form class="calc-form" enctype="multipart/form-data"
                     style="margin: 0; display: inline-block"
                     method="post" action="{{ oq_engine_server_url }}/v1/calc/run">


### PR DESCRIPTION
That button leverages the api endpoint for running a standard calculation, that is already forbidden in aelo mode.