### PR TITLE
Kuehn model bug fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Claudio Schill]
+  * Fixed minor sigma_mu adjustment factor bug in
+    the Kuehn et al. (2020) GMM
+
   [Michele Simionato]
   * Fixed bug in `get_ry0_distance` breaking conditioned GMFs
   * Made sure lon and lat are rounded to 5 digits in the site collection

--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -488,13 +488,27 @@ def _retrieve_sigma_mu_data(trt, region):
         trt == const.TRT.SUBDUCTION_INTERFACE else \
         REGION_TERMS_SLAB[region]["file_unc"]
     fle = h5py.File(os.path.join(BASE_PATH, fname), "r")
+
+    mag = fle["M"][:]
+    rrup = fle["R"][:]
+    periods = fle["T"][:]
+    pga = fle["PGA"][:]
+    pgv = fle["PGV"][:]
+    sa = fle["SA"][:]
+
+    # Order of the tables is not guaranteed
+    # Get indices to perform sorting
+    mag_idx = np.argsort(mag)
+    rrup_idx = np.argsort(rrup)
+    periods_idx = np.argsort(periods)
+
     sigma_mu = {
-        "M": fle["M"][:],
-        "R": fle["R"][:],
-        "periods": fle["T"][:],
-        "PGA":  fle["PGA"][:],
-        "PGV": fle["PGV"][:],
-        "SA": fle["SA"][:]}
+        "M": mag[mag_idx],
+        "R": rrup[rrup_idx],
+        "periods": periods[periods_idx],
+        "PGA":  pga[mag_idx, :][:, rrup_idx],
+        "PGV": pgv[mag_idx, :][:, rrup_idx],
+        "SA": sa[mag_idx, :, :][:, rrup_idx, :][:, :, periods_idx]}
     fle.close()
     return sigma_mu
 


### PR DESCRIPTION
Ensure the sigma_mu_data for the Kuehn model is sorted on loading. 
Fixes downstream bug that assumed these values were already sorted.

Fixes https://github.com/gem/oq-engine/issues/8856