### PR TITLE
Modification to Kuehn sigma_mu_adjustment calculation

### DIFF
--- a/.github/workflows/macos_intel_install.yml
+++ b/.github/workflows/macos_intel_install.yml
@@ -60,7 +60,9 @@ jobs:
           pip3 install pytest
           oq --version
           oq dbserver start
-          pytest -vsx --color=yes ~/work/oq-engine/oq-engine/openquake/hazardlib/tests/gsim/kotha_2020_test.py
-          pytest -vsx --color=yes /Users/runner/work/oq-engine/oq-engine/openquake/sep
-          pytest -vs  --color=yes /Users/runner/work/oq-engine/oq-engine/openquake/calculators
-          #oq engine --run "https://github.com/gem/oq-engine/blob/master/openquake/server/tests/data/classical.zip?raw=true"
+          #pytest -vsx --color=yes ~/work/oq-engine/oq-engine/openquake/hazardlib/tests/gsim/kotha_2020_test.py
+          #pytest -vsx --color=yes /Users/runner/work/oq-engine/oq-engine/openquake/sep
+          #pytest -vs  --color=yes /Users/runner/work/oq-engine/oq-engine/openquake/calculators
+          oq engine --run https://downloads.openquake.org/jobs/risk_test.zip
+          sleep 3
+          oq engine --run "https://github.com/gem/oq-engine/blob/master/openquake/server/tests/data/classical.zip?raw=true"

--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -37,7 +37,7 @@ Module exports :class:`KuehnEtAl2020SInter`,
 import numpy as np
 import os
 import h5py
-from scipy.interpolate import interp1d
+from scipy.interpolate import RegularGridInterpolator
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable, add_alias
 from openquake.hazardlib import const
@@ -518,41 +518,68 @@ def get_sigma_mu_adjustment(model, imt, mag, rrup):
         sigma_mu for the scenarios (numpy.ndarray)
     """
     if not model:
-        return 0.0
+        return np.zeros_like(mag)
+
+    # Get the correct sigma_mu model
+    is_SA = imt.string not in "PGA PGV"
+    sigma_mu_model = model["SA"] if is_SA else model[imt.string]
+
+    # Points have to be sorted
+    # Mag and Rrup are used in both cases
+    model_m_ind = np.argsort(model["M"])
+    model_r_ind = np.argsort(model["R"])
+    model_m = model["M"][model_m_ind]
+    model_r = model["R"][model_r_ind]
+    sigma_mu_model = sigma_mu_model[model_m_ind, :][:, model_r_ind]
+
+    # Extend the sigma_mu_model as needed
+    # Prevents having to deal with values
+    # outside the model range manually
+    if np.any(mag > model["M"][-1]):
+        sigma_mu_model = np.concatenate(
+            (sigma_mu_model, sigma_mu_model[-1, :][np.newaxis, :]), axis=0)
+        model_m = np.concatenate((model_m, [mag.max()]), axis=0)
+    if np.any(mag < model["M"][0]):
+        sigma_mu_model = np.concatenate(
+            (sigma_mu_model[0, :][np.newaxis, :], sigma_mu_model), axis=0)
+        model_m = np.concatenate(([mag.min()], model_m), axis=0)
+    if np.any(rrup > model["R"][-1]):
+        sigma_mu_model = np.concatenate(
+            (sigma_mu_model, sigma_mu_model[:, -1][:, np.newaxis]), axis=1)
+        model_r = np.concatenate((model_r, [rrup.max()]), axis=0)
+    if np.any(rrup < model["R"][0]):
+        sigma_mu_model = np.concatenate(
+            (sigma_mu_model[:, 0][:, np.newaxis], sigma_mu_model), axis=1)
+        model_r = np.concatenate(([rrup.min()], model_r), axis=0)
+
     if imt.string in "PGA PGV":
-        # PGA and PGV are 2D arrays of dimension [nmags, ndists]
-        sigma_mu = model[imt.string]
-        if mag <= model["M"][0]:
-            sigma_mu_m = sigma_mu[0, :]
-        elif mag >= model["M"][-1]:
-            sigma_mu_m = sigma_mu[-1, :]
-        else:
-            intpl1 = interp1d(model["M"], sigma_mu, axis=0)
-            sigma_mu_m = intpl1(mag)
-        # Linear interpolation with distance
-        intpl2 = interp1d(model["R"], sigma_mu_m, bounds_error=False,
-                          fill_value=(sigma_mu_m[0], sigma_mu_m[-1]))
-        return intpl2(rrup)
-    # In the case of SA the array is of dimension [nmags, ndists, nperiods]
-    # Get values for given magnitude
-    if mag <= model["M"][0]:
-        sigma_mu_m = model["SA"][0, :, :]
-    elif mag >= model["M"][-1]:
-        sigma_mu_m = model["SA"][-1, :, :]
+        # Linear interpolation
+        interp = RegularGridInterpolator(
+            (model_m, model_r), sigma_mu_model, bounds_error=False,)
+        sigma_mu = interp(np.stack((mag, rrup), axis=1))
     else:
-        intpl1 = interp1d(model["M"], model["SA"], axis=0)
-        sigma_mu_m = intpl1(mag)
-    # Get values for period - N.B. ln T, linear sigma mu interpolation
-    if imt.period <= model["periods"][0]:
-        sigma_mu_t = sigma_mu_m[:, 0]
-    elif imt.period >= model["periods"][-1]:
-        sigma_mu_t = sigma_mu_m[:, -1]
-    else:
-        intpl2 = interp1d(np.log(model["periods"]), sigma_mu_m, axis=1)
-        sigma_mu_t = intpl2(np.log(imt.period))
-    intpl3 = interp1d(model["R"], sigma_mu_t, bounds_error=False,
-                      fill_value=(sigma_mu_t[0], sigma_mu_t[-1]))
-    return intpl3(rrup)
+        # Points have to be sorted
+        model_t_ind = np.argsort(model["periods"])
+        model_t = model["periods"][model_t_ind]
+        sigma_mu_model = sigma_mu_model[:, :, model_t_ind]
+
+        # Extend for extreme periods as needed
+        if np.any(imt.period > model["periods"][-1]):
+            sigma_mu_model = np.concatenate(
+                (sigma_mu_model, sigma_mu_model[:, :, -1][:, :, np.newaxis]), axis=2)
+            model_t = np.concatenate((model_t, [imt.period.max()]), axis=0)
+        if np.any(imt.period < model["periods"][0]):
+            sigma_mu_model = np.concatenate(
+                (sigma_mu_model[:, :, 0][:, :, np.newaxis], sigma_mu_model), axis=2)
+            model_t = np.concatenate(([imt.period.min()], model_t), axis=0)
+
+        # Linear interpolation
+        interp = RegularGridInterpolator(
+            (model_m, model_r, np.log(model_t)), sigma_mu_model, bounds_error=False,)
+        sigma_mu = interp(
+            np.stack((mag, rrup, np.ones_like(mag) * np.log(imt.period)), axis=1))
+
+    return sigma_mu
 
 
 class KuehnEtAl2020SInter(GMPE):
@@ -713,9 +740,7 @@ class KuehnEtAl2020SInter(GMPE):
                                           ctx, pga1100)
             # Apply the sigma mu adjustment if necessary
             if self.sigma_mu_epsilon:
-                [mag] = np.unique(np.round(ctx.mag, 2))
-                sigma_mu_adjust = get_sigma_mu_adjustment(
-                    self.sigma_mu_model, imt, mag, ctx.rrup)
+                sigma_mu_adjust = get_sigma_mu_test(self.sigma_mu_model, imt, ctx.mag, ctx.rrup)
                 mean[m] += self.sigma_mu_epsilon * sigma_mu_adjust
             # Get standard deviations
             tau[m] = C["tau"]


### PR DESCRIPTION
PR contains:
1) Bug fix for https://github.com/gem/oq-engine/issues/8856, which is already addressed by https://github.com/gem/oq-engine/pull/8861
2) Removes requirement to only have a single unique magnitude when using `sigma_mu_epsilon` parameter (line 716)
3) Replace multi-step interpolation with single 2D/3D space interpolation to support fast calculation of adjustment factor

To ensure correct adjustment values outside of the model domain, the model domain is manually extended to prevent having to manually deal with out of domain values, as RegularGridInterpolator (https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html#scipy.interpolate.RegularGridInterpolator) does not support specifying fill values for each dimension.