### PR TITLE
Solved hanging of classical calculations due to large packets

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,5 @@
   [Michele Simionato]
-  * Solved hanging of classical calculations due to large packets
-    exceeding the capacity of zmq
+  * Solved hanging of classical calculations due to large zmq packets
 
   [Marco Pagani, Michele Simionato]
   * Added support for the "direct" method in MRD calculations

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Solved hanging of classical calculations due to large packets
+    exceeding the capacity of zmq
+
   [Marco Pagani, Michele Simionato]
   * Added support for the "direct" method in MRD calculations
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Solved hanging of classical calculations due to large zmq packets
+  * Solved the hanging of classical calculations due to large zmq packets
 
   [Marco Pagani, Michele Simionato]
   * Added support for the "direct" method in MRD calculations

--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -109,8 +109,7 @@ def read(*paths, **validators):
 # NB: duplicated in commands/engine.py!!
 config.read = read
 config.read(limit=int, soft_mem_limit=int, hard_mem_limit=int, port=int,
-            serialize_jobs=positiveint, strict=positiveint, code=exec,
-            slowdown_rate=float)
+            serialize_jobs=positiveint, strict=positiveint, code=exec)
 
 if config.directory.custom_tmp:
     os.environ['TMPDIR'] = config.directory.custom_tmp

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -456,15 +456,12 @@ def sendback(res, zsocket, sentbytes):
     calc_id = res.mon.calc_id
     task_no = res.mon.task_no
     nbytes = len(res.pik)
-    # avoid output congestion by waiting a bit
-    wait = config.performance.slowdown_rate * nbytes
-    time.sleep(wait)
     try:
         zsocket.send(res)
         if DEBUG:
             from openquake.commonlib.logs import dblog
             if calc_id:  # None when building the png maps
-                msg = 'sent back %s after %.1f s' % (humansize(nbytes), wait)
+                msg = 'sent back %s' % humansize(nbytes)
                 dblog('DEBUG', calc_id, task_no, msg)
     except Exception:  # like OverflowError
         _etype, exc, tb = sys.exc_info()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -450,7 +450,7 @@ class ClassicalCalculator(base.HazardCalculator):
 
         t0 = time.time()
         req, self.trt_rlzs, self.gids = get_pmaps_gb(self.datastore)
-        self.ntiles = 1 + int(req / (oq.pmap_max_mb * 1024))  # 40 GB
+        self.ntiles = 1 + int(req / (oq.pmap_max_mb / 10.))  # 40 GB
         if self.ntiles > 1:
             self.execute_seq(maxw)
         else:  # regular case

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -449,9 +449,9 @@ class ClassicalCalculator(base.HazardCalculator):
             logging.warning('numba is not installed: using the slow algorithm')
 
         t0 = time.time()
-        req, self.trt_rlzs, self.gids = get_pmaps_gb(self.datastore)
-        logging.info('Required %s total for the Pmaps', humansize(req))
-        self.ntiles = 1 + int(req / oq.pmap_max_mb)  # 40 GB
+        req_gb, self.trt_rlzs, self.gids = get_pmaps_gb(self.datastore)
+        logging.info('Required %s GB total for the Pmaps', req_gb)
+        self.ntiles = 1 + int(req_gb / oq.pmap_max_mb)  # 40 GB
         if self.ntiles > 1:
             self.execute_seq(maxw)
         else:  # regular case

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -450,7 +450,7 @@ class ClassicalCalculator(base.HazardCalculator):
 
         t0 = time.time()
         req_gb, self.trt_rlzs, self.gids = get_pmaps_gb(self.datastore)
-        logging.info('Required %s GB total for the Pmaps', req_gb)
+        logging.info('Required %.3f GB total for the Pmaps', req_gb)
         self.ntiles = 1 + int(req_gb / oq.pmap_max_mb)  # 40 GB
         if self.ntiles > 1:
             self.execute_seq(maxw)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -450,7 +450,8 @@ class ClassicalCalculator(base.HazardCalculator):
 
         t0 = time.time()
         req, self.trt_rlzs, self.gids = get_pmaps_gb(self.datastore)
-        self.ntiles = 1 + int(req / (oq.pmap_max_mb / 10.))  # 40 GB
+        logging.info('Required %s total for the Pmaps', humansize(req))
+        self.ntiles = 1 + int(req / oq.pmap_max_mb)  # 40 GB
         if self.ntiles > 1:
             self.execute_seq(maxw)
         else:  # regular case

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -108,7 +108,7 @@ def main(
         config.read(os.path.abspath(os.path.expanduser(config_file)),
                     limit=int, soft_mem_limit=int, hard_mem_limit=int,
                     port=int, serialize_jobs=valid.boolean,
-                    strict=valid.boolean, code=exec, slowdown_rate=float)
+                    strict=valid.boolean, code=exec)
 
     if no_distribute:
         os.environ['OQ_DISTRIBUTE'] = 'no'

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -467,13 +467,11 @@ max_sites_disagg:
   Example: *max_sites_disagg = 100*
   Default: 10
 
-pmap_max_gb:
-   Control the memory used in large classical calculations. The default is .4
-   (meant for people with 2 GB per core or less) but you can increase it if you
-   have plenty of memory, thus producing less tiles and making the calculation
-   more efficient. For small calculations it has no effect.
-   Example: *pmap_max_gb = 2*
-   Default: .4
+pmap_max_mb:
+   Control the size of the returned pmaps in classical calculations.
+   The default is 40 MB; you can reduce it if zmq cannot keep up.
+   Example: *pmap_max_mb = 20*
+   Default: 40
 
 max_weight:
   INTERNAL
@@ -988,7 +986,7 @@ class OqParam(valid.ParamSet):
     max_potential_gmfs = valid.Param(valid.positiveint, 1E12)
     max_potential_paths = valid.Param(valid.positiveint, 15_000)
     max_sites_disagg = valid.Param(valid.positiveint, 10)
-    pmap_max_gb = valid.Param(valid.positivefloat, .4)
+    pmap_max_mb = valid.Param(valid.positivefloat, 40.)
     mean_hazard_curves = mean = valid.Param(valid.boolean, True)
     std = valid.Param(valid.boolean, False)
     minimum_distance = valid.Param(valid.positivefloat, 0)

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -78,4 +78,3 @@ mosaic_dir =
 
 [performance]
 pointsource_distance = 1000
-slowdown_rate = 0

--- a/openquake/qa_tests_data/classical/case_22/job.ini
+++ b/openquake/qa_tests_data/classical/case_22/job.ini
@@ -3,7 +3,7 @@
 description = Classical PSHA using Alaska 2007 active shallow crust grid model
 calculation_mode = classical
 concurrent_tasks = 10
-pmap_max_mb = 0.000512
+pmap_max_mb = 0.00005
 max_sites_disagg = 5
 split_sources = false
 random_seed = 23

--- a/openquake/qa_tests_data/classical/case_22/job.ini
+++ b/openquake/qa_tests_data/classical/case_22/job.ini
@@ -3,7 +3,7 @@
 description = Classical PSHA using Alaska 2007 active shallow crust grid model
 calculation_mode = classical
 concurrent_tasks = 10
-pmap_max_gb = 5E-7
+pmap_max_mb = 0.000512
 max_sites_disagg = 5
 split_sources = false
 random_seed = 23

--- a/openquake/qa_tests_data/logictree/case_14/job.ini
+++ b/openquake/qa_tests_data/logictree/case_14/job.ini
@@ -3,7 +3,7 @@
 description = Classical PSHA QA test with sites_csv
 calculation_mode = classical
 random_seed = 23
-pmap_max_gb = 5E-7
+pmap_max_mb = 0.000512
 time_per_task = .1
 max_sites_disagg = 1
 

--- a/openquake/qa_tests_data/logictree/case_14/job.ini
+++ b/openquake/qa_tests_data/logictree/case_14/job.ini
@@ -3,7 +3,7 @@
 description = Classical PSHA QA test with sites_csv
 calculation_mode = classical
 random_seed = 23
-pmap_max_mb = 0.000512
+pmap_max_mb = 5E-7
 time_per_task = .1
 max_sites_disagg = 1
 


### PR DESCRIPTION
Finally! Also removed the slowdown_rate hack. Here are the numbers for a 25x reduced EUR calculation:
```
# master
| calc_54023, maxmem=143.0 GB | time_sec | memory_mb | counts    |
|-----------------------------+----------+-----------+-----------|
| total classical             | 122_047  | 133.8     | 732       |
| get_poes                    | 67_945   | 0.0       | 5_504_723 |
| composing pnes              | 25_920   | 0.0       | 5_504_723 |
| computing mean_std          | 24_184   | 0.0       | 37_710    |
| planar contexts             | 1_967    | 0.0       | 1_385_011 |
| ClassicalCalculator.run     | 1_381    | 1_670     | 1         |

# this branch
| calc_54022, maxmem=80.2 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 134_950  | 33.8      | 11_397     |
| get_poes                   | 73_466   | 0.0       | 31_843_565 |
| computing mean_std         | 29_339   | 0.0       | 242_836    |
| composing pnes             | 22_223   | 0.0       | 31_843_565 |
| planar contexts            | 5_156    | 0.0       | 4_317_535  |
| ClassicalCalculator.run    | 1_428    | 1_491     | 1          |
```
There is a small performance penalty but it is well worth it. Interesting to notice that "planar contexts"
becomes a lot slower, but there is also a huge memory saving. We are producing 16x more outputs.
The task distribution is better:
```
| operation-duration | counts |  mean | stddev |     min |   max | slowfac |
|--------------------+--------+-------+--------+---------+-------+---------|
| master             |    646 | 188.9 |    49% | 0.17686 | 294.9 | 1.56086 |
| this branch        |    969 | 139.3 |    46% | 0.15320 | 201.9 | 1.45005 |
```