### PR TITLE
Added dbserver.user in openquake.cfg

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
   [Michele Simionato]
+  * Internal: added dbserver.user in openquake.cfg
   * Solved the hanging of classical calculations due to large zmq packets
+    and reduced memory occupation
 
   [Marco Pagani, Michele Simionato]
   * Added support for the "direct" method in MRD calculations

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -38,9 +38,9 @@ def main(cmd,
 
     if config.multi_user:
         user = getpass.getuser()
-        if user != 'openquake':
-            sys.exit('Only user openquake can start the dbserver but you are '
-                     + user)
+        if user != config.dbserver.user:
+            sys.exit(f'Only user {config.dbserver.user} can start the dbserver '
+                     f'but you are {user}')
 
     status = dbserver.get_status()
     if cmd == 'status':

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -33,6 +33,7 @@ soft_mem_limit = 90
 hard_mem_limit = 99
 
 [dbserver]
+user = openquake
 file = ~/oqdata/db.sqlite3
 # daemon bind address; must be a valid IP address
 # example: 0.0.0.0


### PR DESCRIPTION
Since @vot4anto needs it in the IUSS cluster.