### PR TITLE
Refactored event_based/2

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -105,6 +105,9 @@ def get_computer(cmaker, oqparam, proxy, sids, sitecol,
 
 
 def build_event_based(allproxies, cmaker, oqparam, dstore, monitor):
+    """
+    Launcher of event_based tasks
+    """
     blocksize = int(numpy.ceil(len(allproxies) / 10))
     t0 = time.time()
     n = 0
@@ -113,10 +116,9 @@ def build_event_based(allproxies, cmaker, oqparam, dstore, monitor):
         yield event_based(proxies, cmaker, oqparam, dstore, monitor)
         rem = allproxies[n:]  # remaining ruptures
         dt = time.time() - t0
-        if dt > oqparam.time_per_task and len(rem) > 10:
-            half = len(rem) // 2
-            yield event_based, rem[:half], cmaker, oqparam, dstore
-            yield event_based, rem[half:], cmaker, oqparam, dstore
+        if dt > oqparam.time_per_task and len(rem) > blocksize:
+            for block in block_splitter(proxies, blocksize):
+                yield event_based, block, cmaker, oqparam, dstore
             break
 
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -113,14 +113,16 @@ def build_event_based(allproxies, cmaker, oqparam, dstore, monitor):
     n = 0
     for proxies in block_splitter(allproxies, blocksize):
         n += len(proxies)
-        yield event_based(proxies, cmaker, oqparam, dstore, monitor)
+        res = event_based(proxies, cmaker, oqparam, dstore, monitor)
         rem = allproxies[n:]  # remaining ruptures
         dt = time.time() - t0
         if dt > oqparam.time_per_task and len(rem) > 2*blocksize:
             for block in block_splitter(rem, 2*blocksize):
                 yield event_based, block, cmaker, oqparam, dstore
+            yield res
             return
-
+        else:
+            yield res
 
 def event_based(proxies, cmaker, oqparam, dstore, monitor):
     """

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -117,7 +117,7 @@ def build_event_based(allproxies, cmaker, oqparam, dstore, monitor):
         rem = allproxies[n:]  # remaining ruptures
         dt = time.time() - t0
         if dt > oqparam.time_per_task and len(rem) > blocksize:
-            for block in block_splitter(proxies, blocksize):
+            for block in block_splitter(rem, blocksize):
                 yield event_based, block, cmaker, oqparam, dstore
             break
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -199,6 +199,15 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore):
     return smap
 
 
+def set_mags(oq, dstore):
+    """
+    Set the attribute oq.mags_by_trt
+    """
+    oq.mags_by_trt = {
+        trt: python3compat.decode(dset[:])
+        for trt, dset in dstore['source_mags'].items()}
+
+
 def compute_avg_gmf(gmf_df, weights, min_iml):
     """
     :param gmf_df: a DataFrame with colums eid, sid, rlz, gmv...
@@ -426,10 +435,9 @@ class EventBasedCalculator(base.HazardCalculator):
         if oq.hazard_calculation_id:  # from ruptures
             dstore.parent = datastore.read(oq.hazard_calculation_id)
             self.full_lt = dstore.parent['full_lt']
+            set_mags(oq, dstore)
         elif hasattr(self, 'csm'):  # from sources
-            oq.mags_by_trt = {
-                trt: python3compat.decode(dset[:])
-                for trt, dset in self.datastore['source_mags'].items()}
+            set_mags(oq, dstore)
             self.build_events_from_sources()
             if (oq.ground_motion_fields is False and
                     oq.hazard_curves_from_gmfs is False):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -108,7 +108,7 @@ def build_event_based(allproxies, cmaker, oqparam, dstore, monitor):
     """
     Launcher of event_based tasks
     """
-    blocksize = int(numpy.ceil(len(allproxies) / 10))
+    blocksize = int(numpy.ceil(len(allproxies) / 20))
     t0 = time.time()
     n = 0
     for proxies in block_splitter(allproxies, blocksize):
@@ -116,10 +116,10 @@ def build_event_based(allproxies, cmaker, oqparam, dstore, monitor):
         yield event_based(proxies, cmaker, oqparam, dstore, monitor)
         rem = allproxies[n:]  # remaining ruptures
         dt = time.time() - t0
-        if dt > oqparam.time_per_task and len(rem) > blocksize:
-            for block in block_splitter(rem, blocksize):
+        if dt > oqparam.time_per_task and len(rem) > 2*blocksize:
+            for block in block_splitter(rem, 2*blocksize):
                 yield event_based, block, cmaker, oqparam, dstore
-            break
+            return
 
 
 def event_based(proxies, cmaker, oqparam, dstore, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -272,7 +272,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
     precalc = 'event_based'
     accept_precalc = ['scenario', 'event_based', 'event_based_risk', 'ebrisk']
 
-    def save_tmp(self, monitor, srcfilter=None):
+    def save_tmp(self, monitor):
         """
         Save some useful data in the file calc_XXX_tmp.hdf5
         """
@@ -285,7 +285,6 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         # storing start-stop indices in a smart way, so that the assets are
         # read from the workers in chunks of at most 1 million elements
         monitor.save('start-stop', compactify3(tss))
-        monitor.save('srcfilter', srcfilter)
         monitor.save('crmodel', self.crmodel)
         monitor.save('rlz_id', self.rlzs)
         monitor.save('weights', self.datastore['weights'][:])
@@ -415,11 +414,10 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             elif not hasattr(oq, 'maximum_distance'):
                 raise InvalidFile('Missing maximum_distance in %s'
                                   % oq.inputs['job_ini'])
-            srcfilter = self.src_filter()
             full_lt = self.datastore['full_lt']
             smap = event_based.starmap_from_rups(
-                ebrisk, oq, full_lt, self.sitecol, self.datastore)
-            self.save_tmp(smap.monitor, srcfilter)
+                ebrisk, oq, full_lt, self.sitecol, self.datastore,
+                self.save_tmp)
             smap.reduce(self.agg_dicts)
             if self.gmf_bytes == 0:
                 raise RuntimeError(

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -772,7 +772,7 @@ time_per_task:
   Used in calculations with task splitting. If a task slice takes longer
   then *time_per_task* seconds, then spawn subtasks for the other slices.
   Example: *time_per_task=600*
-  Default: 2000
+  Default: 300
 
 total_losses:
   Used in event based risk calculations to compute total losses and
@@ -1053,7 +1053,7 @@ class OqParam(valid.ParamSet):
     outs_per_task = valid.Param(valid.positiveint, 4)
     ebrisk_maxsize = valid.Param(valid.positivefloat, 2E10)  # used in ebrisk
     time_event = valid.Param(str, 'avg')
-    time_per_task = valid.Param(valid.positivefloat, 2000)
+    time_per_task = valid.Param(valid.positivefloat, 300)
     total_losses = valid.Param(valid.Choice(*ALL_COST_TYPES), None)
     truncation_level = valid.Param(lambda s: valid.positivefloat(s) or 1E-9)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1053,7 +1053,7 @@ class OqParam(valid.ParamSet):
     outs_per_task = valid.Param(valid.positiveint, 4)
     ebrisk_maxsize = valid.Param(valid.positivefloat, 2E10)  # used in ebrisk
     time_event = valid.Param(str, 'avg')
-    time_per_task = valid.Param(valid.positivefloat, 300)
+    time_per_task = valid.Param(valid.positivefloat, 200)
     total_losses = valid.Param(valid.Choice(*ALL_COST_TYPES), None)
     truncation_level = valid.Param(lambda s: valid.positivefloat(s) or 1E-9)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)

--- a/openquake/qa_tests_data/event_based_risk/case_1/job_ins.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1/job_ins.ini
@@ -10,7 +10,6 @@ insurance_csv = {'structural+nonstructural': 'policy_ins.csv'}
 exposure_file = exposure1.zip
 discard_assets = true
 concurrent_tasks = 4
-ebrisk_maxsize = 100
 
 region = 81.1 26, 88 26, 88 30, 81.1 30
 


### PR DESCRIPTION
Improved the slow tasks and memory problem discussed in https://github.com/gem/oq-engine/issues/8891. This is not enough :-(
Here are the figures for Canada with 100,000 years on the spot machine:
```
| calc_38, maxmem=255.5 GB | time_sec | memory_mb | counts  |
|--------------------------+----------+-----------+---------|
| computing gmfs           | 159_575  | 0.0       | 631_665 |
| total event_based        | 122_575  | 1_214     | 543     |
| total build_event_based  | 47_036   | 39.6      | 4_687   |
| filtering ruptures       | 5_928    | 0.0       | 645_465 |
| EventBasedCalculator.run | 3_790    | 27_989    | 1       |
| saving gmfs              | 2_108    | 2_298     | 4_687   |

| operation-duration | counts | mean  | stddev | min     | max   | slowfac |
|--------------------+--------+-------+--------+---------+-------+---------|
| build_event_based  | 259    | 181.6 | 94%    | 6.83455 | 1_276 | 7.02387 |
| event_based        | 543    | 225.7 | 197%   | 0.73090 | 2_445 | 10.8    |

| task              | sent                                                 | received |
|-------------------+------------------------------------------------------+----------|
| build_event_based | cmaker=123.91 MB allproxies=61.17 MB oqparam=2.14 MB | 35.89 GB |
| event_based       | cmaker=811.9 MB proxies=12.78 MB oqparam=4.25 MB     | 74.63 GB |
```
There are tasks using 9+ GB of RAM :-(