### PR TITLE
Making sure the GMVs are 32 bit

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -71,6 +71,7 @@ def count_ruptures(src):
 def strip_zeros(gmf_df):
     # remove the rows with all zero values
     df = gmf_df[gmf_df.columns[3:]]  # strip eid, sid, rlz
+    assert str(df.gmv_0.dtype) == 'float32', df.gmv_0.dtype
     ok = df.to_numpy().sum(axis=1) > 0
     return gmf_df[ok]
 
@@ -172,7 +173,7 @@ def event_based(proxies, cmaker, oqparam, dstore, monitor):
             times.append((proxy['id'], len(computer.ctx.sids),
                           computer.ctx.rrup.min(), dt))
             alldata.append(df)
-    if alldata:
+    if sum(len(df) for df in alldata):
         gmfdata = strip_zeros(pandas.concat(alldata))
     else:
         gmfdata = ()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -127,7 +127,8 @@ def event_based(proxies, cmaker, oqparam, dstore, monitor):
     """
     Compute GMFs and optionally hazard curves
     """
-    alldata = AccumDict(accum=[])
+    alldata = []
+    se_dt = sig_eps_dt(oqparam.imtls)
     sig_eps = []
     times = []  # rup_id, nsites, dt
     hcurves = {}  # key -> poes
@@ -170,14 +171,11 @@ def event_based(proxies, cmaker, oqparam, dstore, monitor):
             dt = time.time() - t0
             times.append((proxy['id'], len(computer.ctx.sids),
                           computer.ctx.rrup.min(), dt))
-            for key in df.columns:
-                alldata[key].extend(df[key])
-    for key, val in sorted(alldata.items()):
-        if key in 'eid sid rlz':
-            alldata[key] = U32(alldata[key])
-        else:
-            alldata[key] = F32(alldata[key])
-    gmfdata = strip_zeros(pandas.DataFrame(alldata))
+            alldata.append(df)
+    if alldata:
+        gmfdata = strip_zeros(pandas.concat(alldata))
+    else:
+        gmfdata = ()
     if len(gmfdata) and oqparam.hazard_curves_from_gmfs:
         hc_mon = monitor('building hazard curves', measuremem=False)
         for (sid, rlz), df in gmfdata.groupby(['sid', 'rlz']):
@@ -191,7 +189,7 @@ def event_based(proxies, cmaker, oqparam, dstore, monitor):
     if not oqparam.ground_motion_fields:
         gmfdata = ()
     return dict(gmfdata=gmfdata, hcurves=hcurves, times=times,
-                sig_eps=numpy.array(sig_eps, sig_eps_dt(oqparam.imtls)))
+                sig_eps=numpy.array(sig_eps, se_dt))
 
 
 def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
@@ -369,7 +367,6 @@ class EventBasedCalculator(base.HazardCalculator):
                 dset = self.datastore['gmf_data/sid']
                 times = result.pop('times')
                 hdf5.extend(self.datastore['gmf_data/rup_info'], times)
-                [task_no] = numpy.unique(times['task_no'])
                 if self.N >= calc.SLICE_BY_EVENT_NSITES:
                     sbe = calc.build_slice_by_event(
                         df.eid.to_numpy(), self.offset)

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -193,6 +193,11 @@ class GmfComputer(object):
                         # gmv can be zero due to the minimum_intensity, coming
                         # from the job.ini or from the vulnerability functions
                 n += len(eids)
+        for key, val in sorted(data.items()):
+            if key in 'eid sid rlz':
+                data[key] = U32(data[key])
+            else:
+                data[key] = F32(data[key])
         return pandas.DataFrame(data)
 
     def compute(self, gsim, num_events, mean_stds):


### PR DESCRIPTION
They were converted back to 64 bit without me knowing it! The solution is to use `pandas.concat` instead of `list.extend`
which also uses less memory. Here is the improvement for Canada with 10,000 years (notice the 10% reduction in memory):
```
$ this branch
| calc_44, maxmem=60.6 GB  | time_sec | memory_mb | counts |
|--------------------------+----------+-----------+--------|
| total gen_event_based    | 15_307   | 141.5     | 1_523  |
| computing gmfs           | 14_516   | 0.0       | 66_469 |
| filtering ruptures       | 718.4    | 0.0       | 67_977 |
| EventBasedCalculator.run | 513.8    | 5_297     | 1      |
| saving gmfs              | 194.9    | 90.5      | 1_469  |

# master
| calc_46, maxmem=67.1 GB  | time_sec | memory_mb | counts |
|--------------------------+----------+-----------+--------|
| total gen_event_based    | 16_222   | 170.9     | 1_530  |
| computing gmfs           | 15_066   | 0.0       | 66_469 |
| filtering ruptures       | 725.2    | 0.0       | 67_977 |
| EventBasedCalculator.run | 524.2    | 5_878     | 1      |
| saving gmfs              | 197.0    | 145.5     | 1_470  |
```
There is basically no change in data transfer and slow tasks:
```
| operation-duration | counts | mean | stddev | min     | max   | slowfac |
|--------------------+--------+------+--------+---------+-------+---------|
| gen_event_based    | 314    | 48.7 | 138%   | 2.06851 | 346.9 | 7.11524 |
| gen_event_based    | 320    | 50.7 | 138%   | 0.76318 | 355.4 | 7.01079 |

| task            | sent                                                | received |
|-----------------+-----------------------------------------------------+----------|
| gen_event_based | cmaker=308.13 MB allproxies=6.92 MB oqparam=2.57 MB | 11.05 GB |
| gen_event_based | cmaker=322.89 MB allproxies=6.94 MB oqparam=2.61 MB | 11.05 GB |
```