### PR TITLE
Transferring the GMFs are dictionaries instead of DataFrames

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -281,13 +281,18 @@ def event_based(proxies, cmaker, dstore, monitor):
     if sum(len(df) for df in alldata):
         gmfdata = strip_zeros(pandas.concat(alldata))
     else:
-        gmfdata = ()
+        gmfdata = {}
     times = numpy.array([tup + (monitor.task_no,) for tup in times], rup_dt)
     times.sort(order='rup_id')
     if not oq.ground_motion_fields:
-        gmfdata = ()
-    return dict(gmfdata=gmfdata, times=times,
+        gmfdata = {}
+    return dict(gmfdata=todict(gmfdata), times=times,
                 sig_eps=numpy.array(sig_eps, se_dt))
+
+def todict(dframe):
+    if len(dframe) == 0:
+        return {}
+    return {k: dframe[k].to_numpy() for k in dframe.columns}
 
 
 def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
@@ -456,12 +461,12 @@ class EventBasedCalculator(base.HazardCalculator):
         if result is None:  # instead of a dict
             raise MemoryError('You ran out of memory!')
         sav_mon = self.monitor('saving gmfs')
-        agg_mon = self.monitor('aggregating hcurves')
         primary = self.oqparam.get_primary_imtls()
         sec_imts = self.oqparam.get_sec_imts()
         with sav_mon:
-            df = result.pop('gmfdata')
-            if len(df):
+            gmfdata = result.pop('gmfdata')
+            if len(gmfdata):
+                df = pandas.DataFrame(gmfdata)
                 dset = self.datastore['gmf_data/sid']
                 times = result.pop('times')
                 hdf5.extend(self.datastore['gmf_data/rup_info'], times)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -258,7 +258,8 @@ def ebrisk(proxies, cmaker, dstore, monitor):
     dic = event_based.event_based(proxies, cmaker, dstore, monitor)
     if len(dic['gmfdata']) == 0:  # no GMFs
         return {}
-    return event_based_risk(dic['gmfdata'], cmaker.oq, monitor)
+    gmf_df = pandas.DataFrame(dic['gmfdata'])
+    return event_based_risk(gmf_df, cmaker.oq, monitor)
 
 
 @base.calculators.add('ebrisk', 'scenario_risk', 'event_based_risk')


### PR DESCRIPTION
There is a 20% reduction in data transfer for the Canada calculation on wilson:
```
| task            | sent                                             | received |
|-----------------+--------------------------------------------------+----------|
| gen_event_based | cmaker=2 GB allproxies=37.21 MB dstore=342.05 KB | 55.07 GB |
| gen_event_based | cmaker=2 GB allproxies=37.27 MB dstore=345.78 KB | 44.06 GB |
```