### PR TITLE
Reduced slow tasks in the ebrisk calculator

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
   [Michele Simionato]
   * Reduced memory consumption in the master node in post_risk
-  * Reduced slow tasks in the ebrisk calculator
+  * Reduced slow tasks in the ebrisk calculator and memory consumption
+    in the master node
 
   [Paolo Tormene]
   * Fixed bug #8907: unable to run ClassicalDamage demo on Windows

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced memory consumption in the master node in post_risk
   * Reduced slow tasks in the ebrisk calculator
 
   [Paolo Tormene]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Reduced slow tasks in the ebrisk calculator
+
   [Paolo Tormene]
   * Fixed bug #8907: unable to run ClassicalDamage demo on Windows
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -222,13 +222,13 @@ def gen_event_based(allproxies, cmaker, dstore, monitor):
     """
     t0 = time.time()
     n = 0
-    for proxies in block_splitter(allproxies, 1_000_000, rup_weight):
+    for proxies in block_splitter(allproxies, 800_000, rup_weight):
         n += len(proxies)
         yield event_based(proxies, cmaker, dstore, monitor)
         rem = allproxies[n:]  # remaining ruptures
         dt = time.time() - t0
         if dt > cmaker.oq.time_per_task and sum(
-                rup_weight(r) for r in rem) > 2_000_000:
+                rup_weight(r) for r in rem) > 1_000_000:
             half = len(rem) // 2
             yield gen_event_based, rem[:half], cmaker, dstore
             yield gen_event_based, rem[half:], cmaker, dstore

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -318,7 +318,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
     if save_tmp:
         save_tmp(smap.monitor)
     gb = groupby(allproxies, operator.itemgetter('trt_smr'))
-    totw = sum(rup_weight['nsites'] for p in allproxies) / (
+    totw = sum(rup_weight(p) for p in allproxies) / (
         oq.concurrent_tasks or 1)
     for trt_smr, proxies in gb.items():
         trt = full_lt.trts[trt_smr // TWO24]

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -301,9 +301,10 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
     Submit the ruptures and apply `func` (event_based or ebrisk)
     """
     set_mags(oq, dstore)
-    nr = len(dstore['ruptures'])
-    logging.info('Reading {:_d} ruptures'.format(nr))
-    allproxies = [RuptureProxy(rec) for rec in dstore['ruptures'][:]]
+    rups = dstore['ruptures'][:]
+    logging.info('Reading {:_d} ruptures'.format(len(rups)))
+    logging.info('Affected sites = %.1f per rupture', rups['nsites'].mean())
+    allproxies = [RuptureProxy(rec) for rec in rups]
     if "station_data" in oq.inputs:
         # this is meant to be used in conditioned scenario calculations with
         # a single rupture; we are taking the first copy of the rupture

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -228,7 +228,7 @@ def gen_event_based(allproxies, cmaker, dstore, monitor):
         rem = allproxies[n:]  # remaining ruptures
         dt = time.time() - t0
         if dt > cmaker.oq.time_per_task and sum(
-                rup_weight(r) for r in rem) > 15_000:
+                rup_weight(r) for r in rem) > 12_000:
             half = len(rem) // 2
             yield gen_event_based, rem[:half], cmaker, dstore
             yield gen_event_based, rem[half:], cmaker, dstore

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -254,7 +254,7 @@ def ebrisk(proxies, cmaker, dstore, monitor):
     """
     cmaker.oq.ground_motion_fields = True
     for block in general.block_splitter(
-            proxies, 10_000, event_based.rup_weight):
+            proxies, 20_000, event_based.rup_weight):
         dic = event_based.event_based(block, cmaker, dstore, monitor)
         if len(dic['gmfdata']):
             gmf_df = pandas.DataFrame(dic['gmfdata'])

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -25,10 +25,8 @@ import numpy
 import pandas
 from scipy import sparse
 
-from openquake.baselib import (
-    hdf5, performance, parallel, general, python3compat)
+from openquake.baselib import hdf5, performance, general, python3compat
 from openquake.hazardlib import stats, InvalidFile
-from openquake.hazardlib.source.rupture import RuptureProxy
 from openquake.commonlib.calc import starmap_from_gmfs, compactify3
 from openquake.risklib.scientific import (
     total_losses, insurance_losses, MultiEventRNG, LOSSID)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -177,13 +177,7 @@ def ebr_from_gmfs(sbe, oqparam, dstore, monitor):
             else:
                 data = dstore['gmf_data/' + col][s0+start:s0+stop]
                 dic[col] = data[idx - start]
-        df = pandas.DataFrame(dic)
-    max_gmvs = oqparam.max_gmvs_per_task
-    if len(df) <= max_gmvs:
-        yield event_based_risk(df, oqparam, monitor)
-    else:
-        for s0, s1 in performance.split_slices(df.eid.to_numpy(), max_gmvs):
-            yield event_based_risk, df[s0:s1], oqparam
+    return event_based_risk(pandas.DataFrame(dic), oqparam, monitor)
 
 
 def event_based_risk(df, oqparam, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -228,8 +228,7 @@ def gen_outputs(df, crmodel, rng, monitor):
     for s0, s1 in monitor.read('start-stop'):
         with ass_mon:
             assets = monitor.read('assets', slice(s0, s1)).set_index('ordinal')
-        taxos = assets.taxonomy.unique()
-        for taxo in taxos:
+        for taxo in assets.taxonomy.unique():
             adf = assets[assets.taxonomy == taxo]
             for start, stop in slices:
                 gdf = df[start:stop]

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -177,7 +177,10 @@ def ebr_from_gmfs(sbe, oqparam, dstore, monitor):
             else:
                 data = dstore['gmf_data/' + col][s0+start:s0+stop]
                 dic[col] = data[idx - start]
-    return event_based_risk(pandas.DataFrame(dic), oqparam, monitor)
+    df = pandas.DataFrame(dic)
+    for s0, s1 in performance.split_slices(
+            dic['eid'], oqparam.max_gmvs_per_task):
+        yield event_based_risk(df[s0:s1], oqparam, monitor)
 
 
 def event_based_risk(df, oqparam, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -298,8 +298,6 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         oq = self.oqparam
         if oq.calculation_mode == 'ebrisk':
             oq.ground_motion_fields = False
-            logging.warning('You should be using the event_based_risk '
-                            'calculator, not ebrisk!')
         parent = self.datastore.parent
         if parent:
             self.datastore['full_lt'] = parent['full_lt']

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -226,7 +226,7 @@ def gen_outputs(df, crmodel, rng, monitor):
             adf = assets[assets.taxonomy == taxo]
             with fil_mon:
                 # *crucial* for the performance of the next step
-                gmf_df = df[numpy.isin(sids, adf.site_id.to_numpy())]
+                gmf_df = df[numpy.isin(sids, adf.site_id.unique())]
             if len(gmf_df) == 0:  # common enough
                 continue
             with mon_risk:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -253,11 +253,12 @@ def ebrisk(proxies, cmaker, dstore, monitor):
     :returns: a dictionary of arrays
     """
     cmaker.oq.ground_motion_fields = True
-    dic = event_based.event_based(proxies, cmaker, dstore, monitor)
-    if len(dic['gmfdata']) == 0:  # no GMFs
-        return {}
-    gmf_df = pandas.DataFrame(dic['gmfdata'])
-    return event_based_risk(gmf_df, cmaker.oq, monitor)
+    for block in general.block_splitter(
+            proxies, 10_000, event_based.rup_weight):
+        dic = event_based.event_based(block, cmaker, dstore, monitor)
+        if len(dic['gmfdata']):
+            gmf_df = pandas.DataFrame(dic['gmfdata'])
+            yield event_based_risk(gmf_df, cmaker.oq, monitor)
 
 
 @base.calculators.add('ebrisk', 'scenario_risk', 'event_based_risk')

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -243,7 +243,9 @@ def build_store_agg(dstore, rbe_df, num_events):
     if dmgs:
         aggnumber = dstore['agg_values']['number']
     # double loop to avoid running out of memory
-    for agg_id in rbe_df.agg_id.unique():
+    agg_ids = rbe_df.agg_id.unique()
+    logging.info("Performing %d aggregations", len(agg_ids))
+    for agg_id in agg_ids:
         gb = rbe_df[rbe_df.agg_id == agg_id].groupby(['rlz_id', 'loss_id'])
         for (rlz_id, loss_id), df in gb:
             ne = num_events[rlz_id]
@@ -269,7 +271,7 @@ def build_store_agg(dstore, rbe_df, num_events):
         units = dstore['cost_calculator'].get_units(oq.loss_types)
         builder = get_loss_builder(dstore, num_events=num_events)
         items = []
-        for agg_id in rbe_df.agg_id.unique():
+        for agg_id in agg_ids:
             gb = rbe_df[rbe_df.agg_id == agg_id].groupby(['rlz_id', 'loss_id'])
             for (rlz_id, loss_id), df in gb:
                 data = {kind: df[kind].to_numpy() for kind in loss_kinds}

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -242,24 +242,22 @@ def build_store_agg(dstore, rbe_df, num_events):
     dmgs = [col for col in columns if col.startswith('dmg_')]
     if dmgs:
         aggnumber = dstore['agg_values']['number']
-    # not using groupby to avoid running out of memory
-    triples = numpy.unique(
-        rbe_df[['agg_id', 'rlz_id', 'loss_id']].to_numpy(), axis=0)
-    for agg_id, rlz_id, loss_id in triples:
-        df = rbe_df[(rbe_df.agg_id == agg_id) &
-                    (rbe_df.rlz_id == rlz_id) &
-                    (rbe_df.loss_id == loss_id)]
-        ne = num_events[rlz_id]
-        aggrisk['agg_id'].append(agg_id)
-        aggrisk['rlz_id'].append(rlz_id)
-        aggrisk['loss_id'].append(loss_id)
-        if dmgs:
-            # infer the number of buildings in nodamage state
-            ndamaged = sum(df[col].sum() for col in dmgs)
-            aggrisk['dmg_0'].append(aggnumber[agg_id] - ndamaged / ne)
-        for col in columns:
-            agg = df[col].sum()
-            aggrisk[col].append(agg * tr if oq.investigation_time else agg/ne)
+    # double loop to avoid running out of memory
+    for agg_id in rbe_df.agg_id.unique():
+        gb = rbe_df[rbe_df.agg_id == agg_id].groupby(['rlz_id', 'loss_id'])
+        for (rlz_id, loss_id), df in gb:
+            ne = num_events[rlz_id]
+            aggrisk['agg_id'].append(agg_id)
+            aggrisk['rlz_id'].append(rlz_id)
+            aggrisk['loss_id'].append(loss_id)
+            if dmgs:
+                # infer the number of buildings in nodamage state
+                ndamaged = sum(df[col].sum() for col in dmgs)
+                aggrisk['dmg_0'].append(aggnumber[agg_id] - ndamaged / ne)
+            for col in columns:
+                agg = df[col].sum()
+                aggrisk[col].append(
+                    agg * tr if oq.investigation_time else agg/ne)
     fix_dtypes(aggrisk)
     aggrisk = pandas.DataFrame(aggrisk)
     dstore.create_df(
@@ -271,12 +269,11 @@ def build_store_agg(dstore, rbe_df, num_events):
         units = dstore['cost_calculator'].get_units(oq.loss_types)
         builder = get_loss_builder(dstore, num_events=num_events)
         items = []
-        for agg_id, rlz_id, loss_id in triples:
-            df = rbe_df[(rbe_df.agg_id == agg_id) &
-                        (rbe_df.rlz_id == rlz_id) &
-                        (rbe_df.loss_id == loss_id)]
-            data = {kind: df[kind].to_numpy() for kind in loss_kinds}
-            items.append([(agg_id, rlz_id, loss_id), data])
+        for agg_id in rbe_df.agg_id.unique():
+            gb = rbe_df[rbe_df.agg_id == agg_id].groupby(['rlz_id', 'loss_id'])
+            for (rlz_id, loss_id), df in gb:
+                data = {kind: df[kind].to_numpy() for kind in loss_kinds}
+                items.append([(agg_id, rlz_id, loss_id), data])
         dic = parallel.Starmap.apply(
             build_aggcurves, (items, builder),
             concurrent_tasks=oq.concurrent_tasks,


### PR DESCRIPTION
Here is Canada with 50,000 years and 50,000 sites: the speedup is 2x with respect to engine-3.17 since the slowest task is now 4x faster than before:
```
# v3.17
| calc_54327, maxmem=115.2 GB  | time_sec | memory_mb | counts    |
|------------------------------+----------+-----------+-----------|
| total ebrisk                 | 75_250   | 117.4     | 1_370     |
| computing gmfs               | 23_258   | 0.0       | 324_382   |
| computing risk               | 20_724   | 0.0       | 1_260_776 |
| filtering GMFs               | 9_813    | 0.0       | 2_228_688 |
| aggregating losses           | 4_130    | 0.0       | 2_988_438 |
| averaging losses             | 3_502    | 0.0       | 2_988_438 |
| reading crmodel              | 3_058    | 636.5     | 1_370     |
| EventBasedRiskCalculator.run | 2_165    | 1_635     | 1         |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| ebrisk             | 274    | 274.6   | 83%    | 71.1    | 1_430   | 5.20812 |

# this branch
| calc_54328, maxmem=147.2 GB  | time_sec | memory_mb | counts    |
|------------------------------+----------+-----------+-----------|
| total ebrisk                 | 60_100   | 1_050     | 273       |
| computing gmfs               | 26_506   | 0.0       | 324_382   |
| computing risk               | 12_216   | 0.0       | 324_003   |
| filtering GMFs               | 11_253   | 0.0       | 432_432   |
| aggregating losses           | 4_667    | 0.0       | 1_007_615 |
| averaging losses             | 1_682    | 0.0       | 1_007_615 |
| filtering ruptures           | 1_382    | 0.0       | 331_603   |
| EventBasedRiskCalculator.run | 1_091    | 1_670     | 1         |
| reading crmodel              | 818.0    | 263.3     | 273       |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| ebrisk             | 273    | 220.1   | 28%    | 31.5    | 370.9   | 1.68477 
```
I have also reduced a lot the memory consumption in the groupby in aggrisk and memory consumption due to resending GMFs.