### PR TITLE
Make sure get_mu_tau_phi logs the nominal bias also while running in multiprocessing

### DIFF
--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -107,6 +107,7 @@ cov_Y_Y_yD:
 """
 
 import logging
+from multiprocessing import get_logger
 from functools import partial
 from dataclasses import dataclass
 
@@ -619,10 +620,17 @@ def get_mu_tau_phi(target_imt, cmaker_Y, ctx_Y,
     nominal_bias_stddev = numpy.sqrt(numpy.mean(numpy.diag(cov_BD_BD_yD)))
 
     [gsim] = cmaker_Y.gsims
-    logging.info("GSIM: %s, IMT: %s, Nominal bias mean: %.3f, "
-                 "Nominal bias stddev: %.3f",
-                 gsim.gmpe if hasattr(gsim, 'gmpe') else gsim,
-                 target_imt, nominal_bias_mean, nominal_bias_stddev)
+
+    logger = get_logger()
+    formatter = logging.Formatter('[%(asctime)s %(levelname)s; %(name)s] [%(processName)s] %(message)s')
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info("GSIM: %s, IMT: %s, Nominal bias mean: %.3f, "
+                "Nominal bias stddev: %.3f",
+                gsim.gmpe if hasattr(gsim, 'gmpe') else gsim,
+                target_imt, nominal_bias_mean, nominal_bias_stddev)
 
     mean_stds = cmaker_Y.get_mean_stds([ctx_Y])[:, 0]  # 0=gsim_idx
     # (4, M, N): mean, StdDev.TOTAL, StdDev.INTER_EVENT,


### PR DESCRIPTION
Addresses part of https://github.com/gem/oq-engine/issues/8915
This is a workaround and it does not produce the desired log format, but the following:
```
[2023-07-25 15:22:00 #98 INFO] ptormene@deb-ptormene running /home/ptormene/Documents/share_PGA/job_stations_seismic.ini [--hc=None]
[2023-07-25 15:22:00 #98 INFO] Using engine version 3.18.0-gitd06dc98b78
[2023-07-25 15:22:00 #98 WARNING] Using 6 cores on deb-ptormene
[2023-07-25 15:22:00 #98 INFO] Running EventBasedCalculator with concurrent_tasks = 24
[2023-07-25 15:22:00 #98 INFO] Checksum of the inputs: 3659344336 (total size 39.59 KB)
[2023-07-25 15:22:00 #98 INFO] Extracting the hazard sites from the site model
/home/ptormene/openquake/lib/python3.10/site-packages/pandas/util/_decorators.py:311: ParserWarning: Both a converter and dtype were specified for column custom_site_id - only the converter will be used
  return func(*args, **kwargs)
[2023-07-25 15:22:00 #98 INFO] Read N=499 hazard sites and L=1 hazard levels
[2023-07-25 15:22:00 #98 INFO] Reading station data from /home/ptormene/Documents/share_PGA/stationlist_seismic.csv
[2023-07-25 15:22:00 #98 INFO] min_iml=[1.e-10]
[2023-07-25 15:22:00 #98 INFO] Reordering the ruptures and storing the events
[2023-07-25 15:22:00 #98 INFO] Reading 1 ruptures
[2023-07-25 15:22:00 #98 INFO] Affected sites = 495.0 per rupture
[2023-07-25 15:22:00 #98 INFO] totw = 0
[2023-07-25 15:22:05,068 INFO; multiprocessing] [SpawnPoolWorker-6] GSIM: [Bradley2013], IMT: PGA, Nominal bias mean: 0.513, Nominal bias stddev: 0.052
[2023-07-25 15:22:05 #98 INFO] gen_event_based 100% [1 submitted, 0 queued]
[2023-07-25 15:22:05 #98 INFO] Received {'gmfdata': '6.7 KB', 'sig_eps': '323 B', 'times': '313 B'} in 4 seconds from gen_event_based
[2023-07-25 15:22:05 #98 INFO] Stored 3.88 KB of GMFs
[2023-07-25 15:22:05 #98 INFO] Checking stored GMFs
[2023-07-25 15:22:05 #98 WARNING] No PGAs over 5 g found
[2023-07-25 15:22:05,358 INFO; multiprocessing] [SpawnPoolWorker-6] process shutting down
[2023-07-25 15:22:05,358 INFO; multiprocessing] [SpawnPoolWorker-6] process exiting with exitcode 0
[2023-07-25 15:22:05 #98 INFO] Exposing the outputs to the database
[2023-07-25 15:22:05 #98 INFO] Stored 181.61 KB on /home/ptormene/oqdata/calc_98.hdf5 in 4 seconds
  id | name
 338 | Events
 339 | Full Report
 340 | Ground Motion Fields
```
I still have not figured out how to inherit the main logger with its configurations (format and log level) or at least how to log calc_id (and tag if present).