### PR TITLE
Disable multiprocessing when working with conditioned GMFs

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -446,6 +446,7 @@ else:
 @compile(["int64[:, :](uint8[:])",
           "int64[:, :](uint16[:])",
           "int64[:, :](uint32[:])",
+          "int64[:, :](int32[:])",
           "int64[:, :](int64[:])"])
 def idx_start_stop(integers):
     # given an array of integers returns an array int64 of shape (n, 3)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -376,6 +376,8 @@ class EventBasedCalculator(base.HazardCalculator):
     accept_precalc = ['event_based', 'ebrisk', 'event_based_risk']
 
     def init(self):
+        if 'station_data' in self.oqparam.inputs:
+            os.environ['OQ_DISTRIBUTE'] = 'no'
         if self.oqparam.cross_correl.__class__.__name__ == 'GodaAtkinson2009':
             logging.warning(
                 'The truncation_level param is ignored with GodaAtkinson2009')


### PR DESCRIPTION
...and fix numeric type mismatch on Windows.

Supersedes https://github.com/gem/oq-engine/pull/8922
Fixes https://github.com/gem/oq-engine/issues/8920
Fixes https://github.com/gem/oq-engine/issues/8915

As @micheles wrote, disabling multiprocessing in this case is correct since there is a single rupture in conditioned GMFs scenarios, so a single core is used.

Perhaps we need to search through the whole code base if we have any other similar cases in which we may have mismatches between numeric data types across different operating systems?