### PR TITLE
Removed SharedMemory experiment

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -193,7 +193,6 @@ import traceback
 import collections
 from unittest import mock
 import multiprocessing.dummy
-import multiprocessing.shared_memory as shmem
 from multiprocessing.connection import wait
 import psutil
 import numpy
@@ -614,38 +613,9 @@ def getargnames(task_func):
         return inspect.getfullargspec(task_func.__call__).args[1:]
 
 
-class SharedArray(object):
-    """
-    Wrapper over a SharedMemory object to be used as a context manager.
-    """
-    def __init__(self, shape, dtype, value):
-        nbytes = numpy.zeros(1, dtype).nbytes * numpy.prod(shape)
-        # NOTE: on Windows nbytes is a numpy.int32 and it causes an
-        # exception. On Linux, it is a numpy.int64 and it works without
-        # problems
-        sm = shmem.SharedMemory(create=True, size=int(nbytes))
-        self.name = sm.name
-        self.shape = shape
-        self.dtype = dtype
-        # fill the SharedMemory buffer with the value
-        arr = numpy.ndarray(shape, dtype, buffer=sm.buf)
-        arr[:] = value
-
-    def __enter__(self):
-        self.sm = shmem.SharedMemory(self.name)
-        return numpy.ndarray(self.shape, self.dtype, buffer=self.sm.buf)
-
-    def __exit__(self, etype, exc, tb):
-        self.sm.close()
-
-    def unlink(self):
-        shmem.SharedMemory(self.name).unlink()
-
-
 class Starmap(object):
     pids = ()
     running_tasks = []  # currently running tasks
-    shared = []  # SharedArrays
     maxtasksperchild = None  # with 1 it hangs on the EUR calculation!
     num_cores = int(config.distribution.get('num_cores', '0'))
     if not num_cores:
@@ -671,7 +641,6 @@ class Starmap(object):
                 cls.num_cores, init_workers,
                 maxtasksperchild=cls.maxtasksperchild)
             cls.pids = [proc.pid for proc in cls.pool._pool]
-            cls.shared = []
             # after spawning the processes restore the original handlers
             # i.e. the ones defined in openquake.engine.engine
             signal.signal(signal.SIGTERM, term_handler)
@@ -684,8 +653,6 @@ class Starmap(object):
 
     @classmethod
     def shutdown(cls):
-        for shared in cls.shared:
-            shmem.SharedMemory(shared.name).unlink()
         # shutting down the pool during the runtime causes mysterious
         # race conditions with errors inside atexit._run_exitfuncs
         if hasattr(cls, 'pool'):
@@ -938,19 +905,6 @@ class Starmap(object):
             logging.info(
                 'Mean time per core=%ds, std=%.1fs, min=%ds, max=%ds',
                 times.mean(), times.std(), times.min(), times.max())
-
-    def create_shared(self, shape, dtype=float, value=0.):
-        """
-        Create an array backed by a SharedMemory buffer.
-
-        :param shape: shape of the array
-        :param dtype: dtype of the array (default float)
-        :param value: initialization value (default 0.)
-        :returns: a SharedArray instance
-        """
-        shared = SharedArray(shape, dtype, value)
-        self.shared.append(shared)
-        return shared
 
 
 def sequential_apply(task, args, concurrent_tasks=Starmap.CT,

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -228,24 +228,3 @@ class SplitTaskTestCase(unittest.TestCase):
         self.assertAlmostEqual(res, 48.6718458266)
         """
         shutil.rmtree(tmpdir)
-
-
-def update_array(shared, index):
-    with shared as array:
-        for i in range(index):
-            for j in range(index):
-                array[i, j] *= .99
-
-
-class SharedMemoryTestCase(unittest.TestCase):
-    def test(self):
-        shape = 10, 10
-        smap = parallel.Starmap(update_array)
-        shared = smap.create_shared(shape, value=1.)
-        for i in range(shape[1]):
-            smap.submit((shared, i))
-        smap.reduce()
-        print()
-        with shared as array:
-            print(array)
-        parallel.Starmap.shutdown()


### PR DESCRIPTION
It was not used except in a test causing issues on Windows. Also, when I tried the feature in real calculations on linux it was not saving memory anyway (perhaps due to the issue mentioned here: https://peps.python.org/pep-0683/), so it was a failed experiment :-(