### PR TITLE
Improved error message when quantiles are not supported in event based risk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved error message when quantiles are not supported in event based risk
   * Reduced memory consumption in the master node in post_risk
   * Reduced slow tasks in the ebrisk calculator and memory consumption
     in the master node

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1932,8 +1932,8 @@ class OqParam(valid.ParamSet):
 
     def is_valid_collect_rlzs(self):
         """
-        sampling_method must be early_weights, only the mean is available,
-        and number_of_logic_tree_samples must be greater than 1.
+        sampling_method must be early_weights and number_of_logic_tree_samples
+        must be greater than 1.
         """
         if self.collect_rlzs is None:
             self.collect_rlzs = self.number_of_logic_tree_samples > 1
@@ -1952,8 +1952,10 @@ class OqParam(valid.ParamSet):
                 raise ValueError('Please specify number_of_logic_tree_samples'
                                  '=%d' % n)
         hstats = list(self.hazard_stats())
-        nostats = not hstats or hstats == ['mean']
-        return nostats and self.number_of_logic_tree_samples > 1 and (
+        if hstats and hstats != ['mean']:
+            msg = '%s: quantiles are not supported with collect_rlzs=true'
+            raise InvalidFile(msg % self.inputs['job_ini'])
+        return self.number_of_logic_tree_samples > 1 and (
             self.sampling_method == 'early_weights')
 
     def check_aggregate_by(self):


### PR DESCRIPTION
I was getting
```python
  File "/opt/openquake/oq-engine/openquake/hazardlib/valid.py", line 1350, in validate
    raise ValueError(doc)
ValueError:
sampling_method must be early_weights, only the mean is available,
and number_of_logic_tree_samples must be greater than 1.
```
Now I get
```python
openquake.baselib.InvalidFile: /home/michele/forMichele/ebRisk_b0_CanadaAll.ini:
quantiles are not supported with collect_rlzs=true
```