### PR TITLE
Reduced slow tasks and memory consumption in the event_based_risk calculator (3x for Chile)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Reduced slow tasks and memory consumption
+    in the event_based_risk calculator (3x for Chile)
+
   [Paolo Tormene]
   * Raise an error if files specified in site_model_file do not have the same
     headers

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -359,6 +359,18 @@ def build_slice_by_event(eids, offset=0):
     return sbe
 
 
+def get_counts(idxs, N):
+    """
+    :param idxs: indices in the range 0..N-1
+    :param N: size of the returned array
+    :returns: an array of size N with the counts of the indices
+    """
+    counts = numpy.zeros(N, int)
+    uni, cnt = numpy.unique(idxs, return_counts=True)
+    counts[uni] = cnt
+    return counts
+
+    
 def starmap_from_gmfs(task_func, oq, dstore):
     """
     :param task_func: function or generator with signature (gmf_df, oq, dstore)
@@ -370,6 +382,14 @@ def starmap_from_gmfs(task_func, oq, dstore):
         ds = dstore.parent
     else:
         ds = dstore
+    N = len(ds['sitecol'])
+    num_assets = get_counts(dstore['assetcol/array']['site_id'], N)
+    def weight(rec, dset=dstore['gmf_data/sid']):
+        s0, s1 = rec['start'], rec['stop']
+        w = num_assets[dset[s0:s1]].sum()
+        print('weight=%s' % w)
+        return w
+
     data = ds['gmf_data']
     try:
         sbe = data['slice_by_event'][:]
@@ -378,8 +398,7 @@ def starmap_from_gmfs(task_func, oq, dstore):
     nrows = sbe[-1]['stop'] - sbe[0]['start']
     maxweight = numpy.ceil(nrows / (oq.concurrent_tasks or 1))
     smap = parallel.Starmap.apply(
-        task_func, (sbe, oq, ds),
-        weight=lambda rec: rec['stop']-rec['start'],
-        maxweight=numpy.clip(maxweight, 1000, 10_000_000),
+        task_func, (sbe, oq, ds), weight=weight,
+        maxweight=numpy.clip(maxweight, 1000, 100_000_000),
         h5=dstore.hdf5)
     return smap

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -382,7 +382,7 @@ def starmap_from_gmfs(task_func, oq, dstore):
         ds = dstore.parent
     else:
         ds = dstore
-    N = len(ds['sitecol'])
+    N = ds['sitecol'].sids.max() + 1
     num_assets = get_counts(dstore['assetcol/array']['site_id'], N)
     def weight(rec, dset=dstore['gmf_data/sid']):
         s0, s1 = rec['start'], rec['stop']

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -396,6 +396,6 @@ def starmap_from_gmfs(task_func, oq, dstore):
         sbe = build_slice_by_event(data['eid'][:])
     smap = parallel.Starmap.apply(
         task_func, (sbe, oq, ds),
-        maxweight=1E6, weight=weight,
+        maxweight=10_000_000, weight=weight,
         h5=dstore.hdf5)
     return smap

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -396,6 +396,6 @@ def starmap_from_gmfs(task_func, oq, dstore):
         sbe = build_slice_by_event(data['eid'][:])
     smap = parallel.Starmap.apply(
         task_func, (sbe, oq, ds),
-        maxweight=10_000_000, weight=weight,
+        maxweight=50_000_000, weight=weight,
         h5=dstore.hdf5)
     return smap

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -394,10 +394,8 @@ def starmap_from_gmfs(task_func, oq, dstore):
         sbe = data['slice_by_event'][:]
     except KeyError:
         sbe = build_slice_by_event(data['eid'][:])
-    nrows = sbe[-1]['stop'] - sbe[0]['start']
-    maxweight = numpy.ceil(nrows / (oq.concurrent_tasks or 1))
     smap = parallel.Starmap.apply(
-        task_func, (sbe, oq, ds), weight=weight,
-        maxweight=numpy.clip(maxweight, 1000, 10_000_000),
+        task_func, (sbe, oq, ds),
+        maxweight=1E6, weight=weight,
         h5=dstore.hdf5)
     return smap

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -387,7 +387,6 @@ def starmap_from_gmfs(task_func, oq, dstore):
     def weight(rec, dset=dstore['gmf_data/sid']):
         s0, s1 = rec['start'], rec['stop']
         w = num_assets[dset[s0:s1]].sum()
-        print('weight=%s' % w)
         return w
 
     data = ds['gmf_data']
@@ -399,6 +398,6 @@ def starmap_from_gmfs(task_func, oq, dstore):
     maxweight = numpy.ceil(nrows / (oq.concurrent_tasks or 1))
     smap = parallel.Starmap.apply(
         task_func, (sbe, oq, ds), weight=weight,
-        maxweight=numpy.clip(maxweight, 1000, 100_000_000),
+        maxweight=numpy.clip(maxweight, 1000, 10_000_000),
         h5=dstore.hdf5)
     return smap


### PR DESCRIPTION
Yesterday:
```
| calc_54421, maxmem=460.2 GB  | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total ebr_from_gmfs          | 262_160  | 2_238     | 252     |
| computing risk               | 233_888  | 0.0       | 17_647  |
| aggregating losses           | 24_088   | 0.0       | 124_628 |
| EventBasedRiskCalculator.run | 7_721    | 81.8      | 1       |
| averaging losses             | 2_257    | 0.0       | 124_628 |
| reading crmodel              | 633.2    | 2_103     | 252     |
| filtering GMFs               | 626.0    | 0.0       | 17_892  |
| reading assets               | 320.3    | 0.0       | 1_512   |
| importing inputs             | 155.5    | 83.3      | 1       |
| saving avg_losses            | 120.2    | 324.2     | 252     |
| reading exposure             | 101.0    | 102.1     | 1       |
| PostRiskCalculator.run       | 63.5     | 0.54688   | 1       |
| reading GMFs                 | 47.3     | 140.3     | 204     |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| ebr_from_gmfs      | 257    | 1_020   | 117%   | 0.05242 | 7_286   | 7.14230 |
```
Today:
```
| calc_54438, maxmem=221.2 GB  | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total ebr_from_gmfs          | 297_926  | 1_978     | 983     |
| computing risk               | 259_800  | 0.0       | 69_793  |
| aggregating losses           | 26_585   | 0.0       | 500_969 |
| averaging losses             | 4_835    | 0.0       | 500_969 |
| reading crmodel              | 3_181    | 276.8     | 983     |
| EventBasedRiskCalculator.run | 2_781    | 2_424     | 1       |
| reading assets               | 1_821    | 0.0       | 5_898   |
| filtering GMFs               | 704.1    | 0.0       | 69_793  |
| saving avg_losses            | 553.0    | 810.2     | 983     |
| importing inputs             | 153.0    | 2_401     | 1       |
| reading GMFs                 | 108.9    | 632.2     | 983     |
| reading exposure             | 100.1    | 2_178     | 1       |
| PostRiskCalculator.run       | 59.0     | 1.60156   | 1       |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| ebr_from_gmfs      | 983    | 303.1   | 18%    | 78.2    | 478.2   | 1.57770 |
```
The slowest task is 15x faster than before. The improvement on ebr_from_gmfs is 3.14x:
```
Received {'avg': '56.04 GB'} in 7408 seconds from ebr_from_gmfs
=>
Received {'avg': '178.12 GB'} in 2357 seconds from ebr_from_gmfs
```