### PR TITLE
add missing regression coefficient for pga_scale

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -80,6 +80,7 @@ Anne Hulsey              (@annehulsey)          July 2022
 Nicole Paul              (@nicolepaul)          May 2023
 Claudio Schill           (@claudio525)          June 2023
 Astha Poudel             (@asthapoudel)         July 2023
+Lana Todorovich          (@LanaTodorovic93)     August 2023
 
 Project management
 ------------------

--- a/openquake/sep/classes.py
+++ b/openquake/sep/classes.py
@@ -175,8 +175,9 @@ class ZhuLiquefactionGeneral(SecondaryPeril):
     """
     outputs = ["LiqProb"]
 
-    def __init__(self, intercept=24.1, cti_coeff=0.355, vs30_coeff=-4.784):
+    def __init__(self, intercept=24.1, pgam_coeff = 2.067, cti_coeff=0.355, vs30_coeff=-4.784):
         self.intercept = intercept
+        self.pgam_coeff = pgam_coeff
         self.cti_coeff = cti_coeff
         self.vs30_coeff = vs30_coeff
 

--- a/openquake/sep/liquefaction/liquefaction.py
+++ b/openquake/sep/liquefaction/liquefaction.py
@@ -90,6 +90,7 @@ def zhu_liquefaction_probability_general(
     cti: Union[float, np.ndarray],
     vs30: Union[float, np.ndarray],
     intercept: float = 24.1,
+    pgam_coeff: float = 2.067,
     cti_coeff: float = 0.355,
     vs30_coeff: float = -4.784,
 ) -> Union[float, np.ndarray]:
@@ -115,7 +116,7 @@ def zhu_liquefaction_probability_general(
         Probability of liquefaction at the site.
     """
     pga_scale = pga * zhu_magnitude_correction_factor(mag)
-    Xg = (np.log(pga_scale)
+    Xg = (pgam_coeff * np.log(pga_scale)
           + cti_coeff * cti
           + vs30_coeff * np.log(vs30)
           + intercept)

--- a/openquake/sep/tests/test_sep_suite_2.py
+++ b/openquake/sep/tests/test_sep_suite_2.py
@@ -109,9 +109,9 @@ class test_liquefaction_cali_small(unittest.TestCase):
             pga=self.pga, mag=self.mag, cti=self.sites["cti"], 
             vs30=self.sites["vs30"])
 
-        zlp = np.array([0.79003182, 0.43775041, 0.70513967, 0.84349872,
-            0.88613944, 0.86409455, 0.48914665, 0.0606366 , 0.85349938,
-            0.69109006])
+        zlp = np.array([0.506859, 0.383202, 0.438535, 0.807301,
+            0.807863, 0.595353, 0.079580, 0.003111, 0.792592,
+            0.603895])
 
         np.testing.assert_array_almost_equal(self.sites["zhu_liq_prob"], zlp)
 


### PR DESCRIPTION
The model for calculating the probability of liquefaction (Zhu et al., 2015) is missing a regression coefficient for PGAm. The suggested additions resolve #8961 