### PR TITLE
Use 'residents' instead of 'occupants_avg' or 'occupants_night' when calculating consequences for 'homeless'

### DIFF
--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1667,7 +1667,7 @@ def get_agg_value(consequence, agg_values, agg_id, xltype):
     elif consequence == 'fatalities':
         return aval['occupants_night']
     elif consequence == 'homeless':
-        return aval['redsidents']
+        return aval['residents']
     elif consequence in ('loss', 'losses'):
         if xltype.endswith('_ins'):
             xltype = xltype[:-4]

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1651,7 +1651,7 @@ def consequence(consequence, coeffs, asset, dmgdist, loss_type):
     elif consequence == 'fatalities':
         return dmgdist @ coeffs * asset['occupants_night']
     elif consequence == 'homeless':
-        return dmgdist @ coeffs * asset['occupants_avg']
+        return dmgdist @ coeffs * asset['residents']
 
 
 def get_agg_value(consequence, agg_values, agg_id, xltype):
@@ -1667,7 +1667,7 @@ def get_agg_value(consequence, agg_values, agg_id, xltype):
     elif consequence == 'fatalities':
         return aval['occupants_night']
     elif consequence == 'homeless':
-        return aval['occupants_night']
+        return aval['redsidents']
     elif consequence in ('loss', 'losses'):
         if xltype.endswith('_ins'):
             xltype = xltype[:-4]


### PR DESCRIPTION
Fixes https://github.com/gem/oq-engine/issues/8966

A more comprehensive work is being done in https://github.com/gem/oq-engine/pull/8940
Menwhile, this fixes the most urgent matter.