### PR TITLE
In the action for MacOS Intel, do `oq --version` before starting the dbserver

### DIFF
--- a/.github/workflows/macos_intel_install.yml
+++ b/.github/workflows/macos_intel_install.yml
@@ -49,6 +49,7 @@ jobs:
           fi
           source ~/openquake/bin/activate
           pip3 install pytest pyshp flake8
+          oq --version  # makes numba compile, so dbserver start becomes quicker
           oq dbserver start
           sleep 10
 


### PR DESCRIPTION
Therefore numba is compiled in advanced and dbserver start should become quicker, hopefully avoiding timeouts like https://github.com/gem/oq-engine/actions/runs/6104264616/job/16573456615#step:6:107