### PR TITLE
When running install.py without --version, install requirements from current stable version instead of master

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Paolo Tormene]
+  * Upgraded requirements: Shapely to version 2.0.1 and Pandas to version 2.0.3
+
   [Michele Simionato, Paolo Tormene]
   * Implemented AEP, OEP curves
 

--- a/install.py
+++ b/install.py
@@ -44,7 +44,6 @@ import tempfile
 import argparse
 import platform
 import subprocess
-import requests
 from urllib.request import urlopen
 try:
     import ensurepip
@@ -211,8 +210,9 @@ def get_branch(version):
     """
     if version is None:
         # retrieve the tag name of the current stable version
-        resp = requests.get('https://pypi.org/pypi/openquake.engine/json')
-        stable_version_number = resp.json()['info']['version']
+        with urlopen('https://pypi.org/pypi/openquake.engine/json') as resp:
+            content = resp.read()
+        stable_version_number = json.loads(content)['info']['version']
         stable_version_tag_name = f'v{stable_version_number}'
         return stable_version_tag_name
     mo = re.match(r'(\d+\.\d+)+', version)

--- a/install.py
+++ b/install.py
@@ -44,6 +44,7 @@ import tempfile
 import argparse
 import platform
 import subprocess
+import requests
 from urllib.request import urlopen
 try:
     import ensurepip
@@ -209,7 +210,11 @@ def get_branch(version):
     Convert "version" into a branch name
     """
     if version is None:
-        return 'master'
+        # retrieve the tag name of the current stable version
+        resp = requests.get('https://pypi.org/pypi/openquake.engine/json')
+        stable_version_number = resp.json()['info']['version']
+        stable_version_tag_name = f'v{stable_version_number}'
+        return stable_version_tag_name
     mo = re.match(r'(\d+\.\d+)+', version)
     if mo:
         return 'engine-' + mo.group(0)


### PR DESCRIPTION
Fixes corner cases like https://github.com/gem/earthquake-scenarios/actions/runs/6236650200/job/16928464634?pr=19 in which the engine is installed without specifying --version, so by default the latest stable version was installed, but requirements were incorrectly taken from master, causing a mismatch with some upgraded packages (in this case pandas)