### PR TITLE
Avoid logging expected tracebacks while testing calls to the engine server api

### DIFF
--- a/.github/workflows/engine_test.yml
+++ b/.github/workflows/engine_test.yml
@@ -78,6 +78,7 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         oq dbserver start
+        # -v 2 also logs the test names
         OQ_APPLICATION_MODE=public ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
   server_read_only_mode:
@@ -101,6 +102,7 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         oq dbserver start
+        # -v 2 also logs the test names
         OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
 
   server_aelo_mode:
@@ -124,4 +126,5 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         oq dbserver start
+        # -v 2 also logs the test names
         OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode

--- a/.github/workflows/engine_test.yml
+++ b/.github/workflows/engine_test.yml
@@ -78,7 +78,7 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         oq dbserver start
-        OQ_APPLICATION_MODE=public ./openquake/server/manage.py test tests.test_public_mode
+        OQ_APPLICATION_MODE=public ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
   server_read_only_mode:
     runs-on: ${{ matrix.os }}
@@ -101,7 +101,7 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         oq dbserver start
-        OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test tests.test_read_only_mode
+        OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
 
   server_aelo_mode:
     runs-on: ${{ matrix.os }}
@@ -124,4 +124,4 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         oq dbserver start
-        OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test tests.test_aelo_mode
+        OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode

--- a/.github/workflows/macos_intel_install.yml
+++ b/.github/workflows/macos_intel_install.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd ~/work/oq-engine/oq-engine
+          # -v 2 also logs the test names
           OQ_APPLICATION_MODE=public ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
       - name: Run tests for the engine server in read-only mode to test installation
@@ -99,6 +100,7 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd ~/work/oq-engine/oq-engine
+          # -v 2 also logs the test names
           OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
 
       # NOTE: we shouldn't need to install the engine in AELO mode on mac
@@ -107,4 +109,5 @@ jobs:
       #   run: |
       #     source ~/openquake/bin/activate
       #     cd ~/work/oq-engine/oq-engine
+      #     -v 2 also logs the test names
       #     OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode

--- a/.github/workflows/macos_intel_install.yml
+++ b/.github/workflows/macos_intel_install.yml
@@ -92,14 +92,14 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd ~/work/oq-engine/oq-engine
-          OQ_APPLICATION_MODE=public ./openquake/server/manage.py test tests.test_public_mode
+          OQ_APPLICATION_MODE=public ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
       - name: Run tests for the engine server in read-only mode to test installation
         if: always()
         run: |
           source ~/openquake/bin/activate
           cd ~/work/oq-engine/oq-engine
-          OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test tests.test_read_only_mode
+          OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
 
       # NOTE: we shouldn't need to install the engine in AELO mode on mac
       # - name: Run tests for the engine server in aelo mode to test installation
@@ -107,4 +107,4 @@ jobs:
       #   run: |
       #     source ~/openquake/bin/activate
       #     cd ~/work/oq-engine/oq-engine
-      #     OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test tests.test_aelo_mode
+      #     OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode

--- a/.github/workflows/macos_m1_monterey_install.yml
+++ b/.github/workflows/macos_m1_monterey_install.yml
@@ -119,18 +119,18 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
-          OQ_APPLICATION_MODE=public ./openquake/server/manage.py test tests.test_public_mode
+          OQ_APPLICATION_MODE=public ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
       - name: Run tests for the engine server in read-only mode to test installation
         if: always()
         run: |
           source ~/openquake/bin/activate
           cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
-          OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test tests.test_read_only_mode
+          OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
 
       - name: Run tests for the engine server in aelo mode to test installation
         if: always()
         run: |
           source ~/openquake/bin/activate
           cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
-          OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test tests.test_aelo_mode
+          OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode

--- a/.github/workflows/macos_m1_monterey_install.yml
+++ b/.github/workflows/macos_m1_monterey_install.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
+          # -v 2 also logs the test names
           OQ_APPLICATION_MODE=public ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
       - name: Run tests for the engine server in read-only mode to test installation
@@ -126,6 +127,7 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
+          # -v 2 also logs the test names
           OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
 
       - name: Run tests for the engine server in aelo mode to test installation
@@ -133,4 +135,5 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
+          # -v 2 also logs the test names
           OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -133,7 +133,7 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=public
-          .\openquake\server\manage.py test tests.test_public_mode
+          .\openquake\server\manage.py test -v 2 tests.test_public_mode
 
       - name: Run tests for the engine server in read-only mode to test installation
         if: always()
@@ -144,7 +144,7 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=read_only
-          .\openquake\server\manage.py test tests.test_read_only_mode
+          .\openquake\server\manage.py test -v 2 tests.test_read_only_mode
 
       - name: Run tests for the engine server in aelo mode to test installation
         if: always()
@@ -156,4 +156,4 @@ jobs:
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=aelo
           set OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg
-          .\openquake\server\manage.py test tests.test_aelo_mode
+          .\openquake\server\manage.py test -v 2 tests.test_aelo_mode

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -133,6 +133,7 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=public
+          # -v 2 also logs the test names
           .\openquake\server\manage.py test -v 2 tests.test_public_mode
 
       - name: Run tests for the engine server in read-only mode to test installation
@@ -144,6 +145,7 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=read_only
+          # -v 2 also logs the test names
           .\openquake\server\manage.py test -v 2 tests.test_read_only_mode
 
       - name: Run tests for the engine server in aelo mode to test installation
@@ -156,4 +158,5 @@ jobs:
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=aelo
           set OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg
+          # -v 2 also logs the test names
           .\openquake\server\manage.py test -v 2 tests.test_aelo_mode

--- a/openquake/server/tests/test_aelo_mode.py
+++ b/openquake/server/tests/test_aelo_mode.py
@@ -30,6 +30,7 @@ import string
 import unittest
 import secrets
 import csv
+import logging
 
 import django
 from django.test import Client
@@ -178,7 +179,9 @@ class EngineServerAeloModeTestCase(EngineServerTestCase):
         self.aelo_run_then_remove(params, failure_reason)
 
     def aelo_invalid_input(self, params, expected_error):
+        logging.disable(logging.CRITICAL)
         resp = self.post('aelo_run', params)
+        logging.disable(logging.NOTSET)
         self.assertEqual(resp.status_code, 400)
         resp_dict = json.loads(resp.content.decode('utf8'))
         print(resp_dict)

--- a/openquake/server/tests/test_aelo_mode.py
+++ b/openquake/server/tests/test_aelo_mode.py
@@ -179,6 +179,7 @@ class EngineServerAeloModeTestCase(EngineServerTestCase):
         self.aelo_run_then_remove(params, failure_reason)
 
     def aelo_invalid_input(self, params, expected_error):
+        # NOTE: avoiding to print the expected traceback
         logging.disable(logging.CRITICAL)
         resp = self.post('aelo_run', params)
         logging.disable(logging.NOTSET)

--- a/openquake/server/tests/test_public_mode.py
+++ b/openquake/server/tests/test_public_mode.py
@@ -27,6 +27,7 @@ import gzip
 import tempfile
 import string
 import random
+import logging
 
 import django
 from django.test import Client
@@ -230,8 +231,10 @@ class EngineServerPublicModeTestCase(EngineServerTestCase):
 
     def test_err_1(self):
         # the rupture XML file has a syntax error
+        logging.disable(logging.CRITICAL)
         job_id = self.postzip('archive_err_1.zip')['job_id']
         self.wait()
+        logging.disable(logging.NOTSET)
 
         # there is no datastore since the calculation did not start
         resp = self.c.get('/v1/calc/%s/datastore' % job_id)
@@ -248,13 +251,17 @@ class EngineServerPublicModeTestCase(EngineServerTestCase):
 
     def test_err_2(self):
         # the file logic-tree-source-model.xml is missing
+        logging.disable(logging.CRITICAL)
         resp = self.postzip('archive_err_2.zip')
+        logging.disable(logging.NOTSET)
         self.assertIn('No such file', resp['tb_str'])
         self.post('%s/remove' % resp['job_id'])
 
     def test_err_3(self):
         # there is no file job.ini, job_hazard.ini or job_risk.ini
+        logging.disable(logging.CRITICAL)
         resp = self.postzip('archive_err_3.zip')
+        logging.disable(logging.NOTSET)
         self.assertIn('There are no .ini files in the archive', resp['tb_str'])
         self.post('%s/remove' % resp['job_id'])
 

--- a/openquake/server/tests/test_public_mode.py
+++ b/openquake/server/tests/test_public_mode.py
@@ -230,8 +230,9 @@ class EngineServerPublicModeTestCase(EngineServerTestCase):
         print(resp.content.decode('utf8'))
 
     def test_err_1(self):
-        # the rupture XML file has a syntax error
+        # NOTE: avoiding to print the expected traceback
         logging.disable(logging.CRITICAL)
+        # the rupture XML file has a syntax error
         job_id = self.postzip('archive_err_1.zip')['job_id']
         self.wait()
         logging.disable(logging.NOTSET)
@@ -250,16 +251,18 @@ class EngineServerPublicModeTestCase(EngineServerTestCase):
         self.assertFalse(job_id in job_ids)
 
     def test_err_2(self):
-        # the file logic-tree-source-model.xml is missing
+        # NOTE: avoiding to print the expected traceback
         logging.disable(logging.CRITICAL)
+        # the file logic-tree-source-model.xml is missing
         resp = self.postzip('archive_err_2.zip')
         logging.disable(logging.NOTSET)
         self.assertIn('No such file', resp['tb_str'])
         self.post('%s/remove' % resp['job_id'])
 
     def test_err_3(self):
-        # there is no file job.ini, job_hazard.ini or job_risk.ini
+        # NOTE: avoiding to print the expected traceback
         logging.disable(logging.CRITICAL)
+        # there is no file job.ini, job_hazard.ini or job_risk.ini
         resp = self.postzip('archive_err_3.zip')
         logging.disable(logging.NOTSET)
         self.assertIn('There are no .ini files in the archive', resp['tb_str'])


### PR DESCRIPTION
This looks like a good compromise