### PR TITLE
On Windows, run manage.py prepending python, otherwise it does nothing

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -133,7 +133,7 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=public
-          .\openquake\server\manage.py test tests.test_public_mode
+          python .\openquake\server\manage.py test tests.test_public_mode
 
       - name: Run tests for the engine server in read-only mode to test installation
         if: always()
@@ -144,7 +144,7 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=read_only
-          .\openquake\server\manage.py test tests.test_read_only_mode
+          python .\openquake\server\manage.py test tests.test_read_only_mode
 
       - name: Run tests for the engine server in aelo mode to test installation
         if: always()
@@ -156,4 +156,4 @@ jobs:
           cd D:\a\oq-engine\oq-engine
           set OQ_APPLICATION_MODE=aelo
           set OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg
-          .\openquake\server\manage.py test tests.test_aelo_mode
+          python .\openquake\server\manage.py test tests.test_aelo_mode


### PR DESCRIPTION
Tests of the engine were green, but they were doing nothing (see https://github.com/gem/oq-engine/actions/runs/6241355892/job/16943393394#step:12:1)

I've re-launched windows tests for this branch: https://github.com/gem/oq-engine/actions/runs/6262524808/job/17004884851