### PR TITLE
Fix engine server tests on Windows

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -132,7 +132,7 @@ jobs:
           Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver start}
           sleep 10
           cd D:\a\oq-engine\oq-engine
-          set OQ_APPLICATION_MODE=public
+          $Env:OQ_APPLICATION_MODE='public'
           # -v 2 also logs the test names
           python .\openquake\server\manage.py test -v 2 tests.test_public_mode
 
@@ -144,7 +144,7 @@ jobs:
           Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver start}
           sleep 10
           cd D:\a\oq-engine\oq-engine
-          set OQ_APPLICATION_MODE=read_only
+          $Env:OQ_APPLICATION_MODE='read_only'
           # -v 2 also logs the test names
           python .\openquake\server\manage.py test -v 2 tests.test_read_only_mode
 
@@ -156,7 +156,7 @@ jobs:
           Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver start}
           sleep 10
           cd D:\a\oq-engine\oq-engine
-          set OQ_APPLICATION_MODE=aelo
-          set OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg
+          $Env:OQ_APPLICATION_MODE='aelo'
+          $Env:OQ_CONFIG_FILE='openquake\server\tests\data\openquake.cfg'
           # -v 2 also logs the test names
           python .\openquake\server\manage.py test -v 2 tests.test_aelo_mode

--- a/openquake/server/tests/test_public_mode.py
+++ b/openquake/server/tests/test_public_mode.py
@@ -31,6 +31,7 @@ import logging
 
 import django
 from django.test import Client
+from unittest import skipIf
 from openquake.baselib import config
 from openquake.commonlib.logs import dbcmd
 from openquake.engine.export import core
@@ -341,6 +342,7 @@ class EngineServerPublicModeTestCase(EngineServerTestCase):
         self.assertEqual(resp.content,
                          b'Please provide the "xml_text" parameter')
 
+    @skipIf(sys.platform == 'win32', 'Causing PermissionError on Windows')
     def test_check_fs_access(self):
         with tempfile.NamedTemporaryFile(buffering=0, prefix='oq-test_') as f:
             filename = f.name

--- a/openquake/server/tests/test_public_mode.py
+++ b/openquake/server/tests/test_public_mode.py
@@ -342,6 +342,8 @@ class EngineServerPublicModeTestCase(EngineServerTestCase):
         self.assertEqual(resp.content,
                          b'Please provide the "xml_text" parameter')
 
+    # NOTE: on_same_fs is an internal feature developed in the context of
+    # hybridge, so it is not a problem skipping it on windows
     @skipIf(sys.platform == 'win32', 'Causing PermissionError on Windows')
     def test_check_fs_access(self):
         with tempfile.NamedTemporaryFile(buffering=0, prefix='oq-test_') as f:


### PR DESCRIPTION
Environment variables were not set properly.
After investigating with Matteo, we decided to skip `test_check_fs_access` on Windows, causing a PermissionError on that operating system; it tests an internal feature that was intrduced in the context of hybridge.
Full tests on windows are running here: https://github.com/gem/oq-engine/actions/runs/6274496806/job/17040006648