### PR TITLE
Use GITHUB_REPOSITORY variable to install requirements from master in actions triggered by a fork

### DIFF
--- a/.github/workflows/engine_test.yml
+++ b/.github/workflows/engine_test.yml
@@ -15,6 +15,7 @@ jobs:
         python-version: ["3.10"]
     env:
       GITHUB_HEAD_REF:  ${{ github.head_ref }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python  ${{ matrix.python-version }}
@@ -23,7 +24,7 @@ jobs:
         python-version:  ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python install.py devel --version=$GITHUB_HEAD_REF
+        python install.py devel --version=$GITHUB_HEAD_REF --repository=$GITHUB_REPOSITORY
     - name: Calculators and documentation tests
       run: |
         source ~/openquake/bin/activate
@@ -38,7 +39,8 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10"]
     env:
-      GITHUB_HEAD_REF:  ${{ github.head_ref }}
+      GITHUB_HEAD_REF: ${{ github.head_ref }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python  ${{ matrix.python-version }}
@@ -47,7 +49,7 @@ jobs:
         python-version:  ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python install.py devel --version=$GITHUB_HEAD_REF
+        python install.py devel --version=$GITHUB_HEAD_REF --repository=$GITHUB_REPOSITORY
     - name: Hazardlib tests
       run: |
         source ~/openquake/bin/activate
@@ -65,6 +67,7 @@ jobs:
         python-version: ["3.10"]
     env:
       GITHUB_HEAD_REF:  ${{ github.head_ref }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python  ${{ matrix.python-version }}
@@ -73,7 +76,7 @@ jobs:
         python-version:  ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python install.py devel --version=$GITHUB_HEAD_REF
+        python install.py devel --version=$GITHUB_HEAD_REF --repository=$GITHUB_REPOSITORY
     - name: Server 'PUBLIC' mode tests
       run: |
         source ~/openquake/bin/activate
@@ -89,6 +92,7 @@ jobs:
         python-version: ["3.10"]
     env:
       GITHUB_HEAD_REF:  ${{ github.head_ref }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python  ${{ matrix.python-version }}
@@ -97,7 +101,7 @@ jobs:
         python-version:  ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python install.py devel --version=$GITHUB_HEAD_REF
+        python install.py devel --version=$GITHUB_HEAD_REF --repository=$GITHUB_REPOSITORY
     - name: Server 'READ_ONLY' mode tests
       run: |
         source ~/openquake/bin/activate
@@ -113,6 +117,7 @@ jobs:
         python-version: ["3.10"]
     env:
       GITHUB_HEAD_REF:  ${{ github.head_ref }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python  ${{ matrix.python-version }}
@@ -121,7 +126,7 @@ jobs:
         python-version:  ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python install.py devel --version=$GITHUB_HEAD_REF
+        python install.py devel --version=$GITHUB_HEAD_REF --repository=$GITHUB_REPOSITORY
     - name: Server 'AELO' mode tests
       run: |
         source ~/openquake/bin/activate

--- a/install.py
+++ b/install.py
@@ -537,7 +537,8 @@ if __name__ == '__main__':
     parser.add_argument("--dbport",
                         help="DbServer port (default 1907 or 1908)")
     parser.add_argument("--repository",
-                        help="gem/oq-engine or a fork",
+                        help=("The owner and repository name. For example,"
+                              " 'gem/oq-engine' or 'forkowner/oq-engine'"),
                         default='gem/oq-engine')
     args = parser.parse_args()
     if args.inst:

--- a/install.py
+++ b/install.py
@@ -338,7 +338,7 @@ def fix_version(commit, venv):
         f.write(''.join(lines))
 
 
-def install(inst, version, repository='gem/oq-engine'):
+def install(inst, version, repository):
     """
     Install the engine in one of the three possible modes
     """
@@ -548,6 +548,6 @@ if __name__ == '__main__':
         if args.remove:
             remove(inst)
         else:
-            install(inst, args.version)
+            install(inst, args.version, args.repository)
     else:
         sys.exit("Please specify the kind of installation")

--- a/install.py
+++ b/install.py
@@ -204,10 +204,12 @@ def ensure(pip=None, pyvenv=None):
                    % sys.executable))
 
 
-def get_branch(version, inst):
+def get_requirements_branch(version, inst, repository):
     """
     Convert "version" into a branch name
     """
+    if repository != 'gem/oq-engine':
+        return 'master'
     if version is None:
         if (inst is devel or inst is devel_server):
             return 'master'
@@ -336,7 +338,7 @@ def fix_version(commit, venv):
         f.write(''.join(lines))
 
 
-def install(inst, version):
+def install(inst, version, repository='gem/oq-engine'):
     """
     Install the engine in one of the three possible modes
     """
@@ -383,7 +385,7 @@ def install(inst, version):
                                    'pip', 'wheel'])
 
     # install the requirements
-    branch = get_branch(version, inst)
+    branch = get_requirements_branch(version, inst, repository)
     if sys.platform == 'darwin':
         mac = '_' + platform.machine(),  # x86_64 or arm64
     else:
@@ -534,6 +536,9 @@ if __name__ == '__main__':
                         help="version to install (default stable)")
     parser.add_argument("--dbport",
                         help="DbServer port (default 1907 or 1908)")
+    parser.add_argument("--repository",
+                        help="gem/oq-engine or a fork",
+                        default='gem/oq-engine')
     args = parser.parse_args()
     if args.inst:
         inst = globals()[args.inst]


### PR DESCRIPTION
This way, from a fork, requirements will always be read from master (i.e. we don't accept changes in the requirements from forks).