### PR TITLE
Always get requirements from master while installing from a fork but not from a different repository

### DIFF
--- a/install.py
+++ b/install.py
@@ -208,8 +208,13 @@ def get_requirements_branch(version, inst, repository):
     """
     Convert "version" into a branch name
     """
-    if repository != 'gem/oq-engine':
+    repository_owner, repository_name = repository.split('/')
+    # in forks of oq-engine, always read requirements from master
+    if (repository_owner != 'gem' and repository_name == 'oq-engine'):
         return 'master'
+    # in cases such as 'install.py user', for instance while running tests from
+    # another gem repository, we need requirements to be read from the latest
+    # stable version unless differently specified.
     if version is None:
         if (inst is devel or inst is devel_server):
             return 'master'

--- a/install.py
+++ b/install.py
@@ -210,7 +210,7 @@ def get_requirements_branch(version, inst, repository):
     """
     repository_owner, repository_name = repository.split('/')
     # in forks of oq-engine, always read requirements from master
-    if (repository_owner != 'gem' and repository_name == 'oq-engine'):
+    if repository_owner != 'gem' and repository_name == 'oq-engine':
         return 'master'
     # in cases such as 'install.py user', for instance while running tests from
     # another gem repository, we need requirements to be read from the latest


### PR DESCRIPTION
Otherwise we would have a mismatch e.g. when running tests from another gem repository installing the engine with `python install.py user` (in that case we need to get the requirements from the latest stable release instead)