### PR TITLE
AELO: hide hmaps and realizations from outputs page and make vs30 input field readonly

### DIFF
--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -40,6 +40,11 @@
       </thead>
       <tbody>
         <% _.each(outputs, function(output) { %>
+        {% if application_mode == 'AELO' %}
+        <% if (output.get('type') == 'hmaps' || output.get('type') == 'realizations') { %>
+        <%   return; // works like continue in underscore.js %>
+        <% }%>
+        {% endif %}
         <tr class="success">
           <td><%= output.get('id') || 'New' %></td>
           <td><%= output.get('name') %></td>

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -41,7 +41,7 @@
       <tbody>
         <% _.each(outputs, function(output) { %>
         {% if application_mode == 'AELO' %}
-        <% if (output.get('type') == 'hmaps' || output.get('type') == 'realizations') { %>
+        <% if (['hmaps', 'realizations'].indexOf(output.get('type')) >= 0) { %>
         <%   return; // works like continue in underscore.js %>
         <% }%>
         {% endif %}

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -37,7 +37,7 @@
               <!-- <label for"lon">Longitude:</label> -->
               <input type="text" id="lon" name="lon" placeholder="{{ aelo_form_placeholders.lon }}"/>
               <!-- <label for"vs30">Vs30:</label> -->
-              <input type="text" id="vs30" name="vs30" placeholder="{{ aelo_form_placeholders.vs30 }}"/>
+              <input type="text" id="vs30" name="vs30" placeholder="{{ aelo_form_placeholders.vs30 }}" readonly />
               <!-- <label for"siteid">Site ID:</label> -->
               <input type="text" id="siteid" name="siteid" placeholder="{{ aelo_form_placeholders.siteid }}"/>
               <button id="submit_aelo_calc" type="submit" class="btn">Submit</button>

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -958,12 +958,14 @@ def web_engine(request, **kwargs):
 @cross_domain_ajax
 @require_http_methods(['GET'])
 def web_engine_get_outputs(request, calc_id, **kwargs):
+    application_mode = settings.APPLICATION_MODE.upper()
     job = logs.dbcmd('get_job', calc_id)
     with datastore.read(job.ds_calc_dir + '.hdf5') as ds:
         hmaps = 'png' in ds
     size_mb = '?' if job.size_mb is None else '%.2f' % job.size_mb
     return render(request, "engine/get_outputs.html",
-                  dict(calc_id=calc_id, size_mb=size_mb, hmaps=hmaps))
+                  dict(calc_id=calc_id, size_mb=size_mb, hmaps=hmaps,
+                       application_mode=application_mode))
 
 
 @csrf_exempt


### PR DESCRIPTION
As requested by Nico. Part of https://github.com/gem/oq-engine/issues/9043.