### PR TITLE
Do not allow all users to see other users outputs by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Paolo Tormene]
+  * In the WebUI users are not allowed to see other users outputs by default
+    (the old default can be obtained setting ACL_ON = False)
+
   [Manuela Villani, Michele Simionato]
   * Computed ASCE-41 outputs for AELO project
 

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -111,8 +111,8 @@ MIDDLEWARE = (
 
 # Authentication is not enabled by default
 LOCKDOWN = False
-# Allow all users to see other users outputs by default
-ACL_ON = False
+# Forbid users to see other users outputs by default
+ACL_ON = True
 
 # Add additional paths (as regular expressions) that don't require
 # authentication.


### PR DESCRIPTION
This is crucial in AELO mode, but it is a safer setting in general.
@antonioettorre for your information, after this change, if we want to allow all users to see other users outputs (e.g. in one of our clusters), we need to set `ACL_ON = False` in `local_settings.py`.