### PR TITLE
Make the calculator tests parallelizable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto
 *.xml text eol=lf
-*.csv text eol=crlf
+#*.csv text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto
 *.xml text eol=lf
-#*.csv text eol=crlf
+*.csv text eol=crlf

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1217,6 +1217,8 @@ def import_gmfs_hdf5(dstore, oqparam):
     :param oqparam: an OqParam instance
     :returns: event_ids
     """
+    # NB: you cannot access an external link if the file it points to is already open,
+    # therefore you cannot run in parallel two calculations starting from the same GMFs
     dstore['gmf_data'] = h5py.ExternalLink(oqparam.inputs['gmfs'], "gmf_data")
     attrs = _getset_attrs(oqparam)
     oqparam.hazard_imtls = {imt: [0] for imt in attrs['imts']}

--- a/openquake/calculators/tests/__init__.py
+++ b/openquake/calculators/tests/__init__.py
@@ -138,8 +138,7 @@ class CalculatorTestCase(unittest.TestCase):
         oq = oqvalidation.OqParam(**params)
         oq._input_files = readinput.get_input_files(oq)
         oq.validate()
-        # change this when debugging the test
-        log = logs.init('calc', params)
+        log = logs.init('job', params)
         return base.calculators(oq, log.calc_id)
 
     def run_calc(self, testfile, job_ini, **kw):

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -593,7 +593,10 @@ agg_id
 
 class ReinsuranceTestCase(CalculatorTestCase):
 
-    def test_no_reinsurance(self):
+    def test_reinsurance(self):
+        # many tests have to be kept together since the parallelization
+        # does not work with h5py.ExternalLink (used here to read gmfs.hdf5)
+
         rf = "{'structural+nonstructural': 'no_reinsurance.xml'}"
         self.run_calc(reinsurance_1.__file__, 'job.ini', reinsurance_file=rf)
         [fname] = export(('reinsurance-risk_by_event', 'csv'),
@@ -601,7 +604,7 @@ class ReinsuranceTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/no_reinsurance-risk_by_event.csv',
                               fname, delta=1E-5)
 
-    def test_prop(self):
+        # test prop
         rf = "{'structural+nonstructural': 'reinsurance_prop.xml'}"
         self.run_calc(reinsurance_1.__file__, 'job.ini', reinsurance_file=rf)
         [fname] = export(('reinsurance-risk_by_event', 'csv'),
@@ -612,7 +615,7 @@ class ReinsuranceTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/reinsurance-aggcurves_prop.csv', fname,
                               delta=1E-5)
 
-    def test_nonprop(self):
+        # test nonprop
         rf = "{'structural+nonstructural': 'reinsurance_np.xml'}"
         self.run_calc(reinsurance_1.__file__, 'job.ini', reinsurance_file=rf)
         [fname] = export(('reinsurance-risk_by_event', 'csv'),
@@ -623,7 +626,7 @@ class ReinsuranceTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/reinsurance-aggcurves_np.csv', fname,
                               delta=1E-5)
 
-    def test_prop_nonprop(self):
+        # test_prop_nonprop
         self.run_calc(reinsurance_1.__file__, 'job.ini')
         [fname] = export(('reinsurance-risk_by_event', 'csv'),
                          self.calc.datastore)
@@ -637,14 +640,7 @@ class ReinsuranceTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/reinsurance-avg_portfolio.csv',
                               fname, delta=1E-5)
 
-    def test_overspill_with_xlwr(self):
-        self.run_calc(reinsurance_3.__file__, 'job.ini')
-        [fname] = export(('reinsurance-risk_by_event', 'csv'),
-                         self.calc.datastore)
-        self.assertEqualFiles('expected/reinsurance-risk_by_event.csv',
-                              fname, delta=5E-5)
-
-    def test_many_levels(self):
+        # test_many_levels
         self.run_calc(reinsurance_1.__file__, 'job2.ini')
         [fname] = export(('reinsurance-risk_by_event', 'csv'),
                          self.calc.datastore)
@@ -661,6 +657,13 @@ class ReinsuranceTestCase(CalculatorTestCase):
                          self.calc.datastore)
         self.assertEqualFiles('expected/reinsurance-avg_policy.csv',
                               fname, delta=1E-5)
+
+    def test_overspill_with_xlwr(self):
+        self.run_calc(reinsurance_3.__file__, 'job.ini')
+        [fname] = export(('reinsurance-risk_by_event', 'csv'),
+                         self.calc.datastore)
+        self.assertEqualFiles('expected/reinsurance-risk_by_event.csv',
+                              fname, delta=5E-5)
 
     def test_post_risk(self):
         # calculation from a source model producing 4 events

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -593,7 +593,7 @@ agg_id
 
 class ReinsuranceTestCase(CalculatorTestCase):
 
-    def test_reinsurance(self):
+    def test_reinsurance_gmfs(self):
         # many tests have to be kept together since the parallelization
         # does not work with h5py.ExternalLink (used here to read gmfs.hdf5)
 

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -293,8 +293,8 @@ class RunShowExportTestCase(unittest.TestCase):
     def test_export_calc(self):
         tempdir = tempfile.mkdtemp()
         with Print.patch() as p:
-            sap.runline('openquake.commands export hcurves -e csv '
-                        f'--export-dir={tempdir}')
+            sap.runline(f'openquake.commands export hcurves {self.calc_id}'
+                        f' -e csv --export-dir={tempdir}')
         fnames = os.listdir(tempdir)
         self.assertIn(str(fnames[0]), str(p))
         shutil.rmtree(tempdir)

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -29,6 +29,7 @@ from openquake.commonlib.logs import (
     get_datadir, get_calc_ids, get_last_calc_id, CALC_REGEX, dbcmd, init)
 
 
+# FIXME: you should never use this
 def hdf5new(datadir=None):
     """
     Return a new `hdf5.File by` instance with name determined by the last
@@ -77,18 +78,9 @@ def _read(calc_id: int, datadir, mode, haz_id=None):
     # low level function to read a datastore file
     ddir = datadir or get_datadir()
     ppath = None
-    if calc_id < 0:  # look at the old calculations of the current user
-        calc_ids = get_calc_ids(ddir)
-        try:
-            jid = calc_ids[calc_id]
-        except IndexError:
-            raise IndexError(
-                'There are %d old calculations, cannot '
-                'retrieve the %s' % (len(calc_ids), calc_id))
-    else:
-        jid = calc_id
     # look in the db
-    job = dbcmd('get_job', jid)
+    job = dbcmd('get_job', calc_id)
+    jid = job.id
     if job:
         path = job.ds_calc_dir + '.hdf5'
         hc_id = job.hazard_calculation_id
@@ -153,7 +145,7 @@ def build_dstore_log(description='custom calculation', parent=()):
     :returns: DataStore instance associated to the .calc_id
     """
     dic = dict(description=description, calculation_mode='custom')
-    log = init('calc', dic)
+    log = init('job', dic)
     dstore = new(log.calc_id, log.get_oqparam(validate=False))
     dstore.parent = parent
     return dstore, log

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -274,10 +274,10 @@ class LogContext:
                                       self.calc_id, hc_id)
 
 
-def init(job_or_calc, job_ini, log_level='info', log_file=None,
+def init(dummy, job_ini, log_level='info', log_file=None,
          user_name=None, hc_id=None, host=None, tag=''):
     """
-    :param job_or_calc: the string "job" or "calcXXX"
+    :param dummy: ignored parameter, exists for backward compatibility
     :param job_ini: path to the job.ini file or dictionary of parameters
     :param log_level: the log level as a string or number
     :param log_file: path to the log file (if any)
@@ -292,13 +292,5 @@ def init(job_or_calc, job_ini, log_level='info', log_file=None,
     3. create a job in the database if job_or_calc == "job"
     4. return a LogContext instance associated to a calculation ID
     """
-    assert job_or_calc != 'calc'
-    if job_or_calc == "job":
-        calc_id = 0
-    elif job_or_calc.startswith("calc"):
-        1/0
-        calc_id = int(job_or_calc[4:])
-    else:
-        raise ValueError(job_or_calc)
-    return LogContext(job_ini, calc_id, log_level, log_file,
+    return LogContext(job_ini, 0, log_level, log_file,
                       user_name, hc_id, host, tag)

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -204,14 +204,15 @@ class LogContext:
         if hc_id:
             self.params['hazard_calculation_id'] = hc_id
         if calc_id == 0:
+            datadir = get_datadir()
             self.calc_id = dbcmd(
-                'create_job',
-                get_datadir(),
+                'create_job', datadir,
                 self.params['calculation_mode'],
                 self.params.get('description', 'test'),
-                user_name,
-                hc_id,
-                host)
+                user_name, hc_id, host)
+            path = os.path.join(datadir, 'calc_%d.hdf5' % self.calc_id)
+            if os.path.exists(path):  # sanity check on the calculation ID
+                raise RuntimeError('There is a pre-existing file %s' % path)
             self.usedb = True
         elif calc_id == -1:
             # only works in single-user situations

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -292,11 +292,11 @@ def init(job_or_calc, job_ini, log_level='info', log_file=None,
     3. create a job in the database if job_or_calc == "job"
     4. return a LogContext instance associated to a calculation ID
     """
+    assert job_or_calc != 'calc'
     if job_or_calc == "job":
         calc_id = 0
-    elif job_or_calc == "calc":
-        calc_id = -1
     elif job_or_calc.startswith("calc"):
+        1/0
         calc_id = int(job_or_calc[4:])
     else:
         raise ValueError(job_or_calc)

--- a/openquake/commonlib/tests/datastore_test.py
+++ b/openquake/commonlib/tests/datastore_test.py
@@ -33,7 +33,8 @@ class DataStoreTestCase(unittest.TestCase):
     def setUp(self):
         log = logs.init(
             "job", {'calculation_mode': 'scenario', 'sites': '0 0'})
-        self.dstore = datastore.new(log.calc_id, log.get_oqparam())
+        with log:
+            self.dstore = datastore.new(log.calc_id, log.get_oqparam())
 
     def tearDown(self):
         self.dstore.close()

--- a/openquake/commonlib/tests/datastore_test.py
+++ b/openquake/commonlib/tests/datastore_test.py
@@ -78,27 +78,6 @@ class DataStoreTestCase(unittest.TestCase):
         mo = re.search(r'hello_\d+', path)
         self.assertIsNotNone(mo)
 
-    def test_read(self):
-        # windows does not manage permissions properly. Skip the test
-        if sys.platform == 'win32':
-            raise unittest.SkipTest('Windows')
-
-        # case of a non-existing directory
-        with self.assertRaises(OSError):
-            datastore.read(42, 'r', '/fake/directory')
-        # case of a non-existing file
-        with self.assertRaises(IOError):
-            datastore.read(42, 'r', '/tmp')
-        # case of no read permission
-        tmp = tempfile.mkdtemp()
-        fname = os.path.join(tmp, 'calc_42.hdf5')
-        open(fname, 'w').write('')
-        os.chmod(fname, 0)
-        with self.assertRaises(IOError) as ctx:
-            datastore.read(42, 'r', tmp)
-        self.assertIn('permission denied', str(ctx.exception).lower())
-        os.remove(fname)
-
     def test_store_retrieve_files(self):
         fnames = []
         for cwd, dirs, files in os.walk(os.path.dirname(__file__)):

--- a/openquake/commonlib/tests/datastore_test.py
+++ b/openquake/commonlib/tests/datastore_test.py
@@ -41,7 +41,8 @@ class DataStoreTestCase(unittest.TestCase):
 
     def test_hdf5(self):
         # store numpy arrays as hdf5 files
-        self.assertEqual(len(self.dstore), 4)
+        lst = ['oqparam', 'performance_data', 'task_info', 'task_sent']
+        self.assertEqual(sorted(self.dstore), lst)
         # performance_data, task_info, task_sent
         self.dstore['/key1'] = value1 = numpy.array(['a', 'b'], dtype=bytes)
         self.dstore['/key2'] = numpy.array([1, 2])

--- a/openquake/engine/tests/aelo_test.py
+++ b/openquake/engine/tests/aelo_test.py
@@ -46,7 +46,7 @@ def test_CCA():
     job_ini = os.path.join(MOSAIC_DIR, 'CCA/in/job_vs30.ini')
     for (site, lon, lat), expected in zip(SITES, EXPECTED):
         dic = dict(lon=lon, lat=lat, site=site, vs30='760')
-        with logs.init('calc', job_ini) as log:
+        with logs.init('job', job_ini) as log:
             log.params.update(get_params_from(dic, MOSAIC_DIR))
             calc = base.calculators(log.get_oqparam(), log.calc_id)
             calc.run()

--- a/openquake/hazardlib/tests/calc/mrd_test.py
+++ b/openquake/hazardlib/tests/calc/mrd_test.py
@@ -24,7 +24,6 @@ from openquake.baselib.performance import Monitor
 from openquake.hazardlib.calc.mrd import (
     update_mrd, get_uneven_bins_edges, calc_mean_rate_dist)
 from openquake.hazardlib.contexts import read_cmakers, read_ctx_by_grp
-from openquake.commonlib import datastore
 from openquake.hazardlib.cross_correlation import BakerJayaram2008
 
 PLOT = False
@@ -40,7 +39,7 @@ class MRD01TestCase(unittest.TestCase):
         from openquake.calculators import base
 
         job_ini = os.path.join(CWD, 'expected', 'mrd', 'job.ini')
-        with logs.init('calc', job_ini) as log:
+        with logs.init('job', job_ini) as log:
             calc = base.calculators(log.get_oqparam(), log.calc_id)
             calc.run()
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -113,9 +113,10 @@ def create_job(db, datadir, calculation_mode='to be set',
                user_name=user_name or getpass.getuser(),
                calculation_mode=calculation_mode,
                ds_calc_dir=datadir, hazard_calculation_id=hc_id, host=host)
-    job_id = db('INSERT INTO job (?S) VALUES (?X)', job.keys(), job.values()).lastrowid
+    job_id = db('INSERT INTO job (?S) VALUES (?X)', job.keys(), job.values()
+                ).lastrowid
     db('UPDATE job SET ds_calc_dir=?x WHERE id=?x',
-       os.path.join(datadir, 'calc_%s' % job_id), job_id)
+       os.path.join(datadir, 'calc_%s.hdf5' % job_id), job_id)
     return job_id
 
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -108,16 +108,15 @@ def create_job(db, datadir, calculation_mode='to be set',
     :returns:
         the job ID
     """
-    calc_id = get_calc_id(db, datadir) + 1
     # NB: is_running=1 is needed to make views_test.py happy on Jenkins
-    job = dict(id=calc_id, is_running=1, description=description,
+    job = dict(is_running=1, description=description,
                user_name=user_name or getpass.getuser(),
                calculation_mode=calculation_mode,
-               hazard_calculation_id=hc_id,
-               ds_calc_dir=os.path.join(datadir, 'calc_%s' % calc_id),
-               host=host)
-    return db('INSERT INTO job (?S) VALUES (?X)',
-              job.keys(), job.values()).lastrowid
+               ds_calc_dir=datadir, hazard_calculation_id=hc_id, host=host)
+    job_id = db('INSERT INTO job (?S) VALUES (?X)', job.keys(), job.values()).lastrowid
+    db('UPDATE job SET ds_calc_dir=?x WHERE id=?x',
+       os.path.join(datadir, 'calc_%s' % job_id), job_id)
+    return job_id
 
 
 def import_job(db, calc_id, calc_mode, description, user_name, status,
@@ -180,27 +179,6 @@ def get_job(db, job_id, username=None):
         return
     else:
         return joblist[-1]
-
-
-def get_calc_id(db, datadir, job_id=None):
-    """
-    Return the latest calc_id by looking both at the datastore
-    and the database.
-
-    :param db: a :class:`openquake.commonlib.dbapi.Db` instance
-    :param datadir: the directory containing the datastores
-    :param job_id: a job ID; if None, returns the latest job ID
-    """
-    from openquake.commonlib import datastore  # avoid circular import
-    calcs = datastore.get_calc_ids(datadir)
-    calc_id = 0 if not calcs else calcs[-1]
-    if job_id is None:
-        try:
-            job_id = db('SELECT seq FROM sqlite_sequence WHERE name="job"',
-                        scalar=True)
-        except NotFound:
-            job_id = 0
-    return max(calc_id, job_id)
 
 
 def get_weight(db, job_id):


### PR DESCRIPTION
This is a spectacular improvement since I can finally run all tests locally in 1.5 minutes rather than waiting 20+ minutes for the actions. The trick is to install pytest-xdist and then run
```
$ pytest openquake/calculators -n auto
```