### PR TITLE
Optimized the calculation of quantile hazard maps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,13 +1,19 @@
+  [Michele Simionato]
+  * Optimized the calculation of quantile hazard maps (7x)
+  * Internal: stored `_rates` instead of `_poes` in classical calculations
+
   [Lana Todorovic, Anirudh Rao]
-  * Added several regional liquefaction models to the secondary perils module, including:
-    ZhuEtAl2017LiquefactionCoastal and ZhuEtAl2017LiquefactionGeneral, 
+  * Added several regional liquefaction models to the secondary perils module,
+    including:
+    ZhuEtAl2017LiquefactionCoastal and ZhuEtAl2017LiquefactionGeneral,
     RashidianBaise2020Liquefaction, AllstadtEtAl2022Liquefaction,
-    AkhlagiEtAl2021LiquefactionA and AkhlagiEtAl2021LiquefactionB (experimental),
+    AkhlagiEtAl2021LiquefactionA and AkhlagiEtAl2021LiquefactionB
+    (experimental),
     Bozzoni2021LiquefactionEurope, TodorovicSilva2022NonParametric
   * Added new site parameters required by some of these new models to site.py
-  * Added LiqOccur as a valid IMT, referring to the occurrence or non-occurrence 
-    of liquefaction at a site
-  * Added basic documentation for the secondary perils module 
+  * Added LiqOccur as a valid IMT, referring to the occurrence or
+    non-occurrence of liquefaction at a site
+  * Added basic documentation for the secondary perils module
     (originally written by @cossatot and extended by @LanaTodorovic93)
   * Added rock-slope co-seismic failure computation of Grant et al. (2016)
 

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -203,7 +203,7 @@ def quantile_curve(quantile, curves, weights=None):
         assert len(weights) == R, (len(weights), R)
     result = numpy.zeros(curves.shape[1:])
     for idx, _ in numpy.ndenumerate(result):
-        data = numpy.array([a[idx] for a in curves])
+        data = curves[(slice(None), ) + idx]
         sorted_idxs = numpy.argsort(data)
         cum_weights = numpy.cumsum(weights[sorted_idxs])
         # get the quantile from the interpolated CDF


### PR DESCRIPTION
There is a 7x speedup for EUR:
```
# before
| ncalls      | cumtime | path                                        |
|-------------+---------+---------------------------------------------|
| 4614        | 188.384 | stats.py:177(quantile_curve)                |
| 1661040     | 121.965 | stats.py:206(<listcomp>)                    |
| 3326131     | 17.056  | fromnumeric.py:51(_wrapfunc)                |
| 1661065     | 11.506  | fromnumeric.py:1012(argsort)                |
| 1538        | 6.843   | getters.py:220(get_hcurve)                  |

# after
| ncalls      | cumtime | path                                        |
|-------------+---------+---------------------------------------------|
| 4614        | 27.579  | stats.py:177(quantile_curve)                |
| 3326131     | 15.649  | fromnumeric.py:51(_wrapfunc)                |
| 1661065     | 10.250  | fromnumeric.py:1012(argsort)                |
| 1538        | 6.613   | getters.py:220(get_hcurve)                  |
```