### PR TITLE
Speeding up count_ruptures in event_based

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Speeding up `count_ruptures` for multifault sources, which gives a *huge*
+    in some calculations (like event_based for Dominican Republic)
+
   [Marco Pagani]
   * Fixed a bug in the code that resamples a line, with a small effect
     on the hazard of models containing simple fault sources

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -396,6 +396,7 @@ class EventBasedCalculator(base.HazardCalculator):
         Prefilter the composite source model and store the source_info
         """
         oq = self.oqparam
+        logging.info('Counting the ruptures in the CompositeSourceModel')
         self.csm.fix_src_offset()  # NB: essential
         sources = self.csm.get_sources()
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -396,22 +396,21 @@ class EventBasedCalculator(base.HazardCalculator):
         Prefilter the composite source model and store the source_info
         """
         oq = self.oqparam
-        logging.info('Counting the ruptures in the CompositeSourceModel')
-        self.csm.fix_src_offset()  # NB: essential
         sources = self.csm.get_sources()
 
-        # weighting the heavy sources
+        logging.info('Counting the ruptures in the CompositeSourceModel')
         self.datastore.swmr_on()
-        nrups = parallel.Starmap(
-            count_ruptures, [(src,) for src in sources if src.code in b'AMC'],
+        nrups = parallel.Starmap( # weighting the heavy sources
+            count_ruptures, [(src,) for src in sources if src.code != b'P'],
             progress=logging.debug
         ).reduce()
         for src in sources:
             try:
                 src.num_ruptures = nrups[src.source_id]
-            except KeyError:  # light source
+            except KeyError:  # point source
                 src.num_ruptures = src.count_ruptures()
             src.weight = src.num_ruptures
+        self.csm.fix_src_offset()  # NB: essential
         maxweight = sum(sg.weight for sg in self.csm.src_groups) / (
             self.oqparam.concurrent_tasks or 1)
         eff_ruptures = AccumDict(accum=0)  # grp_id => potential ruptures

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -92,6 +92,8 @@ class AreaSource(ParametricSeismicSource):
         :meth:`openquake.hazardlib.source.base.BaseSeismicSource.count_ruptures`
         for description of parameters and return value.
         """
+        if self.num_ruptures:
+            return self.num_ruptures
         polygon_mesh = self.polygon.discretize(self.area_discretization)
         return (len(polygon_mesh) *
                 len(self.get_annual_occurrence_rates()) *

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -217,6 +217,8 @@ class ComplexFaultSource(ParametricSeismicSource):
         See :meth:
         `openquake.hazardlib.source.base.BaseSeismicSource.count_ruptures`.
         """
+        if self.num_ruptures:
+            return self.num_ruptures
         whole_fault_surface = ComplexFaultSurface.from_fault_data(
             self.edges, self.rupture_mesh_spacing)
         whole_fault_mesh = whole_fault_surface.mesh
@@ -248,8 +250,7 @@ class ComplexFaultSource(ParametricSeismicSource):
         if len(mag_rates) == 1:  # not splittable
             yield self
             return
-        if not hasattr(self, '_nr'):
-            self.count_ruptures()
+        self.count_ruptures()
         for i, (mag, rate) in enumerate(mag_rates):
             src = copy.copy(self)
             src.mfd = mfd.ArbitraryMFD([mag], [rate])

--- a/openquake/hazardlib/source/kite_fault.py
+++ b/openquake/hazardlib/source/kite_fault.py
@@ -200,22 +200,20 @@ class KiteFaultSource(ParametricSeismicSource):
 
             # Get the geometry of all the ruptures that the fault surface
             # accommodates
-            triples = []
-            for triple in self._gen_triples(surface.mesh, rup_len, rup_wid,
-                                         f_strike=fstrike, f_dip=fdip):
-                triples.append(triple)
-            if len(triples) < 1:
+            surfaces = list(self._gen_surfaces(surface.mesh, rup_len, rup_wid,
+                                               f_strike=fstrike, f_dip=fdip))
+            if len(surfaces) < 1:
                 continue
-            occurrence_rate = mag_occ_rate / len(triples)
+            occurrence_rate = mag_occ_rate / len(surfaces)
 
             # Rupture generator
-            for surf, j, i in triples[::step]:
+            for surf in surfaces[::step]:
                 hypocenter = surf.get_center()
                 # Yield an instance of a ParametricProbabilisticRupture
                 yield ppr(mag, self.rake, self.tectonic_region_type,
                           hypocenter, surf, occurrence_rate, tom)
 
-    def _gen_triples(self, omsh, rup_s, rup_d, f_strike=1, f_dip=1):
+    def _gen_surfaces(self, omsh, rup_s, rup_d, f_strike=1, f_dip=1):
         # Returns all the surfaces admitted by a given geometry i.e. number of
         # nodes along strike and dip
 
@@ -234,7 +232,7 @@ class KiteFaultSource(ParametricSeismicSource):
         #     A tuple containing the surface and the indexes of the top right
         #     node of the mesh representing the rupture.
         for msh, j, i in _gen_meshes(omsh, rup_s, rup_d, f_strike, f_dip):
-            yield KiteSurface(msh), j, i
+            yield KiteSurface(msh)
 
     def get_fault_surface_area(self) -> float:
         """

--- a/openquake/hazardlib/source/kite_fault.py
+++ b/openquake/hazardlib/source/kite_fault.py
@@ -168,16 +168,14 @@ class KiteFaultSource(ParametricSeismicSource):
         # Set magnitude scaling relationship, temporal occurrence model and
         # mesh of the fault surface
         step = kwargs.get('step', 1)
-        for mag, mag_occ_rate, meshes in self._gen_meshes(step):
-            if len(meshes):
-                occurrence_rate = mag_occ_rate / len(meshes)
-                for msh in meshes[::step]:
-                    surf = KiteSurface(msh)
-                    hypocenter = surf.get_center()
-                    # Yield an instance of a ParametricProbabilisticRupture
-                    yield ppr(mag, self.rake, self.tectonic_region_type,
-                              hypocenter, surf, occurrence_rate,
-                              self.temporal_occurrence_model)
+        for mag, occ_rate, meshes in self._gen_meshes(step):
+            for msh in meshes[::step]:
+                surf = KiteSurface(msh)
+                hypocenter = surf.get_center()
+                # Yield an instance of a ParametricProbabilisticRupture
+                yield ppr(mag, self.rake, self.tectonic_region_type,
+                          hypocenter, surf, occ_rate,
+                          self.temporal_occurrence_model)
 
     def _gen_meshes(self, step=1):
         surface = self.surface
@@ -215,7 +213,8 @@ class KiteFaultSource(ParametricSeismicSource):
             # Get the geometry of all the ruptures that the fault surface
             # accommodates
             meshes = _get_meshes(surface.mesh, rup_len, rup_wid, fstrike, fdip)
-            yield mag, mag_occ_rate, meshes
+            if len(meshes):
+                yield mag, mag_occ_rate / len(meshes), meshes
 
     def get_fault_surface_area(self) -> float:
         """

--- a/openquake/hazardlib/source/kite_fault.py
+++ b/openquake/hazardlib/source/kite_fault.py
@@ -151,9 +151,9 @@ class KiteFaultSource(ParametricSeismicSource):
         self._rupture_count = collections.Counter()
         self._rupture_rates = collections.Counter()
         for rup in self.iter_ruptures():
-            mag_lab = '{:.2f}'.format(rup.mag)
-            self._rupture_count[mag_lab] += 1
-            self._rupture_rates[mag_lab] += rup.occurrence_rate
+            mag_str = '{:.2f}'.format(rup.mag)
+            self._rupture_count[mag_str] += 1
+            self._rupture_rates[mag_str] += rup.occurrence_rate
 
         return sum(self._rupture_count.values())
 
@@ -250,13 +250,13 @@ class KiteFaultSource(ParametricSeismicSource):
         if len(self._rupture_rates) == 1:  # not splittable
             yield self
             return
-        for mag_lab in self._rupture_count:
-            if self._rupture_rates[mag_lab] == 0:
+        for mag_str in self._rupture_count:
+            if self._rupture_rates[mag_str] == 0:
                 continue
             src = copy.copy(self)
-            mag = float(mag_lab)
-            src.mfd = mfd.ArbitraryMFD([mag], [self._rupture_rates[mag_lab]])
-            src.num_ruptures = self._rupture_count[mag_lab]
+            mag = float(mag_str)
+            src.mfd = mfd.ArbitraryMFD([mag], [self._rupture_rates[mag_str]])
+            src.num_ruptures = self._rupture_count[mag_str]
             yield src
 
     @property

--- a/openquake/hazardlib/source/kite_fault.py
+++ b/openquake/hazardlib/source/kite_fault.py
@@ -153,11 +153,11 @@ class KiteFaultSource(ParametricSeismicSource):
         # Counting ruptures and rates
         self._rupture_count = collections.Counter()
         self._rupture_rates = collections.Counter()
-        for rup in self.iter_ruptures():
-            mag_str = '{:.2f}'.format(rup.mag)
-            self._rupture_count[mag_str] += 1
-            self._rupture_rates[mag_str] += rup.occurrence_rate
-
+        for mag, occ_rate, meshes in self._gen_meshes():
+            n = len(meshes)
+            mag_str = '{:.2f}'.format(mag)
+            self._rupture_count[mag_str] += n
+            self._rupture_rates[mag_str] += occ_rate * n
         return sum(self._rupture_count.values())
 
     def iter_ruptures(self, **kwargs):

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -202,6 +202,8 @@ class SimpleFaultSource(ParametricSeismicSource):
         See :meth:
         `openquake.hazardlib.source.base.BaseSeismicSource.count_ruptures`.
         """
+        if self.num_ruptures:
+            return self.num_ruptures
         whole_fault_surface = SimpleFaultSurface.from_fault_data(
             self.fault_trace, self.upper_seismogenic_depth,
             self.lower_seismogenic_depth, self.dip, self.rupture_mesh_spacing)
@@ -328,8 +330,7 @@ class SimpleFaultSource(ParametricSeismicSource):
         if len(mag_rates) == 1:  # not splittable
             yield self
             return
-        if not hasattr(self, '_nr'):
-            self.count_ruptures()
+        self.count_ruptures()
         for i, (mag, rate) in enumerate(mag_rates):
             # This is needed in order to reproduce the logic in the
             # `rupture_count` method


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/9066. This is tripling the speed of an example calculation I have:
```
# before
| calc_15024, maxmem=5.5 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total sample_ruptures      | 196.3    | 30.4      | 42     |
| EventBasedCalculator.run   | 368.8    | 603.4     | 1      |

# after
| calc_15023, maxmem=6.1 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total sample_ruptures      | 198.1    | 6.00000   | 42     |
| EventBasedCalculator.run   | 137.1    | 603.2     | 1      |
```