### PR TITLE
Restored ds_calc_dir as it was

### DIFF
--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -82,7 +82,7 @@ def _read(calc_id: int, datadir, mode, haz_id=None):
     job = dbcmd('get_job', calc_id)
     if job:
         jid = job.id
-        path = job.ds_calc_dir
+        path = job.ds_calc_dir + '.hdf5'
         hc_id = job.hazard_calculation_id
         if not hc_id and haz_id:
             dbcmd('update_job', jid, {'hazard_calculation_id': haz_id})
@@ -90,7 +90,7 @@ def _read(calc_id: int, datadir, mode, haz_id=None):
         if hc_id and hc_id != jid:
             hc = dbcmd('get_job', hc_id)
             if hc:
-                ppath = hc.ds_calc_dir
+                ppath = hc.ds_calc_dir + '.hdf5'
             else:
                 ppath = os.path.join(ddir, 'calc_%d.hdf5' % hc_id)
     else:  # when using oq run there is no job in the db

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -116,7 +116,7 @@ def create_job(db, datadir, calculation_mode='to be set',
     job_id = db('INSERT INTO job (?S) VALUES (?X)', job.keys(), job.values()
                 ).lastrowid
     db('UPDATE job SET ds_calc_dir=?x WHERE id=?x',
-       os.path.join(datadir, 'calc_%s.hdf5' % job_id), job_id)
+       os.path.join(datadir, 'calc_%s' % job_id), job_id)
     return job_id
 
 


### PR DESCRIPTION
It was accidentally changed yesterday causing an additional extension .hdf5.hdf5 to be added to the calculation files and other issues plugin side (via `oq dump/restore`).