### PR TITLE
Do not run useless tests in Monterey

### DIFF
--- a/.github/workflows/macos_m1_monterey_install.yml
+++ b/.github/workflows/macos_m1_monterey_install.yml
@@ -80,26 +80,6 @@ jobs:
           oq dbserver start
           sleep 10
 
-      - name: Run demos to test installation
-        run: |
-          set -x
-          source ~/openquake/bin/activate
-          oq info venv
-          oq info cfg
-          cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/demos
-          ls -lrt
-          # run demos with job_hazard.ini and job_risk.ini
-          for demo_dir in $(find . -type d | sort); do
-             if [ -f $demo_dir/job_hazard.ini ]; then
-                 oq engine --run $demo_dir/job_hazard.ini --exports csv,hdf5
-                 oq engine --run $demo_dir/job_risk.ini --exports csv,hdf5 --hc -1
-             fi
-          done
-          # run the other demos
-          for ini in $(find . -name job.ini | sort); do
-              oq engine --run $ini --exports csv,hdf5
-          done
-
       - name: Run tests for calculators and advanced manual to test installation
         if: always()
         run: |

--- a/.github/workflows/macos_m1_monterey_install.yml
+++ b/.github/workflows/macos_m1_monterey_install.yml
@@ -102,18 +102,22 @@ jobs:
           # -v 2 also logs the test names
           OQ_APPLICATION_MODE=public ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
-      - name: Run tests for the engine server in read-only mode to test installation
-        if: always()
+      - name: Run demos to test installation
         run: |
+          set -x
           source ~/openquake/bin/activate
-          cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
-          # -v 2 also logs the test names
-          OQ_APPLICATION_MODE=read_only ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
-
-      - name: Run tests for the engine server in aelo mode to test installation
-        if: always()
-        run: |
-          source ~/openquake/bin/activate
-          cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
-          # -v 2 also logs the test names
-          OQ_APPLICATION_MODE=aelo OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode
+          oq info venv
+          oq info cfg
+          cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/demos
+          ls -lrt
+          # run demos with job_hazard.ini and job_risk.ini
+          for demo_dir in $(find . -type d | sort); do
+             if [ -f $demo_dir/job_hazard.ini ]; then
+                 oq engine --run $demo_dir/job_hazard.ini --exports csv,hdf5
+                 oq engine --run $demo_dir/job_risk.ini --exports csv,hdf5 --hc -1
+             fi
+          done
+          # run the other demos
+          for ini in $(find . -name job.ini | sort); do
+              oq engine --run $ini --exports csv,hdf5
+          done


### PR DESCRIPTION
There is no point in running tests in AELO mode or read-only mode since those modes are meant only for linux servers. Also, moved the demos *after* the tests.