### PR TITLE
Fixed misprint making counting the ruptures ultra-slow in event_based

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -403,7 +403,7 @@ class EventBasedCalculator(base.HazardCalculator):
         with self.monitor('counting ruptures', measuremem=True):
             nrups = parallel.Starmap( # weighting the heavy sources
                 count_ruptures, [(src,) for src in sources
-                                 if src.code == b'AMSC'],
+                                 if src.code in b'AMSC'],
                 progress=logging.debug).reduce()
             # NB: multifault sources must be considered light to avoid a large
             # data transfer, even if .count_ruptures can be slow


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/9061. Fortunately the typo was introduced recently, i.e. only in master and does not affect any official release.