### PR TITLE
Separate tests for calculators and advanced manual, to avoid false negatives in case of broken calculators

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -78,32 +78,7 @@ jobs:
           C:\Users\runneradmin\openquake\Scripts\activate.ps1
           python -m pip install pytest pyshp flake8
 
-      - name: Run all demos
-        run: |
-          C:\Users\runneradmin\openquake\Scripts\activate.ps1
-          # FIXME: why those different exports? (using the same as in run-demos.sh)
-          oq --version
-          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver start}
-          Write-Host "Run all demos having only job.ini"
-          $iniFilePaths = Get-ChildItem D:\a\oq-engine\oq-engine\demos -Recurse -Filter job.ini
-          foreach($iniFilePath in $iniFilePaths) {
-            Write-Host "Run $($iniFilePath.FullName)"
-            oq engine --run $iniFilePath.FullName --exports csv,hdf5
-          }
-          Write-Host "Run all demos having only job_hazard.ini and job_risk.ini"
-          $demoDirs = Get-ChildItem D:\a\oq-engine\oq-engine\demos -Recurse -Directory
-          foreach($demoDir in $demoDirs) {
-            $jobHazardPaths = Get-ChildItem $demoDir -Filter job_hazard.ini
-            foreach($jobHazardPath in $jobHazardPaths) {
-              Write-Host "Run $($jobHazardPath.FullName)"
-              oq engine --run $jobHazardPath.FullName --exports csv,hdf5
-              $jobRiskPath = $demoDir.FullName + "\job_risk.ini"
-              Write-Host "Run $($jobRiskPath)"
-              oq engine --run $jobRiskPath --exports csv,hdf5 --hc -1
-            }
-          }
-
-      - name: Run tests for calculators and advanced manual
+      - name: Run tests for calculators
         if: always()
         run: |
           C:\Users\runneradmin\openquake\Scripts\activate.ps1
@@ -111,7 +86,13 @@ jobs:
           Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver start}
           cd D:\a\oq-engine\oq-engine
           pytest --doctest-modules --disable-warnings --color=yes --durations=10 openquake/calculators
-          cd doc/adv-manual
+      - name: Run tests for advanced manual
+        if: always()
+        run: |
+          C:\Users\runneradmin\openquake\Scripts\activate.ps1
+          oq --version
+          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver start}
+          cd D:\a\oq-engine\oq-engine\doc\adv-manual
           pytest @(get-childitem -name *.rst)
 
       - name: Run tests for hazardlib, sep, commands, engine, hmtk, risklib, commonlib and baselib to test installation
@@ -160,3 +141,29 @@ jobs:
           $Env:OQ_CONFIG_FILE='openquake\server\tests\data\openquake.cfg'
           # -v 2 also logs the test names
           python .\openquake\server\manage.py test -v 2 tests.test_aelo_mode
+
+      - name: Run all demos
+        run: |
+          C:\Users\runneradmin\openquake\Scripts\activate.ps1
+          # FIXME: why those different exports? (using the same as in run-demos.sh)
+          oq --version
+          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver start}
+          Write-Host "Run all demos having only job.ini"
+          $iniFilePaths = Get-ChildItem D:\a\oq-engine\oq-engine\demos -Recurse -Filter job.ini
+          foreach($iniFilePath in $iniFilePaths) {
+            Write-Host "Run $($iniFilePath.FullName)"
+            oq engine --run $iniFilePath.FullName --exports csv,hdf5
+          }
+          Write-Host "Run all demos having only job_hazard.ini and job_risk.ini"
+          $demoDirs = Get-ChildItem D:\a\oq-engine\oq-engine\demos -Recurse -Directory
+          foreach($demoDir in $demoDirs) {
+            $jobHazardPaths = Get-ChildItem $demoDir -Filter job_hazard.ini
+            foreach($jobHazardPath in $jobHazardPaths) {
+              Write-Host "Run $($jobHazardPath.FullName)"
+              oq engine --run $jobHazardPath.FullName --exports csv,hdf5
+              $jobRiskPath = $demoDir.FullName + "\job_risk.ini"
+              Write-Host "Run $($jobRiskPath)"
+              oq engine --run $jobRiskPath --exports csv,hdf5 --hc -1
+            }
+          }
+


### PR DESCRIPTION
This avoids cases such as https://github.com/gem/oq-engine/actions/runs/6398861200/job/17369882385#step:10:50
that look green even if there's an error in the tests for calculators.

I've also moved demos to the bottom.