### PR TITLE
Fixed mesh creation in surface/kite_fault.py

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed mesh creation in surface/kite_fault.py
   * Disabled SLOW MODE on macOS, since the amount of free memory returned by
     psutil cannot be trusted
   * Speeding up `count_ruptures` for multifault sources, which gives a *huge*

--- a/openquake/hazardlib/geo/surface/kite_fault.py
+++ b/openquake/hazardlib/geo/surface/kite_fault.py
@@ -988,7 +988,7 @@ def _update(npr, rdist, angle, laidx, g, pl, pr, sd, idl, forward):
 
         # Update rdist
         new_rdist = rdist[k]
-        if rdist[k] > 0 and abs(az12 - angle[k] > 2):
+        if rdist[k] > 0 and abs(az12 - angle[k]) > 2:
             new_rdist = update_rdist(rdist[k], az12, angle[k], sd)
 
         coo = get_coo(forward, g, pl[k], pr[k], az12, hdist, vdist, tdist,

--- a/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
@@ -774,7 +774,7 @@ class SouthAmericaSegmentTest(unittest.TestCase):
         smsh = KiteSurface.from_profiles(self.profiles, sampling,
                                          sampling, idl, alg)
         idx = np.isfinite(smsh.mesh.lons[:, :])
-        self.assertEqual(np.sum(np.sum(idx)), 205)
+        self.assertEqual(np.sum(np.sum(idx)), 207)
 
         if PLOTTING:
             title = 'Top of the slab'


### PR DESCRIPTION
There was a clear misprint in `abs(az12 - angle[k] > 2)`