### PR TITLE
Optimized the GmfComputer more

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -243,7 +243,7 @@ def event_based(proxies, cmaker, stations, dstore, monitor):
     se_dt = sig_eps_dt(oq.imtls)
     sig_eps = []
     times = []  # rup_id, nsites, dt
-    fmon = monitor('filtering ruptures', measuremem=False)
+    fmon = monitor('instantiating GmfComputer', measuremem=False)
     mmon = monitor('computing mean_stds', measuremem=False)
     cmon = monitor('computing gmfs', measuremem=False)
     umon = monitor('updating gmfs', measuremem=False)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1487,7 +1487,7 @@ class OqParam(valid.ParamSet):
                     mini[imt] = 0
         if 'default' in mini:
             del mini['default']
-        min_iml = numpy.array([mini.get(imt) or 1E-10 for imt in self.imtls])
+        min_iml = F64([mini.get(imt) or 1E-10 for imt in self.imtls])
         return min_iml
 
     def get_max_iml(self):

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -115,9 +115,8 @@ from openquake.baselib.python3compat import decode
 from openquake.baselib.general import AccumDict
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import correlation, cross_correlation
-from openquake.hazardlib.source.rupture import get_eid_rlz
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib.calc.gmf import GmfComputer, exp, strip_zeros
+from openquake.hazardlib.calc.gmf import GmfComputer, exp
 from openquake.hazardlib.const import StdDev
 from openquake.hazardlib.geo.geodetic import geodetic_distance
 from openquake.hazardlib.gsim.base import ContextMaker
@@ -231,9 +230,6 @@ class ConditionedGmfComputer(GmfComputer):
         :returns: (dict with fields eid, sid, gmv_X, ...), dt
         """
         data = AccumDict(accum=[])
-        data['eid'].append(self.eid_sid_rlz[0])
-        data['sid'].append(self.eid_sid_rlz[1])
-        data['rlz'].append(self.eid_sid_rlz[2])
         rng = numpy.random.default_rng(self.seed)
         for g, (gsim, rlzs) in enumerate(self.cmaker.gsims.items()):
             with rmon:
@@ -245,7 +241,7 @@ class ConditionedGmfComputer(GmfComputer):
             with umon:
                 self.update(data, array, rlzs, [mea, tau+phi, tau, phi])
         with umon:
-            return strip_zeros(data)
+            return self.strip_zeros(data)
 
     def compute(self, gsim, rlzs, mea, tau, phi, rng):
         """

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -231,9 +231,9 @@ class ConditionedGmfComputer(GmfComputer):
         :returns: (dict with fields eid, sid, gmv_X, ...), dt
         """
         data = AccumDict(accum=[])
-        data['eid'].append(self.sid_eid_rlz[0])
-        data['sid'].append(self.sid_eid_rlz[1])
-        data['rlz'].append(self.sid_eid_rlz[2])
+        data['eid'].append(self.eid_sid_rlz[0])
+        data['sid'].append(self.eid_sid_rlz[1])
+        data['rlz'].append(self.eid_sid_rlz[2])
         rng = numpy.random.default_rng(self.seed)
         for g, (gsim, rlzs) in enumerate(self.cmaker.gsims.items()):
             with rmon:

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -231,6 +231,9 @@ class ConditionedGmfComputer(GmfComputer):
         :returns: (dict with fields eid, sid, gmv_X, ...), dt
         """
         data = AccumDict(accum=[])
+        data['eid'].append(self.sid_eid_rlz[0])
+        data['sid'].append(self.sid_eid_rlz[1])
+        data['rlz'].append(self.sid_eid_rlz[2])
         rng = numpy.random.default_rng(self.seed)
         for g, (gsim, rlzs) in enumerate(self.cmaker.gsims.items()):
             with rmon:

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -397,7 +397,7 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
         for all sites in the collection. First dimension represents
         sites and second one is for realizations.
     """
-    cmaker = ContextMaker(rupture.tectonic_region_type, {gsim: [0]},
+    cmaker = ContextMaker(rupture.tectonic_region_type, {gsim: U32([0])},
                           dict(truncation_level=truncation_level,
                                imtls={str(imt): [1] for imt in imts}))
     cmaker.scenario = True
@@ -405,6 +405,6 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
     gc = GmfComputer(rupture, sites, cmaker, correlation_model)
     gc.ebrupture['n_occ'] = realizations
     mean_stds = cmaker.get_mean_stds([gc.ctx])[:, 0]
-    res = gc.compute(gsim, [0], mean_stds,
+    res = gc.compute(gsim, U32([0]), mean_stds,
                      numpy.random.default_rng(seed))
     return {imt: res[:, m] for m, imt in enumerate(gc.imts)}

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -99,16 +99,15 @@ def set_max_min(array, mean, max_iml, min_iml, mmi_index):
 
 
 @compile("uint32[:,:](uint32[:],uint32[:],uint32[:],uint32[:])")
-def build_eid_sid_rlz(rlzs, sids, eid, rlz):
-    eid_sid_rlz = numpy.zeros((3, len(sids)*len(eid)), U32)
+def build_eid_sid_rlz(allrlzs, sids, eids, rlzs):
+    eid_sid_rlz = numpy.zeros((3, len(sids) * len(eids)), U32)
     idx = 0
-    for r in rlzs:
-        ok = rlz == r
-        for r, e in zip(rlz[ok], eid[ok]):
-            for s in sids:
-                eid_sid_rlz[0, idx] = e
-                eid_sid_rlz[1, idx] = s
-                eid_sid_rlz[2, idx] = r
+    for rlz in allrlzs:
+        for eid in eids[rlzs == rlz]:
+            for sid in sids:
+                eid_sid_rlz[0, idx] = eid
+                eid_sid_rlz[1, idx] = sid
+                eid_sid_rlz[2, idx] = rlz
                 idx += 1
     return eid_sid_rlz
 

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -98,19 +98,18 @@ def set_max_min(array, mean, max_iml, min_iml, mmi_index):
                 array[n, :, e] = 0
 
 
-#@compile("uint32[:,:](uint32[:],uint32[:],uint32[:],uint32[:])")
+@compile("uint32[:,:](uint32[:],uint32[:],uint32[:],uint32[:])")
 def build_eid_sid_rlz(rlzs, sids, eid, rlz):
-    N = len(sids)
-    eid_sid_rlz = numpy.zeros((3, N*len(eid)), U32)
-    ne = 0
+    eid_sid_rlz = numpy.zeros((3, len(sids)*len(eid)), U32)
+    idx = 0
     for r in rlzs:
-        eids = eid[rlz == r]
-        E = len(eids)
-        NE = N * E
-        eid_sid_rlz[0, ne:ne+NE] = numpy.repeat(eids, N)
-        eid_sid_rlz[1, ne:ne+NE] = numpy.tile(sids, E)
-        eid_sid_rlz[2, ne:ne+NE] = r
-        ne += NE
+        ok = rlz == r
+        for r, e in zip(rlz[ok], eid[ok]):
+            for s in sids:
+                eid_sid_rlz[0, idx] = e
+                eid_sid_rlz[1, idx] = s
+                eid_sid_rlz[2, idx] = r
+                idx += 1
     return eid_sid_rlz
 
 

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -205,6 +205,7 @@ class GmfComputer(object):
         self.M = M = len(self.gmv_fields)
         self.sig = numpy.zeros((E, M), F32)  # same for all events
         self.eps = numpy.zeros((E, M), F32)  # not the same
+        # slow part, building an array of shape (3, NE)
         self.eid_sid_rlz = build_eid_sid_rlz(rlzs, self.ctx.sids, eid, rlz)
 
     def build_sig_eps(self, se_dt):

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -99,19 +99,19 @@ def set_max_min(array, mean, max_iml, min_iml, mmi_index):
 
 
 #@compile("uint32[:,:](uint32[:],uint32[:],uint32[:],uint32[:])")
-def build_sid_eid_rlz(rlzs, sids, eid, rlz):
+def build_eid_sid_rlz(rlzs, sids, eid, rlz):
     N = len(sids)
-    sid_eid_rlz = numpy.zeros((3, N*len(eid)), U32)
+    eid_sid_rlz = numpy.zeros((3, N*len(eid)), U32)
     ne = 0
     for r in rlzs:
         eids = eid[rlz == r]
         E = len(eids)
         NE = N * E
-        sid_eid_rlz[0, ne:ne+NE] = numpy.repeat(eids, N)
-        sid_eid_rlz[1, ne:ne+NE] = numpy.tile(sids, E)
-        sid_eid_rlz[2, ne:ne+NE] = r
+        eid_sid_rlz[0, ne:ne+NE] = numpy.repeat(eids, N)
+        eid_sid_rlz[1, ne:ne+NE] = numpy.tile(sids, E)
+        eid_sid_rlz[2, ne:ne+NE] = r
         ne += NE
-    return sid_eid_rlz
+    return eid_sid_rlz
 
 
 class GmfComputer(object):
@@ -207,7 +207,7 @@ class GmfComputer(object):
         self.M = M = len(self.gmv_fields)
         self.sig = numpy.zeros((E, M), F32)  # same for all events
         self.eps = numpy.zeros((E, M), F32)  # not the same
-        self.sid_eid_rlz = build_sid_eid_rlz(rlzs, self.ctx.sids, eid, rlz)
+        self.eid_sid_rlz = build_eid_sid_rlz(rlzs, self.ctx.sids, eid, rlz)
 
     def build_sig_eps(self, se_dt):
         """
@@ -261,9 +261,9 @@ class GmfComputer(object):
             rng = numpy.random.default_rng(self.seed)
 
         data = AccumDict(accum=[])
-        data['eid'].append(self.sid_eid_rlz[0])
-        data['sid'].append(self.sid_eid_rlz[1])
-        data['rlz'].append(self.sid_eid_rlz[2])
+        data['eid'].append(self.eid_sid_rlz[0])
+        data['sid'].append(self.eid_sid_rlz[1])
+        data['rlz'].append(self.eid_sid_rlz[2])
         for g, (gs, rlzs) in enumerate(self.cmaker.gsims.items()):
             with cmon:
                 array = self.compute(gs, rlzs, mean_stds[:, g], rng)  # NME

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -206,6 +206,10 @@ class GmfComputer(object):
         return sig_eps
 
     def update(self, data, array, rlzs, mean_stds, max_iml=None):
+        """
+        Updates the data dictionary with the values coming from the array
+        of GMVs. Also indirectly updates the arrays .sig and .eps.
+        """
         min_iml = self.cmaker.min_iml
         mag = self.ebrupture.rupture.mag
         mean = mean_stds[0]
@@ -221,6 +225,7 @@ class GmfComputer(object):
         set_max_min(array, mean, max_iml, min_iml, mmi_index)
         for m, gmv_field in enumerate(self.gmv_fields):
             data[gmv_field].append(array[:, m].T.reshape(-1))
+
         if self.sec_perils:
             n = 0
             for rlz in rlzs:
@@ -249,8 +254,7 @@ class GmfComputer(object):
         df['eid'] = self.eid_sid_rlz[0]
         df['sid'] = self.eid_sid_rlz[1]
         df['rlz'] = self.eid_sid_rlz[2]
-        gmf_df = df[ok]
-        return gmf_df
+        return df[ok]
 
     def compute_all(self, max_iml=None,
                     mmon=Monitor(), cmon=Monitor(), umon=Monitor()):


### PR DESCRIPTION
The bottleneck was in `build_eid_sid_rlz` which is now numbified. Here are the numbers for SAM on oq1:
```
# master
| calc_54948, maxmem=0.5 GB | time_sec | memory_mb | counts    |
|---------------------------+----------+-----------+-----------|
| total gen_event_based     | 298_749  | 30.4      | 10_023    |
| updating gmfs             | 151_165  | 0.0       | 4_798_363 |
| computing mean_stds       | 69_160   | 0.0       | 1_224_412 |
| filtering ruptures        | 49_920   | 0.0       | 1_228_686 |
| computing gmfs            | 19_450   | 0.0       | 3_573_951 |
| EventBasedCalculator.run  | 1_904    | 144.3     | 1         |

# this branch
| calc_54946, maxmem=0.5 GB | time_sec | memory_mb | counts    |
|---------------------------+----------+-----------+-----------|
| total gen_event_based     | 165_493  | 29.2      | 10_014    |
| computing mean_stds       | 67_199   | 0.0       | 1_224_412 |
| instantiating GmfComputer | 51_612   | 0.0       | 1_228_686 |
| computing gmfs            | 19_084   | 0.0       | 3_573_951 |
| updating gmfs             | 9_921    | 0.0       | 4_798_363 |
| EventBasedCalculator.run  | 1_195    | 144.6     | 1         |
```