### PR TITLE
Optimized the GmfComputer a bit more

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -277,7 +277,9 @@ def event_based(proxies, cmaker, stations, dstore, monitor):
                 assert cmaker.scenario
                 df = computer.compute_all(dstore, rmon, cmon, umon)
             else:  # regular GMFs
-                df = computer.compute_all(max_iml, mmon, cmon, umon)
+                with mmon:
+                    mean_stds = cmaker.get_mean_stds([computer.ctx])
+                df = computer.compute_all(mean_stds, max_iml, cmon, umon)
             sig_eps.append(computer.build_sig_eps(se_dt))
             dt = time.time() - t0
             times.append((proxy['id'], computer.ctx.rrup.min(), dt))

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -163,8 +163,8 @@ class ScenarioTestCase(CalculatorTestCase):
         # choosing invalid GMPE
         with self.assertRaises(RuntimeError) as ctx:
             self.run_calc(case_15.__file__, 'job.ini')
-        self.assertIn("([AtkinsonBoore2006Modified2011], PGA, source_id=0)"
-                      " CorrelationButNoInterIntraStdDevs", str(ctx.exception))
+        self.assertIn("([AtkinsonBoore2006Modified2011], PGA, "
+                      "CorrelationButNoInterIntraStdDevs)", str(ctx.exception))
 
     def test_case_16(self):
         # check exposures with exposureFields

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -258,14 +258,11 @@ class GmfComputer(object):
         # remove the rows with all zero values
         return df[ok]
 
-    def compute_all(self, max_iml=None,
-                    mmon=Monitor(), cmon=Monitor(), umon=Monitor()):
+    def compute_all(self, mean_stds, max_iml=None,
+                    cmon=Monitor(), umon=Monitor()):
         """
         :returns: DataFrame with fields eid, rlz, sid, gmv_X, ...
         """
-        with mmon:
-            mean_stds = self.cmaker.get_mean_stds([self.ctx])  # (4, G, M, N)
-
         rng = numpy.random.default_rng(self.seed)
         data = AccumDict(accum=[])
         for g, (gs, rlzs) in enumerate(self.cmaker.gsims.items()):

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -153,14 +153,12 @@ class GmfComputer(object):
         self.amplifier = amplifier
         self.sec_perils = sec_perils
         # `rupture` is an EBRupture instance in the engine
-        if hasattr(rupture, 'source_id'):
+        if hasattr(rupture, 'rupture'):
             self.ebrupture = rupture
-            self.source_id = rupture.source_id  # the underlying source
             self.seed = rupture.seed
             rupture = rupture.rupture  # the underlying rupture
         else:  # in the hazardlib tests
             self.ebrupture = {'e0': 0, 'n_occ': 1, 'seed': rupture.seed}
-            self.source_id = '?'
             self.seed = rupture.seed
         ctxs = list(cmaker.get_ctx_iter([rupture], sitecol))
         if not ctxs:
@@ -301,9 +299,8 @@ class GmfComputer(object):
                     mean_stds[:, m], m, imt, gsim, intra_eps[m], idxs)
             except Exception as exc:
                 raise RuntimeError(
-                    '(%s, %s, source_id=%r) %s: %s' %
-                    (gsim, imt, self.source_id,
-                     exc.__class__.__name__, exc)
+                    '(%s, %s, %s): %s' %
+                    (gsim, imt, exc.__class__.__name__, exc)
                 ).with_traceback(exc.__traceback__)
         if self.amplifier:
             self.amplifier.amplify_gmfs(

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -175,20 +175,18 @@ class GmfComputer(object):
         """
         Initialize the attributes eid, rlz, sig, eps with shapes E, E, EM, EM
         """
-        rlzs = numpy.concatenate(list(self.cmaker.gsims.values()))
+        self.rlzs = numpy.concatenate(list(self.cmaker.gsims.values()))
         if isinstance(self.ebrupture, dict):  # with keys e0, n_occ, seed
             dic = self.ebrupture
         else:
             dic = vars(self.ebrupture)
-        eid, rlz = get_eid_rlz(dic, rlzs, self.cmaker.scenario)
+        eid, rlz = get_eid_rlz(dic, self.rlzs, self.cmaker.scenario)
         self.eid, self.rlz = eid, rlz
         self.N = len(self.ctx)
         self.E = E = len(self.eid)
         self.M = M = len(self.gmv_fields)
         self.sig = numpy.zeros((E, M), F32)  # same for all events
         self.eps = numpy.zeros((E, M), F32)  # not the same
-        # slow part, building an array of shape (3, NE)
-        self.eid_sid_rlz = build_eid_sid_rlz(rlzs, self.ctx.sids, eid, rlz)
 
     def build_sig_eps(self, se_dt):
         """
@@ -221,8 +219,7 @@ class GmfComputer(object):
             M = len(self.cmaker.imts)
             max_iml = numpy.full(M, numpy.inf, float)
         set_max_min(array, mean, max_iml, min_iml, mmi_index)
-        for m, gmv_field in enumerate(self.gmv_fields):
-            data[gmv_field].append(array[:, m].T.reshape(-1))
+        data['gmv'].append(array)
 
         if self.sec_perils:
             n = 0
@@ -241,17 +238,24 @@ class GmfComputer(object):
         """
         :returns: a DataFrame with the nonzero GMVs
         """
-        # build dataframe
+        # building an array of shape (3, NE)
+        eid_sid_rlz = build_eid_sid_rlz(
+            self.rlzs, self.ctx.sids, self.eid, self.rlz)
+
         for key, val in sorted(data.items()):
-            data[key] = numpy.concatenate(data[key], dtype=F32)
+            data[key] = numpy.concatenate(data[key], axis=-1, dtype=F32)
+        gmv = data.pop('gmv')  # shape (N, M, E)
+        ok = gmv.sum(axis=1).T.reshape(-1) > 0
+        for m, gmv_field in enumerate(self.gmv_fields):
+            data[gmv_field] = gmv[:, m].T.reshape(-1)
+
+        # build dataframe
         df = pandas.DataFrame(data)
-        assert str(df.gmv_0.dtype) == 'float32', df.gmv_0.dtype
+        df['eid'] = eid_sid_rlz[0]
+        df['sid'] = eid_sid_rlz[1]
+        df['rlz'] = eid_sid_rlz[2]
 
         # remove the rows with all zero values
-        ok = df.to_numpy().sum(axis=1) > 0
-        df['eid'] = self.eid_sid_rlz[0]
-        df['sid'] = self.eid_sid_rlz[1]
-        df['rlz'] = self.eid_sid_rlz[2]
         return df[ok]
 
     def compute_all(self, max_iml=None,


### PR DESCRIPTION
By reducing the number of calls to numpy.concatenate by M times. Unfortunately, there is no effect in practice.
Here are the numbers for SAM on oq1:
```
# before
| calc_54950, maxmem=0.5 GB | time_sec | memory_mb | counts    |
|---------------------------+----------+-----------+-----------|
| total gen_event_based     | 159_183  | 29.7      | 10_014    |
| computing mean_stds       | 66_799   | 0.0       | 1_224_412 |
| instantiating GmfComputer | 51_591   | 0.0       | 1_228_686 |
| computing gmfs            | 12_768   | 0.0       | 1_477_313 |
| updating gmfs             | 9_868    | 0.0       | 2_701_725 |
| EventBasedCalculator.run  | 1_139    | 143.7     | 1         |

# after
| calc_54952, maxmem=0.5 GB | time_sec | memory_mb | counts    |
|---------------------------+----------+-----------+-----------|
| total gen_event_based     | 160_074  | 29.9      | 10_014    |
| computing mean_stds       | 66_952   | 0.0       | 1_224_412 |
| instantiating GmfComputer | 50_965   | 0.0       | 1_228_686 |
| computing gmfs            | 12_775   | 0.0       | 1_477_313 |
| updating gmfs             | 10_385   | 0.0       | 2_701_725 |
| EventBasedCalculator.run  | 1_141    | 144.5     | 1         |
```