### PR TITLE
Raised clear error message

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,13 @@
+  [Michele Simionato]
+  * Internal: raised a clear error message when get_composite_source_model is
+   called without passing a datastore in presence of multifault sources
+
   [Christopher Brooks]
   * Added non-ergodic implementation of Zhao et al. (2016) GMM (ray-tracing
     of travel paths through anelastically attenuating volcanic regions and
     subsequent adjustment of the path term based on this distance to reduce
     the predicted ground-motion).
-  
+
   [Michele Simionato]
   * Optimized (2x) the generation of ground motion fields
   * Internal: using a single random number generator inside the GmfComputer

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -279,7 +279,9 @@ def fix_geometry_sections(smdict, dstore):
     s2i = {suid: i for i, suid in enumerate(sections)}
     for idx, sec in enumerate(sections.values()):
         sec.suid = idx
-    if dstore and sections:
+    if sections:
+        assert dstore, ('You forgot to pass the dstore to '
+                        'get_composite_source_model')
         with hdf5.File(dstore.tempname, 'w') as h5:
             h5.save_vlen('multi_fault_sections',
                          [kite_to_geom(sec) for sec in sections.values()])


### PR DESCRIPTION
When get_composite_source_model is called without passing a datastore in presence of multifault sources.
