### PR TITLE
Using sphinx 6.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           pip install -U pip
           pip install -r ./requirements-py38-linux64.txt
-          pip install pydata-sphinx-theme
+          pip install sphinx==6.2 pydata-sphinx-theme
       - name: Install oq engine
         run: |
           pip install -e .[dev]

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ extras_require = {
         'pdbpp',
         'ipython',
         'silx',
-        'sphinx==4.4',
+        'sphinx==6.2',
         'sphinx-theme',
         'pydata-sphinx-theme',
     ]


### PR DESCRIPTION
We are now at version 7 but only version 6 is compatible with our manual.