### PR TITLE
Minor speedup when computing the GMFs

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -278,7 +278,11 @@ def event_based(proxies, cmaker, stations, dstore, monitor):
                 df = computer.compute_all(dstore, rmon, cmon, umon)
             else:  # regular GMFs
                 with mmon:
-                    mean_stds = cmaker.get_mean_stds([computer.ctx])
+                    mean_stds = cmaker.get_mean_stds(
+                        [computer.ctx], split_by_mag=False)
+                    # avoid numba type error
+                    computer.ctx.flags.writeable = True
+
                 df = computer.compute_all(mean_stds, max_iml, cmon, umon)
             sig_eps.append(computer.build_sig_eps(se_dt))
             dt = time.time() - t0

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -82,7 +82,7 @@ def set_max_min(array, mean, max_iml, min_iml, mmi_index):
                 array[n, :, e] = 0
 
 
-@compile("uint32[:,:](uint32[:],uint32[:],uint32[:],uint32[:])")
+@compile("(uint32[:],uint32[:],uint32[:],uint32[:])")
 def build_eid_sid_rlz(allrlzs, sids, eids, rlzs):
     eid_sid_rlz = numpy.zeros((3, len(sids) * len(eids)), U32)
     idx = 0


### PR DESCRIPTION
By not splitting by mag. Here is the situation for Chile on oq1:
```
| calc_54957, maxmem=0.5 GB | time_sec | memory_mb | counts    |
|---------------------------+----------+-----------+-----------|
| total gen_event_based     | 157_175  | 38.3      | 10_014    |
| computing mean_stds       | 64_561   | 0.0       | 1_224_412 |
| instantiating GmfComputer | 50_431   | 0.0       | 1_228_686 |
| computing gmfs            | 12_770   | 0.0       | 1_477_313 |
| updating gmfs             | 10_368   | 0.0       | 2_701_725 |
| EventBasedCalculator.run  | 1_167    | 144.4     | 1         |
```