### PR TITLE
Add a test checking newlines in extracted ruptures

### DIFF
--- a/openquake/baselib/tests/flake8_test.py
+++ b/openquake/baselib/tests/flake8_test.py
@@ -74,7 +74,8 @@ def get_long_funcs(mod_or_pkg, maxlen):
 @numba.njit
 def check_newlines(bytes):
     """
-    :returns: 0 if the newlines are \r\n, 1 for \n and 2 for \r
+    :returns: 0 if the newlines are \r\n, 1 for \n, 2 for \r and 3 for two
+    consecutive \r
     """
     n1 = len(bytes) - 1
     for i, byte in enumerate(bytes):
@@ -84,6 +85,8 @@ def check_newlines(bytes):
         elif byte == CR:
             if (i < n1 and bytes[i+1] != LF) or i == n1:
                 return 2  # \r ending
+            if i > 0 and bytes[i-1] == CR:
+                return 3
     return 0
 
 
@@ -155,6 +158,9 @@ def test_csv(OVERWRITE=False):
                     raise ValueError('Found \\n line ending in %s' % fname)
                 elif error == 2:
                     raise ValueError('Found \\r line ending in %s' % fname)
+                elif error == 3:
+                    raise ValueError('Found two consecutive \\r line endings'
+                                     ' in %s' % fname)
 
 
 def test_forbid_long_funcs():


### PR DESCRIPTION
As requested in https://github.com/gem/oq-engine/pull/9134#issue-1956433100

I've also modified the utility to check newlines in csv files in order to also identify cases with double \r line endings.