### PR TITLE
Fixed sanity check on the disagg_rates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed another bug in disaggregation for mutex sources
   * Fixed a bug in `disagg_sources` for mutex sources: src_mutex
     was not passed
   * Internal: forced the colon convention on mutex sources

--- a/openquake/calculators/postproc/disagg_by_rel_sources.py
+++ b/openquake/calculators/postproc/disagg_by_rel_sources.py
@@ -122,15 +122,18 @@ def disagg_sources(csm, rel_ids, imts, imls, oq, sitecol, dstore):
     Ns, M1 = len(rel_ids), len(imldic)
     rates = numpy.zeros((Ns, shp['mag'], shp['dist'], shp['eps'], M1))
     std = numpy.zeros((Ns, shp['mag'], shp['dist'], M1))
-    for srcid, std4D, rates4D, rates2D in smap:
+    rates2D = 0.  # (Ns, M1)
+    for srcid, std4D, rates4D, _rates2D in smap:
         bname = basename(srcid, '!;')
         idx = src2idx[bname]
         rates[idx] += rates4D
         std[idx] += std4D @ weights[bname] # shape (Ma, D, M, G) -> (Ma, D, M)
+        rates2D += _rates2D
     dic = dict(
         shape_descr=['source_id', 'mag', 'dist', 'eps', 'imt'],
         source_id=rel_ids, mag=middle(mags), dist=middle(dists),
-        eps=middle(eps), imt=imts, iml=imls)
+        eps=middle(eps), imt=imts, iml=imls, view=rates.sum(axis=(1, 2, 3)),
+        rates2D=rates2D)
     mean_disagg_by_src = hdf5.ArrayWrapper(rates, dic)
     dic2 = dict(
         shape_descr=['source_id', 'mag', 'dist', 'imt'],

--- a/openquake/engine/tests/aelo_test.py
+++ b/openquake/engine/tests/aelo_test.py
@@ -81,8 +81,4 @@ def test_JPN():
         calc = base.calculators(log.get_oqparam(), log.calc_id)
         calc.run()
     df = views.view('compare_disagg_rates', calc.datastore)
-    assert str(df) == '''\
-       imt                    src  disagg_rate  interp_rate
-0      PGA  IF-NPSS-Nankai_Trough     0.020527     0.020202
-1  SA(0.2)  IF-NPSS-Nankai_Trough     0.026339     0.026202
-2  SA(1.0)  IF-NPSS-Nankai_Trough     0.026264     0.026018'''
+    aac(df.disagg_rate, df.interp_rate, rtol=.01)

--- a/openquake/engine/tests/aelo_test.py
+++ b/openquake/engine/tests/aelo_test.py
@@ -83,6 +83,6 @@ def test_JPN():
     df = views.view('compare_disagg_rates', calc.datastore)
     assert str(df) == '''\
        imt                    src  disagg_rate  interp_rate
-0      PGA  IF-NPSS-Nankai_Trough     0.181918     0.020202
-1  SA(0.2)  IF-NPSS-Nankai_Trough     0.227975     0.026202
-2  SA(1.0)  IF-NPSS-Nankai_Trough     0.248096     0.026018'''
+0      PGA  IF-NPSS-Nankai_Trough     0.020527     0.020202
+1  SA(0.2)  IF-NPSS-Nankai_Trough     0.026339     0.026202
+2  SA(1.0)  IF-NPSS-Nankai_Trough     0.026264     0.026018'''


### PR DESCRIPTION
Hopefully fixes the JPN model. The issue was that the `mutex_weight` was ignored when disaggregating. For AELO
I get the following numbers:
```
         imt                    src  disagg_rate  interp_rate
0       PGA                IF-CPHL     0.000680     0.000680
3       PGA  IF-NPSS-Nankai_Trough     0.000104     0.000103
1       PGA              SLNE-CPCF     0.003033     0.003032
2       PGA              SLSW-CPHL     0.015749     0.015747
4   SA(0.2)                IF-CPHL     0.000640     0.000616
7   SA(0.2)  IF-NPSS-Nankai_Trough     0.000012     0.000001
5   SA(0.2)              SLNE-CPCF     0.004250     0.004200
6   SA(0.2)              SLSW-CPHL     0.018440     0.018282
8   SA(1.0)                IF-CPHL     0.001803     0.001780
11  SA(1.0)  IF-NPSS-Nankai_Trough     0.003413     0.003342
9   SA(1.0)              SLNE-CPCF     0.003622     0.003598
10  SA(1.0)              SLSW-CPHL     0.013069     0.012998
```
The only bad looking one is
```
7   SA(0.2)  IF-NPSS-Nankai_Trough     0.000012     0.000001
```