### PR TITLE
Write in bold text the asce7 and asce41 outputs in aelo mode

### DIFF
--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -217,3 +217,7 @@ footer.footer form label {
      line-height: 12px;
      margin: 0px;
 }
+
+tr.asce_output {
+    font-weight: bold;
+}

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -45,7 +45,7 @@
         <%   return; // works like continue in underscore.js %>
         <% }%>
         {% endif %}
-        <tr class="success">
+        <tr class={% if application_mode == 'AELO' %}<%= ['asce7', 'asce41'].indexOf(output.get('type')) >= 0 ? "asce_output" : "" %>{% else %}""{% endif %}>
           <td><%= output.get('id') || 'New' %></td>
           <td><%= output.get('name') %></td>
           <td <% if (output.get('size_mb')) { %>title="Size: <%= Math.max((Math.round(output.get('size_mb') * 100) / 100), 0.01).toFixed(2) %>MB"<% } %>><%= output.get('type') %></td>

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -45,6 +45,7 @@
         <%   return; // works like continue in underscore.js %>
         <% }%>
         {% endif %}
+        {# In the general case we were using the "success" class, coloring the line in green, but the color adds no information in this case #}
         <tr class={% if application_mode == 'AELO' %}<%= ['asce7', 'asce41'].indexOf(output.get('type')) >= 0 ? "asce_output" : "" %>{% else %}""{% endif %}>
           <td><%= output.get('id') || 'New' %></td>
           <td><%= output.get('name') %></td>

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -45,7 +45,7 @@
         <%   return; // works like continue in underscore.js %>
         <% }%>
         {% endif %}
-        {# In the general case we were using the "success" class, coloring the line in green, but the color adds no information in this case #}
+        {# In the general case we were using the "success" class, coloring the line in green, but the color adds no information in the list of outputs #}
         <tr class={% if application_mode == 'AELO' %}<%= ['asce7', 'asce41'].indexOf(output.get('type')) >= 0 ? "asce_output" : "" %>{% else %}""{% endif %}>
           <td><%= output.get('id') || 'New' %></td>
           <td><%= output.get('name') %></td>


### PR DESCRIPTION
I am also removing the "success" class to the output lines in general (not only in AELO mode), because it gives the green color to the line, which makes sense in the list of calculations to identify calculations that completed successfully, but it is meaningless in the list of outputs.