### PR TITLE
Restored dbserver.ensure_on()

### DIFF
--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -124,10 +124,12 @@ def main(
         os.makedirs(datadir)
 
     fname = os.path.expanduser(config.dbserver.file)
-    if config.dbserver.host == 'local' and not os.path.exists(fname):
-        upgrade_db = True  # automatically creates the db
-        yes = True
+    if config.dbserver.host == 'local':
+        if not os.path.exists(fname):
+            upgrade_db = True  # automatically creates the db
+            yes = True
     else:
+        dbserver.ensure_on()
         # check that we are talking to the right server
         err = dbserver.check_foreign()
         if err:


### PR DESCRIPTION
Some actions were breaking during the night with the error
```python
  File "/home/aettorre/GIT/oq-engine/openquake/commands/engine.py", line 132, in main
    err = dbserver.check_foreign()
  File "/home/aettorre/GIT/oq-engine/openquake/server/dbserver.py", line 126, in check_foreign
    remote_server_path = logs.dbcmd('get_path')
  File "/home/aettorre/GIT/oq-engine/openquake/commonlib/logs.py", line 71, in dbcmd
    res = sock.send((action,) + args)
  File "/home/aettorre/GIT/oq-engine/openquake/baselib/zeromq.py", line 180, in send
    raise TimeoutError('While sending %r to %s' %
openquake.baselib.zeromq.TimeoutError: While sending ('get_path',) to tcp://localhost:1908
```
Regression introduced by working at https://github.com/gem/oq-engine/issues/9146.