### PR TITLE
Move ML liquefaction model reading to classes.py

### DIFF
--- a/openquake/sep/classes.py
+++ b/openquake/sep/classes.py
@@ -44,11 +44,17 @@ from openquake.sep.liquefaction.liquefaction import (
 from openquake.sep.liquefaction.lateral_spreading import (
     hazus_lateral_spreading_displacement
 )
-
 from openquake.sep.liquefaction.vertical_settlement import (
     hazus_vertical_settlement,
     HAZUS_VERT_SETTLEMENT_TABLE
 )
+from os import path
+import gzip
+try:
+    import onnxruntime
+except ImportError:
+     onnxruntime = None
+
 
 class SecondaryPeril(metaclass=abc.ABCMeta):
     """
@@ -506,7 +512,10 @@ class TodorovicSilva2022NonParametric(SecondaryPeril):
         pass
 
     def prepare(self, sites):
-        pass
+        model_file = 'liquefaction/data/todorovic_silva_2022/random_forest_v1.onnx.gz'
+        model_path = path.join(path.dirname(__file__), model_file)
+        with gzip.open(model_path, 'rb') as f:
+            self.model = f.read()
 
     def compute(self, mag, imt_gmf, sites):
         out = []
@@ -521,10 +530,11 @@ class TodorovicSilva2022NonParametric(SecondaryPeril):
                 continue
         # Raise error if either PGA or PGV is missing
         if pga is None or pgv is None:
-            raise ValueError("Both PGA and PGV are required to compute liquefaction probability using the AllstadtEtAl2022Liquefaction model")
+            raise ValueError("Both PGA and PGV are required to compute liquefaction probability using the TodorovicSilva2022NonParametric model")
         
         out_class, out_prob = todorovic_silva_2022_nonparametric_general(pga=pga,
-                    pgv=pgv, vs30=sites.vs30, dw=sites.dw, wtd=sites.gwd, precip=sites.precip)
+                    pgv=pgv, vs30=sites.vs30, dw=sites.dw, wtd=sites.gwd, 
+                    precip=sites.precip, model=self.model)
         out.append(out_class)
         out.append(out_prob)
         return out

--- a/openquake/sep/tests/test_sep_suite_2.py
+++ b/openquake/sep/tests/test_sep_suite_2.py
@@ -26,6 +26,10 @@ from openquake.sep.liquefaction import (
     todorovic_silva_2022_nonparametric_general
 )
 
+from openquake.sep.classes import (
+    TodorovicSilva2022NonParametric
+)
+
 from openquake.sep.liquefaction.lateral_spreading import (
     hazus_lateral_spreading_displacement
 )
@@ -265,13 +269,16 @@ class test_liquefaction_cali_small(unittest.TestCase):
         np.testing.assert_array_almost_equal(out_class, clq)
 
     def test_todorovic_2022(self):
-        out_class, out_prob = todorovic_silva_2022_nonparametric_general(
-            pgv=self.pgv, vs30=self.sites["vs30"], dw=self.sites["dw"], wtd=self.sites["gwd"], 
-            precip=self.sites["precip"])
+        model_instance = TodorovicSilva2022NonParametric()
+        model_instance.prepare(self.sites)
 
-        clq = np.array([0, 0, 0, 0, 0, 1, 0, 0, 1, 1])
-        zlp = np.array([0.142747, 0.084723, 0.483987, 0.419369, 0.444786, 0.706952,
-                        0.323834, 0.394872, 0.934869, 0.607842])
+        out_class, out_prob = todorovic_silva_2022_nonparametric_general(pga=self.pga,
+            pgv=self.pgv, vs30=self.sites["vs30"], dw=self.sites["dw"], wtd=self.sites["gwd"], 
+            precip=self.sites["precip"], model=model_instance.model)
+
+        clq = np.array([0, 0, 1, 0, 0, 0, 1, 0, 1, 0])
+        zlp = np.array([0.125497, 0.466357, 0.520865, 0.472025, 0.490519, 0.24198,
+                        0.570745, 0., 0.61262 , 0.331562])
 
         np.testing.assert_array_almost_equal(out_class, clq)
         np.testing.assert_array_almost_equal(out_prob, zlp)


### PR DESCRIPTION
Read the ML model file only once per calculation. Previously it was being read each time the results were computed - resulting in 3,000 file reads for a scenario calculation involving 1,000 realizations × 3 GMMs.