### PR TITLE
Set upper limit for the Goda & Atkinson cross-correlation coeffient

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Anirudh Rao]
+  * Limited the cross-correlation coefficient of GodaAtkinson2009 
+    to have an upper bound of 1.0
+
   [Paolo Tormene]
   * Added commands `oq plot mean_hcurves_rtgm,governing_mce,disagg_by_src`
 

--- a/openquake/hazardlib/cross_correlation.py
+++ b/openquake/hazardlib/cross_correlation.py
@@ -147,7 +147,9 @@ class GodaAtkinson2009(CrossCorrelationBetween):
         angle = np.pi/2. - (theta1 + theta2 * ITmin * (Tmin / Tmax) ** theta3 *
                             np.log10(Tmin / 0.25)) * np.log10(Tmax / Tmin)
         delta = 1 + np.cos(-1.5 * np.log10(Tmax / Tmin))
-        return (1. - np.cos(angle) + delta) / 3.
+        corr = (1. - np.cos(angle) + delta) / 3.
+
+        return max(corr, 1)
 
     def get_inter_eps(self, imts, num_events, rng):
         """


### PR DESCRIPTION
The original formulation does not explicitly support PGA, so the engine implementation treats PGA as equivalent to SA(0.05). But this can lead to correlation coefficients > 1.0 for IMT pairs like {PGA, SA(0.1)}. Here, we simply limit the correlation coefficient to have an upper bound of 1.0.