### PR TITLE
Do not refresh the outputs page automatically

### DIFF
--- a/openquake/server/static/js/engine_get_outputs.js
+++ b/openquake/server/static/js/engine_get_outputs.js
@@ -68,19 +68,10 @@
         });
     var outputs = new Outputs();
 
-    var refresh_outputs;
-
-    function setTimer() {
-        refresh_outputs = setInterval(function() { outputs.fetch({reset: true}) }, 30000);
-    }
-
     /* classic event management */
     $(document).ready(
         function() {
-
             var output_table = new OutputTable({ outputs: outputs });
             outputs.fetch({reset: true});
-            setTimer()
-
         });
 })($, Backbone, _, gem_oq_server_url, gem_calc_id);


### PR DESCRIPTION
Fixes https://github.com/gem/oq-engine/issues/9168

The automatic refresh did not serve any actual purpose in the outputs page (when a calculation is over, its outputs are produced once and they remain static) and it made it harder to inspect the page and work on its styling.

