### PR TITLE
AELO: add a warning to the outputs page if ASCE outputs are missing since the hazard is too low

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -468,9 +468,7 @@ class ClassicalCalculator(base.HazardCalculator):
             self.execute_big(maxw)
         self.store_info()
         if self.cfactor[0] == 0:
-            raise RuntimeError(
-                'The hazard is 0 since the site(s) is(are) far from all'
-                ' seismic sources included in the hazard model.')
+            raise RuntimeError('There are no ruptures close to the site(s)')
         logging.info('cfactor = {:_d}/{:_d} = {:.1f}'.format(
             int(self.cfactor[1]), int(self.cfactor[0]),
             self.cfactor[1] / self.cfactor[0]))

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -468,7 +468,9 @@ class ClassicalCalculator(base.HazardCalculator):
             self.execute_big(maxw)
         self.store_info()
         if self.cfactor[0] == 0:
-            raise RuntimeError('There are no ruptures close to the site(s)')
+            raise RuntimeError(
+                'The hazard is 0 since the site(s) is(are) far from all'
+                ' seismic sources included in the hazard model.')
         logging.info('cfactor = {:_d}/{:_d} = {:.1f}'.format(
             int(self.cfactor[1]), int(self.cfactor[0]),
             self.cfactor[1] / self.cfactor[0]))

--- a/openquake/server/templates/engine/get_outputs_aelo.html
+++ b/openquake/server/templates/engine/get_outputs_aelo.html
@@ -6,6 +6,11 @@
     <div class="container">
       <div class="row">
         <div id="oq-body-wrapper">
+          {% if low_hazard %}
+          <div id="warning-box" class="alert alert-warning" style=>
+            Warning: the ASCE outputs are missing since the hazard is too low
+          </div>
+          {% endif %}
           <div class="span12">
               <h2>Outputs from calculation {{ calc_id }}</h2>
               <div id="my-outputs" class="well"></div>

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1005,9 +1005,11 @@ def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
             asce41 = json.loads(asce41_js)
             for key, value in asce41.items():
                 asce41_with_units[key + ' (g)'] = value
+        low_hazard = asce7 is None or asce41 is None
     return render(request, "engine/get_outputs_aelo.html",
                   dict(calc_id=calc_id, size_mb=size_mb,
-                       asce7=asce7_with_units, asce41=asce41_with_units))
+                       asce7=asce7_with_units, asce41=asce41_with_units,
+                       low_hazard=low_hazard))
 
 
 @csrf_exempt


### PR DESCRIPTION
This is what it looks like on the aelo-beta machine
![image](https://github.com/gem/oq-engine/assets/350930/17f697ef-4da4-4f69-ae68-94b064700ea6)
