### PR TITLE
Fixed wrong `mean_rates_by_src` in presence of the colon convention

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed wrong `mean_rates_by_src` in presence of the colon convention
   * If there are no sources close to the (single) site, do not raise an error
   * Fixed a bug with --hc taking the parent site collection instead of
     the child site collection

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -535,7 +535,6 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         The sum of the mean_rates_by_src must correspond to the mean_rates_ss
         """
-        return
         exp = self.datastore['mean_rates_ss'][:]
         got = mean_rates_by_src[0].sum(axis=2)  # sum over the sources
         numpy.testing.assert_allclose(got, exp)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -537,7 +537,9 @@ class ClassicalCalculator(base.HazardCalculator):
         """
         exp = self.datastore['mean_rates_ss'][:]
         got = mean_rates_by_src[0].sum(axis=2)  # sum over the sources
-        numpy.testing.assert_allclose(got, exp)
+        # skipping the first value which can be wrong due to the cutoff
+        # (happens in logictree/case_05)
+        numpy.testing.assert_allclose(got[1:], exp[1:])
 
     def execute_big(self, maxw):
         """

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -122,6 +122,8 @@ class LogicTreeTestCase(CalculatorTestCase):
                                    'SSC-AS-001!KOR_c1_M1_2',
                                    'SSC-AS-001!KOR_c1_M1_3'])
 
+    # NB: this test is sensitive to the lower cutoff for the rates
+    # it produces a huge rate 103.6 for the minimum level, cut off at 19.5
     def test_case_05(self):
         # use_rates, two sources, two uncertainties per source, full_enum
         self.assert_curves_ok(['curve-mean.csv'], case_05.__file__)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -270,9 +270,14 @@ class FarAwayRupture(Exception):
 def basename(src, splitchars='.:'):
     """
     :returns: the base name of a split source
+
+    >>> basename('SC:10;0')
+    "SC;0"
     """
     src_id = src if isinstance(src, str) else src.source_id
-    return re.split('[%s]' % splitchars, src_id)[0]
+    for char in splitchars:
+        src_id = re.sub(r'\%s\d+' % char, '', src_id)
+    return src_id
 
 
 def get_num_distances(gsims):

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1102,9 +1102,7 @@ class FullLogicTree(object):
         """
         :returns: a list of Gt weights
         """
-        out = []
-        for g, trs in enumerate(trt_rlzs):
-            out.append(sum(self.weights[r] for r in trs % TWO24))
+        out = [sum(self.weights[r] for r in trs % TWO24) for trs in trt_rlzs]
         return out
 
     def get_smr_by_ltp(self):

--- a/openquake/qa_tests_data/logictree/case_12/job.ini
+++ b/openquake/qa_tests_data/logictree/case_12/job.ini
@@ -5,6 +5,7 @@ calculation_mode = classical
 random_seed = 19
 postproc_func = disagg_by_rel_sources.main
 postproc_args = {"imts": ["PGA"], "imls": [.1]}
+
 [geometry]
 
 sites = 29.9 31.2


### PR DESCRIPTION
`contexts.basename` was wrong causing wrong numbers. This is potentially affecting AELO calculations. Discovered while restoring the sanity check on `mean_rates_ss`.