### PR TITLE
Create the database directory automatically

### DIFF
--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -39,7 +39,6 @@ def main(cmd,
                      f'but you are {user}')
 
     if cmd == 'upgrade':
-        dbapi.db('PRAGMA foreign_keys = ON')  # honor ON DELETE CASCADE
         applied = db.actions.upgrade_db(dbapi.db)
         if applied:
             print('Applied upgrades', applied)

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -304,6 +304,9 @@ class Db(object):
         try:
             return self.local.conn
         except AttributeError:
+            dname = os.path.dirname(self.args[0])
+            if not os.path.exists(dname):
+                os.makedirs(dname)
             self.local.conn = self.connect(*self.args, **self.kw)
             #  honor ON DELETE CASCADE
             self.local.conn.execute('PRAGMA foreign_keys = ON')

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -304,8 +304,8 @@ class Db(object):
         try:
             return self.local.conn
         except AttributeError:
-            dname = os.path.dirname(self.args[0])
-            if not os.path.exists(dname):
+            dname = os.path.dirname(self.args[0])  # empty for :memory:
+            if dname and not os.path.exists(dname):
                 os.makedirs(dname)
             self.local.conn = self.connect(*self.args, **self.kw)
             #  honor ON DELETE CASCADE


### PR DESCRIPTION
Solves the error
```
 $ oq dbserver upgrade
Traceback (most recent call last):
  File "/home/michele/oq-engine/openquake/commonlib/dbapi.py", line 305, in conn
    return self.local.conn
AttributeError: '_thread._local' object has no attribute 'conn'
```
discovered by Antonio.