### PR TITLE
Improved `build_global_exposure`/2

### DIFF
--- a/utils/build_global_exposure
+++ b/utils/build_global_exposure
@@ -68,20 +68,6 @@ def fix(arr):
             ID1[i] = '%s-%s' % (id0, ID1[i])
 
 
-def exposure_by_geohash(lines, names, common, monitor):
-    df = pandas.read_csv(io.BytesIO(zlib.decompress(lines)), names=names,
-                         dtype=CONV, usecols=common)
-    if len(df):
-        dt = hdf5.build_dt(CONV, names, '<StringIO>')
-        array = numpy.zeros(len(df), dt)
-        for col in df.columns:
-            array[col] = df[col].to_numpy()
-        array = add_geohash3(array)
-        fix(array)
-        for gh in numpy.unique(array['geohash3']):
-            yield gh, array[array['geohash3']==gh]
-
-
 def collect_exposures(grm_dir):
     """
     Collect the files of kind Exposure_<Country>.xml
@@ -97,14 +83,33 @@ def collect_exposures(grm_dir):
     return out
 
 
-def gen_chunks(fnames, fields, csize=200_000):
-    for fname in fnames:
-        lines = list(open(fname + '.bak', newline='', encoding='utf-8-sig',
-                          errors='ignore'))
-        header = [col.strip() for col in lines[0].split(',')]
-        for block in general.block_splitter(lines[1:], csize):
-            comp = zlib.compress('\r\n'.join(block).encode('utf8'))
-            yield comp, header, fields
+def exposure_by_geohash(lines, names, common, monitor):
+    if isinstance(lines, bytes):
+        data = io.BytesIO(lines)
+    else:
+        data = io.StringIO(lines)
+    df = pandas.read_csv(data, names=names, dtype=CONV, usecols=common)
+    dt = hdf5.build_dt(CONV, names, '<BytesIO>')
+    array = numpy.zeros(len(df), dt)
+    for col in df.columns:
+        array[col] = df[col].to_numpy()
+    array = add_geohash3(array)
+    fix(array)
+    for gh in numpy.unique(array['geohash3']):
+        yield gh, array[array['geohash3']==gh]
+
+
+def gen_tasks(fname, fields, monitor):
+    lines = list(open(fname + '.bak', newline='', encoding='utf-8-sig',
+                      errors='ignore'))
+    header = [col.strip() for col in lines[0].split(',')]
+    for i, block in enumerate(general.block_splitter(lines[1:], 200_000)):
+        data = '\r\n'.join(block)
+        if i == 0:
+            yield from exposure_by_geohash(data, header, fields, monitor)
+        else:
+            data = zlib.compress(data.encode('utf8'))
+            yield exposure_by_geohash, data, header, fields
 
 
 def read_world_exposure(grm_dir, dstore):
@@ -133,7 +138,8 @@ def read_world_exposure(grm_dir, dstore):
     dstore.create_dset('exposure/slice_by_gh3', slc_dt, fillvalue=None)
 
     dstore.swmr_on()
-    smap = Starmap(exposure_by_geohash, gen_chunks(csvfiles, common),
+    Starmap.num_cores = 8
+    smap = Starmap(gen_tasks, [(c, common) for c in csvfiles],
                    h5=dstore.hdf5)
     s = 0
     for gh3, arr in smap:

--- a/utils/build_global_exposure
+++ b/utils/build_global_exposure
@@ -85,7 +85,7 @@ def collect_exposures(grm_dir):
 
 def exposure_by_geohash(lines, names, common, monitor):
     if isinstance(lines, bytes):
-        data = io.BytesIO(lines)
+        data = io.BytesIO(zlib.decompress(lines))
     else:
         data = io.StringIO(lines)
     df = pandas.read_csv(data, names=names, dtype=CONV, usecols=common)
@@ -100,14 +100,16 @@ def exposure_by_geohash(lines, names, common, monitor):
 
 
 def gen_tasks(fname, fields, monitor):
-    lines = list(open(fname + '.bak', newline='', encoding='utf-8-sig',
-                      errors='ignore'))
+    f = open(fname + '.bak', newline='', encoding='utf-8-sig', errors='ignore')
+    with f:
+        lines = list(f)
     header = [col.strip() for col in lines[0].split(',')]
     for i, block in enumerate(general.block_splitter(lines[1:], 200_000)):
         data = '\r\n'.join(block)
         if i == 0:
             yield from exposure_by_geohash(data, header, fields, monitor)
         else:
+            print(fname)
             data = zlib.compress(data.encode('utf8'))
             yield exposure_by_geohash, data, header, fields
 

--- a/utils/build_global_exposure
+++ b/utils/build_global_exposure
@@ -100,7 +100,7 @@ def exposure_by_geohash(lines, names, common, monitor):
 
 
 def gen_tasks(fname, fields, monitor):
-    f = open(fname + '.bak', newline='', encoding='utf-8-sig', errors='ignore')
+    f = open(fname, newline='', encoding='utf-8-sig', errors='ignore')
     with f:
         lines = list(f)
     header = [col.strip() for col in lines[0].split(',')]
@@ -140,7 +140,6 @@ def read_world_exposure(grm_dir, dstore):
     dstore.create_dset('exposure/slice_by_gh3', slc_dt, fillvalue=None)
 
     dstore.swmr_on()
-    Starmap.num_cores = 8
     smap = Starmap(gen_tasks, [(c, common) for c in csvfiles],
                    h5=dstore.hdf5)
     s = 0

--- a/utils/build_global_exposure
+++ b/utils/build_global_exposure
@@ -18,7 +18,9 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import io
 import logging
+import pandas
 import numpy
 import h5py
 from openquake.baselib import general, hdf5, sap, performance
@@ -37,7 +39,8 @@ OCCUPANTS_PER_ASSET_AVERAGE OCCUPANTS_PER_ASSET_DAY
 OCCUPANTS_PER_ASSET_NIGHT OCCUPANTS_PER_ASSET_TRANSIT
 TOTAL_AREA_SQM TOTAL_REPL_COST_USD'''.split()}
 CONV['ASSET_ID'] = (numpy.string_, 24)
-CONV[None] = str
+for f in (None, 'ID_1'):
+    CONV[f] = str
 TAGS = {'TAXONOMY': [], 'ID_0': [], 'ID_1': [], 'OCCUPANCY': []}
 IGNORE = set('NAME_0 NAME_1 SETTLEMENT'.split())
 
@@ -64,14 +67,18 @@ def fix(arr):
             ID1[i] = '%s-%s' % (id0, ID1[i])
 
 
-def exposure_by_geohash(fname, common, monitor):
-    aw = hdf5.read_csv(fname, CONV, errors='ignore', usecols=common)
-    if hasattr(aw, 'array') and len(aw.array):
-        for slc in general.gen_slices(0, len(aw.array), 1_000_000):
-            arr = add_geohash3(aw.array[slc])
-            fix(arr)
-            for gh in numpy.unique(arr['geohash3']):
-                yield gh, arr[arr['geohash3']==gh]
+def exposure_by_geohash(lines, names, common, monitor):
+    df = pandas.read_csv(io.StringIO('\r\n'.join(lines)), names=names,
+                         dtype=CONV, usecols=common)
+    if len(df):
+        dt = hdf5.build_dt(CONV, names, '<StringIO>')
+        array = numpy.zeros(len(df), dt)
+        for col in df.columns:
+            array[col] = df[col].to_numpy()
+        array = add_geohash3(array)
+        fix(array)
+        for gh in numpy.unique(array['geohash3']):
+            yield gh, array[array['geohash3']==gh]
 
 
 def collect_exposures(grm_dir):
@@ -87,6 +94,15 @@ def collect_exposures(grm_dir):
             if fname.startswith('Exposure_'):  # i.e. Exposure_Chile.xml
                 out.append(os.path.join(expodir, fname))
     return out
+
+
+def gen_chunks(fnames, fields, csize=1_000_000):
+    for fname in fnames:
+        lines = list(open(fname, newline='', encoding='utf-8-sig',
+                          errors='ignore'))
+        header = [col.strip() for col in lines[0].split(',')]
+        for block in general.block_splitter(lines[1:], csize):
+            yield block, header, fields
 
 
 def read_world_exposure(grm_dir, dstore):
@@ -115,7 +131,7 @@ def read_world_exposure(grm_dir, dstore):
     dstore.create_dset('exposure/slice_by_gh3', slc_dt, fillvalue=None)
 
     dstore.swmr_on()
-    smap = Starmap(exposure_by_geohash, [(c, common) for c in csvfiles],
+    smap = Starmap(exposure_by_geohash, gen_chunks(csvfiles, common),
                    h5=dstore.hdf5)
     s = 0
     for gh3, arr in smap:


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/9227. Now the figures are
```
[#56285 INFO] Received 26508 * 497.53 KB {'tot': '12.58 GB'} in 330 seconds
<Monitor [michele], duration=493.16890954971313s, memory=21.13 GB>
| calc_56285, maxmem=29.4 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total exposure_by_geohash  | 1_911    | 35.7      | 10_113 |
| total gen_tasks            | 1_017    | 34.5      | 16_658 |
```
faster than before (493s < 574s).