### PR TITLE
Improved build_global_exposure/4

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -42,7 +42,7 @@ vuint32 = h5py.special_dtype(vlen=numpy.uint32)
 vfloat32 = h5py.special_dtype(vlen=numpy.float32)
 vfloat64 = h5py.special_dtype(vlen=numpy.float64)
 
-CSVFile = collections.namedtuple('CSVFile', 'fname header fields weight')
+CSVFile = collections.namedtuple('CSVFile', 'fname header fields size')
 FLOAT = (float, numpy.float32, numpy.float64)
 INT = (int, numpy.int32, numpy.uint32, numpy.int64, numpy.uint64)
 MAX_ROWS = 10_000_000
@@ -913,7 +913,9 @@ def find_error(fname, errors, dtype):
 
 def sniff(fnames, sep=',', ignore=set()):
     """
-    Infer the common fields of a set of CSV files (stripping the pre-headers)
+    Read the first line of a set of CSV files by stripping the pre-headers.
+
+    :returns: a list of CSVFile namedtuples.
     """
     common = None
     files = []

--- a/utils/build_global_exposure
+++ b/utils/build_global_exposure
@@ -90,20 +90,20 @@ def collect_exposures(grm_dir):
     return out, csvfiles
 
 
-def exposure_by_geohash(lines, names, common, monitor):
-    if hasattr(lines, 'fname'):
-        inp = lines.fname
+def exposure_by_geohash(data, file, monitor):
+    if data is None:
+        inp = file.fname
         skip = 1
-    elif isinstance(lines, bytes):
-        inp = io.BytesIO(zlib.decompress(lines))
+    elif isinstance(data, bytes):
+        inp = io.BytesIO(zlib.decompress(data))
         skip = 0
     else:
-        inp = io.StringIO(lines)
+        inp = io.StringIO(data)
         skip = 0
-    df = pandas.read_csv(inp, names=names, dtype=CONV, usecols=common,
-                         skiprows=skip)
+    df = pandas.read_csv(
+        inp, names=file.header, dtype=CONV, usecols=file.fields, skiprows=skip)
     if len(df):
-        dt = hdf5.build_dt(CONV, names, '<BytesIO>')
+        dt = hdf5.build_dt(CONV, file.header, '<BytesIO>')
         array = numpy.zeros(len(df), dt)
         for col in df.columns:
             array[col] = df[col].to_numpy()
@@ -115,25 +115,22 @@ def exposure_by_geohash(lines, names, common, monitor):
 
 def gen_tasks(files, monitor):
     for file in files:
-        if file.weight < 10_000_000:  # small file
-            yield from exposure_by_geohash(
-                file, file.header, file.fields, monitor)
+        if file.size < 10_000_000:  # small file
+            yield from exposure_by_geohash(None, file, monitor)
             continue
         f = open(file.fname, newline='',
                  encoding='utf-8-sig', errors='ignore')
         with f:
             lines = list(f)
-        header = [col.strip() for col in lines[0].split(',')]
         for i, block in enumerate(general.block_splitter(lines[1:], 500_000)):
             data = '\r\n'.join(block)
             if i == 0:
-                yield from exposure_by_geohash(
-                    data, header, file.fields, monitor)
+                yield from exposure_by_geohash(data, file, monitor)
             else:
                 print(file.fname)
                 # compressing saves memory when pickling-unpickling
                 data = zlib.compress(data.encode('utf8'))
-                yield exposure_by_geohash, data, header, file.fields
+                yield exposure_by_geohash, data, file
 
 
 def read_world_exposure(grm_dir, dstore):
@@ -155,7 +152,7 @@ def read_world_exposure(grm_dir, dstore):
     dstore.create_dset('exposure/slice_by_gh3', slc_dt, fillvalue=None)
     dstore.swmr_on()
     smap = Starmap.apply(gen_tasks, (files,),
-                         weight=operator.attrgetter('weight'), h5=dstore.hdf5)
+                         weight=operator.attrgetter('size'), h5=dstore.hdf5)
     s = 0
     for gh3, arr in smap:
         for name in files[0].fields:

--- a/utils/build_global_exposure
+++ b/utils/build_global_exposure
@@ -22,7 +22,6 @@ import io
 import zlib
 import logging
 import operator
-import collections
 import pandas
 import numpy
 import h5py
@@ -46,7 +45,6 @@ for f in (None, 'ID_1'):
     CONV[f] = str
 TAGS = {'TAXONOMY': [], 'ID_0': [], 'ID_1': [], 'OCCUPANCY': []}
 IGNORE = set('NAME_0 NAME_1 SETTLEMENT'.split())
-File = collections.namedtuple('File', 'fname weight fields')
 
 
 def add_geohash3(array):
@@ -75,10 +73,9 @@ def collect_exposures(grm_dir):
     """
     Collect the files of kind Exposure_<Country>.xml.
 
-    :returns: xmlfiles, csvfiles, csvsizes
+    :returns: xmlfiles, csvfiles
     """
     out = []
-    sizes = []
     csvfiles = []
     for region in os.listdir(grm_dir):
         expodir = os.path.join(grm_dir, region, 'Exposure', 'Exposure')
@@ -90,28 +87,38 @@ def collect_exposures(grm_dir):
                 out.append(fullname)
                 exposure, _ = _get_exposure(fullname)
                 csvfiles.extend(exposure.datafiles)
-                sizes.extend(map(os.path.getsize, exposure.datafiles))
-    return out, csvfiles, sizes
+    return out, csvfiles
 
 
 def exposure_by_geohash(lines, names, common, monitor):
-    if isinstance(lines, bytes):
-        data = io.BytesIO(zlib.decompress(lines))
+    if hasattr(lines, 'fname'):
+        inp = lines.fname
+        skip = 1
+    elif isinstance(lines, bytes):
+        inp = io.BytesIO(zlib.decompress(lines))
+        skip = 0
     else:
-        data = io.StringIO(lines)
-    df = pandas.read_csv(data, names=names, dtype=CONV, usecols=common)
-    dt = hdf5.build_dt(CONV, names, '<BytesIO>')
-    array = numpy.zeros(len(df), dt)
-    for col in df.columns:
-        array[col] = df[col].to_numpy()
-    array = add_geohash3(array)
-    fix(array)
-    for gh in numpy.unique(array['geohash3']):
-        yield gh, array[array['geohash3']==gh]
+        inp = io.StringIO(lines)
+        skip = 0
+    df = pandas.read_csv(inp, names=names, dtype=CONV, usecols=common,
+                         skiprows=skip)
+    if len(df):
+        dt = hdf5.build_dt(CONV, names, '<BytesIO>')
+        array = numpy.zeros(len(df), dt)
+        for col in df.columns:
+            array[col] = df[col].to_numpy()
+        array = add_geohash3(array)
+        fix(array)
+        for gh in numpy.unique(array['geohash3']):
+            yield gh, array[array['geohash3']==gh]
 
 
 def gen_tasks(files, monitor):
     for file in files:
+        if file.weight < 10_000_000:  # small file
+            yield from exposure_by_geohash(
+                file, file.header, file.fields, monitor)
+            continue
         f = open(file.fname, newline='',
                  encoding='utf-8-sig', errors='ignore')
         with f:
@@ -136,10 +143,8 @@ def read_world_exposure(grm_dir, dstore):
 
     :param grm_dir: directory containing the global risk model
     """
-    fnames, csvfiles, csvsizes = collect_exposures(grm_dir)
-    common = sorted(hdf5.read_common_header(csvfiles) - IGNORE)
-    assert common, 'There is no common header subset among %s' % csvfiles
-
+    fnames, csvfiles = collect_exposures(grm_dir)
+    files = hdf5.sniff(csvfiles, ',', IGNORE)
     dtlist = [(t, U32) for t in TAGS] + \
         [(f, F32) for f in set(CONV)-set(TAGS)-{'ASSET_ID', None}] + \
         [('ASSET_ID', h5py.string_dtype('ascii', 25))]
@@ -148,14 +153,12 @@ def read_world_exposure(grm_dir, dstore):
         dstore.create_dset('tagcol/' + tagname, U32)
     slc_dt = numpy.dtype([('gh3', U16), ('start', U32), ('stop', U32)])
     dstore.create_dset('exposure/slice_by_gh3', slc_dt, fillvalue=None)
-
     dstore.swmr_on()
-    files = [File(c, w, common) for c, w in zip(csvfiles, csvsizes)]
     smap = Starmap.apply(gen_tasks, (files,),
                          weight=operator.attrgetter('weight'), h5=dstore.hdf5)
     s = 0
     for gh3, arr in smap:
-        for name in common:
+        for name in files[0].fields:
             if name in TAGS:
                 TAGS[name].append(arr[name])
             else:


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/9227. By using pandas directly on small files I get much faster:
```
Received 16291 * 472.46 KB {'tot': '7.34 GB'} in 209 seconds
<Monitor [michele], duration=294.58053159713745s, memory=13.18 GB>
| calc_56312, maxmem=28.8 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total exposure_by_geohash  | 1_667    | 26.5      | 3_365  |
| total gen_tasks            | 444.2    | 6.26842   | 13_001 |

| operation-duration  | counts | mean | stddev | min     | max   | slowfac |
|---------------------+--------+------+--------+---------+-------+---------|
| exposure_by_geohash | 75     | 22.2 | 23%    | 0.25935 | 31.2  | 1.40277 |
| gen_tasks           | 19     | 23.4 | 180%   | 0.33477 | 152.3 | 6.51578 |
```