### PR TITLE
Removed the obsolete `by_country` hack

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the obsolete `by_country` hack when managing the global exposures
   * Changed `oq sample` to use pandas for reading/writing CSVs, thus fixing
     the issue of quoted newlines
   * Fixed `oq check_input exposure.xml`

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -985,7 +985,6 @@ def get_exposure(oqparam, h5=None):
         exposure = Global.exposure = asset.Exposure.read_all(
             oqparam.inputs['exposure'], oqparam.calculation_mode,
             oqparam.ignore_missing_costs,
-            by_country='country' in asset.tagset(oqparam.aggregate_by),
             errors='ignore' if oqparam.ignore_encoding_errors else None,
             infr_conn_analysis=oqparam.infrastructure_connectivity_analysis,
             aggregate_by=oqparam.aggregate_by)


### PR DESCRIPTION
It was needed 5 years ago when the CSV exposures where missing the `ID_0` field. Simplifies my life for my #9227.