### PR TITLE
Let the help button point to the AELO user guide when in AELO mode

### DIFF
--- a/openquake/server/templates/engine/base.html
+++ b/openquake/server/templates/engine/base.html
@@ -55,7 +55,11 @@
                   </li>
                   {% endif %}
                   <li class="actions">
+                      {% if application_mode == 'AELO' %}
+                      <a href="https://docs.openquake.org/.aelo/AELO_Web_Service_User_Guide.pdf" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
+                      {% else %}
                       <a href="https://docs.openquake.org/oq-engine/latest/manual/" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
+                      {% endif %}
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
I added the manual to https://docs.openquake.org/.aelo/AELO_Web_Service_User_Guide.pdf
I removed from the file name any reference to versioning, so it will be sufficient to replace that file to keep linking to the latest version. Perhaps it would be better to use some kind of alias instead, if we want to keep also older versions of the file and point always to the latest.