### PR TITLE
small fixes to aelo plotting

### DIFF
--- a/openquake/calculators/postproc/aelo_plots.py
+++ b/openquake/calculators/postproc/aelo_plots.py
@@ -115,8 +115,11 @@ def plot_mean_hcurves_rtgm(dstore, update_dstore=False):
     for m, hcurve in enumerate(mean_hcurve):
         AFE.append(to_rates(hcurve, window, minrate=1E-12))
         # get the AFE of the iml that will be disaggregated for each IMT
-        afe_RTGM.append(_find_afe_target(
-            numpy.array(imls[m]), numpy.array(AFE[m]), rtgm_probmce[m]))
+        if rtgm_probmce[m] < imls[m][0]:
+            afe_RTGM.append(0.0)
+        else:
+            afe_RTGM.append(_find_afe_target(
+                numpy.array(imls[m]), numpy.array(AFE[m]), rtgm_probmce[m]))
 
     plt = import_plt()
     plt.figure(figsize=(12, 9))
@@ -304,8 +307,8 @@ def plot_disagg_by_src(dstore, update_dstore=False):
                     ax1.loglog(imls_o, afes, 'silver', linewidth=0.7)
             # if it is, plot in color
             else:
-                ax[m].loglog(imls, afes, c=viridis(i), label=str(src))
-                ax1.loglog(imls_o, afes, c=viridis(i), label=str(src))
+                ax[m].loglog(imls, afes, c=viridis(i), label=str(mrs.src_id[ind]))
+                ax1.loglog(imls_o, afes, c=viridis(i), label=str(mrs.src_id[ind]))
                 i += 1
         # populate subplot - maximum component
         ax[m].grid('both')

--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -84,6 +84,7 @@ PGA,0.37,0.43,0.50,0.55,0.56,0.53,0.46,0.42
 '''), index_col='imt')
 
 # hard-coded for year 1
+# NOTE: consider lower thresholds of IMLs and impact on plots in Year 3
 # TODO: interpolate for vs30 != 760 and for different periods
 # NOTE: for meanHCs_afe_RTGM and disaggr_by_src we want to display these
 # three imts, that are mandatory in this context. For the plot of governing


### PR DESCRIPTION
Addressing two small issues in AELO plots:

1. there were problems getting the AFE when the compute_RTGM interpolated the hazard curve (to lower IMLs) to find the probMCE, e.g. when `rtgm_probmce[m] < imls[m][0]`. This only affects the hazard curve plot after `_find_afe_target` fails. In this PR, we automatically assign `afe_RTGM=0.0` if `rtgm_probmce[m] < imls[m][0]`. Also added a note to our future selves in compute_RTGM.py for checking the lower limit of the IMLs used in Year 3.
2. Fixed a label issue for most contributing sources on the hazard curves per source plots. 