### PR TITLE
AELO: better handle cases with low or zero hazard

### DIFF
--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -205,6 +205,49 @@ def get_deterministic(prob_mce, mag_dist_eps, sigma_by_src):
     return det.to_dict(), np.array(mag_dist_eps_sig, dt)
 
 
+def get_low_hazard_asce07():
+    na = 'n.a.'
+    asce07 = {
+             'PGA': 0,
+             'PGA_2_50': 0,
+             'PGA_84th': na,
+             'PGA_det': na,
+
+             'Ss': na,
+             'Ss_RT': na,
+             'CRS': na,
+             'Ss_84th': na,
+             'Ss_det': na,
+             'Ss_seismicity': 'Low',
+
+             'S1': na,
+             'S1_RT': na,
+             'CR1': na,
+             'S1_84th': na,
+             'S1_det': na,
+             'S1_seismicity': 'Low',
+             }
+    return asce07
+
+
+def get_low_hazard_asce41():
+    na = 'n.a.'
+    asce41 = {'BSE2N_Ss': na,
+              'BSE2E_Ss': na,
+              'Ss_5_50': na,
+              'BSE1N_Ss': na,
+              'BSE1E_Ss': na,
+              'Ss_20_50': na,
+              'BSE2N_S1': na,
+              'BSE2E_S1': na,
+              'S1_5_50': na,
+              'BSE1N_S1': na,
+              'BSE1E_S1': na,
+              'S1_20_50': na,
+              }
+    return asce41
+
+
 def get_mce_asce07(prob_mce, det_imt, DLLs, dstore, low_haz=False):
     """
     :param prob_mce: Probabilistic Maximum Considered Earthquake (UHGM for PGA)
@@ -360,6 +403,10 @@ def main(dstore, csm):
         else:
             dstore['warnings'] = warning
         logging.warning(warning)
+        asce07 = get_low_hazard_asce07()
+        asce41 = get_low_hazard_asce41()
+        dstore['asce07'] = hdf5.dumps(asce07)
+        dstore['asce41'] = hdf5.dumps(asce41)
         return
     if dstore['mean_rates_ss'][:].max() < MIN_AFE:
         warning = (
@@ -371,6 +418,10 @@ def main(dstore, csm):
         else:
             dstore['warnings'] = warning
         logging.warning(warning)
+        asce07 = get_low_hazard_asce07()
+        asce41 = get_low_hazard_asce41()
+        dstore['asce07'] = hdf5.dumps(asce07)
+        dstore['asce41'] = hdf5.dumps(asce41)
         return
     logging.info('Computing Risk Targeted Ground Motion')
     oq = dstore['oqparam']

--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -215,7 +215,7 @@ def get_low_hazard_asce07():
 
              'Ss': na,
              'Ss_RT': na,
-             'CRS': na,
+             'CRs': na,
              'Ss_84th': na,
              'Ss_det': na,
              'Ss_seismicity': 'Low',
@@ -311,7 +311,7 @@ def get_mce_asce07(prob_mce, det_imt, DLLs, dstore, low_haz=False):
 
              'Ss': mce['SA(0.2)'],
              'Ss_RT': prob_mce_out['SA(0.2)'],
-             'CRS': crs,
+             'CRs': crs,
              'Ss_84th': det_imt['SA(0.2)'],
              'Ss_det': det_mce['SA(0.2)'],
              'Ss_seismicity': Ss_seismicity,

--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -350,10 +350,27 @@ def main(dstore, csm):
         logging.warning('Missing module rtgmpy: skipping AELO calculation')
         return
     if len(dstore['rup/mag']) == 0:
-        logging.warning('Zero hazard: skipping AELO calculation')
+        warning = (
+            'The seismic hazard at the site is 0: there are no ruptures'
+            ' close to the site. ASCE 7-16 and ASCE 41-17 parameters'
+            ' cannot be computed.')
+        if 'warnings' in dstore:
+            warnings = dstore['warnings'][()].decode('utf8')
+            dstore['warnings'] = warnings + '\n' + warning
+        else:
+            dstore['warnings'] = warning
+        logging.warning(warning)
         return
     if dstore['mean_rates_ss'][:].max() < MIN_AFE:
-        logging.warning('Ultra-low hazard: skipping AELO calculation')
+        warning = (
+            'The seismic hazard at the site is very low. ASCE 7-16 and'
+            ' ASCE 41-17 parameters cannot be computed.')
+        if 'warnings' in dstore:
+            warnings = dstore['warnings'][()].decode('utf8')
+            dstore['warnings'] = warnings + '\n' + warning
+        else:
+            dstore['warnings'] = warning
+        logging.warning(warning)
         return
     logging.info('Computing Risk Targeted Ground Motion')
     oq = dstore['oqparam']

--- a/openquake/server/templates/engine/get_outputs_aelo.html
+++ b/openquake/server/templates/engine/get_outputs_aelo.html
@@ -6,9 +6,9 @@
     <div class="container">
       <div class="row">
         <div id="oq-body-wrapper">
-          {% if low_hazard %}
+          {% if warnings %}
           <div id="warning-box" class="alert alert-warning" style=>
-            Warning: the ASCE outputs are missing since the hazard is too low
+            {{ warnings }}
           </div>
           {% endif %}
           <div class="span12">

--- a/openquake/server/templates/engine/get_outputs_aelo.html
+++ b/openquake/server/templates/engine/get_outputs_aelo.html
@@ -6,13 +6,13 @@
     <div class="container">
       <div class="row">
         <div id="oq-body-wrapper">
-          {% if warnings %}
-          <div id="warning-box" class="alert alert-warning" style=>
-            {{ warnings }}
-          </div>
-          {% endif %}
           <div class="span12">
               <h2>Outputs from site: {{ site_name }}, lat: {{ lat }}, lon: {{ lon }}, vs30: {{ vs30 }}</h2>
+              {% if warnings %}
+              <div id="warning-box" class="alert alert-warning" style=>
+                  WARNING: {{ warnings }}
+              </div>
+              {% endif %}
               <div id="my-outputs" class="well"></div>
               <div id="to-full-outputs">
                 <a href="{{ oq_engine_server_url }}/engine/{{ calc_id }}/outputs" class="btn btn-sm">

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1023,7 +1023,7 @@ def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
                     continue
                 if not isinstance(value, float):
                     asce07_with_units[key] = value
-                elif key in ('CRS', 'CR1'):
+                elif key in ('CRs', 'CR1'):
                     # NOTE: (-) stands for adimensional
                     asce07_with_units[key + ' (-)'] = "%.2f" % round(
                         value, ASCE_VIEW_DECIMALS)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1025,10 +1025,10 @@ def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
                     asce07_with_units[key] = value
                 elif key in ('CRS', 'CR1'):
                     # NOTE: (-) stands for adimensional
-                    asce07_with_units[key + ' (-)'] = round(
+                    asce07_with_units[key + ' (-)'] = "%.2f" % round(
                         value, ASCE_VIEW_DECIMALS)
                 else:
-                    asce07_with_units[key + ' (g)'] = round(
+                    asce07_with_units[key + ' (g)'] = "%.2f" % round(
                         value, ASCE_VIEW_DECIMALS)
         if 'asce41' in ds:
             asce41_js = ds['asce41'][()].decode('utf8')
@@ -1036,8 +1036,11 @@ def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
             for key, value in asce41.items():
                 if not key.startswith('BSE'):
                     continue
-                asce41_with_units[key + ' (g)'] = round(
-                    value, ASCE_VIEW_DECIMALS)
+                if not isinstance(value, float):
+                    asce41_with_units[key] = value
+                else:
+                    asce41_with_units[key + ' (g)'] = "%.2f" % round(
+                        value, ASCE_VIEW_DECIMALS)
         lon, lat = ds['oqparam'].sites[0][:2]  # e.g. [[-61.071, 14.686, 0.0]]
         vs30 = ds['oqparam'].override_vs30  # e.g. 760.0
         site_name = ds['oqparam'].description  # e.g. 'AELO Year 1, CCA'

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -53,7 +53,8 @@ from openquake.calculators.extract import extract as _extract
 from openquake.engine import __version__ as oqversion
 from openquake.engine.export import core
 from openquake.engine import engine, aelo
-from openquake.engine.aelo import get_params_from
+from openquake.engine.aelo import (
+    get_params_from, PRELIMINARY_MODELS, PRELIMINARY_MODEL_WARNING)
 from openquake.engine.export.core import DataStoreExportError
 from openquake.server import utils
 
@@ -571,7 +572,8 @@ def calc_run(request):
                         status=status)
 
 
-def aelo_callback(job_id, job_owner_email, outputs_uri, inputs, exc=None):
+def aelo_callback(
+        job_id, job_owner_email, outputs_uri, inputs, exc=None, warnings=None):
     if not job_owner_email:
         return
     from_email = 'aelonoreply@openquake.org'
@@ -579,6 +581,9 @@ def aelo_callback(job_id, job_owner_email, outputs_uri, inputs, exc=None):
     reply_to = 'aelosupport@openquake.org'
     body = (f"Input values: lon = {inputs['lon']}, lat = {inputs['lat']},"
             f" vs30 = {inputs['vs30']}, siteid = {inputs['siteid']}\n\n")
+    if warnings is not None:
+        for warning in warnings:
+            body += warning + '\n'
     if exc:
         subject = f'Job {job_id} failed'
         body += f'There was an error running job {job_id}:\n{exc}'
@@ -987,6 +992,16 @@ def web_engine_get_outputs(request, calc_id, **kwargs):
                        application_mode=application_mode))
 
 
+def is_model_preliminary(ds):
+    # TODO: it would be better having the model written explicitly into the
+    # datastore
+    model = ds['oqparam'].base_path.split(os.path.sep)[-2]
+    if model in PRELIMINARY_MODELS:
+        return True
+    else:
+        return False
+
+
 @cross_domain_ajax
 @require_http_methods(['GET'])
 def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
@@ -996,7 +1011,10 @@ def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
     asce07_with_units = {}
     asce41_with_units = {}
     ASCE_VIEW_DECIMALS = 2
+    warnings = None
     with datastore.read(job.ds_calc_dir + '.hdf5') as ds:
+        if is_model_preliminary(ds):
+            warnings = PRELIMINARY_MODEL_WARNING
         if 'asce07' in ds:
             asce07_js = ds['asce07'][()].decode('utf8')
             asce07 = json.loads(asce07_js)
@@ -1023,12 +1041,17 @@ def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
         lon, lat = ds['oqparam'].sites[0][:2]  # e.g. [[-61.071, 14.686, 0.0]]
         vs30 = ds['oqparam'].override_vs30  # e.g. 760.0
         site_name = ds['oqparam'].description  # e.g. 'AELO Year 1, CCA'
-    low_hazard = asce07 is None or asce41 is None
+        if 'warnings' in ds:
+            ds_warnings = ds['warnings'][()].decode('utf8')
+            if warnings is None:
+                warnings = ds_warnings
+            else:
+                warnings += '\n' + ds_warnings
     return render(request, "engine/get_outputs_aelo.html",
                   dict(calc_id=calc_id, size_mb=size_mb,
                        asce07=asce07_with_units, asce41=asce41_with_units,
                        lon=lon, lat=lat, vs30=vs30, site_name=site_name,
-                       low_hazard=low_hazard))
+                       warnings=warnings))
 
 
 @csrf_exempt


### PR DESCRIPTION
1. Added a warning both in the email and in the simplified outputs page when using "preliminary" models ('CEA', 'CHN', 'NEA')
2. Improved logging and added warning to the simplified outputs page in case of zero or low hazard
3. If ASCE tables can not be computed, they are anyway stored and displayed with zeros, n.a. and 'Low' values
4. The warning was moved below the outputs title and it was prefixed with "WARNING: "
5. Numbers are formatted to always display 2 decimal places also when the last digit is zero