### PR TITLE
Fixed `extract_from_zip` when managing zip files coming from MACOSX

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed `extract_from_zip` when managing zip files coming from MACOSX;
+
   [Paolo Tormene]
   * Internal: extended the MosaicGetter to a GlobalModelGetter class with
     the ability to associate points to countries

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Fixed `extract_from_zip` when managing zip files coming from MACOSX;
+  * Fixed `extract_from_zip` when managing zip files coming from MACOSX
 
   [Paolo Tormene]
   * Internal: extended the MosaicGetter to a GlobalModelGetter class with

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -97,7 +97,7 @@ class DuplicatedPoint(Exception):
     """
 
 
-# used in extract_from_zip
+# used in extract_fom_zip
 def collect_files(dirpath, cond=lambda fullname: True):
     """
     Recursively collect the files contained inside dirpath.
@@ -130,7 +130,8 @@ def extract_from_zip(path, ext='.ini', targetdir=None):
     with zipfile.ZipFile(path) as archive:
         archive.extractall(targetdir)
     return [f for f in collect_files(targetdir)
-            if os.path.basename(f).endswith(ext)]
+            if os.path.basename(f).endswith(ext)
+            and '__MACOSX' not in f]
 
 
 def unzip_rename(zpath, name):


### PR DESCRIPTION
A test.zip file provided by @raoanirudh was not working due to a binary file `/tmp/tmpbghgqaok/__MACOSX/._job.ini` being considered instead of  `/tmp/tmpbghgqaok/job.ini`