### PR TITLE
Updated RaghukanthIyengar2007TestCase to use `contexts.get_mean_stds`

### DIFF
--- a/openquake/hazardlib/tests/gsim/raghukanth_iyengar_2007_test.py
+++ b/openquake/hazardlib/tests/gsim/raghukanth_iyengar_2007_test.py
@@ -30,7 +30,7 @@ and subclasses of same.
 import warnings
 import numpy as np
 
-from openquake.hazardlib import gsim
+from openquake.hazardlib import gsim, contexts, imt
 from openquake.hazardlib.tests.gsim.utils import BaseGSIMTestCase
 
 from openquake.hazardlib.gsim.raghukanth_iyengar_2007 import (
@@ -65,23 +65,18 @@ class RaghukanthIyengar2007TestCase(BaseGSIMTestCase):
         gmpe = self.GSIM_CLASS()
         ctx.mag = np.array([6.5])
         ctx.rhypo = ctx.rrup = np.array([100.])
-        im_type = sorted(gmpe.COEFFS_BEDROCK.sa_coeffs)[0]
-        std_types = list(gmpe.DEFINED_FOR_STANDARD_DEVIATION_TYPES)
-
         # set critical value to trigger warning
         ctx.vs30 = np.array([170.])
+        imts = [imt.from_string('SA(0.01)')]
 
         with warnings.catch_warnings(record=True) as warning_stream:
             warnings.simplefilter('always')
-
-            mean = gmpe.get_mean_and_stddevs(
-                ctx, ctx, ctx, im_type, std_types)[0]
+            contexts.get_mean_stds(gmpe, ctx, imts)
 
             # confirm type and content of warning
             assert len(warning_stream) == 1
             assert issubclass(warning_stream[-1].category, UserWarning)
             assert 'not supported' in str(warning_stream[-1].message).lower()
-            assert np.all(np.isnan(mean))
 
 
 class RaghukanthIyengar2007KoynaWarnaTestCase(RaghukanthIyengar2007TestCase):

--- a/openquake/hazardlib/tests/gsim/raghukanth_iyengar_2007_test.py
+++ b/openquake/hazardlib/tests/gsim/raghukanth_iyengar_2007_test.py
@@ -77,7 +77,7 @@ class RaghukanthIyengar2007TestCase(BaseGSIMTestCase):
             assert len(warning_stream) == 1
             assert issubclass(warning_stream[-1].category, UserWarning)
             assert 'not supported' in str(warning_stream[-1].message).lower()
-            assert np.all(np.isnan(mean))		
+            assert np.all(np.isnan(mean))
 
 
 class RaghukanthIyengar2007KoynaWarnaTestCase(RaghukanthIyengar2007TestCase):

--- a/openquake/hazardlib/tests/gsim/raghukanth_iyengar_2007_test.py
+++ b/openquake/hazardlib/tests/gsim/raghukanth_iyengar_2007_test.py
@@ -71,12 +71,13 @@ class RaghukanthIyengar2007TestCase(BaseGSIMTestCase):
 
         with warnings.catch_warnings(record=True) as warning_stream:
             warnings.simplefilter('always')
-            contexts.get_mean_stds(gmpe, ctx, imts)
+            mean, _, _, _ = contexts.get_mean_stds(gmpe, ctx, imts)
 
             # confirm type and content of warning
             assert len(warning_stream) == 1
             assert issubclass(warning_stream[-1].category, UserWarning)
             assert 'not supported' in str(warning_stream[-1].message).lower()
+            assert np.all(np.isnan(mean))		
 
 
 class RaghukanthIyengar2007KoynaWarnaTestCase(RaghukanthIyengar2007TestCase):


### PR DESCRIPTION
It was still using the old API. There is a broken test due to numpy 1.26, fixed in https://github.com/gem/oq-engine/pull/9290.