### PR TITLE
Extend `oq plot_assets` to plot the contour of the countries

### DIFF
--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -54,7 +54,8 @@ def main(calc_id: int = -1, site_model=False):
     fig = p.figure()
     ax = fig.add_subplot(111)
     if region:
-        pp = PolygonPatch(shapely.wkt.loads(region), alpha=0.1)
+        region_geom = shapely.wkt.loads(region)
+        pp = PolygonPatch(region_geom, alpha=0.1)
         ax.add_patch(pp)
     ax.grid(True)
     if site_model and 'site_model' in dstore:
@@ -83,10 +84,13 @@ def main(calc_id: int = -1, site_model=False):
         else:
             ax.add_patch(PolygonPatch(poly, fc=colour, alpha=0.1))
 
-    minx = assetcol['lon'].min()
-    maxx = assetcol['lon'].max()
-    miny = assetcol['lat'].min()
-    maxy = assetcol['lat'].max()
+    if region:
+        minx, miny, maxx, maxy = region_geom.bounds
+    else:
+        minx = assetcol['lon'].min()
+        maxx = assetcol['lon'].max()
+        miny = assetcol['lat'].min()
+        maxy = assetcol['lat'].max()
     w, h = maxx - minx, maxy - miny
     ax.set_xlim(minx - 0.2 * w, maxx + 0.2 * w)
     ax.set_ylim(miny - 0.2 * h, maxy + 0.2 * h)

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -94,9 +94,7 @@ def main(calc_id: int = -1, site_model=False):
     w, h = maxx - minx, maxy - miny
     ax.set_xlim(minx - 0.2 * w, maxx + 0.2 * w)
     ax.set_ylim(miny - 0.2 * h, maxy + 0.2 * h)
-    # ax.set_aspect(1)
     ax.legend()
-    # p.title("Assets and sites")
     p.savefig('assets.png', alpha=True, dpi=300)
     p.show()
 

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -20,6 +20,7 @@ import os
 import numpy
 import fiona
 import shapely
+import logging
 from shapely.geometry import MultiPolygon, shape
 from openquake.commonlib import datastore
 from openquake.hazardlib.geo.utils import cross_idl
@@ -95,7 +96,9 @@ def main(calc_id: int = -1, site_model=False):
     ax.set_xlim(minx - 0.2 * w, maxx + 0.2 * w)
     ax.set_ylim(miny - 0.2 * h, maxy + 0.2 * h)
     ax.legend()
-    p.savefig('assets.png', alpha=True, dpi=300)
+    filename = 'assets.png'
+    p.savefig(filename, alpha=True, dpi=300)
+    logging.info(f'Plot saved to {filename}')
     p.show()
 
 

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -16,19 +16,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import numpy
+import fiona
 import shapely
+from shapely.geometry import MultiPolygon, shape
 from openquake.commonlib import datastore
 from openquake.hazardlib.geo.utils import cross_idl
+from openquake.qa_tests_data import global_risk
 
 
 def main(calc_id: int = -1, site_model=False):
     """
     Plot the sites and the assets
     """
+
     # NB: matplotlib is imported inside since it is a costly import
     import matplotlib.pyplot as p
     from openquake.hmtk.plotting.patch import PolygonPatch
+
+    shapefile_dir = os.path.dirname(global_risk.__file__)
+    shapefile_path = os.path.join(shapefile_dir, 'geoBoundariesCGAZ_ADM0.shp')
+    polys = [shape(pol['geometry']) for pol in fiona.open(shapefile_path)]
+    cm = p.get_cmap('RdBu')
+    num_colours = len(polys)
+
     dstore = datastore.read(calc_id)
     try:
         region = dstore['oqparam'].region
@@ -62,7 +74,26 @@ def main(calc_id: int = -1, site_model=False):
         disc = numpy.unique(dstore['discarded']['lon', 'lat'])
         p.scatter(disc['lon'], disc['lat'], marker='x', color='red',
                   label='discarded')
+
+    for idx, poly in enumerate(polys):
+        colour = cm(1. * idx / num_colours)
+        if isinstance(poly, MultiPolygon):
+            for onepoly in poly.geoms:
+                ax.add_patch(PolygonPatch(onepoly, fc=colour, alpha=0.1))
+        else:
+            ax.add_patch(PolygonPatch(poly, fc=colour, alpha=0.1))
+
+    minx = assetcol['lon'].min()
+    maxx = assetcol['lon'].max()
+    miny = assetcol['lat'].min()
+    maxy = assetcol['lat'].max()
+    w, h = maxx - minx, maxy - miny
+    ax.set_xlim(minx - 0.2 * w, maxx + 0.2 * w)
+    ax.set_ylim(miny - 0.2 * h, maxy + 0.2 * h)
+    # ax.set_aspect(1)
     ax.legend()
+    # p.title("Assets and sites")
+    p.savefig('assets.png', alpha=True, dpi=300)
     p.show()
 
 

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -27,7 +27,8 @@ from openquake.hazardlib.geo.utils import cross_idl
 from openquake.qa_tests_data import global_risk
 
 
-def main(calc_id: int = -1, site_model=False):
+def main(calc_id: int = -1, site_model=False, shapefile_path=None,
+         save_to=None):
     """
     Plot the sites and the assets
     """
@@ -36,8 +37,10 @@ def main(calc_id: int = -1, site_model=False):
     import matplotlib.pyplot as p
     from openquake.hmtk.plotting.patch import PolygonPatch
 
-    shapefile_dir = os.path.dirname(global_risk.__file__)
-    shapefile_path = os.path.join(shapefile_dir, 'geoBoundariesCGAZ_ADM0.shp')
+    if shapefile_path is None:
+        shapefile_dir = os.path.dirname(global_risk.__file__)
+        shapefile_path = os.path.join(
+            shapefile_dir, 'geoBoundariesCGAZ_ADM0.shp')
     polys = [shape(pol['geometry']) for pol in fiona.open(shapefile_path)]
     cm = p.get_cmap('RdBu')
     num_colours = len(polys)
@@ -96,11 +99,13 @@ def main(calc_id: int = -1, site_model=False):
     ax.set_xlim(minx - 0.2 * w, maxx + 0.2 * w)
     ax.set_ylim(miny - 0.2 * h, maxy + 0.2 * h)
     ax.legend()
-    filename = 'assets.png'
-    p.savefig(filename, alpha=True, dpi=300)
-    logging.info(f'Plot saved to {filename}')
+    if save_to:
+        p.savefig(save_to, alpha=True, dpi=300)
+        logging.info(f'Plot saved to {save_to}')
     p.show()
 
 
 main.calc_id = 'a computation id'
 main.site_model = 'plot the site model too'
+main.shapefile_path = 'a shapefile with country/region borders'
+main.save_to = 'save the plot to this filename'


### PR DESCRIPTION
Fixes https://github.com/gem/oq-engine/issues/9294

I have also added a couple of parameters, so for instance you can do something like this:
`oq plot_assets -1 openquake/qa_tests_data/mosaic/ModelBoundaries.shp assets.png`
In this case, it would use a different shapefile with respect to the default geoboundaries (this way we can also display a shapefile with a different admin level) and it would also save the plot to the given filename.