### PR TITLE
Changed the weighted quantile algorithm to not depend on `numpy.argsort`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
   [Michele Simionato]
   * Changed the weighted quantile algorithm to not depend on numpy.argsort
+    (since numpy 1.25 argsort produces a different sorting on machines with
+    AVX-512 enabled processors, causing different quantiles when the weights
+    are not all equal)
   * Improved error message for missing fields in the exposure CSV files
   * Internal: removed dbserver.user in openquake.cfg
   * Fixed `extract_from_zip` when managing zip files coming from MACOSX

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the weighted quantile algorithm to not depend on numpy.argsort
   * Improved error message for missing fields in the exposure CSV files
   * Internal: removed dbserver.user in openquake.cfg
   * Fixed `extract_from_zip` when managing zip files coming from MACOSX

--- a/openquake/qa_tests_data/classical_risk/case_master/expected/avg_losses-quantile-0.15.csv
+++ b/openquake/qa_tests_data/classical_risk/case_master/expected/avg_losses-quantile-0.15.csv
@@ -1,3 +1,3 @@
-#,,,,,,,,"generated_by='OpenQuake engine 3.19.0-gitc093471329', start_date='2023-12-21T06:41:15', checksum=2065913176, investigation_time=50.0, risk_investigation_time=50.0"
+#,,,,,,,,"generated_by='OpenQuake engine 3.19.0-git3784624a21', start_date='2023-12-21T07:33:35', checksum=2065913176, investigation_time=50.0, risk_investigation_time=50.0"
 asset_id,taxonomy,lon,lat,business_interruption,contents,nonstructural,occupants,structural
-a3,tax1,-122.57000,38.11300,9.27133E+00,6.15716E+01,8.29307E+01,1.85427E-04,3.11339E+01
+a3,tax1,-122.57000,38.11300,1.05218E+01,7.00475E+01,9.41579E+01,2.10435E-04,3.51617E+01

--- a/openquake/qa_tests_data/classical_risk/case_master/expected/loss_maps-quantile-0.15.csv
+++ b/openquake/qa_tests_data/classical_risk/case_master/expected/loss_maps-quantile-0.15.csv
@@ -1,3 +1,3 @@
-#,,,,,,,,"generated_by='OpenQuake engine 3.19.0-gitc093471329', start_date='2023-12-21T06:41:15', checksum=2065913176, kind='quantile-0.15', risk_investigation_time=50.0"
+#,,,,,,,,"generated_by='OpenQuake engine 3.19.0-git3784624a21', start_date='2023-12-21T07:33:35', checksum=2065913176, kind='quantile-0.15', risk_investigation_time=50.0"
 asset_id,taxonomy,lon,lat,business_interruption~poe-0.02,contents~poe-0.02,nonstructural~poe-0.02,occupants~poe-0.02,structural~poe-0.02
-a3,tax1,-122.57000,38.11300,1.13949E+02,8.25346E+02,1.04705E+03,2.27898E-03,3.51518E+02
+a3,tax1,-122.57000,38.11300,1.25676E+02,9.37727E+02,1.14966E+03,2.51352E-03,3.59451E+02


### PR DESCRIPTION
Otherwise different numbers were given on machines with  AVX-512 enabled processors (due to https://numpy.org/devdocs/release/1.25.0-notes.html#performance-improvements-and-changes).