### PR TITLE
AELO: do not raise an error if no sources are close to the site

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -483,8 +483,9 @@ class HazardCalculator(BaseCalculator):
                 sys.platform != 'darwin'):
             # macos tells that there is no memory when there is, so we
             # must not enter in SLOW MODE there
-            msg = ('Entering SLOW MODE. You have %.1f GB available, but the '
-                   'engine would like at least 0.25 GB per core, i.e. %.1f GB: '
+            msg = ('Entering SLOW MODE. You have %.1f GB available, '
+                   'but the engine would like at least 0.25 GB per core, '
+                   'i.e. %.1f GB: '
                    'https://github.com/gem/oq-engine/blob/master/doc/faq.md'
                    ) % (avail, required)
             if oq.concurrent_tasks:
@@ -584,7 +585,8 @@ class HazardCalculator(BaseCalculator):
         elif 'hazard_curves' in oq.inputs:  # read hazard from file
             assert not oq.hazard_calculation_id, (
                 'You cannot use --hc together with hazard_curves')
-            haz_sitecol = readinput.get_site_collection(oq, self.datastore.hdf5)
+            haz_sitecol = readinput.get_site_collection(
+                oq, self.datastore.hdf5)
             self.load_crmodel()  # must be after get_site_collection
             self.read_exposure(haz_sitecol)  # define .assets_by_site
             df = readinput.Global.pmap.to_dframe()

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -247,6 +247,8 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                     except RuntimeError as exc:
                         if (len(self.oqparam.sites) == 1 and
                                 'no sources close to the site' in str(exc)):
+                            # NOTE: for AELO we want to complete the job
+                            #       successfully anyway
                             pass
                         else:
                             raise

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -242,16 +242,7 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                     self.pre_execute()
                 self.result = self.execute()
                 if self.result is not None:
-                    try:
-                        self.post_execute(self.result)
-                    except RuntimeError as exc:
-                        if (len(self.oqparam.sites) == 1 and
-                                'no sources close to the site' in str(exc)):
-                            # NOTE: for AELO we want to complete the job
-                            #       successfully anyway
-                            pass
-                        else:
-                            raise
+                    self.post_execute(self.result)
                 self.post_process()
                 self.export(kw.get('exports', ''))
             except Exception as exc:

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -242,7 +242,14 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                     self.pre_execute()
                 self.result = self.execute()
                 if self.result is not None:
-                    self.post_execute(self.result)
+                    try:
+                        self.post_execute(self.result)
+                    except RuntimeError as exc:
+                        if (len(self.oqparam.sites) == 1 and
+                                'no sources close to the site' in str(exc)):
+                            pass
+                        else:
+                            raise
                 self.post_process()
                 self.export(kw.get('exports', ''))
             except Exception as exc:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -471,8 +471,8 @@ class ClassicalCalculator(base.HazardCalculator):
         self.store_info()
         if self.cfactor[0] == 0:
             if self.N == 1:
-                logging.error('The site is far from all seismic sources'
-                              ' included in the hazard model')
+                logging.warning('The site is far from all seismic sources'
+                                ' included in the hazard model')
             else:
                 raise RuntimeError('The sites are far from all seismic sources'
                                    ' included in the hazard model')

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -303,8 +303,12 @@ class PreClassicalCalculator(base.HazardCalculator):
         totsites = sum(row[source_reader.NUM_SITES]
                        for row in self.csm.source_info.values())
         if totsites == 0:
-            raise RuntimeError('There are no sources close to the site(s)! '
-                               'Use oq plot sources? to debug')
+            if self.N == 1:
+                logging.warning('There are no sources close to the site!')
+            else:
+                raise RuntimeError(
+                    'There are no sources close to the site(s)! '
+                    'Use oq plot sources? to debug')
 
         fname = self.oqparam.inputs.get('delta_rates')
         if fname:


### PR DESCRIPTION
Fixing another corner case of point 3 of the summary, that was partially addressed in https://github.com/gem/oq-engine/pull/9272:

1. uncovered by the Mosaic:
- Job fails
- No results
- Message: The site is not covered by any model of the Mosaic

2. in a region we’ve decided to not use yet (CEA, CHN, NEA)
- Job runs correctly
- Results are available
- Message (in the email and if possible on the webpage): Results are preliminary. The seismic hazard model used for the site is under review and will be updated during Year 3.

3. not near enough to any earthquake sources:
- Job runs correctly
- Results are 0. On the first page: Ss and S1 will be n.a.
- Message (in the email and if possible on the webpage): The seismic hazard at the site is 0: there are no ruptures close to the site. ASCE 7-16 and ASCE 41-17 parameters cannot be computed.

4. where the hazard curve is so low that we can’t reach 1%-in-50yr risk,
- Job runs correctly
- Results are very low. On the first page: Ss and S1 will be n.a.
- Message (in the email and if possible on the webpage): The seismic hazard at the site is very low. ASCE 7-16 and ASCE 41-17 parameters cannot be computed.