### PR TITLE
Fixing zmq without DbServer

### DIFF
--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -24,7 +24,7 @@ import getpass
 import logging
 import traceback
 from datetime import datetime
-from openquake.baselib import config, zeromq, parallel
+from openquake.baselib import config, zeromq, parallel, workerpool as w
 from openquake.commonlib import readinput, dbapi, global_model_getter
 
 LEVELS = {'debug': logging.DEBUG,
@@ -57,6 +57,9 @@ def dbcmd(action, *args):
     """
     dbhost = os.environ.get('OQ_DATABASE', config.dbserver.host)
     if dbhost == 'local':
+        if action.startswith('workers_'):
+            master = w.WorkerMaster()  # zworkers
+            return getattr(master, action[8:])()
         from openquake.server.db import actions
         try:
             func = getattr(actions, action)

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -54,7 +54,6 @@ class DbServer(object):
                     sock.send(self.pid)
                     continue
                 elif cmd.startswith('workers_'):
-                    # call parallel.workers_start et similar routines
                     master = w.WorkerMaster(args[0])  # zworkers
                     msg = getattr(master, cmd[8:])()
                     sock.send(msg)


### PR DESCRIPTION
Fixes the error in the mosaic actions:
```python
  File "/home/openquake/openquake/lib/python3.10/site-packages/openquake/engine/engine.py", line 416, in run_jobs
    cleanup('kill')
  File "/home/openquake/openquake/lib/python3.10/site-packages/openquake/engine/engine.py", line 359, in cleanup
    logs.dbcmd('workers_kill', config.zworkers)
  File "/home/openquake/openquake/lib/python3.10/site-packages/openquake/commonlib/logs.py", line 64, in dbcmd
    return dbapi.db(action, *args)
  File "/home/openquake/openquake/lib/python3.10/site-packages/openquake/commonlib/dbapi.py", line 341, in __call__
    raise exc.__class__('%s: %s %s' % (exc, templ, args))
sqlite3.OperationalError: near "workers_kill": syntax error: workers_kill ()
```