### PR TITLE
Allow to manually trigger creation of demos artifacts for given releases

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -60,8 +60,8 @@ jobs:
               GITHUB_BR=`echo ${{ github.head_ref }}`
               python install.py devel --version ${GITHUB_INPUT_REF}
           fi
-      - name: Run demos and upload to ci.openquake.org if not workflow_dispatch
-        if: github.event.inputs.git-ref == ''
+      - name: Run demos and upload to ci.openquake.org
+        # if: github.event.inputs.git-ref == ''
         shell: bash
         env:
           DOCS_SSH: ${{ secrets.DOCS_ARTIFACTS }}

--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -61,6 +61,7 @@ jobs:
               python install.py devel --version ${GITHUB_INPUT_REF}
           fi
       - name: Run demos and upload to ci.openquake.org
+        # uncomment the line below to avoid running this part when triggering the action manually
         # if: github.event.inputs.git-ref == ''
         shell: bash
         env:


### PR DESCRIPTION
I would like to trigger the creation of artifacts for demos using engine LTR and latest releases, so I can test them with the QGIS plugin. Was there a reason why we wanted to run demos and upload them to ci.openquake.org only if the workflow is not triggered manually?