### PR TITLE
read_ctx_by_grp returns empty dict if no values

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1780,7 +1780,7 @@ def read_ctx_by_grp(dstore):
     dtlist = []
     for par, val in params.items():
         if len(val) == 0:
-            return []
+            return {}
         elif par == 'probs_occur':
             item = (par, object)
         elif par == 'occurrence_rate':


### PR DESCRIPTION
This PR fixes an issue when performing a disaggregation and all sources are distance filtered out. Previous versions handled this gracefully, but it now raises and exception due to the return type of `read_ctx_by_grp`

```
[2024-01-11 02:42:45 #96 INFO] classical  88% [9 submitted, 0 queued]
[2024-01-11 02:42:46 #96 INFO] classical 100% [9 submitted, 0 queued]
[2024-01-11 02:42:46 #96 INFO] Mean time per core=7s, std=3.5s, min=0s, max=12s
[2024-01-11 02:42:46 #96 INFO] Received 9 * 1.09 KB {'source_data': '4.87 KB', 'pnemap': '3.52 KB', 'cfactor': '1.32 KB', 'grp_id': '45 B', 'task_no': '45 B', 'rup_data': '45 B'} in 20 seconds from classical
[2024-01-11 02:42:46 #96 INFO] Stored 0 B of PoEs
[2024-01-11 02:42:47 #96 WARNING] The site is far from all seismic sources included in the hazard model
[2024-01-11 02:42:47 #96 INFO] {'mag': 19, 'dist': 17, 'lon': 1, 'lat': 1, 'eps': 16, 'trt': 1, 'N': 1, 'M': 1, 'P': 1, 'Z': 12}
/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/hazardlib/gsim/base.py:295: ExperimentalWarning: NZNSHM2022_KuehnEtAl2020SInter is experimental and may change in future versions - the user is liable for their application
  warnings.warn(msg, ExperimentalWarning)
[2024-01-11 02:42:47 #96 INFO] Building N * M * P * Z = 12 intensities
[2024-01-11 02:42:47 #96 INFO] Reading contexts
/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/hazardlib/gsim/base.py:295: ExperimentalWarning: NZNSHM2022_KuehnEtAl2020SInter is experimental and may change in future versions - the user is liable for their application
  warnings.warn(msg, ExperimentalWarning)
Traceback (most recent call last):
  File "/home/chrisdc/.virtualenv/runzi-openquake-py3.10/bin/oq", line 33, in <module>
    sys.exit(load_entry_point('openquake.engine', 'console_scripts', 'oq')())
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/commands/__main__.py", line 48, in oq
    sap.run(commands, prog='oq')
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/sap.py", line 212, in run
    return _run(parser(funcdict, **parserkw), argv)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/sap.py", line 203, in _run
    return func(**dic)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/commands/engine.py", line 181, in main
    run_jobs(jobs)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/engine/engine.py", line 408, in run_jobs
    run_calc(jobctx)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/engine/engine.py", line 281, in run_calc
    calc.run(shutdown=True)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/base.py", line 254, in run
    raise exc from None
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/base.py", line 243, in run
    self.result = self.execute()
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/disaggregation.py", line 158, in execute
    return self.full_disaggregation()
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/disaggregation.py", line 243, in full_disaggregation
    return self.compute()
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/disaggregation.py", line 263, in compute
    totctxs = sum(len(ctx) for ctx in ctx_by_grp.values())
AttributeError: 'list' object has no attribute 'values'
```