### PR TITLE
Simplified `logs.init` and a few other things

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1439,7 +1439,7 @@ def run_calc(job_ini, **kw):
     :param kw: parameters to override
     :returns: a Calculator instance
     """
-    with logs.init("job", job_ini) as log:
+    with logs.init(job_ini) as log:
         log.params.update(kw)
         calc = calculators(log.get_oqparam(), log.calc_id)
         calc.run()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -529,8 +529,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if oq.disagg_by_src:
             mrs = self.haz.store_mean_rates_by_src(acc)
             if oq.use_rates and self.N == 1:  # sanity check
-                #self.check_mean_rates(mrs)
-                pass
+                self.check_mean_rates(mrs)
 
     def check_mean_rates(self, mean_rates_by_src):
         """

--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -472,4 +472,5 @@ def main(dstore, csm):
     else:
         plot_mean_hcurves_rtgm(dstore, update_dstore=True)
         plot_disagg_by_src(dstore, update_dstore=True)
-        plot_governing_mce(dstore, update_dstore=True)
+        plt = plot_governing_mce(dstore, update_dstore=True)
+        plt.close()

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -170,7 +170,7 @@ class PreClassicalCalculator(base.HazardCalculator):
         oq = self.oqparam
         csm = self.csm
         self.store()
-        cmakers = read_cmakers(self.datastore, csm)
+        self.cmakers = cmakers = read_cmakers(self.datastore, csm)
         trt_smrs = [U32(sg[0].trt_smrs) for sg in csm.src_groups]
         self.datastore.hdf5.save_vlen('trt_smrs', trt_smrs)
         self.sitecol = sites = csm.sitecol if csm.sitecol else None

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -51,7 +51,7 @@ def _run(job_ini, concurrent_tasks, pdb, reuse_input, loglevel, exports,
             params['hazard_calculation_id'] = hc_id
     dic = readinput.get_params(job_ini, params)
     # set the logs first of all
-    log = logs.init("job", dic, getattr(logging, loglevel.upper()),
+    log = logs.init(dic, log_level=getattr(logging, loglevel.upper()),
                     user_name=user_name, host=host)
     logs.dbcmd('update_job', log.calc_id,
                {'status': 'executing', 'pid': os.getpid()})

--- a/openquake/commands/shell.py
+++ b/openquake/commands/shell.py
@@ -49,7 +49,7 @@ class OpenQuake(object):
         # TODO: more utilities will be added when deemed useful
 
     def get_calc(self, job_ini):
-        log = logs.init("job", job_ini)
+        log = logs.init(job_ini)
         log.__enter__()
         return calculators(log.get_oqparam(), log.calc_id)
 

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -278,11 +278,11 @@ class LogContext:
                                       self.calc_id, hc_id)
 
 
-def init(dummy, job_ini, log_level='info', log_file=None,
+def init(job_ini, dummy=None, log_level='info', log_file=None,
          user_name=None, hc_id=None, host=None, tag=''):
     """
-    :param dummy: ignored parameter, exists for backward compatibility
     :param job_ini: path to the job.ini file or dictionary of parameters
+    :param dummy: ignored parameter, exists for backward compatibility
     :param log_level: the log level as a string or number
     :param log_file: path to the log file (if any)
     :param user_name: user running the job (None means current user)
@@ -297,5 +297,7 @@ def init(dummy, job_ini, log_level='info', log_file=None,
     3. create a job in the database if job_or_calc == "job"
     4. return a LogContext instance associated to a calculation ID
     """
+    if job_ini in ('job', 'calc'):  # backward compatibility
+        job_ini = dummy
     return LogContext(job_ini, 0, log_level, log_file,
                       user_name, hc_id, host, tag)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -583,7 +583,7 @@ pointsource_distance:
 postproc_func:
   Specify a postprocessing function in calculators/postproc.
   Example: *postproc_func = compute_mrd.main*
-  Default: '' (no postprocessing)
+  Default: 'dummy.main' (no postprocessing)
 
 postproc_args:
   Specify the arguments to be passed to the postprocessing function

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -308,7 +308,7 @@ def create_jobs(job_inis, log_level=logging.INFO, log_file=None,
     except Exception:  # gaierror
         host = None
     if len(job_inis) > 1 and not hc_id and not multi:  # first job as hc
-        job = logs.init("job", job_inis[0], log_level, log_file,
+        job = logs.init('job', job_inis[0], log_level, log_file,
                         user_name, hc_id, host)
         hc_id = job.calc_id
         jobs = [job]

--- a/openquake/engine/tests/aelo_test.py
+++ b/openquake/engine/tests/aelo_test.py
@@ -51,7 +51,7 @@ def test_PAC():
     if rtgmpy:
         s = calc.datastore['asce07'][()].decode('ascii')
         asce07 = json.loads(s)
-        aac(asce07['PGA'], 0.83414, atol=5E-5)
+        aac(asce07['PGA'], 0.89807, atol=5E-5)
 
 
 def test_CCA():

--- a/openquake/engine/tests/aelo_test.py
+++ b/openquake/engine/tests/aelo_test.py
@@ -45,7 +45,7 @@ ASCE41 = [1.5, 1.4308, 1.4308, 1.0, 0.83393, 0.83393, 0.6, 0.6, 0.98649, 0.4,
 
 def test_PAC():
     job_ini = os.path.join(MOSAIC_DIR, 'PAC/in/job.ini')
-    with logs.init('job', job_ini) as log:
+    with logs.init(job_ini) as log:
         calc = base.calculators(log.get_oqparam(), log.calc_id)
         calc.run()
     if rtgmpy:
@@ -59,7 +59,7 @@ def test_CCA():
     job_ini = os.path.join(MOSAIC_DIR, 'CCA/in/job_vs30.ini')
     for (site, lon, lat), expected in zip(SITES, EXPECTED):
         dic = dict(lon=lon, lat=lat, site=site, vs30='760')
-        with logs.init('job', job_ini) as log:
+        with logs.init(job_ini) as log:
             log.params.update(get_params_from(
                 dic, MOSAIC_DIR, exclude=['USA']))
             calc = base.calculators(log.get_oqparam(), log.calc_id)
@@ -93,7 +93,7 @@ def test_JPN():
     # test with mutex sources
     job_ini = os.path.join(MOSAIC_DIR, 'JPN/in/job_vs30.ini')
     dic = dict(lon=139, lat=36, site='JPN-site', vs30='760')
-    with logs.init('job', job_ini) as log:
+    with logs.init(job_ini) as log:
         log.params.update(get_params_from(
             dic, MOSAIC_DIR, exclude=['USA']))
         calc = base.calculators(log.get_oqparam(), log.calc_id)
@@ -107,7 +107,7 @@ def test_KOR():
     # test with same name sources
     job_ini = os.path.join(MOSAIC_DIR, 'KOR/in/job_vs30.ini')
     dic = dict(lon=128.8, lat=35, site='KOR-site', vs30='760')
-    with logs.init('job', job_ini) as log:
+    with logs.init(job_ini) as log:
         log.params.update(get_params_from(
             dic, MOSAIC_DIR, exclude=['USA']))
         calc = base.calculators(log.get_oqparam(), log.calc_id)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -28,7 +28,7 @@ than 20 lines of code:
    from openquake.calculators.base import calculators
 
    def main(job_ini):
-       with logs.init('job', job_ini) as log:
+       with logs.init(job_ini) as log:
            calc = calculators(log.get_oqparam(), log.calc_id)
            calc.run(individual_rlzs='true', shutdown=True)
            print('The hazard curves are in %s::/hcurves-rlzs'

--- a/openquake/hazardlib/tests/calc/mrd_test.py
+++ b/openquake/hazardlib/tests/calc/mrd_test.py
@@ -39,7 +39,7 @@ class MRD01TestCase(unittest.TestCase):
         from openquake.calculators import base
 
         job_ini = os.path.join(CWD, 'expected', 'mrd', 'job.ini')
-        with logs.init('job', job_ini) as log:
+        with logs.init(job_ini) as log:
             calc = base.calculators(log.get_oqparam(), log.calc_id)
             calc.run()
 

--- a/openquake/qa_tests_data/mosaic/PAC/in/job.ini
+++ b/openquake/qa_tests_data/mosaic/PAC/in/job.ini
@@ -6,6 +6,7 @@ random_seed = 23
 mosaic_model = PAC
 ps_grid_spacing = 0
 pointsource_distance = 100
+split_sources = false
 
 [geometry]
 

--- a/openquake/qa_tests_data/mosaic/PAC/in/ssm/interface_trimmed/int_fs_z1_ah.xml
+++ b/openquake/qa_tests_data/mosaic/PAC/in/ssm/interface_trimmed/int_fs_z1_ah.xml
@@ -12,7 +12,7 @@ xmlns:gml="http://www.opengis.net/gml"
     tectonicRegion="Subduction Interface"
     >
         <complexFaultSource
-        id="int_sosol"
+        id="int_sosol-1"
         name="Subduction interface sosol - MSR: ah - Declustering: uh"
         tectonicRegion="Subduction Interface"
         >


### PR DESCRIPTION
In particular I restored the sanity check and renamed the first source in the PAC test.
Also saved memory in matplotlib and fixed the default `postproc_func` to `dummy.main`.
Continuation of https://github.com/gem/oq-engine/pull/9341.