### PR TITLE
Improved `oq mosaic run_site file.csv`

### DIFF
--- a/openquake/commands/mosaic.py
+++ b/openquake/commands/mosaic.py
@@ -156,6 +156,9 @@ def run_site(lonlat_or_fname, *, hc: int = None, slowest: int = None,
 
     if lonlat_or_fname.endswith('.csv'):
         res = from_file(lonlat_or_fname, concurrent_jobs)
+        if not res:
+            # serious problem to debug
+            import pdb; pdb.set_trace()
         header = sorted(res[0])
         rows = [[row[k] for k in header] for row in res]
         fname = os.path.abspath('asce41.org')

--- a/openquake/commands/mosaic.py
+++ b/openquake/commands/mosaic.py
@@ -110,7 +110,7 @@ def from_file(fname, concurrent_jobs=8):
         if not all_sites and model in done:
             continue
         done[model] = True
-        siteid = model + ('%d,%d' % tuple(lonlat))
+        siteid = model + ('%+d,%+d' % tuple(lonlat))
         dic = dict(siteid=siteid, lon=lonlat[0], lat=lonlat[1])
         tags.append(siteid)
         allparams.append(get_params_from(dic, config.directory.mosaic_dir))

--- a/openquake/commands/mosaic.py
+++ b/openquake/commands/mosaic.py
@@ -114,7 +114,6 @@ def from_file(fname, concurrent_jobs=8):
         dic = dict(siteid=siteid, lon=lonlat[0], lat=lonlat[1])
         tags.append(siteid)
         allparams.append(get_params_from(dic, config.directory.mosaic_dir))
-        break
 
     logging.root.handlers = []
     logctxs = engine.create_jobs(allparams, config.distribution.log_level,


### PR DESCRIPTION
Now we store the integer coordinates of the sites in the output file. Here is an example:
```org
| BSE1E_S1 | BSE1E_Ss | BSE1N_S1 | BSE1N_Ss | BSE2E_S1 | BSE2E_Ss | BSE2N_S1 | BSE2N_Ss | S1_20_50 | S1_5_50 | Ss_20_50 | Ss_5_50 | siteid   |
|----------+----------+----------+----------+----------+----------+----------+----------+----------+---------+----------+---------+----------|
| 0.10000  | 0.48000  | 0.18000  | 0.78000  | 0.20000  | 0.89000  | 0.28000  | 1.17000  | 0.10000  | 0.20000 | 0.48000  | 0.89000 | SSA43,11 |
```