### PR TITLE
Remove references to advanced manual from names of workflow steps for macos

### DIFF
--- a/.github/workflows/macos_intel_install.yml
+++ b/.github/workflows/macos_intel_install.yml
@@ -73,7 +73,7 @@ jobs:
               oq engine --run $ini --exports csv,hdf5
           done
 
-      - name: Run tests for calculators and advanced manual to test installation
+      - name: Run tests for calculators to test installation
         if: always()
         run: |
           source ~/openquake/bin/activate

--- a/.github/workflows/macos_m1_install.yml
+++ b/.github/workflows/macos_m1_install.yml
@@ -80,7 +80,7 @@ jobs:
           oq dbserver upgrade
           sleep 5
 
-      - name: Run tests for calculators and advanced manual to test installation
+      - name: Run tests for calculators to test installation
         if: always()
         run: |
           source ~/openquake/bin/activate


### PR DESCRIPTION
The step names were outdated and misleading