### PR TITLE
Adding a test for a vertical section

### DIFF
--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -25,6 +25,7 @@ from openquake.hazardlib.geo import utils
 from openquake.hazardlib.geo import Point
 
 TOLERANCE = 0.1
+SMALL = 1e-2
 
 
 def _update(rtra, rtra_prj, proj, pnt):
@@ -65,6 +66,7 @@ def _resample(coo, sect_len, orig_extremes):
         # Computing distances from the reference point
         dis = utils.get_dist(txy, rtra_prj[-1])
         if idx_vtx > 0:
+
             # Fixing distances for points before the index
             dis[0:idx_vtx] = 100000
 
@@ -129,6 +131,16 @@ def _resample(coo, sect_len, orig_extremes):
 
 
 def _get_same_dir(rtra, coo):
+
+    # If the line is vertical
+    if (np.abs(rtra[-2][0] - rtra[-1][0]) < SMALL and
+            np.abs(rtra[-2][1] - rtra[-1][1]) < SMALL):
+        same_dir = True
+        if coo[-1, 2] < rtra[-1][2]:
+            same_dir = False
+        breakpoint()
+        return same_dir
+
 
     # Azimuth of the resampled edge
     azim_rsmp_edge = geodetic.azimuth(rtra[-2][0], rtra[-2][1],
@@ -322,7 +334,6 @@ class Line(object):
         from the first point in the original line, a line segment is defined as
         the line connecting the last point in the resampled line and the next
         point in the original line.
-
 
         :param float sect_len:
             The length of the section, in km.

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -138,9 +138,7 @@ def _get_same_dir(rtra, coo):
         same_dir = True
         if coo[-1, 2] < rtra[-1][2]:
             same_dir = False
-        breakpoint()
         return same_dir
-
 
     # Azimuth of the resampled edge
     azim_rsmp_edge = geodetic.azimuth(rtra[-2][0], rtra[-2][1],

--- a/openquake/hazardlib/geo/surface/kite_fault.py
+++ b/openquake/hazardlib/geo/surface/kite_fault.py
@@ -770,7 +770,7 @@ def _create_mesh(rprof, ref_idx, edge_sd, idl, align):
     # Fix the orientation of the mesh
     msh = _fix_right_hand(msh)
 
-    # This is for debugging
+    # INFO: this is just for debugging
     # _dbg_plot_mesh(msh)
 
     return msh
@@ -925,6 +925,7 @@ def _fix_profiles(profiles, profile_sd, align, idl):
     lengths = np.array([prf.get_length() for prf in rprofiles])
     if np.max(lengths) - np.min(lengths) > profile_sd * 0.1:
         ref_idx = np.argmax(lengths)
+
 
     # Check that in each profile the points are equally spaced
     for pro in rprofiles:
@@ -1088,7 +1089,7 @@ def _get_resampled_profs(npr, profs, sd, proj, idl, ref_idx, forward=True):
     # Build profiles
     npr = _build_profiles(new_edges)
 
-    # This is for debugging purposes
+    # INFO: this is just for debugging purposes
     # monotonic, i_prof = _profiles_depth_is_monotonically_increasing(npr)
 
     # Check the sampled edges
@@ -1096,7 +1097,7 @@ def _get_resampled_profs(npr, profs, sd, proj, idl, ref_idx, forward=True):
         edg = np.array(new_edges[key])
         _check_sampling(edg, proj)
 
-    # This is used only for debugging purposes
+    # INFO: this is used only for debugging purposes
     # ax = _dbg_plot(new_edges, profs, npr, ref_idx)
 
     return npr

--- a/openquake/hazardlib/tests/geo/line_test.py
+++ b/openquake/hazardlib/tests/geo/line_test.py
@@ -33,6 +33,7 @@ def _plott(rtra_prj, txy):
     ax.axis('equal')
     plt.show()
 
+
 class LineResampleTestCase(unittest.TestCase):
 
     def test_resample(self):

--- a/openquake/hazardlib/tests/geo/surface/data/section_1680_ucf.xml
+++ b/openquake/hazardlib/tests/geo/surface/data/section_1680_ucf.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <geometryModel
+    name="sections_rupture200"
+    >
+                <section
+        id="1680"
+        >
+            <kiteSurface>
+                <profile>
+                    <gml:LineString>
+                        <gml:posList>
+                            -122.0011 37.6073 0.0 -122.0011 37.6072 5.1
+                        </gml:posList>
+                    </gml:LineString>
+                </profile>
+                <profile>
+                    <gml:LineString>
+                        <gml:posList>
+                            -121.9813 37.5952 0.0 -121.9813 37.5952 5.1
+                        </gml:posList>
+                    </gml:LineString>
+                </profile>
+                <profile>
+                    <gml:LineString>
+                        <gml:posList>
+                            -121.9802 37.5943 0.0 -121.9803 37.5942 5.1
+                        </gml:posList>
+                    </gml:LineString>
+                </profile>
+            </kiteSurface>
+        </section>
+    </geometryModel>
+</nrml>

--- a/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
@@ -20,6 +20,7 @@ import glob
 import unittest
 import numpy as np
 import matplotlib.pyplot as plt
+from openquake.hazardlib.nrml import read
 from openquake.hazardlib.geo import geodetic
 from openquake.hazardlib.geo import Point, Line
 from openquake.hazardlib.geo.mesh import Mesh
@@ -30,7 +31,7 @@ from openquake.hazardlib.geo.surface.kite_fault import (
 from openquake.hazardlib.nrml import to_python
 from openquake.hazardlib.sourceconverter import SourceConverter
 
-
+NS = "{http://openquake.org/xmlns/nrml/0.5}"
 BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 PLOTTING = False
 aae = np.testing.assert_almost_equal
@@ -1030,6 +1031,20 @@ class TestProfilesFromSimpleFault(unittest.TestCase):
             pro[0].coo[-1, 1], coo[1][-1], decimal=3)
 
 
+class TestSectionsUCF3(unittest.TestCase):
+
+    def test_section_1680(self):
+        # Read the profiles and create the surface
+        path = os.path.join(BASE_DATA_PATH, 'section_1680_ucf.xml')
+        prfs = _get_profiles(path)
+        hsmpl = 5
+        vsmpl = 5
+        idl = False
+        alg = False
+        self.srfc = KiteSurface.from_profiles(
+            prfs['1680'][0], vsmpl, hsmpl, idl=idl, align=alg)
+
+
 def _read_profiles(path: str, prefix: str = 'cs') -> (list, list):
     """
     Reads a set of files each one containing a profile
@@ -1069,3 +1084,28 @@ def _read_profile(filename: str) -> Line:
                                 float(aa[1]),
                                 float(aa[2])))
     return Line(points)
+
+def _get_profiles(fname):
+    """ Gets profiles from a Geometry Model """
+    [node] = read(fname)
+    all_profiles = {}
+    # Parse file
+    for section in node:
+        if section.tag == f"{NS}section":
+            # Parse the surfaces in each section
+            for surface in section:
+                section_profiles = []
+                if surface.tag == f"{NS}kiteSurface":
+                    # Parse the profiles for each surface
+                    profiles = []
+                    for profile in surface:
+                        # Get poslists
+                        for points in profile.LineString:
+                            pnts = np.array(~points)
+                            rng = range(0, len(pnts), 3)
+                            pro = Line([Point(pnts[i], pnts[i+1], pnts[i+2])
+                                        for i in rng])
+                            profiles.append(pro)
+                    section_profiles = [profiles]
+            all_profiles[section['id']] = section_profiles
+    return all_profiles

--- a/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
@@ -30,6 +30,7 @@ from openquake.hazardlib.geo.surface.kite_fault import (
     get_profiles_from_simple_fault_data)
 from openquake.hazardlib.nrml import to_python
 from openquake.hazardlib.sourceconverter import SourceConverter
+from openquake.hazardlib.geo.geodetic import npoints_towards, azimuth
 
 NS = "{http://openquake.org/xmlns/nrml/0.5}"
 BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
@@ -1009,7 +1010,6 @@ class TestProfilesFromSimpleFault(unittest.TestCase):
         pro = get_profiles_from_simple_fault_data(trace, usd, lsd, dip,
                                                   rup_mesh_spacing)
 
-        from openquake.hazardlib.geo.geodetic import npoints_towards, azimuth
 
         # This is the initial width
         width = (lsd - usd) / np.sin(np.radians(dip))
@@ -1037,12 +1037,18 @@ class TestSectionsUCF3(unittest.TestCase):
         # Read the profiles and create the surface
         path = os.path.join(BASE_DATA_PATH, 'section_1680_ucf.xml')
         prfs = _get_profiles(path)
-        hsmpl = 5
-        vsmpl = 5
+        hsmpl = 5.0
+        vsmpl = 5.0
         idl = False
         alg = False
-        self.srfc = KiteSurface.from_profiles(
+        srfc = KiteSurface.from_profiles(
             prfs['1680'][0], vsmpl, hsmpl, idl=idl, align=alg)
+
+        PLOTTING = True
+        if PLOTTING:
+            title = 'UCF 1680'
+            ppp(prfs['1680'][0], srfc, title, ax_equal=True)
+        breakpoint()
 
 
 def _read_profiles(path: str, prefix: str = 'cs') -> (list, list):
@@ -1085,6 +1091,7 @@ def _read_profile(filename: str) -> Line:
                                 float(aa[2])))
     return Line(points)
 
+
 def _get_profiles(fname):
     """ Gets profiles from a Geometry Model """
     [node] = read(fname)
@@ -1103,8 +1110,9 @@ def _get_profiles(fname):
                         for points in profile.LineString:
                             pnts = np.array(~points)
                             rng = range(0, len(pnts), 3)
-                            pro = Line([Point(pnts[i], pnts[i+1], pnts[i+2])
-                                        for i in rng])
+                            pro = Line([Point(
+                                pnts[i], pnts[i + 1], pnts[i + 2])
+                                for i in rng])
                             profiles.append(pro)
                     section_profiles = [profiles]
             all_profiles[section['id']] = section_profiles

--- a/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
@@ -1043,8 +1043,16 @@ class TestSectionsUCF3(unittest.TestCase):
         alg = False
         srfc = KiteSurface.from_profiles(
             prfs['1680'][0], vsmpl, hsmpl, idl=idl, align=alg)
-
-        PLOTTING = True
+        # Expected mesh
+        expected = np.array([[[-122.0011, -121.9802],
+                              [-122.0011, -121.98029804]],
+                             [[37.6073, 37.5943],
+                              [37.60720196, 37.59420196]],
+                             [[0., 0.],
+                              [4.99998812, 4.99998065]]])
+        # Test
+        aae(srfc.mesh.array, expected)
+        # Plottin the surface
         if PLOTTING:
             title = 'UCF 1680'
             ppp(prfs['1680'][0], srfc, title, ax_equal=True)

--- a/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
@@ -1048,7 +1048,6 @@ class TestSectionsUCF3(unittest.TestCase):
         if PLOTTING:
             title = 'UCF 1680'
             ppp(prfs['1680'][0], srfc, title, ax_equal=True)
-        breakpoint()
 
 
 def _read_profiles(path: str, prefix: str = 'cs') -> (list, list):

--- a/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
@@ -20,14 +20,14 @@ import unittest
 import numpy as np
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
-from openquake.hazardlib.nrml import read
+
 from openquake.hazardlib.geo.geodetic import (
     geodetic_distance, npoints_towards)
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.nrml import to_python
 from openquake.hazardlib.sourceconverter import SourceConverter
 from openquake.hazardlib.tests.geo.surface.kite_fault_test import (
-    _read_profiles)
+    _read_profiles, _get_profiles)
 from openquake.hazardlib.geo import Point, Line
 from openquake.hazardlib.geo.surface.multi import MultiSurface
 from openquake.hazardlib.geo.surface.kite_fault import (
@@ -35,7 +35,7 @@ from openquake.hazardlib.geo.surface.kite_fault import (
     _get_proj_from_profiles)
 from openquake.hazardlib.tests.geo.surface.kite_fault_test import plot_mesh_2d
 
-NS = "{http://openquake.org/xmlns/nrml/0.5}"
+
 BASE_PATH = os.path.dirname(__file__)
 BASE_DATA_PATH = os.path.join(BASE_PATH, 'data')
 PLOTTING = False
@@ -561,29 +561,3 @@ def _plt_results(clo, cla, dst, msrf, title, boundary=True):
     _ = plt.clabel(cs)
     plt.title(title)
     return fig, ax
-
-
-def _get_profiles(fname):
-    """ Gets profiles from a Geometry Model """
-    [node] = read(fname)
-    all_profiles = {}
-    # Parse file
-    for section in node:
-        if section.tag == f"{NS}section":
-            # Parse the surfaces in each section
-            for surface in section:
-                section_profiles = []
-                if surface.tag == f"{NS}kiteSurface":
-                    # Parse the profiles for each surface
-                    profiles = []
-                    for profile in surface:
-                        # Get poslists
-                        for points in profile.LineString:
-                            pnts = np.array(~points)
-                            rng = range(0, len(pnts), 3)
-                            pro = Line([Point(pnts[i], pnts[i+1], pnts[i+2])
-                                        for i in rng])
-                            profiles.append(pro)
-                    section_profiles = [profiles]
-            all_profiles[section['id']] = section_profiles
-    return all_profiles


### PR DESCRIPTION
@CB-quakemodel while parsing the UCF3 model on his Windows machine found that the refactored version of the Kite Surface code was breaking. This PR adds code that better addresses the case of a vertical section. 
<img width="752" alt="image" src="https://github.com/gem/oq-engine/assets/318811/efd6e52d-8141-471e-8833-814cd8bbd509">
