### PR TITLE
Add pinax.announcements package to manage temporary broadcast messages via the admin interface

### DIFF
--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -33,7 +33,8 @@ except ImportError:
 
 TEST = 'test' in sys.argv
 
-INSTALLED_APPS = ('openquake.server.db',)
+INSTALLED_APPS = ('openquake.server.db',
+                  'pinax.announcements',)
 
 OQSERVER_ROOT = os.path.dirname(__file__)
 

--- a/openquake/server/templates/engine/base.html
+++ b/openquake/server/templates/engine/base.html
@@ -1,3 +1,4 @@
+{% load pinax_announcements_tags %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -76,6 +77,17 @@
   {% endblock header %}
 
   {% block main %}
+  {% announcements as announcement_list %}
+  {% if announcement_list %}
+  <div class="announcements" style="padding: 20px; background-color: #ff9800; color: white; margin-bottom: 15px;">
+    {% for announcement in announcement_list %}
+      <div class="announcement">
+        <strong>{{ announcement.title }}</strong><br />
+          {{ announcement.content }}
+      </div>
+    {% endfor %}
+  </div>
+  {% endif %}
   {% endblock main %}
   <div id="outdated"></div>
   {% block footer %}

--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -3,6 +3,7 @@
   <title>{% block title %}OpenQuake engine: outputs from calculation {{ calc_id }}{% endblock %}</title>
 
   {% block main %}
+  {{ block.super }}
   <div class="content-wrap">
     <div class="container">
       <div class="row">

--- a/openquake/server/templates/engine/get_outputs_aelo.html
+++ b/openquake/server/templates/engine/get_outputs_aelo.html
@@ -2,6 +2,7 @@
   <title>{% block title %}OpenQuake engine: outputs from calculation {{ calc_id }}{% endblock %}</title>
 
   {% block main %}
+  {{ block.super }}
   <div class="content-wrap">
     <div class="container">
       <div class="row">

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -16,6 +16,7 @@
   {% endblock nav-items %}
 
   {% block main %}
+  {{ block.super }}
   <div class="content-wrap">
     <div class="container">
       <div class="row">

--- a/openquake/server/templates/engine/license.html
+++ b/openquake/server/templates/engine/license.html
@@ -3,6 +3,7 @@
   <title>{% block title %}OpenQuake engine: license{% endblock %}</title>
 
   {% block main %}
+  {{ block.super }}
   <div class="content-wrap">
     <div class="container">
       <div class="row">

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -30,6 +30,9 @@ urlpatterns = [
     re_path(r'^v1/available_gsims$', views.get_available_gsims),
     re_path(r'^v1/on_same_fs$', views.on_same_fs, name="on_same_fs"),
     re_path(r'^v1/ini_defaults$', views.get_ini_defaults, name="ini_defaults"),
+    re_path(
+        r"^announcements/",
+        include("pinax.announcements.urls", namespace="pinax_announcements")),
 ]
 
 # it is useful to disable the default redirect if the usage is via API only
@@ -75,11 +78,11 @@ if settings.LOCKDOWN:
     urlpatterns += [
         re_path(r'^admin/', admin.site.urls),
         re_path(r'accounts/login/$',
-            LoginView.as_view(
-                template_name='account/login.html',
-                extra_context={'application_mode': application_mode},
-            ),
-            name="login"),
+                LoginView.as_view(
+                    template_name='account/login.html',
+                    extra_context={'application_mode': application_mode},
+                ),
+                name="login"),
         re_path(r'^accounts/logout/$', LogoutView.as_view(
             template_name='account/logout.html'), name="logout"),
         re_path(r'^accounts/ajax_login/$', views.ajax_login),


### PR DESCRIPTION
This is a proposal to obtain what we discussed during last scrum.
It requires a migration.
The configuration via the admin interface is intuitive:
![Screenshot from 2024-01-18 17-31-03](https://github.com/gem/oq-engine/assets/350930/1be43175-7476-4c82-bd30-e0f286d43002)
Then the result is something like:
![Screenshot from 2024-01-18 17-31-21](https://github.com/gem/oq-engine/assets/350930/d2eff923-5472-4d22-aff9-3ff37bc21a95)
Obviously this is just a draft and the style can be further improved.

NOTE: the most painful aspect of this addition is that it would require the dependency from `pinax-announcements==4.0.0`