### PR TITLE
Disable the slow check on the sources bounding box

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -225,10 +225,10 @@ class PreClassicalCalculator(base.HazardCalculator):
                     # do not split the pointsources
                     smap.submit((pointsources + pointlike, sites, cmaker))
                 else:
-                    for block in block_splitter(pointsources, 1000):
+                    for block in block_splitter(pointsources, 2000):
                         smap.submit((block, sites, cmaker))
                     others.extend(pointlike)
-            for block in block_splitter(others, 20):
+            for block in block_splitter(others, 40):
                 smap.submit((block, sites, cmaker))
         normal = smap.reduce()
         if atomic_sources:  # case_35

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -837,8 +837,6 @@ def _check_csm(csm, oqparam, h5):
         csm.sitecol = h5['sitecol']
     else:
         csm.sitecol = get_site_collection(oqparam, h5)
-    if csm.sitecol is None:  # missing sites.csv (test_case_1_ruptures)
-        return
 
     if os.environ.get('OQ_CHECK_INPUT'):
         # slow checks
@@ -870,6 +868,9 @@ def _check_csm(csm, oqparam, h5):
             raise BBoxError(
                 'The bounding box of the sources is larger than half '
                 'the globe: %d degrees' % (bbox[2] - bbox[0]))
+
+    if csm.sitecol is None:  # missing sites.csv (test_case_1_ruptures)
+        return
 
 
 # tested in test_mosaic

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -837,6 +837,8 @@ def _check_csm(csm, oqparam, h5):
         csm.sitecol = h5['sitecol']
     else:
         csm.sitecol = get_site_collection(oqparam, h5)
+    if csm.sitecol is None:  # missing sites.csv (test_case_1_ruptures)
+        return
 
     if os.environ.get('OQ_CHECK_INPUT'):
         # slow checks
@@ -868,9 +870,6 @@ def _check_csm(csm, oqparam, h5):
             raise BBoxError(
                 'The bounding box of the sources is larger than half '
                 'the globe: %d degrees' % (bbox[2] - bbox[0]))
-
-    if csm.sitecol is None:  # missing sites.csv (test_case_1_ruptures)
-        return
 
 
 # tested in test_mosaic

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -223,6 +223,7 @@ def get_csm(oq, full_lt, dstore=None):
 
     logging.info('Applying uncertainties')
     groups = _build_groups(full_lt, smdict)
+    logging.info('Done')
 
     # checking the changes
     changes = sum(sg.changes for sg in groups)


### PR DESCRIPTION
This has a good effect on the performance of the AELO tests on hendrix. The preclassical for Pavia on the thinkstation goes down from 147s to 102s (33% speedup).