### PR TITLE
Moved the OQ_SAMPLE_SOURCES functionality in the source_reader

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -82,12 +82,9 @@ def collapse_nphc(src):
         src.magnitude_scaling_relationship = PointMSR()
 
 
-def _filter(srcs, min_mag, fraction=1.):
-    # filter by magnitude and optionally sample source
-    # count the ruptures
+def _filter(srcs, min_mag):
+    # filter by magnitude and count the ruptures
     mmag = getdefault(min_mag, srcs[0].tectonic_region_type)
-    if fraction < 1.:
-        srcs = general.random_filter(srcs, fraction)
     out = [src for src in srcs if src.get_mags()[-1] >= mmag]
     for ss in out:
         ss.num_ruptures = ss.count_ruptures()
@@ -117,7 +114,7 @@ def preclassical(srcs, sites, cmaker, monitor):
             splits.extend(split_source(src))
         else:
             splits.append(src)
-    splits = _filter(splits, cmaker.oq.minimum_magnitude, cmaker.fraction)
+    splits = _filter(splits, cmaker.oq.minimum_magnitude)
     mon = monitor('weighting sources', measuremem=False)
     if sites is None or spacing == 0:
         if sites is None:
@@ -205,10 +202,8 @@ class PreClassicalCalculator(base.HazardCalculator):
         logging.info('Starting preclassical with %d source groups',
                      len(sources_by_key))
         smap = parallel.Starmap(preclassical, h5=self.datastore.hdf5)
-        ss = os.environ.get('OQ_SAMPLE_SOURCES')
         for grp_id, srcs in sources_by_key.items():
             cmaker = cmakers[grp_id]
-            cmaker.fraction = float(ss) if ss else 1.
             pointsources, pointlike, others = [], [], []
             for src in srcs:
                 if hasattr(src, 'location'):

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -545,9 +545,7 @@ class EngineRunJobTestCase(unittest.TestCase):
         # event based risk with post processing
         job_ini = os.path.join(
             os.path.dirname(case_master.__file__), 'job.ini')
-        with Print.patch() as p:
-            [log] = run_jobs(create_jobs([job_ini], 'error'))
-        self.assertIn('id | name', str(p))
+        [log] = run_jobs(create_jobs([job_ini], 'error'))
 
         # check the exported outputs
         expected = set('''\


### PR DESCRIPTION
This gives a 21x speedup in the slowest task for CHN when running the mosaic tests:
```
# before
| calc_2291, maxmem=11.3 GB  | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 2_489    | 902.0     | 721       |
| computing mean_std         | 767.5    | 0.0       | 45_821    |
| ClassicalCalculator.run    | 697.2    | 1_026     | 1         |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 721    | 3.45199 | 569%   | 0.32808 | 526.7   | 152.6   |

# after
| calc_2759, maxmem=8.6 GB   | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 1_924    | 31.8      | 718       |
| computing mean_std         | 735.0    | 0.0       | 44_865    |
| ClassicalCalculator.run    | 194.1    | 1_070     | 1         |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 718    | 2.67923 | 44%    | 0.10194 | 24.9    | 9.30638 |
```