### PR TITLE
Return HttpResponseNotFound if the requested calc_id does not exist

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -971,6 +971,8 @@ def web_engine(request, **kwargs):
 def web_engine_get_outputs(request, calc_id, **kwargs):
     application_mode = settings.APPLICATION_MODE.upper()
     job = logs.dbcmd('get_job', calc_id)
+    if job is None:
+        return HttpResponseNotFound()
     with datastore.read(job.ds_calc_dir + '.hdf5') as ds:
         if 'png' in ds:
             # NOTE: only one hmap can be visualized currently


### PR DESCRIPTION
Otherwise, the error message was ugly:

```python
ERROR Internal Server Error: /engine/100/outputs
Traceback (most recent call last):
 File "/home/ascarpati/openquake/lib64/python3.11/site-packages/django/core/handlers/exception.py", line 47,
in inner
   response = get_response(request)
              ^^^^^^^^^^^^^^^^^^^^^
 File "/home/ascarpati/openquake/lib64/python3.11/site-packages/django/core/handlers/base.py", line 181, in _
get_response
   response = wrapped_callback(request, *callback_args, **callback_kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/home/ascarpati/oq-engine/openquake/server/views.py", line 111, in wrap
   response = func(request, *args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/home/ascarpati/openquake/lib64/python3.11/site-packages/django/views/decorators/http.py", line 40, in
 inner
   return func(request, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/home/ascarpati/oq-engine/openquake/server/views.py", line 974, in web_engine_get_outputs
   with datastore.read(job.ds_calc_dir + '.hdf5') as ds:
                       ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'ds_calc_dir'
ERROR "GET /engine/100/outputs HTTP/1.1" 500 84106
```