### PR TITLE
Added a forgotten call to `_set_coordinate_shift`

### DIFF
--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -144,6 +144,7 @@ class MultiSurface(BaseSurface):
         # Set the multiline representing the rupture traces i.e. vertical
         # projections at the surface of the top of ruptures
         self.tors = geo.MultiLine(tors)
+        self.tors._set_coordinate_shift()
 
     def get_min_distance(self, mesh):
         """

--- a/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
@@ -211,10 +211,10 @@ class MultiSurfaceWithNaNsTestCase(unittest.TestCase):
     def test_get_edge_set(self):
         # The vertexes of the expected edges are the first and last vertexes of
         # the topmost row of the mesh
-        expected = [np.array([[-70.33, 19.65, 0.],
-                              [-70.57740671, 19.66979434, 0.0]]),
-                    np.array([[-70.10327766, 19.67957463, 0.0],
-                              [-70.33, 19.65, 0.0]])]
+        expected = [np.array([[-70.1, 19.68, 0.],
+                              [-70.32703837, 19.65038823, 0.0]]),
+                    np.array([[-70.33, 19.65, 0.0],
+                              [-70.57740671, 19.66979434, 0.0]])]
         self.msrf._set_tor()
 
         if PLOTTING:


### PR DESCRIPTION
When calling `MultiSurface._set_tor` a `MultiLine` instance is generated, however the method `_set_coordinate_shift()` was not called, so `test_get_edge_set` was expecting the wrong numbers. This has no impact on any engine calculation, since  `_set_coordinate_shift()`  is called later on in the workflow, only the test is affected.