### PR TITLE
Using numba in line and multiline

### DIFF
--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -590,6 +590,7 @@ def get_tu(ui, ti, sl, weights):
     return t_upp, u_upp
 
 
+#@compile('(float64[:,:],float64[:,:],float64[:])')
 def get_ti_weights(ui, ti, segments_len):
     """
     Compute the weights

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -80,7 +80,7 @@ def _resample(coo, sect_len, orig_extremes):
         if idx < len(dis) - 1:
 
             pnt = find_t(txy[idx + 1, :], txy[idx, :], rtra_prj[-1], sect_len)
-            if pnt.sum() == 0:
+            if np.isnan(pnt).any():
                 raise ValueError('Did not find the intersection')
             _update(rtra, rtra_prj, proj, pnt)
             inc_len += sect_len
@@ -680,7 +680,7 @@ def find_t(pnt0, pnt1, ref_pnt, distance):
 
     # In this case the line is not intersecting the sphere
     if chk < 0:
-        return np.zeros(3)
+        return np.array([np.nan, np.nan, np.nan])
 
     # Computing the points of intersection
     pu = (-pb + (pb**2 - 4 * pa * pc)**0.5) / (2 * pa)

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -81,7 +81,7 @@ def _resample(coo, sect_len, orig_extremes):
 
             pnt = find_t(
                 txy[idx + 1, :], txy[idx, :], rtra_prj[-1], sect_len)
-            if pnt is None:
+            if len(pnt) == 0:
                 raise ValueError('Did not find the intersection')
             _update(rtra, rtra_prj, proj, pnt)
             inc_len += sect_len
@@ -636,9 +636,10 @@ def get_versor(arr):
     """
     Returns the versor (i.e. a unit vector) of a vector
     """
-    return np.divide(arr.T, np.linalg.norm(arr, axis=1)).T
+    return (arr.T / np.linalg.norm(arr, axis=1)).T
 
 
+#@compile("(float64[3],float64[3],float64[3],float64)")
 def find_t(pnt0, pnt1, ref_pnt, distance):
     """
     Find the point on the segment within `pnt0` and `pnt1` at `distance` from
@@ -656,7 +657,6 @@ def find_t(pnt0, pnt1, ref_pnt, distance):
     :returns:
         A 1D :class:`numpy.ndarray` instance of length 3
     """
-
     x1 = pnt0[0]
     y1 = pnt0[1]
     z1 = pnt0[2]
@@ -681,7 +681,7 @@ def find_t(pnt0, pnt1, ref_pnt, distance):
 
     # In this case the line is not intersecting the sphere
     if chk < 0:
-        return None
+        return np.zeros(0)
 
     # Computing the points of intersection
     pu = (-pb + (pb**2 - 4 * pa * pc)**0.5) / (2 * pa)

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -79,8 +79,7 @@ def _resample(coo, sect_len, orig_extremes):
         # compute the new sample by interpolation
         if idx < len(dis) - 1:
 
-            pnt = find_t(
-                txy[idx + 1, :], txy[idx, :], rtra_prj[-1], sect_len)
+            pnt = find_t(txy[idx + 1, :], txy[idx, :], rtra_prj[-1], sect_len)
             if len(pnt) == 0:
                 raise ValueError('Did not find the intersection')
             _update(rtra, rtra_prj, proj, pnt)
@@ -639,7 +638,7 @@ def get_versor(arr):
     return (arr.T / np.linalg.norm(arr, axis=1)).T
 
 
-#@compile("(float64[3],float64[3],float64[3],float64)")
+#@compile("(float64[:],float64[:],float64[:],float64)")
 def find_t(pnt0, pnt1, ref_pnt, distance):
     """
     Find the point on the segment within `pnt0` and `pnt1` at `distance` from

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -433,24 +433,22 @@ class Line(object):
             An instance of :class:`openquake.hazardlib.geo.mesh.Mesh`
         """
 
-        # Sites
-        mlo = mesh.lons
-        mla = mesh.lats
+        # all sites
+        lons = np.concatenate([mesh.lons, self.coo[:, 0]])
+        lats = np.concatenate([mesh.lats, self.coo[:, 1]])
 
-        # Projection
-        lons = list(mlo.flatten()) + list(self.coo[:, 0])
-        lats = list(mla.flatten()) + list(self.coo[:, 1])
+        # projection
         west, east, north, south = utils.get_spherical_bounding_box(lons, lats)
         proj = utils.OrthographicProjection(west, east, north, south)
 
-        # Projected coordinates for the trace
+        # projected coordinates for the trace
         tcoo = self.coo[:, 0], self.coo[:, 1]
         txy = np.zeros_like(self.coo)
         txy[:, 0], txy[:, 1] = proj(*tcoo)
 
-        # Projected coordinates for the sites
-        sxy = np.zeros((len(mla), 2))
-        sxy[:, 0], sxy[:, 1] = proj(mlo, mla)
+        # projected coordinates for the sites
+        sxy = np.zeros((len(mesh), 2))
+        sxy[:, 0], sxy[:, 1] = proj(mesh.lons, mesh.lats)
 
         # Compute u hat and t hat for each segment. tmp has shape
         # (num_segments x 3)

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -590,18 +590,19 @@ def get_tu(ui, ti, sl, weights):
     return t_upp, u_upp
 
 
-#@compile('(float64[:,:],float64[:,:],float64[:])')
+@compile('(float64[:,:],float64[:,:],float64[:])')
 def get_ti_weights(ui, ti, segments_len):
     """
     Compute the weights
     """
+    S1, S2 = ui.shape
     weights = np.zeros_like(ui)
     terma = np.zeros_like(ui)
     term1 = np.zeros_like(ui)
     term2 = np.zeros_like(ui)
-    idx_on_trace = np.zeros_like(ui[0, :], dtype=bool)
+    idx_on_trace = np.zeros(S2, dtype=np.bool_)
 
-    for i in range(ti.shape[0]):
+    for i in range(S1):
 
         # More general case
         cond0 = np.abs(ti[i, :]) >= TOLERANCE

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -80,7 +80,7 @@ def _resample(coo, sect_len, orig_extremes):
         if idx < len(dis) - 1:
 
             pnt = find_t(txy[idx + 1, :], txy[idx, :], rtra_prj[-1], sect_len)
-            if len(pnt) == 0:
+            if pnt.sum() == 0:
                 raise ValueError('Did not find the intersection')
             _update(rtra, rtra_prj, proj, pnt)
             inc_len += sect_len
@@ -638,7 +638,7 @@ def get_versor(arr):
     return (arr.T / np.linalg.norm(arr, axis=1)).T
 
 
-#@compile("(float64[:],float64[:],float64[:],float64)")
+@compile("(float64[:],float64[:],float64[:],float64)")
 def find_t(pnt0, pnt1, ref_pnt, distance):
     """
     Find the point on the segment within `pnt0` and `pnt1` at `distance` from
@@ -680,7 +680,7 @@ def find_t(pnt0, pnt1, ref_pnt, distance):
 
     # In this case the line is not intersecting the sphere
     if chk < 0:
-        return np.zeros(0)
+        return np.zeros(3)
 
     # Computing the points of intersection
     pu = (-pb + (pb**2 - 4 * pa * pc)**0.5) / (2 * pa)
@@ -688,9 +688,9 @@ def find_t(pnt0, pnt1, ref_pnt, distance):
     y = y1 + pu * (y2 - y1)
     z = z1 + pu * (z2 - z1)
 
-    if (x >= np.min([x1, x2]) and x <= np.max([x1, x2]) and
-            y >= np.min([y1, y2]) and y <= np.max([y1, y2]) and
-            z >= np.min([z1, z2]) and z <= np.max([z1, z2])):
+    if (x >= min(x1, x2) and x <= max(x1, x2) and
+            y >= min(y1, y2) and y <= max(y1, y2) and
+            z >= min(z1, z2) and z <= max(z1, z2)):
         out = [x, y, z]
     else:
         pu = (-pb - (pb**2 - 4 * pa * pc)**0.5) / (2 * pa)

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -61,7 +61,7 @@ class MultiLine():
                                           self.overall_strike)
 
         ep_mesh = get_endpoints_mesh(self.lines)
-        u, _ = get_tu(self.shift, *get_tus(self.lines, ep_mesh))
+        u, _ = self.get_tu(ep_mesh)
         self.u_max = np.abs(u).max()
 
     def set_overall_strike(self):
@@ -79,10 +79,12 @@ class MultiLine():
         self.overall_strike = avg_azim
         self.lines = nl
 
-    # used only in the multiline_test
     def get_tu(self, mesh):
-        return get_tu(self.shift, *get_tus(self.lines, mesh))
-        
+        """
+        Given a mesh, computes the T and U coordinates for the multiline
+        """
+        return _get_tu(self.shift, *get_tus(self.lines, mesh))
+
     def get_rx_distance(self, mesh):
         """
         :param mesh:
@@ -92,7 +94,7 @@ class MultiLine():
             A :class:`numpy.ndarray` instance with the Rx distance. Note that
             the Rx distance is directly taken from the GC2 t-coordinate.
         """
-        uut, tut = get_tu(self.shift, *get_tus(self.lines, mesh))
+        uut, tut = self.get_tu(mesh)
         return tut[0]
 
     def get_ry0_distance(self, mesh):
@@ -100,7 +102,7 @@ class MultiLine():
         :param mesh:
             An instance of :class:`openquake.hazardlib.geo.mesh.Mesh`
         """
-        uut, tut = get_tu(self.shift, *get_tus(self.lines, mesh))
+        uut, tut = self.get_tu(mesh)
 
         ry0 = np.zeros_like(uut)
         ry0[uut < 0] = abs(uut[uut < 0])
@@ -258,10 +260,7 @@ def get_coordinate_shift(lines: list, olon: float, olat: float,
     return np.cos(np.radians(overall_strike - azimuths))*distances
 
 
-def get_tu(shifts, tupps, uupps, weis):
-    """
-    Given a mesh, computes the T and U coordinates for the multiline
-    """
+def _get_tu(shifts, tupps, uupps, weis):
     for i, (shift, tupp, uupp, wei) in enumerate(
             zip(shifts, tupps, uupps, weis)):
         if i == 0:  # initialize

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -130,15 +130,16 @@ def get_tus(lines: list, mesh: Mesh):
         An instance of :class:`openquake.hazardlib.geo.mesh.Mesh` with the
         sites location.
     """
-    uupps = []
-    tupps = []
-    weis = []
-    for line in lines:
-        tupp, uupp, wei = line.get_tu(mesh)
-        wei_sum = np.squeeze(np.sum(wei, axis=0))
-        uupps.append(uupp)
-        tupps.append(tupp)
-        weis.append(wei_sum)
+    L = len(lines)
+    N = len(mesh)
+    tupps = np.zeros((L, N))
+    uupps = np.zeros((L, N))
+    weis = np.zeros((L, N))
+    for i, line in enumerate(lines):
+        tu, uu, we = line.get_tu(mesh)
+        tupps[i] = tu
+        uupps[i] = uu
+        weis[i] = we.sum(axis=0)
     return tupps, uupps, weis
 
 
@@ -261,16 +262,16 @@ def get_tu(shifts, tupps, uupps, weis):
     """
     Given a mesh, computes the T and U coordinates for the multiline
     """
-    for i, (shift, tupp, uupp, wei_sum) in enumerate(
+    for i, (shift, tupp, uupp, wei) in enumerate(
             zip(shifts, tupps, uupps, weis)):
         if i == 0:  # initialize
-            uut = (uupp + shift) * wei_sum
-            tut = tupp * wei_sum
-            wet = copy.copy(wei_sum)
+            uut = (uupp + shift) * wei
+            tut = tupp * wei
+            wet = wei.copy()
         else:  # update the values
-            uut += (uupp + shift) * wei_sum
-            tut += tupp * wei_sum
-            wet += wei_sum
+            uut += (uupp + shift) * wei
+            tut += tupp * wei
+            wet += wei
 
     # Normalize by the sum of weights
     uut /= wet

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -21,6 +21,7 @@ Module :mod:`openquake.hazardlib.geo.multiline` defines
 
 import copy
 import numpy as np
+from openquake.baselib.performance import compile
 from openquake.hazardlib.geo import utils
 from openquake.hazardlib.geo.mesh import Mesh, RectangularMesh
 from openquake.hazardlib.geo.line import get_average_azimuth
@@ -260,6 +261,7 @@ def get_coordinate_shift(lines: list, olon: float, olat: float,
     return np.cos(np.radians(overall_strike - azimuths))*distances
 
 
+@compile('float64[:],float64[:,:],float64[:,:],float64[:,:]')
 def _get_tu(shifts, tupps, uupps, weis):
     for i, (shift, tupp, uupp, wei) in enumerate(
             zip(shifts, tupps, uupps, weis)):

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -263,8 +263,6 @@ def get_tu(shifts, tupps, uupps, weis):
     """
     for i, (shift, tupp, uupp, wei_sum) in enumerate(
             zip(shifts, tupps, uupps, weis)):
-        if len(wei_sum.shape) > 1:
-            wei_sum = np.squeeze(wei_sum)
         if i == 0:  # initialize
             uut = (uupp + shift) * wei_sum
             tut = tupp * wei_sum

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -97,7 +97,7 @@ class MultiSurface(BaseSurface):
         """
         self.surfaces = surfaces
         self.tol = tol
-        self._set_tor()
+        self.tor = None
         self.areas = None
 
     # called at each instantiation
@@ -137,7 +137,7 @@ class MultiSurface(BaseSurface):
 
         # Set the multiline representing the rupture traces i.e. vertical
         # projections at the surface of the top of ruptures
-        self.tors = geo.MultiLine(tors)
+        self.tor = geo.MultiLine(tors)
 
     def get_min_distance(self, mesh):
         """
@@ -355,7 +355,9 @@ class MultiSurface(BaseSurface):
             A :class:`numpy.ndarray` instance with the Rx distance. Note that
             the Rx distance is directly taken from the GC2 t-coordinate.
         """
-        uut, tut = self.tors.get_tu(mesh)
+        if self.tor is None:
+            self._set_tor()
+        uut, tut = self.tor.get_tu(mesh)
         rx = tut[0] if len(tut[0].shape) > 1 else tut
         return rx
 
@@ -365,4 +367,6 @@ class MultiSurface(BaseSurface):
             An instance of :class:`openquake.hazardlib.geo.mesh.Mesh` with the
             coordinates of the sites.
         """
-        return self.tors.get_ry0_distance(mesh)
+        if self.tor is None:
+            self._set_tor()
+        return self.tor.get_ry0_distance(mesh)

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -363,7 +363,7 @@ class MultiSurface(BaseSurface):
             tu, uu, we = line.get_tu(mesh)
             tupps.append(tu)
             uupps.append(uu)
-            weis.append(np.squeeze(np.sum(we, axis=0)))
+            weis.append(we.sum(axis=0))
 
         # `get_tu` is a function in the multiline module
         uut, tut = get_tu(self.tors.shift, tupps, uupps, weis)

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -27,7 +27,7 @@ from openquake.hazardlib.geo import utils
 from openquake.hazardlib import geo
 from openquake.hazardlib.geo.surface import (
     PlanarSurface, SimpleFaultSurface, ComplexFaultSurface)
-from openquake.hazardlib.geo.multiline import get_tu
+from openquake.hazardlib.geo.multiline import get_tu, get_tus
 
 
 class MultiSurface(BaseSurface):
@@ -356,17 +356,8 @@ class MultiSurface(BaseSurface):
             A :class:`numpy.ndarray` instance with the Rx distance. Note that
             the Rx distance is directly taken from the GC2 t-coordinate.
         """
-        tupps = []
-        uupps = []
-        weis = []
-        for line in self.tors.lines:
-            tu, uu, we = line.get_tu(mesh)
-            tupps.append(tu)
-            uupps.append(uu)
-            weis.append(we.sum(axis=0))
-
-        # `get_tu` is a function in the multiline module
-        uut, tut = get_tu(self.tors.shift, tupps, uupps, weis)
+        # `get_tu(s)` are functions in the multiline module
+        uut, tut = get_tu(self.tors.shift, *get_tus(self.tors.lines, mesh))
         rx = tut[0] if len(tut[0].shape) > 1 else tut
         return rx
 

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -27,7 +27,6 @@ from openquake.hazardlib.geo import utils
 from openquake.hazardlib import geo
 from openquake.hazardlib.geo.surface import (
     PlanarSurface, SimpleFaultSurface, ComplexFaultSurface)
-from openquake.hazardlib.geo.multiline import get_tu, get_tus
 
 
 class MultiSurface(BaseSurface):
@@ -356,8 +355,7 @@ class MultiSurface(BaseSurface):
             A :class:`numpy.ndarray` instance with the Rx distance. Note that
             the Rx distance is directly taken from the GC2 t-coordinate.
         """
-        # `get_tu(s)` are functions in the multiline module
-        uut, tut = get_tu(self.tors.shift, *get_tus(self.tors.lines, mesh))
+        uut, tut = self.tors.get_tu(mesh)
         rx = tut[0] if len(tut[0].shape) > 1 else tut
         return rx
 

--- a/openquake/hazardlib/tests/geo/line_test.py
+++ b/openquake/hazardlib/tests/geo/line_test.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 import matplotlib.pyplot as plt
 from openquake.hazardlib import geo
+from openquake.hazardlib.geo.line import find_t
 
 PLOTTING = False
 
@@ -483,12 +484,10 @@ class LineSphereIntersectionTest(unittest.TestCase):
 
     def test01(self):
         """ See example https://www.geogebra.org/m/mwanwvwj """
-        pnt0 = np.array([13, 2, 9])
-        # pnt1 = np.array([7, -4, 6])
-        pnt1 = np.array([5, -6, 5])
-        ref_pnt = np.array([0, 0, 0])
+        pnt0 = np.array([13., 2., 9.])
+        pnt1 = np.array([5., -6., 5.])
+        ref_pnt = np.array([0., 0., 0.])
         distance = 10.
-        from openquake.hazardlib.geo.line import find_t
         computed = find_t(pnt0, pnt1, ref_pnt, distance)
         expected = np.array([6.92, -4.08, 5.96])
         np.testing.assert_almost_equal(computed, expected, decimal=1)

--- a/openquake/hazardlib/tests/geo/surface/multi2_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi2_test.py
@@ -39,6 +39,7 @@ class Ry0TestCase(unittest.TestCase):
 
     def _test_ry0(self, sfc):
         msurf = MultiSurface([sfc])
+        msurf._set_tor()
         mesh, mlons, mlats = get_mesh(-0.2, 0.6, -0.2, 0.3, 0.0025)
         ry0 = msurf.get_ry0_distance(mesh)
 
@@ -54,7 +55,7 @@ class Ry0TestCase(unittest.TestCase):
             ax = plot_pattern(lons, lats, np.reshape(ry0, mlons.shape),
                               mlons, mlats, label, num, show=False)
             plot_mesh_2d(ax, msurf.surfaces[0])
-            ax.plot(msurf.tors.olon, msurf.tors.olat, 'sg', mfc='none',
+            ax.plot(msurf.tor.olon, msurf.tor.olat, 'sg', mfc='none',
                     mec='green')
             plt.show()
 
@@ -138,8 +139,9 @@ class MultiSurfaceSimpleFaultSurfaceTestCase(unittest.TestCase):
 
         # Multi surface
         self.msfc = MultiSurface([sfc1, sfc2], tol=2.)
+        self.msfc._set_tor()
 
     def test_get_tor(self):
         # Testing, coo1 and coo2 are inverted due to the origin inversion
-        aae(self.coo2, self.msfc.tors.lines[0].coo[:, 0:2], decimal=2)
-        aae(self.coo1, self.msfc.tors.lines[1].coo[:, 0:2], decimal=2)
+        aae(self.coo2, self.msfc.tor.lines[0].coo[:, 0:2], decimal=2)
+        aae(self.coo1, self.msfc.tor.lines[1].coo[:, 0:2], decimal=2)

--- a/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
@@ -69,6 +69,7 @@ class MultiSurfaceOneTestCase(unittest.TestCase):
         prf3 = Line([Point(0.3, 0, 0), Point(0.3, -0.00001, 20.)])
         sfca = KiteSurface.from_profiles([prf1, prf2, prf3], 1., 1.)
         self.msrf = MultiSurface([sfca])
+        self.msrf._set_tor()
 
     def test_get_width(self):
         # Surface is almost vertical. The width must be equal to the depth
@@ -136,6 +137,7 @@ class MultiSurfaceTwoTestCase(unittest.TestCase):
 
         # Create the surface and mesh needed for the test
         self.msrf = MultiSurface([sfca, sfcb])
+        self.msrf._set_tor()
         self.coo = np.array([[-0.1, 0.0], [0.0, 0.1]])
         self.mesh = Mesh(self.coo[:, 0], self.coo[:, 1])
 
@@ -192,6 +194,7 @@ class MultiSurfaceWithNaNsTestCase(unittest.TestCase):
         self.srfc50 = srfc50
         self.srfc51 = srfc51
         self.msrf = MultiSurface([srfc50, srfc51])
+        self.msrf._set_tor()
         self.mesh = mesh
         self.los = [self.msrf.surfaces[0].mesh.lons,
                     self.msrf.surfaces[1].mesh.lons]
@@ -222,12 +225,12 @@ class MultiSurfaceWithNaNsTestCase(unittest.TestCase):
                 mesh = sfc.mesh
                 ax.plot(mesh.lons, mesh.lats, '.', color=col)
                 ax.plot(mesh.lons[0, :],  mesh.lats[0, :], lw=3)
-            for line in self.msrf.tors.lines:
+            for line in self.msrf.tor.lines:
                 ax.plot(line.coo[:, 0], line.coo[:, 1], 'x-r')
             plt.show()
 
         # Note that method is executed when the object is initialized
-        for es, expct in zip(self.msrf.tors.lines, expected):
+        for es, expct in zip(self.msrf.tor.lines, expected):
             np.testing.assert_array_almost_equal(es.coo, expct, decimal=2)
 
     def test_get_strike(self):
@@ -341,9 +344,9 @@ class MultiSurfaceWithNaNsTestCase(unittest.TestCase):
         if PLOTTING:
             title = f'{type(self).__name__} - Ry0'
             fig, ax = _plt_results(self.clo, self.cla, dst, self.msrf, title)
-            for line in self.msrf.tors.lines:
+            for line in self.msrf.tor.lines:
                 ax.plot(line.coo[:, 0], line.coo[:, 1], '-r', lw=3)
-            ax.plot(self.msrf.tors.olon, self.msrf.tors.olat, 'o')
+            ax.plot(self.msrf.tor.olon, self.msrf.tor.olat, 'o')
             plt.show()
 
         # Saving data
@@ -378,6 +381,7 @@ class NZLTestCase(unittest.TestCase):
         for sec in gmodel.sections:
             sfcs.append(gmodel.sections[sec])
         self.msrf = MultiSurface(sfcs)
+        self.msrf._set_tor()
 
         # Create second surface
         keys = list(gmodel.sections)
@@ -394,7 +398,7 @@ class NZLTestCase(unittest.TestCase):
                 for pro in sfc.profiles:
                     ax.plot(pro.coo[:, 0], pro.coo[:, 1], '--b')
             # Plotting traces
-            for line in self.msrf.tors.lines:
+            for line in self.msrf.tor.lines:
                 col = np.random.rand(3)
                 coo = line.coo
                 ax.plot(coo[:, 0], coo[:, 1], color=col)

--- a/openquake/hazardlib/tests/geo/surface/multi_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi_test.py
@@ -44,14 +44,15 @@ class GetTorTestCase(unittest.TestCase):
         """ Planar rupture """
         tmp = os.path.join(cd, 'data', 'msurface18.csv')
         surf = MultiSurface.from_csv(tmp)
+        surf._set_tor()
 
         # Expected value inferred from the input file
         expected = numpy.array([[-117.955505, 33.769615, 0],
                                 [-117.9903, 33.797646, 0]])
-        aae(expected, surf.tors.lines[0].coo)
+        aae(expected, surf.tor.lines[0].coo)
         expected = numpy.array([[-117.9903, 33.797646, 0],
                                 [-117.99624, 33.802425, 0]])
-        aae(expected, surf.tors.lines[1].coo)
+        aae(expected, surf.tor.lines[1].coo)
 
 
 class MultiSurfaceTestCase(unittest.TestCase):
@@ -316,7 +317,7 @@ def _plotting(surf, dst, mlons, mlats, lons=[], lats=[], label=''):
                       mlons, mlats, label, num, show=False)
     lons = surf.surfaces[0].mesh.lons
     lats = surf.surfaces[0].mesh.lats
-    for line in surf.tors.lines:
+    for line in surf.tor.lines:
         ax.plot(line.coo[:, 0], line.coo[:, 1], '-r')
         ax.plot(line.coo[0, 0], line.coo[0, 1], 'g', marker="$s$", ms=5)
         ax.plot(line.coo[-1, 0], line.coo[-1, 1], 'r', marker="$e$",


### PR DESCRIPTION
This gives some speedup, but it is not expected to do much in many-site situations, since the problem of redundant calculations has not been tackled yet.
Still, the improvement in the test NZ2 in the oq-risk-tests is 6x in "total classical":
```
# branch get_tu
| calc_7471, maxmem=7.2 GB   | time_sec  | memory_mb | counts |
|----------------------------+-----------+-----------+--------|
| ClassicalCalculator.run    | 20.6      | 203.0     | 1      |
| total classical            | 16.1      | 9.08984   | 11     |
| total preclassical         | 6.87849   | 8.24219   | 16     |
| iter_ruptures              | 3.52899   | 1.96484   | 4_554  |

# master
| calc_7019, maxmem=7.9 GB   | time_sec  | memory_mb | counts |
|----------------------------+-----------+-----------+--------|
| total classical            | 97.6      | 39.2      | 11     |
| ClassicalCalculator.run    | 91.6      | 203.8     | 1      |
| iter_ruptures              | 64.3      | 120.0     | 4_554  |
| total preclassical         | 46.8      | 174.4     | 16     |
```
Notice also the spectacular improvement in `iter_ruptures` (18x). The situation for single site calculations looks much better, but there is still a lot to do. Here is the situation for the reduces USA model with 23,000+ sites:
```
# before
| calc_10, maxmem=73.8 GB    | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 61_182   | 233.0     | 159       |
| nonplanar contexts         | 45_211   | 0.0       | 10_448    |
| get_poes                   | 9_788    | 0.0       | 6_578_206 |
| computing mean_std         | 2_609    | 0.0       | 56_653    |
| ClassicalCalculator.run    | 2_170    | 847.8     | 1         |
| iter_ruptures              | 1_954    | 46.4      | 159       |
| total preclassical         | 363.0    | 12.5      | 53        |
| composing pnes             | 770.9    | 0.0       | 6_578_206 |

# after
| calc_12, maxmem=69.0 GB    | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 47_844   | 181.5     | 159       |
| nonplanar contexts         | 33_804   | 0.0       | 10_448    |
| get_poes                   | 9_740    | 0.0       | 6_578_206 |
| computing mean_std         | 2_563    | 0.0       | 56_653    |
| ClassicalCalculator.run    | 1_689    | 849.4     | 1         |
| composing pnes             | 759.2    | 0.0       | 6_578_206 |
| total preclassical         | 301.0    | 11.3      | 53        |
| iter_ruptures              | 141.7    | 1.15104   | 159       |
```