### PR TITLE
Using numba in  `get_spherical_bounding_box` 

### DIFF
--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -174,13 +174,11 @@ class Line(object):
         """
         self = cls.__new__(cls)
         self.coo = coo
-        self.coo.flags.writeable = False  # avoid dirty coding
         return self
 
     def __init__(self, points):
         points = utils.clean_points(points)  # can remove points!
         self.coo = np.array([[p.x, p.y, p.z] for p in points])
-        self.coo.flags.writeable = False  # avoid dirty coding
 
     @property
     def points(self):

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -282,50 +282,6 @@ class Line(object):
                                                lons[1:], lats[1:])
         return get_average_azimuth(azimuths, distances)
 
-    def resample_old(self, section_length):
-        """
-        Resample this line into sections.  The first point in the resampled
-        line corresponds to the first point in the original line.  Starting
-        from the first point in the original line, a line segment is defined as
-        the line connecting the last point in the resampled line and the next
-        point in the original line.  The line segment is then split into
-        sections of length equal to ``section_length``. The resampled line is
-        obtained by concatenating all sections.  The number of sections in a
-        line segment is calculated as follows: ``round(segment_length /
-        section_length)``.  Note that the resulting line has a length that is
-        an exact multiple of ``section_length``, therefore its length is in
-        general smaller or greater (depending on the rounding) than the length
-        of the original line.  For a straight line, the difference between the
-        resulting length and the original length is at maximum half of the
-        ``section_length``.  For a curved line, the difference may be larger,
-        because of corners getting cut.
-
-        :param section_length:
-            The length of the section, in km.
-        :type section_length:
-            float
-        :returns:
-            A new line resampled into sections based on the given length.
-        :rtype:
-            An instance of :class:`Line`
-        """
-        resampled_points = []
-        # 1. Resample the first section. 2. Loop over the remaining points
-        # in the line and resample the remaining sections.
-        # 3. Extend the list with the resampled points, except the first one
-        # (because it's already contained in the previous set of
-        # resampled points).
-        resampled_points.extend(
-            self[0].equally_spaced_points(self[1], section_length))
-
-        # Skip the first point, it's already resampled
-        for i in range(2, len(self)):
-            points = resampled_points[-1].equally_spaced_points(
-                self[i], section_length)
-            resampled_points.extend(points[1:])
-
-        return Line(resampled_points)
-
     def resample(self, sect_len: float, orig_extremes=False):
         """
         Resample this line into sections.  The first point in the resampled

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -410,8 +410,9 @@ class Mesh(object):
             on number of points in the mesh and their arrangement.
         """
         # create a projection centered in the center of points collection
-        proj = geo_utils.OrthographicProjection(
-            *geo_utils.get_spherical_bounding_box(self.lons, self.lats))
+        sbb = geo_utils.get_spherical_bounding_box(
+            self.lons.flatten(), self.lats.flatten())
+        proj = geo_utils.OrthographicProjection(*sbb)
 
         # project all the points and create a shapely multipoint object.
         # need to copy an array because otherwise shapely misinterprets it
@@ -527,8 +528,9 @@ class Mesh(object):
             # the mesh doesn't contain even a single cell
             return self._get_proj_convex_hull()
 
-        proj = geo_utils.OrthographicProjection(
-            *geo_utils.get_spherical_bounding_box(self.lons, self.lats))
+        sbb = geo_utils.get_spherical_bounding_box(
+            self.lons.flatten(), self.lats.flatten())
+        proj = geo_utils.OrthographicProjection(*sbb)
         if len(self.lons.shape) == 1:  # 1D mesh
             lons = self.lons.reshape(len(self.lons), 1)
             lats = self.lats.reshape(len(self.lats), 1)

--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -350,7 +350,8 @@ class BaseSurface:
             Values are floats in decimal degrees.
         """
         mesh = _get_finite_mesh(self.mesh)
-        return utils.get_spherical_bounding_box(mesh.lons, mesh.lats)
+        return utils.get_spherical_bounding_box(
+            mesh.lons.flatten(), mesh.lats.flatten())
 
     def get_middle_point(self):
         """

--- a/openquake/hazardlib/geo/surface/gridded.py
+++ b/openquake/hazardlib/geo/surface/gridded.py
@@ -85,7 +85,8 @@ class GriddedSurface(BaseSurface):
             northern and southern borders of the bounding box respectively.
             Values are floats in decimal degrees.
         """
-        return utils.get_spherical_bounding_box(self.mesh.lons, self.mesh.lats)
+        return utils.get_spherical_bounding_box(
+            self.mesh.lons.flatten(), self.mesh.lats.flatten())
 
     def get_surface_boundaries(self):
         """

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -286,12 +286,13 @@ class MultiSurface(BaseSurface):
         lons = []
         lats = []
         deps = []
+        conc = np.concatenate
         for surf in self.surfaces:
-            lons_surf, lats_surf, deps_surf = surf.get_surface_boundaries_3d()
-            lons.extend(lons_surf)
-            lats.extend(lats_surf)
-            deps.extend(deps_surf)
-        return lons, lats, deps
+            coo = surf.get_surface_boundaries_3d()
+            lons.append(coo[0])
+            lats.append(coo[1])
+            deps.append(coo[2])
+        return conc(lons), conc(lats), conc(deps)
 
     def _get_areas(self):
         """

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -242,7 +242,7 @@ class MultiSurface(BaseSurface):
             west, east, north, south = surf.get_bounding_box()
             lons.extend([west, east])
             lats.extend([north, south])
-        return utils.get_spherical_bounding_box(lons, lats)
+        return utils.get_spherical_bounding_box(np.array(lons), np.array(lats))
 
     def get_middle_point(self):
         """

--- a/openquake/hazardlib/geo/surface/simple_fault.py
+++ b/openquake/hazardlib/geo/surface/simple_fault.py
@@ -116,8 +116,8 @@ class SimpleFaultSurface(BaseSurface):
             raise ValueError("the fault trace must have at least two points")
         if not fault_trace.horizontal():
             raise ValueError("the fault trace must be horizontal")
-        tlats = [point.latitude for point in fault_trace.points]
-        tlons = [point.longitude for point in fault_trace.points]
+        tlats = numpy.array([point.latitude for point in fault_trace.points])
+        tlons = numpy.array([point.longitude for point in fault_trace.points])
         if geo_utils.line_intersects_itself(tlons, tlats):
             raise ValueError("fault trace intersects itself")
         if not 0.0 < dip <= 90.0:

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -43,7 +43,6 @@ KM_TO_DEGREES = 0.0089932  # 1 degree == 111 km
 DEGREES_TO_RAD = 0.01745329252  # 1 radians = 57.295779513 degrees
 EARTH_RADIUS = geo.geodetic.EARTH_RADIUS
 spherical_to_cartesian = geo.geodetic.spherical_to_cartesian
-SphericalBB = collections.namedtuple('SphericalBB', 'west east north south')
 MAX_EXTENT = 5000  # km, decided by M. Simionato
 BASE32 = [ch.encode('ascii') for ch in '0123456789bcdefghjkmnpqrstuvwxyz']
 CODE32 = U8([ord(c) for c in '0123456789bcdefghjkmnpqrstuvwxyz'])
@@ -476,6 +475,7 @@ def get_spherical_bounding_box(lons, lats):
         180 degrees (it is impossible to define a single hemisphere
         bound to poles that would contain the whole collection).
     """
+    lons.nbytes
     ok = numpy.isfinite(lons)
     if not ok.all():
         lons = lons[ok]
@@ -498,7 +498,7 @@ def get_spherical_bounding_box(lons, lats):
                    for lon in lons):
             raise ValueError('points collection has longitudinal extent '
                              'wider than 180 deg')
-    return SphericalBB(west, east, north, south)
+    return west, east, north, south
 
 
 class OrthographicProjection(object):

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -460,7 +460,7 @@ def get_bounding_box(obj, maxdist):
 
 # NB: returns (west, east, north, south) which is DIFFERENT from
 # get_bounding_box return (west, south, east, north)
-@compile("(f8[:],f8[:])")
+@compile(["(f8[:],f8[:])", "(f4[:],f4[:])"])
 def get_spherical_bounding_box(lons, lats):
     """
     Given a collection of points find and return the bounding box,
@@ -478,7 +478,6 @@ def get_spherical_bounding_box(lons, lats):
         180 degrees (it is impossible to define a single hemisphere
         bound to poles that would contain the whole collection).
     """
-    assert len(lons.shape) == 1, lons.shape
     ok = numpy.isfinite(lons)
     if not ok.all():
         lons = lons[ok]

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -460,7 +460,7 @@ def get_bounding_box(obj, maxdist):
 
 # NB: returns (west, east, north, south) which is DIFFERENT from
 # get_bounding_box return (west, south, east, north)
-#@compile(["(f8[:],f8[:])", "(f8[:,:],f8[:,:])"])
+@compile("(f8[:],f8[:])")
 def get_spherical_bounding_box(lons, lats):
     """
     Given a collection of points find and return the bounding box,
@@ -478,6 +478,7 @@ def get_spherical_bounding_box(lons, lats):
         180 degrees (it is impossible to define a single hemisphere
         bound to poles that would contain the whole collection).
     """
+    assert len(lons.shape) == 1, lons.shape
     ok = numpy.isfinite(lons)
     if not ok.all():
         lons = lons[ok]
@@ -489,7 +490,6 @@ def get_spherical_bounding_box(lons, lats):
         # points are lying on both sides of the international date line
         # (meridian 180). the actual west longitude is the lowest positive
         # longitude and east one is the highest negative.
-        lons = lons.flatten()  # in case of a RectangularMesh
         west = lons[lons > 0].min()
         east = lons[lons < 0].max()
         ext0 = get_longitudinal_extent(west, lons)

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -382,6 +382,7 @@ def line_intersects_itself(lons, lats, closed_shape=False):
     return False
 
 
+@compile("(f8,f8)")
 def get_longitudinal_extent(lon1, lon2):
     """
     Return the distance between two longitude values as an angular measure.
@@ -458,6 +459,7 @@ def get_bounding_box(obj, maxdist):
 
 # NB: returns (west, east, north, south) which is DIFFERENT from
 # get_bounding_box return (west, south, east, north)
+#@compile("(f8[:],f8[:])")
 def get_spherical_bounding_box(lons, lats):
     """
     Given a collection of points find and return the bounding box,
@@ -481,18 +483,15 @@ def get_spherical_bounding_box(lons, lats):
         lons = lons[ok]
         lats = lats[ok]
 
-    north, south = numpy.max(lats), numpy.min(lats)
-    west, east = numpy.min(lons), numpy.max(lons)
-    assert (-180 <= west <= 180) and (-180 <= east <= 180), (west, east)
+    north, south = lats.max(), lats.min()
+    west, east = lons.min(), lons.max()
     if get_longitudinal_extent(west, east) < 0:
         # points are lying on both sides of the international date line
         # (meridian 180). the actual west longitude is the lowest positive
         # longitude and east one is the highest negative.
-        if hasattr(lons, 'flatten'):
-            # fixes test_surface_crossing_international_date_line
-            lons = lons.flatten()
-        west = min(lon for lon in lons if lon > 0)
-        east = max(lon for lon in lons if lon < 0)
+        lons = lons.flatten()  # in case of a RectangularMesh
+        west = lons[lons > 0].min()
+        east = lons[lons < 0].max()
         if not all((get_longitudinal_extent(west, lon) >= 0
                     and get_longitudinal_extent(lon, east) >= 0)
                    for lon in lons):
@@ -795,8 +794,7 @@ def bbox2poly(bbox):
 # length 6 = .61 km  resolution, length 5 = 2.4 km resolution,
 # length 4 = 20 km, length 3 = 78 km
 # used in SiteCollection.geohash
-@compile(['(f8[:],f8[:],u1)',
-          '(f4[:],f4[:],u1)'])
+@compile(['(f8[:],f8[:],u1)', '(f4[:],f4[:],u1)'])
 def geohash(lons, lats, length):
     """
     Encode a position given in lon, lat into a geohash of the given lenght

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -495,7 +495,7 @@ def get_spherical_bounding_box(lons, lats):
         ext1 = get_longitudinal_extent(lons, east)
         if not ((ext0 >= 0) & (ext1 >= 0)).all():
             raise ValueError('points collection has longitudinal extent '
-                             'wider than 180 deg')
+                             'wider than 180 degrees')
     return west, east, north, south
 
 

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -122,12 +122,15 @@ class NonParametricSeismicSource(BaseSeismicSource):
                 surfaces.extend(rup.surface.surfaces)
             else:
                 surfaces.append(rup.surface)
-        lons = []
-        lats = []
-        for surf in surfaces:
+        S = len(surfaces)
+        lons = numpy.zeros(2*S)
+        lats = numpy.zeros(2*S)
+        for i, surf in enumerate(surfaces):
             lo1, lo2, la1, la2 = surf.get_bounding_box()
-            lons.extend([lo1, lo2])
-            lats.extend([la1, la2])
+            lons[2*i] = lo1
+            lons[2*i + 1] = lo2
+            lats[2*i] = la1
+            lats[2*i + 1] = la2
         west, east, north, south = get_spherical_bounding_box(lons, lats)
         a1 = maxdist * KM_TO_DEGREES
         a2 = angular_distance(maxdist, north, south)

--- a/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
@@ -260,15 +260,15 @@ class MultiSurfaceWithNaNsTestCase(unittest.TestCase):
         aae(a1 + a2, area)
 
     def test_get_bounding_box(self):
-        bb = self.msrf.get_bounding_box()
+        west, east, north, south = self.msrf.get_bounding_box()
         if PLOTTING:
             _, ax = plt.subplots(1, 1)
-            ax.plot([bb.west, bb.east, bb.east, bb.west],
-                    [bb.south, bb.south, bb.north, bb.north], '-')
+            ax.plot([west, east, east, west],
+                    [south, south, north, north], '-')
             ax.plot(self.los[0], self.las[0], '.')
             ax.plot(self.los[1], self.las[1], '.')
             plt.show()
-        aae([bb.west, bb.east, bb.south, bb.north],
+        aae([west, east, south, north],
             [-70.5772, -70.1032, 19.650, 19.7405], decimal=2)
 
     def test_get_middle_point(self):

--- a/openquake/hazardlib/tests/geo/utils_test.py
+++ b/openquake/hazardlib/tests/geo/utils_test.py
@@ -28,7 +28,9 @@ aac = numpy.testing.assert_allclose
 
 class CleanPointTestCase(unittest.TestCase):
     def test_exact_duplicates(self):
-        a, b, c = geo.Point(1, 2, 3), geo.Point(3, 4, 5), geo.Point(5, 6, 7)
+        a, b, c = [geo.Point(1., 2., 3.),
+                   geo.Point(3., 4., 5.),
+                   geo.Point(5., 6., 7.)]
         self.assertEqual(utils.clean_points([a, a, a, b, a, c, c]),
                          [a, b, a, c])
 
@@ -49,77 +51,77 @@ class LineIntersectsItselfTestCase(unittest.TestCase):
             self.assertEqual(False, self.func(lons, lats, closed_shape=True))
 
     def test_doesnt_intersect(self):
-        lons = numpy.array([-1, -2, -3, -5])
-        lats = numpy.array([0,  2,  4,  6])
+        lons = numpy.array([-1., -2., -3., -5.])
+        lats = numpy.array([0.,  2.,  4.,  6.])
         self.assertEqual(False, self.func(lons, lats))
         self.assertEqual(False, self.func(lons, lats, closed_shape=True))
 
     def test_intersects(self):
-        lons = numpy.array([0, 0, 1, -1])
-        lats = numpy.array([0, 1, 0,  1])
+        lons = numpy.array([0., 0., 1., -1.])
+        lats = numpy.array([0., 1., 0.,  1.])
         self.assertEqual(True, self.func(lons, lats))
         self.assertEqual(True, self.func(lons, lats, closed_shape=True))
 
     def test_intersects_on_a_pole(self):
-        lons = numpy.array([45, 165, -150, 80])
-        lats = numpy.array([-80, -80, -80, -70])
+        lons = numpy.array([45., 165., -150., 80.])
+        lats = numpy.array([-80., -80., -80., -70.])
         self.assertEqual(True, self.func(lons, lats))
         self.assertEqual(True, self.func(lons, lats, closed_shape=True))
 
     def test_intersects_only_after_being_closed(self):
-        lons = numpy.array([0, 0, 1, 1])
-        lats = numpy.array([0, 1, 0, 1])
+        lons = numpy.array([0., 0., 1., 1.])
+        lats = numpy.array([0., 1., 0., 1.])
         self.assertEqual(False, self.func(lons, lats))
         self.assertEqual(True, self.func(lons, lats, closed_shape=True))
 
     def test_intersects_on_international_date_line(self):
-        lons = numpy.array([178, 178, -178, 170])
-        lats = numpy.array([0, 10, 0, 5])
+        lons = numpy.array([178., 178., -178., 170.])
+        lats = numpy.array([0., 10., 0., 5.])
         self.assertEqual(True, self.func(lons, lats))
 
     def test_doesnt_intersect_on_international_date_line(self):
-        lons = numpy.array([178, 178, 179, -178])
-        lats = numpy.array([0, 10, 5, 5])
+        lons = numpy.array([178., 178., 179., -178.])
+        lats = numpy.array([0., 10., 5., 5.])
         self.assertEqual(False, self.func(lons, lats))
 
 
 class GetLongitudinalExtentTestCase(unittest.TestCase):
     def test_positive(self):
-        self.assertEqual(utils.get_longitudinal_extent(10, 20), 10)
-        self.assertEqual(utils.get_longitudinal_extent(-120, 30), 150)
+        self.assertEqual(utils.get_longitudinal_extent(10., 20.), 10)
+        self.assertEqual(utils.get_longitudinal_extent(-120., 30.), 150)
 
     def test_negative(self):
-        self.assertEqual(utils.get_longitudinal_extent(20, 10), -10)
-        self.assertEqual(utils.get_longitudinal_extent(-10, -15), -5)
+        self.assertEqual(utils.get_longitudinal_extent(20., 10.), -10)
+        self.assertEqual(utils.get_longitudinal_extent(-10., -15.), -5)
 
     def test_international_date_line(self):
         self.assertEqual(utils.get_longitudinal_extent(-178.3, 177.7), -4)
         self.assertEqual(utils.get_longitudinal_extent(177.7, -178.3), 4)
 
-        self.assertEqual(utils.get_longitudinal_extent(95, -180 + 94), 179)
-        self.assertEqual(utils.get_longitudinal_extent(95, -180 + 96), -179)
+        self.assertEqual(utils.get_longitudinal_extent(95., -180. + 94), 179)
+        self.assertEqual(utils.get_longitudinal_extent(95., -180. + 96), -179)
 
     def test_check_extent(self):
-        ext = utils.check_extent([10, 20], [30, 40])
+        ext = utils.check_extent([10., 20.], [30, 40])
         self.assertEqual(ext, (847, 711, 909))
 
-        ext = utils.check_extent([-10, 0], [30, 40])
-        self.assertEqual(ext, (553, 958, 909))
+        ext = utils.check_extent([-10., 0.], [30., 40.])
+        self.assertEqual(ext, (553., 958., 909.))
 
-        ext = utils.check_extent([170, -181], [30, 40])
-        self.assertEqual(ext, (553, 872, 909))
+        ext = utils.check_extent([170., -181.], [30., 40.])
+        self.assertEqual(ext, (553., 872., 909.))
 
-        ext = utils.check_extent([1, 359], [89, 89])
-        self.assertEqual(ext, (0, 3, 0))
-
-        with self.assertRaises(ValueError):
-            utils.check_extent([10, 90, 170], [20, 30, 40])
+        ext = utils.check_extent([1., 359.], [89., 89.])
+        self.assertEqual(ext, (0., 3., 0.))
 
         with self.assertRaises(ValueError):
-            utils.check_extent([-10, 20, 170], [30, 40, 50])
+            utils.check_extent([10., 90., 170.], [20., 30., 40.])
 
         with self.assertRaises(ValueError):
-            utils.check_extent([1, 359], [89, -89])
+            utils.check_extent([-10., 20., 170.], [30., 40., 50.])
+
+        with self.assertRaises(ValueError):
+            utils.check_extent([1., 359.], [89., -89.])
 
 
 class GetSphericalBoundingBox(unittest.TestCase):
@@ -128,23 +130,23 @@ class GetSphericalBoundingBox(unittest.TestCase):
         self.func = utils.get_spherical_bounding_box
 
     def test_one_point(self):
-        lons = numpy.array([20])
-        lats = numpy.array([-40])
+        lons = numpy.array([20.])
+        lats = numpy.array([-40.])
         self.assertEqual(self.func(lons, lats), (20, 20, -40, -40))
 
     def test_small_extent(self):
-        lons = numpy.array([10, -10])
-        lats = numpy.array([50,  60])
+        lons = numpy.array([10., -10])
+        lats = numpy.array([50.,  60])
         self.assertEqual(self.func(lons, lats), (-10, 10, 60, 50))
 
     def test_international_date_line(self):
-        lons = numpy.array([-20, 180, 179, 178])
-        lats = numpy.array([-1,   -2,   1,   2])
+        lons = numpy.array([-20., 180., 179., 178.])
+        lats = numpy.array([-1.,   -2.,   1.,   2.])
         self.assertEqual(self.func(lons, lats), (178, -20, 2, -2))
 
     def test_too_wide_longitudinal_extent(self):
-        for lons, lats in [([-45, -135, 135, 45], [80] * 4),
-                           ([0, 10, -175], [0] * 4)]:
+        for lons, lats in [([-45, -135, 135., 45], [80.] * 4),
+                           ([0, 10, -175.], [0.] * 4)]:
             with self.assertRaises(ValueError) as ae:
                 self.func(numpy.array(lons), numpy.array(lats))
                 self.assertEqual(str(ae.exception),

--- a/openquake/hazardlib/tests/geo/utils_test.py
+++ b/openquake/hazardlib/tests/geo/utils_test.py
@@ -74,7 +74,7 @@ class LineIntersectsItselfTestCase(unittest.TestCase):
 
     def test_intersects_on_international_date_line(self):
         lons = numpy.array([178, 178, -178, 170])
-        lats = [0, 10, 0, 5]
+        lats = numpy.array([0, 10, 0, 5])
         self.assertEqual(True, self.func(lons, lats))
 
     def test_doesnt_intersect_on_international_date_line(self):


### PR DESCRIPTION
It gives a minor speedup (4-5% in the performance test) but it helps with code clarity. Notice that `get_spherical_bounding_box` is used in `get_tu`, i.e. if affects the performance of the `rx, ry0` distances.