### PR TITLE
Removed redundant projections in `Line.get_tu`

### DIFF
--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -109,10 +109,9 @@ def _surf_param(surface, sites, param, dcache):
         if surface.tor is None:
             surface._set_tor()
         if param == 'rx':
-            uut, tut = surface.tor.get_tu(sites)
-            dist = tut[0] if len(tut[0].shape) > 1 else tut
+            dist = surface.get_rx_distance(sites)
         elif param == 'ry0':
-            dist = surface.tor.get_ry0_distance(sites)
+            dist = surface.get_ry0_distance(sites)
     elif param in ('closest_point', 'clon', 'clat'):
         t = _closest_points(surface.surfaces, sites, dcache)
         if param == 'closest_point':

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -19,6 +19,7 @@
  Module :mod:`openquake.hazardlib.geo.line` defines :class:`Line`.
 """
 import numpy as np
+from openquake.baselib.general import cached_property
 from openquake.baselib.performance import compile
 from openquake.hazardlib.geo import geodetic
 from openquake.hazardlib.geo import utils
@@ -171,14 +172,15 @@ class Line(object):
         """
         self = cls.__new__(cls)
         self.coo = coo
-        self.proj = utils.OrthographicProjection.from_lons_lats(
-            coo[:, 0], coo[:, 1])
         return self
 
     def __init__(self, points):
         points = utils.clean_points(points)  # can remove points!
         self.coo = np.array([[p.x, p.y, p.z] for p in points])
-        self.proj = utils.OrthographicProjection.from_lons_lats(
+
+    @cached_property
+    def proj(self):
+        return utils.OrthographicProjection.from_lons_lats(
             self.coo[:, 0], self.coo[:, 1])
 
     @property

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -20,7 +20,6 @@
 """
 import copy
 import numpy as np
-from openquake.baselib.general import cached_property
 from openquake.baselib.performance import compile
 from openquake.hazardlib.geo import geodetic
 from openquake.hazardlib.geo import utils

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -49,7 +49,7 @@ def _resample(coo, sect_len, orig_extremes):
 
     # Project the coordinates of the trace and save them in `txy`
     proj = utils.OrthographicProjection.from_lons_lats(coo[:, 0], coo[:, 1])
-    txy = proj.coords(coo[:, 0], coo[:, 1], coo[:, 2])
+    txy = proj.coords(coo[:, 0], coo[:, 1], coo[:, 2]).T
 
     # Compute the total length of the original trace
     # tot_len = sum(utils.get_dist(txy[i], txy[i - 1]) for i in range(1, N))
@@ -411,10 +411,10 @@ class Line(object):
         (num_segments x num_sites).
         """
         # Sites projected coordinates
-        sxy = self.proj.coords(mesh.lons, mesh.lats)
+        sxy = self.proj.coords(mesh.lons, mesh.lats).T
 
         # Polyline projected coordinates
-        txy = self.proj.coords(self.coo[:, 0], self.coo[:, 1])
+        txy = self.proj.coords(self.coo[:, 0], self.coo[:, 1]).T
 
         # Initializing ti and ui coordinates
         ui = np.zeros((txy.shape[0] - 1, sxy.shape[0]))
@@ -443,7 +443,7 @@ class Line(object):
             composing the trace
         """
         # Projected coordinates
-        sx, sy = self.proj(self.coo[:, 0], self.coo[:, 1])
+        sx, sy = self.proj.coords(self.coo[:, 0], self.coo[:, 1])
         slen = ((sx[1:] - sx[:-1])**2 + (sy[1:] - sy[:-1])**2)**0.5
         sg = np.zeros((len(sx) - 1, 3))
         sg[:, 0] = sx[1:] - sx[:-1]

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -18,7 +18,6 @@
 """
  Module :mod:`openquake.hazardlib.geo.line` defines :class:`Line`.
 """
-import copy
 import numpy as np
 from openquake.baselib.performance import compile
 from openquake.hazardlib.geo import geodetic
@@ -420,7 +419,7 @@ class Line(object):
 
         # For each section
         for i in range(ui.shape[0]):
-            tmp = copy.copy(sxy)
+            tmp = np.copy(sxy)
             tmp[:, 0] -= txy[i, 0]
             tmp[:, 1] -= txy[i, 1]
             ui[i, :] = tmp @ uhat[i, 0:2]

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -49,7 +49,7 @@ def _resample(coo, sect_len, orig_extremes):
 
     # Project the coordinates of the trace and save them in `txy`
     proj = utils.OrthographicProjection.from_lons_lats(coo[:, 0], coo[:, 1])
-    txy = proj.coords(coo[:, 0], coo[:, 1], coo[:, 2]).T
+    txy = proj(coo[:, 0], coo[:, 1], coo[:, 2]).T
 
     # Compute the total length of the original trace
     # tot_len = sum(utils.get_dist(txy[i], txy[i - 1]) for i in range(1, N))
@@ -411,10 +411,10 @@ class Line(object):
         (num_segments x num_sites).
         """
         # Sites projected coordinates
-        sxy = self.proj.coords(mesh.lons, mesh.lats).T
+        sxy = self.proj(mesh.lons, mesh.lats).T
 
         # Polyline projected coordinates
-        txy = self.proj.coords(self.coo[:, 0], self.coo[:, 1]).T
+        txy = self.proj(self.coo[:, 0], self.coo[:, 1]).T
 
         # Initializing ti and ui coordinates
         ui = np.zeros((txy.shape[0] - 1, sxy.shape[0]))
@@ -443,7 +443,7 @@ class Line(object):
             composing the trace
         """
         # Projected coordinates
-        sx, sy = self.proj.coords(self.coo[:, 0], self.coo[:, 1])
+        sx, sy = self.proj(self.coo[:, 0], self.coo[:, 1])
         slen = ((sx[1:] - sx[:-1])**2 + (sy[1:] - sy[:-1])**2)**0.5
         sg = np.zeros((len(sx) - 1, 3))
         sg[:, 0] = sx[1:] - sx[:-1]

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -173,20 +173,19 @@ class Line(object):
         """
         self = cls.__new__(cls)
         self.coo = coo
+        self.proj = utils.OrthographicProjection.from_lons_lats(
+            coo[:, 0], coo[:, 1])
         return self
 
     def __init__(self, points):
         points = utils.clean_points(points)  # can remove points!
         self.coo = np.array([[p.x, p.y, p.z] for p in points])
+        self.proj = utils.OrthographicProjection.from_lons_lats(
+            self.coo[:, 0], self.coo[:, 1])
 
     @property
     def points(self):
         return [self[i] for i in range(len(self.coo))]
-
-    @cached_property
-    def proj(self):
-        return utils.OrthographicProjection.from_lons_lats(
-            self.coo[:, 0], self.coo[:, 1])
 
     def __eq__(self, other):
         """

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -49,8 +49,7 @@ def _resample(coo, sect_len, orig_extremes):
 
     # Project the coordinates of the trace and save them in `txy`
     proj = utils.OrthographicProjection.from_lons_lats(coo[:, 0], coo[:, 1])
-    txy = coo.copy()
-    txy[:, 0], txy[:, 1] = proj(coo[:, 0], coo[:, 1])
+    txy = proj.coords(coo[:, 0], coo[:, 1], coo[:, 2])
 
     # Compute the total length of the original trace
     # tot_len = sum(utils.get_dist(txy[i], txy[i - 1]) for i in range(1, N))
@@ -391,21 +390,6 @@ class Line(object):
         :param mesh:
             An instance of :class:`openquake.hazardlib.geo.mesh.Mesh`
         """
-        # all sites
-        lons = np.concatenate([mesh.lons, self.coo[:, 0]])
-        lats = np.concatenate([mesh.lats, self.coo[:, 1]])
-
-        # projection
-        proj = utils.OrthographicProjection.from_lons_lats(lons, lats)
-
-        # projected coordinates for the trace
-        txy = np.zeros((len(self.coo), 2))
-        txy[:, 0], txy[:, 1] = proj(self.coo[:, 0], self.coo[:, 1])
-
-        # projected coordinates for the sites
-        sxy = np.zeros((len(mesh), 2))
-        sxy[:, 0], sxy[:, 1] = proj(mesh.lons, mesh.lats)
-
         # Compute u hat and t hat for each segment. tmp has shape
         # (num_segments x 3)
         slen, uhat, that = self.get_tu_hat()
@@ -427,12 +411,10 @@ class Line(object):
         (num_segments x num_sites).
         """
         # Sites projected coordinates
-        sxy = np.zeros((len(mesh.lons), 2))
-        sxy[:, 0], sxy[:, 1] = self.proj(mesh.lons, mesh.lats)
+        sxy = self.proj.coords(mesh.lons, mesh.lats)
 
         # Polyline projected coordinates
-        txy = np.zeros_like(self.coo)
-        txy[:, 0], txy[:, 1] = self.proj(self.coo[:, 0], self.coo[:, 1])
+        txy = self.proj.coords(self.coo[:, 0], self.coo[:, 1])
 
         # Initializing ti and ui coordinates
         ui = np.zeros((txy.shape[0] - 1, sxy.shape[0]))

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -89,41 +89,6 @@ class MultiLine(object):
         """
         return _get_tu(self.shift, *get_tus(self.lines, mesh))
 
-    def get_rx_distance(self, mesh):
-        """
-        :param mesh:
-            An instance of :class:`openquake.hazardlib.geo.mesh.Mesh` with the
-            coordinates of the sites.
-        :returns:
-            A :class:`numpy.ndarray` instance with the Rx distance. Note that
-            the Rx distance is directly taken from the GC2 t-coordinate.
-        """
-        uut, tut = self.get_tu(mesh)
-        return tut[0]
-
-    def get_ry0_distance(self, mesh):
-        """
-        :param mesh:
-            An instance of :class:`openquake.hazardlib.geo.mesh.Mesh`
-        """
-        uut, tut = self.get_tu(mesh)
-
-        ry0 = np.zeros_like(uut)
-        ry0[uut < 0] = abs(uut[uut < 0])
-
-        condition = uut > self.u_max
-        ry0[condition] = uut[condition] - self.u_max
-
-        return ry0
-
-    def to_mesh(self):
-        """
-        Assuming the L lines are all segments (i.e. contains 2 points)
-        returns a RectangularMesh of shape (L, 2)
-        """
-        coo = np.array([ln.coo for ln in self.lines])  # shape (L, 2, 3)
-        return RectangularMesh(coo[:, :, 0], coo[:, :, 1])
-
 
 def get_tus(lines: list, mesh: Mesh):
     """

--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -318,7 +318,7 @@ class BaseSurface:
             dep = numpy.min(top_edge.depths)
             return dep
 
-    def _get_top_edge_centroid(self):
+    def get_top_edge_centroid(self):
         """
         Return :class:`~openquake.hazardlib.geo.point.Point` representing the
         surface's top edge centroid.

--- a/openquake/hazardlib/geo/surface/kite_fault.py
+++ b/openquake/hazardlib/geo/surface/kite_fault.py
@@ -1067,7 +1067,8 @@ def _get_resampled_profs(npr, profs, sd, proj, idl, ref_idx, forward=True):
 
             # If the edge starts with the first index
             if i_from == unique[0]:
-                tmp = _resample(parr[cseg[0]:cseg[1], cseg[2]], sd, True)
+                line = Line.from_coo(parr[cseg[0]:cseg[1], cseg[2]])
+                tmp = _resample(line, sd, True)
 
                 if len(tmp) < 3:
                     tmp = tmp[:, :]

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -328,4 +328,10 @@ class MultiSurface(BaseSurface):
         """
         if self.tor is None:
             self._set_tor()
-        return self.tor.get_ry0_distance(mesh)
+
+        uut, tut = self.tor.get_tu(mesh)
+        ry0 = np.zeros_like(uut)
+        ry0[uut < 0] = np.abs(uut[uut < 0])
+        condition = uut > self.tor.u_max
+        ry0[condition] = uut[condition] - self.tor.u_max
+        return ry0

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -244,6 +244,7 @@ class MultiSurface(BaseSurface):
             lats.extend([north, south])
         return utils.get_spherical_bounding_box(np.array(lons), np.array(lats))
 
+    # NB: this is only called by CharacteristicSources, see logictree/case_20
     def get_middle_point(self):
         """
         If :class:`MultiSurface` is defined by a single surface, simply

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -937,10 +937,10 @@ class PlanarSurface(BaseSurface):
                    array.uv2 * yy.reshape(yy.shape + (1, )))
         return Mesh(*geo_utils.cartesian_to_spherical(vectors))
 
-    def _get_top_edge_centroid(self):
+    def get_top_edge_centroid(self):
         """
         Overrides :meth:`superclass' method
-        <openquake.hazardlib.geo.surface.base.BaseSurface._get_top_edge_centroid>`
+        <openquake.hazardlib.geo.surface.base.BaseSurface.get_top_edge_centroid>`
         in order to avoid creating a mesh.
         """
         lon, lat = geo_utils.get_middle_point(

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -554,7 +554,7 @@ class OrthographicProjection(object):
         self.sin_phi0 = numpy.sin(self.phi0)
         self.sin_pi_over_4 = (2 ** 0.5) / 2
 
-    def __call__(self, lons, lats, reverse=False):
+    def __call__(self, lons, lats, deps=None, reverse=False):
         assert not numpy.isnan(lons).any(), lons
         if not reverse:
             lambdas, phis = numpy.radians(lons), numpy.radians(lats)
@@ -591,20 +591,10 @@ class OrthographicProjection(object):
             xx[idx] = xx[idx] - 360.
             idx = xx <= -180.
             xx[idx] = xx[idx] + 360.
-        return numpy.array([xx, yy])
-
-    def coords(self, lons, lats, deps=None):
-        """
-        :returns: array of shape (2, N) or (3, N) of projected coordinates
-        """
         if deps is None:
-            txy = numpy.zeros((2, len(lons)))
+            return numpy.array([xx, yy])
         else:
-            txy = numpy.zeros((3, len(lons)))
-        txy[0], txy[1] = self(lons, lats)
-        if deps is not None:
-            txy[2] = deps
-        return txy
+            return numpy.array([xx, yy, deps])
 
         
 def get_middle_point(lon1, lat1, lon2, lat2):

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -594,7 +594,20 @@ class OrthographicProjection(object):
             xx[idx] = xx[idx] + 360.
             return xx, yy
 
+    def coords(self, lons, lats, deps=None):
+        """
+        :returns: array of shape (N, 2) or (N, 3) of projected coordinates
+        """
+        if deps is None:
+            txy = numpy.zeros((len(lons), 2))
+        else:
+            txy = numpy.zeros((len(lons), 3))
+        txy[:, 0], txy[:, 1] = self(lons, lats)
+        if deps is not None:
+            txy[:, 2] = deps
+        return txy
 
+        
 def get_middle_point(lon1, lat1, lon2, lat2):
     """
     Given two points return the point exactly in the middle lying on the same

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -571,10 +571,9 @@ class OrthographicProjection(object):
                                  'center lon=%s lat=%s' %
                                  (numpy.degrees(self.lambda0),
                                   numpy.degrees(self.phi0)))
-            xx = numpy.cos(phis) * numpy.sin(lambdas)
+            xx = numpy.cos(phis) * numpy.sin(lambdas) * EARTH_RADIUS
             yy = (self.cos_phi0 * numpy.sin(phis) - self.sin_phi0 * cos_phis
-                  * numpy.cos(lambdas))
-            return xx * EARTH_RADIUS, yy * EARTH_RADIUS
+                  * numpy.cos(lambdas)) * EARTH_RADIUS
         else:
             # "reverse" mode, arguments are actually abscissae
             # and ordinates in 2d space
@@ -592,19 +591,19 @@ class OrthographicProjection(object):
             xx[idx] = xx[idx] - 360.
             idx = xx <= -180.
             xx[idx] = xx[idx] + 360.
-            return xx, yy
+        return numpy.array([xx, yy])
 
     def coords(self, lons, lats, deps=None):
         """
-        :returns: array of shape (N, 2) or (N, 3) of projected coordinates
+        :returns: array of shape (2, N) or (3, N) of projected coordinates
         """
         if deps is None:
-            txy = numpy.zeros((len(lons), 2))
+            txy = numpy.zeros((2, len(lons)))
         else:
-            txy = numpy.zeros((len(lons), 3))
-        txy[:, 0], txy[:, 1] = self(lons, lats)
+            txy = numpy.zeros((3, len(lons)))
+        txy[0], txy[1] = self(lons, lats)
         if deps is not None:
-            txy[:, 2] = deps
+            txy[2] = deps
         return txy
 
         

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -342,7 +342,7 @@ class SiteCollection(object):
         """
         sfc = rup.surface
         if point == 'TC':
-            pnt = sfc._get_top_edge_centroid()
+            pnt = sfc.get_top_edge_centroid()
             lon, lat = pnt.x, pnt.y
         elif point == 'BC':
             lon, lat = get_middle_point(


### PR DESCRIPTION
See commit 25d39881f0. This gives a good speedup of the performance tests from 105s to 72s (30%). Also, some refactoring.