### PR TITLE
Storing the rupture_idxs in the file `_tmp.hdf5`

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -210,7 +210,10 @@ class PreClassicalCalculator(base.HazardCalculator):
                     pointsources.append(src)
                 elif hasattr(src, 'nodal_plane_distribution'):
                     pointlike.append(src)
-                elif src.code in b'CFN':  # send the heavy sources
+                elif src.code == b'F':  # split multi fault sources
+                    for split in src:
+                        smap.submit(([split], sites, cmaker))
+                elif src.code in b'CN':  # send the heavy sources
                     smap.submit(([src], sites, cmaker))
                 else:
                     others.append(src)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -191,11 +191,7 @@ class PreClassicalCalculator(base.HazardCalculator):
                 cmakers[grp_id].set_weight(sg, sites)
                 atomic_sources.extend(sg)
             else:
-                for src in sg:
-                    if hasattr(src, 'rupture_idxs'):  # multiFault
-                        normal_sources.extend(split_source(src))
-                    else:
-                        normal_sources.append(src)
+                normal_sources.extend(sg)
 
         # run preclassical for non-atomic sources
         sources_by_key = groupby(normal_sources, operator.attrgetter('grp_id'))
@@ -210,10 +206,10 @@ class PreClassicalCalculator(base.HazardCalculator):
                     pointsources.append(src)
                 elif hasattr(src, 'nodal_plane_distribution'):
                     pointlike.append(src)
-                elif src.code == b'F':  # split multi fault sources
-                    for split in src:
+                elif src.code == b'F':  # multi fault source
+                    for split in split_source(src):
                         smap.submit(([split], sites, cmaker))
-                elif src.code in b'CN':  # send the heavy sources
+                elif src.code in b'CN':  # other heavy sources
                     smap.submit(([src], sites, cmaker))
                 else:
                     others.append(src)

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -539,7 +539,7 @@ class ClassicalTestCase(CalculatorTestCase):
         csm = self.calc.datastore['_csm']
         tmpname = general.gettemp()
         [src] = csm.src_groups[0].sources
-        src.rupture_idxs = [tuple(map(str, idxs)) for idxs in src.rupture_idxs]
+        src._rupture_idxs = [tuple(map(str, idxs)) for idxs in src.rupture_idxs]
         out = write_source_model(tmpname, csm.src_groups)
         self.assertEqual(out[0], tmpname)
         self.assertEqual(out[1], tmpname + '.hdf5')

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -528,7 +528,10 @@ class ClassicalTestCase(CalculatorTestCase):
 
     def test_case_65(self):
         # multiFaultSource with infer_occur_rates=true
-        self.run_calc(case_65.__file__, 'job.ini')
+        self.run_calc(case_65.__file__, 'job.ini',
+                      calculation_mode='preclassical')
+        hc_id = str(self.calc.datastore.calc_id)
+        self.run_calc(case_65.__file__, 'job.ini', hazard_calculation_id=hc_id)
         rates = self.calc.datastore['rup/occurrence_rate'][:]
         aac(rates, [0.356675, 0.105361], atol=5e-7)
 
@@ -539,7 +542,8 @@ class ClassicalTestCase(CalculatorTestCase):
         csm = self.calc.datastore['_csm']
         tmpname = general.gettemp()
         [src] = csm.src_groups[0].sources
-        src._rupture_idxs = [tuple(map(str, idxs)) for idxs in src.rupture_idxs]
+        src._rupture_idxs = [
+            tuple(map(str, idxs)) for idxs in src.rupture_idxs]
         out = write_source_model(tmpname, csm.src_groups)
         self.assertEqual(out[0], tmpname)
         self.assertEqual(out[1], tmpname + '.hdf5')

--- a/openquake/hazardlib/nrml_to.py
+++ b/openquake/hazardlib/nrml_to.py
@@ -99,9 +99,9 @@ def to_wkt(geom, coords):
 # https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry
 def appendrow(row, rows, chatty, sections=(), s2i={}):
     if row.code == 'F':  # row.coords is a multiFaultSource
-        row.coords.rupture_idxs = [tuple(s2i[idx] for idx in idxs)
-                                   for idxs in row.coords.rupture_idxs]
-        row.coords.set_sections(sections)
+        rupture_idxs = [tuple(s2i[idx] for idx in idxs)
+                        for idxs in row.coords.rupture_idxs]
+        row.coords.set_sections(sections, rupture_idxs)
         row.coords = [row.coords.polygon.coords]
     row.wkt = wkt = to_wkt(row.geom, row.coords)
     if wkt.startswith('POINT'):

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -87,6 +87,17 @@ class MultiFaultSource(BaseSeismicSource):
             self.temporal_occurrence_model = PoissonTOM(investigation_time)
         super().__init__(source_id, name, tectonic_region_type)
 
+    @property
+    def rupture_idxs(self):
+        """
+        Read a list of U16 arrays from hdf5path if set
+        """
+        if hasattr(self, '_rupture_idxs'):
+            # set by the SourceConverter or by the tests
+            return self._rupture_idxs
+        with hdf5.File(self.hdf5path, 'r') as f:
+            return f[f'rupture_idxs/{self.source_id}'][:]
+        
     def is_gridded(self):
         return True  # convertible to HDF5
 
@@ -109,7 +120,6 @@ class MultiFaultSource(BaseSeismicSource):
             return self.sections  # empty hdf5path
         with hdf5.File(self.hdf5path, 'r') as f:
             geoms = f['multi_fault_sections'][:]  # small
-            self.rupture_idxs = f[f'rupture_idxs/{self.source_id}'][:]
         sections = [geom_to_kite(geom) for geom in geoms]
         for idx, sec in enumerate(sections):
             sec.idx = idx
@@ -133,7 +143,7 @@ class MultiFaultSource(BaseSeismicSource):
             for idx in rupture_idxs[i]:
                 sections[idx]
         self.sections = sections
-        self.rupture_idxs = rupture_idxs
+        self._rupture_idxs = rupture_idxs
 
     def iter_ruptures(self, **kwargs):
         """
@@ -147,8 +157,9 @@ class MultiFaultSource(BaseSeismicSource):
         step = kwargs.get('step', 1)
         n = len(self.mags)
         sec = self.get_sections()  # KiteSurfaces
+        rupture_idxs = self.rupture_idxs
         for i in range(0, n, step**2):
-            idxs = self.rupture_idxs[i]
+            idxs = rupture_idxs[i]
             if len(idxs) == 1:
                 sfc = sec[idxs[0]]
             else:
@@ -262,7 +273,7 @@ def load(hdf5path):
             probs = data['probs_occur'][:]
             src = MultiFaultSource(key, name, trt, probs, mags, rakes,
                                    itime, infer)
-            src.rupture_idxs = data['rupture_idxs'][:]
+            src._rupture_idxs = data['rupture_idxs'][:]
             src.hdf5path = hdf5path
             srcs.append(src)
     return srcs

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -182,7 +182,7 @@ class MultiFaultSource(BaseSeismicSource):
             yield self.source_id, lst
             return
         for i, slc in enumerate(gen_slices(0, len(self.mags), BLOCKSIZE)):
-            yield '%s:%d' % (self.source_id, i), lst[slc]
+            yield '%s.%d' % (self.source_id, i), lst[slc]
 
     def __iter__(self):
         if len(self.mags) <= BLOCKSIZE:  # already split
@@ -191,7 +191,7 @@ class MultiFaultSource(BaseSeismicSource):
         # split in blocks of BLOCKSIZE ruptures each
         for i, slc in enumerate(gen_slices(0, len(self.mags), BLOCKSIZE)):
             src = self.__class__(
-                '%s:%d' % (self.source_id, i),
+                '%s.%d' % (self.source_id, i),
                 self.name,
                 self.tectonic_region_type,
                 self.probs_occur[slc],

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -349,7 +349,8 @@ def fix_geometry_sections(smdict, dstore):
                     if dstore:
                         src.hdf5path = dstore.tempname
                     rupture_idxs = [U16([s2i[idx] for idx in idxs])
-                                    for idxs in src.rupture_idxs]
+                                    for idxs in src._rupture_idxs]
+                    delattr(src, '_rupture_idxs')  # set by the SourceConverter
                     with hdf5.File(dstore.tempname, 'r+') as h5:
                         for srcid, block in src.gen_blocks(rupture_idxs):
                             h5.save_vlen(f'rupture_idxs/{srcid}', block)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -461,11 +461,12 @@ def _get_csm(full_lt, groups, event_based, set_wkt):
                        'of {:_d} points!')
                 for src in sources:
                     # check on MultiFaultSources and NonParametricSources
-                    mesh_size = getattr(src, 'mesh_size', 0)
-                    if mesh_size > 1E6:
-                        logging.warning(msg.format(
-                            src.source_id, src.count_ruptures(), mesh_size))
-                    src._wkt = src.wkt()
+                    #mesh_size = getattr(src, 'mesh_size', 0)
+                    #if mesh_size > 1E6:
+                    #    logging.warning(msg.format(
+                    #        src.source_id, src.count_ruptures(), mesh_size))
+                    #src._wkt = src.wkt()
+                    pass
             src_groups.append(sourceconverter.SourceGroup(trt, sources))
     if set_wkt:
         for ag in atomic:

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -1148,11 +1148,12 @@ class SourceConverter(RuptureConverter):
                 for idx in idxs:
                     assert U32(idx).max() < TWO16, idx
             # NB: the sections will be fixed later on, in source_reader
-            mfs = MultiFaultSource(sid, name, trt, idxs,
+            mfs = MultiFaultSource(sid, name, trt,
                                    dic['probs_occur'],
                                    dic['mag'], dic['rake'],
                                    self.investigation_time,
                                    self.infer_occur_rates)
+            mfs.rupture_idxs = idxs
             return mfs
         probs = []
         mags = []
@@ -1180,9 +1181,10 @@ class SourceConverter(RuptureConverter):
             mags = rounded_unique(mags, idxs)
         rakes = numpy.array(rakes)
         # NB: the sections will be fixed later on, in source_reader
-        mfs = MultiFaultSource(sid, name, trt, idxs, probs, mags, rakes,
+        mfs = MultiFaultSource(sid, name, trt, probs, mags, rakes,
                                self.investigation_time,
                                self.infer_occur_rates)
+        mfs.rupture_idxs = idxs
         return mfs
 
     def convert_sourceModel(self, node):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -1153,7 +1153,7 @@ class SourceConverter(RuptureConverter):
                                    dic['mag'], dic['rake'],
                                    self.investigation_time,
                                    self.infer_occur_rates)
-            mfs.rupture_idxs = idxs
+            mfs._rupture_idxs = idxs
             return mfs
         probs = []
         mags = []
@@ -1184,7 +1184,7 @@ class SourceConverter(RuptureConverter):
         mfs = MultiFaultSource(sid, name, trt, probs, mags, rakes,
                                self.investigation_time,
                                self.infer_occur_rates)
-        mfs.rupture_idxs = idxs
+        mfs._rupture_idxs = idxs
         return mfs
 
     def convert_sourceModel(self, node):

--- a/openquake/hazardlib/tests/contexts_test.py
+++ b/openquake/hazardlib/tests/contexts_test.py
@@ -400,9 +400,9 @@ class GetCtxs01TestCase(unittest.TestCase):
         src = ssm[0][0]
         sections = list(geom.sections.values())
         s2i = {idx: i for i, idx in enumerate(geom.sections)}
-        src.rupture_idxs = [tuple(s2i[idx] for idx in idxs)
-                            for idxs in src.rupture_idxs]
-        src.set_sections(sections)
+        rupture_idxs = [tuple(s2i[idx] for idx in idxs)
+                        for idxs in src.rupture_idxs]
+        src.set_sections(sections, rupture_idxs)
         self.src = src
 
         # Create site-collection
@@ -457,9 +457,9 @@ class GetCtxs02TestCase(unittest.TestCase):
         src = ssm[0][0]
         sections = list(geom.sections.values())
         s2i = {idx: i for i, idx in enumerate(geom.sections)}
-        src.rupture_idxs = [tuple(s2i[idx] for idx in idxs)
-                            for idxs in src.rupture_idxs]
-        src.set_sections(sections)
+        rupture_idxs = [tuple(s2i[idx] for idx in idxs)
+                        for idxs in src.rupture_idxs]
+        src.set_sections(sections, rupture_idxs)
         self.src = src
 
         # Create site-collection

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -85,8 +85,8 @@ class MultiFaultTestCase(unittest.TestCase):
     def test_ok(self):
         # test instantiation
         src = MultiFaultSource("01", "test", "Moon Crust",
-                               self.rup_idxs, self.pmfs, self.mags, self.rakes)
-        src.set_sections(self.sections)
+                               self.pmfs, self.mags, self.rakes)
+        src.set_sections(self.sections, self.rup_idxs)
         src.mutex_weight = 1.
 
         # test conversion to XML
@@ -139,10 +139,10 @@ class MultiFaultTestCase(unittest.TestCase):
     def test_ko(self):
         # test set_sections, 3 is not a known section ID
         rup_idxs = [[0], [1], [3], [0], [1], [3], [0]]
-        mfs = MultiFaultSource("01", "test", "Moon Crust", rup_idxs,
+        mfs = MultiFaultSource("01", "test", "Moon Crust",
                                self.pmfs, self.mags, self.rakes)
         with self.assertRaises(IndexError):
-            mfs.set_sections(self.sections)
+            mfs.set_sections(self.sections, rup_idxs)
 
 
 def main():

--- a/openquake/hazardlib/tests/sourceconverter_test.py
+++ b/openquake/hazardlib/tests/sourceconverter_test.py
@@ -505,9 +505,9 @@ class MultiFaultSourceModelTestCase(unittest.TestCase):
         sections = list(sec.values())
         s2i = {idx: i for i, idx in enumerate(sec)}
         src = ssm[0][0]
-        src.rupture_idxs = [tuple(s2i[idx] for idx in idxs)
-                            for idxs in src.rupture_idxs]
-        src.set_sections(sections)   # fix sections
+        rupture_idxs = [tuple(s2i[idx] for idx in idxs)
+                        for idxs in src.rupture_idxs]
+        src.set_sections(sections, rupture_idxs)   # fix sections
         rups = list(ssm[0][0].iter_ruptures())
 
         # Check data for the second rupture


### PR DESCRIPTION
This saves a lot of memory (from 3GB per core to <1 GB per core for the USA model). In the reduced version `OQ_SAMPLE_SITES=.0001 oq run USA/in/job_vs30.ini` one gets
```
# before
| calc_52, maxmem=55.2 GB    | time_sec  | memory_mb | counts  |
|----------------------------+-----------+-----------+---------|
| total classical            | 22_296    | 199.1     | 242     |
| nonplanar contexts         | 20_315    | 0.0       | 877     |
| ClassicalCalculator.run    | 1_303     | 2_103     | 1       |

# after
| calc_51, maxmem=52.0 GB    | time_sec  | memory_mb | counts  |
|----------------------------+-----------+-----------+---------|
| total classical            | 22_218    | 142.6     | 242     |
| nonplanar contexts         | 20_182    | 0.01172   | 877     |
| ClassicalCalculator.run    | 1_321     | 757.0     | 1       |
```