### PR TITLE
Refined KiteSurfaces

### DIFF
--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -341,6 +341,7 @@ class Line(object):
         idx = np.nonzero(np.abs(np.diff(azim)) > delta)[0]
         pidx = sorted(pidx.union(set(idx + 1)))
         self.coo = coo[pidx]
+        return self
 
     def resample_to_num_points(self, num_points):
         """

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -24,7 +24,7 @@ import numpy as np
 from openquake.baselib.performance import compile
 from openquake.hazardlib.geo import utils
 from openquake.hazardlib.geo.mesh import Mesh
-from openquake.hazardlib.geo.line import get_average_azimuth
+from openquake.hazardlib.geo.line import Line, get_average_azimuth
 from openquake.hazardlib.geo.geodetic import geodetic_distance, azimuth
 
 
@@ -62,8 +62,9 @@ class MultiLine(object):
         olon, olat, soidx = get_origin(ep, strike_east, avg_azim)
 
         # Reorder the lines according to the origin and compute the shift
-        self.lines = [self.lines[i] for i in soidx]
-        self.shift = get_coordinate_shift(self.lines, olon, olat, avg_azim)
+        lines = [self.lines[i] for i in soidx]
+        self.coos = [ln.coo for ln in lines]
+        self.shift = get_coordinate_shift(lines, olon, olat, avg_azim)
         self.u_max = np.abs(self.get_uts(ep)[0]).max()
 
     def get_uts(self, mesh):
@@ -75,8 +76,8 @@ class MultiLine(object):
         tupps = np.zeros((L, N))
         uupps = np.zeros((L, N))
         weis = np.zeros((L, N))
-        for i, line in enumerate(self.lines):
-            tu, uu, we = line.get_tuw(mesh)
+        for i, coo in enumerate(self.coos):
+            tu, uu, we = Line.from_coo(coo).get_tuw(mesh)
             tupps[i] = tu
             uupps[i] = uu
             weis[i] = we.sum(axis=0)

--- a/openquake/hazardlib/geo/surface/kite_fault.py
+++ b/openquake/hazardlib/geo/surface/kite_fault.py
@@ -137,7 +137,7 @@ class KiteSurface(BaseSurface):
         iro = iro[iro <= 1]
         # top_left, top_right coordinates
         lo, la = self.mesh.lons[iro, ico], self.mesh.lats[iro, ico]
-        return Line.from_vectors(lo, la)
+        return Line.from_vectors(lo, la).keep_corners(delta=1.)
 
     def is_vertical(self):
         """ True if all the profiles, and hence the surface, are vertical """

--- a/openquake/hazardlib/geo/surface/kite_fault.py
+++ b/openquake/hazardlib/geo/surface/kite_fault.py
@@ -121,7 +121,8 @@ class KiteSurface(BaseSurface):
         """
         Provides longitude and latitude coordinates of the vertical surface
         projection of the top of rupture. This is used in the GC2 method to
-        compute the Rx and Ry0 distances.
+        compute the Rx and Ry0 distances. NB: keep_corners is used to reduce
+        the line, with a tolerance of 1 km.
 
         One important note here. The kite fault surface uses a rectangular
         mesh to describe the geometry of the rupture; some nodes can be NaN.

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -117,8 +117,7 @@ class MultiSurface(BaseSurface):
                 # PlanarSurfaces together in NonParametricSources
                 # the `idx` is used only in MultiFaultSources
                 # srfc.tor_line.idx = getattr(srfc, 'idx', None)
-                srfc.tor_line.keep_corners(self.tol)
-                tors.append(srfc.tor_line)
+                tors.append(srfc.tor_line.keep_corners(self.tol))
 
             elif isinstance(srfc, PlanarSurface):
                 lo = []
@@ -133,8 +132,7 @@ class MultiSurface(BaseSurface):
                 lats = srfc.mesh.lats[0, :]
                 coo = np.array([[lo, la] for lo, la in zip(lons, lats)])
                 line = geo.line.Line.from_vectors(coo[:, 0], coo[:, 1])
-                line.keep_corners(self.tol)
-                tors.append(line)
+                tors.append(line.keep_corners(self.tol))
 
             else:
                 raise ValueError(f"Surface {str(srfc)} not supported")

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -84,7 +84,7 @@ class MultiSurface(BaseSurface):
         return Mesh(np.concatenate(lons), np.concatenate(lats),
                     np.concatenate(deps))
 
-    def __init__(self, surfaces: list, tol: float = 1):
+    def __init__(self, surfaces, tor=None, tol=1.):
         """
         Intialize a multi surface object from a list of surfaces
 
@@ -97,7 +97,7 @@ class MultiSurface(BaseSurface):
         """
         self.surfaces = surfaces
         self.tol = tol
-        self.tor = None
+        self.tor = tor
         self.areas = None
 
     # called at each instantiation

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -166,6 +166,8 @@ class MultiFaultSource(BaseSeismicSource):
                 sfc = MultiSurface([sec[idx] for idx in idxs])
             rake = self.rakes[i]
             hypo = sec[idxs[0]].get_middle_point()
+            #if len(idxs) == 1:
+            #    import pdb; pdb.set_trace()
             data = [(p, o) for o, p in enumerate(self.probs_occur[i])]
             if self.infer_occur_rates:
                 yield ParametricProbabilisticRupture(

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -160,14 +160,9 @@ class MultiFaultSource(BaseSeismicSource):
         rupture_idxs = self.rupture_idxs
         for i in range(0, n, step**2):
             idxs = rupture_idxs[i]
-            if len(idxs) == 1:
-                sfc = sec[idxs[0]]
-            else:
-                sfc = MultiSurface([sec[idx] for idx in idxs])
+            sfc = MultiSurface([sec[idx] for idx in idxs])
             rake = self.rakes[i]
-            hypo = sec[idxs[0]].get_middle_point()
-            #if len(idxs) == 1:
-            #    import pdb; pdb.set_trace()
+            hypo = sfc.get_middle_point()
             data = [(p, o) for o, p in enumerate(self.probs_occur[i])]
             if self.infer_occur_rates:
                 yield ParametricProbabilisticRupture(

--- a/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/kite_fault_test.py
@@ -224,12 +224,11 @@ class KiteSurfaceFromMeshTest(unittest.TestCase):
         self.assertTrue(perc_diff < 0.5)
 
     def test_get_tor(self):
-        """ test calculation of trace (i.e. surface projection of tor) """
-        lons = np.flipud([0.0, 0.05, 0.1, 0.15, 0.20])
-        lats = np.array([0.0, 0.0, 0.0, 0.0, 0.05])
+        # test calculation of trace (i.e. surface projection of tor)
+        # notice that .tor_line also does a .keep_corners
         coo = self.ksfc.tor_line.coo
-        aae(lons, coo[:, 0])
-        aae(lats, coo[:, 1])
+        aae(coo[:, 0], [0.2 , 0.05, 0.])
+        aae(coo[:, 1], [0.0, 0.0, 0.05])
 
     def test_geom(self):
         geom = kite_to_geom(self.ksfc)
@@ -280,8 +279,8 @@ class KiteSurfaceWithNaNs(unittest.TestCase):
         coo = self.srfc.tor_line.coo
 
         # Expected results extracted manually from the mesh
-        elo = np.array([10.0110047, 10.04738, 10.0982533, 10.1491267, 10.2])
-        ela = np.array([44.9913493, 45.0000316, 45.0000436, 45.0000331, 45.])
+        elo = np.array([10.01100473, 10.04737998, 10.2])
+        ela = np.array([44.99134933, 45.00003155, 45.])
 
         if PLOTTING:
             _, ax = plt.subplots(1, 1)
@@ -347,7 +346,7 @@ class KiteSurfaceWithNaNs(unittest.TestCase):
             z = np.reshape(dst, self.mlons.shape)
             cs = plt.contour(self.mlons, self.mlats, z, 10, colors='k')
             _ = plt.clabel(cs)
-            coo = self.srfc.to_line
+            coo = self.srfc.tor_line
             ax.plot(coo[:, 0], coo[:, 1], '-g', lw=4)
             plt.title(f'{self.NAME} - Rx')
             plt.show()

--- a/openquake/hazardlib/tests/geo/surface/multi2_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi2_test.py
@@ -116,7 +116,6 @@ class MultiSurfaceSimpleFaultSurfaceTestCase(unittest.TestCase):
     Test the construction and use of multi fault surfaces based on simple-fault
     surfaces
     """
-
     def setUp(self):
 
         mspc = 1.0
@@ -143,5 +142,5 @@ class MultiSurfaceSimpleFaultSurfaceTestCase(unittest.TestCase):
 
     def test_get_tor(self):
         # Testing, coo1 and coo2 are inverted due to the origin inversion
-        aae(self.coo2, self.msfc.tor.lines[0].coo[:, 0:2], decimal=2)
-        aae(self.coo1, self.msfc.tor.lines[1].coo[:, 0:2], decimal=2)
+        aae(self.coo2, self.msfc.tor.coos[0][:, 0:2], decimal=2)
+        aae(self.coo1, self.msfc.tor.coos[1][:, 0:2], decimal=2)

--- a/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi_kite_test.py
@@ -230,8 +230,8 @@ class MultiSurfaceWithNaNsTestCase(unittest.TestCase):
             plt.show()
 
         # Note that method is executed when the object is initialized
-        for es, expct in zip(self.msrf.tor.lines, expected):
-            np.testing.assert_array_almost_equal(es.coo, expct, decimal=2)
+        for coo, expct in zip(self.msrf.tor.coos, expected):
+            np.testing.assert_array_almost_equal(coo, expct, decimal=2)
 
     def test_get_strike(self):
         # Since the two surfaces dip to the north, we expect the strike to

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -122,7 +122,7 @@ class MultiFaultTestCase(unittest.TestCase):
         sitecol._set('z1pt0', 100.)
         sitecol._set('z2pt5', 5.)
         gsim = valid.gsim('AbrahamsonEtAl2014NSHMPMean')
-        cmaker = contexts.simple_cmaker([gsim], ['PGA'], cache_distances=1)
+        cmaker = contexts.simple_cmaker([gsim], ['PGA'], cache_distances=0)
         [ctx] = cmaker.from_srcs([src], sitecol)
         assert len(ctx) == src.count_ruptures()
 
@@ -132,7 +132,7 @@ class MultiFaultTestCase(unittest.TestCase):
         aac(ctx.rjb, [0., 27.51904144, 55.03833836, 0., 0., 27.51904144, 0.])
         aac(ctx.rx, [0, 1.10377738e-01, 3.39619736e-01, 1.68873152e-05,
                      1.64545240e-05, 1.65508566e-01, 3.33385038e-05])
-        aac(ctx.ry0, [0., 27.519258, 55.038008, 0., 0., 27.518444, 0.])
+        aac(ctx.ry0, [0., 27.518885, 55.036336, 0., 0., 27.518444, 0.])
         aac(ctx.clon, [10., 10.35, 10.7, 10., 10., 10.35, 10.])
         aac(ctx.clat, 45.)
 


### PR DESCRIPTION
By calling `.keep_corners` in the `tor_line`. This will reduce the disk space occupation since we are going to store the `tor_lines` for multi fault sources in the next PR. Also, changed `MultiFaultSource.iter_ruptures` to always return ruptures with MultiSurfaces: this is affecting slightly the numbers in the multi_surface_test.