### PR TITLE
Optimized the distance calculations in multi fault sources/1

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -106,7 +106,7 @@ def preclassical(srcs, sites, cmaker, secparams, monitor):
         multiplier = 1
         sf = None
     splits = []
-    mon = monitor('setting msparams', measuremem=False)
+    mon = monitor('building msparams', measuremem=False)
     for src in srcs:
         if src.code == b'F':
             with mon:

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -57,7 +57,6 @@ def get_dparam(surface, sites, param):
     elif param == 'clon_clat':
         t = surface.get_closest_points(sites)  # tested in classical/case_83
         dist = t.array.T[:, 0:2]  # shape (N, 2)
-        print(surface.idx, dist)
     else:
         raise ValueError('Unknown distance measure %r' % param)
     return dist

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -26,7 +26,6 @@ from scipy.interpolate import interp1d
 
 from openquake.baselib.python3compat import raise_
 from openquake.hazardlib import site
-from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.geo.utils import (
     KM_TO_DEGREES, angular_distance, get_bounding_box,
     get_longitudinal_extent, BBoxError, spherical_to_cartesian)
@@ -45,7 +44,7 @@ def magstr(mag):
     return '%.2f' % numpy.float32(mag)
 
 
-def _surf_param(surface, sites, param):
+def get_dparam(surface, sites, param):
     # compute distances without any cache
     if param == 'rrup':
         dist = surface.get_min_distance(sites)
@@ -80,13 +79,13 @@ def get_distances(rupture, sites, param):
         else:
             dist = rupture.hypocenter.distance_to_mesh(sites)
     elif param == 'rrup':
-        dist = _surf_param(surf, sites, 'rrup')
+        dist = get_dparam(surf, sites, 'rrup')
     elif param == 'rx':
-        dist = _surf_param(surf, sites, 'rx')
+        dist = get_dparam(surf, sites, 'rx')
     elif param == 'ry0':
-        dist = _surf_param(surf, sites, 'ry0')
+        dist = get_dparam(surf, sites, 'ry0')
     elif param == 'rjb':
-        dist = _surf_param(surf, sites, 'rjb')
+        dist = get_dparam(surf, sites, 'rjb')
     elif param == 'rhypo':
         dist = rupture.hypocenter.distance_to_mesh(sites)
     elif param == 'repi':
@@ -98,7 +97,7 @@ def get_distances(rupture, sites, param):
     elif param == 'azimuthcp':
         dist = surf.get_azimuth_of_closest_point(sites)
     elif param == 'clon_clat':
-        dist = _surf_param(surf, sites, param)
+        dist = get_dparam(surf, sites, param)
     elif param == "rvolc":
         # Volcanic distance not yet supported, defaulting to zero
         dist = numpy.zeros_like(sites.lons)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -57,6 +57,7 @@ def get_dparam(surface, sites, param):
     elif param == 'clon_clat':
         t = surface.get_closest_points(sites)  # tested in classical/case_83
         dist = t.array.T[:, 0:2]  # shape (N, 2)
+        print(surface.idx, dist)
     else:
         raise ValueError('Unknown distance measure %r' % param)
     return dist

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -819,7 +819,7 @@ class ContextMaker(object):
             rup, point='TC', toward_azimuth=90,
             direction='positive', hdist=hdist, step=5.,
             req_site_params=self.REQUIRES_SITES_PARAMETERS)
-        ctxs = self.genctxs([rup], sitecol, src_id=0)
+        ctxs = list(self.genctxs([rup], sitecol, src_id=0))
         return self.recarray(ctxs)
 
     def from_srcs(self, srcs, sitecol):
@@ -923,9 +923,10 @@ class ContextMaker(object):
         :yields: a context array for each rupture
         """
         magdist = self.maximum_distance(same_mag_rups[0].mag)
+        secdists = getattr(self, 'secdists', None)
         for rup in same_mag_rups:
-            if self.secdists:
-                rrups = get_secdists(rup, 'rrup', self.secdists)
+            if secdists:
+                rrups = get_secdists(rup, 'rrup', secdists)
                 rrup = numpy.min(rrups, axis=0)
             else:
                 rrup = get_distances(rup, sites, 'rrup')
@@ -947,15 +948,15 @@ class ContextMaker(object):
             for param in self.REQUIRES_DISTANCES - {'rrup'}:
                 if param == 'clon':
                     set_distances(ctx, rup, r_sites, 'clon_clat',
-                                  self.secdists, mask)
+                                  secdists, mask)
                 elif param == 'clat':
                     pass
                 else:
                     set_distances(ctx, rup, r_sites, param,
-                                  self.secdists, mask)
+                                  secdists, mask)
             if self.fewsites and 'clon' not in self.REQUIRES_DISTANCES:
                 set_distances(ctx, rup, r_sites, 'clon_clat',
-                              self.secdists, mask)
+                              secdists, mask)
 
             # Equivalent distances
             reqv_obj = (self.reqv.get(self.trt) if self.reqv else None)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -72,15 +72,7 @@ cshm_polygon = shapely.geometry.Polygon([(171.6, -43.3), (173.2, -43.3),
 
 
 def get_secdists(rup, param, secdists):
-    dists = []
-    for sec in rup.surface.surfaces:
-        try:
-            dist = secdists[sec.idx, param]
-        except KeyError:  # section too distant
-            pass
-        else:
-            dists.append(dist)
-    return dists
+    return [secdists[sec.idx, param] for sec in rup.surface.surfaces]
 
 
 def set_distances(ctx, rup, sites, param, secdists, mask):
@@ -933,13 +925,7 @@ class ContextMaker(object):
         for rup in same_mag_rups:
             if self.secdists:
                 rrups = get_secdists(rup, 'rrup', self.secdists)
-                if not rrups:
-                    # all sections are too distant
-                    continue
-                try:
-                    rrup = numpy.min(rrups, axis=0)
-                except:
-                    import pdb; pdb.set_trace()
+                rrup = numpy.min(rrups, axis=0)
             else:
                 rrup = get_distances(rup, sites, 'rrup')
             mask = rrup <= magdist

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -945,7 +945,7 @@ class ContextMaker(object):
         magdist = self.maximum_distance(same_mag_rups[0].mag)
         for rup in same_mag_rups:
             if self.secdists:
-                rrups = [self.secdists[sec.idx, 'rrup']
+                rrups = [self.secdists.get((sec.idx, 'rrup'), 9999.)
                          for sec in rup.surface.surfaces]
                 rrup = numpy.min(rrups, axis=0)
             else:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -674,6 +674,7 @@ class ContextMaker(object):
         self.poe_mon = monitor('get_poes', measuremem=False)
         self.pne_mon = monitor('composing pnes', measuremem=False)
         self.ir_mon = monitor('iter_ruptures', measuremem=True)
+        self.sec_mon = monitor('building secdists', measuremem=True)
         self.delta_mon = monitor('getting delta_rates', measuremem=False)
         self.col_mon = monitor('collapsing contexts', measuremem=False)
         self.task_no = getattr(monitor, 'task_no', 0)
@@ -1003,7 +1004,8 @@ class ContextMaker(object):
             return self.pla_mon.iter(genctxs(src, sitecol, self))
         elif hasattr(src, 'source_id'):  # other source
             if src.code == b'F' and step == 1:
-                self.secdists = _build_secdists(src, sitecol, self)
+                with self.sec_mon:
+                    self.secdists = _build_secdists(src, sitecol, self)
             else:
                 self.secdists = None
             minmag = self.maximum_distance.x[0]

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -535,7 +535,7 @@ def _build_secdists(src, sitecol, cmaker):
         out[sec.idx, 'rrup'] = rrup[mask]
         for param in dparams:
             out[sec.idx, param] = get_dparam(sec, sites, param)
-    # use case_65 to debug this
+    # use multi_fault_test to debug this
     return out
 
     

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -851,7 +851,7 @@ class ContextMaker(object):
         :returns: a dictionary with the rupture parameters
         """
         dic = {}
-        if self.secdists:
+        if hasattr(self, 'secdists') and self.secdists:
             msparam = rup.surface.msparam
         else:
             msparam = None

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -673,7 +673,7 @@ class ContextMaker(object):
         self.gmf_mon = monitor('computing mean_std', measuremem=False)
         self.poe_mon = monitor('get_poes', measuremem=False)
         self.pne_mon = monitor('composing pnes', measuremem=False)
-        self.ir_mon = monitor('iter_ruptures', measuremem=True)
+        self.ir_mon = monitor('iter_ruptures', measuremem=False)
         self.sec_mon = monitor('building secdists', measuremem=True)
         self.delta_mon = monitor('getting delta_rates', measuremem=False)
         self.col_mon = monitor('collapsing contexts', measuremem=False)

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -219,14 +219,15 @@ class MultiFaultSource(BaseSeismicSource):
             hypo = sfc.get_middle_point()
             data = [(p, o) for o, p in enumerate(self.probs_occur[i])]
             if self.infer_occur_rates:
-                yield ParametricProbabilisticRupture(
+                rup = ParametricProbabilisticRupture(
                     self.mags[i], rake, self.tectonic_region_type,
                     hypo, sfc, self.occur_rates[i],
                     self.temporal_occurrence_model)
             else:
-                yield NonParametricProbabilisticRupture(
+                rup = NonParametricProbabilisticRupture(
                     self.mags[i], rake, self.tectonic_region_type, hypo, sfc,
                     PMF(data))
+            yield rup
 
     def gen_slices(self):
         if len(self.mags) <= BLOCKSIZE:  # already split

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -192,7 +192,7 @@ class MultiFaultSource(BaseSeismicSource):
             geoms = f['multi_fault_sections'][:]  # small
         if idxs is None:
             idxs = range(len(geoms))
-        sections = [geom_to_kite(geom) for geom in geoms]
+        sections = [geom_to_kite(geom) for geom in geoms[idxs]]
         for sec, idx in zip(sections, idxs):
             sec.idx = idx
         return sections

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -34,7 +34,7 @@ from openquake.hazardlib.nrml import SourceModel
 
 BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 aac = numpy.testing.assert_allclose
-PLOTTING = True
+PLOTTING = False
 
 
 class MultiFaultTestCase(unittest.TestCase):

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -34,7 +34,7 @@ from openquake.hazardlib.nrml import SourceModel
 
 BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 aac = numpy.testing.assert_allclose
-PLOTTING = False
+PLOTTING = True
 
 
 class MultiFaultTestCase(unittest.TestCase):
@@ -133,17 +133,6 @@ class MultiFaultTestCase(unittest.TestCase):
         [ctx] = cmaker.from_srcs([src], sitecol)
         assert len(ctx) == src.count_ruptures()
 
-        # compare with the expected distances
-        tol = 1e-4
-        aac(ctx.rrup, [0., 27.51933, 55.03832,  0., 0., 27.51933, 0.], atol=tol)
-        aac(ctx.rjb, [0., 27.51907, 55.03832,  0., 0., 27.51907, 0.], atol=tol)
-        aac(ctx.rx, [0, 1.102163e-01, 3.392963e-01, 1.686259e-05,
-                     1.643886e-05, 1.653083e-01, 3.3298e-05], atol=tol)
-        aac(ctx.ry0, [0., 27.518915, 55.03632, 0., 0., 27.5184749,0.],
-            atol=tol)
-        aac(ctx.clon, [10., 10.35, 10.7, 10., 10., 10.35, 10.])
-        aac(ctx.clat, 45.)
-
         if PLOTTING:
             # plotting the 3 sections and then the multisurface
             # corresponding to the 6-th rupture, with idxs=[1, 2];
@@ -157,6 +146,17 @@ class MultiFaultTestCase(unittest.TestCase):
             plt.scatter(mesh5.lons, mesh5.lats, marker='.')
             plt.scatter(ctx.clon[5], ctx.clat[5], marker='o')
             plt.show()
+
+        # compare with the expected distances
+        tol = 1e-4
+        aac(ctx.rrup, [0., 27.51933, 55.03832,  0., 0., 27.51933, 0.], atol=tol)
+        aac(ctx.rjb, [0., 27.51907, 55.03832,  0., 0., 27.51907, 0.], atol=tol)
+        aac(ctx.rx, [0, 1.102163e-01, 3.392963e-01, 1.686259e-05,
+                     1.643886e-05, 1.653083e-01, 3.3298e-05], atol=tol)
+        aac(ctx.ry0, [0., 27.518915, 55.03632, 0., 0., 27.5184749,0.],
+            atol=tol)
+        aac(ctx.clon, [10., 10.35, 10.7, 10., 10., 10.35, 10.])
+        aac(ctx.clat, 45.)
             
     def test_ko(self):
         # test invalid section IDs

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -127,11 +127,11 @@ class MultiFaultTestCase(unittest.TestCase):
         sitecol._set('z1pt0', 100.)
         sitecol._set('z2pt5', 5.)
         gsim = valid.gsim('AbrahamsonEtAl2014NSHMPMean')
-        cmaker = contexts.simple_cmaker([gsim], ['PGA'], cache_distances=0)
+        cmaker = contexts.simple_cmaker([gsim], ['PGA'])
         [ctx] = cmaker.from_srcs([src], sitecol)
         assert len(ctx) == src.count_ruptures()
 
-        # compare with the expected distances computed without cache
+        # compare with the expected distances
         tol = 1e-4
         aac(ctx.rrup, [0., 27.51933, 55.03832,  0., 0., 27.51933, 0.], atol=tol)
         aac(ctx.rjb, [0., 27.51907, 55.03832,  0., 0., 27.51907, 0.], atol=tol)
@@ -175,7 +175,7 @@ def main():
     print(mon)
 
     gsim = valid.gsim('AbrahamsonEtAl2014NSHMPMean')
-    cmaker = contexts.simple_cmaker([gsim], ['PGA'], cache_distances=1)
+    cmaker = contexts.simple_cmaker([gsim], ['PGA'])
     secparams = build_secparams(src.get_sections())
     src.set_msparams(secparams)
     [ctxt] = cmaker.from_srcs([src], sitecol)
@@ -220,7 +220,7 @@ def main100sites():
     sitecol._set('z1pt0', 100.)
     sitecol._set('z2pt5', 5.)
     gsim = valid.gsim('AbrahamsonEtAl2014NSHMPMean')
-    cmaker = contexts.simple_cmaker([gsim], ['PGA'], cache_distances=1)
+    cmaker = contexts.simple_cmaker([gsim], ['PGA'])
     secparams = build_secparams(src.get_sections())
     srcfilter = calc.filters.SourceFilter(sitecol, cmaker.maximum_distance)
     src.set_msparams(secparams)

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -65,21 +65,15 @@ class MultiFaultTestCase(unittest.TestCase):
         sections = {0: sfc_a, 1: sfc_b, 2: sfc_c}
 
         # Rupture indexes
-        rup_idxs = [numpy.uint16(x) for x in [[0], [1], [2], [0, 1], [0, 2],
-                                              [1, 2], [0, 1, 2]]]
+        rup_idxs = [numpy.uint16(x) for x in [[1, 2], [0], [1], [2],
+                                              [0, 1], [0, 2], [0, 1, 2]]]
 
         # Magnitudes
         rup_mags = [5.8, 5.8, 5.8, 6.2, 6.2, 6.2, 6.5]
         rakes = [90.0, 90.0, 90.0, 90.0, 90.0, 90.0, 90.0]
 
         # Occurrence probabilities of occurrence
-        pmfs = [[0.90, 0.10],
-                [0.90, 0.10],
-                [0.90, 0.10],
-                [0.90, 0.10],
-                [0.90, 0.10],
-                [0.90, 0.10],
-                [0.90, 0.10]]
+        pmfs = [[0.90, 0.10]] * 7
         self.sections = sections
         self.rup_idxs = rup_idxs
         self.pmfs = numpy.array(pmfs)
@@ -114,7 +108,7 @@ class MultiFaultTestCase(unittest.TestCase):
         # check the stored section indices
         with hdf5.File(gm_hdf5, 'r') as f:
             lines = python3compat.decode(f['01/rupture_idxs'][:])
-        self.assertEqual(lines, ['0', '1', '2', '0 1', '0 2', '1 2', '0 1 2'])
+        self.assertEqual(lines, ['1 2', '0', '1', '2', '0 1', '0 2', '0 1 2'])
 
         # test rupture generation
         secparams = build_secparams(src.get_sections())
@@ -135,27 +129,27 @@ class MultiFaultTestCase(unittest.TestCase):
 
         if PLOTTING:
             # plotting the 3 sections and then the multisurface
-            # corresponding to the 6-th rupture, with idxs=[1, 2];
+            # corresponding to the first rupture, with idxs=[1, 2];
             # the closest point to the site has longitude 10.35
             for sec in src.get_sections():
                 lons = sec.mesh.lons
                 lats = sec.mesh.lats
                 plt.scatter(lons, lats, alpha=.1)
             plt.scatter(sitecol.lons, sitecol.lats, marker='+')
-            mesh5 = rups[5].surface.mesh
-            plt.scatter(mesh5.lons, mesh5.lats, marker='.')
-            plt.scatter(ctx.clon[5], ctx.clat[5], marker='o')
+            mesh0 = rups[0].surface.mesh
+            plt.scatter(mesh0.lons, mesh0.lats, marker='.')
+            plt.scatter(ctx.clon[0], ctx.clat[0], marker='o')
             plt.show()
 
         # compare with the expected distances
         tol = 1e-4
-        aac(ctx.rrup, [0., 27.51933, 55.03832,  0., 0., 27.51933, 0.], atol=tol)
-        aac(ctx.rjb, [0., 27.51907, 55.03832,  0., 0., 27.51907, 0.], atol=tol)
-        aac(ctx.rx, [0, 1.102163e-01, 3.392963e-01, 1.686259e-05,
-                     1.643886e-05, 1.653083e-01, 3.3298e-05], atol=tol)
-        aac(ctx.ry0, [0., 27.518915, 55.03632, 0., 0., 27.5184749,0.],
+        aac(ctx.rrup, [27.51933, 0., 27.51933, 55.03832,  0., 0., 0.], atol=tol)
+        aac(ctx.rjb, [27.51907, 0., 27.51907, 55.03832,  0., 0., 0.], atol=tol)
+        aac(ctx.rx, [1.653083e-01, 0, 1.102163e-01, 3.392963e-01, 1.686259e-05,
+                     1.643886e-05, 3.3298e-05], atol=tol)
+        aac(ctx.ry0, [27.5184749, 0., 27.518915, 55.03632, 0., 0., 0.],
             atol=tol)
-        aac(ctx.clon, [10., 10.35, 10.7, 10., 10., 10.35, 10.])
+        aac(ctx.clon, [10.35, 10., 10.35, 10.7, 10., 10., 10.])
         aac(ctx.clat, 45.)
             
     def test_ko(self):


### PR DESCRIPTION
Optimizing all except the rx/ry0 distances, which are the most expensive to compute but also the most difficult to optimize. This, together with all the changes of the last two weeks, is nearly enough to solve the USA model issue. Now running 1/4th of the calculations takes 16 hours instead of the 34 hours of two weeks ago:
```
# before
| calc_28, maxmem=280.9 GB   | time_sec  | memory_mb | counts      |
|----------------------------+-----------+-----------+-------------|
| total classical            | 8_883_213 | 1_473     | 2_455       |
| nonplanar contexts         | 6_823_374 | 0.0       | 599_520     |
| get_poes                   | 1_106_907 | 0.0       | 277_316_214 |
| computing mean_std         | 497_244   | 0.0       | 2_264_940   |
| composing pnes             | 288_123   | 0.0       | 277_316_214 |
| ClassicalCalculator.run    | 122_958   | 7_294     | 1           |
| planar contexts            | 62_135    | 0.0       | 35_216_137  |
| iter_ruptures              | 62_035    | 0.01159   | 1_052_426   |
| total postclassical        | 10_336    | 1_016     | 110         |
| combine pmaps              | 5_725     | 0.0       | 116_825     |
| read PoEs                  | 4_561     | 1_016     | 110         |
| total preclassical         | 1_975     | 372.3     | 391         |
| reading sources            | 1_923     | 2_028     | 146         |

# after
| calc_71, maxmem=279.8 GB   | time_sec  | memory_mb | counts      |
|----------------------------+-----------+-----------+-------------|
| total classical            | 4_491_087 | 768.9     | 2_489       |
| get_poes                   | 1_134_020 | 0.0       | 276_601_116 |
| computing mean_std         | 510_579   | 0.0       | 2_241_038   |
| composing pnes             | 328_975   | 0.0       | 276_601_116 |
| iter_ruptures              | 248_408   | 0.01044   | 1_390_426   |
| planar contexts            | 89_783    | 0.0       | 58_200_746  |
| ClassicalCalculator.run    | 57_468    | 7_906     | 1           |
| total preclassical         | 19_115    | 373.3     | 391         |
| setting msparams           | 18_850    | 0.0       | 266         |
| total postclassical        | 10_530    | 1_004     | 110         |
| building secdists          | 9_665     | 0.00167   | 19_152      |
| reading sources            | 3_007     | 2_376     | 266         |
```
The slow tasks are actually worse:
```
| operation-duration | counts | mean    | stddev | min       | max    | slowfac |
|--------------------+--------+---------+--------+-----------+--------+---------|
| classical          | 146    | 60_844  | 62%    | 624.2     | 97_221 | 1.59788 |
| classical          | 266    | 16_884  | 83%    | 635.1     | 40_508 | 2.39925 |
```
Still, we are saved since the calculation of the distances is 3x faster (and `iter_ruptures` 4x faster). Since the old calculation was done with half the tiles the improvement is actually bigger.