### PR TITLE
Fixed the change in the AELO numbers for China

### DIFF
--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -104,7 +104,7 @@ class MultiFaultSource(BaseSeismicSource):
                  infer_occur_rates=False):
         nrups = len(magnitudes)
         assert len(occurrence_probs) == len(rakes) == nrups
-        self.probs_occur = F32(occurrence_probs)
+        self.probs_occur = occurrence_probs
         self.mags = F32(magnitudes)
         self.rakes = F32(rakes)
         self.infer_occur_rates = infer_occur_rates


### PR DESCRIPTION
They were caused by this commit entered on Tuesday morning: https://github.com/gem/oq-engine/commit/bfd8681688e246a9cad32284da0fbc860ccf6abb. I will add a fast test sensitive to the issue later on, since it is hard.