### PR TITLE
Doubled the speed of single site calculations with multiFaultSources

### DIFF
--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -126,6 +126,13 @@ def azimuth(lons1, lats1, lons2, lats2):
     return (360 - true_course) % 360
 
 
+def azimuths(coos):
+    """
+    Compute the azimuths from an array of lines with shape (L, 2, 3)
+    """
+    return azimuth(coos[:, 0, 0], coos[:, 0, 1], coos[:, 1, 0], coos[:, 1, 1])
+
+
 def distance(lons1, lats1, depths1, lons2, lats2, depths2):
     """
     Calculate a distance between two points (or collections of points)

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -258,7 +258,7 @@ class Line(object):
 
     def get_azimuths(self):
         """
-        Return the azimuths of all the segments omposing the polyline
+        Return the azimuths of all the segments composing the polyline
         """
         if len(self.coo) == 2:
             return [self[0].azimuth(self[1])]

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -222,6 +222,15 @@ class Line(object):
         s02eq_s089n
         >>> print(line.flip())
         s089n_s02eq
+        >>> line.get_azimuths()
+        [0.0]
+        >>> line.flip().get_azimuths()
+        [180.0]
+        >>> line = Line([Point(1, 0), Point(2, 0)])
+        >>> line.get_azimuths()
+        [90.0]
+        >>> line.flip().get_azimuths()
+        [270.0]
         """
         return self.from_coo(np.flip(self.coo, axis=0))
 

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -82,7 +82,6 @@ def get_avg_azim_flipped(lines):
 
     # Compute the mean azimuth
     for i in np.nonzero(flipped)[0]:
-        lines[i] = lines[i].flip()
         avgaz[i] = (avgaz[i] + 180) % 360  # opposite azimuth
     avg_azim = utils.angular_mean(avgaz, llenghts) % 360
     return avg_azim, flipped
@@ -102,7 +101,9 @@ class MultiLine(object):
         olon, olat, self.soidx = get_origin(ep, avg_azim)
 
         # compute the shift with respect to the origins
-        origins = np.array([lines[i].coo[0] for i in self.soidx])
+        # NB: the origin is the first point (0) unless the line is flipped (1)
+        origins = np.array([lines[i].coo[int(f)]
+                            for i, f in zip(self.soidx, self.flipped)])
         self.shift = get_coordinate_shift(origins, olon, olat, avg_azim)
         self.u_max = u_max
         

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -41,7 +41,7 @@ def get_avg_azim_flipped(lines):
     # compute the overall strike and the origin of the multiline
     # get lenghts and average azimuths
     llenghts = np.array([ln.get_length() for ln in lines])
-    if (llenghts == 2).all():
+    if all(len(ln) == 2 for ln in lines):
         # fast lane for the engine
         coos = np.array([ln.coo for ln in lines])
         avgaz = geodetic.azimuths(coos) 
@@ -50,7 +50,7 @@ def get_avg_azim_flipped(lines):
         avgaz = np.array([line.average_azimuth() for line in lines])
 
     # determine the flipped lines
-    flipped = get_flipped(lines, llenghts, avgaz)
+    flipped = get_flipped(llenghts, avgaz)
     
     # Compute the average azimuth
     for i in np.nonzero(flipped)[0]:
@@ -135,7 +135,7 @@ class MultiLine(object):
         return ';'.join(str(Line.from_coo(coo)) for coo in self.coos)
 
 
-def get_flipped(lines, llens, avgaz):
+def get_flipped(llens, avgaz):
     """
     :returns: a boolean array with the flipped lines
     """

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -46,12 +46,11 @@ def get_azim_flipped(lines):
     # determine the flipped lines
     flipped = get_flipped(lines, llenghts, avgaz)
     
-    # Compute the prevalent azimuth
-    avgazims_corr = np.copy(avgaz)
+    # Compute the average azimuth
     for i in np.nonzero(flipped)[0]:
         lines[i] = lines[i].flip()
-        avgazims_corr[i] = (avgaz[i] + 180) % 360  # opposite azimuth
-    avg_azim = utils.angular_mean(avgazims_corr, llenghts) % 360
+        avgaz[i] = (avgaz[i] + 180) % 360  # opposite azimuth
+    avg_azim = utils.angular_mean(avgaz, llenghts) % 360
     return avg_azim, flipped
 
 

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -50,7 +50,7 @@ def get_azim_flipped(lines):
     avgazims_corr = np.copy(avgaz)
     for i in np.nonzero(flipped)[0]:
         lines[i] = lines[i].flip()
-        avgazims_corr[i] = lines[i].average_azimuth()
+        avgazims_corr[i] = (avgaz[i] + 180) % 360  # opposite azimuth
     avg_azim = utils.angular_mean(avgazims_corr, llenghts) % 360
     return avg_azim, flipped
 

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -41,8 +41,14 @@ def get_avg_azim_flipped(lines):
     # compute the overall strike and the origin of the multiline
     # get lenghts and average azimuths
     llenghts = np.array([ln.get_length() for ln in lines])
-    avgaz = np.array([line.average_azimuth() for line in lines])
-    
+    if (llenghts == 2).all():
+        # fast lane for the engine
+        coos = np.array([ln.coo for ln in lines])
+        avgaz = geodetic.azimuths(coos) 
+    else:
+        # slow lane, only for some tests in hazardlib
+        avgaz = np.array([line.average_azimuth() for line in lines])
+
     # determine the flipped lines
     flipped = get_flipped(lines, llenghts, avgaz)
     

--- a/openquake/hazardlib/tests/geo/surface/multi2_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi2_test.py
@@ -39,7 +39,6 @@ class Ry0TestCase(unittest.TestCase):
 
     def _test_ry0(self, sfc):
         msurf = MultiSurface([sfc])
-        msurf.tor.set_u_max()
         mesh, mlons, mlats = get_mesh(-0.2, 0.6, -0.2, 0.3, 0.0025)
         ry0 = msurf.get_ry0_distance(mesh)
 


### PR DESCRIPTION
Most of the time was spent computing the azimuths. There is now a fast lane.
Here are the numbers for the performance test
```
# master
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2001    0.015    0.000   12.138    0.006 multi_fault.py:150(iter_ruptures)
     2000    0.008    0.000    9.495    0.005 multi.py:159(__init__)
     2000    0.061    0.000    9.437    0.005 multiline.py:46(__init__)
   243972    0.350    0.000    5.463    0.000 line.py:269(average_azimuth)
     2000    0.041    0.000    3.925    0.002 multiline.py:52(<listcomp>)
   429116    2.026    0.000    2.721    0.000 geodetic.py:67(geodetic_distance)
     2000    0.030    0.000    2.695    0.001 multiline.py:51(<listcomp>)
   174486    0.113    0.000    2.666    0.000 line.py:326(get_length)
   243972    0.166    0.000    2.327    0.000 line.py:259(get_azimuths)
     2000    0.011    0.000    2.267    0.001 multi.py:255(get_middle_point)
   174486    0.239    0.000    2.123    0.000 line.py:312(get_lengths)
     2000    0.036    0.000    2.063    0.001 multi.py:275(<listcomp>)
   174782    0.080    0.000    2.035    0.000 base.py:148(get_min_distance)

# azimuths
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2001    0.014    0.000    6.337    0.003 multi_fault.py:150(iter_ruptures)
     2000    0.007    0.000    3.812    0.002 multi.py:159(__init__)
     2000    0.090    0.000    3.756    0.002 multiline.py:68(__init__)
     2000    0.023    0.000    2.871    0.001 multiline.py:40(get_avg_azim_flipped)
     2000    0.028    0.000    2.631    0.001 multiline.py:43(<listcomp>)
   174486    0.111    0.000    2.602    0.000 line.py:335(get_length)
     2000    0.011    0.000    2.155    0.001 multi.py:255(get_middle_point)
   174486    0.238    0.000    2.068    0.000 line.py:321(get_lengths)
     2000    0.033    0.000    1.959    0.001 multi.py:275(<listcomp>)
   174782    0.073    0.000    1.935    0.000 base.py:148(get_min_distance)
```
There is a good benefit also for many-site calculations, for instance this is the usa_ucerf test:
```
# master
| calc_95240, maxmem=9.0 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 203.5    | 152.4     | 28      |
| total preclassical         | 144.9    | 25.0      | 13      |
| setting msparams           | 134.4    | 0.0       | 6       |
| iter_ruptures              | 97.9     | 0.0       | 2_619   |
# azimuths
| calc_95239, maxmem=8.9 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 170.5    | 152.6     | 28      |
| total preclassical         | 130.5    | 25.9      | 13      |
| setting msparams           | 119.8    | 0.0       | 6       |
| iter_ruptures              | 65.4     | 0.0       | 2_619   |
```