### PR TITLE
Rounded magnitudes in the SourceConverter also for multiFaultSources

### DIFF
--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -533,7 +533,7 @@ class ClassicalTestCase(CalculatorTestCase):
         hc_id = str(self.calc.datastore.calc_id)
         self.run_calc(case_65.__file__, 'job.ini', hazard_calculation_id=hc_id)
         rates = self.calc.datastore['rup/occurrence_rate'][:]
-        aac(rates, [0.356675, 0.105361], atol=5e-7)
+        aac(rates, [0.105361, 0.356675], atol=5e-7)
 
         [f] = export(('hcurves/mean', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/hcurve-mean.csv', f, delta=1E-5)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -22,6 +22,7 @@ import time
 import logging
 import warnings
 import itertools
+import operator
 import collections
 from unittest.mock import patch
 import numpy
@@ -66,6 +67,7 @@ DIST_BINS = sqrscale(80, 1000, NUM_BINS)
 MULTIPLIER = 150  # len(mean_stds arrays) / len(poes arrays)
 MEA = 0
 STD = 1
+bymag = operator.attrgetter('mag')
 # These coordinates were provided by M Gerstenberger (personal
 # communication, 10 August 2018)
 cshm_polygon = shapely.geometry.Polygon([(171.6, -43.3), (173.2, -43.3),
@@ -1053,7 +1055,9 @@ class ContextMaker(object):
                     shift_hypo=self.shift_hypo, step=step))
                 for i, rup in enumerate(allrups):
                     rup.rup_id = src.offset + i
-                allrups = [rup for rup in allrups if minmag < rup.mag < maxmag]
+                allrups = sorted([rup for rup in allrups
+                                  if minmag < rup.mag < maxmag],
+                                 key=bymag)
                 if not allrups:
                     return iter([])
                 self.num_rups = len(allrups)

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -84,7 +84,7 @@ class MultiFaultSource(BaseSeismicSource):
         # the results are STRONGLY dependent on the precision,
         # in particular the AELO tests for CHN would break
         self.probs_occur = F64(occurrence_probs)  # 64 bit!
-        self.mags = np.round(F32(magnitudes))
+        self.mags = F32(magnitudes)
         self.rakes = F32(rakes)
         self.infer_occur_rates = infer_occur_rates
         self.investigation_time = investigation_time

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -84,7 +84,7 @@ class MultiFaultSource(BaseSeismicSource):
         # the results are STRONGLY dependent on the precision,
         # in particular the AELO tests for CHN would break
         self.probs_occur = F64(occurrence_probs)  # 64 bit!
-        self.mags = F32(magnitudes)
+        self.mags = np.round(F32(magnitudes))
         self.rakes = F32(rakes)
         self.infer_occur_rates = infer_occur_rates
         self.investigation_time = investigation_time

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -40,8 +40,9 @@ from openquake.hazardlib.source.base import BaseSeismicSource
 U16 = np.uint16
 F32 = np.float32
 F64 = np.float64
-BLOCKSIZE = 10_000
-# NB: if too large, very few sources will be generated
+BLOCKSIZE = 2_000
+# NB: if too large, very few sources will be generated and a lot of
+# memory will be used
 
 
 class MultiFaultSource(BaseSeismicSource):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -1150,7 +1150,7 @@ class SourceConverter(RuptureConverter):
             # NB: the sections will be fixed later on, in source_reader
             mfs = MultiFaultSource(sid, name, trt,
                                    dic['probs_occur'],
-                                   dic['mag'], dic['rake'],
+                                   mags, dic['rake'],
                                    self.investigation_time,
                                    self.infer_occur_rates)
             mfs._rupture_idxs = idxs


### PR DESCRIPTION
It was forgotten, done for XML sources but not for HDF5 sources. It has a substantial performance benefit:
```
# before
| calc_100, maxmem=141.1 GB  | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 147_151  | 233.4     | 312        |
| get_poes                   | 92_879   | 0.0       | 48_221_881 |
| computing mean_std         | 22_299   | 0.0       | 363_566    |
| composing pnes             | 7_942    | 0.0       | 48_221_881 |
| iter_ruptures              | 7_599    | 0.0       | 296        |
| nonplanar contexts         | 7_375    | 0.0       | 102_194    |
| total preclassical         | 7_109    | 17.0      | 104        |
| setting msparams           | 7_071    | 0.0       | 104        |
| ClassicalCalculator.run    | 2_081    | 730.9     | 1          |

# after
| calc_103, maxmem=149.1 GB  | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 130_376  | 151.6     | 1_110      |
| get_poes                   | 75_855   | 0.0       | 11_093_652 |
| computing mean_std         | 24_920   | 0.0       | 85_479     |
| nonplanar contexts         | 9_136    | 0.0       | 103_555    |
| iter_ruptures              | 8_418    | 0.0       | 1_322      |
| total preclassical         | 7_902    | 7.98047   | 519        |
| composing pnes             | 7_893    | 0.0       | 11_093_652 |
| setting msparams           | 7_708    | 0.0       | 519        |
| ClassicalCalculator.run    | 1_616    | 737.7     | 1          |
```