### PR TITLE
Using numba more in MultiLine

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -90,7 +90,7 @@ def _get_tu(rup, dparam, mask):
         idx = tor.soidx[s]
         flip = int(tor.flipped[idx])
         tuw[s] = arr[idx, :, flip, :]  # shape (N, 3)
-    return multiline._get_tu(tor.shift, tuw, N)
+    return multiline.get_tu(tor.shift, tuw, N)
 
 
 def set_distances(ctx, rup, r_sites, param, dparam, mask, tu):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -85,12 +85,12 @@ def _get_tu(rup, dparam, mask):
     S, N = arr.shape[:2]
     # keep the flipped values and then reorder the surface indices
     # arr has shape (S, N, 2, 3) where 2 refer to the flipping
-    tuw = numpy.zeros((3, S, N), F32)
+    tuw = numpy.zeros((S, N, 3), F32)
     for s in range(S):
         idx = tor.soidx[s]
         flip = int(tor.flipped[idx])
-        tuw[:, s, :] = arr[idx, :, flip, :].T  # shape (3, N)
-    return multiline._get_tu(tor.shift, tuw)
+        tuw[s] = arr[idx, :, flip, :]  # shape (N, 3)
+    return multiline._get_tu(tor.shift, tuw, N)
 
 
 def set_distances(ctx, rup, r_sites, param, dparam, mask, tu):

--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -150,7 +150,7 @@ def _get_same_dir(rtra, coo):
 
 
 @compile('(f8[:,:],f8[:,:],f8[:],f8[:,:])')
-def get_tu(ui, ti, sl, weights):
+def line_get_tu(ui, ti, sl, weights):
     """
     Compute the T and U quantitities.
 
@@ -260,7 +260,7 @@ def get_tuw(lam0, phi0, coo, slen, uhat, that, lons, lats):
     out = np.empty((N, 3), np.float32)
     ui, ti = get_ui_ti(lam0, phi0, coo, lons, lats, uhat, that)
     weights, iot = get_ti_weights(ui, ti, slen)
-    t, u = get_tu(ui, ti, slen, weights)
+    t, u = line_get_tu(ui, ti, slen, weights)
     t[iot] = 0.0
     out[:, 0] = t
     out[:, 1] = u

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -111,7 +111,7 @@ class MultiLine(object):
         """
         if self.u_max is None:
             N = 2 * len(self.lines)
-            t, u = _get_tu(self.shift, self.get_tuws(self.ep), N)
+            t, u = get_tu(self.shift, self.get_tuws(self.ep), N)
             self.u_max = np.abs(u).max()
         assert self.u_max > 0
         return self.u_max
@@ -159,7 +159,7 @@ class MultiLine(object):
         """
         Given a mesh, computes the T and U coordinates for the multiline
         """
-        return _get_tu(self.shift, self.get_tuws(mesh), len(mesh))
+        return get_tu(self.shift, self.get_tuws(mesh), len(mesh))
 
     def get_tuw_df(self, sites):
         # debug method to be called in genctxs
@@ -243,12 +243,19 @@ def get_coordinate_shift(origins: list, olon: float, olat: float,
     return np.float32(np.cos(np.radians(overall_strike - azimuths)) * distances)
 
 
-def _get_tu(shift, tuws, N):
+# called by contexts.py
+def get_tu(shift, tuws, N):
+    """
+    :param shift: multiline shift array
+    :param tuws: iterator producing arrays of shape (N, 3)
+    :param N: number of sites
+    """
     # `shift` has shape L and `tuws` shape (L, N, 3)
     ts = np.zeros(N, np.float32)
     us = np.zeros(N, np.float32)
     ws = np.zeros(N, np.float32)
     for i, tuw in enumerate(tuws):
+        assert len(tuw) == N, (len(tuw), N)
         t, u, w = tuw[:, 0], tuw[:, 1], tuw[:, 2]
         ts += t * w
         us += (u + shift[i]) * w

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -21,7 +21,6 @@ Module :mod:`openquake.hazardlib.geo.multiline` defines
 
 import numpy as np
 import pandas as pd
-from openquake.baselib.performance import compile
 from openquake.hazardlib.geo import utils
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.geo.line import get_tuws, get_tuw

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -99,8 +99,8 @@ class MultiLine(object):
         # compute the shift with respect to the origins
         origins = np.zeros((len(lines), 2))
         for i, idx in enumerate(self.soidx):
-            flip = int(self.flipped[idx])
-            # if the line is flipped take the point 1 instead of 0
+            flip = -1 if self.flipped[idx] else 0
+            # if the line is flipped take the final point as origin
             origins[i] = lines[idx].coo[flip, 0:2]
         self.shift = get_coordinate_shift(origins, olon, olat, avg_azim)
         self.u_max = u_max

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -111,14 +111,14 @@ class MultiLine(object):
         """
         if self.u_max is None:
             N = 2 * len(self.lines)
-            t, u = get_tu(self.shift, self.get_tuws(self.ep), N)
+            t, u = get_tu(self.shift, self.gen_tuws(self.ep), N)
             self.u_max = np.abs(u).max()
         assert self.u_max > 0
         return self.u_max
 
-    def get_tuws(self, mesh):
+    def gen_tuws(self, mesh):
         """
-        :return: array of shape (L, N, 3)
+        :yields: L arrays of shape (N, 3)
         """
         nsegs = [len(ln) - 1 for ln in self.lines]  # segments per line
         if len(set(nsegs)) == 1:
@@ -159,7 +159,7 @@ class MultiLine(object):
         """
         Given a mesh, computes the T and U coordinates for the multiline
         """
-        return get_tu(self.shift, self.get_tuws(mesh), len(mesh))
+        return get_tu(self.shift, self.gen_tuws(mesh), len(mesh))
 
     def get_tuw_df(self, sites):
         # debug method to be called in genctxs
@@ -168,7 +168,7 @@ class MultiLine(object):
         ts = []
         us = []
         ws = []
-        for li, tuw in enumerate(self.get_tuws()):
+        for li, tuw in enumerate(self.gen_tuws()):
             for s, sid in enumerate(sites.sids):
                 sids.append(sid)
                 ls.append(li)

--- a/openquake/hazardlib/geo/surface/multi.py
+++ b/openquake/hazardlib/geo/surface/multi.py
@@ -320,7 +320,6 @@ class MultiSurface(BaseSurface):
             A :class:`numpy.ndarray` instance with the Rx distance. Note that
             the Rx distance is directly taken from the GC2 t-coordinate.
         """
-        self.tor.set_u_max()
         tut, uut = self.tor.get_tu(mesh)
         rx = tut[0] if len(tut[0].shape) > 1 else tut
         return rx

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -168,7 +168,7 @@ class MultiFaultSource(BaseSeismicSource):
             occur_rates = self.occur_rates
             tom = PoissonTOM(self.investigation_time)
         for i in range(0, n, step**2):
-            if msparams[i]['u_max'] == 0:  # rupture far away
+            if msparams[i]['area'] == 0:  # rupture far away
                 continue
             idxs = rupture_idxs[i]
             sfc = MultiSurface([sec[idx] for idx in idxs], msparams[i])

--- a/openquake/hazardlib/tests/geo/surface/multi2_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi2_test.py
@@ -93,6 +93,7 @@ class Ry0TestCase(unittest.TestCase):
         aae(er['ry0'], ry0, decimal=1)
 
     def test_ry0c(self):
+        # this is a test where len(sfc.tor) == 4, i.e. there are 4 segments
         pro1 = Line([Point(0.5, 0.05, 0.0), Point(0.5, 0.1, 15.0)])
         pro2 = Line([Point(0.4, 0.05, 0.0), Point(0.4, 0.1, 15.0)])
         pro3 = Line([Point(0.35, 0.0, 0.0), Point(0.3, 0.05, 15.0)])
@@ -116,7 +117,6 @@ class MultiSurfaceSimpleFaultSurfaceTestCase(unittest.TestCase):
     surfaces
     """
     def setUp(self):
-
         mspc = 1.0
         usd = 0.0
         lsd = 15.0
@@ -126,7 +126,7 @@ class MultiSurfaceSimpleFaultSurfaceTestCase(unittest.TestCase):
 
         # Surface 1
         p1 = point_at(0.0, 0.0, 90.0, 20.0)
-        self.coo1 = [[0, 0], [p1[0], p1[1]], [0.3, -0.05]]
+        self.coo1 = [[0, 0], [p1[0], p1[1]]]
         trace = Line([pnt(co[0], co[1]) for co in self.coo1])
         sfc1 = ffd(trace, usd, lsd, dip, mspc)
 

--- a/openquake/hazardlib/tests/geo/surface/multi2_test.py
+++ b/openquake/hazardlib/tests/geo/surface/multi2_test.py
@@ -131,7 +131,7 @@ class MultiSurfaceSimpleFaultSurfaceTestCase(unittest.TestCase):
         sfc1 = ffd(trace, usd, lsd, dip, mspc)
 
         # Surface 2
-        self.coo2 = [[-0.15, 0.0], [-0.05, 0.0]]
+        self.coo2 = [[-0.15, 0.0], [-0.05, 0.0], [0.3, -0.05]]
         trace = Line([pnt(co[0], co[1]) for co in self.coo2])
         sfc2 = ffd(trace, usd, lsd, dip, mspc)
 


### PR DESCRIPTION
This gives a 33% speedup in set_msparams:
```
# before
| calc_110748, maxmem=15.2 GB | time_sec | memory_mb | counts |
|-----------------------------+----------+-----------+--------|
| total preclassical          | 3_503    | 34.5      | 297    |
| setting msparams            | 3_318    | 0.0       | 208    |
| PreClassicalCalculator.run  | 386.2    | 2_998     | 1      |

# after
| calc_110746, maxmem=16.1 GB | time_sec | memory_mb | counts |
|-----------------------------+----------+-----------+--------|
| total preclassical          | 2_353    | 60.6      | 297    |
| setting msparams            | 2_178    | 0.0       | 208    |
| PreClassicalCalculator.run  | 317.7    | 2_962     | 1      |
```