### PR TITLE
Extended the `region` constraint to discard event based ruptures

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Extended the `region` constraint to discard event based ruptures
   * Added an uniqueness check to source IDs in the same branch
   * Extended the command `oq sample` to multi fault sources
   * Fixed the reading of ruptures with a multisurface with meshes

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -485,7 +485,8 @@ class EventBasedCalculator(base.HazardCalculator):
                 continue
             rgb = self.full_lt.get_rlzs_by_gsim(sg.sources[0].trt_smr)
             cmaker = ContextMaker(sg.trt, rgb, oq)
-            if oq.region or oq.mosaic_model:
+            if oq.calculation_mode == 'event_based' and (
+                    oq.region or oq.mosaic_model):
                 cmaker.model_geom = model_geom
             for src_group in sg.split(maxweight):
                 allargs.append((src_group, cmaker, srcfilter.sitecol))

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -23,6 +23,7 @@ import logging
 import operator
 import numpy
 import pandas
+from shapely import wkt
 from openquake.baselib import hdf5, parallel, python3compat
 from openquake.baselib.general import (
     AccumDict, humansize, groupby, block_splitter)
@@ -473,7 +474,9 @@ class EventBasedCalculator(base.HazardCalculator):
         source_data = AccumDict(accum=[])
         allargs = []
         srcfilter = self.srcfilter
-        if oq.mosaic_model:  # 3-letter mosaic model
+        if oq.region:
+            model_geom = wkt.loads(oq.region)
+        elif oq.mosaic_model:  # 3-letter mosaic model
             mosaic_df = readinput.read_mosaic_df(buffer=0).set_index('code')
             model_geom = mosaic_df.loc[oq.mosaic_model].geom
         logging.info('Building ruptures')
@@ -482,7 +485,7 @@ class EventBasedCalculator(base.HazardCalculator):
                 continue
             rgb = self.full_lt.get_rlzs_by_gsim(sg.sources[0].trt_smr)
             cmaker = ContextMaker(sg.trt, rgb, oq)
-            if oq.mosaic_model:
+            if oq.region or oq.mosaic_model:
                 cmaker.model_geom = model_geom
             for src_group in sg.split(maxweight):
                 allargs.append((src_group, cmaker, srcfilter.sitecol))

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -48,7 +48,8 @@ MAX_RUPTURES = 2000
 def get_rup_array(ebruptures, srcfilter=nofilter, model_geom=None):
     """
     Convert a list of EBRuptures into a numpy composite array, by filtering
-    out the ruptures far away from every site
+    out the ruptures far away from every site. If a shapely polygon is passed
+    in model_geom, ruptures outside the polygon are discarded.
     """
     if not BaseRupture._code:
         BaseRupture.init()  # initialize rupture codes
@@ -275,7 +276,7 @@ def sample_ruptures(sources, cmaker, sitecol=None, monitor=Monitor()):
             source_data['weight'].append(src.weight)
             source_data['taskno'].append(monitor.task_no)
         t0 = time.time()
-        rup_array = get_rup_array(eb_ruptures, srcfilter)
+        rup_array = get_rup_array(eb_ruptures, srcfilter, model_geom)
         dt = time.time() - t0
         if len(rup_array):
             yield AccumDict(dict(rup_array=rup_array, source_data=source_data,


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/8112.
Before `region` was used only to discard sites and assets outside the region. Here is an example:
```
region = -122.6 38.3, -121.5 38.3, -121.5 37.9, -122.6 37.9
```
It works by wrapping the coordinates with a` POLYGON((...))` string and then using shapely to build the poligon.
