### PR TITLE
More optimization of `set msparams`

### DIFF
--- a/openquake/hazardlib/geo/line.py
+++ b/openquake/hazardlib/geo/line.py
@@ -268,20 +268,6 @@ def get_tuw(lam0, phi0, coo, slen, uhat, that, lons, lats):
     return out
 
 
-@compile('(f8[:],f8[:],f8[:,:,:],f8[:,:],f8[:,:,:],f8[:,:,:],f8[:],f8[:])')
-def get_tuws(lam0s, phi0s, coos, slens, uhats, thats, lons, lats):
-    """
-    :returns: array of float32 of shape (L, N, 3)
-    """
-    L = len(lam0s)
-    N = len(lons)
-    out = np.empty((L, N, 3), np.float32)
-    for i, (lam0, phi0, coo, slen, uhat, that) in enumerate(
-            zip(lam0s, phi0s, coos, slens, uhats, thats)):
-        out[i] = get_tuw(lam0, phi0, coo, slen, uhat, that, lons, lats)
-    return out
-
-
 class Line(object):
     """
     This class represents a geographical line, which is basically
@@ -542,7 +528,7 @@ class Line(object):
         :param mesh:
             An instance of :class:`openquake.hazardlib.geo.mesh.Mesh`
         """
-        slen, uhat, that = self.tu_hat
+        slen, uhat, that = self.sut_hat
         tuw = get_tuw(self.proj.lam0, self.proj.phi0,
                       self.coo, slen, uhat, that,
                       mesh.lons, mesh.lats)
@@ -557,7 +543,7 @@ class Line(object):
                          self.coo, mesh.lons, mesh.lats, uhat, that)
 
     @cached_property
-    def tu_hat(self):
+    def sut_hat(self):
         """
         Return the unit vectors defining the local origin for each segment of
         the trace.

--- a/openquake/hazardlib/tests/geo/line_test.py
+++ b/openquake/hazardlib/tests/geo/line_test.py
@@ -335,7 +335,7 @@ class ComputeUiTiTest(unittest.TestCase):
         mesh = geo.Mesh(coo[:, 0], coo[:, 1])
 
         # slen, uhat and that as expected
-        slen, uhat, that = line.tu_hat
+        slen, uhat, that = line.sut_hat
         np.testing.assert_almost_equal(np.array([[1, 0, 0]]), uhat, decimal=5)
 
         # Now computing ui and ti
@@ -357,7 +357,7 @@ class ComputeUiTiTest(unittest.TestCase):
         mesh, plons, plats = get_mesh(-0.4, 0.6, -0.2, 0.3, 0.005)
 
         # slen, uhat and that as expected
-        slen, uhat, that = line.tu_hat
+        slen, uhat, that = line.sut_hat
 
         # Now computing ui and ti
         ui, ti = line.get_ui_ti(mesh, uhat, that)
@@ -428,7 +428,7 @@ class ComputeWeightsTest(unittest.TestCase):
         mesh, plons, plats = get_mesh(-0.5, 1.0, -0.5, 1.0, 0.01)
 
         # slen, uhat and that
-        slen, uhat, that = line.tu_hat
+        slen, uhat, that = line.sut_hat
 
         # Compute ui and ti
         ui, ti = line.get_ui_ti(mesh, uhat, that)
@@ -453,7 +453,7 @@ class ComputeWeightsTest(unittest.TestCase):
         mesh, plons, plats = get_mesh(-0.2, 0.6, -0.8, 0.1, 0.0025)
 
         # slen, uhat and that
-        slen, uhat, that = line.tu_hat
+        slen, uhat, that = line.sut_hat
 
         # Compute ui and ti
         ui, ti = line.get_ui_ti(mesh, uhat, that)


### PR DESCRIPTION
```
| ncalls   | cumtime  | path                                         |
|----------+----------+----------------------------------------------|
| 585      | 1316.758 | preclassical.py:96(preclassical)             |
| 208      | 1170.144 | multi_fault.py:113(set_msparams)             |
| 208      | 1169.022 | multi.py:67(build_msparams)                  |
| 895929   | 1090.049 | multiline.py:169(__init__)                   |
| 895929   | 739.864  | multiline.py:194(gen_tuws)                   |
| 895929   | 630.452  | multiline.py:51(get_tuws)                    |
| 1        | 167.747  | base.py:546(pre_execute)                     |
| 1        | 167.746  | base.py:469(read_inputs)                     |
| 895929   | 147.301  | multiline.py:241(get_tu)                     |
```