### PR TITLE
Fixed exporting from calculations with a grand parent

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed exporting from calculations with a grand parent
   * Added an uniqueness check to source IDs in the same branch
   * Extended the command `oq sample` to multi fault sources
   * Fixed the reading of ruptures with a multisurface with meshes

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -207,6 +207,9 @@ class DataStore(collections.abc.MutableMapping):
                 self.hdf5 = hdf5.File(self.filename, mode)
             except OSError as exc:
                 raise OSError('%s in %s' % (exc, self.filename))
+            hc_id = self.hdf5['oqparam'].hazard_calculation_id
+            if hc_id:
+                self.parent = read(hc_id)
         return self
 
     @property

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -207,7 +207,10 @@ class DataStore(collections.abc.MutableMapping):
                 self.hdf5 = hdf5.File(self.filename, mode)
             except OSError as exc:
                 raise OSError('%s in %s' % (exc, self.filename))
-            hc_id = self.hdf5['oqparam'].hazard_calculation_id
+            try:
+                hc_id = self.hdf5['oqparam'].hazard_calculation_id
+            except KeyError:
+                hc_id = None
             if hc_id:
                 self.parent = read(hc_id)
         return self


### PR DESCRIPTION
In a workflow with a grand parent calculation, like this one
```
$ oq engine --run job_ses.ini #grand-parent
$ oq engine --run job_gmfs_50.ini --hc -1 #parent
$ oq engine --run job_damage.ini --hc -1 #child
```
the exporter failed:
```python
$ oq engine --eos -1 /tmp
  File "/home/michele/oq-engine/openquake/calculators/export/risk.py", line 369, in export_damages_csv
    rlzs = dstore['full_lt'].get_realizations()
           ~~~~~~^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/commonlib/datastore.py", line 495, in __getitem__
    raise KeyError(
"No 'full_lt' found in <DataStore /home/michele/oqdata/calc_112043.hdf5 open> and ancestors"
```
This is now fixed.