### PR TITLE
Restored the old signature of the MultiFaultSource class

### DIFF
--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -258,7 +258,7 @@ def save(mfsources, sectiondict, hdf5path, msparams=False):
             raise IndexError('The section index %s in source %r is invalid'
                              % (exc.args[0], src.source_id))
         all_ridxs.append(rids)
-        delattr(src, '_rupture_idxs')  # was set by the SourceConverter
+        delattr(src, '_rupture_idxs')  # save memory
         src.hdf5path = hdf5path
 
     # store data

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -76,11 +76,12 @@ class MultiFaultSource(BaseSeismicSource):
     hdf5path = ''
 
     def __init__(self, source_id: str, name: str, tectonic_region_type: str,
-                 occurrence_probs: Union[list, np.ndarray],
+                 rupture_idxs: list, occurrence_probs: Union[list, np.ndarray],
                  magnitudes: list, rakes: list, investigation_time=0,
                  infer_occur_rates=False):
         nrups = len(magnitudes)
         assert len(occurrence_probs) == len(rakes) == nrups
+        self._rupture_idxs = rupture_idxs
         # NB: using 32 bits for the occurrence_probs would be a disaster:
         # the results are STRONGLY dependent on the precision,
         # in particular the AELO tests for CHN would break
@@ -302,9 +303,10 @@ def load(hdf5path):
             mags = data['mags'][:]
             rakes = data['rakes'][:]
             probs = data['probs_occur'][:]
-            src = MultiFaultSource(key, name, trt, probs, mags, rakes,
+            src = MultiFaultSource(key, name, trt,
+                                   data['rupture_idxs'][:],
+                                   probs, mags, rakes,
                                    itime, infer)
-            src._rupture_idxs = data['rupture_idxs'][:]
             src.hdf5path = hdf5path
             srcs.append(src)
     return srcs

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -1148,12 +1148,11 @@ class SourceConverter(RuptureConverter):
                 for idx in idxs:
                     assert U32(idx).max() < TWO16, idx
             # NB: the sections will be fixed later on, in source_reader
-            mfs = MultiFaultSource(sid, name, trt,
+            mfs = MultiFaultSource(sid, name, trt, idxs,
                                    dic['probs_occur'],
                                    mags, dic['rake'],
                                    self.investigation_time,
                                    self.infer_occur_rates)
-            mfs._rupture_idxs = idxs
             return mfs
         probs = []
         mags = []
@@ -1181,10 +1180,9 @@ class SourceConverter(RuptureConverter):
             mags = rounded_unique(mags, idxs)
         rakes = numpy.array(rakes)
         # NB: the sections will be fixed later on, in source_reader
-        mfs = MultiFaultSource(sid, name, trt, probs, mags, rakes,
+        mfs = MultiFaultSource(sid, name, trt, idxs, probs, mags, rakes,
                                self.investigation_time,
                                self.infer_occur_rates)
-        mfs._rupture_idxs = idxs
         return mfs
 
     def convert_sourceModel(self, node):

--- a/openquake/hazardlib/tests/source/multi_fault_test.py
+++ b/openquake/hazardlib/tests/source/multi_fault_test.py
@@ -84,8 +84,7 @@ class MultiFaultTestCase(unittest.TestCase):
     def test_ok(self):
         # test instantiation
         src = MultiFaultSource("01", "test", "Moon Crust",
-                               self.pmfs, self.mags, self.rakes)
-        src._rupture_idxs = self.rup_idxs
+                               self.rup_idxs, self.pmfs, self.mags, self.rakes)
         src.mutex_weight = 1.
 
         # test conversion into XML
@@ -157,8 +156,7 @@ class MultiFaultTestCase(unittest.TestCase):
         # test invalid section IDs
         rup_idxs = [[0], [1], [3], [0], [1], [3], [0]]
         mfs = MultiFaultSource("01", "test", "Moon Crust",
-                               self.pmfs, self.mags, self.rakes)
-        mfs._rupture_idxs = rup_idxs
+                               rup_idxs, self.pmfs, self.mags, self.rakes)
         with self.assertRaises(IndexError) as ctx:
             save([mfs], self.sections, 'dummy.hdf5')
         self.assertEqual(str(ctx.exception),


### PR DESCRIPTION
The change was meant to be temporary.