### PR TITLE
Added a view `exposure_by_country`

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -39,7 +39,7 @@ from openquake.hazardlib import logictree, calc, source, geo
 from openquake.hazardlib.contexts import (
     KNOWN_DISTANCES, ContextMaker, Collapser
 )
-from openquake.commonlib import util
+from openquake.commonlib import util, readinput
 from openquake.risklib import riskmodels
 from openquake.risklib.scientific import (
     losses_by_period, return_periods, LOSSID, LOSSTYPE)
@@ -1643,3 +1643,19 @@ def view_gh3(token, dstore):
     # print(sorted(cnt))
     return numpy.array([stats('gh3', cnt)],
                        dt('kind counts mean stddev min max'))
+
+
+@view.add('exposure_by_country')
+def view_exposure_by_country(token, dstore):
+    geom_df = readinput.read_global_risk_df()
+    assetcol = dstore['assetcol']
+    lonlats = numpy.zeros((len(assetcol), 2), F32)
+    lonlats[:, 0] = assetcol['lon']
+    lonlats[:, 1] = assetcol['lat']
+    codes = geo.utils.geolocate(lonlats, geom_df)
+    uni, cnt = numpy.unique(codes, return_counts=True)
+    out = numpy.zeros(len(uni), dt('country num_assets'))
+    out['country'] = uni
+    out['num_assets'] = cnt
+    out.sort(order='num_assets')
+    return out

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1651,7 +1651,7 @@ def view_exposure_by_country(token, dstore):
     Returns a table with the number of assets per country. The countries
     are defined as in the file geoBoundariesCGAZ_ADM0.shp
     """
-    geom_df = readinput.read_global_risk_df()
+    geom_df = readinput.read_countries_df()
     assetcol = dstore['assetcol']
     lonlats = numpy.zeros((len(assetcol), 2), F32)
     lonlats[:, 0] = assetcol['lon']

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1647,6 +1647,10 @@ def view_gh3(token, dstore):
 
 @view.add('exposure_by_country')
 def view_exposure_by_country(token, dstore):
+    """
+    Returns a table with the number of assets per country. The countries
+    are defined as in the file geoBoundariesCGAZ_ADM0.shp
+    """
     geom_df = readinput.read_global_risk_df()
     assetcol = dstore['assetcol']
     lonlats = numpy.zeros((len(assetcol), 2), F32)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1469,12 +1469,18 @@ def read_geometries(fname, code, buffer=0):
 
 
 def read_mosaic_df(buffer=0.1):
+    """
+    :returns: a DataFrame of geometries for the mosaic models
+    """
     fname = os.path.join(os.path.dirname(mosaic.__file__),
                          'ModelBoundaries.shp')
     return read_geometries(fname, 'code', buffer)
 
 
 def read_global_risk_df(buffer=0.1):
+    """
+    :returns: a DataFrame of geometries for the world countries
+    """
     fname = os.path.join(os.path.dirname(global_risk.__file__),
                          'geoBoundariesCGAZ_ADM0.shp')
     return read_geometries(fname, 'shapeGroup', buffer)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1477,7 +1477,7 @@ def read_mosaic_df(buffer=0.1):
     return read_geometries(fname, 'code', buffer)
 
 
-def read_global_risk_df(buffer=0.1):
+def read_countries_df(buffer=0.1):
     """
     :returns: a DataFrame of geometries for the world countries
     """

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -568,12 +568,13 @@ class ReadGeometryTestCase(unittest.TestCase):
         mosaic_dir = os.path.dirname(mosaic.__file__)
         geom_df = readinput.read_mosaic_df()
         self.assertEqual(len(geom_df), 30)
-        sites_df = pandas.read_csv(os.path.join(mosaic_dir, 'scenarios.csv'),
-                                   usecols=['lat', 'lon'])
+        sites_df = pandas.read_csv(
+            os.path.join(mosaic_dir, 'famous_ruptures.csv'),
+            usecols=['lat', 'lon'])
         lonlats = sites_df[['lon', 'lat']].to_numpy()
         sites_df['code'] = geolocate(lonlats, geom_df)
         t1 = time.time()
-        self.assertEqual(len(sites_df), 108)
+        self.assertEqual(len(sites_df), 90)
         print('Associated in %.1f seconds' % (t1-t0), sites_df)
 
         t0 = time.time()
@@ -581,5 +582,5 @@ class ReadGeometryTestCase(unittest.TestCase):
         self.assertEqual(len(risk_df), 218)
         sites_df['code'] = geolocate(lonlats, risk_df)  # this is fast
         t1 = time.time()
-        self.assertEqual(len(sites_df), 108)
+        self.assertEqual(len(sites_df), 90)
         print('Associated in %.1f seconds' % (t1-t0), sites_df)

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -577,7 +577,7 @@ class ReadGeometryTestCase(unittest.TestCase):
         print('Associated in %.1f seconds' % (t1-t0), sites_df)
 
         t0 = time.time()
-        risk_df = readinput.read_global_risk_df()  # this is slow
+        risk_df = readinput.read_countries_df()  # this is slow
         self.assertEqual(len(risk_df), 218)
         sites_df['code'] = geolocate(lonlats, risk_df)  # this is fast
         t1 = time.time()

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -146,6 +146,10 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
         tiles = cll.split_max(1)  # 2 tiles of 1 site each
         self.assertEqual(len(tiles), 2)
 
+        # test split_by_gh3
+        tiles = cll.split_by_gh3()
+        self.assertEqual([t.gh3 for t in tiles], [7415, 24765])
+
         # test geohash
         assert_eq(cll.geohash(4), numpy.array([b's5x1', b'7zrh']))
 


### PR DESCRIPTION
This is needed by the Aristotle project https://github.com/gem/oq-engine/issues/9227. We can use the taxonomy mapping corresponding to the country with more assets. Here is what happens for the event based risk demo (Nepal):
```
$ oq show exposure_by_country
| country | num_assets |
|---------+------------|
| 119     | 24         |
| IND     | 928        |
| NPL     | 8_111      |
```
NB: also added an utility `SiteCollection.split_by_gh3` that will be useful in the future.