### PR TITLE
Add ARISTOTLE mode

### DIFF
--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -175,7 +175,8 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 1
 # confusion between different installations when the WebUI is used
 SERVER_NAME = socket.gethostname()
 
-APPLICATION_MODES = ['PUBLIC', 'RESTRICTED', 'AELO', 'READ_ONLY']
+APPLICATION_MODES = [
+    'PUBLIC', 'RESTRICTED', 'AELO', 'ARISTOTLE', 'READ_ONLY']
 
 # case insensitive
 APPLICATION_MODE = 'public'
@@ -223,7 +224,7 @@ except ImportError:
 # both the default setting and the one specified in the local settings
 APPLICATION_MODE = os.environ.get('OQ_APPLICATION_MODE', APPLICATION_MODE)
 
-if TEST and APPLICATION_MODE.upper() == 'AELO':
+if TEST and APPLICATION_MODE.upper() in ('AELO', 'ARISTOTLE'):
     EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
     # FIXME: this is mandatory, but it writes anyway in /tmp/app-messages.
     #        We should redefine it to a different directory for each test,
@@ -231,12 +232,12 @@ if TEST and APPLICATION_MODE.upper() == 'AELO':
     #        parallel
     EMAIL_FILE_PATH = os.path.join(tempfile.gettempdir(), 'app-messages')
 
-if APPLICATION_MODE.upper() in ('RESTRICTED', 'AELO'):
+if APPLICATION_MODE.upper() in ('RESTRICTED', 'AELO', 'ARISTOTLE'):
     LOCKDOWN = True
 
 STATIC_URL = '%s/static/' % WEBUI_PATHPREFIX
 
-if LOCKDOWN and APPLICATION_MODE == 'AELO':
+if LOCKDOWN and APPLICATION_MODE.upper() in ('AELO', 'ARISTOTLE'):
     # check essential constants are defined
     try:
         EMAIL_BACKEND  # noqa

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -268,6 +268,21 @@ tr.asce_output {
     padding-bottom: 10px!important;
 }
 
+.aristotle_form_row label {
+    margin-bottom: 10px;
+}
+
+.aristotle_form_row label {
+    display: inline-block;
+    width: 100px;
+}
+
+.aristotle_form_row input {
+    /* width: calc(100% - 110px); /1* Adjust according to label width *1/ */
+    box-sizing: border-box;
+}
+
+
 /* customization of bootstrap button hover, to avoid turning to black */
 .btn:hover, .btn:focus {
     color: #fff!important;

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -525,5 +525,80 @@
             $("#aelo_run_form > input").click(function() {
                 $(this).css("background-color", "white");
             });
+
+            // NOTE: if not in aristotle mode, aristotle_run_form does not exist, so this can never be triggered
+            $("#aristotle_get_rupture_form").submit(function (event) {
+                $('#submit_aristotle_get_rupture').prop('disabled', true);
+                $('#submit_aristotle_get_rupture').text('Retrieving rupture data...');
+                var formData = {
+                    shakemap_id: $("#shakemap_id").val(),
+                };
+                $.ajax({
+                    type: "POST",
+                    url: gem_oq_server_url + "/v1/calc/aristotle_get_rupture_data",
+                    data: formData,
+                    dataType: "json",
+                    encode: true,
+                }).done(function (data) {
+                    // console.log(data);
+                    $('#lat').val(data.lat);
+                    $('#lon').val(data.lon);
+                    $('#dep').val(data.dep);
+                    $('#mag').val(data.mag);
+                    $('#rake').val(data.rake);
+                }).error(function (data) {
+                    var resp = JSON.parse(data.responseText);
+                    if ("invalid_inputs" in resp) {
+                        for (var i = 0; i < resp.invalid_inputs.length; i++) {
+                            var input_id = resp.invalid_inputs[i];
+                            $("#aristotle_get_rupture_form > input#" + input_id).css("background-color", "#F2DEDE");
+                        }
+                    }
+                    var err_msg = resp.error_msg;
+                    diaerror.show(false, "Error", err_msg);
+                }).always(function () {
+                    $('#submit_aristotle_get_rupture').prop('disabled', false);
+                    $('#submit_aristotle_get_rupture').text('Retrieve rupture data');
+                });
+                event.preventDefault();
+            });
+            $("#aristotle_run_form > input").click(function() {
+                $(this).css("background-color", "white");
+            });
+            $("#aristotle_run_form").submit(function (event) {
+                $('#submit_aristotle_calc').prop('disabled', true);
+                var formData = {
+                    lon: $("#lon").val(),
+                    lat: $("#lat").val(),
+                    dep: $("#dep").val(),
+                    mag: $("#mag").val(),
+                    rake: $("#rake").val(),
+                };
+                $.ajax({
+                    type: "POST",
+                    url: gem_oq_server_url + "/v1/calc/aristotle_run",
+                    data: formData,
+                    dataType: "json",
+                    encode: true,
+                }).done(function (data) {
+                    console.log(data);
+                }).error(function (data) {
+                    var resp = JSON.parse(data.responseText);
+                    if ("invalid_inputs" in resp) {
+                        for (var i = 0; i < resp.invalid_inputs.length; i++) {
+                            var input_id = resp.invalid_inputs[i];
+                            $("#aristotle_run_form > input#" + input_id).css("background-color", "#F2DEDE");
+                        }
+                    }
+                    var err_msg = resp.error_msg;
+                    diaerror.show(false, "Error", err_msg);
+                }).always(function () {
+                    $('#submit_aristotle_calc').prop('disabled', false);
+                });
+                event.preventDefault();
+            });
+            $("#aristotle_run_form > input").click(function() {
+                $(this).css("background-color", "white");
+            });
         });
 })($, Backbone, _, gem_oq_server_url);

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -573,6 +573,8 @@
                     dep: $("#dep").val(),
                     mag: $("#mag").val(),
                     rake: $("#rake").val(),
+                    dip: $("#dip").val(),
+                    strike: $("#strike").val()
                 };
                 $.ajax({
                     type: "POST",

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -546,6 +546,10 @@
                     $('#dep').val(data.dep);
                     $('#mag').val(data.mag);
                     $('#rake').val(data.rake);
+                    $('#trt').empty();
+                    $.each(data.trts, function(index, trt) {
+                        $('#trt').append('<option value="' + trt + '">' + trt + '</option>');
+                    });
                 }).error(function (data) {
                     var resp = JSON.parse(data.responseText);
                     if ("invalid_inputs" in resp) {
@@ -574,7 +578,8 @@
                     mag: $("#mag").val(),
                     rake: $("#rake").val(),
                     dip: $("#dip").val(),
-                    strike: $("#strike").val()
+                    strike: $("#strike").val(),
+                    trt: $('#trt').val()
                 };
                 $.ajax({
                     type: "POST",

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -87,6 +87,14 @@
                 <input class="aristotle-input" type="text" id="rake" name="rake" placeholder="{{ aristotle_form_placeholders.rake }}"/>
               </div>
               <div class="aristotle_form_row">
+                <label for"dip">{{ aristotle_form_placeholders.dip }}</label>
+                <input class="aristotle-input" type="text" id="dip" name="dip" placeholder="{{ aristotle_form_placeholders.dip }}"/>
+              </div>
+              <div class="aristotle_form_row">
+                <label for"strike">{{ aristotle_form_placeholders.strike }}</label>
+                <input class="aristotle-input" type="text" id="strike" name="strike" placeholder="{{ aristotle_form_placeholders.strike }}"/>
+              </div>
+              <div class="aristotle_form_row">
                 <button id="submit_aristotle_calc" type="submit" class="btn">Submit</button>
                 <!-- <input type="submit"> -->
               </div>

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -45,6 +45,53 @@
               <!-- <input type="submit"> -->
             </form>
           </div>
+          {% elif application_mode == 'ARISTOTLE' %}
+          <div class="span12">
+            <h2>Run an ARISTOTLE calculation</h2>
+            {% if not user.email %}
+            <h3>
+              WARNING: no email address is speficied for your user account, therefore email notifications will be disabled
+            </h3>
+            {% endif %}
+            <form id="aristotle_get_rupture_form" method="post">
+              {% csrf_token %}
+              <div class="aristotle_form_row">
+                <label for"shakemap_id">{{ aristotle_form_placeholders.shakemap_id }}</label>
+                <input class="aristotle-input" type="text" id="shakemap_id" name="shakemap_id" placeholder="{{ aristotle_form_placeholders.shakemap_id }}"/>
+              </div>
+              <div class="aristotle_form_row">
+                <button id="submit_aristotle_get_rupture" type="submit" class="btn">Retrieve rupture data</button>
+                <!-- <input type="submit"> -->
+              </div>
+            </form>
+            <form id="aristotle_run_form" method="post">
+              {% csrf_token %}
+              <div class="aristotle_form_row">
+                <label for"lat">{{ aristotle_form_placeholders.lat }}</label>
+                <input class="aristotle-input" type="text" id="lat" name="lat" placeholder="{{ aristotle_form_placeholders.lat }}"/>
+              </div>
+              <div class="aristotle_form_row">
+                <label for"lon">{{ aristotle_form_placeholders.lon }}</label>
+                <input class="aristotle-input" type="text" id="lon" name="lon" placeholder="{{ aristotle_form_placeholders.lon }}"/>
+              </div>
+              <div class="aristotle_form_row">
+                <label for"dep">{{ aristotle_form_placeholders.dep }}</label>
+                <input class="aristotle-input" type="text" id="dep" name="dep" placeholder="{{ aristotle_form_placeholders.dep }}"/>
+              </div>
+              <div class="aristotle_form_row">
+                <label for"mag">{{ aristotle_form_placeholders.mag }}</label>
+                <input class="aristotle-input" type="text" id="mag" name="mag" placeholder="{{ aristotle_form_placeholders.mag }}"/>
+              </div>
+              <div class="aristotle_form_row">
+                <label for"rake">{{ aristotle_form_placeholders.rake }}</label>
+                <input class="aristotle-input" type="text" id="rake" name="rake" placeholder="{{ aristotle_form_placeholders.rake }}"/>
+              </div>
+              <div class="aristotle_form_row">
+                <button id="submit_aristotle_calc" type="submit" class="btn">Submit</button>
+                <!-- <input type="submit"> -->
+              </div>
+            </form>
+          </div>
           {% endif %}
           <div class="span12">
             <h2>List of calculations{% if server_name %} from {{ server_name }}{% endif %}</h2>

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -95,6 +95,11 @@
                 <input class="aristotle-input" type="text" id="strike" name="strike" placeholder="{{ aristotle_form_placeholders.strike }}"/>
               </div>
               <div class="aristotle_form_row">
+                <label for="trt">{{ aristotle_form_placeholders.trt }}</label>
+                <select name="trt" id="trt">
+                </select>
+              </div>
+              <div class="aristotle_form_row">
                 <button id="submit_aristotle_calc" type="submit" class="btn">Submit</button>
                 <!-- <input type="submit"> -->
               </div>

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -88,11 +88,11 @@
               </div>
               <div class="aristotle_form_row">
                 <label for"dip">{{ aristotle_form_placeholders.dip }}</label>
-                <input class="aristotle-input" type="text" id="dip" name="dip" placeholder="{{ aristotle_form_placeholders.dip }}"/>
+                <input class="aristotle-input" type="text" id="dip" name="dip" placeholder="{{ aristotle_form_placeholders.dip }}" value="90"/>
               </div>
               <div class="aristotle_form_row">
                 <label for"strike">{{ aristotle_form_placeholders.strike }}</label>
-                <input class="aristotle-input" type="text" id="strike" name="strike" placeholder="{{ aristotle_form_placeholders.strike }}"/>
+                <input class="aristotle-input" type="text" id="strike" name="strike" placeholder="{{ aristotle_form_placeholders.strike }}" value="0"/>
               </div>
               <div class="aristotle_form_row">
                 <label for="trt">{{ aristotle_form_placeholders.trt }}</label>

--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -41,6 +41,14 @@ if settings.APPLICATION_MODE.upper() == 'AELO':
         re_path(r'^(\d+)/abort$', views.calc_abort),
         re_path(r'^(\d+)/remove$', views.calc_remove),
     ])
+elif settings.APPLICATION_MODE.upper() == 'ARISTOTLE':
+    urlpatterns.extend([
+        re_path(r'^aristotle_get_rupture_data$',
+                views.aristotle_get_rupture_data),
+        re_path(r'^aristotle_run$', views.aristotle_run),
+        re_path(r'^(\d+)/abort$', views.calc_abort),
+        re_path(r'^(\d+)/remove$', views.calc_remove),
+    ])
 elif settings.APPLICATION_MODE.upper() != 'READ_ONLY':
     urlpatterns.extend([
         re_path(r'^(\d+)/abort$', views.calc_abort),

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -742,52 +742,6 @@ def aristotle_run(request):
         lon=lon, lat=lat, dep=dep, mag=mag, rake=rake, dip=dip, strike=strike,
         trt=trt)
 
-    # # build a LogContext object associated to a database job
-    # try:
-    #     params = get_params_from(
-    #         dict(sites='%s %s' % (lon, lat), vs30=vs30, siteid=siteid),
-    #         config.directory.mosaic_dir, exclude=['USA'])
-    #     logging.root.handlers = []  # avoid breaking the logs
-    # except Exception as exc:
-    #     response_data = {'status': 'failed', 'error_cls': type(exc).__name__,
-    #                      'error_msg': str(exc)}
-    #     return HttpResponse(
-    #         content=json.dumps(response_data), content_type=JSON, status=400)
-    # [jobctx] = engine.create_jobs(
-    #     [params],
-    #     config.distribution.log_level, None, utils.get_user(request), None)
-    # job_id = jobctx.calc_id
-
-    # outputs_uri_web = request.build_absolute_uri(
-    #     reverse('outputs_aelo', args=[job_id]))
-
-    # outputs_uri_api = request.build_absolute_uri(
-    #     reverse('results', args=[job_id]))
-
-    # log_uri = request.build_absolute_uri(
-    #     reverse('log', args=[job_id, '0', '']))
-
-    # traceback_uri = request.build_absolute_uri(
-    #     reverse('traceback', args=[job_id]))
-
-    # response_data = dict(
-    #     status='created', job_id=job_id, outputs_uri=outputs_uri_api,
-    #     log_uri=log_uri, traceback_uri=traceback_uri)
-
-    # job_owner_email = request.user.email
-    # if not job_owner_email:
-    #     response_data['WARNING'] = (
-    #         'No email address is speficied for your user account,'
-    #         ' therefore email notifications will be disabled. As soon as'
-    #         ' the job completes, you can access its outputs at the following'
-    #         ' link: %s. If the job fails, the error traceback will be'
-    #         ' accessible at the following link: %s'
-    #         % (outputs_uri_api, traceback_uri))
-
-    # # spawn the AELO main process
-    # mp.Process(target=aelo.main, args=(
-    #     lon, lat, vs30, siteid, job_owner_email, outputs_uri_web, jobctx,
-    #     aelo_callback)).start()
     return HttpResponse(content=json.dumps(response_data), content_type=JSON,
                         status=200)
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -619,7 +619,7 @@ def get_trts(lon, lat):
         config.directory.mosaic_dir, 'site_model.hdf5')
     site_model = hdf5.File(site_model_path).read_df('model_trt_gsim_weight')
     trts = set(
-        site_model[site_model['model']==mosaic_model.encode('utf8')]['trt'])
+        site_model[site_model['model'] == mosaic_model.encode('utf8')]['trt'])
     return [trt.decode('utf8') for trt in trts]
 
 
@@ -658,7 +658,7 @@ def aristotle_get_rupture_data(request):
         if '404: Not Found' in str(exc):
             error_msg = f'Shakemap id "{shakemap_id}" was not found'
         elif 'There is not rupture.json' in str(exc):
-            error_msg = (f'Shakemap id "{shakemap_id} was found, but it'
+            error_msg = (f'Shakemap id "{shakemap_id}" was found, but it'
                          f' has no associated rupture data')
         else:
             error_msg = str(exc)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -107,6 +107,8 @@ ARISTOTLE_FORM_PLACEHOLDERS = {
     'dep': 'Depth',
     'mag': 'Magnitude',
     'rake': 'Rake',
+    'dip': 'Dip',
+    'strike': 'Strike',
 }
 
 # disable check on the export_dir, since the WebUI exports in a tmpdir
@@ -692,6 +694,16 @@ def aristotle_run(request):
     except Exception as exc:
         validation_errs[ARISTOTLE_FORM_PLACEHOLDERS['rake']] = str(exc)
         invalid_inputs.append('rake')
+    try:
+        dip = valid.positivefloat(request.POST.get('dip'))
+    except Exception as exc:
+        validation_errs[ARISTOTLE_FORM_PLACEHOLDERS['dip']] = str(exc)
+        invalid_inputs.append('dip')
+    try:
+        strike = valid.positivefloat(request.POST.get('strike'))
+    except Exception as exc:
+        validation_errs[ARISTOTLE_FORM_PLACEHOLDERS['strike']] = str(exc)
+        invalid_inputs.append('strike')
     if validation_errs:
         err_msg = 'Invalid input value'
         err_msg += 's\n' if len(validation_errs) > 1 else '\n'
@@ -705,7 +717,8 @@ def aristotle_run(request):
                             content_type=JSON, status=400)
     # TODO: run aristotle calculation
     # FIXME:
-    response_data = dict(lon=lon, lat=lat, dep=dep, mag=mag, rake=rake)
+    response_data = dict(
+        lon=lon, lat=lat, dep=dep, mag=mag, rake=rake, dip=dip, strike=strike)
 
     # # build a LogContext object associated to a database job
     # try:


### PR DESCRIPTION
![image](https://github.com/gem/oq-engine/assets/350930/add755dc-32eb-4953-b50d-85888d997e03)

When APPLICATION_MODE is set to ARISTOTLE, the webui displays a form to retrieve rupture information given a shakemap id. That form triggers an ajax call that populates a second form with pre-populated (editable) variables, plus dip, strike and a selector for trt that is populated based on the mosaic model corresponding to the lon and lat of the rupture that was retrieved.
The submit button currently only collects the user-edited values and the selected trt, printing those values in the console.
What comes after that is still to be done.

NOTE: site_model.hdf5 needs to be put into mosaic_dir in order to make it possible to retrieve the set of trts.