### PR TITLE
Gzipping the _rates

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -400,7 +400,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.cmakers = read_cmakers(self.datastore, self.csm)
         self.cfactor = numpy.zeros(3)
         self.rel_ruptures = AccumDict(accum=0)  # grp_id -> rel_ruptures
-        self.datastore.create_df('_rates', rates_dt.items())
+        self.datastore.create_df('_rates', rates_dt.items(), 'gzip')
         self.datastore.create_dset('_rates/slice_by_sid', slice_dt)
         # NB: compressing the dataset causes a big slowdown in writing :-(
 


### PR DESCRIPTION
This gives a 4.4x reduction in disk space and 4x speedup in postclassical for the USA model on the spot machine:
```
# before
$ oq run USA/in/job_vs30.ini --hc 223
| calc_234, maxmem=227.6 GB | time_sec | memory_mb | counts  |
|---------------------------+----------+-----------+---------|
| total postclassical       | 335_266  | 1_942     | 185     |
| reading rates             | 326_871  | 1_942     | 185     |
| combine pmaps             | 8_317    | 0.0       | 234_133 |
| ClassicalCalculator.run   | 3_337    | 144.6     | 1       |

# after
$ oq run USA/in/job_vs30.ini --hc 206
| calc_232, maxmem=226.4 GB | time_sec | memory_mb | counts  |
|---------------------------+----------+-----------+---------|
| total postclassical       | 87_052   | 1_937     | 185     |
| reading rates             | 78_661   | 1_937     | 185     |
| combine pmaps             | 8_313    | 0.0       | 234_133 |
| ClassicalCalculator.run   | 979.6    | 149.2     | 1       |
```
The huge speedup is only visible in machines with slow disks and with large calculations. With small calculation, the common sense is right and indeed gzipping worsen the performance:
```
| calc_236, maxmem=72.5 GB   | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total postclassical        | 1_271    | 539.0     | 47        |
| total postclassical        | 1_331    | 539.6     | 47        |
```