### PR TITLE
Made `store_rates` faster by not splitting by IMT

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -283,24 +283,21 @@ class Hazard:
         """
         Store pnes inside the _rates dataset
         """
-        # store by IMT to save memory
-        for m, imt in enumerate(self.imtls):
-            slc = self.imtls(imt)
-            rates = pnemap.to_rates(slc)  # shape (N, L1, G)
-            idxs, lids, gids = rates.nonzero()
-            if len(idxs) == 0:  # happens in case_60
-                return 0
-            sids = pnemap.sids[idxs]
-            hdf5.extend(self.datastore['_rates/sid'], sids)
-            hdf5.extend(self.datastore['_rates/gid'], gids + gid)
-            hdf5.extend(self.datastore['_rates/lid'], lids + slc.start)
-            hdf5.extend(self.datastore['_rates/rate'], rates[idxs, lids, gids])
+        rates = pnemap.to_rates()  # shape (N, L1, G)
+        idxs, lids, gids = rates.nonzero()
+        if len(idxs) == 0:  # happens in case_60
+            return 0
+        sids = pnemap.sids[idxs]
+        hdf5.extend(self.datastore['_rates/sid'], sids)
+        hdf5.extend(self.datastore['_rates/gid'], gids + gid)
+        hdf5.extend(self.datastore['_rates/lid'], lids)
+        hdf5.extend(self.datastore['_rates/rate'], rates[idxs, lids, gids])
 
-            # slice_by_sid contains 3x6=18 slices in classical/case_22
-            # which has 6 IMTs each one with 20 levels
-            sbs = build_slice_by_sid(sids, self.offset)
-            hdf5.extend(self.datastore['_rates/slice_by_sid'], sbs)
-            self.offset += len(sids)
+        # slice_by_sid contains 3x6=18 slices in classical/case_22
+        # which has 6 IMTs each one with 20 levels
+        sbs = build_slice_by_sid(sids, self.offset)
+        hdf5.extend(self.datastore['_rates/slice_by_sid'], sbs)
+        self.offset += len(sids)
 
         self.acc['nsites'] = self.offset
         return self.offset * 12  # 4 + 2 + 2 + 4 bytes


### PR DESCRIPTION
Here is USA on the spot machine:
```
# before (475,028 slices)
| calc_238, maxmem=211.1 GB  | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 252_235  | 115.8     | 4_861      |
| get_poes                   | 115_482  | 0.0       | 11_766_465 |
| computing mean_std         | 61_330   | 0.0       | 80_638     |
| composing pnes             | 46_501   | 0.0       | 11_766_465 |
| total postclassical        | 13_887   | 1_932     | 185        |
| combine pmaps              | 9_000    | 0.0       | 234_133    |
| ClassicalCalculator.run    | 5_006    | 8_041     | 1          |
| reading rates              | 4_798    | 1_932     | 185        |
| storing rates              | 3_153    | 547.9     | 4_861      |

# after (67,837 slices)
| calc_239, maxmem=241.1 GB  | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 259_808  | 116.3     | 4_861      |
| get_poes                   | 119_378  | 0.0       | 11_766_465 |
| computing mean_std         | 63_596   | 0.0       | 80_638     |
| composing pnes             | 47_375   | 0.0       | 11_766_465 |
| total postclassical        | 12_165   | 1_943     | 185        |
| combine pmaps              | 9_130    | 0.0       | 234_133    |
| ClassicalCalculator.run    | 4_783    | 9_651     | 1          |
| reading rates              | 2_943    | 1_943     | 185        |
| storing rates              | 3_192    | 544.4     | 4_861      |
```
By reducing by 7x the number of slices reading the rates becomes a lot faster (2_943s << 4_798s) while storing the rates is only marginally slower.