### PR TITLE
Removed Python version check in install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -277,11 +277,6 @@ def before_checks(inst, venv, port, remove, usage):
     if port:
         inst.DBPORT = int(port)
 
-    # check python version
-    if PYVER < (3, 9, 0):
-        sys.exit('Error: you need at least Python 3.9, but you have %s' %
-                 '.'.join(map(str, sys.version_info)))
-
     # check platform
     if ((inst is server and sys.platform != 'linux') or (
             inst is devel_server and sys.platform != 'linux')):


### PR DESCRIPTION
We want to be able to install old engine versions (for instance the LTS 3.16 which works with Python 3.8) so install.py must also work with old Python versions.