### PR TITLE
Reducing memory consumption in postclassical

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -259,33 +259,17 @@ def is_ok(value, expected):
     return value == expected
 
 
-def decode_lol(lol):
-    """
-    :returns: a list of lists of decoded values
-    """
-    if len(lol) and len(lol[0]) and isinstance(lol[0][0], bytes):
-        return [decode(lst) for lst in lol]
-    else:
-        return lol
-
-
-def extract_cols(datagrp, sel, slc, columns):
+def extract_cols(datagrp, sel, slices, columns):
     """
     :param datagrp: something like and HDF5 data group
     :param sel: dictionary column name -> value specifying a selection
-    :param slc: a slice object specifying the rows considered
+    :param slices: list of slices
     :param columns: the full list of column names
     :returns: a dictionary col -> array of values
     """
-    first = columns[0]
-    nrows = len(datagrp[first])
-    if slc.start is None and slc.stop is None:  # split in slices
-        slcs = general.gen_slices(0, nrows, MAX_ROWS)
-    else:
-        slcs = [slc]
     acc = general.AccumDict(accum=[])  # col -> arrays
-    for slc in slcs:
-        if sel:
+    if sel:
+        for slc in slices:
             ok = slice(None)
             dic = {col: datagrp[col][slc] for col in sel}
             for col in sel:
@@ -295,10 +279,14 @@ def extract_cols(datagrp, sel, slc, columns):
                     ok &= is_ok(dic[col], sel[col])
             for col in columns:
                 acc[col].append(datagrp[col][slc][ok])
-        else:  # avoid making unneeded copies
-            for col in columns:
-                acc[col].append(datagrp[col][slc])
-    return {k: numpy.concatenate(decode_lol(vs)) for k, vs in acc.items()}
+    else:  # avoid making unneeded copies
+        for col in columns:
+            dset = datagrp[col]
+            for slc in slices:
+                acc[col].append(dset[slc])
+    for k, vs in acc.items():
+        acc[k] = numpy.concatenate(vs, dtype=vs[0].dtype)
+    return acc
 
 
 class File(h5py.File):
@@ -374,12 +362,13 @@ class File(h5py.File):
         for k, v in kw.items():
             attrs[k] = v
 
-    def read_df(self, key, index=None, sel=(), slc=slice(None)):
+    def read_df(self, key, index=None, sel=(), slc=slice(None), slices=()):
         """
         :param key: name of the structured dataset
         :param index: pandas index (or multi-index), possibly None
         :param sel: dictionary used to select subsets of the dataset
         :param slc: slice object to extract a slice of the dataset
+        :param slices: an array of shape (N, 2) with start,stop indices
         :returns: pandas DataFrame associated to the dataset
         """
         dset = self.getitem(key)
@@ -389,7 +378,14 @@ class File(h5py.File):
             return dset2df(dset, index, sel)
         elif '__pdcolumns__' in dset.attrs:
             columns = dset.attrs['__pdcolumns__'].split()
-            dic = extract_cols(dset, sel, slc, columns)
+            if len(slices):
+                slcs = [slice(s0, s1) for s0, s1 in slices]
+            elif slc.start is None and slc.stop is None:  # split in slices
+                slcs = list(general.gen_slices(
+                    0, len(dset[columns[0]]), MAX_ROWS))
+            else:
+                slcs = [slc]
+            dic = extract_cols(dset, sel, slcs, columns)
             if index is None:
                 return pandas.DataFrame(dic)
             else:

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -285,7 +285,9 @@ def extract_cols(datagrp, sel, slices, columns):
             for slc in slices:
                 acc[col].append(dset[slc])
     for k, vs in acc.items():
-        acc[k] = numpy.concatenate(vs, dtype=vs[0].dtype)
+        acc[k] = arr = numpy.concatenate(vs, dtype=vs[0].dtype)
+        if len(arr) and isinstance(arr[0], bytes):
+            acc[k] = numpy.array(decode(arr))
     return acc
 
 

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -157,23 +157,6 @@ class DisaggregationCalculator(base.HazardCalculator):
         """Performs the disaggregation"""
         return self.full_disaggregation()
 
-    def get_curve(self, sid, rlzs):
-        """
-        Get the hazard curves for the given site ID and realizations.
-
-        :param sid: site ID
-        :param rlzs: a matrix of indices of shape Z
-        :returns: a list of Z arrays of PoEs
-        """
-        poes = []
-        hcurve = self.pgetter.get_hcurve(sid)
-        for z, rlz in enumerate(rlzs):
-            pc = hcurve.extract(rlz)
-            if z == 0:
-                self.curves.append(pc.array[:, 0])
-            poes.append(pc.array[:, 0])
-        return poes
-
     def full_disaggregation(self):
         """
         Run the disaggregation phase.

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -253,7 +253,8 @@ def set_oqparam(oq, assetcol, dstore):
     sec_losses = []  # one insured loss for each loss type with a policy
     try:
         policy_df = dstore.read_df('policy')
-        policy_df['loss_type'] = python3compat.decode(policy_df['loss_type'])
+        policy_df['loss_type'] = python3compat.decode(
+            policy_df['loss_type'].to_numpy())
     except KeyError:
         pass
     else:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -253,8 +253,6 @@ def set_oqparam(oq, assetcol, dstore):
     sec_losses = []  # one insured loss for each loss type with a policy
     try:
         policy_df = dstore.read_df('policy')
-        policy_df['loss_type'] = python3compat.decode(
-            policy_df['loss_type'].to_numpy())
     except KeyError:
         pass
     else:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -253,6 +253,7 @@ def set_oqparam(oq, assetcol, dstore):
     sec_losses = []  # one insured loss for each loss type with a policy
     try:
         policy_df = dstore.read_df('policy')
+        policy_df['loss_type'] = python3compat.decode(policy_df['loss_type'])
     except KeyError:
         pass
     else:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -191,16 +191,15 @@ class PmapGetter(object):
             return self._pmap
         G = len(self.trt_rlzs)
         with hdf5.File(self.filename) as dstore:
-            for start, stop in self.slices:
-                rates_df = dstore.read_df('_rates', slc=slice(start, stop))
-                for sid, df in rates_df.groupby('sid'):
-                    try:
-                        array = self._pmap[sid].array
-                    except KeyError:
-                        array = numpy.zeros((self.L, G))
-                        self._pmap[sid] = probability_map.ProbabilityCurve(
-                            array)
-                    array[df.lid, df.gid] = df.rate
+            rates_df = dstore.read_df('_rates', slices=self.slices)
+            for sid, df in rates_df.groupby('sid'):
+                try:
+                    array = self._pmap[sid].array
+                except KeyError:
+                    array = numpy.zeros((self.L, G))
+                    self._pmap[sid] = probability_map.ProbabilityCurve(
+                        array)
+                array[df.lid, df.gid] = df.rate
         return self._pmap
 
     # used in risk calculations where there is a single site per getter

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -187,7 +187,7 @@ class PmapGetter(object):
         """
         Build the probability curves from the underlying dataframes
         """
-        if self._pmap:
+        if self._pmap or len(self.slices) == 0:
             return self._pmap
         G = len(self.trt_rlzs)
         with hdf5.File(self.filename) as dstore:

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -168,7 +168,7 @@ agg_id
 
         with self.assertRaises(ValueError) as ctx:
             self.run_calc(case_1.__file__, 'job2.ini',
-                          insurance_csv="{'structural': 'policy_ins_ko.csv'}")
+                          insurance_file="{'structural': 'policy_ins_ko.csv'}")
         self.assertIn(
             "Please check deductible values. Values larger than the insurance"
             " limit were found for asset(s) {3}.",


### PR DESCRIPTION
By optimizing `read_df` for multiple slices. For the USA on the spot machine:
```
# before
| calc_245, maxmem=226.0 GB | time_sec | memory_mb | counts  |
|---------------------------+----------+-----------+---------|
| total postclassical       | 87_334   | 2_201     | 185     |
| reading rates             | 78_934   | 2_201     | 185     |
| combine pmaps             | 8_321    | 0.0       | 234_133 |
| ClassicalCalculator.run   | 1_055    | 150.1     | 1       |

# after
| calc_246, maxmem=184.7 GB | time_sec | memory_mb | counts  |
|---------------------------+----------+-----------+---------|
| total postclassical       | 88_906   | 2_166     | 185     |
| reading rates             | 80_485   | 2_166     | 185     |
| combine pmaps             | 8_340    | 0.0       | 234_133 |
| ClassicalCalculator.run   | 1_018    | 96.8      | 1       |

```