### PR TITLE
Changelog2ghrel

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -101,6 +101,11 @@ jobs:
         run: |
           pip install -e .[dev]
           python3 -c "import openquake.baselib as m; print(m.__version__.rpartition('.')[0])"
+      - name: Check consistency between debian/changelog and CONTRIBUTORS.txt
+        shell: bash
+        run: |
+          ./helpers/changelog2ghrel.sh --check
+
       - name: Make docs and rsync to docs.openquake.org
         shell: bash
         env:

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -71,7 +71,7 @@ Elena Manea              (@manea)               August 2021
 Shreyasvi Chandrasekhar  (@Shreyasvi91)         November 2021
 Giuseppina Tusa          (@gtus23)              December 2021
 Miguel Leonardo-Suárez   (@mleonardos)          December 2021
-Manuela Villani          (@mvillani)            January 2022
+Manuela Villani          (@ManuelaVillani)      January 2022
 Prajakta Jadhav          (@Prajakta-Jadhav-25)  February 2022
 Dharma Wijewickreme      (@Dharma-Wijewickreme) February 2022
 Tom Son                  (@SnowNooDLe)          March 2022
@@ -83,7 +83,6 @@ Claudio Schill           (@claudio525)          June 2023
 Astha Poudel             (@asthapoudel)         July 2023
 Lana Todorovic           (@LanaTodorovic93)     August 2023
 Christopher Brooks       (@CB-quakemodel)       September 2023
-Manuela Villani          (@ManuelaVillani)      September 2023
 Chris di Caprio          (@chrisdicaprio)       January 2024
 
 Project management

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Matteo Nastasio]
+  * Add helper to check consistency between debian/changelog and CONTRIBUTORS.txt
+
   [Michele Simionato]
   * Optimized reading rates in postclassical
   * Reduced data transfer in classical calculations by gzipping the rates

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-  [Matteo Nastasio]
+  [Matteo Nastasi]
   * Add helper to check consistency between debian/changelog and CONTRIBUTORS.txt
 
   [Michele Simionato]

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -e
 
 which grep sed sort uniq >/dev/null
 if [ $? -ne 0 ]; then
@@ -58,7 +58,7 @@ version_in="$1"
 if [ ! -f debian/changelog ]; then
     usage 1
 fi
-LIST_CONTRIB="$(set -e ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+LIST_CONTRIB="$(set -o pipefail ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
 IFS='
 '

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 set -x
+set +o pipefail
 
 which grep sed sort uniq >/dev/null
 if [ $? -ne 0 ]; then
@@ -60,7 +61,7 @@ if [ ! -f debian/changelog ]; then
     usage 1
 fi
 set +e
-LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+LIST_CONTRIB="$(set +o pipefail ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 set -e
 
 IFS='

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 set -x
 
 which grep sed sort uniq head >/dev/null

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -x
 
-which grep sed sort uniq >/dev/null
+which grep sed sort uniq head >/dev/null
 if [ $? -ne 0 ]; then
-    which grep sed sort uniq
+    which grep sed sort uniq head
 fi
 
 NL='
@@ -35,7 +35,7 @@ per_ver_changelog () {
         if [ "$version_in" ]; then
             cat debian/changelog | sed -n "/^python3-oq-engine (${version_in}-.*/,/^python3-oq-engine .*/p"
         else
-            cat debian/changelog | sed '/^python3-oq-engine.*/q' | sed '$ d' 
+            cat debian/changelog | sed '/^python3-oq-engine.*/q' | head -n -1
         fi
     )
 }

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -82,9 +82,6 @@ fi
 # TEST VERSION WITHOUT set +o
 LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
-# JUST FOR TEST
-set -o pipefail
-LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 IFS='
 '
 for contr in $LIST_CONTRIB; do
@@ -94,9 +91,6 @@ for contr in $LIST_CONTRIB; do
         exit 1
     fi
 done
-
-# FIXME: just for test
-false
 
 if [ "$perform_check" = "TRUE" ]; then
     exit 0

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -31,12 +31,14 @@ EOF
 per_ver_changelog () {
     version_in="$1"
     
-    ( if [ "$version_in" ]; then
-          cat debian/changelog | sed -n "/^python3-oq-engine (${version_in}-.*/,/^python3-oq-engine .*/p"
-      else
-          cat debian/changelog | sed '/^python3-oq-engine.*/q' | sed '$ d' 
-      fi )
-    }
+    (
+        if [ "$version_in" ]; then
+            cat debian/changelog | sed -n "/^python3-oq-engine (${version_in}-.*/,/^python3-oq-engine .*/p"
+        else
+            cat debian/changelog | sed '/^python3-oq-engine.*/q' | sed '$ d' 
+        fi
+    )
+}
 
 #
 #  MAIN
@@ -56,7 +58,12 @@ version_in="$1"
 if [ ! -f debian/changelog ]; then
     usage 1
 fi
-LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+
+# LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+
+LIST_CONTRIB_P1="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g')"
+LIST_CONTRIB_P2="$(echo "$LIST_CONTRIB_P1" | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g')"
+LIST_CONTRIB="$(echo "$LIST_CONTRIB_P2" | sed 's/\] *$//g' | sort | uniq)"
 
 IFS='
 '

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -60,9 +60,6 @@ per_ver_changelog () {
 #  MAIN
 #
 
-# FIXME: just for test
-false
-
 perform_check=FALSE
 if [ "$1" = "--help" -o "$1" = "-h" ]; then
     usage 0
@@ -79,7 +76,11 @@ if [ ! -f debian/changelog ]; then
 fi
 # NOTE: this pipe chain produce on github action a SIGPIPE, to prevent false errors we desable
 #       pipefail with 'set +o'
-LIST_CONTRIB="$(set +o pipefail ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+# CORRECT
+# LIST_CONTRIB="$(set +o pipefail ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+
+# TEST VERSION WITHOUT set +o
+LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
 IFS='
 '
@@ -90,6 +91,9 @@ for contr in $LIST_CONTRIB; do
         exit 1
     fi
 done
+
+# FIXME: just for test
+false
 
 if [ "$perform_check" = "TRUE" ]; then
     exit 0

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-set -o pipefail
+# set -e
 set -x
+
+trap "" PIPE
 
 which grep sed sort uniq head >/dev/null
 if [ $? -ne 0 ]; then

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
-set -e
 set -x
 
-# trap "" PIPE
-
-which grep sed sort uniq head >/dev/null
+which grep sed sort uniq >/dev/null
 if [ $? -ne 0 ]; then
-    which grep sed sort uniq head
+    which grep sed sort uniq
 fi
 
 NL='
@@ -38,7 +35,7 @@ per_ver_changelog () {
         if [ "$version_in" ]; then
             cat debian/changelog | sed -n "/^python3-oq-engine (${version_in}-.*/,/^python3-oq-engine .*/p"
         else
-            cat debian/changelog | sed '/^python3-oq-engine.*/q' | head -n -1
+            cat debian/changelog | sed '/^python3-oq-engine.*/q' | sed '$ d' 
         fi
     )
 }
@@ -61,12 +58,7 @@ version_in="$1"
 if [ ! -f debian/changelog ]; then
     usage 1
 fi
-
-# LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
-
-LIST_CONTRIB_P1="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g')"
-LIST_CONTRIB_P2="$(echo "$LIST_CONTRIB_P1" | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g')"
-LIST_CONTRIB="$(echo "$LIST_CONTRIB_P2" | sed 's/\] *$//g' | sort | uniq)"
+LIST_CONTRIB="$(set -e ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
 IFS='
 '

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -58,7 +58,7 @@ version_in="$1"
 if [ ! -f debian/changelog ]; then
     usage 1
 fi
-LIST_CONTRIB="$(set -o pipefail ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
 IFS='
 '

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-#
-
-#
-#
-
 set -x
+
+which grep sed sort uniq >/dev/null
+if [ $? -ne 0 ]; then
+    which grep sed sort uniq
+fi
+
 NL='
 '
 

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
-set -e
+#
+# changelog2ghrel.sh  Copyright (C) 2024 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>
 set -x
-# set +o pipefail
 
 which grep sed sort uniq >/dev/null
 if [ $? -ne 0 ]; then
@@ -46,6 +59,9 @@ per_ver_changelog () {
 #  MAIN
 #
 
+# FIXME: just for test
+false
+
 perform_check=FALSE
 if [ "$1" = "--help" -o "$1" = "-h" ]; then
     usage 0
@@ -60,6 +76,8 @@ version_in="$1"
 if [ ! -f debian/changelog ]; then
     usage 1
 fi
+# NOTE: this pipe chain produce on github action a SIGPIPE, to prevent false errors we desable
+#       pipefail with 'set +o'
 LIST_CONTRIB="$(set +o pipefail ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
 IFS='

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>
 set -x
+set -e
 
 which grep sed sort uniq >/dev/null
 if [ $? -ne 0 ]; then

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# set -e
+set -e
 set -x
 
-trap "" PIPE
+# trap "" PIPE
 
 which grep sed sort uniq head >/dev/null
 if [ $? -ne 0 ]; then

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 
 which grep sed sort uniq >/dev/null
 if [ $? -ne 0 ]; then
@@ -58,7 +59,9 @@ version_in="$1"
 if [ ! -f debian/changelog ]; then
     usage 1
 fi
+set +e
 LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+set -e
 
 IFS='
 '

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -83,6 +83,7 @@ fi
 LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
 # JUST FOR TEST
+set -o pipefail
 per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq
 IFS='
 '

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -60,9 +60,7 @@ version_in="$1"
 if [ ! -f debian/changelog ]; then
     usage 1
 fi
-set +e
 LIST_CONTRIB="$(set +o pipefail ; per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
-set -e
 
 IFS='
 '

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 set -x
-set +o pipefail
+# set +o pipefail
 
 which grep sed sort uniq >/dev/null
 if [ $? -ne 0 ]; then

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -4,7 +4,7 @@
 #
 #
 
-# set -x
+set -x
 NL='
 '
 

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -85,7 +85,7 @@ LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,
 IFS='
 '
 for contr in $LIST_CONTRIB; do
-    grep -q "${contr}[ \t]\+" CONTRIBUTORS.txt
+    grep -q "^${contr}[ \t]\+" CONTRIBUTORS.txt
     if [ $? -ne 0 ]; then
         echo "Contributor '$contr' not found in CONTRIBUTORS.txt"
         exit 1

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -83,7 +83,7 @@ fi
 LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
 # JUST FOR TEST
-set -o pipefail
+# set -o pipefail
 per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq
 IFS='
 '

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -83,8 +83,8 @@ fi
 LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
 # JUST FOR TEST
-# set -o pipefail
-per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq
+set -o pipefail
+LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 IFS='
 '
 for contr in $LIST_CONTRIB; do

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+
+#
+#
+
+# set -x
+NL='
+'
+
+usage () {
+cat <<EOF
+
+  ./helpers/changelog2ghrel.sh [-c|--check] [<maj.min.bugfix>]
+  ./helpers/changelog2ghrel.sh [-h|--help]
+
+    -c                if present checks contributors of current block of
+                      changelog 
+    <maj.min.bugfix>  if present extracts the block of changelog related
+                      to a specific oq-engine release
+
+    -h|--help         this help
+
+  exit with 0 if success, different from 0 if some error occured
+
+EOF
+    exit $1
+}
+
+per_ver_changelog () {
+    version_in="$1"
+    
+    ( if [ "$version_in" ]; then
+          cat debian/changelog | sed -n "/^python3-oq-engine (${version_in}-.*/,/^python3-oq-engine .*/p"
+      else
+          cat debian/changelog | sed '/^python3-oq-engine.*/q' | sed '$ d' 
+      fi )
+    }
+
+#
+#  MAIN
+#
+
+perform_check=FALSE
+if [ "$1" = "--help" -o "$1" = "-h" ]; then
+    usage 0
+fi
+
+if [ "$1" = "--check" -o "$1" = "-c" ]; then
+    perform_check=TRUE
+    shift
+fi
+version_in="$1"
+
+if [ ! -f debian/changelog ]; then
+    usage 1
+fi
+LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
+
+IFS='
+'
+for contr in $LIST_CONTRIB; do
+    grep -q "${contr}[ \t]\+" CONTRIBUTORS.txt
+    if [ $? -ne 0 ]; then
+        echo "Contributor '$contr' not found in CONTRIBUTORS.txt"
+        exit 1
+    fi
+done
+
+if [ "$perform_check" = "TRUE" ]; then
+    exit 0
+fi
+
+IFS='
+'
+dict_contribs=""
+LIST_CONTRIB=$(echo "$LIST_CONTRIB")
+for contr in $LIST_CONTRIB; do
+    gh_contr="$(grep "^${contr}" CONTRIBUTORS.txt | grep '(@[^)]\+)' | sed 's/.*(@/@/g;s/).*//g')"
+        
+    dict_contribs="$dict_contribs$contr|$contr ($gh_contr)$NL"
+done        
+
+per_ver_changelog "$version_in" | grep -v -- '^ --' | sed '/./b;:n;N;s/\n$//;tn' \
+| sed 's/^[a-z][^(]*(\([^\-]\+\).*/## Release \1/g;' | sed 's/^  \(\[.*\]\)/_\1_/g' \
+| sed 's/^  //g' > /tmp/changelog2ghrel_$$.txt
+echo "$dict_contribs" | sed '/./!d;s/\([^|]*\)|*\(.*\)/s%\1%\2%g/' - | sed -f - /tmp/changelog2ghrel_$$.txt
+
+rm -f /tmp/changelog2ghrel_$$.txt
+
+

--- a/helpers/changelog2ghrel.sh
+++ b/helpers/changelog2ghrel.sh
@@ -82,6 +82,8 @@ fi
 # TEST VERSION WITHOUT set +o
 LIST_CONTRIB="$(per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq)"
 
+# JUST FOR TEST
+per_ver_changelog "$version_in"| grep '^  \[[^\]*\]$' | sed 's/,/,\n/g' | sed 's/^ \+//g' | sed 's/^\[//g' | sed 's/, *$//g' | sed 's/\] *$//g' | sort | uniq
 IFS='
 '
 for contr in $LIST_CONTRIB; do


### PR DESCRIPTION
Integrate into **Docs** action (**Check consistency between debian/changelog and CONTRIBUTORS.txt** step) a check that all contributors of current release are present in **CONTRIBUTORS.txt** file.
The same script used to perform the check above is used to convert **changelog** file to **markdown changelog** used for github releases.