### PR TITLE
Produce 4x less tiles if `config.distribution.compress` is set

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -146,6 +146,9 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
         # size_mb is the maximum size of the pmap array in GB
         size_mb = (len(cmaker.gsims) * cmaker.imtls.size * len(sitecol)
                    * 8 / 1024**2)
+        if config.distribution.compress:
+            size_mb /= 4  # produce 4x less tiles
+
         # NB: the parameter config.memory.pmap_max_mb avoids the hanging
         # of oq1 due to too large zmq packets
         itiles = int(numpy.ceil(size_mb / cmaker.pmap_max_mb))

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -556,7 +556,9 @@ class SiteCollection(object):
         """
         Split a SiteCollection into a set of tiles with contiguous site IDs
         """
-        if hint > len(self):
+        if hint <= 1:
+            return [self]
+        elif hint > len(self):
             hint = len(self)
         tiles = []
         for sids in numpy.array_split(self.sids, hint):


### PR DESCRIPTION
Since the compression will produce blocks well under the zmq limit anyway. Here is the difference for USA on cole
```
# before
| calc_9912, maxmem=276.2 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 323_591  | 146.9     | 4_859      |
| get_poes                   | 130_606  | 0.0       | 11_707_444 |
| computing mean_std         | 93_974   | 0.0       | 80_238     |
| composing pnes             | 51_755   | 0.0       | 11_707_444 |
| total postclassical        | 11_323   | 1_886     | 185        |
| combine pmaps              | 8_571    | 0.0       | 234_133    |
| ClassicalCalculator.run    | 4_313    | 4_078     | 1          |
| reading rates              | 2_660    | 1_886     | 185        |
| storing rates              | 2_154    | 474.2     | 4_859      |

# after
| calc_9917, maxmem=296.3 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 321_043  | 146.6     | 1_483      |
| get_poes                   | 129_698  | 0.0       | 10_693_080 |
| computing mean_std         | 93_332   | 0.0       | 71_872     |
| composing pnes             | 51_287   | 0.0       | 10_693_080 |
| total postclassical        | 11_354   | 1_869     | 185        |
| combine pmaps              | 8_553    | 0.0       | 234_133    |
| ClassicalCalculator.run    | 4_250    | 3_356     | 1          |
| reading rates              | 2_709    | 1_869     | 185        |
| storing rates              | 2_309    | 3_272     | 1_483      |
```