### PR TITLE
Removed parameter `rupture_usgs_id`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,14 @@
+  [Michele Simionato]
+  * Added `oq show usgs_rupture:<usgs_id>` printing the rupture parameters
+
   [Matteo Nastasi]
-  * Add helper to check consistency between debian/changelog and CONTRIBUTORS.txt
+  * Add helper to check consistency between debian/changelog and
+    CONTRIBUTORS.txt
 
   [Michele Simionato]
   * Added an optional flag `config.distribution.compress` to reduce the
     data transfer by compressing pickles larger than 1 MB
-  * Optimized reading rates in postclassical
+  * Optimized postclassical both for regular and tiling calculations
   * Saving disk space in classical calculations (~4x) by gzipping the rates
   * Removed Python version checks in install.py
 

--- a/demos/hazard/ScenarioCase3/job.ini
+++ b/demos/hazard/ScenarioCase3/job.ini
@@ -1,6 +1,6 @@
 [general]
 
-description = Scenario Calculation with Complex Fault Rupture
+description = Scenario Calculation with Planar Rupture
 calculation_mode = scenario
 ses_seed = 3
 
@@ -19,7 +19,8 @@ reference_depth_to_1pt0km_per_sec = 100.0
 [calculation]
 
 rupture_dict = {
-  'lon': 1.0, 'lat': -1.2, 'dep': 10, 'mag': 5, 'rake': 0, 'strike': 45}
+  'lon': 1.0, 'lat': -1.2, 'dep': 10, 'mag': 5, 'rake': 0,
+  'strike': 45, 'dip': 90}
 intensity_measure_types = PGA
 truncation_level = 3.0
 maximum_distance = 200

--- a/demos/hazard/ScenarioCase3/job.ini
+++ b/demos/hazard/ScenarioCase3/job.ini
@@ -19,7 +19,7 @@ reference_depth_to_1pt0km_per_sec = 100.0
 [calculation]
 
 rupture_dict = {
-  'lon': 1.0, 'lat': -1.2, 'dep': 10, 'mag': 5, 'rake': 0, 'strike': 90}
+  'lon': 1.0, 'lat': -1.2, 'dep': 10, 'mag': 5, 'rake': 0, 'strike': 45}
 intensity_measure_types = PGA
 truncation_level = 3.0
 maximum_distance = 200

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -38,7 +38,6 @@ from openquake.hazardlib.calc.gmf import GmfComputer
 from openquake.hazardlib.calc.conditioned_gmfs import ConditionedGmfComputer
 from openquake.hazardlib import InvalidFile
 from openquake.hazardlib.geo.utils import geolocate
-from openquake.hazardlib.shakemap.parsers import get_rupture_dict
 from openquake.hazardlib.calc.stochastic import get_rup_array, rupture_dt
 from openquake.hazardlib.source.rupture import (
     RuptureProxy, EBRupture, get_ruptures)
@@ -663,8 +662,6 @@ class EventBasedCalculator(base.HazardCalculator):
             if (oq.ground_motion_fields is False and
                     oq.hazard_curves_from_gmfs is False):
                 return {}
-        elif not oq.rupture_dict and oq.rupture_usgs_id:
-            oq.rupture_dict.update(get_rupture_dict(oq.rupture_usgs_id))
         elif not oq.rupture_dict and 'rupture_model' not in oq.inputs:
             logging.warning(
                 'There is no rupture_model, the calculator will just '

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -36,6 +36,7 @@ from openquake.baselib.hdf5 import FLOAT, INT, get_shape_descr
 from openquake.baselib.performance import performance_view, Monitor
 from openquake.baselib.python3compat import encode, decode
 from openquake.hazardlib import logictree, calc, source, geo
+from openquake.hazardlib.shakemap.parsers import get_rupture_dict
 from openquake.hazardlib.contexts import (
     KNOWN_DISTANCES, ContextMaker, Collapser
 )
@@ -1506,6 +1507,21 @@ def view_rup(token, dstore):
     df = dstore.read_df('rup', sel=dict(src_id=src_id))
     df = df.sort_values(['rup_id', 'sids']).set_index('rup_id')
     return df
+
+
+@view.add('usgs_rupture')
+def view_usgs_rupture(token, dstore):
+    """
+    Show the parameters of a rupture downloaded from the USGS site.
+    $ oq show usgs_rupture:us70006sj8
+    {'lon': 74.628, 'lat': 35.5909, 'dep': 13.8, 'mag': 5.6, 'rake': 0.0}
+    """
+    try:
+        usgs_id = token.split(':', 1)[1]
+    except IndexError:
+        print('Use the syntax oq show usgs_rupture:<id>')
+        return []
+    return get_rupture_dict(usgs_id)
 
     
 @view.add('collapsible')

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -119,15 +119,16 @@ def make_figure_avg_gmf(extractors, what):
     imt = what.split('=')[1]
     ax = fig.add_subplot(1, 1, 1)
     ax.grid(True)
-    ax.set_title('Avg GMF for %s' % imt)
     ax.set_xlabel('Lon')
     ax.set_ylabel('Lat')
     if len(extractors) == 2:  # compare two avg_gmf
+        ax.set_title('Delta GMF for %s' % imt)
         ex1, ex2 = extractors
         avg_gmf = ex1.get(what)
         avg_gmf2 = ex2.get(what)
         gmf = avg_gmf[imt] - avg_gmf2[imt]
     else:  # plot a single avg_gmf
+        ax.set_title('Avg GMF for %s' % imt)
         [ex] = extractors
         avg_gmf = ex.get(what)
         gmf = avg_gmf[imt]

--- a/openquake/commands/shakemap2gmfs.py
+++ b/openquake/commands/shakemap2gmfs.py
@@ -1,4 +1,20 @@
-
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# 
+# Copyright (C) 2024, GEM Foundation
+# 
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import logging
 import numpy
@@ -38,7 +54,7 @@ def main(id, site_model, *, num_gmfs: int = 0, random_seed: int = 42,
                  site_effects=site_effects,
                  inputs={'job_ini': '<memory>',
                          'site_model': [os.path.abspath(site_model)]})
-    with logs.init("job", param) as log:
+    with logs.init(param) as log:
         oq = log.get_oqparam()
         calc = calculators(oq, log.calc_id)
         haz_sitecol = get_site_collection(oq)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -714,11 +714,6 @@ ses_seed:
   Example: *ses_seed = 123*.
   Default: 42
 
-rupture_usgs_id:
-  Used in Aristotle calculations to download a rupture from the USGS site
-  Example: *rupture_usgs_id = usp000fjta*.
-  Default: no default
-
 shakemap_id:
   Used in ShakeMap calculations to download a ShakeMap from the USGS site
   Example: *shakemap_id = usp000fjta*.
@@ -1079,7 +1074,6 @@ class OqParam(valid.ParamSet):
     ses_per_logic_tree_path = valid.Param(
         valid.compose(valid.nonzero, valid.positiveint), 1)
     ses_seed = valid.Param(valid.positiveint, 42)
-    rupture_usgs_id = valid.Param(valid.nice_string, None)
     shakemap_id = valid.Param(valid.nice_string, None)
     shakemap_uri = valid.Param(valid.dictionary, {})
     shift_hypo = valid.Param(valid.boolean, False)

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -912,13 +912,13 @@ def _width_length(mag, rake):
         return 10.0 ** (-1.14 + 0.35 * mag), 10.0 ** (-1.88 + 0.50 * mag)
 
 
+# copied from the Input Preparation Toolkit (IPT) algorithm
 def build_planar(hypocenter, mag, rake, strike=0., dip=90., trt='*'):
     """
     Build a rupture with a PlanarSurface suitable for scenario calculations
     """
     # copying the algorithm used in PlanarSurface.from_hypocenter
     # with a fixed Magnitude-Scaling Relationship
-
     rdip = math.radians(dip)
     rup_width, rup_length = _width_length(mag, rake)
     # calculate the height of the rupture being projected
@@ -957,6 +957,7 @@ def build_planar(hypocenter, mag, rake, strike=0., dip=90., trt='*'):
         hor_dist, vertical_increment, azimuth=(strike + 180 - theta) % 360)
     bottom_right = rupture_center.point_at(
         hor_dist, vertical_increment, azimuth=(strike + theta) % 360)
+    # print(dip, strike, top_left, top_right, bottom_left, bottom_right)
     surf = PlanarSurface(strike, dip, top_left, top_right,
                          bottom_right, bottom_left)
     rup = BaseRupture(mag, rake, trt, hypocenter, surf)


### PR DESCRIPTION
Since the download will be done externally to the engine by using `get_rupture_id`. Also, some cleanup.