### PR TITLE
Removed the ExternalLink feature

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -28,7 +28,6 @@ import traceback
 from datetime import datetime
 from shapely import wkt
 import psutil
-import h5py
 import numpy
 import pandas
 
@@ -40,7 +39,6 @@ from openquake.hazardlib import (
 from openquake.hazardlib.site_amplification import Amplifier
 from openquake.hazardlib.site_amplification import AmplFunction
 from openquake.hazardlib.calc.filters import SourceFilter, getdefault
-from openquake.hazardlib.calc.disagg import to_rates
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap.maps import get_sitecol_shakemap
 from openquake.hazardlib.shakemap.gmfs import to_gmfs

--- a/openquake/calculators/tests/event_based_risk_test.py
+++ b/openquake/calculators/tests/event_based_risk_test.py
@@ -607,9 +607,6 @@ agg_id
 class ReinsuranceTestCase(CalculatorTestCase):
 
     def test_reinsurance_gmfs(self):
-        # many tests have to be kept together since the parallelization
-        # does not work with h5py.ExternalLink (used here to read gmfs.hdf5)
-
         rf = "{'structural+nonstructural': 'no_reinsurance.xml'}"
         self.run_calc(reinsurance_1.__file__, 'job.ini', reinsurance_file=rf)
         [fname] = export(('reinsurance-risk_by_event', 'csv'),


### PR DESCRIPTION
The comment inside the code explains why. To be backported to engine-3.19.