### PR TITLE
Reduced by half the data transfer in classical by using 32 bit rates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced by half the data transfer in classical by using 32 bit rates
   * Fixed a bug in `oq zip` which was missing the exposure.csv files
   * Introduced a parameter `config.memory.avg_losses_max`
   * Changed `import_gmfs_hdf5` to not use ExternalLinks

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -56,6 +56,7 @@ get_weight = operator.attrgetter('weight')
 slice_dt = numpy.dtype([('idx', U32), ('start', int), ('stop', int)])
 
 
+# NB: using 32 bit ratemaps
 def get_pmaps_gb(dstore):
     """
     :returns: memory required on the master node to keep the pmaps
@@ -66,7 +67,7 @@ def get_pmaps_gb(dstore):
     all_trt_smrs = dstore['trt_smrs'][:]
     trt_rlzs = full_lt.get_trt_rlzs(all_trt_smrs)
     gids = full_lt.get_gids(all_trt_smrs)
-    return len(trt_rlzs) * N * L * 8 / 1024**3, trt_rlzs, gids
+    return len(trt_rlzs) * N * L * 4 / 1024**3, trt_rlzs, gids
 
 
 def build_slices(idxs, offset=0):
@@ -444,7 +445,7 @@ class ClassicalCalculator(base.HazardCalculator):
         max_gs = max(num_gs)
         maxsize = get_maxsize(len(self.oqparam.imtls), max_gs)
         logging.info('Considering {:_d} contexts at once'.format(maxsize))
-        size = max_gs * N * L * 8
+        size = max_gs * N * L * 4
         avail = min(psutil.virtual_memory().available, config.memory.limit)
         if avail < size:
             raise MemoryError(
@@ -522,7 +523,7 @@ class ClassicalCalculator(base.HazardCalculator):
         oq = self.oqparam
         L = oq.imtls.size
         Gt = len(self.trt_rlzs)
-        self.pmap = ProbabilityMap(self.sitecol.sids, L, Gt).fill(0)
+        self.pmap = ProbabilityMap(self.sitecol.sids, L, Gt).fill(0, F32)
         allargs = []
         if 'sitecol' in self.datastore.parent:
             ds = self.datastore.parent

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -340,7 +340,7 @@ class ProbabilityMap(object):
         for g in range(G):
             yield self.__class__(self.sids, L, 1).new(self.array[:, :, [g]])
 
-    def fill(self, value):
+    def fill(self, value, dt=F64):
         """
         :param value: a scalar probability
 
@@ -348,7 +348,7 @@ class ProbabilityMap(object):
         and build the .sidx array
         """
         assert 0 <= value <= 1, value
-        self.array = numpy.empty(self.shape)
+        self.array = numpy.empty(self.shape, dt)
         self.array.fill(value)
         return self
 

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -395,7 +395,7 @@ class ProbabilityMap(object):
         return curves
 
     def to_rates(self, itime=1.):
-        pnes = self.array.astype(F32)
+        pnes = self.array
         # Physically, an extremely small intensity measure level can have an
         # extremely large probability of exceedence,however that probability
         # cannot be exactly 1 unless the level is exactly 0. Numerically,
@@ -404,7 +404,7 @@ class ProbabilityMap(object):
         # Here we solve the issue by replacing the unphysical probabilities
         # 1 with .9999999999999999 (the float64 closest to 1).
         pnes[pnes == 0.] = 1.11E-16
-        rates = -numpy.log(pnes)
+        rates = -numpy.log(pnes).astype(F32)
         return self.new(rates / itime)
 
     def to_dict(self, gid=0):

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -395,7 +395,7 @@ class ProbabilityMap(object):
         return curves
 
     def to_rates(self, itime=1.):
-        pnes = self.array
+        pnes = self.array.astype(F32)
         # Physically, an extremely small intensity measure level can have an
         # extremely large probability of exceedence,however that probability
         # cannot be exactly 1 unless the level is exactly 0. Numerically,


### PR DESCRIPTION
Storing rates doubles its performance indeed:
```
# before
| calc_278, maxmem=59.1 GB   | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 880.1    | 47.5      | 80      |
| ClassicalCalculator.run    | 303.3    | 1_366     | 1       |
| storing rates              | 32.0     | 124.1     | 1       |
# after
| calc_280, maxmem=56.7 GB   | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 873.3    | 47.3      | 80      |
| ClassicalCalculator.run    | 288.3    | 961.0     | 1       |
| storing rates              | 14.8     | 0.0       | 1       |
```