### PR TITLE
Removed an excessive check on the rupture_idxs

### DIFF
--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -1145,8 +1145,6 @@ class SourceConverter(RuptureConverter):
             with context(self.fname, node):
                 idxs = [x.decode('utf8').split() for x in dic['rupture_idxs']]
                 mags = rounded_unique(dic['mag'], idxs)
-                for idx in idxs:
-                    assert U32(idx).max() < TWO16, idx
             # NB: the sections will be fixed later on, in source_reader
             mfs = MultiFaultSource(sid, name, trt, idxs,
                                    dic['probs_occur'],


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/9534.
The rupture_idxs at the XML levek can be generic unique strings, since they are converted into integer indices later on.