### PR TITLE
Cors headers tools_only mode

### DIFF
--- a/openquake/server/local_settings.py.tools
+++ b/openquake/server/local_settings.py.tools
@@ -27,6 +27,7 @@ USE_TZ = True
 
 # cors-headers
 CORS_ALLOW_ALL_ORIGINS = True
+CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/openquake/server/local_settings.py.tools
+++ b/openquake/server/local_settings.py.tools
@@ -25,6 +25,13 @@ CSRF_TRUSTED_ORIGINS = ['https://*.openquake.org']
 # to install fixtures for cookie_consent
 USE_TZ = True
 
+# cors-headers
+CORS_ALLOW_ALL_ORIGINS = True
+
+MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
+]
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/openquake/server/local_settings.py.tools
+++ b/openquake/server/local_settings.py.tools
@@ -28,10 +28,6 @@ USE_TZ = True
 # cors-headers
 CORS_ALLOW_ALL_ORIGINS = True
 
-MIDDLEWARE = [
-    "corsheaders.middleware.CorsMiddleware",
-]
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -231,10 +231,16 @@ if os.environ['OQ_APPLICATION_MODE'] not in APPLICATION_MODES:
         f' one of {APPLICATION_MODES}')
 
 if APPLICATION_MODE in ('TOOLS_ONLY',):
+    # add installed_apps for cookie-consent and corsheader
     for app in ('django.contrib.auth', 'django.contrib.contenttypes',
-                'cookie_consent',):
+                'cookie_consent', 'corsheaders',):
         if app not in INSTALLED_APPS:
             INSTALLED_APPS += (app,)
+            
+    # add middleware for corsheader        
+    for app_cors in ('corsheaders.middleware.CorsMiddleware',):
+        if app_cors not in MIDDLEWARE:
+        
     if 'django.template.context_processors.request' not in CONTEXT_PROCESSORS:
         CONTEXT_PROCESSORS.append('django.template.context_processors.request')
     COOKIE_CONSENT_NAME = "cookie_consent"

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -240,7 +240,8 @@ if APPLICATION_MODE in ('TOOLS_ONLY',):
     # add middleware for corsheader        
     for app_cors in ('corsheaders.middleware.CorsMiddleware',):
         if app_cors not in MIDDLEWARE:
-        
+            MIDDLEWARE += (app_cors,)
+
     if 'django.template.context_processors.request' not in CONTEXT_PROCESSORS:
         CONTEXT_PROCESSORS.append('django.template.context_processors.request')
     COOKIE_CONSENT_NAME = "cookie_consent"


### PR DESCRIPTION
Added boolean variable, installed_apps and middleware for django-cors-headers in settings and local_settings tools template.

The tests for tools.openquake.org are green here: https://jenkins.vpn.openquake.org/job/zdevel_oq-platform-tools/18