### PR TITLE
ARISTOTLE: disable button to retrieve trts and enable it if lon or lat are changed and they are both non-empty

### DIFF
--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -527,6 +527,18 @@
             });
 
             // NOTE: if not in aristotle mode, aristotle_run_form does not exist, so this can never be triggered
+            $('#lon').on('input', function() {
+                $('#mosaic_model').empty();
+                var lon = $(this).val().trim();
+                var lat = $('#lat').val().trim();
+                $('#aristotle_get_trts_btn').prop('disabled', lon === '' || lat === '');
+            });
+            $('#lat').on('input', function() {
+                $('#mosaic_model').empty();
+                var lat = $(this).val().trim();
+                var lon = $('#lon').val().trim();
+                $('#aristotle_get_trts_btn').prop('disabled', lon === '' || lat === '');
+            });
             $("#aristotle_get_rupture_form").submit(function (event) {
                 $('#submit_aristotle_get_rupture').prop('disabled', true);
                 $('#submit_aristotle_get_rupture').text('Retrieving rupture data...');

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -87,7 +87,7 @@
                 <input class="aristotle-input" type="text" id="rake" name="rake" placeholder="{{ aristotle_form_placeholders.rake }}"/>
               </div>
               <div class="aristotle_form_row">
-                <button id="aristotle_get_trts_btn" type="button" class="btn" style="margin-bottom: 5px;">Retrieve tectonic region types</button>
+                <button id="aristotle_get_trts_btn" type="button" class="btn" style="margin-bottom: 5px;" disabled>Retrieve tectonic region types</button>
                 <span id='mosaic_model'/>
               </div>
               <div class="aristotle_form_row">


### PR DESCRIPTION
 When lon or lat are modified, also the text area displaying the mosaic model covering the given coordinates is emptied