### PR TITLE
Reduced the memory consumption in classical calculations

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -64,7 +64,8 @@ KNOWN_DISTANCES = frozenset('''rrup rx_ry0 rx ry0 rjb rhypo repi rcdpp azimuth
 azimuthcp rvolc clon_clat clon clat'''.split())
 NUM_BINS = 256
 DIST_BINS = sqrscale(80, 1000, NUM_BINS)
-MULTIPLIER = 150  # len(mean_stds arrays) / len(poes arrays)
+# the MULTIPLIER is fundamental for the memory consumption in the contexts
+MULTIPLIER = 50  # len(mean_stds arrays) / len(poes arrays)
 MEA = 0
 STD = 1
 bymag = operator.attrgetter('mag')


### PR DESCRIPTION
EUR was running out of memory with 2 IMTs for Anirudh, using more than 4 GB per core.