### PR TITLE
Fixed error message for minimum_magnitude

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1892,17 +1892,14 @@ class OqParam(valid.ParamSet):
         """
         if 'gsim_logic_tree' not in self.inputs:
             return True  # disable the check
-        gsim_lt = self.inputs['gsim_logic_tree']
+        gsim_lt = self.inputs['gsim_logic_tree']  # set self._trts
         trts = set(self.maximum_distance)
-        unknown = ', '.join(trts - self._trts - {'default'})
+        unknown = ', '.join(trts - self._trts - set(self.minimum_magnitude)
+                            - {'default'})
         if unknown:
             self.error = ('setting the maximum_distance for %s which is '
                           'not in %s' % (unknown, gsim_lt))
             return False
-        for trt, val in self.maximum_distance.items():
-            if trt not in self._trts and trt != 'default':
-                self.error = 'tectonic region %r not in %s' % (trt, gsim_lt)
-                return False
         if 'default' not in trts and trts < self._trts:
             missing = ', '.join(self._trts - trts)
             self.error = 'missing distance for %s and no default' % missing

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1239,6 +1239,11 @@ class OqParam(valid.ParamSet):
 
         # cut maximum_distance with minimum_magnitude
         if hasattr(self, 'maximum_distance'):
+            extra = set(self.minimum_magnitude) - set(self.maximum_distance)
+            if extra:
+                raise InvalidFile('%s: minimum_magnitude contains %s which is '
+                                  'not in the maximum_distance' %
+                                  (self.inputs['job_ini'], extra))
             # can be missing in post-calculations
             self.maximum_distance.cut(self.minimum_magnitude)
 

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1239,11 +1239,6 @@ class OqParam(valid.ParamSet):
 
         # cut maximum_distance with minimum_magnitude
         if hasattr(self, 'maximum_distance'):
-            extra = set(self.minimum_magnitude) - set(self.maximum_distance)
-            if extra:
-                raise InvalidFile('%s: minimum_magnitude contains %s which is '
-                                  'not in the maximum_distance' %
-                                  (self.inputs['job_ini'], extra))
             # can be missing in post-calculations
             self.maximum_distance.cut(self.minimum_magnitude)
 

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -227,15 +227,19 @@ class IntegrationDistance(dict):
         >>> maxdist.cut({'default': 5.})
         >>> maxdist
         {'default': [(5.0, 87.5), (8.0, 200.0)]}
+
+        >>> maxdist = IntegrationDistance.new('200')
+        >>> maxdist.cut({"Active Shallow Crust": 5.2, "default": 4.})
+        >>> maxdist
+        {'default': [(4.0, 200.0), (10.2, 200)], 'Active Shallow Crust': [(5.2, 200.0), (10.2, 200)]}
         """
-        all_trts = set(self) | set(min_mag_by_trt)
         if 'default' not in self:
             maxval = max(self.values(),
                          key=lambda val: max(dist for mag, dist in val))
             self['default'] = maxval
         if 'default' not in min_mag_by_trt:
             min_mag_by_trt['default'] = min(min_mag_by_trt.values())
-        for trt in all_trts:
+        for trt in set(self) | set(min_mag_by_trt):
             min_mag = getdefault(min_mag_by_trt, trt)
             if not min_mag:
                 continue


### PR DESCRIPTION
One of the demos of Alejandro was giving a misleading error message
```python
Invalid maximum_distance={'Subduction Interface': [(6.0, 400.0), (10.2, 400.0)],
'Subduction IntraSlab': [(6.0, 400.0), (10.2, 400.0)],
'Active Shallow Crust': [(5.0, 350.0), (10.2, 350.0)],
'default': [(5.0, 350.0), (10.2, 350.0)],
'Deep Seismicity': [(6.0, 350.0), (10.2, 350.0)]}:
setting the maximum_distance for Deep Seismicity which is not in
/home/michele/Downloads/eb_risk_demo/inputs/hazard/gmpe_logic_tree.xml
```
Now it runs, like it did in v3.16.