### PR TITLE
[WIP] Aki and Richards test fix

### DIFF
--- a/openquake/hazardlib/geo/surface/complex_fault.py
+++ b/openquake/hazardlib/geo/surface/complex_fault.py
@@ -141,13 +141,14 @@ class ComplexFaultSurface(BaseSurface):
     @classmethod
     def check_aki_richards_convention(cls, edges):
         """
-        Verify that surface (as defined by corner points) conforms with Aki and
+        Verify that surface conforms with Aki and
         Richard convention (i.e. surface dips right of surface strike)
+        Test with 2 adjacent edges to allow for very large, curved surfaces
 
         This method doesn't have to be called by hands before creating the
         surface object, because it is called from :meth:`from_fault_data`.
         """
-        # 1) extract 4 points of surface mesh 
+        # 1) extract 4 points of surface mesh from adjacent edges 
         # 2) compute cross products between left and right edges and top edge
         # (these define vectors normal to the surface)
         # 3) compute dot products between cross product results and
@@ -155,14 +156,14 @@ class ComplexFaultSurface(BaseSurface):
         # both angles are less then 90 degrees then the surface is correctly
         # defined)
         ul = edges[0].points[0]
-        u2 = edges[0].points[1]
+        u1 = edges[0].points[1]
         bl = edges[-1].points[0]
-        b2 = edges[-1].points[1]
+        b1 = edges[-1].points[1]
         
         ul, ur, bl, br = spherical_to_cartesian(
-            [ul.longitude, u2.longitude, bl.longitude, b2.longitude],
-            [ul.latitude, u2.latitude, bl.latitude, b2.latitude],
-            [ul.depth, b2.depth, bl.depth, b2.depth],
+            [ul.longitude, u1.longitude, bl.longitude, b1.longitude],
+            [ul.latitude, u1.latitude, bl.latitude, b1.latitude],
+            [ul.depth, b1.depth, bl.depth, b1.depth],
         )
 
         top_edge = ur - ul
@@ -261,7 +262,6 @@ class ComplexFaultSurface(BaseSurface):
             raise ValueError("mesh spacing must be positive")
 
         cls.check_surface_validity(edges)
-        #cls._check_edges(edges)
         cls.check_aki_richards_convention(edges)
 
     @classmethod

--- a/openquake/hazardlib/geo/surface/complex_fault.py
+++ b/openquake/hazardlib/geo/surface/complex_fault.py
@@ -23,7 +23,7 @@ Module :mod:`openquake.hazardlib.geo.surface.complex_fault` defines
 import numpy
 import shapely
 
-from openquake.baselib.python3compat import round
+#from openquake.baselib.python3compat import round
 from openquake.baselib.node import Node
 from openquake.hazardlib.geo.line import Line
 from openquake.hazardlib.geo.point import Point
@@ -178,10 +178,10 @@ class ComplexFaultSurface(BaseSurface):
 
         # rounding to 1st digit, to avoid ValueError raised for floating point
         # imprecision
-        angle_ul = round(
+        angle_ul = numpy.round(
             numpy.degrees(numpy.arccos(numpy.dot(ul, left_cross_top))), 1
         )
-        angle_ur = round(
+        angle_ur = numpy.round(
             numpy.degrees(numpy.arccos(numpy.dot(ur, right_cross_top))), 1
         )
 
@@ -284,7 +284,7 @@ class ComplexFaultSurface(BaseSurface):
         cls.check_fault_data(edges, mesh_spacing)
         surface_nodes = [complex_fault_node(edges)]
         mean_length = numpy.mean([edge.get_length() for edge in edges])
-        num_hor_points = int(round(mean_length / mesh_spacing)) + 1
+        num_hor_points = int(numpy.round(mean_length / mesh_spacing)) + 1
         if num_hor_points <= 1:
             raise ValueError(
                 'mesh spacing %.1f km is too big for mean length %.1f km' %
@@ -295,7 +295,7 @@ class ComplexFaultSurface(BaseSurface):
 
         vert_edges = [Line(v_edge) for v_edge in zip(*edges)]
         mean_width = numpy.mean([v_edge.get_length() for v_edge in vert_edges])
-        num_vert_points = int(round(mean_width / mesh_spacing)) + 1
+        num_vert_points = int(numpy.round(mean_width / mesh_spacing)) + 1
         if num_vert_points <= 1:
             raise ValueError(
                 'mesh spacing %.1f km is too big for mean width %.1f km' %

--- a/openquake/hazardlib/geo/surface/complex_fault.py
+++ b/openquake/hazardlib/geo/surface/complex_fault.py
@@ -31,8 +31,6 @@ from openquake.hazardlib.geo.surface.base import BaseSurface
 from openquake.hazardlib.geo.surface.planar import PlanarSurface
 from openquake.hazardlib.geo.mesh import Mesh, RectangularMesh
 from openquake.hazardlib.geo.utils import spherical_to_cartesian
-from openquake.hazardlib.geo.geodetic import azimuth
-from openquake.hazardlib.geo.utils import plane_fit
 
 from pyproj import Proj, CRS
 
@@ -161,8 +159,6 @@ class ComplexFaultSurface(BaseSurface):
         bl = edges[-1].points[0]
         b2 = edges[-1].points[1]
         
-        print("points to test: ", ul, u2, bl, b2)
-        
         ul, ur, bl, br = spherical_to_cartesian(
             [ul.longitude, u2.longitude, bl.longitude, b2.longitude],
             [ul.latitude, u2.latitude, bl.latitude, b2.latitude],
@@ -192,67 +188,10 @@ class ComplexFaultSurface(BaseSurface):
         )
 
         if (angle_ul > 90) or (angle_ur > 90):
-            print("angles: ", angle_ul, angle_ur)
             raise ValueError(
                 "Surface does not conform with Aki & Richards convention"
             )
             
-    @classmethod        
-    def _check_edges(cls, edges):
-        """
-        This checks that all the edges follow the right hand rule
-        :param list edges:
-            The list of edges to be analysed.
-        :return:
-            An instance of :class:`numpy.ndarray` of cardinality equal to the
-            number of edges. Where integers are positive, the edges need to be
-            flipped.
-        """
-
-        # Check the input
-        if len(edges) < 1:
-            return None
-
-        # Create a matrix of points
-        pnts = []
-        for edge in edges:
-            pnts += [[pnt.longitude, pnt.latitude, pnt.depth]
-                     for pnt in edge.points]
-        pnts = numpy.array(pnts)
-
-        # Project the points using Lambert Conic Conformal
-        fmt = "+proj=lcc +lon_0={:f} +lat_1={:f} +lat_2={:f}"
-        mla = numpy.mean(pnts[:, 1])
-        srs = CRS.from_proj4(fmt.format(numpy.mean(pnts[:, 0]), mla - 10, mla + 10))
-        p = Proj(srs)
-
-        # From m to km
-        x, y = p(pnts[:, 0], pnts[:, 1])
-        x = x / 1e3  # m -> km
-        y = y / 1e3  # m -> km
-
-        # Fit the plane
-        tmp = numpy.vstack((x.flatten(), y.flatten(), pnts[:, 2].flatten())).T
-        _, ppar = plane_fit(tmp)
-
-        # Analyse the edges
-        chks = []
-        for edge in edges:
-
-            epnts = numpy.array([[pnt.longitude, pnt.latitude, pnt.depth] for pnt in
-                              edge.points[0:2]])
-            ex, ey = p(epnts[:, 0], epnts[:, 1])
-            ex = ex / 1e3
-            ey = ey / 1e3
-
-            # Check the edge direction Vs the perpendicular to the plane
-            idx = [0, -1]
-            edgv = numpy.array([numpy.diff(ex[idx])[0], numpy.diff(ey[idx])[0]])
-            chks.append(numpy.sign(numpy.cross(ppar[:2], edgv)))
-        
-            if numpy.any(numpy.greater(chks, 0)):
-                print("some edges do not conform to Aki and Richards convention", print(numpy.array(chks)))
-              
 
     @classmethod
     def check_surface_validity(cls, edges):

--- a/openquake/hazardlib/geo/surface/complex_fault.py
+++ b/openquake/hazardlib/geo/surface/complex_fault.py
@@ -32,8 +32,6 @@ from openquake.hazardlib.geo.surface.planar import PlanarSurface
 from openquake.hazardlib.geo.mesh import Mesh, RectangularMesh
 from openquake.hazardlib.geo.utils import spherical_to_cartesian
 
-from pyproj import Proj, CRS
-
 def edge_node(name, points):
     """
     :param name: 'faultTopEdge', 'intermediateEdge' or 'faultBottomEdge'
@@ -136,7 +134,6 @@ class ComplexFaultSurface(BaseSurface):
         if self.strike is None:
             self.get_dip()  # this should cache strike value
         return self.strike
-
             
     @classmethod
     def check_aki_richards_convention(cls, edges):
@@ -193,7 +190,6 @@ class ComplexFaultSurface(BaseSurface):
                 "Surface does not conform with Aki & Richards convention"
             )
             
-
     @classmethod
     def check_surface_validity(cls, edges):
         """


### PR DESCRIPTION
The Aki and Richard's convention test currently compares the upper and lower left and right-hand edges of a complex fault.  Though this works well in most cases, there are some instances in which a fault source will fail the check even when it is correctly specified, as shown in the example figure.
![image](https://github.com/gem/oq-engine/assets/37081055/1564b0fa-5d8c-4aa7-8b5a-82c0732ea425)

In the example, the fault surface is created in the mbtk sub function, which also checks that the edges are correctly specified while constructing the fault surface. If we have a lot of curvature in the complex fault surface, taking the corners of the surface for calculating the cross-products gives a sort of averaged normal to the surface which is greater than 90 and therefore fails the check. 
As an alternative, we can check that two adjacent edges follow the Aki and Richard's convention instead of checking the entire fault surface. If we want to be really certain, we could check the first two and last two edges, but I think it's unlikely that a fault surface will have flipped half way through.

Related to https://github.com/GEMScienceTools/oq-mbtk/pull/395