### PR TITLE
Fixed the check for development installations

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -522,8 +522,9 @@ def check_dependencies():
     Print a warning if we forgot to update the dependencies.
     Works only for development installations.
     """
-    if 'git' not in engine_version():
-        return  # do nothing
+    import openquake
+    if 'site-packages' in openquake.__path__[0]:
+        return  # do nothing for non-devel installations
     pyver = '%d%d' % (sys.version_info[0], sys.version_info[1])
     system = sys.platform
     if system == 'linux':


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/9018. The check `'git' in engine_version()` does not work for user and server installations, because the version is hard-coded in the source code inside `baselib/__init__.py` with a line
```python
# the version is managed by packager.sh with a sed
__version__ = "3.20.0-git9024804731a750123773da831b0e3ab3c4995fff"
```
This is breaking the QGIS action which installs in user mode.