### PR TITLE
Fix in create_gmf_data when importing a CSV

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -719,6 +719,7 @@ class HazardCalculator(BaseCalculator):
         self.sitecol, self.assetcol, discarded, exposure = \
             readinput.get_sitecol_assetcol(
                 oq, haz_sitecol, self.crmodel.loss_types, self.datastore)
+
         # this is overriding the sitecol in test_case_miriam
         self.datastore['sitecol'] = self.sitecol
         if len(discarded):
@@ -1235,7 +1236,7 @@ def import_gmfs_csv(dstore, oqparam, sitecol):
     data = numpy.concatenate(gmvlst)
     data.sort(order='eid')
     create_gmf_data(dstore, oqparam.get_primary_imtls(),
-                    oqparam.sec_imts, data=data)
+                    oqparam.sec_imts, data=data, N=len(sitecol.complete))
     dstore['weights'] = numpy.ones(1)
     return eids
 
@@ -1308,14 +1309,17 @@ def import_gmfs_hdf5(dstore, oqparam):
     return events['id']
 
 
-def create_gmf_data(dstore, prim_imts, sec_imts=(), data=None):
+def create_gmf_data(dstore, prim_imts, sec_imts=(), data=None, N=None):
     """
     Create and possibly populate the datasets in the gmf_data group
     """
     oq = dstore['oqparam']
     R = dstore['full_lt'].get_num_paths()
     M = len(prim_imts)
-    N = 0 if data is None else data['sid'].max() + 1
+    if data is None:
+        N = 0
+    else:
+        assert N is not None  # pass len(complete) here
     items = [('sid', U32 if N == 0 else data['sid']),
              ('eid', U32 if N == 0 else data['eid'])]
     for m in range(M):
@@ -1385,7 +1389,8 @@ def store_shakemap(calc, sitecol, shakemap, gmf_dict):
                for s in numpy.arange(N, dtype=U32)]
         oq.hazard_imtls = {str(imt): [0] for imt in imts}
         data = numpy.array(lst, oq.gmf_data_dt())
-        create_gmf_data(calc.datastore, imts, data=data)
+        create_gmf_data(
+            calc.datastore, imts, data=data, N=len(sitecol.complete))
 
 
 def read_shakemap(calc, haz_sitecol, assetcol):

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -961,9 +961,9 @@ def extract_avg_gmf(dstore, what):
     if 'station_data' in dstore:
         # discard the stations from the avg_gmf plot
         stations = dstore['station_data/site_id'][:]
-        ok = ~numpy.isin(sitecol.sids, stations)
+        ok = (avg_gmf > 0) & ~numpy.isin(sitecol.sids, stations)
     else:
-        ok = slice(None)
+        ok = avg_gmf > 0
     yield imt, avg_gmf[sitecol.sids[ok]]
     yield 'sids', sitecol.sids[ok]
     yield 'lons', sitecol.lons[ok]

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -219,7 +219,7 @@ class ScenarioTestCase(CalculatorTestCase):
 
         # check that stations are discarded when extracting avg_gmf
         aw = extract(self.calc.datastore, 'avg_gmf?imt=PGA')
-        self.assertEqual(len(aw.PGA), 581)
+        self.assertEqual(len(aw.PGA), 571)
 
     def test_case_21_different_columns_stations(self):
         # conditioned gmfs

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -175,8 +175,6 @@ def plot_avg_gmf(calc_id, imt):
     coll = ax.scatter(avg_gmf['lons'], avg_gmf['lats'], c=gmf, cmap='jet',
                       s=markersize)
     plt.colorbar(coll)
-    sitecol = ex.get('sitecol').array
-    ax.plot(sitecol['lon'], sitecol['lat'], '+')
 
     ax = add_borders(ax)
 

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -175,6 +175,8 @@ def plot_avg_gmf(calc_id, imt):
     coll = ax.scatter(avg_gmf['lons'], avg_gmf['lats'], c=gmf, cmap='jet',
                       s=markersize)
     plt.colorbar(coll)
+    sitecol = ex.get('sitecol').array
+    ax.plot(sitecol['lon'], sitecol['lat'], '+')
 
     ax = add_borders(ax)
 


### PR DESCRIPTION
We must pass `N=len(sitecol.complete)` otherwise we may miss sites. Also reverted the extractor to extract only nonzero values for avg_gmf.