### PR TITLE
Fixed a bug in `oq extract "ruptures?rup_id=XXX`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a bug in `oq extract "ruptures?rup_id=XXX`
   * Raising an early error if the user forgets to specify a site_model_file
     when needed (i.e. for parameters region and xvf)
 

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -322,12 +322,10 @@ def get_ebrupture(dstore, rup_id):  # used in show rupture
     """
     rups = dstore['ruptures'][:]  # read everything in memory
     rupgeoms = dstore['rupgeoms']  # do not read everything in memory
-    idx = numpy.searchsorted(rups['id'], rup_id)
-    if idx == len(rups):
+    idxs, = numpy.where(rups['id'] == rup_id)
+    if len(idxs) == 0:
         raise ValueError(f"Missing {rup_id=}")
-    rec = rups[idx]
-    if rec['id'] != rup_id:
-        raise ValueError(f"Missing {rup_id=}")
+    [rec] = rups[idxs]
     trts = dstore.getitem('full_lt').attrs['trts']
     trt = trts[rec['trt_smr'] // TWO24]
     geom = rupgeoms[rec['geom_id']]


### PR DESCRIPTION
Causing errors like this:
```python
  File "/home/michele/oq-engine/openquake/calculators/getters.py", line 327, in get_ebrupture
    raise ValueError(f"Missing {rup_id=}")
ValueError: Missing rup_id=285452116498852
```
The feature was implemented in engine-3.17 and has been wrong from the beginning.