### PR TITLE
Added a check to forbid `individual_rlzs=true` and `collect_rlzs=true`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a check to forbid `individual_rlzs=true` and `collect_rlzs=true`
   * Fixed a bug in `oq extract "ruptures?rup_id=XXX`
   * Raising an early error if the user forgets to specify a site_model_file
     when needed (i.e. for parameters region and xvf)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -2034,6 +2034,11 @@ class OqParam(valid.ParamSet):
             self.collect_rlzs = self.number_of_logic_tree_samples > 1
         if self.job_type == 'hazard':
             return True
+
+        # there are more checks for risk calculations
+        if self.collect_rlzs and self.individual_rlzs:
+            raise InvalidFile("%s: you cannot have individual_rlzs=true with "
+                              "collect_rlzs=true" % self.inputs['job_ini'])
         if self.calculation_mode == 'event_based_damage':
             ini = self.inputs['job_ini']
             if not self.investigation_time:

--- a/openquake/qa_tests_data/logictree/case_17/job.ini
+++ b/openquake/qa_tests_data/logictree/case_17/job.ini
@@ -41,7 +41,6 @@ maximum_distance = 200.0
 mean = false
 
 [output]
-
 individual_rlzs = true
 export_dir = /tmp
 


### PR DESCRIPTION
Only for risk calculations. For instance @CatalinaYepes's job for Quito can work by setting
```
individual_rlzs=true
collect_rlzs=false
```
or
```
individual_rlzs=false
collect_rlzs=true
```
Otherwise it will raise an error
```python
openquake.baselib.InvalidFile: /home/michele/Downloads/cata/job.ini: you cannot have individual_rlzs=true with collect_rlzs=true
```