### PR TITLE
Improved `oq info mfd` and added `oq info msr`

### DIFF
--- a/doc/user-guide/index.rst
+++ b/doc/user-guide/index.rst
@@ -9,7 +9,7 @@ several sections, each of which is intended to provide a detailed description
 of a specific aspect of the engine. 
 
 The first section, :ref:`workflows`, describes the various calculation workflows 
-that are curently supported by the OpenQuake engine. 
+that are currently supported by the OpenQuake engine. 
 
 The second section, :ref:`input-models`, describes the input models that are required
 to run various OpenQuake engine calculations and their file formats. 

--- a/doc/user-guide/workflows/index.rst
+++ b/doc/user-guide/workflows/index.rst
@@ -40,11 +40,6 @@ each calculator can be extended independently of the others so that additional c
 be easily introduced, without affecting the overall calculation workflow. Each workflow is described in more detail in 
 the following sections.
 
-List of OpenQuake engine commands
----------------------------------
-
-The list of available commands for OpenQuake engine can be found `here <https://docs.openquake.org/oq-engine/master/reference/openquake.commands.html>`_
-
 .. toctree::
    :maxdepth: 1
    :caption: Seismic Hazard:

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -35,6 +35,7 @@ from openquake.baselib.general import groupby, gen_subclasses, humansize
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import gsim, nrml, imt, logictree
 from openquake.hazardlib.mfd.base import BaseMFD
+from openquake.hazardlib.scalerel.base import BaseMSR
 from openquake.hazardlib.source.base import BaseSeismicSource
 from openquake.hazardlib.valid import pmf_map
 from openquake.commonlib.oqvalidation import OqParam
@@ -105,7 +106,7 @@ def do_build_reports(directory):
 
 choices = ['calculators', 'cfg', 'consequences',
            'gsims', 'imts', 'views', 'exports', 'disagg',
-           'extracts', 'parameters', 'sources', 'mfds', 'venv']
+           'extracts', 'parameters', 'sources', 'mfds', 'msrs', 'venv']
 
 
 def is_upper(func):
@@ -177,6 +178,9 @@ def main(what, report=False):
             print(docs[param])
     elif what == 'mfds':
         for cls in gen_subclasses(BaseMFD):
+            print(cls.__name__)
+    elif what == 'msrs':
+        for cls in gen_subclasses(BaseMSR):
             print(cls.__name__)
     elif what == 'venv':
         print(sys.prefix)

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -58,6 +58,26 @@ def print_features(fiona_file):
     print(text_table(rows, header, ext='org'))
 
 
+def print_subclass(what, cls):
+    """
+    Print the docstring of the given subclass, or print all available
+    subclasses.
+    """
+    split = what.split(':')
+    if len(split) == 1:
+        # no subclass specified, print all
+        for cls in gen_subclasses(cls):
+            print(cls.__name__)
+    else:
+        # print the specified subclass, if known
+        for cls in gen_subclasses(cls):
+            if cls.__name__ == split[1]:
+                print(cls.__doc__)
+                break
+        else:
+            print('Unknown class %s' % split[1])
+
+
 def source_model_info(sm_nodes):
     """
     Extract information about source models. Returns a table
@@ -106,7 +126,7 @@ def do_build_reports(directory):
 
 choices = ['calculators', 'cfg', 'consequences',
            'gsims', 'imts', 'views', 'exports', 'disagg',
-           'extracts', 'parameters', 'sources', 'mfds', 'msrs', 'venv']
+           'extracts', 'parameters', 'sources', 'mfd', 'msr', 'venv']
 
 
 def is_upper(func):
@@ -176,12 +196,10 @@ def main(what, report=False):
         for param in params:
             print(param)
             print(docs[param])
-    elif what == 'mfds':
-        for cls in gen_subclasses(BaseMFD):
-            print(cls.__name__)
-    elif what == 'msrs':
-        for cls in gen_subclasses(BaseMSR):
-            print(cls.__name__)
+    elif what.startswith('mfd'):
+        print_subclass(what, BaseMFD)
+    elif what.startswith('msr'):
+        print_subclass(what, BaseMSR)
     elif what == 'venv':
         print(sys.prefix)
     elif what == 'cfg':


### PR DESCRIPTION
Here are a few examples of use:
```
$ oq info mfd
ArbitraryMFD
EvenlyDiscretizedMFD
MultiMFD
TaperedGRMFD
TruncatedGRMFD
YoungsCoppersmith1985MFD
$ oq info mfd:ArbitraryMFD

    An arbitrary MFD is defined as a list of tuples of magnitude values and
    their corresponding rates

    :param magnitudes:
        List of magnitudes
    :param occurrence_rates:
        The list of non-negative float values representing the actual
        annual occurrence rates. The resulting histogram has as many bins
        as this list length.
$ oq info msr
BaseMSRSigma
AllenHayesInterfaceBilinear
AllenHayesInterfaceLinear
AllenHayesIntraslab
GSCCascadia
GSCEISB
GSCEISI
GSCEISO
GSCOffshoreThrustsHGT
GSCOffshoreThrustsWIN
GermanyMSR
Leonard2010_SCR
Leonard2010_SCR_M0
Leonard2010_SCR_MX
Leonard2014_Interplate
Leonard2014_SCR
PeerMSR
StrasserInterface
StrasserIntraslab
ThingbaijamInterface
ThingbaijamStrikeSlip
WC1994
WC1994_QCSS
CEUS2011
CScalingMSR
PointMSR
$ oq info msr:CScalingMSR

    A parametric mag-area scaling: log10(A) = Mw -C
    with coefficient C ranging from 3.70 to 4.40
 ```