### PR TITLE
Improved `oq info imt` and `oq info gsim`

### DIFF
--- a/doc/user-guide/useful-oq-commands.rst
+++ b/doc/user-guide/useful-oq-commands.rst
@@ -55,7 +55,7 @@ Probably the most important command. *oq info* has several features.
         $ oq info cfg         # list openquake.cfg locations in order
         # oq info consequences# list available consequences
 	$ oq info gsims       # list available GSIMs
-        $ oq info imts        # list known IMTs
+        $ oq info imt         # list known IMTs
 	$ oq info views       # list available views
 	$ oq info exports     # list available exports
         $ oq info disagg      # list available disaggregation kinds

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -34,6 +34,7 @@ from openquake.baselib import config
 from openquake.baselib.general import groupby, gen_subclasses, humansize
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import gsim, nrml, imt, logictree, site
+from openquake.hazardlib.gsim.base import registry
 from openquake.hazardlib.mfd.base import BaseMFD
 from openquake.hazardlib.scalerel.base import BaseMSR
 from openquake.hazardlib.source.base import BaseSeismicSource
@@ -78,7 +79,7 @@ def print_subclass(what, cls):
             print('Unknown class %s' % split[1])
 
 
-def print_imts(what):
+def print_imt(what):
     """
     Print the docstring of the given IMT, or print all available
     IMTs.
@@ -98,6 +99,26 @@ def print_imts(what):
                     break
         else:
             print('Unknown IMT %s' % split[1])
+
+
+def print_gsim(what):
+    """
+    Print the docstring of the given GSIM, or print all available
+    GSIMs.
+    """
+    split = what.split(':')
+    if len(split) == 1:
+        # no GSIM specified, print all
+        for gs in sorted(registry):
+            print(gs)
+    else:
+        # print the docstring of the specified GSIM, if known
+        for gs, cls in registry.items():
+            if cls.__name__ == split[1]:
+                print(cls.__doc__)
+                break
+        else:
+            print('Unknown GSIM %s' % split[1])
 
 
 def source_model_info(sm_nodes):
@@ -147,7 +168,7 @@ def do_build_reports(directory):
 
 
 choices = ['calculators', 'cfg', 'consequences',
-           'gsims', 'imt', 'views', 'exports', 'disagg',
+           'gsim', 'imt', 'views', 'exports', 'disagg',
            'extracts', 'parameters', 'sources', 'mfd', 'msr', 'venv']
 
 
@@ -175,14 +196,10 @@ def main(what, report=False):
         print(fields.replace(',', '\t'))
         for row in rows:
             print('\t'.join(map(str, row)))
-    elif what == 'gsims':
-        for gs in gsim.get_available_gsims():
-            print(gs)
-    elif what == 'portable_gsims':
-        for gs in gsim.get_portable_gsims():
-            print(gs)
+    elif what.startswith('gsim'):
+        print_gsim(what)
     elif what.startswith('imt'):
-        print_imts(what)
+        print_imt(what)
     elif what == 'views':
         for name in sorted(view):
             print(name)

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -147,7 +147,7 @@ def do_build_reports(directory):
 
 
 choices = ['calculators', 'cfg', 'consequences',
-           'gsims', 'imts', 'views', 'exports', 'disagg',
+           'gsims', 'imt', 'views', 'exports', 'disagg',
            'extracts', 'parameters', 'sources', 'mfd', 'msr', 'venv']
 
 
@@ -181,7 +181,7 @@ def main(what, report=False):
     elif what == 'portable_gsims':
         for gs in gsim.get_portable_gsims():
             print(gs)
-    elif what.startswith('imts'):
+    elif what.startswith('imt'):
         print_imts(what)
     elif what == 'views':
         for name in sorted(view):

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -78,6 +78,28 @@ def print_subclass(what, cls):
             print('Unknown class %s' % split[1])
 
 
+def print_imts(what):
+    """
+    Print the docstring of the given IMT, or print all available
+    IMTs.
+    """
+    split = what.split(':')
+    if len(split) == 1:
+        # no IMT specified, print all
+        for im in vars(imt).values():
+            if inspect.isfunction(im) and is_upper(im):
+                print(im.__name__)
+    else:
+        # print the docstring of the specified IMT, if known
+        for im in vars(imt).values():
+            if inspect.isfunction(im) and is_upper(im):
+                if im.__name__ == split[1]:
+                    print(im.__doc__)
+                    break
+        else:
+            print('Unknown IMT %s' % split[1])
+
+
 def source_model_info(sm_nodes):
     """
     Extract information about source models. Returns a table
@@ -159,10 +181,8 @@ def main(what, report=False):
     elif what == 'portable_gsims':
         for gs in gsim.get_portable_gsims():
             print(gs)
-    elif what == 'imts':
-        for im in vars(imt).values():
-            if inspect.isfunction(im) and is_upper(im):
-                print(im.__name__)
+    elif what.startswith('imts'):
+        print_imts(what)
     elif what == 'views':
         for name in sorted(view):
             print(name)


### PR DESCRIPTION
Similarly to what we did for `mfd` and `msr`. Examples:
```
$ oq info imt:PGA

    Peak ground acceleration during an earthquake measured in units
    of ``g``, times of gravitational acceleration.
    
$ oq info gsim:BooreAtkinson2008

    Implements GMPE developed by David M. Boore and Gail M. Atkinson
    and published as "Ground-Motion Prediction Equations for the
    Average Horizontal Component of PGA, PGV, and 5%-Damped PSA
    at Spectral Periods between 0.01 and 10.0 s" (2008, Earthquake Spectra,
    Volume 24, No. 1, pages 99-138).
```