### PR TITLE
Saving disk space in conditioned GMFs calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Saving disk space in conditioned GMFs scenarios
   * Fixed the passing of parameters to the underlying GMPE in NRCan15SiteTerm
   * Added another check for missing gsim in scenario calculations
   * Using custom `hcurves` and `uhs` exporters in AELO mode

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -348,6 +348,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         oq.concurrent_tasks or 1)
     logging.info('totw = {:_d}'.format(round(totw)))
     if station_data is not None:
+        # assume scenario with a single true rupture
         rlzs_by_gsim = full_lt.get_rlzs_by_gsim(0)
         cmaker = ContextMaker(trt, rlzs_by_gsim, oq)
         cmaker.scenario = True

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -232,15 +232,13 @@ class ConditionedGmfComputer(GmfComputer):
         self.init_eid_rlz_sig_eps()
         data = AccumDict(accum=[])
         rng = numpy.random.default_rng(self.seed)
+        mea, sig, tau, phi = self.cmaker.mean_covs
         for g, (gsim, rlzs) in enumerate(self.cmaker.gsims.items()):
-            with rmon:
-                mea = dstore['conditioned/gsim_%d/mea' % g][:]
-                tau = dstore['conditioned/gsim_%d/tau' % g][:]
-                phi = dstore['conditioned/gsim_%d/phi' % g][:]
             with cmon:
-                array = self.compute(gsim,rlzs, mea, tau, phi, rng)
+                array = self.compute(gsim, rlzs, mea[g], tau[g], phi[g], rng)
             with umon:
-                self.update(data, array, rlzs, [mea, tau+phi, tau, phi])
+                self.update(data, array, rlzs, [mea[g], tau[g] + phi[g],
+                                                tau[g], phi[g]])
         with umon:
             return self.strip_zeros(data)
 

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -232,7 +232,7 @@ class ConditionedGmfComputer(GmfComputer):
         self.init_eid_rlz_sig_eps()
         data = AccumDict(accum=[])
         rng = numpy.random.default_rng(self.seed)
-        mea, sig, tau, phi = self.cmaker.mean_covs
+        mea, tau, phi = self.cmaker.mea_tau_phi
         for g, (gsim, rlzs) in enumerate(self.cmaker.gsims.items()):
             with cmon:
                 array = self.compute(gsim, rlzs, mea[g], tau[g], phi[g], rng)


### PR DESCRIPTION
Closing https://github.com/gem/oq-engine/issues/9387. There is further margin for improvement by using shared memory, but it is tricky and left to the future if needed. Here are the figures for the attached calculation [job.zip](https://github.com/gem/oq-engine/files/15329766/job.zip), which has only 686 sites:
```
# before using more disk space
| calc_63655, maxmem=9.7 GB    | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total gen_event_based        | 4_021    | 24.2      | 34     |
| computing gmfs               | 3_866    | 0.0       | 500    |
| EventBasedRiskCalculator.run | 305.7    | 492.4     | 1      |
| EventBasedCalculator.run     | 298.2    | 439.2     | 1      |
| total ebr_from_gmfs          | 93.7     | 172.5     | 33     |
| reading mea,tau,phi          | 84.3     | 0.0       | 500    |
| reading crmodel              | 45.7     | 171.5     | 33     |
| computing risk               | 33.4     | 0.0       | 2_177  |
| updating gmfs                | 32.3     | 0.0       | 1000   |
| instantiating GmfComputer    | 22.4     | 0.0       | 500    |
| saving avg_gmf               | 18.5     | 197.7     | 1      |

$ oq show job_info 63655
| task            | sent                                                  | received | mean_recv |
|-----------------+-------------------------------------------------------+----------+-----------|
| gen_event_based | stations=3.94 MB cmaker=714.56 KB allproxies=81.07 KB | 10.24 MB | 308.34 KB |
| ebr_from_gmfs   | oqparam=129.33 KB sbe=26.85 KB dstore=5.38 KB         | 20.56 MB | 638.08 KB |

# after using more memory
| calc_63576, maxmem=11.9 GB   | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| total event_based            | 3_180    | 23.7      | 34     |
| computing gmfs               | 3_126    | 0.0       | 500    |
| EventBasedRiskCalculator.run | 283.6    | 494.4     | 1      |
| EventBasedCalculator.run     | 276.2    | 445.3     | 1      |
| total ebr_from_gmfs          | 94.6     | 52.4      | 34     |
| reading crmodel              | 48.0     | 52.4      | 34     |
| computing risk               | 32.3     | 0.0       | 2_243  |
| updating gmfs                | 29.1     | 0.0       | 1000   |
| instantiating GmfComputer    | 19.3     | 0.0       | 500    |
| saving avg_gmf               | 18.6     | 187.6     | 1      |

$ oq show job_info 63576
| task          | sent                                             | received | mean_recv |
|---------------+--------------------------------------------------+----------+-----------|
| event_based   | cmaker=2.81 GB stations=3.94 MB proxies=81.07 KB | 10.24 MB | 308.34 KB |
| ebr_from_gmfs | oqparam=133.24 KB sbe=27.15 KB dstore=5.54 KB    | 20.92 MB | 629.99 KB |
```
It is important to notice that the calculation has `number_of_ground_motion_fields=500`, with a smaller number (say 100) the old approach would have been quite faster. The different in disk space occupation is 10x:
```
| /home/michele/oqdata/calc_63655.hdf5 | 183.95 MB |
| /home/michele/oqdata/calc_63576.hdf5 | 18.04 MB  |
```
With more sites the saving can be much larger, for instance I measured a 60x in a scenario_damage with 2307 sites provided months ago by Catalina, which however have become 2x slower due to the time spent in data transfer instead of reading from the disk.