### PR TITLE
Saving memory in conditioned scenarios

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -412,6 +412,10 @@ class SharedArray(object):
     """
     Wrapper over a SharedMemory object to be used as a context manager.
     """
+    @classmethod
+    def new(cls, array):
+        return cls(array.shape, array.dtype, array)
+
     def __init__(self, shape, dtype, value):
         # NOTE: on Windows numpy.zeros(1, dtype).nbytes is a numpy.int32 and
         # causes issues, so it is converted into a Python int below
@@ -433,6 +437,20 @@ class SharedArray(object):
 
     def unlink(self):
         shmem.SharedMemory(self.name).unlink()
+
+
+class SharedObject(object):
+    """
+    A container of SharedArrays
+    """
+    def __init__(self, **kw):
+        self.names = list(kw)
+        for k, arr in kw.items():
+            setattr(self, k, SharedArray.new(arr))
+
+    def unlink(self):
+        for name in self.names:
+            getattr(self, name).unlink()
 
 
 def vectorize_arg(idx):

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -18,6 +18,7 @@
 
 import os
 import time
+import atexit
 import multiprocessing.shared_memory as shmem
 import pstats
 import pickle
@@ -447,6 +448,7 @@ class SharedObject(object):
         self.names = list(kw)
         for k, arr in kw.items():
             setattr(self, k, SharedArray.new(arr))
+        atexit.register(self.unlink)
 
     def unlink(self):
         for name in self.names:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -382,6 +382,9 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         cmaker = ContextMaker(trt, rlzs_by_gsim, oq, extraparams=extra)
         cmaker.min_mag = getdefault(oq.minimum_magnitude, trt)
         if station_data is not None:
+            if parallel.oq_distribute() == 'zmq':
+                logging.warning('Conditioned scenarios are not meant to be run'
+                                ' on a cluster')
             cmaker.shr_obj = performance.SharedObject(mea=mea, tau=tau, phi=phi)
         for block in block_splitter(proxies, totw, rup_weight):
             args = block, cmaker, (station_data, station_sites), dstore

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -26,7 +26,7 @@ import numpy
 import pandas
 import fiona
 from shapely import geometry
-from openquake.baselib import config, hdf5, parallel, python3compat
+from openquake.baselib import config, hdf5, parallel, performance, python3compat
 from openquake.baselib.general import (
     AccumDict, humansize, groupby, block_splitter)
 from openquake.hazardlib.probability_map import ProbabilityMap, get_mean_curve
@@ -257,7 +257,9 @@ def event_based(proxies, cmaker, stations, dstore, monitor):
                     continue
             if hasattr(computer, 'station_data'):  # conditioned GMFs
                 assert cmaker.scenario
-                df = computer.compute_all(cmaker.mea_tau_phi, cmon, umon)
+                s = cmaker.shr_obj
+                with s.mea as mea, s.tau as tau, s.phi as phi:
+                    df = computer.compute_all([mea, tau, phi], cmon, umon)
             else:  # regular GMFs
                 with mmon:
                     mean_stds = cmaker.get_mean_stds(
@@ -380,7 +382,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         cmaker = ContextMaker(trt, rlzs_by_gsim, oq, extraparams=extra)
         cmaker.min_mag = getdefault(oq.minimum_magnitude, trt)
         if station_data is not None:
-            cmaker.mea_tau_phi = mea, tau, phi
+            cmaker.shr_obj = performance.SharedObject(mea=mea, tau=tau, phi=phi)
         for block in block_splitter(proxies, totw, rup_weight):
             args = block, cmaker, (station_data, station_sites), dstore
             smap.submit(args)


### PR DESCRIPTION
By using shared memory. The improvement is HUGE. The following calculation (taken from the Gorkha scenario,
[job.zip](https://github.com/gem/oq-engine/files/15331098/job.zip)) which was not running at all with 48 GB of RAM, with errors like
```python
[2024-05-16 07:38:33 #12498 INFO] event_based  40% [20 submitted, 0 queued]
Process SpawnPoolWorker-57:
Traceback (most recent call last):
  File "/usr/lib64/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib64/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib64/python3.11/multiprocessing/pool.py", line 114, in worker
    task = get()
           ^^^^^
  File "/usr/lib64/python3.11/multiprocessing/queues.py", line 367, in get
    return _ForkingPickler.loads(res)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
_pickle.UnpicklingError: invalid load key, '\xc3'.
```
Now runs in 2 minutes:
```
| calc_2, maxmem=30.9 GB    | time_sec | memory_mb | counts |
|---------------------------+----------+-----------+--------|
| EventBasedCalculator.run  | 136.2    | 40.0      | 1      |
| total event_based         | 99.6     | 31.8      | 34     |
| updating gmfs             | 49.2     | 0.0       | 400    |
| instantiating GmfComputer | 44.7     | 0.0       | 100    |
```
