### PR TITLE
Making sure atexit functions are called before shutting down the ProcessPool

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -184,6 +184,7 @@ import ast
 import sys
 import stat
 import time
+import atexit
 import socket
 import signal
 import pickle
@@ -723,6 +724,7 @@ class Starmap(object):
 
     @classmethod
     def shutdown(cls):
+        atexit._run_exitfuncs()
         # shutting down the pool during the runtime causes mysterious
         # race conditions with errors inside atexit._run_exitfuncs
         if hasattr(cls, 'pool'):

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -238,7 +238,7 @@ class ConditionedGmfComputer(GmfComputer):
             with cmon:
                 array = self.compute(gsim, rlzs, mea, tau, phi, rng)
             with umon:
-                self.update(data, array, rlzs, [mea, tau + phi, tau, phi])
+                self.update(data, array, rlzs, [mea])
         with umon:
             return self.strip_zeros(data)
 


### PR DESCRIPTION
Hopefully will fix the error in the oq-risk-tests
```
[gw1] linux -- Python 3.11.7 /home/openquake/openquake/bin/python3
worker 'gw1' crashed while running 'tests.py::test_conditioned_gmfs2'
/usr/local/lib/python3.11/multiprocessing/resource_tracker.py:254:
UserWarning: resource_tracker: There appear to be 2 leaked shared_memory
objects to clean up at shutdown
```