### PR TITLE
Explicit unlink of the shared memory

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -18,7 +18,6 @@
 
 import os
 import time
-import atexit
 import multiprocessing.shared_memory as shmem
 import pstats
 import pickle
@@ -448,7 +447,6 @@ class SharedObject(object):
         self._names = list(kw)
         for k, arr in kw.items():
             setattr(self, k, SharedArray.new(arr))
-        atexit.register(self.unlink)
 
     def unlink(self):
         for name in self._names:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -386,6 +386,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
                 logging.warning('Conditioned scenarios are not meant to be run'
                                 ' on a cluster')
             cmaker.shr_obj = performance.SharedObject(mea=mea, tau=tau, phi=phi)
+            smap.unlink = cmaker.shr_obj.unlink
         for block in block_splitter(proxies, totw, rup_weight):
             args = block, cmaker, (station_data, station_sites), dstore
             smap.submit(args)
@@ -716,6 +717,7 @@ class EventBasedCalculator(base.HazardCalculator):
               else gen_event_based)
         smap = starmap_from_rups(eb, oq, self.full_lt, self.sitecol, dstore)
         acc = smap.reduce(self.agg_dicts)
+        smap.unlink()  # shared memory
         if 'gmf_data' not in dstore:
             return acc
         if oq.ground_motion_fields:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -717,7 +717,8 @@ class EventBasedCalculator(base.HazardCalculator):
               else gen_event_based)
         smap = starmap_from_rups(eb, oq, self.full_lt, self.sitecol, dstore)
         acc = smap.reduce(self.agg_dicts)
-        smap.unlink()  # shared memory
+        if 'station_data' in oq.inputs:
+            smap.unlink()  # shared memory
         if 'gmf_data' not in dstore:
             return acc
         if oq.ground_motion_fields:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -387,6 +387,8 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
                                 ' on a cluster')
             cmaker.shr_obj = performance.SharedObject(mea=mea, tau=tau, phi=phi)
             smap.unlink = cmaker.shr_obj.unlink
+        else:
+            smap.unlink = lambda: None
         for block in block_splitter(proxies, totw, rup_weight):
             args = block, cmaker, (station_data, station_sites), dstore
             smap.submit(args)
@@ -717,8 +719,7 @@ class EventBasedCalculator(base.HazardCalculator):
               else gen_event_based)
         smap = starmap_from_rups(eb, oq, self.full_lt, self.sitecol, dstore)
         acc = smap.reduce(self.agg_dicts)
-        if 'station_data' in oq.inputs:
-            smap.unlink()  # shared memory
+        smap.unlink()  # shared memory
         if 'gmf_data' not in dstore:
             return acc
         if oq.ground_motion_fields:


### PR DESCRIPTION
Continuation of #9674. This time it shouldl fix the error in the oq-risk-tests:
```
[gw1] linux -- Python 3.11.7 /home/openquake/openquake/bin/python3
worker 'gw1' crashed while running 'tests.py::test_conditioned_gmfs2'
/usr/local/lib/python3.11/multiprocessing/resource_tracker.py:254:
UserWarning: resource_tracker: There appear to be 2 leaked shared_memory
objects to clean up at shutdown
```