### PR TITLE
Improve form layouts

### DIFF
--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -18,6 +18,38 @@ h2 {
     }
 }
 
+@media (min-width: 1070px) and (max-width: 1120px) {
+    .aelo-input,
+    .aelo-select {
+        width: 170px!important;
+    }
+}
+
+@media (min-width: 960px) and (max-width: 1069px) {
+    .aelo-input,
+    .aelo-select {
+        width: 160px!important;
+    }
+}
+
+@media (min-width: 760px) and (max-width: 959px) {
+    .aelo-input {
+        width: 80%!important;
+    }
+    .aelo-select {
+        width: 170px!important;
+    }
+}
+
+@media (min-width: 640px) and (max-width: 759px) {
+    .aelo-input {
+        width: 80%!important;
+    }
+    .aelo-select {
+        width: 140px!important;
+    }
+}
+
 .container,
 .navbar-static-top .container,
 .navbar-fixed-top .container,
@@ -262,10 +294,31 @@ tr.asce_output {
 }
 
 .aelo-input {
-    width: 241px;
+    width: 193px;
     vertical-align: top!important;
     height: 11px!important;
     padding-bottom: 10px!important;
+}
+
+.aelo-label {
+    font-weight: bold;
+}
+
+.aelo-select {
+    height: 33px!important;
+}
+
+.table-aelo-form {
+    margin-bottom: 0;
+}
+
+.table-aelo-form tr th {
+    padding: 0;
+}
+
+.table-aelo-form td {
+    padding: 0;
+    border-top: 0;
 }
 
 .aristotle_form_row label {
@@ -280,6 +333,10 @@ tr.asce_output {
 .aristotle_form_row input {
     /* width: calc(100% - 110px); /1* Adjust according to label width *1/ */
     box-sizing: border-box;
+}
+
+.aristotle-select {
+    width: 206px;
 }
 
 
@@ -340,7 +397,7 @@ table#aristotle-losses {
     width: 100%;
 }
 
-table#aristotle-losses th, td {
+table#aristotle-losses th td {
     border: 1px solid #dddddd;
     text-align: left;
     padding: 8px;

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -33,24 +33,36 @@
             {% endif %}
             <form id="aelo_run_form" method="post">
               {% csrf_token %}
-              <!-- <label for"lat">Latitude:</label> -->
-              <input class="aelo-input" type="text" id="lat" name="lat" placeholder="{{ aelo_form_placeholders.lat }}"/>
-              <!-- <label for"lon">Longitude:</label> -->
-              <input class="aelo-input" type="text" id="lon" name="lon" placeholder="{{ aelo_form_placeholders.lon }}"/>
-              <!-- <label for"vs30">Vs30:</label> -->
-              <input class="aelo-input" type="text" id="vs30" name="vs30" placeholder="{{ aelo_form_placeholders.vs30 }}" readonly />
-              <!-- <label for"siteid">Site ID:</label> -->
-              <input class="aelo-input" type="text" id="siteid" name="siteid" placeholder="{{ aelo_form_placeholders.siteid }}"/>
-                <label for="asce_version">{{ aelo_form_placeholders.asce_version }}</label>
-                <select name="asce_version" id="asce_version">
-                  {% for asce_version in asce_versions %}
-                  {% if asce_version == default_asce_version %}
-                  <option value="{{ asce_version }}" selected>{{ asce_version }}</option>
-                  {% else %}
-                  <option value="{{ asce_version }}">{{ asce_version }}</option>
-                  {% endif %}
-                  {% endfor %}
-                </select>
+              <table class="table-aelo-form table">
+                <thead>
+                  <tr>
+                    <th><label class="aelo-label" for"lat">Latitude:</label></th>
+                    <th><label class="aelo-label" for"lon">Longitude:</label></th>
+                    <th><label class="aelo-label" for"vs30">Vs30:</label></th>
+                    <th><label class="aelo-label" for"siteid">Site ID:</label></th>
+                    <th><label class="aelo-label" for="asce_version">{{ aelo_form_placeholders.asce_version }}</label></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><input class="aelo-input" type="text" id="lat" name="lat" placeholder="{{ aelo_form_placeholders.lat }}"/></td>
+                    <td><input class="aelo-input" type="text" id="lon" name="lon" placeholder="{{ aelo_form_placeholders.lon }}"/></td>
+                    <td><input class="aelo-input" type="text" id="vs30" name="vs30" placeholder="{{ aelo_form_placeholders.vs30 }}" readonly /></td>
+                    <td><input class="aelo-input" type="text" id="siteid" name="siteid" placeholder="{{ aelo_form_placeholders.siteid }}"/></td>
+                    <td>
+                        <select class="aelo-select" name="asce_version" id="asce_version">
+                        {% for asce_version in asce_versions %}
+                        {% if asce_version == default_asce_version %}
+                        <option value="{{ asce_version }}" selected>{{ asce_version }}</option>
+                        {% else %}
+                        <option value="{{ asce_version }}">{{ asce_version }}</option>
+                        {% endif %}
+                        {% endfor %}
+                        </select>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
               <button id="submit_aelo_calc" type="submit" class="btn">Submit</button>
               <!-- <input type="submit"> -->
             </form>
@@ -103,7 +115,7 @@
               </div>
               <div class="aristotle_form_row">
                 <label for="trt">{{ aristotle_form_placeholders.trt }}</label>
-                <select name="trt" id="trt">
+                <select name="trt" id="trt" class="aristotle-select">
                 </select>
               </div>
               <div class="aristotle_form_row">

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -36,11 +36,11 @@
               <table class="table-aelo-form table">
                 <thead>
                   <tr>
-                    <th><label class="aelo-label" for"lat">Latitude:</label></th>
-                    <th><label class="aelo-label" for"lon">Longitude:</label></th>
-                    <th><label class="aelo-label" for"vs30">Vs30:</label></th>
-                    <th><label class="aelo-label" for"siteid">Site ID:</label></th>
-                    <th><label class="aelo-label" for="asce_version">{{ aelo_form_placeholders.asce_version }}</label></th>
+                    <th><label class="aelo-label" for"lat">{{ aelo_form_labels.lat }}</label></th>
+                    <th><label class="aelo-label" for"lon">{{ aelo_form_labels.lon }}</label></th>
+                    <th><label class="aelo-label" for"vs30">{{ aelo_form_labels.vs30 }}</label></th>
+                    <th><label class="aelo-label" for"siteid">{{ aelo_form_labels.siteid }}</label></th>
+                    <th><label class="aelo-label" for="asce_version">{{ aelo_form_labels.asce_version }}</label></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -78,11 +78,11 @@
             <form id="aristotle_get_rupture_form" method="post" enctype="multipart/form-data">
               {% csrf_token %}
               <div class="aristotle_form_row">
-                <label for"usgs_id">{{ aristotle_form_placeholders.usgs_id }}</label>
+                <label for"usgs_id">{{ aristotle_form_labels.usgs_id }}</label>
                 <input class="aristotle-input" type="text" id="usgs_id" name="usgs_id" placeholder="{{ aristotle_form_placeholders.usgs_id }}" value="us6000jllz"/>
               </div>
               <div class="aristotle_form_row">
-                <label for"rupture_file">{{ aristotle_form_placeholders.rupture_file }}</label>
+                <label for"rupture_file">{{ aristotle_form_labels.rupture_file }}</label>
                 <input class="aristotle-input" type="file" id="rupture_file_input" name="rupture_file" placeholder="{{ aristotle_form_placeholders.rupture_file }}" >
                 <button type="button" id="clearFile">Clear File</button>
               </div>
@@ -94,56 +94,56 @@
             <form id="aristotle_run_form" method="post" enctype="multipart/form-data">
               {% csrf_token %}
               <div class="aristotle_form_row">
-                <label for"lon">{{ aristotle_form_placeholders.lon }}</label>
+                <label for"lon">{{ aristotle_form_labels.lon }}</label>
                 <input class="aristotle-input" type="text" id="lon" name="lon" placeholder="{{ aristotle_form_placeholders.lon }}" disabled />
               </div>
               <div class="aristotle_form_row">
-                <label for"lat">{{ aristotle_form_placeholders.lat }}</label>
+                <label for"lat">{{ aristotle_form_labels.lat }}</label>
                 <input class="aristotle-input" type="text" id="lat" name="lat" placeholder="{{ aristotle_form_placeholders.lat }}" disabled />
               </div>
               <div class="aristotle_form_row">
-                <label for"dep">{{ aristotle_form_placeholders.dep }}</label>
+                <label for"dep">{{ aristotle_form_labels.dep }}</label>
                 <input class="aristotle-input" type="text" id="dep" name="dep" placeholder="{{ aristotle_form_placeholders.dep }}" disabled />
               </div>
               <div class="aristotle_form_row">
-                <label for"mag">{{ aristotle_form_placeholders.mag }}</label>
+                <label for"mag">{{ aristotle_form_labels.mag }}</label>
                 <input class="aristotle-input" type="text" id="mag" name="mag" placeholder="{{ aristotle_form_placeholders.mag }}" disabled />
               </div>
               <div class="aristotle_form_row">
-                <label for"rake">{{ aristotle_form_placeholders.rake }}</label>
+                <label for"rake">{{ aristotle_form_labels.rake }}</label>
                 <input class="aristotle-input" type="text" id="rake" name="rake" placeholder="{{ aristotle_form_placeholders.rake }}" disabled />
               </div>
               <div class="aristotle_form_row">
-                <label for="trt">{{ aristotle_form_placeholders.trt }}</label>
+                <label for="trt">{{ aristotle_form_labels.trt }}</label>
                 <select name="trt" id="trt" class="aristotle-select">
                 </select>
               </div>
               <div class="aristotle_form_row">
-                <label for"dip">{{ aristotle_form_placeholders.dip }}</label>
+                <label for"dip">{{ aristotle_form_labels.dip }}</label>
                 <input class="aristotle-input" type="text" id="dip" name="dip" placeholder="{{ aristotle_form_placeholders.dip }}" value="90"/>
               </div>
               <div class="aristotle_form_row">
-                <label for"strike">{{ aristotle_form_placeholders.strike }}</label>
+                <label for"strike">{{ aristotle_form_labels.strike }}</label>
                 <input class="aristotle-input" type="text" id="strike" name="strike" placeholder="{{ aristotle_form_placeholders.strike }}" value="0"/>
               </div>
               <div class="aristotle_form_row">
-                <label for"maximum_distance">{{ aristotle_form_placeholders.maximum_distance }}</label>
+                <label for"maximum_distance">{{ aristotle_form_labels.maximum_distance }}</label>
                 <input class="aristotle-input" type="text" id="maximum_distance" name="maximum_distance" placeholder="{{ aristotle_form_placeholders.maximum_distance }}" value="300"/>
               </div>
               <div class="aristotle_form_row">
-                <label for"truncation_level">{{ aristotle_form_placeholders.truncation_level }}</label>
+                <label for"truncation_level">{{ aristotle_form_labels.truncation_level }}</label>
                 <input class="aristotle-input" type="text" id="truncation_level" name="truncation_level" placeholder="{{ aristotle_form_placeholders.truncation_level }}" value="3"/>
               </div>
               <div class="aristotle_form_row">
-                <label for"number_of_ground_motion_fields">{{ aristotle_form_placeholders.number_of_ground_motion_fields }}</label>
+                <label for"number_of_ground_motion_fields">{{ aristotle_form_labels.number_of_ground_motion_fields }}</label>
                 <input class="aristotle-input" type="text" id="number_of_ground_motion_fields" name="number_of_ground_motion_fields" placeholder="{{ aristotle_form_placeholders.number_of_ground_motion_fields }}" value="100"/>
               </div>
               <div class="aristotle_form_row">
-                <label for"asset_hazard_distance">{{ aristotle_form_placeholders.asset_hazard_distance }}</label>
+                <label for"asset_hazard_distance">{{ aristotle_form_labels.asset_hazard_distance }}</label>
                 <input class="aristotle-input" type="text" id="asset_hazard_distance" name="asset_hazard_distance" placeholder="{{ aristotle_form_placeholders.asset_hazard_distance }}" value="15"/>
               </div>
               <div class="aristotle_form_row">
-                <label for"ses_seed">{{ aristotle_form_placeholders.ses_seed }}</label>
+                <label for"ses_seed">{{ aristotle_form_labels.ses_seed }}</label>
                 <input class="aristotle-input" type="text" id="ses_seed" name="ses_seed" placeholder="{{ aristotle_form_placeholders.ses_seed }}" value="42"/>
               </div>
               <div class="aristotle_form_row">


### PR DESCRIPTION
- Full restructuring of the AELO form, using a table and handling browser resizing via media queries
- Minor fix in the ARISTOTLE form, making input and select fields consistent in width
- Differentiation of contents of labels and placeholders in both forms

![image](https://github.com/gem/oq-engine/assets/350930/0ad7bde2-8e92-4898-910b-516373414fce)
