### PR TITLE
Fixed "slow lane" for the New Zealand model

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-  [Michele Simionato]
+  [Michele Simionato, Marco Pagani]
   * Fixed the multifault rupture indices and the MultiLine class so
     that the New Zealand model can run
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Fixed the multifault rupture indices and the MultiLine class so
+    that the New Zealand model can run
+
   [Paolo Tormene, Michele Simionato]
   * Added a new parameter `asce_version` for AELO calculations
 

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -203,24 +203,24 @@ class MultiLine(object):
             # fast lane, when the number of segments is constant
             lam0s, phi0s, coos, slens, uhats, thats = build_line_params(
                 self.lines)
-            out = get_tuws(lam0s, phi0s, coos, slens, uhats, thats,
+            return get_tuws(lam0s, phi0s, coos, slens, uhats, thats,
                            self.soidx, self.flipped, lons, lats)
-        else:
-            # slow lane
-            out = []
-            for idx in self.soidx:
-                line = self.lines[idx]
-                slen, uhat, that = line.sut_hat
-                if self.flipped[idx]:
-                    coo = np.flipud(line.coo[:, 0:2])
-                    uhat = -uhat
-                    that = -that
-                else:
-                    coo = line.coo[:, :2]
-                tuw = get_tuw(line.proj.lam0, line.proj.phi0, coo,
-                              slen, uhat, that,  lons, lats)
-                out.append(tuw)
-        return out
+        # else slow lane
+        out = []
+        for idx in self.soidx:
+            line = self.lines[idx]
+            slen, uhat, that = line.sut_hat
+            if self.flipped[idx]:
+                coo = np.flipud(line.coo[:, 0:2])
+                uhat = -uhat
+                that = -that
+            else:
+                coo = line.coo[:, :2]
+            tuw = get_tuw(line.proj.lam0, line.proj.phi0, coo,
+                          slen, uhat, that,  lons, lats)
+            out.append(tuw)
+        return np.array(out)
+
 
     def get_tuw_df(self, sites):
         # debug method to be called in genctxs

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -36,10 +36,12 @@ from openquake.hazardlib.geo.utils import (
 from openquake.hazardlib.source.base import BaseSeismicSource
 
 U16 = np.uint16
+U32 = np.uint32
 F32 = np.float32
 F64 = np.float64
 BLOCKSIZE = 5_000
 TWO16 = 2 ** 16
+TWO32 = 2 ** 32
 # NB: if too large, very few sources will be generated and a lot of
 # memory will be used
 
@@ -253,12 +255,12 @@ def save(mfsources, sectiondict, hdf5path):
     """
     Utility to serialize MultiFaultSources and optionally computing msparams
     """
-    assert len(sectiondict) < TWO16, len(sectiondict)
+    assert len(sectiondict) < TWO32, len(sectiondict)
     s2i = {idx: i for i, idx in enumerate(sectiondict)}
     all_rids = []
     for src in mfsources:
         try:
-            rids = [U16([s2i[idx] for idx in idxs])
+            rids = [U32([s2i[idx] for idx in idxs])
                     for idxs in src._rupture_idxs]
         except KeyError as exc:
             raise IndexError('The section index %s in source %r is invalid'


### PR DESCRIPTION
Fixes the error
```
TypeError: No matching definition for argument type(s) array(float32, 1d, C), reflected list(array(float32, 2d, C))<iv=None>
```
Also extends the section indices to 32 bit.

I have checked that the USA model still run using 3 GB per core.