### PR TITLE
Reduced the memory consumption and improved the performance in postclassical

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduce the memory consumption in postclassical
   * Extended the `delta_loss` warning to scenario_risk calculations
     and documented it
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Reduce the memory consumption in postclassical
+  * Reduced the memory consumption in postclassical
   * Extended the `delta_loss` warning to scenario_risk calculations
     and documented it
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -163,11 +163,10 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
             yield result
 
 
-def postclassical(pgetter, N, hstats, individual_rlzs,
+def postclassical(pgetter, hstats, individual_rlzs,
                   max_sites_disagg, amplifier, monitor):
     """
     :param pgetter: an :class:`openquake.commonlib.getters.PmapGetter`
-    :param N: the total number of sites
     :param hstats: a list of pairs (statname, statfunc)
     :param individual_rlzs: if True, also build the individual curves
     :param max_sites_disagg: if there are less sites than this, store rup info
@@ -726,7 +725,7 @@ class ClassicalCalculator(base.HazardCalculator):
         allargs = [
             (getters.PmapGetter(dstore, self.full_lt, slices,
                                 oq.imtls, oq.poes, oq.use_rates),
-             N, hstats, individual, oq.max_sites_disagg, self.amplifier)
+             hstats, individual, oq.max_sites_disagg, self.amplifier)
             for slices in allslices]
         self.hazard = {}  # kind -> array
         hcbytes = 8 * N * S * M * L1

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -192,8 +192,9 @@ class PmapGetter(object):
         G = len(self.trt_rlzs)
         with hdf5.File(self.filename) as dstore:
             for start, stop in self.slices:
-                # reading one slice at the time to save memory in the groupby
+                # reading one slice at the time to save memory
                 rates_df = dstore.read_df('_rates', slc=slice(start, stop))
+                # not using groupby to save memory
                 for sid in rates_df.sid.unique():
                     df = rates_df[rates_df.sid == sid]
                     try:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -194,7 +194,8 @@ class PmapGetter(object):
             for start, stop in self.slices:
                 # reading one slice at the time to save memory in the groupby
                 rates_df = dstore.read_df('_rates', slc=slice(start, stop))
-                for sid, df in rates_df.groupby('sid'):
+                for sid in rates_df.sid.unique():
+                    df = rates_df[rates_df.sid == sid]
                     try:
                         array = self._pmap[sid].array
                     except KeyError:


### PR DESCRIPTION
This is only marginally better for New Zealand:
```
# before
| calc_99956999, maxmem=75.4 GB | time_sec | memory_mb | counts |
|-------------------------------+----------+-----------+--------|
| total postclassical           | 7_860    | 117.1     | 250    |
| combine pmaps                 | 5_033    | 0.0       | 3_991  |
| reading rates                 | 2_272    | 116.4     | 250    |
| compute stats                 | 429.0    | 0.0       | 3_991  |
| ClassicalCalculator.run       | 101.6    | 1_731     | 1      |
# after
| calc_99957000, maxmem=73.3 GB | time_sec | memory_mb | counts |
|-------------------------------+----------+-----------+--------|
| total postclassical           | 6_335    | 110.8     | 250    |
| combine pmaps                 | 5_177    | 0.0       | 3_991  |
| reading rates                 | 540.0    | 110.0     | 250    |
| compute stats                 | 475.9    | 0.0       | 3_991  |
| ClassicalCalculator.run       | 89.3     | 1_712     | 1      |
```