### PR TITLE
Add the arguments maximum_distance and number_of_ground_motion_fields to the oq mosaic aristotle command

### DIFF
--- a/openquake/commands/mosaic.py
+++ b/openquake/commands/mosaic.py
@@ -301,7 +301,9 @@ def callback(job_id, params, exc=None):
 
 
 def aristotle(mosaic_dir='', *,
-              rupfname: str = FAMOUS,  maximum_distance: int = 300):
+              rupfname: str = FAMOUS,
+              maximum_distance: int = 300,
+              number_of_ground_motion_fields: int = 10):
     """
     Run Aristotle calculations starting from a file with planar
     ruptures (by default "famous_ruptures.csv"). You must pass
@@ -312,7 +314,6 @@ def aristotle(mosaic_dir='', *,
         sys.exit('mosaic_dir is not specified in openquake.cfg')
     trt = None
     truncation_level = 3
-    number_of_ground_motion_fields = 10
     asset_hazard_distance = 15
     ses_seed = 42
     t0 = time.time()
@@ -341,6 +342,7 @@ def aristotle(mosaic_dir='', *,
 aristotle.mosaic_dir = 'Directory containing site_model.hdf5 and exposure.hdf5'
 aristotle.rupfname = 'Filename with planar ruptures'
 aristotle.maximum_distance = 'Maximum distance in km'
+aristotle.number_of_ground_motion_fields = 'Number of ground motion fields'
 
 # ################################## main ################################## #
 

--- a/openquake/commands/mosaic.py
+++ b/openquake/commands/mosaic.py
@@ -300,7 +300,8 @@ def callback(job_id, params, exc=None):
     aristotle_res['res_list'].append((job_id, description, error))
 
 
-def aristotle(mosaic_dir='', rupfname=FAMOUS):
+def aristotle(mosaic_dir='', *,
+              rupfname: str = FAMOUS,  maximum_distance: int = 300):
     """
     Run Aristotle calculations starting from a file with planar
     ruptures (by default "famous_ruptures.csv"). You must pass
@@ -310,7 +311,6 @@ def aristotle(mosaic_dir='', rupfname=FAMOUS):
     if not mosaic_dir and not config.directory.mosaic_dir:
         sys.exit('mosaic_dir is not specified in openquake.cfg')
     trt = None
-    maximum_distance = 300
     truncation_level = 3
     number_of_ground_motion_fields = 10
     asset_hazard_distance = 15
@@ -340,6 +340,7 @@ def aristotle(mosaic_dir='', rupfname=FAMOUS):
 
 aristotle.mosaic_dir = 'Directory containing site_model.hdf5 and exposure.hdf5'
 aristotle.rupfname = 'Filename with planar ruptures'
+aristotle.maximum_distance = 'Maximum distance in km'
 
 # ################################## main ################################## #
 


### PR DESCRIPTION
The default values are still 300 and 10, but from tests we can do `oq mosaic aristotle ./mosaic_dir --maximum-distance 100 --number-of-ground-motion-fields 10` to customize them.