### PR TITLE
Reduced memory consumption in the realization weights

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -117,7 +117,7 @@ def build_weights(realizations):
     """
     :returns: an array with the realization weights of shape R
     """
-    arr = numpy.array([rlz.weight['default'] for rlz in realizations])
+    arr = numpy.array([rlz.weight[-1] for rlz in realizations])
     return arr
 
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -191,7 +191,7 @@ def postclassical(pgetter, weights, wget, hstats, individual_rlzs,
     """
     :param pgetter: a :class:`openquake.commonlib.getters.MapGetter`
     :param weights: a list of ImtWeights
-    :param wget: function weight array, imt -> weight
+    :param wget: function (weights[:, :], imt) -> weights[:]
     :param hstats: a list of pairs (statname, statfunc)
     :param individual_rlzs: if True, also build the individual curves
     :param max_sites_disagg: if there are less sites than this, store rup info

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -37,7 +37,7 @@ def classical_risk(riskinputs, oqparam, monitor):
     """
     crmodel = monitor.read('crmodel')
     result = dict(loss_curves=[], stat_curves=[])
-    weights = [w['default'] for w in oqparam._weights]
+    weights = oqparam._weights[:, -1]
     statnames, stats = zip(*oqparam._stats)
     mon = monitor('getting hazard', measuremem=False)
     for ri in riskinputs:
@@ -94,12 +94,11 @@ class ClassicalRiskCalculator(base.RiskCalculator):
         super().pre_execute()
         if '_rates' not in self.datastore:  # when building short report
             return
-        full_lt = self.datastore['full_lt']
+        full_lt = self.datastore['full_lt'].init()
         self.realizations = full_lt.get_realizations()
-        weights = [rlz.weight for rlz in self.realizations]
         stats = list(oq.hazard_stats().items())
         oq._stats = stats
-        oq._weights = weights
+        oq._weights = full_lt.weights
         self.riskinputs = self.build_riskinputs()
         self.A = len(self.assetcol)
         self.L = len(self.crmodel.loss_types)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -191,7 +191,8 @@ class DisaggregationCalculator(base.HazardCalculator):
                 for sid in self.sitecol.sids:
                     hcurve = self.pgetter.get_hcurve(sid)
                     mean = getters.build_stat_curve(
-                        hcurve, oq.imtls, stats.mean_curve, full_lt.weights)
+                        hcurve, oq.imtls, stats.mean_curve, full_lt.weights,
+                        full_lt.wget)
                     # get the closest realization to the mean
                     rlzs[sid] = util.closest_to_ref(hcurve.T, mean)[:Z]
             self.datastore['best_rlzs'] = rlzs

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -79,10 +79,9 @@ def build_hcurves(calc):
     the stored GMFs. Works only for few sites.
     """
     oq = calc.oqparam
-    rlzs = calc.full_lt.get_realizations()
     # compute and save statistics; this is done in process and can
     # be very slow if there are thousands of realizations
-    weights = [rlz.weight['weight'] for rlz in rlzs]
+    weights = calc.full_lt.weights[:, -1]
     # NB: in the future we may want to save to individual hazard
     # curves if oq.individual_rlzs is set; for the moment we
     # save the statistical curves only
@@ -683,7 +682,7 @@ class EventBasedCalculator(base.HazardCalculator):
         self.offset = 0
         if oq.hazard_calculation_id:  # from ruptures
             dstore.parent = datastore.read(oq.hazard_calculation_id)
-            self.full_lt = dstore.parent['full_lt']
+            self.full_lt = dstore.parent['full_lt'].init()
             set_mags(oq, dstore)
         elif hasattr(self, 'csm'):  # from sources
             set_mags(oq, dstore)

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -567,8 +567,7 @@ def export_disagg_csv(ekey, dstore):
                   tectonic_region_types=decode(bins['TRT'].tolist()),
                   lon=lon, lat=lat)
         if spec.startswith('rlzs') or oq.iml_disagg:
-            weights = numpy.array([rlzs[r].weight['weight']
-                                   for r in best_rlzs[s]])
+            weights = numpy.array([rlzs[r].weight[-1] for r in best_rlzs[s]])
             weights /= weights.sum()  # normalize to 1
             md['weights'] = weights.tolist()
             md['rlz_ids'] = best_rlzs[s].tolist()

--- a/openquake/calculators/postproc/compute_mrd.py
+++ b/openquake/calculators/postproc/compute_mrd.py
@@ -59,7 +59,7 @@ def combine_mrds(acc, g_weights):
     g = next(iter(acc))  # first key
     out = numpy.zeros(acc[g].shape)  # shape (L1, L1, N)
     for g in acc:
-        out += acc[g] * g_weights[g]['weight']
+        out += acc[g] * g_weights[g]
     return out
 
 

--- a/openquake/calculators/postproc/disagg_by_rel_sources.py
+++ b/openquake/calculators/postproc/disagg_by_rel_sources.py
@@ -119,7 +119,7 @@ def submit_sources(dstore, csm, edges, shp, imts, imls_by_sid, oq, sites):
             src2idx[sid, source_id] = idx
             smlt = csm.full_lt.source_model_lt.reduce(source_id, num_samples=0)
             gslt = csm.full_lt.gsim_lt.reduce(smlt.tectonic_region_types)
-            weights[sid, source_id] = [rlz.weight['weight'] for rlz in gslt]
+            weights[sid, source_id] = [rlz.weight[-1] for rlz in gslt]
             relt = FullLogicTree(smlt, gslt)
             Z = relt.get_num_paths()
             assert Z, relt  # sanity check

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -72,8 +72,9 @@ class LogicTreeTestCase(CalculatorTestCase):
             sitecol = self.calc.datastore['sitecol']
             trs = full_lt.get_trt_rlzs(self.calc.datastore['trt_smrs'][:])
             rmap = calc_rmap(csm.src_groups, full_lt, sitecol, oq)[0]
+            wget = full_lt.gsim_lt.wget
             mean_rates = calc_mean_rates(
-                rmap, full_lt.g_weights(trs), oq.imtls)
+                rmap, full_lt.g_weights(trs), wget, oq.imtls)
             er = exp_rates[exp_rates < 1]
             mr = mean_rates[mean_rates < 1]
             aac(mr, er, atol=1e-6)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -756,8 +756,7 @@ def get_full_lt(oqparam):
     full_lt = logictree.FullLogicTree(source_model_lt, gsim_lt, oversampling)
     p = full_lt.source_model_lt.num_paths * gsim_lt.get_num_paths()
 
-    imtweight = full_lt.gsim_lt.branches[0].weight
-    if len(imtweight.dic) > 1 and oqparam.use_rates:
+    if full_lt.gsim_lt.has_imt_weights() and oqparam.use_rates:
         raise ValueError('use_rates=true cannot be used with imtWeight')
 
     if oqparam.number_of_logic_tree_samples:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -849,8 +849,10 @@ def get_composite_source_model(oqparam, dstore=None):
          an open datastore where to save the source info
     """
     logging.info('Reading %s', oqparam.inputs['source_model_logic_tree'])
-    full_lt = get_full_lt(oqparam)
-    path = get_cache_path(oqparam, dstore.hdf5 if dstore else None)
+    h5 = dstore.hdf5 if dstore else None
+    with Monitor('building full_lt', measuremem=True, h5=h5) :
+        full_lt = get_full_lt(oqparam)  # builds the weights
+    path = get_cache_path(oqparam, h5)
     if os.path.exists(path):
         from openquake.commonlib import datastore  # avoid circular import
         with datastore.read(os.path.realpath(path)) as ds:

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1865,7 +1865,7 @@ class LogicTreeProcessorTestCase(unittest.TestCase):
         probs = lt.random(1, self.seed, 'early_weights')
         [rlz] = lt.sample(list(self.gmpe_lt), probs, 'early_weights')
         self.assertEqual(rlz.value, ('[ChiouYoungs2008]', '[SadighEtAl1997]'))
-        self.assertEqual(rlz.weight['default'], 0.5)
+        self.assertEqual(rlz.weight[-1], 0.5)
         self.assertEqual(('gB0', 'gA1'), rlz.lt_path)
 
 
@@ -1898,7 +1898,7 @@ class LogicTreeSourceSpecificUncertaintyTest(unittest.TestCase):
     def mean(self, rlzs):
         R = len(rlzs)
         paths = ['_'.join(rlz.sm_lt_path) for rlz in rlzs]
-        return sum(self.value[path] * rlz.weight['weight']
+        return sum(self.value[path] * rlz.weight[-1]
                    for rlz, path in zip(rlzs, paths)) / R
 
     def test_full_path(self):
@@ -1931,7 +1931,7 @@ class LogicTreeSourceSpecificUncertaintyTest(unittest.TestCase):
                    0.1]       # b3_.
         # b1_b21 has weight 0.7 * 0.09284 = 0.064988
         numpy.testing.assert_almost_equal(
-            weights, [rlz.weight['weight'] for rlz in rlzs])
+            weights, [rlz.weight[-1] for rlz in rlzs])
 
         numpy.testing.assert_almost_equal(self.mean(rlzs), 0.13375)
 
@@ -1950,7 +1950,7 @@ class LogicTreeSourceSpecificUncertaintyTest(unittest.TestCase):
         # the weights are all equal
         weights = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
         numpy.testing.assert_almost_equal(
-            weights, [rlz.weight['weight'] for rlz in rlzs])
+            weights, [rlz.weight[-1] for rlz in rlzs])
         numpy.testing.assert_almost_equal(self.mean(rlzs), 0.106)
 
     def test_sampling_late_weights(self):
@@ -1969,7 +1969,7 @@ class LogicTreeSourceSpecificUncertaintyTest(unittest.TestCase):
                    0.18919751558, 0.09459875780, 0.094598757,
                    0.09459875779]
         numpy.testing.assert_almost_equal(
-            weights, [rlz.weight['weight'] for rlz in rlzs])
+            weights, [rlz.weight[-1] for rlz in rlzs])
         numpy.testing.assert_almost_equal(self.mean(rlzs), 0.119865739)
 
     def test_smlt_bad(self):

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -714,7 +714,7 @@ Subduction Interface,gA1,[SadighEtAl1997],w=1.0>''')
         self.assertEqual(rlz.ordinal, 0)
         self.assertEqual(rlz.sm_lt_path, ('b1', 'b5', 'b7'))
         self.assertEqual(rlz.gsim_lt_path, ('gB0', 'gA1'))
-        self.assertEqual(rlz.weight['default'], 1.)
+        self.assertEqual(rlz.weight, [1.])
 
     def test_many_rlzs(self):
         oqparam = tests.get_oqparam('classical_job.ini')

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -762,5 +762,6 @@ def disagg_source(groups, site, reduced_lt, edges_shapedic,
         disaggs.append(dis)
     std4D = collect_std(disaggs)
     gws = reduced_lt.g_weights(trt_rlzs)
-    rates3D = calc_mean_rates(rmap, gws, oq.imtls, list(imldic))  # (N, M, L1)
+    rates3D = calc_mean_rates(rmap, gws, reduced_lt.gsim_lt.wget,
+                              oq.imtls, list(imldic))  # (N, M, L1)
     return site.id, source_id, std4D, drates4D, rates3D[0]

--- a/openquake/hazardlib/calc/mean_rates.py
+++ b/openquake/hazardlib/calc/mean_rates.py
@@ -79,7 +79,7 @@ def calc_rmap(src_groups, full_lt, sitecol, oq):
     return rmap, ctxs, cmakers
 
 
-def calc_mean_rates(rmap, gweights, imtls, imts=None):
+def calc_mean_rates(rmap, gweights, wget, imtls, imts=None):
     """
     :returns: mean hazard rates as an array of shape (N, M, L1)
     """
@@ -88,10 +88,11 @@ def calc_mean_rates(rmap, gweights, imtls, imts=None):
     if imts is None:
         imts = imtls
     M = len(imts)
+    if len(gweights.shape) == 1:  # fast_mean
+        return (rmap.array @ gweights).reshape(M, L1)
     rates = numpy.zeros((N, M, L1))
     for m, imt in enumerate(imts):
-        rates[:, m, :] = rmap.array[:, imtls(imt), :] @ [
-            gw[imt] for gw in gweights]
+        rates[:, m, :] = rmap.array[:, imtls(imt), :] @ wget(gweights, imt)
     return rates
 
 

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -31,7 +31,8 @@ import numpy
 from openquake.baselib import hdf5
 from openquake.baselib.python3compat import decode
 from openquake.baselib.node import Node as N, context
-from openquake.baselib.general import duplicated, BASE183, group_array
+from openquake.baselib.general import (
+    duplicated, BASE183, group_array, cached_property)
 from openquake.hazardlib import valid, nrml, pmf, lt, InvalidFile
 from openquake.hazardlib.gsim.mgmpe.avg_poe_gmpe import AvgPoeGMPE
 from openquake.hazardlib.gsim.base import CoeffsTable
@@ -93,17 +94,6 @@ class ImtWeight(object):
                 raise InvalidLogicTree(
                     'There are duplicated IMTs in the weights')
 
-    def __mul__(self, other):
-        new = object.__new__(self.__class__)
-        if isinstance(other, self.__class__):
-            keys = set(self.dic) | set(other.dic)
-            new.dic = {k: self[k] * other[k] for k in keys}
-        else:  # assume a float
-            new.dic = {k: self.dic[k] * other for k in self.dic}
-        return new
-
-    __rmul__ = __mul__
-
     def __add__(self, other):
         new = object.__new__(self.__class__)
         if isinstance(other, self.__class__):
@@ -113,14 +103,6 @@ class ImtWeight(object):
         return new
 
     __radd__ = __add__
-
-    def __truediv__(self, other):
-        new = object.__new__(self.__class__)
-        if isinstance(other, self.__class__):
-            new.dic = {k: self.dic[k] / other[k] for k in self.dic}
-        else:  # assume a float
-            new.dic = {k: self.dic[k] / other for k in self.dic}
-        return new
 
     def is_one(self):
         """
@@ -245,6 +227,27 @@ class GsimLogicTree(object):
             raise InvalidLogicTree(
                 '%s is missing in %s' % (set(tectonic_region_types), fname))
 
+    @cached_property
+    def imti(self):
+        # build imti dictionary
+        imts = {}
+        for br in self.branches:
+            imts.update(br.weight.dic)
+        # uppercase is sorted before lowercase, so 'weight' is the last
+        return {imt: i for (i, imt) in enumerate(sorted(imts))}
+
+    # this is nontrivial only for Canada, see logictree/case_39
+    def wget(self, weights, imt=None):
+        """
+        :param weight: an array of weights of shape (R, 1) or (R, M+1)
+        :returns: imt-index for imt-dependent weights
+        """
+        try:
+            i = self.imti[imt]
+        except KeyError:
+            i = len(self.imti) - 1
+        return weights[:, i]
+        
     @property
     def req_site_params(self):
         site_params = set()
@@ -506,7 +509,7 @@ class GsimLogicTree(object):
                    for i, trt in enumerate(self.values)]
         rlzs = []
         for i in range(n):
-            weight = ImtWeight.new(1.)
+            weight = numpy.ones(1)
             lt_path = []
             lt_uid = []
             value = []
@@ -514,7 +517,7 @@ class GsimLogicTree(object):
                 branch = brlist[i]
                 lt_path.append(branch.id)
                 lt_uid.append(branch.id if branch.effective else '.')
-                weight *= branch.weight
+                weight[0] *= branch.weight['weight']
                 value.append(branch.gsim)
             rlz = lt.Realization(tuple(value), weight, i, tuple(lt_uid))
             rlzs.append(rlz)
@@ -553,14 +556,16 @@ class GsimLogicTree(object):
             groups.append([b for b in self.branches if b.trt == trt])
         # with T tectonic region types there are T groups and T branches
         for i, branches in enumerate(itertools.product(*groups)):
-            weight = ImtWeight.new(1.)
+            weight = numpy.ones(len(self.imti))
             lt_path = []
             lt_uid = []
             value = []
             for trt, branch in zip(self.values, branches):
                 lt_path.append(branch.id)
                 lt_uid.append(branch.id if branch.effective else '.')
-                weight *= branch.weight
+                for imt in branch.weight.dic:
+                    i = self.imti.get(imt, len(self.imti))
+                    weight[i] *= branch.weight[imt]
                 value.append(branch.gsim)
             yield lt.Realization(tuple(value), weight, i, tuple(lt_uid))
 

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -256,6 +256,12 @@ class GsimLogicTree(object):
                 site_params.update(gsim.REQUIRES_SITES_PARAMETERS)
         return site_params
 
+    def has_imt_weights(self):
+        """
+        :returns: True if the logic tree has IMT-dependend weights
+        """
+        return len(self.branches[0].weight.dic) > 1
+
     def check_imts(self, imts):
         """
         Make sure the IMTs are recognized by all GSIMs in the logic tree

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -73,12 +73,6 @@ class ImtWeight(object):
     """
     A composite weight by IMTs extracted from the gsim_logic_tree_file
     """
-    @classmethod
-    def new(cls, weight):
-        self = object.__new__(cls)
-        self.dic = {'weight': weight}
-        return self
-
     def __init__(self, branch, fname):
         with context(fname, branch.uncertaintyWeight):
             nodes = list(branch.getnodes('uncertaintyWeight'))
@@ -245,6 +239,7 @@ class GsimLogicTree(object):
         try:
             i = self.imti[imt]
         except KeyError:
+            # the default weight is stored in the last index
             i = len(self.imti) - 1
         return weights[:, i]
         

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1066,6 +1066,8 @@ class FullLogicTree(object):
         assert self.Re <= TWO24, len(self.sm_rlzs)
         self.trti = {trt: i for i, trt in enumerate(self.gsim_lt.values)}
         self.trts = list(self.gsim_lt.values)
+        if self.get_num_paths() >= 100_000:
+            logging.info('Building realization weights')
         self.weights = numpy.array(
             [rlz.weight for rlz in self.get_realizations()])
         return self

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1066,12 +1066,11 @@ class FullLogicTree(object):
         assert self.Re <= TWO24, len(self.sm_rlzs)
         self.trti = {trt: i for i, trt in enumerate(self.gsim_lt.values)}
         self.trts = list(self.gsim_lt.values)
-        if self.get_num_paths() >= 100_000:
-            logging.info('Building realization weights')
+        if self.get_num_paths() >= 10_000:
+            logging.info('Building realizations')
         self.weights = numpy.array(
             [rlz.weight for rlz in self.get_realizations()])
         return self
-
 
     def wget(self, weights, imt):
         """

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -44,7 +44,7 @@ from openquake.baselib.general import (
 from openquake.hazardlib import nrml, InvalidFile, pmf, valid
 from openquake.hazardlib.sourceconverter import SourceGroup
 from openquake.hazardlib.gsim_lt import (
-    GsimLogicTree, bsnodes, fix_bytes, keyno, abs_paths, ImtWeight)
+    GsimLogicTree, bsnodes, fix_bytes, keyno, abs_paths)
 from openquake.hazardlib.lt import (
     Branch, BranchSet, count_paths, Realization, CompositeLogicTree,
     dummy_branchset, LogicTreeError, parse_uncertainty, random)
@@ -68,7 +68,6 @@ source_dt = numpy.dtype([
     ('source', hdf5.vstr),
 ])
 
-
 source_model_dt = numpy.dtype([
     ('name', hdf5.vstr),
     ('weight', F32),
@@ -76,13 +75,13 @@ source_model_dt = numpy.dtype([
     ('samples', U32),
 ])
 
-src_group_dt = numpy.dtype(
-    [('trt_smr', U32),
-     ('name', hdf5.vstr),
-     ('trti', U16),
-     ('effrup', I32),
-     ('totrup', I32),
-     ('sm_id', U32),
+src_group_dt = numpy.dtype([
+    ('trt_smr', U32),
+    ('name', hdf5.vstr),
+    ('trti', U16),
+    ('effrup', I32),
+    ('totrup', I32),
+    ('sm_id', U32),
 ])
 
 branch_dt = numpy.dtype([
@@ -1091,7 +1090,7 @@ class FullLogicTree(object):
             gids.append(numpy.arange(g, g + len(rbg)))
             g += len(rbg)
         return gids
-        
+
     def get_trt_rlzs(self, all_trt_smrs):
         """
         :returns: a list with Gt arrays of dtype uint32
@@ -1150,7 +1149,7 @@ class FullLogicTree(object):
     @cached_property
     def sd(self):
         return group_array(self.source_model_lt.source_data, 'source')
-    
+
     def get_trt_smrs(self, src_id=None):
         """
         :returns: a tuple of indices trt_smr for the given source
@@ -1180,7 +1179,7 @@ class FullLogicTree(object):
         :param srm: source model realization index
         :returns: list of sources with the same base source ID
         """
-        if not self.trti: # empty gsim_lt
+        if not self.trti:  # empty gsim_lt
             return srcs
         sd = self.sd
         out = []
@@ -1195,7 +1194,7 @@ class FullLogicTree(object):
             if smr is None and ';' in src.source_id:
                 # assume <base_id>;<smr>
                 smr = _get_smr(src.source_id)
-            if smr is None:  # called by .reduce_groups 
+            if smr is None:  # called by .reduce_groups
                 try:
                     # check if ambiguous source ID
                     srcid, fname = srcid.rsplit('!')

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -425,8 +425,8 @@ def _cdf(weighted_objects):
         w = obj.weight
         if isinstance(obj.weight, (float, int)):
             weights.append(w)
-        else:
-            weights.append(w['weight'])
+        else:  # assume array
+            weights.append(w[-1])
     return numpy.cumsum(weights)
 
 


### PR DESCRIPTION
For instance the EUR model has 302_990_625 realizations and trying to build the realizations causes cole to run out of memory (512 GB) after 2.5 hours. Now building the weights takes only 25 minutes and requires < 100 GB of RAM.
However, the performance is dominated by `full_lt.get_rlzs_by_gsim` which is pretty slow and memory consuming.
Here is the time spent in `full_lt.init()` for New Zealand with ~1M realizations:
```
| old vs new       | time_sec | memory_mb | counts |
|------------------+----------+-----------+--------|
| building full_lt |     54.5 |     639.6 |      1 |
| building full_lt |     52.9 |     365.8 |      1 |
```
The memory is nearly halved.