### PR TITLE
Removed reduce-rlzs feature

### DIFF
--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -683,8 +683,9 @@ hazard_uhs-std.csv
 
         # check the reduction from 10 to 2 realizations
         rlzs = extract(self.calc.datastore, 'realizations').array
-        ae(rlzs['branch_path'], [b'AA~A', b'B.~A'])
-        aac(rlzs['weight'], [.7, .3])
+        ae(rlzs['branch_path'], [b'AA~A', b'AA~A', b'AA~A', b'AA~A', b'AA~A',
+                                 b'AA~A', b'AA~A', b'B.~A', b'B.~A', b'B.~A'])
+        aac(rlzs['weight'], [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
 
         # check the hazard curves
         fnames = export(('hcurves', 'csv'), self.calc.datastore)
@@ -705,13 +706,6 @@ hazard_uhs-std.csv
         ae(list(cmakers[0].gsims.values()), [[1, 3, 5], [2], [0, 4]])
         ae(list(cmakers[1].gsims.values()), [[7, 9], [6, 8]])
         # there are two slices 0:3 and 3:5 with length 3 and 2 respectively
-
-        # testing unique_paths mode
-        self.run_calc(case_71.__file__, 'job.ini', concurrent_tasks='0',
-                      oversampling='reduce-rlzs')
-        self.assertEqual(len(self.calc.realizations), 5)
-        [fname] = export(('hcurves/mean', 'csv'), self.calc.datastore)
-        self.assertEqualFiles('expected/hcurves.csv', fname)
 
     def test_case_73(self):
         # test LT

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -565,10 +565,8 @@ number_of_logic_tree_samples:
 
 oversampling:
   When equal to "forbid" raise an error if tot_samples > num_paths in classical
-  calculations; when equal to "tolerate" do not raise the error (the default);
-  when equal to "reduce_rlzs" reduce the realizations to the unique paths with
-  weights num_samples/tot_samples
-  Example: *oversampling = reduce_rlzs*
+  calculations; when equal to "tolerate" do not raise the error (the default).
+  Example: *oversampling = forbid*
   Default: tolerate
 
 poes:
@@ -1058,7 +1056,7 @@ class OqParam(valid.ParamSet):
     num_epsilon_bins = valid.Param(valid.positiveint, 1)
     num_rlzs_disagg = valid.Param(valid.positiveint, 0)
     oversampling = valid.Param(
-        valid.Choice('forbid', 'tolerate', 'reduce-rlzs'), 'tolerate')
+        valid.Choice('forbid', 'tolerate'), 'tolerate')
     poes = valid.Param(valid.probabilities, [])
     poes_disagg = valid.Param(valid.probabilities, [])
     pointsource_distance = valid.Param(valid.floatdict, {'default': PSDIST})

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -749,10 +749,7 @@ def get_full_lt(oqparam):
         elif trt.lower() not in trts_lower:
             logging.warning('Unknown TRT=%s in [reqv] section' % trt)
     gsim_lt = get_gsim_lt(oqparam, trts or ['*'])
-    if len(oqparam.source_id) == 1:
-        oversampling = 'reduce-rlzs'
-    else:
-        oversampling = oqparam.oversampling
+    oversampling = oqparam.oversampling
     full_lt = logictree.FullLogicTree(source_model_lt, gsim_lt, oversampling)
     p = full_lt.source_model_lt.num_paths * gsim_lt.get_num_paths()
 

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1135,8 +1135,6 @@ class FullLogicTree(object):
         """
         :returns: the source_model_lt ``num_samples`` parameter
         """
-        if self.oversampling == 'reduce-rlzs':
-            return len(self.get_realizations())
         return self.source_model_lt.num_samples
 
     @property
@@ -1255,17 +1253,13 @@ class FullLogicTree(object):
                 sm_rlzs.extend([sm_rlz] * sm_rlz.samples)
             gsim_rlzs = self.gsim_lt.sample(
                 num_samples, self.seed + 1, self.sampling_method)
-            if self.oversampling == 'reduce-rlzs':
-                eff_rlzs = get_eff_rlzs(sm_rlzs, gsim_rlzs)
-                rlzs.extend(eff_rlzs)
-            else:
-                for i, gsim_rlz in enumerate(gsim_rlzs):
-                    rlz = LtRealization(i, sm_rlzs[i].lt_path, gsim_rlz,
-                                        sm_rlzs[i].weight * gsim_rlz.weight)
-                    rlzs.append(rlz)
-                if self.sampling_method.startswith('early_'):
-                    for rlz in rlzs:
-                        rlz.weight[:] = 1. / num_samples
+            for i, gsim_rlz in enumerate(gsim_rlzs):
+                rlz = LtRealization(i, sm_rlzs[i].lt_path, gsim_rlz,
+                                    sm_rlzs[i].weight * gsim_rlz.weight)
+                rlzs.append(rlz)
+            if self.sampling_method.startswith('early_'):
+                for rlz in rlzs:
+                    rlz.weight[:] = 1. / num_samples
         else:  # full enumeration
             gsim_rlzs = list(self.gsim_lt)
             i = 0

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-001-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-001-PGA.csv
@@ -1,3 +1,3 @@
-#,,,"generated_by='OpenQuake engine 3.17.0-git00a1846f48', start_date='2023-03-29T05:59:43', checksum=628017107, kind='rlz-001', investigation_time=1.0, imt='PGA'"
+#,,,"generated_by='OpenQuake engine 3.20.0-gitcdeb3e7b0b', start_date='2024-05-25T16:26:14', checksum=628017107, kind='rlz-001', investigation_time=1.0, imt='PGA'"
 lon,lat,depth,poe-0.0010000
-0.00000,0.00000,0.00000,0.000000E+00
+0.00000,0.00000,0.00000,6.321205E-01

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-002-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-002-PGA.csv
@@ -1,0 +1,3 @@
+#,,,"generated_by='OpenQuake engine 3.20.0-git0b44a3aca0', start_date='2024-05-25T17:48:14', checksum=628017107, kind='rlz-002', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000
+0.00000,0.00000,0.00000,6.321205E-01

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-003-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-003-PGA.csv
@@ -1,0 +1,3 @@
+#,,,"generated_by='OpenQuake engine 3.20.0-git0b44a3aca0', start_date='2024-05-25T17:48:14', checksum=628017107, kind='rlz-003', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000
+0.00000,0.00000,0.00000,6.321205E-01

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-004-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-004-PGA.csv
@@ -1,0 +1,3 @@
+#,,,"generated_by='OpenQuake engine 3.20.0-git0b44a3aca0', start_date='2024-05-25T17:48:14', checksum=628017107, kind='rlz-004', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000
+0.00000,0.00000,0.00000,6.321205E-01

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-005-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-005-PGA.csv
@@ -1,0 +1,3 @@
+#,,,"generated_by='OpenQuake engine 3.20.0-git0b44a3aca0', start_date='2024-05-25T17:48:14', checksum=628017107, kind='rlz-005', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000
+0.00000,0.00000,0.00000,6.321205E-01

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-006-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-006-PGA.csv
@@ -1,0 +1,3 @@
+#,,,"generated_by='OpenQuake engine 3.20.0-git0b44a3aca0', start_date='2024-05-25T17:48:14', checksum=628017107, kind='rlz-006', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000
+0.00000,0.00000,0.00000,6.321205E-01

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-007-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-007-PGA.csv
@@ -1,0 +1,3 @@
+#,,,"generated_by='OpenQuake engine 3.20.0-git0b44a3aca0', start_date='2024-05-25T17:48:14', checksum=628017107, kind='rlz-007', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000
+0.00000,0.00000,0.00000,0.000000E+00

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-008-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-008-PGA.csv
@@ -1,0 +1,3 @@
+#,,,"generated_by='OpenQuake engine 3.20.0-git0b44a3aca0', start_date='2024-05-25T17:48:14', checksum=628017107, kind='rlz-008', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000
+0.00000,0.00000,0.00000,0.000000E+00

--- a/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-009-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_68/expected/hazard_curve-rlz-009-PGA.csv
@@ -1,0 +1,3 @@
+#,,,"generated_by='OpenQuake engine 3.20.0-git0b44a3aca0', start_date='2024-05-25T17:48:14', checksum=628017107, kind='rlz-009', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000
+0.00000,0.00000,0.00000,0.000000E+00


### PR DESCRIPTION
It was meant for AELO, but it is not used there, and it complicates the logic a lot. I checked that there are no changes to the AELO numbers.