### PR TITLE
Avoid setting the OQ_APPLICATION_MODE env variable outside the context of the webui

### DIFF
--- a/openquake/server/middleware.py
+++ b/openquake/server/middleware.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import re
 
 from django.conf import settings
@@ -59,7 +58,5 @@ class LoginRequiredMiddleware:
                     return HttpResponseForbidden()
                 else:
                     return HttpResponseRedirect(settings.LOGIN_URL)
-
-        os.environ['OQ_APPLICATION_MODE'] = settings.APPLICATION_MODE
 
         return self.get_response(request)

--- a/openquake/server/middleware.py
+++ b/openquake/server/middleware.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import re
 
 from django.conf import settings
@@ -58,5 +59,7 @@ class LoginRequiredMiddleware:
                     return HttpResponseForbidden()
                 else:
                     return HttpResponseRedirect(settings.LOGIN_URL)
+
+        os.environ['OQ_APPLICATION_MODE'] = settings.APPLICATION_MODE
 
         return self.get_response(request)

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -223,6 +223,10 @@ except ImportError:
         # settings in this file only will be used
         pass
 
+# NOTE: the OQ_APPLICATION_MODE environment variable, if defined, overrides
+# both the default setting and the one specified in the local settings
+APPLICATION_MODE = os.environ.get('OQ_APPLICATION_MODE', APPLICATION_MODE)
+
 if APPLICATION_MODE not in APPLICATION_MODES:
     raise ValueError(
         f'Invalid application mode: "{APPLICATION_MODE}". It must be'

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -223,13 +223,7 @@ except ImportError:
         # settings in this file only will be used
         pass
 
-# NOTE: the OQ_APPLICATION_MODE environment variable, if defined, overrides
-# both the default setting and the one specified in the local settings
-APPLICATION_MODE = os.environ.get('OQ_APPLICATION_MODE', APPLICATION_MODE)
-if not os.environ.get('OQ_APPLICATION_MODE'):
-    os.environ['OQ_APPLICATION_MODE'] = APPLICATION_MODE
-
-if os.environ['OQ_APPLICATION_MODE'] not in APPLICATION_MODES:
+if APPLICATION_MODE not in APPLICATION_MODES:
     raise ValueError(
         f'Invalid application mode: "{APPLICATION_MODE}". It must be'
         f' one of {APPLICATION_MODES}')

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import getpass
 import requests
 import logging
@@ -101,6 +102,10 @@ def oq_server_context_processor(request):
     A custom context processor which allows injection of additional
     context variables.
     """
+
+    # NOTE: defining env variable at runtime, instead of defining it when the
+    # engine imports variable from the server module
+    os.environ['OQ_APPLICATION_MODE'] = settings.APPLICATION_MODE
 
     context = {}
 


### PR DESCRIPTION
Instead, we set the env variable in the LoginRequiredMiddleware for authenticated users

Fixes https://github.com/gem/oq-engine/issues/9710