### PR TITLE
Removed .gitattribues for CSV

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 * text=auto
 *.xml text eol=lf
-*.csv text eol=crlf
 *.onnx binary


### PR DESCRIPTION
For 10 years we had no problems with CSV files, even if the line-ending was not `crlf`. Since @ptormene set `.csv text eol=crlf` in the `.gitattributes` we have too often super-annoying fake merge conflicts due to the CSV files. Reverting to the old situation hoping to solve the problem for non git-savvy users.