### PR TITLE
Restored warning when setting maximum_distance for a TRT missing in the gsim_lt

### DIFF
--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -68,7 +68,7 @@ jobs:
         cd openquake
         ruff check --preview --select NPY201 .
         pytest calculators -k 'risk or damage' -x --doctest-modules --disable-warnings --color=yes --durations=5
-        pytest -x --doctest-modules --disable-warnings --color=yes --durations=8 sep commands engine hmtk risklib commonlib baselib hazardlib
+        pytest -xs --doctest-modules --disable-warnings --color=yes --durations=8 sep commands engine hmtk risklib commonlib baselib hazardlib
 
   server_public_mode:
     runs-on: ${{ matrix.os }}

--- a/openquake/baselib/tests/flake8_test.py
+++ b/openquake/baselib/tests/flake8_test.py
@@ -167,8 +167,8 @@ def test_csv():
                         fix_newlines(fname, lines)
                     except Exception as exc:
                         raise ValueError('%s: %s' % (fname, exc))
-                elif error:
-                    print('Wrong line ending in', fname, file=sys.stderr)
+                #elif error:
+                #    print('Wrong line ending in', fname, file=sys.stderr)
                 elif error == 1:
                     raise ValueError('Found \\n line ending in %s' % fname)
                 elif error == 2:

--- a/openquake/baselib/tests/flake8_test.py
+++ b/openquake/baselib/tests/flake8_test.py
@@ -167,8 +167,8 @@ def test_csv():
                         fix_newlines(fname, lines)
                     except Exception as exc:
                         raise ValueError('%s: %s' % (fname, exc))
-                #elif error:
-                #    print('Wrong line ending in', fname, file=sys.stderr)
+                elif error:
+                    print('Wrong line ending in', fname, file=sys.stderr)
                 elif error == 1:
                     raise ValueError('Found \\n line ending in %s' % fname)
                 elif error == 2:

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1944,6 +1944,9 @@ class OqParam(valid.ParamSet):
             self.error = ('setting the maximum_distance for %s which is '
                           'not in %s' % (unknown, gsim_lt))
             return False
+        for trt, val in self.maximum_distance.items():
+            if trt not in self._trts and trt != 'default':
+                logging.warning('tectonic region %r not in %s', trt, gsim_lt)
         if 'default' not in trts and trts < self._trts:
             missing = ', '.join(self._trts - trts)
             self.error = 'missing distance for %s and no default' % missing

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1946,6 +1946,7 @@ class OqParam(valid.ParamSet):
             return False
         for trt, val in self.maximum_distance.items():
             if trt not in self._trts and trt != 'default':
+                # not a problem, the associated maxdist will simply be ignored
                 logging.warning('tectonic region %r not in %s', trt, gsim_lt)
         if 'default' not in trts and trts < self._trts:
             missing = ', '.join(self._trts - trts)


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/9591