### PR TITLE
Fix templates for AELO and ARISTOTLE local settings

### DIFF
--- a/openquake/server/local_settings.py.aelo_aristotle
+++ b/openquake/server/local_settings.py.aelo_aristotle
@@ -1,6 +1,8 @@
 import os
 
-APPLICATION_MODE = 'AELO'
+APPLICATION_MODE = <'AELO'|'ARISTOTLE'>
+ALLOWED_HOSTS = (<hostname>, 'localhost', '127.0.0.1')
+CSRF_TRUSTED_ORIGINS = [<protocol:hostname>]
 
 DISABLE_VERSION_WARNING = True
 
@@ -29,12 +31,12 @@ EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_PASS')
 #       specified in /etc/nginx/conf.d/webui.conf
 SERVER_NAME = <localhost>
 SERVER_PORT = <8800>
-USE_HTTPS = <False>
+USE_HTTPS = <True|False>
 
 # Set to True if using NGINX or some other reverse proxy
 # Externally visible url and port number is different from Django visible
 # values
-USE_REVERSE_PROXY = <False>
+USE_REVERSE_PROXY = <True|False>
 
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 

--- a/openquake/server/local_settings.py.aelo_aristotle
+++ b/openquake/server/local_settings.py.aelo_aristotle
@@ -2,7 +2,7 @@ import os
 
 APPLICATION_MODE = <'AELO'|'ARISTOTLE'>
 ALLOWED_HOSTS = (<hostname>, 'localhost', '127.0.0.1')
-CSRF_TRUSTED_ORIGINS = [<protocol:hostname>]
+CSRF_TRUSTED_ORIGINS = [<protocol://hostname>]
 
 DISABLE_VERSION_WARNING = True
 


### PR DESCRIPTION
We had a couple of missing variables that are needed in AELO and ARISTOTLE installations.
We were using the AELO template also for ARISTOTLE, but it was not obvious, so I made it explicit.