### PR TITLE
Added variable OQ_DEBUG_SITE

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -982,20 +982,23 @@ def extract_avg_gmf(dstore, what):
     [imt] = qdict['imt']
     imti = info['imt'][imt]
     try:
-        sitecol = dstore['complete']
+        complete = dstore['complete']
     except KeyError:
-        sitecol = dstore['sitecol']
+        if dstore.parent:
+            complete = dstore.parent['sitecol'].complete
+        else:
+            complete = dstore['sitecol'].complete
     avg_gmf = dstore['avg_gmf'][0, :, imti]
     if 'station_data' in dstore:
         # discard the stations from the avg_gmf plot
         stations = dstore['station_data/site_id'][:]
-        ok = (avg_gmf > 0) & ~numpy.isin(sitecol.sids, stations)
+        ok = (avg_gmf > 0) & ~numpy.isin(complete.sids, stations)
     else:
         ok = avg_gmf > 0
-    yield imt, avg_gmf[sitecol.sids[ok]]
-    yield 'sids', sitecol.sids[ok]
-    yield 'lons', sitecol.lons[ok]
-    yield 'lats', sitecol.lats[ok]
+    yield imt, avg_gmf[complete.sids[ok]]
+    yield 'sids', complete.sids[ok]
+    yield 'lons', complete.lons[ok]
+    yield 'lats', complete.lats[ok]
 
 
 @extract.add('num_events')

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1029,6 +1029,10 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, exp_types=(), h5=None):
     asset_hazard_distance = max(oqparam.asset_hazard_distance.values())
     if haz_sitecol is None:
         haz_sitecol = get_site_collection(oqparam, h5)
+    siteid = os.environ.get('OQ_DEBUG_SITE')
+    if siteid:
+        haz_sitecol.array = haz_sitecol[
+            haz_sitecol['custom_site_id'] == siteid.encode('ascii')]
     try:
         exp = haz_sitecol.exposure
     except AttributeError:

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1031,6 +1031,7 @@ def get_sitecol_assetcol(oqparam, haz_sitecol=None, exp_types=(), h5=None):
         haz_sitecol = get_site_collection(oqparam, h5)
     siteid = os.environ.get('OQ_DEBUG_SITE')
     if siteid:
+        oqparam.concurrent_tasks = 0
         haz_sitecol.array = haz_sitecol[
             haz_sitecol['custom_site_id'] == siteid.encode('ascii')]
     try:


### PR DESCRIPTION
Useful for debugging, for instance with
```
$ OQ_DEBUG_SITE=EXP1063 oq run job_losses.ini --hc -1
```
Also fixed `extract/avg_gmf` to work with two-file calculations.