### PR TITLE
Small refactoring of get_rlzs_by_gsim

### DIFF
--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1310,11 +1310,11 @@ class FullLogicTree(object):
             smr = sm.ordinal
             rlzs_sm = get_rlzs(smr)
             for trti in trtis:
-                dic = acc[smr + TWO24 * trti]
+                rbg = acc[smr + TWO24 * trti]
                 for rlz in rlzs_sm:
-                    dic[rlz.gsim_rlz.value[trti]].append(rlz.ordinal)
-                for k in dic:
-                    dic[k] = U32(dic[k])
+                    rbg[rlz.gsim_rlz.value[trti]].append(rlz.ordinal)
+                for gsim in rbg:
+                    rbg[gsim] = U32(rbg[gsim])
         return acc
 
     def get_rlzs_by_gsim(self, trt_smr):

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1017,6 +1017,21 @@ def _get_smr(source_id):
     return int(smr)
 
 
+def _build_ddic(trtis, sm_rlzs, get_rlzs):
+    # returns a double dictionary trt_smr -> gsim -> rlzs
+    acc = AccumDict(accum=AccumDict(accum=[]))
+    for sm in sm_rlzs:
+        smr = sm.ordinal
+        rlzs_sm = get_rlzs(smr)
+        for trti in trtis:
+            rbg = acc[smr + TWO24 * trti]
+            for rlz in rlzs_sm:
+                rbg[rlz.gsim_rlz.value[trti]].append(rlz.ordinal)
+            acc[smr + TWO24 * trti] = {gsim: U32(rbg[gsim])
+                                       for gsim in sorted(rbg)}
+    return acc
+
+
 class FullLogicTree(object):
     """
     The full logic tree as composition of
@@ -1281,41 +1296,26 @@ class FullLogicTree(object):
         # return dictionary gsim->rlzs
         if not hasattr(self, '_rlzs_by'):
             rlzs = self.get_realizations()
+            trtis = range(len(self.gsim_lt.values))
             if self.source_model_lt.filename == 'fake.xml':  # scenario
                 smr_by_ltp = {'~'.join(sm_rlz.lt_path): i
                               for i, sm_rlz in enumerate(self.sm_rlzs)}
                 smidx = numpy.zeros(self.get_num_paths(), int)		
                 for rlz in rlzs:		
                     smidx[rlz.ordinal] = smr_by_ltp['~'.join(rlz.sm_lt_path)]
-                acc = self._buildacc(lambda smr: rlzs[smidx == smr])
+                self._rlzs_by = _build_ddic(trtis, self.sm_rlzs,
+                                            lambda smr: rlzs[smidx == smr])
             else:  # classical and event based
                 start = 0
                 slices = []
                 for sm in self.sm_rlzs:
                     slices.append(slice(start, start + sm.samples))
                     start += sm.samples
-                acc = self._buildacc(lambda smr: rlzs[slices[smr]])
-            self._rlzs_by = {}
-            for trtsmr, dic in acc.items():
-                self._rlzs_by[trtsmr] = {
-                    gsim: rlzs for gsim, rlzs in sorted(dic.items())}
+                self._rlzs_by = _build_ddic(trtis, self.sm_rlzs,
+                                            lambda smr: rlzs[slices[smr]])
         if not self._rlzs_by:
             return {}
         return self._rlzs_by[trt_smr]
-
-    def _buildacc(self, get_rlzs):
-        acc = AccumDict(accum=AccumDict(accum=[]))  # trt_smr->gsim->rlzs
-        trtis = range(len(self.gsim_lt.values))
-        for sm in self.sm_rlzs:
-            smr = sm.ordinal
-            rlzs_sm = get_rlzs(smr)
-            for trti in trtis:
-                rbg = acc[smr + TWO24 * trti]
-                for rlz in rlzs_sm:
-                    rbg[rlz.gsim_rlz.value[trti]].append(rlz.ordinal)
-                for gsim in rbg:
-                    rbg[gsim] = U32(rbg[gsim])
-        return acc
 
     def get_rlzs_by_gsim(self, trt_smr):
         """


### PR DESCRIPTION
Save 5 GB of RAM in EUR:
```
# before
| calc_464, maxmem=181.4 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| PreClassicalCalculator.run | 2_660    | 111_210   | 1       |
| total preclassical         | 1_591    | 175.5117  | 352     |
| importing inputs           | 1_251    | 84_957    | 1       |
| composite source model     | 1_249    | 84_935    | 1       |
| building full_lt           | 1_234    | 84_765    | 1       |

# after
| calc_465, maxmem=176.6 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| PreClassicalCalculator.run | 2_659    | 106_655   | 1       |
| total preclassical         | 1_590    | 175.4844  | 352     |
| importing inputs           | 1_242    | 84_955    | 1       |
| composite source model     | 1_240    | 84_931    | 1       |
| building full_lt           | 1_226    | 84_767    | 1       |
```