### PR TITLE
Rewritten `oq compare assetcol`

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1713,7 +1713,8 @@ def view_aggrisk(token, dstore):
     Returns a table with the aggregate risk by realization and loss type
     """
     gsim_lt = dstore['full_lt/gsim_lt']
-    df = dstore.read_df('aggrisk', sel={'agg_id': 0})
+    K = dstore['risk_by_event'].attrs.get('K', 0)
+    df = dstore.read_df('aggrisk', sel={'agg_id': K})
     dt = [('gsim', vstr), ('weight', float)] + [
         (lt, float) for lt in LOSSTYPE[df.loss_id.unique()]]
     rlzs = list(gsim_lt)

--- a/openquake/commands/compare.py
+++ b/openquake/commands/compare.py
@@ -332,42 +332,22 @@ def compare_events(calc_ids: int):
     print(df)
 
 
-def get_asset_ids(ds):
-    ids = ds['assetcol']['id'][:]
-    if ds['oqparam'].aristotle:
-        N = 3  # length of mosaic model codes
-        ids = numpy.array([id_[N:] for id_ in ids])
-    return ids
-
-
-def same_length(ds0, ds1, what):
-    len0 = len(ds0[what])
-    len1 = len(ds1[what])
-    if len0 != len1:
-        print(f'The {what}s have different lengths: {len0} != {len1}')
-        return False
-    else:
-        print(f'The {what}s have the same lengths')
-        return True
-
-
 def compare_column_values(array0, array1, what, calc_id0, calc_id1):
-    diff_idxs = numpy.where(array0 != array1)[0]
+    if isinstance(array0[0], (float, numpy.float32, numpy.float64)):
+        diff_idxs = numpy.where(numpy.abs(array0 - array1) > 1E-5)[0]
+    else:
+        diff_idxs = numpy.where(array0 != array1)[0]
     if len(diff_idxs) == 0:
         print(f'The column {what} is okay')
         return
     print(f"There are {len(diff_idxs)} different elements "
           f"in the '{what}' column.")
     for ordinal, idx in enumerate(diff_idxs):
-        if ordinal > 5:
+        if ordinal > 1:
             print('[...]')
             break
         print(f"Index {idx}: {array0[idx]} in calc {calc_id0},"
               f" {array1[idx]} in calc {calc_id1}")
-    if numpy.array_equal(numpy.sort(array0), numpy.sort(array1)):
-        print(f'However, the sorted "{what}"s are equal')
-    else:
-        print(f'"{what}"s remain different even after sorting them')
 
 
 def check_column_names(array0, array1, what, calc_id0, calc_id1):
@@ -394,23 +374,18 @@ def compare_assetcol(calc_ids: int):
     """
     ds0 = datastore.read(calc_ids[0])
     ds1 = datastore.read(calc_ids[1])
-    if not same_length(ds0, ds1, 'assetcol'):
-        return
-    check_column_names(
-            ds0['assetcol'].array, ds1['assetcol'].array,
-            'assetcol', calc_ids[0], calc_ids[1])
-    ids0 = get_asset_ids(ds0)
-    ids1 = get_asset_ids(ds1)
-    compare_column_values(ids0, ids1, 'id', calc_ids[0], calc_ids[1])
     array0 = ds0['assetcol'].array
     array1 = ds1['assetcol'].array
-    for col in ds0['assetcol'].array.dtype.names:
-        if col == 'id':
-            continue
-        values0 = array0[col]
-        values1 = array1[col]
-        compare_column_values(values0, values1,
-                              col, calc_ids[0], calc_ids[1])
+    oq0 = ds0['oqparam']
+    oq1 = ds1['oqparam']
+    if oq0.aristotle:
+        array0['id'] = [id[3:] for id in array0['id']]
+    if oq1.aristotle:
+        array1['id'] = [id[3:] for id in array1['id']]
+    check_column_names(array0, array1, 'assetcol', *calc_ids)
+    fields = set(array0.dtype.names) & set(array1.dtype.names) - {
+        'site_id', 'id', 'ordinal'}
+    check_intersect(array0, array1, 'id', sorted(fields), calc_ids)
 
 
 def check_intersect(array0, array1, kfield, vfields, calc_ids):

--- a/openquake/commands/compare.py
+++ b/openquake/commands/compare.py
@@ -390,8 +390,11 @@ def compare_assetcol(calc_ids: int):
         array1['id'] = [id[3:] for id in array1['id']]
     check_column_names(array0, array1, 'assetcol', *calc_ids)
     fields = set(array0.dtype.names) & set(array1.dtype.names) - {
-        'site_id', 'id', 'ordinal'}
-    check_intersect(array0, array1, 'id', sorted(fields), calc_ids)
+        'site_id', 'id', 'ordinal', 'taxonomy'}
+    arr0, arr1 = check_intersect(array0, array1, 'id', sorted(fields), calc_ids)
+    taxo0 = ds0['assetcol/tagcol/taxonomy'][:][arr0['taxonomy']]
+    taxo1 = ds1['assetcol/tagcol/taxonomy'][:][arr1['taxonomy']]
+    compare_column_values(taxo0, taxo1, 'taxonomy')
 
 
 def check_intersect(array0, array1, kfield, vfields, calc_ids):
@@ -408,6 +411,7 @@ def check_intersect(array0, array1, kfield, vfields, calc_ids):
     arr1 = array1[numpy.isin(val1, common)]
     for col in vfields:
         compare_column_values(arr0[col], arr1[col], col)
+    return arr0, arr1
 
 
 def compare_sitecol(calc_ids: int):

--- a/openquake/commands/compare.py
+++ b/openquake/commands/compare.py
@@ -407,6 +407,10 @@ def check_intersect(array0, array1, kfield, vfields, calc_ids):
     val1 = array1[kfield]
     common = numpy.intersect1d(val0, val1, assume_unique=True)
     print(f'Comparing {kfield=}, {len(val0)=}, {len(val1)=}, {len(common)=}')
+    if len(val0) < len(val1):
+        print('A missing asset is %s' % (set(val1)-set(val0)).pop())
+    elif len(val1) < len(val0):
+        print('A missing asset is %s' % (set(val0)-set(val1)).pop())
     arr0 = array0[numpy.isin(val0, common)]
     arr1 = array1[numpy.isin(val1, common)]
     for col in vfields:

--- a/openquake/commands/compare.py
+++ b/openquake/commands/compare.py
@@ -332,22 +332,28 @@ def compare_events(calc_ids: int):
     print(df)
 
 
-def compare_column_values(array0, array1, what, calc_id0, calc_id1):
+def delta(a, b):
+    """
+    :returns: the relative differences between a and b; zeros return zeros
+    """
+    c = a + b
+    ok = c != 0.
+    res = numpy.zeros_like(a)
+    res[ok] = numpy.abs(a[ok] - b[ok]) / c[ok]
+    return res
+
+
+def compare_column_values(array0, array1, what):
     if isinstance(array0[0], (float, numpy.float32, numpy.float64)):
-        diff_idxs = numpy.where(numpy.abs(array0 - array1) > 1E-5)[0]
+        diff_idxs = numpy.where(delta(array0, array1) > 1E-5)[0]
     else:
         diff_idxs = numpy.where(array0 != array1)[0]
     if len(diff_idxs) == 0:
         print(f'The column {what} is okay')
         return
     print(f"There are {len(diff_idxs)} different elements "
-          f"in the '{what}' column.")
-    for ordinal, idx in enumerate(diff_idxs):
-        if ordinal > 1:
-            print('[...]')
-            break
-        print(f"Index {idx}: {array0[idx]} in calc {calc_id0},"
-              f" {array1[idx]} in calc {calc_id1}")
+          f"in the '{what}' column:")
+    print(array0[diff_idxs], array1[diff_idxs])
 
 
 def check_column_names(array0, array1, what, calc_id0, calc_id1):
@@ -401,7 +407,7 @@ def check_intersect(array0, array1, kfield, vfields, calc_ids):
     arr0 = array0[numpy.isin(val0, common)]
     arr1 = array1[numpy.isin(val1, common)]
     for col in vfields:
-        compare_column_values(arr0[col], arr1[col], col, *calc_ids)
+        compare_column_values(arr0[col], arr1[col], col)
 
 
 def compare_sitecol(calc_ids: int):


### PR DESCRIPTION
So that it can be used for Aristotle comparisons. Now I get
```
$ oq compare assetcol 145996 145997
The assetcol arrays have different columns:
Calc 145996:
('id', 'ordinal', 'lon', 'lat', 'site_id', 'value-number', 'value-contents', 'value-nonstructural', 'value-structural', 'value-residents', 'occupants_day', 'occupants_night', 'occupants_transit', 'value-area', 'occupants_avg', 'ideductible', 'taxonomy', 'ID_0', 'ID_1', 'OCCUPANCY')
Calc 145997:
('id', 'ordinal', 'lon', 'lat', 'site_id', 'occupants_day', 'value-nonstructural', 'occupants_transit', 'value-residents', 'value-contents', 'value-structural', 'occupants_night', 'value-area', 'value-number', 'occupants_avg', 'ideductible', 'taxonomy', 'ID_1', 'NAME_1', 'NAME_0', 'OCCUPANCY', 'ID_2', 'ID_0')
Comparing kfield='id', len(val0)=18155, len(val1)=19168, len(common)=18155
The column ID_0 is okay
The column ID_1 is okay
The column OCCUPANCY is okay
The column ideductible is okay
The column lat is okay
The column lon is okay
The column occupants_avg is okay
The column occupants_day is okay
The column occupants_night is okay
The column occupants_transit is okay
There are 11179 different elements in the 'taxonomy' column:
[45 54 65 ... 55 72 56] [47 56 67 ... 57 74 58]
The column value-area is okay
The column value-contents is okay
The column value-nonstructural is okay
The column value-number is okay
The column value-residents is okay
The column value-structural is okay
```