### PR TITLE
Remove all warnings and errors and improve 'docs' workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -380,18 +380,42 @@ jobs:
           # PAY ATTENTION: engine folder is 'doc', not 'docs'
           # cd doc && make html && make latexpdf
           cd doc && make html 2>&1 | tee full.log
+
+          warn_found=n
+          err_found=n
           # NOTE: without '|| true' the action would fail if there are no warnings
           grep WARNING < full.log > warnings.log || true
-          echo
-          echo "=== WARNINGS ==="
-          echo
-          cat warnings.log
-          echo
-          echo
-          echo "=== WARNINGS SUMMARY ==="
-          cat warnings.log |  sed 's/.*WARNING/WARNING/g' | sed "s/WARNING: 'myst' cross-reference target not found.*/WARNING: 'myst' cross-reference target not found/g" | sed 's/WARNING: undefined label.*/WARNING: undefined label/g' | sed 's/WARNING: duplicate label.*/WARNING: duplicate label/g' | sed 's/WARNING: Duplicate explicit target name.*/WARNING: Duplicate explicit target name/g' | sort | uniq -c
+          grep ERROR < full.log > errors.log || true
 
+          if [ $(wc -c < warnings.log) -gt 0 ]; then
+              echo
+              echo "=== WARNINGS FOUND ==="
+              echo
+              cat warnings.log
+              echo
+              echo
+              echo "=== WARNINGS SUMMARY ==="
+              cat warnings.log |  sed 's/.*WARNING/WARNING/g' | sed "s/WARNING: 'myst' cross-reference target not found.*/WARNING: 'myst' cross-reference target not found/g" | sed 's/WARNING: undefined label.*/WARNING: undefined label/g' | sed 's/WARNING: duplicate label.*/WARNING: duplicate label/g' | sed 's/WARNING: Duplicate explicit target name.*/WARNING: Duplicate explicit target name/g' | sort | uniq -c
+              warn_found=y
+          else
+              echo "=== NO WARNINGS FOUND ==="
+          fi
 
+          if [ $(wc -c < errors.log) -gt 0 ]; then
+              echo
+              echo "=== ERRORS FOUND ==="
+              echo
+              cat errors.log
+              echo
+              err_found=y
+          else
+              echo "=== NO ERRORS FOUND ==="
+          fi
+
+          if [ "$warn_found" = "y" -o "$err_found" = "y" ]; then
+              echo "fix all warnings and errors to complete this workflow"
+              exit 1
+          fi
 
           # if [ "$DOCS_SSH" ]; then
           #     echo "Uploading OpenQuake Manual (PDF)"

--- a/doc/user-guide/configuration-file/classical-psha-config.rst
+++ b/doc/user-guide/configuration-file/classical-psha-config.rst
@@ -156,7 +156,7 @@ list of comma-separated integers. For example::
 	rlz_index = 22,23
 
 If ``num_rlzs_disagg`` is specified, the user cannot specify ``rlz_index``, and vice versa. If ``num_rlzs_disagg`` or 
-``rlz_index``is specified, then the mean disaggregation is automatically computed from the selected realizations.
+``rlz_index`` is specified, then the mean disaggregation is automatically computed from the selected realizations.
 
 As mentioned above, the user also has the option to perform disaggregation by directly specifying the intensity measure 
 level to be disaggregated, rather than specifying the probability of exceedance. An example is shown below::

--- a/doc/user-guide/inputs/exposure-models-inputs.rst
+++ b/doc/user-guide/inputs/exposure-models-inputs.rst
@@ -737,39 +737,50 @@ file, as shown in the following snippet from the full file::
 
 	<?xml version="1.0" encoding="UTF-8"?>
 	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+        xmlns="http://openquake.org/xmlns/nrml/0.5">
 	
-	<exposureModel id="exposure_example_with_tags"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>Exposure Model Example with Tags</description>
+	  <exposureModel id="exposure_example_with_tags"
+	                 category="buildings"
+	                 taxonomySource="GEM_Building_Taxonomy_2.0">
+
+	    <description>Exposure Model Example with Tags</description>
 	
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
-	    </costTypes>
-	    <area type="per_asset" unit="SQM" />
-	  </conversions>
+            <conversions>
+
+	      <costTypes>
+
+	        <costType name="structural" type="per_area" unit="USD" />
+
+	      </costTypes>
+	      <area type="per_asset" unit="SQM" />
+
+	    </conversions>
 	
-	  <tagNames>state county tract city zip cresta</tagNames>
+	    <tagNames>state county tract city zip cresta</tagNames>
 	
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10000" />
-	      </costs>
-	      <occupancies>
-	        <occupancy occupants="20" period="day" />
-	      </occupancies>
-	      <tags state="California" county="Solano" tract="252702"
-	            city="Suisun" zip="94585" cresta="A.11"/>
-	    </asset>
-	  </assets>
+	    <assets>
+
+	      <asset id="a1" taxonomy="Adobe" number="5" area="100" >
+
+	        <location lon="-122.000" lat="38.113" />
+	        <costs>
+
+	          <cost type="structural" value="10000"/>
 	
-	</exposureModel>
+	        </costs>
+	        <occupancies>
+
+	          <occupancy occupants="20" period="day" />
+	
+	        </occupancies>
+	        <tags state="California" county="Solano" tract="252702" city="Suisun" zip="94585" cresta="A.11"/>
+
+	      </asset>
+
+	    </assets>
 	
 	</nrml>
+	
 
 The tag values for the different tags can then be specified for each asset as shown in the following snippet from the 
 same file:

--- a/doc/user-guide/inputs/rupture-model-inputs.rst
+++ b/doc/user-guide/inputs/rupture-model-inputs.rst
@@ -134,18 +134,26 @@ An example of gridded rupture is shown below in the listing below::
 
 .. code-block:: xml
 
-	<?xml version='1.0' encoding='utf-8'?>
+	<?xml version="1.0" encoding="UTF-8"?>
 	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-              <griddedRupture probs_occur="0.984 0.016">
-                    <magnitude>8.2</magnitude>
-                    <rake>90.0</rake>
-                    <hypocenter depth="19.2" lat="35.301" lon="140.859"/>
-                    <griddedSurface>
-                        <gml:posList>
-                            141.659 35.121 9.8 141.659 35.099 9.6 141.659 35.076 9.4 ...
-                        </gml:posList>
-                    </griddedSurface>
-              </griddedRupture>
+	xmlns="http://openquake.org/xmlns/nrml/0.5">
+	<griddedRupture probs_occur="0.984 0.016">
+
+	    <magnitude>8.2</magnitude>
+	    <rake>90.0</rake>
+	    <hypocenter depth="19.2" lat="35.301" lon="140.859"/>
+	    <griddedSurface>
+    
+	      <gml:posList>
+
+	        141.659 35.121 9.8 141.659 35.099 9.6 141.659 35.076 9.4 ...
+
+	      </gml:posList>
+
+	    </griddedSurface>
+
+	</griddedRupture>
+
 	</nrml>
 
+ 


### PR DESCRIPTION
In this PR:
- remove all warnings and errors from documentation build
- introduce failure of 'docs' workflow if new warnings or errors are introduced
![error](https://github.com/gem/oq-engine/assets/1670278/5c3cd4f1-bdea-45f6-96c5-dc428dcf3c94)
