### PR TITLE
Change footer css: bigger and dark-grey font, plus some additional vertical padding

### DIFF
--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -217,6 +217,10 @@ footer.footer a {
     color: rgb(0, 0, 0, 0.8);
 }
 
+footer.footer .pull-left span {
+    font-weight: bold;
+}
+
 #new-release-box {
     display: none;
 }

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -199,19 +199,22 @@ nav.main-nav ul li.tools {
 
 footer.footer {
     background: #bebebe;
-    font-size: 12px;
+    font-size: 16px;
     position: fixed;
     bottom: 0;
-    padding-left: 10%;
-    padding-right: 10%;
     float: left;
     width: 80%;
     height: auto;
-    padding-top: 0;
+    color: rgb(0, 0, 0, 0.8);
+    padding: 0.2rem 10%;
 }
 
 footer.footer form label {
     color: #fff;
+}
+
+footer.footer a {
+    color: rgb(0, 0, 0, 0.8);
 }
 
 #new-release-box {

--- a/openquake/server/templates/engine/includes/footer.html
+++ b/openquake/server/templates/engine/includes/footer.html
@@ -1,7 +1,7 @@
   <footer id="footer" class="footer">
     <div class="container">
       <div class="pull-left">
-        <a href="https://github.com/gem/oq-engine" target="_blank">OpenQuake Engine</a> <em>{{ oq_engine_version }}</em> |
+        <a href="https://github.com/gem/oq-engine" target="_blank">OpenQuake Engine</a> <span>{{ oq_engine_version }}</span> |
         <a href="{% url "license" %}">License</a> |
         <a href="https://groups.google.com/forum/#%21forum/openquake-users" target="_blank">Feedback</a>
       </div>


### PR DESCRIPTION
The white on gray small text was really hard to read. If we want to add also the AELO version to the same footer, this change will make it more visible too.

Before:
![image](https://github.com/gem/oq-engine/assets/350930/b51b7c3b-ecb1-488e-8250-8288a62efb74)

After:
![image](https://github.com/gem/oq-engine/assets/350930/d3225fc9-0794-4f2e-8041-33d0a7dc5c8c)
