### PR TITLE
Run demos automatically also on push to branches engine-3.20 and engine-3.21

### DIFF
--- a/.github/workflows/demos_ltr_latest.yml
+++ b/.github/workflows/demos_ltr_latest.yml
@@ -9,7 +9,7 @@ on:
         required: true
   push:
     # TODO: it would be better to point to ltr and latest
-    branches: [ engine-3.16, engine-3.17, engine-3.18, engine-3.19, engine-3.20]
+    branches: [ engine-3.16, engine-3.17, engine-3.18, engine-3.19, engine-3.20, engine-3.21]
 jobs:
   demos:
     runs-on: ubuntu-latest

--- a/.github/workflows/demos_ltr_latest.yml
+++ b/.github/workflows/demos_ltr_latest.yml
@@ -9,7 +9,7 @@ on:
         required: true
   push:
     # TODO: it would be better to point to ltr and latest
-    branches: [ engine-3.16, engine-3.17, engine-3.18, engine-3.19]
+    branches: [ engine-3.16, engine-3.17, engine-3.18, engine-3.19, engine-3.20]
 jobs:
   demos:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The zipped demos are used in integration tests with the QGIS plugin to check compatibility with different engine releases.
NOTE: probably it would be sufficient to keep in the list only branches engine-3.16 and engine-3.20, preferably referring to them via aliases such as `ltr` and `latest`.