### PR TITLE
Extended `oq info` to .csv files

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -42,7 +42,7 @@ vuint32 = h5py.special_dtype(vlen=numpy.uint32)
 vfloat32 = h5py.special_dtype(vlen=numpy.float32)
 vfloat64 = h5py.special_dtype(vlen=numpy.float64)
 
-CSVFile = collections.namedtuple('CSVFile', 'fname header fields size')
+CSVFile = collections.namedtuple('CSVFile', 'fname header fields size skip')
 FLOAT = (float, numpy.float32, numpy.float64)
 INT = (int, numpy.int32, numpy.uint32, numpy.int64, numpy.uint64)
 MAX_ROWS = 10_000_000
@@ -922,9 +922,11 @@ def sniff(fnames, sep=',', ignore=set()):
     files = []
     for fname in fnames:
         with open(fname, encoding='utf-8-sig', errors='ignore') as f:
+            skip = 0
             while True:
                 first = next(f)
                 if first.startswith('#'):
+                    skip += 1
                     continue
                 break
             header = first.strip().split(sep)
@@ -932,7 +934,7 @@ def sniff(fnames, sep=',', ignore=set()):
                 common = set(header)
             else:
                 common &= set(header)
-            files.append(CSVFile(fname, header, common, os.path.getsize(fname)))
+            files.append(CSVFile(fname, header, common, os.path.getsize(fname), skip))
     common -= ignore
     assert common, 'There is no common header subset among %s' % fnames
     return files

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -25,12 +25,13 @@ import logging
 import operator
 import collections
 
+import numpy
+import pandas
 import fiona
 from shapely.geometry import shape
-import numpy
 from decorator import FunctionMaker
 
-from openquake.baselib import config
+from openquake.baselib import config, hdf5
 from openquake.baselib.general import groupby, gen_subclasses, humansize
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import nrml, imt, logictree, site, geo
@@ -283,6 +284,13 @@ def main(what, report=False):
             with mock.patch.object(logging.root, 'info'):  # reduce logging
                 do_build_reports(what)
         print(mon)
+    elif what.endswith('.csv'):
+        [rec] = hdf5.sniff([what])
+        df = pandas.read_csv(what, skiprows=rec.skip)
+        if len(df) > 25:
+            dots = pandas.DataFrame({col: ['...'] for col in df.columns})
+            df = pandas.concat([df[:10], dots, df[-10:]])
+        print(text_table(df, ext='org'))
     elif what.endswith('.xml'):
         node = nrml.read(what)
         tag = node[0].tag


### PR DESCRIPTION
Useful for pretty-pretting. For instance
```
$ oq info site_model.csv
| lon     | lat     | vs30  | z1pt0 |
|---------+---------+-------+-------|
| 81.5505 | 30.3613 | 760.0 | 100   |
| 81.7589 | 30.3613 | 760.0 | 100   |
| 81.9674 | 30.3613 | 760.0 | 100   |
| 80.9232 | 30.1814 | 760.0 | 100   |
| 81.1313 | 30.1814 | 760.0 | 100   |
| 81.3394 | 30.1814 | 760.0 | 100   |
| 81.5474 | 30.1814 | 760.0 | 100   |
| 81.7555 | 30.1814 | 760.0 | 100   |
| 81.9636 | 30.1814 | 760.0 | 100   |
| 82.1716 | 30.1814 | 760.0 | 100   |
| ...     | ...     | ...   | ...   |
| 87.9280 | 26.5841 | 760.0 | 100   |
| 88.1291 | 26.5841 | 760.0 | 100   |
| 86.7105 | 26.4043 | 760.0 | 100   |
| 86.9113 | 26.4043 | 760.0 | 100   |
| 87.1121 | 26.4043 | 760.0 | 100   |
| 87.3130 | 26.4043 | 760.0 | 100   |
| 87.5138 | 26.4043 | 760.0 | 100   |
| 87.7146 | 26.4043 | 760.0 | 100   |
| 87.9154 | 26.4043 | 760.0 | 100   |
| 88.1162 | 26.4043 | 760.0 | 100   |
```