### PR TITLE
Removed exporter for `disagg-stats-traditional`

### DIFF
--- a/doc/user-guide/outputs/disaggregation-outputs.rst
+++ b/doc/user-guide/outputs/disaggregation-outputs.rst
@@ -133,7 +133,6 @@ disaggregation results in the traditional form. Simply write
 ::
 
    user@ubuntu:~$ oq export disagg-rlzs-traditional <calc_id>
-   user@ubuntu:~$ oq export disagg-stats-traditional <calc_id>
 
 For instance for the realization magnitude output you will get
 

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -534,14 +534,13 @@ def export_mean_disagg_by_src(ekey, dstore):
 
 @export.add(('disagg-rlzs', 'csv'),
             ('disagg-stats', 'csv'),
-            ('disagg-rlzs-traditional', 'csv'),
-            ('disagg-stats-traditional', 'csv'))
+            ('disagg-rlzs-traditional', 'csv'))
 def export_disagg_csv(ekey, dstore):
     name, ext = ekey
     spec = name[7:]  # rlzs, stats, rlzs-traditional, stats-traditional
     oq = dstore['oqparam']
     sitecol = dstore['sitecol']
-    rlzs = dstore['full_lt'].get_realizations()
+    ws = dstore['weights'][:]
     best_rlzs = dstore['best_rlzs'][:]
     N = len(best_rlzs)
     P = len(oq.poes) or 1
@@ -569,7 +568,7 @@ def export_disagg_csv(ekey, dstore):
                   tectonic_region_types=decode(bins['TRT'].tolist()),
                   lon=lon, lat=lat)
         if spec.startswith('rlzs') or oq.iml_disagg:
-            weights = numpy.array([rlzs[r].weight[-1] for r in best_rlzs[s]])
+            weights = ws[best_rlzs[s]]
             weights /= weights.sum()  # normalize to 1
             md['weights'] = weights.tolist()
             md['rlz_ids'] = best_rlzs[s].tolist()

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1163,7 +1163,8 @@ def extract_disagg(dstore, what):
     else:
         poei = slice(None)
     if 'traditional' in spec:
-        spec = spec[:4]  # rlzs or stats
+        spec = spec.split('-')[0]
+        assert spec in {'rlzs', 'stats'}, spec
         traditional = True
     else:
         traditional = False
@@ -1208,8 +1209,7 @@ def extract_disagg(dstore, what):
     attrs['shape_descr'] = [k.lower() for k in disag_tup] + ['imt', 'poe']
     rlzs = dstore['best_rlzs'][sid]
     if spec == 'rlzs':
-        weight = dstore['full_lt'].init().rlzs['weight']
-        weights = weight[rlzs]
+        weights = dstore['weights'][:][rlzs]
         weights /= weights.sum()  # normalize to 1
         attrs['weights'] = weights.tolist()
     extra = ['rlz%d' % rlz for rlz in rlzs] if spec == 'rlzs' else ['mean']


### PR DESCRIPTION
Since I do not see how to implement it without changing the storage. To be discussed with the hazard team.
Currently it is broken, as reported in the mailing list. You can see the error even in the disaggregation demo:
```python
KeyError: "No 'disagg-stat/Mag_Dist' found in <DataStore >"
```
Also, made some optimization on the weights management.