### PR TITLE
Remove `engine_version` from AELO changelog

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -625,7 +625,7 @@ class HazardCalculator(BaseCalculator):
             df = (~pmap).to_dframe()
             self.datastore.create_df('_rates', df)
             self.datastore['assetcol'] = self.assetcol
-            self.datastore['full_lt'] = fake = logictree.FullLogicTree.fake()
+            self.datastore['full_lt'] = logictree.FullLogicTree.fake()
             self.datastore['trt_rlzs'] = U32([[0]])
             self.save_crmodel()
             self.datastore.swmr_on()
@@ -711,7 +711,7 @@ class HazardCalculator(BaseCalculator):
             # for instance in classical damage case_8a
             pass
         else:  # build a fake; used by risk-from-file calculators
-            self.datastore['full_lt'] = fake = logictree.FullLogicTree.fake()
+            self.datastore['full_lt'] = logictree.FullLogicTree.fake()
 
     @general.cached_property
     def R(self):
@@ -925,7 +925,8 @@ class HazardCalculator(BaseCalculator):
         oq = self.oqparam
         if oq.job_type == 'risk':
             # the decode below is used in aristotle calculations
-            taxonomies = python3compat.decode(self.assetcol.tagcol.taxonomy[1:])
+            taxonomies = python3compat.decode(
+                self.assetcol.tagcol.taxonomy[1:])
             uniq = numpy.unique(self.assetcol['taxonomy'])
             taxdic = {taxi: taxo for taxi, taxo in enumerate(taxonomies, 1)
                       if taxi in uniq}
@@ -1133,7 +1134,8 @@ class RiskCalculator(HazardCalculator):
         if not hasattr(self.crmodel, 'tmap'):
             taxonomies = self.assetcol.tagcol.taxonomy[1:]
             taxdic = {i: taxo for i, taxo in enumerate(taxonomies, 1)}
-            self.crmodel.tmap = readinput.taxonomy_mapping(self.oqparam, taxdic)
+            self.crmodel.tmap = readinput.taxonomy_mapping(self.oqparam,
+                                                           taxdic)
         with self.monitor('building riskinputs'):
             if self.oqparam.hazard_calculation_id:
                 dstore = self.datastore.parent

--- a/openquake/qa_tests_data/mosaic/aelo_changelog.ini
+++ b/openquake/qa_tests_data/mosaic/aelo_changelog.ini
@@ -1,22 +1,24 @@
 [2.1.0]
 date: 2024-12-31
-engine_version: engine-3.22
-notes: Changed presentation
+notes:
+    Changed presentation
+    Requires engine-3.22
 private: see file XXX
 
 [2.0.0]
 date: 2024-09-30
-engine_version: engine-3.21
 notes:
   Preliminary version only available on the beta machine.
   It has the following features:
   1. extended to 10 IMTs
   2. implemented ASCE17
   3. ...
+  Requires engine-3.21
 private: see file XXX
 
 [1.0.0]
 date: 2024-06-31
-engine_version: engine-3.20
-notes: Initial version
+notes:
+    Initial version
+    Requires engine-3.20
 private: see file XXX

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -431,12 +431,9 @@ table#aristotle-losses th td {
 .changelog td:nth-child(1), .changelog th:nth-child(1) {
     width: 15%;
 }
-.changelog td:nth-child(2), .changelog th:nth-child(2) {
+.changelog td:nth-child(2), .changelog th:nth-child(3) {
     width: 15%;
 }
-.changelog td:nth-child(3), .changelog th:nth-child(3) {
-    width: 15%;
-}
-.changelog td:nth-child(4), .changelog th:nth-child(4) {
-    width: 55%;
+.changelog td:nth-child(3), .changelog th:nth-child(4) {
+    width: 70%;
 }

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -431,9 +431,9 @@ table#aristotle-losses th td {
 .changelog td:nth-child(1), .changelog th:nth-child(1) {
     width: 15%;
 }
-.changelog td:nth-child(2), .changelog th:nth-child(3) {
+.changelog td:nth-child(2), .changelog th:nth-child(2) {
     width: 15%;
 }
-.changelog td:nth-child(3), .changelog th:nth-child(4) {
+.changelog td:nth-child(3), .changelog th:nth-child(3) {
     width: 70%;
 }


### PR DESCRIPTION
![Screenshot from 2024-06-24 10-08-58](https://github.com/gem/oq-engine/assets/350930/4eca9845-804a-4c36-9829-1feaf29de3af)

In the example aelo_changelog.ini I moved the `engine_version` to the bottom of the corresponding note.