### PR TITLE
Added a view `long_ruptures`

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1790,7 +1790,10 @@ def view_long_ruptures(token, dstore):
     for src in dstore['_csm'].get_sources():
         maxlen = source.point.get_rup_maxlen(src)
         if src.code in b'MPA' and maxlen > 900.:
-            lst.append((src.source_id, maxlen))
-    arr = numpy.array(lst, [('source_id', object), ('maxlen', float)])
+            usd = src.upper_seismogenic_depth
+            lsd = src.lower_seismogenic_depth
+            lst.append((src.source_id, maxlen, usd, lsd))
+    arr = numpy.array(lst, [('source_id', object), ('maxlen', float),
+                            ('usd', float), ('lsd', float)])
     arr.sort(order='maxlen')
     return arr

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1792,8 +1792,9 @@ def view_long_ruptures(token, dstore):
         if src.code in b'MPA' and maxlen > 900.:
             usd = src.upper_seismogenic_depth
             lsd = src.lower_seismogenic_depth
-            lst.append((src.source_id, maxlen, usd, lsd))
+            maxmag, rate = src.get_annual_occurrence_rates()[-1]
+            lst.append((src.source_id, maxlen, maxmag, usd, lsd))
     arr = numpy.array(lst, [('source_id', object), ('maxlen', float),
-                            ('usd', float), ('lsd', float)])
+                            ('maxmag', float), ('usd', float), ('lsd', float)])
     arr.sort(order='maxlen')
     return arr

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1782,3 +1782,15 @@ def view_fastmean(token, dstore):
 @view.add('gw')
 def view_gw(token, dstore):
     return numpy.round(dstore['gweights'][:].sum(), 3)
+
+
+@view.add('long_ruptures')
+def view_long_ruptures(token, dstore):
+    lst = []
+    for src in dstore['_csm'].get_sources():
+        maxlen = source.point.get_rup_maxlen(src)
+        if src.code in b'MPA' and maxlen > 900.:
+            lst.append((src.source_id, maxlen))
+    arr = numpy.array(lst, [('source_id', object), ('maxlen', float)])
+    arr.sort(order='maxlen')
+    return arr

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -476,3 +476,21 @@ def grid_point_sources(sources, ps_grid_spacing, msr, cnt=0, monitor=Monitor()):
         else:  # there is a single source
             out.append(ps[idxs[0]])
     return {grp_id: out, 'cnt': cnt}
+
+
+def get_rup_maxlen(src):
+    """
+    :returns: the maximum rupture length for point sources and area sources
+    """
+    if hasattr(src, 'nodal_plane_distribution'):
+        maxmag, rate = src.get_annual_occurrence_rates()[-1]
+        width = src.lower_seismogenic_depth - src.upper_seismogenic_depth
+        msr = src.magnitude_scaling_relationship
+        rar = src.rupture_aspect_ratio
+        lens = []
+        for _, np in src.nodal_plane_distribution.data:
+            area = msr.get_median_area(maxmag, np.rake)
+            dims = get_rupdims(numpy.array([area]), np.dip, width, rar)[0]
+            lens.append(dims[0])
+        return max(lens)
+    return 0.


### PR DESCRIPTION
The goal is to find the models in the mosaic affected by the problem of extra-long point ruptures probably due to a wrong
`width = src.lower_seismogenic_depth - src.upper_seismogenic_depth`. The command to give is
```
$ oq run NAF/in/job.ini -p calculation_mode=preclassical,ps_grid_spacing=0,split_sources=false
$ oq show long_ruptures
| source_id | maxlen | usd | lsd     |
|-----------+--------+-----+---------|
| SC_51;0   | 958.9  | 0.0 | 45.0000 |
| BG_51     | 958.9  | 0.0 | 45.0000 |
| SC_51;1   | 1_451  | 0.0 | 45.0000 |
```