### PR TITLE
Fixed `modified_gsim` when the underlying GMPE has arguments

### DIFF
--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -192,9 +192,7 @@ def modified_gsim(gmpe, **kwargs):
     """
     Builds a ModifiableGMPE from a gmpe
     """
-    text = '[ModifiableGMPE]\n'
-    [(gmpe_name, kw)] = toml.loads(gmpe._toml).items()
-    text += f'gmpe.{gmpe_name} = {_fix_toml(kw)}\n'
+    text = gmpe._toml.replace('[', '[ModifiableGMPE.gmpe.') + '\n'
     text += toml.dumps({'ModifiableGMPE': kwargs})
     return gsim(text)
 


### PR DESCRIPTION
Solves a problem in GEESE with the NAF logic tree
```xml
.<?xml version="1.0" encoding="utf-8"?>
<nrml
xmlns="http://openquake.org/xmlns/nrml/0.5"
xmlns:gml="http://www.opengis.net/gml"
>
    <logicTree
    logicTreeID="lt"
    >
        <logicTreeBranchSet
        applyToTectonicRegionType="Tectonic_Type_C"
        branchSetID="bs0"
        uncertaintyType="gmpeModel"
        >
            <logicTreeBranch
            branchID="br0"
            >
                <uncertaintyModel>
                    [ModifiableGMPE.gmpe.AtkinsonBoore2006Modified2011]
[ModifiableGMPE.add_between_within_stds]
with_betw_ratio = 1.5
                </uncertaintyModel>
                <uncertaintyWeight>
                    5.0000000E-01
                </uncertaintyWeight>
            </logicTreeBranch>
            <logicTreeBranch
            branchID="br1"
            >
                <uncertaintyModel>
                    [ModifiableGMPE.gmpe.NRCan15SiteTerm]
gmpe_name = 'PezeshkEtAl2011NEHRPBC'
[ModifiableGMPE.add_between_within_stds]
with_betw_ratio = 1.5
                </uncertaintyModel>
                <uncertaintyWeight>
                    5.0000000E-01
                </uncertaintyWeight>
            </logicTreeBranch>
        </logicTreeBranchSet>
    </logicTree>
</nrml>
```