### PR TITLE
AELO: Display the asce_version in the outputs page and rename ASCE 7-16 and ASCE 41-17 to ASCE 16 and ASCE 41

### DIFF
--- a/openquake/calculators/export/__init__.py
+++ b/openquake/calculators/export/__init__.py
@@ -22,8 +22,8 @@ from openquake.baselib.writers import write_csv
 
 
 DISPLAY_NAME = {
-    'asce07': 'ASCE 7-16 Parameters',
-    'asce41': 'ASCE 41-17 Parameters',
+    'asce07': 'ASCE 7 Parameters',
+    'asce41': 'ASCE 41 Parameters',
     'mag_dst_eps_sig': "Deterministic Earthquake Scenarios",
     'asset_risk': 'Exposure + Risk',
     'gmf_data': 'Ground Motion Fields',

--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -454,12 +454,12 @@ def process_sites(dstore, csm, DLLs, ASCE_version):
         if mrs.sum() == 0:
             warning = (
                 'Zero hazard: there are no ruptures close to the site.'
-                ' ASCE 7-16 and ASCE 41-17 parameters cannot be computed.'
+                ' ASCE 7 and ASCE 41 parameters cannot be computed.'
                 ' See User Guide.')
             yield site, None, warning
 
         elif mean_rates.max() < MIN_AFE:
-            warning = ('Very low hazard: ASCE 7-16 and ASCE 41-17'
+            warning = ('Very low hazard: ASCE 7 and ASCE 41'
                        ' parameters cannot be computed. See User Guide.')
             yield site, None, warning
 
@@ -467,7 +467,7 @@ def process_sites(dstore, csm, DLLs, ASCE_version):
                 (rtgm_df.ProbMCE.to_numpy()[sa10] < 0.04):
             warning = (
                 'The MCE at the site is very low. Users may need to'
-                ' increase the ASCE 7-16 and ASCE 41-17 parameter values'
+                ' increase the ASCE 7 and ASCE 41 parameter values'
                 ' to user-specified minimums (e.g., Ss=0.11g and'
                 ' S1=0.04g). See User Guide.')
             yield site, rtgm_df, warning
@@ -503,8 +503,8 @@ def calc_asce(dstore, csm, job_imts, DLLs, rtgm):
         logging.info(f'(%.1f,%.1f) {mce=}', lon, lat)
         logging.info(f'(%.1f,%.1f) {det_mce=}', lon, lat)
         asce41 = get_asce41(dstore, mce, rtgm_df.fact.to_numpy(), sid)
-        logging.info('(%.1f,%.1f) ASCE 7-16=%s', lon, lat, asce07)
-        logging.info('(%.1f,%.1f) ASCE 41-17=%s', lon, lat, asce41)
+        logging.info('(%.1f,%.1f) ASCE 7=%s', lon, lat, asce07)
+        logging.info('(%.1f,%.1f) ASCE 41=%s', lon, lat, asce41)
         yield sid, mag_dst_eps_sig, asce07, asce41, mce_df
 
 

--- a/openquake/server/templates/engine/get_outputs_aelo.html
+++ b/openquake/server/templates/engine/get_outputs_aelo.html
@@ -8,7 +8,7 @@
       <div class="row">
         <div id="oq-body-wrapper">
           <div class="span12">
-              <h2>Outputs from site: {{ site_name }}, lat: {{ lat }}, lon: {{ lon }}, vs30: {{ vs30 }}{% if calc_aelo_version is not None %}, AELO version: {{ calc_aelo_version }}{% endif %}</h2>
+              <h2>Outputs from site: {{ site_name }}, lat: {{ lat }}, lon: {{ lon }}, vs30: {{ vs30 }}{% if calc_aelo_version is not None %}, AELO version: {{ calc_aelo_version }}{% endif %}, {{ asce_version }}</h2>
               {% if warnings %}
               <div id="warning-box" class="alert alert-warning" style=>
                   WARNING: {{ warnings }}

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1382,6 +1382,11 @@ def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
         vs30 = ds['oqparam'].override_vs30  # e.g. 760.0
         site_name = ds['oqparam'].description[9:]  # e.g. 'AELO for CCA'->'CCA'
         try:
+            asce_version = ds['oqparam'].asce_version
+        except AttributeError:
+            # for backwards compatibility on old calculations
+            asce_version = oqvalidation.OqParam.asce_version.default
+        try:
             calc_aelo_version = ds.get_attr('/', 'aelo_version')
         except KeyError:
             calc_aelo_version = '1.0.0'
@@ -1396,6 +1401,7 @@ def web_engine_get_outputs_aelo(request, calc_id, **kwargs):
                        asce07=asce07_with_units, asce41=asce41_with_units,
                        lon=lon, lat=lat, vs30=vs30, site_name=site_name,
                        calc_aelo_version=calc_aelo_version,
+                       asce_version=asce_version,
                        warnings=warnings))
 
 


### PR DESCRIPTION
![image](https://github.com/gem/oq-engine/assets/350930/2ebde0f0-0665-4e5b-90fe-9aa46aad3714)

@ManuelaVillani please double check if this is ok also for ASCE 41.
