### PR TITLE
Saving a bit more memory in classical calculations

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -65,7 +65,7 @@ azimuthcp rvolc clon_clat clon clat'''.split())
 NUM_BINS = 256
 DIST_BINS = sqrscale(80, 1000, NUM_BINS)
 # the MULTIPLIER is fundamental for the memory consumption in the contexts
-MULTIPLIER = 50  # len(mean_stds arrays) / len(poes arrays)
+MULTIPLIER = 25  # len(mean_stds arrays) / len(poes arrays)
 MEA = 0
 STD = 1
 bymag = operator.attrgetter('mag')


### PR DESCRIPTION
Here is performance.zip on my mini-pc:
```
# before
| calc_31392, maxmem=15.0 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 9_245    | 78.1016   | 66      |
| get_poes                   | 5_086    | 0.0       | 382_180 |
| computing mean_std         | 1_748    | 0.0       | 7_710   |
| composing pnes             | 1_592    | 0.0       | 382_180 |
| ClassicalCalculator.run    | 601.1    | 118.2188  | 1       |

# after
| calc_31390, maxmem=14.1 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 8_703    | 64.6309   | 66      |
| get_poes                   | 4_859    | 0.0       | 359_960 |
| computing mean_std         | 1_564    | 0.0       | 14_434  |
| composing pnes             | 1_522    | 0.0       | 359_960 |
| ClassicalCalculator.run    | 569.2    | 113.0273  | 1       |
```
Incidentally, it is 32 seconds faster even if the number of calls to "computing mean_std" doubles. The number of calls to "get_poes" and "composing poes" decreases a bit.