### PR TITLE
Disabled data compression

### DIFF
--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -22,7 +22,7 @@ serialize_jobs = 1
 log_level = info
 submit_cmd =
 min_input_size = 1_000_000
-compress = ok
+compress =
 
 [memory]
 # use at most 1 TiB for the poes


### PR DESCRIPTION
Since it is slightly faster and using less memory. Here is an example for reduced AUS:
```
# with compression
| calc_10543, maxmem=82.7 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 169_847  | 51.4284   | 849       |
| get_poes                   | 84_539   | 0.0       | 8_052_107 |
| computing mean_std         | 47_774   | 0.0       | 322_388   |
| composing pnes             | 29_532   | 0.0       | 8_052_107 |
| planar contexts            | 5_432    | 0.0       | 4_296_554 |
| total postclassical        | 3_531    | 139.6289  | 254       |
| combine pmaps              | 2_590    | 0.0       | 25_630    |
| ClassicalCalculator.run    | 2_132    | 7_141     | 1         |
# received 15.5 GB in 1624 seconds [unpik=162.64s]

# without compression
| calc_10544, maxmem=82.2 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 170_188  | 45.5794   | 849       |
| get_poes                   | 84_862   | 0.0       | 8_052_107 |
| computing mean_std         | 47_771   | 0.0       | 322_388   |
| composing pnes             | 29_527   | 0.0       | 8_052_107 |
| planar contexts            | 5_429    | 0.0       | 4_296_554 |
| total postclassical        | 3_526    | 145.1406  | 254       |
| combine pmaps              | 2_583    | 0.0       | 25_630    |
| ClassicalCalculator.run    | 2_108    | 7_204     | 1         |
# received 18.77 GB in 1607 seconds [unpik=4.90s]
```