### PR TITLE
Disabled check on too many branches if `smlt_branch` is given

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Disabled check on too many branches if smlt_branch is given
+  * Worked on disaggregation by multifault source
+
   [Michele Simionato, Christopher Brooks]
   * Internal: added a function for filtering sites around a rupture
 

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -607,7 +607,8 @@ class SourceModelLogicTree(object):
                 branch = Branch(bs_id, branch_id, weight, value)
                 self.branches[branch_id] = branch
                 branchset.branches.append(branch)
-            self.shortener[branch_id] = keyno(branch_id, bsno, brno)
+            if self.branchID == '':
+                self.shortener[branch_id] = keyno(branch_id, bsno, brno)
             weight_sum += weight
         if zeros:
             branch = Branch(bs_id, zero_id, sum(zeros), '')

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -562,7 +562,7 @@ class SourceModelLogicTree(object):
         values = []
         bsno = len(self.branchsets)
         zeros = []
-        if len(branches) > len(BASE183):
+        if self.branchID == '' and len(branches) > len(BASE183):
             msg = ('%s: the branchset %s has too many branches (%d > %d)\n'
                    'you should split it, see https://docs.openquake.org/'
                    'oq-engine/advanced/latest/logic_trees.html')

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -588,7 +588,7 @@ class SourceModelLogicTree(object):
                 except Exception as exc:
                     raise LogicTreeError(
                         value_node, self.filename, str(exc)) from exc
-                if self.branchID and branchnode['branchID'] != self.branchID:
+                if self.branchID and self.branchID not in branchnode['branchID']:
                     value = ''  # reduce all branches except branchID
                 elif self.source_id:  # only the files containing source_id
                     srcid = self.source_id.split('@')[0]


### PR DESCRIPTION
And made it possible to filter branches with a substring, for instance
```
$ oq engine --run job02_drouetv311_t02_42.ini -p smlt_branch=ZONELESS
```
will only consider the branch IDs containing the substring "ZONELESS".
In practice, this solves the problem of more than 183 branches.