### PR TITLE
Make sure CONTEXT_PROCESSORS is defined for all application modes

### DIFF
--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -79,6 +79,7 @@ jobs:
     env:
       GITHUB_HEAD_REF:  ${{ github.head_ref }}
       FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+      OQ_APPLICATION_MODE: PUBLIC
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python  ${{ matrix.python-version }}
@@ -96,7 +97,7 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         # -v 2 also logs the test names
-        OQ_APPLICATION_MODE=PUBLIC ./openquake/server/manage.py test -v 2 tests.test_public_mode
+        ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
   server_read_only_mode:
     runs-on: ${{ matrix.os }}
@@ -107,6 +108,7 @@ jobs:
     env:
       GITHUB_HEAD_REF:  ${{ github.head_ref }}
       FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+      OQ_APPLICATION_MODE: READ_ONLY
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python  ${{ matrix.python-version }}
@@ -124,7 +126,7 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         # -v 2 also logs the test names
-        OQ_APPLICATION_MODE=READ_ONLY ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
+        ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
 
   server_aelo_mode:
     runs-on: ${{ matrix.os }}
@@ -135,6 +137,8 @@ jobs:
     env:
       GITHUB_HEAD_REF:  ${{ github.head_ref }}
       FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+      OQ_APPLICATION_MODE: AELO
+      OQ_CONFIG_FILE: openquake/server/tests/data/openquake.cfg
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python  ${{ matrix.python-version }}
@@ -155,4 +159,4 @@ jobs:
         ./openquake/server/manage.py loaddata openquake/server/fixtures/0001_cookie_consent_required_plus_hide_cookie_bar.json
         ./openquake/server/manage.py collectstatic --noinput
         # -v 2 also logs the test names
-        OQ_APPLICATION_MODE=AELO OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode
+        ./openquake/server/manage.py test -v 2 tests.test_aelo_mode

--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -151,5 +151,8 @@ jobs:
     - name: Server 'AELO' mode tests
       run: |
         source ~/openquake/bin/activate
+        ./openquake/server/manage.py migrate
+        ./openquake/server/manage.py loaddata openquake/server/fixtures/0001_cookie_consent_required_plus_hide_cookie_bar.json
+        ./openquake/server/manage.py collectstatic --noinput
         # -v 2 also logs the test names
         OQ_APPLICATION_MODE=AELO OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aelo_mode

--- a/openquake/server/local_settings.py.aelo_aristotle
+++ b/openquake/server/local_settings.py.aelo_aristotle
@@ -40,10 +40,6 @@ USE_REVERSE_PROXY = <True|False>
 
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
-# cors-headers
-CORS_ALLOW_ALL_ORIGINS = True
-CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/openquake/server/local_settings.py.aelo_aristotle
+++ b/openquake/server/local_settings.py.aelo_aristotle
@@ -40,9 +40,6 @@ USE_REVERSE_PROXY = <True|False>
 
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
-# to install fixtures for cookie_consent
-USE_TZ = True
-
 # cors-headers
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'

--- a/openquake/server/local_settings.py.pam
+++ b/openquake/server/local_settings.py.pam
@@ -31,10 +31,6 @@ STATIC_ROOT = '/var/www/webui'
 
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
-# cors-headers
-CORS_ALLOW_ALL_ORIGINS = True
-CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/openquake/server/local_settings.py.pam
+++ b/openquake/server/local_settings.py.pam
@@ -31,9 +31,6 @@ STATIC_ROOT = '/var/www/webui'
 
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
-# to install fixtures for cookie_consent
-USE_TZ = True
-
 # cors-headers
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'

--- a/openquake/server/local_settings.py.server
+++ b/openquake/server/local_settings.py.server
@@ -21,10 +21,6 @@ STATIC_ROOT = '/var/www/webui'
 # Furthermore, the user `openquake` must own that directory.
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
-# cors-headers
-CORS_ALLOW_ALL_ORIGINS = True
-CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/openquake/server/local_settings.py.server
+++ b/openquake/server/local_settings.py.server
@@ -21,9 +21,6 @@ STATIC_ROOT = '/var/www/webui'
 # Furthermore, the user `openquake` must own that directory.
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
-# to install fixtures for cookie_consent
-USE_TZ = True
-
 # cors-headers
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'

--- a/openquake/server/local_settings.py.tools
+++ b/openquake/server/local_settings.py.tools
@@ -22,10 +22,6 @@ WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 # To avoid Origin checking failed
 CSRF_TRUSTED_ORIGINS = ['https://*.openquake.org']
 
-# cors-headers
-CORS_ALLOW_ALL_ORIGINS = True
-CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.

--- a/openquake/server/local_settings.py.tools
+++ b/openquake/server/local_settings.py.tools
@@ -22,9 +22,6 @@ WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 # To avoid Origin checking failed
 CSRF_TRUSTED_ORIGINS = ['https://*.openquake.org']
 
-# to install fixtures for cookie_consent
-USE_TZ = True
-
 # cors-headers
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -89,6 +89,22 @@ AUTHENTICATION_BACKENDS = ()
 # system time zone.
 TIME_ZONE = 'UTC'
 
+# USE_TZ = True is the default for Django >= 5.0. From Django documentation:
+# "
+# When support for time zones is enabled, Django stores datetime information
+# in UTC in the database, uses time-zone-aware datetime objects internally,
+# and translates them to the end user’s time zone in templates and forms.
+# This is handy if your users live in more than one time zone and you want
+# to display datetime information according to each user’s wall clock.
+# Even if your website is available in only one time zone, it’s still good
+# practice to store data in UTC in your database. The main reason is daylight
+# saving time (DST). Many countries have a system of DST, where clocks are
+# moved forward in spring and backward in autumn. If you’re working in local
+# time, you’re likely to encounter errors twice a year, when the transitions
+# happen.
+# "
+USE_TZ = True
+
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -196,6 +196,8 @@ MAX_AELO_SITE_NAME_LEN = 256
 
 GOOGLE_ANALYTICS_TOKEN = None
 
+CONTEXT_PROCESSORS = TEMPLATES[0]['OPTIONS']['context_processors']
+
 # OpenQuake Standalone tools (IPT, Taxtweb, Taxonomy Glossary)
 if STANDALONE and WEBUI:
     INSTALLED_APPS += (
@@ -206,7 +208,6 @@ if STANDALONE and WEBUI:
 
     FILE_PATH_FIELD_DIRECTORY = datastore.get_datadir()
 
-    CONTEXT_PROCESSORS = TEMPLATES[0]['OPTIONS']['context_processors']
     CONTEXT_PROCESSORS.insert(0, 'django.template.context_processors.request')
     CONTEXT_PROCESSORS.append('openquakeplatform.utils.oq_context_processor')
 
@@ -242,7 +243,8 @@ if APPLICATION_MODE not in ('PUBLIC',):
             MIDDLEWARE += (app_cors,)
 
     if 'django.template.context_processors.request' not in CONTEXT_PROCESSORS:
-        CONTEXT_PROCESSORS.append('django.template.context_processors.request')
+        CONTEXT_PROCESSORS.insert(
+            0, 'django.template.context_processors.request')
     COOKIE_CONSENT_NAME = "cookie_consent"
     COOKIE_CONSENT_MAX_AGE = 31536000  # 1 year in seconds
     COOKIE_CONSENT_LOG_ENABLED = False

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -217,10 +217,17 @@ CONTEXT_PROCESSORS = TEMPLATES[0]['OPTIONS']['context_processors']
 # OpenQuake Standalone tools (IPT, Taxtweb, Taxonomy Glossary)
 if STANDALONE and WEBUI:
     INSTALLED_APPS += (
-        'openquakeplatform',
+        'openquakeplatform', 'corsheaders',
     )
 
     INSTALLED_APPS += STANDALONE_APPS
+
+    # cors-headers configuration
+    corsheader_middleware = 'corsheaders.middleware.CorsMiddleware'
+    if corsheader_middleware not in MIDDLEWARE:
+        MIDDLEWARE += (corsheader_middleware,)
+    CORS_ALLOW_ALL_ORIGINS = True
+    CORS_URLS_REGEX = r'^/taxtweb/explanation/.*$'
 
     FILE_PATH_FIELD_DIRECTORY = datastore.get_datadir()
 
@@ -247,16 +254,11 @@ except ImportError:
 APPLICATION_MODE = os.environ.get('OQ_APPLICATION_MODE', APPLICATION_MODE)
 
 if APPLICATION_MODE not in ('PUBLIC',):
-    # add installed_apps for cookie-consent and corsheader
+    # add installed_apps for cookie-consent
     for app in ('django.contrib.auth', 'django.contrib.contenttypes',
-                'cookie_consent', 'corsheaders',):
+                'cookie_consent',):
         if app not in INSTALLED_APPS:
             INSTALLED_APPS += (app,)
-
-    # add middleware for corsheader
-    for app_cors in ('corsheaders.middleware.CorsMiddleware',):
-        if app_cors not in MIDDLEWARE:
-            MIDDLEWARE += (app_cors,)
 
     if 'django.template.context_processors.request' not in CONTEXT_PROCESSORS:
         CONTEXT_PROCESSORS.insert(


### PR DESCRIPTION
After merging https://github.com/gem/oq-engine/pull/9765 it was impossible to run migrations in the aelo-beta machine, because in settings.py it was trying to append something to an undefined CONTEXT_PROCESSORS variable. Defining CONTEXT_PROCESSORS in advance for all application modes, we managed to successfully update the aelo-beta machine and this change should also solve the same problem in ARISTOTLE mode.
We added to server tests for AELO mode a few additional steps: running migrations, installing fixtures for cookie consent and running collectstatic. These are needed in our server installations. Still in these tests we are installing the engine in devel mode, but in the future we may consider testing a full server installation (much more complicated, with gunicorn, nginx and so on).

We also changed settings.py to add CORS-related stuff only when the standalone tools are enabled.