### PR TITLE
Implemented a smarter SLURM algorithm

### DIFF
--- a/openquake/baselib/slurm.py
+++ b/openquake/baselib/slurm.py
@@ -1,5 +1,5 @@
 import sys
-from openquake.baselib.parallel import slurm_task
+from openquake.baselib.parallel import slurm_tasks
 
 if __name__ == '__main__':
-    slurm_task(*sys.argv[1:])
+    slurm_tasks(*sys.argv[1:])

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -610,7 +610,8 @@ class ClassicalCalculator(base.HazardCalculator):
             if sg.atomic or sg.weight <= maxw:
                 allargs.append((gid, self.sitecol, cm, ds))
             else:
-                tiles = self.sitecol.split(numpy.ceil(sg.weight / maxw))
+                tiles = self.sitecol.split(
+                    numpy.ceil(sg.weight / maxw), minsize=oq.max_sites_disagg)
                 logging.info('Group #%d, %d tiles', cm.grp_id, len(tiles))
                 for tile in tiles:
                     allargs.append((gid, tile, cm, ds))

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -536,7 +536,7 @@ class SiteCollection(object):
         """
         return self.split(numpy.ceil(len(self) / max_sites))
 
-    def split(self, ntiles):
+    def split(self, ntiles, minsize=1):
         """
         :param ntiles: number of tiles to generate (rounded if float)
         :returns: self if there are <=1 tiles, otherwise the tiles
@@ -544,6 +544,8 @@ class SiteCollection(object):
         # if ntiles > nsites produce N tiles with a single site each
         ntiles = min(int(numpy.ceil(ntiles)), len(self))
         if ntiles <= 1:
+            return [self]
+        if len(self) < ntiles * minsize:  # do not split
             return [self]
         tiles = []
         for i in range(ntiles):

--- a/openquake/qa_tests_data/classical/case_22/job.ini
+++ b/openquake/qa_tests_data/classical/case_22/job.ini
@@ -3,7 +3,7 @@
 description = Classical PSHA using Alaska 2007 active shallow crust grid model
 calculation_mode = classical
 concurrent_tasks = 10
-max_sites_disagg = 5
+max_sites_disagg = 1
 split_sources = false
 random_seed = 23
 


### PR DESCRIPTION
Job arrays on the CEA cluster have a limit of 300 sub-jobs which cannot be raised. Switched to not using job arrays and spawning SLURM jobs using 128 cores instead.