### PR TITLE
Fix dev-tools installation

### DIFF
--- a/openquake/server/local_settings.py.tools
+++ b/openquake/server/local_settings.py.tools
@@ -1,7 +1,5 @@
 APPLICATION_MODE = 'TOOLS_ONLY'
 
-# Enable authentication
-LOCKDOWN = False
 # Disable sharing of results across users
 ACL_ON = True
 

--- a/openquake/server/templates/engine/includes/cookie_bar.html
+++ b/openquake/server/templates/engine/includes/cookie_bar.html
@@ -44,7 +44,7 @@
                         };
                         /* We may want to logout the user when pressing 'Decline all'
                         const csrftoken = getCookie('csrftoken');
-                        fetch("{% url 'logout' %}", {
+                        fetch("{#{% url 'logout' %}#}", {
                             method: 'POST',
                             headers: {
                                 'Content-Type': 'application/json',


### PR DESCRIPTION
* Fix commenting out a jinja variable correctly (it was inside a commented section of javascript, but jinja interpreted it anyway, looking for an url that is missing when authentication is disabled
* Fix local_settings.py.tools template, that had a redundant redefinition of LOCKDOWN