### PR TITLE
Saving the rates on temporary files in tiling calculations

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -1041,9 +1041,6 @@ class Starmap(object):
         self.socket.__exit__(None, None, None)
         self.tasks.clear()
         self.unlink()
-        if dist == 'slurm':
-            for fname in os.listdir(self.monitor.calc_dir):
-                os.remove(os.path.join(self.monitor.calc_dir, fname))
         if len(self.busytime) > 1:
             times = numpy.array(list(self.busytime.values()))
             logging.info(

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -37,7 +37,7 @@ import collections
 
 from openquake.commands.plot_assets import main as plot_assets
 from openquake.baselib import general, hdf5, python3compat, config
-from openquake.baselib import performance, parallel
+from openquake.baselib import parallel
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import (
     InvalidFile, site, stats, logictree, source_reader)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -78,8 +78,10 @@ def store_rates(rates, sites_per_task, mon):
     chunks = rates['sid'] // sites_per_task
     for chunk in numpy.unique(chunks):
         chunk_dir = os.path.join(calc_dir, str(chunk))
-        if not os.path.exists(chunk_dir):
+        try:
             os.mkdir(chunk_dir)
+        except FileExistsError:  # somebody else wrote it
+            pass
         rats = rates[chunks == chunk]
         fname = os.path.join(calc_dir, f'{chunk}/{mon.task_no}.hdf5')
         with hdf5.File(fname, 'a') as h5:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -300,12 +300,12 @@ def make_hmap_png(hmap, lons, lats):
     return dict(img=Image.open(bio), m=hmap['m'], p=hmap['p'])
 
 
-def map_getters(dstore):
+def map_getters(dstore, full_lt=None):
     """
     :returns: a list of pairs (MapGetter, weights)
     """
     oq = dstore['oqparam']
-    full_lt = dstore['full_lt'].init()
+    full_lt = full_lt or dstore['full_lt'].init()
     R = full_lt.get_num_paths()
     req_gb, trt_rlzs, gids = get_pmaps_gb(dstore, full_lt)
     if oq.fastmean:
@@ -767,7 +767,8 @@ class ClassicalCalculator(base.HazardCalculator):
 
         wget = self.full_lt.wget
         allargs = [(getter, weights, wget, hstats, individual, oq.max_sites_disagg,
-                    self.amplifier) for getter, weights in map_getters(dstore)]
+                    self.amplifier)
+                   for getter, weights in map_getters(dstore, self.full_lt)]
         if not allargs:  # case_60
             return
         self.hazard = {}  # kind -> array

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -562,7 +562,7 @@ class ClassicalCalculator(base.HazardCalculator):
         smap = parallel.Starmap(classical, allargs, h5=self.datastore.hdf5)
         acc = smap.reduce(self.agg_dicts, acc)
         with self.monitor('storing rates', measuremem=True):
-            self.haz.store_rates(self.pmap, self.N, self._monitor)
+            self.haz.store_rates(self.pmap, self._monitor)
         del self.pmap
         if oq.disagg_by_src:
             mrs = self.haz.store_mean_rates_by_src(acc)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -750,8 +750,10 @@ class ClassicalCalculator(base.HazardCalculator):
         if hasattr(self, 'ntiles'):
             fnames = [os.path.join(self._monitor.calc_dir, f)
                       for f in os.listdir(self._monitor.calc_dir)]
+        elif len(dstore['_rates/sid']) == 0:  # in case_60
+            return
         else:
-            fnames = [self.datastore.filename]
+            fnames = [dstore.filename]
         allargs = [
             (getters.MapGetter(fname, trt_rlzs, self.R, oq),
              weights, wget, hstats, individual, oq.max_sites_disagg,

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -178,10 +178,9 @@ class DisaggregationCalculator(base.HazardCalculator):
         self.M = len(self.imts)
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
-        nrows = len(dstore['_rates/sid'])
         trt_rlzs = full_lt.get_trt_rlzs(dstore['trt_smrs'][:])
         self.pgetter = getters.MapGetter(
-            dstore.filename, trt_rlzs, self.R, [(0, nrows + 1)], oq)
+            dstore.filename, trt_rlzs, self.R, oq)
 
         # build array rlzs (N, Z)
         if oq.rlz_index is None:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -157,7 +157,7 @@ def map_getters(dstore, full_lt=None):
     oq = dstore['oqparam']
     full_lt = full_lt or dstore['full_lt'].init()
     R = full_lt.get_num_paths()
-    req_gb, trt_rlzs, gids = get_pmaps_gb(dstore, full_lt)
+    _req_gb, trt_rlzs, _gids = get_pmaps_gb(dstore, full_lt)
     if oq.fastmean:
         weights = dstore['gweights'][:]
         trt_rlzs = numpy.zeros(len(weights))  # reduces the data transfer
@@ -284,8 +284,6 @@ class MapGetter(object):
                         array = numpy.zeros((self.L, self.G))
                         self._map[sid] = array
                     array[df.lid, df.gid] = df.rate
-                    #if sid == 4123:
-                    #    print(df)
         return self._map
 
     # used in risk calculations where there is a single site per getter

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -175,6 +175,18 @@ def map_getters(dstore, full_lt=None):
             for dirname in dirnames]
 
 
+class ZeroGetter(object):
+    """
+    Return an array of zeros of shape (L, R)
+    """
+    def __init__(self, L, R):
+        self.L = L
+        self.R = R
+
+    def get_hazard(self):
+        return numpy.zeros((self.L, self.R))
+
+
 class CurveGetter(object):
     """
     Hazard curve builder used in classical_risk/classical_damage.
@@ -190,7 +202,7 @@ class CurveGetter(object):
             for sid in pmap:
                 rates[sid] = pmap[sid]  # shape (L, G)
         return {sid: cls(sid, rates[sid], mgetter.trt_rlzs, mgetter.R)
-                for sid in rates}
+                for sid in rates}, ZeroGetter(mgetter.L, mgetter.R)
 
     def __init__(self, sid, rates, trt_rlzs, R):
         self.sid = sid

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -44,8 +44,7 @@ from openquake.risklib import riskmodels
 from openquake.risklib.scientific import (
     losses_by_period, return_periods, LOSSID, LOSSTYPE)
 from openquake.baselib.writers import build_header, scientificformat
-from openquake.calculators.classical import get_pmaps_gb
-from openquake.calculators.getters import get_ebrupture, MapGetter
+from openquake.calculators.getters import get_ebrupture, MapGetter, get_pmaps_gb
 from openquake.calculators.extract import extract
 
 TWO24 = 2**24

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -49,7 +49,6 @@ code2cls = rupture.BaseRupture.init()
 
 # ############## utilities for the classical calculator ############### #
 
-
 # used only in the view global_hcurves
 def convert_to_array(pmap, nsites, imtls, inner_idx=0):
     """

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -24,6 +24,7 @@ submit_cmd = oq run
 min_input_size = 1_000_000
 compress =
 slurm_chunk = 50
+save_on_tmp = 
 
 [memory]
 # use at most 1 TiB for the poes


### PR DESCRIPTION
This solves the hanging issue in SLURM calculations. This is EUR on cole with OQ_SAMPLE_SOURCES=.01 and 10,000 tasks (data transfer 39x smaller, "reading rates" a bit slower):
```
# before
| calc_10571, maxmem=80.3 GB | time_sec | memory_mb | counts      |
|----------------------------+----------+-----------+-------------|
| total classical            | 141_590  | 102.8164  | 13_379      |
| planar contexts            | 46_356   | 0.0       | 242_783_052 |
| get_poes                   | 44_733   | 0.0       | 13_742_509  |
| total postclassical        | 28_757   | 18.9258   | 9_448       |
| reading rates              | 4_845    | 0.3164    | 9_448       |
| ClassicalCalculator.run    | 1_780    | 2_961     | 1           |

| task              | sent                                            | received |
|-------------------+-------------------------------------------------+----------|
| classical         | sitecol=116.74 GB cmaker=2.85 GB dstore=2.13 MB | 25.84 GB |

# after
| calc_10570, maxmem=85.5 GB | time_sec | memory_mb | counts      |
|----------------------------+----------+-----------+-------------|
| total classical            | 162_036  | 95.9531   | 13_379      |
| planar contexts            | 46_519   | 0.0       | 242_783_052 |
| get_poes                   | 44_513   | 0.0       | 13_742_509  |
| total postclassical        | 29_593   | 18.9453   | 9_448       |
| reading rates              | 6_024    | 0.1562    | 9_448       |
| ClassicalCalculator.run    | 2_052    | 517.3     | 1           |

| task      | sent                                            | received  |
|-----------+-------------------------------------------------+-----------|
| classical | sitecol=116.74 GB cmaker=2.85 GB dstore=2.13 MB | 683.15 MB |
```