### PR TITLE
Saving the rates on temporary files in tiling calculations/2

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -1041,9 +1041,6 @@ class Starmap(object):
         self.socket.__exit__(None, None, None)
         self.tasks.clear()
         self.unlink()
-        if dist == 'slurm':
-            for fname in os.listdir(self.monitor.calc_dir):
-                os.remove(os.path.join(self.monitor.calc_dir, fname))
         if len(self.busytime) > 1:
             times = numpy.array(list(self.busytime.values()))
             logging.info(

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -37,7 +37,7 @@ import collections
 
 from openquake.commands.plot_assets import main as plot_assets
 from openquake.baselib import general, hdf5, python3compat, config
-from openquake.baselib import performance, parallel
+from openquake.baselib import parallel
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib import (
     InvalidFile, site, stats, logictree, source_reader)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1152,9 +1152,9 @@ class RiskCalculator(HazardCalculator):
     def _gen_riskinputs(self, dstore):
         out = []
         asset_df = self.assetcol.to_dframe('site_id')
-        getterdict, zerogetter = getters.CurveGetter.build(dstore)
+        getterdict = getters.CurveGetter.build(dstore)
         for sid, assets in asset_df.groupby(asset_df.index):
-            getter = getterdict.get(sid, zerogetter)
+            getter = getterdict[sid]
             # hcurves, shape (R, N)
             for slc in general.split_in_slices(
                     len(assets), self.oqparam.assets_per_site_limit):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -718,10 +718,10 @@ class ClassicalCalculator(base.HazardCalculator):
         oq = self.oqparam
         hstats = oq.hazard_stats()
         N, S, M, P, L1, individual = self._create_hcurves_maps()
-        if self.datastore.parent:
-            dstore = self.datastore.parent
-        else:
+        if '_rates000' in set(self.datastore):
             dstore = self.datastore
+        else:
+            dstore = self.datastore.parent
         wget = self.full_lt.wget
         allargs = [(getter, wget, hstats, individual, oq.max_sites_disagg,
                     self.amplifier) for getter in getters.map_getters(

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -78,8 +78,10 @@ def store_rates(rates, sites_per_task, mon):
     chunks = rates['sid'] // sites_per_task
     for chunk in numpy.unique(chunks):
         chunk_dir = os.path.join(calc_dir, str(chunk))
-        if not os.path.exists(chunk_dir):
+        try:
             os.mkdir(chunk_dir)
+        except FileExistsError:  # somebody else wrote it
+            pass
         rats = rates[chunks == chunk]
         fname = os.path.join(calc_dir, f'{chunk}/{mon.task_no}.hdf5')
         with hdf5.File(fname, 'a') as h5:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -300,12 +300,12 @@ def make_hmap_png(hmap, lons, lats):
     return dict(img=Image.open(bio), m=hmap['m'], p=hmap['p'])
 
 
-def map_getters(dstore):
+def map_getters(dstore, full_lt=None):
     """
     :returns: a list of pairs (MapGetter, weights)
     """
     oq = dstore['oqparam']
-    full_lt = dstore['full_lt'].init()
+    full_lt = full_lt or dstore['full_lt'].init()
     R = full_lt.get_num_paths()
     req_gb, trt_rlzs, gids = get_pmaps_gb(dstore, full_lt)
     if oq.fastmean:
@@ -767,7 +767,8 @@ class ClassicalCalculator(base.HazardCalculator):
 
         wget = self.full_lt.wget
         allargs = [(getter, weights, wget, hstats, individual, oq.max_sites_disagg,
-                    self.amplifier) for getter, weights in map_getters(dstore)]
+                    self.amplifier)
+                   for getter, weights in map_getters(dstore, self.full_lt)]
         if not allargs:  # case_60
             return
         self.hazard = {}  # kind -> array

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -478,7 +478,7 @@ class ClassicalCalculator(base.HazardCalculator):
             self.check_memory(len(self.sitecol), oq.imtls.size, maxw)
             self.execute_reg(maxw)
         else:
-            self.execute_big(maxw * .75)
+            self.execute_big(maxw)
         self.store_info()
         if self.cfactor[0] == 0:
             if self.N == 1:
@@ -571,6 +571,7 @@ class ClassicalCalculator(base.HazardCalculator):
         allargs = []
         self.ntiles = []
         if config.distribution.save_on_tmp:
+            logging.info('Storing the rates in %s', self._monitor.calc_dir)
             self.datastore.hdf5.attrs['scratch_dir'] = self._monitor.calc_dir
         if '_csm' in self.datastore.parent:
             ds = self.datastore.parent

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -502,8 +502,7 @@ class ClassicalCalculator(base.HazardCalculator):
             logging.info('cfactor = {:_d}/{:_d} = {:.1f}'.format(
                 int(self.cfactor[1]), int(self.cfactor[0]),
                 self.cfactor[1] / self.cfactor[0]))
-        if any(name.startswith('_rates') for name in self.datastore):
-            self.build_curves_maps()
+        self.build_curves_maps()
         if not oq.hazard_calculation_id:
             self.classical_time = time.time() - t0
         return True
@@ -718,7 +717,7 @@ class ClassicalCalculator(base.HazardCalculator):
         oq = self.oqparam
         hstats = oq.hazard_stats()
         N, S, M, P, L1, individual = self._create_hcurves_maps()
-        if '_rates000' in set(self.datastore):
+        if '_rates000' in set(self.datastore) or not self.datastore.parent:
             dstore = self.datastore
         else:
             dstore = self.datastore.parent
@@ -727,6 +726,7 @@ class ClassicalCalculator(base.HazardCalculator):
                     self.amplifier) for getter in getters.map_getters(
                         dstore, self.full_lt)]
         if not allargs:  # case_60
+            logging.warning('No rates were generated')
             return
         self.hazard = {}  # kind -> array
         hcbytes = 8 * N * S * M * L1

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -204,7 +204,8 @@ def postclassical(pgetter, wget, hstats, individual_rlzs,
         return {}
 
     if amplifier:
-        with hdf5.File(pgetter.filename, 'r') as f:
+        # amplification is meant for few sites, i.e. no tiling
+        with hdf5.File(pgetter.filenames[0], 'r') as f:
             ampcode = f['sitecol'].ampcode
         imtls = DictArray({imt: amplifier.amplevels
                            for imt in pgetter.imtls})

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -562,7 +562,7 @@ class ClassicalCalculator(base.HazardCalculator):
         smap = parallel.Starmap(classical, allargs, h5=self.datastore.hdf5)
         acc = smap.reduce(self.agg_dicts, acc)
         with self.monitor('storing rates', measuremem=True):
-            self.haz.store_rates(self.pmap, self.N, self._monitor)
+            self.haz.store_rates(self.pmap, self._monitor)
         del self.pmap
         if oq.disagg_by_src:
             mrs = self.haz.store_mean_rates_by_src(acc)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -750,8 +750,10 @@ class ClassicalCalculator(base.HazardCalculator):
         if hasattr(self, 'ntiles'):
             fnames = [os.path.join(self._monitor.calc_dir, f)
                       for f in os.listdir(self._monitor.calc_dir)]
+        elif len(dstore['_rates/sid']) == 0:  # in case_60
+            return
         else:
-            fnames = [self.datastore.filename]
+            fnames = [dstore.filename]
         allargs = [
             (getters.MapGetter(fname, trt_rlzs, self.R, oq),
              weights, wget, hstats, individual, oq.max_sites_disagg,

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -92,16 +92,15 @@ class ClassicalRiskCalculator(base.RiskCalculator):
         """
         oq = self.oqparam
         super().pre_execute()
-        if '_rates' not in self.datastore:  # when building short report
-            return
-        full_lt = self.datastore['full_lt'].init()
-        stats = list(oq.hazard_stats().items())
-        oq._stats = stats
-        oq._weights = full_lt.weights
-        self.riskinputs = self.build_riskinputs()
-        self.A = len(self.assetcol)
-        self.L = len(self.crmodel.loss_types)
-        self.S = len(oq.hazard_stats())
+        if any(name.startswith('_rates') for name in self.datastore):
+            full_lt = self.datastore['full_lt'].init()
+            stats = list(oq.hazard_stats().items())
+            oq._stats = stats
+            oq._weights = full_lt.weights
+            self.riskinputs = self.build_riskinputs()
+            self.A = len(self.assetcol)
+            self.L = len(self.crmodel.loss_types)
+            self.S = len(oq.hazard_stats())
 
     def post_execute(self, result):
         """

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -92,7 +92,9 @@ class ClassicalRiskCalculator(base.RiskCalculator):
         """
         oq = self.oqparam
         super().pre_execute()
-        if any(name.startswith('_rates') for name in self.datastore):
+        parent = self.datastore.parent
+        if any(name.startswith('_rates') for name in self.datastore) or \
+           any(name.startswith('_rates') for name in parent):
             full_lt = self.datastore['full_lt'].init()
             stats = list(oq.hazard_stats().items())
             oq._stats = stats

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -177,6 +177,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         self.M = len(self.imts)
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
+        # disaggregation is meant for few sites, i.e. no tiling
         assert self.N < getters.CHUNKS, (self.N, getters.CHUNKS)
         self.mgetters = getters.map_getters(dstore, full_lt, disagg=True)
 

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -31,7 +31,7 @@ from openquake.hazardlib import stats, map_array, valid
 from openquake.hazardlib.calc import disagg, mean_rates
 from openquake.hazardlib.contexts import read_cmakers, read_ctx_by_grp
 from openquake.commonlib import util
-from openquake.calculators import base, getters, classical
+from openquake.calculators import base, getters
 
 POE_TOO_BIG = '''\
 Site #%d: you are trying to disaggregate for poe=%s.
@@ -177,7 +177,7 @@ class DisaggregationCalculator(base.HazardCalculator):
         self.M = len(self.imts)
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
-        assert self.N < classical.CHUNKS, (self.N, classical.CHUNKS)
+        assert self.N < getters.CHUNKS, (self.N, getters.CHUNKS)
         self.mgetters = getters.map_getters(dstore, full_lt, disagg=True)
 
         # build array rlzs (N, Z)

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -178,10 +178,9 @@ class DisaggregationCalculator(base.HazardCalculator):
         self.M = len(self.imts)
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
-        nrows = len(dstore['_rates/sid'])
         trt_rlzs = full_lt.get_trt_rlzs(dstore['trt_smrs'][:])
         self.pgetter = getters.MapGetter(
-            dstore.filename, trt_rlzs, self.R, [(0, nrows + 1)], oq)
+            dstore.filename, trt_rlzs, self.R, oq)
 
         # build array rlzs (N, Z)
         if oq.rlz_index is None:

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -179,8 +179,9 @@ class DisaggregationCalculator(base.HazardCalculator):
         dstore = (self.datastore.parent if self.datastore.parent
                   else self.datastore)
         trt_rlzs = full_lt.get_trt_rlzs(dstore['trt_smrs'][:])
-        self.pgetter = getters.MapGetter(
-            dstore.filename, trt_rlzs, self.R, oq)
+        names = ['_rates%03d' % sid for sid in self.sitecol.sids]
+        self.pgetters = [getters.MapGetter(
+            dstore.filename, name, trt_rlzs, self.R, oq) for name in names]
 
         # build array rlzs (N, Z)
         if oq.rlz_index is None:
@@ -188,7 +189,7 @@ class DisaggregationCalculator(base.HazardCalculator):
             rlzs = numpy.zeros((self.N, Z), int)
             if self.R > 1:
                 for sid in self.sitecol.sids:
-                    hcurve = self.pgetter.get_hcurve(sid)
+                    hcurve = self.pgetters[sid].get_hcurve(sid)
                     mean = getters.build_stat_curve(
                         hcurve, oq.imtls, stats.mean_curve, full_lt.weights,
                         full_lt.wget)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -157,7 +157,7 @@ def map_getters(dstore, full_lt=None):
     oq = dstore['oqparam']
     full_lt = full_lt or dstore['full_lt'].init()
     R = full_lt.get_num_paths()
-    req_gb, trt_rlzs, gids = get_pmaps_gb(dstore, full_lt)
+    _req_gb, trt_rlzs, _gids = get_pmaps_gb(dstore, full_lt)
     if oq.fastmean:
         weights = dstore['gweights'][:]
         trt_rlzs = numpy.zeros(len(weights))  # reduces the data transfer
@@ -284,8 +284,6 @@ class MapGetter(object):
                         array = numpy.zeros((self.L, self.G))
                         self._map[sid] = array
                     array[df.lid, df.gid] = df.rate
-                    #if sid == 4123:
-                    #    print(df)
         return self._map
 
     # used in risk calculations where there is a single site per getter

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -17,6 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import operator
+import collections
 import numpy
 
 from openquake.baselib import general, hdf5
@@ -198,13 +199,18 @@ class CurveGetter(object):
     """
     @classmethod
     def build(cls, dstore):
+        """
+        :returns: a dictionary sid -> CurveGetter
+        """
         rates = {}
         for mgetter in map_getters(dstore):
             pmap = mgetter.init()
             for sid in pmap:
                 rates[sid] = pmap[sid]  # shape (L, G)
-        return {sid: cls(sid, rates[sid], mgetter.trt_rlzs, mgetter.R)
-                for sid in rates}, ZeroGetter(mgetter.L, mgetter.R)
+        dic = collections.defaultdict(lambda: ZeroGetter(mgetter.L, mgetter.R))
+        for sid in rates:
+            dic[sid] = cls(sid, rates[sid], mgetter.trt_rlzs, mgetter.R)
+        return dic                
 
     def __init__(self, sid, rates, trt_rlzs, R):
         self.sid = sid

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -151,7 +151,7 @@ def get_pmaps_gb(dstore, full_lt=None):
     return len(trt_rlzs) * N * L * 4 / 1024**3, trt_rlzs, gids
 
 
-def map_getters(dstore, full_lt=None):
+def map_getters(dstore, full_lt=None, disagg=False):
     """
     :returns: a list of pairs (MapGetter, weights)
     """
@@ -159,7 +159,7 @@ def map_getters(dstore, full_lt=None):
     full_lt = full_lt or dstore['full_lt'].init()
     R = full_lt.get_num_paths()
     _req_gb, trt_rlzs, _gids = get_pmaps_gb(dstore, full_lt)
-    if oq.fastmean:
+    if oq.fastmean and not disagg:
         weights = dstore['gweights'][:]
         trt_rlzs = numpy.zeros(len(weights))  # reduces the data transfer
     else:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -175,6 +175,18 @@ def map_getters(dstore, full_lt=None):
             for dirname in dirnames]
 
 
+class ZeroGetter(object):
+    """
+    Return an array of zeros of shape (L, R)
+    """
+    def __init__(self, L, R):
+        self.L = L
+        self.R = R
+
+    def get_hazard(self):
+        return numpy.zeros((self.L, self.R))
+
+
 class CurveGetter(object):
     """
     Hazard curve builder used in classical_risk/classical_damage.
@@ -190,7 +202,7 @@ class CurveGetter(object):
             for sid in pmap:
                 rates[sid] = pmap[sid]  # shape (L, G)
         return {sid: cls(sid, rates[sid], mgetter.trt_rlzs, mgetter.R)
-                for sid in rates}
+                for sid in rates}, ZeroGetter(mgetter.L, mgetter.R)
 
     def __init__(self, sid, rates, trt_rlzs, R):
         self.sid = sid

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -658,7 +658,7 @@ class ClassicalTestCase(CalculatorTestCase):
         L1 = L // len(oq.imtls)
         branches = self.calc.datastore['full_lt/gsim_lt'].branches
         gsims = [br.gsim for br in branches]
-        df = self.calc.datastore.read_df('_rates')
+        df = self.calc.datastore.read_df('_rates000')
         del df['sid']
         for g, gsim in enumerate(gsims):
             curve = numpy.zeros(L1, oq.imt_dt())

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -517,7 +517,7 @@ class ClassicalTestCase(CalculatorTestCase):
 
     def test_case_60(self):
         # pointsource approx with CampbellBozorgnia2003NSHMP2007
-        # the hazard curve MUST be zero; it was not originally
+        # the hazard curve MUST be zero; it was not, originally,
         # due to a wrong dip angle of 0 instead of 90
         self.run_calc(case_60.__file__, 'job.ini')
         [f] = export(('hcurves/mean', 'csv'), self.calc.datastore)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -44,8 +44,7 @@ from openquake.risklib import riskmodels
 from openquake.risklib.scientific import (
     losses_by_period, return_periods, LOSSID, LOSSTYPE)
 from openquake.baselib.writers import build_header, scientificformat
-from openquake.calculators.classical import get_pmaps_gb
-from openquake.calculators.getters import get_ebrupture, MapGetter
+from openquake.calculators.getters import get_ebrupture, MapGetter, get_pmaps_gb
 from openquake.calculators.extract import extract
 
 TWO24 = 2**24

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -49,7 +49,6 @@ code2cls = rupture.BaseRupture.init()
 
 # ############## utilities for the classical calculator ############### #
 
-
 # used only in the view global_hcurves
 def convert_to_array(pmap, nsites, imtls, inner_idx=0):
     """

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -24,6 +24,7 @@ submit_cmd = oq run
 min_input_size = 1_000_000
 compress =
 slurm_chunk = 50
+save_on_tmp = 
 
 [memory]
 # use at most 1 TiB for the poes


### PR DESCRIPTION
This second approach stores only one file per task, to avoid running out of inodes on supercomputers.
```
# before
| calc_10571, maxmem=80.3 GB | time_sec | memory_mb | counts      |
|----------------------------+----------+-----------+-------------|
| total classical            | 141_590  | 102.8164  | 13_379      |
| planar contexts            | 46_356   | 0.0       | 242_783_052 |
| get_poes                   | 44_733   | 0.0       | 13_742_509  |
| total postclassical        | 28_757   | 18.9258   | 9_448       |
| reading rates              | 4_845    | 0.3164    | 9_448       |
| ClassicalCalculator.run    | 1_780    | 2_961     | 1           |

| task              | sent                                            | received |
|-------------------+-------------------------------------------------+----------|
| classical         | sitecol=116.74 GB cmaker=2.85 GB dstore=2.13 MB | 25.84 GB |

# after
| calc_10572, maxmem=106.3 GB | time_sec | memory_mb | counts      |
|-----------------------------+----------+-----------+-------------|
| total classical             | 146_199  | 58.3906   | 13_379      |
| planar contexts             | 46_493   | 0.0       | 242_783_052 |
| get_poes                    | 44_718   | 0.0       | 13_742_509  |
| total postclassical         | 29_410   | 300.3     | 256         |
| reading rates               | 4_655    | 282.7     | 256         |
| ClassicalCalculator.run     | 1_760    | 501.2     | 1           |

| task      | sent                                            | received  |
|-----------+-------------------------------------------------+-----------|
| classical | sitecol=116.74 GB cmaker=2.85 GB dstore=2.13 MB | 683.15 MB |
```
The data transfer is 39x less and I managed to improve even on "reading rates"!
Moreover, the calculation runs on the CEA cluster without hanging.