### PR TITLE
Storing the rates as a single dataset again

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -625,6 +625,8 @@ class HazardCalculator(BaseCalculator):
                 oq, oq.inputs['hazard_curves'])
             df = (~pmap).to_dframe()
             self.datastore.create_df('_rates', df)
+            slices = numpy.array([(0, 0, len(df))], getters.slice_dt)
+            self.datastore['_rates/slice_by_idx'] = slices
             self.datastore['assetcol'] = self.assetcol
             self.datastore['full_lt'] = logictree.FullLogicTree.fake()
             self.datastore['trt_rlzs'] = U32([[0]])

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -70,7 +70,10 @@ def _store(rates, num_chunks, h5, offset=0):
         hdf5.extend(h5['_rates/lid'], ch_rates['lid'])
         hdf5.extend(h5['_rates/rate'], ch_rates['rate'])
     iss = numpy.array(idx_start_stop, getters.slice_dt)
-    hdf5.extend(h5['_rates/slice_by_idx'], iss)
+    if '_rates/slice_by_idx' in h5:
+        hdf5.extend(h5['_rates/slice_by_idx'], iss)
+    else:  # writing small file
+        h5['_rates/slice_by_idx'] = iss
     return offset
 
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -429,10 +429,9 @@ class ClassicalCalculator(base.HazardCalculator):
 
         # create empty dataframes
         self.chunks = getters.get_num_chunks(self.datastore)
-        if oq.calculation_mode == 'classical':
-            self.datastore.create_df(
-                '_rates', [(n, rates_dt[n]) for n in rates_dt.names], 'gzip')
-            self.datastore.create_dset('_rates/slice_by_idx', getters.slice_dt)
+        self.datastore.create_df(
+            '_rates', [(n, rates_dt[n]) for n in rates_dt.names], 'gzip')
+        self.datastore.create_dset('_rates/slice_by_idx', getters.slice_dt)
 
     def check_memory(self, N, L, maxw):
         """
@@ -466,7 +465,7 @@ class ClassicalCalculator(base.HazardCalculator):
             oq.mags_by_trt = {
                 trt: python3compat.decode(dset[:])
                 for trt, dset in parent['source_mags'].items()}
-            if any(name.startswith('_rates') for name in parent):
+            if '_rates' in parent:
                 self.build_curves_maps()  # repeat post-processing
                 return {}
 
@@ -710,7 +709,7 @@ class ClassicalCalculator(base.HazardCalculator):
         oq = self.oqparam
         hstats = oq.hazard_stats()
         N, S, M, P, L1, individual = self._create_hcurves_maps()
-        if '_rates000' in set(self.datastore) or not self.datastore.parent:
+        if '_rates' in set(self.datastore) or not self.datastore.parent:
             dstore = self.datastore
         else:
             dstore = self.datastore.parent

--- a/openquake/calculators/classical_risk.py
+++ b/openquake/calculators/classical_risk.py
@@ -93,8 +93,7 @@ class ClassicalRiskCalculator(base.RiskCalculator):
         oq = self.oqparam
         super().pre_execute()
         parent = self.datastore.parent
-        if any(name.startswith('_rates') for name in self.datastore) or \
-           any(name.startswith('_rates') for name in parent):
+        if '_rates' in self.datastore or '_rates' in parent:
             full_lt = self.datastore['full_lt'].init()
             stats = list(oq.hazard_stats().items())
             oq._stats = stats

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -184,9 +184,8 @@ class DisaggregationCalculator(base.HazardCalculator):
             Z = oq.num_rlzs_disagg
             rlzs = numpy.zeros((self.N, Z), int)
             if self.R > 1:
-                for mgetter in self.mgetters:
-                    sid = int(mgetter.name[6:])  # strip _rates
-                    hcurve = mgetter.get_hcurve(sid)
+                for sid in range(self.N):
+                    hcurve = self.mgetters[sid].get_hcurve(sid)
                     mean = getters.build_stat_curve(
                         hcurve, oq.imtls, stats.mean_curve, full_lt.weights,
                         full_lt.wget)

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -659,7 +659,7 @@ class ClassicalTestCase(CalculatorTestCase):
         L1 = L // len(oq.imtls)
         branches = self.calc.datastore['full_lt/gsim_lt'].branches
         gsims = [br.gsim for br in branches]
-        df = self.calc.datastore.read_df('_rates000')
+        df = self.calc.datastore.read_df('_rates')
         del df['sid']
         for g, gsim in enumerate(gsims):
             curve = numpy.zeros(L1, oq.imt_dt())


### PR DESCRIPTION
Since it is much faster. Here is EUR on cole:
```
$ OQ_SAMPLE_SOURCES=.01 oq run EUR.zip
| calc_10601, maxmem=168.3 GB | time_sec | memory_mb | counts     |
|-----------------------------+----------+-----------+------------|
| total classical             | 408_954  | 54.9922   | 535        |
| get_poes                    | 189_549  | 0.0       | 59_111_087 |
| computing mean_std          | 132_811  | 0.0       | 2_368_383  |
| composing pnes              | 69_631   | 0.0       | 59_111_087 |
| total fast_mean             | 7_019    | 434.3     | 711        |
| reading rates               | 6_954    | 434.1     | 711        |
| ClassicalCalculator.run     | 4_153    | 410.2     | 1          |

| operation-duration | counts | mean   | stddev | min    | max     | slowfac |
|--------------------+--------+--------+--------+--------+---------+---------|
| classical          | 535    | 764.4  | 87%    | 1.3402 | 1_712   | 2.2398  |
| fast_mean          | 711    | 9.8715 | 42%    | 5.0090 | 18.5227 | 1.8764  |

| task      | sent                                            | received  |
|-----------+-------------------------------------------------+-----------|
| classical | sitecol=9.62 GB cmaker=130.3 MB dstore=87.25 KB | 104.76 KB |
| fast_mean | pgetter=27.55 MB                                | 1.04 GB   |

$ du -sh tmp/calc_10601/
45G     tmp/calc_10601/
```
For comparison, with enging-3.20 it was faster with 4771 tasks:
```
| calc_10587, maxmem=94.7 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 354_679  | 99.6      | 4_771      |
| get_poes                   | 192_400  | 0.0       | 24_348_287 |
| computing mean_std         | 68_347   | 0.0       | 521_346    |
| composing pnes             | 67_439   | 0.0       | 24_348_287 |
| planar contexts            | 18_483   | 0.0       | 97_845_201 |
| total fast_mean            | 8_731    | 108.8     | 2_996      |
| reading rates              | 8_675    | 108.8     | 2_996      |
| ClassicalCalculator.run    | 4_112    | 4_127     | 1          |
| iter_ruptures              | 3_100    | 0.0       | 3_489_359  |
| storing rates              | 2_380    | 241.5     | 4_771      |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 4_050  | 87.6    | 11%    | 0.99199 | 129.8   | 1.48183 |
| fast_mean          | 2_996  | 2.91415 | 27%    | 0.01258 | 4.74377 | 1.62784 |

| task      | sent                                              | received |
|-----------+---------------------------------------------------+----------+
| classical | sitecol=26.36 GB cmaker=510.71 MB dstore=660.5 KB | 42.29 GB |
| fast_mean | pgetter=91.85 MB gweights=24.29 MB                | 1.48 GB  |
```