### PR TITLE
use extrapolation in order to handle floating point edge cases

### DIFF
--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -563,7 +563,7 @@ def get_sigma_mu_adjustment(model, imt, mag, rrup):
     if imt.string in "PGA PGV":
         # Linear interpolation
         interp = RegularGridInterpolator(
-            (model_m, model_r), sigma_mu_model, bounds_error=True,)
+            (model_m, model_r), sigma_mu_model, bounds_error=False, fill_value=None)
         sigma_mu = interp(np.stack((mag, rrup), axis=1))
     else:
         model_t = model["periods"]
@@ -573,17 +573,17 @@ def get_sigma_mu_adjustment(model, imt, mag, rrup):
             sigma_mu_model = np.concatenate(
                 (sigma_mu_model, sigma_mu_model[:, :, -1][:, :, np.newaxis]),
                 axis=2)
-            model_t = np.concatenate((model_t, [imt.period.max()]), axis=0)
+            model_t = np.concatenate((model_t, [imt.period]), axis=0)
         if np.any(imt.period < model["periods"][0]):
             sigma_mu_model = np.concatenate(
                 (sigma_mu_model[:, :, 0][:, :, np.newaxis], sigma_mu_model),
                 axis=2)
-            model_t = np.concatenate(([imt.period.min()], model_t), axis=0)
+            model_t = np.concatenate(([imt.period], model_t), axis=0)
 
         # Linear interpolation
         interp = RegularGridInterpolator(
             (model_m, model_r, np.log(model_t)), sigma_mu_model,
-            bounds_error=True,)
+            bounds_error=False, fill_value=None)
         sigma_mu = interp(
             np.stack((mag, rrup, np.ones_like(mag) * np.log(imt.period)),
                      axis=1))


### PR DESCRIPTION
Fixes:
- handles floating point edge case in interpolation / extrapolation
- bug in use of IMT class


## Interpoloation / Extrapolation

While running a disaggregation in which the GMCM logic tree included `NZNSHM2022_KuehnEtAl2020SInter` I encountered the following error:

```
[2024-07-17 14:24:15 #45 INFO] Received 1 * 100 B in 0 seconds [unpik=0.00s] from compute_disagg                                                                                                                   
{'tot': '100 B'}                                                                                                                                                                                                   
Traceback (most recent call last):                                                                                                                                                                                 
  File "/home/chrisdc/.virtualenvs/openquake-e-py3.10/bin/oq", line 8, in <module>                                                                                                                                 
    sys.exit(oq())                                                                                                                                                                                                 
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/commands/__main__.py", line 48, in oq                                                                                                               
    sap.run(commands, prog='oq')
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/sap.py", line 212, in run
    return _run(parser(funcdict, **parserkw), argv)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/sap.py", line 203, in _run
    return func(**dic)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/commands/engine.py", line 182, in main
    run_jobs(jobs)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/engine/engine.py", line 403, in run_jobs
    run_calc(jobctx)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/engine/engine.py", line 278, in run_calc
    calc.run(shutdown=True)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/base.py", line 284, in run
    raise exc from None
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/base.py", line 268, in run
    self.result = self.execute()
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/disaggregation.py", line 158, in execute
    return self.full_disaggregation()
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/disaggregation.py", line 226, in full_disaggregation
    return self.compute()
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/disaggregation.py", line 313, in compute
    results = smap.reduce(self.agg_result, acc)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/parallel.py", line 953, in reduce
    return self.submit_all().reduce(agg, acc)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/parallel.py", line 654, in reduce
    for result in self:
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/parallel.py", line 640, in __iter__
    yield from self._iter()
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/parallel.py", line 630, in _iter
    out = result.get()
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/parallel.py", line 455, in get
    raise etype(msg)
ValueError: 
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/baselib/parallel.py", line 478, in new
    val = func(*args)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/calculators/disaggregation.py", line 90, in compute_disagg
    out.extend(res)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/hazardlib/calc/disagg.py", line 494, in disagg_by_magi
    self.init(magi, src_mutex, mon0, mon1, mon2, mon3)
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/hazardlib/calc/disagg.py", line 435, in init
    self.mea[magi], self.std[magi] = self.cmaker.get_mean_stds(
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/hazardlib/contexts.py", line 1247, in get_mean_stds
    adj = compute(gsim, ctx, self.imts, *out[:, g, :, slc])
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/hazardlib/gsim/nz22/nz_nshm2022_kuehn_2020.py", line 331, in compute
    sigma_mu_adjust = get_sigma_mu_adjustment(
  File "/home/chrisdc/NSHM/DEV/CALCULATION/oq-engine/openquake/hazardlib/gsim/kuehn_2020.py", line 587, in get_sigma_mu_adjustment
    sigma_mu = interp(
  File "/home/chrisdc/.virtualenvs/openquake-e-py3.10/lib/python3.10/site-packages/scipy/interpolate/_rgi.py", line 329, in __call__
    xi, xi_shape, ndim, nans, out_of_bounds = self._prepare_xi(xi)
  File "/home/chrisdc/.virtualenvs/openquake-e-py3.10/lib/python3.10/site-packages/scipy/interpolate/_rgi.py", line 383, in _prepare_xi
    raise ValueError("One of the requested xi is out of bounds "
ValueError: One of the requested xi is out of bounds in dimension 2
```

This is due to the `KuehnEtAl2020SInter` interpolator not allowing extrapolation:
```
interp = RegularGridInterpolator(
            (model_m, model_r, np.log(model_t)), sigma_mu_model,
            bounds_error=True,)
```

Extrapolation should not be necessary since `get_sigma_mu_adjustment()` extends the `sigma_mu_model` if values outside the range are requested. However, I believe I encountered an edge case where floating point precision resulted in `RegularGridInterpolator` attempting extrapolation.

This is further demonstrated by the fact that the calculation I was attempting did not even necessitate extrapolation as it was on the boundary of the existing `sigma_mu_model`. The values of the model and rupture values that resulted in the error:
```
model_m=array([4. , 4.5, 5. , 5.5, 6. , 6.5, 7. , 7.5, 8. , 8.5, 9. , 9.5])                                                                                                                                        
model_r=array([  10.        ,   15.84893192,   25.11886432,   39.81071706,                                                                                                                                         
         63.09573445,  100.        ,  158.48931925,  251.18864315,                                                                                                                                                 
        398.10717055,  500.        ,  630.95734448,  800.        ,                                                                                                                                                 
       1000.        ])                                                                                                                                                                                             
model_t=array([ 0.01 ,  0.02 ,  0.03 ,  0.05 ,  0.075,  0.1  ,  0.15 ,  0.2  ,                                                                                                                                     
        0.25 ,  0.3  ,  0.4  ,  0.5  ,  0.75 ,  1.   ,  1.5  ,  2.   ,                                                                                                                                             
        3.   ,  4.   ,  5.   ,  7.5  , 10.   ])                                                                                                                                                                    
mag=array([5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2,                                                                                                                                        
       5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2, 5.2,                                                                                                                                            
       5.2, 5.2, 5.2, 5.2, 5.2], dtype=float32)                                                                                                                                                                    
rrup=array([35.861782, 31.300354, 28.61209 , 30.253008, 31.692646, 39.66656 ,
       32.321083, 31.248156, 39.627525, 32.540756, 35.010014, 34.75858 ,
       36.49196 , 27.88818 , 24.366224, 25.690031, 29.899588, 28.339233,
       25.143734, 26.698534, 35.994354, 35.55922 , 37.264206, 36.181873,
       34.21193 , 36.91213 , 37.411453, 26.420443, 27.412632, 34.052315,
       30.944475], dtype=float32)
imt.period=10.0
```

## IMT bug

In the course of testing the change, I found a bug in the use of `imt`. Type `openquake.hazardlib.imt.IMT` does not have `min()` and `max()` methods.
