### PR TITLE
Fix a couple of details in ARISTOTLE mode

### DIFF
--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -577,6 +577,7 @@
             });
             $('#clearStationDataFile').click(function() {
                 $('#station_data_file_input').val('');
+                $('#maximum_distance_stations').val('');
                 $('#maximum_distance_stations').prop('disabled', true);
             });
             $("#aristotle_run_form > input").click(function() {

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -1,7 +1,7 @@
 {% extends "engine/base.html" %}
 
   {% block nav-items %}
-                {% if application_mode != 'AELO' and application_mode != 'READ_ONLY' %}
+                {% if application_mode != 'AELO' and application_mode != 'ARISTOTLE' and application_mode != 'READ_ONLY' %}
                 <li class="calc">
                   <form class="calc-form form-horizontal"
                         enctype="multipart/form-data"


### PR DESCRIPTION
Fixes https://github.com/gem/oq-engine/issues/9853

* Reset maximum_distance_stations to blank when station data file is cleared
* Do not display the `Run a Calculation` button in the header, so the user can run a calculation only using the specific web form for ARISTOTLE.