### PR TITLE
ARISTOTLE: improve format of losses table, plus other improvements

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1740,7 +1740,7 @@ def view_aggrisk(token, dstore):
     AVG = len(rlzs)
     arr = numpy.zeros(AVG + 1, dt)
     for r, rlz in enumerate(rlzs):
-        arr[r]['gsim'] = repr(repr(rlz.value[0]))
+        arr[r]['gsim'] = repr(rlz.value[0])
         arr[r]['weight'] = rlz.weight[-1]
     for r, loss_id, loss in zip(df.rlz_id, df.loss_id, df.loss):
         rlz = rlzs[r]

--- a/openquake/engine/aristotle.py
+++ b/openquake/engine/aristotle.py
@@ -72,7 +72,7 @@ def trivial_callback(
     print('Finished job(s) %d correctly. Params: %s' % (job_id, params))
 
 
-def get_rupture_dict(dic):
+def get_rupture_dict(dic, ignore_shakemap=False):
     """
     :param dic: a dictionary with keys usgs_id and rupture_file
     :returns: a new dictionary with keys usgs_id, rupture_file, lon, lat...
@@ -94,7 +94,7 @@ def get_rupture_dict(dic):
     elif dic.get('lon') is not None:  # when called from `oq mosaic aristotle`
         rupdic = dic
     else:
-        rupdic = download_rupture_dict(usgs_id)
+        rupdic = download_rupture_dict(usgs_id, ignore_shakemap)
     return rupdic
 
 
@@ -102,7 +102,8 @@ def get_aristotle_allparams(rupture_dict, maximum_distance, trt,
                             truncation_level, number_of_ground_motion_fields,
                             asset_hazard_distance, ses_seed,
                             exposure_hdf5=None, station_data_file=None,
-                            maximum_distance_stations=None):
+                            maximum_distance_stations=None,
+                            ignore_shakemap=False):
     """
     :returns: a list of dictionaries suitable for an Aristotle calculation
     """
@@ -111,7 +112,7 @@ def get_aristotle_allparams(rupture_dict, maximum_distance, trt,
             config.directory.mosaic_dir, 'exposure.hdf5')
     inputs = {'exposure': [exposure_hdf5],
               'job_ini': '<in-memory>'}
-    rupdic = get_rupture_dict(rupture_dict)
+    rupdic = get_rupture_dict(rupture_dict, ignore_shakemap)
     rupture_file = rupdic.pop('rupture_file')
     if rupture_file:
         inputs['rupture_model'] = rupture_file
@@ -174,7 +175,7 @@ def main_cmd(usgs_id, rupture_file=None, rupture_dict=None,
              maximum_distance='300', trt=None, truncation_level='3',
              number_of_ground_motion_fields='10', asset_hazard_distance='15',
              ses_seed='42', exposure_hdf5=None, station_data_file=None,
-             maximum_distance_stations=None):
+             maximum_distance_stations=None, ignore_shakemap=False):
     """
     This script is meant to be called from the command-line
     """
@@ -185,7 +186,7 @@ def main_cmd(usgs_id, rupture_file=None, rupture_dict=None,
             rupture_dict, maximum_distance, trt, truncation_level,
             number_of_ground_motion_fields, asset_hazard_distance,
             ses_seed, exposure_hdf5, station_data_file,
-            maximum_distance_stations)
+            maximum_distance_stations, ignore_shakemap)
     except Exception as exc:
         callback(None, dict(usgs_id=usgs_id), exc=exc)
         return
@@ -212,9 +213,11 @@ main_cmd.number_of_ground_motion_fields = 'Number of ground motion fields'
 main_cmd.asset_hazard_distance = 'Asset hazard distance'
 main_cmd.ses_seed = 'SES seed'
 main_cmd.station_data_file = 'CSV file with the station data'
-main_cmd.maximum_ditance_stations = 'Maximum distance from stations in km'
+main_cmd.maximum_distance_stations = 'Maximum distance from stations in km'
 main_cmd.exposure_hdf5 = ('File containing the exposure, site model '
                           'and vulnerability functions')
+main_cmd.ignore_shakemap = (
+    'Used to test retrieving rupture data from finite-fault info')
 
 if __name__ == '__main__':
     sap.run(main_cmd)

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -551,6 +551,12 @@
                     $('#dep').val(data.dep);
                     $('#mag').val(data.mag);
                     $('#rake').val(data.rake);
+                    if ('dip' in data) {
+                        $('#dip').val(data.dip);
+                    }
+                    if ('strike' in data) {
+                        $('#strike').val(data.strike);
+                    }
                     $('#mosaic_model').text('(' + data.lon + ', ' + data.lat + ')' + ' is covered by model ' + data.mosaic_model);
                     $('#trt').empty();
                     $.each(data.trts, function(index, trt) {
@@ -576,6 +582,8 @@
                 $('#rupture_file_input').val('');
                 $('#dip').prop('disabled', false);
                 $('#strike').prop('disabled', false);
+                $('#dip').val('90');
+                $('#strike').val('0');
             });
             $('#rupture_file_input').on('change', function() {
                 $('#dip').prop('disabled', $(this).val() != '');

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -574,6 +574,12 @@
             });
             $('#clearRuptureFile').click(function() {
                 $('#rupture_file_input').val('');
+                $('#dip').prop('disabled', false);
+                $('#strike').prop('disabled', false);
+            });
+            $('#rupture_file_input').on('change', function() {
+                $('#dip').prop('disabled', $(this).val() != '');
+                $('#strike').prop('disabled', $(this).val() != '');
             });
             $('#clearStationDataFile').click(function() {
                 $('#station_data_file_input').val('');

--- a/openquake/server/templates/engine/get_outputs_aristotle.html
+++ b/openquake/server/templates/engine/get_outputs_aristotle.html
@@ -71,7 +71,7 @@
                   {% if forloop.counter == 2 %}
                   {{ item|floatformat:"6" }}
                   {% else %}
-                  {{ item|floatformat:"2g" }}
+                  {{ item|humanize_number }}
                   {% endif %}
                 {% else %}
                   {{ item|stringformat:"s"|linebreaksbr }}

--- a/openquake/server/templates/engine/get_outputs_aristotle.html
+++ b/openquake/server/templates/engine/get_outputs_aristotle.html
@@ -66,7 +66,7 @@
         {% for row in losses %}
           <tr {% if forloop.last %}style="border-top: 2px solid black;"{% endif%}>
             {% for item in row %}
-              <td {% if forloop.counter == 2 %}style="border-right: 2px solid black; text-align: left;"{% else %}style="text-align: right;"{% endif %}>
+              <td style="border: 1px solid #ddd; {% if forloop.counter == 2 %}border-right: 2px solid black; %}{% endif %}{% if forloop.counter < 3 %}text-align: left;{% else %}text-align: right;{% endif %}">
                 {% if item|stringformat:"s"|floatformat %}
                   {% if forloop.counter == 2 %}
                   {{ item|floatformat:"6" }}
@@ -74,7 +74,7 @@
                   {{ item|floatformat:"2g" }}
                   {% endif %}
                 {% else %}
-                  {{ item|stringformat:"s" }}
+                  {{ item|stringformat:"s"|linebreaksbr }}
                 {% endif %}
               </td>
             {% endfor %}

--- a/openquake/server/templatetags/servertags.py
+++ b/openquake/server/templatetags/servertags.py
@@ -11,6 +11,24 @@ def get_imt(string):
     return string.split('-')[1].rstrip('.png')
 
 
+@register.filter
+def humanize_number(value):
+    """
+    Converts a large number into a human-readable format, e.g., 1000 -> 1K
+    """
+    try:
+        value = float(value)
+    except (ValueError, TypeError):
+        return str(value)
+    if value < 1000:
+        return f'{value:.2f}'
+    if 1000 <= value < 1000000:
+        return f'{value/1000:.2f}K'
+    if 1000000 <= value < 1000000000:
+        return f'{value/1000000:.2f}M'
+    return f'{value/1000000000:.2f}B'
+
+
 @register.simple_tag()
 def no_optional_cookie_groups_except_hide_cookie_bar_exist(request):
     from cookie_consent.models import CookieGroup

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -822,7 +822,13 @@ def aristotle_validate(request):
                          "invalid_inputs": invalid_inputs}
         return HttpResponse(content=json.dumps(response_data),
                             content_type=JSON, status=400)
-    rupdic = get_rupture_dict(dic)
+    try:
+        rupdic = get_rupture_dict(dic)
+    except Exception as exc:
+        msg = f'Unable to retrieve rupture data: {exc}'
+        response_data = {"status": "failed", "error_msg": msg}
+        return HttpResponse(content=json.dumps(response_data),
+                            content_type=JSON, status=500)
     return rupdic, *params.values()
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -826,7 +826,9 @@ def aristotle_validate(request):
         rupdic = get_rupture_dict(dic)
     except Exception as exc:
         msg = f'Unable to retrieve rupture data: {exc}'
-        response_data = {"status": "failed", "error_msg": msg}
+        response_data = {"status": "failed", "error_msg": msg,
+                         "error_cls": type(exc).__name__}
+        logging.error('', exc_info=True)
         return HttpResponse(content=json.dumps(response_data),
                             content_type=JSON, status=500)
     return rupdic, *params.values()

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -822,8 +822,11 @@ def aristotle_validate(request):
                          "invalid_inputs": invalid_inputs}
         return HttpResponse(content=json.dumps(response_data),
                             content_type=JSON, status=400)
+    ignore_shakemap = request.POST.get('ignore_shakemap', False)
+    if ignore_shakemap == 'True':
+        ignore_shakemap = True
     try:
-        rupdic = get_rupture_dict(dic)
+        rupdic = get_rupture_dict(dic, ignore_shakemap)
     except Exception as exc:
         msg = f'Unable to retrieve rupture data: {exc}'
         response_data = {"status": "failed", "error_msg": msg,


### PR DESCRIPTION
Losses table:

- better text alignment
- multi-line gsims
- human-readable values

Other:

- handle exceptions in case retrieving rupture data fails for any reason
- if a rupture file is selected, disable dip and strike and get their values from the parsed rupture (we still need to check the management of dip and strike when the usgs shakemap is used, but it can be done in a separate PR)

![image](https://github.com/user-attachments/assets/4f04bba8-1043-4522-91b0-6a8131ae3398)

![image](https://github.com/user-attachments/assets/ac7b4b93-fb31-495f-b68b-4c692e7c73fd)
