### PR TITLE
Using half the memory in postclassical

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Using half the memory in postclassical
+  * Using half the memory in postclassical by using 32 bit arrays
+  * Using half the memory on Windows by using half the threads by default
   * Fixed a bug in conditional spectrum calculations with a non-contributing TRT
 
   [Savvinos Aristeidou]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Using half the memory in postclassical
   * Fixed a bug in conditional spectrum calculations with a non-contributing TRT
 
   [Savvinos Aristeidou]

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -225,14 +225,14 @@ def postclassical(pgetter, wget, hstats, individual_rlzs,
     pmap_by_kind = {}
     if R == 1 or individual_rlzs:
         pmap_by_kind['hcurves-rlzs'] = [
-            MapArray(sids, M, L1).fill(0) for r in range(R)]
+            MapArray(sids, M, L1).fill(0, F32) for r in range(R)]
     if hstats:
         pmap_by_kind['hcurves-stats'] = [
-            MapArray(sids, M, L1).fill(0) for r in range(S)]
+            MapArray(sids, M, L1).fill(0, F32) for r in range(S)]
     combine_mon = monitor('combine pmaps', measuremem=False)
     compute_mon = monitor('compute stats', measuremem=False)
     hmaps_mon = monitor('make_hmaps', measuremem=False)
-    sidx = MapArray(sids, 1, 1).fill(0).sidx
+    sidx = MapArray(sids, 1, 1).fill(0, F32).sidx
     for sid in sids:
         idx = sidx[sid]
         with combine_mon:

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -335,7 +335,7 @@ class MapGetter(object):
         """
         M = self.M
         L1 = self.L // M
-        means = MapArray(U32(self.sids), M, L1).fill(0)
+        means = MapArray(U32(self.sids), M, L1).fill(0, F32)
         for sid in self.sids:
             idx = means.sidx[sid]
             rates = self._map[sid]  # shape (L, G)

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -135,7 +135,7 @@ def make_hmaps(pmaps, imtls, poes):
     M, P = len(imtls), len(poes)
     hmaps = []
     for pmap in pmaps:
-        hmap = map_array.MapArray(pmaps[0].sids, M, P).fill(0)
+        hmap = map_array.MapArray(pmaps[0].sids, M, P).fill(0, F32)
         for m, imt in enumerate(imtls):
             data = map_array.compute_hazard_maps(
                 pmap.array[:, m], imtls[imt], poes)  # (N, P)

--- a/openquake/engine/tests/aelo_test.py
+++ b/openquake/engine/tests/aelo_test.py
@@ -121,7 +121,7 @@ def test_CCA():
         if rtgmpy:
             [fname] = export(('rtgm', 'csv'), calc.datastore)
             df = pandas.read_csv(fname, skiprows=1)
-            aac(df.RTGM, expected, atol=5E-5)
+            aac(df.RTGM, expected, atol=1.5E-4)
 
     if rtgmpy:
         # check asce07 exporter
@@ -136,7 +136,7 @@ def test_CCA():
         # check asce41 exporter
         [fname] = export(('asce41', 'csv'), calc.datastore)
         df = pandas.read_csv(fname, skiprows=1)
-        aac(df.value, ASCE41, atol=5E-5)
+        aac(df.value, ASCE41, atol=1.5E-4)
 
         # test no close ruptures
         dic = dict(sites='%s %s' % (-83.37, 15.15), site='wayfar', vs30='760')
@@ -227,8 +227,8 @@ def test_JPN():
     expected_uhs = pandas.read_csv(expected, skiprows=1, index_col='period')
     expected_uhs.columns = ["poe-0.02", "poe-0.05", "poe-0.1", "poe-0.2",
                             "poe-0.5"]
-
-    assert str(df2) == str(expected_uhs)
+    for col in expected_uhs.columns:
+        aac(df2[col], expected_uhs[col], atol=1E-5)
 
     if rtgmpy:
         # check all plots created

--- a/openquake/hazardlib/calc/mean_rates.py
+++ b/openquake/hazardlib/calc/mean_rates.py
@@ -23,6 +23,7 @@ from openquake.hazardlib.calc.hazard_curve import classical
 from openquake.hazardlib.map_array import MapArray
 from openquake.hazardlib.contexts import get_cmakers
 
+F32 = numpy.float32
 CUTOFF = 1E-12
 
 
@@ -64,7 +65,7 @@ def calc_rmap(src_groups, full_lt, sitecol, oq):
     Gt = sum(len(cm.gsims) for cm in cmakers)
     logging.info('Computing rate map with N=%d, L=%d, Gt=%d',
                  len(sitecol), oq.imtls.size, Gt)
-    rmap = MapArray(sitecol.sids, L, Gt).fill(0)
+    rmap = MapArray(sitecol.sids, L, Gt).fill(0, F32)
     ctxs = []
     for group, cmaker in zip(src_groups, cmakers):
         G = len(cmaker.gsims)

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -282,7 +282,7 @@ class MapArray(object):
         N, L, Gt = self.array.shape
         assert Gt == len(trt_rlzs), (Gt, len(trt_rlzs))
         R = full_lt.get_num_paths()
-        out = MapArray(range(N), L, R).fill(0.)
+        out = MapArray(range(N), L, R).fill(0., F32)
         for g, trs in enumerate(trt_rlzs):
             for sid in range(N):
                 for rlz in trs % TWO24:


### PR DESCRIPTION
By using 32 bit floats, which is right, since the rates are already stored in 32 bit (i.e. we were wasting memory).