### PR TITLE
Refined the tiling calculator

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -588,7 +588,9 @@ class ClassicalCalculator(base.HazardCalculator):
             ds = self.datastore.parent
         else:
             ds = self.datastore
-        for cm, ntiles in zip(self.cmakers, self.ntiles):
+        pairs = sorted(zip(self.cmakers, self.ntiles), key=lambda cn: cn[1])
+        # first the tasks with few tiles, then the ones with many tiles
+        for cm, ntiles in pairs:
             cm.gsims = list(cm.gsims)  # save data transfer
             sg = self.csm.src_groups[cm.grp_id]
             cm.rup_indep = getattr(sg, 'rup_interdep', None) != 'mutex'

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -42,7 +42,7 @@ avg_losses_max = 900_000_000
 conditioned_gmf_gb = 10
 
 # parallel tiling parameters
-pmap_max_gb = .75
+pmap_max_gb = .6
 
 [dbserver]
 file = ~/oqdata/db.sqlite3

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -207,7 +207,7 @@ def get_maxsize(M, G):
     """
     :returns: an integer N such that arrays N*M*G fits in the CPU cache
     """
-    maxs = 10 * TWO20 // (M*G)
+    maxs = 8 * TWO20 // (M*G)
     assert maxs > 1, maxs
     return maxs
 
@@ -1132,7 +1132,8 @@ class ContextMaker(object):
         with self.gmf_mon:
             # split_by_mag=False because already contains a single mag
             mean_stdt = self.get_mean_stds([ctx], split_by_mag=False)
-            # print('MB', mean_stdt.nbytes / TWO20)
+            # ms, poes = mean_stdt.nbytes / TWO20, len(ctx) * M * G / (2*TWO20)
+            # print('mean_stds=%.1fM, poes=%.1fM' % (ms, poes))
 
         # making plenty of slices so that the array `poes` is small
         for slc in split_in_slices(len(ctx), 2*L1):
@@ -1141,7 +1142,6 @@ class ContextMaker(object):
             with self.poe_mon:
                 # this is allocating at most a few MB of RAM
                 poes = numpy.zeros((len(ctxt), M*L1, G))
-                # print('MB', poes.nbytes / TWO20)
                 # NB: using .empty would break the MixtureModelGMPETestCase
                 for g, gsim in enumerate(self.gsims):
                     ms = mean_stdt[:2, g, :, slc]

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1132,8 +1132,8 @@ class ContextMaker(object):
         with self.gmf_mon:
             # split_by_mag=False because already contains a single mag
             mean_stdt = self.get_mean_stds([ctx], split_by_mag=False)
-            # ms, poes = mean_stdt.nbytes / TWO20, len(ctx) * M * G / (2*TWO20)
-            # print('mean_stds=%.1fM, poes=%.1fM' % (ms, poes))
+            #ms, poes = mean_stdt.nbytes / TWO20, len(ctx) * 4 * M * G / TWO20
+            #print('C=%d, mean_stds=%.1fM, poes=%.1fM' % (len(ctx), ms, poes))
 
         # making plenty of slices so that the array `poes` is small
         for slc in split_in_slices(len(ctx), 2*L1):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -207,7 +207,7 @@ def get_maxsize(M, G):
     """
     :returns: an integer N such that arrays N*M*G fits in the CPU cache
     """
-    maxs = 20 * TWO20 // (M*G)
+    maxs = 10 * TWO20 // (M*G)
     assert maxs > 1, maxs
     return maxs
 
@@ -1132,7 +1132,7 @@ class ContextMaker(object):
         with self.gmf_mon:
             # split_by_mag=False because already contains a single mag
             mean_stdt = self.get_mean_stds([ctx], split_by_mag=False)
-            # print('MB', mean_stdt.nbytes // TWO20)
+            # print('MB', mean_stdt.nbytes / TWO20)
 
         # making plenty of slices so that the array `poes` is small
         for slc in split_in_slices(len(ctx), 2*L1):
@@ -1141,6 +1141,7 @@ class ContextMaker(object):
             with self.poe_mon:
                 # this is allocating at most a few MB of RAM
                 poes = numpy.zeros((len(ctxt), M*L1, G))
+                # print('MB', poes.nbytes / TWO20)
                 # NB: using .empty would break the MixtureModelGMPETestCase
                 for g, gsim in enumerate(self.gsims):
                     ms = mean_stdt[:2, g, :, slc]

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -670,7 +670,7 @@ class CompositeSourceModel:
         if not heavy:
             maxsrc = max(srcs, key=lambda s: s.weight)
             logging.info('Heaviest: %s', maxsrc)
-        return max_weight
+        return max_weight * 1.02  # increased a bit to produce a bit less tasks
 
     def __toh5__(self):
         G = len(self.src_groups)


### PR DESCRIPTION
1. improved the task distribution by sending the small tasks first
2. improved the task distribution by sending a little less tasks (to stay under 2*num_cores)
3. reduced the memory consumption by reducing `pmap_max_gb`
4.  reduced the memory consumption and improved speed by reducing `maxsize`
Here is the improvement for USA on hendrix:
````
# before
| calc_27, maxmem=46.4 GB    | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 131_700  | 125.6445  | 154        |
| get_poes                   | 61_753   | 0.0       | 1_905_686  |
| computing mean_std         | 37_298   | 0.0       | 39_454     |
| composing pnes             | 15_833   | 0.0       | 1_905_686  |
| planar contexts            | 12_335   | 0.0       | 15_393_838 |
| ClassicalCalculator.run    | 3_632    | 831.1     | 1          |

# after, avoided slow tasks and using less memory
| calc_10676, maxmem=40.5 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 142_862  | 143.9375  | 152        |
| get_poes                   | 66_203   | 0.0       | 3_523_958  |
| computing mean_std         | 44_552   | 0.0       | 73_154     |
| composing pnes             | 15_881   | 0.0       | 3_523_958  |
| planar contexts            | 11_301   | 0.0       | 15_167_976 |
| ClassicalCalculator.run    | 3_209    | 1_796     | 1          |
````