### PR TITLE
Reduced the memory consumption in event_based calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
   [Michele Simionato]
-  * Reduced the memory occupation in `gen_poes`: now all models can be run with 32 GB
-    of RAM
+  * Reduced the memory consumption in event_based calculations: now even calculations
+    with 5 million sites can be run using ~4 GB per core
+  * Reduced the memory occupation in `gen_poes`
   * Using half the memory in postclassical by using 32 bit arrays
   * Using half the memory on Windows by using half the threads by default
   * Fixed a bug in conditional spectrum calculations with a non-contributing TRT

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -212,7 +212,7 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr, se_dt,
             except FarAwayRupture:
                 # skip this rupture
                 continue
-        if stations:  # conditioned GMFs
+        if stations and stations[0]:  # conditioned GMFs
             assert cmaker.scenario
             with shr['mea'] as mea, shr['tau'] as tau, shr['phi'] as phi:
                 df = computer.compute_all([mea, tau, phi], cmon, umon)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -266,7 +266,7 @@ def event_based(proxies, cmaker, stations, dstore, monitor):
                 sitecol.complete = dstore['complete']
         maxdist = oq.maximum_distance(cmaker.trt)
         srcfilter = SourceFilter(sitecol.complete, maxdist)
-        rupgeoms = dstore['rupgeoms']
+        rupgeoms = dstore['rupgeoms'][:]
     for block in block_splitter(proxies, 10_000, rup_weight):
         yield _event_based(block, cmaker, stations, rupgeoms, srcfilter,
                            monitor.shared, se_dt, fmon, cmon, umon, mmon)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -267,7 +267,11 @@ def event_based(proxies, cmaker, stations, dstore, monitor):
                 sitecol.complete = dstore['complete']
         maxdist = oq.maximum_distance(cmaker.trt)
         srcfilter = SourceFilter(sitecol.complete, maxdist)
-        rupgeoms = dstore['rupgeoms'][:]
+        dset = dstore['rupgeoms']
+        rupgeoms = {}
+        for proxy in proxies:
+            geom_id = proxy['geom_id']
+            rupgeoms[geom_id] = dset[geom_id]
     for block in block_splitter(proxies, 10_000, rup_weight):
         yield _event_based(block, cmaker, stations, rupgeoms, srcfilter,
                            monitor.shared, se_dt, fmon, cmon, umon, mmon)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -266,7 +266,6 @@ def event_based(proxies, cmaker, stations, dstore, monitor):
                         [computer.ctx], split_by_mag=False)
                     # avoid numba type error
                     computer.ctx.flags.writeable = True
-
                 df = computer.compute_all(mean_stds, max_iml, cmon, umon)
             sig_eps.append(computer.build_sig_eps(se_dt))
             dt = time.time() - t0
@@ -717,7 +716,8 @@ class EventBasedCalculator(base.HazardCalculator):
 
         # event_based in parallel
         eb = (event_based if ('station_data' in oq.inputs or
-                              parallel.oq_distribute() == 'slurm')
+                              parallel.oq_distribute() == 'slurm'
+                              or self.N > 500_000)
               else gen_event_based)
         smap = starmap_from_rups(eb, oq, self.full_lt, self.sitecol, dstore)
         acc = smap.reduce(self.agg_dicts)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -279,7 +279,9 @@ def gen_event_based(allproxies, cmaker, stations, dstore, monitor):
     # split it two large tasks, i.e. tasks that are estimated to take
     # more than time_per_task, except in case of stations
     t0 = time.time()
+    oq = cmaker.oq
     n = 0
+    time_per_task = 10 * oq.time_per_task if oq.correl_model else oq.time_per_task
     for proxies in block_splitter(allproxies, 50_000, rup_weight):
         n += len(proxies)
         yield from event_based(proxies, cmaker, stations, dstore, monitor)
@@ -287,7 +289,7 @@ def gen_event_based(allproxies, cmaker, stations, dstore, monitor):
         rem_weight = sum(rup_weight(r) for r in rem)
         dt = time.time() - t0
         print(f'{monitor.task_no=} {rem_weight=}, {len(proxies)=}, {dt=}')
-        if dt > cmaker.oq.time_per_task and rem_weight > 60_000:
+        if dt > time_per_task and rem_weight > 60_000:
             half = len(rem) // 2
             yield gen_event_based, rem[:half], cmaker, stations, dstore
             yield gen_event_based, rem[half:], cmaker, stations, dstore

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -212,7 +212,7 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr, se_dt,
             except FarAwayRupture:
                 # skip this rupture
                 continue
-        if hasattr(computer, 'station_data'):  # conditioned GMFs
+        if stations:  # conditioned GMFs
             assert cmaker.scenario
             with shr['mea'] as mea, shr['tau'] as tau, shr['phi'] as phi:
                 df = computer.compute_all([mea, tau, phi], cmon, umon)
@@ -370,7 +370,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         cmaker = ContextMaker(trt, rlzs_by_gsim, oq, extraparams=extra)
         cmaker.min_mag = getdefault(oq.minimum_magnitude, trt)
         if station_data is not None:
-            if parallel.oq_distribute() == 'zmq':
+            if parallel.oq_distribute() in ('zmq', 'slurm'):
                 logging.error('Conditioned scenarios are not meant to be run'
                               ' on a cluster')
             smap.share(mea=mea, tau=tau, phi=phi)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -229,8 +229,7 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
         times.append((proxy['id'], computer.ctx.rrup.min(), dt))
         alldata.append(df)
     if sum(len(df) for df in alldata):
-        gmfdata = pandas.concat(alldata)
-        print(gmfdata.memory_usage().sum() / 1024**2)
+        gmfdata = pandas.concat(alldata)  # ~40 MB
     else:
         gmfdata = {}
     times = numpy.array([tup + (fmon.task_no,) for tup in times], rup_dt)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -279,6 +279,7 @@ def gen_event_based(allproxies, cmaker, stations, dstore, monitor):
     t0 = time.time()
     n = 0
     for proxies in block_splitter(allproxies, 10_000, rup_weight):
+        # print('---', sum(rup_weight(r) for r in proxies), len(proxies))
         n += len(proxies)
         yield from event_based(proxies, cmaker, stations, dstore, monitor)
         rem = allproxies[n:]  # remaining ruptures

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -250,12 +250,13 @@ def event_based(proxies, cmaker, stations, dstore, monitor):
     """
     oq = cmaker.oq
     se_dt = sig_eps_dt(oq.imtls)
-    fmon = monitor('instantiating GmfComputer', measuremem=True)
+    rmon = monitor('reading sites and ruptures', measuremem=True)
+    fmon = monitor('instantiating GmfComputer', measuremem=False)
     mmon = monitor('computing mean_stds', measuremem=False)
     cmon = monitor('computing gmfs', measuremem=False)
     umon = monitor('updating gmfs', measuremem=False)
     cmaker.scenario = 'scenario' in oq.calculation_mode
-    with dstore:
+    with dstore, rmon:
         if dstore.parent:
             sitecol = dstore['sitecol']
             if 'complete' in dstore.parent:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -351,9 +351,9 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         station_data, station_sites = None, None
 
     gb = groupby(allproxies, operator.itemgetter('trt_smr'))
-    totw = sum(rup_weight(p) for p in allproxies) / (
+    maxw = sum(rup_weight(p) for p in allproxies) / (
         oq.concurrent_tasks or 1)
-    logging.info('totw = {:_d}'.format(round(totw)))
+    logging.info('maxw = {:_d}'.format(round(maxw)))
     if station_data is not None:
         # assume scenario with a single true rupture
         rlzs_by_gsim = full_lt.get_rlzs_by_gsim(0)
@@ -394,7 +394,8 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
                 logging.error('Conditioned scenarios are not meant to be run'
                               ' on a cluster')
             smap.share(mea=mea, tau=tau, phi=phi)
-        for block in block_splitter(proxies, totw, rup_weight):
+        # producing slightly less than concurrent_tasks thanks to the 1.02
+        for block in block_splitter(proxies, maxw * 1.02, rup_weight):
             args = block, cmaker, (station_data, station_sites), dstore
             smap.submit(args)
     return smap

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -280,16 +280,14 @@ def gen_event_based(allproxies, cmaker, stations, dstore, monitor):
     # more than time_per_task, except in case of stations
     t0 = time.time()
     n = 0
-    blocks = list(block_splitter(allproxies, 50_000, rup_weight))
-    time_per_block = cmaker.oq.time_per_task / len(blocks)
-    for proxies in blocks:
+    for proxies in block_splitter(allproxies, 50_000, rup_weight):
         n += len(proxies)
         yield from event_based(proxies, cmaker, stations, dstore, monitor)
         rem = allproxies[n:]  # remaining ruptures
         rem_weight = sum(rup_weight(r) for r in rem)
         dt = time.time() - t0
         print(f'{monitor.task_no=} {rem_weight=}, {len(proxies)=}, {dt=}')
-        if dt > time_per_block and rem_weight > 60_000:
+        if dt > cmaker.oq.time_per_task and rem_weight > 60_000:
             half = len(rem) // 2
             yield gen_event_based, rem[:half], cmaker, stations, dstore
             yield gen_event_based, rem[half:], cmaker, stations, dstore

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -280,14 +280,16 @@ def gen_event_based(allproxies, cmaker, stations, dstore, monitor):
     # more than time_per_task, except in case of stations
     t0 = time.time()
     n = 0
-    for proxies in block_splitter(allproxies, 50_000, rup_weight):
+    blocks = list(block_splitter(allproxies, 50_000, rup_weight))
+    time_per_block = cmaker.oq.time_per_task / len(blocks)
+    for proxies in blocks:
         n += len(proxies)
         yield from event_based(proxies, cmaker, stations, dstore, monitor)
         rem = allproxies[n:]  # remaining ruptures
+        rem_weight = sum(rup_weight(r) for r in rem)
         dt = time.time() - t0
-        print('---', sum(rup_weight(r) for r in proxies), len(proxies), dt)
-        if dt > cmaker.oq.time_per_task and sum(
-                rup_weight(r) for r in rem) > 60_000:
+        print(f'{monitor.task_no=} {rem_weight=}, {len(proxies)=}, {dt=}')
+        if dt > time_per_block and rem_weight > 60_000:
             half = len(rem) // 2
             yield gen_event_based, rem[:half], cmaker, stations, dstore
             yield gen_event_based, rem[half:], cmaker, stations, dstore
@@ -723,8 +725,7 @@ class EventBasedCalculator(base.HazardCalculator):
                 dstore.create_dset('gmf_data/slice_by_event', slice_dt)
 
         # event_based in parallel
-        eb = (event_based if ('station_data' in oq.inputs or self.N > 500_000)
-              else gen_event_based)
+        eb = event_based if 'station_data' in oq.inputs else gen_event_based
         smap = starmap_from_rups(eb, oq, self.full_lt, self.sitecol, dstore)
         acc = smap.reduce(self.agg_dicts)
         if 'gmf_data' not in dstore:

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -228,16 +228,12 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
         dt = time.time() - t0
         times.append((proxy['id'], computer.ctx.rrup.min(), dt))
         alldata.append(df)
-    if sum(len(df) for df in alldata):
-        gmfdata = pandas.concat(alldata)  # ~40 MB
-    else:
-        gmfdata = {}
     times = numpy.array([tup + (fmon.task_no,) for tup in times], rup_dt)
     times.sort(order='rup_id')
-    if not cmaker.oq.ground_motion_fields:
-        gmfdata = {}
-    if len(gmfdata) == 0:
+    if sum(len(df) for df in alldata) == 0:
         return dict(gmfdata={}, times=times, sig_eps=())
+
+    gmfdata = pandas.concat(alldata)  # ~40 MB
     return dict(gmfdata={k: gmfdata[k].to_numpy() for k in gmfdata.columns},
                 times=times, sig_eps=numpy.concatenate(sig_eps, dtype=se_dt))
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -212,7 +212,7 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr, se_dt,
             except FarAwayRupture:
                 # skip this rupture
                 continue
-        if stations and stations[0]:  # conditioned GMFs
+        if stations and stations[0] is not None:  # conditioned GMFs
             assert cmaker.scenario
             with shr['mea'] as mea, shr['tau'] as tau, shr['phi'] as phi:
                 df = computer.compute_all([mea, tau, phi], cmon, umon)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -219,6 +219,8 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
                 df = computer.compute_all([mea, tau, phi], cmon, umon)
         else:  # regular GMFs
             with mmon:
+                # shape (4, G, M, N) for 1M sites, 10 IMTs and 10 GSIMs
+                # gives 3 GB of RAM
                 mean_stds = cmaker.get_mean_stds(
                     [computer.ctx], split_by_mag=False)
                 # avoid numba type error

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -289,10 +289,10 @@ def ebrisk(proxies, cmaker, stations, dstore, monitor):
     cmaker.oq.ground_motion_fields = True
     for block in general.block_splitter(
             proxies, 20_000, event_based.rup_weight):
-        dic = event_based.event_based(block, cmaker, stations, dstore, monitor)
-        if len(dic['gmfdata']):
-            gmf_df = pandas.DataFrame(dic['gmfdata'])
-            yield event_based_risk(gmf_df, cmaker.oq, monitor)
+        for dic in event_based.event_based(block, cmaker, stations, dstore, monitor):
+            if len(dic['gmfdata']):
+                gmf_df = pandas.DataFrame(dic['gmfdata'])
+                yield event_based_risk(gmf_df, cmaker.oq, monitor)
 
 
 @base.calculators.add('ebrisk', 'scenario_risk', 'event_based_risk')

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1120,7 +1120,7 @@ class OqParam(valid.ParamSet):
     ebrisk_maxsize = valid.Param(valid.positivefloat, 2E10)  # used in ebrisk
     tectonic_region_type = valid.Param(valid.utf8, '*')
     time_event = valid.Param(str, 'avg')
-    time_per_task = valid.Param(valid.positivefloat, 600)  # over 600 OOM for SAM
+    time_per_task = valid.Param(valid.positivefloat, 600)
     total_losses = valid.Param(valid.Choice(*ALL_COST_TYPES), None)
     truncation_level = valid.Param(lambda s: valid.positivefloat(s) or 1E-9)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -815,7 +815,7 @@ time_per_task:
   Used in calculations with task splitting. If a task slice takes longer
   then *time_per_task* seconds, then spawn subtasks for the other slices.
   Example: *time_per_task=1000*
-  Default: 1200
+  Default: 600
 
 total_losses:
   Used in event based risk calculations to compute total losses and
@@ -1120,8 +1120,7 @@ class OqParam(valid.ParamSet):
     ebrisk_maxsize = valid.Param(valid.positivefloat, 2E10)  # used in ebrisk
     tectonic_region_type = valid.Param(valid.utf8, '*')
     time_event = valid.Param(str, 'avg')
-    time_per_task = valid.Param(valid.positivefloat, 1200)
-    # NB: time_per_task > 1200 breaks oq1 (OOM on the master) for Canada EBR
+    time_per_task = valid.Param(valid.positivefloat, 600)  # over 600 OOM for SAM
     total_losses = valid.Param(valid.Choice(*ALL_COST_TYPES), None)
     truncation_level = valid.Param(lambda s: valid.positivefloat(s) or 1E-9)
     uniform_hazard_spectra = valid.Param(valid.boolean, False)


### PR DESCRIPTION
By orders of magnitude in the case of calculations with millions of sites. Here is an example for SAM (539,831 sites):
```
# before
| calc_73491, maxmem=15.9 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total gen_event_based      | 4_010    | 16.7014   | 1_083   |
| computing mean_stds        | 1_591    | 0.0       | 150_198 |
| instantiating GmfComputer  | 1_270    | 13.3077   | 151_119 |
| computing gmfs             | 825.2    | 0.0       | 155_456 |
| EventBasedCalculator.run   | 532.0    | 212.1     | 1       |
# after
| calc_75747, maxmem=7.7 GB  | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total event_based          | 3_674    | 55.1172   | 1_085   |
| computing mean_stds        | 1_557    | 0.0       | 150_198 |
| instantiating GmfComputer  | 1_019    | 0.0       | 151_119 |
| computing gmfs             | 815.2    | 0.0       | 155_456 |
| EventBasedCalculator.run   | 509.3    | 209.4     | 1       |
```
We are using half the memory and we are also a bit faster. Moreover, I have removed the `gen_event_based` logic that was difficult to reason about, using more memory and sometimes generating too many tasks.