### PR TITLE
Improve documentation of server installation and fix a corner case in using temporary directory

### DIFF
--- a/doc/getting-started/installation-instructions/server.md
+++ b/doc/getting-started/installation-instructions/server.md
@@ -28,6 +28,17 @@ sudo mkdir /var/www
 sudo chown -R openquake /var/www/
 ```
 
+#### Configure the engine temporary folder
+
+By default, the engine stores temporary files into the system temporary directory. In case you want to use a different directory, you can customize it through the `/opt/openquake/openquake.cfg` configuration file. For instance, after creating the folder `/opt/openquake/tmp`, add to `/opt/openquake/openquake/cfg`:
+
+```yaml
+[directory]
+    custom_tmp = /opt/openquake/tmp
+```
+
+You can also setup a cron job in order to automatically delete old temporary files.
+
 #### Configure the directory to store the server user access log
 
 By default, user access information is logged through the standard Django logger.
@@ -42,14 +53,14 @@ sudo mkdir /var/log/oq-engine
 sudo chown -R openquake /var/log/oq-engine
 ```
 
-Upgrade the database to host users and sessions:
+#### Upgrade the database to host users and sessions
 
 ```console
 cd /opt/openquake/src/oq-engine/openquake/server
 sudo -u openquake /opt/openquake/venv/bin/python3 manage.py migrate
 ```
 
-Install fixtures for cookie consent:
+#### Install fixtures for cookie consent
 
 ```console
 cd /opt/openquake/src/oq-engine/openquake/server
@@ -67,12 +78,15 @@ Required or optional cookies or groups of them can be added, removed or edited v
 New custom cookies can be managed similarly to what is done in `openquake/server/templates/engine/includes/cookie_analytics.html`.
 Please refer to `https://django-cookie-consent.readthedocs.io/en/latest/` for further details on how to customize cookies in Django.
 
-Add a new local superuser:
+#### Add a new local superuser
 
 ```console
 cd /opt/openquake/src/oq-engine/openquake/server
 sudo -u openquake /opt/openquake/venv/bin/python3 manage.py createsuperuser
 ```
+
+#### Setup static files
+
 To setup static files in Django, issue the following commands, making sure to refer to the actual folder where the engine was installed or cloned (see above):
 
 ```console

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -735,7 +735,7 @@ def aristotle_get_rupture_data(request):
 
 
 def copy_to_temp_dir_with_unique_name(source_file_path):
-    temp_dir = tempfile.gettempdir()
+    temp_dir = config.directory.custom_tmp or tempfile.gettempdir()
     temp_file = tempfile.NamedTemporaryFile(delete=False, dir=temp_dir)
     temp_file_path = temp_file.name
     # Close the NamedTemporaryFile to prevent conflicts on Windows


### PR DESCRIPTION
For some reason, in the aristotle-beta machine, uploaded input files were saved into `/tmp` instead of using the directory specified in the configuration file, even though the TMPDIR environment variable was properly set (and visible via os.environ). With this change, the specified directory is used. Django still saves the original uploaded files to `/tmp`, but it automatically deletes them as soon as the request is completely processed.