### PR TITLE
Fixed a critical memory bug in event based calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
   [Michele Simionato]
-  * Made `minimum_magnitude` and `minimum_intensity` mandatory in event based calculations
+  * Fixed a critical memory bug causing over 80 GB per core to be needed for
+    event based calculations with ~6 million sites
+  * Made `minimum_magnitude` and `minimum_intensity` mandatory in event based
+    calculations
   * Reduced the memory consumption in event_based calculations: now even calculations
     with 5 million sites can be run using ~4 GB per core
   * Reduced the memory occupation in `gen_poes`

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -28,7 +28,7 @@ import fiona
 from shapely import geometry
 from openquake.baselib import config, hdf5, parallel, python3compat
 from openquake.baselib.general import (
-    AccumDict, humansize, groupby, block_splitter)
+    AccumDict, humansize, groupby, block_splitter, getsizeof)
 from openquake.hazardlib.map_array import MapArray, get_mean_curve
 from openquake.hazardlib.stats import geom_avg_std, compute_stats
 from openquake.hazardlib.calc.stochastic import sample_ruptures
@@ -236,6 +236,7 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
         return dict(gmfdata={}, times=times, sig_eps=())
 
     gmfdata = pandas.concat(alldata)  # ~40 MB
+    # print(getsizeof(gmfdata)/1024**2)
     return dict(gmfdata={k: gmfdata[k].to_numpy() for k in gmfdata.columns},
                 times=times, sig_eps=numpy.concatenate(sig_eps, dtype=se_dt))
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -28,7 +28,7 @@ import fiona
 from shapely import geometry
 from openquake.baselib import config, hdf5, parallel, python3compat
 from openquake.baselib.general import (
-    AccumDict, humansize, groupby, block_splitter, getsizeof)
+    AccumDict, humansize, groupby, block_splitter)
 from openquake.hazardlib.map_array import MapArray, get_mean_curve
 from openquake.hazardlib.stats import geom_avg_std, compute_stats
 from openquake.hazardlib.calc.stochastic import sample_ruptures
@@ -236,7 +236,6 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
         return dict(gmfdata={}, times=times, sig_eps=())
 
     gmfdata = pandas.concat(alldata)  # ~40 MB
-    # print(getsizeof(gmfdata)/1024**2)
     return dict(gmfdata={k: gmfdata[k].to_numpy() for k in gmfdata.columns},
                 times=times, sig_eps=numpy.concatenate(sig_eps, dtype=se_dt))
 

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -393,7 +393,13 @@ class Mesh(object):
         this mesh to each point of the target mesh and returns the lowest found
         for each.
         """
-        return cdist(self.xyz, mesh.xyz).min(axis=0)
+        # mesh.xyz has shape (N, 3)
+        if len(mesh) <= 1000: # few sites, use faster approach
+            mindist = cdist(self.xyz, mesh.xyz).min(axis=0)
+        else:  # save memory avoiding calculating a matrix of shape len(self)*N
+            mindist = numpy.array([cdist(self.xyz, xyz.reshape(1, 3)).min()
+                                   for xyz in mesh.xyz])
+        return mindist
 
     def get_closest_points(self, mesh):
         """

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -26,7 +26,7 @@ import shapely.geometry
 import shapely.ops
 
 from alpha_shapes import Alpha_Shaper
-from openquake.baselib.general import cached_property
+from openquake.baselib.general import cached_property, gen_slices
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo import geodetic
 from openquake.hazardlib.geo import utils as geo_utils
@@ -393,13 +393,12 @@ class Mesh(object):
         this mesh to each point of the target mesh and returns the lowest found
         for each.
         """
-        # mesh.xyz has shape (N, 3)
-        if len(mesh) <= 1000: # few sites, use faster approach
-            mindist = cdist(self.xyz, mesh.xyz).min(axis=0)
-        else:  # save memory avoiding calculating a matrix of shape len(self)*N
-            mindist = numpy.array([cdist(self.xyz, xyz.reshape(1, 3)).min()
-                                   for xyz in mesh.xyz])
-        return mindist
+        # mesh.xyz has shape (N, 3); we split in slices to avoid running out of memory
+        # in the large array of shape len(self)*N
+        dists = []
+        for slc in gen_slices(0, len(mesh), 100_000):
+            dists.append(cdist(self.xyz, mesh.xyz[slc]).min(axis=0))
+        return numpy.concatenate(dists)
 
     def get_closest_points(self, mesh):
         """

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -396,7 +396,7 @@ class Mesh(object):
         # mesh.xyz has shape (N, 3); we split in slices to avoid running out of memory
         # in the large array of shape len(self)*N
         dists = []
-        for slc in gen_slices(0, len(mesh), 100_000):
+        for slc in gen_slices(0, len(mesh), 10_000):
             dists.append(cdist(self.xyz, mesh.xyz[slc]).min(axis=0))
         return numpy.concatenate(dists)
 


### PR DESCRIPTION
Only visible with million of sites, thus it went unnoticed for 10 years. The required memory for the Zurich calculation goes down from > 80 GB per core to < 2 GB per core.