### PR TITLE
Fix broken reference link

### DIFF
--- a/openquake/hazardlib/calc/cond_spectra.py
+++ b/openquake/hazardlib/calc/cond_spectra.py
@@ -82,13 +82,17 @@ def _cs_out(mean_stds, probs, rho, imti, imls, cs_poes,
                 c[m, 2, p] = ws @ (term2**2 + term3**2)
 
 
-# http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.845.163&rep=rep1&type=pdf
+# Lin, T., Harmsen, S. C., Baker, J. W., & Luco, N. (2013). 
+# Conditional spectrum computation incorporating multiple 
+# causal earthquakes and ground-motion prediction models. 
+# Bulletin of the Seismological Society of America, 103(2 A), 1103–1116. 
+# https://doi.org/10.1785/0120110293
 def get_cs_out(cmaker, ctxt, imti, imlsNP, tom, _c=None):
     """
     Compute the contributions to the conditional spectra, in a form
     suitable for later composition.
 
-    NB: at the present if works only for poissonian contexts
+    NB: at the present it works only for Poissonian contexts
 
     :param ctxt:
        a context array


### PR DESCRIPTION
Current reference link in the docstring for the conditional spectra calculator seems broken (http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.845.163&rep=rep1&type=pdf). Adding the citation to Lin et al. (2013) and the doi link to the paper instead.