### PR TITLE
G-times speedup and G-times memory reduction in event_based calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -10,7 +10,7 @@
   * Made `minimum_magnitude` and `minimum_intensity` mandatory in event based
     calculations
   * Reduced the memory consumption in event_based calculations: now even calculations
-    with 5 million sites can be run using ~3 GB per core
+    with 5 million sites can be run with ~2 GB per core
   * Reduced the memory occupation in `gen_poes`
   * Using half the memory in postclassical by using 32 bit arrays
   * Using half the memory on Windows by using half the threads by default

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Optimized the calculation of mean and stdevs in event based calculations, with
+    a speedup of 13x for the EUR model
+
   [Chris di Caprio]
   * Allowed extrapolation in the Kuehn (2020) GMPEs to solve numeric issues
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,8 +7,7 @@
     "object has no attribute msparams"
   * Fixed a critical memory bug causing over 80 GB per core to be needed for
     event based calculations with ~6 million sites
-  * Made `minimum_magnitude` and `minimum_intensity` mandatory in event based
-    calculations
+  * Made `minimum_intensity` mandatory in event based calculations
   * Reduced the memory consumption in event_based calculations: now even calculations
     with 5 million sites can be run with ~2 GB per core
   * Reduced the memory occupation in `gen_poes`

--- a/debian/changelog
+++ b/debian/changelog
@@ -10,7 +10,7 @@
   * Made `minimum_magnitude` and `minimum_intensity` mandatory in event based
     calculations
   * Reduced the memory consumption in event_based calculations: now even calculations
-    with 5 million sites can be run using ~4 GB per core
+    with 5 million sites can be run using ~3 GB per core
   * Reduced the memory occupation in `gen_poes`
   * Using half the memory in postclassical by using 32 bit arrays
   * Using half the memory on Windows by using half the threads by default

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -914,11 +914,9 @@ class HazardCalculator(BaseCalculator):
             if self.sitecol and oq.imtls:
                 logging.info('Read N=%d hazard sites and L=%d hazard levels',
                              len(self.sitecol), oq.imtls.size)
-        if oq.calculation_mode.startswith(('event_based', 'ebrisk')) and self.N > 1000:
-            if oq.minimum_magnitude == {'default': 0}:
-                oq.raise_invalid(f'minimum_magnitude must be set, see {EBDOC}')
-            if len(oq.min_iml) == 0:
-                oq.raise_invalid(f'minimum_intensity must be set, see {EBDOC}')
+        if (oq.calculation_mode.startswith(('event_based', 'ebrisk')) and
+                self.N > 1000 and len(oq.min_iml) == 0):
+            oq.raise_invalid(f'minimum_intensity must be set, see {EBDOC}')
 
         if oq_hazard:
             parent = self.datastore.parent

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -216,14 +216,9 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
         if stations and stations[0] is not None:  # conditioned GMFs
             assert cmaker.scenario
             with shr['mea'] as mea, shr['tau'] as tau, shr['phi'] as phi:
-                df = computer.compute_all([mea, tau, phi], cmon, umon)
+                df = computer.compute_all([mea, tau, phi], mmon, cmon, umon)
         else:  # regular GMFs
-            with mmon:
-                # shape (4, G, M, N) for 1M sites, 10 IMTs and 10 GSIMs
-                # gives 3 GB of RAM
-                mean_stds = cmaker.get_mean_stds(
-                    [computer.ctx], split_by_mag=False)
-            df = computer.compute_all(mean_stds, max_iml, cmon, umon)
+            df = computer.compute_all(None, max_iml, mmon, cmon, umon)
         sig_eps.append(computer.build_sig_eps(se_dt))
         dt = time.time() - t0
         times.append((proxy['id'], computer.ctx.rrup.min(), dt))

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -216,7 +216,7 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
         if stations and stations[0] is not None:  # conditioned GMFs
             assert cmaker.scenario
             with shr['mea'] as mea, shr['tau'] as tau, shr['phi'] as phi:
-                df = computer.compute_all([mea, tau, phi], mmon, cmon, umon)
+                df = computer.compute_all([mea, tau, phi], max_iml, mmon, cmon, umon)
         else:  # regular GMFs
             df = computer.compute_all(None, max_iml, mmon, cmon, umon)
         sig_eps.append(computer.build_sig_eps(se_dt))

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -223,8 +223,6 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
                 # gives 3 GB of RAM
                 mean_stds = cmaker.get_mean_stds(
                     [computer.ctx], split_by_mag=False)
-                # avoid numba type error
-                computer.ctx.flags.writeable = True
             df = computer.compute_all(mean_stds, max_iml, cmon, umon)
         sig_eps.append(computer.build_sig_eps(se_dt))
         dt = time.time() - t0

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -111,11 +111,9 @@ from functools import partial
 from dataclasses import dataclass
 
 import numpy
-from openquake.baselib.general import AccumDict
-from openquake.baselib.performance import Monitor
 from openquake.hazardlib import correlation, cross_correlation
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib.calc.gmf import GmfComputer, exp
+from openquake.hazardlib.calc.gmf import GmfComputer
 from openquake.hazardlib.const import StdDev
 from openquake.hazardlib.geo.geodetic import geodetic_distance
 from openquake.hazardlib.contexts import ContextMaker

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -225,23 +225,6 @@ class ConditionedGmfComputer(GmfComputer):
             self.cross_correl_between, self.cross_correl_within,
             self.cmaker.maximum_distance, sigma=False)
 
-    def _compute(self, mean_stds, m, imt, gsim, intra_eps, idxs, rng=None):
-        # mea, tau, phi with shapes (N,1), (N,N), (N,N)
-        mu_Y, cov_WY_WY, cov_BY_BY = mean_stds
-        E = len(idxs)
-        eps = self.correlation_cutoff
-        if self.cmaker.truncation_level <= 1E-9:
-            gmf = exp(mu_Y, imt != "MMI")
-            gmf = gmf.repeat(E, axis=1)
-        else:
-            # add a cutoff to remove negative eigenvalues
-            cov_Y_Y = cov_WY_WY + cov_BY_BY + numpy.eye(len(cov_WY_WY)) * eps
-            arr = rng.multivariate_normal(
-                mu_Y.flatten(), cov_Y_Y, size=E,
-                check_valid="raise", tol=1e-5, method="cholesky")
-            gmf = exp(arr, imt != "MMI").T
-        return gmf  # shapes (N, E)
-
 
 @dataclass
 class TempResult:

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -199,7 +199,6 @@ class ConditionedGmfComputer(GmfComputer):
         self.cross_correl_between = (
             cross_correl_between or cross_correlation.GodaAtkinson2009())
         self.cross_correl_within = cross_correlation.BakerJayaram2008()
-        self.correlation_cutoff = cmaker.oq.correlation_cutoff
         self.rupture = rupture
         self.sitecol = sitecol
         self.station_sitecol = station_sitecol

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -225,7 +225,8 @@ class ConditionedGmfComputer(GmfComputer):
             self.cross_correl_between, self.cross_correl_within,
             self.cmaker.maximum_distance, sigma=False)
 
-    def compute_all(self, mea_tau_phi, cmon=Monitor(), umon=Monitor()):
+    def compute_all(self, mea_tau_phi,
+                    mmon=Monitor(), cmon=Monitor(), umon=Monitor()):
         """
         :returns: (dict with fields eid, sid, gmv_X, ...), dt
         """

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -225,59 +225,19 @@ class ConditionedGmfComputer(GmfComputer):
             self.cross_correl_between, self.cross_correl_within,
             self.cmaker.maximum_distance, sigma=False)
 
-    def compute_all(self, mea_tau_phi,
-                    mmon=Monitor(), cmon=Monitor(), umon=Monitor()):
-        """
-        :returns: (dict with fields eid, sid, gmv_X, ...), dt
-        """
-        self.init_eid_rlz_sig_eps()
-        data = AccumDict(accum=[])
-        rng = numpy.random.default_rng(self.seed)
-        for g, (gsim, rlzs) in enumerate(self.cmaker.gsims.items()):
-            mea = mea_tau_phi[0][g]
-            tau = mea_tau_phi[1][g]
-            phi = mea_tau_phi[2][g]
-            with cmon:
-                array = self.compute(gsim, rlzs, mea, tau, phi, rng)
-            with umon:
-                self.update(data, array, rlzs, [mea])
-        with umon:
-            df = self.strip_zeros(data)
-            return df
-
-    def compute(self, gsim, rlzs, mea, tau, phi, rng):
-        """
-        :param gsim: GSIM used to compute mean_stds
-        :param rlzs: realizations associated to the gsim
-        :param mea: array of shape (M, N, 1)
-        :param tau: array of shape (M, N, N)
-        :param phi: array of shape (M, N, N)
-        :returns: a 32 bit array of shape (N, M, E)
-        """
-        M, N, _ = mea.shape
-        E = numpy.isin(self.rlz, rlzs).sum()
-        result = numpy.zeros((M, N, E), F32)
-        for m, im in enumerate(self.cmaker.imtls):
-            mu_Y_yD = mea[m]
-            cov_WY_WY_wD = tau[m]
-            cov_BY_BY_yD = phi[m]
-            result[m] = self._compute(
-                mu_Y_yD, cov_WY_WY_wD, cov_BY_BY_yD, im, E, rng)
-        if self.amplifier:
-            self.amplifier.amplify_gmfs(
-                self.ctx.ampcode, result, self.imts, self.seed)
-        return result.transpose(1, 0, 2)
-
-    def _compute(self, mu_Y, cov_WY_WY, cov_BY_BY, imt, num_events, rng):
+    def _compute(self, mean_stds, m, imt, gsim, intra_eps, idxs, rng=None):
+        # mea, tau, phi with shapes (N,1), (N,N), (N,N)
+        mu_Y, cov_WY_WY, cov_BY_BY = mean_stds
+        E = len(idxs)
         eps = self.correlation_cutoff
         if self.cmaker.truncation_level <= 1E-9:
             gmf = exp(mu_Y, imt != "MMI")
-            gmf = gmf.repeat(num_events, axis=1)
+            gmf = gmf.repeat(E, axis=1)
         else:
             # add a cutoff to remove negative eigenvalues
             cov_Y_Y = cov_WY_WY + cov_BY_BY + numpy.eye(len(cov_WY_WY)) * eps
             arr = rng.multivariate_normal(
-                mu_Y.flatten(), cov_Y_Y, size=num_events,
+                mu_Y.flatten(), cov_Y_Y, size=E,
                 check_valid="raise", tol=1e-5, method="cholesky")
             gmf = exp(arr, imt != "MMI").T
         return gmf  # shapes (N, E)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -110,7 +110,6 @@ def get_distances(rupture, sites, param):
         dist = numpy.zeros_like(sites.lons)
     else:
         raise ValueError('Unknown distance measure %r' % param)
-    dist.flags.writeable = False
     return dist
 
 

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -363,7 +363,7 @@ class GmfComputer(object):
             # mea, tau, phi with shapes (N,1), (N,N), (N,N)
             mu_Y, cov_WY_WY, cov_BY_BY = mean_stds
             E = len(idxs)
-            eps = self.correlation_cutoff
+            eps = self.cmaker.oq.correlation_cutoff
             if self.cmaker.truncation_level <= 1E-9:
                 gmf = exp(mu_Y, imt.string != "MMI")
                 gmf = gmf.repeat(E, axis=1)

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -226,6 +226,10 @@ class GmfComputer(object):
         self.cross_correl = cross_correl or NoCrossCorrelation(
             cmaker.truncation_level)
         self.gmv_fields = [f'gmv_{m}' for m in range(len(cmaker.imts))]
+        self.mmi_index = -1
+        for m, imt in enumerate(cmaker.imtls):
+            if imt == 'MMI':
+                self.mmi_index = m
 
     def init_eid_rlz_sig_eps(self):
         """
@@ -261,14 +265,10 @@ class GmfComputer(object):
         mag = self.ebrupture.rupture.mag
         if len(mean.shape) == 3:  # shape (M, N, 1) for conditioned gmfs
             mean = mean[:, :, 0]
-        mmi_index = -1
-        for m, imt in enumerate(self.cmaker.imtls):
-            if imt == 'MMI':
-                mmi_index = m
         if max_iml is None:
             max_iml = numpy.full(self.M, numpy.inf, float)
 
-        set_max_min(array, mean, max_iml, min_iml, mmi_index)
+        set_max_min(array, mean, max_iml, min_iml, self.mmi_index)
         data['gmv'].append(array)
 
         if self.sec_perils:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -816,7 +816,6 @@ class ContextMaker(object):
                     if small_distances.any():
                         array = numpy.array(array)  # make a copy first
                         array[small_distances] = self.minimum_distance
-                        array.flags.writeable = False
                         ctx[name] = array
             slc = slice(start, start + len(ctx))
             for par in dd:
@@ -1158,7 +1157,6 @@ class ContextMaker(object):
         :param rup_indep: rupture flag (false for mutex ruptures)
         :yields: poes, ctxt, invs with poes of shape (N, L, G)
         """
-        ctx.flags.writeable = True
         ctx.mag = numpy.round(ctx.mag, 3)
         for mag in numpy.unique(ctx.mag):
             ctxt = ctx[ctx.mag == mag]
@@ -1216,7 +1214,6 @@ class ContextMaker(object):
         for ctx in ctxs:
             for poes, ctxt, invs in self.gen_poes(ctx, rup_indep):
                 with self.pne_mon:
-                    ctxt.flags.writeable = True  # avoid numba type error
                     pmap.update(poes, invs, ctxt, itime, rup_mutex)
 
     # called by gen_poes and by the GmfComputer
@@ -1245,8 +1242,6 @@ class ContextMaker(object):
             start = 0
             for ctx in recarrays:
                 slc = slice(start, start + len(ctx))
-                # make the context immutable
-                ctx.flags.writeable = False
                 adj = compute(gsim, ctx, self.imts, *out[:, g, :, slc])
                 if adj is not None:
                     self.adj[gsim].append(adj)
@@ -1273,8 +1268,6 @@ class ContextMaker(object):
         start = 0
         for ctx in recarrays:
             slc = slice(start, start + len(ctx))
-            # make the context immutable
-            ctx.flags.writeable = False
             adj = compute(gsim, ctx, self.imts, *out[:, :, slc])
             if adj is not None:
                 self.adj[gsim].append(adj)

--- a/openquake/hazardlib/tests/gsim/can15/nbcc_aa13_test.py
+++ b/openquake/hazardlib/tests/gsim/can15/nbcc_aa13_test.py
@@ -54,8 +54,7 @@ class NBCC2015_AA13TestCase(unittest.TestCase):
             cmaker.scenario = True
             ebr.n_occ = len(cmaker.gsims)
             gc = gmf.GmfComputer(ebr, inp.sitecol, cmaker)
-            mean_stds = cmaker.get_mean_stds([gc.ctx])
-            gmfdata = pandas.DataFrame(gc.compute_all(mean_stds))
+            gmfdata = pandas.DataFrame(gc.compute_all())
             del gmfdata['rlz']  # the info is encoded in the eid
             fname = 'NBCC2015_AA13_%s.csv' % cmaker.trt.replace(' ', '')
             path = os.path.join(CWD, 'data', 'CAN15', fname)

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -94,11 +94,9 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
         assert_eq(cll.mesh.depths, [30, -5.6])
         for arr in (cll.vs30, cll.z1pt0, cll.z2pt5):
             self.assertIsInstance(arr, numpy.ndarray)
-            self.assertEqual(arr.flags.writeable, True)
             self.assertEqual(arr.dtype, float)
         for arr in (cll.vs30measured,):
             self.assertIsInstance(arr, numpy.ndarray)
-            self.assertEqual(arr.flags.writeable, True)
             self.assertEqual(arr.dtype, bool)
         self.assertEqual(len(cll), 2)
 


### PR DESCRIPTION
G is the number of GSIMs, G=19 for EUR so a huge memory reduction is expecting, but this is visible only if you have millions of sites. There is also a huge speedup, ideally of G times, visible also with few sites:
```
# EUR, 13x speedup in " computing mean_stds"
| calc_510, maxmem=44.4 GB   | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| computing mean_stds        | 9_236    | 0.0       | 261_700 |
| computing mean_stds        | 717.8    | 0.0       | 284_334 |
```
Here are the numbers for SAM, ~20,000 ruptures, half million sites and G=3:
```
# before
| calc_2804, maxmem=6.1 GB   | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total event_based          | 427.8    | 45.2305   | 165    |
| computing mean_stds        | 170.2519 | 0.0       | 20_257 |
| instantiating GmfComputer  | 127.0037 | 0.0       | 20_381 |
| computing gmfs             | 94.6061  | 0.0       | 20_342 |
# after
| calc_2803, maxmem=12.0 GB  | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total event_based          | 318.5    | 65.0625   | 165    |
| computing mean_stds        | 58.1481  | 0.0       | 20_342 |
| instantiating GmfComputer  | 127.9250 | 0.0       | 20_381 |
| computing gmfs             | 96.3396  | 0.0       | 20_342 |
```
Notice the 2x reduction in memory and the 3x speedup in "computing mean_stds" due to wasted calculations in the previous version ( the speedup in due to `numpy.isin(self.rlz, rlzs)` being false most of the times).