### PR TITLE
Update install.py

### DIFF
--- a/debian/systemd/openquake-dbserver.service
+++ b/debian/systemd/openquake-dbserver.service
@@ -9,6 +9,7 @@ Group=openquake
 Environment=
 WorkingDirectory=/usr/share/openquake/engine
 ExecStart=/opt/openquake/bin/oq dbserver start -f
+Type=exec
 Restart=always
 RestartSec=30
 KillMode=control-group

--- a/debian/systemd/openquake-webui.service
+++ b/debian/systemd/openquake-webui.service
@@ -13,6 +13,7 @@ WorkingDirectory=/usr/share/openquake/engine
 ExecStart=/opt/openquake/bin/python3 -m openquake.server.manage runserver 127.0.0.1:8800 --noreload
 # Using gunicorn (Nginx or another webserver is needed for static content)
 # ExecStart=/opt/openquake/bin/gunicorn --bind 127.0.0.1:8800 --workers 4 --timeout 1200 wsgi:application
+Type=exec
 Restart=always
 RestartSec=30
 KillMode=control-group

--- a/install.py
+++ b/install.py
@@ -177,6 +177,7 @@ Group=openquake
 Environment=
 WorkingDirectory={OQDATA}
 ExecStart=/opt/openquake/venv/bin/oq {command}
+Type=exec
 Restart=always
 RestartSec=30
 KillMode=control-group


### PR DESCRIPTION
The exec type is similar to simple, but the service manager will consider the unit started immediately after the main service binary has been executed. 

The service manager will delay starting of follow-up units until that point. (Or in other words: simple proceeds with further jobs right after fork() returns, while exec will not proceed before both fork() and execve() in the service process succeeded.)

 Note that this means systemctl start command lines for exec services will report failure when the service's binary cannot be invoked successfully (for example because the selected User= doesn't exist, or the service binary is missing)