### PR TITLE
Splitting by blocks of gsims to avoid excessive tiling

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -236,19 +236,11 @@ def distinct(keys):
     return outlist
 
 
-def ceil(a, b):
+def ceil(x):
     """
-    Divide a / b and return the biggest integer close to the quotient.
-
-    :param a:
-        a number
-    :param b:
-        a positive number
-    :returns:
-        the biggest integer close to the quotient
+    Converts the result of math.ceil into an integer
     """
-    assert b > 0, b
-    return int(math.ceil(float(a) / b))
+    return int(math.ceil(x))
 
 
 def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -644,7 +644,7 @@ class HazardCalculator(BaseCalculator):
             calc.run(remove=False)
             calc.datastore.close()
             for name in (
-                'csm param sitecol assetcol crmodel realizations max_weight '
+                'csm param sitecol assetcol crmodel realizations max_gb max_weight '
                 'amplifier policy_df treaty_df full_lt exported trt_rlzs gids'
             ).split():
                 if hasattr(calc, name):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -589,8 +589,7 @@ class ClassicalCalculator(base.HazardCalculator):
             ds = self.datastore
         # pairs = sorted(zip(self.cmakers, self.ntiles), key=lambda cn: cn[1])
         # first the tasks with few tiles, then the ones with many tiles
-        for cm, sites in self.csm.split(
-                self.cmakers, self.sitecol, self.max_weight, self.gids):
+        for cm, sites in self.csm.split(self.cmakers, self.sitecol, self.max_weight):
             sg = self.csm.src_groups[cm.grp_id]
             cm.rup_indep = getattr(sg, 'rup_interdep', None) != 'mutex'
             cm.save_on_tmp = config.distribution.save_on_tmp

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -491,7 +491,7 @@ class ClassicalCalculator(base.HazardCalculator):
             logging.warning('numba is not installed: using the slow algorithm')
 
         t0 = time.time()
-        if self.datastore['GN_splits'].attrs['tiling']:
+        if self.datastore['tiles'].attrs['tiling']:
             self.execute_big()
         else:
             self.execute_reg()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -377,8 +377,8 @@ class ClassicalCalculator(base.HazardCalculator):
         G = pnemap.array.shape[2]
         rates = self.pmap.array
         sidx = self.pmap.sidx[pnemap.sids]
-        for i, gid in enumerate(self.gids[grp_id]):
-            rates[sidx, :, gid] += pnemap.array[:, :, i % G]
+        for i, g in enumerate(self.cmakers[grp_id].gid):
+            rates[sidx, :, g] += pnemap.array[:, :, i % G]
         return acc
 
     def create_rup(self):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -490,7 +490,7 @@ class ClassicalCalculator(base.HazardCalculator):
             logging.warning('numba is not installed: using the slow algorithm')
 
         t0 = time.time()
-        if self.datastore['size_gb'].attrs['tiling']:
+        if self.datastore['GN_splits'].attrs['tiling']:
             self.execute_big()
         else:
             self.execute_reg()

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -160,9 +160,10 @@ def get_num_chunks(dstore):
     """
     msd = dstore['oqparam'].max_sites_disagg
     try:
-        chunks = max(int(4 * dstore['rates_max_gb'][()]), msd)
+        req_gb = dstore['GN_splits'].attrs['req_gb']
     except KeyError:
-        chunks = msd
+        return msd
+    chunks = max(int(4 * req_gb), msd)
     return chunks
 
     

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -160,7 +160,7 @@ def get_num_chunks(dstore):
     """
     msd = dstore['oqparam'].max_sites_disagg
     try:
-        req_gb = dstore['GN_splits'].attrs['req_gb']
+        req_gb = dstore['tiles'].attrs['req_gb']
     except KeyError:
         return msd
     chunks = max(int(4 * req_gb), msd)

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -139,7 +139,7 @@ def get_pmaps_gb(dstore, full_lt=None):
     """
     :returns: memory required on the master node to keep the pmaps
     """
-    N = len(dstore['sitecol'])
+    N = len(dstore['sitecol/sids'])
     L = dstore['oqparam'].imtls.size
     full_lt = full_lt or dstore['full_lt'].init()
     if 'trt_smrs' not in dstore:  # starting from hazard_curves.csv
@@ -148,7 +148,8 @@ def get_pmaps_gb(dstore, full_lt=None):
         trt_smrs = dstore['trt_smrs'][:]
     trt_rlzs = full_lt.get_trt_rlzs(trt_smrs)
     gids = full_lt.get_gids(trt_smrs)
-    return len(trt_rlzs) * N * L * 4 / 1024**3, trt_rlzs, gids
+    max_gb = len(trt_rlzs) * N * L * 4 / 1024**3
+    return max_gb, trt_rlzs, gids
 
 
 def get_num_chunks(dstore):

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -179,8 +179,9 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     dstore.create_dset('size_gb', numpy.array(sizes),
                        attrs=dict(req_gb=req_gb, tiling=not regular))
     if not regular:
-        ntasks = sum(1 for _ in csm.split(cmakers, sitecol, max_weight, gids))
-        logging.info('This will be a tiling calculation with %d tasks', ntasks)
+        nsites = [len(tile) for cm, tile in csm.split(cmakers, sitecol, max_weight, gids)]
+        logging.info('This will be a tiling calculation with %d tasks, min_sites=%d',
+                     len(nsites), min(nsites))
         if req_gb >= 30 and (not config.directory.custom_tmp or
                              not config.distribution.save_on_tmp):
             logging.info('We suggest to set custom_tmp and save_on_tmp')

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -179,7 +179,7 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     dstore.create_dset('size_gb', numpy.array(sizes),
                        attrs=dict(req_gb=req_gb, tiling=not regular))
     if not regular:
-        nsites = [len(tile) for cm, tile in csm.split(cmakers, sitecol, max_weight, gids)]
+        nsites = [len(tile) for cm, tile in csm.split(cmakers, sitecol, max_weight)]
         logging.info('This will be a tiling calculation with %d tasks, min_sites=%d',
                      len(nsites), min(nsites))
         if req_gb >= 30 and (not config.directory.custom_tmp or

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -176,10 +176,11 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     sizes = [len(cm.gsims) * oq.imtls.size * N * 8 / 1024**3 for cm in cmakers]
     ok = req_gb < max_gb and max(sizes) < max_gb
     regular = ok or oq.disagg_by_src or N < oq.max_sites_disagg or oq.tile_spec
+    nsites = [len(tile) for cm, tile in csm.split(cmakers, sitecol, max_weight)]
     dstore.create_dset('size_gb', numpy.array(sizes),
-                       attrs=dict(req_gb=req_gb, tiling=not regular))
+                       attrs=dict(req_gb=req_gb, tiling=not regular,
+                                  num_tasks=len(nsites)))
     if not regular:
-        nsites = [len(tile) for cm, tile in csm.split(cmakers, sitecol, max_weight)]
         logging.info('This will be a tiling calculation with %d tasks, min_sites=%d',
                      len(nsites), min(nsites))
         if req_gb >= 30 and (not config.directory.custom_tmp or

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -176,14 +176,14 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     sizes = [len(cm.gsims) * oq.imtls.size * N * 8 / 1024**3 for cm in cmakers]
     ok = req_gb < max_gb and max(sizes) < max_gb
     regular = ok or oq.disagg_by_src or N < oq.max_sites_disagg or oq.tile_spec
-    GN_splits = numpy.array([(cm.grp_id, len(cm.gsims), len(tile))
+    tiles = numpy.array([(cm.grp_id, len(cm.gsims), len(tile))
                              for cm, tile in csm.split(cmakers, sitecol, max_weight)],
                             [('grp_id', U16), ('G', U16), ('N', U32)])
-    dstore.create_dset('GN_splits', GN_splits, fillvalue=None,
+    dstore.create_dset('tiles', tiles, fillvalue=None,
                        attrs=dict(req_gb=req_gb, tiling=not regular))
     if not regular:
         logging.info('This will be a tiling calculation with %d tasks, min_sites=%d',
-                     len(GN_splits), min(GN_splits['N']))
+                     len(tiles), min(tiles['N']))
         if req_gb >= 30 and (not config.directory.custom_tmp or
                              not config.distribution.save_on_tmp):
             logging.info('We suggest to set custom_tmp and save_on_tmp')

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -176,13 +176,14 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     sizes = [len(cm.gsims) * oq.imtls.size * N * 8 / 1024**3 for cm in cmakers]
     ok = req_gb < max_gb and max(sizes) < max_gb
     regular = ok or oq.disagg_by_src or N < oq.max_sites_disagg or oq.tile_spec
-    nsites = [len(tile) for cm, tile in csm.split(cmakers, sitecol, max_weight)]
-    dstore.create_dset('size_gb', numpy.array(sizes),
-                       attrs=dict(req_gb=req_gb, tiling=not regular,
-                                  num_tasks=len(nsites)))
+    GN_splits = numpy.array([(cm.grp_id, len(cm.gsims), len(tile))
+                             for cm, tile in csm.split(cmakers, sitecol, max_weight)],
+                            [('grp_id', U16), ('G', U16), ('N', U32)])
+    dstore.create_dset('GN_splits', GN_splits, fillvalue=None,
+                       attrs=dict(req_gb=req_gb, tiling=not regular))
     if not regular:
         logging.info('This will be a tiling calculation with %d tasks, min_sites=%d',
-                     len(nsites), min(nsites))
+                     len(GN_splits), min(GN_splits['N']))
         if req_gb >= 30 and (not config.directory.custom_tmp or
                              not config.distribution.save_on_tmp):
             logging.info('We suggest to set custom_tmp and save_on_tmp')

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -184,7 +184,7 @@ class ClassicalTestCase(CalculatorTestCase):
                 'hazard_curve-mean-SA(2.0).csv',
         ], case_22.__file__, delta=1E-6)
         splits = self.calc.datastore['GN_splits'][:]
-        self.assertEqual(len(splits), 12)
+        self.assertEqual(len(splits), 10)
 
     def test_case_23(self):  # filtering away on TRT
         self.assert_curves_ok(['hazard_curve.csv'],

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -183,7 +183,7 @@ class ClassicalTestCase(CalculatorTestCase):
                 'hazard_curve-mean-SA(1.0).csv',
                 'hazard_curve-mean-SA(2.0).csv',
         ], case_22.__file__, delta=1E-6)
-        splits = self.calc.datastore['GN_splits'][:]
+        splits = self.calc.datastore['tiles'][:]
         self.assertEqual(len(splits), 10)
 
     def test_case_23(self):  # filtering away on TRT

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -183,7 +183,7 @@ class ClassicalTestCase(CalculatorTestCase):
                 'hazard_curve-mean-SA(1.0).csv',
                 'hazard_curve-mean-SA(2.0).csv',
         ], case_22.__file__, delta=1E-6)
-        self.assertGreater(max(self.calc.ntiles), 2)
+        self.assertTrue(self.calc.datastore['size_gb'].attrs['tiling'])
 
     def test_case_23(self):  # filtering away on TRT
         self.assert_curves_ok(['hazard_curve.csv'],

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -183,7 +183,8 @@ class ClassicalTestCase(CalculatorTestCase):
                 'hazard_curve-mean-SA(1.0).csv',
                 'hazard_curve-mean-SA(2.0).csv',
         ], case_22.__file__, delta=1E-6)
-        self.assertTrue(self.calc.datastore['size_gb'].attrs['tiling'])
+        splits = self.calc.datastore['GN_splits'][:]
+        self.assertEqual(len(splits), 10)
 
     def test_case_23(self):  # filtering away on TRT
         self.assert_curves_ok(['hazard_curve.csv'],

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -184,7 +184,7 @@ class ClassicalTestCase(CalculatorTestCase):
                 'hazard_curve-mean-SA(2.0).csv',
         ], case_22.__file__, delta=1E-6)
         splits = self.calc.datastore['GN_splits'][:]
-        self.assertEqual(len(splits), 10)
+        self.assertEqual(len(splits), 12)
 
     def test_case_23(self):  # filtering away on TRT
         self.assert_curves_ok(['hazard_curve.csv'],

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -785,6 +785,9 @@ specific_assets:
 split_sources:
   INTERNAL
 
+split_by_gsim:
+  INTERNAL
+
 outs_per_task:
   How many outputs per task to generate (honored in some calculators)
   Example: *outs_per_task = 3*
@@ -1116,6 +1119,7 @@ class OqParam(valid.ParamSet):
     spatial_correlation = valid.Param(valid.Choice('yes', 'no', 'full'), 'yes')
     specific_assets = valid.Param(valid.namelist, [])
     split_sources = valid.Param(valid.boolean, True)
+    split_by_gsim = valid.Param(valid.boolean, False)
     outs_per_task = valid.Param(valid.positiveint, 4)
     ebrisk_maxsize = valid.Param(valid.positivefloat, 2E10)  # used in ebrisk
     tectonic_region_type = valid.Param(valid.utf8, '*')

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -31,8 +31,8 @@ from scipy.interpolate import interp1d
 
 from openquake.baselib import config
 from openquake.baselib.general import (
-    AccumDict, DictArray, RecordBuilder, sqrscale,
-    gen_slices, split_in_slices, block_splitter)
+    AccumDict, DictArray, RecordBuilder, split_in_slices, block_splitter,
+    sqrscale)
 from openquake.baselib.performance import Monitor, split_array, kround0
 from openquake.baselib.python3compat import decode
 from openquake.hazardlib import valid, imt as imt_module
@@ -1814,7 +1814,7 @@ def get_effect_by_mag(mags, sitecol1, gsims_by_trt, maximum_distance, imtls):
     return dict(zip(mags, gmv))
 
 
-def get_cmakers(src_groups, full_lt, oq, N=1):
+def get_cmakers(src_groups, full_lt, oq):
     """
     :params src_groups: a list of SourceGroups
     :param full_lt: a FullLogicTree instance
@@ -1838,22 +1838,9 @@ def get_cmakers(src_groups, full_lt, oq, N=1):
         cmaker.grp_id = grp_id
         cmakers.append(cmaker)
     gids = full_lt.get_gids(cm.trt_smrs for cm in cmakers)
-    out = []
-    for cmaker in cmakers:
-        gsims = list(cmaker.gsims)
-        gid = gids[cmaker.grp_id]
-        assert len(gid) == len(gsims)
-        if 'classical' in oq.calculation_mode and N > 10_000 and len(gsims) > 3:
-            # split in blocks of at least 2 gsims
-            for slc in gen_slices(0, len(gid), 2):
-                cm = copy.copy(cmaker)
-                cm.gid = gid[slc]
-                cm.gsims = gsims[slc]
-                out.append(cm)
-        else:
-            cmaker.gid = gid
-            out.append(cmaker)
-    return out
+    for cm in cmakers:
+        cm.gid = gids[cm.grp_id]
+    return cmakers
 
 
 def read_cmakers(dstore, csm=None):
@@ -1864,7 +1851,6 @@ def read_cmakers(dstore, csm=None):
     """
     from openquake.hazardlib.site_amplification import AmplFunction
     oq = dstore['oqparam']
-    N = len(dstore['sitecol/sids'])
     oq.mags_by_trt = {
         k: decode(v[:]) for k, v in dstore['source_mags'].items()}
     if 'amplification' in oq.inputs and oq.amplification_method == 'kernel':
@@ -1875,7 +1861,7 @@ def read_cmakers(dstore, csm=None):
     if csm is None:
         csm = dstore['_csm']
         csm.full_lt = dstore['full_lt'].init()
-    cmakers = get_cmakers(csm.src_groups, csm.full_lt, oq, N)
+    cmakers = get_cmakers(csm.src_groups, csm.full_lt, oq)
     if 'delta_rates' in dstore:  # aftershock
         for cmaker in cmakers:
             cmaker.deltagetter = DeltaRatesGetter(dstore)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -683,14 +683,13 @@ class CompositeSourceModel:
             nsplits = general.ceil(grp.weight / max_weight)
             if size_gb / nsplits > max_gb:
                 nsplits = general.ceil(size_gb / max_gb)
-            if nsplits < 5:  # split in tiles only
-                for sites in sitecol.split(nsplits, minsize=oq.max_sites_disagg):
-                    yield cmaker, sites
-            else:  # split in gsims first, then in tiles
-                for cm in self._split(cmaker, nsplits):
-                    splits = general.ceil(nsplits * len(cm.gsims) / len(cmaker.gsims))
-                    for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
-                        yield cm, sites
+            for sites in sitecol.split(nsplits, minsize=oq.max_sites_disagg):
+                yield cmaker, sites
+            # split in gsims first, then in tiles
+            # for cm in self._split(cmaker, nsplits):
+            #    splits = general.ceil(nsplits * len(cm.gsims) / len(cmaker.gsims))
+            #    for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
+            #        yield cm, sites
 
     def _split(self, cmaker, nsplits):
         gsims = list(cmaker.gsims)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -673,25 +673,25 @@ class CompositeSourceModel:
             logging.info('Heaviest: %s', maxsrc)
         return max_weight * 1.02  # increased a bit to produce a bit less tasks
 
-    def split(self, cmakers, sitecol, max_weight, gids):
+    def split(self, cmakers, sitecol, max_weight):
         N = len(sitecol)
         oq = cmakers[0].oq
         max_gb = float(config.memory.pmap_max_gb)
         for cmaker in cmakers:
             size_gb = len(cmaker.gsims) * oq.imtls.size * N * 8 / 1024**3
             grp = self.src_groups[cmaker.grp_id]
-            cmaker.gid = gids[cmaker.grp_id]
             nsplits = general.ceil(grp.weight / max_weight)
             if size_gb / nsplits > max_gb:
                 nsplits = general.ceil(size_gb / max_gb)
             if nsplits <= 10:  # split in tiles only
                 for sites in sitecol.split(nsplits, minsize=oq.max_sites_disagg):
+                    print(cmaker.grp_id, len(cmaker.gsims), nsplits)
                     yield cmaker, sites
             else:  # split in gsims first, then in tiles
                 for cm in self._split(cmaker, nsplits):
                     splits = nsplits * len(cm.gsims) / len(cmaker.gsims)
+                    print(cm.grp_id, len(cm.gsims), splits)
                     for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
-                        print(cm.grp_id, len(cm.gsims), len(sites))
                         yield cm, sites
 
     def _split(self, cmaker, nsplits):

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -684,16 +684,20 @@ class CompositeSourceModel:
             nsplits = general.ceil(grp.weight / max_weight)
             if size_gb / nsplits > max_gb:
                 nsplits = general.ceil(size_gb / max_gb)
-            for cm in self._split(cmaker, nsplits):
-                splits = nsplits * len(cm.gsims) / len(cmaker.gsims)
-                for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
-                    # print(cm.grp_id, len(cm.gsims), len(sites))
-                    yield cm, sites
+            if nsplits <= 10:  # split in tiles only
+                for sites in sitecol.split(nsplits, minsize=oq.max_sites_disagg):
+                    yield cmaker, sites
+            else:  # split in gsims first, then in tiles
+                for cm in self._split(cmaker, nsplits):
+                    splits = nsplits * len(cm.gsims) / len(cmaker.gsims)
+                    for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
+                        print(cm.grp_id, len(cm.gsims), len(sites))
+                        yield cm, sites
 
     def _split(self, cmaker, nsplits):
         gsims = list(cmaker.gsims)
         G = len(gsims)
-        for slc in general.gen_slices(0, G, G // nsplits + 1):
+        for slc in general.gen_slices(0, G, general.ceil(G / nsplits)):
             cm = copy.copy(cmaker)
             cm.gid = cmaker.gid[slc]
             cm.gsims = gsims[slc]

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -683,13 +683,14 @@ class CompositeSourceModel:
             nsplits = general.ceil(grp.weight / max_weight)
             if size_gb / nsplits > max_gb:
                 nsplits = general.ceil(size_gb / max_gb)
-            for sites in sitecol.split(nsplits, minsize=oq.max_sites_disagg):
-                yield cmaker, sites
-            # split in gsims first, then in tiles
-            # for cm in self._split(cmaker, nsplits):
-            #    splits = general.ceil(nsplits * len(cm.gsims) / len(cmaker.gsims))
-            #    for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
-            #        yield cm, sites
+            if oq.split_by_gsim:
+                # disabled since slower
+                for cm in self._split(cmaker, nsplits):
+                    yield cm, sitecol
+            else:
+                # normal case
+                for sites in sitecol.split(nsplits, minsize=oq.max_sites_disagg):
+                    yield cmaker, sites
 
     def _split(self, cmaker, nsplits):
         gsims = list(cmaker.gsims)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -689,7 +689,7 @@ class CompositeSourceModel:
                     yield cmaker, sites
             else:  # split in gsims first, then in tiles
                 for cm in self._split(cmaker, nsplits):
-                    splits = nsplits * len(cm.gsims) / len(cmaker.gsims)
+                    splits = general.ceil(nsplits * len(cm.gsims) / len(cmaker.gsims))
                     print(cm.grp_id, len(cm.gsims), splits)
                     for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
                         yield cm, sites

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -685,12 +685,10 @@ class CompositeSourceModel:
                 nsplits = general.ceil(size_gb / max_gb)
             if nsplits <= 10:  # split in tiles only
                 for sites in sitecol.split(nsplits, minsize=oq.max_sites_disagg):
-                    print(cmaker.grp_id, len(cmaker.gsims), nsplits)
                     yield cmaker, sites
             else:  # split in gsims first, then in tiles
                 for cm in self._split(cmaker, nsplits):
                     splits = general.ceil(nsplits * len(cm.gsims) / len(cmaker.gsims))
-                    print(cm.grp_id, len(cm.gsims), splits)
                     for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
                         yield cm, sites
 

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -683,7 +683,7 @@ class CompositeSourceModel:
             nsplits = general.ceil(grp.weight / max_weight)
             if size_gb / nsplits > max_gb:
                 nsplits = general.ceil(size_gb / max_gb)
-            if nsplits <= 10:  # split in tiles only
+            if nsplits < 5:  # split in tiles only
                 for sites in sitecol.split(nsplits, minsize=oq.max_sites_disagg):
                     yield cmaker, sites
             else:  # split in gsims first, then in tiles

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -687,6 +687,7 @@ class CompositeSourceModel:
             for cm in self._split(cmaker, nsplits):
                 splits = nsplits * len(cm.gsims) / len(cmaker.gsims)
                 for sites in sitecol.split(splits, minsize=oq.max_sites_disagg):
+                    # print(cm.grp_id, len(cm.gsims), len(sites))
                     yield cm, sites
 
     def _split(self, cmaker, nsplits):


### PR DESCRIPTION
Here is the situation for EUR with ~13,000 sites (OQ_SAMPLE_SITES=.05):
```
# before
| calc_10756, maxmem=92.4 GB | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 248_276  | 380.9     | 310        |
| get_poes                   | 115_370  | 0.0       | 25_097_633 |
| computing mean_std         | 46_205   | 0.0       | 511_569    |
| composing pnes             | 39_954   | 0.0       | 25_097_633 |
| planar contexts            | 32_493   | 0.0       | 38_634_582 |
| iter_ruptures              | 18_360   | 0.0       | 1_456_861  |
| nonplanar contexts         | 6_924    | 0.0       | 1_124_431  |
| ClassicalCalculator.run    | 2_846    | 3_029     | 1          |
| total postclassical        | 2_220    | 515.6     | 35         |

# after
| calc_10762, maxmem=103.3 GB | time_sec | memory_mb | counts     |
|-----------------------------+----------+-----------+------------|
| total classical             | 263_581  | 286.1     | 380        |
| get_poes                    | 108_747  | 0.0       | 26_046_173 |
| planar contexts             | 54_841   | 0.0       | 53_453_006 |
| composing pnes              | 39_047   | 0.0       | 26_046_173 |
| computing mean_std          | 35_188   | 0.0       | 523_427    |
| iter_ruptures               | 24_612   | 0.0       | 1_999_227  |
| nonplanar contexts          | 12_476   | 0.0       | 1_731_636  |
| ClassicalCalculator.run     | 2_682    | 3_100     | 1          |
| total postclassical         | 2_715    | 477.1     | 35         |

| operation-duration | counts | mean   | stddev | min    | max     | slowfac |
|--------------------+--------+--------+--------+--------+---------+---------|
| classical          | 310    | 800.9  | 39%   | 0.2585  | 1_059   | 1.3222  |
| classical          | 380    | 693.6  | 40%   | 0.2840  | 1_075   | 1.5499  |
```
It is worse, and even worse on the IUSS cluster:
```
# new
| calc_1262, maxmem=5.1 GB   | time_sec | memory_mb | counts      |
|----------------------------+----------+-----------+-------------|
| total classical            | 548_130  | 329.1     | 1_028       |
| get_poes                   | 202_078  | 0.0       | 53_960_693  |
| planar contexts            | 140_589  | 0.0       | 147_442_914 |
| composing pnes             | 78_683   | 0.0       | 53_960_693  |
| iter_ruptures              | 61_119   | 0.0       | 5_408_904   |
| computing mean_std         | 56_549   | 0.0       | 1_084_059   |
| nonplanar contexts         | 36_888   | 0.0       | 4_667_549   |
| total postclassical        | 5_754    | 463.7     | 71          |
| combine pmaps              | 3_447    | 0.0       | 26_015      |
| reading rates              | 2_222    | 410.3     | 71          |
| ClassicalCalculator.run    | 1_948    | 3_878     | 1           |

# old
| calc_1259, maxmem=7.1 GB   | time_sec | memory_mb | counts      |
|----------------------------+----------+-----------+-------------|
| total classical            | 500_907  | 482.5     | 805         |
| get_poes                   | 217_845  | 0.0       | 51_856_522  |
| planar contexts            | 84_470   | 0.0       | 108_128_350 |
| composing pnes             | 82_329   | 0.0       | 51_856_522  |
| computing mean_std         | 81_255   | 0.0       | 1_063_454   |
| iter_ruptures              | 49_011   | 0.0       | 4_173_226   |
| nonplanar contexts         | 17_953   | 0.0       | 3_116_798   |
| total postclassical        | 4_271    | 469.2     | 71          |
| combine pmaps              | 3_514    | 0.0       | 26_015      |
| ClassicalCalculator.run    | 1_876    | 6_904     | 1           |
| reading rates              | 668.6    | 415.8     | 71          |
```
This is why the splitting by gsims is disabled by default.