### PR TITLE
Add to taxonomy_mapping.csv the mappings for Canada and USA

### DIFF
--- a/openquake/qa_tests_data/mosaic/taxonomy_mapping.csv
+++ b/openquake/qa_tests_data/mosaic/taxonomy_mapping.csv
@@ -215,3 +215,5 @@ FSM,,taxonomy_mapping_Oceania.csv
 NCL,,taxonomy_mapping_Oceania.csv
 MNP,,taxonomy_mapping_Northern_Mariana_Islands.csv
 PLW,,taxonomy_mapping_Oceania.csv
+CAN,CAN,taxonomy_mapping_Canada.csv
+USA,USA,taxonomy_mapping_United_States.csv


### PR DESCRIPTION
I used the script with the updated taxonomy_mapping.csv and created a complete and a reduced exposure.hdf5 files. I tested them on my laptop for an event in the USA, successfully. Then I saved a backup copy of the exposure.hdf5 file that is currently in the aristotle-beta machine and replaced the file with the one containing mappings also for USA and CAN.