### PR TITLE
WebUI: customize login form to include a warning about the possibility to be banned after failing multiple login attempts

### DIFF
--- a/openquake/server/forms.py
+++ b/openquake/server/forms.py
@@ -22,7 +22,7 @@ from django.contrib.auth.forms import AuthenticationForm
 
 class CustomAuthenticationForm(AuthenticationForm):
     """
-    Customizing the invalid_login message to include a warning about the
+    Overriding the invalid_login message to include a warning about the
     possibility to be banned after some failed login attempts
     """
     error_messages = {

--- a/openquake/server/forms.py
+++ b/openquake/server/forms.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2024 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+from django.utils.translation import gettext_lazy as _
+from django.contrib.auth.forms import AuthenticationForm
+
+
+class CustomAuthenticationForm(AuthenticationForm):
+    """
+    Customizing the invalid_login message to include a warning about the
+    possibility to be banned after some failed login attempts
+    """
+    error_messages = {
+        "invalid_login": _(
+            "Please enter a correct %(username)s and password. Note that both "
+            "fields may be case-sensitive. WARNING! If you fail multiple "
+            "times, your account might be locked."
+        ),
+        "inactive": _("This account is inactive."),
+    }

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
-# Copyright (C) 2014-2023 GEM Foundation
+# Copyright (C) 2014-2024 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published
@@ -102,8 +102,9 @@ else:
     if settings.LOCKDOWN:
         from django.contrib import admin
         from django.contrib.auth.views import (
-            LoginView, LogoutView, PasswordResetView, PasswordResetDoneView,
+            LogoutView, PasswordResetView, PasswordResetDoneView,
             PasswordResetConfirmView, PasswordResetCompleteView)
+        from .views import CustomLoginView
 
         admin.autodiscover()
         admin.site.site_url = '%s/engine/' % settings.WEBUI_PATHPREFIX
@@ -126,7 +127,7 @@ else:
         urlpatterns += [
             re_path(r'^admin/', admin.site.urls),
             re_path(r'accounts/login/$',
-                    LoginView.as_view(
+                    CustomLoginView.as_view(
                         template_name='account/login.html',
                         extra_context={'application_mode': application_mode},
                     ),

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
-# Copyright (C) 2015-2023 GEM Foundation
+# Copyright (C) 2015-2024 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published
@@ -69,6 +69,11 @@ from wsgiref.util import FileWrapper
 
 if settings.LOCKDOWN:
     from django.contrib.auth import authenticate, login, logout
+    from django.contrib.auth.views import LoginView
+    from .forms import CustomAuthenticationForm
+
+    class CustomLoginView(LoginView):
+        authentication_form = CustomAuthenticationForm
 
 CWD = os.path.dirname(__file__)
 METHOD_NOT_ALLOWED = 405


### PR DESCRIPTION
Fixes https://github.com/gem/oq-engine/issues/9868

We don't know in advance the precise rules about the number of allowed consecutive login attempts and about the amount of time the user will be banned after failing too many attempts, because such rules are defined via Fail2Ban in each specific installation. Therefore, the warning is intentionally generic.