### PR TITLE
Various refactoring

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -33,10 +33,7 @@ from decorator import decorator
 import psutil
 import numpy
 import pandas
-try:
-    import numba
-except ImportError:
-    numba = None
+import numba
 
 from openquake.baselib.general import humansize, fast_agg
 from openquake.baselib import hdf5
@@ -420,31 +417,19 @@ def vectorize_arg(idx):
 
 
 # numba helpers
-if numba:
-    # NB: without cache=True the tests would take hours!!
+# NB: without cache=True the tests would take hours!!
 
-    def jittable(func):
-        """Calls numba.njit with a cache"""
-        jitfunc = numba.njit(func, error_model='numpy', cache=True)
-        jitfunc.jittable = True
-        return jitfunc
+def jittable(func):
+    """Calls numba.njit with a cache"""
+    jitfunc = numba.njit(func, error_model='numpy', cache=True)
+    jitfunc.jittable = True
+    return jitfunc
 
-    def compile(sigstr):
-        """
-        Compile a function Ahead-Of-Time using the given signature string
-        """
-        return numba.njit(sigstr, error_model='numpy', cache=True)
-
-else:
-
-    def jittable(func):
-        """Do nothing decorator, used if numba is missing"""
-        func.jittable = True
-        return func
-
-    def compile(sigstr):
-        """Do nothing decorator, used if numba is missing"""
-        return lambda func: func
+def compile(sigstr):
+    """
+    Compile a function Ahead-Of-Time using the given signature string
+    """
+    return numba.njit(sigstr, error_model='numpy', cache=True)
 
 
 # used when reading _rates/sid

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -123,21 +123,15 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
         # disagg_by_src still works since the atomic group contains a single
         # source 'case' (mutex combination of case:01, case:02)
         for srcs in groupby(sources, valid.basename).values():
-            pmap = MapArray(
-                sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(
-                cmaker.rup_indep)
-            result = hazclassical(srcs, sitecol, cmaker, pmap)
-            result['pnemap'] = (~pmap).to_rates()
+            result = hazclassical(srcs, sitecol, cmaker)
+            result['pnemap'] = (~result.pop('pmap')).to_rates()
             yield result
     else:
         # use most memory here; limited by pmap_max_gb
-        pmap = MapArray(
-            sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(
-                cmaker.rup_indep)
-        result = hazclassical(sources, sitecol, cmaker, pmap)
+        result = hazclassical(sources, sitecol, cmaker)
         if tiling:
             del result['source_data']  # save some data transfer
-        rates = (~pmap).to_rates()
+        rates = (~result.pop('pmap')).to_rates()
         if tiling and cmaker.save_on_tmp:
             # tested in case_22
             scratch = parallel.scratch_dir(monitor.calc_id)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -124,13 +124,13 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
         # source 'case' (mutex combination of case:01, case:02)
         for srcs in groupby(sources, valid.basename).values():
             result = hazclassical(srcs, sitecol, cmaker)
-            result['pnemap'] = (~result.pop('pmap')).to_rates()
+            result['pnemap'] = result['pnemap'].to_rates()
             yield result
     else:
         result = hazclassical(sources, sitecol, cmaker)
         if tiling:
             del result['source_data']  # save some data transfer
-        rates = (~result.pop('pmap')).to_rates()
+        rates = result.pop('pnemap').to_rates()
         if tiling and cmaker.save_on_tmp:
             # tested in case_22
             scratch = parallel.scratch_dir(monitor.calc_id)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -127,7 +127,6 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
             result['pnemap'] = (~result.pop('pmap')).to_rates()
             yield result
     else:
-        # use most memory here; limited by pmap_max_gb
         result = hazclassical(sources, sitecol, cmaker)
         if tiling:
             del result['source_data']  # save some data transfer

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -100,6 +100,7 @@ def classical(group, sitecol, cmaker):
     if cluster:
         cmaker.tom = FatedTOM(time_span=1)
 
+    # using most memory here; limited by pmap_max_gb
     pmap = MapArray(
         sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(rup_indep)
     dic = PmapMaker(cmaker, src_filter, group).make(pmap)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -192,9 +192,7 @@ def calc_hazard_curve(site1, src, gsims, oqparam, monitor=Monitor()):
     cmaker = ContextMaker(trt, gsims, vars(oqparam), monitor)
     cmaker.tom = src.temporal_occurrence_model
     srcfilter = SourceFilter(site1, oqparam.maximum_distance)
-    pmap = MapArray(site1.sids, oqparam.imtls.size, 1).fill(1)
-    PmapMaker(cmaker, srcfilter, [src]).make(pmap)
-    pmap.array[:] = 1. - pmap.array
+    pmap = PmapMaker(cmaker, srcfilter, [src]).make()['pmap']
     if not pmap:  # filtered away
         return numpy.zeros((oqparam.imtls.size, len(gsims)))
     return pmap.array[0]

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -66,7 +66,6 @@ def classical(group, sitecol, cmaker):
     """
     src_filter = SourceFilter(sitecol, cmaker.maximum_distance)
     cluster = getattr(group, 'cluster', None)
-    rup_indep = getattr(group, 'rup_interdep', None) != 'mutex'
     trts = set()
     for src in group:
         if not src.num_ruptures:

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -68,7 +68,7 @@ def _cluster(sids, imtls, tom, gsims, pmap):
     return ~pmapclu
 
 
-def classical(group, sitecol, cmaker, pmap=None):
+def classical(group, sitecol, cmaker):
     """
     Compute the hazard curves for a set of sources belonging to the same
     tectonic region type for all the GSIMs associated to that TRT.
@@ -78,7 +78,6 @@ def classical(group, sitecol, cmaker, pmap=None):
     :returns:
         a dictionary with keys pmap, source_data, rup_data, extra
     """
-    not_passed_pmap = pmap is None
     src_filter = SourceFilter(sitecol, cmaker.maximum_distance)
     cluster = getattr(group, 'cluster', None)
     rup_indep = getattr(group, 'rup_interdep', None) != 'mutex'
@@ -100,11 +99,9 @@ def classical(group, sitecol, cmaker, pmap=None):
         cmaker.tom = PoissonTOM(time_span) if time_span else None
     if cluster:
         cmaker.tom = FatedTOM(time_span=1)
-    if not_passed_pmap:
-        pmap = MapArray(
-            sitecol.sids, cmaker.imtls.size, len(cmaker.gsims))
-        pmap.fill(rup_indep)
 
+    pmap = MapArray(
+        sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(rup_indep)
     dic = PmapMaker(cmaker, src_filter, group).make(pmap)
     if getattr(group, 'src_interdep', None) != 'mutex' and rup_indep:
         pmap.array[:] = 1. - pmap.array
@@ -112,8 +109,7 @@ def classical(group, sitecol, cmaker, pmap=None):
         pmap.array[:] = _cluster(sitecol.sids, cmaker.imtls,
                                  group.temporal_occurrence_model,
                                  cmaker.gsims, pmap).array
-    if not_passed_pmap:
-        dic['pmap'] = pmap
+    dic['pmap'] = pmap
     return dic
 
 

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -85,7 +85,7 @@ def classical(group, sitecol, cmaker):
         cmaker.tom = PoissonTOM(time_span) if time_span else None
     if cluster:
         cmaker.tom = FatedTOM(time_span=1)
-    indep  = rup_indep and getattr(group, 'src_interdep', None) != 'mutex'
+    indep = rup_indep and getattr(group, 'src_interdep', None) != 'mutex'
     # using most memory here; limited by pmap_max_gb
     pmap = MapArray(
         sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(indep)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -99,12 +99,12 @@ def classical(group, sitecol, cmaker):
         cmaker.tom = PoissonTOM(time_span) if time_span else None
     if cluster:
         cmaker.tom = FatedTOM(time_span=1)
-
+    indep  = rup_indep and getattr(group, 'src_interdep', None) != 'mutex'
     # using most memory here; limited by pmap_max_gb
     pmap = MapArray(
-        sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(rup_indep)
+        sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(indep)
     dic = PmapMaker(cmaker, src_filter, group).make(pmap)
-    if getattr(group, 'src_interdep', None) != 'mutex' and rup_indep:
+    if indep:
         pmap.array[:] = 1. - pmap.array
     if cluster:
         pmap.array[:] = _cluster(sitecol.sids, cmaker.imtls,

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -85,14 +85,9 @@ def classical(group, sitecol, cmaker):
         cmaker.tom = PoissonTOM(time_span) if time_span else None
     if cluster:
         cmaker.tom = FatedTOM(time_span=1)
-    indep = rup_indep and getattr(group, 'src_interdep', None) != 'mutex'
-    # using most memory here; limited by pmap_max_gb
-    pmap = MapArray(
-        sitecol.sids, cmaker.imtls.size, len(cmaker.gsims)).fill(indep)
-    dic = PmapMaker(cmaker, src_filter, group).make(pmap)
-    if indep:
-        pmap.array[:] = 1. - pmap.array
+    dic = PmapMaker(cmaker, src_filter, group).make()
     if cluster:
+        pmap = dic['pmap']
         tom = group.temporal_occurrence_model
         for nocc in range(0, 50):
             prob_n_occ = tom.get_probability_n_occurrences(tom.occurrence_rate, nocc)
@@ -101,7 +96,6 @@ def classical(group, sitecol, cmaker):
             else:
                 pmapclu.array += (1.-pmap.array)**nocc * prob_n_occ
         pmap.array[:] = (~pmapclu).array
-    dic['pmap'] = pmap
     return dic
 
 

--- a/openquake/hazardlib/calc/mean_rates.py
+++ b/openquake/hazardlib/calc/mean_rates.py
@@ -72,7 +72,7 @@ def calc_rmap(src_groups, full_lt, sitecol, oq):
         dic = classical(group, sitecol, cmaker)
         if len(dic['rup_data']) == 0:  # the group was filtered away
             continue
-        rates = to_rates(dic['pmap'].array)
+        rates = to_rates(1. - dic['pnemap'].array)
         ctxs.append(numpy.concatenate(dic['rup_data']).view(numpy.recarray))
         for i, gid in enumerate(gids[cmaker.grp_id]):
             # += tested in logictree/case_05

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -154,25 +154,6 @@ def is_modifiable(gsim):
     return hasattr(gsim, 'gmpe') and hasattr(gsim, 'params')
 
 
-def split_by_occur(ctx):
-    """
-    :returns: [poissonian] or [poissonian, nonpoissonian,...]
-    """
-    nan = numpy.isnan(ctx.occurrence_rate)
-    out = []
-    if 0 < nan.sum() < len(ctx):
-        out.append(ctx[~nan])
-        nonpoisson = ctx[nan]
-        for shp in set(np.probs_occur.shape[1] for np in nonpoisson):
-            # ctxs with the same shape of prob_occur are concatenated
-            p_array = [p for p in nonpoisson if p.probs_occur.shape[1] == shp]
-            arr = numpy.concatenate(p_array, p_array[0].dtype)
-            out.append(arr.view(numpy.recarray))
-    else:
-        out.append(ctx)
-    return out
-
-
 def concat(ctxs):
     """
     Concatenate context arrays.

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1150,10 +1150,8 @@ class ContextMaker(object):
         """
         rup_indep = not rup_mutex
         sids = numpy.unique(ctxs[0].sids)
-        pmap = MapArray(sids, size(self.imtls), len(self.gsims))
-        pmap.fill(rup_indep)
-        self.update(pmap, ctxs, tom or PoissonTOM(self.investigation_time),
-                    rup_mutex)
+        pmap = MapArray(sids, size(self.imtls), len(self.gsims)).fill(rup_indep)
+        self.update(pmap, ctxs, tom or PoissonTOM(self.investigation_time), rup_mutex)
         return ~pmap if rup_indep else pmap
 
     def ratesNLG(self, srcgroup, sitecol):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1177,7 +1177,7 @@ class ContextMaker(object):
         for ctx in ctxs:
             for poes, ctxt, invs in self.gen_poes(ctx, rup_indep=True):
                 with self.pne_mon:
-                    pmap.update(poes, invs, ctxt, itime, {})
+                    pmap.update_indep(poes, invs, ctxt, itime)
 
     def update_mutex(self, pmap, ctxs, tom, rup_mutex):
         """
@@ -1188,7 +1188,10 @@ class ContextMaker(object):
         for ctx in ctxs:
             for poes, ctxt, invs in self.gen_poes(ctx, rup_indep=False):
                 with self.pne_mon:
-                    pmap.update(poes, invs, ctxt, tom.time_span, rup_mutex)
+                    if rup_mutex:
+                        pmap.update_mutex(poes, invs, ctxt, tom.time_span, rup_mutex)
+                    else:
+                        pmap.update_indep(poes, invs, ctxt, tom.time_span)
 
     # called by gen_poes and by the GmfComputer
     def get_mean_stds(self, ctxs, split_by_mag=True):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1555,7 +1555,6 @@ class PmapMaker(object):
         self.source_data = AccumDict(accum=[])
         grp_id = self.sources[0].grp_id
         if self.src_mutex or not self.rup_indep:
-            pmap.fill(0)
             self._make_src_mutex(pmap)
             if self.src_mutex:
                 pmap.array = self.grp_probability * pmap.array

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1516,8 +1516,13 @@ class PmapMaker(object):
         self.source_data['ctimes'].append(dt)
         self.source_data['taskno'].append(cm.task_no)
 
-    def make(self, pmap):
-        dic = {}
+    def make(self):
+        sitecol = self.srcfilter.sitecol
+        indep = self.rup_indep and not self.src_mutex
+        # using most memory here; limited by pmap_max_gb
+        pmap = MapArray(
+            sitecol.sids, self.cmaker.imtls.size, len(self.cmaker.gsims)).fill(indep)
+        dic = {'pmap': pmap}
         self.rupdata = []
         self.source_data = AccumDict(accum=[])
         grp_id = self.sources[0].grp_id
@@ -1543,6 +1548,8 @@ class PmapMaker(object):
             # (mps-0!b1;0, mps-0!b1;1, ...); you can simply use the first,
             # since in `store_mean_rates_by_src` we use corename
             dic['basename'] = valid.basename(self.sources[0])
+        if indep:
+            pmap.array[:] = 1. - pmap.array
         return dic
 
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1151,7 +1151,10 @@ class ContextMaker(object):
         rup_indep = not rup_mutex
         sids = numpy.unique(ctxs[0].sids)
         pmap = MapArray(sids, size(self.imtls), len(self.gsims)).fill(rup_indep)
-        self.update(pmap, ctxs, tom or PoissonTOM(self.investigation_time), rup_mutex)
+        if rup_mutex:
+            self.update_mutex(pmap, ctxs, tom or PoissonTOM(self.investigation_time), rup_mutex)
+        else:
+            self.update_indep(pmap, ctxs, tom or PoissonTOM(self.investigation_time))
         return ~pmap if rup_indep else pmap
 
     def ratesNLG(self, srcgroup, sitecol):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1122,7 +1122,7 @@ class ContextMaker(object):
                         gsim.set_poes(ms, self, ctxt, poes[:, :, g])
             yield poes
 
-    def gen_poes(self, ctx, rup_indep=True):
+    def gen_poes(self, ctx):
         """
         :param ctx: a vectorized context (recarray) of size N
         :param rup_indep: rupture flag (false for mutex ruptures)
@@ -1131,7 +1131,7 @@ class ContextMaker(object):
         ctx.mag = numpy.round(ctx.mag, 3)
         for mag in numpy.unique(ctx.mag):
             ctxt = ctx[ctx.mag == mag]
-            kctx, invs = self.collapser.collapse(ctxt, self.col_mon, rup_indep)
+            kctx, invs = self.collapser.collapse(ctxt, self.col_mon, rup_indep=True)
             if invs is None:  # no collapse
                 for poes in self._gen_poes(ctxt):
                     invs = numpy.arange(len(poes), dtype=U32)
@@ -1175,7 +1175,7 @@ class ContextMaker(object):
         else:
             itime = tom.time_span
         for ctx in ctxs:
-            for poes, ctxt, invs in self.gen_poes(ctx, rup_indep=True):
+            for poes, ctxt, invs in self.gen_poes(ctx):
                 with self.pne_mon:
                     pmap.update_indep(poes, invs, ctxt, itime)
 
@@ -1186,7 +1186,7 @@ class ContextMaker(object):
         :param rup_mutex: dictionary (src_id, rup_id) -> weight
         """
         for ctx in ctxs:
-            for poes, ctxt, invs in self.gen_poes(ctx, rup_indep=False):
+            for poes, ctxt, invs in self.gen_poes(ctx):
                 with self.pne_mon:
                     if rup_mutex:
                         pmap.update_mutex(poes, invs, ctxt, tom.time_span, rup_mutex)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1188,10 +1188,7 @@ class ContextMaker(object):
         for ctx in ctxs:
             for poes, ctxt, invs in self.gen_poes(ctx):
                 with self.pne_mon:
-                    if rup_mutex:
-                        pmap.update_mutex(poes, invs, ctxt, tom.time_span, rup_mutex)
-                    else:
-                        pmap.update_indep(poes, invs, ctxt, tom.time_span)
+                    pmap.update_mutex(poes, invs, ctxt, tom.time_span, rup_mutex)
 
     # called by gen_poes and by the GmfComputer
     def get_mean_stds(self, ctxs, split_by_mag=True):
@@ -1514,7 +1511,10 @@ class PmapMaker(object):
             nctxs += len(ctxs)
             nsites += n
             esites += src.esites
-            cm.update_mutex(pm, ctxs, tom, self.rup_mutex)
+            if self.rup_mutex:
+                cm.update_mutex(pm, ctxs, tom, self.rup_mutex)
+            else:
+                cm.update_indep(pm, ctxs, tom)
             if hasattr(src, 'mutex_weight'):
                 arr = 1. - pm.array if self.rup_indep else pm.array
                 pmap.array += arr * src.mutex_weight

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1517,11 +1517,11 @@ class PmapMaker(object):
         self.source_data['taskno'].append(cm.task_no)
 
     def make(self):
-        sitecol = self.srcfilter.sitecol
+        sids = self.srcfilter.sitecol.sids
         indep = self.rup_indep and not self.src_mutex
         # using most memory here; limited by pmap_max_gb
         pmap = MapArray(
-            sitecol.sids, self.cmaker.imtls.size, len(self.cmaker.gsims)).fill(indep)
+            sids, self.cmaker.imtls.size, len(self.cmaker.gsims)).fill(indep)
         dic = {'pmap': pmap}
         self.rupdata = []
         self.source_data = AccumDict(accum=[])
@@ -1529,7 +1529,7 @@ class PmapMaker(object):
         if self.src_mutex or not self.rup_indep:
             self._make_src_mutex(pmap)
             if self.src_mutex:
-                pmap.array = self.grp_probability * pmap.array
+                pmap.array *= self.grp_probability
         else:
             self._make_src_indep(pmap)
         dic['cfactor'] = self.cmaker.collapser.cfactor

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1463,6 +1463,7 @@ class PmapMaker(object):
             # assume all sources have the same tom
             cm.update(pmap, concat(allctxs), tom, self.rup_mutex)
             allctxs.clear()
+        pmap.array[:] = 1. - pmap.array
         dt = time.time() - t0
         nsrcs = len(self.sources)
         for src in self.sources:
@@ -1545,8 +1546,6 @@ class PmapMaker(object):
             # (mps-0!b1;0, mps-0!b1;1, ...); you can simply use the first,
             # since in `store_mean_rates_by_src` we use corename
             dic['basename'] = valid.basename(self.sources[0])
-        if indep:
-            pmap.array[:] = 1. - pmap.array
         return dic
 
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -157,32 +157,20 @@ def is_modifiable(gsim):
 def concat(ctxs):
     """
     Concatenate context arrays.
-    :returns: [] or [poisson_ctx] or [poisson_ctx, nonpoisson_ctx, ...]
+    :returns: [] or [poisson_ctx] or [nonpoisson_ctx, ...]
     """
     if not ctxs:
         return []
-    out, poisson, nonpoisson, nonparam = [], [], [], []
-    for ctx in ctxs:
-        if numpy.isnan(ctx.occurrence_rate).all():
-            nonparam.append(ctx)
-
-        # If ctx has probs_occur and occur_rate is parametric non-poisson
-        elif hasattr(ctx, 'probs_occur') and ctx.probs_occur.shape[1] >= 1:
-            nonpoisson.append(ctx)
-        else:
-            poisson.append(ctx)
-    if poisson:
-        out.append(numpy.concatenate(poisson).view(numpy.recarray))
-    if nonpoisson:
-        # ctxs with the same shape of prob_occur are concatenated
-        # and different shape sets are appended separately
-        for shp in set(ctx.probs_occur.shape[1] for ctx in nonpoisson):
-            p_array = [p for p in nonpoisson
-                       if p.probs_occur.shape[1] == shp]
+    ctx = ctxs[0]
+    out = []
+    # if ctx has probs_occur, it is assumed to be non-poissonian
+    if hasattr(ctx, 'probs_occur') and ctx.probs_occur.shape[1] >= 1:
+        # case 27, 29, 62, 65, 75, 78, 80
+        for shp in set(ctx.probs_occur.shape[1] for ctx in ctxs):
+            p_array = [p for p in ctxs if p.probs_occur.shape[1] == shp]
             out.append(numpy.concatenate(p_array).view(numpy.recarray))
-    if nonparam:
-        out.append(numpy.concatenate(nonparam).view(numpy.recarray))
-    assert len(out) == 1, out
+    else:
+        out.append(numpy.concatenate(ctxs).view(numpy.recarray))
     return out
 
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1491,7 +1491,6 @@ class PmapMaker(object):
         esites = 0
         nctxs = 0
         sids = self.srcfilter.sitecol.sids
-        # using most memory here; limited by pmap_max_gb
         pmap = MapArray(
             sids, self.cmaker.imtls.size, len(self.cmaker.gsims)).fill(0)
         for src in self.sources:

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -23,8 +23,9 @@ Module :mod:`openquake.hazardlib.geo.surface.planar` contains
 import math
 import logging
 import numpy
+import numba
 from openquake.baselib.node import Node
-from openquake.baselib.performance import numba, compile
+from openquake.baselib.performance import compile
 from openquake.hazardlib.geo.geodetic import (
     point_at, spherical_to_cartesian, fast_spherical_to_cartesian)
 from openquake.hazardlib.geo import Point, Line

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -378,17 +378,17 @@ class MapArray(object):
         """
         rates = ctxt.occurrence_rate
         probs_occur = fix_probs_occur(ctxt.probs_occur)
-        idxs = self.sidx[ctxt.sids]
+        sidxs = self.sidx[ctxt.sids]
         for i in range(self.shape[-1]):  # G indices
             if len(mutex_weight) == 0:  # indep
                 update_pmap_i(self.array[:, :, i], poes[:, :, i], invs, rates,
-                              probs_occur, idxs, itime)
+                              probs_occur, sidxs, itime)
             else:  # mutex
                 weights = [mutex_weight[src_id, rup_id]
                            for src_id, rup_id in zip(ctxt.src_id, ctxt.rup_id)]
                 update_pmap_m(self.array[:, :, i], poes[:, :, i],
                               invs, rates, probs_occur,
-                              numpy.array(weights), idxs, itime)
+                              numpy.array(weights), sidxs, itime)
 
     def __invert__(self):
         return self.new(1. - self.array)

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -160,7 +160,7 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
                      rup_interdep=group.rup_interdep,
                      grp_probability=group.grp_probability)
         cmaker = ContextMaker(src.tectonic_region_type, gsim_by_trt, param)
-        crv = classical(group, self.sites, cmaker)['pmap']
+        crv = ~classical(group, self.sites, cmaker)['pnemap']
         npt.assert_almost_equal(numpy.array([0.35000, 0.32497, 0.10398]),
                                 crv.array[0, :, 0], decimal=4)
 

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -100,7 +100,7 @@ class CollapseTestCase(unittest.TestCase):
         cmaker = contexts.ContextMaker(
             srcs[0].tectonic_region_type, self.gsims, params)
         res = classical(srcs, self.sitecol, cmaker)
-        pmap = res['pmap']
+        pmap = ~res['pnemap']
         effrups = sum(res['source_data']['nrupts'])
         curve = pmap.array[0, :, 0]
         return curve, srcs, effrups, weights


### PR DESCRIPTION
1. Some simplification taking into account that numba is mandatory now
2. Moved the creation of the MapArray inside contexts.py
3. Returning `pnemap` instead of `pmap` in classical
4. Split the logic between `indep` and `mutex`
5. Removed offending line `assert len(out) == 1`
6. Removed 63 lines in total