### PR TITLE
Saving memory by using 32 bit rates

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -173,7 +173,7 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     max_weight = csm.get_max_weight(oq)
     max_gb = float(config.memory.pmap_max_gb)
     req_gb, trt_rlzs, gids = getters.get_pmaps_gb(dstore, csm.full_lt)
-    fac = oq.imtls.size * N * 8 / 1024**3
+    fac = oq.imtls.size * N * 4 / 1024**3
     sizes = [len(cm.gsims) * fac for cm in cmakers]
     ok = req_gb < max_gb and max(sizes) < max_gb
     regular = ok or oq.disagg_by_src or N < oq.max_sites_disagg or oq.tile_spec

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -77,7 +77,7 @@ class LogicTreeTestCase(CalculatorTestCase):
                 rmap, full_lt.g_weights(trt_smrs), wget, oq.imtls)
             er = exp_rates[exp_rates < 1]
             mr = mean_rates[mean_rates < 1]
-            aac(mr, er, atol=1e-6)
+            aac(mr, er, atol=8e-6)
 
     def test_case_01(self):
         # same source in two source models
@@ -335,8 +335,7 @@ hazard_uhs-std.csv
         mean_poes = self.calc.datastore['hcurves-stats'][0, 0]  # shape (M, L1)
         window = self.calc.datastore['oqparam'].investigation_time
         mean_rates = to_rates(mean_poes, window)
-        rates_by_source = self.calc.datastore[
-            'mean_rates_by_src'][0]  # (M, L1, Ns)
+        rates_by_source = self.calc.datastore['mean_rates_by_src'][0]  # (M, L1, Ns)
         aac(mean_rates, rates_by_source.sum(axis=2), atol=5E-7)
 
     def test_case_20(self):

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -41,7 +41,7 @@ avg_losses_max = 900_000_000
 conditioned_gmf_gb = 10
 
 # parallel tiling parameters
-pmap_max_gb = .5
+pmap_max_gb = .4
 
 [dbserver]
 file = ~/oqdata/db.sqlite3

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -41,7 +41,7 @@ avg_losses_max = 900_000_000
 conditioned_gmf_gb = 10
 
 # parallel tiling parameters
-pmap_max_gb = .6
+pmap_max_gb = .5
 
 [dbserver]
 file = ~/oqdata/db.sqlite3

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1464,7 +1464,7 @@ class PmapMaker(object):
         # using most memory here; limited by pmap_max_gb
         pnemap = MapArray(
             sids, self.cmaker.imtls.size, len(self.cmaker.gsims),
-            not self.cluster).fill(self.cluster)
+            not self.cluster).fill(self.cluster, F64 if self.cluster else F32)
         for src in self.sources:
             tom = getattr(src, 'temporal_occurrence_model',
                           PoissonTOM(self.cmaker.investigation_time))

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -681,7 +681,6 @@ class ContextMaker(object):
         self.ctx_mon = monitor('nonplanar contexts', measuremem=False)
         self.gmf_mon = monitor('computing mean_std', measuremem=False)
         self.poe_mon = monitor('get_poes', measuremem=False)
-        self.pne_mon = monitor('composing pnes', measuremem=False)
         self.ir_mon = monitor('iter_ruptures', measuremem=False)
         self.sec_mon = monitor('building dparam', measuremem=True)
         self.delta_mon = monitor('getting delta_rates', measuremem=False)
@@ -1175,12 +1174,11 @@ class ContextMaker(object):
         :param ctxs: a list of context arrays with 0 or 1 element
         """
         for poes, ctxt, invs in self.gen_poes(ctx):
-            with self.pne_mon:
-                if isinstance(tom, FatedTOM):
-                    for inv, sidx in zip(invs, pmap.sidx[ctxt.sids]):
-                        pmap.array[sidx] *= 1. - poes[inv]
-                else:
-                    pmap.update_indep(poes, invs, ctxt, tom.time_span)
+            if isinstance(tom, FatedTOM):
+                for inv, sidx in zip(invs, pmap.sidx[ctxt.sids]):
+                    pmap.array[sidx] *= 1. - poes[inv]
+            else:
+                pmap.update_indep(poes, invs, ctxt, tom.time_span)
 
     def update_mutex(self, pmap, ctx, tom, rup_mutex):
         """
@@ -1189,8 +1187,7 @@ class ContextMaker(object):
         :param rup_mutex: dictionary (src_id, rup_id) -> weight
         """
         for poes, ctxt, invs in self.gen_poes(ctx):
-            with self.pne_mon:
-                pmap.update_mutex(poes, invs, ctxt, tom.time_span, rup_mutex)
+            pmap.update_mutex(poes, invs, ctxt, tom.time_span, rup_mutex)
 
     # called by gen_poes and by the GmfComputer
     def get_mean_stds(self, ctxs, split_by_mag=True):

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -111,7 +111,6 @@ class AvgPoeGMPE(GMPE):
         """
         cm = copy.copy(cmaker)
         cm.poe_mon = performance.Monitor()  # avoid double counts
-        cm.pne_mon = performance.Monitor()  # avoid double counts
         cm.gsims = self.gsims
         avgs = []
         for poes, ctxt, invs in cm.gen_poes(ctx):

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -172,6 +172,14 @@ sig_i = t.void(t.float64[:, :, :],                     # pmap
                t.uint32[:],                            # sids
                t.float64)                              # itime
 
+sig_r = t.void(t.float32[:, :, :],                     # pmap
+               t.float64[:, :, :],                     # poes
+               t.uint32[:],                            # invs
+               t.float64[:],                           # rates
+               t.float64[:, :],                        # probs_occur
+               t.uint32[:],                            # sids
+               t.float64)                              # itime
+
 sig_m = t.void(t.float64[:, :, :],                     # pmap
                t.float64[:, :, :],                     # poes
                t.uint32[:],                            # invs
@@ -194,7 +202,7 @@ def update_pmap_i(arr, poes, inv, rates, probs_occur, sidxs, itime):
                 arr[sidx, :, g] *= get_pnes(rate, probs, poes[i, :, g], itime)  # shape L
 
 
-@compile(sig_i)
+@compile(sig_r)
 def update_pmap_r(arr, poes, inv, rates, probs_occur, sidxs, itime):
     G = arr.shape[2]
     for i, rate, probs, sidx in zip(inv, rates, probs_occur, sidxs):

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -688,7 +688,7 @@ class CompositeSourceModel:
         oq = cmakers[0].oq
         max_gb = float(config.memory.pmap_max_gb)
         for cmaker in cmakers:
-            size_gb = len(cmaker.gsims) * oq.imtls.size * N * 8 / 1024**3
+            size_gb = len(cmaker.gsims) * oq.imtls.size * N * 4 / 1024**3
             grp = self.src_groups[cmaker.grp_id]
             nsplits = general.ceil(grp.weight / max_weight)
             if size_gb / nsplits > max_gb:

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -230,10 +230,10 @@ class MultiPointTestCase(unittest.TestCase):
         hcurves = calc_hazard_curves(groups, sitecol, imtls, gsim_by_trt)
         expected = [9.999978e-01, 9.084040e-01, 1.489753e-01, 3.690966e-03,
                     2.763261e-05]
-        npt.assert_allclose(hcurves['PGA'][0], expected, rtol=3E-4)
+        npt.assert_allclose(hcurves['PGA'][0], expected, rtol=1E-3)
 
         # splitting in point sources
         [[mps1, mps2]] = groups
         psources = list(mps1) + list(mps2)
         hcurves = calc_hazard_curves(psources, sitecol, imtls, gsim_by_trt)
-        npt.assert_allclose(hcurves['PGA'][0], expected, rtol=3E-4)
+        npt.assert_allclose(hcurves['PGA'][0], expected, rtol=4E-3)

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -229,9 +229,9 @@ class MixtureModelGMPETestCase(unittest.TestCase):
                                 -19.36079032, -20.57460101, -21.64201335])
         expected = numpy.around(expected, 5)
         hcm_lnpga = numpy.around(numpy.log(hcm["PGA"].flatten()), 5)
-        perc_diff = 100.0 * ((hcm_lnpga / expected) - 1.0)
-        numpy.testing.assert_allclose(perc_diff, numpy.zeros(len(perc_diff)),
-                                      atol=0.04)
+        rel_diff = ((hcm_lnpga / expected) - 1.0)
+        okdiff = rel_diff[numpy.isfinite(rel_diff)]
+        assert (okdiff < .03).all()
 
 
 # an area source with 388 point sources and 4656 ruptures


### PR DESCRIPTION
Finally, after many failed attempt in the last years. This works only for the rates produced by regular sources (i.e. non-mutex, non-cluster) but it is good enough. Here is performance.zip on my machine:
```
# before
| calc_40823, maxmem=24.3 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 7_058    | 77.6055   | 32        |
| get_poes                   | 4_499    | 0.0       | 1_072_198 |
| computing mean_std         | 1_264    | 0.0       | 21_444    |
| ClassicalCalculator.run    | 485.8    | 0.0       | 1         |

# after
| calc_40822, maxmem=15.7 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 6_774    | 77.4180   | 32        |
| get_poes                   | 4_425    | 0.0       | 1_072_198 |
| computing mean_std         | 1_219    | 0.0       | 21_444    |
| ClassicalCalculator.run    | 459.2    | 62.6562   | 1         |
```
We are saving a lot of RAM (less than 1 GB per thread) and we are slightly faster too.