### PR TITLE
Looping by gsim in `gen_poes`

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -32,7 +32,7 @@ from openquake.baselib import (
 from openquake.baselib.general import (
     AccumDict, DictArray, block_splitter, groupby, humansize)
 from openquake.hazardlib import valid, InvalidFile
-from openquake.hazardlib.contexts import read_cmakers, get_maxsize
+from openquake.hazardlib.contexts import read_cmakers
 from openquake.hazardlib.calc.hazard_curve import classical as hazclassical
 from openquake.hazardlib.calc import disagg
 from openquake.hazardlib.map_array import MapArray, rates_dt
@@ -44,6 +44,7 @@ U32 = numpy.uint32
 F32 = numpy.float32
 F64 = numpy.float64
 I64 = numpy.int64
+TWO20 = 2 ** 20
 TWO24 = 2 ** 24
 TWO32 = 2 ** 32
 BUFFER = 1.5  # enlarge the pointsource_distance sphere to fix the weight;
@@ -426,10 +427,7 @@ class ClassicalCalculator(base.HazardCalculator):
         assuming all sites are affected (upper limit)
         """
         num_gs = [len(cm.gsims) for cm in self.cmakers]
-        max_gs = max(num_gs)
-        maxsize = get_maxsize(len(self.oqparam.imtls), max_gs)
-        logging.info('Considering {:_d} contexts at once'.format(maxsize))
-        size = max_gs * N * L * 4
+        size = max(num_gs) * N * L * 4
         avail = min(psutil.virtual_memory().available, config.memory.limit)
         if avail < size:
             raise MemoryError(

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1108,8 +1108,8 @@ class ContextMaker(object):
 
         with self.poe_mon:
             poes = numpy.zeros((len(ctx), M*L1), F32)
-            ms, ps = mean_stdt.nbytes / TWO20, poes.nbytes / TWO20
-            print('C=%d, mean_stds=%.1fM, poes=%.1fM' % (len(ctx), ms, ps))
+            #ms, ps = mean_stdt.nbytes / TWO20, poes.nbytes / TWO20
+            #print('C=%d, mean_stds=%.1fM, poes=%.1fM' % (len(ctx), ms, ps))
             # making plenty of slices so that the array `poes` is small
             for slc in split_in_slices(len(ctx), split):
                 # this is allocating at most a few MB of RAM
@@ -1502,14 +1502,7 @@ class PmapMaker(object):
                     # needed for Disaggregator.init
                     ctx.src_id = valid.fragmentno(src)
                 self.rupdata.append(ctx)
-            n = ctx.nbytes // self.maxsize
-            if n > 1:
-                print(f'{n=}')
-                # split in chunks of maxsize each
-                for c in numpy.array_split(ctx, n):
-                    yield c  # for EUR c has ~500 elements
-            else:
-                yield ctx
+            yield ctx
 
     def _make_src_indep(self):
         # sources with the same ID

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -165,53 +165,46 @@ def get_lvl(hcurve, imls, poe):
 
 t = numba.types
 sig_i = t.void(t.float32[:, :, :],                     # pmap
-               t.float32[:, :, :],                     # poes
+               t.float32[:, :],                        # poes
                t.uint32[:],                            # invs
                t.float64[:],                           # rates
                t.float64[:, :],                        # probs_occur
                t.uint32[:],                            # sids
-               t.float64)                              # itime
-
+               t.float64,                              # itime
+               t.int64)                                # g
 sig_m = t.void(t.float32[:, :, :],                     # pmap
-               t.float32[:, :, :],                     # poes
+               t.float32[:, :],                        # poes
                t.uint32[:],                            # invs
                t.float64[:],                           # rates
                t.float64[:, :],                        # probs_occur
                t.float64[:],                           # weights
                t.uint32[:],                            # sids
-               t.float64)                              # itime
+               t.float64,                              # itime
+               t.int64)                                # g
 
 
 @compile(sig_i)
-def update_pmap_i(arr, poes, inv, rates, probs_occur, sidxs, itime):
-    G = arr.shape[2]
-    for i, rate, probs, sidx in zip(inv, rates, probs_occur, sidxs):
-        no_probs = len(probs) == 0
-        for g in range(G):
-            if no_probs:
-                arr[sidx, :, g] *= numpy.exp(-rate * poes[i, :, g] * itime)
-            else:  # nonparametric rupture
-                arr[sidx, :, g] *= get_pnes(rate, probs, poes[i, :, g], itime)  # shape L
-
-
-@compile(sig_i)
-def update_pmap_r(arr, poes, inv, rates, probs_occur, sidxs, itime):
-    G = arr.shape[2]
+def update_pmap_i(arr, poes, inv, rates, probs_occur, sidxs, itime, g):
     for i, rate, probs, sidx in zip(inv, rates, probs_occur, sidxs):
         if len(probs) == 0:
-            for g in range(G):
-                arr[sidx, :, g] += rate * poes[i, :, g] * itime
+            arr[sidx, :, g] *= numpy.exp(-rate * poes[i] * itime)
         else:  # nonparametric rupture
-            for g in range(G):
-                arr[sidx, :, g] += -numpy.log(get_pnes(rate, probs, poes[i, :, g], itime))
+            arr[sidx, :, g] *= get_pnes(rate, probs, poes[i], itime)  # shape L
+
+
+@compile(sig_i)
+def update_pmap_r(arr, poes, inv, rates, probs_occur, sidxs, itime, g):
+    for i, rate, probs, sidx in zip(inv, rates, probs_occur, sidxs):
+        if len(probs) == 0:
+            arr[sidx, :, g] += rate * poes[i] * itime
+        else:  # nonparametric rupture
+            arr[sidx, :, g] += -numpy.log(get_pnes(rate, probs, poes[i], itime))
 
 
 @compile(sig_m)
-def update_pmap_m(arr, poes, inv, rates, probs_occur, weights, sidxs, itime):
-    G = arr.shape[2]
+def update_pmap_m(arr, poes, inv, rates, probs_occur, weights, sidxs, itime, g):
     for i, rate, probs, w, sidx in zip(inv, rates, probs_occur, weights, sidxs):
-        for g in range(G):
-            arr[sidx, :, g] += (1. - get_pnes(rate, probs, poes[i, :, g], itime)) * w
+        arr[sidx, :, g] += (1. - get_pnes(rate, probs, poes[i], itime)) * w
 
 
 def fix_probs_occur(probs_occur):
@@ -383,18 +376,18 @@ class MapArray(object):
         arr = self.to_rates().to_array()
         return pandas.DataFrame({name: arr[name] for name in arr.dtype.names})
 
-    def update_indep(self, poes, invs, ctxt, itime):
+    def update_indep(self, poes, invs, ctxt, itime, g):
         """
         Update probabilities for independent ruptures
         """
         rates = ctxt.occurrence_rate
         sidxs = self.sidx[ctxt.sids]
         if self.rates:
-            update_pmap_r(self.array, poes, invs, rates, ctxt.probs_occur, sidxs, itime)
+            update_pmap_r(self.array, poes, invs, rates, ctxt.probs_occur, sidxs, itime, g)
         else:
-            update_pmap_i(self.array, poes, invs, rates, ctxt.probs_occur, sidxs, itime)
+            update_pmap_i(self.array, poes, invs, rates, ctxt.probs_occur, sidxs, itime, g)
 
-    def update_mutex(self, poes, invs, ctxt, itime, mutex_weight):
+    def update_mutex(self, poes, invs, ctxt, itime, mutex_weight, g):
         """
         Update probabilities for mutex ruptures
         """
@@ -403,7 +396,7 @@ class MapArray(object):
         sidxs = self.sidx[ctxt.sids]
         weights = numpy.array([mutex_weight[src_id, rup_id]
                                for src_id, rup_id in zip(ctxt.src_id, ctxt.rup_id)])
-        update_pmap_m(self.array, poes, invs, rates, probs_occur, weights, sidxs, itime)
+        update_pmap_m(self.array, poes, invs, rates, probs_occur, weights, sidxs, itime, g)
 
     def __invert__(self):
         return self.new(1. - self.array)


### PR DESCRIPTION
This is making the performance worse:
```
$ OQ_SAMPLE_SOURCES=.01 oq run EUR.zip 
# before
| calc_10791, maxmem=117.8 GB | time_sec | memory_mb | counts     |
|-----------------------------+----------+-----------+------------|
| total classical             | 282_441  | 55.7617   | 599        |
| get_poes                    | 174_312  | 0.0       | 41_891_918 |
| computing mean_std          | 76_456   | 0.0       | 841_819    |
| total fast_mean             | 4_497    | 355.2     | 889        |
| reading rates               | 4_347    | 355.1     | 889        |
| planar contexts             | 3_549    | 0.0       | 6_969_518  |
| ClassicalCalculator.run     | 3_126    | 450.2     | 1          |

# after
| calc_10792, maxmem=120.8 GB | time_sec | memory_mb | counts    |
|-----------------------------+----------+-----------+-----------|
| total classical             | 323_314  | 81.5195   | 599       |
| get_poes                    | 181_409  | 0.0       | 3_765_251 |
| computing mean_std          | 64_340   | 0.0       | 3_765_251 |
| total fast_mean             | 4_507    | 353.9     | 889       |
| reading rates               | 4_360    | 353.8     | 889       |
| planar contexts             | 3_684    | 0.0       | 6_969_518 |
| ClassicalCalculator.run     | 3_381    | 407.4     | 1         |
```
Abandoning the approach.