### PR TITLE
Using 32 bit floats also in `mean_stds`

### DIFF
--- a/openquake/calculators/tests/classical_damage_test.py
+++ b/openquake/calculators/tests/classical_damage_test.py
@@ -147,4 +147,4 @@ class ClassicalDamageTestCase(CalculatorTestCase):
 
         # checking custom_site_id in UHS curves
         [mean] = export(('uhs', 'csv'), self.calc.datastore)
-        self.assertEqualFiles('expected/uhs-mean.csv', mean, delta=1E-5)
+        self.assertEqualFiles('expected/uhs-mean.csv', mean, delta=2E-5)

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -49,9 +49,8 @@ intra event standard deviations.''' % (
             self.corr.__class__.__name__, self.gsim.__class__.__name__)
 
 
-@compile(["float64[:,:](float64[:,:], boolean)",
-          "float64[:](float64[:], boolean)",
-          "float64(float64, boolean)"])
+@compile(["(float32[:,:], boolean)", "(float32[:], boolean)", "(float32, boolean)",
+          "(float64[:,:], boolean)", "(float64[:], boolean)", "(float64, boolean)"])
 def exp(vals, notMMI):
     """
     Exponentiate the values unless the IMT is MMI

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -326,7 +326,7 @@ class GmfComputer(object):
             if mean_stds is None:
                 with mmon:
                     ms = numpy.zeros((4, M, self.N))
-                    self.cmaker.set_MN([self.ctx], gs, ms)
+                    self.cmaker.set_ms([self.ctx], gs, ms)
             else:  # conditioned
                 ms = (mean_stds[0][g], mean_stds[1][g], mean_stds[2][g])
             with cmon:

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -316,6 +316,7 @@ class GmfComputer(object):
         conditioned = mean_stds is not None
         self.init_eid_rlz_sig_eps()
         rng = numpy.random.default_rng(self.seed)
+        M = len(self.imts)
         data = AccumDict(accum=[])
         for g, (gs, rlzs) in enumerate(self.cmaker.gsims.items()):
             idxs, = numpy.where(numpy.isin(self.rlz, rlzs))
@@ -324,7 +325,8 @@ class GmfComputer(object):
                 continue
             if mean_stds is None:
                 with mmon:
-                    ms = self.cmaker.get_4MN([self.ctx], gs)
+                    ms = numpy.zeros((4, M, self.N))
+                    self.cmaker.set_MN([self.ctx], gs, ms)
             else:  # conditioned
                 ms = (mean_stds[0][g], mean_stds[1][g], mean_stds[2][g])
             with cmon:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -521,7 +521,7 @@ def _build_dparam(src, sitecol, cmaker):
 # the only way to speedup is to reduce the maximum_distance, then the array
 # will become shorter in the N dimension (number of affected sites), or to
 # collapse the ruptures, then truncnorm_sf will be called less times
-@compile("(float64[:,:,:], float64[:,:], float64, float32[:,:])")
+@compile("(float32[:,:,:], float64[:,:], float64, float32[:,:])")
 def _set_poes(mean_std, loglevels, phi_b, out):
     L1 = loglevels.size // len(loglevels)
     for m, levels in enumerate(loglevels):
@@ -1192,7 +1192,7 @@ class ContextMaker(object):
             pmap.update_mutex(poes, invs, ctxt, tom.time_span, rup_mutex)
 
     # called by gen_poes and by the GmfComputer
-    def get_mean_stds(self, ctxs, split_by_mag=True, outputs=4):
+    def get_mean_stds(self, ctxs, split_by_mag=True):
         """
         :param ctxs: a list of contexts with N=sum(len(ctx) for ctx in ctxs)
         :param split_by_mag: where to split by magnitude
@@ -1201,7 +1201,7 @@ class ContextMaker(object):
         N = sum(len(ctx) for ctx in ctxs)
         M = len(self.imts)
         G = len(self.gsims)
-        out = numpy.zeros((outputs, G, M, N))
+        out = numpy.zeros((4, G, M, N), F32)
         if all(isinstance(ctx, numpy.recarray) for ctx in ctxs):
             # contexts already vectorized
             recarrays = ctxs

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1212,10 +1212,10 @@ class ContextMaker(object):
                 recarrays, dtype=recarrays[0].dtype).view(numpy.recarray)
             recarrays = split_array(recarr, U32(numpy.round(recarr.mag*100)))
         for g, gsim in enumerate(self.gsims):
-            self.set_MN(recarrays, gsim, out[:, g])
+            self.set_ms(recarrays, gsim, out[:, g])
         return out
 
-    def set_MN(self, ctxs, gsim, out):
+    def set_ms(self, ctxs, gsim, out):
         """
         Called by the GmfComputer
         """

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -528,7 +528,7 @@ def _set_poes(mean_std, loglevels, phi_b, out):
         mL1 = m * L1
         mea, std = mean_std[:, m]  # shape N
         for lvl, iml in enumerate(levels):
-            out[mL1 + lvl] = truncnorm_sf(phi_b, (iml - mea) / std)
+            out[mL1 + lvl] = truncnorm_sf(phi_b, (F32(iml) - mea) / std)
 
 # ############################ ContextMaker ############################### #
 
@@ -1404,7 +1404,7 @@ def set_poes(gsim, mean_std, cmaker, ctx, out, slc):
         outs = []
         weights, signs = zip(*gsim.weights_signs)
         for s in signs:
-            ms = numpy.array(mean_std)  # make a copy
+            ms = mean_std.copy()
             for m in range(len(loglevels)):
                 ms[0, m] += s * adj
             outs.append(_get_poes(ms, loglevels, phi_b))
@@ -1467,7 +1467,7 @@ class PmapMaker(object):
                 src.temporal_occurrence_model = FatedTOM(time_span=1)
 
         M, G = len(self.cmaker.imtls), len(self.cmaker.gsims)
-        self.maxsize = 8 * TWO20 // (M*G)  # crucial for a fast get_mean_stds
+        self.maxsize = 6 * TWO20 // (M*G)  # crucial for a fast get_mean_stds
 
     def count_bytes(self, ctxs):
         # # usuful for debugging memory issues

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -521,7 +521,7 @@ def _build_dparam(src, sitecol, cmaker):
 # the only way to speedup is to reduce the maximum_distance, then the array
 # will become shorter in the N dimension (number of affected sites), or to
 # collapse the ruptures, then truncnorm_sf will be called less times
-@compile("(float32[:,:,:], float64[:,:], float64, float32[:,:])")
+@compile("(float32[:,:,:], float64[:,:], float32, float32[:,:])")
 def _set_poes(mean_std, loglevels, phi_b, out):
     L1 = loglevels.size // len(loglevels)
     for m, levels in enumerate(loglevels):
@@ -615,7 +615,7 @@ class ContextMaker(object):
         self.ses_seed = param.get('ses_seed', 42)
         self.ses_per_logic_tree_path = param.get('ses_per_logic_tree_path', 1)
         self.truncation_level = param.get('truncation_level', 99.)
-        self.phi_b = ndtr(self.truncation_level)
+        self.phi_b = F32(ndtr(self.truncation_level))
         self.num_epsilon_bins = param.get('num_epsilon_bins', 1)
         self.disagg_bin_edges = param.get('disagg_bin_edges', {})
         self.ps_grid_spacing = param.get('ps_grid_spacing')

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -521,14 +521,14 @@ def _build_dparam(src, sitecol, cmaker):
 # the only way to speedup is to reduce the maximum_distance, then the array
 # will become shorter in the N dimension (number of affected sites), or to
 # collapse the ruptures, then truncnorm_sf will be called less times
-@compile("(float32[:,:,:], float64[:,:], float32, float32[:,:])")
+@compile("(float32[:,:,:], float32[:,:], float32, float32[:,:])")
 def _set_poes(mean_std, loglevels, phi_b, out):
     L1 = loglevels.size // len(loglevels)
     for m, levels in enumerate(loglevels):
         mL1 = m * L1
         mea, std = mean_std[:, m]  # shape N
         for lvl, iml in enumerate(levels):
-            out[mL1 + lvl] = truncnorm_sf(phi_b, (F32(iml) - mea) / std)
+            out[mL1 + lvl] = truncnorm_sf(phi_b, (iml - mea) / std)
 
 # ############################ ContextMaker ############################### #
 
@@ -1396,7 +1396,7 @@ def set_poes(gsim, mean_std, cmaker, ctx, out, slc):
         float number, and if ``imts`` dictionary contain wrong or
         unsupported IMTs (see :attr:`DEFINED_FOR_INTENSITY_MEASURE_TYPES`).
     """
-    loglevels = cmaker.loglevels.array
+    loglevels = F32(cmaker.loglevels.array)
     phi_b = cmaker.phi_b
     _M, L1 = loglevels.shape
     if hasattr(gsim, 'weights_signs'):  # for nshmp_2014, case_72

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -35,8 +35,7 @@ except ImportError:
     from scipy.special import ndtr
 
 
-@compile(["float64[:,:](float64, float32[:,:])",
-          "float64[:](float64, float32[:])"])
+@compile(["(float32, float32[:,:])", "(float32, float32[:])"])
 def truncnorm_sf(phi_b, values):
     """
     Fast survival function for truncated normal distribution.

--- a/openquake/hazardlib/stats.py
+++ b/openquake/hazardlib/stats.py
@@ -35,8 +35,8 @@ except ImportError:
     from scipy.special import ndtr
 
 
-@compile(["float64[:,:](float64, float64[:,:])",
-          "float64[:](float64, float64[:])"])
+@compile(["float64[:,:](float64, float32[:,:])",
+          "float64[:](float64, float32[:])"])
 def truncnorm_sf(phi_b, values):
     """
     Fast survival function for truncated normal distribution.


### PR DESCRIPTION
This is giving a bit more performance:
```
# before
| calc_61774, maxmem=14.4 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 6_115    | 75.5703   | 32        |
| get_poes                   | 4_032    | 0.0       | 1_072_198 |
| computing mean_std         | 1_128    | 0.0       | 21_444    |
| ClassicalCalculator.run    | 417.4    | 60.0078   | 1         |

# after
| calc_61773, maxmem=14.7 GB | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 5_846    | 51.9258   | 32        |
| get_poes                   | 3_873    | 0.0       | 1_419_998 |
| computing mean_std         | 1_044    | 0.0       | 28_400    |
| ClassicalCalculator.run    | 399.7    | 63.4023   | 1         |
```