### PR TITLE
Fix warning when starting from an old calculation

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -376,7 +376,7 @@ def run_jobs(jobctxs, concurrent_jobs=None):
                     # here the logger is not initialized yet
                     print('Starting from a hazard (%d) computed with'
                           ' an obsolete version of the engine: %s' %
-                          (hc_id, version))
+                          (hc_id, prev_version))
     jobarray = len(jobctxs) > 1 and jobctxs[0].multi
     try:
         poll_queue(jobctxs[0].calc_id, poll_time=15)


### PR DESCRIPTION
The warning added in #7909 prints the current version number of the engine in the message about starting from an old version, instead of the old version number. Fixed to print the old version number in this PR.