### PR TITLE
Added maximum_distance=magdist feature

### DIFF
--- a/doc/user-guide/extras/faq.rst
+++ b/doc/user-guide/extras/faq.rst
@@ -303,6 +303,32 @@ model on a computer with an i7 processor you will see something like this::
 The estimate is rather rough, so do not take it at the letter. The runtime can be reduced by orders of magnitude by
 tuning parameters like the ``pointsource_distance`` and ``ps_grid_spacing``, discussed at length in the advanced manual.
 
+****************************************************
+Are hazard maps and uniform hazard spectra reliable?
+****************************************************
+
+There is a situation were hazard maps and uhs are TOTALLY UNRELIABLE
+and there is nothing you can do about it. This happens for *low hazard sites*,
+i.e. sites where the hazard curve is all below the reference `poe` used
+to compute the hazard map. By definition, in this case the hazard map
+is zero and the UHS contains at least a point of zero value. This
+situation is very instable numerically: it is enough to slightly
+increase the `maximum_distance` and a rupture that before was
+discarded can give a small contribution, produce a hazard curve over
+the reference `poe` and therefore a nonzero hazard map value.  The
+same will happen if you change the geometry discretization step or the
+magnitude step. Low hazard curves, in the region of small intensities,
+are very sensitive to small changes in the parameters and therefore
+cannot be reliably computed. This is unavoidable, low intensities are
+affected by far away ruptures and low magnitude ruptures, and
+therefore very sensitive to the way the engine (or the hazard modeler)
+cuts such ruptures. Luckily, this has no practical effect on the risk,
+since the assets on sites of low hazard are not subjected to
+damages. Still, the hazard scientist must be aware that hazard maps
+and uniform hazard spectra cannot be trusted when the corresponding
+hazard curves are below or close the reference `poe` in the low intensity
+region.
+
 *************************************************
 How should I interpret the "Realizations" output?
 *************************************************

--- a/doc/user-guide/extras/faq.rst
+++ b/doc/user-guide/extras/faq.rst
@@ -318,7 +318,7 @@ world, however, there is minimum magnitude and there is a
 finite maximum distance, so ruptures are discarded from the
 calculation. If enough ruptures are discarded, the probability of
 exceedence will stay under 1, no matter how small the intensity is.
-The hazard curve is given by the formula
+For poissonian curves the hazard curve is given by the formula
 
 .. math::
 

--- a/doc/user-guide/extras/faq.rst
+++ b/doc/user-guide/extras/faq.rst
@@ -307,27 +307,29 @@ tuning parameters like the ``pointsource_distance`` and ``ps_grid_spacing``, dis
 Are hazard maps and uniform hazard spectra reliable?
 ****************************************************
 
-There is a situation were hazard maps and uhs are TOTALLY UNRELIABLE
-and there is nothing you can do about it. This happens for *low hazard sites*,
-i.e. sites where the hazard curve is all below the reference `poe` used
-to compute the hazard map. By definition, in this case the hazard map
-is zero and the UHS contains at least a point of zero value. This
-situation is very instable numerically: it is enough to slightly
-increase the `maximum_distance` and a rupture that before was
-discarded can give a small contribution, produce a hazard curve over
-the reference `poe` and therefore a nonzero hazard map value.  The
-same will happen if you change the geometry discretization step or the
-magnitude step. Low hazard curves, in the region of small intensities,
-are very sensitive to small changes in the parameters and therefore
-cannot be reliably computed. This is unavoidable, low intensities are
-affected by far away ruptures and low magnitude ruptures, and
-therefore very sensitive to the way the engine (or the hazard modeler)
-cuts such ruptures. Luckily, this has no practical effect on the risk,
-since the assets on sites of low hazard are not subjected to
-damages. Still, the hazard scientist must be aware that hazard maps
-and uniform hazard spectra cannot be trusted when the corresponding
-hazard curves are below or close the reference `poe` in the low intensity
-region.
+Users should be aware that there is a situation were hazard maps and
+uhs are TOTALLY UNRELIABLE and there is nothing you can do about
+it. This happens for *low hazard sites*, i.e. sites where the hazard
+curve is all below the reference `poe` used to compute the hazard
+map. By definition, in this case the hazard map is zero and the UHS
+contains at least a point of zero value. This situation is very
+instable numerically: it is enough to slightly increase the
+`maximum_distance` and a rupture that before was discarded can give a
+small contribution, produce a hazard curve over the reference `poe`
+and therefore a nonzero hazard map value.  The same will happen if you
+change the geometry discretization step or the magnitude step. It is
+even worse than that. Low hazard curves, in the region of small intensities,
+tend to be flat, so even if the curve is slightly over the reference poe,
+a small change to the curve will correspond to a huge
+change in the intensity and therefore the hazard maps cannot be reliably
+computed. This is unavoidable, low intensities are affected by far
+away ruptures and low magnitude ruptures, and therefore very sensitive
+to the way the engine (or the hazard modeler) cuts such
+ruptures. Luckily, this has no practical effect on the risk, since the
+assets on sites of low hazard are subjected to very low damages. Still, the
+hazard scientist must be aware that hazard maps and uniform hazard
+spectra cannot be trusted when the corresponding hazard curves are
+below or close to the reference `poe` in the low intensity region.
 
 *************************************************
 How should I interpret the "Realizations" output?

--- a/doc/user-guide/extras/faq.rst
+++ b/doc/user-guide/extras/faq.rst
@@ -304,32 +304,62 @@ The estimate is rather rough, so do not take it at the letter. The runtime can b
 tuning parameters like the ``pointsource_distance`` and ``ps_grid_spacing``, discussed at length in the advanced manual.
 
 ****************************************************
-Are hazard maps and uniform hazard spectra reliable?
+Is the hazard reliable for all sites?
 ****************************************************
 
-Users should be aware that there is a situation were hazard maps and
-uhs are TOTALLY UNRELIABLE and there is nothing you can do about
-it. This happens for *low hazard sites*, i.e. sites where the hazard
-curve is all below the reference `poe` used to compute the hazard
-map. By definition, in this case the hazard map is zero and the UHS
-contains at least a point of zero value. This situation is very
+Users should be aware that there is a situation were hazard curves
+are necessarily **unreliable**, i.e. very sensitive to small variations
+in parameters such as the maximum distance and the minimum magnitude.
+
+This happens when the low intensity part of the hazard curves is
+well below 1. In an ideal world, for extremely small intensities
+the probability of exceedence should tend to one; in the real
+world, however, there is minimum magnitude and there is a
+finite maximum distance, so ruptures are discarded from the
+calculation. If enough ruptures are discarded, the probability of
+exceedence will stay under 1, no matter how small the intensity is.
+The hazard curve is given by the formula
+
+.. math::
+
+  poe(iml) = 1 - e^{-(Σ r_i p_i(iml)) t}
+
+where the sum is over the ruptures, :math:`r_i` is the occurrence rate,
+:math:`p_i(iml)` is the probability of exceeding the intensity level
+:math:`iml` and :math:`t` is the investigation time. For low
+intensities the probabilities :math:`p_i(iml)` are at most 1
+and the maximum poe can be approximated with
+
+.. math::
+
+  poe_{max} ~ (Σ r_i) t
+
+which can be much smaller than 1 if the occurrence rate times the
+investigation time is small and there are not many ruptures.  In this
+situation a small change in the maximum distance or the minimum
+magnitude can cause a large variation in the number of ruptures and
+therefore a large change in :math:`poe_{max}`.  The worst case is when
+:math:`poe_{max}` is below the reference `poe` used to compute the
+hazard map. By definition, in this case the hazard map is zero and the
+UHS contains at least a point of zero value. This situation is very
 instable numerically: it is enough to slightly increase the
 `maximum_distance` and a rupture that before was discarded can give a
 small contribution, produce a hazard curve over the reference `poe`
 and therefore a nonzero hazard map value.  The same will happen if you
 change the geometry discretization step or the magnitude step. It is
-even worse than that. Low hazard curves, in the region of small intensities,
-tend to be flat, so even if the curve is slightly over the reference poe,
-a small change to the curve will correspond to a huge
-change in the intensity and therefore the hazard maps cannot be reliably
-computed. This is unavoidable, low intensities are affected by far
-away ruptures and low magnitude ruptures, and therefore very sensitive
-to the way the engine (or the hazard modeler) cuts such
+even worse than that. Low hazard curves, in the region of small
+intensities, tend to be flat, so even if the curve is slightly over
+the reference poe, a small change to the curve will correspond to a
+huge change in the intensity and therefore the hazard maps cannot be
+reliably computed. This is unavoidable, low intensities are affected
+by far away ruptures and low magnitude ruptures, and therefore very
+sensitive to the way the engine (or the hazard modeler) cuts such
 ruptures. Luckily, this has no practical effect on the risk, since the
-assets on sites of low hazard are subjected to very low damages. Still, the
-hazard scientist must be aware that hazard maps and uniform hazard
-spectra cannot be trusted when the corresponding hazard curves are
-below or close to the reference `poe` in the low intensity region.
+assets on sites of low hazard are subjected to very low
+damages. Still, the hazard scientist must be aware that hazard maps
+and uniform hazard spectra cannot be trusted when the corresponding
+hazard curves are below or close to the reference `poe` in the low
+intensity region.
 
 *************************************************
 How should I interpret the "Realizations" output?

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1531,7 +1531,7 @@ def extract_high_sites(dstore, what):
     """
     max_poe = max(dstore['oqparam'].poes)
     max_hazard = dstore.sel('hcurves-stats', stat='mean', lvl=0)[:, 0, :, 0]  # NSML1 -> NM
-    return (max_hazard > max_poe).all(axis=1)  # shape N
+    return (max_hazard > max_poe * 1.02).all(axis=1)  # shape N
 
 
 # #####################  extraction from the WebAPI ###################### #

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1521,8 +1521,20 @@ def extract_med_gmv(dstore, what):
     """
     return extract_(dstore, 'med_gmv/' + what)
 
-# #####################  extraction from the WebAPI ###################### #
 
+@extract.add('high_sites')
+def extract_high_sites(dstore, what):
+    """
+    Returns an array of boolean with the high hazard sites (poe > max_poe)
+    Example:
+    http://127.0.0.1:8800/v1/calc/30/extract/high_sites
+    """
+    max_poe = max(dstore['oqparam'].poes)
+    max_hazard = dstore.sel('hcurves-stats', stat='mean', lvl=0)[:, 0, :, 0]  # NSML1 -> NM
+    return (max_hazard > max_poe).all(axis=1)  # shape N
+
+
+# #####################  extraction from the WebAPI ###################### #
 
 class WebAPIError(RuntimeError):
     """

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1525,13 +1525,12 @@ def extract_med_gmv(dstore, what):
 @extract.add('high_sites')
 def extract_high_sites(dstore, what):
     """
-    Returns an array of boolean with the high hazard sites (poe > max_poe)
+    Returns an array of boolean with the high hazard sites (max_poe > .2)
     Example:
     http://127.0.0.1:8800/v1/calc/30/extract/high_sites
     """
-    max_poe = max(dstore['oqparam'].poes)
     max_hazard = dstore.sel('hcurves-stats', stat='mean', lvl=0)[:, 0, :, 0]  # NSML1 -> NM
-    return (max_hazard > max_poe * 1.02).all(axis=1)  # shape N
+    return (max_hazard > .2).all(axis=1)  # shape N
 
 
 # #####################  extraction from the WebAPI ###################### #

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -233,6 +233,17 @@ def text_table(data, header=None, fmt=None, ext='rst'):
             lines.append(sepline)
     return '\n'.join(lines)
 
+@view.add('high_hazard')
+def view_high_hazard(token, dstore):
+    """
+    Returns the sites with hazard curve below max(poes)
+    """
+    oq = dstore['oqparam']
+    max_poe= max(oq.poes)
+    max_hazard = dstore.sel('hcurves-stats', stat='mean', lvl=0)[:, 0, :, 0]  # NSML1 -> NM
+    high = (max_hazard > max_poe).all(axis=1)
+    return max_hazard[high]
+
 
 @view.add('worst_sources')
 def view_worst_sources(token, dstore):

--- a/openquake/commands/compare.py
+++ b/openquake/commands/compare.py
@@ -156,7 +156,7 @@ class Comparator(object):
         if len(diff_idxs) == 0:
             print('There are no differences within the tolerances '
                   'atol=%s, rtol=%d%%, sids=%s' % (atol, rtol * 100, sids))
-            sys.exit(0)
+            return (), ()
         arr = arrays.transpose(1, 0, 2)  # shape (N, C, L)
         for sid, array in sorted(zip(sids[diff_idxs], arr[diff_idxs])):
             # each array has shape (C, L)

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -47,6 +47,8 @@ def make_figure_magdist(extractors, what):
     grp = ex.dstore['source_mags']
     ax.set_xlabel('magnitude')
     ax.set_ylabel('distance')
+    ax.set_xlim(4, 10)
+    ax.set_ylim(0, 600)
     for trt in grp:
         magdist = ex.oqparam.maximum_distance(trt)
         mags = numpy.float64(grp[trt][:])
@@ -54,8 +56,6 @@ def make_figure_magdist(extractors, what):
         ax.plot(mags, dsts, '-', label=trt)
         ax.grid(True)
         ax.legend()
-    ax.set_xlim(mags.min() - .1, mags.max() + .1)
-    ax.set_ylim(0, dsts.max() + 10)
     return plt
 
 def make_figure_hcurves(extractors, what):

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -545,7 +545,7 @@ class EngineRunJobTestCase(unittest.TestCase):
         with Print.patch() as p:
             sap.runline('openquake.commands compare uhs -2 -3')
         print(p)
-        self.assertIn('rms-diff', str(p))
+        self.assertIn('There are no differences', str(p))
         # testing different sitecols
         with read(-1, 'r+') as ds1:
             sitecol = ds1['sitecol']

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -207,7 +207,7 @@ class IntegrationDistance(dict):
         {'default': [(2.5, 50), (10.2, 50)]}
         """
         if value == 'magdist':
-            items_by_trt = {'default': [(3, 0), (6, 200), (10, 600)]}
+            items_by_trt = {'default': [(3, 0), (6, 150), (10, 600)]}
         else:
             items_by_trt = floatdict(value)
         self = cls()

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -207,7 +207,7 @@ class IntegrationDistance(dict):
         {'default': [(2.5, 50), (10.2, 50)]}
         """
         if value == 'magdist':
-            items_by_trt = {'default': [(MINMAG, 0), (5, 100), (MAXMAG, 700)]}
+            items_by_trt = {'default': [(3, 0), (6, 200), (10, 600)]}
         else:
             items_by_trt = floatdict(value)
         self = cls()

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -206,7 +206,10 @@ class IntegrationDistance(dict):
         >>> md
         {'default': [(2.5, 50), (10.2, 50)]}
         """
-        items_by_trt = floatdict(value)
+        if value == 'magdist':
+            items_by_trt = {'default': [(MINMAG, 0), (5, 100), (MAXMAG, 700)]}
+        else:
+            items_by_trt = floatdict(value)
         self = cls()
         for trt, items in items_by_trt.items():
             if isinstance(items, list):

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -692,8 +692,9 @@ class CompositeSourceModel:
             grp = self.src_groups[cmaker.grp_id]
             nsplits = general.ceil(max(size_gb / max_gb, grp.weight / max_weight))
             if oq.split_by_gsim:
+                nsplits /= 2  # generate less tasks
                 for cm in self._split(cmaker, nsplits):
-                    n = .5 * nsplits * len(cm.gsims) / len(cmaker.gsims)
+                    n = nsplits * len(cm.gsims) / len(cmaker.gsims)
                     for sites in sitecol.split(n, minsize=oq.max_sites_disagg):
                         yield cm, sites
             else:  # regular tiling

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -693,7 +693,7 @@ class CompositeSourceModel:
             nsplits = general.ceil(max(size_gb / max_gb, grp.weight / max_weight))
             if oq.split_by_gsim:
                 for cm in self._split(cmaker, nsplits):
-                    n = nsplits * len(cm.gsims) / len(cmaker.gsims)
+                    n = .5 * nsplits * len(cm.gsims) / len(cmaker.gsims)
                     for sites in sitecol.split(n, minsize=oq.max_sites_disagg):
                         yield cm, sites
             else:  # regular tiling

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -692,7 +692,7 @@ class CompositeSourceModel:
             grp = self.src_groups[cmaker.grp_id]
             nsplits = general.ceil(max(size_gb / max_gb, grp.weight / max_weight))
             if oq.split_by_gsim:
-                nsplits /= 2  # generate less tasks
+                nsplits *= .75  # generate less tasks
                 for cm in self._split(cmaker, nsplits):
                     n = nsplits * len(cm.gsims) / len(cmaker.gsims)
                     for sites in sitecol.split(n, minsize=oq.max_sites_disagg):


### PR DESCRIPTION
For experimentation purposes, off by default. It double the speed of classical calculations without changing the stable numbers. Added an FAQ with an explanation of the unstable numbers, when the hazard is strongly dependent on the cutting of the ruptures.