### PR TITLE
Implemented partial tiling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Refined the tiling calculator (partial tiling)
   * Optimized "computing pnes" in classical calculations (3x in the common case)
     and fully switched to 32 bit rates, thus saving memory and improving performance
 

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -172,12 +172,10 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     oq = cmakers[0].oq
     max_weight = csm.get_max_weight(oq)
     max_gb = float(config.memory.pmap_max_gb)
-    max_mb = float(config.memory.pmap_max_mb)
     req_gb, trt_rlzs, gids = getters.get_pmaps_gb(dstore, csm.full_lt)
     fac = oq.imtls.size * N * 4 / 1024**3
-    sizes = [len(cm.gsims) * fac for cm in cmakers]
-    ok = req_gb < max_gb and max(sizes) < max_mb / 1024
-    regular = ok or oq.disagg_by_src or N < oq.max_sites_disagg or oq.tile_spec
+    regular = (req_gb < max_gb or oq.disagg_by_src or
+               N < oq.max_sites_disagg or oq.tile_spec)
     tiles = numpy.array(
         [(cm.grp_id, len(cm.gsims), len(tile), len(cm.gsims)*fac*len(tile)/N)
          for cm, tile in csm.split(cmakers, sitecol, max_weight)],


### PR DESCRIPTION
Useful in medium sized calculations, avoids the excessive time spent building the contexts in full tiling. Here are the numbers for USA on the spot machine (see also the 11x speedup in `iter_ruptures`):
```
# spot, full tiling
| calc_25, maxmem=94.4 GB    | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 17_435   | 167.0156  | 152       |
| get_poes                   | 6_145    | 0.0       | 1_480_978 |
| computing mean_std         | 5_276    | 0.0       | 32_436    |
| planar contexts            | 2_776    | 0.0       | 8_632_001 |
| total postclassical        | 892.2    | 333.2     | 57        |
| iter_ruptures              | 863.5    | 0.0       | 392_217   |

# spot, partial tiling
| calc_26, maxmem=90.2 GB    | time_sec | memory_mb | counts    |
|----------------------------+----------+-----------+-----------|
| total classical            | 13_661   | 205.3     | 174       |
| get_poes                   | 5_959    | 0.0       | 1_311_354 |
| computing mean_std         | 4_886    | 0.0       | 27_278    |
| total postclassical        | 935.8    | 519.1     | 57        |
| planar contexts            | 150.4495 | 0.0       | 322_152   |
| iter_ruptures              | 78.5344  | 0.0       | 10_741    |
```