### PR TITLE
Saving memory in the classical calculator by reducing the size of the .rmap

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -497,7 +497,7 @@ class ClassicalCalculator(base.HazardCalculator):
         oq = self.oqparam
         L = oq.imtls.size
         Gt = len(self.trt_rlzs)
-        self.rmap = MapArray(self.sitecol.sids, L, Gt).fill(0)
+        self.rmap = MapArray(self.sitecol.sids, L, Gt)
         allargs = []
         if 'sitecol' in self.datastore.parent:
             ds = self.datastore.parent
@@ -516,6 +516,7 @@ class ClassicalCalculator(base.HazardCalculator):
             sg = self.csm.src_groups[cm.grp_id]
             cm.rup_indep = getattr(sg, 'rup_interdep', None) != 'mutex'
             cm.save_on_tmp = config.distribution.save_on_tmp
+            cm.num_chunks = self.num_chunks
             if sg.atomic or sg.weight <= maxw:
                 blks = [sg]
             else:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -354,12 +354,15 @@ class ClassicalCalculator(base.HazardCalculator):
         if source_id:
             # accumulate the rates for the given source
             acc[source_id] += self.haz.get_rates(rmap, grp_id)
-        if rmap is None:  # already stored in the workers
+        if rmap is None:
+            # already stored in the workers, case_22
             pass
         elif dic.get('allsources'):
+            # store the rates directly, case_03
             self.store(rmap.to_array(rmap.gid[0]))
         else:
-            self.rmap += rmap  # add rates
+            # add the rates
+            self.rmap += rmap
         return acc
 
     def create_rup(self):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -492,8 +492,8 @@ class ClassicalCalculator(base.HazardCalculator):
         acc = AccumDict(accum=0.)  # src_id -> pmap
         oq = self.oqparam
         L = oq.imtls.size
-        Gt = len(self.trt_rlzs)
-        self.rmap = MapArray(self.sitecol.sids, L, Gt)
+        self.Gt = len(self.trt_rlzs)
+        self.rmap = MapArray(self.sitecol.sids, L, self.Gt)
         allargs = []
         if 'sitecol' in self.datastore.parent:
             ds = self.datastore.parent
@@ -531,7 +531,8 @@ class ClassicalCalculator(base.HazardCalculator):
         smap = parallel.Starmap(classical, allargs, h5=self.datastore.hdf5)
         acc = smap.reduce(self.agg_dicts, acc)
         with self.monitor('storing rates', measuremem=True):
-            self.store(self.rmap.to_array())
+            for g in range(self.Gt):
+                self.store(self.rmap.to_array(g))
         del self.rmap
         if oq.disagg_by_src:
             mrs = self.haz.store_mean_rates_by_src(acc)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -499,8 +499,8 @@ class ClassicalCalculator(base.HazardCalculator):
         acc = AccumDict(accum=0.)  # src_id -> pmap
         oq = self.oqparam
         L = oq.imtls.size
-        self.Gt = len(self.trt_rlzs)
-        self.rmap = MapArray(self.sitecol.sids, L, self.Gt)
+        Gt = len(self.trt_rlzs)
+        self.rmap = MapArray(self.sitecol.sids, L, Gt)
         allargs = []
         if 'sitecol' in self.datastore.parent:
             ds = self.datastore.parent

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -21,7 +21,7 @@ import warnings
 import numpy
 import pandas
 import numba
-from openquake.baselib.general import cached_property
+from openquake.baselib.general import cached_property, AccumDict
 from openquake.baselib.performance import compile
 from openquake.hazardlib.tom import get_pnes
 
@@ -236,6 +236,7 @@ class MapArray(object):
         self.sids = sids
         self.shape = (len(sids), shape_y, shape_z)
         self.rates = rates
+        self.acc = AccumDict(accum=numpy.zeros(self.shape[:2], F32))
 
     @cached_property
     def sidx(self):
@@ -247,9 +248,12 @@ class MapArray(object):
             idxs[sid] = idx
         return idxs
 
-    def new(self, array):
+    def new(self, acc):
         new = copy.copy(self)
-        new.array = array
+        if isinstance(acc, numpy.ndarray):
+            new.array = acc
+        else:
+            new.acc = acc
         return new
 
     def split(self):
@@ -320,7 +324,9 @@ class MapArray(object):
         """
         if self.rates:
             return self
-
+        if self.acc:
+            return self.new({g: -numpy.log(self.acc[g]) / itime
+                             for g in self.acc})
         pnes = self.array
         # Physically, an extremely small intensity measure level can have an
         # extremely large probability of exceedence,however that probability
@@ -338,13 +344,22 @@ class MapArray(object):
         Assuming self contains an array of rates,
         returns a composite array with fields sid, lid, gid, rate
         """
-        rates = self.array
-        idxs, lids, gids = rates.nonzero()
-        out = numpy.zeros(len(idxs), rates_dt)
-        out['sid'] = self.sids[idxs]
-        out['lid'] = lids
-        out['gid'] = gids + gid
-        out['rate'] = rates[idxs, lids, gids]
+        if hasattr(self, 'array') :
+            rates = self.array
+            idxs, lids, gids = rates.nonzero()
+            out = numpy.zeros(len(idxs), rates_dt)
+            out['sid'] = self.sids[idxs]
+            out['lid'] = lids
+            out['gid'] = gids + gid
+            out['rate'] = rates[idxs, lids, gids]
+        else:
+            rates = self.acc[gid]
+            idxs, lids = rates.nonzero()
+            out = numpy.zeros(len(idxs), rates_dt)
+            out['sid'] = self.sids[idxs]
+            out['lid'] = lids
+            out['gid'] = gid
+            out['rate'] = rates[idxs, lids]
         return out
 
     def interp4D(self, imtls, poes):
@@ -412,15 +427,14 @@ class MapArray(object):
         return self.new(self.array ** n)
 
     def __iadd__(self, other):
-        if not hasattr(self, 'array'):
-            self.fill(0)
         sidx = self.sidx[other.sids]
-        if hasattr(other, 'gid'):
-            G = other.array.shape[2]  # NLG
+        G = other.array.shape[2]  # NLG
+        if hasattr(self, 'array'):
             for i, g in enumerate(other.gid):
                 self.array[sidx, :, g] += other.array[:, :, i % G]
         else:
-            self.array[sidx] += other.array
+            for i, g in enumerate(other.gid):
+                self.acc[g][sidx] += other.array[:, :, i % G]
         return self
 
     def __repr__(self):

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -412,6 +412,8 @@ class MapArray(object):
         return self.new(self.array ** n)
 
     def __iadd__(self, other):
+        if not hasattr(self, 'array'):
+            self.fill(0)
         sidx = self.sidx[other.sids]
         if hasattr(other, 'gid'):
             G = other.array.shape[2]  # NLG


### PR DESCRIPTION
This is relevant for the USA model. Thanks to this optimization it is possible to skip the inefficiencies of the tiling calculator and to get a significant speedup. On the spot machine with 5% of the sites I get
```
# before
| calc_35, maxmem=325.6 GB   | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 641_709  | 1_001     | 261        |
| iter_ruptures              | 280_966  | 0.0       | 862_623    |
| nonplanar contexts         | 167_273  | 0.0       | 225_198    |
| get_poes                   | 92_612   | 0.0       | 28_485_270 |
| planar contexts            | 84_474   | 0.0       | 13_565_889 |
| computing mean_std         | 59_294   | 0.0       | 707_652    |
| building dparam            | 12_419   | 0.0       | 18_512     |
| ClassicalCalculator.run    | 7_184    | 3_541     | 1          |

# after, 4x speedup, 4x less memory
| calc_38, maxmem=86.5 GB    | time_sec | memory_mb | counts     |
|----------------------------+----------+-----------+------------|
| total classical            | 161_056  | 130.0625  | 300        |
| get_poes                   | 86_338   | 0.0       | 13_441_481 |
| computing mean_std         | 46_847   | 0.0       | 274_423    |
| nonplanar contexts         | 8_616    | 0.0       | 76_473     |
| iter_ruptures              | 6_862    | 0.0       | 25_864     |
| total preclassical         | 3_317    | 93.9805   | 306        |
| ClassicalCalculator.run    | 2_758    | 3_497     | 1          |
```