### PR TITLE
When exporting gmfs, include secondary perils (if available)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Paolo Tormene]
+  * Updated extractor for gmf_data for a single event id (used by the IRMT
+    QGIS plugin), including data for secondary perils
+
   [Michele Simionato]
   * Refined the tiling calculator (partial tiling, task weighting, saving memory)
   * Optimized "computing pnes" in classical calculations (3x in the common case)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -952,7 +952,7 @@ def extract_gmf_npz(dstore, what):
         # zero GMF
         yield 'rlz-%03d' % rlzi, []
     else:
-        imts = [imt for imt in oq.imtls]
+        imts = list(oq.imtls)
         sec_imts = oq.sec_imts
         gmfa = _gmf(df, n, imts, sec_imts)
         yield 'rlz-%03d' % rlzi, util.compose_arrays(sites, gmfa)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -953,10 +953,7 @@ def extract_gmf_npz(dstore, what):
         yield 'rlz-%03d' % rlzi, []
     else:
         imts = [imt for imt in oq.imtls]
-        try:
-            sec_imts = oq.sec_imts
-        except AttributeError:
-            sec_imts = []
+        sec_imts = oq.sec_imts
         gmfa = _gmf(df, n, imts, sec_imts)
         yield 'rlz-%03d' % rlzi, util.compose_arrays(sites, gmfa)
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -897,11 +897,11 @@ def extract_losses_by_asset(dstore, what):
         yield 'rlz-000', data
 
 
-def _gmf(df, num_sites, imts):
+def _gmf(df, num_sites, imts, sec_imts):
     # convert data into the composite array expected by QGIS
-    gmfa = numpy.zeros(num_sites, [(imt, F32) for imt in imts])
-    for m, imt in enumerate(imts):
-        gmfa[imt][U32(df.sid)] = df[f'gmv_{m}']
+    gmfa = numpy.zeros(num_sites, [(imt, F32) for imt in imts + sec_imts])
+    for m, imt in enumerate(imts + sec_imts):
+        gmfa[imt][U32(df.sid)] = df[f'gmv_{m}'] if imt in imts else df[imt]
     return gmfa
 
 
@@ -952,7 +952,12 @@ def extract_gmf_npz(dstore, what):
         # zero GMF
         yield 'rlz-%03d' % rlzi, []
     else:
-        gmfa = _gmf(df, n, oq.imtls)
+        imts = [imt for imt in oq.imtls]
+        try:
+            sec_imts = oq.sec_imts
+        except AttributeError:
+            sec_imts = []
+        gmfa = _gmf(df, n, imts, sec_imts)
         yield 'rlz-%03d' % rlzi, util.compose_arrays(sites, gmfa)
 
 


### PR DESCRIPTION
Companion of https://github.com/gem/oq-irmt-qgis/pull/866