### PR TITLE
Storing the rates in the `scratch_dir` even for regular calculations

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -130,20 +130,17 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
         result = hazclassical(sources, sitecol, cmaker)
         # print(f"{monitor.task_no=} {result['rmap'].size_mb=}")
         rmap = result.pop('rmap').remove_zeros()
-        if fewsites:
+        if fewsites or not atomic:
             result['rmap'] = rmap
             result['rmap'].gid = cmaker.gid
-        elif cmaker.custom_tmp and cmaker.tiling:  # tested in case_22
+        elif cmaker.custom_tmp:  # tested in case_22
             del result['source_data']
             if len(rmap.array):
                 rates = rmap.to_array(cmaker.gid)
                 _store(rates, cmaker.num_chunks, None, monitor)
-        elif atomic:
+        else:
             del result['source_data']
             result['rmap'] = rmap.to_array(cmaker.gid)
-        else:
-            result['rmap'] = rmap
-            result['rmap'].gid = cmaker.gid
         yield result
 
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -518,7 +518,7 @@ class ClassicalCalculator(base.HazardCalculator):
             self.create_rup()  # create the rup/ datasets BEFORE swmr_on()
         for block, tile, cm in self.csm.split(
                 self.cmakers, self.sitecol, self.max_weight,
-                self.num_chunks if tiling else None):
+                self.num_chunks, tiling):
             allargs.append((block, tile, cm, ds))
 
         # log info about the heavy sources

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -126,11 +126,10 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
             result['rmap'].gid = cmaker.gid
             yield result
     else:
-        fewsites = len(sitecol) <= cmaker.oq.max_sites_disagg
         result = hazclassical(sources, sitecol, cmaker)
-        # print(f"{monitor.task_no=} {result['rmap'].size_mb=}")
         rmap = result.pop('rmap').remove_zeros()
-        if fewsites or not atomic:
+        # print(f"{monitor.task_no=} {rmap=}")
+        if rmap.size_mb < 1 or not atomic:
             result['rmap'] = rmap
             result['rmap'].gid = cmaker.gid
         elif cmaker.custom_tmp:  # tested in case_22

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -109,7 +109,7 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
     """
     # NB: removing the yield would cause terrible slow tasks
     cmaker.init_monitoring(monitor)
-    atomic = (cmaker.atomic or sources is None) and not cmaker.disagg_by_src
+    atomic = sources is None and not cmaker.disagg_by_src
     with dstore:
         if sources is None:  # read the sources from the datastore
             arr = dstore.getitem('_csm')[cmaker.grp_id]
@@ -129,7 +129,7 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
         result = hazclassical(sources, sitecol, cmaker)
         # print(f"{monitor.task_no=} {result['rmap'].size_mb=}")
         rmap = result.pop('rmap').remove_zeros()
-        if cmaker.tiling and cmaker.custom_tmp:  # tested in case_22
+        if cmaker.custom_tmp and cmaker.tiling:  # tested in case_22
             del result['source_data']
             if len(rmap.array):
                 rates = rmap.to_array(cmaker.gid)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -109,7 +109,7 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
     """
     # NB: removing the yield would cause terrible slow tasks
     cmaker.init_monitoring(monitor)
-    allsources = sources is None or cmaker.atomic
+    atomic = (cmaker.atomic or sources is None) and not cmaker.disagg_by_src
     with dstore:
         if sources is None:  # read the sources from the datastore
             arr = dstore.getitem('_csm')[cmaker.grp_id]
@@ -134,7 +134,7 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
             if len(rmap.array):
                 rates = rmap.to_array(cmaker.gid)
                 _store(rates, cmaker.num_chunks, None, monitor)
-        elif allsources and not cmaker.disagg_by_src:
+        elif atomic:
             del result['source_data']
             result['rmap'] = rmap.to_array(cmaker.gid)
         else:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -126,10 +126,14 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
             result['rmap'].gid = cmaker.gid
             yield result
     else:
+        fewsites = len(sitecol) <= cmaker.oq.max_sites_disagg
         result = hazclassical(sources, sitecol, cmaker)
         # print(f"{monitor.task_no=} {result['rmap'].size_mb=}")
         rmap = result.pop('rmap').remove_zeros()
-        if cmaker.custom_tmp and cmaker.tiling:  # tested in case_22
+        if fewsites:
+            result['rmap'] = rmap
+            result['rmap'].gid = cmaker.gid
+        elif cmaker.custom_tmp and cmaker.tiling:  # tested in case_22
             del result['source_data']
             if len(rmap.array):
                 rates = rmap.to_array(cmaker.gid)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -503,13 +503,13 @@ class ClassicalCalculator(base.HazardCalculator):
         else:
             ds = self.datastore
         allargs = []
+        if config.directory.custom_tmp:
+            scratch = parallel.scratch_dir(self.datastore.calc_id)
+            logging.info('Storing the rates in %s', scratch)
+            self.datastore.hdf5.attrs['scratch_dir'] = scratch
         if tiling:
             assert not oq.disagg_by_src
             assert self.N > self.oqparam.max_sites_disagg, self.N
-            if config.directory.custom_tmp:
-                scratch = parallel.scratch_dir(self.datastore.calc_id)
-                logging.info('Storing the rates in %s', scratch)
-                self.datastore.hdf5.attrs['scratch_dir'] = scratch
         else:  # regular calculator
             self.create_rup()  # create the rup/ datasets BEFORE swmr_on()
         for block, tile, cm in self.csm.split(
@@ -527,7 +527,7 @@ class ClassicalCalculator(base.HazardCalculator):
                          redweight(src))
         if not heavy:
             maxsrc = max(srcs, key=redweight)
-            logging.info('Heaviest: %s, weight=%.1f',
+            logging.info('Heaviest: %r, weight=%.1f',
                          maxsrc.source_id, redweight(maxsrc))
 
         self.datastore.swmr_on()  # must come before the Starmap

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -186,12 +186,15 @@ def map_getters(dstore, full_lt=None, disagg=False):
         trt_rlzs = numpy.zeros(len(weights))  # reduces the data transfer
     else:
        weights = full_lt.weights
+    fnames = [dstore.filename]
     try:
         scratch_dir = dstore.hdf5.attrs['scratch_dir']
-        fnames = [os.path.join(scratch_dir, f) for f in os.listdir(scratch_dir)
-                  if f.endswith('.hdf5')]
     except KeyError:  # no tiling
-        fnames = [dstore.filename]
+        pass
+    else:
+        for f in os.listdir(scratch_dir):
+            if f.endswith('.hdf5'):
+                fnames.append(os.path.join(scratch_dir, f))
     out = []
     for chunk in range(chunks):
         getter = MapGetter(fnames, chunk, trt_rlzs, R, oq)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -193,11 +193,11 @@ def store_tiles(dstore, csm, sitecol, cmakers):
         logging.info('mem_gb = %.2f', mem_gb)
     regular = (mem_gb < max_gb or oq.disagg_by_src or
                N < oq.max_sites_disagg or oq.tile_spec)
-    num_chunks = None if regular else 1
+    triples = csm.split(cmakers, sitecol, max_weight, tiling=not regular)
     tiles = numpy.array(
         [(cm.grp_id, len(cm.gsims), len(tile),
           cm.weight, len(cm.gsims) * fac * len(tile) / N)
-         for _, tile, cm in csm.split(cmakers, sitecol, max_weight, num_chunks)],
+         for _, tile, cm in triples],
         [('grp_id', U16), ('G', U16), ('N', U32), ('weight', F32), ('gb', F32)])
     dstore.create_dset('tiles', tiles, fillvalue=None,
                        attrs=dict(req_gb=req_gb, mem_gb=mem_gb, tiling=not regular))

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1528,10 +1528,6 @@ class OqParam(valid.ParamSet):
         return (self.risk_investigation_time or self.investigation_time) / (
             self.investigation_time * self.ses_per_logic_tree_path)
 
-    @property
-    def manytasks(self):
-        return self.concurrent_tasks > 2
-
     def risk_event_rates(self, num_events, num_haz_rlzs):
         """
         :param num_events: the number of events per risk realization

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1528,6 +1528,10 @@ class OqParam(valid.ParamSet):
         return (self.risk_investigation_time or self.investigation_time) / (
             self.investigation_time * self.ses_per_logic_tree_path)
 
+    @property
+    def manytasks(self):
+        return self.concurrent_tasks > 2
+
     def risk_event_rates(self, num_events, num_haz_rlzs):
         """
         :param num_events: the number of events per risk realization

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -444,7 +444,8 @@ class MapArray(object):
         return self
 
     def __repr__(self):
-        return '<MapArray(%d, %d, %d)>' % self.shape
+        tup = self.shape + (self.size_mb,)
+        return '<MapArray(%d, %d, %d)[%.1fM]>' % tup
 
 
 @compile("(float32[:, :], float32[:, :], uint32[:])")

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -694,7 +694,7 @@ class CompositeSourceModel:
             sg = self.src_groups[grp_id]
             mul = .4 if sg.weight < max_weight / 3 else 1.
             self.splits[cmaker.grp_id] *= mul
-            if num_chunks:  # tiling
+            if tiling:
                 self.splits[grp_id] = max(self.splits[grp_id], sg.weight / max_weight)
             yield from self._split(cmaker, sitecol, max_weight, num_chunks, tiling)
 


### PR DESCRIPTION
and not only for tiling calculations. If the rmap is small, store in calc_XXX.hdf5 as usual, to avoid producing many small files (one per task) in small calculations.