### PR TITLE
Saving data transfer in classical calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,10 @@
+  [Michele Simionato]
+  * Honored the custom_tmp in classical calculations
+
   [Lana Todorovic]
   * Implemented Nowicki Jessee et al. (2018) landslide geospatial model that
     computes the areal coverage by landslide occurrence.
-  
+
   [Paolo Tormene]
   * Updated extractor for gmf_data for a single event id (used by the IRMT
     QGIS plugin), including data for secondary perils

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Honored the custom_tmp in classical calculations
+  * Honored the custom_tmp in classical calculations and saved data transfer
+    by using TileGetters
 
   [Lana Todorovic]
   * Implemented Nowicki Jessee et al. (2018) landslide geospatial model that

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -114,8 +114,9 @@ def classical(sources, sitecol, cmaker, dstore, monitor):
         if sources is None:  # read the sources from the datastore
             arr = dstore.getitem('_csm')[cmaker.grp_id]
             sources = pickle.loads(zlib.decompress(arr.tobytes()))
-        if sitecol is None:  # read the sites
-            sitecol = dstore['sitecol']  # super-fast
+        if sitecol is None or callable(sitecol):  # read the sites
+            complete = dstore['sitecol'].complete  # super-fast
+            sitecol = sitecol(complete)
 
     if cmaker.disagg_by_src and not cmaker.atomic:
         # in case_27 (Japan) we do NOT enter here;

--- a/openquake/calculators/disaggregation.py
+++ b/openquake/calculators/disaggregation.py
@@ -290,7 +290,8 @@ class DisaggregationCalculator(base.HazardCalculator):
                 continue
 
             # split by tiles
-            for tile in self.sitecol.split(ntasks):
+            for tile_get in self.sitecol.split(ntasks):
+                tile = tile_get(self.sitecol)
                 ctx = ctxt[numpy.isin(ctxt.sids, tile.sids)]
                 if len(ctx) * cmaker.Z > maxsize:
                     # split by magbin too

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -194,11 +194,13 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     regular = (mem_gb < max_gb or oq.disagg_by_src or
                N < oq.max_sites_disagg or oq.tile_spec)
     triples = csm.split(cmakers, sitecol, max_weight, tiling=not regular)
-    tiles = numpy.array(
-        [(cm.grp_id, len(cm.gsims), len(tile),
-          cm.weight, len(cm.gsims) * fac * len(tile) / N)
-         for _, tile, cm in triples],
-        [('grp_id', U16), ('G', U16), ('N', U32), ('weight', F32), ('gb', F32)])
+    tiles = []
+    for _, tile_get, cm in triples:
+        tile = tile_get(sitecol)
+        tiles.append((cm.grp_id, len(cm.gsims), len(tile),
+                      cm.weight, len(cm.gsims) * fac * len(tile) / N))
+    tiles = numpy.array(tiles, [('grp_id', U16), ('G', U16), ('N', U32),
+                                ('weight', F32), ('gb', F32)])
     dstore.create_dset('tiles', tiles, fillvalue=None,
                        attrs=dict(req_gb=req_gb, mem_gb=mem_gb, tiling=not regular))
     Ns = tiles['N']

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -207,7 +207,7 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     logging.info('This will be a %s calculation with %d tasks, '
                  'min_sites=%d, max_sites=%d', 'regular' if regular else 'tiling',
                  len(tiles), Ns.min(), Ns.max())
-    if mem_gb >= 30 and not config.directory.custom_tmp:
+    if req_gb >= 30 and not config.directory.custom_tmp:
         logging.info('We suggest to set custom_tmp')
     return req_gb, max_weight, trt_rlzs, gids
 

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -20,6 +20,7 @@ serialize_jobs = 1
 # num_cores = 1
 # log level for jobs spawned by the WebAPI
 log_level = info
+master_cores =
 submit_cmd = oq run
 min_input_size = 1_000_000
 compress =

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -389,8 +389,6 @@ class MapArray(object):
     # dangerous since it changes the shape by removing sites
     def remove_zeros(self):
         ok = self.array.sum(axis=(1, 2)) > 0
-        if ok.sum() == 0:  # avoid empty array
-            ok = slice(0, 1)
         new = self.__class__(self.sids[ok], self.shape[1], self.shape[2], self.rates)
         new.array = self.array[ok]
         return new

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -76,16 +76,19 @@ def rnd5(lons):
     return numpy.round(lons, 5)
 
 
-def tile(tileno, ntiles):
+class Tile:
     """
-    :returns: a tile extractor complete->filtered
+    An extractor complete->tile
     """
-    def new(complete):
+    def __init__(self, tileno, ntiles):
+        self.tileno = tileno
+        self.ntiles = ntiles
+
+    def __call__(self, complete):
         sc = SiteCollection.__new__(SiteCollection)
-        sc.array = complete.array[complete.sids % ntiles == tileno]
+        sc.array = complete.array[complete.sids % self.ntiles == self.tileno]
         sc.complete = complete
         return sc
-    return new
 
 
 class Site(object):
@@ -559,7 +562,7 @@ class SiteCollection(object):
         ntiles = min(int(numpy.ceil(ntiles)), maxtiles)
         if ntiles <= 1:
             return [lambda complete: complete]
-        return [tile(i, ntiles) for i in range(ntiles)]
+        return [Tile(i, ntiles) for i in range(ntiles)]
 
     def split_in_tiles(self, hint):
         """

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -558,11 +558,9 @@ class SiteCollection(object):
         :param ntiles: number of tiles to generate (rounded if float)
         :returns: self if there are <=1 tiles, otherwise the tiles
         """
-        maxtiles = int(numpy.ceil(len(self) / minsize))
-        ntiles = min(int(numpy.ceil(ntiles)), maxtiles)
-        if ntiles <= 1:
-            return [lambda complete: complete]
-        return [Tile(i, ntiles) for i in range(ntiles)]
+        maxtiles = numpy.ceil(len(self) / minsize)
+        ntiles = min(numpy.ceil(ntiles), maxtiles)
+        return [Tile(i, ntiles) for i in range(int(ntiles))]
 
     def split_in_tiles(self, hint):
         """

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -76,7 +76,7 @@ def rnd5(lons):
     return numpy.round(lons, 5)
 
 
-class Tile:
+class TileGetter:
     """
     An extractor complete->tile
     """
@@ -560,7 +560,7 @@ class SiteCollection(object):
         """
         maxtiles = numpy.ceil(len(self) / minsize)
         ntiles = min(numpy.ceil(ntiles), maxtiles)
-        return [Tile(i, ntiles) for i in range(int(ntiles))]
+        return [TileGetter(i, ntiles) for i in range(int(ntiles))]
 
     def split_in_tiles(self, hint):
         """

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -76,6 +76,18 @@ def rnd5(lons):
     return numpy.round(lons, 5)
 
 
+def tile(tileno, ntiles):
+    """
+    :returns: a tile extractor complete->filtered
+    """
+    def new(complete):
+        sc = SiteCollection.__new__(SiteCollection)
+        sc.array = complete.array[complete.sids % ntiles == tileno]
+        sc.complete = complete
+        return sc
+    return new
+
+
 class Site(object):
     """
     Site object represents a geographical location defined by its position
@@ -546,16 +558,8 @@ class SiteCollection(object):
         maxtiles = int(numpy.ceil(len(self) / minsize))
         ntiles = min(int(numpy.ceil(ntiles)), maxtiles)
         if ntiles <= 1:
-            return [self]
-        tiles = []
-        for i in range(ntiles):
-            sc = SiteCollection.__new__(SiteCollection)
-            # smart trick to split in "homogenous" tiles
-            sc.array = self.array[self.sids % ntiles == i]
-            sc.complete = self
-            if len(sc):
-                tiles.append(sc)
-        return tiles
+            return [lambda complete: complete]
+        return [tile(i, ntiles) for i in range(ntiles)]
 
     def split_in_tiles(self, hint):
         """

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -709,8 +709,8 @@ class CompositeSourceModel:
         cmaker.weight = sg.weight
         cmaker.atomic = sg.atomic
         if tiling:
-            for sites in sitecol.split(splits, minsize=cmaker.oq.max_sites_disagg):
-                yield None, sites, cmaker
+            for tile in sitecol.split(splits, minsize=cmaker.oq.max_sites_disagg):
+                yield None, tile, cmaker
         elif sg.atomic or sg.weight <= max_weight:
             for tile in sitecol.split(splits):
                 yield None, tile, cmaker


### PR DESCRIPTION
By passing a TileGetter instead of a tile. This can reduce the data transfer in output by many orders of magnitude.
Also, introduced a `master_cores` variable in openquake.cfg to be used in SLURM mode.
NB: I not measuring anymore "storing rates" while in the workers, to avoid confusion with the slow part is in the master node.
Here is USA on cole with half the sites:
```
| task      | sent                                           | received |
|-----------+------------------------------------------------+----------|
| classical | sitecol=3.15 GB cmaker=1.91 GB sources=1.27 GB | 16.06 GB |
| classical | cmaker=1.91 GB sources=1.27 GB dstore=76.98 KB | 10.67 GB |
```