### PR TITLE
Refactored the task splitting in classical calculations

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -505,7 +505,6 @@ class ClassicalCalculator(base.HazardCalculator):
             ds = self.datastore.parent
         else:
             ds = self.datastore
-        allargs = []
         if config.directory.custom_tmp:
             scratch = parallel.scratch_dir(self.datastore.calc_id)
             logging.info('Storing the rates in %s', scratch)
@@ -515,6 +514,7 @@ class ClassicalCalculator(base.HazardCalculator):
             assert self.N > self.oqparam.max_sites_disagg, self.N
         else:  # regular calculator
             self.create_rup()  # create the rup/ datasets BEFORE swmr_on()
+        allargs = []
         for cmaker, tiles, blocks in self.csm.split(
                 self.cmakers, self.sitecol, self.max_weight,
                 self.num_chunks, tiling):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -423,7 +423,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.num_chunks = getters.get_num_chunks(self.datastore)
         # create empty dataframes
         self.datastore.create_df(
-            '_rates', [(n, rates_dt[n]) for n in rates_dt.names], GZIP)
+            '_rates', [(n, rates_dt[n]) for n in rates_dt.names])
         self.datastore.create_dset('_rates/slice_by_idx', getters.slice_dt)
 
     def check_memory(self, N, L, maxw):

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -160,7 +160,7 @@ def get_num_chunks(dstore):
     """
     msd = dstore['oqparam'].max_sites_disagg
     try:
-        req_gb = dstore['tiles'].attrs['req_gb']
+        req_gb = dstore['source_groups'].attrs['req_gb']
     except KeyError:
         return msd
     chunks = max(int(5 * req_gb), msd)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -197,7 +197,7 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     Ns = data['tiles']
     ntasks = Ns @ data['blocks']
     logging.info('This will be a %s calculation with ~%d tasks, '
-                 'min_sites=%d, max_sites=%d', 'regular' if regular else 'tiling',
+                 'min_tiles=%d, max_tiles=%d', 'regular' if regular else 'tiling',
                  ntasks, Ns.min(), Ns.max())
     if req_gb >= 30 and not config.directory.custom_tmp:
         logging.info('We suggest to set custom_tmp')

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -173,7 +173,7 @@ class ClassicalTestCase(CalculatorTestCase):
 
     def test_case_22(self):
         # crossing date line calculation for Alaska
-        # this also tests the splitting in two tiles
+        # this also tests the splitting in tiles
         tmp = tempfile.gettempdir()
         with mock.patch.dict(config.memory, {'pmap_max_gb': 1E-5}), \
              mock.patch.dict(config.directory, {'custom_tmp': tmp}):
@@ -187,7 +187,7 @@ class ClassicalTestCase(CalculatorTestCase):
         ], case_22.__file__, delta=1E-6)
         data = self.calc.datastore['source_groups'][:]
         self.assertEqual(data['gsims'], 4)
-        self.assertEqual(data['tiles'], 9)   
+        self.assertEqual(data['tiles'], 10)
         self.assertEqual(data['blocks'], 1)        
 
     def test_case_23(self):  # filtering away on TRT

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -185,8 +185,10 @@ class ClassicalTestCase(CalculatorTestCase):
                 'hazard_curve-mean-SA(1.0).csv',
                 'hazard_curve-mean-SA(2.0).csv',
         ], case_22.__file__, delta=1E-6)
-        splits = self.calc.datastore['tiles'][:]
-        self.assertEqual(len(splits), 10)
+        data = self.calc.datastore['source_groups'][:]
+        self.assertEqual(data['gsims'], 4)
+        self.assertEqual(data['tiles'], 9)   
+        self.assertEqual(data['blocks'], 1)        
 
     def test_case_23(self):  # filtering away on TRT
         self.assert_curves_ok(['hazard_curve.csv'],

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -558,11 +558,9 @@ class SiteCollection(object):
         :param ntiles: number of tiles to generate (rounded if float)
         :returns: self if there are <=1 tiles, otherwise the tiles
         """
-        maxtiles = int(numpy.ceil(len(self) / minsize))
-        ntiles = min(int(numpy.ceil(ntiles)), maxtiles)
-        if ntiles <= 1:
-            return [lambda complete: complete]
-        return [Tile(i, ntiles) for i in range(ntiles)]
+        maxtiles = numpy.ceil(len(self) / minsize)
+        ntiles = min(numpy.ceil(ntiles), maxtiles)
+        return [Tile(i, ntiles) for i in range(int(ntiles))]
 
     def split_in_tiles(self, hint):
         """

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -680,22 +680,20 @@ class CompositeSourceModel:
         oq = cmakers[0].oq
         max_mb = float(config.memory.pmap_max_mb)
         mb_per_gsim = oq.imtls.size * N * 4 / 1024**2
-        self.splits = numpy.ceil(
-            [len(cm.gsims) * mb_per_gsim / max_mb for cm in cmakers])
+        self.splits = []
         # send heavy groups first
         grp_ids = numpy.argsort([sg.weight for sg in self.src_groups])[::-1]
         for cmaker in cmakers[grp_ids]:
             grp_id = cmaker.grp_id
             sg = self.src_groups[grp_id]
             mul = .4 if sg.weight < max_weight / 3 else 1.
-            self.splits[cmaker.grp_id] *= mul
+            splits = numpy.ceil(mul * len(cmaker.gsims) * mb_per_gsim / max_mb)
             if tiling:
-                splits = numpy.ceil(max(self.splits[grp_id], sg.weight / max_weight))
+                splits = numpy.ceil(max(splits, sg.weight / max_weight))
                 blocks = 1
             else:
-                splits = self.splits[grp_id]
                 blocks = numpy.ceil(sg.weight / max_weight / splits)
-
+            self.splits.append(splits)
             cmaker.gsims = list(cmaker.gsims)  # save data transfer
             cmaker.codes = sg.codes
             cmaker.rup_indep = getattr(sg, 'rup_interdep', None) != 'mutex'

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -690,7 +690,7 @@ class CompositeSourceModel:
             mul = .4 if sg.weight < max_weight / 3 else 1.
             self.splits[cmaker.grp_id] *= mul
             if tiling:
-                splits = max(self.splits[grp_id], numpy.ceil(sg.weight / max_weight))
+                splits = numpy.ceil(max(self.splits[grp_id], sg.weight / max_weight))
                 blocks = 1
             else:
                 splits = self.splits[grp_id]


### PR DESCRIPTION
So that useful information can be stored in the `source_groups` dataset. For instance for a reduced USA calculation one gets
```
| gsims | tiles | blocks | size_mb  | weight  | codes | trt                  |
|-------+-------+--------+----------+---------+-------+----------------------|
| 31    | 2     | 113    | 124.4061 | 139_517 | PSXp  | Stable Shallow Crust |
| 4     | 1     | 21     | 16.0524  | 12_817  | PSXp  | Active Shallow Crust |
| 3     | 1     | 3      | 12.0393  | 1_794   | CX    | Subduction Interface |
| 2     | 1     | 3      | 8.0262   | 1_469   | Pp    | Subduction Inslab    |
| 31    | 1     | 1      | 124.4061 | 3.0930  | N     | Stable Shallow Crust |
| 31    | 1     | 1      | 124.4061 | 3.0930  | N     | Stable Shallow Crust |
```
I am also not gzipping the rates when stored in calc_XXX.hdf5, thus doubling the storage speed.