### PR TITLE
Making it possible to measure the total memory occupation on a cluster

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -203,7 +203,7 @@ from openquake.baselib import config, hdf5
 from openquake.baselib.python3compat import decode
 from openquake.baselib.zeromq import zmq, Socket
 from openquake.baselib.performance import (
-    Monitor, memory_rss, init_performance)
+    Monitor, memory_gb, init_performance)
 from openquake.baselib.general import (
     split_in_blocks, block_splitter, AccumDict, humansize, CallableDict,
     gettemp, engine_version, shortlist, compress, decompress, mp as mp_context)
@@ -996,14 +996,7 @@ class Starmap(object):
                 self.h5['task_sent'] = str(task_sent)
                 name = res.mon.operation[6:]  # strip 'total '
                 n = self.name + ':' + name if name == 'split_task' else name
-                if sys.platform != 'darwin':
-                    # it normally works on macOS, but not in notebooks calling
-                    # notebooks, which is the case relevant for Marco Pagani
-                    mem_gb = (memory_rss(os.getpid()) + sum(
-                        memory_rss(pid) for pid in Starmap.pids)) / GB
-                else:
-                    # measure only the memory used by the main process
-                    mem_gb = memory_rss(os.getpid()) / GB
+                mem_gb = memory_gb(Starmap.pids)
                 res.mon.save_task_info(self.h5, res, n, mem_gb)
                 res.mon.flush(self.h5)
             elif res.func:  # add subtask

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -166,6 +166,13 @@ def memory_rss(pid):
         return 0
 
 
+def memory_gb(pids):
+    """
+    :returns: the total memory allocated by the current process and all the PIDs
+    """
+    return sum(map(memory_rss, [os.getpid()] + list(pids))) / 1024**3
+
+
 # this is not thread-safe
 class Monitor(object):
     """

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -278,6 +278,7 @@ class WorkerPool(object):
         print(f'Starting oq-zworkerpool on {self.hostname}', file=sys.stderr)
         setproctitle('oq-zworkerpool')
         self.pool = general.mp.Pool(self.num_workers, init_workers)
+        pids = [proc.pid for proc in self.pool._pool]
         # start control loop accepting the commands stop
         try:
             ctrl_url = 'tcp://0.0.0.0:%s' % self.ctrl_port
@@ -297,6 +298,8 @@ class WorkerPool(object):
                     elif cmd == 'get_executing':
                         executing = sorted(os.listdir(self.executing))
                         ctrlsock.send(' '.join(executing))
+                    elif cmd == 'memory_gb':
+                        ctrlsock.send(performance.memory_gb(pids))
                     elif isinstance(cmd, tuple):
                         _func, _args, taskno, mon = cmd
                         self.pool.apply_async(


### PR DESCRIPTION
Before `oq show performance` showed the memory occupation only on the master node.