### PR TITLE
add requirements timezonefinder 6.5.2 only for Linux OS

### DIFF
--- a/requirements-py310-linux64.txt
+++ b/requirements-py310-linux64.txt
@@ -3,6 +3,7 @@
 # GEM Mirror
 #
 https://wheelhouse.openquake.org/v3/linux/py310/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py310/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py310/pyzmq-26.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py310/pandas-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py310/kiwisolver-1.4.5-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl

--- a/requirements-py311-linux64.txt
+++ b/requirements-py311-linux64.txt
@@ -3,6 +3,7 @@
 # GEM Mirror
 #
 https://wheelhouse.openquake.org/v3/linux/py311/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py311/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/pyzmq-26.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/kiwisolver-1.4.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

--- a/requirements-py39-linux64.txt
+++ b/requirements-py39-linux64.txt
@@ -3,6 +3,7 @@
 # GEM Mirror
 #
 https://wheelhouse.openquake.org/v3/linux/py39/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py39/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py39/contourpy-1.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py39/h5py-3.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py39/kiwisolver-1.4.5-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl


### PR DESCRIPTION
After merging these PRs: https://github.com/gem/oq-engine/pull/9883/files#diff-9d3cf80206902cfc89f95413947cd0d6fdbb82a0944e149fe1bb8e7a0f123872R44  we introduced an optional dependency (needed by ARISTOTLE) from timezonefinder==6.5.2.