### PR TITLE
Parallelized storing the rates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
   * Honored the custom_tmp in classical calculations and saved data transfer
-    by using TileGetters
+    by using TileGetters, then parallelized the saving of the rates
 
   [Lana Todorovic]
   * Implemented Nowicki Jessee et al. (2018) landslide geospatial model that

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -146,7 +146,6 @@ def classical(sources, sitegetter, cmaker, dstore, monitor):
                 rates = rmap.to_array(cmaker.gid)
                 _store(rates, cmaker.num_chunks, None, monitor)
             else:
-                del result['source_data']
                 result['rmap'] = rmap.to_array(cmaker.gid)
         elif rmap.size_mb:
             result['rmap'] = rmap
@@ -370,7 +369,7 @@ class ClassicalCalculator(base.HazardCalculator):
         elif isinstance(rmap, numpy.ndarray):
             # store the rates directly, case_03
             with self.monitor('storing rates', measuremem=True):
-                self.store(rmap, self.gids[grp_id])
+                _store(rmap, self.num_chunks, self.datastore)
         else:
             # aggregating rates is ultra-fast compared to storing
             self.rmap += rmap

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -547,6 +547,8 @@ class ClassicalCalculator(base.HazardCalculator):
         logging.info('Storing %s', self.rmap)
         with self.monitor('converting rates', measuremem=True):
             rates = self.rmap.to_array()
+        logging.info('Got {:_d} records, {}'.format(
+            len(rates), humansize(rates.nbytes)))
         if len(rates) and self.N > 1000 and config.directory.custom_tmp:
             mcores = int(config.distribution.master_cores or 8)
             slices = split_in_slices(len(rates), mcores)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -24,13 +24,12 @@ import pickle
 import psutil
 import logging
 import operator
-from multiprocessing.pool import Pool
 import numpy
 import pandas
 from PIL import Image
 from openquake.baselib import parallel, performance, hdf5, config, python3compat
 from openquake.baselib.general import (
-    AccumDict, DictArray, groupby, humansize, split_in_blocks)
+    AccumDict, DictArray, groupby, humansize, split_in_blocks, mp)
 from openquake.hazardlib import valid, InvalidFile
 from openquake.hazardlib.contexts import read_cmakers
 from openquake.hazardlib.calc.hazard_curve import classical as hazclassical
@@ -557,7 +556,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 mon.task_no = smap.task_no + g
                 allargs.append((rates_g, g, self.N, self.num_chunks, mon))
             with self.monitor('storing rates', measuremem=True), \
-                 Pool(mcores) as pool:
+                 mp.Pool(mcores) as pool:
                 pool.starmap(save_rmap, allargs)
         elif self.rmap.acc:
             with self.monitor('storing rates', measuremem=True):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -53,7 +53,7 @@ BUFFER = 1.5  # enlarge the pointsource_distance sphere to fix the weight;
 # with ps_grid_spacing=50
 
 
-def _store(rates, num_chunks, h5, mon, gzip=GZIP):
+def _store(rates, num_chunks, h5, mon=None, gzip=GZIP):
     if len(rates) == 0:
         return
     if h5 is None:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -54,6 +54,7 @@ BUFFER = 1.5  # enlarge the pointsource_distance sphere to fix the weight;
 
 
 def _store(rates, num_chunks, h5, mon, gzip=GZIP):
+    assert len(rates)
     if h5 is None:
         scratch = parallel.scratch_dir(mon.calc_id)
         h5 = hdf5.File(f'{scratch}/{mon.task_no}.hdf5', 'a')
@@ -439,11 +440,12 @@ class ClassicalCalculator(base.HazardCalculator):
                 'You have only %s of free RAM' % humansize(avail))
 
     def store(self, rates, gid, mon):
-        logging.info('Storing %s, gid=%s', humansize(rates.nbytes), gid)
-        if config.directory.custom_tmp:
-            _store(rates, self.num_chunks, None, mon)
-        else:
-            _store(rates, self.num_chunks, self.datastore, mon)
+        if len(rates):
+            logging.info('Storing %s, gid=%s', humansize(rates.nbytes), gid)
+            if config.directory.custom_tmp:
+                _store(rates, self.num_chunks, None, mon)
+            else:
+                _store(rates, self.num_chunks, self.datastore, mon)
 
     def execute(self):
         """

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -545,9 +545,7 @@ class ClassicalCalculator(base.HazardCalculator):
         smap = parallel.Starmap(classical, allargs, h5=self.datastore.hdf5)
         acc = smap.reduce(self.agg_dicts, AccumDict(accum=0.))
         logging.info('Storing %s', self.rmap)
-        dist = parallel.oq_distribute()
-        if (self.rmap.acc and config.directory.custom_tmp
-                and self.N > 1000 and dist != 'no'):
+        if self.rmap.acc and config.directory.custom_tmp and self.N > 1000:
             # tested in the oq-risk-tests
             mcores = int(config.distribution.master_cores or 8)
             allargs = []

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -140,7 +140,7 @@ def classical(sources, sitegetter, cmaker, dstore, monitor):
         result = hazclassical(sources, sitecol, cmaker)
         rmap = result.pop('rmap').remove_zeros()
         # print(f"{monitor.task_no=} {rmap=}")
-        if rmap.size_mb and cmaker.blocks == 1:
+        if rmap.size_mb and cmaker.blocks == 1 and not cmaker.disagg_by_src:
             del result['source_data']
             if cmaker.custom_tmp:
                 rates = rmap.to_array(cmaker.gid)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -56,7 +56,8 @@ BUFFER = 1.5  # enlarge the pointsource_distance sphere to fix the weight;
 def _store(rates, num_chunks, h5, mon=None, gzip=GZIP):
     if len(rates) == 0:
         return
-    if h5 is None:
+    newh5 = h5 is None
+    if newh5:
         scratch = parallel.scratch_dir(mon.calc_id)
         h5 = hdf5.File(f'{scratch}/{mon.task_no}.hdf5', 'a')
     chunks = rates['sid'] % num_chunks
@@ -79,7 +80,10 @@ def _store(rates, num_chunks, h5, mon=None, gzip=GZIP):
         hdf5.extend(h5['_rates/rate'], ch_rates['rate'])
     iss = numpy.array(idx_start_stop, getters.slice_dt)
     hdf5.extend(h5['_rates/slice_by_idx'], iss)
-    return h5.filename
+    if newh5:
+        fname = h5.filename
+        h5.close()
+        return fname
 
 
 class Set(set):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -549,7 +549,9 @@ class ClassicalCalculator(base.HazardCalculator):
         acc = smap.reduce(self.agg_dicts, AccumDict(accum=0.))
         if config.directory.custom_tmp:
             allargs = [(g, self.num_chunks) for g in self.rmap.acc]
-            savemap = parallel.Starmap(save_rmap, allargs, h5=self.datastore)
+            savemap = parallel.Starmap(save_rmap, allargs, h5=self.datastore,
+                                       distribute='processpool')
+            savemap.num_cores = 8
             dic = {'sids': self.rmap.sids}
             for g, arr in self.rmap.acc.items():
                 dic['rates_%d' % g] = arr

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -24,7 +24,7 @@ import pickle
 import psutil
 import logging
 import operator
-import multiprocessing
+from multiprocessing.pool import Pool
 import numpy
 import pandas
 from PIL import Image
@@ -557,7 +557,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 mon.task_no = smap.task_no + g
                 allargs.append((rates_g, g, self.N, self.num_chunks, mon))
             with self.monitor('storing rates', measuremem=True), \
-                 multiprocessing.pool.Pool(mcores) as pool:
+                 Pool(mcores) as pool:
                 pool.starmap(save_rmap, allargs)
         elif self.rmap.acc:
             with self.monitor('storing rates', measuremem=True):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -27,14 +27,14 @@ import operator
 import numpy
 import pandas
 from PIL import Image
-from openquake.baselib import parallel, hdf5, config, python3compat
+from openquake.baselib import parallel, performance, hdf5, config, python3compat
 from openquake.baselib.general import (
-    AccumDict, DictArray, groupby, humansize, split_in_blocks, split_in_slices)
+    AccumDict, DictArray, groupby, humansize, split_in_blocks)
 from openquake.hazardlib import valid, InvalidFile
 from openquake.hazardlib.contexts import read_cmakers
 from openquake.hazardlib.calc.hazard_curve import classical as hazclassical
 from openquake.hazardlib.calc import disagg
-from openquake.hazardlib.map_array import MapArray, rates_dt
+from openquake.hazardlib.map_array import MapArray, rates_dt, from_rates_g
 from openquake.commonlib import calc
 from openquake.calculators import base, getters, preclassical
 
@@ -110,9 +110,9 @@ def store_ctxs(dstore, rupdata_list, grp_id):
 
 #  ########################### task functions ############################ #
     
-def save_rmap(slc, num_chunks, mon):
-    with mon.shared['rates'] as rates:
-        _store(rates[slc], num_chunks, None, mon)
+def save_rmap(rates_g, g, sids, num_chunks, mon):
+    rates = from_rates_g(rates_g, g, sids)
+    _store(rates, num_chunks, None, mon)
 
 
 def classical(sources, sitegetter, cmaker, dstore, monitor):
@@ -545,24 +545,24 @@ class ClassicalCalculator(base.HazardCalculator):
         smap = parallel.Starmap(classical, allargs, h5=self.datastore.hdf5)
         acc = smap.reduce(self.agg_dicts, AccumDict(accum=0.))
         logging.info('Storing %s', self.rmap)
-        with self.monitor('converting rates', measuremem=True):
-            rates = self.rmap.to_array()
-        logging.info('Got {:_d} records, {}'.format(
-            len(rates), humansize(rates.nbytes)))
-        if len(rates) and self.N > 1000 and config.directory.custom_tmp:
+        dist = parallel.oq_distribute()
+        if (self.rmap.acc and config.directory.custom_tmp
+                and self.N > 1000 and dist != 'no'):
+            # tested in the oq-risk-tests
             mcores = int(config.distribution.master_cores or 8)
-            slices = split_in_slices(len(rates), mcores)
-            allargs = [(slc, self.num_chunks) for slc in slices]
-            dist = parallel.oq_distribute()
-            savemap = parallel.Starmap(
-                save_rmap, allargs, h5=self.datastore,
-                distribute='no' if dist == 'no' else 'processpool')
-            savemap.num_cores = mcores
-            savemap.share(rates=rates)
-            savemap.reduce()
-        elif len(rates):
+            allargs = []
+            for g, rates_g in self.rmap.acc.items():
+                mon = performance.Monitor()
+                mon.calc_id = self.datastore.calc_id
+                mon.task_no = smap.task_no + g
+                allargs.append((rates_g, g, self.rmap.sids, self.num_chunks, mon))
             with self.monitor('storing rates', measuremem=True):
-                _store(rates, self.num_chunks, self.datastore)
+                parallel.multispawn(save_rmap, allargs, mcores, logfinish=False)
+        elif self.rmap.acc:
+            with self.monitor('storing rates', measuremem=True):
+                for g, rates_g in self.rmap.acc.items():
+                    rates = from_rates_g(rates_g, g, self.rmap.sids)
+                    _store(rates, self.num_chunks, self.datastore)
         del self.rmap
         if oq.disagg_by_src:
             mrs = self.haz.store_mean_rates_by_src(acc)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -176,9 +176,9 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     # build source_groups
     triples = csm.split(cmakers, sitecol, max_weight)
     data = numpy.array(
-        [(len(cm.gsims), tiles, blocks, len(cm.gsims) * fac * 1024,
+        [(cm.grp_id, len(cm.gsims), tiles, blocks, len(cm.gsims) * fac * 1024,
           cm.weight, cm.codes, cm.trt) for cm, tiles, blocks in triples],
-        [('gsims', U16), ('tiles', U16), ('blocks', U16),
+        [('grp_id', U16), ('gsims', U16), ('tiles', U16), ('blocks', U16),
          ('size_mb', F32), ('weight', F32), ('codes', '<S8'), ('trt', '<S20')])
 
     # determine light groups and tiling

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -665,26 +665,27 @@ class ClassicalTestCase(CalculatorTestCase):
     def test_case_76(self):
         # CanadaSHM6 GMPEs
         self.run_calc(case_76.__file__, 'job.ini')
-        oq = self.calc.oqparam
-        L = oq.imtls.size  # 25 levels x 9 IMTs
-        L1 = L // len(oq.imtls)
-        branches = self.calc.datastore['full_lt/gsim_lt'].branches
-        gsims = [br.gsim for br in branches]
-        df = self.calc.datastore.read_df('_rates')
-        del df['sid']
-        for g, gsim in enumerate(gsims):
-            curve = numpy.zeros(L1, oq.imt_dt())
-            df_for_g = df[df.gid == g]
-            poes = numpy.zeros(L)
-            poes[df_for_g.lid] = calc.disagg.to_probs(df_for_g.rate)
-            for im in oq.imtls:
-                curve[im] = poes[oq.imtls(im)]
-            gs = gsim.__class__.__name__
-            if 'submodel' in gsim._toml:
-                gs += '_' + gsim.kwargs['submodel']
-            got = general.gettemp(text_table(curve, ext='org'))
-            delta = .0003 if sys.platform == 'darwin' else 1E-5
-            self.assertEqualFiles('expected/%s.org' % gs, got, delta=delta)
+        if not config.directory.custom_tmp:
+            oq = self.calc.oqparam
+            L = oq.imtls.size  # 25 levels x 9 IMTs
+            L1 = L // len(oq.imtls)
+            branches = self.calc.datastore['full_lt/gsim_lt'].branches
+            gsims = [br.gsim for br in branches]
+            df = self.calc.datastore.read_df('_rates')
+            del df['sid']
+            for g, gsim in enumerate(gsims):
+                curve = numpy.zeros(L1, oq.imt_dt())
+                df_for_g = df[df.gid == g]
+                poes = numpy.zeros(L)
+                poes[df_for_g.lid] = calc.disagg.to_probs(df_for_g.rate)
+                for im in oq.imtls:
+                    curve[im] = poes[oq.imtls(im)]
+                gs = gsim.__class__.__name__
+                if 'submodel' in gsim._toml:
+                    gs += '_' + gsim.kwargs['submodel']
+                got = general.gettemp(text_table(curve, ext='org'))
+                delta = .0003 if sys.platform == 'darwin' else 1E-5
+                self.assertEqualFiles('expected/%s.org' % gs, got, delta=delta)
 
     def test_case_77(self):
         # test calculation for modifiable GMPE with original tabular GMM

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -364,11 +364,15 @@ class MapArray(object):
         pnes[pnes == 0.] = 1.11E-16
         return self.new(-numpy.log(pnes) / itime)
 
-    def to_array(self, gid):
+    def to_array(self, gid=None):
         """
         Assuming self contains an array of rates,
         returns a composite array with fields sid, lid, gid, rate
         """
+        if gid is None:
+            gid = sorted(self.acc)
+        if len(gid) == 0:
+            return numpy.array([], rates_dt)
         outs = []
         for i, g in enumerate(gid):
             if hasattr(self, 'array') :

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -361,18 +361,8 @@ class MapArray(object):
                 rates_g = self.array[:, :, i]
             else:
                 rates_g = self.acc[g]
-            for lid, rates in enumerate(rates_g.T):
-                idxs, = rates.nonzero()
-                if len(idxs):
-                    out = numpy.zeros(len(idxs), rates_dt)
-                    out['sid'] = self.sids[idxs]
-                    out['lid'] = lid
-                    out['gid'] = g
-                    out['rate'] = rates[idxs]
-                    outs.append(out)
-        if not outs:
-            return numpy.array([], rates_dt)
-        elif len(outs) == 1:
+            outs.append(from_rates_g(rates_g, g, self.sids))
+        if len(outs) == 1:
             return outs[0]
         return numpy.concatenate(outs, dtype=rates_dt)
 
@@ -459,3 +449,26 @@ class MapArray(object):
 def iadd(arr, array, sidx):
     for i, sid in enumerate(sidx):
         arr[sid] += array[i]
+
+
+def from_rates_g(rates_g, g, sids):
+    """
+    :param rates_g: an array of shape (N, L)
+    :param g: an integer representing a GSIM index
+    :param sids: an array of site IDs
+    """
+    outs = []
+    for lid, rates in enumerate(rates_g.T):
+        idxs, = rates.nonzero()
+        if len(idxs):
+            out = numpy.zeros(len(idxs), rates_dt)
+            out['sid'] = sids[idxs]
+            out['lid'] = lid
+            out['gid'] = g
+            out['rate'] = rates[idxs]
+            outs.append(out)
+    if not outs:
+        return numpy.array([], rates_dt)
+    elif len(outs) == 1:
+        return outs[0]
+    return numpy.concatenate(outs, dtype=rates_dt)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -699,7 +699,7 @@ class CompositeSourceModel:
             cmaker.rup_indep = getattr(sg, 'rup_interdep', None) != 'mutex'
             cmaker.custom_tmp = config.directory.custom_tmp
             cmaker.num_chunks = num_chunks
-            cmaker.tiling = tiling
+            cmaker.blocks = blocks
             cmaker.weight = sg.weight
             cmaker.atomic = sg.atomic
             if sg.atomic:


### PR DESCRIPTION
But only if `custom_tmp` is set. This works quite well in the IUSS cluster, the time spent in EUR with 10% of the sites goes down from 321s to 79s, i.e. 4x less (it means 40 minutes less in the full calculation).