### PR TITLE
Parallelized storing the rates/3

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -556,7 +556,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if (self.rmap.acc and config.directory.custom_tmp and self.N > 1000
                 and parallel.oq_distribute() != 'no'):
             # tested in the oq-risk-tests
-            mcores = int(config.distribution.master_cores or 8)
+            mcores = int(config.distribution.master_cores or 16)
             allargs = []
             for g, rates_g in self.rmap.acc.items():
                 mon = performance.Monitor()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -562,7 +562,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 yield rmap, mon
 
         with self.monitor('storing rates', measuremem=True):
-            logging.info('Processing %s rmaps', self.rmap)
+            logging.info('Processing %s', self.rmap)
             if (self.rmap.acc and config.directory.custom_tmp and self.N > 1000
                     and parallel.oq_distribute() != 'no'):
                 # tested in the oq-risk-tests

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -553,24 +553,22 @@ class ClassicalCalculator(base.HazardCalculator):
         smap = parallel.Starmap(classical, allargs, h5=self.datastore.hdf5)
         acc = smap.reduce(self.agg_dicts, AccumDict(accum=0.))
         logging.info('Storing %s', self.rmap)
+        allargs = []
+        for g, rates_g in self.rmap.acc.items():
+            mon = performance.Monitor()
+            mon.calc_id = self.datastore.calc_id
+            mon.task_no = smap.task_no + g
+            allargs.append((rates_g, g, self.N, self.num_chunks, mon))
         if (self.rmap.acc and config.directory.custom_tmp and self.N > 1000
                 and parallel.oq_distribute() != 'no'):
             # tested in the oq-risk-tests
             mcores = int(config.distribution.master_cores or 16)
-            allargs = []
-            for g, rates_g in self.rmap.acc.items():
-                mon = performance.Monitor()
-                mon.calc_id = self.datastore.calc_id
-                mon.task_no = smap.task_no + g
-                allargs.append((rates_g, g, self.N, self.num_chunks, mon))
-            with self.monitor('storing rates', measuremem=True), \
-                 mp.Pool(mcores) as pool:
-                pool.starmap(save_rates, allargs)
+            with self.monitor('storing rates', measuremem=True), mp.Pool(mcores) as p:
+                p.starmap(save_rates, allargs)
         elif self.rmap.acc:
             with self.monitor('storing rates', measuremem=True):
-                for g, rates_g in self.rmap.acc.items():
-                    rates = from_rates_g(rates_g, g, self.rmap.sids)
-                    _store(rates, self.num_chunks, self.datastore)
+                for args in allargs:
+                    save_rates(*args)
         del self.rmap
         if oq.disagg_by_src:
             mrs = self.haz.store_mean_rates_by_src(acc)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -552,13 +552,14 @@ class ClassicalCalculator(base.HazardCalculator):
         self.datastore.swmr_on()  # must come before the Starmap
         smap = parallel.Starmap(classical, allargs, h5=self.datastore.hdf5)
         acc = smap.reduce(self.agg_dicts, AccumDict(accum=0.))
-        logging.info('Storing %s', self.rmap)
+
         allargs = []
-        for i, rmap in enumerate(self.rmap.gen_chunks(self.num_chunks)):
+        for rmap in self.rmap.gen_chunks(self.num_chunks):
             mon = performance.Monitor()
             mon.calc_id = self.datastore.calc_id
-            mon.task_no = smap.task_no + i
+            mon.task_no = rmap.chunk_no + smap.task_no
             allargs.append((rmap, mon))
+        logging.info('Processing %d rmaps from %s', len(allargs), self.rmap)
         if (self.rmap.acc and config.directory.custom_tmp and self.N > 1000
                 and parallel.oq_distribute() != 'no'):
             # tested in the oq-risk-tests

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -568,7 +568,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 # tested in the oq-risk-tests
                 mcores = int(config.distribution.master_cores or 16)
                 with mp.Pool(mcores) as p:
-                    for _ in p.imap_unordered(save_rates, genargs(), chunksize=mcores):
+                    for _ in p.imap_unordered(save_rates, genargs(), self.num_chunks):
                         pass
             elif self.rmap.acc:
                 for rmap, mon in genargs():

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -565,7 +565,7 @@ class ClassicalCalculator(base.HazardCalculator):
             # tested in the oq-risk-tests
             mcores = int(config.distribution.master_cores or 16)
             with self.monitor('storing rates', measuremem=True), mp.Pool(mcores) as p:
-                p.starmap(save_rates, allargs)
+                p.starmap_async(save_rates, allargs, chunksize=mcores)
         elif self.rmap.acc:
             with self.monitor('storing rates', measuremem=True):
                 for args in allargs:

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -278,18 +278,18 @@ class MapArray(object):
 
     def gen_chunks(self, num_chunks):
         """
-        :yields: num_chunks rate maps of shape (C, L, G)
+        :yields: many rate maps of shape (C, L, 1)
         """
-        gids = sorted(self.acc)
         for chunk in range(num_chunks):
             ch = self.sids % num_chunks == chunk
-            rates = [rates_g[ch] for g, rates_g in self.acc.items()]
-            rmap = self.__class__(self.sids[ch], self.shape[1], len(gids))
-            rmap.array = numpy.array(rates).transpose(1, 2, 0)  # (C, L, G)
-            rmap.gids = gids
-            rmap.chunk = chunk
-            rmap.num_chunks = num_chunks
-            yield rmap
+            sids = self.sids[ch]
+            for g, rates_g in self.acc.items():
+                rmap = self.__class__(sids, self.shape[1], 1)
+                rmap.array = rates_g[ch, :, None]
+                rmap.gids = [g]
+                rmap.chunk = chunk
+                rmap.num_chunks = num_chunks
+                yield rmap
 
     def fill(self, value):
         """

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -267,9 +267,29 @@ class MapArray(object):
         """
         :yields: G MapArrays of shape (N, L, 1)
         """
-        _N, L, G = self.array.shape
+        _N, L, G = self.shape
         for g in range(G):
-            yield self.__class__(self.sids, L, 1).new(self.array[:, :, [g]])
+            if hasattr(self, 'array'):
+                new = self.__class__(self.sids, L, 1).new(self.array[:, :, [g]])
+            else:
+                new = self.__class__(self.sids, L, 1).new(self.acc[g][:, :, None])
+            new.gids = [g]
+            yield new
+
+    def gen_chunks(self, num_chunks):
+        """
+        :yields: num_chunks rate maps of shape (C, L, G)
+        """
+        gids = sorted(self.acc)
+        for chunk in range(num_chunks):
+            ch = self.sids % num_chunks == chunk
+            rates = [rates_g[ch] for g, rates_g in self.acc.items()]
+            rmap = self.__class__(self.sids[ch], self.shape[1], len(gids))
+            rmap.array = numpy.array(rates).transpose(1, 2, 0)  # (C, L, G)
+            rmap.gids = gids
+            rmap.chunk = chunk
+            rmap.num_chunks = num_chunks
+            yield rmap
 
     def fill(self, value):
         """

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -280,14 +280,14 @@ class MapArray(object):
         """
         :yields: many rate maps of shape (C, L, 1)
         """
-        for chunk in range(num_chunks):
-            ch = self.sids % num_chunks == chunk
+        for chunk_no in range(num_chunks):
+            ch = self.sids % num_chunks == chunk_no
             sids = self.sids[ch]
             for g, rates_g in self.acc.items():
                 rmap = self.__class__(sids, self.shape[1], 1)
                 rmap.array = rates_g[ch, :, None]
                 rmap.gids = [g]
-                rmap.chunk = chunk
+                rmap.chunk_no = chunk_no
                 rmap.num_chunks = num_chunks
                 yield rmap
 


### PR DESCRIPTION
Supersedes https://github.com/gem/oq-engine/pull/9931. This is much faster than before for the EUR calculation,
storing rates goes down from 1776s to 687s and the memory occupation is reduced by half. However, we can still improve a lot, since the cores are most of the time in "D" state, i.e. waiting from input. Using shared arrays is the way to go, but has to be done carefully because there are limits on the number of shared arrays, i.e. one per `gid` would not work :-(