### PR TITLE
Restored multiple outputs per task in classical calculations

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -831,13 +831,12 @@ class Starmap(object):
         """
         Log the progress of the computation in percentage
         """
-        queued = len(self.task_queue)
-        total = self.task_no
-        done = total - len(self.tasks)
-        percent = int(float(done) / total * 100)
+        done = self.task_no - len(self.tasks)
+        percent = int(done / self.task_no * 100)
         if not hasattr(self, 'prev_percent'):  # first time
             self.prev_percent = 0
         elif percent > self.prev_percent:
+            queued = len(self.task_queue)
             self.progress('%s %3d%% [%d submitted, %d queued]',
                           self.name, percent, self.task_no, queued)
             self.prev_percent = percent
@@ -977,8 +976,8 @@ class Starmap(object):
         isocket = iter(self.socket)  # read from the PULL socket
         finished = set()
         while self.tasks:
-            self.log_percent()
             res = next(isocket)
+            self.log_percent()
             if self.calc_id != res.mon.calc_id:
                 logging.warning('Discarding a result from job %s, since this '
                                 'is job %s', res.mon.calc_id, self.calc_id)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -151,8 +151,7 @@ def classical(sources, tilegetter, cmaker, dstore, monitor):
         if sources is None:  # read the full group from the datastore
             arr = dstore.getitem('_csm')[cmaker.grp_id]
             sources = pickle.loads(zlib.decompress(arr.tobytes()))
-        complete = dstore['sitecol'].complete  # super-fast
-        sitecol = tilegetter(complete)
+        sitecol = dstore['sitecol'].complete  # super-fast
 
     if cmaker.disagg_by_src and not cmaker.atomic:
         # in case_27 (Japan) we do NOT enter here;
@@ -164,8 +163,8 @@ def classical(sources, tilegetter, cmaker, dstore, monitor):
             yield result
         return
 
-    for tilegetter in sitecol.split(tilegetter.ntiles):
-        result = hazclassical(sources, tilegetter(complete), cmaker)
+    for tileget in sitecol.split(tilegetter.ntiles):
+        result = hazclassical(sources, tileget(sitecol), cmaker)
         if cmaker.disagg_by_src:
             # do not remove zeros, otherwise AELO for JPN will break
             # since there are 4 sites out of 18 with zeros

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -176,8 +176,8 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     # build source_groups
     triples = csm.split(cmakers, sitecol, max_weight)
     data = numpy.array(
-        [(cm.grp_id, len(cm.gsims), tiles, blocks, len(cm.gsims) * fac * 1024,
-          cm.weight, cm.codes, cm.trt) for cm, tiles, blocks in triples],
+        [(cm.grp_id, len(cm.gsims), tg.ntiles, blocks, len(cm.gsims) * fac * 1024,
+          cm.weight, cm.codes, cm.trt) for cm, tg, blocks in triples],
         [('grp_id', U16), ('gsims', U16), ('tiles', U16), ('blocks', U16),
          ('size_mb', F32), ('weight', F32), ('codes', '<S8'), ('trt', '<S20')])
 
@@ -200,10 +200,10 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     dstore.create_dset('source_groups', data, fillvalue=None,
                        attrs=dict(req_gb=req_gb, mem_gb=mem_gb, tiling=tiling))
     Ns = data['tiles']
-    ntasks = Ns @ data['blocks']
+    outs = Ns @ data['blocks']
     if not tiling:
-        logging.info('This will be a calculation with ~%d tasks, '
-                     'min_tiles=%d, max_tiles=%d', ntasks, Ns.min(), Ns.max())
+        logging.info('This will be a calculation with ~%d outputs, '
+                     'min_tiles=%d, max_tiles=%d', outs, Ns.min(), Ns.max())
     if req_gb >= 30 and not config.directory.custom_tmp:
         logging.info('We suggest to set custom_tmp')
     return req_gb, max_weight, trt_rlzs, gids

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -85,6 +85,8 @@ class TileGetter:
         self.ntiles = ntiles
 
     def __call__(self, complete):
+        if self.ntiles == 1:
+            return complete
         sc = SiteCollection.__new__(SiteCollection)
         sc.array = complete.array[complete.sids % self.ntiles == self.tileno]
         sc.complete = complete

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -689,7 +689,7 @@ class CompositeSourceModel:
 
     def split(self, cmakers, sitecol, max_weight, num_chunks=1, tiling=False):
         """
-        :yields: (cmaker, ntiles, nblocks) for each source group
+        :yields: (cmaker, sitegetter, nblocks) for each source group
         """
         N = len(sitecol)
         oq = cmakers[0].oq
@@ -719,7 +719,7 @@ class CompositeSourceModel:
             cmaker.blocks = blocks
             cmaker.weight = sg.weight
             cmaker.atomic = sg.atomic
-            yield cmaker, splits, blocks
+            yield cmaker, site.TileGetter(0, splits), blocks
 
     def __toh5__(self):
         G = len(self.src_groups)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -709,7 +709,7 @@ class CompositeSourceModel:
                 splits = numpy.ceil(max(splits, sg.weight / max_weight))
                 blocks = 1
             else:
-                blocks = numpy.ceil(sg.weight / max_weight / splits)
+                blocks = numpy.ceil(sg.weight / max_weight)
             self.splits.append(splits)
             cmaker.gsims = list(cmaker.gsims)  # save data transfer
             cmaker.codes = sg.codes

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -689,7 +689,7 @@ class CompositeSourceModel:
 
     def split(self, cmakers, sitecol, max_weight, num_chunks=1, tiling=False):
         """
-        :yields: (cmaker, sitegetter, nblocks) for each source group
+        :yields: (cmaker, tilegetter, nblocks) for each source group
         """
         N = len(sitecol)
         oq = cmakers[0].oq

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -685,7 +685,7 @@ class CompositeSourceModel:
         max_weight = tot_weight / (oq.concurrent_tasks or 1)
         logging.info('tot_weight={:_d}, max_weight={:_d}, num_sources={:_d}'.
                      format(int(tot_weight), int(max_weight), len(srcs)))
-        return max_weight * 1.02  # increased to produce a bit less tasks
+        return max_weight * 1.05  # increased to produce a bit less tasks
 
     def split(self, cmakers, sitecol, max_weight, num_chunks=1, tiling=False):
         """


### PR DESCRIPTION
To save data transfer in the cmakers. For instance for half of the USA on the engine192 machine one gets
```
This will be a calculation with ~5017 outputs, min_tiles=2, max_tiles=21
Sent 384 classical tasks, 2.09 GB
```
instead of
```
This will be a calculation with ~610 tasks, min_tiles=2, max_tiles=21
Sent 384 classical tasks, 8.67 GB
```
