### PR TITLE
Removed remote_user and remote_python from openquake.cfg

### DIFF
--- a/ansible/cluster/templates/openquake.zmq.cfg.j2
+++ b/ansible/cluster/templates/openquake.zmq.cfg.j2
@@ -55,9 +55,8 @@ username =
 password =
 
 [zworkers]
-host_cores = 
+host_cores =
 ctrl_port = 1909
-remote_python =
 
 [directory]
 # the base directory containing the <user>/oqdata directories:

--- a/docker/openquake.cfg
+++ b/docker/openquake.cfg
@@ -54,7 +54,6 @@ password =
 [zworkers]
 host_cores = 
 ctrl_port = 1909
-remote_python =
 
 [directory]
 # the base directory containing the <user>/oqdata directories:

--- a/openquake/commands/workers.py
+++ b/openquake/commands/workers.py
@@ -20,11 +20,12 @@
 import sys
 import getpass
 from openquake.baselib import config, workerpool, parallel as p
+from openquake.commonlib import logs
 
 CHOICES = 'start stop status restart wait kill debug'.split()
 
 
-def main(cmd):
+def main(cmd, job_id: int=-1):
     """
     start/stop the workers, or return their status
     """
@@ -35,8 +36,13 @@ def main(cmd):
     if dist == 'zmq':
         master = workerpool.WorkerMaster(config.zworkers)
         print(getattr(master, cmd)())
+    elif dist == 'slurm':
+        job = logs.dbcmd('get_job', job_id)
+        master = workerpool.WorkerMaster(job.id)
+        print(getattr(master, cmd)())
     else:
         print('Nothing to do: oq_distribute=%s' % dist)
 
 
 main.cmd = dict(help='command', choices=CHOICES)
+main.job_id = dict(help='running job')

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -70,8 +70,6 @@ password =
 [zworkers]
 host_cores = 127.0.0.1 -1
 ctrl_port = 1909
-remote_python =
-remote_user = 
 
 [directory]
 # the base directory containing the <user>/oqdata directories:


### PR DESCRIPTION
They were not used. Also, added a `get_zworkers` utility to be used in the command `oq workers`.