### PR TITLE
ARISTOTLE: solve some corner cases in reading station data

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -393,7 +393,7 @@ def download_station_data_file(usgs_id):
             except (LookupError, UnicodeDecodeError,
                     json.decoder.JSONDecodeError) as exc:
                 # TODO: return this also to the webui
-                logging.error(str(exc))
+                logging.warning(str(exc))
                 return None
             else:
                 original_len = len(stations)

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -390,9 +390,11 @@ def download_station_data_file(usgs_id):
             stations_json_str = urlopen(stationlist_url).read()
             try:
                 stations = read_usgs_stations_json(stations_json_str)
-            except (LookupError, UnicodeDecodeError) as exc:
-                # TODO: return this info also to the webui
-                logging.warning(str(exc))
+            except (LookupError, UnicodeDecodeError,
+                    json.decoder.JSONDecodeError) as exc:
+                # TODO: return this also to the webui
+                logging.error(str(exc))
+                return None
             else:
                 original_len = len(stations)
                 seismic_len = len(

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -391,17 +391,29 @@ def download_station_data_file(usgs_id):
             try:
                 stations = read_usgs_stations_json(stations_json_str)
             except (LookupError, UnicodeDecodeError) as exc:
-                logging.info(str(exc))
+                # TODO: return this info also to the webui
+                logging.warning(str(exc))
             else:
                 original_len = len(stations)
+                seismic_len = len(
+                    stations[stations['station_type'] == 'seismic'])
                 df = usgs_to_ecd_format(stations, exclude_imts=('SA(3.0)',))
                 if len(df) < 1:
                     if original_len > 1:
-                        logging.warning(
-                            f'{original_len} stations were found, but they'
-                            f' were all discarded')
+                        if seismic_len > 1:
+                            # TODO: return this info also to the webui
+                            logging.warning(
+                                f'{original_len} stations were found, but the'
+                                f' {seismic_len} seismic stations were all'
+                                f' discarded')
+                        else:
+                            # TODO: return this info also to the webui
+                            logging.warning(
+                                f'{original_len} stations were found, but none'
+                                f' of them are seismic')
                     else:
-                        logging.warning('No seismic stations found')
+                        # TODO: return this info also to the webui
+                        logging.warning('No stations were found')
                 else:
                     with tempfile.NamedTemporaryFile(
                             delete=False, mode='w+', newline='',


### PR DESCRIPTION
I would like to provide more information to the webui user in a separate PR, but for now I am aiming at fixing the broken tests and better handling cases in which seismic stations are discarded.

Running aristotle tests locally, only one error remains, for usgs_id `us70008dx7`:

```python
Traceback (most recent call last):                                                                                                                                                                                                           
  File "/home/ptormene/GIT/oq-engine/openquake/engine/aristotle.py", line 217, in main_cmd                                                                                                                                                   
    engine.run_jobs([job])                                                                                                                                                                                                                   
  File "/home/ptormene/GIT/oq-engine/openquake/engine/engine.py", line 404, in run_jobs                                                                                                                                                      
    run_calc(jobctx)                                                                                                                                                                                                                         
  File "/home/ptormene/GIT/oq-engine/openquake/engine/engine.py", line 269, in run_calc                                                                                                                                                      
    calc.run(shutdown=True)                                                                                                                                                                                                                  
  File "/home/ptormene/GIT/oq-engine/openquake/calculators/base.py", line 288, in run                                                                                                                                                        
    raise exc from None                                                                                                                                                                                                                      
  File "/home/ptormene/GIT/oq-engine/openquake/calculators/base.py", line 271, in run                                                                                                                                                        
    self.pre_execute()                                                                                                                                                                                                                       
  File "/home/ptormene/GIT/oq-engine/openquake/calculators/event_based_risk.py", line 347, in pre_execute                                                                                                                                    
    super().pre_execute()                                                                                                                                                                                                                    
  File "/home/ptormene/GIT/oq-engine/openquake/calculators/base.py", line 644, in pre_execute                                                                                                                                                
    calc.run(remove=False)
  File "/home/ptormene/GIT/oq-engine/openquake/calculators/base.py", line 288, in run
    raise exc from None
  File "/home/ptormene/GIT/oq-engine/openquake/calculators/base.py", line 272, in run
    self.result = self.execute()
  File "/home/ptormene/GIT/oq-engine/openquake/calculators/event_based.py", line 695, in execute
    smap = starmap_from_rups(event_based, oq, self.full_lt, self.sitecol, dstore)
  File "/home/ptormene/GIT/oq-engine/openquake/calculators/event_based.py", line 345, in starmap_from_rups
    raise ValueError(
ValueError: The calculation is too large: G=15, M=4, N=4603. You must reduce the number of sites i.e. enlarge region_grid_spacing)
```