### PR TITLE
Refined the task distribution

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -372,7 +372,7 @@ def split_in_blocks(sequence, hint, weight=lambda item: 1, key=nokey):
     assert hint > 0, hint
     assert len(items) > 0, len(items)
     total_weight = float(sum(weight(item) for item in items))
-    return block_splitter(items, math.ceil(total_weight / hint), weight, key)
+    return block_splitter(items, total_weight / hint, weight, key)
 
 
 def assert_close(a, b, rtol=1e-07, atol=0, context=None):

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -372,7 +372,7 @@ def split_in_blocks(sequence, hint, weight=lambda item: 1, key=nokey):
     assert hint > 0, hint
     assert len(items) > 0, len(items)
     total_weight = float(sum(weight(item) for item in items))
-    return block_splitter(items, total_weight / hint, weight, key)
+    return block_splitter(items, math.ceil(total_weight / hint), weight, key)
 
 
 def assert_close(a, b, rtol=1e-07, atol=0, context=None):

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -81,6 +81,7 @@ def _store(rates, num_chunks, h5, mon=None, gzip=GZIP):
     hdf5.extend(h5['_rates/slice_by_idx'], iss)
     if newh5:
         fname = h5.filename
+        h5.flush()
         h5.close()
         return fname
 
@@ -608,6 +609,8 @@ class ClassicalCalculator(base.HazardCalculator):
             for g, N, jid, num_chunks in genargs():
                 rates = self.rmap.to_array(g)
                 _store(rates, self.num_chunks, self.datastore)
+        else:
+            logging.warning('Empty ratemap')
         del self.rmap
         if oq.disagg_by_src:
             mrs = self.haz.store_mean_rates_by_src(acc)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -558,7 +558,11 @@ class ClassicalCalculator(base.HazardCalculator):
                 self.cmakers, self.sitecol, self.max_weight,
                 self.num_chunks, tiling):
             for block in blocks:
-                allargs.append((block, tilegetters, cmaker, ds))
+                if tiling:
+                    for tgetter in tilegetters:
+                        allargs.append((block, [tgetter], cmaker, ds))
+                else:
+                    allargs.append((block, tilegetters, cmaker, ds))
                 n_out.append(len(tilegetters))
         if tiling:
             logging.info('This will be a tiling calculation with %d outputs, '

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -517,8 +517,8 @@ class ClassicalCalculator(base.HazardCalculator):
         fraction = os.environ.get('OQ_SAMPLE_SOURCES')
         if fraction:
             est_time = classical_time / float(fraction)
-            logging.info('Estimated time for the classical part: %.1f hours',
-                         est_time / 3600)
+            logging.info('Estimated time for the classical part: %.1f hours '
+                         '(upper limit)', est_time / 3600)
         if self.cfactor[0] == 0:
             if self.N == 1:
                 logging.error('The site is far from all seismic sources'

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -555,8 +555,7 @@ class ClassicalCalculator(base.HazardCalculator):
         allargs = []
         n_out = []
         for cmaker, tilegetters, blocks in self.csm.split(
-                self.cmakers, self.sitecol, self.max_weight,
-                self.num_chunks, tiling):
+                self.cmakers, self.sitecol, self.max_weight, self.num_chunks, tiling):
             for block in blocks:
                 if tiling:
                     for tgetter in tilegetters:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -173,7 +173,8 @@ def classical(sources, tilegetters, cmaker, dstore, monitor):
         # print(f"{monitor.task_no=} {rmap=}")
 
         if rmap.size_mb and cmaker.blocks == 1 and not cmaker.disagg_by_src:
-            del result['source_data']
+            if len(tilegetters) > 1:
+                del result['source_data']
             if cmaker.custom_tmp:
                 rates = rmap.to_array(cmaker.gid)
                 _store(rates, cmaker.num_chunks, None, monitor)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -557,16 +557,13 @@ class ClassicalCalculator(base.HazardCalculator):
         for cmaker, tilegetters, blocks in self.csm.split(
                 self.cmakers, self.sitecol, self.max_weight,
                 self.num_chunks, tiling):
-            sg = self.csm.src_groups[cmaker.grp_id]
-            for block in split_in_blocks(sg, blocks, get_weight):
-                allargs.append((block if blocks > 1 else None,
-                                tilegetters, cmaker, ds))
+            for block in blocks:
+                allargs.append((block, tilegetters, cmaker, ds))
                 n_out.append(len(tilegetters))
-
-        logging.info('This will be a %s calculation with %d outputs, '
-                     '%d tasks, min_tiles=%d, max_tiles=%d',
-                     'tiling' if tiling else 'regular',
-                     sum(n_out), len(allargs), min(n_out), max(n_out))
+        if tiling:
+            logging.info('This will be a tiling calculation with %d outputs, '
+                         '%d tasks, min_tiles=%d, max_tiles=%d',
+                         sum(n_out), len(allargs), min(n_out), max(n_out))
 
         # log info about the heavy sources
         srcs = self.csm.get_sources()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -28,8 +28,7 @@ import numpy
 import pandas
 from PIL import Image
 from openquake.baselib import parallel, hdf5, config, python3compat
-from openquake.baselib.general import (
-    AccumDict, DictArray, groupby, humansize, split_in_blocks)
+from openquake.baselib.general import AccumDict, DictArray, groupby, humansize
 from openquake.hazardlib import valid, InvalidFile
 from openquake.hazardlib.contexts import read_cmakers
 from openquake.hazardlib.calc.hazard_curve import classical as hazclassical

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -176,7 +176,7 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     # build source_groups
     triples = csm.split(cmakers, sitecol, max_weight)
     data = numpy.array(
-        [(cm.grp_id, len(cm.gsims), len(tgets), blocks, len(cm.gsims) * fac * 1024,
+        [(cm.grp_id, len(cm.gsims), len(tgets), len(blocks), len(cm.gsims) * fac * 1024,
           cm.weight, cm.codes, cm.trt) for cm, tgets, blocks in triples],
         [('grp_id', U16), ('gsims', U16), ('tiles', U16), ('blocks', U16),
          ('size_mb', F32), ('weight', F32), ('codes', '<S8'), ('trt', '<S20')])
@@ -191,6 +191,12 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     max_gb = float(config.memory.pmap_max_gb or parallel.Starmap.num_cores / 4.)
     regular = (mem_gb < max_gb or oq.disagg_by_src or
                N < oq.max_sites_disagg or oq.tile_spec)
+    if regular:
+        n_out = data['tiles'] @ data['blocks']
+        n_tasks = data['blocks'].sum()
+        logging.info('This will be a regular calculation with %d outputs, '
+                     '%d tasks, min_tiles=%d, max_tiles=%d',
+                     n_out, n_tasks, data['tiles'].min(), data['tiles'].max())
 
     # store source_groups
     if oq.tiling is None:

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -200,7 +200,9 @@ def store_tiles(dstore, csm, sitecol, cmakers):
 
     # store source_groups
     if oq.tiling is None:
-        tiling = not regular
+        # use tiling with OQ_SAMPLE_SOURCES to avoid slow tasks
+        ss = os.environ.get('OQ_SAMPLE_SOURCES') is not None
+        tiling = ss or not regular
     else:
         tiling = oq.tiling
     dstore.create_dset('source_groups', data, fillvalue=None,

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -185,10 +185,11 @@ class ClassicalTestCase(CalculatorTestCase):
                 'hazard_curve-mean-SA(1.0).csv',
                 'hazard_curve-mean-SA(2.0).csv',
         ], case_22.__file__, delta=1E-6)
-        data = self.calc.datastore['source_groups'][:]
+        data = self.calc.datastore['source_groups']
+        self.assertTrue(data.attrs['tiling'])
         self.assertEqual(data['gsims'], 4)
         self.assertEqual(data['tiles'], 1)
-        self.assertEqual(data['blocks'], 10)
+        self.assertEqual(data['blocks'], 2)
 
     def test_case_23(self):  # filtering away on TRT
         self.assert_curves_ok(['hazard_curve.csv'],

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -307,6 +307,12 @@ def view_contents(token, dstore):
     tot = (dstore.filename, humansize(os.path.getsize(dstore.filename)))
     data = sorted((dstore.getsize(key), key) for key in dstore)
     rows = [(key, humansize(nbytes)) for nbytes, key in data] + [tot]
+    scratch_dir = dstore['/'].attrs.get('scratch_dir')
+    if scratch_dir:
+        size = 0
+        for fname in os.listdir(scratch_dir):
+            size += os.path.getsize(os.path.join(scratch_dir, fname))
+        rows.append((scratch_dir, humansize(size)))
     return numpy.array(rows, dt('dataset size'))
 
 

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -812,13 +812,7 @@ def view_task_hazard(token, dstore):
                      taskno, len(sdata), num_ruptures, eff_sites,
                      rec['weight'], rec['duration'])
     else:
-        w = dstore.read_df('source_info').groupby('grp_id').weight.sum()
-        tdata = dstore.read_df('tiles').loc[taskno]
-        grp_id = int(tdata.grp_id)
-        msg = ('taskno={:_d}, grp_id={:_d}, G={:_d}, N={:_d}, weight={:.1f}, '
-               'duration={:.1f}s').format(
-                   taskno, grp_id, int(tdata.G), int(tdata.N),
-                   w.loc[grp_id] / tdata.G, rec['duration'])
+        msg = ''
     return msg
 
 

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -21,7 +21,7 @@ import warnings
 import numpy
 import pandas
 import numba
-from openquake.baselib.general import cached_property
+from openquake.baselib.general import cached_property, humansize
 from openquake.baselib.performance import compile
 from openquake.hazardlib.tom import get_pnes
 
@@ -424,8 +424,8 @@ class MapArray(object):
         return self
 
     def __repr__(self):
-        tup = self.shape + (self.size_mb,)
-        return f'<{self.__class__.__name__}(%d, %d, %d)[%.1fM]>' % tup
+        tup = self.shape + (humansize(self.array.nbytes),)
+        return f'<{self.__class__.__name__}(%d, %d, %d)[%s]>' % tup
 
 
 @compile("(float32[:, :], float32[:, :], uint32[:])")

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -703,15 +703,12 @@ class CompositeSourceModel:
             grp_id = cmaker.grp_id
             sg = self.src_groups[grp_id]
             splits = numpy.ceil(len(cmaker.gsims) * mb_per_gsim / max_mb)
-            if sg.atomic:
-                blocks = [None]
-            elif tiling:
+            if sg.atomic or tiling:
                 splits = numpy.ceil(max(splits, sg.weight / max_weight))
                 blocks = [None]
             else:
                 hint = numpy.ceil(sg.weight / max_weight)
-                blocks = list(general.split_in_blocks(
-                    sg, hint, lambda src: src.weight))
+                blocks = list(general.split_in_blocks(sg, hint, lambda s: s.weight))
             self.splits.append(splits)
             cmaker.tiling = tiling
             cmaker.gsims = list(cmaker.gsims)  # save data transfer

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -704,7 +704,9 @@ class CompositeSourceModel:
             sg = self.src_groups[grp_id]
             splits = numpy.ceil(len(cmaker.gsims) * mb_per_gsim / max_mb)
             if sg.atomic or tiling:
-                splits = numpy.ceil(max(splits, sg.weight / max_weight))
+                # splits/4 reduce the number of tasks for very light groups
+                # (will use 4x more memory, but pmap_max_mb is only 120 MB)
+                splits = numpy.ceil(max(splits / 4, sg.weight / max_weight))
                 blocks = [None]
             else:
                 hint = numpy.ceil(sg.weight / max_weight)


### PR DESCRIPTION
and extended `oq show contents` to show the size of the scratch_dir. Also use tiling when OQ_SAMPLE_SOURCES is set, to avoid slow tasks.