### PR TITLE
Saving memory and disk space in CollapsedPointSources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Internal: reduced the space used by the CollapsedPointSources (2.7x)
   * Fixed the site model association procedure to work in conditioned
     scenario calculations
   * Used `oq engine --run` to submit asynchronous jobs to SLURM and

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -41,7 +41,7 @@ import subprocess
 import collections
 import multiprocessing
 from contextlib import contextmanager
-from collections.abc import Mapping, Container, MutableSequence
+from collections.abc import Mapping, Container, Sequence, MutableSequence
 import numpy
 import pandas
 from decorator import decorator
@@ -1795,3 +1795,20 @@ def loada(arr):
     23
     """
     return pickle.loads(bytes(arr))
+
+
+class Unique(Sequence):
+    """
+    Compress objects containing copies
+    """
+    def __init__(self, objects):
+        pickles = [pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
+                   for obj in objects]
+        uni, self.inv = numpy.unique(pickles, return_inverse=True)
+        self.uni = [pickle.loads(pik) for pik in uni]
+
+    def __getitem__(self, i):
+        return self.uni[self.inv[i]]
+
+    def __len__(self):
+        return len(self.inv)

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1797,9 +1797,9 @@ def loada(arr):
     return pickle.loads(bytes(arr))
 
 
-class Unique(Sequence):
+class Deduplicate(Sequence):
     """
-    Compress objects containing copies
+    Deduplicate lists containing duplicated objects
     """
     def __init__(self, objects):
         pickles = [pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1801,14 +1801,20 @@ class Deduplicate(Sequence):
     """
     Deduplicate lists containing duplicated objects
     """
-    def __init__(self, objects):
+    def __init__(self, objects, check_one=False):
         pickles = [pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
                    for obj in objects]
         uni, self.inv = numpy.unique(pickles, return_inverse=True)
         self.uni = [pickle.loads(pik) for pik in uni]
+        if check_one:
+            assert len(self.uni) == 1, self.uni
 
     def __getitem__(self, i):
         return self.uni[self.inv[i]]
+
+    def __repr__(self):
+        name = self[0].__class__.__name__
+        return '<Deduplicated %s %d/%d>' % (name, len(self.uni), len(self.inv))
 
     def __len__(self):
         return len(self.inv)

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -598,12 +598,10 @@ class ClassicalCalculator(base.HazardCalculator):
         if (self.rmap.size_mb and config.directory.custom_tmp and
             self.N > 1000 and parallel.oq_distribute() != 'no'):
             # tested in the oq-risk-tests
-            mcores = int(config.distribution.master_cores or 16)
             savemap = parallel.Starmap(save_rates, genargs(),
                                        h5=self.datastore,
                                        distribute='processpool')
             savemap.share(rates=self.rmap.array)
-            savemap.num_cores = mcores
             savemap.reduce()
         elif self.rmap.size_mb:
             for g, N, jid, num_chunks in genargs():

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1857,3 +1857,9 @@ def view_long_ruptures(token, dstore):
                             ('maxmag', float), ('usd', float), ('lsd', float)])
     arr.sort(order='maxlen')
     return arr
+
+@view.add('msr')
+def view_msr(token, dstore):
+    dic = dstore['_csm'].get_msr_by_grp()
+    pairs = list(dic.items())
+    return numpy.array(pairs, dt('grp_id msr'))

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1840,11 +1840,17 @@ def view_fastmean(token, dstore):
 
 @view.add('gw')
 def view_gw(token, dstore):
+    """
+    Display the gweights
+    """
     return numpy.round(dstore['gweights'][:].sum(), 3)
 
 
 @view.add('long_ruptures')
 def view_long_ruptures(token, dstore):
+    """
+    Display the planar ruptures with maxlen > 900 km
+    """
     lst = []
     for src in dstore['_csm'].get_sources():
         maxlen = source.point.get_rup_maxlen(src)

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -899,6 +899,7 @@ def geohash(lons, lats, length):
     return chars
 
 
+# corresponds to blocks of 2.4 km
 def geohash5(coords):
     """
     :returns: a geohash of length 5*len(points) as a string
@@ -911,6 +912,7 @@ def geohash5(coords):
     return b'_'.join(row.tobytes() for row in arr).decode('ascii')
 
 
+# corresponds to blocks of 78 km
 def geohash3(lons, lats):
     """
     :returns: a geohash of length 3 as a 16 bit integer

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -46,7 +46,7 @@ class MultiPointSource(ParametricSeismicSource):
     lower_seismogenic_depth, nodal_plane_distribution, hypocenter_distribution
     """
     code = b'M'
-    MODIFICATIONS = set(())
+    MODIFICATIONS = set()
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, magnitude_scaling_relationship, rupture_aspect_ratio,

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -370,19 +370,32 @@ class PointSource(ParametricSeismicSource):
 def psources_to_pdata(pointsources, name):
     """
     Build a pdata dictionary from a list of homogeneous point sources
-    with the same tom, trt, npd and hcd.
+    with the same tom, trt, msr.
     """
     ps = pointsources[0]
+    dt = [(f, numpy.float32) for f in 'lon lat rar usd lsd'.split()]
+    array = numpy.empty(len(pointsources), dt)
+    for i, ps in enumerate(pointsources):
+        rec = array[i]
+        loc = ps.location
+        rec['lon'] = loc.x
+        rec['lat'] = loc.y
+        rec['rar'] = ps.rupture_aspect_ratio
+        rec['usd'] = ps.upper_seismogenic_depth
+        rec['lsd'] = ps.lower_seismogenic_depth
     pdata = dict(name=name,
+                 array=array,
                  tom=ps.temporal_occurrence_model,
                  trt=ps.tectonic_region_type,
-                 npd=ps.nodal_plane_distribution,
-                 hcd=ps.hypocenter_distribution,
+                 msr=ps.magnitude_scaling_relationship,
                  rms=ps.rupture_mesh_spacing,
-                 mfd=Deduplicate([ps.mfd for ps in pointsources]),
-                 msr=Deduplicate([ps.magnitude_scaling_relationship
-                                  for ps in pointsources]))
+                 npd=Deduplicate([ps.nodal_plane_distribution
+                                  for ps in pointsources]),
+                 hcd=Deduplicate([ps.hypocenter_distribution
+                                  for ps in pointsources]),
+                 mfd=Deduplicate([ps.mfd for ps in pointsources]))
     return pdata
+
 
 def pdata_to_psources(pdata):
     """
@@ -396,23 +409,25 @@ def pdata_to_psources(pdata):
     rms = pdata['rms']
     mfd = pdata['mfd']
     msr = pdata['msr']
-    for i, rec in pdata['array']:
-        yield PointSource(
+    out = []
+    for i, rec in enumerate(pdata['array']):
+        out.append(PointSource(
             source_id=f'{name}:{i}',
             name=name,
             tectonic_region_type=trt,
             mfd=mfd[i],
             rupture_mesh_spacing=rms,
-            magnitude_scaling_relationship=msr[i],
+            magnitude_scaling_relationship=msr,
             rupture_aspect_ratio=rec['rar'],
             upper_seismogenic_depth=rec['usd'],
             lower_seismogenic_depth=rec['lsd'],
             location=Point(rec['lon'], rec['lat']),
-            nodal_plane_distribution=npd,
-            hypocenter_distribution=hcd,
-            temporal_occurrence_model=tom)
+            nodal_plane_distribution=npd[i],
+            hypocenter_distribution=hcd[i],
+            temporal_occurrence_model=tom))
+    return out
 
-    
+
 class CollapsedPointSource(PointSource):
     """
     Source typology representing a cluster of point sources around a
@@ -425,7 +440,7 @@ class CollapsedPointSource(PointSource):
 
     def __init__(self, source_id, pointsources):
         self.source_id = source_id
-        self.pointsources = pointsources
+        self.pdata = psources_to_pdata(pointsources, source_id)
         self.tectonic_region_type = pointsources[0].tectonic_region_type
         self.magnitude_scaling_relationship = (
             pointsources[0].magnitude_scaling_relationship)
@@ -436,6 +451,13 @@ class CollapsedPointSource(PointSource):
         self.nodal_plane_distribution = PMF(
             [(1., NodalPlane(self.strike, self.dip, self.rake))])
         self.hypocenter_distribution = PMF([(1., self.dep)])
+
+    @property
+    def pointsources(self):
+        """
+        :returns: the underlying point sources
+        """
+        return pdata_to_psources(self.pdata)
 
     def get_annual_occurrence_rates(self):
         """
@@ -473,7 +495,8 @@ class CollapsedPointSource(PointSource):
         """
         :returns: the total number of underlying ruptures
         """
-        return sum(src.count_ruptures() for src in self.pointsources)
+        return sum(src.count_ruptures()
+                   for src in pdata_to_psources(self.pdata))
 
 
 def grid_point_sources(

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -73,6 +73,7 @@ def msr_name(src):
     """
     :returns: string representation of the MSR or "Undefined" if not applicable
     """
+    # NB: the MSR is None for characteristicFault sources
     try:
         return str(src.magnitude_scaling_relationship)
     except AttributeError:   # no MSR for nonparametric sources

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -26,6 +26,7 @@ import numpy
 from openquake.baselib import parallel, general, hdf5, python3compat, config
 from openquake.hazardlib import nrml, sourceconverter, InvalidFile, calc, site
 from openquake.hazardlib.source.multi_fault import save_and_split
+from openquake.hazardlib.source.point import msr_name
 from openquake.hazardlib.valid import basename, fragmentno
 from openquake.hazardlib.lt import apply_uncertainties
 
@@ -664,6 +665,16 @@ class CompositeSourceModel:
                         '%s contains more than 2**30 ruptures' % src)
                 # print(src, src.offset, offset)
             src_id += 1
+
+    def get_msr_by_grp(self):
+        """
+        :returns: a dictionary grp_id -> MSR string
+        """
+        acc = general.AccumDict(accum=set())
+        for grp_id, sg in enumerate(self.src_groups):
+            for src in sg:
+                acc[grp_id].add(msr_name(src))
+        return {grp_id: ' '.join(sorted(acc[grp_id])) for grp_id in acc}
 
     def get_max_weight(self, oq):  # used in preclassical
         """

--- a/openquake/hazardlib/tests/mfd/arbitrary_test.py
+++ b/openquake/hazardlib/tests/mfd/arbitrary_test.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import numpy
-from openquake.baselib.general import Unique
+from openquake.baselib.general import Deduplicate
 from openquake.hazardlib.mfd import ArbitraryMFD
 from openquake.hazardlib.tests.mfd.base_test import BaseMFDTestCase
 
@@ -74,7 +74,7 @@ class ArbitraryMFDTestCase(BaseMFDTestCase):
                             occurrence_rates=(1., 2.5, 3.))
         mfd2 = ArbitraryMFD(magnitudes=(4., 5., 6.),
                             occurrence_rates=(1., 2., 3.))
-        mfd = Unique([mfd0, mfd1, mfd2])
+        mfd = Deduplicate([mfd0, mfd1, mfd2])
         self.assertEqual(len(mfd.uni), 2)
         self.assertEqual(len(mfd.inv), 3)
         numpy.testing.assert_equal(mfd[1].occurrence_rates, [1., 2.5, 3.])

--- a/openquake/hazardlib/tests/mfd/arbitrary_test.py
+++ b/openquake/hazardlib/tests/mfd/arbitrary_test.py
@@ -13,31 +13,29 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import numpy
+from openquake.baselib.general import Unique
 from openquake.hazardlib.mfd import ArbitraryMFD
-
 from openquake.hazardlib.tests.mfd.base_test import BaseMFDTestCase
 
 class ArbitrarydMFDMFDConstraintsTestCase(BaseMFDTestCase):
     def test_empty_occurrence_rates(self):
         exc = self.assert_mfd_error(
             ArbitraryMFD,
-            magnitudes=[4., 5.], occurrence_rates=[]
-        )
+            magnitudes=[4., 5.], occurrence_rates=[])
         self.assertEqual(str(exc), 'at least one bin must be specified')
 
     def test_negative_occurrence_rate(self):
         exc = self.assert_mfd_error(
             ArbitraryMFD,
-            magnitudes=[4., 5.], occurrence_rates=[-0.1, 1]
-        )
+            magnitudes=[4., 5.], occurrence_rates=[-0.1, 1])
         self.assertEqual(str(exc), 'all occurrence rates '
                                       'must not be negative')
 
     def test_all_zero_occurrence_rates(self):
         exc = self.assert_mfd_error(
             ArbitraryMFD,
-            magnitudes=[4., 5.], occurrence_rates=[0, 0]
-        )
+            magnitudes=[4., 5.], occurrence_rates=[0, 0])
         self.assertEqual(str(exc), 'at least one occurrence rate '
                                       'must be positive')
 
@@ -45,8 +43,7 @@ class ArbitrarydMFDMFDConstraintsTestCase(BaseMFDTestCase):
     def test_unequal_lengths(self):
         exc = self.assert_mfd_error(
             ArbitraryMFD,
-            magnitudes=[4., 5., 6.], occurrence_rates=[0.1, 1]
-        )
+            magnitudes=[4., 5., 6.], occurrence_rates=[0.1, 1])
         self.assertEqual(str(exc),
                          'lists of magnitudes and rates must have same length')
 
@@ -68,3 +65,17 @@ class ArbitraryMFDTestCase(BaseMFDTestCase):
             {"magnitudes": [7, 8, 9], "occurrence_rates": [0, 2, 1]})
         self.assertListEqual(mfd.magnitudes, [7, 8, 9])
         self.assertListEqual(mfd.occurrence_rates, [0, 2, 1])
+
+    def test_three_instances(self):
+        # instances 1 and 3 are identical, instance 2 is different
+        mfd0 = ArbitraryMFD(magnitudes=(4., 5., 6.),
+                            occurrence_rates=(1., 2., 3.))
+        mfd1 = ArbitraryMFD(magnitudes=(4., 5., 6.),
+                            occurrence_rates=(1., 2.5, 3.))
+        mfd2 = ArbitraryMFD(magnitudes=(4., 5., 6.),
+                            occurrence_rates=(1., 2., 3.))
+        mfd = Unique([mfd0, mfd1, mfd2])
+        self.assertEqual(len(mfd.uni), 2)
+        self.assertEqual(len(mfd.inv), 3)
+        numpy.testing.assert_equal(mfd[1].occurrence_rates, [1., 2.5, 3.])
+        numpy.testing.assert_equal(mfd[2].occurrence_rates, [1., 2., 3.])

--- a/openquake/hazardlib/tests/source/area_test.py
+++ b/openquake/hazardlib/tests/source/area_test.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
 
+from openquake.baselib.general import Unique
 from openquake.hazardlib.const import TRT
 from openquake.hazardlib.scalerel.peer import PeerMSR
 from openquake.hazardlib.mfd import TruncatedGRMFD, EvenlyDiscretizedMFD
@@ -61,6 +62,8 @@ class AreaSourceIterRupturesTestCase(unittest.TestCase):
                                                 Point(0, 0), Point(-2, 0)]),
                                        discretization=66.7,
                                        rupture_mesh_spacing=5)
+        mfds = Unique([src.magnitude_scaling_relationship for src in source])
+        self.assertEqual(len(mfds.uni), 1)  # there is a single MFD
         ruptures = list(source.iter_ruptures())
         self.assertEqual(len(ruptures), source.count_ruptures())
         self.assertEqual(len(ruptures), 9 * 4)

--- a/openquake/hazardlib/tests/source/area_test.py
+++ b/openquake/hazardlib/tests/source/area_test.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
 
-from openquake.baselib.general import Unique
+from openquake.baselib.general import Deduplicate
 from openquake.hazardlib.const import TRT
 from openquake.hazardlib.scalerel.peer import PeerMSR
 from openquake.hazardlib.mfd import TruncatedGRMFD, EvenlyDiscretizedMFD
@@ -62,7 +62,7 @@ class AreaSourceIterRupturesTestCase(unittest.TestCase):
                                                 Point(0, 0), Point(-2, 0)]),
                                        discretization=66.7,
                                        rupture_mesh_spacing=5)
-        mfds = Unique([src.magnitude_scaling_relationship for src in source])
+        mfds = Deduplicate([src.magnitude_scaling_relationship for src in source])
         self.assertEqual(len(mfds.uni), 1)  # there is a single MFD
         ruptures = list(source.iter_ruptures())
         self.assertEqual(len(ruptures), source.count_ruptures())

--- a/utils/read_group
+++ b/utils/read_group
@@ -10,7 +10,7 @@ def main(grp_id: int, calc_id: int=-1):
     Determine how much memory is needed to read a source group.
     To be run after a (pre)classical calculation.
     """
-    dstore = datastore.read(115049)
+    dstore = datastore.read(calc_id)
     with performance.Monitor(measuremem=True) as mon:
         arr = dstore.getitem('_csm')[grp_id]
         grp = pickle.loads(zlib.decompress(arr.tobytes()))


### PR DESCRIPTION
The USA model could not run on the irene cluster since it required nearly 3 GB per core in tiling mode. The memory was in the CollapsedPointSources:
```
$ ./read_group 0 # collapsed point sources
<SourceGroup Stable Shallow Crust, 6718 source(s), weight=1717556>
<Monitor [michele], duration=7.528344631195068s, memory=2.65 GB>
```
After this change the problem is solved (nearly 3x improvement):
```
$ utils/read_group 0 # collapsed point sources
<SourceGroup Stable Shallow Crust, 6718 source(s), weight=1717556>
<Monitor [michele], duration=2.2747690677642822s, memory=1009.41 MB>
```