### PR TITLE
Improved the task distribution and reduced the data transfer in non-tiling calculations

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -563,10 +563,11 @@ class ClassicalCalculator(base.HazardCalculator):
                 if tiling:
                     for tgetter in tilegetters:
                         allargs.append((block, [tgetter], cmaker, ds))
+                    n_out.append(len(tilegetters))
                 else:
                     for tgetters in block_splitter(tilegetters, splits):
                         allargs.append((block, tgetters, cmaker, ds))
-                n_out.append(len(tilegetters))
+                        n_out.append(len(tgetters))
         if tiling:
             logging.info('This will be a tiling calculation with %d outputs, '
                          '%d tasks, min_tiles=%d, max_tiles=%d',

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -551,7 +551,6 @@ class ClassicalCalculator(base.HazardCalculator):
         if tiling:
             assert not oq.disagg_by_src
             assert self.N > self.oqparam.max_sites_disagg, self.N
-            self.max_weight *= 2  # produce half the tasks
         else:  # regular calculator
             self.create_rup()  # create the rup/ datasets BEFORE swmr_on()
         allargs = []

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -567,7 +567,7 @@ class ClassicalCalculator(base.HazardCalculator):
                     for tgetters in block_splitter(tilegetters, splits):
                         allargs.append((block, tgetters, cmaker, ds))
                 n_out.append(len(tilegetters))
-        logging.info('This will be a %s calculation with %d outputs, '
+        logging.info('This is a %s calculation with %d outputs, '
                      '%d tasks, min_tiles=%d, max_tiles=%d',
                      'tiling' if tiling else 'regular',
                      sum(n_out), len(allargs), min(n_out), max(n_out))

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -556,14 +556,15 @@ class ClassicalCalculator(base.HazardCalculator):
             self.create_rup()  # create the rup/ datasets BEFORE swmr_on()
         allargs = []
         n_out = []
-        for cmaker, tilegetters, blocks in self.csm.split(
-                self.cmakers, self.sitecol, self.max_weight, self.num_chunks, tiling):
+        for cmaker, tilegetters, blocks, splits in self.csm.split(
+                self.cmakers, self.sitecol, self.max_weight, self.num_chunks,
+                tiling):
             for block in blocks:
                 if tiling:
                     for tgetter in tilegetters:
                         allargs.append((block, [tgetter], cmaker, ds))
                 else:
-                    for tgetters in block_splitter(tilegetters, 20):
+                    for tgetters in block_splitter(tilegetters, splits):
                         allargs.append((block, tgetters, cmaker, ds))
                 n_out.append(len(tilegetters))
         if tiling:

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -568,10 +568,10 @@ class ClassicalCalculator(base.HazardCalculator):
                     for tgetters in block_splitter(tilegetters, splits):
                         allargs.append((block, tgetters, cmaker, ds))
                         n_out.append(len(tgetters))
-        if tiling:
-            logging.info('This will be a tiling calculation with %d outputs, '
-                         '%d tasks, min_tiles=%d, max_tiles=%d',
-                         sum(n_out), len(allargs), min(n_out), max(n_out))
+        logging.info('This will be a %s calculation with %d outputs, '
+                     '%d tasks, min_tiles=%d, max_tiles=%d',
+                     'tiling' if tiling else 'regular',
+                     sum(n_out), len(allargs), min(n_out), max(n_out))
 
         # log info about the heavy sources
         srcs = self.csm.get_sources()

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -28,7 +28,8 @@ import numpy
 import pandas
 from PIL import Image
 from openquake.baselib import parallel, hdf5, config, python3compat
-from openquake.baselib.general import AccumDict, DictArray, groupby, humansize
+from openquake.baselib.general import (
+    AccumDict, DictArray, groupby, humansize, block_splitter)
 from openquake.hazardlib import valid, InvalidFile
 from openquake.hazardlib.contexts import read_cmakers
 from openquake.hazardlib.calc.hazard_curve import classical as hazclassical
@@ -562,7 +563,8 @@ class ClassicalCalculator(base.HazardCalculator):
                     for tgetter in tilegetters:
                         allargs.append((block, [tgetter], cmaker, ds))
                 else:
-                    allargs.append((block, tilegetters, cmaker, ds))
+                    for tgetters in block_splitter(tilegetters, 20):
+                        allargs.append((block, tgetters, cmaker, ds))
                 n_out.append(len(tilegetters))
         if tiling:
             logging.info('This will be a tiling calculation with %d outputs, '

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -563,11 +563,10 @@ class ClassicalCalculator(base.HazardCalculator):
                 if tiling:
                     for tgetter in tilegetters:
                         allargs.append((block, [tgetter], cmaker, ds))
-                    n_out.append(len(tilegetters))
                 else:
                     for tgetters in block_splitter(tilegetters, splits):
                         allargs.append((block, tgetters, cmaker, ds))
-                        n_out.append(len(tgetters))
+                n_out.append(len(tilegetters))
         logging.info('This will be a %s calculation with %d outputs, '
                      '%d tasks, min_tiles=%d, max_tiles=%d',
                      'tiling' if tiling else 'regular',

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -171,12 +171,14 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     max_weight = csm.get_max_weight(oq)
 
     # build source_groups
-    triples = csm.split(cmakers, sitecol, max_weight)
+    quartets = csm.split(cmakers, sitecol, max_weight)
     data = numpy.array(
-        [(cm.grp_id, len(cm.gsims), len(tgets), len(blocks), len(cm.gsims) * fac * 1024,
-          cm.weight, cm.codes, cm.trt) for cm, tgets, blocks in triples],
+        [(cm.grp_id, len(cm.gsims), len(tgets), len(blocks), splits,
+          len(cm.gsims) * fac * 1024, cm.weight, cm.codes, cm.trt)
+         for cm, tgets, blocks, splits in quartets],
         [('grp_id', U16), ('gsims', U16), ('tiles', U16), ('blocks', U16),
-         ('size_mb', F32), ('weight', F32), ('codes', '<S8'), ('trt', '<S20')])
+         ('splits', U16), ('size_mb', F32), ('weight', F32),
+         ('codes', '<S8'), ('trt', '<S20')])
 
     # determine light groups and tiling
     light, = numpy.where(data['blocks'] == 1)
@@ -196,9 +198,10 @@ def store_tiles(dstore, csm, sitecol, cmakers):
         tiling = oq.tiling
     if not tiling:
         n_out = data['tiles'] @ data['blocks']
+        n_tasks = (data['tiles'] / data['splits']) @ data['blocks']
         logging.info('This will be a regular calculation with %d outputs, '
-                     'min_tiles=%d, max_tiles=%d',
-                     n_out, data['tiles'].min(), data['tiles'].max())
+                     '~%.0f tasks, min_tiles=%d, max_tiles=%d',
+                     n_out, n_tasks, data['tiles'].min(), data['tiles'].max())
 
     # store source_groups
     dstore.create_dset('source_groups', data, fillvalue=None,

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -198,9 +198,9 @@ def store_tiles(dstore, csm, sitecol, cmakers):
         tiling = oq.tiling
     if not tiling:
         n_out = data['tiles'] @ data['blocks']
-        n_tasks = (data['tiles'] / data['splits']) @ data['blocks']
+        n_tasks = numpy.ceil(data['tiles'] / data['splits']) @ data['blocks']
         logging.info('This will be a regular calculation with %d outputs, '
-                     '~%.0f tasks, min_tiles=%d, max_tiles=%d',
+                     '%.0f tasks, min_tiles=%d, max_tiles=%d',
                      n_out, n_tasks, data['tiles'].min(), data['tiles'].max())
 
     # store source_groups

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -196,12 +196,6 @@ def store_tiles(dstore, csm, sitecol, cmakers):
         tiling = ss or not regular
     else:
         tiling = oq.tiling
-    if not tiling:
-        n_out = data['tiles'] @ data['blocks']
-        n_tasks = numpy.ceil(data['tiles'] / data['splits']) @ data['blocks']
-        logging.info('This will be a regular calculation with %d outputs, '
-                     '%.0f tasks, min_tiles=%d, max_tiles=%d',
-                     n_out, n_tasks, data['tiles'].min(), data['tiles'].max())
 
     # store source_groups
     dstore.create_dset('source_groups', data, fillvalue=None,

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -196,10 +196,9 @@ def store_tiles(dstore, csm, sitecol, cmakers):
         tiling = oq.tiling
     if not tiling:
         n_out = data['tiles'] @ data['blocks']
-        n_tasks = data['blocks'].sum()
         logging.info('This will be a regular calculation with %d outputs, '
-                     '%d tasks, min_tiles=%d, max_tiles=%d',
-                     n_out, n_tasks, data['tiles'].min(), data['tiles'].max())
+                     'min_tiles=%d, max_tiles=%d',
+                     n_out, data['tiles'].min(), data['tiles'].max())
 
     # store source_groups
     dstore.create_dset('source_groups', data, fillvalue=None,

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -185,7 +185,7 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     mem_gb = req_gb - sum(len(cm.gsims) * fac for cm in cmakers[light])
     if len(light):
         logging.info('mem_gb = %.2f', mem_gb)
-    max_gb = float(config.memory.pmap_max_gb)
+    max_gb = float(config.memory.pmap_max_gb or parallel.Starmap.num_cores/8)
     regular = (mem_gb < max_gb or oq.disagg_by_src or
                N < oq.max_sites_disagg or oq.tile_spec)
     if oq.tiling is None:

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -43,8 +43,8 @@ avg_losses_max = 900_000_000
 # store at most 10 GB
 conditioned_gmf_gb = 10
 
-# parallel tiling parameters, by default pmap_max_gb=num_cores/4
-pmap_max_gb = 3
+# parallel tiling parameters, by default pmap_max_gb=num_cores/8
+pmap_max_gb =
 pmap_max_mb = 120
 
 [dbserver]

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -716,9 +716,6 @@ class CompositeSourceModel:
             sg = self.src_groups[grp_id]
             splits = numpy.ceil(G * mb_per_gsim / max_mb)
             if sg.atomic or tiling:
-                # splits/4 reduce the number of tasks for very light groups
-                # (will use 4x more memory, but pmap_max_mb is only 120 MB)
-                splits = numpy.ceil(max(splits / 4, sg.weight / max_weight))
                 blocks = [None]
                 hint = 100
             else:

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -716,9 +716,7 @@ class CompositeSourceModel:
             sg = self.src_groups[grp_id]
             splits = numpy.ceil(G * mb_per_gsim / max_mb)
             if sg.atomic or tiling:
-                # splits/4 reduce the number of tasks for very light groups
-                # (will use 4x more memory, but pmap_max_mb is only 120 MB)
-                splits = numpy.ceil(max(splits / 4, sg.weight / max_weight))
+                splits = numpy.ceil(max(splits, sg.weight / max_weight))
                 blocks = [None]
                 hint = 100
             else:

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -694,7 +694,7 @@ class CompositeSourceModel:
                 logging.info(msg.format(src, src.num_ruptures, spc))
         assert tot_weight
         max_weight = tot_weight / (oq.concurrent_tasks or 1)
-        max_weight *= 1.1  # increased to produce fewer tasks
+        max_weight *= 1.05  # increased to produce fewer tasks
         logging.info('tot_weight={:_d}, max_weight={:_d}, num_sources={:_d}'.
                      format(int(tot_weight), int(max_weight), len(srcs)))
         return max_weight
@@ -721,7 +721,12 @@ class CompositeSourceModel:
                 blocks = [None]
             else:
                 hint = numpy.ceil(sg.weight / max_weight)
-                blocks = list(general.split_in_blocks(sg, hint, lambda s: s.weight))
+                mul = hint // 100
+                if mul:  # avoid too much data transfer
+                    hint = 100
+                    splits *= mul                
+                blocks = list(general.split_in_blocks(
+                    sg, hint, lambda s: s.weight))
             self.splits.append(splits)
             cmaker.tiling = tiling
             cmaker.gsims = list(cmaker.gsims)  # save data transfer

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -716,7 +716,9 @@ class CompositeSourceModel:
             sg = self.src_groups[grp_id]
             splits = numpy.ceil(G * mb_per_gsim / max_mb)
             if sg.atomic or tiling:
-                splits = numpy.ceil(max(splits, sg.weight / max_weight))
+                # splits/4 reduce the number of tasks for very light groups
+                # (will use 4x more memory, but pmap_max_mb is only 120 MB)
+                splits = numpy.ceil(max(splits / 4, sg.weight / max_weight))
                 blocks = [None]
                 hint = 100
             else:


### PR DESCRIPTION
The trick is to limit the number of source blocks to 100 by splitting in more tiles. The improvement for the USA calculation `OQ_SAMPLE_SOURCES=.1 oq run USA/in/job_vs30.ini -c4096 -p maximum_distance=magdist tiling=false`
is spectacular:
```
# master
| calc_11043, maxmem=219.6 GB | time_sec | memory_mb | counts      |
|-----------------------------+----------+-----------+-------------|
| total classical             | 571_599  | 107.8333  | 125_726     |
| computing mean_std          | 265_038  | 0.0       | 4_099_537   |
| get_poes                    | 260_293  | 0.0       | 181_433_495 |
| total postclassical         | 10_481   | 315.5     | 577         |
| ClassicalCalculator.run     | 7_701    | 16_919    | 1           |
| nonplanar contexts          | 5_694    | 0.0       | 164_996     |

| operation-duration | counts | mean     | stddev | min     | max     | slowfac |
|--------------------+--------+----------+--------+---------+---------+---------|
| classical          | 3_286  | 173.8548 | 164%   | 17.3846 | 4_830   | 27.7818 |

| task              | sent                                                | received  |
|-------------------+-----------------------------------------------------+-----------|
| classical         | cmaker=17.94 GB sources=53.61 MB tilegetters=2.7 MB | 695.98 GB |

# this branch
| calc_11046, maxmem=170.3 GB | time_sec | memory_mb | counts      |
|-----------------------------+----------+-----------+-------------|
| total classical             | 641_329  | 90.6562   | 107_430     |
| get_poes                    | 260_819  | 0.0       | 165_934_051 |
| computing mean_std          | 239_159  | 0.0       | 3_719_309   |
| planar contexts             | 78_034   | 0.0       | 145_916_453 |
| iter_ruptures               | 49_311   | 0.0       | 5_877_063   |
| nonplanar contexts          | 17_159   | 0.0       | 210_716     |
| total postclassical         | 11_751   | 311.8     | 577         |
| ClassicalCalculator.run     | 4_230    | 2_323     | 1           |

| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| classical          | 3_047  | 209.9   | 48%    | 20.5973 | 755.7   | 3.5997  |

| task              | sent                                                 | received  |
|-------------------+------------------------------------------------------+-----------|
| classical         | cmaker=15.46 GB sources=839.1 MB tilegetters=2.66 MB | 319.64 GB |
```
In short:
data transfer: 2.2x better
slowest task: 6.4x better
memory: 1.3 better
