### PR TITLE
Changed the `oq engine` command to run calculations in parallel by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Changed the `oq engine` command to run parallel calculations by default
+    unless the `--seq` flag is passed; removed the `--multi` flag
   * Internal: reduced the space used by the CollapsedPointSources (2.7x)
   * Fixed the site model association procedure to work in conditioned
     scenario calculations

--- a/doc/user-guide/inputs/seismic-source-model-inputs.rst
+++ b/doc/user-guide/inputs/seismic-source-model-inputs.rst
@@ -1019,11 +1019,7 @@ while calculations with a single nodal plane and hypocenter for each source will
 
 If you are interested only in speed and not in precision, you can set ``calculation_mode=preclassical``, run the 
 sensitivity analysis in parallel very quickly and then use the ``ps_grid_spacing`` value corresponding to the minimum 
-weight of the source model, which can be read from the logs. Here is the trick to run the calculations in parallel::
-
-	$ oq engine --multi --run job.ini -p calculation_mode=preclassical
-
-And here is how to extract the weight information, in the example of Alaska, with job IDs in the range 31692-31695::
+weight of the source model, which can be read from the logs. Here is how to extract the weight information, in the example of Alaska, with job IDs in the range 31692-31695::
 
 	$ oq db get_weight 31692
 	<Row(description=Alaska{'ps_grid_spacing': 0}, message=tot_weight=1_929_504, max_weight=120_594, num_sources=150_254)>

--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -242,7 +242,7 @@ def debug_task(msg, mon):
 
 
 def call(func, args, taskno, mon, executing):
-    fname = os.path.join(executing, str(taskno))
+    fname = os.path.join(executing, f'{mon.calc_id}-{taskno}')
     # NB: very hackish way of keeping track of the running tasks,
     # used in get_executing, could litter the file system
     open(fname, 'w').close()

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -19,7 +19,7 @@ import os
 import sys
 import getpass
 import logging
-from openquake.baselib import config
+from openquake.baselib import config, parallel
 from openquake.baselib.general import safeprint
 from openquake.hazardlib import valid
 from openquake.commonlib import logs, datastore
@@ -77,7 +77,7 @@ def main(
         list_hazard_calculations=False,
         list_risk_calculations=False,
         delete_uncompleted_calculations=False,
-        multi=False,
+        seq=False,
         reuse_input=False,
         *,
         log_file=None,
@@ -173,8 +173,12 @@ def main(
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
         job_inis = [os.path.expanduser(f) for f in run]
+        if (len(job_inis) > 1 and not seq and
+                parallel.oq.distribute() in ('no', 'processpool')):
+            raise ValueError('Specify --seq if you want to run multiple '
+                             'jobs sequentially')
         jobs = create_jobs(job_inis, log_level, log_file, user_name,
-                           hc_id, multi)
+                           hc_id, not seq)
         for job in jobs:
             job.params.update(pars)
             job.params['exports'] = exports
@@ -244,7 +248,7 @@ main.list_risk_calculations = dict(
     abbrev='--lrc', help='List risk calculation information')
 main.delete_uncompleted_calculations = dict(
     abbrev='--duc', help='Delete all the uncompleted calculations')
-main.multi = 'Run multiple job.inis in parallel'
+main.seq = 'Run multiple job.inis sequentially'
 main.reuse_input = 'Read the CompositeSourceModel from the cache (if any)'
 
 # options

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -174,9 +174,9 @@ def main(
             if log_file is not None else None
         job_inis = [os.path.expanduser(f) for f in run]
         if (len(job_inis) > 1 and not seq and
-                parallel.oq.distribute() in ('no', 'processpool')):
-            raise ValueError('Specify --seq if you want to run multiple '
-                             'jobs sequentially')
+                parallel.oq_distribute() in ('no', 'processpool')):
+            sys.exit('Please specify --seq if you want to run multiple '
+                     'jobs sequentially')
         jobs = create_jobs(job_inis, log_level, log_file, user_name,
                            hc_id, not seq)
         for job in jobs:

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -115,7 +115,7 @@ def main(job_ini,
         dic.update(params)
         dic['exports'] = ','.join(exports)
     jobs = create_jobs(dics, loglevel, hc_id=hc,
-                       user_name=user_name, host=host, multi=False)
+                       user_name=user_name, host=host, multi=True)
     job_id = jobs[0].calc_id
     run_jobs(jobs, nodes=nodes)
     return job_id


### PR DESCRIPTION
Unless the `--seq` flag is passed. This is consistent with the usage in the `zmq` and `slurm` strategies.
Also fixed the AELO tests by going back to  `fname = os.path.join(executing, f'{mon.calc_id}-{taskno}')`