### PR TITLE
Restored `oq engine --multi --run` as it was

### DIFF
--- a/.github/workflows/docker_dev.yml
+++ b/.github/workflows/docker_dev.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           docker build --build-arg oq_branch=master -t openquake/engine:nightly -f docker/Dockerfile.dev docker
           docker image ls
-          time docker run openquake/engine:nightly "oq engine --seq --run /usr/src/oq-engine/demos/risk/ScenarioDamage/job_hazard.ini /usr/src/oq-engine/demos/risk/ScenarioDamage/job_risk.ini"
+          time docker run openquake/engine:nightly "oq engine --run /usr/src/oq-engine/demos/risk/ScenarioDamage/job_hazard.ini /usr/src/oq-engine/demos/risk/ScenarioDamage/job_risk.ini"
           echo " push image engine with tag nightly on docker hub "
           docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
           docker push openquake/engine:nightly

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,4 @@
   [Michele Simionato]
-  * Changed the `oq engine` command to run parallel calculations by default
-    unless the `--seq` flag is passed; removed the `--multi` flag
   * Internal: reduced the space used by the CollapsedPointSources (2.7x)
   * Fixed the site model association procedure to work in conditioned
     scenario calculations

--- a/doc/contributing/developing-with-the-engine.rst
+++ b/doc/contributing/developing-with-the-engine.rst
@@ -119,7 +119,7 @@ different values of the strike angle (0, 90 and 180 degrees).
 The relevant code is something like this:
 
 .. python:
-  """Sensitivy of the risk from the strike parameter"""
+  """Sensitivity of the risk from the strike parameter"""
   import os
   from openquake.engine import engine
 

--- a/doc/contributing/developing-with-the-engine.rst
+++ b/doc/contributing/developing-with-the-engine.rst
@@ -160,9 +160,7 @@ variable OQ_DISTRIBUTE to 'zmq'. This is the easiest way to parallelize the jobs
 which makes sense since in this case the jobs are small.
 
 After running the script you will have 3 calculations and you can see the effect
-on the risk by looking at the portfolio_loss:
-
-.. bash::
+on the risk by looking at the portfolio_loss::
 
    $ oq show portfolio_loss -3  # strike=0
    +------+------------+

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -19,7 +19,7 @@ import os
 import sys
 import getpass
 import logging
-from openquake.baselib import config, parallel
+from openquake.baselib import config
 from openquake.baselib.general import safeprint
 from openquake.hazardlib import valid
 from openquake.commonlib import logs, datastore

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -77,7 +77,7 @@ def main(
         list_hazard_calculations=False,
         list_risk_calculations=False,
         delete_uncompleted_calculations=False,
-        seq=False,
+        multi=False,
         reuse_input=False,
         *,
         log_file=None,
@@ -173,16 +173,11 @@ def main(
         log_file = os.path.expanduser(log_file) \
             if log_file is not None else None
         job_inis = [os.path.expanduser(f) for f in run]
-        if (len(job_inis) > 1 and not seq and
-                parallel.oq_distribute() in ('no', 'processpool')):
-            sys.exit('Please specify --seq if you want to run multiple '
-                     'jobs sequentially')
-        jobs = create_jobs(job_inis, log_level, log_file, user_name,
-                           hc_id, not seq)
+        jobs = create_jobs(job_inis, log_level, log_file, user_name, hc_id)
         for job in jobs:
             job.params.update(pars)
             job.params['exports'] = exports
-        run_jobs(jobs, nodes=nodes, sbatch=True)
+        run_jobs(jobs, nodes=nodes, sbatch=True, precalc=not multi)
 
     # hazard
     elif list_hazard_calculations:

--- a/openquake/commands/run.py
+++ b/openquake/commands/run.py
@@ -114,10 +114,9 @@ def main(job_ini,
     for dic in dics:
         dic.update(params)
         dic['exports'] = ','.join(exports)
-    jobs = create_jobs(dics, loglevel, hc_id=hc,
-                       user_name=user_name, host=host, multi=True)
+    jobs = create_jobs(dics, loglevel, hc_id=hc, user_name=user_name, host=host)
     job_id = jobs[0].calc_id
-    run_jobs(jobs, nodes=nodes)
+    run_jobs(jobs, nodes=nodes, precalc=True)
     return job_id
 
 

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -191,7 +191,6 @@ class LogContext:
     """
     Context manager managing the logging functionality
     """
-    multi = False  # set in create_jobs
     oqparam = None
 
     def __init__(self, params, log_level='info', log_file=None,

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -395,9 +395,13 @@ def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False, precalc=False
                 pickle.dump(jobctxs, f)
             w.WorkerMaster(job_id).send_jobs()
             print('oq engine --show-log %d to see the progress' % job_id)
-        elif len(jobctxs) > 1 and not precalc and dist in ('zmq', 'slurm'):
-            parallel.multispawn(
-                run_calc, [(ctx,) for ctx in jobctxs], concurrent_jobs)
+        elif len(jobctxs) > 1 and dist in ('zmq', 'slurm'):
+            if precalc:
+                run_calc(jobctxs[0])
+                args = [(ctx,) for ctx in jobctxs[1:]]
+            else:
+                args = [(ctx,) for ctx in jobctxs]
+            parallel.multispawn(run_calc, args, concurrent_jobs)
         else:
             for jobctx in jobctxs:
                 run_calc(jobctx)


### PR DESCRIPTION
Because now I know how to do it correctly, i.e. in `run_jobs` and not in `create_jobs`. Continuation of https://github.com/gem/oq-engine/pull/9959.
