### PR TITLE
Saving mean_tau_phi

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
-  * Added parameter `mea_tau_phi` to save the corrisponding parameters
-    for each rupture, site, gsim and imt in GMF calculations
+  * Added a parameter `mea_tau_phi` in the job.ini to save mean, tau and phi
+    for each rupture, site, gsim and imt in a GMF calculation
   * Internal: changed `oq run` to automatically generate the db when possible
   * Added a check on missing risk files
   * Reduced the space used by the CollapsedPointSources (2.7x)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Added parameter `mea_tau_phi` to save the corrisponding parameters
+    for each rupture, site, gsim and imt in GMF calculations
   * Internal: changed `oq run` to automatically generate the db when possible
   * Added a check on missing risk files
   * Reduced the space used by the CollapsedPointSources (2.7x)

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1382,7 +1382,8 @@ def create_gmf_data(dstore, prim_imts, sec_imts=(), data=None, N=None):
                      investigation_time=oq.investigation_time or 0,
                      effective_time=eff_time)
     if oq.mean_tau_phi:
-        dstore.create_df('mean_tau_phi', GmfComputer.mtp_dt.descr)
+        dstore.create_df(
+            'mean_tau_phi', GmfComputer.mtp_dt.descr, compression='gzip')
 
     if data is not None:
         _df = pandas.DataFrame(dict(items))

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1381,9 +1381,9 @@ def create_gmf_data(dstore, prim_imts, sec_imts=(), data=None, N=None):
                      imts=' '.join(map(str, prim_imts)),
                      investigation_time=oq.investigation_time or 0,
                      effective_time=eff_time)
-    if oq.mean_tau_phi:
+    if oq.mea_tau_phi:
         dstore.create_df(
-            'mean_tau_phi', GmfComputer.mtp_dt.descr, compression='gzip')
+            'mea_tau_phi', GmfComputer.mtp_dt.descr, compression='gzip')
 
     if data is not None:
         _df = pandas.DataFrame(dict(items))

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -43,6 +43,7 @@ from openquake.hazardlib import (
     InvalidFile, site, stats, logictree, source_reader)
 from openquake.hazardlib.site_amplification import Amplifier
 from openquake.hazardlib.site_amplification import AmplFunction
+from openquake.hazardlib.calc.gmf import GmfComputer
 from openquake.hazardlib.calc.filters import SourceFilter, getdefault
 from openquake.hazardlib.source import rupture
 from openquake.hazardlib.shakemap.maps import get_sitecol_shakemap
@@ -1380,6 +1381,9 @@ def create_gmf_data(dstore, prim_imts, sec_imts=(), data=None, N=None):
                      imts=' '.join(map(str, prim_imts)),
                      investigation_time=oq.investigation_time or 0,
                      effective_time=eff_time)
+    if oq.mean_tau_phi:
+        dstore.create_df('mean_tau_phi', GmfComputer.mtp_dt.descr)
+
     if data is not None:
         _df = pandas.DataFrame(dict(items))
         avg_gmf = numpy.zeros((2, N, M + len(sec_imts)), F32)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -221,7 +221,7 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
                 df = computer.compute_all([mea, tau, phi], max_iml, mmon, cmon, umon)
         else:  # regular GMFs
             df = computer.compute_all(None, max_iml, mmon, cmon, umon)
-            if oq.mean_tau_phi:
+            if oq.mea_tau_phi:
                 mtp = numpy.array(computer.mea_tau_phi, GmfComputer.mtp_dt)
                 mea_tau_phi.append(mtp)
         sig_eps.append(computer.build_sig_eps(se_dt))
@@ -236,9 +236,9 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
     gmfdata = pandas.concat(alldata)  # ~40 MB
     dic = dict(gmfdata={k: gmfdata[k].to_numpy() for k in gmfdata.columns},
                times=times, sig_eps=numpy.concatenate(sig_eps, dtype=se_dt))
-    if oq.mean_tau_phi:
+    if oq.mea_tau_phi:
         mtpdata = numpy.concatenate(mea_tau_phi, dtype=GmfComputer.mtp_dt)
-        dic['mean_tau_phi'] = {col: mtpdata[col] for col in mtpdata.dtype.names}
+        dic['mea_tau_phi'] = {col: mtpdata[col] for col in mtpdata.dtype.names}
     return dic
 
 
@@ -576,11 +576,11 @@ class EventBasedCalculator(base.HazardCalculator):
                 hdf5.extend(self.datastore['gmf_data/sigma_epsilon'], sig_eps)
                 self.offset += len(df)
 
-            # optionally save mean_tau_phi
-            mtp = result.pop('mean_tau_phi', None)
+            # optionally save mea_tau_phi
+            mtp = result.pop('mea_tau_phi', None)
             if mtp:
                 for col, arr in mtp.items():
-                    hdf5.extend(self.datastore[f'mean_tau_phi/{col}'], arr)
+                    hdf5.extend(self.datastore[f'mea_tau_phi/{col}'], arr)
         return acc
 
     def _read_scenario_ruptures(self):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -577,7 +577,7 @@ class EventBasedCalculator(base.HazardCalculator):
                 self.offset += len(df)
 
             # optionally save mean_tau_phi
-            mtp = result.pop('mean_tau_phi')
+            mtp = result.pop('mean_tau_phi', None)
             if mtp:
                 for col, arr in mtp.items():
                     hdf5.extend(self.datastore[f'mean_tau_phi/{col}'], arr)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -198,11 +198,13 @@ def get_computer(cmaker, proxy, srcfilter, station_data, station_sitecol):
 
 def _event_based(proxies, cmaker, stations, srcfilter, shr,
                  fmon, cmon, umon, mmon):
+    oq = cmaker.oq
     alldata = []
     sig_eps = []
     times = []
-    max_iml = cmaker.oq.get_max_iml()
-    se_dt = sig_eps_dt(cmaker.oq.imtls)
+    max_iml = oq.get_max_iml()
+    se_dt = sig_eps_dt(oq.imtls)
+    mea_tau_phi = []
     for proxy in proxies:
         t0 = time.time()
         with fmon:
@@ -219,6 +221,9 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
                 df = computer.compute_all([mea, tau, phi], max_iml, mmon, cmon, umon)
         else:  # regular GMFs
             df = computer.compute_all(None, max_iml, mmon, cmon, umon)
+            if oq.mean_tau_phi:
+                mtp = numpy.array(computer.mea_tau_phi, GmfComputer.mtp_dt)
+                mea_tau_phi.append(mtp)
         sig_eps.append(computer.build_sig_eps(se_dt))
         dt = time.time() - t0
         times.append((proxy['id'], computer.ctx.rrup.min(), dt))
@@ -229,8 +234,12 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
         return dict(gmfdata={}, times=times, sig_eps=())
 
     gmfdata = pandas.concat(alldata)  # ~40 MB
-    return dict(gmfdata={k: gmfdata[k].to_numpy() for k in gmfdata.columns},
-                times=times, sig_eps=numpy.concatenate(sig_eps, dtype=se_dt))
+    dic = dict(gmfdata={k: gmfdata[k].to_numpy() for k in gmfdata.columns},
+               times=times, sig_eps=numpy.concatenate(sig_eps, dtype=se_dt))
+    if oq.mean_tau_phi:
+        mtpdata = numpy.concatenate(mea_tau_phi, dtype=GmfComputer.mtp_dt)
+        dic['mean_tau_phi'] = {col: mtpdata[col] for col in mtpdata.dtype.names}
+    return dic
 
 
 def event_based(proxies, cmaker, stations, dstore, monitor):
@@ -330,6 +339,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         # assume scenario with a single true rupture
         rlzs_by_gsim = full_lt.get_rlzs_by_gsim(0)
         cmaker = ContextMaker(trt, rlzs_by_gsim, oq)
+        cmaker.gid = numpy.arange(len(rlzs_by_gsim))
         cmaker.scenario = True
         maxdist = oq.maximum_distance(cmaker.trt)
         srcfilter = SourceFilter(sitecol.complete, maxdist)
@@ -360,6 +370,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         extra = sitecol.array.dtype.names
         rlzs_by_gsim = full_lt.get_rlzs_by_gsim(trt_smr)
         cmaker = ContextMaker(trt, rlzs_by_gsim, oq, extraparams=extra)
+        cmaker.gid = numpy.arange(len(rlzs_by_gsim))
         cmaker.min_mag = getdefault(oq.minimum_magnitude, trt)
         if station_data is not None:
             if parallel.oq_distribute() in ('zmq', 'slurm'):
@@ -477,11 +488,14 @@ class EventBasedCalculator(base.HazardCalculator):
             mosaic_df = readinput.read_mosaic_df(buffer=.1).set_index('code')
             model_geom = mosaic_df.loc[oq.mosaic_model].geom
         logging.info('Building ruptures')
-        for sg in self.csm.src_groups:
+        g_index = 0
+        for sg_id, sg in enumerate(self.csm.src_groups):
             if not sg.sources:
                 continue
             rgb = self.full_lt.get_rlzs_by_gsim(sg.sources[0].trt_smr)
             cmaker = ContextMaker(sg.trt, rgb, oq)
+            cmaker.gid = numpy.arange(g_index, g_index + len(rgb))
+            g_index += len(rgb)
             if oq.mosaic_model or 'geometry' in oq.inputs:
                 cmaker.model_geom = model_geom
             for src_group in sg.split(maxweight):
@@ -561,6 +575,12 @@ class EventBasedCalculator(base.HazardCalculator):
                 sig_eps = result.pop('sig_eps')
                 hdf5.extend(self.datastore['gmf_data/sigma_epsilon'], sig_eps)
                 self.offset += len(df)
+
+            # optionally save mean_tau_phi
+            mtp = result.pop('mean_tau_phi')
+            if mtp:
+                for col, arr in mtp.items():
+                    hdf5.extend(self.datastore[f'mean_tau_phi/{col}'], arr)
         return acc
 
     def _read_scenario_ruptures(self):
@@ -608,6 +628,7 @@ class EventBasedCalculator(base.HazardCalculator):
             rup = readinput.get_rupture(oq)
             oq.mags_by_trt = {trt: ['%.2f' % rup.mag]}
             self.cmaker = ContextMaker(trt, rlzs_by_gsim, oq)
+            self.cmaker.gid = numpy.arange(len(rlzs_by_gsim))
             if self.N > oq.max_sites_disagg:  # many sites, split rupture
                 ebrs = []
                 for i in range(ngmfs):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -365,6 +365,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         save_tmp(smap.monitor)
 
     # NB: for conditioned scenarios we are looping on a single trt
+    toml_gsims = []
     for trt_smr, proxies in gb.items():
         trt = full_lt.trts[trt_smr // TWO24]
         extra = sitecol.array.dtype.names
@@ -372,6 +373,8 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         cmaker = ContextMaker(trt, rlzs_by_gsim, oq, extraparams=extra)
         cmaker.gid = numpy.arange(len(rlzs_by_gsim))
         cmaker.min_mag = getdefault(oq.minimum_magnitude, trt)
+        for gsim in rlzs_by_gsim:
+            toml_gsims.append(gsim._toml)
         if station_data is not None:
             if parallel.oq_distribute() in ('zmq', 'slurm'):
                 logging.error('Conditioned scenarios are not meant to be run'
@@ -381,6 +384,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         for block in block_splitter(proxies, maxw * 1.02, rup_weight):
             args = block, cmaker, (station_data, station_sites), dstore
             smap.submit(args)
+    dstore['gsims'] = numpy.array(toml_gsims)
     return smap
 
 

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -46,6 +46,7 @@ from openquake.qa_tests_data.event_based.spatial_correlation import (
     case_1 as sc1, case_2 as sc2, case_3 as sc3)
 
 aac = numpy.testing.assert_allclose
+ae = numpy.testing.assert_equal
 
 
 def strip_calc_id(fname):
@@ -384,6 +385,16 @@ class EventBasedTestCase(CalculatorTestCase):
         self.run_calc(case_16.__file__, 'job.ini', hazard_calculation_id=hid)
         tmp = gettemp(view('global_gmfs', self.calc.datastore))
         self.assertEqualFiles('expected/global_gmfs.txt', tmp)
+
+        # checking mean_tau_phi
+        df = self.calc.datastore.read_df('mean_tau_phi')
+        ae(len(df.rid.unique()), 12)
+        ae(df.sid.unique(), [101, 108])
+        ae(df.gid.unique(), [0, 3, 1])
+        ae(df.mid.unique(), [0, 1, 2])
+        ae(len(df.mea.unique()), 54)
+        ae(len(df.tau.unique()), 7)
+        ae(len(df.phi.unique()), 7)
 
     def test_case_17(self):  # oversampling
         # also, grp-00 does not produce ruptures

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -386,12 +386,12 @@ class EventBasedTestCase(CalculatorTestCase):
         tmp = gettemp(view('global_gmfs', self.calc.datastore))
         self.assertEqualFiles('expected/global_gmfs.txt', tmp)
 
-        # checking mean_tau_phi
-        df = self.calc.datastore.read_df('mean_tau_phi')
-        ae(len(df.rid.unique()), 12)
-        ae(df.sid.unique(), [101, 108])
-        ae(df.gid.unique(), [0, 3, 1])
-        ae(df.mid.unique(), [0, 1, 2])
+        # checking mea_tau_phi
+        df = self.calc.datastore.read_df('mea_tau_phi')
+        ae(len(df.rup_id.unique()), 12)
+        ae(df.site_id.unique(), [101, 108])
+        ae(df.gsim_id.unique(), [0, 3, 1])
+        ae(df.imt_id.unique(), [0, 1, 2])
         ae(len(df.mea.unique()), 54)
         ae(len(df.tau.unique()), 7)
         ae(len(df.phi.unique()), 7)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -709,6 +709,11 @@ sampling_method:
   Example: *sampling_method = early_latin*.
   Default: 'early_weights'
 
+mean_tau_phi:
+  Save the mean and standard deviations computed by the GMPEs
+  Example: *mean_tau_phi = true*
+  Default: False
+
 sec_peril_params:
   INTERNAL
 
@@ -1110,6 +1115,7 @@ class OqParam(valid.ParamSet):
     sampling_method = valid.Param(
         valid.Choice('early_weights', 'late_weights',
                      'early_latin', 'late_latin'), 'early_weights')
+    mean_tau_phi = valid.Param(valid.boolean, False)
     secondary_perils = valid.Param(valid.namelist, [])
     sec_peril_params = valid.Param(valid.dictionary, {})
     secondary_simulations = valid.Param(valid.dictionary, {})

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -709,9 +709,9 @@ sampling_method:
   Example: *sampling_method = early_latin*.
   Default: 'early_weights'
 
-mean_tau_phi:
+mea_tau_phi:
   Save the mean and standard deviations computed by the GMPEs
-  Example: *mean_tau_phi = true*
+  Example: *mea_tau_phi = true*
   Default: False
 
 sec_peril_params:
@@ -1115,7 +1115,7 @@ class OqParam(valid.ParamSet):
     sampling_method = valid.Param(
         valid.Choice('early_weights', 'late_weights',
                      'early_latin', 'late_latin'), 'early_weights')
-    mean_tau_phi = valid.Param(valid.boolean, False)
+    mea_tau_phi = valid.Param(valid.boolean, False)
     secondary_perils = valid.Param(valid.namelist, [])
     sec_peril_params = valid.Param(valid.dictionary, {})
     secondary_simulations = valid.Param(valid.dictionary, {})

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -194,8 +194,8 @@ class GmfComputer(object):
         :mod:`openquake.hazardlib.sep`. Can be ``None``, in which
         case no secondary perils need to be evaluated.
     """
-    mtp_dt = numpy.dtype([('rid', I64), ('sid', U32), ('gid', U16), ('mid', U8),
-                          ('mea', F32), ('tau', F32), ('phi', F32)])
+    mtp_dt = numpy.dtype([('rup_id', I64), ('site_id', U32), ('gsim_id', U16),
+                          ('imt_id', U8), ('mea', F32), ('tau', F32), ('phi', F32)])
 
     # The GmfComputer is called from the OpenQuake Engine. In that case
     # the rupture is an EBRupture instance containing a
@@ -213,7 +213,6 @@ class GmfComputer(object):
         elif len(cmaker.gsims) == 0:
             raise ValueError('No GSIMs')
         self.cmaker = cmaker
-        self.mean_tau_phi = cmaker.oq.mean_tau_phi
         self.imts = [from_string(imt) for imt in cmaker.imtls]
         self.cmaker = cmaker
         self.gsims = sorted(cmaker.gsims)
@@ -390,7 +389,7 @@ class GmfComputer(object):
         # regular case, sets self.sig, returns gmf
         im = imt.string
         mean, sig, tau, phi = mean_stds  # shapes N
-        if self.mean_tau_phi:
+        if self.cmaker.oq.mea_tau_phi:
             min_iml = self.cmaker.min_iml[m]
             gmv = numpy.exp(mean)
             for s, sid in enumerate(self.ctx.sids):

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -391,9 +391,11 @@ class GmfComputer(object):
         im = imt.string
         mean, sig, tau, phi = mean_stds  # shapes N
         if self.mean_tau_phi:
+            min_iml = self.cmaker.min_iml[m]
             for s, sid in enumerate(self.ctx.sids):
-                self.mea_tau_phi.append(
-                    (self.rup_id, sid, gsim.gid, m, mean[s], tau[s], phi[s]))
+                if mean[s] > min_iml:
+                    self.mea_tau_phi.append(
+                        (self.rup_id, sid, gsim.gid, m, mean[s], tau[s], phi[s]))
 
         if self.cmaker.truncation_level <= 1E-9:
             # for truncation_level = 0 there is only mean, no stds

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -31,7 +31,10 @@ from openquake.hazardlib.cross_correlation import NoCrossCorrelation
 from openquake.hazardlib.contexts import ContextMaker, FarAwayRupture
 from openquake.hazardlib.imt import from_string
 
+U8 = numpy.uint8
+U16 = numpy.uint16
 U32 = numpy.uint32
+I64 = numpy.int64
 F32 = numpy.float32
 
 
@@ -191,6 +194,9 @@ class GmfComputer(object):
         :mod:`openquake.hazardlib.sep`. Can be ``None``, in which
         case no secondary perils need to be evaluated.
     """
+    mtp_dt = numpy.dtype([('rid', I64), ('sid', U32), ('gid', U16), ('mid', U8),
+                          ('mea', F32), ('tau', F32), ('phi', F32)])
+
     # The GmfComputer is called from the OpenQuake Engine. In that case
     # the rupture is an EBRupture instance containing a
     # :class:`openquake.hazardlib.source.rupture.Rupture` instance as an
@@ -207,6 +213,7 @@ class GmfComputer(object):
         elif len(cmaker.gsims) == 0:
             raise ValueError('No GSIMs')
         self.cmaker = cmaker
+        self.mean_tau_phi = cmaker.oq.mean_tau_phi
         self.imts = [from_string(imt) for imt in cmaker.imtls]
         self.cmaker = cmaker
         self.gsims = sorted(cmaker.gsims)
@@ -214,6 +221,7 @@ class GmfComputer(object):
         self.amplifier = amplifier
         self.sec_perils = sec_perils
         self.ebrupture = rupture
+        self.rup_id = rupture.id
         self.seed = rupture.seed
         rupture = rupture.rupture  # the underlying rupture
         ctxs = list(cmaker.get_ctx_iter([rupture], sitecol))
@@ -225,6 +233,7 @@ class GmfComputer(object):
             self.sites = sitecol.complete.filtered(self.ctx.sids)
         self.cross_correl = cross_correl or NoCrossCorrelation(
             cmaker.truncation_level)
+        self.mea_tau_phi = []
         self.gmv_fields = [f'gmv_{m}' for m in range(len(cmaker.imts))]
         self.mmi_index = -1
         for m, imt in enumerate(cmaker.imtls):
@@ -318,6 +327,7 @@ class GmfComputer(object):
         rng = numpy.random.default_rng(self.seed)
         data = AccumDict(accum=[])
         for g, (gs, rlzs) in enumerate(self.cmaker.gsims.items()):
+            gs.gid = self.cmaker.gid[g]
             idxs, = numpy.where(numpy.isin(self.rlz, rlzs))
             E = len(idxs)
             if E == 0:  # crucial for performance
@@ -379,7 +389,12 @@ class GmfComputer(object):
 
         # regular case, sets self.sig, returns gmf
         im = imt.string
-        mean, sig, tau, phi = mean_stds
+        mean, sig, tau, phi = mean_stds  # shapes N
+        if self.mean_tau_phi:
+            for s, sid in enumerate(self.ctx.sids):
+                self.mea_tau_phi.append(
+                    (self.rup_id, sid, gsim.gid, m, mean[s], tau[s], phi[s]))
+
         if self.cmaker.truncation_level <= 1E-9:
             # for truncation_level = 0 there is only mean, no stds
             if self.correlation_model:

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -392,8 +392,9 @@ class GmfComputer(object):
         mean, sig, tau, phi = mean_stds  # shapes N
         if self.mean_tau_phi:
             min_iml = self.cmaker.min_iml[m]
+            gmv = numpy.exp(mean)
             for s, sid in enumerate(self.ctx.sids):
-                if mean[s] > min_iml:
+                if gmv[s] > min_iml:
                     self.mea_tau_phi.append(
                         (self.rup_id, sid, gsim.gid, m, mean[s], tau[s], phi[s]))
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -194,7 +194,7 @@ def trivial(ctx, name):
 
 
 class Oq(object):
-    mean_tau_phi = False
+    mea_tau_phi = False
 
     def __init__(self, **hparams):
         vars(self).update(hparams)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -194,6 +194,8 @@ def trivial(ctx, name):
 
 
 class Oq(object):
+    mean_tau_phi = False
+
     def __init__(self, **hparams):
         vars(self).update(hparams)
 
@@ -557,6 +559,8 @@ class ContextMaker(object):
     def __init__(self, trt, gsims, oq, monitor=Monitor(), extraparams=()):
         self.trt = trt
         self.gsims = gsims
+        # NB: the gid array can be overridden later on
+        self.gid = numpy.arange(len(gsims), dtype=numpy.uint16)
         if isinstance(oq, dict):
             param = oq
             oq = Oq(**param)

--- a/openquake/qa_tests_data/event_based/case_16/job.ini
+++ b/openquake/qa_tests_data/event_based/case_16/job.ini
@@ -32,3 +32,4 @@ vs30_tolerance = 600
 
 [hazard_outputs]
 ground_motion_fields = true
+mean_tau_phi = true

--- a/openquake/qa_tests_data/event_based/case_16/job.ini
+++ b/openquake/qa_tests_data/event_based/case_16/job.ini
@@ -32,4 +32,4 @@ vs30_tolerance = 600
 
 [hazard_outputs]
 ground_motion_fields = true
-mean_tau_phi = true
+mea_tau_phi = true

--- a/openquake/qa_tests_data/event_based/case_22/job.ini
+++ b/openquake/qa_tests_data/event_based/case_22/job.ini
@@ -50,3 +50,4 @@ export_dir = /tmp
 hazard_maps = true
 uniform_hazard_spectra = true
 poes = 0.1 0.02
+mean_tau_phi = true

--- a/openquake/qa_tests_data/event_based/case_22/job.ini
+++ b/openquake/qa_tests_data/event_based/case_22/job.ini
@@ -50,4 +50,4 @@ export_dir = /tmp
 hazard_maps = true
 uniform_hazard_spectra = true
 poes = 0.1 0.02
-mean_tau_phi = true
+mea_tau_phi = true


### PR DESCRIPTION
Supersedes https://github.com/gem/oq-engine/pull/9965.
To be refined with an exporter (?). For the moment run the following:
```
$ oq run openquake/qa_tests_data/event_based/case_16/job.ini 
$ oq show mean_tau_phi
     rid  sid  gid  mid       mea       tau       phi
0     52  101    0    0 -7.117550  0.243153  0.601205
1     52  108    0    0 -6.886802  0.243153  0.601205
2     52  101    0    1 -6.203413  0.224732  0.668210
3     52  108    0    1 -6.002697  0.224732  0.668210
4     52  101    0    2 -6.795646  0.329270  0.692387
5     52  108    0    2 -6.608540  0.329270  0.692387
6    326  101    1    0 -6.863467  0.000000  0.000000
7    326  108    1    0 -6.601220  0.000000  0.000000
8    326  101    1    1 -6.160913  0.000000  0.000000
9    326  108    1    1 -5.918740  0.000000  0.000000
10   326  101    1    2 -6.855125  0.000000  0.000000
11   326  108    1    2 -6.628300  0.000000  0.000000
...
```
Legend:
```
rid = rupture ID
sid = site ID
gid = gsim ID
mid = Intensity Measure Type ID
mea = mean
tau = tau standard deviation
phi = phi standard deviation
```
The performance is good in SAM with 83,000 sites:
```
# without mean_tau_phi
| calc_11300, maxmem=107.8 GB | time_sec | memory_mb | counts    |
|-----------------------------+----------+-----------+-----------|
| total event_based           | 4_993    | 65.0820   | 378       |
| instantiating GmfComputer   | 2_266    | 0.0       | 842_672   |
| updating gmfs               | 975.1    | 0.0       | 1_878_488 |
| computing gmfs              | 567.8    | 0.0       | 1_162_416 |
| computing mean_stds         | 513.6    | 0.0       | 1_162_416 |

# with mean_tau_phi
| calc_11301, maxmem=115.5 GB | time_sec | memory_mb | counts    |
|-----------------------------+----------+-----------+-----------|
| total event_based           | 6_142    | 132.2969  | 378       |
| instantiating GmfComputer   | 2_598    | 0.0       | 842_672   |
| updating gmfs               | 1_067    | 0.0       | 1_878_488 |
| computing gmfs              | 933.0    | 0.0       | 1_162_416 |
| computing mean_stds         | 487.8    | 0.0       | 1_162_416 |
```
The amount of data stored is abysmal, much worse than the GMFs:
```
| dataset                              | size      |
|--------------------------------------+-----------|
| gmf_data                             | 1.34 GB   |
| mean_tau_phi                         | 10.79 GB  |
```
However gzipping mean_tau_phi helps a lot (5x reduction)