### PR TITLE
Minor refinement of the task distribution

### DIFF
--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -594,7 +594,7 @@ class SiteCollection(object):
         if ntiles <= 1:
             return [TileGetter(0, 1)]
         maxtiles = numpy.ceil(len(self) / minsize)
-        ntiles = min(int(ntiles), maxtiles)
+        ntiles = min(round(ntiles), maxtiles)
         return [TileGetter(i, ntiles) for i in range(int(ntiles))]
 
     def split_in_tiles(self, hint):

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -588,13 +588,11 @@ class SiteCollection(object):
 
     def split(self, ntiles, minsize=1):
         """
-        :param ntiles: number of tiles to generate (rounded if float)
+        :param ntiles: number of tiles to generate (ceiled if float)
         :returns: self if there are <=1 tiles, otherwise the tiles
         """
-        if ntiles <= 1:
-            return [TileGetter(0, 1)]
         maxtiles = numpy.ceil(len(self) / minsize)
-        ntiles = min(round(ntiles), maxtiles)
+        ntiles = min(numpy.ceil(ntiles), maxtiles)
         return [TileGetter(i, ntiles) for i in range(int(ntiles))]
 
     def split_in_tiles(self, hint):

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -594,7 +594,7 @@ class SiteCollection(object):
         if ntiles <= 1:
             return [TileGetter(0, 1)]
         maxtiles = numpy.ceil(len(self) / minsize)
-        ntiles = min(numpy.ceil(ntiles), maxtiles)
+        ntiles = min(int(ntiles), maxtiles)
         return [TileGetter(i, ntiles) for i in range(int(ntiles))]
 
     def split_in_tiles(self, hint):

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -722,7 +722,7 @@ class CompositeSourceModel:
             else:
                 blocks = list(general.split_in_blocks(
                     sg, min(hint, oq.max_blocks), lambda s: s.weight))
-                tiles = max(splits * hint / oq.max_blocks, splits)
+                tiles = max(hint * splits / oq.max_blocks, splits)
             tilegetters = list(sitecol.split(tiles, oq.max_sites_disagg))
             self.splits.append(splits)
             cmaker.tiling = tiling

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -720,9 +720,10 @@ class CompositeSourceModel:
                 blocks = [None]
                 tiles = max(hint, splits)
             else:
+                # if hint > max_blocks generate max_blocks and more tiles
                 blocks = list(general.split_in_blocks(
                     sg, min(hint, oq.max_blocks), lambda s: s.weight))
-                tiles = max(hint * splits / oq.max_blocks, splits)
+                tiles = max(hint / oq.max_blocks * splits, splits)
             tilegetters = list(sitecol.split(tiles, oq.max_sites_disagg))
             self.splits.append(splits)
             cmaker.tiling = tiling

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -734,7 +734,7 @@ class CompositeSourceModel:
             cmaker.blocks = len(blocks)
             cmaker.weight = sg.weight
             cmaker.atomic = sg.atomic
-            yield cmaker, tilegetters, blocks, round(splits)
+            yield cmaker, tilegetters, blocks, numpy.ceil(splits)
 
     def __toh5__(self):
         G = len(self.src_groups)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -714,18 +714,16 @@ class CompositeSourceModel:
             G = len(cmaker.gsims)
             grp_id = cmaker.grp_id
             sg = self.src_groups[grp_id]
-            splits = numpy.ceil(G * mb_per_gsim / max_mb)
-            hint = numpy.ceil(sg.weight / max_weight)
+            splits = G * mb_per_gsim / max_mb
+            hint = sg.weight / max_weight
             if sg.atomic or tiling:
                 blocks = [None]
-                tilegetters = list(sitecol.split(
-                    max(hint, splits), oq.max_sites_disagg))
+                tiles = max(hint, splits)
             else:
                 blocks = list(general.split_in_blocks(
                     sg, min(hint, oq.max_blocks), lambda s: s.weight))
-                tilegetters = list(sitecol.split(
-                    int(G * mb_per_gsim / max_mb * hint / oq.max_blocks),
-                    oq.max_sites_disagg))
+                tiles = max(splits * hint / oq.max_blocks, splits)
+            tilegetters = list(sitecol.split(tiles, oq.max_sites_disagg))
             self.splits.append(splits)
             cmaker.tiling = tiling
             cmaker.gsims = list(cmaker.gsims)  # save data transfer

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -734,7 +734,7 @@ class CompositeSourceModel:
             cmaker.blocks = len(blocks)
             cmaker.weight = sg.weight
             cmaker.atomic = sg.atomic
-            yield cmaker, tilegetters, blocks, splits
+            yield cmaker, tilegetters, blocks, round(splits)
 
     def __toh5__(self):
         G = len(self.src_groups)


### PR DESCRIPTION
Here is the improvement for the calculation `$ OQ_SAMPLE_SITES=.1 oq run job_vs30.ini -c 2048`:
```
| operation-duration | counts | mean    | stddev | min     | max      | slowfac |
|--------------------+--------+---------+--------+---------+----------+---------|
| classical          | 1_488  | 292.4   | 112%   | 29.7451 | 1_698    | 5.8061  |
| classical          | 1_632  | 249.5   | 95%    | 34.2077 | 1_498    | 6.0023  |
```
The total runtime goes down from 48 to 45 minutes and the memory also improves a bit:
```
# before
| calc_11314, maxmem=169.1 GB | time_sec | memory_mb | counts     |
|-----------------------------+----------+-----------+------------|
| total classical             | 435_104  | 207.7     | 5_152      |
| get_poes                    | 209_621  | 0.0       | 31_174_052 |
| computing mean_std          | 114_743  | 0.0       | 642_187    |

# after
| calc_11315, maxmem=164.6 GB | time_sec | memory_mb | counts     |
|-----------------------------+----------+-----------+------------|
| total classical             | 407_185  | 167.2578  | 5_397      |
| get_poes                    | 193_621  | 0.0       | 32_740_962 |
| computing mean_std          | 98_646   | 0.0       | 676_112    |
```