### PR TITLE
Extended `oq sample` so that it can reduce the expected files in the gsim tests

### DIFF
--- a/openquake/commands/sample.py
+++ b/openquake/commands/sample.py
@@ -22,6 +22,7 @@ import numpy
 import pandas
 from openquake.hazardlib import (
     valid, nrml, sourceconverter, sourcewriter, logictree)
+from openquake.hazardlib.tests.gsim.utils import reduce_gsim_test
 from openquake.baselib import general
 
 
@@ -95,6 +96,9 @@ def main(fname, reduction_factor: valid.probability,
         arr = numpy.array(general.random_filter(array, reduction_factor))
         numpy.save(fname, arr)
         print('Extracted %d rows out of %d' % (len(arr), len(array)))
+        return
+    elif fname.endswith('_test.py'):
+        print(reduce_gsim_test(fname, reduction_factor))
         return
     node = nrml.read(fname)
     model = node[0]

--- a/openquake/hazardlib/tests/gsim/nz22/nz_nshm2022_abrahamson_gulerce_2020_test.py
+++ b/openquake/hazardlib/tests/gsim/nz22/nz_nshm2022_abrahamson_gulerce_2020_test.py
@@ -30,18 +30,21 @@ from openquake.hazardlib.gsim.nz22.nz_nshm2022_abrahamson_gulerce_2020 import (
 class NZNSHM2022_AbrahamsonGulerce2020TestCase(BaseGSIMTestCase):
 
     FILES = [
-        "nz22/ag2020/AG20_{}_GLO_GNS_MEAN.csv",
-        "nz22/ag2020/AG20_{}_GLO_GNS_TOTAL_STDDEV.csv",
+        "nz22/ag2020/AG20_%s_GLO_GNS_MEAN.csv",
+        "nz22/ag2020/AG20_%s_GLO_GNS_TOTAL_STDDEV.csv",
     ]
     REG = "GLO"
     ADJ = False
     SIGMA_MU_EPSILON = 0.0
 
     def test_all(self):
-        for gcls, trt in zip([NZNSHM2022_AbrahamsonGulerce2020SInter, NZNSHM2022_AbrahamsonGulerce2020SSlab],
-                             ['INTERFACE', 'SLAB']):
+        for gcls, trt in zip(
+                [NZNSHM2022_AbrahamsonGulerce2020SInter,
+                 NZNSHM2022_AbrahamsonGulerce2020SSlab],
+                ['INTERFACE',
+                 'SLAB']):
             self.GSIM_CLASS = gcls
-            mean_file, std_file = [f.format(trt) for f in self.FILES]
+            mean_file, std_file = [f % trt for f in self.FILES]
             
             self.check(
                 mean_file,

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -283,6 +283,7 @@ def reduce_gsim_test(fname, redfactor):
     """
     :param fname: a test file, like campbell_bozorgnia_2014_test.py
     :param redfactor: reduction factor in the range 0..1
+    :returns: a message telling how much the CSV files were reduced
 
     Reduce the mean and stddev files used by a gsim test by the redfactor
     """

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -80,6 +80,16 @@ def normalize(csvfnames):
                 writer.writerow([row[idx[c]] for c in cols])
 
 
+def check_large_files(fnames):
+    """
+    Log a warning for large files
+    """
+    maxsize = 1024**2
+    for fname in fnames:
+        if os.path.getsize(fname) > maxsize:
+            logging.warning(f'{fname} is larger than 1M')
+
+
 def read_cmaker_df(gsim, csvfnames):
     """
     :param gsim:
@@ -213,9 +223,11 @@ class BaseGSIMTestCase(unittest.TestCase):
             std_discrep_percentage = max_discrep_percentage
         fnames = [os.path.join(self.BASE_DATA_PATH, filename)
                   for filename in filenames]
+        check_large_files(fnames)
         if NORMALIZE:
             normalize(fnames)
             return
+
         gsim = self.GSIM_CLASS(**kwargs)
         out_types = ["MEAN"]
         for sdt in contexts.STD_TYPES:
@@ -273,7 +285,10 @@ def _reduce_files(fnames, redfactor):
 
 def reduce_gsim_test(fname, redfactor):
     """
-    Reduce the mean and stddev files used by a test file.
+    :param fname: a test file, like campbell_bozorgnia_2014_test.py
+    :param redfactor: reduction factor in the range 0..1
+
+    Reduce the mean and stddev files used by a gsim test by the redfactor
     """
     before_after = np.zeros(2)
     glob = runpy.run_path(fname)

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -21,6 +21,7 @@ import csv
 import runpy
 import logging
 import unittest
+import warnings
 
 import numpy as np
 import pandas
@@ -78,16 +79,6 @@ def normalize(csvfnames):
                         if f.startswith(('site_', 'rup_', 'dist_')))
             if tup in commonset:
                 writer.writerow([row[idx[c]] for c in cols])
-
-
-def check_large_files(fnames):
-    """
-    Log a warning for large files
-    """
-    maxsize = 1024**2
-    for fname in fnames:
-        if os.path.getsize(fname) > maxsize:
-            logging.warning(f'{fname} is larger than 1M')
 
 
 def read_cmaker_df(gsim, csvfnames):
@@ -217,13 +208,22 @@ class BaseGSIMTestCase(unittest.TestCase):
                   for k, v in cls.__dict__.items() if k.endswith('_FILE')]
         return fnames
 
+    def check_large_files(cls, fnames):
+        """
+        Log a warning for large files
+        """
+        maxsize = 1024**2
+        for fname in fnames:
+            if os.path.getsize(fname) > maxsize:
+                warnings.warn(f'{cls.__module__}: {fname} is larger than 1M')
+
     def check(self, *filenames, max_discrep_percentage,
               std_discrep_percentage=None, truncation_level=99., **kwargs):
         if std_discrep_percentage is None:
             std_discrep_percentage = max_discrep_percentage
         fnames = [os.path.join(self.BASE_DATA_PATH, filename)
                   for filename in filenames]
-        check_large_files(fnames)
+        self.check_large_files(fnames)
         if NORMALIZE:
             normalize(fnames)
             return

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -280,4 +280,4 @@ def reduce_gsim_test(fname, redfactor):
     for cls in glob.values():
         if hasattr(cls, 'get_files'):
             before_after += _reduce_files(cls.get_files(), redfactor)
-    return 'Reduced %d lines -> %d lines' % before_after
+    return 'Reduced %d lines -> %d lines' % tuple(before_after)


### PR DESCRIPTION
This is the first step towards https://github.com/gem/oq-engine/issues/9973. The second step is to forbid large CSV files to enter in the repository. For the moment, we just print a warning on sys.stderr.