### PR TITLE
Changed `.gen_poes` to return also mea, sig

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1156,7 +1156,7 @@ class ContextMaker(object):
                     yield poes, mea, sig, ctxt[slc], invs
             else:  # collapse
                 poes = numpy.concatenate([p[0] for p in self._gen_poes(kctx)])
-                yield poes, 0, 0, ctxt, invs
+                yield poes, 0, 0, ctxt, invs  # FIXME: 0, 0 is wrong but not used
 
     # used in source_disagg
     def get_pmap(self, ctxs, tom=None, rup_mutex={}):


### PR DESCRIPTION
For usage in the median_spectrum processor. This is doubling the speed:
```
| calc_23758, maxmem=5.6 GB     | time_sec | memory_mb | counts  |
|-------------------------------+----------+-----------+---------|
| total compute_median_spectrum | 13.4823  | 30.3281   | 18      |
| total compute_median_spectrum | 6.9183   | 31.3477   | 18      |
```