### PR TITLE
ARISTOTLE: add a command to plot the rupture in 3D and improve plotting all sources in 2D

### DIFF
--- a/openquake/calculators/postproc/plots.py
+++ b/openquake/calculators/postproc/plots.py
@@ -108,6 +108,7 @@ def add_rupture(ax, dstore, rup_id=0):
 
 
 def plot_rupture(dstore):
+    # NB: matplotlib is imported inside since it is a costly import
     plt = import_plt()
     _fig, ax = plt.subplots(figsize=(10, 10))
     ax.set_aspect('equal')
@@ -119,6 +120,30 @@ def plot_rupture(dstore):
     ax.set_xlim(min_x - BUF_ANGLE, max_x + BUF_ANGLE)
     ax.set_ylim(min_y - BUF_ANGLE, max_y + BUF_ANGLE)
     ax.legend()
+    return plt
+
+
+def plot_rupture_3d(dstore):
+    # NB: matplotlib is imported inside since it is a costly import
+    plt = import_plt()
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    ebr = get_ebrupture(dstore, rup_id=0)
+    rup = ebr.rupture
+    lon, lat, depth = rup.surface.get_surface_boundaries_3d()
+    lon_grid = numpy.array([[lon[0], lon[1]], [lon[3], lon[2]]])
+    lat_grid = numpy.array([[lat[0], lat[1]], [lat[3], lat[2]]])
+    depth_grid = numpy.array([[depth[0], depth[1]], [depth[3], depth[2]]])
+    ax.plot_surface(lon_grid, lat_grid, depth_grid, color='b', alpha=0.6,
+                    label='Rupture')
+    ax.plot(rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z, marker='*',
+            color='orange', label='Hypocenter', alpha=.5,
+            linestyle='', markersize=8)
+    ax.set_xlabel('Longitude')
+    ax.set_ylabel('Latitude')
+    ax.set_zlabel('Depth')
+    ax.legend()
+    plt.show()
     return plt
 
 

--- a/openquake/calculators/postproc/plots.py
+++ b/openquake/calculators/postproc/plots.py
@@ -130,12 +130,13 @@ def plot_rupture_3d(dstore):
     ax = fig.add_subplot(111, projection='3d')
     ebr = get_ebrupture(dstore, rup_id=0)
     rup = ebr.rupture
-    lon, lat, depth = rup.surface.get_surface_boundaries_3d()
-    lon_grid = numpy.array([[lon[0], lon[1]], [lon[3], lon[2]]])
-    lat_grid = numpy.array([[lat[0], lat[1]], [lat[3], lat[2]]])
-    depth_grid = numpy.array([[depth[0], depth[1]], [depth[3], depth[2]]])
-    ax.plot_surface(lon_grid, lat_grid, depth_grid, color='b', alpha=0.6,
-                    label='Rupture')
+    for surf_idx, surface in enumerate(rup.surface.surfaces):
+        lon, lat, depth = surface.get_surface_boundaries_3d()
+        lon_grid = numpy.array([[lon[0], lon[1]], [lon[3], lon[2]]])
+        lat_grid = numpy.array([[lat[0], lat[1]], [lat[3], lat[2]]])
+        depth_grid = numpy.array([[depth[0], depth[1]], [depth[3], depth[2]]])
+        ax.plot_surface(lon_grid, lat_grid, depth_grid, alpha=0.6,
+                        label='Surface %d' % surf_idx)
     ax.plot(rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z, marker='*',
             color='orange', label='Hypocenter', alpha=.5,
             linestyle='', markersize=8)

--- a/openquake/calculators/postproc/plots.py
+++ b/openquake/calculators/postproc/plots.py
@@ -94,7 +94,7 @@ def plot_avg_gmf(ex, imt):
     return plt
 
 
-def plot_surface(ax, surface, label):
+def add_surface(ax, surface, label):
     ax.fill(*surface.get_surface_boundaries(), alpha=.5, edgecolor='grey',
             label=label)
     return surface.get_bounding_box()
@@ -109,14 +109,14 @@ def add_rupture(ax, dstore, rup_id=0):
         min_y = 90
         max_y = -90
         for surf_idx, surface in enumerate(rup.surface.surfaces):
-            min_x_, max_x_, max_y_, min_y_ = plot_surface(
+            min_x_, max_x_, max_y_, min_y_ = add_surface(
                 ax, surface, 'Surface %d' % surf_idx)
             min_x = min(min_x, min_x_)
             max_x = max(max_x, max_x_)
             min_y = min(min_y, min_y_)
             max_y = max(max_y, max_y_)
     else:
-        min_x, max_x, max_y, min_y = plot_surface(ax, rup.surface, 'Surface')
+        min_x, max_x, max_y, min_y = add_surface(ax, rup.surface, 'Surface')
     ax.plot(rup.hypocenter.x, rup.hypocenter.y, marker='*',
             color='orange', label='Hypocenter', alpha=.5,
             linestyle='', markersize=8)
@@ -139,7 +139,7 @@ def plot_rupture(dstore):
     return plt
 
 
-def plot_surface_3d(ax, surface, label):
+def add_surface_3d(ax, surface, label):
     lon, lat, depth = surface.get_surface_boundaries_3d()
     lon_grid = numpy.array([[lon[0], lon[1]], [lon[3], lon[2]]])
     lat_grid = numpy.array([[lat[0], lat[1]], [lat[3], lat[2]]])
@@ -156,9 +156,9 @@ def plot_rupture_3d(dstore):
     rup = ebr.rupture
     if hasattr(rup.surface, 'surfaces'):
         for surf_idx, surface in enumerate(rup.surface.surfaces):
-            plot_surface_3d(ax, surface, 'Surface %d' % surf_idx)
+            add_surface_3d(ax, surface, 'Surface %d' % surf_idx)
     else:
-        plot_surface_3d(ax, rup.surface, 'Surface')
+        add_surface_3d(ax, rup.surface, 'Surface')
     ax.plot(rup.hypocenter.x, rup.hypocenter.y, rup.hypocenter.z, marker='*',
             color='orange', label='Hypocenter', alpha=.5,
             linestyle='', markersize=8)

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -32,7 +32,7 @@ from openquake.hazardlib.calc.filters import getdefault, IntegrationDistance
 from openquake.calculators.extract import (
     Extractor, WebExtractor, clusterize)
 from openquake.calculators.postproc.plots import (
-    plot_avg_gmf, import_plt, add_borders, plot_rupture)
+    plot_avg_gmf, import_plt, add_borders, plot_rupture, plot_rupture_3d)
 from openquake.calculators.postproc.aelo_plots import (
     plot_mean_hcurves_rtgm, plot_disagg_by_src, plot_governing_mce)
 
@@ -1037,10 +1037,18 @@ def make_figure_rupture(extractors, what):
     """
     $ oq plot "rupture?"
     """
-    # NB: matplotlib is imported inside since it is a costly import
     [ex] = extractors
     dstore = ex.dstore
     return plot_rupture(dstore)
+
+
+def make_figure_rupture_3d(extractors, what):
+    """
+    $ oq plot "rupture_3d?"
+    """
+    [ex] = extractors
+    dstore = ex.dstore
+    return plot_rupture_3d(dstore)
 
 
 def plot_wkt(wkt_string):


### PR DESCRIPTION
When plotting the rupture in 2D, instead of plotting the overall convex hull, we plot all surfaces
Example before this PR:
![us20003k7a](https://github.com/user-attachments/assets/ce9830b8-c0de-4236-b429-00c8c6c6b8c8)
Example after this PR:
![Figure_1](https://github.com/user-attachments/assets/a70439b7-0dbb-4120-9305-297977bca321)

Here is also an example of the same rupture plotted in 3D:
![Figure_2](https://github.com/user-attachments/assets/0fd5a7f5-18a6-4ceb-980e-cbac078b2d61)

