### PR TITLE
oqparam.to_ini() fix

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -2282,8 +2282,8 @@ def to_ini(key, val):
         return f'{key} = {", ".join(c for c in coords[:-1])}'
     elif key == 'hazard_imtls':
         return f"intensity_measure_types_and_levels = {val}"
-    elif key in ('reqv_ignore_sources', 'poes', 'poes_disagg', 'disagg_outputs',
-                 'quantiles', 'source_id', 'source_nodes', 'soil_intensities'):
+    elif key in ('reqv_ignore_sources', 'poes', 'quantiles', 'disagg_outputs',
+                 'source_id', 'source_nodes', 'soil_intensities'):
         return f"{key} = {' '.join(map(str, val))}"
     else:
         if val is None:

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -2282,8 +2282,8 @@ def to_ini(key, val):
         return f'{key} = {", ".join(c for c in coords[:-1])}'
     elif key == 'hazard_imtls':
         return f"intensity_measure_types_and_levels = {val}"
-    elif key in ('reqv_ignore_sources', 'poes', 'quantiles',
-                 'source_id', 'source_nodes', 'soil_intensities'):
+    elif key in ('reqv_ignore_sources', 'poes', 'poes_disagg', 'disagg_outputs',
+                 'quantiles', 'source_id', 'source_nodes', 'soil_intensities'):
         return f"{key} = {' '.join(map(str, val))}"
     else:
         if val is None:


### PR DESCRIPTION
Added some disaggregation parameters (poes, outputs) to the oqparams which must be split into a list within the text version of the job ini (previously was outputting as a string of a list so error was arising when executing the exported job files)