### PR TITLE
Extended `oq reset` to also remove the `custom_tmp` directory, if any

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Extended `oq reset` to also remove the `custom_tmp` directory, if any
   * Added classes CampbellBozorgnia2019, CampbellBozorgnia2019HighQ, CampbellBozorgnia2019LowQ
   * Reduced the size of the large CSV files in hazardlib and added a check
     to forbid files larger than 600k

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -223,7 +223,7 @@ def scratch_dir(job_id):
     tmp = config.directory.custom_tmp or tempfile.gettempdir()
     dirname = os.path.join(tmp, f'calc_{job_id}')
     try:
-        os.mkdir(dirname)
+        os.makedirs(dirname)
     except FileExistsError:  # already created
         pass
     return dirname

--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -17,7 +17,9 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import os
 import re
+import shutil
 import getpass
+from openquake.baselib import config
 from openquake.baselib.general import humansize
 from openquake.commonlib import logs, datastore
 
@@ -51,6 +53,10 @@ def purge_all(user=None):
             if mo is not None:
                 calc_id = int(mo.group(1))
                 purge_one(calc_id, user, force=True)
+    custom_tmp = config.directory.custom_tmp
+    if custom_tmp and os.path.exists(custom_tmp):
+        shutil.rmtree(custom_tmp)
+        print(f'Removed {custom_tmp}')
 
 
 def purge(status, days, force):


### PR DESCRIPTION
Otherwise old temporarily files will pollute new calculations breaking the postclassical.