### PR TITLE
Fixed the tiling test

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -177,7 +177,7 @@ def classical(sources, tilegetters, cmaker, dstore, monitor):
         if rmap.size_mb and cmaker.blocks == 1 and not cmaker.disagg_by_src:
             if len(tilegetters) > 1:
                 del result['source_data']
-            if cmaker.custom_tmp:
+            if config.directory.custom_tmp:
                 rates = rmap.to_array(cmaker.gid)
                 _store(rates, cmaker.num_chunks, None, monitor)
             else:
@@ -199,7 +199,7 @@ def tiling(tilegetter, cmaker, dstore, monitor):
         sitecol = dstore['sitecol'].complete  # super-fast
     result = hazclassical(sources, tilegetter(sitecol), cmaker)
     rmap = result.pop('rmap').remove_zeros()
-    if cmaker.custom_tmp:
+    if config.directory.custom_tmp:
         rates = rmap.to_array(cmaker.gid)
         _store(rates, cmaker.num_chunks, None, monitor)
     else:

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import sys
 import gzip
 import tempfile
@@ -172,10 +173,12 @@ class ClassicalTestCase(CalculatorTestCase):
         return self.calc.datastore['hcurves-stats'][3, 0]
 
     def test_case_22(self):
-        # crossing date line calculation for Alaska
-        # this also tests the splitting in tiles
+        # crossing date line calculation for Alaska testing full tiling
+        # NB: requires disabling the parallelization otherwise the
+        # workers would read the real custom_tmp and not the mocked one
         tmp = tempfile.gettempdir()
-        with mock.patch.dict(config.memory, {'pmap_max_gb': 1E-5}), \
+        with mock.patch.dict(os.environ, {'OQ_DISTRIBUTE': 'no'}), \
+             mock.patch.dict(config.memory, {'pmap_max_gb': 1E-5}), \
              mock.patch.dict(config.directory, {'custom_tmp': tmp}):
             self.assert_curves_ok([
                 '/hazard_curve-mean-PGA.csv',
@@ -193,7 +196,7 @@ class ClassicalTestCase(CalculatorTestCase):
 
     def test_case_22_bis(self):
         # crossing date line calculation for Alaska
-        # this also tests the splitting in tiles
+        # this also tests full tiling without custom_dir
         with mock.patch.dict(config.memory, {'pmap_max_gb': 1E-5}), \
              mock.patch.dict(config.directory, {'custom_tmp': ''}):
             self.assert_curves_ok([

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -730,7 +730,6 @@ class CompositeSourceModel:
             cmaker.gsims = list(cmaker.gsims)  # save data transfer
             cmaker.codes = sg.codes
             cmaker.rup_indep = getattr(sg, 'rup_interdep', None) != 'mutex'
-            cmaker.custom_tmp = config.directory.custom_tmp
             cmaker.num_chunks = num_chunks
             cmaker.blocks = len(blocks)
             cmaker.weight = sg.weight


### PR DESCRIPTION
It was failing with parallelization on, due to the workers reading the real `custom_tmp` and not the mocked one.