### PR TITLE
Fixed the `assert(losses)` error in the view delta_loss

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed the `assert(losses)` error in the view delta_loss in the case of few events
+
 python3-oq-engine (3.21.0-1~xenial01) xenial; urgency=low
 
   [Paolo Tormene]

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1342,10 +1342,10 @@ def view_delta_loss(token, dstore):
     K = dstore['risk_by_event'].attrs.get('K', 0)
     df = dstore.read_df('risk_by_event', 'event_id',
                         dict(agg_id=K, loss_id=li))
-    if len(df) == 0:  # for instance no fatalities
+    if len(df) < 10:  # for instance for fatalities
         return {'delta': numpy.zeros(1),
                 'loss_types': view_loss_ids(token, dstore),
-                'error': f"There are no relevant events for {loss_type=}"}
+                'error': f"There are only {len(df)} events for {loss_type=}"}
     if oq.calculation_mode == 'scenario_risk':
         if oq.number_of_ground_motion_fields == 1:
             return {'delta': numpy.zeros(1),


### PR DESCRIPTION
It happened for the Isle of Man calculation 99958998.