### PR TITLE
Work around unicode error when exporting strings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Made `scientific_format` resilient against encoding errors
+
   [Ilaria Oliveti]
   * Fixed the GMPE Tusa-Langer-Azzaro (2019) table of coefficients, the
     IMTs were incorrectly using Hz instead of seconds

--- a/openquake/baselib/node.py
+++ b/openquake/baselib/node.py
@@ -200,7 +200,7 @@ def scientificformat(value, fmt='%13.9E', sep=' ', sep2=':'):
     if isinstance(value, numpy.bool_):
         return '1' if value else '0'
     elif isinstance(value, bytes):
-        return value.decode('utf8')
+        return value.decode('utf8', 'ignore')
     elif isinstance(value, str):
         return value
     elif hasattr(value, '__len__'):


### PR DESCRIPTION
A bytestring `bs` is *formally* valid UTF8 if `bs.decode('utf8')` does not raise an error. The bytestrings in the Portugal exposure are formally valid UTF8, however, when exporting them, the function `get_assets` truncates to 100 characters and the truncation can break the UTF8 validity. With this fix, the problem is ignored and the exporter works. It is cheating , but the strings are wrong anyway: formally valid UTF8 does not mean that the string was really UTF8 at the beginning, rather that it was converted in some way, so we are full of strings like 
```
‚àö√Ögua Longa
‚àö√Öguas Santas
‚àö√Örvore
‚àö√ßlhavo (S‚àö¬£o Salvador)
‚àö√áncora
√Ågua Longa
√Ågua Rev√©s e Crasto
√Åguas Belas
√Åguas Frias
√Åguas Livres
√Åguas Santas
√Ålvaro
√Årvore
√Åzere
√Çncora
√âvora Monte (Santa Maria)
√âvora de Alcoba√ßa
√çlhavo (S√£o Salvador)
√çnsua
```
which are formally valid UTF8 but I do not believe for a moment that there were square roots in the names in the original encoding. Fixing the exposure is hard and out-of-scope for this PR. I also cannot devise an automatic method to detect such situations, unless we decide a set of valid characters and reject all the rest, but it is hard to decide which is the right set a valid characters given all the languages in the world. From the point of the calculation this is a non-issue since the strings are not used at all except in the exporter.