### PR TITLE
User-dependent `scratch_dir`

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -186,6 +186,7 @@ import time
 import socket
 import signal
 import pickle
+import getpass
 import inspect
 import logging
 import operator
@@ -221,7 +222,7 @@ def scratch_dir(job_id):
     :returns: scratch directory associated to the given job_id
     """
     tmp = config.directory.custom_tmp or tempfile.gettempdir()
-    dirname = os.path.join(tmp, f'calc_{job_id}')
+    dirname = os.path.join(tmp, getpass.getuser(), f'calc_{job_id}')
     try:
         os.makedirs(dirname)
     except FileExistsError:  # already created


### PR DESCRIPTION
To support multiple users in SLURM.