### PR TITLE
Removed command `oq dbserver upgrade`

### DIFF
--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -96,6 +96,7 @@ jobs:
     - name: Server 'PUBLIC' mode tests
       run: |
         source ~/openquake/bin/activate
+        oq engine --upgrade-db
         # -v 2 also logs the test names
         ./openquake/server/manage.py test -v 2 tests.test_public_mode
 
@@ -125,6 +126,7 @@ jobs:
     - name: Server 'READ_ONLY' mode tests
       run: |
         source ~/openquake/bin/activate
+        oq engine --upgrade-db
         # -v 2 also logs the test names
         ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
 
@@ -155,6 +157,7 @@ jobs:
     - name: Server 'AELO' mode tests
       run: |
         source ~/openquake/bin/activate
+        oq engine --upgrade-db
         ./openquake/server/manage.py migrate
         ./openquake/server/manage.py loaddata openquake/server/fixtures/0001_cookie_consent_required_plus_hide_cookie_bar.json
         ./openquake/server/manage.py collectstatic --noinput

--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -34,7 +34,7 @@ jobs:
         set -e
         source ~/openquake/bin/activate
         pip install pytest https://wheelhouse.openquake.org/v3/py/rtgmpy-1.0.0-py3-none-any.whl
-        oq dbserver upgrade
+        oq engine --upgrade-db
         pytest --doctest-modules -x --disable-warnings --color=yes --durations=10 openquake/calculators -k 'not risk and not damage'
 
   hazardlib:
@@ -64,7 +64,7 @@ jobs:
         set -e
         source ~/openquake/bin/activate
         pip install pyshp pytest flake8 ruff https://wheelhouse.openquake.org/v3/py/rtgmpy-1.0.0-py3-none-any.whl
-        oq dbserver upgrade
+        oq engine --upgrade-db
         cd openquake
         ruff check --preview .
         pytest calculators -k 'risk or damage' -x --doctest-modules --disable-warnings --color=yes --durations=5

--- a/.github/workflows/macos_m1_install.yml
+++ b/.github/workflows/macos_m1_install.yml
@@ -77,7 +77,7 @@ jobs:
           fi
           source ~/openquake/bin/activate
           pip3 install pytest pyshp flake8
-          oq dbserver upgrade
+          oq engine --upgrade-db
           sleep 5
 
       - name: Run tests for calculators to test installation

--- a/.github/workflows/ubuntu_install.yml
+++ b/.github/workflows/ubuntu_install.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         source ~/openquake/bin/activate
         pip install pytest
-        oq dbserver upgrade
+        oq engine --upgrade-db
         cd ~/work/oq-engine/oq-engine
         #
         export MPLBACKEND=Agg

--- a/.github/workflows/webui_rh_test.yml
+++ b/.github/workflows/webui_rh_test.yml
@@ -83,7 +83,7 @@ jobs:
          pip freeze
          mkdir /var/log/oq-engine/
          chown -R openquake /var/log/oq-engine/
-         runuser -l openquake -c '/opt/openquake/venv/bin/oq dbserver upgrade &'
+         runuser -l openquake -c '/opt/openquake/venv/bin/oq engine --upgrade-db &'
          # Wait the DbServer to come up
          #echo "Waiting DBServer up on port 1907...."
          #while ! nc -z localhost 1907; do

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           C:\Users\runneradmin\openquake\Scripts\activate.ps1
           oq --version
-          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver upgrade}
+          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' engine --upgrade-db}
           cd D:\a\oq-engine\oq-engine
           pytest --doctest-modules --disable-warnings --color=yes --durations=10 openquake/calculators
 
@@ -93,7 +93,7 @@ jobs:
         run: |
           C:\Users\runneradmin\openquake\Scripts\activate.ps1
           oq --version
-          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver upgrade}
+          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' engine --upgrade-db}
           sleep 10
           cd D:\a\oq-engine\oq-engine\openquake
           pytest --doctest-modules --disable-warnings --color=yes --durations=10 hazardlib sep commands engine hmtk risklib commonlib baselib
@@ -103,7 +103,7 @@ jobs:
         run: |
           C:\Users\runneradmin\openquake\Scripts\activate.ps1
           oq --version
-          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver upgrade}
+          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' engine --upgrade-db}
           sleep 10
           cd D:\a\oq-engine\oq-engine
           $Env:OQ_APPLICATION_MODE='PUBLIC'
@@ -115,7 +115,7 @@ jobs:
         run: |
           C:\Users\runneradmin\openquake\Scripts\activate.ps1
           oq --version
-          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver upgrade}
+          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' engine --upgrade-db}
           sleep 10
           cd D:\a\oq-engine\oq-engine
           $Env:OQ_APPLICATION_MODE='READ_ONLY'
@@ -126,7 +126,7 @@ jobs:
         run: |
           C:\Users\runneradmin\openquake\Scripts\activate.ps1
           oq --version
-          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' dbserver upgrade}
+          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' engine --upgrade-db}
           Write-Host "Run all demos having only job.ini"
           $iniFilePaths = Get-ChildItem D:\a\oq-engine\oq-engine\demos -Recurse -Filter job.ini
           foreach($iniFilePath in $iniFilePaths) {

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -20,8 +20,8 @@ import sys
 import signal
 import getpass
 from openquake.baselib import config
-from openquake.commonlib import logs, dbapi
-from openquake.server import dbserver, db
+from openquake.commonlib import logs
+from openquake.server import dbserver
 
 
 def main(cmd,

--- a/openquake/commands/dbserver.py
+++ b/openquake/commands/dbserver.py
@@ -39,13 +39,7 @@ def main(cmd,
                      f'but you are {user}')
 
     if cmd == 'upgrade':
-        applied = db.actions.upgrade_db(dbapi.db)
-        if applied:
-            print('Applied upgrades', applied)
-        else:
-            print('Already upgraded')
-        dbapi.db.close()
-        return
+        sys.exit('Use oq engine --upgrade-db instead')
 
     if (os.environ.get('OQ_DATABASE', config.dbserver.host) == '127.0.0.1'
         and getpass.getuser() != 'openquake'):

--- a/openquake/server/db/upgrade_manager.py
+++ b/openquake/server/db/upgrade_manager.py
@@ -25,6 +25,7 @@ import urllib.request
 import logging
 import importlib
 import sqlite3
+from openquake.commonlib.dbapi import db
 
 
 class DuplicatedVersion(RuntimeError):
@@ -330,16 +331,18 @@ class UpgradeManager(object):
         return upgrader
 
 
-def upgrade_db(conn, pkg_name='openquake.server.db.schema.upgrades',
+def upgrade_db(conn=None, pkg_name='openquake.server.db.schema.upgrades',
                skip_versions=()):
     """
     Upgrade a database by running several scripts in a single transaction.
 
-    :param conn: a DB API 2 connection
+    :param conn: a DB API 2 connection (if None use dbapi.db.conn)
     :param str pkg_name: the name of the package with the upgrade scripts
     :param list skip_versions: the versions to skip
     :returns: the version numbers of the new scripts applied the database
     """
+    if conn is None:
+        conn = db.conn
     upgrader = UpgradeManager.instance(conn, pkg_name)
     t0 = time.time()
     # run the upgrade scripts


### PR DESCRIPTION
*There should be one-- and preferably only one --obvious way to do it*
`oq dbserver upgrade` is not passing through the DbServer, so it is non-obvious.
The right way is `oq engine --upgrade-db`, which passes through the DbServer when needed. We will see how many actions will break and we fill fix them.