### PR TITLE
Refined cleaning custom_tmp in `oq reset`

### DIFF
--- a/openquake/commands/purge.py
+++ b/openquake/commands/purge.py
@@ -55,8 +55,15 @@ def purge_all(user=None):
                 purge_one(calc_id, user, force=True)
     custom_tmp = config.directory.custom_tmp
     if custom_tmp and os.path.exists(custom_tmp):
-        shutil.rmtree(custom_tmp)
-        print(f'Removed {custom_tmp}')
+        for path in os.listdir(custom_tmp):
+            fullpath = os.path.join(custom_tmp, path)
+            if os.path.isdir(fullpath):
+                try:
+                    shutil.rmtree(fullpath)
+                except PermissionError:
+                    pass
+                else:
+                    print(f'Removed {fullpath}')
 
 
 def purge(status, days, force):


### PR DESCRIPTION
We skip permission errors which are unavoidable since other users may have written in the custom_tmp. Continuation of https://github.com/gem/oq-engine/pull/10013 and https://github.com/gem/oq-engine/pull/9995.