### PR TITLE
ARISTOTLE: Fix a corner case when the user uploads a rupture and uses a custom rupture identifier

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -722,7 +722,7 @@ def aristotle_get_rupture_data(request):
     if isinstance(res, HttpResponse):  # error
         return res
     rupdic, station_data_file = res
-    if not os.path.isfile(station_data_file):
+    if station_data_file is None or not os.path.isfile(station_data_file):
         rupdic['station_data_error'] = (
             'Unable to collect station data: %s' % station_data_file)
         station_data_file = None


### PR DESCRIPTION
The station data in that case is None and there was a wrong check on it

NOTE: The user might insert a valid USGS id and also upload a rupture. In that case the rupture uploaded by the user would override the one downloaded from the USGS website and the station data might be also downloaded. Therefore in both cases we need to inform the user about the presence/absence of station data for the given rupture identifier.