### PR TITLE
Saving median_spectrum_disagg

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -45,6 +45,7 @@ F32 = numpy.float32
 F64 = numpy.float64
 I64 = numpy.int64
 TWO24 = 2 ** 24
+TWO30 = 2 ** 30
 TWO32 = 2 ** 32
 GZIP = 'gzip'
 BUFFER = 1.5  # enlarge the pointsource_distance sphere to fix the weight;
@@ -115,7 +116,10 @@ def store_ctxs(dstore, rupdata_list, grp_id):
         nr = len(rupdata)
         known = set(rupdata.dtype.names)
         for par in dstore['rup']:
-            if par == 'grp_id':
+            if par == 'rup_id':
+                rup_id = I64(rupdata['src_id']) * TWO30 + rupdata['rup_id']
+                hdf5.extend(dstore['rup/rup_id'], rup_id)
+            elif par == 'grp_id':
                 hdf5.extend(dstore['rup/grp_id'], numpy.full(nr, grp_id))
             elif par == 'probs_occur':
                 dstore.hdf5.save_vlen('rup/probs_occur', rupdata[par])
@@ -441,8 +445,10 @@ class ClassicalCalculator(base.HazardCalculator):
                     dt = U16  # storing only for few sites
                 elif param == 'probs_occur':
                     dt = hdf5.vfloat64
-                elif param in ('src_id', 'rup_id'):
+                elif param == 'src_id':
                     dt = U32
+                elif param == 'rup_id':
+                    dt = I64
                 elif param == 'grp_id':
                     dt = U16
                 else:

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -44,7 +44,6 @@ from openquake.risklib.scientific import LOSSTYPE, LOSSID
 from openquake.risklib.asset import tagset
 from openquake.commonlib import calc, util, oqvalidation, datastore
 from openquake.calculators import getters
-from openquake.calculators.postproc.median_spectrum import get_mea_sig_wei
 
 U16 = numpy.uint16
 U32 = numpy.uint32
@@ -519,33 +518,6 @@ def extract_median_spectra(dstore, what):
         grp_id=numpy.arange(dic['grp_id']),
         kind=['mea', 'sig', 'wei'],
         period=dic['period']))
-
-
-@extract.add('median_spectrum_disagg')
-def extract_median_spectrum_disagg(dstore, what):
-    """
-    Median spectrum disaggregation by group and rupture.
-    Use it as /extract/median_spectrum?site_id=0_poe_id=0
-    """
-    qdict = parse(what)
-    [site_id] = qdict['site_id']
-    [poe_id] = qdict['poe_id']
-    imts = list(dstore['oqparam'].imtls)
-    cmakers = read_cmakers(dstore)
-    ctx_by_grp = read_ctx_by_grp(dstore)
-    ref_uhs = dstore.sel("hmaps-stats", site_id=site_id, stat="mean")[0, 0]
-    for grp_id, ctx in ctx_by_grp.items():
-        cmaker = cmakers[grp_id]
-        mea, sig, wei = get_mea_sig_wei(cmaker, ctx, ref_uhs)  # (G, M, C)
-        for m, imt in enumerate(imts):
-            tag = f'grp{grp_id}-{imt}'
-            ws = wei[:, m, :, poe_id]
-            ok = (ws > 0).any(axis=0)
-            arr = general.compose_arrays(
-                rup_id=ctx.rup_id[ok], mag=ctx.mag[ok], rrup=ctx.rrup[ok],
-                mea=mea[:, m, ok].T, sig=sig[:, m, ok].T,
-                wei=ws[:, ok].T)
-            yield tag, arr
 
 
 @extract.add('effect')

--- a/openquake/calculators/postproc/median_spectrum.py
+++ b/openquake/calculators/postproc/median_spectrum.py
@@ -25,6 +25,7 @@ from openquake.baselib import hdf5, sap, parallel, general, performance
 from openquake.hazardlib import contexts
 
 U32 = np.uint32
+I64 = np.int64
 F32 = np.float32
 
 
@@ -151,6 +152,7 @@ def main(dstore, csm):
     cmakers = contexts.read_cmakers(dstore)
     G = {cm.grp_id: len(cm.gsims) for cm in cmakers}
     ctx_by_grp = contexts.read_ctx_by_grp(dstore)
+    # check_rup_unique(ctx_by_grp)
     totsize = sum(len(ctx) * G[grp_id] for grp_id, ctx in ctx_by_grp.items())
     blocksize = totsize / (oq.concurrent_tasks or 1)
     smap = parallel.Starmap(compute_median_spectrum, h5=dstore)
@@ -172,7 +174,7 @@ def main(dstore, csm):
     if N == 1 and P == 1:
         for cm in cmakers:
             G = len(cm.gsims)
-            dtlist = [('rup_id', U32), ('mag', F32), ('rrup', F32)]
+            dtlist = [('rup_id', I64), ('mag', F32), ('rrup', F32)]
             dt = (F32, (M,))
             for g in range(G):
                 dtlist.append((f'mea{g}', dt))


### PR DESCRIPTION
Only if there is a single site and a single poe. Made sure the saved `rup_id` is unique and consistent with the one in event_based calculations. Part of https://github.com/gem/oq-engine/issues/9979.