### PR TITLE
Fixed extract_dependencies for appconf

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -514,6 +514,8 @@ def extract_dependencies(lines):
             pkg = 'django'
         elif pkg == 'pyshp':
             pkg = 'shapefile'
+        elif pkg == 'django_appconf':
+            pkg = 'appconf'
         yield pkg, version
 
 


### PR DESCRIPTION
`oq webui start` fails without this fix. How it is possible that the test did not signal this??