### PR TITLE
Raised an error in case of non-invertible hazard curves

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Raised an error in case of non-invertible hazard curves, affecting
+    disaggregation and site-specific hazard spectrum calculations
   * Changed the ruptures.csv exporter to also export the source IDs
   * Specifying total_losses is now mandatory in damage calculations with
     multiple loss types

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -819,7 +819,7 @@ class ClassicalCalculator(base.HazardCalculator):
             # check numerical stability of the hmaps around the poes
             if self.N <= oq.max_sites_disagg and not self.amplifier:
                 mean_hcurves = self.datastore.sel('hcurves-stats', stat='mean')[:, 0]
-                check_hmaps(mean_hcurves, oq.imtls, oq.poes, delta=.05)
+                check_hmaps(mean_hcurves, oq.imtls, oq.poes)
 
     def plot_hmaps(self):
         """

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -34,7 +34,7 @@ from openquake.hazardlib import valid, InvalidFile
 from openquake.hazardlib.contexts import read_cmakers
 from openquake.hazardlib.calc.hazard_curve import classical as hazclassical
 from openquake.hazardlib.calc import disagg
-from openquake.hazardlib.map_array import RateMap, MapArray, rates_dt
+from openquake.hazardlib.map_array import RateMap, MapArray, rates_dt, check_hmaps
 from openquake.commonlib import calc
 from openquake.calculators import base, getters, preclassical, views
 
@@ -626,6 +626,7 @@ class ClassicalCalculator(base.HazardCalculator):
 
     def _post_regular(self, acc):
         # save the rates and performs some checks
+        oq = self.oqparam
         if self.rmap.size_mb:
             logging.info('Processing %s', self.rmap)
 
@@ -647,9 +648,9 @@ class ClassicalCalculator(base.HazardCalculator):
                 rates = self.rmap.to_array(g)
                 _store(rates, self.num_chunks, self.datastore)
         del self.rmap
-        if self.oqparam.disagg_by_src:
+        if oq.disagg_by_src:
             mrs = self.haz.store_mean_rates_by_src(acc)
-            if self.oqparam.use_rates and self.N == 1:  # sanity check
+            if oq.use_rates and self.N == 1:  # sanity check
                 self.check_mean_rates(mrs)
 
     # NB: the largest mean_rates_by_src is SUPER-SENSITIVE to numerics!
@@ -814,6 +815,11 @@ class ClassicalCalculator(base.HazardCalculator):
 
         if 'hmaps-stats' in self.datastore and not oq.tile_spec:
             self.plot_hmaps()
+
+            # check numerical stability of the hmaps around the poes
+            if self.N <= oq.max_sites_disagg and not self.amplifier:
+                mean_hcurves = self.datastore.sel('hcurves-stats', stat='mean')[:, 0]
+                check_hmaps(mean_hcurves, oq.imtls, oq.poes, delta=.05)
 
     def plot_hmaps(self):
         """

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -226,9 +226,11 @@ class DisaggregationTestCase(CalculatorTestCase):
         self.run_calc(case_13.__file__, 'job.ini')
 
     def test_case_14(self):
-        # check split_by_mag with NGAEastUSGS, see bug
-        # https://github.com/gem/oq-engine/issues/8780
-        self.run_calc(case_14.__file__, 'job.ini')
+        # check non-invertible hazard curve
+        with self.assertRaises(ValueError) as ctx:
+            self.run_calc(case_14.__file__, 'job.ini')
+        self.assertIn('The PGA hazard curve for sid=0 cannot be inverted reliably',
+                      str(ctx.exception))
 
     # NB: the largest mean_rates_by_src is SUPER-SENSITIVE to numerics!
     # in particular it has very different values between 2 and 16 cores(!)

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -229,7 +229,7 @@ class DisaggregationTestCase(CalculatorTestCase):
         # check non-invertible hazard curve
         with self.assertRaises(ValueError) as ctx:
             self.run_calc(case_14.__file__, 'job.ini')
-        self.assertIn('The PGA hazard curve for sid=0 cannot be inverted reliably',
+        self.assertIn('The PGA hazard curve for site_id=0 cannot be inverted',
                       str(ctx.exception))
 
     # NB: the largest mean_rates_by_src is SUPER-SENSITIVE to numerics!

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -172,6 +172,29 @@ def check_hmaps(hcurves, imtls, poes):
                         f'The {imt} hazard curve for {site_id=} cannot be '
                         f'inverted reliably around {poe=}: {iml=}, {iml99=}')
 
+
+# not used right now
+def get_lvl(hcurve, imls, poe):
+    """
+    :param hcurve: a hazard curve, i.e. array of L1 PoEs
+    :param imls: L1 intensity measure levels
+    :returns: index of the intensity measure level associated to the poe
+
+    >>> imls = numpy.array([.1, .2, .3, .4])
+    >>> hcurve = numpy.array([1., .99, .90, .8])
+    >>> get_lvl(hcurve, imls, 1)
+    0
+    >>> get_lvl(hcurve, imls, .99)
+    1
+    >>> get_lvl(hcurve, imls, .91)
+    2
+    >>> get_lvl(hcurve, imls, .8)
+    3
+    """
+    [[iml]] = compute_hazard_maps(hcurve.reshape(1, -1), imls, [poe])
+    iml -= 1E-10  # small buffer
+    return numpy.searchsorted(imls, iml)
+
 # ############################# probability maps ##############################
 
 t = numba.types

--- a/openquake/qa_tests_data/disagg/case_14/job.ini
+++ b/openquake/qa_tests_data/disagg/case_14/job.ini
@@ -21,7 +21,7 @@ reference_depth_to_2pt5km_per_sec = 0.57
 source_model_logic_tree_file = ssmLT_denver.xml
 gsim = NGAEastUSGSSeedB_bca10d
 investigation_time = 1.0
-intensity_measure_types_and_levels = {"PGA": [0.0001, 0.002]}
+intensity_measure_types_and_levels = {"PGA": logscale(0.0001, 1, 20)}
 truncation_level = 5.0
 maximum_distance = 200
 horiz_comp_to_geom_mean = true
@@ -30,7 +30,7 @@ horiz_comp_to_geom_mean = true
 sites_csv = sites_dsg.csv
 
 [disaggregation]
-poes_disagg = 0.002105 0.000404
+poes = 0.002105 0.000404
 mag_bin_width = 0.5
 distance_bin_width = 25.0
 coordinate_bin_width = 100
@@ -38,7 +38,3 @@ num_epsilon_bins = 10
 num_rlzs_disagg = 0
 disagg_outputs = Mag_Dist_Eps
 epsilon_star = true
-
-[output]
-poes = 0.002105 0.000404
-


### PR DESCRIPTION
Disaggregations that silently gave bogus numbers (like the test disagg/case_14) now will raise a clear error.
NB: the check might break AELO calculations.