### PR TITLE
[WIP] Adding USGS basin scaling factors to required GMMs

### DIFF
--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -42,6 +42,48 @@ CONSTANTS = {"b4": 0.1, "f3": 0.05, "Vb": 200,
 _a0 = CallableDict()
 
 
+def _get_z1pt0_usgs_basin_scaling(z, imt):
+    """
+    Get the USGS basin model scaling factor for z1pt0
+
+    Upper and lower z1pt0 values taken from GmmUtils.java in the
+    USGS 2023 conterminous US NSHM gitlab repo. 
+    """
+    z_scale = _get_usgs_basin_scaling(
+        z, basin_upper=0.3, basin_lower=0.5, period=imt.period)
+    
+    return z_scale
+
+
+def _get_z2pt5_usgs_basin_scaling(z, imt):
+    """
+    Get the USGS basin model scaling factor for z2pt5
+
+    Upper and lower z2pt5 values taken from GmmUtils.java in the
+    USGS 2023 conterminous US NSHM gitlab repo. 
+    """
+    z_scale = _get_usgs_basin_scaling(
+        z, basin_upper=1.0, basin_lower=3.0, period=imt.period)
+    
+    return z_scale
+    
+
+def _get_usgs_basin_scaling(z2pt5, basin_upper, basin_lower, period):
+    """
+    Get the USGS basin model scaling factor to be applied to the
+    basin amplification term (taken from GmmUtils.java in the USGS
+    2023 conterminous US NSHM gitlab repo). Can be used to scale
+    either z1pt0 or z2pt5.
+    """
+    constr = np.clip(z2pt5, basin_upper, basin_lower)
+    basin_range = basin_lower - basin_upper
+    z_scale = (constr - basin_upper) / basin_range
+    if period == 0.75:
+        return 0.585 * z_scale
+    else:
+        return z_scale
+    
+
 def _get_sigma_mu_adjustment(sat_region, trt, imt, epi_adjs_table):
     """
     Get the sigma_mu_adjustment (epistemic uncertainty) factor to be applied
@@ -358,6 +400,8 @@ class ParkerEtAl2020SInter(GMPE):
                                   "AK", "Cascadia", "CAM_S", "CAM_N", "JP_Pac",
                                   "JP_Phi", "SA_N", "SA_S", "TW_W", "TW_E")
     :param str basin: Choice of basin region ("Out" or "Seattle")
+    :param bool usgs_basin_scaling: Scaling factor to be applied to basin term
+                                    based on USGS basin model
     :param float sigma_mu_epsilon: Number of standard deviations to multiply
                                    sigma_mu (which is the standard deviations 
                                    of the median) for the epistemic uncertainty
@@ -386,10 +430,10 @@ class ParkerEtAl2020SInter(GMPE):
     #: interface events
     REQUIRES_DISTANCES = {'rrup'}
     REQUIRES_ATTRIBUTES = {'region', 'saturation_region', 'basin', 
-                           'sigma_mu_epsilon'}
+                           'sigma_mu_epsilon', 'usgs_basin_scaling'}
 
     def __init__(self, region=None, saturation_region=None, basin=None, 
-                 sigma_mu_epsilon=0.0):
+                 usgs_basin_scaling=False, sigma_mu_epsilon=0.0):
         """
         Enable setting regions to prevent messy overriding
         and code duplication.
@@ -400,6 +444,11 @@ class ParkerEtAl2020SInter(GMPE):
         else:
             self.saturation_region = saturation_region
         self.basin = basin
+        self.usgs_basin_scaling = usgs_basin_scaling
+        if (self.usgs_basin_scaling and 'z2pt5' not in
+            self.REQUIRES_SITES_PARAMETERS):
+            raise ValueError('User must specify a GSIM class for this GMPE '
+                             'which considers the z2pt5 site parameter.')
         self.sigma_mu_epsilon = sigma_mu_epsilon
         with open(EPI_ADJS) as f:
             self.epi_adjs_table = pd.read_csv(f.name).set_index('Region')
@@ -415,6 +464,12 @@ class ParkerEtAl2020SInter(GMPE):
         for m, imt in enumerate(imts):
             C = self.COEFFS[imt]
 
+            # USGS basin scaling factor is imt-dependent
+            if self.usgs_basin_scaling:
+                usgs_baf = _get_z2pt5_usgs_basin_scaling(ctx.z2pt5, imt)
+            else:
+                usgs_baf = 1.0
+
             # Regional Mb factor
             if self.saturation_region in self.MB_REGIONS:
                 m_b = self.MB_REGIONS[self.saturation_region]
@@ -429,7 +484,7 @@ class ParkerEtAl2020SInter(GMPE):
                 C, C_PGA, ctx.mag, ctx.rrup, m_b)
             fd = _depth_scaling(trt, C, ctx)
             fd_pga = _depth_scaling(trt, C_PGA, ctx)
-            fb = _basin_term(self.region, self.basin, C, ctx)
+            fb = _basin_term(self.region, self.basin, C, ctx) * usgs_baf
             flin = _linear_amplification(self.region, C, ctx.vs30)
             fnl = _non_linear_term(C, imt, ctx.vs30, fp_pga, fm_pga, c0_pga,
                                    fd_pga)


### PR DESCRIPTION
Apply the USGS basin scaling factor to each GMM required for the 2023 US conterminous model. This scaling factor is described here in the USGS gitlab within the functions called `deltaZ1scale` and `deltaZ25scale`:

https://code.usgs.gov/ghsc/nshmp/nshmp-lib/-/blob/main/src/main/java/gov/usgs/earthquake/nshmp/gmm/GmmUtils.java

This is an initial implementation just for the ParkeEtAl2020 subduction GMMs. If it is not too significant of a refactoring to be able to obtain the pre-basin amplification mean for each GMM within ModifiableGMPE (and also return the basin term separately), we can instead use ModifiableGMPE (rather than hard-coding this scaling into each GMM used in the 2023 US conterminous model/importing the functions from one GMM to the others).

Also note the z1pt0 scaling function is not used here, I just provide for completeness prior to likely porting of this capability into ModifiableGMPE.