### PR TITLE
Refactoring to homogenise GMM basin terms

### DIFF
--- a/openquake/hazardlib/gsim/abrahamson_2014.py
+++ b/openquake/hazardlib/gsim/abrahamson_2014.py
@@ -240,7 +240,7 @@ def _get_site_response_term(C, imt, vs30, sa1180):
     return site_resp_term
 
 
-def _get_soil_depth_term(region, C, z1pt0, vs30):
+def _get_basin_term(region, C, z1pt0, vs30):
     """
     Compute and return soil depth term.  See page 1042.
     """
@@ -392,7 +392,7 @@ def _get_sa_at_1180(region, C, imt, ctx):
             _get_site_response_term(C, imt, vs30_1180, ref_iml) +
             _get_hanging_wall_term(C, ctx) +
             _get_top_of_rupture_depth_term(C, imt, ctx) +
-            _get_soil_depth_term(region, C, fake_z1pt0, vs30_1180) +
+            _get_basin_term(region, C, fake_z1pt0, vs30_1180) +
             _get_regional_term(region, C, imt, vs30_1180, ctx.rrup))
 
 def get_epistemic_sigma(ctx):
@@ -486,7 +486,7 @@ class AbrahamsonEtAl2014(GMPE):
             # f5 = _get_site_response_term(C, imt, ctx.vs30, sa1180)
             # f6 = _get_top_of_rupture_depth_term(C, imt, ctx)
             # f7 = _get_faulting_style_term(C, ctx)
-            # f10 =_get_soil_depth_term(self.region, C, ctx.z1pt0, ctx.vs30)
+            # f10 = _get_basin_term(self.region, C, ctx.z1pt0, ctx.vs30)
             # fre = _get_regional_term(self.region, C, imt, ctx.vs30, ctx.rrup)
 
             # get the mean value
@@ -495,8 +495,7 @@ class AbrahamsonEtAl2014(GMPE):
                        _get_site_response_term(C, imt, ctx.vs30, sa1180) +
                        _get_top_of_rupture_depth_term(C, imt, ctx) +
                        _get_faulting_style_term(C, ctx) +
-                       _get_soil_depth_term(self.region, C, ctx.z1pt0,
-                                            ctx.vs30))
+                       _get_basin_term(self.region, C, ctx.z1pt0, ctx.vs30))
 
             mean[m] += _get_regional_term(
                 self.region, C, imt, ctx.vs30, ctx.rrup)

--- a/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
+++ b/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
@@ -288,7 +288,7 @@ def get_reference_basin_depth(region, vs30):
     return np.exp(ln_zref)
 
 
-def get_basin_depth_scaling(C, region, vs30, z25):
+def _get_basin_term(C, region, vs30, z25):
     """
     Returns the basin depth scaling term, applicable only for the Cascadia
     and Japan regions, defined in equations 3.9 - 3.11 and corrected in the
@@ -353,7 +353,7 @@ def get_mean_acceleration(C, trt, region, ctx, pga1000, apply_adjustment):
             get_rupture_depth_scaling_term(C, trt, ctx) +
             get_inslab_scaling_term(C, trt, region, ctx.mag, ctx.rrup) +
             get_site_amplification_term(C, region, ctx.vs30, pga1000) +
-            get_basin_depth_scaling(C, region, ctx.vs30, z25))
+            _get_basin_term(C, region, ctx.vs30, z25))
 
 
 def _get_f2(t1, t2, t3, t4, alpha, period):

--- a/openquake/hazardlib/gsim/abrahamson_silva_2008.py
+++ b/openquake/hazardlib/gsim/abrahamson_silva_2008.py
@@ -157,7 +157,7 @@ def _compute_large_distance_term(C, ctx):
     return large_distance_term
 
 
-def _compute_soil_depth_term(C, imt, z1pt0, vs30):
+def _get_basin_term(C, imt, z1pt0, vs30):
     """
     Compute and return soil depth model term, that is the 9-th term in
     equation 1, page 74. The calculation of this term is explained in
@@ -189,7 +189,7 @@ def _compute_imt1100(C_PGA, ctx):
             _compute_hanging_wall_term(C_PGA, ctx) +
             _compute_top_of_rupture_depth_term(C_PGA, ctx) +
             _compute_large_distance_term(C_PGA, ctx) +
-            _compute_soil_depth_term(C_PGA, imt, ctx.z1pt0, vs30_1100) +
+            _get_basin_term(C_PGA, imt, ctx.z1pt0, vs30_1100) +
             # this is the site response term in case of vs30=1100
             ((C_PGA['a10'] + C_PGA['b'] * CONSTS['n']) *
              np.log(vs30_star / C_PGA['VLIN'])))
@@ -474,7 +474,7 @@ class AbrahamsonSilva2008(GMPE):
                        _compute_hanging_wall_term(C, ctx) +
                        _compute_top_of_rupture_depth_term(C, ctx) +
                        _compute_large_distance_term(C, ctx) +
-                       _compute_soil_depth_term(C, imt, ctx.z1pt0, ctx.vs30))
+                       _get_basin_term(C, imt, ctx.z1pt0, ctx.vs30))
 
             sig[m], tau[m], phi[m] = _get_stddevs(C, C_PGA, pga1100, ctx)
 

--- a/openquake/hazardlib/gsim/afshari_stewart_2016.py
+++ b/openquake/hazardlib/gsim/afshari_stewart_2016.py
@@ -132,15 +132,21 @@ def get_magnitude_term(C, ctx):
     return term
 
 
+def _get_basin_term(C, ctx, region):
+    """
+    Return the basin term (equation 9)
+    """
+    dz1 = ctx.z1pt0 - np.exp(_get_lnmu_z1(region, ctx.vs30))
+    fb = C['c5'] * dz1
+    fb[dz1 > CONSTANTS["dz1ref"]] = (C["c5"] * CONSTANTS["dz1ref"])
+    return fb
+
+
 def get_site_amplification(region, C, ctx):
     """
     Returns the site amplification term
     """
-    # Gets delta normalised z1
-    dz1 = ctx.z1pt0 - np.exp(_get_lnmu_z1(region, ctx.vs30))
-    f_s = C["c5"] * dz1
-    # Calculates site amplification term
-    f_s[dz1 > CONSTANTS["dz1ref"]] = (C["c5"] * CONSTANTS["dz1ref"])
+    f_s = _get_basin_term(C, ctx, region) # First get basin term
     idx = ctx.vs30 > CONSTANTS["v1"]
     f_s[idx] += (C["c4"] * np.log(CONSTANTS["v1"] / C["vref"]))
     idx = np.logical_not(idx)

--- a/openquake/hazardlib/gsim/aristeidou_2023.py
+++ b/openquake/hazardlib/gsim/aristeidou_2023.py
@@ -142,7 +142,7 @@ def _get_site_amplification_term(C, ctx):
     return f_s
 
 
-def _get_basin_response_term(C, ctx):
+def _get_basin_term(C, ctx):
     """
     Returns the basin response term defined in equation (9), p. 1611
     """
@@ -258,7 +258,7 @@ class AristeidouEtAl2023(GMPE):
             f_s = _get_site_amplification_term(C, ctx)
 
             # Basin-effects correction function:
-            f_basin = _get_basin_response_term(C, ctx)
+            f_basin = _get_basin_term(C, ctx)
 
             # log of the functional form considered
             mean[m] = np.squeeze(C["a"] + f_m + f_d + f_sof + f_s + f_basin)

--- a/openquake/hazardlib/gsim/bahrampouri_2021_duration.py
+++ b/openquake/hazardlib/gsim/bahrampouri_2021_duration.py
@@ -61,18 +61,25 @@ def _get_path_term(C, ctx):
     return fpath
 
 
-def _get_site_term(C, ctx):
+def _get_basin_term(C, ctx):
     """
-    Implementing Eqs. 5, 6 and 12
+    Get the basin term
     """
     mean_z1pt0 = (np.exp(((-5.23 / 2.) * np.log((ctx.vs30 ** 2. +
                   412.39 ** 2.) / (1360 ** 2. + 412.39 ** 2.)))-0.9))
     delta_z1pt0 = np.round(ctx.z1pt0 - mean_z1pt0, 4)
-    fsite = []
-    for i, value in enumerate(delta_z1pt0):
-        s = (np.round(C['s1'] * np.log(min(ctx.vs30[i], 600.) / 600.) +
-             C['s2']*min(delta_z1pt0[i], 250.0) + C['s3'], 4))
-        fsite.append(s)
+    return C['s2'] * np.minimum(delta_z1pt0, 250.0)
+
+
+def _get_site_term(C, ctx):
+    """
+    Implementing Eqs. 5, 6 and 12
+    """
+    fbasin = _get_basin_term(C, ctx)
+
+    fsite = np.round(C['s1'] * np.log(np.clip(ctx.vs30, None, 600.0) / 600.0) +
+                     fbasin + C['s3'], 4)
+
     return fsite
 
 

--- a/openquake/hazardlib/gsim/bayless_abrahamson_2018.py
+++ b/openquake/hazardlib/gsim/bayless_abrahamson_2018.py
@@ -86,7 +86,7 @@ def _linear_site_response(C, ctx):
     return fsl
 
 
-def _soil_depth_scaling(C, ctx):
+def _get_basin_term(C, ctx):
     """ Compute the soil depth scaling term """
     # Set the c11 coefficient - See eq.13b at page 2093
     c11 = np.ones_like(ctx.vs30) * C['c11a']
@@ -190,7 +190,7 @@ def _get_mean_linear(C, ctx):
             _linear_site_response(C, ctx) +
             _ztor_scaling(C, ctx) +
             _normal_fault_effect(C, ctx) +
-            _soil_depth_scaling(C, ctx))
+            _get_basin_term(C, ctx))
     return mean
 
 

--- a/openquake/hazardlib/gsim/boore_2014.py
+++ b/openquake/hazardlib/gsim/boore_2014.py
@@ -40,7 +40,7 @@ CONSTS = {
     "v2": 300.0}
 
 
-def _get_basin_depth_term(region, C, ctx, period):
+def _get_basin_term(region, C, ctx, period):
     """
     In the case of the base model the basin depth term is switched off.
     Therefore we return an array of zeros.
@@ -204,7 +204,7 @@ def _get_site_scaling(kind, region, C, pga_rock, ctx, period, rjb):
     if kind == 'stewart':
         fbd = 0.  # there is no basin term in the Stewart models
     else:
-        fbd = _get_basin_depth_term(region, C, ctx, period)
+        fbd = _get_basin_term(region, C, ctx, period)
     return flin + fnl + fbd
 
 

--- a/openquake/hazardlib/gsim/boore_2020.py
+++ b/openquake/hazardlib/gsim/boore_2020.py
@@ -101,7 +101,7 @@ def _get_pga_on_rock(C, rup, dists):
 def _get_site_scaling(C, pga_rock, sites):
     """
     Returns the site-scaling term (equation 5), broken down into a
-    linear scaling, a nonlinear scaling and a basin scaling term
+    linear scaling and a nonlinear scaling
     """
     flin = _get_linear_site_term(C, sites.vs30)
     fnl = _get_nonlinear_site_term(C, sites.vs30, pga_rock)

--- a/openquake/hazardlib/gsim/bozorgnia_campbell_2016.py
+++ b/openquake/hazardlib/gsim/bozorgnia_campbell_2016.py
@@ -45,7 +45,7 @@ def _get_anelastic_attenuation_term(sgn, C, rrup):
     return f_atn
 
 
-def _get_basin_response_term(SJ, C, z2pt5):
+def _get_basin_term(SJ, C, z2pt5):
     """
     Returns the basin response term, f_sed, defined in equation 20
 
@@ -150,7 +150,7 @@ def get_mean_values(SJ, sgn, C, ctx):
             _get_style_of_faulting_term(C, ctx) +
             _get_hanging_wall_term(C, ctx) +
             _get_shallow_site_response_term(SJ, C, ctx.vs30) +
-            _get_basin_response_term(SJ, C, temp_z2pt5) +
+            _get_basin_term(SJ, C, temp_z2pt5) +
             _get_hypocentral_depth_term(C, ctx) +
             _get_fault_dip_term(C, ctx) +
             _get_anelastic_attenuation_term(sgn, C, ctx.rrup))

--- a/openquake/hazardlib/gsim/bradley_2013.py
+++ b/openquake/hazardlib/gsim/bradley_2013.py
@@ -46,6 +46,16 @@ cbd_polygon = shapely.geometry.Polygon(
      (172.6220, -43.5233)])
 
 
+def _get_basin_term(C, z1pt0):
+    """
+    Get the basin term
+    """
+    fb1 = C['phi5'] * (1.0 - 1.0 / np.cosh(
+        C['phi6'] * (z1pt0 - C['phi7']).clip(0, np.inf)))
+    fb2 = C['phi8'] / np.cosh(0.15 * (z1pt0 - 15).clip(0, np.inf))
+    return fb1 + fb2
+
+
 def _adjust_mean_model(region, in_cshm, in_cbd, imt_per, b13_mean):
     dL2L = dS2S = np.array(np.zeros(np.shape(b13_mean)))
     # If the site is in the CBD polygon, get dL2L and dS2S terms
@@ -373,10 +383,7 @@ def _get_mean(ctx, C, ln_y_ref, exp1, exp2, v1):
         + C['phi2'] * (exp1 - exp2)
         * np.log((np.exp(ln_y_ref) + C['phi4']) / C['phi4'])
         # third line
-        + C['phi5']
-        * (1.0 - 1.0 / np.cosh(
-            C['phi6'] * (z1pt0 - C['phi7']).clip(0, np.inf)))
-        + C['phi8'] / np.cosh(0.15 * (z1pt0 - 15).clip(0, np.inf))
+        + _get_basin_term(C, ctx.z1pt0)
         # fourth line
         + eta + epsilon)
 

--- a/openquake/hazardlib/gsim/bradley_2013.py
+++ b/openquake/hazardlib/gsim/bradley_2013.py
@@ -47,9 +47,6 @@ cbd_polygon = shapely.geometry.Polygon(
 
 
 def _get_basin_term(C, z1pt0):
-    """
-    Get the basin term
-    """
     fb1 = C['phi5'] * (1.0 - 1.0 / np.cosh(
         C['phi6'] * (z1pt0 - C['phi7']).clip(0, np.inf)))
     fb2 = C['phi8'] / np.cosh(0.15 * (z1pt0 - 15).clip(0, np.inf))
@@ -367,11 +364,7 @@ def _get_mean(ctx, C, ln_y_ref, exp1, exp2, v1):
 
     Implements eq. 5
     """
-    # we do not support estimating of basin depth and instead
-    # rely on it being available (since we require it).
-    z1pt0 = ctx.z1pt0
-
-    # we consider random variables being zero since we want
+    # We consider random variables being zero since we want
     # to find the exact mean value.
     eta = epsilon = 0
 

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
@@ -27,7 +27,7 @@ from openquake.hazardlib import const
 from openquake.hazardlib.imt import PGA, PGV, PGD, CAV, SA
 
 
-def _compute_basin_response_term(C, z2pt5):
+def _get_basin_term(C, z2pt5):
     """
     Returns the basin response term (equation 12, page 146)
     """
@@ -76,7 +76,7 @@ def _compute_imt1100(C, ctx, get_pga_site=False):
                      _compute_distance_term(C, ctx) +
                      _compute_style_of_faulting_term(C, ctx) +
                      _compute_hanging_wall_term(C, ctx) +
-                     _compute_basin_response_term(C, ctx.z2pt5) +
+                     _get_basin_term(C, ctx.z2pt5) +
                      fsite)
     # If PGA at the site is needed then remove factor for rock and
     # re-calculate on correct site condition
@@ -321,7 +321,7 @@ class CampbellBozorgnia2008(GMPE):
                        _compute_style_of_faulting_term(C, ctx) +
                        _compute_hanging_wall_term(C, ctx) +
                        _compute_shallow_site_response(C, ctx, pga1100) +
-                       _compute_basin_response_term(C, ctx.z2pt5))
+                       _get_basin_term(C, ctx.z2pt5))
 
             # If it is necessary to ensure that Sa(T) >= PGA
             # (see previous comment)

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
@@ -59,7 +59,7 @@ def _get_anelastic_attenuation_term(C, rrup):
     return f_atn
 
 
-def _get_basin_response_term(SJ, C, z2pt5):
+def _get_basin_term(SJ, C, z2pt5):
     """
     Returns the basin response term defined in equation 20
     """
@@ -309,7 +309,7 @@ def get_mean_values(SJ, C, ctx, a1100=None):
             _get_style_of_faulting_term(C, ctx) +
             _get_hanging_wall_term(C, ctx) +
             _get_shallow_site_response_term(SJ, C, temp_vs30, a1100) +
-            _get_basin_response_term(SJ, C, temp_z2pt5) +
+            _get_basin_term(SJ, C, temp_z2pt5) +
             _get_hypocentral_depth_term(C, ctx) +
             _get_fault_dip_term(C, ctx) +
             _get_anelastic_attenuation_term(C, ctx.rrup))

--- a/openquake/hazardlib/gsim/can20/can_shm6_active_crust.py
+++ b/openquake/hazardlib/gsim/can20/can_shm6_active_crust.py
@@ -86,7 +86,7 @@ def _get_site_scaling_ba14(kind, region, C, pga_rock, sites, period, rjb):
         BSSA14_1100[0], BSSA14_2000[0], sites.vs30[sites.vs30 > 1100], imt)
 
     fnl = BA14._get_nonlinear_site_term(C, sites.vs30, pga_rock)
-    fbd = BA14._get_basin_depth_term(region, C, sites, period)  # returns 0
+    fbd = BA14._get_basin_term(region, C, sites, period)  # returns 0
     fbd = 0.0
 
     return flin + fnl + fbd

--- a/openquake/hazardlib/gsim/can20/can_shm6_active_crust.py
+++ b/openquake/hazardlib/gsim/can20/can_shm6_active_crust.py
@@ -205,7 +205,7 @@ class CanadaSHM6_ActiveCrust_ChiouYoungs2014(ChiouYoungs2014):
     """
     #: Required site parameters are Vs30, Vs30 measured flag
     #: and Z1.0.
-    REQUIRES_SITES_PARAMETERS = {'vs30', 'vs30measured'}
+    REQUIRES_SITES_PARAMETERS = {'vs30', 'vs30measured', 'z1pt0'}
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """

--- a/openquake/hazardlib/gsim/can20/can_shm6_interface.py
+++ b/openquake/hazardlib/gsim/can20/can_shm6_interface.py
@@ -260,7 +260,7 @@ class CanadaSHM6_Interface_AtkinsonMacias2009(AtkinsonMacias2009):
     """
 
     REQUIRES_DISTANCES = {'rrup', 'rjb'}
-    REQUIRES_SITES_PARAMETERS = {'vs30', 'z1pt0'}
+    REQUIRES_SITES_PARAMETERS = {'vs30'}
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = {PGA, PGV, SA}
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):

--- a/openquake/hazardlib/gsim/chao_2020.py
+++ b/openquake/hazardlib/gsim/chao_2020.py
@@ -123,7 +123,7 @@ def _fvs30(geology, C, ctx):
                     C['c27'] if geology else C['c28'])
 
 
-def _fz1pt0(C, ctx):
+def _get_basin_term(C, ctx):
     """
     z1pt0 factor.
     """
@@ -217,7 +217,7 @@ class ChaoEtAl2020SInter(GMPE):
             sa1180 = np.exp(med + math.log(1180/s['vs30_ref']) * C['c24'])
             med += _fc(C, imt, ctx.vs30, sa1180)
             med += np.log(ctx.vs30 / s['vs30_ref']) * C['c24']
-            med += _fz1pt0(C, ctx)
+            med += _get_basin_term(C, ctx)
 
             sig[m], tau[m], phi[m] = get_stddevs(self.SBCR, C, ctx.mag)
 

--- a/openquake/hazardlib/gsim/chiou_youngs_2008.py
+++ b/openquake/hazardlib/gsim/chiou_youngs_2008.py
@@ -26,6 +26,19 @@ from openquake.hazardlib import const
 from openquake.hazardlib.imt import PGA, PGV, SA
 
 
+def _get_basin_term(C, z1pt0):
+    """
+    Return the basin term describing effects of deep sediment sites and shallow
+    sediment sites through z1pt0 
+    """
+    # Equation 3.10
+    deep_soil = C['phi5'] * (1.0 - 1.0 / np.cosh(C['phi6'] * (
+        z1pt0 - C['phi7']).clip(0, np.inf)))
+    # Equation 3.11
+    shallow_soil = C['phi8'] / np.cosh(0.15 * (z1pt0 - 15).clip(0, np.inf))
+    return deep_soil + shallow_soil
+
+
 def _get_ln_y_ref(ctx, C):
     """
     Get an intensity on a reference soil.
@@ -98,10 +111,7 @@ def _get_mean(ctx, C, ln_y_ref, exp1, exp2):
         + C['phi2'] * (exp1 - exp2)
         * np.log((np.exp(ln_y_ref) + C['phi4']) / C['phi4'])
         # third line
-        + C['phi5']
-        * (1.0 - 1.0 / np.cosh(
-            C['phi6'] * (z1pt0 - C['phi7']).clip(0, np.inf)))
-        + C['phi8'] / np.cosh(0.15 * (z1pt0 - 15).clip(0, np.inf))
+        + _get_basin_term(C, z1pt0)
         # fourth line
         + eta + epsilon
     )

--- a/openquake/hazardlib/gsim/chiou_youngs_2014.py
+++ b/openquake/hazardlib/gsim/chiou_youngs_2014.py
@@ -140,7 +140,7 @@ def _get_mean(ctx, C, ln_y_ref, exp1, exp2):
     return ln_y
 
 
-def get_basin_depth_term(region, C, centered_z1pt0):
+def _get_basin_term(region, C, centered_z1pt0):
     """
     Returns the basin depth scaling
     """
@@ -533,7 +533,7 @@ def get_mean_stddevs(region, C, ctx, imt, conf):
 
     # for Z1.0 = 0.0 no deep soil correction is applied
     dz1pt0[ctx.z1pt0 <= 0.0] = 0.0
-    f_z1pt0 = get_basin_depth_term(region, C, dz1pt0)
+    f_z1pt0 = _get_basin_term(region, C, dz1pt0)
 
     # Get linear amplification term
     f_lin = get_linear_site_term(region, C, ctx)

--- a/openquake/hazardlib/gsim/hassani_atkinson_2020.py
+++ b/openquake/hazardlib/gsim/hassani_atkinson_2020.py
@@ -173,7 +173,7 @@ def _fvs30(C, vs30):
                     C['cv2'] * np.log10(vs30 / s['vref']), fvs30)
 
 
-def _fz2pt5(C, z2pt5):
+def _get_basin_term(C, z2pt5):
     """
     Z2pt5 factor.
     """
@@ -288,7 +288,7 @@ class HassaniAtkinson2020SInter(GMPE):
             clf = _clf(self.SUFFIX, C, mag)
             fsnonlin = _fsnonlin_ss14(C, ctx.vs30, pga_rock)
             fvs30 = _fvs30(C, ctx.vs30)
-            fz2pt5 = _fz2pt5(C, ctx.z2pt5)
+            fz2pt5 = _get_basin_term(C, ctx.z2pt5)
             ff0 = _ff0(C, imt, ctx.f0)
 
             mean[m] = 10 ** (fm + fdsigma + fz + fkappa + fgamma

--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -400,7 +400,7 @@ def _get_ln_z_ref(CZ, vs30):
     return ln_z_ref
 
 
-def get_basin_response_term(C, region, vs30, z_value):
+def _get_basin_term(C, region, vs30, z_value):
     """
     Returns the basin response term, based on the region and the depth
     to a given velocity layer
@@ -460,10 +460,10 @@ def get_mean_values(C, region, trt, m_b, ctx, a1100=None):
     if region in ("CAS", "JPN"):
         # For Cascadia and Japan Z2.5 is used as the basin parameter (in m
         # rather than km)
-        mean += get_basin_response_term(C, region, vs30, z_values)
+        mean += _get_basin_term(C, region, vs30, z_values)
     elif region in ("NZL", "TWN"):
         # For New Zealand and Taiwan Z1.0 (m) is used as the basin parameter
-        mean += get_basin_response_term(C, region, vs30, z_values)
+        mean += _get_basin_term(C, region, vs30, z_values)
     else:
         pass
     return mean

--- a/openquake/hazardlib/gsim/nz22/nz_nshm2022_kuehn_2020.py
+++ b/openquake/hazardlib/gsim/nz22/nz_nshm2022_kuehn_2020.py
@@ -56,7 +56,7 @@ from openquake.hazardlib.gsim.nz22.const import (
 )
 
 
-def get_basin_response_term(C, region, vs30, z_value):
+def _get_basin_term(C, region, vs30, z_value):
     """
     Returns the basin response term, based on the region and the depth
     to a given velocity layer
@@ -199,10 +199,10 @@ def get_mean_values(C, region, trt, m_b, ctx, a1100=None):
     if region in ("CAS", "JPN"):
         # For Cascadia and Japan Z2.5 is used as the basin parameter (in m
         # rather than km)
-        mean += get_basin_response_term(C, region, vs30, z_values)
+        mean += _get_basin_term(C, region, vs30, z_values)
     elif region in ("NZL", "TWN"):
         # For New Zealand and Taiwan Z1.0 (m) is used as the basin parameter
-        mean += get_basin_response_term(C, region, vs30, z_values)
+        mean += _get_basin_term(C, region, vs30, z_values)
     else:
         pass
     return mean

--- a/openquake/hazardlib/gsim/nz22/nz_nshm2022_parker.py
+++ b/openquake/hazardlib/gsim/nz22/nz_nshm2022_parker.py
@@ -49,7 +49,7 @@ from openquake.hazardlib.gsim.parker_2020 import (
     _linear_amplification,
     _magnitude_scaling,
     _path_term,
-    _basin_term,
+    _get_basin_term,
     CONSTANTS,
 )
 
@@ -339,7 +339,7 @@ class NZNSHM2022_ParkerEtAl2020SInter(ParkerEtAl2020SInter):
             )  # backarc term applied to path function for reference rock PGA
             fd = _depth_scaling(trt, C, ctx)
             fd_pga = _depth_scaling(trt, C_PGA, ctx)
-            fb = _basin_term(self.region, self.basin, C, ctx)
+            fb = _get_basin_term(self.region, self.basin, C, ctx)
             flin = _linear_amplification(self.region, C, ctx.vs30)
             fnl = _non_linear_term(
                 C, imt, ctx.vs30, fp_pga, fm_pga, c0_pga, fd_pga

--- a/openquake/hazardlib/gsim/nz22/stafford_2022.py
+++ b/openquake/hazardlib/gsim/nz22/stafford_2022.py
@@ -33,7 +33,7 @@ from openquake.hazardlib.gsim.chiou_youngs_2014 import (
     get_geometric_spreading,
     get_magnitude_scaling,
     get_directivity,
-    get_basin_depth_term,
+    _get_basin_term,
     get_linear_site_term,
     get_nonlinear_site_term,
 )
@@ -428,7 +428,7 @@ def get_mean_stddevs(
     dz1pt0 = _get_centered_z1pt0("Stafford2022", ctx)
     # for Z1.0 = 0.0 no deep soil correction is applied
     dz1pt0[ctx.z1pt0 <= 0.0] = 0.0
-    f_z1pt0 = get_basin_depth_term("Stafford2022", C, dz1pt0)
+    f_z1pt0 = _get_basin_term("Stafford2022", C, dz1pt0)
     # Get linear amplification term
     f_lin = get_linear_site_term("Stafford2022", C, ctx)
     # Get nonlinear amplification term

--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -42,6 +42,48 @@ CONSTANTS = {"b4": 0.1, "f3": 0.05, "Vb": 200,
 _a0 = CallableDict()
 
 
+def _get_z1pt0_usgs_basin_scaling(z, imt):
+    """
+    Get the USGS basin model scaling factor for z1pt0
+
+    Upper and lower z1pt0 values taken from GmmUtils.java in the
+    USGS 2023 conterminous US NSHM gitlab repo. 
+    """
+    z_scale = _get_usgs_basin_scaling(
+        z, basin_upper=0.3, basin_lower=0.5, period=imt.period)
+    
+    return z_scale
+
+
+def _get_z2pt5_usgs_basin_scaling(z, imt):
+    """
+    Get the USGS basin model scaling factor for z2pt5
+
+    Upper and lower z2pt5 values taken from GmmUtils.java in the
+    USGS 2023 conterminous US NSHM gitlab repo. 
+    """
+    z_scale = _get_usgs_basin_scaling(
+        z, basin_upper=1.0, basin_lower=3.0, period=imt.period)
+    
+    return z_scale
+    
+
+def _get_usgs_basin_scaling(z2pt5, basin_upper, basin_lower, period):
+    """
+    Get the USGS basin model scaling factor to be applied to the
+    basin amplification term (taken from GmmUtils.java in the USGS
+    2023 conterminous US NSHM gitlab repo). Can be used to scale
+    either z1pt0 or z2pt5.
+    """
+    constr = np.clip(z2pt5, basin_upper, basin_lower)
+    basin_range = basin_lower - basin_upper
+    z_scale = (constr - basin_upper) / basin_range
+    if period == 0.75:
+        return 0.585 * z_scale
+    else:
+        return z_scale
+    
+
 def _get_sigma_mu_adjustment(sat_region, trt, imt, epi_adjs_table):
     """
     Get the sigma_mu_adjustment (epistemic uncertainty) factor to be applied
@@ -358,6 +400,8 @@ class ParkerEtAl2020SInter(GMPE):
                                   "AK", "Cascadia", "CAM_S", "CAM_N", "JP_Pac",
                                   "JP_Phi", "SA_N", "SA_S", "TW_W", "TW_E")
     :param str basin: Choice of basin region ("Out" or "Seattle")
+    :param bool usgs_basin_scaling: Scaling factor to be applied to basin term
+                                    based on USGS basin model
     :param float sigma_mu_epsilon: Number of standard deviations to multiply
                                    sigma_mu (which is the standard deviations 
                                    of the median) for the epistemic uncertainty
@@ -386,10 +430,10 @@ class ParkerEtAl2020SInter(GMPE):
     #: interface events
     REQUIRES_DISTANCES = {'rrup'}
     REQUIRES_ATTRIBUTES = {'region', 'saturation_region', 'basin', 
-                           'sigma_mu_epsilon'}
+                           'sigma_mu_epsilon', 'usgs_basin_scaling'}
 
     def __init__(self, region=None, saturation_region=None, basin=None, 
-                 sigma_mu_epsilon=0.0):
+                 usgs_basin_scaling=False, sigma_mu_epsilon=0.0):
         """
         Enable setting regions to prevent messy overriding
         and code duplication.
@@ -400,6 +444,11 @@ class ParkerEtAl2020SInter(GMPE):
         else:
             self.saturation_region = saturation_region
         self.basin = basin
+        self.usgs_basin_scaling = usgs_basin_scaling
+        if (self.usgs_basin_scaling and 'z2pt5' not in
+            self.REQUIRES_SITES_PARAMETERS):
+            raise ValueError('User must specify a GSIM class for this GMPE '
+                             'which considers the z2pt5 site parameter.')
         self.sigma_mu_epsilon = sigma_mu_epsilon
         with open(EPI_ADJS) as f:
             self.epi_adjs_table = pd.read_csv(f.name).set_index('Region')
@@ -415,6 +464,12 @@ class ParkerEtAl2020SInter(GMPE):
         for m, imt in enumerate(imts):
             C = self.COEFFS[imt]
 
+            # USGS basin scaling factor is imt-dependent
+            if self.usgs_basin_scaling:
+                usgs_baf = _get_z2pt5_usgs_basin_scaling(ctx.z2pt5, imt)
+            else:
+                usgs_baf = 1.0
+
             # Regional Mb factor
             if self.saturation_region in self.MB_REGIONS:
                 m_b = self.MB_REGIONS[self.saturation_region]
@@ -429,7 +484,7 @@ class ParkerEtAl2020SInter(GMPE):
                 C, C_PGA, ctx.mag, ctx.rrup, m_b)
             fd = _depth_scaling(trt, C, ctx)
             fd_pga = _depth_scaling(trt, C_PGA, ctx)
-            fb = _basin_term(self.region, self.basin, C, ctx)
+            fb = _basin_term(self.region, self.basin, C, ctx) * usgs_baf
             flin = _linear_amplification(self.region, C, ctx.vs30)
             fnl = _non_linear_term(C, imt, ctx.vs30, fp_pga, fm_pga, c0_pga,
                                    fd_pga)

--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -40,7 +40,7 @@ CONSTANTS = {"b4": 0.1, "f3": 0.05, "Vb": 200,
              "vref_fnl": 760, "V1": 270, "vref": 760}
 
 _a0 = CallableDict()
-    
+
 
 def _get_sigma_mu_adjustment(sat_region, trt, imt, epi_adjs_table):
     """
@@ -388,8 +388,8 @@ class ParkerEtAl2020SInter(GMPE):
     REQUIRES_ATTRIBUTES = {'region', 'saturation_region', 'basin', 
                            'sigma_mu_epsilon'}
 
-    def __init__(self, region=None, saturation_region=None, basin=None, 
-                 usgs_basin_scaling=False, sigma_mu_epsilon=0.0):
+    def __init__(self, region=None, saturation_region=None, basin=None,
+                 sigma_mu_epsilon=0.0):
         """
         Enable setting regions to prevent messy overriding
         and code duplication.

--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -40,48 +40,6 @@ CONSTANTS = {"b4": 0.1, "f3": 0.05, "Vb": 200,
              "vref_fnl": 760, "V1": 270, "vref": 760}
 
 _a0 = CallableDict()
-
-
-def _get_z1pt0_usgs_basin_scaling(z, imt):
-    """
-    Get the USGS basin model scaling factor for z1pt0
-
-    Upper and lower z1pt0 values taken from GmmUtils.java in the
-    USGS 2023 conterminous US NSHM gitlab repo. 
-    """
-    z_scale = _get_usgs_basin_scaling(
-        z, basin_upper=0.3, basin_lower=0.5, period=imt.period)
-    
-    return z_scale
-
-
-def _get_z2pt5_usgs_basin_scaling(z, imt):
-    """
-    Get the USGS basin model scaling factor for z2pt5
-
-    Upper and lower z2pt5 values taken from GmmUtils.java in the
-    USGS 2023 conterminous US NSHM gitlab repo. 
-    """
-    z_scale = _get_usgs_basin_scaling(
-        z, basin_upper=1.0, basin_lower=3.0, period=imt.period)
-    
-    return z_scale
-    
-
-def _get_usgs_basin_scaling(z2pt5, basin_upper, basin_lower, period):
-    """
-    Get the USGS basin model scaling factor to be applied to the
-    basin amplification term (taken from GmmUtils.java in the USGS
-    2023 conterminous US NSHM gitlab repo). Can be used to scale
-    either z1pt0 or z2pt5.
-    """
-    constr = np.clip(z2pt5, basin_upper, basin_lower)
-    basin_range = basin_lower - basin_upper
-    z_scale = (constr - basin_upper) / basin_range
-    if period == 0.75:
-        return 0.585 * z_scale
-    else:
-        return z_scale
     
 
 def _get_sigma_mu_adjustment(sat_region, trt, imt, epi_adjs_table):
@@ -146,7 +104,7 @@ def _a0_2(trt, region, basin, C, C_PGA):
     return C[region + "_a0slab"], C_PGA[region + "_a0slab"]
 
 
-def _basin_term(region, basin, C, ctx=None):
+def _get_basin_term(region, basin, C, ctx=None):
     """
     Basin term main handler.
     """
@@ -400,8 +358,6 @@ class ParkerEtAl2020SInter(GMPE):
                                   "AK", "Cascadia", "CAM_S", "CAM_N", "JP_Pac",
                                   "JP_Phi", "SA_N", "SA_S", "TW_W", "TW_E")
     :param str basin: Choice of basin region ("Out" or "Seattle")
-    :param bool usgs_basin_scaling: Scaling factor to be applied to basin term
-                                    based on USGS basin model
     :param float sigma_mu_epsilon: Number of standard deviations to multiply
                                    sigma_mu (which is the standard deviations 
                                    of the median) for the epistemic uncertainty
@@ -430,7 +386,7 @@ class ParkerEtAl2020SInter(GMPE):
     #: interface events
     REQUIRES_DISTANCES = {'rrup'}
     REQUIRES_ATTRIBUTES = {'region', 'saturation_region', 'basin', 
-                           'sigma_mu_epsilon', 'usgs_basin_scaling'}
+                           'sigma_mu_epsilon'}
 
     def __init__(self, region=None, saturation_region=None, basin=None, 
                  usgs_basin_scaling=False, sigma_mu_epsilon=0.0):
@@ -444,11 +400,6 @@ class ParkerEtAl2020SInter(GMPE):
         else:
             self.saturation_region = saturation_region
         self.basin = basin
-        self.usgs_basin_scaling = usgs_basin_scaling
-        if (self.usgs_basin_scaling and 'z2pt5' not in
-            self.REQUIRES_SITES_PARAMETERS):
-            raise ValueError('User must specify a GSIM class for this GMPE '
-                             'which considers the z2pt5 site parameter.')
         self.sigma_mu_epsilon = sigma_mu_epsilon
         with open(EPI_ADJS) as f:
             self.epi_adjs_table = pd.read_csv(f.name).set_index('Region')
@@ -464,12 +415,6 @@ class ParkerEtAl2020SInter(GMPE):
         for m, imt in enumerate(imts):
             C = self.COEFFS[imt]
 
-            # USGS basin scaling factor is imt-dependent
-            if self.usgs_basin_scaling:
-                usgs_baf = _get_z2pt5_usgs_basin_scaling(ctx.z2pt5, imt)
-            else:
-                usgs_baf = 1.0
-
             # Regional Mb factor
             if self.saturation_region in self.MB_REGIONS:
                 m_b = self.MB_REGIONS[self.saturation_region]
@@ -484,7 +429,7 @@ class ParkerEtAl2020SInter(GMPE):
                 C, C_PGA, ctx.mag, ctx.rrup, m_b)
             fd = _depth_scaling(trt, C, ctx)
             fd_pga = _depth_scaling(trt, C_PGA, ctx)
-            fb = _basin_term(self.region, self.basin, C, ctx) * usgs_baf
+            fb = _get_basin_term(self.region, self.basin, C, ctx)
             flin = _linear_amplification(self.region, C, ctx.vs30)
             fnl = _non_linear_term(C, imt, ctx.vs30, fp_pga, fm_pga, c0_pga,
                                    fd_pga)

--- a/openquake/hazardlib/gsim/phung_2020.py
+++ b/openquake/hazardlib/gsim/phung_2020.py
@@ -38,7 +38,7 @@ def get_stddevs(C):
             phi_tot]
 
 
-def _basin_term(region, C, vs30, z1pt0):
+def _get_basin_term(region, C, vs30, z1pt0):
     """
     Basin term [16].
     """
@@ -182,7 +182,7 @@ class PhungEtAl2020Asc(GMPE):
                     C['phi3'] * (1130 - 360))) * np.log(
                         (sa1130 + C['phi4']) / C['phi4'])
             # basin term [16]
-            lnmed += _basin_term(self.region, C, ctx.vs30, ctx.z1pt0)
+            lnmed += _get_basin_term(self.region, C, ctx.vs30, ctx.z1pt0)
             mean[m] = lnmed
             sig[m], tau[m], phi[m] = get_stddevs(C)
 

--- a/openquake/hazardlib/gsim/sera_amplification_models.py
+++ b/openquake/hazardlib/gsim/sera_amplification_models.py
@@ -431,6 +431,13 @@ class Eurocode8AmplificationDefault(Eurocode8Amplification):
 REGION_SET = ["USNZ", "JP", "TW", "CH", "WA", "TRGR", "WMT", "NWE"]
 
 
+def _get_basin_term(C, z1pt0):
+    """
+    Get basin amplification term
+    """
+    return C["b2"] * np.log(z1pt0)
+
+
 def get_site_amplification(C, psarock, ctx, ck):
     """
     Returns the site amplification model define in equation (9)
@@ -438,7 +445,7 @@ def get_site_amplification(C, psarock, ctx, ck):
     vs30_s = np.copy(ctx.vs30)
     vs30_s[vs30_s > 1000.] = 1000.
     fn_lin = (C["b1"] + ck) * np.log(vs30_s / 760.)
-    fn_z = C["b2"] * np.log(ctx.z1pt0)
+    fn_z = _get_basin_term(C, ctx.z1pt0)
     fn_nl = C["b3"] * np.log((psarock + 0.1 * g) / (0.1 * g)) *\
         np.exp(-np.exp(2.0 * np.log(ctx.vs30) - 11.))
     return fn_lin + fn_z + fn_nl

--- a/openquake/hazardlib/gsim/si_2020.py
+++ b/openquake/hazardlib/gsim/si_2020.py
@@ -117,7 +117,7 @@ def get_shallow_site_response_term(C, vs30, pga760):
     return (f_site_lin + f_site_nl) / np.log(10.0)
 
 
-def get_basin_response_term(C, z_value):
+def _get_basin_term(C, z_value):
     """
     Returns the basin response term (Eq. 3.10)
     """
@@ -131,7 +131,7 @@ def _get_pga_rock(C, trt, imt, ctx):
     mean = (get_base_term(trt, C) +
             get_magnitude_scaling_term(C, imt, ctx.mag) +
             get_geometric_attenuation_term(C, ctx) +
-            get_basin_response_term(C, ctx.z2pt5) +
+            _get_basin_term(C, ctx.z2pt5) +
             get_depth_scaling_term(C, ctx.hypo_depth) +
             get_anelastic_attenuation_term(C, ctx.rrup))
     return 10.0 ** mean
@@ -146,7 +146,7 @@ def get_mean_values(C, trt, imt, ctx, a760):
                            get_depth_scaling_term(C, ctx.hypo_depth) +
                            get_geometric_attenuation_term(C, ctx) +
                            get_anelastic_attenuation_term(C, ctx.rrup) +
-                           get_basin_response_term(C, ctx.z2pt5) +
+                           _get_basin_term(C, ctx.z2pt5) +
                            get_shallow_site_response_term(C, ctx.vs30, a760))
 
     return mean


### PR DESCRIPTION
Initial PR which refactors all existing GMMs in the engine to have a distinct basin term (now always called `_get_basin_term`. This is in anticipation of more refactoring to permit the specification of an alternative basin term within each GMM.