### PR TITLE
Fixed demo broken by the basing term refactoring

### DIFF
--- a/openquake/hazardlib/gsim/can20/can_shm6_active_crust.py
+++ b/openquake/hazardlib/gsim/can20/can_shm6_active_crust.py
@@ -55,6 +55,7 @@ def _check_imts(imts):
                              + str(MAX_SA) + 's.')
 
 
+# NB: this is calling the basin term
 def _get_site_scaling_ba14(kind, region, C, pga_rock, sites, period, rjb):
     """
     Returns the site-scaling term (equation 5), broken down into a
@@ -291,7 +292,7 @@ class CanadaSHM6_ActiveCrust_AbrahamsonEtAl2014(AbrahamsonEtAl2014):
 
     See also header in CanadaSHM6_ActiveCrust.py
     """
-    REQUIRES_SITES_PARAMETERS = {'vs30measured', 'vs30'}
+    REQUIRES_SITES_PARAMETERS = {'vs30measured', 'vs30', 'z1pt0'}
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """

--- a/openquake/hazardlib/gsim/can20/can_shm6_interface.py
+++ b/openquake/hazardlib/gsim/can20/can_shm6_interface.py
@@ -54,7 +54,7 @@ class CanadaSHM6_Interface_AbrahamsonEtAl2015SInter(AbrahamsonEtAl2015SInter):
     """
     MAX_SA = 10.
     MIN_SA = 0.05
-    DEFINED_FOR_INTENSITY_MEASURE_TYPES = set([PGA, PGV, SA])
+    DEFINED_FOR_INTENSITY_MEASURE_TYPES = {PGA, PGV, SA}
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):
         """
@@ -260,7 +260,7 @@ class CanadaSHM6_Interface_AtkinsonMacias2009(AtkinsonMacias2009):
     """
 
     REQUIRES_DISTANCES = {'rrup', 'rjb'}
-    REQUIRES_SITES_PARAMETERS = {'vs30'}
+    REQUIRES_SITES_PARAMETERS = {'vs30', 'z1pt0'}
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = {PGA, PGV, SA}
 
     def compute(self, ctx: np.recarray, imts, mean, sig, tau, phi):


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/10148. The broken demo was MedianSpectrum, depending on the canadians GMMs.