### PR TITLE
Added script `bin/arist`

### DIFF
--- a/bin/arist
+++ b/bin/arist
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+import sys
+from openquake.engine.aristotle import main_cmd
+if __name__ == '__main__':
+    main_cmd(sys.argv[1])  # us7000k9f0


### PR DESCRIPTION
For easy of debugging:
```bash
 $ ./arist us7000k9f0
[2024-11-26 16:16:47 #5105 WARNING] Using 8 processpool workers
[2024-11-26 16:16:49 #5105 WARNING] The closest vs30 site (-110.3 23.9) is distant more than 43 km from site #6 (-109.9 23.7)
[2024-11-26 16:16:49 #5105 WARNING] Sent 1 event_based tasks, 12.16 KB
[2024-11-26 16:16:51 #5105 WARNING] Sent 30 ebr_from_gmfs tasks, 67.73 KB
[2024-11-26 16:16:57 #5105 WARNING] The risk_by_event table is empty, perhaps the hazard is too small?
Finished job(s) 5105 correctly. Params: {'calculation_mode': 'scenario_risk', 'rupture_dict': "{'lon': -108.6922, 'lat': 23.1671, 'dep': 4.0, 'mag': 6.4, 'rake': 0.0, 'local_timestamp': '2023-06-18 13:30:21-07:00', 'time_event': 'day', 'is_point_rup': True, 'usgs_id': 'us7000k9f0'}", 'time_event': 'day', 'maximum_distance': '300', 'mosaic_model': 'MEX', 'tectonic_region_type': 'Active Shallow Crust Ridge', 'truncation_level': '3', 'number_of_ground_motion_fields': '10', 'asset_hazard_distance': '15', 'ses_seed': '42', 'inputs': {'exposure': ['/home/michele/mosaic/exposure.hdf5'], 'job_ini': '<in-memory>', 'station_data': '/tmp/stationsey7akgss.csv'}, 'description': 'us7000k9f0 (23.1671, -108.6922) M6.4'}
```