### PR TITLE
ARISTOTLE: handle corner case completing a job without producing aggrisk

### DIFF
--- a/openquake/server/templates/engine/get_outputs_aristotle.html
+++ b/openquake/server/templates/engine/get_outputs_aristotle.html
@@ -55,6 +55,7 @@
   {% block templates %}
   <script type="text/template" id="output-table-template">
     <div class="aristotle-losses-container">
+      {% if losses_header is not None %}
       <table id="aristotle-losses">
         <thead>
           <tr>
@@ -83,10 +84,15 @@
         {% endfor %}
         </tbody>
       </table>
+      {% else %}
+      <p>{{ losses }}</p>
+      {% endif %}
     </div>
+    {% if losses_header is not None %}
     <div id="aristotle-losses-download">
       <a href="{{ oq_engine_server_url }}/v1/calc/{{ calc_id }}/download_aggrisk" class="btn btn-sm output-action-btn">Download csv</a>
     </div>
+    {% endif %}
     <hr/>
     <table id="output_table" class="table table-hover">
       <thead>

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1574,9 +1574,16 @@ def web_engine_get_outputs_aristotle(request, calc_id):
     time_job_after_event_str = None
     warnings = None
     with datastore.read(job.ds_calc_dir + '.hdf5') as ds:
-        losses = views.view('aggrisk', ds)
-        losses_header = [header.capitalize().replace('_', ' ')
-                         for header in losses.dtype.names]
+        try:
+            losses = views.view('aggrisk', ds)
+        except KeyError:
+            max_avg_gmf = ds['avg_gmf'][0].max()
+            losses = (f'The risk can not be computed since the hazard is too low:'
+                      f' the maximum value of the average GMF is {max_avg_gmf:.5f}')
+            losses_header = None
+        else:
+            losses_header = [header.capitalize().replace('_', ' ')
+                             for header in losses.dtype.names]
         if 'png' in ds:
             avg_gmf = [k for k in ds['png'] if k.startswith('avg_gmf-')]
             assets = 'assets.png' in ds['png']


### PR DESCRIPTION
If the job runs but the hazard is too low (no aggrisk available), display a message in place of the loss table, also indicating the maximum average GMF.
Before this change, attempting to open the outputs page for a job without aggrisk produced an error.

![Screenshot From 2024-11-26 16-32-16](https://github.com/user-attachments/assets/c44fa742-44c7-474c-9ac5-32da9dc216ff)
