### PR TITLE
Fixed download_rupture_dict

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,13 @@
+  [Michele Simionato]
+  * Internal: extended `readinput.get_rupture` to read JSON files in the USGS format
+
   [Christopher Brooks]
   * Added instantiation-level arguments for contextually applying
     the M9 basin term, the CB14 basin term and the USGS basin scaling
     model to the AbrahamsonGulerce2020, KuehnEtAl2020, ParkerEtAl2020,
     ZhaoEtAl2006 and AtkinsonMacias2009 GMMs as required for the 2023
     US NSHM model's subduction interface GMC. Unit tests are also
-    provided for these GMM adjustments. 
+    provided for these GMM adjustments.
 
   [Michele Simionato]
   * Internal: forcing the signature (C, ctx, region, ...) for _get_basin_term

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -54,7 +54,7 @@ from openquake.hazardlib.calc.filters import getdefault
 from openquake.hazardlib.calc.gmf import CorrelationButNoInterIntraStdDevs
 from openquake.hazardlib import (
     source, geo, site, imt, valid, sourceconverter, source_reader, nrml,
-    pmf, logictree, gsim_lt, get_smlt)
+    shakemap, pmf, logictree, gsim_lt, get_smlt)
 from openquake.hazardlib.map_array import MapArray
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo.utils import (
@@ -801,7 +801,7 @@ def get_gsim_lt(oqparam, trts=('*',)):
 
 def get_rupture(oqparam):
     """
-    Read the `rupture_model` XML file or the `rupture_dict` dictionary
+    Read the `rupture_model` JSON/XML file or the `rupture_dict` dictionary
 
     :param oqparam:
         an :class:`openquake.commonlib.oqvalidation.OqParam` instance
@@ -810,10 +810,7 @@ def get_rupture(oqparam):
     """
     rupture_model = oqparam.inputs.get('rupture_model')
     if rupture_model:
-        [rup_node] = nrml.read(oqparam.inputs['rupture_model'])
-        conv = sourceconverter.RuptureConverter(oqparam.rupture_mesh_spacing)
-        rup = conv.convert_node(rup_node)
-        rup.tectonic_region_type = '*'  # there is no TRT for scenario ruptures
+        rup = shakemap.parsers.get_rupture(rupture_model)
     else:  # assume rupture_dict
         r = oqparam.rupture_dict
         hypo = Point(r['lon'], r['lat'], r['dep'])

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -39,8 +39,7 @@ from shapely.geometry import Polygon
 import numpy
 from json.decoder import JSONDecodeError
 from openquake.baselib.general import gettemp
-from openquake.baselib.node import (
-    node_from_xml, Node)
+from openquake.baselib.node import node_from_xml
 from openquake.hazardlib.source.rupture import get_multiplanar
 from openquake.hazardlib import nrml, sourceconverter
 

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -693,7 +693,7 @@ def download_rupture_dict(usgs_id, ignore_shakemap=False):
             'is_point_rup': False,
             'shakemap_array': shakemap_array,
             'trt': oq_rup.tectonic_region_type,
-            'usgs_id': usgs_id, 'rupture_file': rupture_file, 'oq_rup': oq_rup}
+            'usgs_id': usgs_id, 'rupture_file': rupture_file}
 
 
 def get_array_usgs_id(kind, usgs_id):

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -757,10 +757,10 @@ def aristotle_get_rupture_data(request):
             content=json.dumps(response_data), content_type=JSON, status=400)
     rupdic['trts'] = trts
     rupdic['mosaic_models'] = mosaic_models
-    rupdic['rupture_file_from_usgs'] = rupdic['rupture_file']
+    rupdic['rupture_file_from_usgs'] = fname = rupdic['rupture_file']
     rupdic['station_data_file_from_usgs'] = station_data_file
-    if 'rupture_file' in rupdic:
-        [rup_node] = nrml.read(rupdic['rupture_file'])
+    if fname:
+        [rup_node] = nrml.read(fname)
         conv = sourceconverter.RuptureConverter(rupture_mesh_spacing=5.)
         oq_rup = conv.convert_node(rup_node)
         rupdic['rupture_png'] = plot_rupture(

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -764,19 +764,17 @@ def aristotle_get_rupture_data(request):
         rupdic['rupture_png'] = plot_rupture(
             rupdic['oq_rup'], backend='Agg', figsize=(6, 6),
             with_populated_places=True, return_base64=True)
-    else:
-        oq_rup = None
-    if 'shakemap_array' in rupdic:
-        assert oq_rup
-        shakemap_array = rupdic['shakemap_array']
-        figsize = (14, 7)  # fitting in a single row in the template without resizing
-        rupdic['pga_map_png'] = plot_shakemap(
-            shakemap_array, 'PGA', backend='Agg', figsize=figsize,
-            with_populated_places=False, return_base64=True, rupture=oq_rup)
-        rupdic['mmi_map_png'] = plot_shakemap(
-            shakemap_array, 'MMI', backend='Agg', figsize=figsize,
-            with_populated_places=False, return_base64=True, rupture=oq_rup)
-        del rupdic['shakemap_array']
+        if 'shakemap_array' in rupdic:
+            assert oq_rup
+            shakemap_array = rupdic['shakemap_array']
+            figsize = (14, 7)  # fitting in a single row in the template without resizing
+            rupdic['pga_map_png'] = plot_shakemap(
+                shakemap_array, 'PGA', backend='Agg', figsize=figsize,
+                with_populated_places=False, return_base64=True, rupture=oq_rup)
+            rupdic['mmi_map_png'] = plot_shakemap(
+                shakemap_array, 'MMI', backend='Agg', figsize=figsize,
+                with_populated_places=False, return_base64=True, rupture=oq_rup)
+            del rupdic['shakemap_array']
     response_data = rupdic
     return HttpResponse(content=json.dumps(response_data), content_type=JSON,
                         status=200)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -47,7 +47,7 @@ from json.decoder import JSONDecodeError
 
 from openquake.baselib import hdf5, config, parallel
 from openquake.baselib.general import groupby, gettemp, zipfiles, mp
-from openquake.hazardlib import nrml, gsim, valid, sourceconverter
+from openquake.hazardlib import nrml, gsim, valid
 from openquake.commonlib import readinput, oqvalidation, logs, datastore, dbapi
 from openquake.commonlib.calc import get_close_mosaic_models
 from openquake.calculators import base, views
@@ -61,7 +61,7 @@ from openquake.engine import engine, aelo, aristotle
 from openquake.engine.aelo import (
     get_params_from, PRELIMINARY_MODELS, PRELIMINARY_MODEL_WARNING)
 from openquake.engine.export.core import DataStoreExportError
-from openquake.hazardlib.shakemap.parsers import download_station_data_file
+from openquake.hazardlib.shakemap.parsers import get_rupture, download_station_data_file
 from openquake.engine.aristotle import (
     get_trts_around, get_aristotle_params, get_rupture_dict)
 from openquake.server import utils
@@ -760,9 +760,7 @@ def aristotle_get_rupture_data(request):
     rupdic['rupture_file_from_usgs'] = fname = rupdic['rupture_file']
     rupdic['station_data_file_from_usgs'] = station_data_file
     if fname:
-        [rup_node] = nrml.read(fname)
-        conv = sourceconverter.RuptureConverter(rupture_mesh_spacing=5.)
-        oq_rup = conv.convert_node(rup_node)
+        oq_rup = get_rupture(fname)
         rupdic['rupture_png'] = plot_rupture(
             rupdic['oq_rup'], backend='Agg', figsize=(6, 6),
             with_populated_places=True, return_base64=True)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -762,10 +762,9 @@ def aristotle_get_rupture_data(request):
     if fname:
         oq_rup = get_rupture(fname)
         rupdic['rupture_png'] = plot_rupture(
-            rupdic['oq_rup'], backend='Agg', figsize=(6, 6),
+            oq_rup, backend='Agg', figsize=(6, 6),
             with_populated_places=True, return_base64=True)
         if 'shakemap_array' in rupdic:
-            assert oq_rup
             shakemap_array = rupdic['shakemap_array']
             figsize = (14, 7)  # fitting in a single row in the template without resizing
             rupdic['pga_map_png'] = plot_shakemap(

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -54,7 +54,7 @@ from openquake.calculators import base, views
 from openquake.calculators.getters import NotFound
 from openquake.calculators.export import export
 from openquake.calculators.extract import extract as _extract
-from openquake.calculators.postproc.plots import plot_shakemap  # , plot_rupture
+from openquake.calculators.postproc.plots import plot_shakemap, plot_rupture
 from openquake.engine import __version__ as oqversion
 from openquake.engine.export import core
 from openquake.engine import engine, aelo, aristotle
@@ -759,11 +759,18 @@ def aristotle_get_rupture_data(request):
     rupdic['mosaic_models'] = mosaic_models
     rupdic['rupture_file_from_usgs'] = rupdic['rupture_file']
     rupdic['station_data_file_from_usgs'] = station_data_file
-    if 'shakemap_array' in rupdic:
-        shakemap_array = rupdic['shakemap_array']
+    if 'rupture_file' in rupdic:
         [rup_node] = nrml.read(rupdic['rupture_file'])
         conv = sourceconverter.RuptureConverter(rupture_mesh_spacing=5.)
         oq_rup = conv.convert_node(rup_node)
+        rupdic['rupture_png'] = plot_rupture(
+            rupdic['oq_rup'], backend='Agg', figsize=(6, 6),
+            with_populated_places=True, return_base64=True)
+    else:
+        oq_rup = None
+    if 'shakemap_array' in rupdic:
+        assert oq_rup
+        shakemap_array = rupdic['shakemap_array']
         figsize = (14, 7)  # fitting in a single row in the template without resizing
         rupdic['pga_map_png'] = plot_shakemap(
             shakemap_array, 'PGA', backend='Agg', figsize=figsize,

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -47,7 +47,7 @@ from json.decoder import JSONDecodeError
 
 from openquake.baselib import hdf5, config, parallel
 from openquake.baselib.general import groupby, gettemp, zipfiles, mp
-from openquake.hazardlib import nrml, gsim, valid
+from openquake.hazardlib import nrml, gsim, valid, sourceconverter
 from openquake.commonlib import readinput, oqvalidation, logs, datastore, dbapi
 from openquake.commonlib.calc import get_close_mosaic_models
 from openquake.calculators import base, views
@@ -759,18 +759,11 @@ def aristotle_get_rupture_data(request):
     rupdic['mosaic_models'] = mosaic_models
     rupdic['rupture_file_from_usgs'] = rupdic['rupture_file']
     rupdic['station_data_file_from_usgs'] = station_data_file
-    oq_rup = None
-    if 'oq_rup' in rupdic:
-        oq_rup = rupdic['oq_rup']
-        # FIXME: check if we want to display the rupture png as a separate plot, instead
-        # of inserting the hypocenter and the rupture boundaries in the gmf plots
-        # # Agg is a non-interactive backend
-        # rupdic['rupture_png'] = plot_rupture(
-        #     rupdic['oq_rup'], backend='Agg', figsize=(6, 6),
-        #     with_populated_places=True, return_base64=True)
-        del rupdic['oq_rup']
     if 'shakemap_array' in rupdic:
         shakemap_array = rupdic['shakemap_array']
+        [rup_node] = nrml.read(rupdic['rupture_file'])
+        conv = sourceconverter.RuptureConverter(rupture_mesh_spacing=5.)
+        oq_rup = conv.convert_node(rup_node)
         figsize = (14, 7)  # fitting in a single row in the template without resizing
         rupdic['pga_map_png'] = plot_shakemap(
             shakemap_array, 'PGA', backend='Agg', figsize=figsize,


### PR DESCRIPTION
The Aristotle tests were failing with
```
"{'lon': -99.7429, 'lat': 16.9722, 'dep': 20.0,
  'mag': 7.0, 'rake': 0.0, 'local_timestamp': '2021-09-07 20:47:47-05:00',
 'time_event': 'transit', 'is_point_rup': False, 'trt': 'Active Shallow Crust',
 'usgs_id': 'us7000f93v', 'oq_rup': <openquake.hazardlib.source.rupture.BaseRupture object at 0x7f261fe5bd10>}"
 is not a valid Python dictionary
```
The error management is REALLY BAD and will have to be rewritten.