### PR TITLE
Skipping the parsing tests if timezonefinder is missing

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -262,7 +262,7 @@ def rup_to_file(rup, outfile, commentstr):
 
 def utc_to_local_time(utc_timestamp, lon, lat):
     try:
-        # NOTE: optional dependency needed for ARISTOTLE
+        # NOTE: mandatory dependency for ARISTOTLE
         from timezonefinder import TimezoneFinder
     except ImportError:
         raise ImportError(

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -26,6 +26,13 @@ DATA = os.path.join(os.path.dirname(__file__), 'jsondata')
 
 
 class ShakemapParsersTestCase(unittest.TestCase):
+    @classmethod
+    def setUp(cls):
+        try:
+            import timezonefinder
+        except ImportError:
+            raise unittest.SkipTest('Missing timezonefinder')
+
     def test_1(self):
         # wrong usgs_id
         with self.assertRaises(URLError) as ctx:


### PR DESCRIPTION
Otherwise the tests on macos are broken: https://github.com/gem/oq-engine/actions/runs/12060931265/job/33632148524
