### PR TITLE
Fixed Aristotle nightly tests

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -216,7 +216,8 @@ def convert_to_oq_rupture(rup_json):
     ftype = rup_json['features'][0]['geometry']['type']
     assert ftype == 'MultiPolygon', ftype
     multicoords = rup_json['features'][0]['geometry']['coordinates'][0]
-    if is_matrix(multicoords):
+    if is_matrix(multicoords) and len(multicoords[0]) == 4:
+        # convert only if there are 4 vertices
         hyp_depth = rup_json['metadata']['depth']
         rake = rup_json['metadata'].get('rake', 0)
         trt = 'Active Shallow Crust' if hyp_depth < 50 else 'Subduction IntraSlab'

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -59,9 +59,9 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['is_point_rup'], True)
 
     def test_5(self):
-        # no point_rup
+        # 5 vertices instead of 4 in rupture.json
         _rup, dic = get_rup_dic('usp0001ccb', datadir=DATA)
-        self.assertEqual(dic['is_point_rup'], False)
+        self.assertEqual(dic['is_point_rup'], True)
 
 
 """

--- a/openquake/server/tests/test_aristotle_mode.py
+++ b/openquake/server/tests/test_aristotle_mode.py
@@ -282,12 +282,10 @@ class EngineServerTestCase(django.test.TestCase):
         # NOTE: values returned by the USGS often change with time, so we check
         # only that all the expected keys are present and a subset of stable
         # values
-        expected_keys = [
-            'is_point_rup', 'local_timestamp', 'time_event', 'lon', 'lat',
-            'dep', 'mag', 'rake', 'usgs_id',
-            'rupture_file', 'rupture_file_from_usgs',
-            'mmi_map_png', 'pga_map_png',
-            'station_data_file_from_usgs', 'trts', 'mosaic_models']
+        expected_keys = ['dep', 'error', 'is_point_rup', 'lat', 'local_timestamp',
+                         'lon', 'mag', 'mmi_map_png', 'mosaic_models', 'pga_map_png',
+                         'rake', 'rupture_file', 'rupture_file_from_usgs',
+                         'station_data_file_from_usgs', 'time_event', 'trts', 'usgs_id']
         self.assertEqual(sorted(ret_dict), sorted(expected_keys))
         self.assertEqual(ret_dict['local_timestamp'],
                          '2024-08-18 07:10:26+12:00')
@@ -297,7 +295,7 @@ class EngineServerTestCase(django.test.TestCase):
             'NEA': ['Cratonic Crust', 'Stable Continental Crust',
                     'Active Shallow Crust', 'Subduction Interface',
                     'Subduction IntraSlab']})
-        self.assertEqual(ret_dict['is_point_rup'], False)
+        self.assertEqual(ret_dict['is_point_rup'], True)
         self.assertEqual(ret_dict['usgs_id'], 'us7000n7n8')
 
     def test_get_point_rupture_data_from_shakemap(self):


### PR DESCRIPTION
There are many errors due to the wrong number of vertices:
```
| None   | us20002926                           | Expecting 4 vertices, got 12 |
| 16     | usp000jq5p (38.329, 46.826) M6.4     |                              |
| 17     | usp000j9rr (38.721, 43.508) M7.1     |                              |
| 18     | usp000j88b (27.73, 88.155) M6.9      |                              |
| 19     | usp000j1en (37.699, -1.672) M5.1     |                              |
| 20     | usp000h60h (18.443, -72.571) M7.0    |                              |
| 21     | usp000hny4 (43.76, 20.73) M5.5       |                              |
| 22     | usp000hk46 (-43.522, 171.83) M7.0    |                              |
| 23     | usp000gvtu (42.334, 13.334) M6.3     |                              |
| 24     | usp000h237 (-0.72, 99.867) M7.6      |                              |
| 25     | usp000gvvw (42.275, 13.464) M5.5     |                              |
| 26     | usp000gscg (10.165, -84.197) M6.1    |                              |
| None   | usp000fjta                           | Expecting 4 vertices, got 8  |
| None   | usp000dgpx                           | Expecting 4 vertices, got 6  |
| None   | usp000e12e                           | Expecting 4 vertices, got 8  |
```