### PR TITLE
Parallelized `get_mean_covs` when conditioning the GMFs

### DIFF
--- a/bin/arist
+++ b/bin/arist
@@ -2,4 +2,5 @@
 import sys
 from openquake.engine.aristotle import main_cmd
 if __name__ == '__main__':
-    main_cmd(sys.argv[1], loglevel='info', userlevel=2)  # us7000k9f0
+    # us7000k9f0
+    main_cmd(sys.argv[1], maximum_distance='200', loglevel='info', userlevel=2)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
+  [Michele Simionato]
+  * Parallelized `get_mean_covs` when conditioning the GMFs
+
   [Christopher Brooks]
   * Added Seattle Basin classes of Kuehn et al. (2020) NGASUB GMM (uses
-    Cascadia coeffs except for basin term). 
+    Cascadia coeffs except for basin term).
   * Added USGS basin scaling and CyberShake adjustments to the NGAWest2
     GMMs + ability to pass base gsim arguments within the NSHMP2014 gsim class.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reduced `conditioned_gmfs_gb` to 9 GB by default
   * Parallelized `get_mean_covs` when conditioning the GMFs
 
   [Christopher Brooks]

--- a/openquake/baselib/tests/parallel_test.py
+++ b/openquake/baselib/tests/parallel_test.py
@@ -276,4 +276,4 @@ class SharedArrayTestCase(unittest.TestCase):
                                   for index, value in zip([0, 1], [.1, .2])]
         ).reduce()
         with self.s_array as arr:
-            print(arr)
+            numpy.testing.assert_allclose(arr, [[.1, .1], [.2, .2]])

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -411,7 +411,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
                 f'The calculation is too large: {G=}, {M=}, {N=}. '
                 'You must reduce the number of sites i.e. enlarge '
                 'region_grid_spacing)')
-        mea, tau, phi = computer.get_mea_tau_phi()
+        mea, tau, phi = computer.get_mea_tau_phi(dstore.hdf5)
         del proxy.geom  # to reduce data transfer
 
     dstore.swmr_on()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -409,8 +409,7 @@ def starmap_from_rups(func, oq, full_lt, sitecol, dstore, save_tmp=None):
         if size > float(config.memory.conditioned_gmf_gb) * 1024**3:
             raise ValueError(
                 f'The calculation is too large: {G=}, {M=}, {N=}. '
-                'You must reduce the number of sites i.e. enlarge '
-                'region_grid_spacing)')
+                'You must reduce the number of sites i.e. maximum_distance')
         mea, tau, phi = computer.get_mea_tau_phi(dstore.hdf5)
         del proxy.geom  # to reduce data transfer
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -90,7 +90,10 @@ def set_concurrent_tasks_default(calc):
         OqParam.concurrent_tasks.default = num_workers * 2
     else:
         num_workers = parallel.Starmap.num_cores
-    logging.warning('Using %d %s workers', num_workers, dist)
+    if dist == 'no':
+        logging.warning('Disabled distribution')
+    else:
+        logging.warning('Using %d %s workers', num_workers, dist)
 
 
 class MasterKilled(KeyboardInterrupt):

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -40,8 +40,8 @@ hard_mem_limit = 99
 # transfer at most 900 MB per core
 avg_losses_max = 900_000_000
 
-# store at most 10 GB
-conditioned_gmf_gb = 10
+# store at most 9 GB, good if you have 32 GB total
+conditioned_gmf_gb = 9
 
 # parallel tiling parameters, by default pmap_max_gb=num_cores/8
 pmap_max_gb =

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -386,9 +386,94 @@ def compute_spatial_cross_covariance_matrix(
     return numpy.linalg.multi_dot([diag1, rho, diag2])
 
 
-def compute_mu_tau_phi(cmaker, sdata, observed_imts, target_imts,
-                       mean_stds_D, mean_stds_Y, target, station_filtered,
-                       compute_cov, cross_correl_between, h5):
+# In scenario/case_21 one has
+# target_imt = PGA = target_imts = observed_imts
+# ctx_Y with 571 elements, like target_sitecol
+# station_data has 140 elements like station_sitecol
+# 18 sites are discarded
+# the total sitecol has 571 + 140 + 18 = 729 sites
+# NB: this is run in parallel
+def get_mu_tau_phi(target_imt, gsim, mean_stds,
+                   target_imts, observed_imts, station_data,
+                   target_sitecol, station_sitecol, compute_cov, r, monitor):
+    # Using Bayes rule, compute the posterior distribution of the
+    # normalized between-event residual H|YD=yD, employing
+    # Engler et al. (2022), eqns B8 and B9 (also B18 and B19),
+    # H|Y2=y2 is normally distributed with mean and covariance:
+    cov_HD_HD_yD = numpy.linalg.pinv(
+        numpy.linalg.multi_dot([r.T_D.T, r.cov_WD_WD_inv, r.T_D])
+        + numpy.linalg.pinv(r.corr_HD_HD))
+
+    mu_HD_yD = numpy.linalg.multi_dot(
+        [cov_HD_HD_yD, r.T_D.T, r.cov_WD_WD_inv, r.zD])
+
+    # Compute the distribution of the conditional between-event
+    # residual B|Y2=y2
+    mu_BD_yD = r.T_D @ mu_HD_yD
+    cov_BD_BD_yD = numpy.linalg.multi_dot([r.T_D, cov_HD_HD_yD, r.T_D.T])
+
+    # Get the nominal bias and its standard deviation as the means of the
+    # conditional between-event residual mean and standard deviation
+    nominal_bias_mean = numpy.mean(mu_BD_yD)
+    nominal_bias_stddev = numpy.sqrt(numpy.mean(numpy.diag(cov_BD_BD_yD)))
+
+    logging.info("GSIM: %s, IMT: %s, Nominal bias mean: %.3f, "
+                 "Nominal bias stddev: %.3f",
+                 gsim.gmpe if hasattr(gsim, 'gmpe') else gsim,
+                 target_imt, nominal_bias_mean, nominal_bias_stddev)
+
+    # Predicted mean at the target sites, from GSIM
+    mu_Y = mean_stds[0, 0][:, None]
+
+    # Predicted uncertainty components at the target sites, from GSIM
+    tau_Y = mean_stds[2, 0][:, None]
+    Y = numpy.diag(mean_stds[3, 0])
+
+    # Compute the mean of the conditional between-event residual B|YD=yD
+    # for the target sites; the shapes are (nsites, nstations),
+    # (nstations, nsites), (nsites, nsites) respectively
+    cov_WY_WD = compute_cov(target_sitecol, station_sitecol,
+                            [target_imt], r.conditioning_imts, Y, r.D)
+    cov_WD_WY = compute_cov(station_sitecol, target_sitecol,
+                            r.conditioning_imts, [target_imt], r.D, Y)
+    cov_WY_WY = compute_cov(target_sitecol, target_sitecol,
+                            [target_imt], [target_imt], Y, Y)
+
+    # Compute the regression coefficient matrix [cov_WY_WD × cov_WD_WD_inv]
+    RC = cov_WY_WD @ r.cov_WD_WD_inv  # shape (nsites, nstations)
+
+    # compute the mean, shape (nsites, 1)
+    mu = mu_Y + tau_Y @ mu_HD_yD[0, None] + RC @ (r.zD - mu_BD_yD)
+
+    # covariance matrices can contain extremely small negative values
+
+    # Compute the conditioned within-event covariance matrix
+    # for the target sites clipped to zero, shape (nsites, nsites)
+    tau = (cov_WY_WY - RC @ cov_WD_WY).clip(min=0)
+
+    # Compute the scaling matrix "C" for the conditioned between-event
+    # covariance matrix
+    if r.native_data_available:
+        C = tau_Y - RC @ r.T_D
+    else:
+        zeros = numpy.zeros((len(target_sitecol), len(r.conditioning_imts)))
+        C = numpy.block([tau_Y, zeros]) - RC @ r.T_D
+
+    # Compute the conditioned between-event covariance matrix
+    # for the target sites clipped to zero, shape (nsites, nsites)
+    phi = numpy.linalg.multi_dot([C, cov_HD_HD_yD, C.T]).clip(min=0)
+    return {(r.g, r.m): (mu, tau, phi)}
+
+
+def get_me_ta_ph(cmaker, sdata, observed_imts, target_imts,
+                 mean_stds_D, mean_stds_Y, target, station_filtered,
+                 compute_cov, cross_correl_between, h5):
+    G = len(cmaker.gsims)
+    M = len(target_imts)
+    N = mean_stds_Y.shape[-1]
+    me = numpy.zeros((G, M, N, 1))
+    ta = numpy.zeros((G, M, N, N))
+    ph = numpy.zeros((G, M, N, N))
     smap = parallel.Starmap(get_mu_tau_phi, h5=h5)
     for g, gsim in enumerate(cmaker.gsims):
         if gsim.DEFINED_FOR_STANDARD_DEVIATION_TYPES == {StdDev.TOTAL}:
@@ -413,7 +498,11 @@ def compute_mu_tau_phi(cmaker, sdata, observed_imts, target_imts,
             smap.submit(
                 (target_imt, gsim, mean_stds_Y[:, g], target_imts, observed_imts,
                  sdata, target, station_filtered, compute_cov, result))
-    return smap.reduce()
+    for (g, m), (mu, tau, phi) in smap.reduce().items():
+        me[g, m] = mu
+        ta[g, m] = tau
+        ph[g, m] = phi
+    return me, ta, ph
 
 
 # tested in openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
@@ -458,106 +547,15 @@ def get_mean_covs(
 
     compute_cov = partial(compute_spatial_cross_covariance_matrix,
                           spatial_correl, cross_correl_within)
-
-    G = len(cmaker.gsims)
-    M = len(target_imts)
-    N = len(ctx_Y)
-    me = numpy.zeros((G, M, N, 1))
-    ta = numpy.zeros((G, M, N, N))
-    ph = numpy.zeros((G, M, N, N))
-    dic = compute_mu_tau_phi(
+    me, ta, ph = get_me_ta_ph(
         cmaker, station_data[mask].copy(), observed_imts, target_imts,
         mean_stds_D, mean_stds_Y, target, station_filtered,
         compute_cov, cross_correl_between, h5)
-    for (g, m), (mu, tau, phi) in dic.items():
-        me[g, m] = mu
-        ta[g, m] = tau
-        ph[g, m] = phi
-
     if sigma:
         return [me, ta + ph, ta, ph]
     else:
         # save memory since sigma = tau + phi is not needed
         return [me, ta, ph]
-
-
-# In scenario/case_21 one has
-# target_imt = PGA = target_imts = observed_imts
-# ctx_Y with 571 elements, like target_sitecol
-# station_data has 140 elements like station_sitecol
-# 18 sites are discarded
-# the total sitecol has 571 + 140 + 18 = 729 sites
-def get_mu_tau_phi(target_imt, gsim, mean_stds,
-                   target_imts, observed_imts, station_data,
-                   target_sitecol, station_sitecol, compute_cov, t):
-
-    # Using Bayes rule, compute the posterior distribution of the
-    # normalized between-event residual H|YD=yD, employing
-    # Engler et al. (2022), eqns B8 and B9 (also B18 and B19),
-    # H|Y2=y2 is normally distributed with mean and covariance:
-    cov_HD_HD_yD = numpy.linalg.pinv(
-        numpy.linalg.multi_dot([t.T_D.T, t.cov_WD_WD_inv, t.T_D])
-        + numpy.linalg.pinv(t.corr_HD_HD))
-
-    mu_HD_yD = numpy.linalg.multi_dot(
-        [cov_HD_HD_yD, t.T_D.T, t.cov_WD_WD_inv, t.zD])
-
-    # Compute the distribution of the conditional between-event
-    # residual B|Y2=y2
-    mu_BD_yD = t.T_D @ mu_HD_yD
-    cov_BD_BD_yD = numpy.linalg.multi_dot([t.T_D, cov_HD_HD_yD, t.T_D.T])
-
-    # Get the nominal bias and its standard deviation as the means of the
-    # conditional between-event residual mean and standard deviation
-    nominal_bias_mean = numpy.mean(mu_BD_yD)
-    nominal_bias_stddev = numpy.sqrt(numpy.mean(numpy.diag(cov_BD_BD_yD)))
-
-    logging.info("GSIM: %s, IMT: %s, Nominal bias mean: %.3f, "
-                 "Nominal bias stddev: %.3f",
-                 gsim.gmpe if hasattr(gsim, 'gmpe') else gsim,
-                 target_imt, nominal_bias_mean, nominal_bias_stddev)
-
-    # Predicted mean at the target sites, from GSIM
-    mu_Y = mean_stds[0, 0][:, None]
-
-    # Predicted uncertainty components at the target sites, from GSIM
-    tau_Y = mean_stds[2, 0][:, None]
-    Y = numpy.diag(mean_stds[3, 0])
-
-    # Compute the mean of the conditional between-event residual B|YD=yD
-    # for the target sites; the shapes are (nsites, nstations),
-    # (nstations, nsites), (nsites, nsites) respectively
-    cov_WY_WD = compute_cov(target_sitecol, station_sitecol,
-                            [target_imt], t.conditioning_imts, Y, t.D)
-    cov_WD_WY = compute_cov(station_sitecol, target_sitecol,
-                            t.conditioning_imts, [target_imt], t.D, Y)
-    cov_WY_WY = compute_cov(target_sitecol, target_sitecol,
-                            [target_imt], [target_imt], Y, Y)
-
-    # Compute the regression coefficient matrix [cov_WY_WD × cov_WD_WD_inv]
-    RC = cov_WY_WD @ t.cov_WD_WD_inv  # shape (nsites, nstations)
-
-    # compute the mean, shape (nsites, 1)
-    mu = mu_Y + tau_Y @ mu_HD_yD[0, None] + RC @ (t.zD - mu_BD_yD)
-
-    # covariance matrices can contain extremely small negative values
-
-    # Compute the conditioned within-event covariance matrix
-    # for the target sites clipped to zero, shape (nsites, nsites)
-    tau = (cov_WY_WY - RC @ cov_WD_WY).clip(min=0)
-
-    # Compute the scaling matrix "C" for the conditioned between-event
-    # covariance matrix
-    if t.native_data_available:
-        C = tau_Y - RC @ t.T_D
-    else:
-        zeros = numpy.zeros((len(target_sitecol), len(t.conditioning_imts)))
-        C = numpy.block([tau_Y, zeros]) - RC @ t.T_D
-
-    # Compute the conditioned between-event covariance matrix
-    # for the target sites clipped to zero, shape (nsites, nsites)
-    phi = numpy.linalg.multi_dot([C, cov_HD_HD_yD, C.T]).clip(min=0)
-    return {(t.g, t.m): (mu, tau, phi)}
 
 
 def _compute_spatial_cross_correlation_matrix(

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -509,7 +509,7 @@ def get_me_ta_ph(cmaker, sdata, observed_imts, target_imts,
 def get_mean_covs(
         rupture, cmaker, station_sitecol, station_data, observed_imt_strs,
         target_sitecol, target_imts, spatial_correl, cross_correl_between,
-        cross_correl_within, sigma, h5):
+        cross_correl_within, sigma=True, h5=None):
     """
     :returns: a list of arrays [mea, sig, tau, phi] or [mea, tau, phi]
     """

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -254,7 +254,7 @@ def aristotle_validate(POST, user, rupture_file=None, station_data_file=None,
 
     # NOTE: in level 1 interface there is no checkbox and the ShakeMap has to be used.
     #       in level 2 interface the checkbox is unchecked by default
-    use_shakemap = True
+    use_shakemap = user.level == 1
     if 'use_shakemap' in POST:
         use_shakemap = POST['use_shakemap'] == 'true'
 


### PR DESCRIPTION
This is doubling the speed of the hazard part for the calculation `us6000jllz`:
```
# before
| calc_31036, maxmem=10.5 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total event_based          | 413.4    | 25.0977   | 10     |
| computing gmfs             | 411.6    | 0.0       | 50     |
| EventBasedCalculator.run   | 346.2    | 251.9     | 1      |
 
# after
| calc_31034, maxmem=18.8 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total event_based          | 418.8    | 3.8320    | 10     |
| computing gmfs             | 416.7    | 0.0       | 50     |
| total get_mu_tau_phi       | 318.6    | 502.4     | 20     |
| EventBasedCalculator.run   | 193.8    | 211.7     | 1      |
```
Also, now the memory consumption is measured more correctly and `conditioned_gmf_gb` has been reduced to 9 GB.