### PR TITLE
Fix the behavior of the calc log visualization

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -442,6 +442,7 @@ def calc_list(request, id=None):
 
     # if id is specified the related dictionary is returned instead the list
     if id is not None:
+        response_data = [job for job in response_data if str(job['id']) == id]
         if not response_data:
             return HttpResponseNotFound()
         [response_data] = response_data


### PR DESCRIPTION
There was a bug in the `calc_list` Django view when called by the `/v1/calc/:id/status` endpoint, that was not filtering the output by the requested id.