### PR TITLE
Added a watchdog killing slow calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added `webapi.calc_timeout` configuration parameter
   * Reduced `conditioned_gmfs_gb` to 8 GB by default
   * Parallelized `get_mean_covs` when conditioning the GMFs
 

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -257,8 +257,11 @@ class LogContext:
 
     def __exit__(self, etype, exc, tb):
         if tb:
-            logging.critical(traceback.format_exc())
-            dbcmd('finish', self.calc_id, 'failed')
+            if etype is SystemExit:
+                dbcmd('finish', self.calc_id, 'aborted')
+            else:
+                logging.error(traceback.format_exc())
+                dbcmd('finish', self.calc_id, 'failed')
         else:
             dbcmd('finish', self.calc_id, 'complete')
         for handler in self.handlers:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -279,6 +279,23 @@ def stop_workers(job_id):
     print(w.WorkerMaster(job_id).stop())
 
 
+def watchdog(calc_id, pid):
+    """
+    If the job takes longer than the timeout, kills it
+    """
+    timeout = int(config.webapi.calc_timeout)
+    while True:
+        time.sleep(3)
+        [(start, status)] = logs.dbcmd(
+            'SELECT start_time, status FROM job WHERE id=?x', calc_id)
+        if status != 'executing':
+            break
+        elif (datetime.now() - start).seconds > timeout:
+            os.kill(pid, signal.SIGTERM)
+            logs.dbcmd('finish', calc_id, 'aborted')
+            break
+
+
 def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False, precalc=False):
     """
     Run jobs using the specified config file and other options.
@@ -361,13 +378,6 @@ def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False, precalc=False
         else:
             for jobctx in jobctxs:
                 run_calc(jobctx)
-    except Exception:
-        ids = [jc.calc_id for jc in jobctxs]
-        rows = logs.dbcmd("SELECT id FROM job WHERE id IN (?X) "
-                          "AND status IN ('created', 'executing')", ids)
-        for jid, in rows:
-            logs.dbcmd("set_status", jid, 'failed')
-        raise
     finally:
         if dist == 'zmq' or (dist == 'slurm' and not sbatch):
             stop_workers(job_id)

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -279,13 +279,12 @@ def stop_workers(job_id):
     print(w.WorkerMaster(job_id).stop())
 
 
-def watchdog(calc_id, pid):
+def watchdog(calc_id, pid, timeout):
     """
     If the job takes longer than the timeout, kills it
     """
-    timeout = int(config.webapi.calc_timeout)
     while True:
-        time.sleep(3)
+        time.sleep(30)
         [(start, status)] = logs.dbcmd(
             'SELECT start_time, status FROM job WHERE id=?x', calc_id)
         if status != 'executing':

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -68,6 +68,8 @@ authkey = changeme
 server = http://localhost:8800
 username =
 password =
+# timeout in seconds for calculations spawned by the webapi
+calc_timeout = 1800
 
 [zworkers]
 host_cores = 127.0.0.1 -1

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -988,7 +988,11 @@ def submit_job(request_files, ini, username, hc_id):
     else:
         proc = mp.Process(target=engine.run_jobs, args=([job],))
         proc.start()
-        mp.Process(target=engine.watchdog, args=(job.calc_id, proc.pid)).start()
+        if config.webapi.calc_timeout:
+            mp.Process(
+                target=engine.watchdog,
+                args=(job.calc_id, proc.pid, int(config.webapi.calc_timeout))
+            ).start()
     return job.calc_id
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -986,7 +986,9 @@ def submit_job(request_files, ini, username, hc_id):
                     CALC_NAME='calc%d' % job.calc_id)
             subprocess.run(submit_cmd, input=yaml.encode('ascii'))
     else:
-        mp.Process(target=engine.run_jobs, args=(jobs,)).start()
+        proc = mp.Process(target=engine.run_jobs, args=([job],))
+        proc.start()
+        mp.Process(target=engine.watchdog, args=(job.calc_id, proc.pid)).start()
     return job.calc_id
 
 


### PR DESCRIPTION
But only in the WebUI. The details are to be discussed. The parameter in openquake.cfg is called `webapi.timeout`.