### PR TITLE
Move `reset_is_running` to be executed whenever the webui is ready

### DIFF
--- a/openquake/commands/webui.py
+++ b/openquake/commands/webui.py
@@ -22,7 +22,7 @@ import subprocess
 import webbrowser
 
 from openquake.baselib import config, general
-from openquake.server import dbserver, db
+from openquake.server import dbserver
 from openquake.server.utils import check_webserver_running
 
 commands = ['start']
@@ -56,8 +56,6 @@ def main(cmd, hostport='127.0.0.1:8800', skip_browser: bool = False):
         sys.exit('This command must be run by the proper user: '
                  'see the documentation for details')
     dbserver.ensure_on()  # start the dbserver in a subprocess
-    # reset any computation left in the 'executing' state
-    db.actions.reset_is_running(dbserver.db)
     print('Starting, using version %s' % general.engine_version())
     runserver(hostport, skip_browser)
 

--- a/openquake/server/apps.py
+++ b/openquake/server/apps.py
@@ -20,6 +20,7 @@ import os
 from django.apps import AppConfig
 from django.conf import settings
 from openquake.baselib import config
+from openquake.server import dbserver, db
 
 
 class ServerConfig(AppConfig):
@@ -33,6 +34,9 @@ class ServerConfig(AppConfig):
         #     Although you can’t import models at the module-level where
         #     AppConfig classes are defined, you can import them in ready()
         import openquake.server.signals  # NOQA
+
+        # reset any computation left in the 'executing' state
+        db.actions.reset_is_running(dbserver.db)
 
         if settings.APPLICATION_MODE not in settings.APPLICATION_MODES:
             raise ValueError(


### PR DESCRIPTION
We need to check if this fixes the behavior after a stop / start of the webui service in production under gunicorn, in particular when the following conditions occur:
1) a job fails because the machine goes OOM, while there are some other pending jobs
2) we stop and restart the webui service
The expected outcome is that all the unfinished calculations will have the status "failed" and they do not prevent new calculations from running.