### PR TITLE
Update documentation on Memory limit

### DIFF
--- a/doc/getting-started/installation-instructions/server.md
+++ b/doc/getting-started/installation-instructions/server.md
@@ -173,7 +173,7 @@ Before=slices.target
 
 [Slice]
 MemoryAccounting=true
-MemoryLimit=10G
+MemoryMax=10G
 CPUAccounting=true
 CPUQuota=50%
 TasksMax=4096


### PR DESCRIPTION
Every day I get the journal `warning Unit uses MemoryLimit=; please use MemoryMax= instead. Support for MemoryLimit= will be removed soon.`.
