### PR TITLE
Fixed some warnings

### DIFF
--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -24,7 +24,7 @@ import getpass
 import tempfile
 import functools
 import subprocess
-from datetime import datetime
+from datetime import datetime, UTC
 import psutil
 from openquake.baselib import (
     DotDict, zeromq as z, general, performance, parallel, config, sap)
@@ -256,7 +256,7 @@ def call(func, args, taskno, mon, executing):
 def errback(job_id, task_no, exc):
     # NB: job_id can be None if the Starmap was invoked without h5
     from openquake.commonlib.logs import dbcmd
-    dbcmd('log', job_id, datetime.utcnow(), 'ERROR',
+    dbcmd('log', job_id, datetime.utcnow(UTC), 'ERROR',
           '%s/%s' % (job_id, task_no), str(exc))
     e = exc.__class__('in job %d, task %d' % (job_id, task_no))
     raise e.with_traceback(exc.__traceback__)

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -746,7 +746,7 @@ def export_assetcol_csv(ekey, dstore):
     df = df[unsorted_cols + tagnames]
     for tagname in tagnames:
         for asset_idx in range(len(assetcol)):
-            tag_id = df[tagname][asset_idx]
+            tag_id = assetcol[tagname][asset_idx]
             tag_str = tagcol.get_tag(tagname, tag_id).split('=')[1]
             df.loc[asset_idx, tagname] = tag_str
     df.drop(columns=['ordinal', 'site_id'], inplace=True)

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -741,12 +741,11 @@ def export_assetcol_csv(ekey, dstore):
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     df = pandas.DataFrame(assetcol)
     tagcol = dstore['assetcol'].tagcol
-    tagnames = tagcol.tagnames
-    sorted_cols = sorted([col for col in tagnames if col in df.columns])
+    tagnames = sorted(tagcol.tagnames)
     unsorted_cols = [col for col in df.columns if col not in tagnames]
-    df = df[unsorted_cols + sorted_cols]
-    for asset_idx in range(len(assetcol)):
-        for tagname in tagnames:
+    df = df[unsorted_cols + tagnames]
+    for tagname in tagnames:
+        for asset_idx in range(len(assetcol)):
             tag_id = df[tagname][asset_idx]
             tag_str = tagcol.get_tag(tagname, tag_id).split('=')[1]
             df.loc[asset_idx, tagname] = tag_str

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -742,13 +742,13 @@ def export_assetcol_csv(ekey, dstore):
     df = pandas.DataFrame(assetcol)
     tagcol = dstore['assetcol'].tagcol
     tagnames = sorted(tagcol.tagnames)
-    unsorted_cols = [col for col in df.columns if col not in tagnames]
-    df = df[unsorted_cols + tagnames]
+    df = df[[col for col in df.columns if col not in tagnames]]
     for tagname in tagnames:
+        tags = []
         for asset_idx in range(len(assetcol)):
             tag_id = assetcol[tagname][asset_idx]
-            tag_str = tagcol.get_tag(tagname, tag_id).split('=')[1]
-            df.loc[asset_idx, tagname] = tag_str
+            tags.append(tagcol.get_tag(tagname, tag_id).split('=')[1])
+        df[tagname] = tags
     df.drop(columns=['ordinal', 'site_id'], inplace=True)
     df['id'] = df['id'].apply(lambda x: x.decode('utf8'))
     dest_csv = dstore.export_path('%s.%s' % ekey)

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -428,6 +428,8 @@ class Row(collections.abc.Sequence):
         return '<Row(%s)>' % ', '.join(items)
 
 
+sqlite3.register_adapter(
+    datetime.datetime, lambda val: val.isoformat())
 sqlite3.register_converter(
     "datetime", lambda val: datetime.datetime.fromisoformat(val.decode()))
 db = Db(sqlite3.connect, os.path.expanduser(config.dbserver.file),

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -189,6 +189,7 @@ NotFound
 import os
 import re
 import sqlite3
+import datetime
 import threading
 import collections
 from openquake.baselib import config
@@ -427,6 +428,8 @@ class Row(collections.abc.Sequence):
         return '<Row(%s)>' % ', '.join(items)
 
 
+sqlite3.register_converter(
+    "datetime", lambda val: datetime.datetime.fromisoformat(val.decode()))
 db = Db(sqlite3.connect, os.path.expanduser(config.dbserver.file),
         isolation_level=None, detect_types=sqlite3.PARSE_DECLTYPES,
         timeout=20)

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -189,7 +189,7 @@ NotFound
 import os
 import re
 import sqlite3
-import datetime
+# import datetime
 import threading
 import collections
 from openquake.baselib import config

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -428,10 +428,10 @@ class Row(collections.abc.Sequence):
         return '<Row(%s)>' % ', '.join(items)
 
 
-sqlite3.register_adapter(
-    datetime.datetime, lambda val: val.isoformat())
-sqlite3.register_converter(
-    "datetime", lambda val: datetime.datetime.fromisoformat(val.decode()))
+# sqlite3.register_adapter(
+#     datetime.datetime, lambda val: val.isoformat())
+# sqlite3.register_converter(
+#     "datetime", lambda val: datetime.datetime.fromisoformat(val.decode()))
 db = Db(sqlite3.connect, os.path.expanduser(config.dbserver.file),
         isolation_level=None, detect_types=sqlite3.PARSE_DECLTYPES,
         timeout=20)

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -23,7 +23,7 @@ import re
 import getpass
 import logging
 import traceback
-from datetime import datetime
+from datetime import datetime, UTC
 from openquake.baselib import config, zeromq, parallel, workerpool as w
 from openquake.commonlib import readinput, dbapi
 
@@ -85,7 +85,7 @@ def dblog(level: str, job_id: int, task_no: int, msg: str):
     Log on the database
     """
     task = 'task #%d' % task_no
-    return dbcmd('log', job_id, datetime.utcnow(), level, task, msg)
+    return dbcmd('log', job_id, datetime.now(UTC), level, task, msg)
 
 
 def get_datadir():
@@ -182,7 +182,7 @@ class LogDatabaseHandler(logging.Handler):
         self.job_id = job_id
 
     def emit(self, record):
-        dbcmd('log', self.job_id, datetime.utcnow(), record.levelname,
+        dbcmd('log', self.job_id, datetime.now(UTC), record.levelname,
               '%s/%s' % (record.processName, record.process),
               record.getMessage())
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -33,7 +33,7 @@ import platform
 import functools
 #import multiprocessing.pool
 from os.path import getsize
-from datetime import datetime
+from datetime import datetime, UTC
 import psutil
 import h5py
 import numpy
@@ -352,7 +352,7 @@ def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False, precalc=False
             raise
     for job in jobctxs:
         dic = {'status': 'executing', 'pid': _PID,
-               'start_time': datetime.utcnow()}
+               'start_time': datetime.now(UTC)}
         logs.dbcmd('update_job', job.calc_id, dic)
     try:
         if dist in ('zmq', 'slurm') and w.WorkerMaster(job_id).status() == []:

--- a/openquake/hazardlib/gsim/zhao_2016.py
+++ b/openquake/hazardlib/gsim/zhao_2016.py
@@ -519,7 +519,7 @@ def get_volc_zones(volc_polygons):
         for i, f in enumerate(inp):
             
             # Get zone_id
-            zone_id[i] = pd.Series(f['properties'])[0]
+            zone_id[i] = pd.Series(f['properties']).iloc[0]
             
             # Per zone get lat and lon of each polygon vertices
             for c, coo in enumerate(f['geometry']['coordinates'][0]):

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -18,7 +18,7 @@
 import os
 import getpass
 import operator
-from datetime import datetime
+from datetime import datetime, UTC
 
 from openquake.baselib import general
 from openquake.hazardlib import valid
@@ -293,7 +293,7 @@ def finish(db, job_id, status):
         a string such as 'successful' or 'failed'
     """
     db('UPDATE job SET ?D WHERE id=?x',
-       dict(is_running=False, status=status, stop_time=datetime.utcnow()),
+       dict(is_running=False, status=status, stop_time=datetime.now(UTC)),
        job_id)
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -31,7 +31,7 @@ import zlib
 import urllib.parse as urlparse
 import re
 import psutil
-from datetime import datetime, timezone
+from datetime import datetime, UTC, timezone
 from urllib.parse import unquote_plus
 from xml.parsers.expat import ExpatError
 from django.http import (
@@ -965,7 +965,7 @@ def submit_job(request_files, ini, username, hc_id):
         jobs = [job]
     except Exception as exc:
         tb = traceback.format_exc()
-        logs.dbcmd('log', job.calc_id, datetime.utcnow(), 'CRITICAL',
+        logs.dbcmd('log', job.calc_id, datetime.now(UTC), 'CRITICAL',
                    'before starting', tb)
         logs.dbcmd('finish', job.calc_id, 'failed')
         exc.job_id = job.calc_id


### PR DESCRIPTION
The following:

- sqlite3 datetime converter is deprecated as of Python 3.12
- DeprecationWarning:
  datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version.
  Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    dict(is_running=False, status=status, stop_time=datetime.utcnow()),
- export/risk.py:752: FutureWarning:
  `Series.__getitem__` treating keys as positions is deprecated. In a future version,
  integer keys will always be treated as labels (consistent with DataFrame behavior).
  To access a value by position, use `ser.iloc[pos]`