### PR TITLE
Fixed an import error with Python 3.10

### DIFF
--- a/openquake/baselib/workerpool.py
+++ b/openquake/baselib/workerpool.py
@@ -24,7 +24,7 @@ import getpass
 import tempfile
 import functools
 import subprocess
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 import psutil
 from openquake.baselib import (
     DotDict, zeromq as z, general, performance, parallel, config, sap)
@@ -33,6 +33,8 @@ try:
 except ImportError:
     def setproctitle(title):
         "Do nothing"
+
+UTC = timezone.utc
 
 
 def init_workers():

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -23,10 +23,11 @@ import re
 import getpass
 import logging
 import traceback
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from openquake.baselib import config, zeromq, parallel, workerpool as w
 from openquake.commonlib import readinput, dbapi
 
+UTC = timezone.utc
 LEVELS = {'debug': logging.DEBUG,
           'info': logging.INFO,
           'warn': logging.WARNING,

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -33,7 +33,7 @@ import platform
 import functools
 #import multiprocessing.pool
 from os.path import getsize
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 import psutil
 import h5py
 import numpy
@@ -51,6 +51,7 @@ from openquake.calculators import base
 from openquake.calculators.base import expose_outputs
 
 
+UTC = timezone.utc
 USER = getpass.getuser()
 OQ_API = 'https://api.openquake.org'
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -18,7 +18,7 @@
 import os
 import getpass
 import operator
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 from openquake.baselib import general
 from openquake.hazardlib import valid
@@ -28,6 +28,7 @@ from openquake.server.db import upgrade_manager
 from openquake.commonlib.dbapi import NotFound
 from openquake.calculators.export import DISPLAY_NAME
 
+UTC = timezone.utc
 JOB_TYPE = '''CASE
 WHEN calculation_mode LIKE '%risk'
 OR calculation_mode LIKE '%bcr'

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -31,7 +31,7 @@ import zlib
 import urllib.parse as urlparse
 import re
 import psutil
-from datetime import datetime, UTC, timezone
+from datetime import datetime, timezone
 from urllib.parse import unquote_plus
 from xml.parsers.expat import ExpatError
 from django.http import (
@@ -70,6 +70,7 @@ from wsgiref.util import FileWrapper
 if settings.LOCKDOWN:
     from django.contrib.auth import authenticate, login, logout
 
+UTC = timezone.utc
 CWD = os.path.dirname(__file__)
 METHOD_NOT_ALLOWED = 405
 NOT_IMPLEMENTED = 501


### PR DESCRIPTION
Fixes the tests running with python 3.10, such as https://gitlab.openquake.org/openquake/oq-risk-tests/-/jobs/51138.