### PR TITLE
Extended the ShakeMap parser to SA(0.6)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Extended the ShakeMap parser to read the intensities associated to SA(0.6)
   * Fixed a bug while exporting realizations.csv for scenario calculations
   * Added `webapi.calc_timeout` configuration parameter
   * Reduced `conditioned_gmfs_gb` to 8 GB by default

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -49,8 +49,8 @@ US_GOV = 'https://earthquake.usgs.gov'
 SHAKEMAP_URL = US_GOV + '/fdsnws/event/1/query?eventid={}&format=geojson'
 F32 = numpy.float32
 SHAKEMAP_FIELDS = set(
-    'LON LAT SVEL MMI PGA PSA03 PSA10 PSA30 '
-    'STDMMI STDPGA STDPSA03 STDPSA10 STDPSA30'
+    'LON LAT SVEL MMI PGA PSA03 PSA06 PSA10 PSA30 '
+    'STDMMI STDPGA STDPSA03 STDPSA06 STDPSA10 STDPSA30'
     .split())
 FIELDMAP = {
     'LON': 'lon',

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -59,15 +59,17 @@ FIELDMAP = {
     'MMI': ('val', 'MMI'),
     'PGA': ('val', 'PGA'),
     'PSA03': ('val', 'SA(0.3)'),
+    'PSA06': ('val', 'SA(0.6)'),
     'PSA10': ('val', 'SA(1.0)'),
     'PSA30': ('val', 'SA(3.0)'),
     'STDMMI': ('std', 'MMI'),
     'STDPGA': ('std', 'PGA'),
     'STDPSA03': ('std', 'SA(0.3)'),
+    'STDPSA06': ('std', 'SA(0.6)'),
     'STDPSA10': ('std', 'SA(1.0)'),
     'STDPSA30': ('std', 'SA(3.0)'),
 }
-REQUIRED_IMTS = {'PGA', 'PSA03', 'PSA10'}
+REQUIRED_IMTS = {'PGA', 'PSA03', 'PSA06', 'PSA10'}
 
 @dataclass
 class User:

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -805,18 +805,22 @@ def _get_shakemap_array(xml_file):
     out = {name: [] for name in idx}
     uncertainty = any(imt.startswith('STD') for imt in out)
     missing = sorted(REQUIRED_IMTS - set(out))
-    if not uncertainty and missing:
-        raise RuntimeError('Missing %s in %s' % (missing, fname))
+    if 'PSA06' in missing:  # old shakemap
+        fieldmap = {f: FIELDMAP[f] for f in FIELDMAP if f != 'PSA06'}
+    else:  # new shakemap
+        fieldmap = FIELDMAP
+        if not uncertainty and missing:
+            raise RuntimeError('Missing %s in %s' % (missing, fname))
     for name in idx:
         i = idx[name]
-        if name in FIELDMAP:
+        if name in fieldmap:
             out[name].append([float(row[i]) for row in rows])
-    dt = sorted((imt[1], F32) for key, imt in FIELDMAP.items()
+    dt = sorted((imt[1], F32) for key, imt in fieldmap.items()
                 if imt[0] == 'val')
     dtlist = [('lon', F32), ('lat', F32), ('vs30', F32),
               ('val', dt), ('std', dt)]
     data = numpy.zeros(len(rows), dtlist)
-    for name, field in sorted(FIELDMAP.items()):
+    for name, field in sorted(fieldmap.items()):
         if name not in out:
             continue
         if isinstance(field, tuple):

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -19,7 +19,7 @@
 import os
 import unittest
 from urllib.error import URLError
-from openquake.hazardlib.shakemap.parsers import get_rup_dic, User, REQUIRED_IMTS
+from openquake.hazardlib.shakemap.parsers import get_rup_dic, User
 
 user = User(level=2, testdir=os.path.join(os.path.dirname(__file__), 'data'))
 
@@ -33,7 +33,6 @@ class ShakemapParsersTestCase(unittest.TestCase):
             raise unittest.SkipTest('Missing timezonefinder')
         else:
             del timezonefinder
-        REQUIRED_IMTS.remove('PSA06')
 
     def test_1(self):
         # wrong usgs_id
@@ -87,10 +86,6 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['require_dip_strike'], False)
         self.assertEqual(dic['station_data_issue'],
                          '3 stations were found, but none of them are seismic')
-
-    @classmethod
-    def tearDown(cls):
-        REQUIRED_IMTS.add('PSA06')
 
 """
 NB: to profile a test you can use

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -19,7 +19,7 @@
 import os
 import unittest
 from urllib.error import URLError
-from openquake.hazardlib.shakemap.parsers import get_rup_dic, User
+from openquake.hazardlib.shakemap.parsers import get_rup_dic, User, REQUIRED_IMTS
 
 user = User(level=2, testdir=os.path.join(os.path.dirname(__file__), 'data'))
 
@@ -33,6 +33,7 @@ class ShakemapParsersTestCase(unittest.TestCase):
             raise unittest.SkipTest('Missing timezonefinder')
         else:
             del timezonefinder
+        REQUIRED_IMTS.remove('PSA06')
 
     def test_1(self):
         # wrong usgs_id
@@ -87,6 +88,9 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['station_data_issue'],
                          '3 stations were found, but none of them are seismic')
 
+    @classmethod
+    def tearDown(cls):
+        REQUIRED_IMTS.add('PSA06')
 
 """
 NB: to profile a test you can use

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -190,4 +190,4 @@ class ShakemapTestCase(unittest.TestCase):
         uridict = dict(kind='usgs_xml', grid_url=f, uncertainty_url=None)
         with self.assertRaises(RuntimeError) as ctx:
             get_sitecol_shakemap(uridict, ['PGA', 'PSA03', 'PSA10'])
-        self.assertIn("Missing ['PSA03', 'PSA10']", str(ctx.exception))
+        self.assertIn("Missing ['PSA03', 'PSA06', 'PSA10']", str(ctx.exception))

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -190,4 +190,5 @@ class ShakemapTestCase(unittest.TestCase):
         uridict = dict(kind='usgs_xml', grid_url=f, uncertainty_url=None)
         with self.assertRaises(RuntimeError) as ctx:
             get_sitecol_shakemap(uridict, ['PGA', 'PSA03', 'PSA10'])
-        self.assertIn("Missing ['PSA03', 'PSA06', 'PSA10']", str(ctx.exception))
+        self.assertIn("is required but not in the available set",
+                      str(ctx.exception))


### PR DESCRIPTION
For old ShakeMaps SA(0.6) will be missing and that has to be managed properly. Right now the priority is to fix the workflow for https://github.com/gem/oq-engine/pull/10245.