### PR TITLE
Add a SUPPRESS_PERMISSION_DENIED_WARNINGS flag to the webui settings

### DIFF
--- a/openquake/server/local_settings.py.aelo_aristotle
+++ b/openquake/server/local_settings.py.aelo_aristotle
@@ -6,8 +6,16 @@ DISABLE_VERSION_WARNING = True
 
 ARISTOTLE_DEFAULT_USGS_ID = ''
 
-# # Static Folder
-# STATIC_ROOT = ''
+# By default it is 'openquake'
+# WEBUI_USER =
+
+# Folder STATIC_ROOT is the full, absolute path to your static files folder.
+# Furthermore, the user WEBUI_USER must own that directory.
+STATIC_ROOT = '/var/www/webui'
+
+# Configure the directory to store the server user access log
+# Furthermore, the user WEBUI_USER must own that directory.
+WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # WEBUI config uncomment and set properly if needed
 # WEBUIURL = 'http://localhost:8800/'
@@ -36,13 +44,6 @@ SERVER_NAME = <localhost>
 # Externally visible url and port number is different from Django visible
 # values
 USE_REVERSE_PROXY = <True|False>
-
-# By default it is 'openquake'
-# WEBUI_USER =
-
-# Configure the directory to store the server user access log
-# Furthermore, the user WEBUI_USER must own that directory.
-WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/openquake/server/local_settings.py.aelo_aristotle
+++ b/openquake/server/local_settings.py.aelo_aristotle
@@ -37,6 +37,11 @@ SERVER_NAME = <localhost>
 # values
 USE_REVERSE_PROXY = <True|False>
 
+# By default it is 'openquake'
+# WEBUI_USER =
+
+# Configure the directory to store the server user access log
+# Furthermore, the user WEBUI_USER must own that directory.
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # Local time zone for this installation. Choices can be found here:

--- a/openquake/server/local_settings.py.aelo_aristotle
+++ b/openquake/server/local_settings.py.aelo_aristotle
@@ -48,3 +48,5 @@ WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 # TIME_ZONE =
 
 DEBUG = False
+
+SUPPRESS_PERMISSION_DENIED_WARNINGS = True

--- a/openquake/server/local_settings.py.pam
+++ b/openquake/server/local_settings.py.pam
@@ -17,8 +17,16 @@ AUTHENTICATION_BACKENDS += (
     'django_pam.auth.backends.PAMBackend',
 )
 
-#Static Folder
+# By default it is 'openquake'
+# WEBUI_USER =
+
+# Folder STATIC_ROOT is the full, absolute path to your static files folder.
+# Furthermore, the user WEBUI_USER must own that directory.
 STATIC_ROOT = '/var/www/webui'
+
+# Configure the directory to store the server user access log
+# Furthermore, the user WEBUI_USER must own that directory.
+WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # WEBUI config uncomment and set properly if needed
 # WEBUIURL = 'http://localhost:8800/'
@@ -29,13 +37,6 @@ STATIC_ROOT = '/var/www/webui'
 # enable WEBUI_PATHPREFIX to place webui pages below a specific path
 # WEBUI_PATHPREFIX='/path/prefix'
 
-# By default it is 'openquake'
-# WEBUI_USER =
-
-# Configure the directory to store the server user access log
-# Furthermore, the user WEBUI_USER must own that directory.
-WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
@@ -45,3 +46,5 @@ WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # This is reasonable in an internal installation, otherwise set it to False
 DEBUG = True
+
+SUPPRESS_PERMISSION_DENIED_WARNINGS = True

--- a/openquake/server/local_settings.py.pam
+++ b/openquake/server/local_settings.py.pam
@@ -29,6 +29,11 @@ STATIC_ROOT = '/var/www/webui'
 # enable WEBUI_PATHPREFIX to place webui pages below a specific path
 # WEBUI_PATHPREFIX='/path/prefix'
 
+# By default it is 'openquake'
+# WEBUI_USER =
+
+# Configure the directory to store the server user access log
+# Furthermore, the user WEBUI_USER must own that directory.
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # Local time zone for this installation. Choices can be found here:

--- a/openquake/server/local_settings.py.server
+++ b/openquake/server/local_settings.py.server
@@ -17,8 +17,11 @@ STATIC_ROOT = '/var/www/webui'
 # the path must start with ``/`` and ending without it (e.g. ``'/path/prefix'``)
 # WEBUI_PATHPREFIX='/path/prefix'
 
+# By default it is 'openquake'
+# WEBUI_USER =
+
 # Configure the directory to store the server user access log
-# Furthermore, the user `openquake` must own that directory.
+# Furthermore, the user WEBUI_USER must own that directory.
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # Local time zone for this installation. Choices can be found here:

--- a/openquake/server/local_settings.py.server
+++ b/openquake/server/local_settings.py.server
@@ -3,9 +3,16 @@ APPLICATION_MODE = 'RESTRICTED'
 # Disable sharing of results across users
 ACL_ON = True
 
+# By default it is 'openquake'
+# WEBUI_USER =
+
 # Folder STATIC_ROOT is the full, absolute path to your static files folder.
-# Furthermore, the user `openquake` must own that directory.
+# Furthermore, the user WEBUI_USER must own that directory.
 STATIC_ROOT = '/var/www/webui'
+
+# Configure the directory to store the server user access log
+# Furthermore, the user WEBUI_USER must own that directory.
+WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # WEBUI config uncomment and set properly if needed
 # WEBUIURL = 'http://localhost:8800/'
@@ -17,13 +24,6 @@ STATIC_ROOT = '/var/www/webui'
 # the path must start with ``/`` and ending without it (e.g. ``'/path/prefix'``)
 # WEBUI_PATHPREFIX='/path/prefix'
 
-# By default it is 'openquake'
-# WEBUI_USER =
-
-# Configure the directory to store the server user access log
-# Furthermore, the user WEBUI_USER must own that directory.
-WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
@@ -32,3 +32,5 @@ WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 # TIME_ZONE =
 
 DEBUG = False
+
+SUPPRESS_PERMISSION_DENIED_WARNINGS = True

--- a/openquake/server/local_settings.py.tools
+++ b/openquake/server/local_settings.py.tools
@@ -5,8 +5,16 @@ APPLICATION_MODE = 'TOOLS_ONLY'
 # Disable sharing of results across users (default True)
 # ACL_ON = True
 
-#Static Folder
+# By default it is 'openquake'
+# WEBUI_USER =
+
+# Folder STATIC_ROOT is the full, absolute path to your static files folder.
+# Furthermore, the user WEBUI_USER must own that directory.
 STATIC_ROOT = '/var/www/webui'
+
+# Configure the directory to store the server user access log
+# Furthermore, the user WEBUI_USER must own that directory.
+WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # WEBUI config uncomment and set properly if needed
 # WEBUIURL = 'http://localhost:8800/'
@@ -17,13 +25,6 @@ STATIC_ROOT = '/var/www/webui'
 # enable WEBUI_PATHPREFIX to place webui pages below a specific path
 # WEBUI_PATHPREFIX='/path/prefix'
 
-# By default it is 'openquake'
-# WEBUI_USER =
-
-# Configure the directory to store the server user access log
-# Furthermore, the user WEBUI_USER must own that directory.
-WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
-
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
@@ -33,3 +34,5 @@ WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # Set debug if the installation is dev mode
 DEBUG = os.environ.get('TOOLS_DEV', False) == 'True'
+
+SUPPRESS_PERMISSION_DENIED_WARNINGS = True

--- a/openquake/server/local_settings.py.tools
+++ b/openquake/server/local_settings.py.tools
@@ -17,6 +17,11 @@ STATIC_ROOT = '/var/www/webui'
 # enable WEBUI_PATHPREFIX to place webui pages below a specific path
 # WEBUI_PATHPREFIX='/path/prefix'
 
+# By default it is 'openquake'
+# WEBUI_USER =
+
+# Configure the directory to store the server user access log
+# Furthermore, the user WEBUI_USER must own that directory.
 WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 
 # Local time zone for this installation. Choices can be found here:

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -33,6 +33,7 @@ except ImportError:
     STANDALONE_APPS = ()
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+WEBUI_USER = 'openquake'
 
 TEST = 'test' in sys.argv
 
@@ -325,7 +326,7 @@ if LOCKDOWN:
     SERVER_PORT = 443
 
     # do not log to file unless running through the webui
-    if getpass.getuser() == 'openquake':  # the user that runs the webui
+    if getpass.getuser() == WEBUI_USER:
         try:
             log_filename = os.path.join(WEBUI_ACCESS_LOG_DIR,  # NOQA
                                         'webui-access.log')


### PR DESCRIPTION
...and add setting variable WEBUI_USER to override the default 'openquake'.

An open browser could keep polling to retrieve the list of calculations even after the session expires, producing in the logs a lot of warnings like `WARNING Forbidden: /v1/calc/list`.
Setting `SUPPRESS_PERMISSION_DENIED_WARNINGS = True` in the local settings it is possible to avoid such logging, still returning 403 responses.