### PR TITLE
Fix the plot_assets command in case the ShakeMap was used...

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1771,6 +1771,8 @@ def view_aggrisk(token, dstore):
         arr[AVG][lt] += loss * rlz.weight[-1]
     arr[AVG]['gsim'] = 'Average'
     arr[AVG]['weight'] = 1
+    if len(arr) == 2:  # only one gsim, equal to the average
+        arr = numpy.delete(arr, 1, axis=0)
     return arr
 
 

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -77,7 +77,7 @@ def main(calc_id: int = -1, site_model=False,
                       label='discarded', s=markersize_discarded)
     min_x, max_x, min_y, max_y = (180, -180, 90, -90)
     if oq.rupture_xml or oq.rupture_dict:
-        use_shakemap = hasattr(dstore['oqparam'], 'shakemap_uri')
+        use_shakemap = len(getattr(dstore['oqparam'], 'shakemap_uri', [])) > 0
         if use_shakemap:
             lon, lat = oq.rupture_dict['lon'], oq.rupture_dict['lat']
         else:

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -77,12 +77,16 @@ def main(calc_id: int = -1, site_model=False,
                       label='discarded', s=markersize_discarded)
     min_x, max_x, min_y, max_y = (180, -180, 90, -90)
     if oq.rupture_xml or oq.rupture_dict:
-        rec = dstore['ruptures'][0]
-        lon, lat, _dep = rec['hypo']
+        use_shakemap = hasattr(dstore['oqparam'], 'shakemap_uri')
+        if use_shakemap:
+            lon, lat = oq.rupture_dict['lon'], oq.rupture_dict['lat']
+        else:
+            rec = dstore['ruptures'][0]
+            lon, lat, _dep = rec['hypo']
+            dist = sitecol.get_cdist(rec)
+            print('rupture(%s, %s), dist=%s' % (lon, lat, dist))
         xlon, xlat = [lon], [lat]
-        dist = sitecol.get_cdist(rec)
-        print('rupture(%s, %s), dist=%s' % (lon, lat, dist))
-        if os.environ.get('OQ_APPLICATION_MODE') == 'ARISTOTLE':
+        if os.environ.get('OQ_APPLICATION_MODE') == 'ARISTOTLE' and not use_shakemap:
             # assuming there is only 1 rupture, so rup_id=0
             rup = get_ebrupture(dstore, rup_id=0).rupture
             ax, min_x, min_y, max_x, max_y = add_rupture(ax, rup)

--- a/openquake/commands/plot_assets.py
+++ b/openquake/commands/plot_assets.py
@@ -77,7 +77,7 @@ def main(calc_id: int = -1, site_model=False,
                       label='discarded', s=markersize_discarded)
     min_x, max_x, min_y, max_y = (180, -180, 90, -90)
     if oq.rupture_xml or oq.rupture_dict:
-        use_shakemap = len(getattr(dstore['oqparam'], 'shakemap_uri', [])) > 0
+        use_shakemap = dstore['oqparam'].shakemap_uri
         if use_shakemap:
             lon, lat = oq.rupture_dict['lon'], oq.rupture_dict['lat']
         else:

--- a/openquake/server/templates/engine/get_outputs_aristotle.html
+++ b/openquake/server/templates/engine/get_outputs_aristotle.html
@@ -33,7 +33,7 @@
               {% if assets %}
               <div class="my-pngs">
                 <a href="{{ oq_engine_server_url }}/v1/calc/{{ calc_id }}/download_png/assets.png" class="btn btn-sm">
-                  Show assets and rupture</a>
+                  Show assets</a>
               </div>
               {% endif %}
             </div>


### PR DESCRIPTION
...and display a a single row in the losses table in that case (or if only one gsim is present).