### PR TITLE
Enable/disable vs30 input field depending from the ASCE version

### DIFF
--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -494,7 +494,8 @@ function capitalizeFirstLetter(val) {
             $('#asce_version').on('change', function() {
                 const asce_version = $(this).val();
                 if (asce_version === 'ASCE7-16') {
-                    $('#vs30').prop('readonly', true).attr('placeholder', 'fixed at 760 m/s');
+                    // NOTE: if vs30 is empty, it is read as 760 and the placeholder is displayed (see below)
+                    $('#vs30').prop('readonly', true).attr('placeholder', 'fixed at 760 m/s').val('');
                 } else if (asce_version === 'ASCE7-22') {
                     $('#vs30').prop('readonly', false).attr('placeholder', 'm/s');
                 }

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -491,6 +491,15 @@ function capitalizeFirstLetter(val) {
                                setTimer();
                            });
 
+            $('#asce_version').on('change', function() {
+                const asce_version = $(this).val();
+                if (asce_version === 'ASCE7-16') {
+                    $('#vs30').prop('readonly', true).attr('placeholder', 'fixed at 760 m/s');
+                } else if (asce_version === 'ASCE7-22') {
+                    $('#vs30').prop('readonly', false).attr('placeholder', 'm/s');
+                }
+            });
+
             // NOTE: if not in aelo mode, aelo_run_form does not exist, so this can never be triggered
             $("#aelo_run_form").submit(function (event) {
                 $('#submit_aelo_calc').prop('disabled', true);


### PR DESCRIPTION
If the user selects ASCE7-22, the vs30 input field becomes editable and the placeholder only displays the measurement unit.
Selecting ASCE7-16, the vs30 input field becomes read-only and its initial value and placeholder are restored.