### PR TITLE
Changes to Preclassical to use without sites

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,9 @@
+  [Richard Styron, Michele Simionato]
+  * Extended the preclassical calculator to work in absence of a site collection
+
   [Michele Simionato]
-  * Added a new output "Aggregated Exposure Values"
+  * Added a new output "Aggregated Exposure Values" (`aggexp_tags`) and a new extractor
+    `aggrisk_tags`;
 
 python3-oq-engine (3.22.0-1~xenial01) xenial; urgency=low
 

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -108,7 +108,7 @@ def preclassical(srcs, sites, cmaker, secparams, monitor):
         multiplier = 1 + len(sites) // 10_000
         sf = SourceFilter(sites, cmaker.maximum_distance).reduce(multiplier)
     else:
-        N = 1
+        N = 0
         multiplier = 1
         sf = None
     splits = []
@@ -117,8 +117,7 @@ def preclassical(srcs, sites, cmaker, secparams, monitor):
     ry0 = 'ry0' in cmaker.REQUIRES_DISTANCES
     for src in srcs:
         if src.code == b'F':
-            #if N <= cmaker.max_sites_disagg:
-            if False:  # turned off for to make run. Not sure what is best
+            if N and N <= cmaker.max_sites_disagg:
                 mask = sf.get_close(secparams) > 0  # shape S
             else:
                 mask = None
@@ -166,7 +165,7 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     :returns: a triple (max_weight, trt_rlzs, gids)
     """
     if sitecol is None:
-        N = 1
+        N = 0
     else:
         N = len(sitecol)
     oq = cmakers[0].oq

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -117,7 +117,8 @@ def preclassical(srcs, sites, cmaker, secparams, monitor):
     ry0 = 'ry0' in cmaker.REQUIRES_DISTANCES
     for src in srcs:
         if src.code == b'F':
-            if N <= cmaker.max_sites_disagg:
+            #if N <= cmaker.max_sites_disagg:
+            if False:  # turned off for to make run. Not sure what is best
                 mask = sf.get_close(secparams) > 0  # shape S
             else:
                 mask = None
@@ -164,7 +165,10 @@ def store_tiles(dstore, csm, sitecol, cmakers):
     Store a `tiles` array if the calculation is large enough.
     :returns: a triple (max_weight, trt_rlzs, gids)
     """
-    N = len(sitecol)
+    if sitecol is None:
+        N = 1
+    else:
+        N = len(sitecol)
     oq = cmakers[0].oq
     fac = oq.imtls.size * N * 4 / 1024**3
     max_weight = csm.get_max_weight(oq)
@@ -249,10 +253,11 @@ class PreClassicalCalculator(base.HazardCalculator):
 
         Gt = len(gweights)
         extra = f'<{Gfull}' if Gt < Gfull else ''
-        nbytes = 4 * len(self.sitecol) * L * Gt
-        # Gt is known before starting the preclassical
-        logging.warning(f'The global pmap would require %s ({Gt=}%s)',
-                        general.humansize(nbytes), extra)
+        if sites is not None:
+            nbytes = 4 * len(self.sitecol) * L * Gt
+            # Gt is known before starting the preclassical
+            logging.warning(f'The global pmap would require %s ({Gt=}%s)',
+                            general.humansize(nbytes), extra)
 
         # do nothing for atomic sources except counting the ruptures
         atomic_sources = []
@@ -410,8 +415,9 @@ class PreClassicalCalculator(base.HazardCalculator):
             self.datastore.hdf5.save_vlen('delta_rates', deltas)
 
         # save 'source_groups'
-        self.req_gb, self.max_weight, self.trt_rlzs, self.gids = (
-            store_tiles(self.datastore, self.csm, self.sitecol, self.cmakers))
+        if self.sitecol is not None:
+            self.req_gb, self.max_weight, self.trt_rlzs, self.gids = (
+                store_tiles(self.datastore, self.csm, self.sitecol, self.cmakers))
 
         # save gsims
         toml = []

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -688,6 +688,10 @@ class ClassicalTestCase(CalculatorTestCase):
         fname = general.gettemp(text_table(ctx, ext='org'))
         self.assertEqualFiles('expected/context.org', fname)
 
+    def test_case_75_pre(self):
+        # test preclassical without sites, as requested by Richard Styron
+        self.run_calc(case_75.__file__, 'pre.ini')
+
     def test_case_76(self):
         # CanadaSHM6 GMPEs
         self.run_calc(case_76.__file__, 'job.ini')

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -676,8 +676,10 @@ def get_site_collection(oqparam, h5=None):
         return h5['sitecol']
     mesh, exp = get_mesh_exp(oqparam, h5)
     if mesh is None and oqparam.ground_motion_fields:
-        raise InvalidFile('You are missing sites.csv or site_model.csv in %s'
-                          % oqparam.inputs['job_ini'])
+        if oqparam.calculation_mode != 'preclassical':
+            raise InvalidFile('You are missing sites.csv or site_model.csv in %s'
+                              % oqparam.inputs['job_ini'])
+        return None
     elif mesh is None:
         # a None sitecol is okay when computing the ruptures only
         return None

--- a/openquake/qa_tests_data/classical/case_75/pre.ini
+++ b/openquake/qa_tests_data/classical/case_75/pre.ini
@@ -1,0 +1,33 @@
+[general]
+
+description = preclassical without sites
+calculation_mode = preclassical
+random_seed = 42
+
+[logic_tree]
+
+number_of_logic_tree_samples = 0
+
+[erf]
+
+rupture_mesh_spacing = 2.5
+complex_fault_mesh_spacing = 10
+width_of_mfd_bin = 0.1
+area_source_discretization = 5.0
+
+[site_params]
+
+reference_vs30_type = measured
+reference_vs30_value = 800.0
+reference_depth_to_1pt0km_per_sec = 30.0
+reference_depth_to_2pt5km_per_sec = 0.57
+
+[calculation]
+
+source_model_logic_tree_file = ssmLT.xml
+gsim_logic_tree_file = gmmLT.xml
+investigation_time = 1.0
+intensity_measure_types_and_levels = {"PGA": logscale(0.005, 3.00, 20)}
+truncation_level = 3
+maximum_distance = {'Active Shallow Crust': 300}
+minimum_magnitude = 4.0


### PR DESCRIPTION
This PR is shows the minimal changes I need to get the preclassical calculator to run without sites, which is necessary for Hamlet. I don't know the best way to handle these changes, especially how best to avoid calling `f N <= cmaker.max_sites_disagg: mask = sf.get_close(secparams) > 0` which I simply disabled.