### PR TITLE
Test the webui using pytest

### DIFF
--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -102,7 +102,7 @@ jobs:
           curl -O https://downloads.openquake.org/test_data/exposure.hdf5
           pip install pytest https://wheelhouse.openquake.org/v3/py/rtgmpy-1.0.0-py3-none-any.whl
           oq engine --upgrade-db
-          # Starting the webui here is not needed by test_public_mode, 
+          # Starting the webui here is not needed by test_public_mode,
           # but here we also want to check that the webui starts without errors
           oq webui start 127.0.0.1:8800 -s &
           echo "Waiting WEBUI up on port 8800...."
@@ -110,8 +110,7 @@ jobs:
            sleep 5 # wait for 5 seconds before check again
           done
           pytest -xs --doctest-modules --disable-warnings --color=yes openquake/commands openquake/engine
-          # -v 2 also logs the test names
-          ./openquake/server/manage.py test -v 2 tests.test_public_mode
+          pytest -v openquake/server/tests/test_public_mode.py
 
   server_read_only_mode:
     runs-on: ${{ matrix.os }}
@@ -140,8 +139,7 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           oq engine --upgrade-db
-          # -v 2 also logs the test names
-          ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
+          pytest -v openquake/server/tests/test_read_only_mode.py
 
   server_aelo_mode:
     runs-on: ${{ matrix.os }}
@@ -174,8 +172,7 @@ jobs:
           ./openquake/server/manage.py migrate
           ./openquake/server/manage.py loaddata openquake/server/fixtures/0001_cookie_consent_required_plus_hide_cookie_bar.json
           ./openquake/server/manage.py collectstatic --noinput
-          # -v 2 also logs the test names
-          ./openquake/server/manage.py test -v 2 tests.test_aelo_mode
+          pytest -v openquake/server/tests/test_aelo_mode.py
 
   server_aristotle_mode:
     runs-on: ${{ matrix.os }}
@@ -186,6 +183,8 @@ jobs:
     env:
       GITHUB_HEAD_REF: ${{ github.head_ref }}
       FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+      OQ_APPLICATION_MODE: ARISTOTLE
+      OQ_CONFIG_FILE: openquake/server/tests/data/openquake.cfg
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python  ${{ matrix.python-version }}
@@ -213,5 +212,4 @@ jobs:
           oq engine --upgrade-db
           ./openquake/server/manage.py migrate
           touch ~/webui-access.log
-          # -v 2 also logs the test names
-          OQ_APPLICATION_MODE=ARISTOTLE OQ_CONFIG_FILE=openquake/server/tests/data/openquake.cfg ./openquake/server/manage.py test -v 2 tests.test_aristotle_mode
+          pytest -v openquake/server/tests/test_aristotle_mode.py

--- a/.github/workflows/macos_intel_install.yml
+++ b/.github/workflows/macos_intel_install.yml
@@ -93,16 +93,14 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd ~/work/oq-engine/oq-engine
-          # -v 2 also logs the test names
-          OQ_APPLICATION_MODE=PUBLIC ./openquake/server/manage.py test -v 2 tests.test_public_mode
+          OQ_APPLICATION_MODE=PUBLIC pytest -v openquake/server/tests/test_public_mode.py
 
       - name: Run tests for the engine server in read-only mode to test installation
         if: always()
         run: |
           source ~/openquake/bin/activate
           cd ~/work/oq-engine/oq-engine
-          # -v 2 also logs the test names
-          OQ_APPLICATION_MODE=READ_ONLY ./openquake/server/manage.py test -v 2 tests.test_read_only_mode
+          OQ_APPLICATION_MODE=READ_ONLY pytest -v openquake/server/tests/test_read_only_mode.py
 
       # NOTE: we shouldn't need to install the engine in AELO mode on mac
       # - name: Run tests for the engine server in aelo mode to test installation

--- a/.github/workflows/macos_m1_install.yml
+++ b/.github/workflows/macos_m1_install.yml
@@ -109,8 +109,14 @@ jobs:
         run: |
           source ~/openquake/bin/activate
           cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
-          # -v 2 also logs the test names
-          OQ_APPLICATION_MODE=PUBLIC ./openquake/server/manage.py test -v 2 tests.test_public_mode
+          OQ_APPLICATION_MODE=PUBLIC pytest -v openquake/server/tests/test_public_mode.py
+
+      - name: Run tests for the engine server in read-only mode to test installation
+        if: always()
+        run: |
+          source ~/openquake/bin/activate
+          cd ~/work/oq-engine/oq-engine
+          OQ_APPLICATION_MODE=READ_ONLY pytest -v openquake/server/tests/test_read_only_mode.py
 
       # NB: the demos are tested on linux; there is no reason a demo should
       # not run on macos, so we can avoid running them

--- a/.github/workflows/macos_m1_install.yml
+++ b/.github/workflows/macos_m1_install.yml
@@ -115,7 +115,7 @@ jobs:
         if: always()
         run: |
           source ~/openquake/bin/activate
-          cd ~/work/oq-engine/oq-engine
+          cd /Users/runner/runner-isolation/actions-runner/_work/oq-engine/oq-engine/
           OQ_APPLICATION_MODE=READ_ONLY pytest -v openquake/server/tests/test_read_only_mode.py
 
       # NB: the demos are tested on linux; there is no reason a demo should

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -122,8 +122,7 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine
           $Env:OQ_APPLICATION_MODE='PUBLIC'
-          # -v 2 also logs the test names
-          python .\openquake\server\manage.py test -v 2 tests.test_public_mode
+          pytest -v openquake\server\tests\test_public_mode.py
 
       - name: Run tests for the engine server in read-only mode to test installation
         if: always() && env.to_run == 0
@@ -134,8 +133,7 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine
           $Env:OQ_APPLICATION_MODE='READ_ONLY'
-          # -v 2 also logs the test names
-          python .\openquake\server\manage.py test -v 2 tests.test_read_only_mode
+          pytest -v openquake\server\tests\test_read_only_mode.py
 
       - name: Run all demos
         if: env.to_run == 0

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -35,7 +35,7 @@ except ImportError:
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 WEBUI_USER = 'openquake'
 
-TEST = 'test' in sys.argv
+TEST = 'test' in sys.argv or any('pytest' in arg for arg in sys.argv)
 
 INSTALLED_APPS = ('openquake.server.db',)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
   slow: a slow test
 addopts = --tb short
+DJANGO_SETTINGS_MODULE = openquake.server.settings

--- a/requirements-py310-linux64.txt
+++ b/requirements-py310-linux64.txt
@@ -76,3 +76,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py310-linux64.txt
+++ b/requirements-py310-linux64.txt
@@ -76,6 +76,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py310-macos_arm64.txt
+++ b/requirements-py310-macos_arm64.txt
@@ -72,6 +72,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py310-macos_arm64.txt
+++ b/requirements-py310-macos_arm64.txt
@@ -72,3 +72,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py310-macos_x86_64.txt
+++ b/requirements-py310-macos_x86_64.txt
@@ -72,6 +72,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py310-macos_x86_64.txt
+++ b/requirements-py310-macos_x86_64.txt
@@ -72,3 +72,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py310-win64.txt
+++ b/requirements-py310-win64.txt
@@ -71,6 +71,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py310-win64.txt
+++ b/requirements-py310-win64.txt
@@ -71,3 +71,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py311-linux64.txt
+++ b/requirements-py311-linux64.txt
@@ -76,3 +76,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py311-linux64.txt
+++ b/requirements-py311-linux64.txt
@@ -76,6 +76,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py311-macos_arm64.txt
+++ b/requirements-py311-macos_arm64.txt
@@ -72,6 +72,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py311-macos_arm64.txt
+++ b/requirements-py311-macos_arm64.txt
@@ -72,3 +72,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py311-macos_x86_64.txt
+++ b/requirements-py311-macos_x86_64.txt
@@ -72,6 +72,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py311-macos_x86_64.txt
+++ b/requirements-py311-macos_x86_64.txt
@@ -72,3 +72,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py311-win64.txt
+++ b/requirements-py311-win64.txt
@@ -72,6 +72,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py311-win64.txt
+++ b/requirements-py311-win64.txt
@@ -72,3 +72,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py312-linux64.txt
+++ b/requirements-py312-linux64.txt
@@ -76,3 +76,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py312-linux64.txt
+++ b/requirements-py312-linux64.txt
@@ -76,6 +76,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py312-macos_arm64.txt
+++ b/requirements-py312-macos_arm64.txt
@@ -72,6 +72,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py312-macos_arm64.txt
+++ b/requirements-py312-macos_arm64.txt
@@ -72,3 +72,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py312-macos_x86_64.txt
+++ b/requirements-py312-macos_x86_64.txt
@@ -72,6 +72,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py312-macos_x86_64.txt
+++ b/requirements-py312-macos_x86_64.txt
@@ -72,3 +72,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py312-win64.txt
+++ b/requirements-py312-win64.txt
@@ -72,6 +72,4 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py312-win64.txt
+++ b/requirements-py312-win64.txt
@@ -72,3 +72,6 @@ https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/django_appconf-1.0.6-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py39-linux64.txt
+++ b/requirements-py39-linux64.txt
@@ -71,6 +71,4 @@ https://wheelhouse.openquake.org/v3/py/urllib3-2.1.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py39-linux64.txt
+++ b/requirements-py39-linux64.txt
@@ -71,3 +71,6 @@ https://wheelhouse.openquake.org/v3/py/urllib3-2.1.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py39-macos_arm64.txt
+++ b/requirements-py39-macos_arm64.txt
@@ -71,6 +71,4 @@ https://wheelhouse.openquake.org/v3/py/urllib3-2.1.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py39-macos_arm64.txt
+++ b/requirements-py39-macos_arm64.txt
@@ -71,3 +71,6 @@ https://wheelhouse.openquake.org/v3/py/urllib3-2.1.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py39-macos_x86_64.txt
+++ b/requirements-py39-macos_x86_64.txt
@@ -71,6 +71,4 @@ https://wheelhouse.openquake.org/v3/py/urllib3-2.1.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py39-macos_x86_64.txt
+++ b/requirements-py39-macos_x86_64.txt
@@ -71,3 +71,6 @@ https://wheelhouse.openquake.org/v3/py/urllib3-2.1.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0

--- a/requirements-py39-win64.txt
+++ b/requirements-py39-win64.txt
@@ -70,6 +70,4 @@ https://wheelhouse.openquake.org/v3/py/urllib3-2.1.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
-
-# FIXME
-pytest-django==4.9.0
+https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/requirements-py39-win64.txt
+++ b/requirements-py39-win64.txt
@@ -70,3 +70,6 @@ https://wheelhouse.openquake.org/v3/py/urllib3-2.1.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/zipp-3.17.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pluggy-1.5.0-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
+
+# FIXME
+pytest-django==4.9.0


### PR DESCRIPTION
It introduces a dependency from the package `pytest-django`, that we need to add to the openquake wheelhouse.