### PR TITLE
Made preclassical faster

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1302,6 +1302,8 @@ class ContextMaker(object):
         t0 = time.time()
         ctxs = list(self.get_ctx_iter(src, sites, step=8))  # reduced
         src.dt = time.time() - t0
+        if src.dt > .01:
+            print(f'{src.source_id=}, {src.dt=}')
         if not ctxs:
             return EPS, 0
         esites = (sum(len(ctx) for ctx in ctxs) * src.num_ruptures /

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1302,8 +1302,8 @@ class ContextMaker(object):
         t0 = time.time()
         ctxs = list(self.get_ctx_iter(src, sites, step=8))  # reduced
         src.dt = time.time() - t0
-        if src.dt > .01:
-            print(f'{src.source_id=}, {src.dt=}')
+        # if src.dt > .01:
+        #     print(f'{src.source_id=}, {src.dt=}')
         if not ctxs:
             return EPS, 0
         esites = (sum(len(ctx) for ctx in ctxs) * src.num_ruptures /

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -300,9 +300,9 @@ class PointSource(ParametricSeismicSource):
             magd_ = list(enumerate(magd))
             npd_ = list(enumerate(npd))
             hdd_ = list(enumerate(hdd))
-            for m, (mrate, mag) in magd_[::-step]:
-                for n, (nrate, np) in npd_[::2]:
-                    for d, (drate, cdep) in hdd_[::2]:
+            for m, (mrate, mag) in magd_[-2:]:
+                for n, (nrate, np) in npd_:
+                    for d, (drate, cdep) in hdd_:
                         rate = mrate * nrate * drate
                         yield PointRupture(
                             mag, self.tectonic_region_type,
@@ -478,7 +478,7 @@ class CollapsedPointSource(PointSource):
         :returns: an iterator over the underlying ruptures
         """
         step = kwargs.get('step', 1)
-        for src in self.pointsources[::step]:
+        for src in self.pointsources[::-step]:
             yield from src.iter_ruptures(**kwargs)
 
     # CollapsedPointSource

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -301,8 +301,8 @@ class PointSource(ParametricSeismicSource):
             npd_ = list(enumerate(npd))
             hdd_ = list(enumerate(hdd))
             for m, (mrate, mag) in magd_[::-step]:
-                for n, (nrate, np) in npd_:
-                    for d, (drate, cdep) in hdd_:
+                for n, (nrate, np) in npd_[::2]:
+                    for d, (drate, cdep) in hdd_[::2]:
                         rate = mrate * nrate * drate
                         yield PointRupture(
                             mag, self.tectonic_region_type,

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -300,7 +300,7 @@ class PointSource(ParametricSeismicSource):
             magd_ = list(enumerate(magd))
             npd_ = list(enumerate(npd))
             hdd_ = list(enumerate(hdd))
-            for m, (mrate, mag) in magd_[-2:]:
+            for m, (mrate, mag) in magd_[-1:]:
                 for n, (nrate, np) in npd_:
                     for d, (drate, cdep) in hdd_:
                         rate = mrate * nrate * drate


### PR DESCRIPTION
By considering only the maximum magnitude in CollapsedPointSources. The speedup is nearly 4x in USA:
```
| operation-duration | counts |    mean | stddev |    min | max   | slowfac |
|--------------------+--------+---------+--------+--------+-------+---------|
| preclassical       |    236 | 17.2596 |   422% | 1.4402 | 1_126 | 65.2259 |
| preclassical       |    252 | 12.9144 |   160% | 1.1521 | 313.8 | 24.2969 |
```