### PR TITLE
Override the `_dj_autoclear_mailbox` test fixture in `pytest_django` to clear the outbox only if it exists

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2025, GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
 import pytest
 from django.core import mail
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from django.core import mail
+
+
+@pytest.fixture(scope="function", autouse=True)
+def _dj_autoclear_mailbox():
+    """
+    Override the `_dj_autoclear_mailbox` test fixture in `pytest_django`
+    to clear the outbox only if it exists.
+    """
+    if hasattr(mail, 'outbox'):
+        del mail.outbox[:]


### PR DESCRIPTION
Doing the same as in https://gitlab.openquake.org/openquake/oq-risk-tests/-/merge_requests/98. If this is done in general, it should fix all cases like https://github.com/GEMScienceTools/oq-mbtk/actions/runs/12922239209/job/36037600138
If this works, we can then revert the changes in the oq-risk-test repo.