### PR TITLE
Using `query_ball_tree` to determine the ruptures close to the sites in global SES calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Reading the site model in calculations with ruptures.hdf5
+  * Reading the site model in calculations with ruptures.hdf5 and making
+    `minimum_intensity` mandatory
   * Added parameter `minimum_engine_version`
 
   [Paolo Tormene, Michele Simionato]

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -315,6 +315,7 @@ def starmap_from_rups_hdf5(oq, sitecol, dstore):
         r.copy('events', dstore.hdf5) # saving the events
         logging.info('Selecting the ruptures close to the sites')
         rups = close_ruptures(r['ruptures'][:], sitecol)
+        dstore['ruptures'] = rups
         R = full_lt.num_samples
         dstore['weights'] = numpy.ones(R) / R
     rups_dic = group_array(rups, 'model', 'trt_smr')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -25,14 +25,15 @@ import numpy
 import pandas
 from shapely import geometry
 from openquake.baselib import config, hdf5, parallel, python3compat
-from openquake.baselib.general import AccumDict, humansize, block_splitter
+from openquake.baselib.general import (
+    AccumDict, humansize, block_splitter, group_array)
 from openquake.hazardlib.geo.packager import fiona
 from openquake.hazardlib.map_array import MapArray, get_mean_curve
 from openquake.hazardlib.stats import geom_avg_std, compute_stats
 from openquake.hazardlib.calc.stochastic import sample_ruptures
 from openquake.hazardlib.contexts import ContextMaker, FarAwayRupture
 from openquake.hazardlib.calc.filters import (
-    magstr, nofilter, getdefault, get_distances, SourceFilter)
+    close_ruptures, magstr, nofilter, getdefault, get_distances, SourceFilter)
 from openquake.hazardlib.calc.gmf import GmfComputer
 from openquake.hazardlib.calc.conditioned_gmfs import ConditionedGmfComputer
 from openquake.hazardlib import logictree, InvalidFile
@@ -296,28 +297,6 @@ def filter_stations(station_df, complete, rup, maxdist):
     return station_data, station_sites
 
 
-def get_nsites(rups, trt_smr, trt, srcfilter):
-    model = rups[0]['model'].decode('ascii')
-    return {(model, trt_smr, trt): srcfilter.get_nsites(rups, trt)}
-
-
-def get_rups_dic(ruptures_hdf5, sitecol, maximum_distance, trts):
-    dic = {}
-    smap = parallel.Starmap(get_nsites)
-    with hdf5.File(ruptures_hdf5) as f:
-        for trt_smr, start, stop in f['trt_smr_start_stop']:
-            slc = slice(start, stop)
-            rups = f['ruptures'][slc]
-            model = rups[0]['model'].decode('ascii')
-            trt = trts[model][trt_smr // TWO24]
-            srcfilter = SourceFilter(sitecol, maximum_distance(trt))
-            dic[model, trt_smr, trt] = rups
-            smap.submit((rups, trt_smr, trt, srcfilter))
-    for key, nsites in smap.reduce().items():
-        dic[key]['nsites'] = nsites
-    return dic
-
-
 def starmap_from_rups_hdf5(oq, sitecol, dstore):
     """
     :returns: a Starmap instance sending event_based tasks
@@ -334,15 +313,20 @@ def starmap_from_rups_hdf5(oq, sitecol, dstore):
                 rlzs_by_gsim[model, trt_smr] = rbg
         dstore['full_lt'] = full_lt  # saving the last lt (hackish)
         r.copy('events', dstore.hdf5) # saving the events
+        logging.info('Selecting the ruptures close to the sites')
+        rups = close_ruptures(r['ruptures'][:], sitecol)
         R = full_lt.num_samples
         dstore['weights'] = numpy.ones(R) / R
-    rups_dic = get_rups_dic(ruptures_hdf5, sitecol, oq.maximum_distance, trts)
+    rups_dic = group_array(rups, 'model', 'trt_smr')
     totw = sum(rup_weight(rups).sum() for rups in rups_dic.values())
     maxw = totw / (oq.concurrent_tasks or 1)
     extra = sitecol.array.dtype.names
     dstore.swmr_on()
     smap = parallel.Starmap(event_based, h5=dstore.hdf5)
-    for (model, trt_smr, trt), rups in rups_dic.items():
+    logging.info('Computing the GMFs')
+    for (model, trt_smr), rups in rups_dic.items():
+        model = model.decode('ascii')
+        trt = trts[model][trt_smr // TWO24]
         proxies = get_proxies(ruptures_hdf5, rups)
         mags = numpy.unique(numpy.round(rups['mag'], 2))
         oq.mags_by_trt = {trt: [magstr(mag) for mag in mags]}

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1417,6 +1417,9 @@ class OqParam(valid.ParamSet):
 
         # checks for event_based
         if 'event_based' in self.calculation_mode:
+            if self.ruptures_hdf5 and not self.minimum_intensity:
+                self.raise_invalid('missing minimum_intensity')
+
             if self.ps_grid_spacing:
                 logging.warning('ps_grid_spacing is ignored in event_based '
                                 'calculations')

--- a/openquake/engine/tests/global_ses_test.py
+++ b/openquake/engine/tests/global_ses_test.py
@@ -17,6 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import numpy
 from openquake.baselib import hdf5
 from openquake.qa_tests_data import mosaic_for_ses
 from openquake.commonlib.datastore import read
@@ -25,6 +26,7 @@ from openquake.engine import global_ses
 
 MOSAIC_DIR = os.path.dirname(mosaic_for_ses.__file__)
 RUP_HDF5 = os.path.join(MOSAIC_DIR, 'rups.hdf5')
+aac = numpy.testing.assert_allclose
 def path(job_ini):
     return os.path.join(MOSAIC_DIR, job_ini)
 
@@ -48,14 +50,18 @@ def setup_module():
     check(dstore, fnames)
 
 
-def test_sites():
+def test_sites():  # 6 sites
     dstore = base.run_calc(path('job_sites.ini')).datastore
-    assert dstore['avg_gmf'].shape == (2, 6, 1)  # 6 sites
+    gmvs = dstore['avg_gmf'][0, :, 0]
+    aac(gmvs, [0.0201735, 0.0202367, 0.0203708,
+               0.0202335, 0.0202477, 0.0202308], atol=1E-6)
 
 
-def test_site_model():
+def test_site_model():  # 5 sites
     dstore = base.run_calc(path('job_sm.ini')).datastore
-    assert dstore['avg_gmf'].shape == (2, 5, 1)  # 5 sites
+    gmvs = dstore['avg_gmf'][0, :, 0]
+    aac(gmvs, [0.020281, 0.020274, 0.020219,
+               0.020302, 0.020263], atol=1E-6)
 
 
 def teardown_module():

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -21,7 +21,7 @@ import sys
 import operator
 from contextlib import contextmanager
 import numpy
-from scipy.spatial import cKDTree, distance
+from scipy.spatial import KDTree, distance
 from scipy.interpolate import interp1d
 
 from openquake.baselib.python3compat import raise_
@@ -327,6 +327,22 @@ def split_source(src):
     return splits
 
 
+def close_ruptures(ruptures, sites, dist=600.):
+    """
+    :returns: array of ruptures close to the sites
+    """    
+    hypos = ruptures['hypo']
+    kr = KDTree(spherical_to_cartesian(hypos[:, 0], hypos[:, 1], hypos[:, 2]))
+    ks = KDTree(spherical_to_cartesian(sites.lons, sites.lats, sites.depths))
+    all_sids = kr.query_ball_tree(ks, dist, eps=.1)
+    out = []
+    for r, sids in enumerate(all_sids):
+        if sids:
+            ruptures[r]['nsites'] = len(sids)
+            out.append(ruptures[r])
+    return numpy.array(out)
+
+
 default = IntegrationDistance({'default': [(MINMAG, 1000), (MAXMAG, 1000)]})
 
 
@@ -436,15 +452,9 @@ class SourceFilter(object):
                 return self.sitecol.sids
             return self.sitecol.within_bbox(bbox)
 
-    def get_nsites(self, rups, trt):
-        """
-        :returns: array of float32 with the number of close sites per rupture
-        """
-        return U32([len(self.close_sids(rup, trt)) for rup in rups])
-
     def _close_sids(self, lon, lat, dep, dist):
         if not hasattr(self, 'kdt'):
-            self.kdt = cKDTree(self.sitecol.xyz)
+            self.kdt = KDTree(self.sitecol.xyz)
         xyz = spherical_to_cartesian(lon, lat, dep)
         sids = U32(self.kdt.query_ball_point(xyz, dist, eps=.001))
         sids.sort()  # for cross-platform consistency

--- a/openquake/qa_tests_data/mosaic_for_ses/job.ini
+++ b/openquake/qa_tests_data/mosaic_for_ses/job.ini
@@ -21,3 +21,4 @@ rupture_model_file = rups.hdf5
 intensity_measure_types = PGA
 truncation_level = 3
 maximum_distance = 200.0
+minimum_intensity = .02

--- a/openquake/qa_tests_data/mosaic_for_ses/job_sites.ini
+++ b/openquake/qa_tests_data/mosaic_for_ses/job_sites.ini
@@ -20,4 +20,5 @@ rupture_model_file = rups.hdf5
 intensity_measure_types_and_levels = {'PGA': logscale(.001, 1, 20)}
 truncation_level = 3
 maximum_distance = 200.0
+minimum_intensity = .02
 hazard_curves_from_gmfs = true

--- a/openquake/qa_tests_data/mosaic_for_ses/job_sm.ini
+++ b/openquake/qa_tests_data/mosaic_for_ses/job_sm.ini
@@ -19,4 +19,5 @@ investigation_time = 1.0
 rupture_model_file = rups.hdf5
 intensity_measure_types_and_levels = {'PGA': logscale(.001, 1, 20)}
 truncation_level = 3
+minimum_intensity = .02
 maximum_distance = 200.0


### PR DESCRIPTION
Which a *huge* performance benefit. Also made `minimum_intensity` mandatory in such calculations.