### PR TITLE
Fixed the instantiation of file-dependent GMPEs from the datastore

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
   [Michele Simionato]
+  * Fixed the instantiation of file-dependent GMPEs from the datastore
   * Optimized slow tasks in classical and preclassical calculations,
-    in some situations tripling the speed of the MEX, SAM and USA models
+    in some situations tripling the speed of the SAM and USA models
   * Reading the site model in calculations with ruptures.hdf5 and making
     `minimum_intensity` mandatory
   * Added parameter `minimum_engine_version`

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import numpy
 from numpy.testing import assert_almost_equal as aae
 from openquake.qa_tests_data.scenario import (
@@ -404,5 +405,11 @@ class ScenarioTestCase(CalculatorTestCase):
         self.run_calc(case_35.__file__, 'job.ini')
         [f] = export(('avg_gmf', 'csv'), self.calc.datastore)
         self.assertEqualFiles('expected/avg_gmf.csv', f, delta=1E-5)
-
-        
+        fname = os.path.join(os.path.dirname(case_35.__file__),
+                             'Wcrust_med_rhypo.hdf5')
+        try:
+            os.rename(fname, fname + '.bak')
+            gsim_lt = self.calc.datastore['full_lt'].gsim_lt
+            print(gsim_lt)
+        finally:
+            os.rename(fname + '.bak', fname)

--- a/openquake/calculators/tests/scenario_test.py
+++ b/openquake/calculators/tests/scenario_test.py
@@ -408,6 +408,9 @@ class ScenarioTestCase(CalculatorTestCase):
         fname = os.path.join(os.path.dirname(case_35.__file__),
                              'Wcrust_med_rhypo.hdf5')
         try:
+            # check that even by removing the .hdf5 table
+            # the GMPETable can be instantiated, since
+            # GsimLogicTree.__from__hdf5__ reads from the attributes
             os.rename(fname, fname + '.bak')
             gsim_lt = self.calc.datastore['full_lt'].gsim_lt
             print(gsim_lt)


### PR DESCRIPTION
`__from_hdf5__` now reads from the attributes and not from the file system.