### PR TITLE
Removed microseconds from the timestamp

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -257,6 +257,8 @@ def utc_to_local_time(utc_timestamp, lon, lat):
     utc_time = utc_zone.localize(utc_time)
     local_zone = pytz.timezone(timezone_str)
     local_timestamp = utc_time.astimezone(local_zone)
+    # NOTE: the validated timestamp format has no microseconds
+    local_timestamp = local_timestamp.replace(microsecond=0)
     return local_timestamp
 
 


### PR DESCRIPTION
Should fix the error reported by @VSilva
```python
Invalid input value
Local timestamp of the event: "'2024-12-17 12:47:25.741000+11:00' does not match the regex '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2})$'"
```

