### PR TITLE
Increased `pmap_max_mb`

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -579,19 +579,21 @@ class ClassicalCalculator(base.HazardCalculator):
     def _execute_regular(self, sgs, ds):
         allargs = []
         n_out = []
-        for cmaker, tilegetters, blocks, splits in self.csm.split(
+        splits = []
+        for cmaker, tilegetters, blocks, nsplits in self.csm.split(
                 self.cmakers, self.sitecol, self.max_weight, self.num_chunks):
             for block in blocks:
-                for tgetters in block_splitter(tilegetters, splits):
+                for tgetters in block_splitter(tilegetters, nsplits):
                     allargs.append((block, tgetters, cmaker, ds))
                 n_out.append(len(tilegetters))
+            splits.append(nsplits)
         logging.warning('This is a regular calculation with %d outputs, '
                         '%d tasks, min_tiles=%d, max_tiles=%d',
                         sum(n_out), len(allargs), min(n_out), max(n_out))
 
         # log info about the heavy sources
         srcs = self.csm.get_sources()
-        maxsrc = max(srcs, key=lambda s: s.weight / self.csm.splits[s.grp_id])
+        maxsrc = max(srcs, key=lambda s: s.weight / splits[s.grp_id])
         logging.info('Heaviest: %s', maxsrc)
 
         L = self.oqparam.imtls.size

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -45,7 +45,7 @@ conditioned_gmf_gb = 8
 
 # parallel tiling parameters, by default pmap_max_gb=num_cores/8
 pmap_max_gb =
-pmap_max_mb = 120
+pmap_max_mb = 500
 
 [dbserver]
 file = ~/oqdata/db.sqlite3

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -711,7 +711,6 @@ class CompositeSourceModel:
         oq = cmakers[0].oq
         max_mb = float(config.memory.pmap_max_mb)
         mb_per_gsim = oq.imtls.size * N * 4 / 1024**2
-        self.splits = []
         # send heavy groups first
         grp_ids = numpy.argsort([sg.weight for sg in self.src_groups])[::-1]
         for cmaker in cmakers[grp_ids]:
@@ -729,7 +728,6 @@ class CompositeSourceModel:
                     sg, min(hint, oq.max_blocks), lambda s: s.weight))
                 tiles = max(hint / oq.max_blocks * splits, splits)
             tilegetters = list(sitecol.split(tiles, oq.max_sites_disagg))
-            self.splits.append(splits)
             cmaker.tiling = tiling
             cmaker.gsims = list(cmaker.gsims)  # save data transfer
             cmaker.codes = sg.codes


### PR DESCRIPTION
This gives a 10-15% performance improvement in some cases (i.e. the USA model), at the cost of using little more memory.
Here are the numbers for performance.zip:
```
# pmap_max_mb = 120, planar contexts is much worse
| calc_26501, maxmem=13.5 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 2_549    | 108.3926  | 62      |
| get_poes                   | 1_513    | 0.0       | 469_887 |
| computing mean_std         | 464.9    | 0.0       | 9_423   |
| planar contexts            | 352.4    | 0.0       | 522_559 |
| ClassicalCalculator.run    | 222.3    | 98.0391   | 1       |

# pmap_max_mb = 500
| calc_26500, maxmem=15.8 GB | time_sec | memory_mb | counts  |
|----------------------------+----------+-----------+---------|
| total classical            | 2_544    | 326.4     | 31      |
| get_poes                   | 1_556    | 0.0       | 453_408 |
| computing mean_std         | 478.5    | 0.0       | 9_081   |
| planar contexts            | 280.1    | 0.0       | 262_788 |
| ClassicalCalculator.run    | 217.8    | 95.3008   | 1       |
```