### PR TITLE
When the PAM authentication backend is used, do not force the user to actualize email notification templates

### DIFF
--- a/openquake/server/management/commands/createnormaluser.py
+++ b/openquake/server/management/commands/createnormaluser.py
@@ -52,11 +52,23 @@ class Command(BaseCommand):
                 request.META['SERVER_PORT'] = '80'
         else:
             request.META['SERVER_PORT'] = settings.SERVER_PORT
+        # NOTE: we don't expect to use email notifications when PAM is enabled, so we
+        # can avoid forcing the user to actualize the templates
+        if 'django_pam.auth.backends.PAMBackend' in settings.AUTHENTICATION_BACKENDS:
+            subject_template_name = \
+                'registration/normal_user_creation_email_subject.txt.default.tmpl'
+            email_template_name = \
+                'registration/normal_user_creation_email_content.txt.default.tmpl'
+        else:
+            subject_template_name = \
+                'registration/normal_user_creation_email_subject.txt'
+            email_template_name = \
+                'registration/normal_user_creation_email_content.txt'
         form.save(
             domain_override=(settings.SERVER_NAME
                              if settings.USE_REVERSE_PROXY else None),
             request=request,
             use_https=settings.USE_HTTPS,
             from_email=settings.EMAIL_HOST_USER,
-            subject_template_name='registration/normal_user_creation_email_subject.txt',
-            email_template_name='registration/normal_user_creation_email_content.txt')
+            subject_template_name=subject_template_name,
+            email_template_name=email_template_name)

--- a/openquake/server/urls.py
+++ b/openquake/server/urls.py
@@ -111,15 +111,31 @@ else:
         application_mode = settings.APPLICATION_MODE
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         registration_templates_dir = os.path.join(curr_dir, 'templates', 'registration')
-        password_reset_email_content_fname = 'password_reset_email_content.txt'
-        password_reset_email_subject_fname = 'password_reset_email_subject.txt'
+        # NOTE: we don't expect to use email notifications when PAM is enabled, so we
+        # can avoid forcing the user to actualize the templates
+        if 'django_pam.auth.backends.PAMBackend' in settings.AUTHENTICATION_BACKENDS:
+            password_reset_email_content_fname = \
+                'password_reset_email_content.txt.default.tmpl'
+            password_reset_email_subject_fname = \
+                'password_reset_email_subject.txt.default.tmpl'
+            normal_user_creation_email_content_fname = \
+                'normal_user_creation_email_content.txt.default.tmpl'
+            normal_user_creation_email_subject_fname = \
+                'normal_user_creation_email_subject.txt.default.tmpl'
+        else:
+            password_reset_email_content_fname = 'password_reset_email_content.txt'
+            password_reset_email_subject_fname = 'password_reset_email_subject.txt'
+            normal_user_creation_email_content_fname = \
+                'normal_user_creation_email_content.txt'
+            normal_user_creation_email_subject_fname = \
+                'normal_user_creation_email_subject.txt'
         # NOTE: checking here (when starting the webui with authentication enabled)
-        # also the existance of actualized files of used when creating a new user
+        # also the existance of actualized files used when creating a new user
         for registration_template_fname in (
                 password_reset_email_content_fname,
                 password_reset_email_subject_fname,
-                'normal_user_creation_email_content.txt',
-                'normal_user_creation_email_subject.txt'):
+                normal_user_creation_email_content_fname,
+                normal_user_creation_email_subject_fname):
             registration_template_path = os.path.join(
                 registration_templates_dir, registration_template_fname)
             assert os.path.isfile(registration_template_path), (


### PR DESCRIPTION
For instance, in oqdb.gem.lan we have authentication administered via PAM and users do not even have associated email addresses to be used for email notifications. In cases like that, it would be annoying to force the actualization of email notification templates after installing the engine.