### PR TITLE
Build and display a preview of the rupture in some workflows in which it was missing

### DIFF
--- a/bin/arist
+++ b/bin/arist
@@ -1,8 +1,66 @@
 #!/usr/bin/env python3
-import sys
-from openquake.engine.impact import main_cmd
-if __name__ == '__main__':
+import argparse
+from openquake.engine.impact import main_cmd, trivial_callback
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run OQ Impact calculation.")
+    parser.add_argument("--usgs_id", type=str, default='FromFile', help="USGS ID")
+    parser.add_argument("--rupture_file", type=str, default=None,
+                        help="Path to rupture file")
+    parser.add_argument("--time_event", type=str, default="day", help="Time event")
+    parser.add_argument("--maximum_distance", type=str, default="200",
+                        help="Maximum distance")
+    parser.add_argument("--mosaic_model", type=str, default=None, help="Mosaic model")
+    parser.add_argument("--trt", type=str, default=None, help="TRT")
+    parser.add_argument("--truncation_level", type=str, default="3",
+                        help="Truncation level")
+    parser.add_argument("--number_of_ground_motion_fields", type=str, default="10",
+                        help="Number of ground motion fields")
+    parser.add_argument("--asset_hazard_distance", type=str, default="15",
+                        help="Asset hazard distance")
+    parser.add_argument("--ses_seed", type=str, default="42", help="SES seed")
+    parser.add_argument("--local_timestamp", type=str, default="",
+                        help="Local timestamp")
+    parser.add_argument("--exposure_hdf5", type=str, default=None,
+                        help="Exposure HDF5 file")
+    parser.add_argument("--station_data_file", type=str, default=None,
+                        help="Station data file")
+    parser.add_argument("--maximum_distance_stations", type=str, default="",
+                        help="Maximum distance stations")
+    parser.add_argument("--msr", type=str, default="",
+                        help="MSR")
+    parser.add_argument("--approach", type=str, default="use_shakemap_from_usgs",
+                        help="Approach")
+    parser.add_argument("--loglevel", type=str, default="info", help="Log level")
+    parser.add_argument("--userlevel", type=int, default=2, help="User level")
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
     # us7000k9f0
-    main_cmd(sys.argv[1], maximum_distance='200', msr='',
-             approach='use_shakemap_from_usgs', loglevel='info',
-             userlevel=1)
+    args = parse_args()
+
+    main_cmd(
+        usgs_id=args.usgs_id,
+        rupture_file=args.rupture_file,
+        callback=trivial_callback,
+        time_event=args.time_event,
+        maximum_distance=args.maximum_distance,
+        mosaic_model=args.mosaic_model,
+        trt=args.trt,
+        truncation_level=args.truncation_level,
+        number_of_ground_motion_fields=args.number_of_ground_motion_fields,
+        asset_hazard_distance=args.asset_hazard_distance,
+        ses_seed=args.ses_seed,
+        local_timestamp=args.local_timestamp,
+        exposure_hdf5=args.exposure_hdf5,
+        station_data_file=args.station_data_file,
+        maximum_distance_stations=args.maximum_distance_stations,
+        msr=args.msr,
+        approach=args.approach,
+        loglevel=args.loglevel,
+        userlevel=args.userlevel
+    )

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -43,7 +43,8 @@ from openquake.baselib import performance
 from openquake.baselib.general import gettemp
 from openquake.baselib.node import node_from_xml
 from openquake.hazardlib import nrml, sourceconverter
-from openquake.hazardlib.source.rupture import get_multiplanar, is_matrix
+from openquake.hazardlib.source.rupture import (
+    get_multiplanar, is_matrix, build_planar_rupture_from_dict)
 from openquake.hazardlib.scalerel import get_available_magnitude_scalerel
 
 NOT_FOUND = 'No file with extension \'.%s\' file found'
@@ -846,7 +847,8 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
         rupdic['station_data_file_from_usgs'] = False
     if not rup_data:
         # in parsers_test
-        return None, rupdic, err
+        rup = build_planar_rupture_from_dict(rupdic)
+        return rup, rupdic, err
 
     rup = convert_to_oq_rupture(rup_data)
     if rup is None:

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -27,7 +27,7 @@ import logging
 import itertools
 import json
 from openquake.baselib import general, hdf5
-from openquake.hazardlib import geo
+from openquake.hazardlib import geo, site, scalerel
 from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib.geo.mesh import (
     Mesh, RectangularMesh, surface_to_arrays)
@@ -47,6 +47,8 @@ TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO30 = 2 ** 30
 TWO32 = 2 ** 32
+
+MSR = scalerel._get_available_class(scalerel.BaseMSR)
 
 pmf_dt = numpy.dtype([
     ('prob', float),
@@ -1018,4 +1020,23 @@ def build_planar(hypocenter, mag, rake, strike=0., dip=90., trt='*'):
     rup = BaseRupture(mag, rake, trt, hypocenter, surf)
     rup.rup_id = 0
     vars(rup).update(vars(hypocenter))
+    return rup
+
+
+def build_planar_rupture_from_dict(rupture_dict):
+    r = rupture_dict
+    hypo = Point(r['lon'], r['lat'], r['dep'])
+    trt = r.get('trt', '*')
+    strike = r.get('strike', 0)
+    dip = r.get('dip', 90)
+    if not r.get('msr'):
+        rup = build_planar(
+            hypo, r['mag'], r.get('rake'),
+            strike, dip, trt)
+    else:
+        aratio = r.get('aspect_ratio', 2.)
+        msr = MSR[r['msr']]()
+        rup = get_planar(
+            site.Site(Point(r['lon'], r['lat'], r['dep'])), msr, r['mag'], aratio,
+            strike, dip, r['rake'], trt, ztor=None)
     return rup


### PR DESCRIPTION
I also made an improvement to the `bin/arist` script, making it easier to run it with different arguments.