### PR TITLE
Removed explicit dependency on pytz

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -240,6 +240,9 @@ def convert_to_oq_rupture(rup_json):
 
 
 def utc_to_local_time(utc_timestamp, lon, lat):
+    """
+    Convert a timestamp '%Y-%m-%dT%H:%M:%S.%fZ' into a datetime object
+    """
     try:
         # NOTE: mandatory dependency for ARISTOTLE
         from timezonefinder import TimezoneFinder

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -31,11 +31,11 @@ import pathlib
 import logging
 import json
 import zipfile
-import pytz
 import base64
 from dataclasses import dataclass
 import pandas as pd
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from shapely.geometry import Polygon
 import numpy
 
@@ -260,13 +260,9 @@ def utc_to_local_time(utc_timestamp, lon, lat):
             'Could not determine the timezone. Using the UTC time')
         return utc_timestamp
     utc_time = datetime.strptime(utc_timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
-    utc_zone = pytz.utc
-    utc_time = utc_zone.localize(utc_time)
-    local_zone = pytz.timezone(timezone_str)
-    local_timestamp = utc_time.astimezone(local_zone)
+    local_timestamp = utc_time.astimezone(ZoneInfo(timezone_str))
     # NOTE: the validated timestamp format has no microseconds
-    local_timestamp = local_timestamp.replace(microsecond=0)
-    return local_timestamp
+    return local_timestamp.replace(microsecond=0)
 
 
 def local_time_to_time_event(local_time):

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -18,7 +18,8 @@
 
 import os
 import unittest
-from openquake.hazardlib.shakemap.parsers import get_rup_dic, User
+from openquake.hazardlib.shakemap.parsers import (
+    get_rup_dic, User, utc_to_local_time)
 
 user = User(level=2, testdir=os.path.join(os.path.dirname(__file__), 'data'))
 
@@ -32,6 +33,10 @@ class ShakemapParsersTestCase(unittest.TestCase):
             raise unittest.SkipTest('Missing timezonefinder')
         else:
             del timezonefinder
+
+    def test_utc_to_local_time(self):
+        loctime = utc_to_local_time('2011-01-01T12:00:00.0Z', 10., 45.)
+        self.assertEqual(str(loctime.tzinfo), 'Europe/Rome')
 
     def test_1(self):
         # wrong usgs_id


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/10091. Unfortunately pandas and Django depend from pytz, so it cannot be removed and we must keep a horrible deprecation warning, present also in the latest pytz :-(