### PR TITLE
Fix modified_gsim to work with gsim which requires a specific distance parameter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,9 @@
 python3-oq-engine (3.23.0-1~xenial01) xenial; urgency=low
 
+  [Christopher Brooks]
+  * Fixed modified_gsim (valid.py) to work with more complex
+    GMMs (e.g. NGAEast GMPE Tables) + added a unit test
+
   [Michele Simionato]
   * Fixed contexts.py: we were incorrectly discarding ruptures with magnitude equal
     to the minimum magnitude

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-python3-oq-engine (3.23.0-1~xenial01) xenial; urgency=low
-
   [Christopher Brooks]
   * Fixed modified_gsim (valid.py) to work with more complex
     GMMs (e.g. NGAEast GMPE Tables) + added a unit test
+
+python3-oq-engine (3.23.0-1~xenial01) xenial; urgency=low
 
   [Michele Simionato]
   * Fixed contexts.py: we were incorrectly discarding ruptures with magnitude equal

--- a/openquake/hazardlib/tests/valid_test.py
+++ b/openquake/hazardlib/tests/valid_test.py
@@ -164,3 +164,13 @@ class ValidationTestCase(unittest.TestCase):
         gmpe = valid.modified_gsim(
             gsim, add_between_within_stds={'with_betw_ratio':1.5})
         valid.gsim(gmpe._toml)  # make sure the generated _toml is valid
+
+    def test_modifiable_gmpe_complex(self):
+        # Make an NGAEast GMPE and apply modifiable GMPE to it
+        text = "[NBCC2015_AA13]\nREQUIRES_DISTANCES=['RJB']\n"
+        text += "DEFINED_FOR_TECTONIC_REGION_TYPE='Active Crust Fault'\n"
+        text += "gmpe_table='WcrustFRjb_low_clC.hdf5'"
+        gsim = valid.gsim(text)
+        gmpe = valid.modified_gsim(
+            gsim, add_between_within_stds={'with_betw_ratio':1.5})
+        valid.gsim(gmpe._toml)  # make sure the generated _toml is valid

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -194,8 +194,11 @@ def modified_gsim(gmpe, **kwargs):
 
     mgs = modified_gsim(gsim, add_between_within_stds={'with_betw_ratio':1.5})
     """
-    text = gmpe._toml.replace('[', '[ModifiableGMPE.gmpe.') + '\n'
-    text += toml.dumps({'ModifiableGMPE': kwargs})
+    text = gmpe._toml.split('\n')[0].replace('[', '[ModifiableGMPE.gmpe.')
+    args = gmpe._toml.split('\n')[1:]
+    for arg in args:
+        text += '\n' + arg
+    text += '\n' + toml.dumps({'ModifiableGMPE': kwargs})
     return gsim(text)
 
 

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -194,8 +194,8 @@ def modified_gsim(gmpe, **kwargs):
 
     mgs = modified_gsim(gsim, add_between_within_stds={'with_betw_ratio':1.5})
     """
-    text = gmpe._toml.split('\n')[0].replace('[', '[ModifiableGMPE.gmpe.')
-    args = gmpe._toml.split('\n')[1:]
+    name, *args = gmpe._toml.split('\n')
+    text = name.replace('[', '[ModifiableGMPE.gmpe.')
     for arg in args:
         text += '\n' + arg
     text += '\n' + toml.dumps({'ModifiableGMPE': kwargs})


### PR DESCRIPTION
The current `modified_gsim` use of `replace` results in the incorrect toml line of `REQUIRES_DISTANCES = [ModifiableGMPE.gmpe. "rjb"]` which prevents instantiation of an NGAEast GMM (as defined in the Canada model's GMM logic tree) with the splitting of GMM sigma correctly:

![Screenshot 2025-02-17 212626](https://github.com/user-attachments/assets/aa0515d4-1f3d-4b35-837e-4511cea237b2)

This PR fixes this by first checking we are apply the `replace` to only the left bracket of the gsim class name (first line of toml).

I have added a unit test which checks this solution works using the GMM the issue was observed for in GEESE.