### PR TITLE
Made it possible to pass the models to the global_ses script

### DIFF
--- a/openquake/commands/show_attrs.py
+++ b/openquake/commands/show_attrs.py
@@ -19,23 +19,28 @@ from openquake.commonlib import datastore
 import h5py
 
 
-def main(key, calc_id: int = -1):
+def main(key, calc_id=-1):
     """
     Show the attributes of a HDF5 dataset in the datastore.
     """
-    ds = datastore.read(calc_id)
     try:
-        attrs = h5py.File.__getitem__(ds.hdf5, key).attrs
+        calc_id = int(calc_id)
+    except ValueError:  # passed filename
+        hdf5 = h5py.File(calc_id)
+    else:
+        hdf5 = datastore.read(calc_id).hdf5
+    try:
+        attrs = h5py.File.__getitem__(hdf5, key).attrs
     except KeyError:
-        print('%r is not in %s' % (key, ds))
+        print('%r is not in %s' % (key, hdf5))
     else:
         if len(attrs) == 0:
             print('%s has no attributes' % key)
         for name, value in attrs.items():
             print(name, value)
     finally:
-        ds.close()
+        hdf5.close()
 
 
 main.key = 'key of the datastore'
-main.calc_id = 'calculation ID'
+main.calc_id = 'calculation ID or filename.hdf5'


### PR DESCRIPTION
```bash
$ python -m openquake.engine.global_ses -h
usage: global_ses.py [-h] [-n 2000] [-s 50] [-m 5.0] [-i PGA,SA(0.1),SA(0.2),SA(0.3),SA(0.6),SA(1.0),SA(2.0)]
                     mosaic_dir out [models]

Storing global SES

positional arguments:
  mosaic_dir            Directory containing the hazard mosaic
  out                   Output file
  models                Models to consider (comma-separated) [default: 'ALL']

options:
  -h, --help            show this help message and exit
  -n 2000, --number-of-logic-tree-samples 2000
                        Number of samples
  -s 50, --ses-per-logic-tree-path 50
                        Number of SES
  -m 5.0, --minimum-magnitude 5.0
                        Minimum magnitude
  -i PGA,SA(0.1),SA(0.2),SA(0.3),SA(0.6),SA(1.0),SA(2.0), --imts PGA,SA(0.1),SA(0.2),SA(0.3),SA(0.6),SA(1.0),SA(2.0)
                        Intensity Measure Types (comma-separated)
```