### PR TITLE
Make it possible to run impact calculations ignoring stations

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -844,8 +844,8 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
                 usgs_id, contents, user)
     if not rupdic:
         rupdic = convert_rup_data(rup_data, usgs_id, rupture_file, shakemap)
-    if (user.level == 2 and download_usgs_stations and not station_data_file
-            and approach != 'use_shakemap_from_usgs'):
+    if (approach != 'use_shakemap_from_usgs' and not station_data_file
+            and download_usgs_stations):
         with monitor('Downloading stations'):
             rupdic['station_data_file'], rupdic['station_data_issue'] = (
                 download_station_data_file(usgs_id, contents, user))

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -763,10 +763,15 @@ def _get_rup_dic_from_xml(usgs_id, user, rupture_file, station_data_file):
 
 def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
                 use_shakemap=False, rupture_file=None,
-                station_data_file=None, monitor=performance.Monitor()):
+                station_data_file=None, download_usgs_stations=True,
+                monitor=performance.Monitor()):
     """
     If the rupture_file is None, download a rupture from the USGS site given
     the ShakeMap ID, else build the rupture locally with the given usgs_id.
+
+    NOTE: this function is called twice by impact_validate: first when retrieving
+    rupture data, then when running the job. Only in the former case we need to
+    attempt to download station data from the USGS
 
     :param dic: dictionary with ShakeMap ID and other parameters
     :param user: User instance
@@ -775,6 +780,7 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
     :param use_shakemap: download the ShakeMap only if True
     :param rupture_file: None
     :param station_data_file: None
+    :param download_usgs_stations: download USGS stations if station_data_file is None
     :returns: (rupture object or None, rupture dictionary, error dictionary or {})
     """
     rupdic = {}
@@ -838,15 +844,15 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
                 usgs_id, contents, user)
     if not rupdic:
         rupdic = convert_rup_data(rup_data, usgs_id, rupture_file, shakemap)
-    if (user.level == 2 and not station_data_file
+    if (user.level == 2 and download_usgs_stations and not station_data_file
             and approach != 'use_shakemap_from_usgs'):
         with monitor('Downloading stations'):
             rupdic['station_data_file'], rupdic['station_data_issue'] = (
                 download_station_data_file(usgs_id, contents, user))
         rupdic['station_data_file_from_usgs'] = True
     else:
-        rupdic['station_data_file'], rupdic['station_data_issue'] = (
-            station_data_file, None)
+        rupdic['station_data_file'] = station_data_file
+        rupdic['station_data_issue'] = None
         rupdic['station_data_file_from_usgs'] = False
     if not rup_data:
         # in parsers_test

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -770,8 +770,8 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
     the ShakeMap ID, else build the rupture locally with the given usgs_id.
 
     NOTE: this function is called twice by impact_validate: first when retrieving
-    rupture data, then when running the job. Only in the former case we need to
-    attempt to download station data from the USGS
+    rupture data, then when running the job. Only in the former case, if stations
+    have not been loaded yet, we try to download them from the USGS
 
     :param dic: dictionary with ShakeMap ID and other parameters
     :param user: User instance

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -780,7 +780,8 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
     :param use_shakemap: download the ShakeMap only if True
     :param rupture_file: None
     :param station_data_file: None
-    :param download_usgs_stations: download USGS stations if station_data_file is None
+    :param download_usgs_stations: download USGS stations, only if
+        station_data_file is None and the ShakeMap is not used
     :returns: (rupture object or None, rupture dictionary, error dictionary or {})
     """
     rupdic = {}

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -862,7 +862,6 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
         except ValueError as exc:
             err = {"status": "failed", "error_msg": str(exc)}
         return rup, rupdic, err
-
     rup = convert_to_oq_rupture(rup_data)
     if rup is None:
         # in parsers_test for us6000jllz

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -251,6 +251,7 @@ def get_tmap_keys(exposure_hdf5, countries):
 
 
 def impact_validate(POST, user, rupture_file=None, station_data_file=None,
+                    download_usgs_stations=True,
                     monitor=performance.Monitor()):
     """
     This is called by `impact_get_rupture_data` and `impact_run`.
@@ -258,6 +259,7 @@ def impact_validate(POST, user, rupture_file=None, station_data_file=None,
     returns (rup, rupdic, [station_file], error).
     In the second case the form contains all fields and returns
     (rup, rupdic, params, error).
+    Only in the former case we need to attempt to download station data from the USGS
     """
     err = {}
     dic, params, err = _validate(POST)
@@ -275,7 +277,7 @@ def impact_validate(POST, user, rupture_file=None, station_data_file=None,
 
     rup, rupdic, err = get_rup_dic(
         dic, user, approach, use_shakemap, rupture_file, station_data_file,
-        monitor)
+        download_usgs_stations, monitor)
     if err:
         return None, None, None, err
     # round floats

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -259,7 +259,8 @@ def impact_validate(POST, user, rupture_file=None, station_data_file=None,
     returns (rup, rupdic, [station_file], error).
     In the second case the form contains all fields and returns
     (rup, rupdic, params, error).
-    Only in the former case we need to attempt to download station data from the USGS
+    Only in the former case, if stations have not been downloaded yet, we try to
+    download station data from the USGS
     """
     err = {}
     dic, params, err = _validate(POST)

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -475,3 +475,8 @@ table#impact-losses th td {
 input[type="radio"] {
   margin-right: 5px; /* Space between radio button and label text */
 }
+
+#clearStationDataFromUsgs {
+    margin-left: 40px;
+    margin-bottom: 8px;
+}

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -868,15 +868,11 @@ function capitalizeFirstLetter(val) {
             });
             $('#clearStationDataFile').click(function() {
                 $('#station_data_file_input').val('');
-                $('#maximum_distance_stations').val('');
-                $('#maximum_distance_stations').prop('disabled', true);
             });
             $('#clearStationDataFromUsgs').click(function() {
                 $('#station_data_file_from_usgs').val('');
                 $('#station_data_file_loaded').val('');
                 $('#station_data_file').val('');
-                $('#maximum_distance_stations').val('');
-                $('#maximum_distance_stations').prop('disabled', true);
             });
             $("#impact_run_form > input").click(function() {
                 $(this).css("background-color", "white");
@@ -944,13 +940,6 @@ function capitalizeFirstLetter(val) {
             });
             $("#impact_run_form > input").click(function() {
                 $(this).css("background-color", "white");
-            });
-            $('#station_data_file_input').on('change', function() {
-                if ($(this).get(0).files.length > 0) {
-                    $('#maximum_distance_stations').prop('disabled', false);
-                } else {
-                    $('#maximum_distance_stations').prop('disabled', true);
-                }
             });
         });
 })($, Backbone, _, gem_oq_server_url);

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -733,6 +733,7 @@ function capitalizeFirstLetter(val) {
                         conversion_issues += '<p>' + data.error + '</p>';
                         $('#rupture_from_usgs_loaded').val('N.A. (conversion issue)');
                     }
+                    // NOTE: these are stations downloaded from the USGS and not those uploaded by the user
                     $('#station_data_file_from_usgs').val(data.station_data_file);
                     if (data.station_data_issue) {
                         $('#station_data_file_loaded').val('N.A. (conversion issue)');

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -733,7 +733,7 @@ function capitalizeFirstLetter(val) {
                         conversion_issues += '<p>' + data.error + '</p>';
                         $('#rupture_from_usgs_loaded').val('N.A. (conversion issue)');
                     }
-                    $('#station_data_file').val(data.station_data_file);
+                    $('#station_data_file_from_usgs').val(data.station_data_file);
                     if (data.station_data_issue) {
                         $('#station_data_file_loaded').val('N.A. (conversion issue)');
                         conversion_issues += '<p>' + data.station_data_issue + '</p>';
@@ -867,6 +867,13 @@ function capitalizeFirstLetter(val) {
             });
             $('#clearStationDataFile').click(function() {
                 $('#station_data_file_input').val('');
+                $('#maximum_distance_stations').val('');
+                $('#maximum_distance_stations').prop('disabled', true);
+            });
+            $('#clearStationDataFromUsgs').click(function() {
+                $('#station_data_file_from_usgs').val('');
+                $('#station_data_file_loaded').val('');
+                $('#station_data_file').val('');
                 $('#maximum_distance_stations').val('');
                 $('#maximum_distance_stations').prop('disabled', true);
             });

--- a/openquake/server/templates/engine/includes/impact_run_form.html
+++ b/openquake/server/templates/engine/includes/impact_run_form.html
@@ -54,7 +54,7 @@
               </div>
               <div class="impact_form_row hidden-for-shakemap hidden">
                 <label for"maximum_distance_stations">{{ impact_form_labels.maximum_distance_stations }}</label>
-                <input class="impact-input" type="text" id="maximum_distance_stations" name="maximum_distance_stations" placeholder="{{ impact_form_placeholders.maximum_distance_stations }}" value="" disabled/>
+                <input class="impact-input" type="text" id="maximum_distance_stations" name="maximum_distance_stations" placeholder="{{ impact_form_placeholders.maximum_distance_stations }}" value=""/>
               </div>
               <div class="impact_form_row">
                 <button id="submit_impact_calc" type="submit" class="btn" disabled>Launch impact calculation</button>

--- a/openquake/server/templates/engine/includes/impact_run_form.html
+++ b/openquake/server/templates/engine/includes/impact_run_form.html
@@ -45,11 +45,12 @@
                 <label for"station_data_file_from_usgs">{{ impact_form_labels.station_data_file_from_usgs }}</label>
                 <input class="impact-input" type="hidden" id="station_data_file_from_usgs" name="station_data_file_from_usgs" placeholder="{{ impact_form_placeholders.station_data_file_from_usgs }}" disabled />
                 <input class="impact-input" type="text" id="station_data_file_loaded" name="station_data_file_loaded" disabled />
+                <button type="button" id="clearStationDataFromUsgs">Clear Data</button>
               </div>
               <div class="impact_form_row hidden-for-shakemap hidden">
                 <label for"station_data_file">{{ impact_form_labels.station_data_file }}</label>
                 <input class="impact-input" type="file" id="station_data_file_input" name="station_data_file" placeholder="{{ impact_form_placeholders.station_data_file }}" {% if user_level != 2 %}disabled{% endif %}>
-                {% if user_level == 2 %}<button type="button" id="clearStationDataFile">Clear File</button>{% endif %}
+                <button type="button" id="clearStationDataFile">Clear File</button>
               </div>
               <div class="impact_form_row hidden-for-shakemap hidden">
                 <label for"maximum_distance_stations">{{ impact_form_labels.maximum_distance_stations }}</label>

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -791,7 +791,8 @@ def impact_run(request):
         station_data_file = station_data_file_from_usgs
     user = request.user
     user.testdir = None
-    # at this stage, do not attempt to re-load station data from the USGS
+    # at this stage, do not attempt to re-load station data from the USGS if they are
+    # missing or if the user explicitly decided to ignore them
     _rup, rupdic, params, err = impact_validate(
         request.POST, user, rupture_path, station_data_file,
         download_usgs_stations=False)


### PR DESCRIPTION
This is a step forward, although specifications indicate that we should not download stations at all unless the user explicitly presses a button to retrieve them. For now it was simpler to keep the workflow as it was (automatically downloading stations if available, contextually to the retrieval of other USGS data), and then allowing the user to press a button to discard stations before running the calculation.