### PR TITLE
Fix the `Use point rupture from the USGS` approach

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -858,6 +858,8 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
     if not rup_data:
         # in parsers_test
         try:
+            if approach == 'use_pnt_rup_from_usgs':
+                rupdic['msr'] = 'PointMSR'
             rup = build_planar_rupture_from_dict(rupdic)
         except ValueError as exc:
             err = {"status": "failed", "error_msg": str(exc)}

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -812,15 +812,14 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
             err = {"status": "failed", "error_msg": str(exc)}
         return rup, rupdic, err
 
-    if rupture_file and rupture_file.endswith('.xml'):
-        rup, rupdic, err = _get_rup_dic_from_xml(
-            usgs_id, user, rupture_file, station_data_file)
+    if rupture_file:
+        if rupture_file.endswith('.xml'):
+            rup, rupdic, err = _get_rup_dic_from_xml(
+                usgs_id, user, rupture_file, station_data_file)
+        elif rupture_file.endswith('.json'):
+            rup, rupdic, rup_data = _get_rup_from_json(usgs_id, rupture_file,
+                                                       station_data_file)
         if err or usgs_id == 'FromFile':
-            return rup, rupdic, err
-    elif rupture_file and rupture_file.endswith('.json'):
-        rup, rupdic, rup_data = _get_rup_from_json(usgs_id, rupture_file,
-                                                   station_data_file)
-        if usgs_id == 'FromFile':
             return rup, rupdic, err
 
     assert usgs_id

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -761,6 +761,18 @@ def _get_rup_dic_from_xml(usgs_id, user, rupture_file, station_data_file):
     return rup, rupdic, err
 
 
+def _get_rup_from_json(usgs_id, rupture_file, station_data_file):
+    rup = None
+    rupdic = {}
+    with open(rupture_file) as f:
+        rup_data = json.load(f)
+    if usgs_id == 'FromFile':
+        rupdic = convert_rup_data(rup_data, usgs_id, rupture_file)
+        rupdic['station_data_file'] = station_data_file
+        rup = convert_to_oq_rupture(rup_data)
+    return rup, rupdic, rup_data
+
+
 def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
                 use_shakemap=False, rupture_file=None,
                 station_data_file=None, download_usgs_stations=True,
@@ -806,12 +818,9 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
         if err or usgs_id == 'FromFile':
             return rup, rupdic, err
     elif rupture_file and rupture_file.endswith('.json'):
-        with open(rupture_file) as f:
-            rup_data = json.load(f)
+        rup, rupdic, rup_data = _get_rup_from_json(usgs_id, rupture_file,
+                                                   station_data_file)
         if usgs_id == 'FromFile':
-            rupdic = convert_rup_data(rup_data, usgs_id, rupture_file)
-            rupdic['station_data_file'] = station_data_file
-            rup = convert_to_oq_rupture(rup_data)
             return rup, rupdic, err
 
     assert usgs_id

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -117,6 +117,15 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['msr'], '')
         self.assertEqual(dic['aspect_ratio'], 2.0)
 
+    def test_8(self):
+        dic_in = {'usgs_id': 'us6000jllz', 'lon': 37.0143, 'lat': 37.2256,
+                  'dep': 10.0, 'mag': 7.8, 'rake': 0.0}
+        rup, dic, _err = get_rup_dic(
+            dic_in, user=user, approach='use_pnt_rup_from_usgs', use_shakemap=True)
+        self.assertEqual(dic['msr'], 'PointMSR')
+        self.assertAlmostEqual(rup.surface.length, 0.0133224)
+        self.assertAlmostEqual(rup.surface.width, 0.0070800)
+
 
 """
 NB: to profile a test you can use

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -747,7 +747,8 @@ def impact_get_rupture_data(request):
             with_cities=False, return_base64=True, rupture=rup)
         del rupdic['shakemap_array']
     elif rup is not None:
-        img_base64 = plot_rupture(rup, figsize=(8, 8), return_base64=True)
+        img_base64 = plot_rupture(rup, backend='Agg', figsize=(8, 8),
+                                  return_base64=True)
         rupdic['rupture_png'] = img_base64
     return HttpResponse(content=json.dumps(rupdic), content_type=JSON,
                         status=200)


### PR DESCRIPTION
I also fixed another little bug: the webui was calling the function to plot the rupture in interactive mode instead of using the appropriate non-interactive backend, causing a warning and potential issues.