### PR TITLE
Fix the management of rake, dip and strike

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -811,7 +811,6 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
         except ValueError as exc:
             err = {"status": "failed", "error_msg": str(exc)}
         return rup, rupdic, err
-
     if rupture_file:
         if rupture_file.endswith('.xml'):
             rup, rupdic, err = _get_rup_dic_from_xml(
@@ -833,6 +832,7 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
             if err:
                 return None, None, err
             if approach == 'build_rup_from_usgs':
+                rupdic['require_dip_strike'] = True
                 rupdic['nodal_planes'], err = _get_nodal_planes(properties)
                 if err:
                     return None, None, err
@@ -840,7 +840,6 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
                     rupdic.update(rupdic['nodal_planes']['NP1'])
         else:
             rupdic = dic.copy()
-            rupdic['require_dip_strike'] = True
     elif ('download/rupture.json' not in contents
           or approach == 'use_finite_rup_from_usgs'):
         # happens for us6000f65h in parsers_test

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -828,7 +828,7 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
     if err:
         return None, None, err
     if approach in ['use_pnt_rup_from_usgs', 'build_rup_from_usgs']:
-        if dic.get('lon', None) is None:  # do not override user-inserted values if present
+        if dic.get('lon', None) is None:  # don't override user-inserted values
             rupdic, err = load_rupdic_from_origin(usgs_id, properties['products'])
             if err:
                 return None, None, err
@@ -852,8 +852,7 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
     if not rup_data and approach not in ['use_pnt_rup_from_usgs',
                                          'build_rup_from_usgs']:
         with monitor('Downloading rupture json'):
-            rup_data, rupture_file = download_rupture_data(
-                usgs_id, contents, user)
+            rup_data, rupture_file = download_rupture_data(usgs_id, contents, user)
     if not rupdic:
         rupdic = convert_rup_data(rup_data, usgs_id, rupture_file, shakemap)
     if (approach != 'use_shakemap_from_usgs' and not station_data_file

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -773,7 +773,7 @@ def _get_rup_from_json(usgs_id, rupture_file, station_data_file):
     return rup, rupdic, rup_data
 
 
-def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
+def get_rup_dic(dic, user=User(),
                 use_shakemap=False, rupture_file=None,
                 station_data_file=None, download_usgs_stations=True,
                 monitor=performance.Monitor()):
@@ -787,8 +787,6 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
 
     :param dic: dictionary with ShakeMap ID and other parameters
     :param user: User instance
-    :param approach: the workflow selected by the user
-        (default: 'use_shakemap_from_usgs')
     :param use_shakemap: download the ShakeMap only if True
     :param rupture_file: None
     :param station_data_file: None
@@ -800,6 +798,7 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
     rup_data = {}
     err = {}
     usgs_id = dic['usgs_id']
+    approach = dic['approach']
     rup = None
     if approach == 'provide_rup_params':
         rupdic = dic.copy()
@@ -811,7 +810,6 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
         except ValueError as exc:
             err = {"status": "failed", "error_msg": str(exc)}
         return rup, rupdic, err
-
     if rupture_file:
         if rupture_file.endswith('.xml'):
             rup, rupdic, err = _get_rup_dic_from_xml(

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -811,6 +811,7 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
         except ValueError as exc:
             err = {"status": "failed", "error_msg": str(exc)}
         return rup, rupdic, err
+
     if rupture_file:
         if rupture_file.endswith('.xml'):
             rup, rupdic, err = _get_rup_dic_from_xml(
@@ -832,7 +833,6 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
             if err:
                 return None, None, err
             if approach == 'build_rup_from_usgs':
-                rupdic['require_dip_strike'] = True
                 rupdic['nodal_planes'], err = _get_nodal_planes(properties)
                 if err:
                     return None, None, err
@@ -840,6 +840,7 @@ def get_rup_dic(dic, user=User(), approach='use_shakemap_from_usgs',
                     rupdic.update(rupdic['nodal_planes']['NP1'])
         else:
             rupdic = dic.copy()
+            rupdic['require_dip_strike'] = True
     elif ('download/rupture.json' not in contents
           or approach == 'use_finite_rup_from_usgs'):
         # happens for us6000f65h in parsers_test

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -106,7 +106,7 @@ class ShakemapParsersTestCase(unittest.TestCase):
 
     def test_7(self):
         dic_in = {'usgs_id': 'us6000jllz', 'lon': None, 'lat': None, 'dep': None,
-                  'mag': None, 'msr': '', 'aspect_ratio': 2.0, 'rake': None,
+                  'mag': None, 'msr': '', 'aspect_ratio': 2, 'rake': None,
                   'dip': None, 'strike': None}
         _rup, dic, _err = get_rup_dic(
             dic_in, user=user, approach='build_rup_from_usgs', use_shakemap=True)
@@ -114,8 +114,6 @@ class ShakemapParsersTestCase(unittest.TestCase):
             dic['nodal_planes'],
             {'NP1': {'dip': 88.71, 'rake': -179.18, 'strike': 317.63},
              'NP2': {'dip': 89.18, 'rake': -1.29, 'strike': 227.61}})
-        self.assertEqual(dic['msr'], '')
-        self.assertEqual(dic['aspect_ratio'], 2.0)
 
     def test_8(self):
         dic_in = {'usgs_id': 'us6000jllz', 'lon': 37.0143, 'lat': 37.2256,
@@ -125,6 +123,31 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['msr'], 'PointMSR')
         self.assertAlmostEqual(rup.surface.length, 0.0133224)
         self.assertAlmostEqual(rup.surface.width, 0.0070800)
+
+    def test_9(self):
+        dic_in = {'usgs_id': 'us6000jllz', 'lon': 37.0143, 'lat': 37.2256, 'dep': 10,
+                  'mag': 7.8, 'msr': 'WC1994', 'aspect_ratio': 3,
+                  'rake': -179.18, 'dip': 88.71, 'strike': 317.63}
+        _rup, dic, _err = get_rup_dic(
+            dic_in, user=user, approach='build_rup_from_usgs', use_shakemap=True)
+        self.assertEqual(dic['dep'], 10)
+        self.assertEqual(dic['dip'], 88.71)
+        self.assertEqual(dic['lat'], 37.2256)
+        self.assertEqual(dic['lon'], 37.0143)
+        self.assertEqual(dic['mag'], 7.8)
+        self.assertEqual(dic['msr'], 'WC1994')
+        self.assertEqual(dic['rake'], -179.18)
+        self.assertEqual(dic['strike'], 317.63)
+        self.assertEqual(dic['require_dip_strike'], True)
+        self.assertEqual(dic['aspect_ratio'], 3)
+
+    def test_10(self):
+        dic_in = {'usgs_id': 'us6000jllz', 'lon': 37.0143, 'lat': 37.2256, 'dep': 10.0,
+                  'mag': 7.8, 'msr': 'WC1994', 'aspect_ratio': 2.0,
+                  'rake': -179.18, 'dip': 88.71, 'strike': 317.63}
+        _rup, _dic, err = get_rup_dic(
+            dic_in, user=user, approach='build_rup_from_usgs', use_shakemap=True)
+        self.assertIn('The depth must be greater', err['error_msg'])
 
 
 """

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -41,25 +41,25 @@ class ShakemapParsersTestCase(unittest.TestCase):
     def test_1(self):
         # wrong usgs_id
         _rup, _rupdic, err = get_rup_dic(
-            {'usgs_id': 'usp0001cc'}, User(level=2, testdir=''),
-            'use_shakemap_from_usgs', use_shakemap=True)
+            {'usgs_id': 'usp0001cc', 'approach': 'use_shakemap_from_usgs'},
+            User(level=2, testdir=''), use_shakemap=True)
         self.assertIn('Unable to download from https://earthquake.usgs.gov/fdsnws/'
                       'event/1/query?eventid=usp0001cc&', err['error_msg'])
 
     def test_2(self):
         _rup, dic, _err = get_rup_dic(
-            {'usgs_id': 'usp0001ccb'}, user=user, approach='use_shakemap_from_usgs',
-            use_shakemap=True)
+                {'usgs_id': 'usp0001ccb', 'approach': 'use_shakemap_from_usgs'},
+                user=user, use_shakemap=True)
         self.assertIsNotNone(dic['shakemap_array'])
         _rup, dic, _err = get_rup_dic(
-            {'usgs_id': 'usp0001ccb'}, user=user, approach='use_shakemap_from_usgs',
-            use_shakemap=False)
+            {'usgs_id': 'usp0001ccb', 'approach': 'use_shakemap_from_usgs'},
+            user=user, use_shakemap=False)
         self.assertIsNone(dic['shakemap_array'])
 
     def test_3(self):
         _rup, dic, _err = get_rup_dic(
-            {'usgs_id': 'us6000f65h'}, user=user, approach='use_pnt_rup_from_usgs',
-            use_shakemap=True)
+            {'usgs_id': 'us6000f65h', 'approach': 'use_pnt_rup_from_usgs'},
+            user=user, use_shakemap=True)
         self.assertEqual(dic['lon'], -73.4822)
         self.assertEqual(dic['lat'], 18.4335)
         self.assertEqual(dic['dep'], 10.0)
@@ -78,8 +78,8 @@ class ShakemapParsersTestCase(unittest.TestCase):
     def test_4(self):
         # point_rup
         _rup, dic, _err = get_rup_dic(
-            {'usgs_id': 'us6000jllz'}, user=user, approach='use_shakemap_from_usgs',
-            use_shakemap=True)
+            {'usgs_id': 'us6000jllz', 'approach': 'use_shakemap_from_usgs'},
+            user=user, use_shakemap=True)
         self.assertEqual(dic['lon'], 37.0143)
         self.assertEqual(dic['lat'], 37.2256)
         self.assertEqual(dic['dep'], 10.)
@@ -88,8 +88,8 @@ class ShakemapParsersTestCase(unittest.TestCase):
     def test_5(self):
         # 12 vertices instead of 4 in rupture.json
         rup, dic, _err = get_rup_dic(
-            {'usgs_id': 'us20002926'}, user=user, approach='use_shakemap_from_usgs',
-            use_shakemap=True)
+            {'usgs_id': 'us20002926', 'approach': 'use_shakemap_from_usgs'},
+            user=user, use_shakemap=True)
         self.assertIsNone(rup)
         self.assertEqual(dic['require_dip_strike'], True)
         self.assertEqual(dic['rupture_issue'],
@@ -97,8 +97,8 @@ class ShakemapParsersTestCase(unittest.TestCase):
 
     def test_6(self):
         _rup, dic, _err = get_rup_dic(
-            {'usgs_id': 'usp0001ccb'}, user=user, approach='use_pnt_rup_from_usgs',
-            use_shakemap=True)
+            {'usgs_id': 'usp0001ccb', 'approach': 'use_pnt_rup_from_usgs'},
+            user=user, use_shakemap=True)
         self.assertEqual(dic['mag'], 6.7)
         self.assertEqual(dic['require_dip_strike'], True)
         self.assertEqual(dic['station_data_issue'],
@@ -107,9 +107,8 @@ class ShakemapParsersTestCase(unittest.TestCase):
     def test_7(self):
         dic_in = {'usgs_id': 'us6000jllz', 'lon': None, 'lat': None, 'dep': None,
                   'mag': None, 'msr': '', 'aspect_ratio': 2, 'rake': None,
-                  'dip': None, 'strike': None}
-        _rup, dic, _err = get_rup_dic(
-            dic_in, user=user, approach='build_rup_from_usgs', use_shakemap=True)
+                  'dip': None, 'strike': None, 'approach': 'build_rup_from_usgs'}
+        _rup, dic, _err = get_rup_dic(dic_in, user=user, use_shakemap=True)
         self.assertEqual(
             dic['nodal_planes'],
             {'NP1': {'dip': 88.71, 'rake': -179.18, 'strike': 317.63},
@@ -117,9 +116,9 @@ class ShakemapParsersTestCase(unittest.TestCase):
 
     def test_8(self):
         dic_in = {'usgs_id': 'us6000jllz', 'lon': 37.0143, 'lat': 37.2256,
-                  'dep': 10.0, 'mag': 7.8, 'rake': 0.0}
-        rup, dic, _err = get_rup_dic(
-            dic_in, user=user, approach='use_pnt_rup_from_usgs', use_shakemap=True)
+                  'dep': 10.0, 'mag': 7.8, 'rake': 0.0,
+                  'approach': 'use_pnt_rup_from_usgs'}
+        rup, dic, _err = get_rup_dic(dic_in, user=user, use_shakemap=True)
         self.assertEqual(dic['msr'], 'PointMSR')
         self.assertAlmostEqual(rup.surface.length, 0.0133224)
         self.assertAlmostEqual(rup.surface.width, 0.0070800)
@@ -127,9 +126,9 @@ class ShakemapParsersTestCase(unittest.TestCase):
     def test_9(self):
         dic_in = {'usgs_id': 'us6000jllz', 'lon': 37.0143, 'lat': 37.2256, 'dep': 10,
                   'mag': 7.8, 'msr': 'WC1994', 'aspect_ratio': 3,
-                  'rake': -179.18, 'dip': 88.71, 'strike': 317.63}
-        _rup, dic, _err = get_rup_dic(
-            dic_in, user=user, approach='build_rup_from_usgs', use_shakemap=True)
+                  'rake': -179.18, 'dip': 88.71, 'strike': 317.63,
+                  'approach': 'build_rup_from_usgs'}
+        _rup, dic, _err = get_rup_dic(dic_in, user=user, use_shakemap=True)
         self.assertEqual(dic['dep'], 10)
         self.assertEqual(dic['dip'], 88.71)
         self.assertEqual(dic['lat'], 37.2256)
@@ -144,9 +143,19 @@ class ShakemapParsersTestCase(unittest.TestCase):
     def test_10(self):
         dic_in = {'usgs_id': 'us6000jllz', 'lon': 37.0143, 'lat': 37.2256, 'dep': 10.0,
                   'mag': 7.8, 'msr': 'WC1994', 'aspect_ratio': 2.0,
-                  'rake': -179.18, 'dip': 88.71, 'strike': 317.63}
+                  'rake': -179.18, 'dip': 88.71, 'strike': 317.63,
+                  'approach': 'build_rup_from_usgs'}
         _rup, _dic, err = get_rup_dic(
-            dic_in, user=user, approach='build_rup_from_usgs', use_shakemap=True)
+            dic_in, user=user, use_shakemap=True)
+        self.assertIn('The depth must be greater', err['error_msg'])
+
+    def test_11(self):
+        dic_in = {'usgs_id': 'UserProvided', 'lon': -9, 'lat': 43, 'dep': 10,
+                  'mag': 8.5, 'msr': 'WC1994', 'aspect_ratio': 1,
+                  'rake': 90, 'dip': 90, 'strike': 0,
+                  'approach': 'provide_rup_params'}
+        _rup, _dic, err = get_rup_dic(
+            dic_in, user=user, use_shakemap=False)
         self.assertIn('The depth must be greater', err['error_msg'])
 
 

--- a/openquake/hazardlib/tests/shakemap/validate_test.py
+++ b/openquake/hazardlib/tests/shakemap/validate_test.py
@@ -61,13 +61,6 @@ class AristotleValidateTestCase(unittest.TestCase):
         self.assertIn('stations', rupdic['station_data_file'])
         self.assertEqual(err, {})
 
-    def test_1c(self):
-        # giving a ValueError with aspect_ratio 2
-        POST = {'usgs_id': 'us6000jllz', 'approach': 'build_rup_from_usgs',
-                'msr': 'WC1994', 'aspect_ratio': '2'}
-        _rup, _rupdic, _params, err = impact_validate(POST, user)
-        self.assertIn('The depth must be greater', err['error_msg'])
-
     def test_2(self):
         POST = {'usgs_id': 'us7000n05d', 'approach': 'build_rup_from_usgs',
                 'msr': ''}

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -751,8 +751,6 @@ function capitalizeFirstLetter(val) {
                     else if (data.require_dip_strike) {
                         $('#dip').prop('disabled', false);
                         $('#strike').prop('disabled', false);
-                        $('#dip').val('90');
-                        $('#strike').val('0');
                     } else {
                         $('#dip').prop('disabled', true);
                         $('#strike').prop('disabled', true);


### PR DESCRIPTION
When collecting rupture data, use the dip, rake and strike of the first available nodal plane. After customizing parameters in the form, those are taken into account when re-building the rupture.

I also fixed the management of the `msr` for the 'Provide earthquake rupture parameters' workflow. Doing that, I noticed that `msr` and `approach` were not validated, so I added them to the validation process and rearranged the propagation of some variables.