### PR TITLE
Fixed `oq plot?hcurves`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed `oq plot?hcurves`: the disaggregation PoEs were plotted in linear
+    scale and not in logarithmic scale
   * Internal: introduced parameter `config.memory.gmf_data_rows`
 
   [Marco Pagani, Michele Simionato]

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -100,12 +100,13 @@ def make_figure_hcurves(extractors, what):
         ax.set_xlabel('%s, site %s, inv_time=%dy' %
                       (imt, site, oq.investigation_time))
         ax.set_ylabel('PoE')
+        ax.set_xlabel('acceleration')
         for ck, arr in got.items():
             if (arr == 0).all():
                 logging.warning('There is a zero curve %s_%s', *ck)
             ax.loglog(imls, arr.flat, '-', label='%s_%s' % ck)
         for poe in oq.poes:
-            ax.plot(imls, [poe]*len(imls), label=f'{poe=}')
+            ax.loglog(imls, [poe]*len(imls), label=f'{poe=}')
         ax.grid(True)
         ax.legend()
     return plt

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -640,7 +640,7 @@ class SourceModelLogicTree(object):
         if abs(weight_sum - 1.0) > pmf.PRECISION:
             raise LogicTreeError(
                 branchset_node, self.filename,
-                "branchset weights don't sum up to 1.0")
+                f"branchset weights sum up to {weight_sum}, not 1")
         if ''.join(values) and len(set(values)) < len(values):
             raise LogicTreeError(
                 branchset_node, self.filename,


### PR DESCRIPTION
 The disaggregation PoEs were plotted in linear scale and not in logarithmic scale. Also, improved the error message for weights not summing up to 1.