### PR TITLE
Provide a feedback in case of SiteAssociationError

### DIFF
--- a/openquake/calculators/postproc/plots.py
+++ b/openquake/calculators/postproc/plots.py
@@ -229,7 +229,10 @@ def plot_rupture(rup, backend=None, figsize=(10, 10),
         import matplotlib
         matplotlib.use(backend)
     _fig, ax = plt.subplots(figsize=figsize)
-    ax.set_title(f"length={rup.surface.length}, width={rup.surface.width}")
+    if hasattr(rup.surface, 'length') and hasattr(rup.surface, 'width'):
+        ax.set_title(f"length={rup.surface.length}, width={rup.surface.width}")
+    elif hasattr(rup.surface, 'get_width') and hasattr(rup.surface, 'get_area'):
+        ax.set_title(f"width={rup.surface.get_width()}, area={rup.surface.get_area()}")
     ax.set_aspect('equal')
     ax.grid(True)
     ax, min_x, min_y, max_x, max_y = add_rupture(ax, rup)

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -27,6 +27,7 @@ from openquake.commonlib import readinput
 from openquake.commonlib.calc import get_close_mosaic_models
 from openquake.hazardlib.shakemap.parsers import get_rup_dic
 from openquake.qa_tests_data import mosaic
+from openquake.hazardlib.geo.utils import SiteAssociationError
 
 MOSAIC_DIR = config.directory.mosaic_dir or os.path.dirname(mosaic.__file__)
 
@@ -305,8 +306,12 @@ def impact_validate(POST, user, rupture_file=None, station_data_file=None,
         params['station_data_file'] = rupdic['station_data_file']
         with monitor('get_oqparams'):
             ap = AristotleParam(**params)
-            oqparams = ap.get_oqparams(
-                dic['usgs_id'], mosaic_models, trts, use_shakemap)
+            try:
+                oqparams = ap.get_oqparams(
+                    dic['usgs_id'], mosaic_models, trts, use_shakemap)
+            except SiteAssociationError as exc:
+                oqparams = None
+                err = {"status": "failed", "error_msg": str(exc)}
         return rup, rupdic, oqparams, err
     else:  # called by impact_get_rupture_data
         return rup, rupdic, params, err

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -20,6 +20,7 @@ import os
 import unittest
 from openquake.hazardlib.shakemap.parsers import (
     get_rup_dic, User, utc_to_local_time)
+from openquake.hazardlib.source.rupture import BaseRupture
 
 user = User(level=2, testdir=os.path.join(os.path.dirname(__file__), 'data'))
 
@@ -157,6 +158,23 @@ class ShakemapParsersTestCase(unittest.TestCase):
         _rup, _dic, err = get_rup_dic(
             dic_in, user=user, use_shakemap=False)
         self.assertIn('The depth must be greater', err['error_msg'])
+
+    def test_12(self):
+        current_dir = os.path.dirname(__file__)
+        rupture_file_path = os.path.join(current_dir, 'data', 'fault_rupture.xml')
+        dic_in = {'usgs_id': 'FromFile', 'approach': 'provide_rup'}
+        rup, dic, _err = get_rup_dic(
+            dic_in, user=user, use_shakemap=False, rupture_file=rupture_file_path)
+        self.assertIsInstance(rup, BaseRupture)
+        self.assertEqual(dic['lon'], 84.4)
+        self.assertEqual(dic['lat'], 27.6)
+        self.assertEqual(dic['dep'], 30.0)
+        self.assertEqual(dic['mag'], 7.0)
+        self.assertEqual(dic['rake'], 90.0)
+        self.assertAlmostEqual(dic['strike'], 295.2473184)
+        self.assertAlmostEqual(dic['dip'], 30.0833517)
+        self.assertEqual(dic['usgs_id'], 'FromFile')
+        self.assertIn('.xml', dic['rupture_file'])
 
 
 """


### PR DESCRIPTION
I also added a test for the 'Provide earthquake rupture' approach.
There was also a problem when plotting the rupture, because some surfaces don't have the properties `length` and `width`. I added a check for that.

Question: in some rupture models used for tests the hypocenter is outside the boundaries of the rupture. Is it something that can happen also in real cases?
