### PR TITLE
Fixing Abrahamson and Gulerce 2020 site term to be exactly consistent with the paper

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+  [Christopher Brooks]
+  * Fixed the AbrahamsonGulerce2020 GMM's ln_zref equations to
+    match as detailed in equations 2.1 and 2.2 of the model's
+    paper.
+
   [Mara Mita, Catarina Costa]
   * Added new landslide models and replaced NewmarkDisplacement,
     GrantEtAl2016RockSlopeFailure, NowickiJessee2018Landslides

--- a/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
+++ b/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
@@ -288,7 +288,6 @@ def get_reference_basin_depth(region, vs30):
         find_mid = (vs30 > 200) & (vs30 < 570)
         ln_zref[find_mid] = 8.52 - 0.88 * np.log(vs30[find_mid]/200)
 
-
     elif region == "JPN":
         ln_zref = np.full_like(vs30, 7.3) # Low vs30 clip value (< 170 m/s)
         # High vs30 clip value
@@ -301,7 +300,7 @@ def get_reference_basin_depth(region, vs30):
     else:
         raise ValueError("No reference basin depth term defined for region %s"
                          % region)
-
+    
     return np.exp(ln_zref)
 
 

--- a/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
+++ b/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
@@ -280,12 +280,28 @@ def get_reference_basin_depth(region, vs30):
     on the Vs30, is returned according to equations 2.1 and 2.2
     """
     if region == "CAS":
-        ln_zref = np.clip(8.52 - 0.88 * np.log(vs30 / 200.0), 7.6, 8.52)
+        ln_zref = np.full_like(vs30, 8.52) # Low vs30 clip value (< 200 m/s)
+        # High vs30 clip value
+        find_upp = vs30 >= 570
+        ln_zref[find_upp] = 7.6
+        # Intermediate values are not clipped
+        find_mid = (vs30 > 200) & (vs30 < 570)
+        ln_zref[find_mid] = 8.52 - 0.88 * np.log(vs30[find_mid]/200)
+
+
     elif region == "JPN":
-        ln_zref = np.clip(7.3 - 2.066 * np.log(vs30 / 170.0), 4.1, 7.3)
+        ln_zref = np.full_like(vs30, 7.3) # Low vs30 clip value (< 170 m/s)
+        # High vs30 clip value
+        find_upp = vs30 > 800
+        ln_zref[find_upp] = 4.1
+        # Intermediate values are not clipped
+        find_mid = (vs30 > 170) & (vs30 <= 800)
+        ln_zref[find_mid] = 7.3 - 2.066 * np.log(vs30[find_mid] / 170.0)
+
     else:
         raise ValueError("No reference basin depth term defined for region %s"
                          % region)
+
     return np.exp(ln_zref)
 
 


### PR DESCRIPTION
The current computation of the ln_zref parameter for the AG2020 GMM is not exactly consistent with the corresponding equations provided in the `get_reference_basin_depth` function's docstring:

<img width="542" alt="image" src="https://github.com/user-attachments/assets/64c086ff-4a22-4e9d-8d5d-49180c138443" />

Initially a clipping was performed for only the intermediate values without dependency on the corresponding vs30. Here this dependency on the site vs30 is implemented. 