### PR TITLE
Separate LSE into LqSE (liquefaction) and LsSE (landslide)

### DIFF
--- a/doc/underlying-science/secondary-perils.rst
+++ b/doc/underlying-science/secondary-perils.rst
@@ -234,14 +234,14 @@ and the probability of liquefaction is calculated using equation (3). Zero proba
 
 The proposed probability threshold to convert to class outcome is 0.4.
 
-Another model's outcome is liquefaction spatial extent, :math:`LSE`. After an earthquake LSE is the spatial area 
+Another model's outcome is liquefaction spatial extent, :math:`LqSE`. After an earthquake, :math:`LqSE` is the spatial area 
 covered by surface manifestations of liquefaction reported as a percentage of liquefied material within that pixel. 
 Logistic regression with the same form was fit for the two models, with only difference in squaring the denominator to 
-improve the fit. The regression coefficients are given in Table 2.:
+improve the fit. The regression coefficients are given in Table 2.
 
 .. math::
 
-	L(P) = \frac{a}{\left( 1 + b\,e^{-c\,P} \right)^2} \\ (9)
+	LqSE(P) = \frac{a}{\left( 1 + b\,e^{-c\,P} \right)^2} \\ (9)
 
 .. raw:: latex
 
@@ -326,7 +326,7 @@ model proposed by `Rashidian et al. (2020) <https://www.sciencedirect.com/scienc
 as a base with slight changes to limit unrealistic extrapolations. The authors proposed capping the mean annual 
 precipitation at :math:`2500 \, \text{mm}`, and :math:`PGV = 150 \, \text{cm/s}`. The magnitude scaling factor 
 :math:`MSF`, explanatory variables, :math:`X`, probability of liquefaction, :math:`P(L)`, and liquefaction spatial 
-extent, :math:`LSE` are calculated using the set of equations previously shown. The proposed probability threshold to 
+extent, :math:`LqSE` are calculated using the set of equations previously shown. The proposed probability threshold to 
 convert to class outcome is 0.4.
 
 #######################
@@ -432,14 +432,13 @@ which is well suited for shallow disrupted slides, one of the most common landsl
 
 .. math::
 
-    F_{s} = \frac{cohesion'}{soildrydensity slabthickness \sin(slope)} + \frac{\tan(frictionangle')}{\tan(slope)} - \frac{saturationcoeff waterdensity \tan(frictionangle')}{soildrydensity \tan(slope)} \\(18)
+    F_{s} = \frac{cohesion'}{sdd\, slabth\, sin(slope)} + \frac{\tan(fricangle')}{\tan(slope)} - \frac{satcoeff\,  waterdensity\, tan(fricangle')}{sdd\, tan(slope)} \\(18)
 
 where: :math:`cohesion' \, [\text{Pa}]` is the effective cohesion with typical values ranging from :math:`20 \text{kPa}` for
-soils up to :math:`20 \, {MPa}` for unfaulted rocks. :math:`slope^\circ` is the slope angle. :math:`frictionangle'^\circ` is 
+soils up to :math:`20 \, {MPa}` for unfaulted rocks. :math:`slope^\circ` is the slope angle. :math:`fricangle'^\circ` is 
 the effective friction angle with typical values ranging from :math:`30^\circ` to :math:`40^\circ`. 
-:math:`\soildrydensity \, [\text{kg/m^3}]` is the dry density of the material. It ranges from :math:`1500 \, \text{kg/m^3}` 
-for soils to :math:`2500 - 3200 \, \text{kg/m^3}`. :math:`slabthickness` is the slope-normal thickness of a failure slab in meters and :math:`saturationcoeff` 
-is the proportion of slab thickness that is saturated. :math:`\waterdensity \, [\text{kg/m^3}]` 
+:math:`sdd \, [\text{kg/m^3}]` is the dry density of the material, :math:`slabth` is the slope-normal thickness of a failure slab in meters and :math:`satcoeff` 
+is the proportion of slab thickness that is saturated. :math:`waterdensity \, [\text{kg/m^3}]` 
 is the unit weight of water which equals to :math:`1000 \, \text{kg/m^3}`.
 
 Note that the units of the input parameters reported in this document corresponds to the format required by the Engine 
@@ -466,7 +465,7 @@ Model a
 
 .. math::
 	
-	\log(Disp_{cm}) = 0.215 + \log [\left( 1 - \frac{critaccel}{PGA}} \right)^{2.341} \cdot \left( \frac{critaccel}{PGA} \right)^{-1.438}] \\ (19)
+	\log(Disp_{cm}) = 0.215 + \log [\left( 1 - \frac{critaccel}{PGA} \right)^{2.341} \cdot \left( \frac{critaccel}{PGA} \right)^{-1.438}] \\ (19)
 
 Model b
 
@@ -639,17 +638,17 @@ Coefficients \alpha and \beta values are estimated for several rock and landcove
 reader is reffered to the original study by `Nowicki Jessee et al. (2018) <https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2017JF004494>`_, 
 where the coefficient values are reported in Table 3. 
 
-Probability of landsliding is then evaluated using logistic regression.
+Probability of landsliding is then evaluated using logistic regression:
 
 .. math::
 
 	P(L) = \frac{1}{1+e^X} \\ (35)
 
-These probabilities are converted to areal percentages to unbias the predictions.
+These probabilities are converted to areal percentages to unbias the predictions:
 
 .. math::
 
-	L_{P}(P) = e^{-7.592 + 5.237 \cdot P - 3.042 \cdot P^2 + 4.035 \cdot P^3} \\ (36)
+	LsSE(P) = e^{-7.592 + 5.237 \cdot P - 3.042 \cdot P^2 + 4.035 \cdot P^3} \\ (36)
 
 Furthermore, we introduced modifications by the USGS, capping the peak ground velocity at :math:`PGV = 211 \, \text{cm/s}`, 
 and compound topographic index at :math:`CTI = 19`. To exclude high probabilities of landsliding in nearly flat areas due to 

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -317,7 +317,7 @@ def ASH():
 
 
 # secondary IMTs
-sec_imts = 'Disp DispProb LiqProb LiqOccur LSE PGDMax LSD PGDGeomMean LsProb'.split()
+sec_imts = 'Disp DispProb LiqProb LiqOccur LqSE LsSE PGDMax LSD PGDGeomMean LsProb'.split()
 
 
 def Disp():
@@ -348,12 +348,19 @@ def LiqOccur():
     return IMT('LiqOccur')
 
 
-def LSE():
+def LqSE():
     """
-    Liquefaction or Landslide spatial extent.
+    Liquefaction spatial extent.
     """
-    return IMT('LSE')
+    return IMT('LqSE')
 
+
+def LsSE():
+    """
+    Landslide spatial extent.
+    """
+    return IMT('LsSE')
+    
 
 def PGDMax(vert_settlement, lat_spread):
     """

--- a/openquake/sep/classes.py
+++ b/openquake/sep/classes.py
@@ -227,7 +227,7 @@ class ZhuEtAl2017LiquefactionCoastal(SecondaryPeril):
     to binary output via the predefined probability threshold.
     """
 
-    outputs = ["LiqProb", "LiqOccur", "LSE"]
+    outputs = ["LiqProb", "LiqOccur", "LqSE"]
 
     def __init__(
         self,
@@ -254,7 +254,7 @@ class ZhuEtAl2017LiquefactionCoastal(SecondaryPeril):
         out = []
         for im, gmf in imt_gmf:
             if im.string == "PGV":
-                prob_liq, out_class, lse = zhu_etal_2017_coastal(
+                prob_liq, out_class, lqse = zhu_etal_2017_coastal(
                     pgv=gmf,
                     vs30=sites.vs30,
                     dr=sites.dr,
@@ -263,7 +263,7 @@ class ZhuEtAl2017LiquefactionCoastal(SecondaryPeril):
                 )
             out.append(prob_liq)
             out.append(out_class)
-            out.append(lse)
+            out.append(lqse)
         return out
 
 
@@ -273,7 +273,7 @@ class ZhuEtAl2017LiquefactionGeneral(SecondaryPeril):
     to binary output via the predefined probability threshold.
     """
 
-    outputs = ["LiqProb", "LiqOccur", "LSE"]
+    outputs = ["LiqProb", "LiqOccur", "LqSE"]
 
     def __init__(
         self,
@@ -300,7 +300,7 @@ class ZhuEtAl2017LiquefactionGeneral(SecondaryPeril):
         out = []
         for im, gmf in imt_gmf:
             if im.string == "PGV":
-                prob_liq, out_class, lse = zhu_etal_2017_general(
+                prob_liq, out_class, lqse = zhu_etal_2017_general(
                     pgv=gmf,
                     vs30=sites.vs30,
                     dw=sites.dw,
@@ -309,7 +309,7 @@ class ZhuEtAl2017LiquefactionGeneral(SecondaryPeril):
                 )
             out.append(prob_liq)
             out.append(out_class)
-            out.append(lse)
+            out.append(lqse)
         return out
 
 
@@ -319,7 +319,7 @@ class RashidianBaise2020Liquefaction(SecondaryPeril):
     to binary output via the predefined probability threshold.
     """
 
-    outputs = ["LiqProb", "LiqOccur", "LSE"]
+    outputs = ["LiqProb", "LiqOccur", "LqSE"]
 
     def __init__(
         self,
@@ -358,7 +358,7 @@ class RashidianBaise2020Liquefaction(SecondaryPeril):
             raise ValueError(
                 "Both PGA and PGV are required to compute liquefaction probability using the RashidianBaise2020Liquefaction model"
             )
-        prob_liq, out_class, lse = rashidian_baise_2020(
+        prob_liq, out_class, lqse = rashidian_baise_2020(
             pga=pga,
             pgv=pgv,
             vs30=sites.vs30,
@@ -368,7 +368,7 @@ class RashidianBaise2020Liquefaction(SecondaryPeril):
         )
         out.append(prob_liq)
         out.append(out_class)
-        out.append(lse)
+        out.append(lqse)
         return out
 
 
@@ -378,7 +378,7 @@ class AllstadtEtAl2022Liquefaction(SecondaryPeril):
     to binary output via the predefined probability threshold.
     """
 
-    outputs = ["LiqProb", "LiqOccur", "LSE"]
+    outputs = ["LiqProb", "LiqOccur", "LqSE"]
 
     def __init__(
         self,
@@ -417,7 +417,7 @@ class AllstadtEtAl2022Liquefaction(SecondaryPeril):
                 "probability using the AllstadtEtAl2022Liquefaction model"
             )
 
-        prob_liq, out_class, lse = allstadt_etal_2022(
+        prob_liq, out_class, lqse = allstadt_etal_2022(
             pga=pga,
             pgv=pgv,
             mag=mag,
@@ -428,7 +428,7 @@ class AllstadtEtAl2022Liquefaction(SecondaryPeril):
         )
         out.append(prob_liq)
         out.append(out_class)
-        out.append(lse)
+        out.append(lqse)
         return out
 
 
@@ -1049,7 +1049,7 @@ class NowickiJessee2018Landslides(SecondaryPeril):
     Computes the landslide probability from PGV and areal coverage.
     """
 
-    outputs = ["LsProb", "LSE"]
+    outputs = ["LsProb", "LsSE"]
 
     def __init__(
         self,
@@ -1090,7 +1090,7 @@ class NowickiJessee2018Landslides(SecondaryPeril):
                 "probability using the NowickiJessee2018Landslides model"
             )
         
-        prob_ls, lse = nowicki_jessee_2018(
+        prob_ls, lsse = nowicki_jessee_2018(
             pga = pga,
             pgv = pgv,
             slope=sites.slope,
@@ -1099,7 +1099,7 @@ class NowickiJessee2018Landslides(SecondaryPeril):
             cti=sites.cti,
         )
         out.append(prob_ls)
-        out.append(lse)
+        out.append(lsse)
             
         return out
         

--- a/openquake/sep/landslide/probability.py
+++ b/openquake/sep/landslide/probability.py
@@ -56,8 +56,8 @@ def sigmoid(x):
 
 
 def _landslide_spatial_extent(p: float):
-    """Calculates the landslide spatial extent (LSE) as per formulae 9
-    from the Reference. LSE after an earthquake can be interpreted as the
+    """Calculates the landslide spatial extent (LsSE) as per formulae 9
+    from the Reference. LsSE after an earthquake can be interpreted as the
     portion of each cell that is expected to have landslide occurrence.
 
     Reference: Nowicki Jessee, M. A., Hamburger, M. W., Allstadt, K., 
@@ -71,8 +71,8 @@ def _landslide_spatial_extent(p: float):
     b = 5.237
     c = -3.042
     d = 4.035
-    LSE = 100 *     np.exp(a + b * p + c * p**2 + d * p**3)
-    return LSE
+    LsSE = 100 * np.exp(a + b * p + c * p**2 + d * p**3)
+    return LsSE
 
     
 def nowicki_jessee_2018(
@@ -117,7 +117,7 @@ def nowicki_jessee_2018(
 
     :returns:
         prob_ls: Probability of landslide.
-        coverage: Landslide areal coverage.
+        LsSE: Landslide areal coverage.
     """
 
     if isinstance(lithology, str):
@@ -145,12 +145,12 @@ def nowicki_jessee_2018(
     )
 
     prob_ls = sigmoid(Xg)
-    LSE = _landslide_spatial_extent(prob_ls)
+    LsSE = _landslide_spatial_extent(prob_ls)
 
     # Slope cutoff proposed by Allstadt et al. (2022), minimum pga threshold proposed by Jibson and Harp (2016)
-    LSE = np.where((slope < 2) | (pga < 0.02), 0, LSE)
+    LsSE = np.where((slope < 2) | (pga < 0.02), 0, LsSE)
 
-    return prob_ls, LSE
+    return prob_ls, LsSE
     
     
 def jibson_etal_2000_probability(

--- a/openquake/sep/liquefaction/liquefaction.py
+++ b/openquake/sep/liquefaction/liquefaction.py
@@ -109,8 +109,8 @@ def _idriss_magnitude_weighting_factor(mag: float):
 
 def _liquefaction_spatial_extent(a: float, b: float, c: float, p: float):
     """
-    Calculates the liquefaction spatial extent (LSE) in % as per formulae 2
-    from the Reference. LSE after an earthquake is the spatial area covered
+    Calculates the liquefaction spatial extent (LqSE) in % as per formulae 2
+    from the Reference. LqSE after an earthquake is the spatial area covered
     by surface manifestations of liquefaction reported as a percentage of a
     pixel at a specific location on the map.
 
@@ -119,8 +119,8 @@ def _liquefaction_spatial_extent(a: float, b: float, c: float, p: float):
     Bulletin of the Seismological Society of America, 107(3), 1365–1385.
     https://doi.org/10.1785/0120160198
     """
-    LSE = a / (1 + b * np.exp(-c * p)) ** 2
-    return LSE
+    LqSE = a / (1 + b * np.exp(-c * p)) ** 2
+    return LqSE
 
 
 def zhu_etal_2015_general(
@@ -195,7 +195,7 @@ def zhu_etal_2017_coastal(
     The optimal threshold probability value to convert the predicted
     probability into binary classification is 0.4 (see p.13 from the
     Reference).
-    Liquefaction spatial extent (LSE) is calculated as per formulae 2 from the
+    Liquefaction spatial extent (LqSE) is calculated as per formulae 2 from the
     Reference. Model's coefficients are given in Table 6 (Model 1).
 
     Reference: Zhu, J., Baise, L. G., & Thompson, E. M. (2017).
@@ -219,7 +219,7 @@ def zhu_etal_2017_coastal(
         prob_liq: Probability of liquefaction at the site.
         out_class: Binary output 0 or 1, i.e., liquefaction nonoccurrence
                    or liquefaction occurrence occurrence.
-        LSE: Liquefaction spatial extent (in %).
+        LqSE: Liquefaction spatial extent (in %).
     """
     Xg = (
         pgv_coeff * np.log(pgv)
@@ -237,8 +237,8 @@ def zhu_etal_2017_coastal(
     # probability when VS30 > 620 m/s.
     prob_liq = np.where((pgv < 3.0) | (vs30 > 620), 0, prob_liq)
     out_class = np.where(prob_liq > 0.4, 1, 0)
-    LSE = _liquefaction_spatial_extent(42.08, 62.59, 11.43, prob_liq)
-    return prob_liq, out_class, LSE
+    LqSE = _liquefaction_spatial_extent(42.08, 62.59, 11.43, prob_liq)
+    return prob_liq, out_class, LqSE
 
 
 def zhu_etal_2017_general(
@@ -265,7 +265,7 @@ def zhu_etal_2017_general(
     The optimal threshold probability value to convert the predicted
     probability into binary classification is 0.4
     (see p.13 from the Reference).
-    Liquefaction spatial extent (LSE) is calculated as per formulae 2 from the
+    Liquefaction spatial extent (LqSE) is calculated as per formulae 2 from the
     Reference. Model's coefficients are given in Table 6 (Model 2).
 
     Reference: Zhu, J., Baise, L. G., & Thompson, E. M. (2017).
@@ -289,7 +289,7 @@ def zhu_etal_2017_general(
         prob_liq: Probability of liquefaction at the site.
         out_class: Binary output 0 or 1, i.e., liquefaction nonoccurrence
                    or liquefaction occurrence occurrence.
-        LSE: Liquefaction spatial extent (in %).
+        LqSE: Liquefaction spatial extent (in %).
     """
     Xg = (
         pgv_coeff * np.log(pgv_scaling_factor * pgv)
@@ -306,8 +306,8 @@ def zhu_etal_2017_general(
     # probability when VS30 > 620 m/s.
     prob_liq = np.where((pgv < 3.0) | (vs30 > 620), 0, prob_liq)
     out_class = np.where(prob_liq > 0.4, 1, 0)
-    LSE = _liquefaction_spatial_extent(49.15, 42.40, 9.165, prob_liq)
-    return prob_liq, out_class, LSE
+    LqSE = _liquefaction_spatial_extent(49.15, 42.40, 9.165, prob_liq)
+    return prob_liq, out_class, LqSE
 
 
 def rashidian_baise_2020(
@@ -336,7 +336,7 @@ def rashidian_baise_2020(
     The optimal threshold probability value to convert the predicted
     probability into binary classification is 0.4
     (see p.13 from Zhu et al., 2017).
-    Liquefaction spatial extent (LSE) is calculated as per formulae 3 from the
+    Liquefaction spatial extent (LqSE) is calculated as per formulae 3 from the
     Reference. Model's coefficients corresponds to the ones for Model 2 from
     Zhu et al., 2017.
 
@@ -386,8 +386,8 @@ def rashidian_baise_2020(
     prob_liq = np.where((pgv < 3.0) | (vs30 > 620), 0, prob_liq)
     prob_liq = np.where(pga < 0.1, 0, prob_liq)
     out_class = np.where(prob_liq > 0.4, 1, 0)
-    LSE = _liquefaction_spatial_extent(49.15, 42.40, 9.165, prob_liq)
-    return prob_liq, out_class, LSE
+    LqSE = _liquefaction_spatial_extent(49.15, 42.40, 9.165, prob_liq)
+    return prob_liq, out_class, LqSE
 
 
 def allstadt_etal_2022(
@@ -467,8 +467,8 @@ def allstadt_etal_2022(
     prob_liq = np.where((pgv < 3.0) | (vs30 > 620), 0, prob_liq)
     prob_liq = np.where(pga < 0.1, 0, prob_liq)
     out_class = np.where(prob_liq > 0.4, 1, 0)
-    LSE = _liquefaction_spatial_extent(49.15, 42.40, 9.165, prob_liq)
-    return prob_liq, out_class, LSE
+    LqSE = _liquefaction_spatial_extent(49.15, 42.40, 9.165, prob_liq)
+    return prob_liq, out_class, LqSE
 
 
 def akhlagi_etal_2021_model_a(

--- a/openquake/sep/tests/test_sep_suite_2.py
+++ b/openquake/sep/tests/test_sep_suite_2.py
@@ -119,7 +119,7 @@ class CaliSmallLandslideTestCase(unittest.TestCase):
         np.testing.assert_array_almost_equal(self.sites["newmark_disp"], nd)
 
     def test_nowicki_jessee_18(self):
-        prob_ls, coverage = nowicki_jessee_2018(
+        prob_ls, LsSE = nowicki_jessee_2018(
             pga=self.pga,
             pgv=self.pgv,
             slope=self.sites["slope"],
@@ -156,7 +156,7 @@ class CaliSmallLandslideTestCase(unittest.TestCase):
             ]
         )
         np.testing.assert_array_almost_equal(prob_ls, zlp)
-        np.testing.assert_array_almost_equal(coverage, cls)
+        np.testing.assert_array_almost_equal(LsSE, cls)
 
 
 class CaliSmallLiquefactionTestCase(unittest.TestCase):
@@ -245,7 +245,7 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
         np.testing.assert_array_almost_equal(out_class, clq)
 
     def test_zhu17_coastal(self):
-        prob_liq, out_class, LSE = zhu_etal_2017_coastal(
+        prob_liq, out_class, LqSE = zhu_etal_2017_coastal(
             pgv=self.pgv,
             vs30=self.sites["vs30"],
             dr=self.sites["dr"],
@@ -267,7 +267,7 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
             ]
         )
         clq = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        lse = np.array(
+        lqse = np.array(
             [
                 0.266467348,
                 0.039739528,
@@ -283,10 +283,10 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(prob_liq, zlp)
         np.testing.assert_array_almost_equal(out_class, clq)
-        np.testing.assert_array_almost_equal(LSE, lse)
+        np.testing.assert_array_almost_equal(LqSE, lqse)
 
     def test_zhu17_general(self):
-        prob_liq, out_class, LSE = zhu_etal_2017_general(
+        prob_liq, out_class, LqSE = zhu_etal_2017_general(
             pgv=self.pgv,
             vs30=self.sites["vs30"],
             dw=self.sites["dw"],
@@ -308,7 +308,7 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
             ]
         )
         clq = np.array([0, 0, 0, 0, 0, 1, 0, 0, 0, 0])
-        lse = np.array(
+        lqse = np.array(
             [
                 1.482171022,
                 0.277301525,
@@ -324,10 +324,10 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(prob_liq, zlp)
         np.testing.assert_array_almost_equal(out_class, clq)
-        np.testing.assert_array_almost_equal(LSE, lse)
+        np.testing.assert_array_almost_equal(LqSE, lqse)
 
     def test_rashidian_baise_2020(self):
-        prob_liq, out_class, LSE = rashidian_baise_2020(
+        prob_liq, out_class, LqSE = rashidian_baise_2020(
             pgv=self.pgv,
             pga=self.pga,
             vs30=self.sites["vs30"],
@@ -350,7 +350,7 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
             ]
         )
         clq = np.array([0, 0, 0, 0, 0, 1, 0, 0, 0, 0])
-        lse = np.array(
+        lqse = np.array(
             [
                 1.482171022,
                 0.277301525,
@@ -366,10 +366,10 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(prob_liq, zlp)
         np.testing.assert_array_almost_equal(out_class, clq)
-        np.testing.assert_array_almost_equal(LSE, lse)
+        np.testing.assert_array_almost_equal(LqSE, lqse)
 
     def test_allstadt_2022(self):
-        prob_liq, out_class, LSE = allstadt_etal_2022(
+        prob_liq, out_class, LqSE = allstadt_etal_2022(
             pgv=self.pgv,
             pga=self.pga,
             mag=self.mag,
@@ -393,7 +393,7 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
             ]
         )
         clq = np.array([0, 0, 0, 0, 0, 1, 0, 0, 0, 0])
-        lse = np.array(
+        lqse = np.array(
             [
                 1.417553345,
                 0.268584431,
@@ -409,7 +409,7 @@ class CaliSmallLiquefactionTestCase(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(prob_liq, zlp)
         np.testing.assert_array_almost_equal(out_class, clq)
-        np.testing.assert_array_almost_equal(LSE, lse)
+        np.testing.assert_array_almost_equal(LqSE, lqse)
 
     def test_akhlagi_2021_model_a(self):
         prob_liq, out_class = akhlagi_etal_2021_model_a(


### PR DESCRIPTION
To clearly distinguish between the Liquefaction and Landslide Speatial Extent, the original imt (LSE) was divided into LqSE (for liquefaction) and LsSE (for landslides).