### PR TITLE
Fix feedback in case of issues occurring while converting the rupture from the USGS format

### DIFF
--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -88,6 +88,14 @@ class ShakemapParsersTestCase(unittest.TestCase):
             user=user, use_shakemap=True)
         self.assertIn('Unable to retrieve rupture geometries', err['error_msg'])
 
+    def test_3d(self):
+        # TODO: make it possible to convert this kind of geometries
+        _rup, dic, _err = get_rup_dic(
+            {'usgs_id': 'us6000jllz', 'approach': 'use_finite_rup_from_usgs'},
+            user=user, use_shakemap=True)
+        self.assertIn('Unable to convert the rupture from the USGS format',
+                      dic['rupture_issue'])
+
     def test_4(self):
         # point_rup
         _rup, dic, _err = get_rup_dic(

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -729,8 +729,8 @@ function capitalizeFirstLetter(val) {
                     $('#rupture_from_usgs').val(data.rupture_from_usgs);
                     $('#rupture_from_usgs_loaded').val(data.rupture_from_usgs ? 'Loaded' : 'N.A.');
                     var conversion_issues = '';
-                    if ('error' in data) {  // data.error comes from the rupture dictionary and refers to rupture importing/converting
-                        conversion_issues += '<p>' + data.error + '</p>';
+                    if ('rupture_issue' in data) {
+                        conversion_issues += '<p>' + data.rupture_issue + '</p>';
                         $('#rupture_from_usgs_loaded').val('N.A. (conversion issue)');
                     }
                     // NOTE: these are stations downloaded from the USGS and not those uploaded by the user


### PR DESCRIPTION
In the current implementation, we can convert only cases that pass the following check:
https://github.com/gem/oq-engine/blob/56bdd92e23905e3b395e392e462ba31be02c6f6b/openquake/hazardlib/shakemap/parsers.py#L230

For instance, we still can not convert the rupture for usgs_id `us6000jllz`, that has the following coordinates:
`[[[36.273, 36.369, 1.0], [36.389, 36.547, 1.0], [36.394, 36.612, 1.0], [36.422, 36.671, 1.0], [36.453, 36.679, 1.0], [36.561, 36.874, 1.0], [36.646, 37.086, 1.0], [36.912, 37.4, 1.0], [37.108, 37.501, 1.0], [37.242, 37.537, 1.0], [37.438, 37.63, 1.0], [37.59, 37.738, 1.0], [37.761, 37.87, 1.0], [38.076, 37.95, 1.0], [38.273, 38.036, 1.0], [38.435, 38.056, 1.0], [38.435, 38.056, 16.0], [38.273, 38.036, 16.0], [38.076, 37.95, 16.0], [37.761, 37.87, 16.0], [37.59, 37.738, 16.0], [37.438, 37.63, 16.0], [37.242, 37.537, 16.0], [37.108, 37.501, 16.0], [36.912, 37.4, 16.0], [36.646, 37.086, 16.0], [36.561, 36.874, 16.0], [36.453, 36.679, 16.0], [36.422, 36.671, 16.0], [36.394, 36.612, 16.0], [36.389, 36.547, 16.0], [36.273, 36.369, 16.0], [36.273, 36.369, 1.0]], [[37.141, 37.333, 1.0], [37.178, 37.431, 1.0], [37.03, 37.17, 1.0], [37.03, 37.17, 16.0], [37.178, 37.431, 16.0], [37.141, 37.333, 16.0], [37.141, 37.333, 1.0]]]
`

Even if we relax the above constraint, we get errors afterwards, e.g. here:
https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/source/rupture.py#L913
https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/source/rupture.py#L891
I suppose we need support from the hazard team to make it possible to accept more complex geometries.

This PR fixes the feedback given to the user, that before was ignored because we recently changed the variable holding the information, but we forgot to retrieve the information from the new variable.