### PR TITLE
When switching between approaches, reset the impact forms to their defaults

### DIFF
--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -187,6 +187,11 @@ IMPACT_FORM_DEFAULTS = {
     'station_data_file': '',
     'maximum_distance_stations': '',
     'msr': 'WC1994',
+    'rupture_from_usgs_loaded': '',
+    'rupture_file_input': '',
+    'require_dip_strike': '',
+    'station_data_file_input': '',
+    'station_data_file_loaded': '',
 }
 
 

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -166,13 +166,16 @@ IMPACT_FORM_PLACEHOLDERS = {
 
 IMPACT_FORM_DEFAULTS = {
     'usgs_id': '',
+    'rupture_from_usgs': '',
+    'rupture_file': '',
     'lon': '',
     'lat': '',
     'dep': '',
     'mag': '',
-    'msr': 'WC1994',
     'aspect_ratio': '2',
     'rake': '',
+    'local_timestamp': '',
+    'time_event': 'day',
     'dip': '90',
     'strike': '0',
     'maximum_distance': '200',
@@ -180,7 +183,10 @@ IMPACT_FORM_DEFAULTS = {
     'number_of_ground_motion_fields': '100',
     'asset_hazard_distance': '15',
     'ses_seed': '42',
+    'station_data_file_from_usgs': '',
+    'station_data_file': '',
     'maximum_distance_stations': '',
+    'msr': 'WC1994',
 }
 
 

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -516,6 +516,22 @@ function capitalizeFirstLetter(val) {
         $('#rupture-map').hide();
     }
 
+    function reset_impact_forms() {
+        for (field in impact_form_defaults) {
+            var input = $('input#' + field);
+            if (input.length) {
+                input.val(impact_form_defaults[field]);
+            }
+        }
+        accessory_fields = ['rupture_from_usgs_loaded', 'rupture_file_input', 'require_dip_strike',
+                            'station_data_file_input', 'station_data_file_loaded']
+        for (field of accessory_fields) {
+            $('input#' + field).val('');
+        }
+        $('#rupture-map').hide();
+        $('#shakemap-image-row').hide();
+    }
+
     /* classic event management */
     $(document).ready(
         function () {
@@ -654,6 +670,7 @@ function capitalizeFirstLetter(val) {
             $('input[name="impact_approach"]').change(function () {
                 const selected_approach = $(this).val();
                 set_retrieve_data_btn_txt('initial');
+                reset_impact_forms();
                 if (approaches_requiring_usgs_id.includes(selected_approach)) {
                     $('#rupture_from_usgs_grp').removeClass('hidden');
                     $('#usgs_id_grp').removeClass('hidden');

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -523,11 +523,6 @@ function capitalizeFirstLetter(val) {
                 input.val(impact_form_defaults[field]);
             }
         }
-        accessory_fields = ['rupture_from_usgs_loaded', 'rupture_file_input', 'require_dip_strike',
-                            'station_data_file_input', 'station_data_file_loaded']
-        for (field of accessory_fields) {
-            $('input#' + field).val('');
-        }
         $('#rupture-map').hide();
         $('#shakemap-image-row').hide();
     }


### PR DESCRIPTION
Based on https://github.com/gem/oq-engine/pull/10391