### PR TITLE
Import `timezonefinder` at runtime as it was before

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -36,7 +36,6 @@ from dataclasses import dataclass
 import pandas as pd
 from datetime import datetime
 from zoneinfo import ZoneInfo
-from timezonefinder import TimezoneFinder
 from shapely.geometry import Polygon
 import numpy
 
@@ -243,6 +242,16 @@ def utc_to_local_time(utc_timestamp, lon, lat):
     """
     Convert a timestamp '%Y-%m-%dT%H:%M:%S.%fZ' into a datetime object
     """
+    try:
+        # NOTE: mandatory dependency for ARISTOTLE
+        from timezonefinder import TimezoneFinder
+    except ImportError:
+        raise ImportError(
+            'The python package "timezonefinder" is not installed. It is'
+            ' required in order to convert the UTC time to the local time of'
+            ' the event. You can install it from'
+            ' https://wheelhouse.openquake.org/v3/linux/ choosing the one'
+            ' corresponding to the installed python version.')
     tf = TimezoneFinder()
     timezone_str = tf.timezone_at(lng=lon, lat=lat)
     if timezone_str is None:


### PR DESCRIPTION
This reverts commit 8a1863fa4e52b065c191aa399ed34eecee0e5652, that broke the MBTK on windows (because `timezonefinder` was recently added to the requirements for Linux, where it's needed for oq-impact, but not to the requirements of the other operating systems).

