### PR TITLE
Make sure to build the rupture with user-specified values if available

### DIFF
--- a/openquake/baselib/tests/flake8_test.py
+++ b/openquake/baselib/tests/flake8_test.py
@@ -50,8 +50,13 @@ def _long_funcs(module, maxlen):
                 raise SyntaxError('%s has more than 15 arguments: %s'
                                   % (dotname, [a.arg for a in args]))
             doc = ast.get_docstring(node)
-            doclines = 0 if doc is None else doc.count('\n') + 1
-            numlines = node.end_lineno - node.lineno - doclines
+            # Adjust start line to skip the docstring if present
+            if (doc and isinstance(node.body[0], ast.Expr)
+                    and isinstance(node.body[0].value, ast.Constant)):
+                start_line = node.body[0].end_lineno + 1  # First line after docstring
+            else:
+                start_line = node.lineno + 1  # First line after function definition
+            numlines = node.end_lineno - start_line
             if numlines > maxlen:
                 out.append((dotname, numlines))
     return out
@@ -204,4 +209,3 @@ def test_get_basin_term():
             if args != ['C', 'ctx', 'region']:
                 msg = f'{mod.__name__}._get_basin_term has a wrong signature '
                 raise RuntimeError(msg + str(args))
-                    

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -827,8 +827,10 @@ def get_rup_dic(dic, user=User(),
     if err:
         return None, None, err
     if approach in ['use_pnt_rup_from_usgs', 'build_rup_from_usgs']:
+        rupdic = dic.copy()
         if dic.get('lon', None) is None:  # don't override user-inserted values
-            rupdic, err = load_rupdic_from_origin(usgs_id, properties['products'])
+            rupdic_, err = load_rupdic_from_origin(usgs_id, properties['products'])
+            rupdic.update(rupdic_)
             if err:
                 return None, None, err
             if approach == 'build_rup_from_usgs':
@@ -838,7 +840,6 @@ def get_rup_dic(dic, user=User(),
                 else:
                     rupdic.update(rupdic['nodal_planes']['NP1'])
         else:
-            rupdic = dic.copy()
             rupdic['require_dip_strike'] = True
     elif 'download/rupture.json' not in contents:
         # happens for us6000f65h in parsers_test

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -827,7 +827,7 @@ def get_rup_dic(dic, user=User(),
     if err:
         return None, None, err
     if approach in ['use_pnt_rup_from_usgs', 'build_rup_from_usgs']:
-        if dic.get('lon', None) is None:  # don't override user-inserted values
+        if dic.get('lon') is None:  # don't override user-inserted values
             rupdic, err = load_rupdic_from_origin(usgs_id, properties['products'])
             for key in dic:
                 if dic[key] is not None:

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -827,10 +827,11 @@ def get_rup_dic(dic, user=User(),
     if err:
         return None, None, err
     if approach in ['use_pnt_rup_from_usgs', 'build_rup_from_usgs']:
-        rupdic = dic.copy()
         if dic.get('lon', None) is None:  # don't override user-inserted values
-            rupdic_, err = load_rupdic_from_origin(usgs_id, properties['products'])
-            rupdic.update(rupdic_)
+            rupdic, err = load_rupdic_from_origin(usgs_id, properties['products'])
+            for key in dic:
+                if dic[key] is not None:
+                    rupdic[key] = dic[key]
             if err:
                 return None, None, err
             if approach == 'build_rup_from_usgs':
@@ -840,6 +841,7 @@ def get_rup_dic(dic, user=User(),
                 else:
                     rupdic.update(rupdic['nodal_planes']['NP1'])
         else:
+            rupdic = dic.copy()
             rupdic['require_dip_strike'] = True
     elif 'download/rupture.json' not in contents:
         # happens for us6000f65h in parsers_test


### PR DESCRIPTION
Without this change, when the user clicked the first time to retrieve rupture data and build the rupture, some values (e.g. the aspect ratio and the msr) were discarded, so the plot was wrong and it became correct only after pressing again the button to rebuild it.