### PR TITLE
Adding to Strasser Interface methods to compute lenght and width

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -95,6 +95,7 @@ Enrico Abcede            (@emabcede30)          September 2024
 Ilaria Oliveti           (@IlariaOliveti)       October 2024
 Catarina Costa           (@catarinaquintela)    February 2025
 Mara Mita                (@MaraMita)            February 2025
+Valeria Cascone          (@ValeriaCascone)      February 2025
 
 Project management
 ------------------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Marco Pagani, Valeria Cascone]
+  * Added an get_width and get_length methods to Strasser et al. (2010) MSR
+
   [Michele Simionato]
   * Added an input `mmi_shapes_file` for use in OQ Impact
 

--- a/openquake/hazardlib/scalerel/strasser2010.py
+++ b/openquake/hazardlib/scalerel/strasser2010.py
@@ -67,6 +67,32 @@ class StrasserInterface(BaseMSRSigma, BaseASRSigma):
         """
         return 0.286
 
+    def get_median_length(self, mag):
+        """
+        Get median length of the rupture given moment magnitude
+        """
+        return 10.0 ** (-2.477 + 0.585 * mag)
+
+    def get_std_dev_length(self, mag):
+        """
+        Get median length standard deviation of the rupture given moment
+        magnitude
+        """
+        return 0.180
+
+    def get_median_width(self, mag):
+        """
+        Get median width of the rupture given moment magnitude
+        """
+        return 10.0 ** (-0.882 + 0.351 * mag)
+
+    def get_std_dev_width(self, mag):
+        """
+        Get median width standard deviation of the rupture given moment
+        magnitude
+        """
+        return 0.173
+
 
 class StrasserIntraslab(BaseMSRSigma, BaseASRSigma):
     """

--- a/openquake/hazardlib/tests/scalerel/msr_test.py
+++ b/openquake/hazardlib/tests/scalerel/msr_test.py
@@ -63,6 +63,14 @@ class BaseMSRTestCase(unittest.TestCase):
         self.assertAlmostEqual(self.msr.get_median_mag(area, rake),
                                expected_value, places=places)
 
+    def _test_get_median_length(self, mag, expected_value, places=7):
+        self.assertAlmostEqual(self.msr.get_median_length(mag),
+                               expected_value, places=places)
+
+    def _test_get_median_width(self, mag, expected_value, places=7):
+        self.assertAlmostEqual(self.msr.get_median_width(mag),
+                               expected_value, places=places)
+
 
 class PeerMSRMSRTestCase(BaseMSRTestCase):
     MSR_CLASS = PeerMSR

--- a/openquake/hazardlib/tests/scalerel/strasser_test.py
+++ b/openquake/hazardlib/tests/scalerel/strasser_test.py
@@ -49,6 +49,22 @@ class StrasserInterfaceTestCase(BaseMSRTestCase):
         self._test_get_median_mag(1541.70045, None, 7.14, places=2)
         self._test_get_median_mag(13803.84265, None, 7.94, places=2)
 
+    def test_get_length(self):
+        """
+        Testing the calculation of rupture length
+        """
+        self._test_get_median_length(6.0, 10.78946722, places=3)
+        self._test_get_median_length(7.0, 41.49540426, places=3)
+        self._test_get_median_length(8.0, 159.58791472, places=3)
+
+    def test_get_width(self):
+        """
+        Testing the calculation of rupture length
+        """
+        self._test_get_median_width(6.0, 16.74942876, places=3)
+        self._test_get_median_width(7.0, 37.58374043, places=3)
+        self._test_get_median_width(8.0, 84.33347578, places=3)
+
 
 class StrasserIntraslabTestCase(BaseMSRTestCase):
     '''


### PR DESCRIPTION
This PR adds to the Strasser et al. MSR for interface ruptures two methods to compute length and width given moment magnitude