### PR TITLE
Extended `source_model.serialise_to_nrml` to accept mesh_spacing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Extended `source_model.serialise_to_nrml` to accept a `mesh_spacing`
+    parameter
+
   [Marco Pagani, Valeria Cascone]
   * Added an get_width and get_length methods to Strasser et al. (2010) MSR
 

--- a/openquake/hmtk/sources/source_model.py
+++ b/openquake/hmtk/sources/source_model.py
@@ -49,6 +49,7 @@ Module implements
 :class:`openquake.hmtk.sources.source_model.mtkSourceModel`, the
 general class to describe a set of seismogenic sources
 """
+
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.sourcewriter import write_source_model
 from openquake.hmtk.sources.point_source import mtkPointSource
@@ -94,7 +95,11 @@ class mtkSourceModel(object):
         return len(self.sources)
 
     def serialise_to_nrml(
-        self, filename, complex_mesh_spacing=2, use_defaults=False
+        self,
+        filename,
+        mesh_spacing=2,
+        complex_mesh_spacing=2,
+        use_defaults=False,
     ):
         """
         Writes the source model to a nrml source model file given by the
@@ -110,7 +115,7 @@ class mtkSourceModel(object):
         """
         source_model = self.convert_to_oqhazardlib(
             PoissonTOM(1.0),
-            2.0,
+            mesh_spacing,
             complex_mesh_spacing,
             10.0,
             use_defaults=use_defaults,

--- a/openquake/hmtk/tests/sources/test_source_model.py
+++ b/openquake/hmtk/tests/sources/test_source_model.py
@@ -115,7 +115,8 @@ class TestSourceModel(unittest.TestCase):
         parser = nrmlSourceModelParser(MODEL_PATH)
         source_model = parser.read_file(2.0)
         # Write to file
-        source_model.serialise_to_nrml(TEST_PATH, 10, True)
+        source_model.serialise_to_nrml(
+            TEST_PATH, complex_mesh_spacing=10, use_defaults=True)
         # Load file back
         parser = nrmlSourceModelParser(TEST_PATH)
         source_model_test = parser.read_file(2.0)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/10395.