### PR TITLE
Remove `require_dip_strike` and the corresponding logic

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -520,7 +520,6 @@ def load_rupdic_from_finite_fault(usgs_id, mag, products):
     rupdic = {'lon': lon, 'lat': lat, 'dep': float(p['depth']),
               'mag': mag, 'rake': 0.,
               'local_timestamp': str(local_time), 'time_event': time_event,
-              'require_dip_strike': True,
               'pga_map_png': None, 'mmi_map_png': None,
               'usgs_id': usgs_id, 'rupture_file': None}
     return rupdic, err
@@ -555,7 +554,6 @@ def load_rupdic_from_origin(usgs_id, products):
     rupdic = {'lon': lon, 'lat': lat, 'dep': dep,
               'mag': mag, 'rake': rake,
               'local_timestamp': str(local_time), 'time_event': time_event,
-              'require_dip_strike': True,
               'pga_map_png': None, 'mmi_map_png': None,
               'usgs_id': usgs_id, 'rupture_file': None}
     return rupdic, err
@@ -676,12 +674,8 @@ def download_mmi(usgs_id, shakemap_contents, user):
 def convert_rup_data(rup_data, usgs_id, rup_path, shakemap_array=None):
     """
     Convert JSON data coming from the USGS into a rupdic with keys
-    lon, lat, dep, mag, rake, local_timestamp, require_dip_strike, shakemap,
-    usgs_id, rupture_file
+    lon, lat, dep, mag, rake, local_timestamp, shakemap, usgs_id, rupture_file
     """
-    # geometry is Point for us7000n05d
-    feats = rup_data['features']
-    require_dip_strike = len(feats) == 1 and feats[0]['geometry']['type'] == 'Point'
     md = rup_data['metadata']
     lon = md['lon']
     lat = md['lat']
@@ -691,7 +685,6 @@ def convert_rup_data(rup_data, usgs_id, rup_path, shakemap_array=None):
     rupdic = {'lon': lon, 'lat': lat, 'dep': md['depth'],
               'mag': md['mag'], 'rake': md['rake'],
               'local_timestamp': str(local_time), 'time_event': time_event,
-              'require_dip_strike': require_dip_strike,
               'shakemap_array': shakemap_array,
               'usgs_id': usgs_id, 'rupture_file': rup_path}
     return rupdic
@@ -836,8 +829,7 @@ def get_rup_dic(dic, user=User(),
     rup = None
     if approach == 'provide_rup_params':
         rupdic = dic.copy()
-        rupdic.update(rupture_file=rupture_file, station_data_file=station_data_file,
-                      require_dip_strike=True)
+        rupdic.update(rupture_file=rupture_file, station_data_file=station_data_file)
         try:
             rup = build_planar_rupture_from_dict(rupdic)
         except ValueError as exc:
@@ -875,7 +867,6 @@ def get_rup_dic(dic, user=User(),
                     rupdic.update(rupdic['nodal_planes']['NP1'])
         else:
             rupdic = dic.copy()
-            rupdic['require_dip_strike'] = True
     elif 'download/rupture.json' not in contents:
         # happens for us6000f65h in parsers_test
         rupdic, err = load_rupdic_from_finite_fault(
@@ -915,7 +906,6 @@ def get_rup_dic(dic, user=User(),
     rup, err_msg = convert_to_oq_rupture(rup_data)
     if rup is None:  # in parsers_test for us6000jllz
         rupdic['rupture_issue'] = err_msg
-        rupdic['require_dip_strike'] = True
     # in parsers_test for usp0001ccb
     return rup, rupdic, err
 

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -192,7 +192,6 @@ IMPACT_FORM_DEFAULTS = {
     'msr': 'WC1994',
     'rupture_from_usgs_loaded': '',
     'rupture_file_input': '',
-    'require_dip_strike': '',
     'station_data_file_input': '',
     'station_data_file_loaded': '',
 }

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -68,7 +68,6 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['rake'], 0.0)
         self.assertEqual(dic['local_timestamp'], '2021-08-14 08:29:08-04:00')
         self.assertEqual(dic['time_event'], 'transit')
-        self.assertEqual(dic['require_dip_strike'], True)
         self.assertEqual(dic['pga_map_png'], None)
         self.assertEqual(dic['mmi_map_png'], None)
         self.assertEqual(dic['usgs_id'], 'us6000f65h')
@@ -105,7 +104,6 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['lon'], 37.0143)
         self.assertEqual(dic['lat'], 37.2256)
         self.assertEqual(dic['dep'], 10.)
-        self.assertEqual(dic['require_dip_strike'], True)
 
     def test_5(self):
         # 12 vertices instead of 4 in rupture.json
@@ -113,7 +111,6 @@ class ShakemapParsersTestCase(unittest.TestCase):
             {'usgs_id': 'us20002926', 'approach': 'use_shakemap_from_usgs'},
             user=user, use_shakemap=True)
         self.assertIsNone(rup)
-        self.assertEqual(dic['require_dip_strike'], True)
         rupture_issue = ('Unable to convert the rupture from the USGS format: at'
                          ' least one surface is not rectangular')
         self.assertEqual(dic['rupture_issue'], rupture_issue)
@@ -123,7 +120,6 @@ class ShakemapParsersTestCase(unittest.TestCase):
             {'usgs_id': 'usp0001ccb', 'approach': 'use_pnt_rup_from_usgs'},
             user=user, use_shakemap=True)
         self.assertEqual(dic['mag'], 6.7)
-        self.assertEqual(dic['require_dip_strike'], True)
         self.assertEqual(dic['station_data_issue'],
                          '3 stations were found, but none of them are seismic')
 
@@ -172,7 +168,6 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['msr'], 'WC1994')
         self.assertEqual(dic['rake'], -179.18)
         self.assertEqual(dic['strike'], 317.63)
-        self.assertEqual(dic['require_dip_strike'], True)
         self.assertEqual(dic['aspect_ratio'], 3)
 
     def test_10(self):

--- a/openquake/hazardlib/tests/shakemap/validate_test.py
+++ b/openquake/hazardlib/tests/shakemap/validate_test.py
@@ -73,7 +73,6 @@ class AristotleValidateTestCase(unittest.TestCase):
                 'msr': 'WC1994'}
         _rup, rupdic, _params, err = impact_validate(POST, user)
         self.assertEqual(rupdic['rupture_from_usgs'], True)
-        self.assertEqual(rupdic['require_dip_strike'], True)
         self.assertEqual(rupdic['mosaic_models'], ['SAM'])
         self.assertIn('stations', rupdic['station_data_file'])
         self.assertEqual(err, {})
@@ -148,7 +147,6 @@ class AristotleValidateTestCase(unittest.TestCase):
         POST = {'usgs_id': 'us7000n7n8', 'approach': 'build_rup_from_usgs',
                 'msr': 'WC1994'}
         _rup, rupdic, _oqparams, err = impact_validate(POST, user)
-        self.assertEqual(rupdic['require_dip_strike'], True)
         self.assertEqual(rupdic['mag'], 7.0)
         self.assertEqual(rupdic['time_event'], 'transit')
         self.assertEqual(rupdic['local_timestamp'], '2024-08-18 07:10:26+12:00')

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -765,7 +765,6 @@ function capitalizeFirstLetter(val) {
                     $('#strike').val('strike' in data ? data.strike : '0');
                     $('#local_timestamp').val(data.local_timestamp);
                     $('#time_event').val(data.time_event);
-                    $('#require_dip_strike').val(data.require_dip_strike);
                     // NOTE: due to security restrictions in web browsers, it is not possible to programmatically
                     //       set a specific file in an HTML file input element using JavaScript or jQuery,
                     //       therefore we can not pre-populate the rupture_file_input with the rupture_file
@@ -791,15 +790,6 @@ function capitalizeFirstLetter(val) {
                     if ($('#rupture_file_input')[0].files.length == 1) {
                         $('#dip').prop('disabled', true);
                         $('#strike').prop('disabled', true);
-                    }
-                    else if (data.require_dip_strike) {
-                        $('#dip').prop('disabled', false);
-                        $('#strike').prop('disabled', false);
-                    } else {
-                        $('#dip').prop('disabled', true);
-                        $('#strike').prop('disabled', true);
-                        $('#dip').val('');
-                        $('#strike').val('');
                     }
                     if ('nodal_planes' in data) {
                         const nodal_planes = data.nodal_planes;
@@ -937,7 +927,6 @@ function capitalizeFirstLetter(val) {
                 formData.append('rake', $("#rake").val());
                 formData.append('dip', $("#dip").val());
                 formData.append('strike', $("#strike").val());
-                formData.append('require_dip_strike', $("#require_dip_strike").val());
                 formData.append('time_event', $("#time_event").val());
                 formData.append('maximum_distance', $("#maximum_distance").val());
                 formData.append('mosaic_model', $('#mosaic_model').val());

--- a/openquake/server/templates/engine/includes/impact_rupture_params_from.html
+++ b/openquake/server/templates/engine/includes/impact_rupture_params_from.html
@@ -35,7 +35,6 @@
                   <label for"rake">{{ impact_form_labels.rake }}</label>
                   <input class="impact-input" type="text" id="rake" name="rake" placeholder="{{ impact_form_placeholders.rake }}" value="{{ impact_form_defaults.rake }}" />
                 </div>
-                <input class="impact-input" type="hidden" id="require_dip_strike" name="require_dip_strike"/> <!-- Coming from parsers.get_rup_dic -->
                 <div class="impact_form_row">
                   <label for"dip">{{ impact_form_labels.dip }}</label>
                   <input class="impact-input" type="text" id="dip" name="dip" placeholder="{{ impact_form_placeholders.dip }}" value="{{ impact_form_defaults.dip}}" />

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -698,7 +698,7 @@ def impact_callback(
         exclude_from_print = [
             'station_data_file', 'station_data_issue', 'station_data_file_from_usgs',
             'trts', 'mosaic_models', 'mosaic_model', 'tectonic_region_type', 'gsim',
-            'shakemap_uri', 'require_dip_strike', 'rupture_file', 'rupture_from_usgs']
+            'shakemap_uri', 'rupture_file', 'rupture_from_usgs']
     for key, val in params.items():
         if key not in ['calculation_mode', 'inputs', 'job_ini',
                        'hazard_calculation_id']:


### PR DESCRIPTION
Based on https://github.com/gem/oq-engine/pull/10414

Now fields are displayed or hidden depending from the chosen approach, so the `require_dip_strike` variable is not needed anymore. I am happy to remove it, because it was tricky and potentially confusing.