### PR TITLE
Temporarily disabled `get_mmi_values` for many assets

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -730,10 +730,13 @@ class HazardCalculator(BaseCalculator):
                 self.read_inputs()
                 self.save_crmodel()
             if oq.impact and 'mmi' in oq.inputs:
-                logging.info('Computing MMI-aggregated values')
-                if mmi_values := self.assetcol.get_mmi_values(
-                        oq.aggregate_by, oq.inputs['mmi']):
-                    self.datastore['mmi_tags'] = mmi_values
+                if len(self.assetcol) < 10_000:
+                    logging.info('Computing MMI-aggregated values')
+                    if mmi_values := self.assetcol.get_mmi_values(
+                            oq.aggregate_by, oq.inputs['mmi']):
+                        self.datastore['mmi_tags'] = mmi_values
+                else:
+                    logging.info('Too many assets to aggregate by MMI!')
 
     def pre_execute_from_parent(self):
         """


### PR DESCRIPTION
This is CRITICAL: all interesting calculations (i.e. the Turkey-Siria earthquake) have become too slow to run :-(
Solving the performance issue will be addressed in the future; for the moment the fast solution is to disable the feature.