### PR TITLE
Changed `mmi_tags` to have only 12 columns

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -12,7 +12,8 @@
   * Fixed a bug in the Thingbaijam et al. (2017) MSR
 
   [Michele Simionato]
-  * Added an input `mmi_shapes_file` for use in OQ Impact
+  * Added an input `mmi_shapes_file` for use in OQ Impact and then
+    a JSON output /v1/calc/:ID/mmi_tags
 
   [Christopher Brooks]
   * Added Boore and Atkinson (2008) site term to the ModifiableGMPE

--- a/doc/api-reference/rest-api.rst
+++ b/doc/api-reference/rest-api.rst
@@ -135,7 +135,21 @@ columns are "ID_1", "loss_type", "value", "lossmea", "lossq05",
 GET /v1/calc/:calc_id/mmi_tags
 **********************************
 
-FIXME
+Get exposure aggregated by MMI regions and tags.
+
+NB: this URL is valid only for ShakeMap based calculations downloading
+the MMI regions from the USGS service/
+
+Otherwise it returns a BadRequest error with HTTP code 400.
+
+Parameters: None
+
+Response:
+
+A JSON object corresponding to a pandas DataFrame. The names of the
+columns are "ID_1", "number", "contents", "nonstructural", "structural",
+"residents", "area",  "occupants_day", "occupants_night", "occupants_transit",
+"occupants_avg",  "mmi".
 
 ***********************************
 GET /v1/calc/:calc_id/extract/:spec

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -731,9 +731,10 @@ class HazardCalculator(BaseCalculator):
                 self.save_crmodel()
             if oq.impact and 'mmi' in oq.inputs:
                 logging.info('Computing MMI-aggregated values')
-                if mmi_values := self.assetcol.get_mmi_values(
-                        oq.aggregate_by, oq.inputs['mmi']):
-                    self.datastore['mmi_tags'] = mmi_values
+                mmi_df = self.assetcol.get_mmi_values(
+                    oq.aggregate_by, oq.inputs['mmi'])
+                if len(mmi_df):
+                    self.datastore.hdf5.create_df('mmi_tags', mmi_df)
 
     def pre_execute_from_parent(self):
         """

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -846,6 +846,14 @@ def extract_aggexp_tags(dstore, what):
     return _aggexp_tags(dstore)[0]
 
 
+@extract.add('mmi_tags')
+def extract_mmi_tags(dstore, what):
+    """
+    Aggregates exposure by MMI regions and tags. Use it as /extract/mmi_tags?
+    """
+    return dstore.read_df('mmi_tags')
+
+
 @extract.add('aggrisk_tags')
 def extract_aggrisk_tags(dstore, what):
     """
@@ -890,36 +898,6 @@ def extract_aggrisk_tags(dstore, what):
                 for qfield, qvalue in zip(qfields, qvalues):
                     acc[qfield].append(qvalue)
     df = pandas.DataFrame(acc)
-    return df
-
-
-@extract.add('mmi_tags')
-def extract_mmi_tags(dstore, what):
-    """
-    Aggregates mmi by tag. Use it as /extract/mmi_tags?
-    """
-    oq = dstore['oqparam']
-    if len(oq.aggregate_by) > 1:  # i.e. [['ID_0'], ['OCCUPANCY']]
-        # see impact_test.py
-        aggby = [','.join(a[0] for a in oq.aggregate_by)]
-    else:  # i.e. [['ID_0', 'OCCUPANCY']]
-        # see event_based_risk_test/case_1
-        [aggby] = oq.aggregate_by
-    keys = numpy.array([line.decode('utf8').split('\t')
-                        for line in dstore['agg_keys'][:]])
-    values = dstore['mmi_tags']
-    acc = general.AccumDict(accum=[])
-    K = len(keys)
-    ok = numpy.zeros(K, bool)
-    for agg_id in range(K):
-        for agg_key, key in zip(aggby, keys[agg_id]):
-            acc[agg_key].append(key)
-        for mmi in list(values):
-            array = values[mmi][agg_id]  # structured array with loss types
-            for lt in array.dtype.names:
-                acc[f'{lt}_{mmi}'].append(array[lt])
-                ok[agg_id] += array[lt]
-    df = pandas.DataFrame(acc)[ok]
     return df
 
 

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -518,6 +518,8 @@ class AssetCollection(object):
             df = pandas.DataFrame(dic)
             df['mmi'] = mmi
             dfs.append(df)
+        if not dfs:
+            return ()
         df = pandas.concat(dfs)
         return df[df.number > 0]
 

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -48,17 +48,16 @@ VAL_FIELDS = {'structural', 'nonstructural', 'contents',
               'business_interruption'}
 
 
-def to_mmi(value, MMIs=('I', 'II', 'III', 'IV', 'V', 'VI', 'VII',
-                        'VIII', 'IX', 'X')):
+def to_mmi(value):
     """
     :param value: float in the range 1..10
-    :returns: string "I" .. "X" representing a MMI
+    :returns: an MMI value in the range 1..10
     """
     if value >= 10.5:
         raise ValueError(f'{value} is too large to be an MMI')
     elif value < 0.5:
         raise ValueError(f'{value} is too small to be an MMI')
-    return MMIs[round(value) - 1]
+    return round(value) - 1
 
 
 def add_dupl_fields(df, oqfields):
@@ -495,7 +494,7 @@ class AssetCollection(object):
         :param mmi_file:
             shapefile containing MMI geometries and values
         :returns:
-            a dictionary MMI -> array with the value fields
+            a DataFrame with columns number, structural, ..., mmi
         """
         out = {}
         with fiona.open(f'zip://{mmi_file}!mi.shp') as f:
@@ -506,11 +505,21 @@ class AssetCollection(object):
                 values = self.get_agg_values(aggregate_by, geom)
                 if values['number'].any():
                     if mmi not in out:
-                        out[mmi] = values
+                        out[mmi] = values[:-1]  # discard total
                     else:
                         for lt in values.dtype.names:
-                            out[mmi][lt] += values[lt]
-        return out
+                            out[mmi][lt] += values[lt][:-1]
+        _aggids, aggtags = self.build_aggids(aggregate_by)
+        aggtags = numpy.array(aggtags)  # shape (K+1, T)
+        dfs = []
+        for mmi in out:
+            dic = {key: aggtags[:, k] for k, key in enumerate(aggregate_by[0])}
+            dic.update({col: out[mmi][col] for col in out[mmi].dtype.names})
+            df = pandas.DataFrame(dic)
+            df['mmi'] = mmi
+            dfs.append(df)
+        df = pandas.concat(dfs)
+        return df[df.number > 0]
 
     # not used yet
     def agg_by_site(self):

--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     re_path(r'^(\d+)/log/(\d*):(\d*)$', views.calc_log, name="log"),
     re_path(r'^result/(\d+)$', views.calc_result),
     re_path(r'^(\d+)/aggrisk_tags$', views.aggrisk_tags),
+    re_path(r'^(\d+)/mmi_tags$', views.mmi_tags),
     re_path(r'^(\d+)/result/list$', views.calc_results),
     re_path(r'^(\d+)/share$', views.calc_share),
     re_path(r'^(\d+)/unshare$', views.calc_unshare),

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1197,7 +1197,36 @@ def aggrisk_tags(request, calc_id):
             content='%s: %s in %s\n%s' %
             (exc.__class__.__name__, exc, 'aggrisk_tags', tb),
             content_type='text/plain', status=400)
+    return HttpResponse(content=df.to_json(), content_type=JSON, status=200)
 
+
+@cross_domain_ajax
+@require_http_methods(['GET', 'HEAD'])
+def mmi_tags(request, calc_id):
+    """
+    Return mmi_tags, by ``calc_id``, as JSON.
+
+    :param request:
+        `django.http.HttpRequest` object.
+    :param calc_id:
+        The id of the requested calculation.
+    :returns:
+        a JSON object as documented in rest-api.rst
+    """
+    job = logs.dbcmd('get_job', int(calc_id))
+    if job is None:
+        return HttpResponseNotFound()
+    if not utils.user_has_permission(request, job.user_name, job.status):
+        return HttpResponseForbidden()
+    try:
+        with datastore.read(job.ds_calc_dir + '.hdf5') as ds:
+            df = _extract(ds, 'mmi_tags')
+    except Exception as exc:
+        tb = ''.join(traceback.format_tb(exc.__traceback__))
+        return HttpResponse(
+            content='%s: %s in %s\n%s' %
+            (exc.__class__.__name__, exc, 'mmi_tags', tb),
+            content_type='text/plain', status=400)
     return HttpResponse(content=df.to_json(), content_type=JSON, status=200)
 
 


### PR DESCRIPTION
The JSON can be extracted by looking at http://HOST/v1/calc/CALCID/mmi_tags.
```
$ oq show mmi_tags
                   ID_1         number     contents  nonstructural    structural      residents          area  occupants_day  occupants_night  occupants_transit  occupants_avg  mmi
 LBN-ADM1-1590546715-B2    231.000000  3.117281e+07   3.521136e+07  3.876309e+07    3281.099854  9.264670e+04    3383.299805      3330.599854        2205.600098    2973.166748    3
 LBN-ADM1-1590546715-B3     36.000000  4.774555e+06   6.103493e+06  6.380899e+06     386.399994  1.548090e+04     286.300018       384.600006         245.699982     305.533356    3
 SYR-ADM1-1590546715-B1     45.000000  8.964385e+05   8.318501e+05  9.950382e+05     256.000000  6.290300e+03     289.399994       262.599976         173.099991     241.699997    3
 SYR-ADM1-1590546715-B2    799.000000  1.559059e+07   1.815720e+07  2.255524e+07    5561.299805  1.126468e+05    4425.600098      5561.100098        3546.199951    4510.966797    3
 SYR-ADM1-1590546715-B3    236.000000  6.686160e+06   6.667411e+06  8.035755e+06    1211.200073  3.895310e+04    1854.599976      1273.700073         887.799988    1338.699951    3
                    ...           ...           ...            ...           ...            ...           ...            ...              ...                ...            ...  ...
```
This is much better than having 65 columns like
```
                  ID_1     number_IV   contents_IV  nonstructural_IV  structural_IV   residents_IV  ...  residents_VIII     area_VIII  occupants_day_VIII  occupants_night_VIII  occupants_transit_VIII  occupants_avg_VIII
LBN-ADM1-1590546715-B2    231.000000  3.117281e+07      3.521136e+07   3.876309e+07    3281.099854  ...        0.000000  0.000000e+00            0.000000              0.000000                0.000000            0.000000
LBN-ADM1-1590546715-B3     36.000000  4.774555e+06      6.103493e+06   6.380899e+06     386.399994  ...        0.000000  0.000000e+00            0.000000              0.000000                0.000000            0.000000
SYR-ADM1-1590546715-B1     45.000000  8.964385e+05      8.318501e+05   9.950382e+05     256.000000  ...        0.000000  0.000000e+00            0.000000              0.000000                0.000000            0.000000
```