### PR TITLE
Not splitting multi-fault sources in preclassical

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -134,7 +134,7 @@ def preclassical(srcs, sites, cmaker, secparams, monitor):
             src.nsites = 1
         # NB: it is crucial to split only the close sources, for
         # performance reasons (think of Ecuador in SAM)
-        if cmaker.split_sources and src.nsites:
+        if cmaker.split_sources and src.nsites and src.code != b'F':
             splits.extend(split_source(src))
         else:
             splits.append(src)

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -135,6 +135,7 @@ def preclassical(srcs, sites, cmaker, secparams, monitor):
         # NB: it is crucial to split only the close sources, for
         # performance reasons (think of Ecuador in SAM)
         if cmaker.split_sources and src.nsites and src.code != b'F':
+            # multifault source have been already split in save_and_split
             splits.extend(split_source(src))
         else:
             splits.append(src)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -385,7 +385,10 @@ class SourceFilter(object):
         try:
             bbox = get_bounding_box(src, maxdist)
         except Exception as exc:
-            raise exc.__class__('source %r: %s' % (src.source_id, exc))
+            msg = ''
+            if '.' in src.source_id:
+                msg = 'Try setting "split_sources = false" in job file'
+            raise exc.__class__(f'source {src.source_id}: {exc}. \n {msg}')
         return bbox
 
     def get_rectangle(self, src):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -385,10 +385,7 @@ class SourceFilter(object):
         try:
             bbox = get_bounding_box(src, maxdist)
         except Exception as exc:
-            msg = ''
-            if '.' in src.source_id:
-                msg = 'Try setting "split_sources = false" in job file'
-            raise exc.__class__(f'source {src.source_id}: {exc}. \n {msg}')
+            raise exc.__class__('source %r: %s' % (src.source_id, exc))
         return bbox
 
     def get_rectangle(self, src):


### PR DESCRIPTION
For jobs that use the [kendra-splitting of multifault sources](https://github.com/gem/oq-engine/pull/10382), jobs sometimes fail with the error: 

`  File "/Users/kjohnson/GEM/oq-engine/openquake/hazardlib/calc/filters.py", line 389, in get_enlarged_box
    raise exc.__class__('source %r: %s' % (src.source_id, exc))
AttributeError: source 'cea24_faults@caf596.0': 'MultiFaultSource' object has no attribute 'msparams'`

This happens when the multifault source, which has already been split by fault tag, is further split by [split_source](https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/calc/filters.py#L291). 

The most direct solution I found is to disable source splitting in the job parameters by adding `split_sources = false ` to the job file. This PR suggests an improved error message for when the job fails for a source whose id contains `.`, signifying a split source. 

There may be a more complete solution, such as properly assigning the msparams when the source is split, or a more elegant way of getting this error message, or a case where the suggested solution doesn't work, so I marked the PR as WIP.  