### PR TITLE
[WIP] Keep multifault tags only for faults with ruptures

### DIFF
--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -385,7 +385,10 @@ class SourceFilter(object):
         try:
             bbox = get_bounding_box(src, maxdist)
         except Exception as exc:
-            raise exc.__class__('source %r: %s' % (src.source_id, exc))
+            msg = ''
+            if '.' in src.source_id:
+                msg = 'Try setting "split_sources = false" in job file'
+            raise exc.__class__(f'source {src.source_id}: {exc}. \n {msg}')
         return bbox
 
     def get_rectangle(self, src):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -385,10 +385,7 @@ class SourceFilter(object):
         try:
             bbox = get_bounding_box(src, maxdist)
         except Exception as exc:
-            msg = ''
-            if '.' in src.source_id:
-                msg = 'Try setting "split_sources = false" in job file'
-            raise exc.__class__(f'source {src.source_id}: {exc}. \n {msg}')
+            raise exc.__class__('source %r: %s' % (src.source_id, exc))
         return bbox
 
     def get_rectangle(self, src):

--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -285,14 +285,19 @@ def _set_rupids_by_tag(src, allrids, dists, s2i):
     used_rupids = []
     src.rupids_by_tag = {}
     for _dist, tag, fids in sorted(closest):
-        src.rupids_by_tag[tag] = []
+        # instantiate rupture id list
+        rids_by_tag = []
+
         # loop through all ruptures in the source 
         for rupid, rids in enumerate(allrids):
             # overlap between the section ids of the rupture and the fault?
             if len(np.intersect1d(rids, fids, assume_unique=True)):
                 if rupid not in used_rupids:
-                    src.rupids_by_tag[tag].append(rupid)
+                    rids_by_tag.append(rupid)
                     used_rupids.append(rupid)
+        # only create the new key for that fault tag if there are ruptures
+        if len(rids_by_tag) > 0:
+            src.rupids_by_tag[tag] = rids_by_tag
 
     # put the rest in another tag
     off_rupids = np.setdiff1d(np.arange(len(allrids)), used_rupids,


### PR DESCRIPTION
It is possible to have multifault sources where a fault lacks unique ruptures not already counted toward faults closer to a site. When splitting the source by faults, this leaves `src.rupids_by_tag[tag]` empty for a fault with no unique ruptures and causes the job to fail while saving the split sources [here](https://github.com/gem/oq-engine/blob/master/openquake/hazardlib/source/multi_fault.py#L358). 

This PR changes the code to wait to create the tag for each fault until it has looped through the ruptures, only creating the tag if ruptures exist. 

I will also try to create a test for this... hence WIP