### PR TITLE
Added type checks to `logs.dbcmd`

### DIFF
--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -33,6 +33,7 @@ LEVELS = {'debug': logging.DEBUG,
           'warn': logging.WARNING,
           'error': logging.ERROR,
           'critical': logging.CRITICAL}
+SIMPLE_TYPES = (str, int, float, datetime, list, tuple, dict, type(None))
 CALC_REGEX = r'(calc|cache)_(\d+)\.hdf5'
 MODELS = []  # to be populated in get_tag
 
@@ -56,6 +57,10 @@ def dbcmd(action, *args):
     :param string action: database action to perform
     :param tuple args: arguments
     """
+    # make sure the passed arguments are simple (i.e. not Django
+    # QueryDict that cannot be deserialized without settings.py)
+    for arg in args:
+        assert isinstance(arg, SIMPLE_TYPES), arg
     dbhost = os.environ.get('OQ_DATABASE', config.dbserver.host)
     if dbhost == '127.0.0.1' and getpass.getuser() != 'openquake':
         # access the database directly


### PR DESCRIPTION
So that type errors are raised on the client side, without breaking the DbServer (like it happened due to a Django QueryDict being passed instead of a regular dict).