### PR TITLE
Do not store the `backarc` parameter when not needed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Do not store the `backarc` parameter when not needed
   * Fixed call to `v1/calc/list` breaking the DbServer
   * Extended the exposure reader to accept .csv.gz files
   * Fixed `oq info calculators` that was still displaying the obsolete and now

--- a/doc/user-guide/configuration-file/hazard-common-config.rst
+++ b/doc/user-guide/configuration-file/hazard-common-config.rst
@@ -82,7 +82,6 @@ file called ``[site_params]``. The simplest possibility is to define uniform sit
 	reference_vs30_value = 760.0
 	reference_depth_to_2pt5km_per_sec = 5.0
 	reference_depth_to_1pt0km_per_sec = 100.0
-        reference_backarc = 0
 
 Alternatively it is possible to define spatially variable soil properties in a separate file; the engine will then 
 assign to each investigation location the values of the closest point used to specify site conditions::

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -630,12 +630,6 @@ random_seed:
   Example: *random_seed = 1234*.
   Default: 42
 
-reference_backarc:
-  Used when there is no site model to specify a global backarc parameter,
-  used in some GMPEs. Can be True or False
-  Example: *reference_backarc = true*.
-  Default: False
-
 reference_depth_to_1pt0km_per_sec:
   Used when there is no site model to specify a global z1pt0 parameter,
   used in some GMPEs.
@@ -1106,7 +1100,6 @@ class OqParam(valid.ParamSet):
         valid.Choice('measured', 'inferred'), 'inferred')
     reference_vs30_value = valid.Param(
         valid.positivefloat, numpy.nan)
-    reference_backarc = valid.Param(valid.boolean, False)
     region = valid.Param(valid.wkt_polygon, None)
     region_grid_spacing = valid.Param(valid.positivefloat, None)
     reqv_ignore_sources = valid.Param(valid.namelist, [])

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -542,8 +542,9 @@ def _smparse(fname, oqparam, arrays, sm_fieldsets):
         try:
             z[name] = sm[name]
         except ValueError:  # missing, use the global parameter
-            # exercised in the test classical/case_28_bis
-            z[name] = check_site_param(oqparam, name)
+            if name != 'backarc':  # backarc has default zero
+                # exercised in the test classical/case_28_bis
+                z[name] = check_site_param(oqparam, name)
     arrays.append(z)
 
 

--- a/openquake/commonlib/tests/data/classical_job.ini
+++ b/openquake/commonlib/tests/data/classical_job.ini
@@ -24,7 +24,6 @@ reference_vs30_type = measured
 reference_vs30_value = 760.0
 reference_depth_to_2pt5km_per_sec = 5.0
 reference_depth_to_1pt0km_per_sec = 100.0
-reference_backarc = false
 
 [calculation]
 

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -39,7 +39,6 @@ param = dict(
     vs30='reference_vs30_value',
     z1pt0='reference_depth_to_1pt0km_per_sec',
     z2pt5='reference_depth_to_2pt5km_per_sec',
-    backarc='reference_backarc',
     region='region',
     xvf='xvf')
 
@@ -445,10 +444,10 @@ class SiteCollection(object):
     xyz = Mesh.xyz
 
     def set_global_params(
-            self, oq, req_site_params=('z1pt0', 'z2pt5', 'backarc')):
+            self, oq, req_site_params=('z1pt0', 'z2pt5')):
         """
         Set the global site parameters
-        (vs30, vs30measured, z1pt0, z2pt5, backarc)
+        (vs30, vs30measured, z1pt0, z2pt5)
         """
         self._set('vs30', oq.reference_vs30_value)
         self._set('vs30measured',
@@ -457,8 +456,6 @@ class SiteCollection(object):
             self._set('z1pt0', oq.reference_depth_to_1pt0km_per_sec)
         if 'z2pt5' in req_site_params:
             self._set('z2pt5', oq.reference_depth_to_2pt5km_per_sec)
-        if 'backarc' in req_site_params:
-            self._set('backarc', oq.reference_backarc)
 
     def filtered(self, indices):
         """

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -443,8 +443,7 @@ class SiteCollection(object):
 
     xyz = Mesh.xyz
 
-    def set_global_params(
-            self, oq, req_site_params=('z1pt0', 'z2pt5')):
+    def set_global_params(self, oq, req_site_params=('z1pt0', 'z2pt5')):
         """
         Set the global site parameters
         (vs30, vs30measured, z1pt0, z2pt5)

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -34,7 +34,6 @@ class SiteModelParam(object):
         self.reference_vs30_type = 'measured'
         self.reference_depth_to_1pt0km_per_sec = 3.4
         self.reference_depth_to_2pt5km_per_sec = 5.6
-        self.reference_backarc = False
 
 
 class SiteTestCase(unittest.TestCase):

--- a/openquake/qa_tests_data/event_based_risk/case_master/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_master/job.ini
@@ -15,7 +15,6 @@ reference_vs30_type = measured
 reference_vs30_value = 760.0
 reference_depth_to_2pt5km_per_sec = 5.0
 reference_depth_to_1pt0km_per_sec = 100.0
-reference_backarc = 1
 
 [erf]
 width_of_mfd_bin = 0.1


### PR DESCRIPTION
It makes things easier to explain during workshops. Notice that not a single model in the mosaic uses the `reference_backarc` global parameter, so it can be removed without breaking anything.