### PR TITLE
Renamed the sources in LogicTreeCase2ClassicalPSHA

### DIFF
--- a/demos/hazard/LogicTreeCase2ClassicalPSHA/source_model.xml
+++ b/demos/hazard/LogicTreeCase2ClassicalPSHA/source_model.xml
@@ -11,7 +11,7 @@ xmlns:gml="http://www.opengis.net/gml"
         tectonicRegion="Active Shallow Crust"
         >
             <simpleFaultSource
-            id="2"
+            id="second"
             name="Simple Fault Source"
             tectonicRegion="Active Shallow Crust"
             >
@@ -48,7 +48,7 @@ xmlns:gml="http://www.opengis.net/gml"
         tectonicRegion="Stable Continental Crust"
         >
             <areaSource
-            id="1"
+            id="first"
             name="Area Source"
             tectonicRegion="Stable Continental Crust"
             >

--- a/demos/hazard/LogicTreeCase2ClassicalPSHA/source_model_logic_tree.xml
+++ b/demos/hazard/LogicTreeCase2ClassicalPSHA/source_model_logic_tree.xml
@@ -12,7 +12,7 @@
             </logicTreeBranchSet>
 
             <logicTreeBranchSet uncertaintyType="abGRAbsolute"
-                                applyToSources="1"
+                                applyToSources="first"
                                 branchSetID="bs2">
                 <logicTreeBranch branchID="b21">
                     <uncertaintyModel>4.6 1.1</uncertaintyModel>
@@ -29,7 +29,7 @@
             </logicTreeBranchSet>
 
             <logicTreeBranchSet uncertaintyType="abGRAbsolute"
-                                applyToSources="2"
+                                applyToSources="second"
                                 branchSetID="bs3">
                 <logicTreeBranch branchID="b31">
                     <uncertaintyModel>3.3 1.0</uncertaintyModel>
@@ -46,7 +46,7 @@
             </logicTreeBranchSet>
 
             <logicTreeBranchSet uncertaintyType="maxMagGRAbsolute"
-                                applyToSources="1"
+                                applyToSources="first"
                                 branchSetID="bs4">
                 <logicTreeBranch branchID="b41">
                     <uncertaintyModel>7.0</uncertaintyModel>
@@ -63,7 +63,7 @@
             </logicTreeBranchSet>
 
             <logicTreeBranchSet uncertaintyType="maxMagGRAbsolute"
-                                applyToSources="2"
+                                applyToSources="second"
                                 branchSetID="bs5">
                 <logicTreeBranch branchID="b51">
                     <uncertaintyModel>7.5</uncertaintyModel>


### PR DESCRIPTION
From "1", "2" to "first", "second" to avoid confusions between source_id (string) and src_id (integer).