### PR TITLE
Add unit test for use of ModifiableGMPE within an AvgGMPE

### DIFF
--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -168,7 +168,7 @@ class ModifiableGMPETest(unittest.TestCase):
         # Test instantiation of a ModifiableGMPE when spec in AvgGMPE
         AvgGMPE(
             b1={'ModifiableGMPE': {
-            'gmpe': {"AbrahamsonEtAl2014": {}},
+            'gmpe': {"YenierAtkinson2015BSSA": {}},
             "add_between_within_stds": {'with_betw_ratio': 1.7},
             'weight': 0.6}},
             b2={'SadighEtAl1997': {'weight': 0.4}})

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -171,7 +171,7 @@ class ModifiableGMPETest(unittest.TestCase):
             'gmpe': {"AtkinsonBoore2006Modified2011": {}},
             "add_between_within_stds": {'with_betw_ratio': 1.7},
             'weight': 0.6}},
-            b2={'SadighEtAl1997': {'weight': 0.4}})
+            b2={'PezeshkEtAl2011NEHRPBC': {'weight': 0.4}})
 
 
 class ModifiableGMPETestSwissAmpl(unittest.TestCase):

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -21,7 +21,6 @@ from openquake.hazardlib import valid
 from openquake.hazardlib.imt import PGA, SA
 from openquake.hazardlib.gsim.base import CoeffsTable
 from openquake.hazardlib.contexts import simple_cmaker
-from openquake.hazardlib.gsim.mgmpe.avg_gmpe import AvgGMPE
 from openquake.hazardlib.gsim.mgmpe.modifiable_gmpe import (
     ModifiableGMPE, _dict_to_coeffs_table)
 

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -21,6 +21,7 @@ from openquake.hazardlib import valid
 from openquake.hazardlib.imt import PGA, SA
 from openquake.hazardlib.gsim.base import CoeffsTable
 from openquake.hazardlib.contexts import simple_cmaker
+from openquake.hazardlib.gsim.mgmpe.avg_gmpe import AvgGMPE
 from openquake.hazardlib.gsim.mgmpe.modifiable_gmpe import (
     ModifiableGMPE, _dict_to_coeffs_table)
 
@@ -162,6 +163,15 @@ class ModifiableGMPETest(unittest.TestCase):
 
         aae(phi[ORIG, 0], 0.6201)
         aae(sig[MODI, 0], 0.5701491121)
+
+    def test_avg_gmpe_mgmpe(self):
+        # Test instantiation of a ModifiableGMPE when spec in AvgGMPE
+        ag = AvgGMPE(
+            b1={'ModifiableGMPE': {
+            'gmpe': {"AbrahamsonEtAl2014": {}},
+            "add_between_within_stds": {'with_betw_ratio': 1.7},
+            'weight': 0.6}},
+            b2={'SadighEtAl1997': {'weight': 0.4}})
 
 
 class ModifiableGMPETestSwissAmpl(unittest.TestCase):

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -166,7 +166,7 @@ class ModifiableGMPETest(unittest.TestCase):
 
     def test_avg_gmpe_mgmpe(self):
         # Test instantiation of a ModifiableGMPE when spec in AvgGMPE
-        ag = AvgGMPE(
+        AvgGMPE(
             b1={'ModifiableGMPE': {
             'gmpe': {"AbrahamsonEtAl2014": {}},
             "add_between_within_stds": {'with_betw_ratio': 1.7},

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -166,13 +166,15 @@ class ModifiableGMPETest(unittest.TestCase):
 
     def test_avg_gmpe_mgmpe(self):
         # Test instantiation of a ModifiableGMPE when spec in AvgGMPE
-        AvgGMPE(
-            b1={'ModifiableGMPE': {
-            'gmpe': {"AtkinsonBoore2006Modified2011": {}},
-            "add_between_within_stds": {'with_betw_ratio': 1.7},
-            'weight': 0.6}},
-            b2={'PezeshkEtAl2011NEHRPBC': {'weight': 0.4}})
-
+        gmm_toml =\
+        """
+        [AvgGMPE]
+        b1.ModifiableGMPE.gmpe.AtkinsonBoore2006Modified2011 = {}
+        b1.ModifiableGMPE.add_between_within_stds.with_betw_ratio = 1.7
+        b1.ModifiableGMPE.weight = 0.6
+        b2.PezeshkEtAl2011NEHRPBC.weight = 0.4
+        """
+        valid.gsim(gmm_toml) # Instantiate using valid.gsim from a toml
 
 class ModifiableGMPETestSwissAmpl(unittest.TestCase):
     """

--- a/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
+++ b/openquake/hazardlib/tests/gsim/mgmpe/modifiable_gmpe_test.py
@@ -168,7 +168,7 @@ class ModifiableGMPETest(unittest.TestCase):
         # Test instantiation of a ModifiableGMPE when spec in AvgGMPE
         AvgGMPE(
             b1={'ModifiableGMPE': {
-            'gmpe': {"YenierAtkinson2015BSSA": {}},
+            'gmpe': {"AtkinsonBoore2006Modified2011": {}},
             "add_between_within_stds": {'with_betw_ratio': 1.7},
             'weight': 0.6}},
             b2={'SadighEtAl1997': {'weight': 0.4}})


### PR DESCRIPTION
This PR adds a unit test checking the instantiation of a ModifiableGMPE within an AvgGMPE - also useful for documentation purposes