### PR TITLE
Also when using the ShakeMap, get sites close to the surface of the rupture

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -868,8 +868,7 @@ def get_rup_dic(dic, user=User(), use_shakemap=False, rupture_file=None,
         usgs_id, user, get_grid, monitor)
     if err:
         return None, None, err
-    if approach in ['use_shakemap_from_usgs', 'use_pnt_rup_from_usgs',
-                    'build_rup_from_usgs']:
+    if approach in ['use_pnt_rup_from_usgs', 'build_rup_from_usgs']:
         if dic.get('lon') is None:  # don't override user-inserted values
             rupdic, err = load_rupdic_from_origin(usgs_id, properties['products'])
             for key in dic:
@@ -891,10 +890,11 @@ def get_rup_dic(dic, user=User(), use_shakemap=False, rupture_file=None,
             usgs_id, properties['mag'], properties['products'])
         if err:
             return None, None, err
-    if approach == 'use_finite_rup_from_usgs':
+    if not rup_data and approach not in ['use_pnt_rup_from_usgs',
+                                         'build_rup_from_usgs']:
         with monitor('Downloading rupture json'):
             rup_data, rupture_file = download_rupture_data(usgs_id, contents, user)
-        if not rupture_file:
+        if not rupture_file and approach == 'use_finite_rup_from_usgs':
             err = {"status": "failed",
                    "error_msg": 'Unable to retrieve rupture geometries'}
             return None, None, err
@@ -904,7 +904,6 @@ def get_rup_dic(dic, user=User(), use_shakemap=False, rupture_file=None,
         rupdic['mmi_file'] = download_mmi(usgs_id, contents, user)
     if approach == 'use_shakemap_from_usgs':
         rupdic['shakemap_array'] = shakemap
-        return rup, rupdic, err
     if not rup_data:  # in parsers_test
         if approach == 'use_pnt_rup_from_usgs':
             rupdic['msr'] = 'PointMSR'

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -913,7 +913,8 @@ def get_rup_dic(dic, user=User(), use_shakemap=False, rupture_file=None,
             err = {"status": "failed", "error_msg": str(exc)}
         return rup, rupdic, err
     rup, err_msg = convert_to_oq_rupture(rup_data)
-    if rup is None:  # in parsers_test for us6000jllz
+    if rup is None and user.level > 1:  # in parsers_test for us6000jllz
+        # NOTE: hiding rupture-related issues to level 1 users
         rupdic['rupture_issue'] = err_msg
     # in parsers_test for usp0001ccb
     return rup, rupdic, err

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -312,6 +312,8 @@ def impact_validate(POST, user, rupture_file=None, station_data_file=None,
 
     # NOTE: in level 1 interface the ShakeMap has to be used.
     #       in level 2 interface it depends from the selected approach
+    if user.level == 1:
+        dic['approach'] = 'use_shakemap_from_usgs'
     use_shakemap = user.level == 1
     if 'use_shakemap' in POST:
         use_shakemap = POST['use_shakemap'] == 'true'

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -115,14 +115,15 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['dep'], 10.)
 
     def test_5(self):
-        # 12 vertices instead of 4 in rupture.json
-        rup, dic, _err = get_rup_dic(
-            {'usgs_id': 'us20002926', 'approach': 'use_finite_rup_from_usgs'},
-            user=user, use_shakemap=True)
-        self.assertIsNone(rup)
-        rupture_issue = ('Unable to convert the rupture from the USGS format: '
-                         'at least one surface is not rectangular')
-        self.assertEqual(dic['rupture_issue'], rupture_issue)
+        for approach in ['use_finite_rup_from_usgs', 'use_shakemap_from_usgs']:
+            # 12 vertices instead of 4 in rupture.json
+            rup, dic, _err = get_rup_dic(
+                {'usgs_id': 'us20002926', 'approach': approach},
+                user=user, use_shakemap=True)
+            self.assertIsNone(rup)
+            rupture_issue = ('Unable to convert the rupture from the USGS format: '
+                             'at least one surface is not rectangular')
+            self.assertEqual(dic['rupture_issue'], rupture_issue)
 
     def test_6(self):
         usgs_id = 'usp0001ccb'

--- a/openquake/server/templates/engine/includes/impact_form_level_2.html
+++ b/openquake/server/templates/engine/includes/impact_form_level_2.html
@@ -19,7 +19,7 @@
                 <label for"usgs_id">{{ impact_form_labels.usgs_id }}</label>
                 <input class="impact-input" type="text" id="usgs_id" name="usgs_id" placeholder="{{ impact_form_placeholders.usgs_id }}" value="{{ impact_default_usgs_id }}"/>
               </div>
-              <div id="rupture_from_usgs_grp" class="impact_form_row hidden">
+              <div id="rupture_from_usgs_grp" class="impact_form_row">
                 <label for"rupture_from_usgs">{{ impact_form_labels.rupture_from_usgs }}</label>
                 <input class="impact-input" type="hidden" id="rupture_from_usgs" name="rupture_data_file_from_usgs" placeholder="{{ impact_form_placeholders.rupture_from_usgs }}" disabled />
                 <input class="impact-input" type="text" id="rupture_from_usgs_loaded" name="rupture_from_usgs_loaded" disabled />


### PR DESCRIPTION
I am also hiding the rupture-related warnings from the level 1 interface.
Note that the most frequent case of conversion issue occurs when the rupture is made available from the USGS as a Point geometry, but in that case we are anyway building a planar rupture based on the coordinates of the hypocenter.

I made locally a full loop on the "famous ruptures" and it was green.