### PR TITLE
Removing references to SMTK

### DIFF
--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -92,7 +92,7 @@ def raise_(tp, value=None, tb=None):
     raise exc
 
 
-# the following is used in the SMTK
+# the following is used in the SMT module of the OQ-MBTK
 # copied from http://lucumr.pocoo.org/2013/5/21/porting-to-python-3-redux/
 def with_metaclass(meta, *bases):
     """

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1726,7 +1726,7 @@ def get_dists(ctx):
 
 
 # used to produce a RuptureContext suitable for legacy code, i.e. for calls
-# to .get_mean_and_stddevs, like for instance in the SMT
+# to .get_mean_and_stddevs, like for instance in the SMT module of the OQ-MBTK
 def full_context(sites, rup, dctx=None):
     """
     :returns: a full RuptureContext with all the relevant attributes

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1667,7 +1667,7 @@ class BaseContext(metaclass=abc.ABCMeta):
         return False
 
 
-# mock of a site collection used in the tests and in the SMT
+# mock of a site collection used in the tests and in the SMT module of the OQ-MBTK
 class SitesContext(BaseContext):
     """
     Sites calculation context for ground shaking intensity models.
@@ -1766,7 +1766,7 @@ def get_mean_stds(gsim, ctx, imts, **kw):
     return out[:, 0] if single else out
 
 
-# mock of a rupture used in the tests and in the SMT
+# mock of a rupture used in the tests and in the module of the OQ-MBTK
 class RuptureContext(BaseContext):
     """
     Rupture calculation context for ground shaking intensity models.

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -900,14 +900,14 @@ class PlanarSurface(BaseSurface):
         return Point(self.corner_lons[3], self.corner_lats[3],
                      self.corner_depths[3])
 
-    @property  # used in the SMTK
+    @property  # used in the SMT module of the OQ-MBTK
     def length(self):
         """
         Return length of the rupture
         """
         return self.array.wlr[1]
 
-    @property  # used in the SMTK
+    @property  # used in the SMT module of the OQ-MBTK
     def width(self):
         """
         Return length of the rupture


### PR DESCRIPTION
SMTK is now the SMT in the OQ-MBTK (super trivial change)