### PR TITLE
Get impact calc description from the USGS when possible; hide some inputs from the email notifications

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -904,6 +904,7 @@ def get_rup_dic(dic, user=User(), use_shakemap=False, rupture_file=None,
         rupdic['mmi_file'] = download_mmi(usgs_id, contents, user)
     if approach == 'use_shakemap_from_usgs':
         rupdic['shakemap_array'] = shakemap
+    rupdic['title'] = properties['title']
     if not rup_data:  # in parsers_test
         if approach == 'use_pnt_rup_from_usgs':
             rupdic['msr'] = 'PointMSR'

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -106,9 +106,12 @@ class AristotleParam:
         if not tmap_keys:
             raise LookupError(f'No taxonomy mapping was found for {countries}')
         logging.root.handlers = []  # avoid breaking the logs
-        params['description'] = (
-            f'{rupdic["usgs_id"]} ({rupdic["lat"]}, {rupdic["lon"]})'
-            f' M{rupdic["mag"]}')
+        if 'title' in rupdic:
+            params['description'] = f'{rupdic["usgs_id"]}: {rupdic["title"]}'
+        else:
+            params['description'] = (
+                f'{rupdic["usgs_id"]} ({rupdic["lat"]}, {rupdic["lon"]})'
+                f' M{rupdic["mag"]}')
         return params
 
 

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -702,7 +702,7 @@ def impact_callback(
         exclude_from_print = [
             'station_data_file', 'station_data_issue', 'station_data_file_from_usgs',
             'trts', 'mosaic_models', 'mosaic_model', 'tectonic_region_type', 'gsim',
-            'shakemap_uri', 'rupture_file', 'rupture_from_usgs']
+            'shakemap_uri', 'rupture_file', 'rupture_from_usgs', 'title', 'mmi_file']
     for key, val in params.items():
         if key not in ['calculation_mode', 'inputs', 'job_ini',
                        'hazard_calculation_id']:


### PR DESCRIPTION
In the calc description I am using the old format in approaches not using the USGS id, or I concatenate the USGS id with the corresponding title, e.g.: `us6000phrk: M 5.7 - 52 km N of Āwash, Ethiopia`