### PR TITLE
Update NowickiJessee2018Landslides model and add AllstadtEtAl2022Landslides

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved the task distribution
   * Exposed the output `avg_gmf`
   * Internal: enhanced `build_global_exposure` to work at admin level 2
   * Do not store the `backarc` parameter when not needed

--- a/doc/underlying-science/secondary-perils.rst
+++ b/doc/underlying-science/secondary-perils.rst
@@ -317,9 +317,9 @@ and the probability of liquefaction is calculated using equation (3). Zero proba
 
 The proposed probability threshold to convert to class outcome is 0.4.
 
-#######################
-Allstadt et al. (2022)
-#######################
+#######################################
+Allstadt et al. (2022) for liquefaction
+#######################################
 
 The model proposed by `Allstadth et al. (2022) <https://journals.sagepub.com/doi/10.1177/87552930211032685>`_ uses the 
 model proposed by `Rashidian et al. (2020) <https://www.sciencedirect.com/science/article/abs/pii/S0013795219312979>`_
@@ -649,9 +649,9 @@ These probabilities are converted to areal percentages to unbias the predictions
 	LSE(P) = e^{-7.592 + 5.237 \cdot P - 3.042 \cdot P^2 + 4.035 \cdot P^3} \\ (36)
 
 
-**********************
-Allstadt et al. (2022)
-**********************
+*************************************
+Allstadt et al. (2022) for landslides
+*************************************
 
 `Allstadth et al. (2022) <https://journals.sagepub.com/doi/10.1177/87552930211032685>`_ introduces modifications to the `Nowicki Jessee et al. (2018) <https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2017JF004494>`_ model, by capping the peak ground velocity at :math:`PGV = 211 \, \text{cm/s}`, 
 and compound topographic index at :math:`CTI = 19`. To exclude high probabilities of landsliding in nearly flat areas due to 

--- a/doc/underlying-science/secondary-perils.rst
+++ b/doc/underlying-science/secondary-perils.rst
@@ -237,11 +237,11 @@ The proposed probability threshold to convert to class outcome is 0.4.
 Another model's outcome is liquefaction spatial extent, :math:`LSE`. After an earthquake LSE is the spatial area 
 covered by surface manifestations of liquefaction reported as a percentage of liquefied material within that pixel. 
 Logistic regression with the same form was fit for the two models, with only difference in squaring the denominator to 
-improve the fit. The regression coefficients are given in Table 2.:
+improve the fit. The regression coefficients are given in Table 2.
 
 .. math::
 
-	L(P) = \frac{a}{\left( 1 + b\,e^{-c\,P} \right)^2} \\ (9)
+	LSE(P) = \frac{a}{\left( 1 + b\,e^{-c\,P} \right)^2} \\ (9)
 
 .. raw:: latex
 
@@ -432,15 +432,12 @@ which is well suited for shallow disrupted slides, one of the most common landsl
 
 .. math::
 
-    F_{s} = \frac{cohesion'}{soildrydensity slabthickness \sin(slope)} + \frac{\tan(frictionangle')}{\tan(slope)} - \frac{saturationcoeff waterdensity \tan(frictionangle')}{soildrydensity \tan(slope)} \\(18)
+    F_{s} = \frac{cohesion'}{sdd\, slabth\, sin(slope)} + \frac{\tan(fricangle')}{\tan(slope)} - \frac{satcoeff\, waterdensity\, tan(fricangle')}{sdd\, tan(slope)} \\(18)
 
 where: :math:`cohesion' \, [\text{Pa}]` is the effective cohesion with typical values ranging from :math:`20 \text{kPa}` for
-soils up to :math:`20 \, {MPa}` for unfaulted rocks. :math:`slope^\circ` is the slope angle. :math:`frictionangle'^\circ` is 
+soils up to :math:`20 \, {MPa}` for unfaulted rocks. :math:`slope^\circ` is the slope angle. :math:`fricangle'^\circ` is 
 the effective friction angle with typical values ranging from :math:`30^\circ` to :math:`40^\circ`. 
-:math:`\soildrydensity \, [\text{kg/m^3}]` is the dry density of the material. It ranges from :math:`1500 \, \text{kg/m^3}` 
-for soils to :math:`2500 - 3200 \, \text{kg/m^3}`. :math:`slabthickness` is the slope-normal thickness of a failure slab in meters and :math:`saturationcoeff` 
-is the proportion of slab thickness that is saturated. :math:`\waterdensity \, [\text{kg/m^3}]` 
-is the unit weight of water which equals to :math:`1000 \, \text{kg/m^3}`.
+:math:`sdd \, [\text{kg/m^3}]` is the dry density of the material. :math:`slabth` is the slope-normal thickness of a failure slab in meters and :math:`satcoeff` is the proportion of slab thickness that is saturated. :math:`waterdensity \, [\text{kg/m^3}]` is the unit weight of water which equals to :math:`1000 \, \text{kg/m^3}`.
 
 Note that the units of the input parameters reported in this document corresponds to the format required by the Engine 
 to produce correct results. The first and second term of the the equation corresponds to the cohesive and 
@@ -453,9 +450,9 @@ Finally, it is important to emphasize that the computed displacements do not nec
 but rather serve as an index of slope performance.
 
 
-*******************
+**************
 Jibson (2007)
-*******************
+**************
 
 `Jibson (2007) <https://www.sciencedirect.com/science/article/pii/S0013795207000300?via%3Dihub>`_ has generated regression equations for
 co-seismic displacements of landslides in terms of i) critical acceleration ratio (i.e., the ratio between the landslide critical acceleration and the PGA) and
@@ -466,7 +463,7 @@ Model a
 
 .. math::
 	
-	\log(Disp_{cm}) = 0.215 + \log [\left( 1 - \frac{critaccel}{PGA}} \right)^{2.341} \cdot \left( \frac{critaccel}{PGA} \right)^{-1.438}] \\ (19)
+	\log(Disp_{cm}) = 0.215 + \log [\left( 1 - \frac{critaccel}{PGA} \right)^{2.341} \cdot \left( \frac{critaccel}{PGA} \right)^{-1.438}] \\ (19)
 
 Model b
 
@@ -587,9 +584,9 @@ dependent from the moment magnitude :math:`M` of the earthquake.
 where :math:`Disp_{cm}` is the earthquake-induced displacement in cm (but converted to m by OQ), :math:`PGA` is g units, :math:`critaccel` is the landslide critical acceleration in g and 
 :math:`M` is the moment magnitude of the earthquake.
 
-***********************
+********************
 Jibson et al. (2000)
-***********************
+********************
 
 `Jibson et al. (2000) <https://www.sciencedirect.com/science/article/pii/S0013795200000399?via%3Dihub>`_  have proposed a regression equation
 predicting co-seismic displacements of landslides as function of the landslide critical acceleration and the Arias Intensity. The authors have modified the equation
@@ -639,22 +636,27 @@ Coefficients \alpha and \beta values are estimated for several rock and landcove
 reader is reffered to the original study by `Nowicki Jessee et al. (2018) <https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2017JF004494>`_, 
 where the coefficient values are reported in Table 3. 
 
-Probability of landsliding is then evaluated using logistic regression.
+Probability of landsliding is then evaluated using logistic regression:
 
 .. math::
 
 	P(L) = \frac{1}{1+e^X} \\ (35)
 
-These probabilities are converted to areal percentages to unbias the predictions.
+These probabilities are converted to areal percentages to unbias the predictions:
 
 .. math::
 
-	L_{P}(P) = e^{-7.592 + 5.237 \cdot P - 3.042 \cdot P^2 + 4.035 \cdot P^3} \\ (36)
+	LSE(P) = e^{-7.592 + 5.237 \cdot P - 3.042 \cdot P^2 + 4.035 \cdot P^3} \\ (36)
 
-Furthermore, we introduced modifications by the USGS, capping the peak ground velocity at :math:`PGV = 211 \, \text{cm/s}`, 
+
+**********************
+Allstadt et al. (2022)
+**********************
+
+`Allstadth et al. (2022) <https://journals.sagepub.com/doi/10.1177/87552930211032685>`_ introduces modifications to the `Nowicki Jessee et al. (2018) <https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2017JF004494>`_ model, by capping the peak ground velocity at :math:`PGV = 211 \, \text{cm/s}`, 
 and compound topographic index at :math:`CTI = 19`. To exclude high probabilities of landsliding in nearly flat areas due to 
 the combination of other predictor variables, areas with slopes less than :math:`2^\circ` are excluded.  Zero probability is 
-heuristically assigned if :math:`PGA = 0.02 \, \text{g}`. Finally, we adopted the USGS recommendation for modifying the 
+heuristically assigned if :math:`PGA < 0.02 \, \text{g}`. The model also adopts the USGS recommendation for modifying the 
 regression coefficient for unconsolidated sediments. The new proposed value is set to :math:`-1.36`. 
 
 

--- a/doc/underlying-science/secondary-perils.rst
+++ b/doc/underlying-science/secondary-perils.rst
@@ -53,10 +53,13 @@ the data, so that important variability between sites is lost.
 Liquefaction models
 -------------------
 
-Several liquefaction models are implemented in the OpenQuake engine. One of them is the method developed for the HAZUS 
+Several liquefaction models are implemented in the OpenQuake-engine, as detailed in the table under 
+`Input models for Secondary Perils <https://docs.openquake.org/oq-engine/master/manual/user-guide/inputs/secondary-perils-inputs.html>`_
+
+One of them models is the method developed for the HAZUS 
 software by the US Federal Emergency Management Agency. This model involves categorization of sites into liquefaction 
-susceptibility classes based on geotechnical characteristics, and a quanitative probability model for each 
-susceptibility class. The remaining models are the academic geospatial models, i.e., statistical models that uses 
+susceptibility classes based on geotechnical characteristics, and a quantitative probability model for each 
+susceptibility class. The remaining models are the academic geospatial models, i.e., statistical models that use 
 globally available input variables as first-order proxies to characterise saturation and density properties of the 
 soil. The shaking component is expressed either in terms of Peak Ground Acceleration , :math:`PGA`, or Peak Ground 
 Velocity , :math:`PGV`. These methods are simplified from older, more comprehensive liquefaction evaluations 
@@ -448,6 +451,9 @@ A variety of regression equations can be used to estimate the earthquake-induced
 some of the equations below may return displacements in cm (:math:`Disp_{cm}`); however, OQ  always converts them to m (:math:`Disp`).
 Finally, it is important to emphasize that the computed displacements do not necessarily correspond directly to measurable slope movements in the field, 
 but rather serve as an index of slope performance.
+
+The table under `Input models for Secondary Perils <https://docs.openquake.org/oq-engine/master/manual/user-guide/inputs/secondary-perils-inputs.html>`_
+provides a detailed list of the landslide models implemented in the OpenQuake-engine.
 
 
 **************

--- a/doc/user-guide/inputs/secondary-perils-inputs.rst
+++ b/doc/user-guide/inputs/secondary-perils-inputs.rst
@@ -4,13 +4,74 @@ Secondary perils
 ================
 
 Several methodologies exist for calculating probabilities and displacements from secondary perils, such as landslides
-and liquefaction. We have implemented multiple models in OpenQuake, each requiring different input datasets with global
-coverage. These inputs are incorporated by adjusting the site model. Performing secondary perils calculations requires 
+and liquefaction. We have implemented multiple models in OpenQuake, each requiring different input datasets, which 
+are incorporated in the site model. Performing secondary perils calculations requires 
 the adjusted `site_model.csv` in addition to the required files for running event-based or scenario analyses. 
 Futhermore, user is asked to define in `job.ini` file which model should be used to perform the analysis using the
 parameter ``secondary_perils``. For example, if one wants to use the HAZUS methodology, they should type::
     
     secondary_perils = HazusLiquefaction
+
+The tables below provide a comprehensive list of the liquefaction and landslide models implemented in the OpenQuake engine. 
+They detail the Intensity Measure Types (IMTs) utilized by each model, the outputs calculated and the additional site 
+model parameters required. 
+
+
++---------------------------------+------------------------+----------+-----------------------------------------+
+| Model                           | Output                 | IMTs     | Additional parameters in the site model |
++=================================+========================+==========+=========================================+
+| HazusLiquefaction               | LiqProb                | PGA, M   | liq_susc_cat, gwd                       |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| ZhuEtAl2015LiquefactionGeneral  | LiqProb/LSE, LiqOccur  | PGA, M   | cti, vs30                               |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| ZhuEtAl2017LiquefactionCoastal  | LiqProb, LiqOccur, LSE | PGV      | vs30, dr, dc, precip                    |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| ZhuEtAl2017LiquefactionGeneral  | LiqProb, LiqOccur, LSE | PGV      | vs30, dw, gwd, precip                   |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| RashidianBaise2020Liquefaction  | LiqProb, LiqOccur, LSE | PGV, PGA | vs30, dw, gwd, precip                   |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| AllstadtEtAl2022Liquefaction    | LiqProb, LiqOccur, LSE | PGV, PGA | vs30, dw, gwd, precip                   |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| AkhlagiEtAl2021LiquefactionA    | LiqProb, LiqOccur      | PGV      | tri, dc, dr, zwb                        |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| AkhlagiEtAl2021LiquefactionB    | LiqProb, LiqOccur      | PGV      | vs30, dc, dr, zwb                       |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| Bozzoni2021LiquefactionEurope   | LiqProb, LiqOccur      | PGA, M   | cti, vs30                               |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| TodorovicSilva2022NonParametric | LiqProb, LiqOccur      | PGV      | vs30, dw, gwd, precip                   |
++---------------------------------+------------------------+----------+-----------------------------------------+
+| HazusDeformation                | PGDMax                 | PGA, M   | liq_susc_cat                            |
++---------------------------------+------------------------+----------+-----------------------------------------+
+
+
+
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| Model                              | Output          | IMTs     | Additional parameters in the site model                                                    |
++====================================+=================+==========+============================================================================================+
+| Jibson2007ALandslides              | Disp            | PGA      | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| Jibson2007BLandslides              | Disp            | PGA, M   | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| ChoRathje2022Landslides            | Disp            | PGV      | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness, tslope, hratio |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| FotopoulouPitilakis2015ALandslides | Disp            | PGV, M   | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| FotopoulouPitilakis2015BLandslides | Disp            | PGA, M   | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| FotopoulouPitilakis2015CLandslides | Disp            | PGA, M   | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| FotopoulouPitilakis2015DLandslides | Disp            | PGV, PGA | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| SaygiliRathje2008Landslides        | Disp            | PGV, PGA | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| RathjeSaygili2009Landslides        | Disp            | PGA, M   | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| JibsonEtAl2000Landslides           | Disp, Disp Prob | IA       | slope, cohesion_mid, friction_mid, saturation, dry_density, slab_thickness                 |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| NowickiJessee2018Landslides        | LSProb, LSE     | PGV      | slope, lithology, landcover                                                                |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
+| AllstadtEtAl2022Landslides         | LSProb, LSE     | PGV, PGA | slope, lithology, landcover                                                                |
++------------------------------------+-----------------+----------+--------------------------------------------------------------------------------------------+
 
 Before demonstrating an example of a site model, we first discuss the implemented functions that are useful for 
 retrieving relevant inputs for sites.

--- a/openquake/sep/classes.py
+++ b/openquake/sep/classes.py
@@ -36,6 +36,7 @@ from openquake.sep.landslide.probability import(
     nowicki_jessee_2018,
     LANDCOVER_TABLE,
     LITHOLOGY_TABLE,
+    allstadt_etal_2022_b,
     jibson_etal_2000_probability,
 )
 from openquake.sep.liquefaction.liquefaction import (
@@ -1098,6 +1099,67 @@ class NowickiJessee2018Landslides(SecondaryPeril):
             landcover=sites.landcover,
             cti=sites.cti,
         )
+        out.append(prob_ls)
+        out.append(lse)
+            
+        return out
+        
+class AllstadtEtAl2022Landslides(SecondaryPeril):
+    """
+    Corrects LSE according to Allstadt et al. (2022).
+    """
+
+    outputs = ["LsProb", "LSE"]
+
+    def __init__(
+        self,
+        intercept: float = -6.30,
+        pgv_coeff: float = 1.65,
+        slope_coeff: float = 0.06,
+        coeff_table_lith = LITHOLOGY_TABLE,
+        coeff_table_cov = LANDCOVER_TABLE,
+        cti_coeff: float = 0.03,
+        interaction_term: float = 0.01,
+    ):
+        self.intercept = intercept
+        self.pgv_coeff = pgv_coeff
+        self.slope_coeff = slope_coeff
+        self.coeff_table_lith = coeff_table_lith
+        self.coeff_table_cov = coeff_table_cov
+        self.cti_coeff = cti_coeff
+        self.interaction_term = interaction_term
+
+    def prepare(self, sites):
+        pass
+
+    def compute(self, mag, imt_gmf, sites):
+        out = []
+        pga = None
+        pgv = None
+        for im, gmf in imt_gmf:
+            if im.string == "PGV":
+                pgv = gmf
+            elif im.string == "PGA":
+                pga = gmf
+            else:
+                continue
+        # Raise error if either PGA or PGV is missing
+        if pga is None or pgv is None:
+            raise ValueError(
+                "Both PGA and PGV are required to compute landslide "
+                "probability using the AllstadtEtAl2022Landslides model"
+            )
+        
+        prob_ls, lse = allstadt_etal_2022_b(
+            pga = pga,
+            pgv = pgv,
+            slope=sites.slope,
+            lithology=sites.lithology,
+            landcover=sites.landcover,
+            cti=sites.cti,
+        )
+        
+        
         out.append(prob_ls)
         out.append(lse)
             

--- a/openquake/sep/classes.py
+++ b/openquake/sep/classes.py
@@ -1092,7 +1092,6 @@ class NowickiJessee2018Landslides(SecondaryPeril):
             )
         
         prob_ls, lse = nowicki_jessee_2018(
-            pga = pga,
             pgv = pgv,
             slope=sites.slope,
             lithology=sites.lithology,

--- a/openquake/sep/landslide/displacement.py
+++ b/openquake/sep/landslide/displacement.py
@@ -130,6 +130,8 @@ def jibson_2007_model_a(
     else:
         Disp[Disp < 1e-10] = 0.0
 
+    Disp = np.where((pga < 1e-5), 0, Disp)
+    
     return Disp
 
 
@@ -231,6 +233,8 @@ def jibson_2007_model_b(
     else:
         Disp[Disp < 1e-10] = 0.0
 
+    Disp = np.where((pga < 1e-5), 0, Disp)
+    
     return Disp
 
 
@@ -284,6 +288,8 @@ def cho_rathje_2022(pgv_, tslope_, crit_accel_, hratio_):
         
     # Small displacements correction
     Disp = [0.0 if value < 1e-10 else value for value in Disp]
+    
+    Disp = np.where((pgv_ < 1e-5), 0, Disp)
 
     return Disp
 
@@ -324,6 +330,8 @@ def fotopoulou_pitilakis_2015_model_a(pgv, mag, crit_accel):
     else:
         Disp = [0.0 if value < 1e-10 else value for value in Disp]
     
+    Disp = np.where((pgv < 1e-5), 0, Disp)
+    
     return Disp
     
     
@@ -362,6 +370,8 @@ def fotopoulou_pitilakis_2015_model_b(pga, mag, crit_accel):
             Disp = 0.0
     else:
         Disp = [0.0 if value < 1e-10 else value for value in Disp]
+    
+    Disp = np.where((pga < 1e-5), 0, Disp)
     
     return Disp
     
@@ -419,6 +429,8 @@ def fotopoulou_pitilakis_2015_model_c(pga, mag, crit_accel):
     else:
         Disp = [0.0 if value < 1e-10 else value for value in Disp]
     
+    Disp = np.where((pga < 1e-5), 0, Disp)
+    
     return Disp
     
     
@@ -450,6 +462,13 @@ def fotopoulou_pitilakis_2015_model_d(pgv, pga, crit_accel):
             pga = 1e-5
     else:
         pga[pga == 0.0] = 1e-5
+        
+    # Corrections of invalid values       
+    if np.isscalar(pga):
+        if pgv == 0.0:
+            pgv = 1e-5
+    else:
+        pgv[pgv == 0.0] = 1e-5
 
     accel_ratio = crit_accel / pga
     
@@ -472,6 +491,8 @@ def fotopoulou_pitilakis_2015_model_d(pgv, pga, crit_accel):
             Disp = 0.0
     else:
         Disp = [0.0 if value < 1e-10 else value for value in Disp]
+    
+    Disp = np.where((pga < 1e-5) | (pgv < 1e-5), 0, Disp)
     
     return Disp
     
@@ -525,6 +546,8 @@ def saygili_rathje_2008(pga, pgv, crit_accel):
             Disp = 0.0
     else:
         Disp = [0.0 if value < 1e-10 else value for value in Disp]
+        
+    Disp = np.where((pga < 1e-5) | (pgv < 1e-5), 0, Disp)
     
     return Disp
     
@@ -579,6 +602,8 @@ def rathje_saygili_2009(pga, mag, crit_accel):
     else:
         Disp = [0.0 if value < 1e-10 else value for value in Disp]
         
+    Disp = np.where((pga < 1e-5), 0, Disp)
+    
     return Disp   
     
     
@@ -620,5 +645,7 @@ def jibson_etal_2000(ia, crit_accel):
             Disp = 0.0
     else:
         Disp[Disp < 1e-10] = 0.0
+    
+    Disp = np.where((ia < 1e-5), 0, Disp)
     
     return Disp

--- a/openquake/sep/landslide/probability.py
+++ b/openquake/sep/landslide/probability.py
@@ -1,4 +1,5 @@
 from typing import Union
+import scipy
 import numpy as np
 
 g: float = 9.81
@@ -66,10 +67,6 @@ LITHOLOGY_TABLE_NJ = {**lithology_values_NJ, **{bytes(k, 'utf-8'): v for k, v in
 LITHOLOGY_TABLE = {**lithology_values, **{bytes(k, 'utf-8'): v for k, v in lithology_values.items()}}
 
 
-def sigmoid(x):
-    return 1.0 / (1.0 + np.exp(-x))
-
-
 def _landslide_spatial_extent(p: float):
     """
     Calculates the landslide spatial extent (LSE) as per formulae 9
@@ -95,7 +92,6 @@ def _landslide_spatial_extent(p: float):
 
     
 def nowicki_jessee_2018(
-    pga: Union[float, np.ndarray],
     pgv: Union[float, np.ndarray],
     slope: Union[float, np.ndarray],
     lithology: str,
@@ -160,7 +156,7 @@ def nowicki_jessee_2018(
         intercept
     )
 
-    prob_ls = sigmoid(Xg)
+    prob_ls = scipy.special.expit(Xg)
     LSE = _landslide_spatial_extent(prob_ls)
 
     return prob_ls, LSE
@@ -199,7 +195,6 @@ def allstadt_etal_2022_b(
     pgv = np.clip(pgv, 1e-5, 211)
     
     prob_ls, LSE = nowicki_jessee_2018 (
-        pga = pga,
         pgv = pgv,
         slope = slope,
         lithology = lithology,

--- a/openquake/sep/tests/test_sep_suite_2.py
+++ b/openquake/sep/tests/test_sep_suite_2.py
@@ -121,7 +121,6 @@ class CaliSmallLandslideTestCase(unittest.TestCase):
 
     def test_nowicki_jessee_18(self):
         prob_ls, coverage = nowicki_jessee_2018(
-            pga=self.pga,
             pgv=self.pgv,
             slope=self.sites["slope"],
             lithology=self.sites["lithology"],
@@ -130,30 +129,30 @@ class CaliSmallLandslideTestCase(unittest.TestCase):
         )
         zlp = np.array(
             [
-                0.070513,
-                0.260801,
-                0.281926,
-                0.980824,
-                0.603409,
-                0.602239,
-                0.856018,
+                0.011672,
+                0.052064,
+                0.057599,
+                0.888425,
+                0.191497,
+                0.190742,
+                0.48066,
                 0.897942,
-                0.62758,
-                0.581753,
+                0.207814,
+                0.17799,
             ]
         )
         cls = np.array(
             [
-                0.071987,
-                0.172675,
-                0.189806,
-                20.709538,
-                0.953252,
-                0.946616,
-                6.037904,
+                0.053605,
+                0.065753,
+                0.067576,
+                8.119564,
+                0.126543,
+                0.126111,
+                0.484645,
                 8.884508,
-                1.104123,
-                0.839227,
+                0.136195,
+                0.119038,
             ]
         )
         np.testing.assert_array_almost_equal(prob_ls, zlp)

--- a/openquake/sep/tests/test_sep_suite_2.py
+++ b/openquake/sep/tests/test_sep_suite_2.py
@@ -14,6 +14,7 @@ from openquake.sep.landslide.displacement import (
 
 from openquake.sep.landslide.probability import (
     nowicki_jessee_2018,
+    allstadt_etal_2022_b,
 )
 
 from openquake.sep.classes import (
@@ -95,16 +96,16 @@ class CaliSmallLandslideTestCase(unittest.TestCase):
     def test_critical_accel(self):
         ca = np.array(
             [
-                5.53795977,
-                6.45917414,
+                5.537960,
+                6.459174,
                 5.791588,
                 0.0001,
-                14.81513269,
-                5.26990181,
-                4.20417316,
-                135.89284561,
-                6.40149393,
-                6.28627584,
+                14.815133,
+                5.269902,
+                4.204173,
+                135.892846,
+                6.401494,
+                6.286276,
             ]
         )
         np.testing.assert_array_almost_equal(self.sites["crit_accel"], ca)
@@ -143,9 +144,50 @@ class CaliSmallLandslideTestCase(unittest.TestCase):
         )
         cls = np.array(
             [
-                0.0,
+                0.071987,
                 0.172675,
-                0.0,
+                0.189806,
+                20.709538,
+                0.953252,
+                0.946616,
+                6.037904,
+                8.884508,
+                1.104123,
+                0.839227,
+            ]
+        )
+        np.testing.assert_array_almost_equal(prob_ls, zlp)
+        np.testing.assert_array_almost_equal(coverage, cls)
+
+
+    def test_allstadt_etal_2022_b(self):
+        prob_ls, coverage = allstadt_etal_2022_b(
+            pga=self.pga,
+            pgv=self.pgv,
+            slope=self.sites["slope"],
+            lithology=self.sites["lithology"],
+            landcover=self.sites["landcover"],
+            cti=self.sites["cti"],
+        )
+        zlp = np.array(
+            [
+                0.070513,
+                0.260801,
+                0.281926,
+                0.980824,
+                0.603409,
+                0.602239,
+                0.856018,
+                0.897942,
+                0.62758,
+                0.581753,
+            ]
+        )
+        cls = np.array(
+            [
+                0,
+                0.172675,
+                0,
                 20.709538,
                 0.953252,
                 0.946616,


### PR DESCRIPTION
- The `NowickiJessee2018Landslides `model was updated to be in agreement with the initial model proposed in Nowicki Jessee et al. (2018)

- The model corrections proposed by Allstadt et al. (2022) are now implemented in the new `AllstadtEtAl2022Landslides `model

- For the other landslide models, the output values are set to 0 if the IM used in the model is smaller than 1e-5.

- The [documentation ](https://docs.openquake.org/oq-engine/master/manual/underlying-science/secondary-perils.html)for these two models has been updated, and the manual now includes a [list of models available](https://docs.openquake.org/oq-engine/master/manual/user-guide/inputs/secondary-perils-inputs.html) for landslide and liquefaction analysis.

References:
Nowicki Jessee, M. A., Hamburger, M. W., Allstadt, K., Wald, D. J., Robeson, S. M., Tanyas, H., et al. (2018) A global empirical model for near-real-time assessment of seismically induced landslides. Journal of Geophysical Research: Earth Surface, 123, 1835–1859. https://doi.org/10.1029/2017JF004494
Allstadt, K. E., Thompson, E. M., Jibson, R. W., Wald, D. J., Hearne, M., Hunter, E. J., Fee, J., Schovanec, H., Slosky, D., & Haynie, K. L. (2022) The US Geological Survey ground failure product: Near-real-time estimates of earthquake-triggered landslides and liquefaction. Earthquake Spectra, 38(1), 5–36. https://doi.org/10.1177/87552930211032685.