### PR TITLE
Instead of just 'Loaded' display 'N stations were loaded'

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -422,7 +422,7 @@ def download_station_data_file(usgs_id, contents, user):
         if len(stations) == 0:
             msg = 'stationlist.json was downloaded, but it contains no features'
             err = {"status": "failed", "error_msg": msg}
-            return None, err
+            return None, 0, err
         original_len = len(stations)
         try:
             seismic_len = len(
@@ -432,7 +432,7 @@ def download_station_data_file(usgs_id, contents, user):
                    f' "station_type" is not specified, so we can not'
                    f' identify the "seismic" stations.')
             err = {"status": "failed", "error_msg": msg}
-            return None, err
+            return None, 0, err
         df = usgs_stations_to_oq_format(
             stations, exclude_imts=('SA(3.0)',), seismic_only=True)
         if len(df) < 1:
@@ -442,21 +442,22 @@ def download_station_data_file(usgs_id, contents, user):
                            f' {seismic_len} seismic stations were all'
                            f' discarded')
                     err = {"status": "failed", "error_msg": msg}
-                    return None, err
+                    return None, 0, err
                 else:
                     msg = (f'{original_len} stations were found, but none'
                            f' of them are seismic')
                     err = {"status": "failed", "error_msg": msg}
-                    return None, err
+                    return None, 0, err
             else:
                 msg = 'No stations were found'
                 err = {"status": "failed", "error_msg": msg}
-                return None, err
+                return None, 0, err
         else:
             station_data_file = gettemp(
                 prefix='stations', suffix='.csv', remove=False)
             df.to_csv(station_data_file, encoding='utf8', index=False)
-            return station_data_file, err
+            n_stations = len(df)
+            return station_data_file, n_stations, err
 
 
 def load_rupdic_from_finite_fault(usgs_id, mag, products):
@@ -782,19 +783,20 @@ def _get_rup_from_json(usgs_id, rupture_file):
 
 def get_stations_from_usgs(usgs_id, user=User(), monitor=performance.Monitor()):
     err = {}
+    n_stations = 0
     try:
         usgs_id = valid.simple_id(usgs_id)
     except ValueError as exc:
         err = {'status': 'failed', 'error_msg': str(exc)}
-        return None, err
+        return None, n_stations, err
     contents, _properties, _shakemap, err = _contents_properties_shakemap(
         usgs_id, user, False, monitor)
     if err:
-        return None, err
+        return None, n_stations, err
     with monitor('Downloading stations'):
-        station_data_file, err = download_station_data_file(
+        station_data_file, n_stations, err = download_station_data_file(
             usgs_id, contents, user)
-    return station_data_file, err
+    return station_data_file, n_stations, err
 
 
 def get_rup_dic(dic, user=User(), use_shakemap=False, rupture_file=None,

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -75,9 +75,10 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['usgs_id'], 'us6000f65h')
         self.assertEqual(dic['rupture_file'], None)
         self.assertIsNotNone(dic['mmi_file'])
-        station_data_file, station_err = get_stations_from_usgs(
+        station_data_file, n_stations, station_err = get_stations_from_usgs(
             usgs_id, user=user)
         self.assertIsNone(station_data_file)
+        self.assertEqual(n_stations, 0)
         self.assertEqual(station_err['error_msg'], 'No stations were found')
 
     def test_3b(self):
@@ -100,9 +101,10 @@ class ShakemapParsersTestCase(unittest.TestCase):
             user=user, use_shakemap=True)
         self.assertIn('Unable to convert the rupture from the USGS format',
                       dic['rupture_issue'])
-        station_data_file, station_err = get_stations_from_usgs(
+        station_data_file, n_stations, station_err = get_stations_from_usgs(
             usgs_id, user=user)
         self.assertIn('stations', station_data_file)
+        self.assertEqual(n_stations, 1)
         self.assertEqual(station_err, {})
 
     def test_4(self):
@@ -131,9 +133,10 @@ class ShakemapParsersTestCase(unittest.TestCase):
             {'usgs_id': usgs_id, 'approach': 'use_pnt_rup_from_usgs'},
             user=user, use_shakemap=True)
         self.assertEqual(dic['mag'], 6.7)
-        station_data_file, station_err = get_stations_from_usgs(
+        station_data_file, n_stations, station_err = get_stations_from_usgs(
             usgs_id, user=user)
         self.assertIsNone(station_data_file)
+        self.assertEqual(n_stations, 0)
         self.assertEqual(station_err['error_msg'],
                          '3 stations were found, but none of them are seismic')
 
@@ -224,9 +227,10 @@ class ShakemapParsersTestCase(unittest.TestCase):
 
     def test_13(self):
         usgs_id = 'us7000n7n8'
-        station_data_file, station_err = get_stations_from_usgs(
+        station_data_file, n_stations, station_err = get_stations_from_usgs(
             usgs_id, user=user)
         self.assertIsNone(station_data_file)
+        self.assertEqual(n_stations, 0)
         self.assertEqual(station_err['error_msg'],
                          'stationlist.json was downloaded, but it contains no features')
 

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -890,7 +890,7 @@ function capitalizeFirstLetter(val) {
                         $('#station_data_file_loaded').val('N.A. (conversion issue)');
                         diaerror.show(false, "Note", '<p>' + data.station_data_issue + '</p>');
                     } else {
-                        $('#station_data_file_loaded').val(data.station_data_file ? 'Loaded' : 'N.A.');
+                        $('#station_data_file_loaded').val(data.station_data_file ? data.n_stations + ' stations were loaded' : 'N.A.');
                     }
                 }).error(function (data) {
                     $('#station_data_file_loaded').val('');

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -777,11 +777,13 @@ def impact_get_stations_from_usgs(request):
         a `django.http.HttpRequest` object containing usgs_id
     """
     usgs_id = request.POST.get('usgs_id')
-    station_data_file, err = get_stations_from_usgs(usgs_id, user=request.user)
+    station_data_file, n_stations, err = get_stations_from_usgs(
+        usgs_id, user=request.user)
     station_data_issue = None
     if err:
         station_data_issue = err['error_msg']
     response_data = dict(station_data_file=station_data_file,
+                         n_stations=n_stations,
                          station_data_issue=station_data_issue)
     return JsonResponse(response_data)
 


### PR DESCRIPTION
It reports the number of loaded seismic stations, giving no information about the amount of them that will be actually used in the calculation or that will be filtered out because they are too distant.