### PR TITLE
Removed the --config-file option from the oq engine command

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,7 @@
   [Michele Simionato]
+  * Removed the --config-file option from the oq engine command
+  * Fixed numeric error in high intensity hazard curves produced by
+    multifault source by using 64 bit PoEs
   * Removed the dependency from pyshp
   * Improved the task distribution
   * Exposed the output `avg_gmf`
@@ -21,8 +24,8 @@
 
   [Marco Pagani]
   * Added a module to the modifiable GMPE computing site response according
-    to Stewart et al. (2020) and Hashash et al. (2020). 
-  * Added a model for AUS23 that replaces the fixed Vs30 ones currently in 
+    to Stewart et al. (2020) and Hashash et al. (2020).
+  * Added a model for AUS23 that replaces the fixed Vs30 ones currently in
     the engine
 
   [Marco Pagani, Valeria Cascone]

--- a/doc/getting-started/running-calculations/command-line.rst
+++ b/doc/getting-started/running-calculations/command-line.rst
@@ -11,7 +11,7 @@ following command::
 The result is the following::
 
 	usage: oq engine [-h] [--log-file LOG_FILE] [--no-distribute] [-y]
-	                 [-c CONFIG_FILE] [--make-html-report YYYY-MM-DD|today] [-u]
+	                 [--make-html-report YYYY-MM-DD|today] [-u]
 	                 [-d] [-w] [--run JOB_INI [JOB_INI ...]]
 	                 [--list-hazard-calculations] [--list-risk-calculations]
 	                 [--delete-calculation CALCULATION_ID]
@@ -37,9 +37,6 @@ The result is the following::
 	                        use in debugging and profiling.
 	  -y, --yes             Automatically answer "yes" when asked to confirm an
 	                        action
-	  -c CONFIG_FILE, --config-file CONFIG_FILE
-	                        Custom openquake.cfg file, to override default
-	                        configurations
 	  --make-html-report YYYY-MM-DD|today, --r YYYY-MM-DD|today
 	                        Build an HTML report of the computation at the given
 	                        date

--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -21,7 +21,6 @@ import getpass
 import logging
 from openquake.baselib import config
 from openquake.baselib.general import safeprint
-from openquake.hazardlib import valid
 from openquake.commonlib import logs, datastore
 from openquake.engine.engine import create_jobs, run_jobs
 from openquake.engine.export import core
@@ -94,7 +93,6 @@ def main(
         export_output=None,
         export_outputs=None,
         param='',
-        config_file=None,
         exports='',
         log_level='info',
         sample_sources=False,
@@ -107,12 +105,6 @@ def main(
     if not run:
         # configure a basic logging
         logging.basicConfig(level=logging.INFO)
-
-    if config_file:
-        config.read(os.path.abspath(os.path.expanduser(config_file)),
-                    limit=int, soft_mem_limit=int, hard_mem_limit=int,
-                    port=int, serialize_jobs=valid.boolean,
-                    strict=valid.boolean, code=exec)
 
     if no_distribute:
         os.environ['OQ_DISTRIBUTE'] = 'no'
@@ -278,8 +270,6 @@ main.export_outputs = dict(
 main.param = dict(
     abbrev='-p', help='Override parameters specified with the syntax '
     'NAME1=VALUE1,NAME2=VALUE2,...')
-main.config_file = ('Custom openquake.cfg file, to override default '
-                    'configurations')
 main.exports = ('Comma-separated string specifing the export formats, '
                 'in order of priority')
 main.log_level = dict(help='Defaults to "info"',


### PR DESCRIPTION
Since it does not work (see https://github.com/gem/oq-engine/issues/10377), the workers will not look at the passed file. We still have the `OQ_CONFIG_FILE` variable on top of the precedence mechanism.