### PR TITLE
Add API endpoint `impact_run_with_shakemap` that runs a calculation given the usgs_id only

### DIFF
--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -38,8 +38,6 @@ class AristotleParam:
     rupture_dict: dict
     time_event: str
     maximum_distance: float
-    mosaic_model: str
-    trt: str
     truncation_level: float
     number_of_ground_motion_fields: int
     asset_hazard_distance: float
@@ -49,6 +47,8 @@ class AristotleParam:
     station_data_file: str = None
     mmi_file: str = None
     maximum_distance_stations: float = None
+    mosaic_model: str = None
+    trt: str = None
 
     def get_oqparams(self, usgs_id, mosaic_models, trts, use_shakemap):
         """

--- a/openquake/server/templates/engine/includes/aelo_form.html
+++ b/openquake/server/templates/engine/includes/aelo_form.html
@@ -2,7 +2,7 @@
             <h2>Run an AELO calculation</h2>
             {% if not user.email %}
             <h3>
-              WARNING: no email address is speficied for your user account, therefore email notifications will be disabled
+              WARNING: no email address is specified for your user account, therefore email notifications will be disabled
             </h3>
             {% endif %}
             <form id="aelo_run_form" method="post">

--- a/openquake/server/templates/engine/includes/impact_form_level_0.html
+++ b/openquake/server/templates/engine/includes/impact_form_level_0.html
@@ -2,7 +2,7 @@
             <h2>Earthquake impact assessment</h2>
             {% if not user.email %}
             <h3>
-              WARNING: no email address is speficied for your user account, therefore email notifications will be disabled
+              WARNING: no email address is specified for your user account, therefore email notifications will be disabled
             </h3>
             {% endif %}
           </div>

--- a/openquake/server/templates/engine/includes/impact_form_level_1.html
+++ b/openquake/server/templates/engine/includes/impact_form_level_1.html
@@ -2,7 +2,7 @@
             <h2>Run an earthquake impact assessment</h2>
             {% if not user.email %}
             <h3>
-              WARNING: no email address is speficied for your user account, therefore email notifications will be disabled
+              WARNING: no email address is specified for your user account, therefore email notifications will be disabled
             </h3>
             {% endif %}
             <form id="impact_get_rupture_form" method="post" enctype="multipart/form-data">

--- a/openquake/server/templates/engine/includes/impact_form_level_2.html
+++ b/openquake/server/templates/engine/includes/impact_form_level_2.html
@@ -2,7 +2,7 @@
             <h2>Run an earthquake impact assessment</h2>
             {% if not user.email %}
             <h3>
-              WARNING: no email address is speficied for your user account, therefore email notifications will be disabled
+              WARNING: no email address is specified for your user account, therefore email notifications will be disabled
             </h3>
             {% endif %}
             <form id="impact_get_rupture_form" method="post" enctype="multipart/form-data">

--- a/openquake/server/v1/calc_urls.py
+++ b/openquake/server/v1/calc_urls.py
@@ -50,6 +50,7 @@ elif settings.APPLICATION_MODE == 'ARISTOTLE':
         re_path(r'^impact_get_rupture_data$',
                 views.impact_get_rupture_data),
         re_path(r'^impact_run$', views.impact_run),
+        re_path(r'^impact_run_with_shakemap$', views.impact_run_with_shakemap),
         re_path(r'^(\d+)/abort$', views.calc_abort),
         re_path(r'^(\d+)/remove$', views.calc_remove),
         re_path(r'^(\d+)/download_aggrisk$', views.download_aggrisk),

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -818,7 +818,7 @@ def create_impact_job(request, params):
         log_uri=log_uri, traceback_uri=traceback_uri)
     if not job_owner_email:
         response_data[job_id]['WARNING'] = (
-            'No email address is speficied for your user account,'
+            'No email address is specified for your user account,'
             ' therefore email notifications will be disabled. As soon as'
             ' the job completes, you can access its outputs at the'
             ' following link: %s. If the job fails, the error traceback'

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1002,7 +1002,7 @@ def aelo_run(request):
     job_owner_email = request.user.email
     if not job_owner_email:
         response_data['WARNING'] = (
-            'No email address is speficied for your user account,'
+            'No email address is specified for your user account,'
             ' therefore email notifications will be disabled. As soon as'
             ' the job completes, you can access its outputs at the following'
             ' link: %s. If the job fails, the error traceback will be'


### PR DESCRIPTION
It avoids the confusion caused by the need of two calls, also because the second call needed to contain some parameters that were not used and that now I have made optional.
With this new endpoint, the script for JRC becomes shorter and way more intuitive.