### PR TITLE
Reverted  https://github.com/gem/oq-engine/pull/10314

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Reverted the consequence functions to contain risk IDs and not taxonomies
+  * Forced the consequence functions to contain risk IDs and not taxonomies
   * OQImpact: now aggregating by ID_2 and not ID_1
   * Removed the --config-file option from the oq engine command
   * Fixed numeric error in high intensity hazard curves produced by

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Reverted the consequence functions to contain risk IDs and not taxonomies
   * OQImpact: now aggregating by ID_2 and not ID_1
   * Removed the --config-file option from the oq engine command
   * Fixed numeric error in high intensity hazard curves produced by

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1029,7 +1029,8 @@ def _cons_coeffs(df, perils, loss_dt, limit_states):
                 coeffs[peril][loss_type] = the_df[limit_states].to_numpy()[0]
             elif len(the_df) > 1:
                 raise ValueError(
-                    f'Multiple consequences for {loss_type=}, {peril=}\n%s' % the_df)
+                    f'Multiple consequences for {loss_type=}, {peril=}\n%s' %
+                    the_df)
     return coeffs
 
 
@@ -1050,19 +1051,22 @@ def get_crmodel(oqparam):
                 return crm
 
     risklist = get_risk_functions(oqparam)
+    limit_states = risklist.limit_states
     perils = numpy.array(sorted(set(rf.peril for rf in risklist)))
-    if not oqparam.limit_states and risklist.limit_states:
-        oqparam.limit_states = risklist.limit_states
-    elif 'damage' in oqparam.calculation_mode and risklist.limit_states:
-        assert oqparam.limit_states == risklist.limit_states
+    if not oqparam.limit_states and limit_states:
+        oqparam.limit_states = limit_states
+    elif 'damage' in oqparam.calculation_mode and limit_states:
+        assert oqparam.limit_states == limit_states
     consdict = {}
     if 'consequence' in oqparam.inputs:
-        if not risklist.limit_states:
+        if not limit_states:
             raise InvalidFile('Missing fragility functions in %s' %
                               oqparam.inputs['job_ini'])
         # build consdict of the form consequence_by_tagname -> tag -> array
         loss_dt = oqparam.loss_dt()
         for by, fnames in oqparam.inputs['consequence'].items():
+            if by == 'taxonomy':  # obsolete name
+                by = 'risk_id'
             if isinstance(fnames, str):  # single file
                 fnames = [fnames]
             # i.e. files collapsed.csv, fatalities.csv, ... with headers like
@@ -1078,7 +1082,7 @@ def get_crmodel(oqparam):
                     raise InvalidFile('Unknown consequence %s in %s' %
                                       (consequence, fnames))
                 bytag = {
-                    tag: _cons_coeffs(grp, perils, loss_dt, risklist.limit_states)
+                    tag: _cons_coeffs(grp, perils, loss_dt, limit_states)
                     for tag, grp in group.groupby(by)}
                 consdict['%s_by_%s' % (consequence, by)] = bytag
     # for instance consdict['collapsed_by_taxonomy']['W_LFM-DUM_H3']
@@ -1141,7 +1145,7 @@ def read_df(fname, lon, lat, id, duplicates_strategy='error'):
     """
     assert duplicates_strategy in (
         'error', 'keep_first', 'keep_last', 'avg'), duplicates_strategy
-    # NOTE: the id field has to be treated as a string even if it contains numbers
+    # NOTE: the id field has to be treated as a string even if contains numbers
     dframe = pandas.read_csv(fname, dtype={id: str})
     dframe[lon] = numpy.round(dframe[lon].to_numpy(), 5)
     dframe[lat] = numpy.round(dframe[lat].to_numpy(), 5)
@@ -1159,12 +1163,11 @@ def read_df(fname, lon, lat, id, duplicates_strategy='error'):
         elif duplicates_strategy == 'avg':
             string_columns = dframe.select_dtypes(include='object').columns
             numeric_columns = dframe.select_dtypes(include='number').columns
-            # Group by lon and lat, averaging numeric columns and concatenating by "|"
+            # group by lon-lat, averaging columns and concatenating by "|"
             # the different contents of string columns
             dframe = dframe.groupby([lon, lat], as_index=False).agg(
                 {**{col: concat_if_different for col in string_columns},
-                 **{col: 'mean' for col in numeric_columns}}
-            )
+                 **{col: 'mean' for col in numeric_columns}})
     return dframe
 
 
@@ -1721,7 +1724,8 @@ def read_cities(fname, lon_name, lat_name, label_name):
     data = pandas.read_csv(fname)
     expected_colnames_set = {lon_name, lat_name, label_name}
     if not expected_colnames_set.issubset(data.columns):
-        raise ValueError(f"CSV file must contain {expected_colnames_set} columns.")
+        raise ValueError(
+            f"CSV file must contain {expected_colnames_set} columns.")
     return data
 
 

--- a/openquake/qa_tests_data/event_based_damage/case_11/structural_consequence_model.csv
+++ b/openquake/qa_tests_data/event_based_damage/case_11/structural_consequence_model.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,ds1,ds2,ds3,ds4
+risk_id,consequence,peril,ds1,ds2,ds3,ds4
 tax1,losses,groundshaking,4.000000E-02,1.600000E-01,3.200000E-01,6.400000E-01
 tax2,losses,groundshaking,4.000000E-02,1.600000E-01,3.200000E-01,6.400000E-01
 tax3,losses,groundshaking,4.000000E-02,1.600000E-01,3.200000E-01,6.400000E-01

--- a/openquake/qa_tests_data/event_based_damage/case_13/structural_consequence_model.csv
+++ b/openquake/qa_tests_data/event_based_damage/case_13/structural_consequence_model.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,LS1,LS2
+risk_id,consequence,peril,LS1,LS2
 RC,losses,groundshaking,4.000000E-02,1.600000E-01
 RM,losses,groundshaking,4.000000E-02,1.600000E-01
 W,losses,groundshaking,4.000000E-02,1.600000E-01

--- a/openquake/qa_tests_data/event_based_damage/case_14/consequences_by_taxonomy.csv
+++ b/openquake/qa_tests_data/event_based_damage/case_14/consequences_by_taxonomy.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,slight,moderate,extreme,complete
+risk_id,consequence,peril,slight,moderate,extreme,complete
 Concrete,losses,groundshaking,0.04,0.31,0.6,1
 Adobe,losses,groundshaking,0.04,0.31,0.6,1
 Stone-Masonry,losses,groundshaking,0.04,0.31,0.6,1

--- a/openquake/qa_tests_data/event_based_damage/case_15/consequences_by_taxonomy.csv
+++ b/openquake/qa_tests_data/event_based_damage/case_15/consequences_by_taxonomy.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,moderate,complete
+risk_id,consequence,peril,moderate,complete
 Concrete,losses,groundshaking,0.31,1
 Adobe,losses,groundshaking,0.31,1
 Stone-Masonry,losses,groundshaking,0.31,1

--- a/openquake/qa_tests_data/event_based_damage/case_16/consequences.csv
+++ b/openquake/qa_tests_data/event_based_damage/case_16/consequences.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,ds1,ds2,ds3,ds4
+risk_id,consequence,peril,ds1,ds2,ds3,ds4
 tax1,losses,groundshaking,5.000000E-02,2.500000E-01,5.000000E-01,7.500000E-01
 tax2,losses,groundshaking,5.000000E-02,2.500000E-01,5.000000E-01,7.500000E-01
 tax3,losses,groundshaking,5.000000E-02,2.500000E-01,5.000000E-01,7.500000E-01

--- a/openquake/qa_tests_data/infrastructure_risk/case_1/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/case_1/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,slight,moderate,extensive,complete
+﻿risk_id,consequence,peril,slight,moderate,extensive,complete
 demand,non_operational,groundshaking,0,1,1,1
 pumping_station1,non_operational,groundshaking,0,1,1,1
 pumping_station2,non_operational,groundshaking,0,1,1,1

--- a/openquake/qa_tests_data/infrastructure_risk/case_2/consequence_multiple_loss_types.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/case_2/consequence_multiple_loss_types.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,slight,moderate,extensive,complete
+risk_id,consequence,peril,slight,moderate,extensive,complete
 bridge1,non_operational,groundshaking,0,0,1,1
 connection,non_operational,groundshaking,0,0,1,1
 bridge1,non_operational,liquefaction,0,0,0,1

--- a/openquake/qa_tests_data/infrastructure_risk/demand_supply/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/demand_supply/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,slight,moderate,extensive,complete
+﻿risk_id,consequence,peril,slight,moderate,extensive,complete
 tank,non_operational,groundshaking,0,1,1,1
 tank1,non_operational,groundshaking,0,1,1,1
 pipe,non_operational,groundshaking,0,1,1,1

--- a/openquake/qa_tests_data/infrastructure_risk/directed/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/directed/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,minor,major
+﻿risk_id,consequence,peril,minor,major
 bridge,non_operational,groundshaking,0,1
 road,non_operational,groundshaking,0,1
 connection,non_operational,groundshaking,0,1

--- a/openquake/qa_tests_data/infrastructure_risk/eff_loss_random/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/eff_loss_random/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,slight,moderate,extensive,complete
+﻿risk_id,consequence,peril,slight,moderate,extensive,complete
 link,non_operational,groundshaking,0,1,1,1
 link1,non_operational,groundshaking,0,1,1,1
 connection,non_operational,groundshaking,0,1,1,1

--- a/openquake/qa_tests_data/infrastructure_risk/five_nodes_demsup_directed/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/five_nodes_demsup_directed/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,minor,major
+﻿risk_id,consequence,peril,minor,major
 bridge,non_operational,groundshaking,0,1
 road,non_operational,groundshaking,0,1
 connection,non_operational,groundshaking,0,1

--- a/openquake/qa_tests_data/infrastructure_risk/five_nodes_demsup_directedunweighted/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/five_nodes_demsup_directedunweighted/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,minor,major
+﻿risk_id,consequence,peril,minor,major
 bridge,non_operational,groundshaking,0,1
 road,non_operational,groundshaking,0,1
 connection,non_operational,groundshaking,0,1

--- a/openquake/qa_tests_data/infrastructure_risk/five_nodes_demsup_multidirected/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/five_nodes_demsup_multidirected/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,minor,major
+﻿risk_id,consequence,peril,minor,major
 bridge,non_operational,groundshaking,0,1
 road,non_operational,groundshaking,0,1
 connection,non_operational,groundshaking,0,1

--- a/openquake/qa_tests_data/infrastructure_risk/multidirected/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/multidirected/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,minor,major
+﻿risk_id,consequence,peril,minor,major
 bridge,non_operational,groundshaking,0,1
 road,non_operational,groundshaking,0,1
 connection,non_operational,groundshaking,0,1

--- a/openquake/qa_tests_data/infrastructure_risk/multigraph/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/multigraph/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,minor,major
+﻿risk_id,consequence,peril,minor,major
 bridge,non_operational,groundshaking,0,1
 road,non_operational,groundshaking,0,1
 connection,non_operational,groundshaking,0,1

--- a/openquake/qa_tests_data/infrastructure_risk/undirected/nonfunctional.csv
+++ b/openquake/qa_tests_data/infrastructure_risk/undirected/nonfunctional.csv
@@ -1,4 +1,4 @@
-﻿taxonomy,consequence,peril,minor,major
+﻿risk_id,consequence,peril,minor,major
 bridge,non_operational,groundshaking,0,1
 road,non_operational,groundshaking,0,1
 connection,non_operational,groundshaking,0,1

--- a/openquake/qa_tests_data/multi_risk/case_1/consequence_model.csv
+++ b/openquake/qa_tests_data/multi_risk/case_1/consequence_model.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,collapse
+risk_id,consequence,peril,collapse
 Heavy_roof,losses,groundshaking,4.000000E-01
 Moderate_roof,losses,groundshaking,2.000000E-01
 Slab_roof,losses,groundshaking,4.000000E-01

--- a/openquake/qa_tests_data/multi_risk/case_1/consequence_model_2.csv
+++ b/openquake/qa_tests_data/multi_risk/case_1/consequence_model_2.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,moderate,collapse
+risk_id,consequence,peril,moderate,collapse
 Heavy_roof,losses,groundshaking,1.500000E-01,4.000000E-01
 Moderate_roof,losses,groundshaking,7.500000E-02,2.000000E-01
 Slab_roof,losses,groundshaking,1.500000E-01,4.000000E-01

--- a/openquake/qa_tests_data/scenario_damage/case_13/consequence_recovery_time.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_13/consequence_recovery_time.csv
@@ -1,2 +1,2 @@
-taxonomy,consequence,peril,slight,moderate,extensive,complete
-MUR-CLBRS-LWAL-HBET-1;2/GOV2,losses,groundshaking,35,90,197,287
+risk_id,consequence,peril,slight,moderate,extensive,complete
+UNM/C_LR/GOV2,losses,groundshaking,35,90,197,287

--- a/openquake/qa_tests_data/scenario_damage/case_13/expected/aggrisk-stats.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_13/expected/aggrisk-stats.csv
@@ -1,3 +1,3 @@
-#,,,,,,,"generated_by='OpenQuake engine 3.23.0-git7df4c4c8e1', start_date='2025-02-04T13:41:43', checksum=3982247066"
+#,,,,,,,"generated_by='OpenQuake engine 3.24.0-gitd79b62c328', start_date='2025-03-31T05:06:48', checksum=1397702736"
 loss_type,dmg_0,dmg_1,dmg_2,dmg_3,dmg_4,losses,stat
 structural,9.81785E+01,7.77490E-01,7.95100E-01,2.45056E-01,3.89033E-03,1.48164E+00,mean

--- a/openquake/qa_tests_data/scenario_damage/case_13/expected/aggrisk.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_13/expected/aggrisk.csv
@@ -1,4 +1,4 @@
-#,,,,,,,,"generated_by='OpenQuake engine 3.23.0-git7df4c4c8e1', start_date='2025-02-04T13:41:43', checksum=3982247066, investigation_time=None, risk_investigation_time=None"
+#,,,,,,,,"generated_by='OpenQuake engine 3.24.0-gitd79b62c328', start_date='2025-03-31T05:06:48', checksum=1397702736, investigation_time=None, risk_investigation_time=None"
 loss_type,rlz_id,no_damage,slight,moderate,extensive,complete,losses_value,losses_ratio
 structural,0,9.90413E+01,4.09205E-01,4.18473E-01,1.28977E-01,2.04754E-03,7.79808E-01,7.79808E-01
 structural,1,9.94248E+01,2.45523E-01,2.51084E-01,7.73860E-02,1.22852E-03,4.67885E-01,4.67885E-01

--- a/openquake/qa_tests_data/scenario_damage/case_14/consequence_model.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_14/consequence_model.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,slight,moderate,extensive,complete
+risk_id,consequence,peril,slight,moderate,extensive,complete
 CR+PC/LDUAL/HBET:4.7/l,losses,groundshaking,1.000000E-01,3.000000E-01,6.000000E-01,1.000000E+00
 CR+PC/LDUAL/HBET:4.7/m,losses,groundshaking,1.000000E-01,3.000000E-01,6.000000E-01,1.000000E+00
 CR+PC/LDUAL/HBET:4.7/p,losses,groundshaking,1.000000E-01,3.000000E-01,6.000000E-01,1.000000E+00

--- a/openquake/qa_tests_data/scenario_damage/case_16/consequence_recovery_time.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_16/consequence_recovery_time.csv
@@ -1,3 +1,3 @@
-taxonomy,consequence,peril,slight,moderate,extensive,complete
+risk_id,consequence,peril,slight,moderate,extensive,complete
 UNM/C_LR/GOV,losses,groundshaking,35,90,197,287
 

--- a/openquake/qa_tests_data/scenario_damage/case_17/consequence_displaced.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_17/consequence_displaced.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,uninhabitable,collapsed
+risk_id,consequence,peril,uninhabitable,collapsed
 ND,homeless,groundshaking,1,0
 UH,homeless,groundshaking,1,0
 CP,homeless,groundshaking,1,0

--- a/openquake/qa_tests_data/scenario_damage/case_17/consequence_fatalities.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_17/consequence_fatalities.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,uninhabitable,collapsed
+risk_id,consequence,peril,uninhabitable,collapsed
 ND,fatalities,groundshaking,0,1
 UH,fatalities,groundshaking,0,1
 CP,fatalities,groundshaking,0,1

--- a/openquake/qa_tests_data/scenario_damage/case_18/consequence_displaced.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_18/consequence_displaced.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,uninhabitable,collapsed
+risk_id,consequence,peril,uninhabitable,collapsed
 ND,homeless,groundshaking,1,0
 UH,homeless,groundshaking,1,0
 CP,homeless,groundshaking,1,0

--- a/openquake/qa_tests_data/scenario_damage/case_18/consequence_fatalities.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_18/consequence_fatalities.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,uninhabitable,collapsed
+risk_id,consequence,peril,uninhabitable,collapsed
 ND,fatalities,groundshaking,0,1
 UH,fatalities,groundshaking,0,1
 CP,fatalities,groundshaking,0,1

--- a/openquake/qa_tests_data/scenario_damage/case_22/consequences.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_22/consequences.csv
@@ -1,7 +1,7 @@
-taxonomy,consequence,peril,slight,moderate,extreme,complete
-Concrete1,losses,groundshaking,0.04,0.31,0.6,1
-Wood1,losses,groundshaking,0.04,0.31,0.6,1
-Concrete1,losses,liquefaction,0,0,0,1
-Wood1,losses,liquefaction,0,0,0,1
-Concrete1,losses,landslide,0,0,0,1
-Wood1,losses,landslide,0,0,0,1
+risk_id,consequence,peril,slight,moderate,extreme,complete
+Concrete,losses,groundshaking,0.04,0.31,0.6,1
+Wood,losses,groundshaking,0.04,0.31,0.6,1
+Concrete,losses,liquefaction,0,0,0,1
+Wood,losses,liquefaction,0,0,0,1
+Concrete,losses,landslide,0,0,0,1
+Wood,losses,landslide,0,0,0,1

--- a/openquake/qa_tests_data/scenario_damage/case_22/mapping_multiple_perils.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_22/mapping_multiple_perils.csv
@@ -1,4 +1,4 @@
-taxonomy,conversion,weight,peril
+taxonomy,risk_id,weight,peril
 Wood1,Wood,1,groundshaking
 Concrete1,Concrete,1,groundshaking
 Wood1,Wood,1,liquefaction

--- a/openquake/qa_tests_data/scenario_damage/case_4b/consequence_model.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_4b/consequence_model.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,ds1,ds2,ds3,ds4
+risk_id,consequence,peril,ds1,ds2,ds3,ds4
 tax1,losses,groundshaking,4.000000E-02,1.600000E-01,3.200000E-01,6.400000E-01
 tax2,losses,groundshaking,4.000000E-02,1.600000E-01,3.200000E-01,6.400000E-01
 tax3,losses,groundshaking,4.000000E-02,1.600000E-01,3.200000E-01,6.400000E-01

--- a/openquake/qa_tests_data/scenario_damage/case_9/consequences_by_taxonomy.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_9/consequences_by_taxonomy.csv
@@ -1,4 +1,4 @@
-taxonomy,consequence,peril,slight,moderate,extensive,complete
+risk_id,consequence,peril,slight,moderate,extensive,complete
 CR_LFINF-DUH_H2,losses,groundshaking,0.05,0.25,0.6,1
 CR_LFINF-DUH_H4,losses,groundshaking,0.05,0.25,0.6,1
 MCF_LWAL-DNO_H3,losses,groundshaking,0.05,0.25,0.6,1

--- a/openquake/risklib/riskmodels.py
+++ b/openquake/risklib/riskmodels.py
@@ -18,7 +18,6 @@
 import re
 import json
 import copy
-import logging
 import functools
 import collections
 import numpy
@@ -523,33 +522,6 @@ class ValidationError(Exception):
     pass
 
 
-# TODO: if the consequence tag is different from "taxonomy", pass
-# the values of the exposure for that tag
-def check_consequences(fname, taxonomies, perils):
-    """
-    Check that the taxonomy field (if any) and the peril field (if any)
-    in the consequence file are consistent with the expected taxonomies
-    and perils
-    """
-    df = pandas.read_csv(fname)
-    if 'taxonomy' in df.columns:
-        csq_taxonomies = set(df['taxonomy'])
-        extra = csq_taxonomies - taxonomies
-        missing = taxonomies - csq_taxonomies
-        if not csq_taxonomies & taxonomies:
-            raise InvalidFile(f'{fname}: no matching taxonomies')
-        elif missing:
-            raise InvalidFile(f'{fname}: missing taxonomies {missing}')
-        elif extra:
-            # tested in event_based_damage/case_15
-            logging.warning(f'In {fname} there are extra taxonomies missing '
-                            f'in the exposure: {extra}')
-    if 'peril' in df.columns:
-        for line, peril in enumerate(df['peril'], 1):
-            if peril not in perils:
-                raise InvalidFile(f'{fname}: unknown {peril=} at {line=}')
-
-
 class CompositeRiskModel(collections.abc.Mapping):
     """
     A container (riskid, kind) -> riskmodel
@@ -622,12 +594,27 @@ class CompositeRiskModel(collections.abc.Mapping):
             else:
                 csq_files.append(fnames)
         for fname in csq_files:
-            check_consequences(fname, set(taxidx), self.perils)
-        for byname, coeffs in self.consdict.items():
-            # reduce the consdict to the taxonomies in the exposure
-            self.consdict[byname] = {taxidx[taxo]: arr
-                                     for taxo, arr in coeffs.items()
-                                     if taxo in taxidx}
+            df = pandas.read_csv(fname)
+            if 'peril' in df.columns:
+                for line, peril in enumerate(df['peril'], 1):
+                    if peril not in self.perils:
+                        raise InvalidFile(
+                            f'{fname}: unknown {peril=} at {line=}')
+
+        cfs = '\n'.join(csq_files)
+        df = self.tmap_df
+        for peril in self.perils:
+            for byname, coeffs in self.consdict.items():
+                # ex. byname = "losses_by_taxonomy"
+                if len(coeffs):
+                    for per, risk_id, weight in zip(
+                            df.peril, df.risk_id, df.weight):
+                        if (per == '*' or per == peril) and risk_id != '?':
+                            try:
+                                coeffs[risk_id][peril]
+                            except KeyError:
+                                raise InvalidFile(
+                                    f'Missing {risk_id=}, {peril=} in\n{cfs}')
 
     def check_risk_ids(self, inputs):
         """
@@ -686,7 +673,6 @@ class CompositeRiskModel(collections.abc.Mapping):
         :returns: a dict consequence_name, loss_type -> array[P, A, E]
         """
         # by construction all assets have the same taxonomy
-        taxi = assets[0]['taxonomy']
         P, A, E, _L, _D = dd5.shape
         csq = AccumDict(accum=numpy.zeros((P, A, E)))
         for byname, coeffs in self.consdict.items():
@@ -702,7 +688,7 @@ class CompositeRiskModel(collections.abc.Mapping):
                             else:  # assume one weigth per peril
                                 [w] = df[df.peril == peril].weight
                             coeff = (dd5[pi, :, :, li, 1:] @
-                                     coeffs[taxi][peril][lt] * w)
+                                     coeffs[risk_id][peril][lt] * w)
                             cAE = scientific.consequence(
                                 consequence, assets, coeff, lt, oq.time_event)
                             csq[consequence, li][pi] += cAE
@@ -717,7 +703,8 @@ class CompositeRiskModel(collections.abc.Mapping):
         if oq.calculation_mode.endswith('_bcr'):
             # classical_bcr calculator
             for riskid, risk_functions in self.risklist.groupby_id().items():
-                self._riskmodels[riskid] = get_riskmodel(riskid, oq, risk_functions)
+                self._riskmodels[riskid] = get_riskmodel(
+                    riskid, oq, risk_functions)
         elif (any(rf.kind == 'fragility' for rf in self.risklist) or
               'damage' in oq.calculation_mode):
             # classical_damage/scenario_damage calculator
@@ -903,10 +890,13 @@ class CompositeRiskModel(collections.abc.Mapping):
     def __getitem__(self, taxo):
         return self._riskmodels[taxo]
 
-    def get_outputs(self, asset_df, haz, sec_losses=(), rndgen=None, country='?'):
+    def get_outputs(
+            self, asset_df, haz, sec_losses=(), rndgen=None, country='?'):
         """
-        :param asset_df: a DataFrame of assets with the same taxonomy and country
-        :param haz: a DataFrame of GMVs on the sites of the assets
+        :param asset_df:
+            a DataFrame of assets with the same taxonomy and country
+        :param haz:
+            a DataFrame of GMVs on the sites of the assets
         :param sec_losses: a list of functions
         :param rndgen: a MultiEventRNG instance
         :returns: a list of dictionaries loss_type-> output


### PR DESCRIPTION
Now the field name in the consequence files must be `risk_id` and not `taxonomy` to prevent confusions.