### PR TITLE
Fixed too many post_classical tasks

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Too many post_classical tasks were generated with an artificially large
+    parameter `max_sites_disagg`
   * Internal: added a flag --wfp to the script `utils/build_global_exposure`
 
   [Paolo Tormene]

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -488,7 +488,7 @@ class ClassicalCalculator(base.HazardCalculator):
                 mean_rates_by_src, dic)
 
         # create empty dataframes
-        self.num_chunks = getters.get_num_chunks(self.datastore)
+        self.num_chunks, _N = getters.get_num_chunks_sites(self.datastore)
         # create empty dataframes
         self.datastore.create_df(
             '_rates', [(n, rates_dt[n]) for n in rates_dt.names])

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -151,19 +151,20 @@ def get_pmaps_gb(dstore, full_lt=None):
     return max_gb, trt_rlzs, gids
 
 
-def get_num_chunks(dstore):
+def get_num_chunks_sites(dstore):
     """
-    :returns: the number of postclassical tasks to generate.
+    :returns: (number of postclassical tasks to generate, number of sites)
 
     It is 5 times the number of GB required to store the rates.
     """
-    msd = dstore['oqparam'].max_sites_disagg
+    N = len(dstore['sitecol/sids'])
+    max_chunks = min(dstore['oqparam'].max_sites_disagg, N)
     try:
         req_gb = dstore['source_groups'].attrs['req_gb']
     except KeyError:
-        return msd
-    chunks = max(int(5 * req_gb), msd)
-    return chunks
+        return max_chunks, N
+    chunks = max(int(5 * req_gb), max_chunks)
+    return chunks, N
 
     
 def map_getters(dstore, full_lt=None, disagg=False):
@@ -172,8 +173,7 @@ def map_getters(dstore, full_lt=None, disagg=False):
     """
     oq = dstore['oqparam']
     # disaggregation is meant for few sites, i.e. no tiling
-    N = len(dstore['sitecol/sids'])
-    chunks = get_num_chunks(dstore)
+    chunks, N = get_num_chunks_sites(dstore)
     if disagg and N > chunks:
         raise ValueError('There are %d sites but only %d chunks' % (N, chunks))
 


### PR DESCRIPTION
One of our sponsors was using `max_sites_disagg = 94493` even in a calculation with a single site.