### PR TITLE
Backported fix to taxonomy mapping with consequences

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Backported fix to taxonomy mapping with consequences
   * Backported fix to 64 bit poes critical for multifault sources
   * Backported fix to workerpool critical for zmq clusters
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1053,6 +1053,8 @@ def get_crmodel(oqparam):
         # build consdict of the form consequence_by_tagname -> tag -> array
         loss_dt = oqparam.loss_dt()
         for by, fnames in oqparam.inputs['consequence'].items():
+            if by == 'risk_id':
+                by = 'taxonomy'
             if isinstance(fnames, str):  # single file
                 fnames = [fnames]
             # i.e. files collapsed.csv, fatalities.csv, ... with headers like

--- a/openquake/qa_tests_data/scenario_damage/case_13/consequence_recovery_time.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_13/consequence_recovery_time.csv
@@ -1,2 +1,2 @@
 taxonomy,consequence,peril,slight,moderate,extensive,complete
-MUR-CLBRS-LWAL-HBET-1;2/GOV2,losses,groundshaking,35,90,197,287
+UNM/C_LR/GOV2,losses,groundshaking,35,90,197,287

--- a/openquake/qa_tests_data/scenario_damage/case_22/consequences.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_22/consequences.csv
@@ -1,7 +1,7 @@
 taxonomy,consequence,peril,slight,moderate,extreme,complete
-Concrete1,losses,groundshaking,0.04,0.31,0.6,1
-Wood1,losses,groundshaking,0.04,0.31,0.6,1
-Concrete1,losses,liquefaction,0,0,0,1
-Wood1,losses,liquefaction,0,0,0,1
-Concrete1,losses,landslide,0,0,0,1
-Wood1,losses,landslide,0,0,0,1
+Concrete,losses,groundshaking,0.04,0.31,0.6,1
+Wood,losses,groundshaking,0.04,0.31,0.6,1
+Concrete,losses,liquefaction,0,0,0,1
+Wood,losses,liquefaction,0,0,0,1
+Concrete,losses,landslide,0,0,0,1
+Wood,losses,landslide,0,0,0,1


### PR DESCRIPTION
So that the old format of the consequence functions will keep working and there is no need for the script utils/fix_consequences.