### PR TITLE
10x speedup when reading the USA exposure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Optimized get_taxidx, thus making reading the USA exposure 10x faster
   * Internal: restored the view portfolio_damage
   * Too many post_classical tasks were generated with an artificially large
     parameter `max_sites_disagg`

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -355,8 +355,9 @@ class AssetCollection(object):
         :returns: dictionary taxonomy string -> taxonomy index starting from 1
         """
         taxonomies = self.tagcol.taxonomy[1:]
+        tuniq = numpy.unique(self['taxonomy'])
         return {taxo: taxi for taxi, taxo in enumerate(taxonomies, 1)
-                if taxi in numpy.unique(self['taxonomy'])}
+                if len(numpy.where(tuniq == taxi)[0])}
 
     @property
     def tagnames(self):


### PR DESCRIPTION
```
# before
2025-04-08T14:15:23,Reading /home/risk/global_risk_model/North_America/Exposure/Exposure/Exposure_United_States.xml
2025-04-08T14:22:08,The most common taxonomy is RES1-W1/H:1-LC with 178834 assets
2025-04-08T15:21:13,Reducing risk model from 606 to 319 risk functions

# after
2025-04-09T07:37:40,Reading /home/risk/global_risk_model/North_America/Exposure/Exposure/Exposure_United_States.xml
2025-04-09T07:44:31,The most common taxonomy is RES1-W1/H:1-LC with 178834 assets
2025-04-09T07:44:34,Reducing risk model from 606 to 319 risk functions
```
From 1h6m to 7 minutes.