### PR TITLE
Fixed wrong tile splitting in the AELO tests

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -281,13 +281,13 @@ class BaseCalculator(metaclass=abc.ABCMeta):
                 # EventBasedCalculator,EventBasedRiskCalculator
                 self.post_process()
                 self.export(kw.get('exports', ''))
-            except Exception as exc:
+            except Exception:
                 if kw.get('pdb'):  # post-mortem debug
                     tb = sys.exc_info()[2]
                     traceback.print_tb(tb)
                     pdb.post_mortem(tb)
                 else:
-                    raise exc from None
+                    raise
             finally:
                 if shutdown:
                     parallel.Starmap.shutdown()

--- a/openquake/calculators/tests/disagg_test.py
+++ b/openquake/calculators/tests/disagg_test.py
@@ -17,6 +17,7 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import os
 import re
+from unittest import mock
 import numpy
 from openquake.baselib import hdf5
 from openquake.baselib.general import gettemp
@@ -227,10 +228,10 @@ class DisaggregationTestCase(CalculatorTestCase):
 
     def test_case_14(self):
         # check non-invertible hazard curve
-        with self.assertRaises(ValueError) as ctx:
+        with mock.patch('logging.error') as err:
             self.run_calc(case_14.__file__, 'job.ini')
         self.assertIn('The PGA hazard curve for site_id=0 cannot be inverted',
-                      str(ctx.exception))
+                      err.call_args[0][0])
 
     # NB: the largest mean_rates_by_src is SUPER-SENSITIVE to numerics!
     # in particular it has very different values between 2 and 16 cores(!)

--- a/openquake/commonlib/logs.py
+++ b/openquake/commonlib/logs.py
@@ -22,7 +22,6 @@ import os
 import re
 import getpass
 import logging
-import traceback
 from datetime import datetime, timezone
 from openquake.baselib import config, zeromq, parallel, workerpool as w
 from openquake.commonlib import readinput, dbapi
@@ -269,7 +268,9 @@ class LogContext:
             if etype is SystemExit:
                 dbcmd('finish', self.calc_id, 'aborted')
             else:
-                logging.error(traceback.format_exc())
+                # remove StreamHandler to avoid logging twice
+                logging.root.removeHandler(self.handlers[-1])
+                logging.exception(f'{etype.__name__}: {exc}')
                 dbcmd('finish', self.calc_id, 'failed')
         else:
             dbcmd('finish', self.calc_id, 'complete')

--- a/openquake/engine/aelo.py
+++ b/openquake/engine/aelo.py
@@ -83,7 +83,7 @@ def get_params_from(inputs, mosaic_dir, exclude=()):
     params['uniform_hazard_spectra'] = 'true'
     params['use_rates'] = 'true'
     params['sites'] = inputs['sites']
-    params['max_sites_disagg'] = '1'
+    params['max_sites_disagg'] = len(lonlats)
     if 'vs30' in inputs:
         params['override_vs30'] = '%(vs30)s' % inputs
     params['distance_bin_width'] = '20'

--- a/openquake/hazardlib/map_array.py
+++ b/openquake/hazardlib/map_array.py
@@ -165,8 +165,8 @@ def check_hmaps(hcurves, imtls, poes):
                     continue
                 rel_err = abs(iml - iml99) / abs(iml + iml99)
                 if  rel_err > .05:
-                    raise ValueError(f'The {imt} hazard curve for {site_id=} cannot '
-                                     f'be inverted reliably around {poe=}')
+                    logging.error(f'The {imt} hazard curve for {site_id=} cannot '
+                                  f'be inverted reliably around {poe=}')
 
 
 # not used right now


### PR DESCRIPTION
`oq.max_sites_disagg` must be big enough to accomodate all sites in a model so that the full site collection is used, and not a tile, otherwise the error
```python
# OQ_ONLY_MODELS=JPN oq mosaic run_site tests/aelo/data/merged_sites.csv ~/AELO2025
  File "/home/michele/oq-engine/openquake/calculators/classical.py", line 371, in get_rates
    return rates.reshape((self.N, self.M, self.L1))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: cannot reshape array of size 4500 into shape (18,20,25)
```
will be raised in JPN. Also, downgraded the error about the non-invertibility of the hazard curve.