### PR TITLE
Restructure the AELO form to handle the vs30 field differently

### DIFF
--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -86,7 +86,7 @@ ASCE_DECIMALS = 5
 
 def get_DLLs(job_imts, vs30):
 
-    if vs30 > 1500:
+    if vs30 >= 1500:
         soil_class_asce = 'A'
     elif vs30 > 914:
         soil_class_asce = 'B'

--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -86,7 +86,7 @@ ASCE_DECIMALS = 5
 
 def get_DLLs(job_imts, vs30):
 
-    if vs30 > 1524:
+    if vs30 > 1500:
         soil_class_asce = 'A'
     elif vs30 > 914:
         soil_class_asce = 'B'

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -19,8 +19,17 @@ h2 {
 }
 
 @media (min-width: 1070px) and (max-width: 1120px) {
+    .table-aelo-form {
+        width: 76%!important;
+    }
+    .table-aelo-form-2 {
+        width: 63%!important;
+    }
+    .aelo-input-siteid {
+        width: 277px!important;
+    }
     .aelo-input {
-        width: 170px!important;
+        width: 170px;
     }
     .aelo-select {
         width: 184px!important;
@@ -28,8 +37,17 @@ h2 {
 }
 
 @media (min-width: 960px) and (max-width: 1069px) {
+    .table-aelo-form {
+        width: 85%!important;
+    }
+    .table-aelo-form-2 {
+        width: 70%!important;
+    }
+    .aelo-input-siteid {
+        width: 267px!important;
+    }
     .aelo-input {
-        width: 160px!important;
+        width: 160px;
     }
     .aelo-select {
         width: 174px!important;
@@ -37,8 +55,17 @@ h2 {
 }
 
 @media (min-width: 760px) and (max-width: 959px) {
+    .table-aelo-form {
+        width: 100%!important;
+    }
+    .table-aelo-form-2 {
+        width: 80%!important;
+    }
+    .aelo-input-siteid {
+        width: 247px!important;
+    }
     .aelo-input {
-        width: 140px!important;
+        width: 140px;
     }
     .aelo-select {
         width: 154px!important;
@@ -46,8 +73,17 @@ h2 {
 }
 
 @media (min-width: 640px) and (max-width: 759px) {
-    .aelo-input {
+    .table-aelo-form {
+        width: 100%!important;
+    }
+    .table-aelo-form-2 {
         width: 80%!important;
+    }
+    .aelo-input-siteid {
+        width: 90%!important;
+    }
+    .aelo-input {
+        width: 80%;
     }
     .aelo-select {
         width: 140px!important;
@@ -311,6 +347,10 @@ tr.asce_output {
     padding-bottom: 10px!important;
 }
 
+.aelo-input-siteid {
+    width: 300px;
+}
+
 .aelo-label {
     font-weight: bold;
 }
@@ -320,15 +360,27 @@ tr.asce_output {
     width: 207px;
 }
 
+.custom-vs30 {
+    display: none;
+}
+
 .table-aelo-form {
+    width: 70%;
     margin-bottom: 0;
 }
 
-.table-aelo-form tr th {
+.table-aelo-form-2 {
+    width: 62%;
+}
+
+.table-aelo-form tr th,
+.table-aelo-form-2 tr th {
     padding: 0;
 }
 
-.table-aelo-form td {
+.table-aelo-form td,
+.table-aelo-form-2 td {
+    width: 33.33333%;
     padding: 0;
     border-top: 0;
 }

--- a/openquake/server/static/css/engine.css
+++ b/openquake/server/static/css/engine.css
@@ -19,25 +19,29 @@ h2 {
 }
 
 @media (min-width: 1070px) and (max-width: 1120px) {
-    .aelo-input,
-    .aelo-select {
+    .aelo-input {
         width: 170px!important;
+    }
+    .aelo-select {
+        width: 184px!important;
     }
 }
 
 @media (min-width: 960px) and (max-width: 1069px) {
-    .aelo-input,
-    .aelo-select {
+    .aelo-input {
         width: 160px!important;
+    }
+    .aelo-select {
+        width: 174px!important;
     }
 }
 
 @media (min-width: 760px) and (max-width: 959px) {
     .aelo-input {
-        width: 80%!important;
+        width: 140px!important;
     }
     .aelo-select {
-        width: 170px!important;
+        width: 154px!important;
     }
 }
 
@@ -313,6 +317,7 @@ tr.asce_output {
 
 .aelo-select {
     height: 33px!important;
+    width: 207px;
 }
 
 .table-aelo-form {

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -637,23 +637,64 @@ function capitalizeFirstLetter(val) {
                                setTimer();
                            });
 
+            $('select#vs30').on('change', function() {
+                const vs30 = $(this).val();
+                if (vs30 === 'custom') {
+                    $('#aelo_form_second_row').show();
+                } else {
+                    $('#aelo_form_second_row').hide();
+                }
+            });
+
             $('#asce_version').on('change', function() {
                 const asce_version = $(this).val();
+                const $vs30_select = $('select#vs30');
+                $vs30_select.empty();
                 if (asce_version === 'ASCE7-16') {
-                    // NOTE: if vs30 is empty, it is read as 760 and the placeholder is displayed (see below)
-                    $('#vs30').prop('readonly', true).attr('placeholder', 'fixed at 760 m/s').val('');
+                    $vs30_select.append(
+                        $('<option>', {
+                            value: 760,
+                            text: '760 m/s'
+                        })
+                    );
                 } else if (asce_version === 'ASCE7-22') {
-                    $('#vs30').prop('readonly', false).attr('placeholder', 'm/s');
+                    const items = [
+                        {value: 1500, text: 'A: Vs30 >= 1500 m/s'},
+                        {value: 1080, text: 'B: Vs30 >= 1080 m/s' },
+                        {value: 760, text: 'BC: Vs30 >= 760 m/s' },
+                        {value: 530, text: 'C: Vs30 >= 530 m/s' },
+                        {value: 365, text: 'CD: Vs30 >= 365 m/s' },
+                        {value: 260, text: 'D: Vs30 >= 260 m/s' },
+                        {value: 185, text: 'DE: Vs30 >= 185 m/s' },
+                        {value: 150, text: 'E: Vs30 >= 150 m/s' },
+                        {value: 260, text: 'Unknown (default: class D)' },
+                        {value: 'custom', text: 'Custom'},
+                    ];
+                    items.forEach(item => {
+                        $vs30_select.append(
+                            $("<option>", {
+                                value: item.value,
+                                text: item.text
+                            })
+                        );
+                    });
                 }
             });
 
             // NOTE: if not in aelo mode, aelo_run_form does not exist, so this can never be triggered
             $("#aelo_run_form").submit(function (event) {
                 $('#submit_aelo_calc').prop('disabled', true);
+                var vs30;
+                const $vs30_select = $('select#vs30');
+                if ($vs30_select.val() === 'custom') {
+                    vs30 = parseFloat($("input#custom_vs30").val());
+                } else {
+                    vs30 = parseFloat($("select#vs30").val());
+                }
                 var formData = {
                     lon: $("#lon").val(),
                     lat: $("#lat").val(),
-                    vs30: $("#vs30").val().trim() === '' ? '760' : $("#vs30").val(),
+                    vs30: vs30,
                     siteid: $("#siteid").val(),
                     asce_version: $("#asce_version").val()
                 };

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -733,18 +733,20 @@ function capitalizeFirstLetter(val) {
 
             // IMPACT
 
-            set_shakemap_version_selector();
-            $.ajax({
-                url:  "/v1/get_impact_form_defaults",
-                method: "GET",
-                dataType: "json",
-                success: function(data) {
-                    impact_form_defaults = data;
-                },
-                error: function(xhr, status, error) {
-                    console.error("Error loading impact_from_defaults:", error);
-                }
-            });
+            if (window.application_mode === 'ARISTOTLE') {
+                set_shakemap_version_selector();
+                $.ajax({
+                    url:  "/v1/get_impact_form_defaults",
+                    method: "GET",
+                    dataType: "json",
+                    success: function(data) {
+                        impact_form_defaults = data;
+                    },
+                    error: function(xhr, status, error) {
+                        console.error("Error loading impact_from_defaults:", error);
+                    }
+                });
+            }
 
             function toggleRunCalcBtnState() {
                 var lonValue = $('#lon').val();

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -679,6 +679,11 @@ function capitalizeFirstLetter(val) {
                         );
                     });
                 }
+                if ($vs30_select.val() === 'custom') {
+                    $('.custom-vs30').fadeIn();
+                } else {
+                    $('.custom-vs30').fadeOut();
+                }
             });
 
             // NOTE: if not in aelo mode, aelo_run_form does not exist, so this can never be triggered

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -660,13 +660,13 @@ function capitalizeFirstLetter(val) {
                 } else if (asce_version === 'ASCE7-22') {
                     const items = [
                         {value: 1500, text: 'A: Vs30 >= 1500 m/s'},
-                        {value: 1080, text: 'B: Vs30 >= 1080 m/s' },
-                        {value: 760, text: 'BC: Vs30 >= 760 m/s' },
-                        {value: 530, text: 'C: Vs30 >= 530 m/s' },
-                        {value: 365, text: 'CD: Vs30 >= 365 m/s' },
-                        {value: 260, text: 'D: Vs30 >= 260 m/s' },
-                        {value: 185, text: 'DE: Vs30 >= 185 m/s' },
-                        {value: 150, text: 'E: Vs30 >= 150 m/s' },
+                        {value: 1080, text: 'B: 914 m/s <= Vs30 < 1500 m/s' },
+                        {value: 760, text: 'BC: 640 m/s <= Vs30 < 914 m/s' },
+                        {value: 530, text: 'C: 442 m/s <= Vs30 >= 640 m/s' },
+                        {value: 365, text: 'CD: 305 m/s <= Vs30 >= 442 m/s' },
+                        {value: 260, text: 'D: 213 m/s <= Vs30 >= 305 m/s' },
+                        {value: 185, text: 'DE: 152 m/s <= Vs30 >= 213 m/s' },
+                        {value: 150, text: 'E: vs30 m/s < 152 m/s' },
                         {value: 260, text: 'Unknown (default: class D)' },
                         {value: 'custom', text: 'Custom'},
                     ];
@@ -734,7 +734,6 @@ function capitalizeFirstLetter(val) {
             // IMPACT
 
             set_shakemap_version_selector();
-
             $.ajax({
                 url:  "/v1/get_impact_form_defaults",
                 method: "GET",

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -640,9 +640,9 @@ function capitalizeFirstLetter(val) {
             $('select#vs30').on('change', function() {
                 const vs30 = $(this).val();
                 if (vs30 === 'custom') {
-                    $('#aelo_form_second_row').show();
+                    $('.custom-vs30').fadeIn();
                 } else {
-                    $('#aelo_form_second_row').hide();
+                    $('.custom-vs30').fadeOut();
                 }
             });
 

--- a/openquake/server/templates/engine/includes/aelo_form.html
+++ b/openquake/server/templates/engine/includes/aelo_form.html
@@ -21,7 +21,7 @@
                   <tr>
                     <td><input class="aelo-input" type="text" id="lat" name="lat" placeholder="{{ aelo_form_placeholders.lat }}"/></td>
                     <td><input class="aelo-input" type="text" id="lon" name="lon" placeholder="{{ aelo_form_placeholders.lon }}"/></td>
-                    <td><input class="aelo-input" type="text" id="vs30" name="vs30" placeholder="{{ aelo_form_placeholders.vs30 }}" readonly /></td>
+                    <td><select class="aelo-select" name="vs30" id="vs30"><option value="760">760 m/s</option></select></td>
                     <td><input class="aelo-input" type="text" id="siteid" name="siteid" placeholder="{{ aelo_form_placeholders.siteid }}"/></td>
                     <td>
                         <select class="aelo-select" name="asce_version" id="asce_version">
@@ -34,6 +34,13 @@
                         {% endfor %}
                         </select>
                     </td>
+                  </tr>
+                  <tr id="aelo_form_second_row" hidden>
+                      <td></td>
+                      <td></td>
+                      <td><input class="aelo-input" type="text" id="custom_vs30" name="custom_vs30" placeholder="{{ aelo_form_placeholders.custom_vs30 }}"/></td>
+                      <td></td>
+                      <td></td>
                   </tr>
                 </tbody>
               </table>

--- a/openquake/server/templates/engine/includes/aelo_form.html
+++ b/openquake/server/templates/engine/includes/aelo_form.html
@@ -13,15 +13,26 @@
                     <th><label class="aelo-label" for"lat">{{ aelo_form_labels.lat }}</label></th>
                     <th><label class="aelo-label" for"lon">{{ aelo_form_labels.lon }}</label></th>
                     <th><label class="aelo-label" for"siteid">{{ aelo_form_labels.siteid }}</label></th>
-                    <th><label class="aelo-label" for="asce_version">{{ aelo_form_labels.asce_version }}</label></th>
-                    <th><label class="aelo-label" for"vs30">{{ aelo_form_labels.vs30 }}</label></th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
                     <td><input class="aelo-input" type="text" id="lat" name="lat" placeholder="{{ aelo_form_placeholders.lat }}"/></td>
                     <td><input class="aelo-input" type="text" id="lon" name="lon" placeholder="{{ aelo_form_placeholders.lon }}"/></td>
-                    <td><input class="aelo-input" type="text" id="siteid" name="siteid" placeholder="{{ aelo_form_placeholders.siteid }}"/></td>
+                    <td><input class="aelo-input aelo-input-siteid" type="text" id="siteid" name="siteid" placeholder="{{ aelo_form_placeholders.siteid }}"/></td>
+                  </tr>
+                </tbody>
+              </table>
+              <table class="table-aelo-form-2 table">
+                <thead>
+                  <tr>
+                    <th><label class="aelo-label" for="asce_version">{{ aelo_form_labels.asce_version }}</label></th>
+                    <th><label class="aelo-label" for"vs30">{{ aelo_form_labels.vs30 }}</label></th>
+                    <th><label class="aelo-label custom-vs30" for"custom_vs30">{{ aelo_form_labels.custom_vs30 }}</label></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
                     <td>
                         <select class="aelo-select" name="asce_version" id="asce_version">
                         {% for asce_version in asce_versions %}
@@ -34,13 +45,7 @@
                         </select>
                     </td>
                     <td><select class="aelo-select" name="vs30" id="vs30"><option value="760">760 m/s</option></select></td>
-                  </tr>
-                  <tr id="aelo_form_second_row" hidden>
-                      <td></td>
-                      <td></td>
-                      <td></td>
-                      <td></td>
-                      <td><input class="aelo-input" type="text" id="custom_vs30" name="custom_vs30" placeholder="{{ aelo_form_placeholders.custom_vs30 }}"/></td>
+                    <td><span class="custom-vs30"><input class="aelo-input" type="text" id="custom_vs30" name="custom_vs30" placeholder="{{ aelo_form_placeholders.custom_vs30 }}"/></span></td>
                   </tr>
                 </tbody>
               </table>

--- a/openquake/server/templates/engine/includes/aelo_form.html
+++ b/openquake/server/templates/engine/includes/aelo_form.html
@@ -12,16 +12,15 @@
                   <tr>
                     <th><label class="aelo-label" for"lat">{{ aelo_form_labels.lat }}</label></th>
                     <th><label class="aelo-label" for"lon">{{ aelo_form_labels.lon }}</label></th>
-                    <th><label class="aelo-label" for"vs30">{{ aelo_form_labels.vs30 }}</label></th>
                     <th><label class="aelo-label" for"siteid">{{ aelo_form_labels.siteid }}</label></th>
                     <th><label class="aelo-label" for="asce_version">{{ aelo_form_labels.asce_version }}</label></th>
+                    <th><label class="aelo-label" for"vs30">{{ aelo_form_labels.vs30 }}</label></th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
                     <td><input class="aelo-input" type="text" id="lat" name="lat" placeholder="{{ aelo_form_placeholders.lat }}"/></td>
                     <td><input class="aelo-input" type="text" id="lon" name="lon" placeholder="{{ aelo_form_placeholders.lon }}"/></td>
-                    <td><select class="aelo-select" name="vs30" id="vs30"><option value="760">760 m/s</option></select></td>
                     <td><input class="aelo-input" type="text" id="siteid" name="siteid" placeholder="{{ aelo_form_placeholders.siteid }}"/></td>
                     <td>
                         <select class="aelo-select" name="asce_version" id="asce_version">
@@ -34,13 +33,14 @@
                         {% endfor %}
                         </select>
                     </td>
+                    <td><select class="aelo-select" name="vs30" id="vs30"><option value="760">760 m/s</option></select></td>
                   </tr>
                   <tr id="aelo_form_second_row" hidden>
                       <td></td>
                       <td></td>
+                      <td></td>
+                      <td></td>
                       <td><input class="aelo-input" type="text" id="custom_vs30" name="custom_vs30" placeholder="{{ aelo_form_placeholders.custom_vs30 }}"/></td>
-                      <td></td>
-                      <td></td>
                   </tr>
                 </tbody>
               </table>

--- a/openquake/server/templates/engine/index.html
+++ b/openquake/server/templates/engine/index.html
@@ -136,5 +136,8 @@
 
   {% block extra_script %}
   {{ block.super }}
+  <script>
+    window.application_mode = "{{ application_mode|escapejs }}";
+  </script>
   <script type="text/javascript" src="{{ STATIC_URL }}js/engine.js"></script>
   {% endblock extra_script %}

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -114,7 +114,7 @@ AELO_FORM_LABELS = {
 AELO_FORM_PLACEHOLDERS = {
     'lon': 'max. 5 decimals',
     'lat': 'max. 5 decimals',
-    'vs30': 'fixed at 760 m/s',
+    'custom_vs30': 'positive float',
     'siteid': f'max. {settings.MAX_AELO_SITE_NAME_LEN} characters',
     'asce_version': 'ASCE version',
 }

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -107,6 +107,7 @@ AELO_FORM_LABELS = {
     'lon': 'Longitude',
     'lat': 'Latitude',
     'vs30': 'Vs30',
+    'custom_vs30': 'Custom Vs30',
     'siteid': 'Site name',
     'asce_version': 'ASCE version',
 }


### PR DESCRIPTION
When the ASCE version is changed, a dropdown selector for vs30 is populated and the user can choose the site class. For each class, the corresponding range is displayed. In addition to the classes A, B, BC, C, CD, D, DE, E, it is possible to choose 'Unknown (default: class D)' or 'Custom'. If the latter is selected, an additional input field appears, in which a positive float can be inserted and used as custom vs30 value.

NOTE: the value of vs30 is determined javascript-side and sent to the backend, where nothing changed with respect to the management of that variable.

As requested by Kendra and Manuela, I also changed the range of vs30 for soil_class_asce 'A' to `>=1500`.

I've also fixed a little bug, avoiding to call impact-related api endpoints from javascript when using a different application mode.