### PR TITLE
Some improvements to the oq-impact level 1 interface

### DIFF
--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -193,7 +193,7 @@ IMPACT_FORM_DEFAULTS = {
     'time_event': 'day',
     'dip': '90',
     'strike': '0',
-    'maximum_distance': '200',
+    'maximum_distance': '300',
     'truncation_level': '3',
     'number_of_ground_motion_fields': '100',
     'asset_hazard_distance': '15',

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -858,6 +858,7 @@ function capitalizeFirstLetter(val) {
                 }).done(function (data) {
                     // console.log(data);
                     $('.impact_time_grp').css('display', 'inline-block');
+                    $('div.impact_time_grp').css('display', 'block');
                     $('#lon').val(data.lon);
                     toggleRunCalcBtnState();
                     $('#lat').val(data.lat);

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -857,6 +857,7 @@ function capitalizeFirstLetter(val) {
                     encode: true,
                 }).done(function (data) {
                     // console.log(data);
+                    $('.impact_time_grp').css('display', 'inline-block');
                     $('#lon').val(data.lon);
                     toggleRunCalcBtnState();
                     $('#lat').val(data.lat);

--- a/openquake/server/templates/engine/includes/impact_run_form.html
+++ b/openquake/server/templates/engine/includes/impact_run_form.html
@@ -9,13 +9,13 @@
                 <select name="trt" id="trt" class="impact-select" {% if user_level != 2 %}disabled{% endif %}>
                 </select>
               </div>
-              <div class="impact_form_row">
-                <label for"local_timestamp">{{ impact_form_labels.local_timestamp }}</label>
-                <input class="impact-input" type="text" id="local_timestamp" name="local_timestamp" placeholder="{{ impact_form_placeholders.local_timestamp }}" disabled />
+              <div class="impact_form_row impact_time_grp">
+                <label class="impact_time_grp" for"local_timestamp">{{ impact_form_labels.local_timestamp }}</label>
+                <input class="impact-input impact_time_grp" type="text" id="local_timestamp" name="local_timestamp" placeholder="{{ impact_form_placeholders.local_timestamp }}" disabled />
               </div>
-              <div class="impact_form_row">
-                <label for"time_event">{{ impact_form_labels.time_event }}</label>
-                <select id="time_event" name="time_event" class="impact-select">
+              <div class="impact_form_row impact_time_grp">
+                <label class="impact_time_grp" for"time_event">{{ impact_form_labels.time_event }}</label>
+                <select id="time_event" name="time_event" class="impact-select impact_time_grp">
                     <option value="day">Day</option>
                     <option value="night">Night</option>
                     <option value="transit">Transit</option>

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -909,7 +909,8 @@ def impact_run_with_shakemap(request):
     Run an impact calculation.
 
     :param request:
-        a `django.http.HttpRequest` object containing a usgs_id
+        a `django.http.HttpRequest` object containing a usgs_id and optionally the time
+        of the day ('day', 'night' or 'transit')
     """
     if request.user.level == 0:
         return HttpResponseForbidden()
@@ -920,6 +921,8 @@ def impact_run_with_shakemap(request):
         return JsonResponse(err, status=400 if 'invalid_inputs' in err else 500)
     post = {key: str(val) for key, val in rupdic.items()
             if key != 'shakemap_array'}
+    if 'time_event' in request.POST:
+        post['time_event'] = request.POST['time_event']
     post['approach'] = 'use_shakemap_from_usgs'
     post['use_shakemap'] = 'true'
     for field in IMPACT_FORM_DEFAULTS:


### PR DESCRIPTION
- The default source-to-site distance for filtering assets was raised from 200km to 300km (NOTE: this new default will be the same also for level 2 users, who will be able to edit it in the form)
- The fields showing the local timestamp of the event and the time of the event (day, night or transit) are now visible also to level 1 users. The local timestamp is not editable and it is visualized only as a reference, whereas the time of the event can be changed, overriding the pre-populated option.
- The API endpoint `impact_run_with_shakemap` was extended to take into account the additional (optional) parameter `time_event`, that can be used to override the time of the event calculated on the base of the local timestamp.