### PR TITLE
IMPACT: improve the management of the ShakeMap version

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -397,7 +397,7 @@ def usgs_stations_to_oq_format(stations, exclude_imts=(), seismic_only=False):
     return df
 
 
-def _get_preferred_item(items):
+def _get_usgs_preferred_item(items):
     # items can be for instance shakemaps, moment tensors or finite faults
     preferred_weights = [item['preferredWeight'] for item in items]
     preferred_idxs = [idx for idx, val in enumerate(preferred_weights)
@@ -488,7 +488,7 @@ def load_rupdic_from_finite_fault(usgs_id, mag, products):
         err = {"status": "failed", "error_msg": err_msg}
         return None, err
     ffs = products['finite-fault']
-    ff = _get_preferred_item(ffs)
+    ff = _get_usgs_preferred_item(ffs)
     p = ff['properties']
     # TODO: we probably need to get the rupture coordinates from shakemap_polygon.txt
     # if 'shakemap_polygon.txt' in ff['contents']:
@@ -535,7 +535,7 @@ def load_rupdic_from_origin(usgs_id, products):
         err = {"status": "failed", "error_msg": err_msg}
         return None, err
     origins = products['origin']
-    origin = _get_preferred_item(origins)
+    origin = _get_usgs_preferred_item(origins)
     p = origin['properties']
     mag = float(p['magnitude'])
     lon = float(p['longitude'])
@@ -685,11 +685,12 @@ def convert_rup_data(rup_data, usgs_id, rup_path, shakemap_array=None):
 
 
 def _contents_properties_shakemap(usgs_id, user, get_grid, monitor,
-                                  shakemap_version='latest'):
+                                  shakemap_version='preferred'):
     # with open(f'/tmp/{usgs_id}.json', 'wb') as f:
     #     url = SHAKEMAP_URL.format(usgs_id)
     #     f.write(urlopen(url).read())
-    #     # NOTE: remove the includesuperseded parameter to download less data for testing
+    #     # NOTE: remove the includesuperseded parameter to download less
+    #             data for testing
     err = {}
     if user.testdir:  # in parsers_test
         fname = os.path.join(user.testdir, usgs_id + '.json')
@@ -711,8 +712,8 @@ def _contents_properties_shakemap(usgs_id, user, get_grid, monitor,
 
     # NB: currently we cannot find a case with missing shakemap
     shakemaps = properties['products']['shakemap']
-    if shakemap_version == 'latest':
-        shakemap = _get_preferred_item(shakemaps)
+    if shakemap_version == 'preferred':
+        shakemap = _get_usgs_preferred_item(shakemaps)
     else:
         [shakemap] = [shm for shm in shakemaps if shm['id'] == shakemap_version]
     contents = shakemap['contents']
@@ -740,10 +741,10 @@ def _get_nodal_planes(properties):
     # try first reading from the moment tensor, if available. If nodal planes can not be
     # collected from there, fallback attempting to read them from the focal mechanism
     if 'moment-tensor' in properties['products']:
-        moment_tensor = _get_preferred_item(properties['products']['moment-tensor'])
+        moment_tensor = _get_usgs_preferred_item(properties['products']['moment-tensor'])
         nodal_planes = _get_nodal_planes_from_product(moment_tensor)
     if not nodal_planes and 'focal-mechanism' in properties['products']:
-        focal_mechanism = _get_preferred_item(properties['products']['focal-mechanism'])
+        focal_mechanism = _get_usgs_preferred_item(properties['products']['focal-mechanism'])
         nodal_planes = _get_nodal_planes_from_product(focal_mechanism)
     if not nodal_planes:
         err = {'status': 'failed',
@@ -818,7 +819,8 @@ def _get_rup_from_json(usgs_id, rupture_file):
     return rup, rupdic, rup_data, err_msg
 
 
-def get_stations_from_usgs(usgs_id, user=User(), monitor=performance.Monitor()):
+def get_stations_from_usgs(usgs_id, user=User(), monitor=performance.Monitor(),
+                           shakemap_version='preferred'):
     err = {}
     n_stations = 0
     try:
@@ -826,9 +828,8 @@ def get_stations_from_usgs(usgs_id, user=User(), monitor=performance.Monitor()):
     except ValueError as exc:
         err = {'status': 'failed', 'error_msg': str(exc)}
         return None, n_stations, err
-    # NOTE: getting stations from the latest (preferred) ShakeMap
     contents, _properties, _shakemap, err = _contents_properties_shakemap(
-        usgs_id, user, False, monitor)
+        usgs_id, user, False, monitor, shakemap_version)
     if err:
         return None, n_stations, err
     with monitor('Downloading stations'):
@@ -845,11 +846,12 @@ def ms_to_utc_date_time(ms):
 
 def get_shakemap_versions(usgs_id, user=User(), monitor=performance.Monitor()):
     err = {}
+    usgs_preferred_version = None
     try:
         usgs_id = valid.simple_id(usgs_id)
     except ValueError as exc:
         err = {'status': 'failed', 'error_msg': str(exc)}
-        return None, err
+        return None, None, err
     if user.testdir:  # in parsers_test
         fname = os.path.join(user.testdir, usgs_id + '.json')
         text = open(fname).read()
@@ -863,18 +865,21 @@ def get_shakemap_versions(usgs_id, user=User(), monitor=performance.Monitor()):
             # in parsers_test
             err_msg = f'Unable to download from {url}: {exc}'
             err = {"status": "failed", "error_msg": err_msg}
-            return None, err
+            return None, None, err
 
     js = json.loads(text)
     properties = js['properties']
     shakemaps = properties['products']['shakemap']
+    usgs_preferred_shakemap = _get_usgs_preferred_item(shakemaps)
+    usgs_preferred_version = usgs_preferred_shakemap['properties']['version']
     sorted_shakemaps = sorted(
         shakemaps, key=lambda x: x["updateTime"], reverse=True)
     shakemap_versions = [
         {'id': shakemap['id'],
+         'number': shakemap['properties']['version'],
          'utc_date_time': ms_to_utc_date_time(shakemap['updateTime'])}
         for shakemap in sorted_shakemaps]
-    return shakemap_versions, err
+    return shakemap_versions, usgs_preferred_version, err
 
 
 def get_rup_dic(dic, user=User(), use_shakemap=False, shakemap_version='latest',

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -882,7 +882,7 @@ def get_shakemap_versions(usgs_id, user=User(), monitor=performance.Monitor()):
     return shakemap_versions, usgs_preferred_version, err
 
 
-def get_rup_dic(dic, user=User(), use_shakemap=False, shakemap_version='latest',
+def get_rup_dic(dic, user=User(), use_shakemap=False, shakemap_version='preferred',
                 rupture_file=None, monitor=performance.Monitor()):
     """
     If the rupture_file is None, download a rupture from the USGS site given

--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -333,7 +333,7 @@ def impact_validate(POST, user, rupture_file=None, station_data_file=None,
     if 'shakemap_version' in POST:
         shakemap_version = POST['shakemap_version']
     else:
-        shakemap_version = 'latest'
+        shakemap_version = 'preferred'
 
     rup, rupdic, err = get_rup_dic(dic, user, use_shakemap, shakemap_version,
                                    rupture_file, monitor)

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -283,6 +283,16 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertIsNone(usgs_preferred_version)
         self.assertIn('Unable to download', err['error_msg'])
 
+    def test_15(self):
+        usgs_id = 'usp0001ccb'
+        shakemap_versions, _usgs_preferred_version, _err = get_shakemap_versions(
+            usgs_id, user=user)
+        first_version = shakemap_versions[0]
+        _rup, dic, _err = get_rup_dic(
+                {'usgs_id': 'usp0001ccb', 'approach': 'use_shakemap_from_usgs'},
+                user=user, use_shakemap=True, shakemap_version=first_version['id'])
+        self.assertIsNotNone(dic['shakemap_array'])
+
 
 """
 NB: to profile a test you can use

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -206,7 +206,8 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['aspect_ratio'], 3)
 
     def test_10(self):
-        dic_in = {'usgs_id': 'us6000jllz', 'lon': 37.0143, 'lat': 37.2256, 'dep': 10.0,
+        dic_in = {'usgs_id': 'us6000jllz',
+                  'lon': 37.0143, 'lat': 37.2256, 'dep': 10.0,
                   'mag': 7.8, 'msr': 'WC1994', 'aspect_ratio': 2.0,
                   'rake': -179.18, 'dip': 88.71, 'strike': 317.63,
                   'approach': 'build_rup_from_usgs'}
@@ -268,16 +269,18 @@ class ShakemapParsersTestCase(unittest.TestCase):
 
     def test_14(self):
         usgs_id = 'us20002926'
-        shakemap_versions, err = get_shakemap_versions(usgs_id, user=user)
+        shakemap_versions, usgs_preferred_version, err = get_shakemap_versions(
+            usgs_id, user=user)
         self.assertEqual(err, {})
         self.assertEqual(len(shakemap_versions), 3)
+        self.assertEqual(usgs_preferred_version, '1')
         first_version = shakemap_versions[0]
         self.assertIn('id', first_version)
         self.assertIn('utc_date_time', first_version)
         usgs_id = 'does_not_exist'
-        shakemap_versions, preferred_version, err = get_shakemap_versions(usgs_id)
+        shakemap_versions, usgs_preferred_version, err = get_shakemap_versions(usgs_id)
         self.assertIsNone(shakemap_versions)
-        self.assertIsNone(preferred_version)
+        self.assertIsNone(usgs_preferred_version)
         self.assertIn('Unable to download', err['error_msg'])
 
 

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -77,7 +77,7 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertEqual(dic['rupture_file'], None)
         self.assertIsNotNone(dic['mmi_file'])
         station_data_file, n_stations, station_err = get_stations_from_usgs(
-            usgs_id, user=user)
+            usgs_id, user=user, shakemap_version='preferred')
         self.assertIsNone(station_data_file)
         self.assertEqual(n_stations, 0)
         self.assertEqual(station_err['error_msg'], 'No stations were found')
@@ -103,7 +103,7 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertIn('Unable to convert the rupture from the USGS format',
                       dic['rupture_issue'])
         station_data_file, n_stations, station_err = get_stations_from_usgs(
-            usgs_id, user=user)
+            usgs_id, user=user, shakemap_version='preferred')
         self.assertIn('stations', station_data_file)
         self.assertEqual(n_stations, 1)
         self.assertEqual(station_err, {})
@@ -111,7 +111,7 @@ class ShakemapParsersTestCase(unittest.TestCase):
     def test_3e(self):
         usgs_id = 'us7000pn9s'
         station_data_file, n_stations, station_err = get_stations_from_usgs(
-            usgs_id, user=user)
+            usgs_id, user=user, shakemap_version='preferred')
         self.assertIn('stations', station_data_file)
         self.assertEqual(n_stations, 1)
         self.assertEqual(station_err, {})
@@ -149,7 +149,7 @@ class ShakemapParsersTestCase(unittest.TestCase):
             user=user, use_shakemap=True)
         self.assertEqual(dic['mag'], 6.7)
         station_data_file, n_stations, station_err = get_stations_from_usgs(
-            usgs_id, user=user)
+            usgs_id, user=user, shakemap_version='preferred')
         self.assertIsNone(station_data_file)
         self.assertEqual(n_stations, 0)
         self.assertEqual(station_err['error_msg'],
@@ -260,7 +260,7 @@ class ShakemapParsersTestCase(unittest.TestCase):
     def test_13(self):
         usgs_id = 'us7000n7n8'
         station_data_file, n_stations, station_err = get_stations_from_usgs(
-            usgs_id, user=user)
+            usgs_id, user=user, shakemap_version='preferred')
         self.assertIsNone(station_data_file)
         self.assertEqual(n_stations, 0)
         self.assertEqual(station_err['error_msg'],
@@ -275,8 +275,9 @@ class ShakemapParsersTestCase(unittest.TestCase):
         self.assertIn('id', first_version)
         self.assertIn('utc_date_time', first_version)
         usgs_id = 'does_not_exist'
-        shakemap_versions, err = get_shakemap_versions(usgs_id)
+        shakemap_versions, preferred_version, err = get_shakemap_versions(usgs_id)
         self.assertIsNone(shakemap_versions)
+        self.assertIsNone(preferred_version)
         self.assertIn('Unable to download', err['error_msg'])
 
 

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -536,10 +536,10 @@ function capitalizeFirstLetter(val) {
             if (data.shakemap_versions_issue) {
                 $select.append(`<option value="error">${data.shakemap_versions_issue}</option>`);
             } else {
-                $select.append('<option value="latest">Use latest</option>');
                 if (data.shakemap_versions.length > 0) {
                     data.shakemap_versions.forEach(function (shakemap_version) {
-                        $select.append(`<option value="${shakemap_version.id}">${shakemap_version.utc_date_time}</option>`);
+                        var usgs_preferred = shakemap_version.number == data.usgs_preferred_version ? " (USGS preferred)" : "";
+                        $select.append(`<option value="${shakemap_version.id}">v${shakemap_version.number}: ${shakemap_version.utc_date_time}${usgs_preferred}</option>`);
                     });
                 } else {
                     $select.append('<option value="">No versions available</option>');
@@ -990,6 +990,7 @@ function capitalizeFirstLetter(val) {
                 var formData = new FormData();
                 const usgs_id = $.trim($("#usgs_id").val());
                 formData.append('usgs_id', usgs_id);
+                formData.append('shakemap_version', $("#shakemap_version").val());
                 $.ajax({
                     type: "POST",
                     url: gem_oq_server_url + "/v1/impact_get_stations_from_usgs",

--- a/openquake/server/tests/test_impact_mode.py
+++ b/openquake/server/tests/test_impact_mode.py
@@ -264,6 +264,7 @@ class EngineServerTestCase(django.test.TestCase):
     def test_run_by_usgs_id_then_remove_calc(self):
         data = dict(usgs_id='us6000jllz',
                     approach='use_shakemap_from_usgs',
+                    shakemap_version='preferred',
                     lon=37.0143, lat=37.2256, dep=10.0, mag=7.8,
                     rake=0.0, dip=90, strike=0,
                     time_event='night',

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -787,8 +787,9 @@ def impact_get_stations_from_usgs(request):
         a `django.http.HttpRequest` object containing usgs_id
     """
     usgs_id = request.POST.get('usgs_id')
+    shakemap_version = request.POST.get('shakemap_version')
     station_data_file, n_stations, err = get_stations_from_usgs(
-        usgs_id, user=request.user)
+        usgs_id, user=request.user, shakemap_version=shakemap_version)
     station_data_issue = None
     if err:
         station_data_issue = err['error_msg']
@@ -809,12 +810,13 @@ def impact_get_shakemap_versions(request):
         a `django.http.HttpRequest` object containing usgs_id
     """
     usgs_id = request.POST.get('usgs_id')
-    shakemap_versions, err = get_shakemap_versions(usgs_id)
+    shakemap_versions, usgs_preferred_version, err = get_shakemap_versions(usgs_id)
     if err:
         shakemap_versions_issue = err['error_msg']
     else:
         shakemap_versions_issue = None
     response_data = dict(shakemap_versions=shakemap_versions,
+                         usgs_preferred_version=usgs_preferred_version,
                          shakemap_versions_issue=shakemap_versions_issue)
     return JsonResponse(response_data)
 


### PR DESCRIPTION
I removed the "Use latest" option, keeping instead the latest version on top, pre-selected.
Together with the time of update, I am also displaying the ShakeMap version number.
I am also displaying in the available options which one is the USGS-preferred one (having the highest `preferredWeight`, see https://earthquake.usgs.gov/data/comcat/#product_preferredWeight).

![Screenshot from 2025-04-23 16-20-10](https://github.com/user-attachments/assets/406114cd-2d70-4de6-adc7-48356b395445)
