### PR TITLE
Added a method `CompositeLogicTree.to_node`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
   [Michele Simionato]
-  * Internal: added a method `CompositeLogicTree.to_node`
+  * Internal: added methods `CompositeLogicTree.to_node` and
+    `CompositeLogicTree.to_nrml`
 
   [Paolo Tormene, Michele Simionato]
   * Added extractor for 'damages-stats'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Internal: added a method `CompositeLogicTree.to_node`
+
   [Paolo Tormene, Michele Simionato]
   * Added extractor for 'damages-stats'
 

--- a/doc/user-guide/inputs/logic-trees-inputs.rst
+++ b/doc/user-guide/inputs/logic-trees-inputs.rst
@@ -568,6 +568,15 @@ The complete realizations can be obtained by not specifying ``applyToBranches``:
 	>>> logictree.get_all_paths() # 2 * 3 * 2 = 12 paths
 	['ACF', 'ACG', 'ADF', 'ADG', 'AEF', 'AEG', 'BCF', 'BCG', 'BDF', 'BDG', 'BEF', 'BEG']
 
+You can serialize a logic tree built programmatically into an XML file
+with a call like this:
+
+.. python:
+
+  with open('lt.xml', 'wb') as f:
+      nrml.write([logictree.to_node()], f)
+
+
 *******************
 The logic tree demo
 *******************

--- a/openquake/baselib/node.py
+++ b/openquake/baselib/node.py
@@ -458,7 +458,7 @@ class Node(object):
     def __init__(self, fulltag, attrib=None, text=None,
                  nodes=None, lineno=None):
         """
-        :param str tag: the Node name
+        :param str fulltag: the Node name
         :param dict attrib: the Node attributes
         :param str text: the Node text (default None)
         :param nodes: an iterable of subnodes (default empty list)

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -660,7 +660,7 @@ class BranchSet(object):
                 yield from branch.bset._enumerate_paths(path_branch)
             else:
                 # here is an example of path_branch[1].value:
-                # [('simpleFaultGeometry', ([(-64.5, -0.38221), (-64.5, 0.38221)],
+                # [('simpleFaultGeometry', ([(-64.5, -0.3822), (-64.5, 0.3822)],
                 #                             2.0, 15.0, 90.0, 2.0))]
                 yield path_branch
 
@@ -817,6 +817,8 @@ class CompositeLogicTree(object):
     """
     def __init__(self, branchsets):
         self.branchsets = branchsets
+        for i, bset in enumerate(branchsets):
+            bset.ordinal = i
         self.basepaths = self._attach_to_branches()
 
     def _attach_to_branches(self):
@@ -915,9 +917,10 @@ def build(*bslists):
     """
     bsets = []
     for i, (utype, applyto, *brlists) in enumerate(bslists):
+        bsid = 'bs%02d' % i
         branches = []
         for brid, value, weight in brlists:
-            branches.append(Branch('bs%02d' % i, brid, weight, value))
+            branches.append(Branch(bsid, brid, weight, value))
         bset = BranchSet(utype, i, dict(applyToBranches=applyto))
         bset.branches = branches
         bsets.append(bset)

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -23,7 +23,7 @@ import numpy
 
 from openquake.baselib.general import CallableDict, BASE183, BASE33489
 from openquake.baselib.node import Node
-from openquake.hazardlib import geo
+from openquake.hazardlib import geo, nrml
 from openquake.hazardlib.sourceconverter import (
     split_coords_2d, split_coords_3d)
 from openquake.hazardlib import valid
@@ -880,6 +880,12 @@ class CompositeLogicTree(object):
                      [branch_to_node(br) for br in bset.branches])
             out.nodes.append(n)
         return out
+
+    def to_nrml(self):
+        """
+        Converts the logic tree into a string in NRML format
+        """
+        return nrml.to_string(self.to_node())
 
     def __repr__(self):
         return '<%s>' % self.branchsets

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -172,7 +172,7 @@ class CompositeLogicTreeTestCase(unittest.TestCase):
         self.assertEqual(clt.basepaths,
                          ['A**', 'B**', '*C*', '*D*', '**E', '**F'])
 
-        xml = nrml.to_string(clt.to_node())
+        xml = clt.to_nrml()
         self.assertEqual(xml, '''<?xml version="1.0" encoding="utf-8"?>
 <nrml
 xmlns="http://openquake.org/xmlns/nrml/0.5"

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -140,40 +140,8 @@ class CollapseTestCase(unittest.TestCase):
         ax.loglog(self.imtls['PGA'], coll, label='coll')
         plt.show()
 
-    
-class CompositeLogicTreeTestCase(unittest.TestCase):
-    def test(self):
-        # simple logic tree with 5 realizations
-        #        _C/ E
-        #    _A_/  \ F
-        #   /   \_D/ E
-        #          \ F
-        #   \_______
-        #            B..
-        bs0 = lt.BranchSet('abGRAbsolute')
-        bs0.branches = [lt.Branch('bs0', 'A', .4, (4.6, 1.1)),
-                        lt.Branch('bs0', 'B', .6, (4.4, 0.9))]
 
-        bs1 = lt.BranchSet('maxMagGRAbsolute',
-                           filters={'applyToBranches': 'A'})
-        bs1.branches = [lt.Branch('bs1', 'C', .5, 7.0),
-                        lt.Branch('bs1', 'D', .5, 7.6)]
-
-        bs2 = lt.BranchSet('applyToTRT',
-                           filters={'applyToBranches': 'CD'})
-        bs2.branches = [lt.Branch('bs2', 'E', .3, 'A'),
-                        lt.Branch('bs2', 'F', .7, 'B')]
-        for branch in bs1.branches:
-            branch.bset = bs2
-        clt = lt.CompositeLogicTree([bs0, bs1, bs2])
-        self.assertEqual(lt.count_paths(bs0.branches), 5)
-        self.assertEqual(clt.get_all_paths(),
-                         ['ACE', 'ACF', 'ADE', 'ADF', 'B..'])
-        self.assertEqual(clt.basepaths,
-                         ['A**', 'B**', '*C*', '*D*', '**E', '**F'])
-
-        xml = clt.to_nrml()
-        self.assertEqual(xml, '''<?xml version="1.0" encoding="utf-8"?>
+EXPECTED_LT = '''<?xml version="1.0" encoding="utf-8"?>
 <nrml
 xmlns="http://openquake.org/xmlns/nrml/0.5"
 xmlns:gml="http://www.opengis.net/gml"
@@ -208,7 +176,7 @@ xmlns:gml="http://www.opengis.net/gml"
         </LogicTreeBranchSet>
         <LogicTreeBranchSet
         applyToBranches="A"
-        branchSetID="bs0"
+        branchSetID="bs1"
         uncertaintyType="maxMagGRAbsolute"
         >
             <LogicTreeBranch
@@ -234,7 +202,7 @@ xmlns:gml="http://www.opengis.net/gml"
         </LogicTreeBranchSet>
         <LogicTreeBranchSet
         applyToBranches="CD"
-        branchSetID="bs0"
+        branchSetID="bs2"
         uncertaintyType="applyToTRT"
         >
             <LogicTreeBranch
@@ -260,7 +228,41 @@ xmlns:gml="http://www.opengis.net/gml"
         </LogicTreeBranchSet>
     </logicTree>
 </nrml>
-''')
+'''
+
+class CompositeLogicTreeTestCase(unittest.TestCase):
+    def test5(self):
+        # simple logic tree with 5 realizations
+        #        _C/ E
+        #    _A_/  \ F
+        #   /   \_D/ E
+        #          \ F
+        #   \_______
+        #            B..
+        bs0 = lt.BranchSet('abGRAbsolute')
+        bs0.branches = [lt.Branch('bs0', 'A', .4, (4.6, 1.1)),
+                        lt.Branch('bs0', 'B', .6, (4.4, 0.9))]
+
+        bs1 = lt.BranchSet('maxMagGRAbsolute',
+                           filters={'applyToBranches': 'A'})
+        bs1.branches = [lt.Branch('bs1', 'C', .5, 7.0),
+                        lt.Branch('bs1', 'D', .5, 7.6)]
+
+        bs2 = lt.BranchSet('applyToTRT',
+                           filters={'applyToBranches': 'CD'})
+        bs2.branches = [lt.Branch('bs2', 'E', .3, 'A'),
+                        lt.Branch('bs2', 'F', .7, 'B')]
+        for branch in bs1.branches:
+            branch.bset = bs2
+        clt = lt.CompositeLogicTree([bs0, bs1, bs2])
+        self.assertEqual(lt.count_paths(bs0.branches), 5)
+        self.assertEqual(clt.get_all_paths(),
+                         ['ACE', 'ACF', 'ADE', 'ADF', 'B..'])
+        self.assertEqual(clt.basepaths,
+                         ['A**', 'B**', '*C*', '*D*', '**E', '**F'])
+
+        xml = clt.to_nrml()
+        self.assertEqual(xml, EXPECTED_LT)
 
     def test_build(self):
         clt = lt.build(['sourceModel', '',

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -140,7 +140,7 @@ class CollapseTestCase(unittest.TestCase):
         ax.loglog(self.imtls['PGA'], coll, label='coll')
         plt.show()
 
-
+    
 class CompositeLogicTreeTestCase(unittest.TestCase):
     def test(self):
         # simple logic tree with 5 realizations
@@ -171,6 +171,96 @@ class CompositeLogicTreeTestCase(unittest.TestCase):
                          ['ACE', 'ACF', 'ADE', 'ADF', 'B..'])
         self.assertEqual(clt.basepaths,
                          ['A**', 'B**', '*C*', '*D*', '**E', '**F'])
+
+        xml = nrml.to_string(clt.to_node())
+        self.assertEqual(xml, '''<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <logicTree
+    logicTreeID="lt"
+    >
+        <LogicTreeBranchSet
+        branchSetID="bs0"
+        uncertaintyType="abGRAbsolute"
+        >
+            <LogicTreeBranch
+            branchID="A"
+            >
+                <uncertaintyModel>
+                    4.6000000E+00 1.1000000E+00
+                </uncertaintyModel>
+                <uncertaintyWeight>
+                    4.0000000E-01
+                </uncertaintyWeight>
+            </LogicTreeBranch>
+            <LogicTreeBranch
+            branchID="B"
+            >
+                <uncertaintyModel>
+                    4.4000000E+00 9.0000000E-01
+                </uncertaintyModel>
+                <uncertaintyWeight>
+                    6.0000000E-01
+                </uncertaintyWeight>
+            </LogicTreeBranch>
+        </LogicTreeBranchSet>
+        <LogicTreeBranchSet
+        applyToBranches="A"
+        branchSetID="bs0"
+        uncertaintyType="maxMagGRAbsolute"
+        >
+            <LogicTreeBranch
+            branchID="C"
+            >
+                <uncertaintyModel>
+                    7.0000000E+00
+                </uncertaintyModel>
+                <uncertaintyWeight>
+                    5.0000000E-01
+                </uncertaintyWeight>
+            </LogicTreeBranch>
+            <LogicTreeBranch
+            branchID="D"
+            >
+                <uncertaintyModel>
+                    7.6000000E+00
+                </uncertaintyModel>
+                <uncertaintyWeight>
+                    5.0000000E-01
+                </uncertaintyWeight>
+            </LogicTreeBranch>
+        </LogicTreeBranchSet>
+        <LogicTreeBranchSet
+        applyToBranches="CD"
+        branchSetID="bs0"
+        uncertaintyType="applyToTRT"
+        >
+            <LogicTreeBranch
+            branchID="E"
+            >
+                <uncertaintyModel>
+                    A
+                </uncertaintyModel>
+                <uncertaintyWeight>
+                    3.0000000E-01
+                </uncertaintyWeight>
+            </LogicTreeBranch>
+            <LogicTreeBranch
+            branchID="F"
+            >
+                <uncertaintyModel>
+                    B
+                </uncertaintyModel>
+                <uncertaintyWeight>
+                    7.0000000E-01
+                </uncertaintyWeight>
+            </LogicTreeBranch>
+        </LogicTreeBranchSet>
+    </logicTree>
+</nrml>
+''')
 
     def test_build(self):
         clt = lt.build(['sourceModel', '',


### PR DESCRIPTION
This is useful to build programmatically logic tree files in NRML format.