### PR TITLE
Not saving `applyToBranches` when empty

### DIFF
--- a/openquake/baselib/node.py
+++ b/openquake/baselib/node.py
@@ -264,7 +264,9 @@ class StreamingXMLWriter(object):
         return tag
 
     def _write(self, text):
-        """Write text by respecting the current indentlevel"""
+        """
+        Write text by respecting the current indentlevel
+        """
         spaces = ' ' * (self.indent * self.indentlevel)
         t = spaces + text.strip() + '\n'
         if hasattr(t, 'encode'):
@@ -272,13 +274,17 @@ class StreamingXMLWriter(object):
         self.stream.write(t)  # expected bytes
 
     def emptyElement(self, name, attrs):
-        """Add an empty element (may have attributes)"""
+        """
+        Add an empty element (may have attributes)
+        """
         attr = ' '.join('%s=%s' % (n, quoteattr(scientificformat(v)))
                         for n, v in sorted(attrs.items()))
         self._write('<%s %s/>' % (name, attr))
 
     def start_tag(self, name, attrs=None):
-        """Open an XML tag"""
+        """
+        Open an XML tag
+        """
         if not attrs:
             self._write('<%s>' % name)
         else:
@@ -290,12 +296,16 @@ class StreamingXMLWriter(object):
         self.indentlevel += 1
 
     def end_tag(self, name):
-        """Close an XML tag"""
+        """
+        Close an XML tag
+        """
         self.indentlevel -= 1
         self._write('</%s>' % name)
 
     def serialize(self, node):
-        """Serialize a node object (typically an ElementTree object)"""
+        """
+        Serialize a node object (typically an ElementTree object)
+        """
         if isinstance(node.tag, types.FunctionType):
             # this looks like a bug of ElementTree: comments are stored as
             # functions!?? see https://hg.python.org/sandbox/python2.7/file/tip/Lib/xml/etree/ElementTree.py#l458
@@ -324,7 +334,7 @@ class StreamingXMLWriter(object):
                     obj = list(itertools.chain(*obj))
                 txt = escape(scientificformat(obj).strip())
             else:
-                txt = escape(scientificformat(node.text).strip())
+                txt = scientificformat(node.text).strip()
             if txt:
                 self._write(txt)
         for subnode in node:
@@ -332,14 +342,17 @@ class StreamingXMLWriter(object):
         self.end_tag(tag)
 
     def __enter__(self):
-        """Write the XML declaration"""
+        """
+        Write the XML declaration
+        """
         self._write('<?xml version="1.0" encoding="%s"?>\n' %
                     self.encoding)
         return self
 
     def __exit__(self, etype, exc, tb):
-        """Close the XML document"""
-        pass
+        """
+        Close the XML document
+        """
 
 
 class SourceLineParser(ElementTree.XMLParser):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1238,7 +1238,7 @@ class OqParam(valid.ParamSet):
                             'intensity_measure_types_and_levels is set')
         if 'iml_disagg' in names_vals:
             # normalize things like SA(0.10) -> SA(0.1)
-            self.iml_disagg = {str(from_string(imt)): [iml]
+            self.iml_disagg = {str(from_string(imt)): [float(iml)]
                                for imt, iml in self.iml_disagg.items()}
             self.hazard_imtls = self.iml_disagg
             if 'intensity_measure_types_and_levels' in names_vals:
@@ -1247,7 +1247,9 @@ class OqParam(valid.ParamSet):
                     ': they will be inferred from the iml_disagg '
                     'dictionary')
         elif 'intensity_measure_types_and_levels' in names_vals:
-            self.hazard_imtls = self.intensity_measure_types_and_levels
+            self.hazard_imtls = {
+                k: [float(x) for x in v] for k, v in
+                self.intensity_measure_types_and_levels.items()}
             delattr(self, 'intensity_measure_types_and_levels')
             lens = set(map(len, self.hazard_imtls.values()))
             if len(lens) > 1:

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -435,7 +435,8 @@ class SourceModelLogicTreeBrokenInputTestCase(unittest.TestCase):
         exc = self._assert_logic_tree_error(
             'lt', {'lt': lt, 'sm.xml': sm}, logictree.LogicTreeError)
         self.assertEqual(exc.lineno, 16)
-        self.assertEqual(exc.message, 'expected single float value',
+        self.assertEqual(exc.message,
+                         "expected single float value, got '123.45z'",
                          "wrong exception message: %s" % exc.message)
 
     def test_incremental_mfd_absolute_wrong_format(self):

--- a/openquake/commonlib/tests/readinput_test.py
+++ b/openquake/commonlib/tests/readinput_test.py
@@ -518,7 +518,7 @@ class SitecolAssetcolTestCase(unittest.TestCase):
             df = site_amplification.AmplFunction.read_df(
                 oq.inputs['amplification'])
             site_amplification.Amplifier(oq.imtls, df)
-        self.assertIn("Found duplicates for (b'F', 0.2)", str(ctx.exception))
+        self.assertIn("Found duplicates for (b'F',", str(ctx.exception))
 
 
 class LogicTreeTestCase(unittest.TestCase):

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -58,7 +58,8 @@ def unknown(utype, node, filename):
     try:
         return float(node.text)
     except (TypeError, ValueError):
-        raise LogicTreeError(node, filename, 'expected single float value')
+        raise LogicTreeError(
+            node, filename, 'expected single float value, got %r' % node.text)
 
 
 parse_uncertainty = CallableDict(keymissing=unknown)
@@ -901,6 +902,9 @@ class CompositeLogicTree(object):
             attrib = dict(uncertaintyType=bset.uncertainty_type,
                           branchSetID=f'bs{bset.ordinal}')
             attrib.update(bset.filters)
+            if 'applyToBranches' in attrib and not attrib['applyToBranches']:
+                # remove empty attribute
+                del attrib['applyToBranches']
             n = Node('logicTreeBranchSet', attrib, None,
                      [br.to_node() for br in bset.branches])
             out.nodes.append(n)

--- a/openquake/risklib/reinsurance.py
+++ b/openquake/risklib/reinsurance.py
@@ -60,12 +60,12 @@ def check_fields(fields, dframe, policyidx, fname, policyfname, treaties,
     if len(indices) > 0:
         raise InvalidFile(
             '%s (rows %s): empty deductible values were found' % (
-                policyfname, [idx + 2 for idx in indices]))
+                policyfname, [int(idx + 2) for idx in indices]))
     [indices] = np.where(np.isnan(dframe.liability.to_numpy()))
     if len(indices) > 0:
         raise InvalidFile(
             '%s (rows %s): empty liability values were found' % (
-                policyfname, [idx + 2 for idx in indices]))
+                policyfname, [int(idx + 2) for idx in indices]))
     [indices] = np.where(dframe.duplicated(subset=[key]).to_numpy())
     if len(indices) > 0:
         # NOTE: reporting only the first row found


### PR DESCRIPTION
And avoided an `escape` in the `StreamingXMLWriter` to fix saving `areaSourceGeometryAbsolute` in NRML.
Also, some fixes for numpy > 2 (https://github.com/gem/oq-engine/issues/10541).