### PR TITLE
Fixed AELO tests

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -869,6 +869,8 @@ def get_source_model_lt(oqparam):
         instance
     """
     smlt = get_smlt(vars(oqparam))
+    for bset in smlt.branchsets:
+        bset.check_duplicates(smlt.filename)
     srcids = set(smlt.source_data['source'])
     for src in oqparam.reqv_ignore_sources:
         if src not in srcids:

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -435,8 +435,6 @@ class SourceModelLogicTree(object):
         self.shortener = {}
         self.branchsets = []
         self.parse_tree(tree)
-        for bset in self.branchsets:
-            bset.check_duplicates(filename)
         self.set_num_paths()
 
     def set_num_paths(self):


### PR DESCRIPTION
Fixes the error
```python
  File "/home/test_ci/openquake/lib/python3.11/site-packages/openquake/calculators/postproc/disagg_by_rel_sources.py", line 123, in submit_sources
    smlt = csm.full_lt.source_model_lt.reduce(source_id, num_samples=0)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/test_ci/openquake/lib/python3.11/site-packages/openquake/hazardlib/logictree.py", line 480, in reduce
    new = self.__class__(self.filename, self.seed, num_samples,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/test_ci/openquake/lib/python3.11/site-packages/openquake/hazardlib/logictree.py", line 439, in __init__
    bset.check_duplicates()
  File "/home/test_ci/openquake/lib/python3.11/site-packages/openquake/hazardlib/lt.py", line 769, in check_duplicates
    raise ValueError(f'Duplicated branches in {bs_id}')
ValueError: /builds/hazard/mosaic/mosaic/unzipped_mosaic_aelo/IND/in/ssmLT.xml: duplicated branches in bs1:
ssm/himalaya_cut.xml
ssm/himalaya_cut.xml
ssm/himalaya_area.xml
ssm/himalaya_m55.xml
```