### PR TITLE
Fixed `oq plot examples`

### DIFF
--- a/bin/run-demos.sh
+++ b/bin/run-demos.sh
@@ -39,6 +39,7 @@ oq extract "disagg_layer?" 14
 
 # do something with the generated data, 9 is the AreaSource demo
 oq engine --lhc
+oq plot examples
 MPLBACKEND=Agg oq plot 'hcurves?kind=stats&imt=PGA' 9
 MPLBACKEND=Agg oq plot 'hmaps?kind=mean&imt=PGA' 9
 MPLBACKEND=Agg oq plot 'uhs?kind=stats' 9

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed an error in `oq plot examples`
+
   [Baran Güryuva, Christopher Brooks]
   * Implemented the EMME24 backbone GMC for crustal
     earthquakes (emme24.py)

--- a/openquake/calculators/checkers.py
+++ b/openquake/calculators/checkers.py
@@ -84,7 +84,7 @@ def check(ini, hc_id=None, exports='', what='', prefix='',
     """
     t0 = time.time()
     outdir = pathlib.Path(os.path.dirname(ini))
-    calc, _log = get_calc_log(ini, hc_id)
+    calc, log = get_calc_log(ini, hc_id)
     calc.run(export_dir='/tmp', close=False)
     if exports:
         calc.export(exports)
@@ -108,7 +108,7 @@ def check(ini, hc_id=None, exports='', what='', prefix='',
             tbl = text_table(df, ext='org')
         bname = prefix + re.sub(r'_\d+\.', '.', os.path.basename(fname))
         assert_close(tbl, outdir / bname, atol, rtol)
-    return calc
+    return calc, log
 
 
 # called in run-demos

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -61,6 +61,9 @@ def getparams(what):
 
 
 def make_figure_magdist(extractors, what):
+    """
+    $ oq plot "magdist?"
+    """
     plt = import_plt()
     _fig, ax = plt.subplots()
     [ex] = extractors


### PR DESCRIPTION
@kirstybayliss reported the error
```python
  File "/home/michele/oq-engine/openquake/baselib/sap.py", line 212, in run
    return _run(parser(funcdict, **parserkw), argv)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/baselib/sap.py", line 203, in _run
    return func(**dic)
           ^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/commands/plot.py", line 1184, in main
    raise SystemExit(''.join(help_msg))
                     ^^^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, NoneType found
```
Also improved `impact_test(1)` by exposing the outputs.