### PR TITLE
Update exposure model input documentation

### DIFF
--- a/doc/user-guide/inputs/exposure-models-inputs.rst
+++ b/doc/user-guide/inputs/exposure-models-inputs.rst
@@ -55,22 +55,24 @@ A simple *Exposure Model Metadata XML* is shown in the listing below:
 	</nrml>
 
 Let us take a look at each of the sections in the above example file.
-There are 5 main section:
+There are 5 main sections:
 - general info
 - conversions
 - occupancyPeriods
 - tagNames
 - assets
 
-And the section of `exposureFields` that can be used when asset information is provided in csv format.
+An additional section, ``exposureFields``, can be included when the asset information is provided in CSV format.
 
+************
 general info
 ************
 
-The general information in the metadata XML is common to all of the assets in the portfolio and needs to be incorporated at 
-the beginning of every *Exposure Model XML* file. There are a number of parameters that compose the general info section, which is 
-intended to provide general information regarding the assets within the *Exposure Model*. These parameters are described 
-below:
+The general information section in the metadata XML provides an overview of the characteristics of the exposure model,
+is common to all of the assets in the portfolio, and needs to be incorporated at 
+the beginning of every *Exposure Model XML* file. There are a number of parameters that compose the general info section,
+which is intended to provide general information regarding the assets within the *Exposure Model*. 
+These parameters are described below:
 
 .. code-block:: xml
 
@@ -89,6 +91,7 @@ below:
 - ``description``: mandatory; a brief string (ASCII) with further information about the *Exposure Model*.
 
 
+***********
 conversions
 ***********
 
@@ -175,10 +178,11 @@ structure was used, it is important to mention that any of the other cost storin
 also be employed.
 
 
+****************
 occupancyPeriods
 ****************
 
-The OpenQuake engine is also capable of estimating human losses, based on the number of occupants in an asset, at a 
+The OpenQuake engine is also capable of estimating human losses based on the number of occupants in an asset, at a 
 certain time of the day. The `occupancyPeriods` section is common to all of the assets in the portfolio. 
 This section is only required for probabilistic or scenario calculations that specify an ``occupants_vulnerability_file``. 
 
@@ -193,8 +197,9 @@ Currently supported valid options for the ``period`` are: ``day``, ``transit``, 
 Currently, the number of ``occupants`` for an asset can only be provided as an aggregated value for the asset.
 
 
+********
 tagNames
-*********
+********
 
 Starting from OpenQuake engine v2.7, the user may also provide a set of tags for each asset in the *Exposure Model*. The 
 primary intended use case for the tags is to enable aggregation or accumulation of risk results (casualties / damages / 
@@ -209,8 +214,9 @@ Note that it is not mandatory that every tag name specified in the metadata sect
 for each asset.
 
 
+******
 assets
-*******
+******
 
 The `assets` section is the part of the file describing the set of assets in the portfolio to be used in seismic damage 
 or risk calculations.
@@ -239,6 +245,7 @@ The asset information in an *Exposure Model* can be provided in different format
 2. **CSV Format**: Asset information can also be provided in one or more CSV files, with the metadata section referencing these files. This approach is useful for large datasets. The CSV files must include headers that match the expected attributes, such as `id`, `lon`, `lat`, `taxonomy`, `number`, `structural`, `area`, and others.
 
 
+**************
 exposureFields
 **************
 
@@ -266,13 +273,15 @@ The example below demonstrates how custom headers in a `.csv` file can be mapped
 	</exposureFields>
 
 
+
 Exposure model in CSV format
--------------------------------
+----------------------------
 
 A combination of XML and CSV formats can be used, where the metadata is defined in XML and the asset data is stored in CSV files. This allows for flexibility and scalability.
 
+**************
 Example `.csv`
-*************
+**************
 
 This example illustrates the use of multiple csv files containing the assets information, in conjunction with the 
 metadata section in the usual xml format.
@@ -359,9 +368,9 @@ file or a spreadsheet can be found at the OpenQuake platform at the following ad
 
 
 Exposure models in XML format
---------------------------------
+-----------------------------
 
-
+*************
 Example XML 1
 *************
 
@@ -452,6 +461,7 @@ aggregated value for all structural units (within a given asset) at each locatio
 need to define other attributes such as ``number`` or ``area``. This mode of representing an *Exposure Model* is probably 
 the simplest one.
 
+*************
 Example XML 2
 *************
 
@@ -536,6 +546,7 @@ out the risk calculations in which the economic cost of each asset is provided, 
 asset, the number of units (buildings) by the “per asset” replacement cost. Note that in this case, there is no need to 
 specify the attribute ``area``.
 
+*************
 Example XML 3
 *************
 
@@ -626,6 +637,7 @@ Once again, the OpenQuake engine needs to carry out some calculations in order t
 In this case, this value is computed by multiplying the aggregated built up ``area`` of each asset by the associated cost 
 per unit area. Notice that in this case, there is no need to specify the attribute ``number``.
 
+*************
 Example XML 4
 *************
 
@@ -714,6 +726,7 @@ the assets for this example:
 In this example, the OpenQuake engine will make use of all the parameters to estimate the various costs of each asset, by 
 multiplying the number of structural units by its average built up area, and then by the respective cost per unit area.
 
+*************
 Example XML 5
 *************
 
@@ -756,6 +769,7 @@ Despite the fact that for the demonstration of how the retrofitting cost can be 
 structure described in Example 1 was used, it is important to mention that any of the other cost storing approaches can 
 also be employed (Examples 2–4).
 
+*************
 Example XML 6
 *************
 
@@ -809,6 +823,7 @@ aggregated values for all of the buildings comprising the asset:
 	
 	</nrml>
 
+*************
 Example XML 7
 *************
 

--- a/doc/user-guide/inputs/exposure-models-inputs.rst
+++ b/doc/user-guide/inputs/exposure-models-inputs.rst
@@ -10,47 +10,14 @@ a cost conversions section that describes how the different areas, costs, and oc
 followed by data regarding each individual asset in the portfolio.
 
 **Note**: Starting from OpenQuake engine v3.0, the *Exposure Model* may be provided using csv files listing the asset 
-information, along with an xml file conatining the metadata section for the exposure model that has been described in the 
-examples above. See Example 8 below for an illustration of an exposure model using csv files.
+information, along with an xml file containing the metadata section for the exposure model that is described in the 
+examples below.
 
-A simple *Exposure Model* comprising a single asset is shown in the listing below:
 
-.. code-block:: xml
+Exposure information
+--------------------
 
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>Exposure Model Example</description>
-	
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
-	    </costTypes>
-	    <area type="per_asset" unit="SQM" />
-	  </conversions>
-	
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10000" />
-	      </costs>
-	      <occupancies>
-	        <occupancy occupants="20" period="day" />
-	      </occupancies>
-	    </asset>
-	  </assets>
-	
-	</exposureModel>
-	
-	</nrml>
-
-Let us take a look at each of the sections in the above example file in turn. The first part of the file contains the 
-metadata section:
+A simple *Exposure Model Metadata XML* is shown in the listing below:
 
 .. code-block:: xml
 
@@ -60,7 +27,7 @@ metadata section:
 	
 	<exposureModel id="exposure_example"
 	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
 	  <description>Exposure Model Example</description>
 	
 	  <conversions>
@@ -69,68 +36,74 @@ metadata section:
 	    </costTypes>
 	    <area type="per_asset" unit="SQM" />
 	  </conversions>
-	
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10000" />
-	      </costs>
-	      <occupancies>
-	        <occupancy occupants="20" period="day" />
-	      </occupancies>
-	    </asset>
-	  </assets>
-	
+
+	<occupancyPeriods>night</occupancyPeriods>
+	<tagNames>OCCUPANCY NAME_1 ID_1 NAME_2 ID_2</tagNames>
+	<assets>Exposure_File_1.csv Exposure_File_2.csv Exposure_File_3.csv </assets>
+
+	<exposureFields>
+		<field oq="taxonomy" input="TAXONOMY" />
+		<field oq="number" input="BUILDINGS" />
+		<field oq="area" input="AREA_PER_DWELLING_SQM" />
+		<field oq="value" type="structural" input="COST_PER_AREA_USD" />
+		<field oq="value" type="nonstructural" input="COST_NONSTRUCTURAL_USD" />
+		<field oq="night" input="OCCUPANTS_PER_ASSET" />
+	</exposureFields>
+
 	</exposureModel>
-	
+		
 	</nrml>
 
-The information in the metadata section is common to all of the assets in the portfolio and needs to be incorporated at 
-the beginning of every *Exposure Model* file. There are a number of parameters that compose the metadata section, which is 
+Let us take a look at each of the sections in the above example file.
+There are 5 main section:
+- general info
+- conversions
+- occupancyPeriods
+- tagNames
+- assets
+
+And the section of `exposureFields` that can be used when asset information is provided in csv format.
+
+general info
+************
+
+The general information in the metadata XML is common to all of the assets in the portfolio and needs to be incorporated at 
+the beginning of every *Exposure Model XML* file. There are a number of parameters that compose the general info section, which is 
 intended to provide general information regarding the assets within the *Exposure Model*. These parameters are described 
 below:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>Exposure Model Example</description>
 
 - ``id``: mandatory; a unique string used to identify the *Exposure Model*. This string can contain letters (a–z; A–Z), numbers (0–9), dashes (–), and underscores (_), with a maximum of 100 characters.
 - ``category``: an optional string used to define the type of assets being stored (e.g: buildings, lifelines).
 - ``taxonomySource``: an optional attribute used to define the taxonomy being used to classify the assets.
 - ``description``: mandatory; a brief string (ASCII) with further information about the *Exposure Model*.
 
-Next, let us look at the part of the file describing the area and cost conversions:
+
+conversions
+***********
+
+The `conversions` section is common to all of the assets in the portfolio and needs to be incorporated in the *Exposure Model XML* file.
+This section describes the area and cost conversions applied to all assets in the exposure model.
 
 .. code-block:: xml
 
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>Exposure Model Example</description>
-	
 	  <conversions>
 	    <costTypes>
 	      <costType name="structural" type="per_area" unit="USD" />
 	    </costTypes>
 	    <area type="per_asset" unit="SQM" />
 	  </conversions>
-	
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10000" />
-	      </costs>
-	      <occupancies>
-	        <occupancy occupants="20" period="day" />
-	      </occupancies>
-	    </asset>
-	  </assets>
-	
-	</exposureModel>
-	
-	</nrml>
+
 
 Notice that the ``costType`` element defines a ``name``, a ``type``, and a ``unit`` attribute.
 
@@ -181,44 +154,68 @@ earthquake. On the other hand, if simplified methodologies based on proxy data s
 to develop the *Exposure Model*, then it is likely that the built up area or economic cost of each building typology will 
 be directly derived, and will be used for the estimation of economic losses.
 
-Finally, let us look at the part of the file describing the set of assets in the portfolio to be used in seismic damage 
-or risk calculations:
+**benefit/cost assessment**
+
+In order to perform a benefit/cost assessment, it is necessary to indicate the retrofitting cost. This parameter is 
+handled in the same manner as the structural cost, and it should be stored according to the format shown in the listing 
+below:
 
 .. code-block:: xml
 
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>Exposure Model Example</description>
-	
 	  <conversions>
 	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
+	      <costType name="structural" type="aggregated" unit="USD"
+	                retrofittedType="per_asset" retrofittedUnit="USD" />
 	    </costTypes>
 	    <area type="per_asset" unit="SQM" />
 	  </conversions>
-	
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10000" />
-	      </costs>
-	      <occupancies>
-	        <occupancy occupants="20" period="day" />
-	      </occupancies>
-	    </asset>
-	  </assets>
-	
-	</exposureModel>
-	
-	</nrml>
 
-Each asset definition involves specifiying a set of mandatory and optional attributes concerning the asset. The following 
+Despite the fact that for the demonstration of how the retrofitting cost can be stored the "per_asset" type of cost 
+structure was used, it is important to mention that any of the other cost storing approaches can 
+also be employed.
+
+
+occupancyPeriods
+****************
+
+The OpenQuake engine is also capable of estimating human losses, based on the number of occupants in an asset, at a 
+certain time of the day. The `occupancyPeriods` section is common to all of the assets in the portfolio. 
+This section is only required for probabilistic or scenario calculations that specify an ``occupants_vulnerability_file``. 
+
+Each entry within this element specifies the number of occupants for the asset for a particular period of the day. 
+
+.. code-block:: xml
+
+	<occupancyPeriods>night</occupancyPeriods>
+
+As shown in the example above, each occupancy entry must define the ``period`` and the ``occupants``. 
+Currently supported valid options for the ``period`` are: ``day``, ``transit``, and ``night``. 
+Currently, the number of ``occupants`` for an asset can only be provided as an aggregated value for the asset.
+
+
+tagNames
+*********
+
+Starting from OpenQuake engine v2.7, the user may also provide a set of tags for each asset in the *Exposure Model*. The 
+primary intended use case for the tags is to enable aggregation or accumulation of risk results (casualties / damages / 
+losses) for each tag. The tags could be used to specify location attributes, occupancy types, or insurance policy codes 
+for the different assets in the *Exposure Model*.
+
+.. code-block:: xml
+
+	<tagNames>OCCUPANCY NAME_1 ID_1 NAME_2 ID_2</tagNames>
+
+Note that it is not mandatory that every tag name specified in the metadata section must be provided with a tag value 
+for each asset.
+
+
+assets
+*******
+
+The `assets` section is the part of the file describing the set of assets in the portfolio to be used in seismic damage 
+or risk calculations.
+
+Each asset definition involves specifying a set of mandatory and optional attributes concerning the asset. The following 
 set of attributes can be assigned to each asset based on the current schema for the *Exposure Model*:
 
 - ``id``: mandatory; a unique string used to identify the given asset, which is used by the OpenQuake engine to relate each asset with its associated results. This string can contain letters (a–z; A–Z), numbers (0–9), dashes (-), and underscores (_), with a maximum of 100 characters.
@@ -234,600 +231,48 @@ cost (``retrofitted``). The combination between the possible options in which th
 to four ways of storing the information about the assets. For each of these cases a brief explanation and example is 
 provided in this section.
 
-Example 1
----------
 
-This example illustrates an *Exposure Model* in which the aggregated cost (structural, nonstructural, contents and 
-business interruption) of the assets of each taxonomy for a set of locations is directly provided. Thus, in order to 
-indicate how the various costs will be defined, the following information needs to be stored in the *Exposure Model* file, 
-as shown in the listing below:
+The asset information in an *Exposure Model* can be provided in different formats, depending on the level of detail and the structure of the data. Below are examples of how to include asset information using the available formats.
 
-.. code-block:: xml
+1. **XML Format**: Asset information can be directly embedded in the XML file, as shown in the examples above. Each asset is defined with attributes such as `id`, `taxonomy`, `location`, `costs`, and optionally `occupancies` and `tags`.
 
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>
-	    Exposure model with aggregated replacement costs for each asset
-	  </description>
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="aggregated" unit="USD" />
-	      <costType name="nonstructural" type="aggregated" unit="USD" />
-	      <costType name="contents" type="aggregated" unit="USD" />
-	      <costType name="business_interruption" type="aggregated" unit="USD/month"/>
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="20000" />
-	        <cost type="nonstructural" value="30000" />
-	        <cost type="contents" value="10000" />
-	        <cost type="business_interruption" value="4000" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
+2. **CSV Format**: Asset information can also be provided in one or more CSV files, with the metadata section referencing these files. This approach is useful for large datasets. The CSV files must include headers that match the expected attributes, such as `id`, `lon`, `lat`, `taxonomy`, `number`, `structural`, `area`, and others.
 
-In this case, the cost ``type`` of each component as been defined as ``aggregated``. Once the way in which each cost is 
-going to be defined has been established, the values for each asset can be stored according to the format shown in the 
-listing:
+
+exposureFields
+**************
+
+It is common for exposure models to include more information than what is strictly required for running a risk calculation in OpenQuake. 
+Additionally, the headers in exposure files often vary depending on the modeller's preferences, language, or conventions 
+(e.g., the field `night` might be labeled as `occupants_night` or `population_at_night`).
+
+This flexibility is only relevant for input models in `.csv` format. To accommodate this, 
+OpenQuake provides a mechanism for mapping custom CSV headers to the required OpenQuake fields.
+This allows users to define a flexible structure for their CSV files while ensuring compatibility with OpenQuake's requirements.
+
+The example below demonstrates how custom headers in a `.csv` file can be mapped to the corresponding OpenQuake attributes:
 
 .. code-block:: xml
 
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>
-	    Exposure model with aggregated replacement costs for each asset
-	  </description>
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="aggregated" unit="USD" />
-	      <costType name="nonstructural" type="aggregated" unit="USD" />
-	      <costType name="contents" type="aggregated" unit="USD" />
-	      <costType name="business_interruption" type="aggregated" unit="USD/month"/>
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="20000" />
-	        <cost type="nonstructural" value="30000" />
-	        <cost type="contents" value="10000" />
-	        <cost type="business_interruption" value="4000" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
+	<assets>Exposure_File_1.csv Exposure_File_2.csv Exposure_File_3.csv </assets>
 
-Each asset is uniquely identified by its ``id``. Then, a pair of coordinates (latitude and longitude) for a ``location`` 
-where the asset is assumed to exist is defined. Each asset must be classified according to a ``taxonomy``, so that the 
-OpenQuake engine is capable of employing the appropriate *Vulnerability Function* or *Fragility Function* in the risk 
-calculations. Finally, the cost values of each ``type`` are stored within the ``costs`` attribute. In this example, the 
-aggregated value for all structural units (within a given asset) at each location is provided directly, so there is no 
-need to define other attributes such as ``number`` or ``area``. This mode of representing an *Exposure Model* is probably 
-the simplest one.
+	<exposureFields>
+		<field oq="taxonomy" input="TAXONOMY" />
+		<field oq="number" input="BUILDINGS" />
+		<field oq="area" input="AREA_PER_DWELLING_SQM" />
+		<field oq="value" type="structural" input="COST_PER_AREA_USD" />
+		<field oq="value" type="nonstructural" input="COST_NONSTRUCTURAL_USD" />
+		<field oq="night" input="OCCUPANTS_PER_ASSET" />
+	</exposureFields>
 
-Example 2
----------
 
-In the snippet shown in the listing below, an *Exposure Model* containing the number of structural units and the 
-associated costs per unit of each asset is presented:
+Exposure model in CSV format
+-------------------------------
 
-.. code-block:: xml
+A combination of XML and CSV formats can be used, where the metadata is defined in XML and the asset data is stored in CSV files. This allows for flexibility and scalability.
 
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>
-	    Exposure model with replacement costs per building for each asset
-	  </description>
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="per_asset" unit="USD" />
-	      <costType name="nonstructural" type="per_asset" unit="USD" />
-	      <costType name="contents" type="per_asset" unit="USD" />
-	      <costType name="business_interruption" type="per_asset" unit="USD/month"/>
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" number="2" taxonomy="Adobe" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="7500" />
-	        <cost type="nonstructural" value="11250" />
-	        <cost type="contents" value="3750" />
-	        <cost type="business_interruption" value="1500" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
-
-For this case, the cost ``type`` has been set to ``per_asset``. Then, the information from each asset can be stored 
-following the format shown in the listing below:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>
-	    Exposure model with replacement costs per building for each asset
-	  </description>
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="per_asset" unit="USD" />
-	      <costType name="nonstructural" type="per_asset" unit="USD" />
-	      <costType name="contents" type="per_asset" unit="USD" />
-	      <costType name="business_interruption" type="per_asset" unit="USD/month"/>
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" number="2" taxonomy="Adobe" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="7500" />
-	        <cost type="nonstructural" value="11250" />
-	        <cost type="contents" value="3750" />
-	        <cost type="business_interruption" value="1500" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
-
-In this example, the various costs for each asset is not provided directly, as in the previous example. In order to carry 
-out the risk calculations in which the economic cost of each asset is provided, the OpenQuake engine multiplies, for each 
-asset, the number of units (buildings) by the “per asset” replacement cost. Note that in this case, there is no need to 
-specify the attribute ``area``.
-
-Example 3
----------
-
-The example shown in the listing below comprises an *Exposure Model* containing the built up area of each asset, and the 
-associated costs are provided per unit area:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>
-	    Exposure model with replacement costs per unit area;
-	    and areas provided as aggregated values for each asset
-	  </description>
-	  <conversions>
-	    <area type="aggregated" unit="SQM" />
-	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
-	      <costType name="nonstructural" type="per_area" unit="USD" />
-	      <costType name="contents" type="per_area" unit="USD" />
-	      <costType name="business_interruption" type="per_area" unit="USD/month"/>
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" area="1000" taxonomy="Adobe" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="5" />
-	        <cost type="nonstructural" value="7.5" />
-	        <cost type="contents" value="2.5" />
-	        <cost type="business_interruption" value="1" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
-
-In order to compile an *Exposure Model* with this structure, the cost ``type`` should be set to ``per_area``. In addition, 
-it is also necessary to specify if the ``area`` that is being store represents the aggregated area of number of units 
-within an asset, or the average area of a single unit. In this particular case, the ``area`` that is being stored is the 
-aggregated built up area per asset, and thus this attribute was set to ``aggregated``. The listing below illustrates the 
-definition of the assets for this example:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>
-	    Exposure model with replacement costs per unit area;
-	    and areas provided as aggregated values for each asset
-	  </description>
-	  <conversions>
-	    <area type="aggregated" unit="SQM" />
-	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
-	      <costType name="nonstructural" type="per_area" unit="USD" />
-	      <costType name="contents" type="per_area" unit="USD" />
-	      <costType name="business_interruption" type="per_area" unit="USD/month"/>
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" area="1000" taxonomy="Adobe" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="5" />
-	        <cost type="nonstructural" value="7.5" />
-	        <cost type="contents" value="2.5" />
-	        <cost type="business_interruption" value="1" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
-
-Once again, the OpenQuake engine needs to carry out some calculations in order to compute the different costs per asset. 
-In this case, this value is computed by multiplying the aggregated built up ``area`` of each asset by the associated cost 
-per unit area. Notice that in this case, there is no need to specify the attribute ``number``.
-
-Example 4
----------
-
-This example demonstrates an *Exposure Model* that defines the number of structural units for each asset, the average 
-built up area per structural unit and the associated costs per unit area. The listing below shows the metadata definition 
-for an *Exposure Model* built in this manner:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>
-	    Exposure model with replacement costs per unit area;
-	    and areas provided per building for each asset
-	  </description>
-	  <conversions>
-	    <area type="per_asset" unit="SQM" />
-	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
-	      <costType name="nonstructural" type="per_area" unit="USD" />
-	      <costType name="contents" type="per_area" unit="USD" />
-	      <costType name="business_interruption" type="per_area" unit="USD/month"/>
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" number="3" area="400" taxonomy="Adobe" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10" />
-	        <cost type="nonstructural" value="15" />
-	        <cost type="contents" value="5" />
-	        <cost type="business_interruption" value="2" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
-
-Similarly to what was described in the previous example, the various costs ``type`` also need to be established as 
-``per_area``, but the ``type`` of area is now defined as ``per_asset``. The listing below illustrates the definition of 
-the assets for this example:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>
-	    Exposure model with replacement costs per unit area;
-	    and areas provided per building for each asset
-	  </description>
-	  <conversions>
-	    <area type="per_asset" unit="SQM" />
-	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
-	      <costType name="nonstructural" type="per_area" unit="USD" />
-	      <costType name="contents" type="per_area" unit="USD" />
-	      <costType name="business_interruption" type="per_area" unit="USD/month"/>
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" number="3" area="400" taxonomy="Adobe" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10" />
-	        <cost type="nonstructural" value="15" />
-	        <cost type="contents" value="5" />
-	        <cost type="business_interruption" value="2" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
-
-In this example, the OpenQuake engine will make use of all the parameters to estimate the various costs of each asset, by 
-multiplying the number of structural units by its average built up area, and then by the respective cost per unit area.
-
-Example 5
----------
-
-In this example, additional information will be included, which is required for other risk analysis besides loss 
-estimation, such as the benefit/cost analysis.
-
-In order to perform a benefit/cost assessment, it is necessary to indicate the retrofitting cost. This parameter is 
-handled in the same manner as the structural cost, and it should be stored according to the format shown in the listing 
-below:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>Exposure model illustrating retrofit costs</description>
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="aggregated" unit="USD"
-	                retrofittedType="per_asset" retrofittedUnit="USD" />
-	    </costTypes>
-	  </conversions>
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="1" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10000" retrofitted="2000" />
-	      </costs>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
-
-Despite the fact that for the demonstration of how the retrofitting cost can be stored the per building type of cost 
-structure described in Example 1 was used, it is important to mention that any of the other cost storing approaches can 
-also be employed (Examples 2–4).
-
-Example 6
----------
-
-The OpenQuake engine is also capable of estimating human losses, based on the number of occupants in an asset, at a 
-certain time of the day. The example *Exposure Model* shown in the listing below illustrates how this parameter is defined 
-for each asset. In addition, this example also serves the purpose of presenting an *Exposure Model* in which three cost 
-types have been defined using three different options.
-
-As previously mentioned, in this example only three costs are being stored, and each one follows a different approach. 
-The ``structural`` cost is being defined as the aggregate replacement cost for all of the buildings comprising the asset 
-(Example 1), the ``nonstructural value`` is defined as the replacement cost per unit area where the area is defined per 
-building comprising the asset (Example 4), and the ``contents`` and ``business_interruption`` values are provided per 
-building comprising the asset (Example 2). The number of occupants at different times of the day are also provided as 
-aggregated values for all of the buildings comprising the asset:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>Exposure model example with occupants</description>
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="aggregated" unit="USD" />
-	      <costType name="nonstructural" type="per_area" unit="USD" />
-	      <costType name="contents" type="per_asset" unit="USD" />
-	      <costType name="business_interruption" type="per_asset" unit="USD/month" />
-	    </costTypes>
-	    <area type="per_asset" unit="SQM" />
-	  </conversions>
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="5" area="200" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="20000" />
-	        <cost type="nonstructural" value="15" />
-	        <cost type="contents" value="2400" />
-	        <cost type="business_interruption" value="1500" />
-	      </costs>
-	      <occupancies>
-	        <occupancy occupants="6" period="day" />
-	        <occupancy occupants="10" period="transit" />
-	        <occupancy occupants="20" period="night" />
-	      </occupancies>
-	    </asset>
-	  </assets>
-	</exposureModel>
-	
-	</nrml>
-
-Example 7
----------
-
-Starting from OpenQuake engine v2.7, the user may also provide a set of tags for each asset in the *Exposure Model*. The 
-primary intended use case for the tags is to enable aggregation or accumulation of risk results (casualties / damages / 
-losses) for each tag. The tags could be used to specify location attributes, occupancy types, or insurance policy codes 
-for the different assets in the *Exposure Model*.
-
-The example *Exposure Model* shown in the listing below illustrates how one or more tags can be defined for each asset:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example_with_tags"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>Exposure Model Example with Tags</description>
-	
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
-	    </costTypes>
-	    <area type="per_asset" unit="SQM" />
-	  </conversions>
-	
-	  <tagNames>state county tract city zip cresta</tagNames>
-	
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10000" />
-	      </costs>
-	      <occupancies>
-	        <occupancy occupants="20" period="day" />
-	      </occupancies>
-	      <tags state="California" county="Solano" tract="252702"
-	            city="Suisun" zip="94585" cresta="A.11"/>
-	    </asset>
-	  </assets>
-	
-	</exposureModel>
-	
-	</nrml>
-
-The list of tag names that will be used in the *Exposure Model* must be provided in the metadata section of the exposure 
-file, as shown in the following snippet from the full file::
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-        xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	  <exposureModel id="exposure_example_with_tags"
-	                 category="buildings"
-	                 taxonomySource="GEM_Building_Taxonomy_2.0">
-
-	    <description>Exposure Model Example with Tags</description>
-	
-            <conversions>
-
-	      <costTypes>
-
-	        <costType name="structural" type="per_area" unit="USD" />
-
-	      </costTypes>
-	      <area type="per_asset" unit="SQM" />
-
-	    </conversions>
-	
-	    <tagNames>state county tract city zip cresta</tagNames>
-	
-	    <assets>
-
-	      <asset id="a1" taxonomy="Adobe" number="5" area="100" >
-
-	        <location lon="-122.000" lat="38.113" />
-	        <costs>
-
-	          <cost type="structural" value="10000"/>
-	
-	        </costs>
-	        <occupancies>
-
-	          <occupancy occupants="20" period="day" />
-	
-	        </occupancies>
-	        <tags state="California" county="Solano" tract="252702" city="Suisun" zip="94585" cresta="A.11"/>
-
-	      </asset>
-
-	    </assets>
-	
-	</nrml>
-	
-
-The tag values for the different tags can then be specified for each asset as shown in the following snippet from the 
-same file:
-
-.. code-block:: xml
-
-	<?xml version="1.0" encoding="UTF-8"?>
-	<nrml xmlns:gml="http://www.opengis.net/gml"
-	      xmlns="http://openquake.org/xmlns/nrml/0.5">
-	
-	<exposureModel id="exposure_example_with_tags"
-	               category="buildings"
-	               taxonomySource="GEM_Building_Taxonomy_2.0">
-	  <description>Exposure Model Example with Tags</description>
-	
-	  <conversions>
-	    <costTypes>
-	      <costType name="structural" type="per_area" unit="USD" />
-	    </costTypes>
-	    <area type="per_asset" unit="SQM" />
-	  </conversions>
-	
-	  <tagNames>state county tract city zip cresta</tagNames>
-	
-	  <assets>
-	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
-	      <location lon="-122.000" lat="38.113" />
-	      <costs>
-	        <cost type="structural" value="10000" />
-	      </costs>
-	      <occupancies>
-	        <occupancy occupants="20" period="day" />
-	      </occupancies>
-	      <tags state="California" county="Solano" tract="252702"
-	            city="Suisun" zip="94585" cresta="A.11"/>
-	    </asset>
-	  </assets>
-	
-	</exposureModel>
-	
-	</nrml>
-
-Note that it is not mandatory that every tag name specified in the metadata section must be provided with a tag value 
-for each asset.
-
-Example 8
----------
+Example `.csv`
+*************
 
 This example illustrates the use of multiple csv files containing the assets information, in conjunction with the 
 metadata section in the usual xml format.
@@ -911,3 +356,594 @@ A web-based tool to build an *Exposure Model* in the Natural hazards’ Risk Mar
 file or a spreadsheet can be found at the OpenQuake platform at the following address: https://platform.openquake.org/ipt/.
 
 .. [1] Within the OpenQuake engine, longitude and latitude coordinates are internally rounded to a precision of 5 digits after the decimal point.
+
+
+Exposure models in XML format
+--------------------------------
+
+
+Example XML 1
+*************
+
+This example illustrates an *Exposure Model* in which the aggregated cost (structural, nonstructural, contents and 
+business interruption) of the assets of each taxonomy for a set of locations is directly provided. Thus, in order to 
+indicate how the various costs will be defined, the following information needs to be stored in the *Exposure Model* file, 
+as shown in the listing below:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>
+	    Exposure model with aggregated replacement costs for each asset
+	  </description>
+	  <conversions>
+	    <costTypes>
+	      <costType name="structural" type="aggregated" unit="USD" />
+	      <costType name="nonstructural" type="aggregated" unit="USD" />
+	      <costType name="contents" type="aggregated" unit="USD" />
+	      <costType name="business_interruption" type="aggregated" unit="USD/month"/>
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" taxonomy="Adobe" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="20000" />
+	        <cost type="nonstructural" value="30000" />
+	        <cost type="contents" value="10000" />
+	        <cost type="business_interruption" value="4000" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+In this case, the cost ``type`` of each component as been defined as ``aggregated``. Once the way in which each cost is 
+going to be defined has been established, the values for each asset can be stored according to the format shown in the 
+listing:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>
+	    Exposure model with aggregated replacement costs for each asset
+	  </description>
+	  <conversions>
+	    <costTypes>
+	      <costType name="structural" type="aggregated" unit="USD" />
+	      <costType name="nonstructural" type="aggregated" unit="USD" />
+	      <costType name="contents" type="aggregated" unit="USD" />
+	      <costType name="business_interruption" type="aggregated" unit="USD/month"/>
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" taxonomy="Adobe" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="20000" />
+	        <cost type="nonstructural" value="30000" />
+	        <cost type="contents" value="10000" />
+	        <cost type="business_interruption" value="4000" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+Each asset is uniquely identified by its ``id``. Then, a pair of coordinates (latitude and longitude) for a ``location`` 
+where the asset is assumed to exist is defined. Each asset must be classified according to a ``taxonomy``, so that the 
+OpenQuake engine is capable of employing the appropriate *Vulnerability Function* or *Fragility Function* in the risk 
+calculations. Finally, the cost values of each ``type`` are stored within the ``costs`` attribute. In this example, the 
+aggregated value for all structural units (within a given asset) at each location is provided directly, so there is no 
+need to define other attributes such as ``number`` or ``area``. This mode of representing an *Exposure Model* is probably 
+the simplest one.
+
+Example XML 2
+*************
+
+In the snippet shown in the listing below, an *Exposure Model* containing the number of structural units and the 
+associated costs per unit of each asset is presented:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>
+	    Exposure model with replacement costs per building for each asset
+	  </description>
+	  <conversions>
+	    <costTypes>
+	      <costType name="structural" type="per_asset" unit="USD" />
+	      <costType name="nonstructural" type="per_asset" unit="USD" />
+	      <costType name="contents" type="per_asset" unit="USD" />
+	      <costType name="business_interruption" type="per_asset" unit="USD/month"/>
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" number="2" taxonomy="Adobe" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="7500" />
+	        <cost type="nonstructural" value="11250" />
+	        <cost type="contents" value="3750" />
+	        <cost type="business_interruption" value="1500" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+For this case, the cost ``type`` has been set to ``per_asset``. Then, the information from each asset can be stored 
+following the format shown in the listing below:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>
+	    Exposure model with replacement costs per building for each asset
+	  </description>
+	  <conversions>
+	    <costTypes>
+	      <costType name="structural" type="per_asset" unit="USD" />
+	      <costType name="nonstructural" type="per_asset" unit="USD" />
+	      <costType name="contents" type="per_asset" unit="USD" />
+	      <costType name="business_interruption" type="per_asset" unit="USD/month"/>
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" number="2" taxonomy="Adobe" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="7500" />
+	        <cost type="nonstructural" value="11250" />
+	        <cost type="contents" value="3750" />
+	        <cost type="business_interruption" value="1500" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+In this example, the various costs for each asset is not provided directly, as in the previous example. In order to carry 
+out the risk calculations in which the economic cost of each asset is provided, the OpenQuake engine multiplies, for each 
+asset, the number of units (buildings) by the “per asset” replacement cost. Note that in this case, there is no need to 
+specify the attribute ``area``.
+
+Example XML 3
+*************
+
+The example shown in the listing below comprises an *Exposure Model* containing the built up area of each asset, and the 
+associated costs are provided per unit area:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>
+	    Exposure model with replacement costs per unit area;
+	    and areas provided as aggregated values for each asset
+	  </description>
+	  <conversions>
+	    <area type="aggregated" unit="SQM" />
+	    <costTypes>
+	      <costType name="structural" type="per_area" unit="USD" />
+	      <costType name="nonstructural" type="per_area" unit="USD" />
+	      <costType name="contents" type="per_area" unit="USD" />
+	      <costType name="business_interruption" type="per_area" unit="USD/month"/>
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" area="1000" taxonomy="Adobe" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="5" />
+	        <cost type="nonstructural" value="7.5" />
+	        <cost type="contents" value="2.5" />
+	        <cost type="business_interruption" value="1" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+In order to compile an *Exposure Model* with this structure, the cost ``type`` should be set to ``per_area``. In addition, 
+it is also necessary to specify if the ``area`` that is being store represents the aggregated area of number of units 
+within an asset, or the average area of a single unit. In this particular case, the ``area`` that is being stored is the 
+aggregated built up area per asset, and thus this attribute was set to ``aggregated``. The listing below illustrates the 
+definition of the assets for this example:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>
+	    Exposure model with replacement costs per unit area;
+	    and areas provided as aggregated values for each asset
+	  </description>
+	  <conversions>
+	    <area type="aggregated" unit="SQM" />
+	    <costTypes>
+	      <costType name="structural" type="per_area" unit="USD" />
+	      <costType name="nonstructural" type="per_area" unit="USD" />
+	      <costType name="contents" type="per_area" unit="USD" />
+	      <costType name="business_interruption" type="per_area" unit="USD/month"/>
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" area="1000" taxonomy="Adobe" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="5" />
+	        <cost type="nonstructural" value="7.5" />
+	        <cost type="contents" value="2.5" />
+	        <cost type="business_interruption" value="1" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+Once again, the OpenQuake engine needs to carry out some calculations in order to compute the different costs per asset. 
+In this case, this value is computed by multiplying the aggregated built up ``area`` of each asset by the associated cost 
+per unit area. Notice that in this case, there is no need to specify the attribute ``number``.
+
+Example XML 4
+*************
+
+This example demonstrates an *Exposure Model* that defines the number of structural units for each asset, the average 
+built up area per structural unit and the associated costs per unit area. The listing below shows the metadata definition 
+for an *Exposure Model* built in this manner:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>
+	    Exposure model with replacement costs per unit area;
+	    and areas provided per building for each asset
+	  </description>
+	  <conversions>
+	    <area type="per_asset" unit="SQM" />
+	    <costTypes>
+	      <costType name="structural" type="per_area" unit="USD" />
+	      <costType name="nonstructural" type="per_area" unit="USD" />
+	      <costType name="contents" type="per_area" unit="USD" />
+	      <costType name="business_interruption" type="per_area" unit="USD/month"/>
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" number="3" area="400" taxonomy="Adobe" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="10" />
+	        <cost type="nonstructural" value="15" />
+	        <cost type="contents" value="5" />
+	        <cost type="business_interruption" value="2" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+Similarly to what was described in the previous example, the various costs ``type`` also need to be established as 
+``per_area``, but the ``type`` of area is now defined as ``per_asset``. The listing below illustrates the definition of 
+the assets for this example:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>
+	    Exposure model with replacement costs per unit area;
+	    and areas provided per building for each asset
+	  </description>
+	  <conversions>
+	    <area type="per_asset" unit="SQM" />
+	    <costTypes>
+	      <costType name="structural" type="per_area" unit="USD" />
+	      <costType name="nonstructural" type="per_area" unit="USD" />
+	      <costType name="contents" type="per_area" unit="USD" />
+	      <costType name="business_interruption" type="per_area" unit="USD/month"/>
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" number="3" area="400" taxonomy="Adobe" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="10" />
+	        <cost type="nonstructural" value="15" />
+	        <cost type="contents" value="5" />
+	        <cost type="business_interruption" value="2" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+In this example, the OpenQuake engine will make use of all the parameters to estimate the various costs of each asset, by 
+multiplying the number of structural units by its average built up area, and then by the respective cost per unit area.
+
+Example XML 5
+*************
+
+In this example, additional information will be included, which is required for other risk analysis besides loss 
+estimation, such as the benefit/cost analysis.
+
+In order to perform a benefit/cost assessment, it is necessary to indicate the retrofitting cost. This parameter is 
+handled in the same manner as the structural cost, and it should be stored according to the format shown in the listing 
+below:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>Exposure model illustrating retrofit costs</description>
+	  <conversions>
+	    <costTypes>
+	      <costType name="structural" type="aggregated" unit="USD"
+	                retrofittedType="per_asset" retrofittedUnit="USD" />
+	    </costTypes>
+	  </conversions>
+	  <assets>
+	    <asset id="a1" taxonomy="Adobe" number="1" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="10000" retrofitted="2000" />
+	      </costs>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+Despite the fact that for the demonstration of how the retrofitting cost can be stored the per building type of cost 
+structure described in Example 1 was used, it is important to mention that any of the other cost storing approaches can 
+also be employed (Examples 2–4).
+
+Example XML 6
+*************
+
+The example *Exposure Model* shown in the listing below illustrates how the occupants parameter is defined 
+for each asset. In addition, this example also serves the purpose of presenting an *Exposure Model* in which three cost 
+types have been defined using three different options.
+
+As previously mentioned, in this example only three costs are being stored, and each one follows a different approach. 
+The ``structural`` cost is being defined as the aggregate replacement cost for all of the buildings comprising the asset 
+(Example 1), the ``nonstructural value`` is defined as the replacement cost per unit area where the area is defined per 
+building comprising the asset (Example 4), and the ``contents`` and ``business_interruption`` values are provided per 
+building comprising the asset (Example 2). The number of occupants at different times of the day are also provided as 
+aggregated values for all of the buildings comprising the asset:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>Exposure model example with occupants</description>
+	  <conversions>
+	    <costTypes>
+	      <costType name="structural" type="aggregated" unit="USD" />
+	      <costType name="nonstructural" type="per_area" unit="USD" />
+	      <costType name="contents" type="per_asset" unit="USD" />
+	      <costType name="business_interruption" type="per_asset" unit="USD/month" />
+	    </costTypes>
+	    <area type="per_asset" unit="SQM" />
+	  </conversions>
+	  <assets>
+	    <asset id="a1" taxonomy="Adobe" number="5" area="200" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="20000" />
+	        <cost type="nonstructural" value="15" />
+	        <cost type="contents" value="2400" />
+	        <cost type="business_interruption" value="1500" />
+	      </costs>
+	      <occupancies>
+	        <occupancy occupants="6" period="day" />
+	        <occupancy occupants="10" period="transit" />
+	        <occupancy occupants="20" period="night" />
+	      </occupancies>
+	    </asset>
+	  </assets>
+	</exposureModel>
+	
+	</nrml>
+
+Example XML 7
+*************
+
+The example *Exposure Model* shown in the listing below illustrates how one or more tags can be defined for each asset:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example_with_tags"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>Exposure Model Example with Tags</description>
+	
+	  <conversions>
+	    <costTypes>
+	      <costType name="structural" type="per_area" unit="USD" />
+	    </costTypes>
+	    <area type="per_asset" unit="SQM" />
+	  </conversions>
+	
+	  <tagNames>state county tract city zip cresta</tagNames>
+	
+	  <assets>
+	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="10000" />
+	      </costs>
+	      <occupancies>
+	        <occupancy occupants="20" period="day" />
+	      </occupancies>
+	      <tags state="California" county="Solano" tract="252702"
+	            city="Suisun" zip="94585" cresta="A.11"/>
+	    </asset>
+	  </assets>
+	
+	</exposureModel>
+	
+	</nrml>
+
+The list of tag names that will be used in the *Exposure Model* must be provided in the metadata section of the exposure 
+file, as shown in the following snippet from the full file:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+        xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	  <exposureModel id="exposure_example_with_tags"
+	                 category="buildings"
+	                 taxonomySource="GEM_Building_Taxonomy_3.3">
+
+	    <description>Exposure Model Example with Tags</description>
+	
+            <conversions>
+
+	      <costTypes>
+
+	        <costType name="structural" type="per_area" unit="USD" />
+
+	      </costTypes>
+	      <area type="per_asset" unit="SQM" />
+
+	    </conversions>
+	
+	    <tagNames>state county tract city zip cresta</tagNames>
+	
+	    <assets>
+
+	      <asset id="a1" taxonomy="Adobe" number="5" area="100" >
+
+	        <location lon="-122.000" lat="38.113" />
+	        <costs>
+
+	          <cost type="structural" value="10000"/>
+	
+	        </costs>
+	        <occupancies>
+
+	          <occupancy occupants="20" period="day" />
+	
+	        </occupancies>
+	        <tags state="California" county="Solano" tract="252702" city="Suisun" zip="94585" cresta="A.11"/>
+
+	      </asset>
+
+	    </assets>
+	
+	</nrml>
+	
+
+The tag values for the different tags can then be specified for each asset as shown in the following snippet from the 
+same file:
+
+.. code-block:: xml
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<nrml xmlns:gml="http://www.opengis.net/gml"
+	      xmlns="http://openquake.org/xmlns/nrml/0.5">
+	
+	<exposureModel id="exposure_example_with_tags"
+	               category="buildings"
+	               taxonomySource="GEM_Building_Taxonomy_3.3">
+	  <description>Exposure Model Example with Tags</description>
+	
+	  <conversions>
+	    <costTypes>
+	      <costType name="structural" type="per_area" unit="USD" />
+	    </costTypes>
+	    <area type="per_asset" unit="SQM" />
+	  </conversions>
+	
+	  <tagNames>state county tract city zip cresta</tagNames>
+	
+	  <assets>
+	    <asset id="a1" taxonomy="Adobe" number="5" area="100" >
+	      <location lon="-122.000" lat="38.113" />
+	      <costs>
+	        <cost type="structural" value="10000" />
+	      </costs>
+	      <occupancies>
+	        <occupancy occupants="20" period="day" />
+	      </occupancies>
+	      <tags state="California" county="Solano" tract="252702"
+	            city="Suisun" zip="94585" cresta="A.11"/>
+	    </asset>
+	  </assets>
+	
+	</exposureModel>
+	
+	</nrml>
+
+Note that it is not mandatory that every tag name specified in the metadata section must be provided with a tag value 
+for each asset.


### PR DESCRIPTION
Update the exposure model input section. Currently, we have XML as the main format and are still using the PDF structure.

The modifications are intended for the web version and encourage the use of CSV exposure files.