### PR TITLE
[WIP]: site-specific and TRT-specific gmc logic trees

### DIFF
--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -40,7 +40,7 @@ from openquake.qa_tests_data.classical import (
     case_60, case_61, case_62, case_63, case_64, case_65, case_66,
     case_67, case_69, case_70, case_72, case_74, case_75, case_76, case_77,
     case_78, case_80, case_81, case_82, case_83, case_84, case_85,
-    case_86, case_87, case_88)
+    case_86, case_87, case_88, case_89)
 
 ae = numpy.testing.assert_equal
 aac = numpy.testing.assert_allclose
@@ -858,3 +858,12 @@ class ClassicalTestCase(CalculatorTestCase):
             'hazard_curve-mean-SA(1.0).csv',
             'hazard_curve-mean-SA(2.0).csv'],
             case_88.__file__)
+
+    def test_case_89(self):
+        # Check execution of site-specific and TRT-specific
+        # GMC logic trees (two GMCs for each TRT in this test)
+        self.assert_curves_ok([
+            'hazard_curve-mean-PGA.csv',
+            'hazard_curve-mean-SA(1.0).csv',
+            'hazard_curve-mean-SA(2.0).csv'],
+            case_89.__file__)

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -50,6 +50,7 @@ class GsimBranch:
     gsim: GMPE
     weight: dict
     effective: bool
+    gmc_region: str | None = None
 
 
 class InvalidLogicTree(Exception):
@@ -547,7 +548,8 @@ class GsimLogicTree(object):
                 self.values[trt].append(gsim)
                 bt = GsimBranch(
                     branchset['applyToTectonicRegionType'],
-                    branch_id, gsim, weight, effective)
+                    branch_id, gsim, weight, effective,
+                    branchset['applyToSiteRegionType'])
                 if effective:
                     branches.append(bt)
                     self.shortener[branch_id] = keyno(branch_id, bsno, brno)
@@ -582,6 +584,7 @@ class GsimLogicTree(object):
             logging.debug(
                 'There are duplicated branchIDs %s in %s', dupl, self.filename)
         branches.sort(key=lambda b: b.trt)
+
         return branches
 
     def get_weight(self, trt, gsim, imt='weight'):

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -546,10 +546,11 @@ class GsimLogicTree(object):
 
                 gsim.weight = weight
                 self.values[trt].append(gsim)
-                bt = GsimBranch(
-                    branchset['applyToTectonicRegionType'],
-                    branch_id, gsim, weight, effective,
-                    branchset['applyToSiteRegionType'])
+                args = [branchset['applyToTectonicRegionType'],
+                        branch_id, gsim, weight, effective]
+                if reg is not None:
+                    args.append(branchset['applyToSiteRegionType'])
+                bt = GsimBranch(*args)
                 if effective:
                     branches.append(bt)
                     self.shortener[branch_id] = keyno(branch_id, bsno, brno)

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -282,7 +282,8 @@ site_param_dt = {
     # other parameters
     'custom_site_id': (numpy.bytes_, 8),
     'region': numpy.uint32,
-    'in_cshm': bool  # used in mcverry
+    'in_cshm': bool,  # used in mcverry
+    'gmc_region': (numpy.bytes_, 100) # Site-specific GMC logic tree
 }
 
 

--- a/openquake/qa_tests_data/classical/README.md
+++ b/openquake/qa_tests_data/classical/README.md
@@ -55,3 +55,5 @@
 | case_87 | Tests execution of NGAEastUSGSGMPE with Chapman and Guo (2021) coastal plains site amp model    
 |
 | case_88 | Tests execution of AtkinsonMacias2009 GMM with BA08 site term specified as input argument
+|
+| case_89 | Tests execution of TRT- and site-specific GMM logic trees

--- a/openquake/qa_tests_data/classical/case_89/gmmLT.xml
+++ b/openquake/qa_tests_data/classical/case_89/gmmLT.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5"
+      xmlns:gml="http://www.opengis.net/gml">
+
+    <logicTree logicTreeID="case_89">
+        
+        <logicTreeBranchSet
+            applyToTectonicRegionType="Subduction Interface"
+            applyToSiteRegionType="Default"
+            branchSetID="int_def"
+            uncertaintyType="gmpeModel">
+                <logicTreeBranch branchID="AM09-BASIN">
+                    <uncertaintyModel>
+                        [AtkinsonMacias2009]
+                            ba08_site_term=true
+                            cb14_basin_term=true
+                    </uncertaintyModel>
+                    <uncertaintyWeight> 1.0 </uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+
+        <logicTreeBranchSet
+            applyToTectonicRegionType="Subduction Interface"
+            applyToSiteRegionType="Cascadia"
+            branchSetID="int_cas"
+            uncertaintyType="gmpeModel">
+                <logicTreeBranch branchID="AM09-BASIN">
+                    <uncertaintyModel>
+                        [AtkinsonMacias2009]
+                            ba08_site_term=true
+                            cb14_basin_term=true
+                            m9_basin_term=true
+                    </uncertaintyModel>
+                    <uncertaintyWeight> 1.0 </uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+
+        <logicTreeBranchSet
+            applyToTectonicRegionType="Active Shallow Crust"
+            applyToSiteRegionType="Default"
+            branchSetID="ascr_def"
+            uncertaintyType="gmpeModel">
+                <logicTreeBranch branchID="ASK14_MEAN">
+                    <uncertaintyModel>AbrahamsonEtAl2014NSHMPMean</uncertaintyModel>
+                    <uncertaintyWeight>0.50</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="BSSA14_MEAN">
+                    <uncertaintyModel>BooreEtAl2014NSHMPMean</uncertaintyModel>
+                    <uncertaintyWeight>0.50</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+
+        <logicTreeBranchSet
+            applyToTectonicRegionType="Active Shallow Crust"
+            applyToSiteRegionType="LA"
+            branchSetID="ascr_la"
+            uncertaintyType="gmpeModel">
+                <logicTreeBranch branchID="CB14_MEAN">
+                    <uncertaintyModel>CampbellBozorgnia2014NSHMPMean</uncertaintyModel>
+                    <uncertaintyWeight>0.50</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="CY14_MEAN">
+                    <uncertaintyModel>ChiouYoungs2014NSHMPMean</uncertaintyModel>
+                    <uncertaintyWeight>0.50</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_89/job.ini
+++ b/openquake/qa_tests_data/classical/case_89/job.ini
@@ -1,0 +1,43 @@
+[general]
+
+description = case_89
+calculation_mode = classical
+random_seed = 23
+
+[geometry]
+
+site_model_file = sites.csv
+
+[logic_tree]
+
+number_of_logic_tree_samples = 100
+
+[erf]
+
+rupture_mesh_spacing = 1 
+complex_fault_mesh_spacing = 10
+width_of_mfd_bin = 0.1
+area_source_discretization = 5.0
+
+[site_params]
+
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 3.08
+reference_depth_to_1pt0km_per_sec = 710
+
+[calculation]
+
+source_model_logic_tree_file = ssmLT.xml
+gsim_logic_tree_file = gmmLT.xml
+investigation_time = 1.0
+intensity_measure_types_and_levels = {"PGA": logscale(0.005, 3.00, 25),
+                                      "SA(1.0)": logscale(0.005, 8.00, 25),
+                                      "SA(2.0)": logscale(0.005, 3.60, 25)}
+truncation_level = 5.0
+horiz_comp_to_geom_mean = true
+maximum_distance = {'Subduction Interface': 500.}
+ps_grid_spacing = 50.0
+
+[output]
+mean_hazard_curves = true

--- a/openquake/qa_tests_data/classical/case_89/sites.csv
+++ b/openquake/qa_tests_data/classical/case_89/sites.csv
@@ -1,0 +1,3 @@
+lon,lat,vs30,z1pt0,z2pt5,gmc_region
+1,-5,681.59,72.1,0.69,"{""Active Shallow Crust"": ""Default"", ""Subduction Interface"": ""Cascadia""}"
+1.25,-5.25,893.99,16.11,0.5,"{""Active Shallow Crust"": ""Los Angeles"", ""Subduction Interface"": ""Default""}"

--- a/openquake/qa_tests_data/classical/case_89/ssm.xml
+++ b/openquake/qa_tests_data/classical/case_89/ssm.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <sourceModel
+    name="ASCR source and a subduction interface source directly overlying on another"
+    >
+        <sourceGroup
+        name="group 1"
+        tectonicRegion="Active Shallow Crust"
+        >
+            <simpleFaultSource
+            id="1"
+            name="Simple Fault Source"
+            tectonicRegion="Active Shallow Crust"
+            >
+                <simpleFaultGeometry>
+                    <gml:LineString>
+                        <gml:posList>
+                            1.0000000E+00 -5.0000000E-01 1.4000000E+00 0.0000000E+00 1.4000000E+00 3.0000000E-01
+                        </gml:posList>
+                    </gml:LineString>
+                    <dip>
+                        3.0000000E+01
+                    </dip>
+                    <upperSeismoDepth>
+                        8.0000000E+00
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        2.0000000E+01
+                    </lowerSeismoDepth>
+                </simpleFaultGeometry>
+                <magScaleRel>
+                    WC1994
+                </magScaleRel>
+                <ruptAspectRatio>
+                    2.0000000E+00
+                </ruptAspectRatio>
+                <truncGutenbergRichterMFD aValue="3.2000000E+00" bValue="9.0000000E-01" maxMag="6.5000000E+00" minMag="5.5000000E+00"/>
+                <rake>
+                    9.0000000E+01
+                </rake>
+            </simpleFaultSource>
+        </sourceGroup>
+        <sourceGroup
+        name="group 2"
+        tectonicRegion="Subduction Interface"
+        >
+            <areaSource
+            id="2"
+            name="Area Source"
+            tectonicRegion="Subduction Interface"
+            >
+                <areaGeometry>
+                    <gml:Polygon>
+                        <gml:exterior>
+                            <gml:LinearRing>
+                                <gml:posList>
+                                    -5.0000000E-01 -5.0000000E-01 -3.0000000E-01 -1.0000000E-01 1.0000000E-01 2.0000000E-01 3.0000000E-01 -8.0000000E-01
+                                </gml:posList>
+                            </gml:LinearRing>
+                        </gml:exterior>
+                    </gml:Polygon>
+                    <upperSeismoDepth>
+                        2.0000000E+01
+                    </upperSeismoDepth>
+                    <lowerSeismoDepth>
+                        4.0000000E+01
+                    </lowerSeismoDepth>
+                </areaGeometry>
+                <magScaleRel>
+                    StrasserInterface
+                </magScaleRel>
+                <ruptAspectRatio>
+                    1.0000000E+00
+                </ruptAspectRatio>
+                <truncGutenbergRichterMFD aValue="4.5000000E+00" bValue="1.0000000E+00" maxMag="8.50000000E+00" minMag="6.5000000E+00"/>
+                <nodalPlaneDist>
+                    <nodalPlane dip="9.0000000E+01" probability="1.0000000E+00" rake="0.0000000E+00" strike="0.0000000E+00"/>
+                </nodalPlaneDist>
+                <hypoDepthDist>
+                    <hypoDepth depth="30.0000000E+00" probability="1.0000000E+00"/>
+                </hypoDepthDist>
+            </areaSource>
+        </sourceGroup>
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_89/ssmLT.xml
+++ b/openquake/qa_tests_data/classical/case_89/ssmLT.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml
+xmlns="http://openquake.org/xmlns/nrml/0.5"
+xmlns:gml="http://www.opengis.net/gml"
+>
+    <logicTree
+    logicTreeID="case_89">
+            <logicTreeBranchSet
+            branchSetID="bs1"
+            uncertaintyType="sourceModel"
+            >
+	    <logicTreeBranch branchID="model">
+		<uncertaintyModel>
+            ssm.xml
+        </uncertaintyModel>
+		<uncertaintyWeight>1.0</uncertaintyWeight>
+        </logicTreeBranch>
+        </logicTreeBranchSet>
+    </logicTree>
+</nrml>


### PR DESCRIPTION
This capability is needed for the 2023 conterminous US model, and likely for other GMCs in upcoming national hazard models.

In summary, this PR permits the addition of `applyToSiteRegionType` for each branchset in a GMC logic tree. This value is linked to the "gmc_region" value per site in the site model to ensure that when more than one GMC is provided for a given TRT (e.g. a default site region, and a Los Angeles site region in the new QA test - classical/case_89) that the correct GMC logic tree (i.e. branchset) is applied to each site. The "gmc_region" value per site is a dict with key per trt and value being the associated GMC logic tree to apply to that site:

<img width="587" alt="image" src="https://github.com/user-attachments/assets/e5157b54-fc60-4d70-a827-289d522bf19f" />

TODO: 
- [ ] Modify context maker to apply the `applyToSiteRegionType` when retrieving gmms on a site-by-site basis (bit complex because of how the realizations are currently made per GMM in the context maker)
- [ ] Parsing of the string rep of the gmc_region mapping in site model (use `ast.literal_eval(dict)`?) and propagating through into `get_mean_stddevs` where need to still then apply on site-by-site basis based on the gmc_region value of each site
- [ ] Add expected results for QA test case 89