### PR TITLE
Improved the error message for invalid area polygons

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,8 @@
   [Lana Todorovic]
-  * Updated units of slope (in m/m) in site model. 
-  
+  * Updated units of slope (in m/m) in site model.
+
   [Michele Simionato]
+  * Improved the validation of area source polygons
   * Internal: added method `CompositeLogicTree.apply_all`
   * Fixed downloading of uncertainty.xml in OQImpact calculations
 

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -905,12 +905,13 @@ class SourceConverter(RuptureConverter):
         :param node: a node with tag areaGeometry
         :returns: a :class:`openquake.hazardlib.source.AreaSource` instance
         """
-        geom = node.areaGeometry
-        coords = split_coords_2d(~geom.Polygon.exterior.LinearRing.posList)
-        polygon = geo.Polygon([geo.Point(*xy) for xy in coords])
-        msr = ~node.magScaleRel
-        area_discretization = geom.attrib.get(
-            'discretization', self.area_source_discretization)
+        with context(self.fname, node):
+            geom = node.areaGeometry
+            coords = split_coords_2d(~geom.Polygon.exterior.LinearRing.posList)
+            polygon = geo.Polygon([geo.Point(*xy) for xy in coords])
+            msr = ~node.magScaleRel
+            area_discretization = geom.attrib.get(
+                'discretization', self.area_source_discretization)
         if area_discretization is None:
             raise ValueError(
                 'The source %r has no `discretization` parameter and the job.'


### PR DESCRIPTION
In this way we will know which is the polygon causing the following error:
```python
File "C:\Users\PC\AppData\Local\Programs\OpenQuake Engine\python3\Lib\site-packages\openquake\hazardlib\source_reader.py", line 164, in read_source_model
    [sm] = nrml.read_source_models([fname], converter)
    ^^^^
  File "C:\Users\PC\AppData\Local\Programs\OpenQuake Engine\python3\Lib\site-packages\openquake\hazardlib\nrml.py", line 336, in read_source_models
    sm = to_python(fname, converter)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\AppData\Local\Programs\OpenQuake Engine\python3\Lib\site-packages\openquake\hazardlib\nrml.py", line 175, in to_python
    return node_to_obj(node, fname, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\AppData\Local\Programs\OpenQuake Engine\python3\Lib\site-packages\openquake\baselib\general.py", line 690, in __call__
    return self[key](obj, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\AppData\Local\Programs\OpenQuake Engine\python3\Lib\site-packages\openquake\hazardlib\nrml.py", line 200, in get_source_model_04
    src = converter.convert_node(src_node)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\AppData\Local\Programs\OpenQuake Engine\python3\Lib\site-packages\openquake\hazardlib\sourceconverter.py", line 757, in convert_node
    obj = getattr(self, 'convert_' + name)(node)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\AppData\Local\Programs\OpenQuake Engine\python3\Lib\site-packages\openquake\hazardlib\sourceconverter.py", line 910, in convert_areaSource
    polygon = geo.Polygon([geo.Point(*xy) for xy in coords])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\PC\AppData\Local\Programs\OpenQuake Engine\python3\Lib\site-packages\openquake\hazardlib\geo\polygon.py", line 58, in __init__
    raise ValueError('polygon perimeter intersects itself')
ValueError: polygon perimeter intersects itself
```