### PR TITLE
IMPACT: ignore ShakeMap items without `version` and better identify the USGS-preferred item

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -867,7 +867,7 @@ def get_shakemap_versions(usgs_id, user=User(), monitor=performance.Monitor()):
     properties = js['properties']
     shakemaps = properties['products']['shakemap']
     usgs_preferred_shakemap = _get_usgs_preferred_item(shakemaps)
-    usgs_preferred_version = usgs_preferred_shakemap['properties']['version']
+    usgs_preferred_version = usgs_preferred_shakemap['id']
     sorted_shakemaps = sorted(
         shakemaps, key=lambda x: x["updateTime"], reverse=True)
     shakemap_versions = [

--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -874,7 +874,8 @@ def get_shakemap_versions(usgs_id, user=User(), monitor=performance.Monitor()):
         {'id': shakemap['id'],
          'number': shakemap['properties']['version'],
          'utc_date_time': ms_to_utc_date_time(shakemap['updateTime'])}
-        for shakemap in sorted_shakemaps]
+        for shakemap in sorted_shakemaps
+        if 'version' in shakemap['properties']]
     return shakemap_versions, usgs_preferred_version, err
 
 

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -273,7 +273,8 @@ class ShakemapParsersTestCase(unittest.TestCase):
             usgs_id, user=user)
         self.assertEqual(err, {})
         self.assertEqual(len(shakemap_versions), 3)
-        self.assertEqual(usgs_preferred_version, '1')
+        self.assertEqual(usgs_preferred_version,
+                         'urn:usgs-product:atlas:shakemap:us20002926:1594162031303')
         first_version = shakemap_versions[0]
         self.assertIn('id', first_version)
         self.assertIn('utc_date_time', first_version)

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -538,7 +538,7 @@ function capitalizeFirstLetter(val) {
             } else {
                 if (data.shakemap_versions.length > 0) {
                     data.shakemap_versions.forEach(function (shakemap_version) {
-                        var usgs_preferred = shakemap_version.number == data.usgs_preferred_version ? " (USGS preferred)" : "";
+                        var usgs_preferred = shakemap_version.id == data.usgs_preferred_version ? " (USGS preferred)" : "";
                         $select.append(`<option value="${shakemap_version.id}">v${shakemap_version.number}: ${shakemap_version.utc_date_time}${usgs_preferred}</option>`);
                     });
                 } else {

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -834,8 +834,7 @@ def impact_get_shakemap_versions(request):
         a `django.http.HttpRequest` object containing usgs_id
     """
     usgs_id = request.POST.get('usgs_id')
-    shakemap_versions, usgs_preferred_version, err = get_shakemap_versions(
-        usgs_id)
+    shakemap_versions, usgs_preferred_version, err = get_shakemap_versions(usgs_id)
     if err:
         shakemap_versions_issue = err['error_msg']
     else:


### PR DESCRIPTION
As observed by @VSilva, the `version` of some ShakeMap items might be missing. E.g., in `official20100227063411530_30` the `properties` for two items are like:
``{'message': 'removed and replaced for catalog consistency', 'original-signature': 'MC0CFA0sdC8zpMHD+QuphPcL4IhrGzdVAhUAll1+gwCS4w009mGB3OG4W9VxtNs=', 'original-signature-version': 'v1'}``
After this PR, these items will be discarded, without raising errors.

We also observed that in some cases (e.g. `official19050709094039000_15`) multiple items share the same `version`. The label showing the `USGS preferred` item was determined assuming that the `version` was unique. I am using the `id` instead (that IS unique), otherwise multiple items could happen to be labeled as USGS-preferred.

In many cases there also is another property called `pdl-client-version` like this: `'pdl-client-version': 'Version 2.4.0 2020-05-11'`. I tried to use it instead of the version number, but it is often missing, so I discarded that approach. Afterwards I also found out that the `pdl-client-version` is the version number of the client software that published the ShakeMap, so  it can not be read as a version of the ShakeMap itself.

After the changes in this PR, we may still have cases in which the list of ShakeMaps contain multiple items sharing the same version number, but differentiated in terms of update time. For now, this is the best compromise I've managed to implement. 