### PR TITLE
Optimized `read_cmakers`

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -451,7 +451,7 @@ class ClassicalCalculator(base.HazardCalculator):
 
     def init_poes(self):
         oq = self.oqparam
-        self.cmakers = read_cmakers(self.datastore, self.csm)
+        self.cmakers = read_cmakers(self.datastore, self.full_lt)
         parent = self.datastore.parent
         if parent:
             # tested in case_43

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -173,10 +173,11 @@ def map_getters(dstore, full_lt=None, disagg=False):
     """
     oq = dstore['oqparam']
     # disaggregation is meant for few sites, i.e. no tiling
-    chunks, N = get_num_chunks_sites(dstore)
-    if disagg and N > chunks:
-        raise ValueError('There are %d sites but only %d chunks' % (N, chunks))
+    n, N = get_num_chunks_sites(dstore)
+    if disagg and N > n:
+        raise ValueError('There are %d sites but only %d chunks' % (N, n))
 
+    # full_lt is None in classical_risk, classical_damage
     full_lt = full_lt or dstore['full_lt'].init()
     R = full_lt.get_num_paths()
     _req_gb, trt_rlzs = get_pmaps_gb(dstore, full_lt)
@@ -196,7 +197,7 @@ def map_getters(dstore, full_lt=None, disagg=False):
             if f.endswith('.hdf5'):
                 fnames.append(os.path.join(scratch_dir, f))
     out = []
-    for chunk in range(chunks):
+    for chunk in range(n):
         getter = MapGetter(fnames, chunk, trt_rlzs, R, oq)
         getter.weights = weights
         out.append(getter)

--- a/openquake/calculators/postproc/med_gmv.py
+++ b/openquake/calculators/postproc/med_gmv.py
@@ -38,7 +38,7 @@ def calc_med_gmv(src_frags, sitecol, cmaker, monitor):
 def main(dstore, csm):
     oq = dstore['oqparam']
     sitecol = dstore['sitecol']
-    cmakers = read_cmakers(dstore, csm)
+    cmakers = read_cmakers(dstore, csm.full_lt)
     oq.mags_by_trt = {
         trt: python3compat.decode(dset[:])
         for trt, dset in dstore['source_mags'].items()}

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -25,7 +25,7 @@ import h5py
 from openquake.baselib import general, parallel, hdf5, config
 from openquake.hazardlib import pmf, geo, source_reader
 from openquake.baselib.general import AccumDict, groupby, block_splitter
-from openquake.hazardlib.contexts import read_cmakers
+from openquake.hazardlib.contexts import get_cmakers
 from openquake.hazardlib.source.point import grid_point_sources
 from openquake.hazardlib.source.base import get_code2cls
 from openquake.hazardlib.sourceconverter import SourceGroup
@@ -234,8 +234,8 @@ class PreClassicalCalculator(base.HazardCalculator):
         csm = self.csm
         self.store()
         logging.info('Building cmakers')
-        self.cmakers = read_cmakers(self.datastore, csm)
         trt_smrs = [U32(sg[0].trt_smrs) for sg in csm.src_groups]
+        self.cmakers = get_cmakers(trt_smrs, csm.full_lt, oq)
         self.datastore.hdf5.save_vlen('trt_smrs', trt_smrs)
         sites = csm.sitecol if csm.sitecol else None
         if sites is None:

--- a/openquake/hazardlib/__init__.py
+++ b/openquake/hazardlib/__init__.py
@@ -320,8 +320,8 @@ class Input(object):
                 for ebr in grp:
                     ebr.n_occ = ngmfs * num_rlzs
                     ebr.trt_smrs = (ebr.trt_smr,)
-
-        return groups, contexts.get_cmakers(groups, self.full_lt, self.oq)
+        trt_smrs = [group[0].trt_smrs for group in groups]
+        return groups, contexts.get_cmakers(trt_smrs, self.full_lt, self.oq)
 
     @property
     def cmaker(self):

--- a/openquake/hazardlib/calc/mean_rates.py
+++ b/openquake/hazardlib/calc/mean_rates.py
@@ -60,7 +60,8 @@ def calc_rmap(src_groups, full_lt, sitecol, oq):
     oq.use_rates = True
     oq.disagg_by_src = False
     L = oq.imtls.size
-    cmakers = get_cmakers(src_groups, full_lt, oq)
+    all_trt_smrs = [sg[0].trt_smrs for sg in src_groups]
+    cmakers = get_cmakers(all_trt_smrs, full_lt, oq)
     Gt = sum(len(cm.gsims) for cm in cmakers)
     logging.info('Computing rate map with N=%d, L=%d, Gt=%d',
                  len(sitecol), oq.imtls.size, Gt)

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -33,6 +33,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         for i, src in enumerate(group):
             src.id = i
             src.grp_id = 0
+            src.trt_smr = 0
             src.num_ruptures = src.count_ruptures()
         aae([src.mutex_weight for src in group],
             [0.0125, 0.0125, 0.0125, 0.0125, 0.1625, 0.1625, 0.0125, 0.0125,


### PR DESCRIPTION
Read it reads only the (small) dataset `trt_smrs` and not the large `_csm`.