### PR TITLE
Added an ordinal argument to the DummyGMPE class

### DIFF
--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -442,9 +442,10 @@ class GMPE(GroundShakingIntensityModel):
         raise NotImplementedError
 
 
-class Dummy(GMPE):
+class DummyGMPE(GMPE):
     """
-    A fake GMPE doing nothing
+    A fake GMPE doing nothing, to be used with zero-weight branches of
+    the logic tree.
     """
     DEFINED_FOR_TECTONIC_REGION_TYPE = const.TRT.ACTIVE_SHALLOW_CRUST
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = {}
@@ -454,6 +455,9 @@ class Dummy(GMPE):
     REQUIRES_SITES_PARAMETERS = set()
     REQUIRES_RUPTURE_PARAMETERS = {'mag'}
     REQUIRES_DISTANCES = {'rrup'}
+
+    def __init__(self, ordinal=0):
+        self.ordinal = ordinal
 
     def compute(self, ctx: numpy.recarray, imts, mean, sig, tau, phi):
         sig[:] = .005

--- a/openquake/qa_tests_data/classical/case_06/gmmLT.xml
+++ b/openquake/qa_tests_data/classical/case_06/gmmLT.xml
@@ -28,7 +28,7 @@
         <uncertaintyWeight>0.50</uncertaintyWeight>
       </logicTreeBranch>
       <logicTreeBranch branchID="dummy">
-        <uncertaintyModel>Dummy</uncertaintyModel>
+        <uncertaintyModel>DummyGMPE</uncertaintyModel>
         <uncertaintyWeight>0.0</uncertaintyWeight>
       </logicTreeBranch>
     </logicTreeBranchSet>
@@ -48,7 +48,7 @@
         <uncertaintyWeight>0.50</uncertaintyWeight>
       </logicTreeBranch>
       <logicTreeBranch branchID="dummy">
-        <uncertaintyModel>Dummy</uncertaintyModel>
+        <uncertaintyModel>DummyGMPE</uncertaintyModel>
         <uncertaintyWeight>0.0</uncertaintyWeight>
       </logicTreeBranch>
     </logicTreeBranchSet>

--- a/openquake/qa_tests_data/classical/case_06/gmmLT0.xml
+++ b/openquake/qa_tests_data/classical/case_06/gmmLT0.xml
@@ -28,7 +28,7 @@
         <uncertaintyWeight>0.50</uncertaintyWeight>
       </logicTreeBranch>
       <logicTreeBranch branchID="dummy">
-        <uncertaintyModel>Dummy</uncertaintyModel>
+        <uncertaintyModel>DummyGMPE</uncertaintyModel>
         <uncertaintyWeight>0.0</uncertaintyWeight>
       </logicTreeBranch>
     </logicTreeBranchSet>

--- a/openquake/qa_tests_data/classical/case_06/gmmLT1.xml
+++ b/openquake/qa_tests_data/classical/case_06/gmmLT1.xml
@@ -15,7 +15,7 @@
         <uncertaintyWeight>0.50</uncertaintyWeight>
       </logicTreeBranch>
       <logicTreeBranch branchID="dummy">
-        <uncertaintyModel>Dummy</uncertaintyModel>
+        <uncertaintyModel>DummyGMPE</uncertaintyModel>
         <uncertaintyWeight>0.0</uncertaintyWeight>
       </logicTreeBranch>
     </logicTreeBranchSet>

--- a/openquake/qa_tests_data/classical/case_07/gsim_logic_tree.xml
+++ b/openquake/qa_tests_data/classical/case_07/gsim_logic_tree.xml
@@ -13,7 +13,7 @@
                 </logicTreeBranch>
 
                 <logicTreeBranch branchID="b2">
-                    <uncertaintyModel>Dummy</uncertaintyModel>
+                    <uncertaintyModel>[DummyGMPE]ordinal=1</uncertaintyModel>
                     <uncertaintyWeight>0.0</uncertaintyWeight>
                 </logicTreeBranch>
 


### PR DESCRIPTION
In this way it is possible to have a branchset with two or more distinct dummy branches. This is needed by the USA 2023 model.