### PR TITLE
In the API endpoint listing the outputs for a job, specify the export type in the url

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Paolo Tormene]
+  * In the API endpoint listing the outputs for a job, the first available
+    export_type is specified in each output url
+
   [Michele Simionato]
   * Added a new uncertainty `abMaxMagAbsolute` to the logic tree
   * Internal: refactored lt.Branch, lt.BranchSet and lt.CompositeLogicTree


### PR DESCRIPTION
E.g. `http://localhost:8800/v1/calc/result/4489?export_type=csv` instead of just `http://localhost:8800/v1/calc/result/4489`.
For the sake of simplicity, the export_type will be the first available one for that output. In the future we may prefer to specify a "preferred" export type for each kind of output or to provide multiple urls, one for each available export format.