### PR TITLE
remove unused copy imports 

### DIFF
--- a/openquake/hazardlib/gsim/abrahamson_2014.py
+++ b/openquake/hazardlib/gsim/abrahamson_2014.py
@@ -22,7 +22,6 @@ Module exports :class:`AbrahamsonEtAl2014`
                :class:`AbrahamsonEtAl2014RegJPN`
                :class:`AbrahamsonEtAl2014RegTWN`
 """
-import copy
 import numpy as np
 
 from scipy import interpolate

--- a/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
+++ b/openquake/hazardlib/gsim/abrahamson_gulerce_2020.py
@@ -22,7 +22,7 @@ Module exports :class:`AbrahamsonGulerce2020SInter`,
                :class:`AbrahamsonGulerce2020SSlab`
 """
 import numpy as np
-import copy
+
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable, add_alias
 from openquake.hazardlib import const
 from openquake.hazardlib.imt import PGA, SA

--- a/openquake/hazardlib/gsim/abrahamson_silva_2008.py
+++ b/openquake/hazardlib/gsim/abrahamson_silva_2008.py
@@ -20,7 +20,6 @@
 Module exports :class:`AbrahamsonSilva2008`.
 """
 import numpy as np
-import copy
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable
 from openquake.hazardlib import const

--- a/openquake/hazardlib/gsim/afshari_stewart_2016.py
+++ b/openquake/hazardlib/gsim/afshari_stewart_2016.py
@@ -21,7 +21,6 @@ Module exports :class:`AfshariStewart2016`,
                :class:`AfshariStewart2016Japan`
 """
 import numpy as np
-import copy
 
 from openquake.baselib.general import CallableDict
 from openquake.hazardlib.gsim.base import CoeffsTable, GMPE

--- a/openquake/hazardlib/gsim/aristeidou_2023.py
+++ b/openquake/hazardlib/gsim/aristeidou_2023.py
@@ -25,7 +25,6 @@ Module exports :class:`AristeidouEtAl2023`
 """
 
 import numpy as np
-import copy
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable
 from openquake.hazardlib import const

--- a/openquake/hazardlib/gsim/aristeidou_2024.py
+++ b/openquake/hazardlib/gsim/aristeidou_2024.py
@@ -27,7 +27,6 @@ Module exports :class:`AristeidouEtAl2024`
 
 import pathlib
 import numpy as np
-import copy
 from scipy.interpolate import interp1d
 
 from openquake.hazardlib import const

--- a/openquake/hazardlib/gsim/bahrampouri_2021_duration.py
+++ b/openquake/hazardlib/gsim/bahrampouri_2021_duration.py
@@ -24,7 +24,6 @@ Module exports :class:`BahrampouriEtAldm2021`
                :class:`BahrampouriEtAldm2021SInter`
 """
 import numpy as np
-import copy
 
 from openquake.hazardlib.gsim.base import CoeffsTable, GMPE
 from openquake.hazardlib import const

--- a/openquake/hazardlib/gsim/bayless_abrahamson_2018.py
+++ b/openquake/hazardlib/gsim/bayless_abrahamson_2018.py
@@ -21,7 +21,6 @@ Module exports :class:`BaylessAbrahamson2018`
 """
 import os
 import numpy as np
-import copy
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable
 from openquake.hazardlib import const

--- a/openquake/hazardlib/gsim/boore_2014.py
+++ b/openquake/hazardlib/gsim/boore_2014.py
@@ -22,7 +22,6 @@ Module exports :class:`BooreEtAl2014`,
                :class:`BooreEtAl2014LowQ`
 """
 import numpy as np
-import copy
 
 from openquake.baselib.general import CallableDict
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable, add_alias

--- a/openquake/hazardlib/gsim/bozorgnia_campbell_2016.py
+++ b/openquake/hazardlib/gsim/bozorgnia_campbell_2016.py
@@ -25,7 +25,6 @@ Module exports :class:`BozorgniaCampbell2016`
                :class:`BozorgniaCampbell2016LowQJapanSite`
 """
 import numpy as np
-import copy
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable, add_alias
 from openquake.hazardlib.gsim.campbell_bozorgnia_2014 import (

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2008.py
@@ -21,7 +21,6 @@ Module exports :class:`CampbellBozorgnia2008`, and
 :class:'CampbellBozorgnia2008Arbitrary'
 """
 import numpy as np
-import copy
 from math import log, exp
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable

--- a/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
+++ b/openquake/hazardlib/gsim/campbell_bozorgnia_2014.py
@@ -25,7 +25,6 @@ Module exports :class:`CampbellBozorgnia2014`
                :class:`CampbellBozorgnia2019LowQ`
 """
 import numpy as np
-import copy
 
 from numpy import exp, radians, cos
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable, add_alias

--- a/openquake/hazardlib/gsim/chao_2020.py
+++ b/openquake/hazardlib/gsim/chao_2020.py
@@ -23,7 +23,6 @@ Module exports :class:`ChaoEtAl2020SInter`
 """
 import math
 import numpy as np
-import copy
 
 from openquake.baselib.general import CallableDict
 from openquake.hazardlib import const

--- a/openquake/hazardlib/gsim/chiou_youngs_2008.py
+++ b/openquake/hazardlib/gsim/chiou_youngs_2008.py
@@ -20,7 +20,6 @@
 Module exports :class:`ChiouYoungs2008`.
 """
 import numpy as np
-import copy
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable
 from openquake.hazardlib import const

--- a/openquake/hazardlib/gsim/chiou_youngs_2014.py
+++ b/openquake/hazardlib/gsim/chiou_youngs_2014.py
@@ -23,7 +23,6 @@ Module exports :class:`ChiouYoungs2014`
 """
 import os
 import pathlib
-import copy
 import numpy as np
 
 from openquake.baselib.general import CallableDict

--- a/openquake/hazardlib/gsim/hassani_atkinson_2020.py
+++ b/openquake/hazardlib/gsim/hassani_atkinson_2020.py
@@ -23,7 +23,6 @@ Module exports :class:`HassaniAtkinson2020SInter`
 """
 import math
 import numpy as np
-import copy
 
 from openquake.hazardlib import const
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable

--- a/openquake/hazardlib/gsim/kuehn_2020.py
+++ b/openquake/hazardlib/gsim/kuehn_2020.py
@@ -39,7 +39,6 @@ Module exports :class:`KuehnEtAl2020SInter`,
 import numpy as np
 import os
 import h5py
-import copy
 from scipy.interpolate import RegularGridInterpolator
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable, add_alias

--- a/openquake/hazardlib/gsim/mgmpe/cb14_basin_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/cb14_basin_term.py
@@ -19,7 +19,6 @@ Module :mod:`openquake.hazardlib.mgmpe.cb14_basin_term` implements
 :class:`~openquake.hazardlib.mgmpe.CB14BasinTerm`
 """
 import numpy as np
-import copy
 
 from openquake.hazardlib import const
 from openquake.hazardlib.gsim.base import GMPE, registry

--- a/openquake/hazardlib/gsim/nz22/nz_nshm2022_kuehn_2020.py
+++ b/openquake/hazardlib/gsim/nz22/nz_nshm2022_kuehn_2020.py
@@ -26,7 +26,6 @@ Module exports :class:`NZNSHM2022_KuehnEtAl2020SInter`
 """
 
 import numpy as np
-import copy
 from scipy.interpolate import interp1d
 
 from openquake.hazardlib.imt import PGA

--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -25,7 +25,6 @@ Module exports :class:`ParkerEtAl2020SInter`
 import os
 import numpy as np
 import pandas as pd
-import copy
 from scipy.special import erf
 
 from openquake.baselib.general import CallableDict

--- a/openquake/hazardlib/gsim/phung_2020.py
+++ b/openquake/hazardlib/gsim/phung_2020.py
@@ -23,7 +23,6 @@ Module exports :class:`PhungEtAl2020SInter`
 """
 import math
 import numpy as np
-import copy
 
 from openquake.hazardlib import const
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable

--- a/openquake/hazardlib/gsim/si_2020.py
+++ b/openquake/hazardlib/gsim/si_2020.py
@@ -21,7 +21,6 @@ Module exports :class:`SiEtAl2020SInter`
                :class:`SiEtAl2020SSlab`
 """
 import numpy as np
-import copy
 
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable
 from openquake.hazardlib import const


### PR DESCRIPTION
Remove leftover imports from GMM basin PR - now using `ctx.z1pt0.copy()` or `ctx.z2pt5.copy()`