### PR TITLE
Saving memory in expo_to_hdf5

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -85,7 +85,7 @@ def sanitize(value):
 
 
 def create(hdf5, name, dtype, shape=(None,), compression=None,
-           fillvalue=0, attrs=None):
+           fillvalue=None, attrs=None):
     """
     :param hdf5: a h5py.File object
     :param name: an hdf5 key string

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -149,6 +149,9 @@ def read_hc_id(hdf5):
     return oq.hazard_calculation_id
 
 
+# NB: the way to store utf8-strings is
+# dstore.create_dset(name, hdf5.vstr, len(strings))[:] = strings
+
 class DataStore(collections.abc.MutableMapping):
     """
     DataStore class to store the inputs/outputs of a calculation on the

--- a/openquake/commonlib/expo_to_hdf5.py
+++ b/openquake/commonlib/expo_to_hdf5.py
@@ -118,8 +118,6 @@ def store_tagcol(dstore, h5tmp):
             arr['country'] = uvals
             arr['counts'] = counts
             dstore['assets_by_country'] = arr
-        else:
-            logging.warning(f'No data for {tagname}')
     dic = dict(__pyclass__='openquake.risklib.asset.TagCollection',
                tagnames=numpy.array(tagnames, hdf5.vstr),
                tagsizes=tagsizes)

--- a/openquake/commonlib/expo_to_hdf5.py
+++ b/openquake/commonlib/expo_to_hdf5.py
@@ -21,7 +21,7 @@ import logging
 import operator
 import pandas
 import numpy
-from openquake.baselib import hdf5, sap, general
+from openquake.baselib import hdf5, sap, general, performance
 from openquake.baselib.parallel import Starmap
 from openquake.hazardlib.geo.utils import geohash3
 from openquake.commonlib.datastore import create_job_dstore
@@ -95,12 +95,15 @@ def store_tagcol(dstore, h5tmp):
     """
     tagsizes = []
     tagnames = []
+    mon = performance.Monitor(h5=dstore)
     for tagname in h5tmp:
-        tagvalues = h5tmp[tagname][:]
+        with mon('read tags'):
+            tagvalues = h5tmp[tagname][:]
         name = 'taxonomy' if tagname == 'TAXONOMY' else tagname
         tagnames.append(name)
-        uvals, inv, counts = numpy.unique(
-            tagvalues, return_inverse=1, return_counts=1)
+        with mon('unique tags'):
+            uvals, inv, counts = numpy.unique(
+                tagvalues, return_inverse=1, return_counts=1)
         size = len(uvals) + 1
         tagsizes.append(size)
         logging.info('Storing %s[%d/%d]', tagname, size, len(inv))

--- a/openquake/commonlib/expo_to_hdf5.py
+++ b/openquake/commonlib/expo_to_hdf5.py
@@ -97,11 +97,11 @@ def store_tagcol(dstore, h5tmp):
     tagnames = []
     mon = performance.Monitor(h5=dstore)
     for tagname in h5tmp:
-        with mon('read tags'):
+        with mon('read tags', savemem=True):
             tagvalues = h5tmp[tagname][:]
         name = 'taxonomy' if tagname == 'TAXONOMY' else tagname
         tagnames.append(name)
-        with mon('unique tags'):
+        with mon('unique tags', savemem=True):
             uvals, inv, counts = numpy.unique(
                 tagvalues, return_inverse=1, return_counts=1)
         size = len(uvals) + 1

--- a/openquake/commonlib/expo_to_hdf5.py
+++ b/openquake/commonlib/expo_to_hdf5.py
@@ -195,7 +195,7 @@ def store(exposures_xml, wfp, dstore):
     for name, dt in dtlist:
         logging.info('Creating assets/%s', name)
     dstore['exposure'] = exposure
-    dstore.create_df('assets', dtlist, 'gzip')
+    dstore.create_df('assets', dtlist) # 'gzip'
     slc_dt = numpy.dtype([('gh3', U16), ('start', U32), ('stop', U32)])
     dstore.create_dset('assets/slice_by_gh3', slc_dt)
     dstore.swmr_on()
@@ -211,10 +211,7 @@ def store(exposures_xml, wfp, dstore):
         name2dic.update(zip(arr['ID_2'], arr['NAME_2']))
         for name in commonfields:
             if name in TAGS:
-                try:
-                    hdf5.extend(h5tmp[name], arr[name])
-                except:
-                    breakpoint()
+                hdf5.extend(h5tmp[name], arr[name])
             else:
                 hdf5.extend(dstore['assets/' + name], arr[name])
         n = len(arr)

--- a/openquake/commonlib/tests/expo_to_hdf5_test.py
+++ b/openquake/commonlib/tests/expo_to_hdf5_test.py
@@ -17,6 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import numpy
+from openquake.baselib import hdf5
 from openquake.commonlib.expo_to_hdf5 import store
 from openquake.commonlib.datastore import create_job_dstore
 
@@ -90,8 +91,8 @@ def test_expo_to_hdf5():
     expo4_xml = os.path.join(os.path.dirname(__file__),
                              'data', 'Exposure_Turkiye.xml')
     job, dstore = create_job_dstore()
-    with job, dstore:
-        store([expo1_xml, expo2_xml, expo3_xml, expo4_xml], True, dstore)
+    with job, dstore, hdf5.File(dstore.tempname, 'w') as h5tmp:
+        store([expo1_xml, expo2_xml, expo3_xml, expo4_xml], True, dstore, h5tmp)
         assets = sorted(dstore['assets/ASSET_ID'][:])
         ae(assets, EXPECTED_ASSETS)
         assert len(dstore['assets/ID_1']) == 30
@@ -101,3 +102,4 @@ def test_expo_to_hdf5():
 
         NAME2s = dstore['NAME_2'][:]
         assert [x.decode('utf8') for x in NAME2s] == EXPECTED_NAME2s
+    os.remove(dstore.tempname)

--- a/utils/build_global_exposure
+++ b/utils/build_global_exposure
@@ -21,7 +21,7 @@ import os
 import logging
 import pandas
 import numpy
-from openquake.baselib import sap, general, performance
+from openquake.baselib import sap, general, performance, hdf5
 from openquake.hazardlib import nrml, gsim_lt, site
 from openquake.risklib.riskmodels import CompositeRiskModel, RiskFuncList
 from openquake.commonlib.datastore import create_job_dstore
@@ -186,7 +186,7 @@ def main(mosaic_dir, grm_dir, wfp=False):
     if wfp:
         description += ' (only for WFP countries)'
     job, dstore = create_job_dstore(description=description)
-    with dstore, job:
+    with dstore, job, hdf5.File(dstore.tempname, 'w') as h5tmp:
         with mon:
             n = build_site_model_gsims(mosaic_dir, grm_dir, dstore)
             logging.info('Stored {:_d} sites'.format(n))
@@ -195,8 +195,9 @@ def main(mosaic_dir, grm_dir, wfp=False):
             n = read_world_tmap(grm_dir, dstore)
             logging.info('Read %d taxonomy mappings', n)
             fnames = collect_exposures(grm_dir)
-            expo_to_hdf5.store(fnames, wfp, dstore)
+            expo_to_hdf5.store(fnames, wfp, dstore, h5tmp)
         logging.info(mon)
+        os.remove(dstore.tempname)
 
 main.mosaic_dir = 'Directory containing the hazard mosaic'
 main.grm_dir = 'Directory containing the global risk model'


### PR DESCRIPTION
By removing the accumulatori and storing the tags in the file `_tmp.hdf5`. Generating the full exposure now takes 33 minutes, 15 GB of RAM and 5.6 GB of disk space (with 4 cores).