### PR TITLE
Added a readability check for `expo_to_hdf5`

### DIFF
--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -149,6 +149,7 @@ def print_peril(what):
 
 def print_geohash(what):
     lon, lat = lon_lat(what.split(':')[1])
+    # print(geo.utils.geohash3(F32([lon]), F32([lat])))
     arr = geo.utils.CODE32[geo.utils.geohash(F32([lon]), F32([lat]), U8(8))]
     gh = b''.join([row.tobytes() for row in arr])
     print(gh.decode('ascii'))

--- a/openquake/commonlib/expo_to_hdf5.py
+++ b/openquake/commonlib/expo_to_hdf5.py
@@ -25,7 +25,7 @@ from openquake.baselib import hdf5, sap, general, performance
 from openquake.baselib.parallel import Starmap
 from openquake.hazardlib.geo.utils import geohash3
 from openquake.commonlib.datastore import create_job_dstore
-from openquake.risklib.asset import _get_exposure
+from openquake.risklib.asset import _get_exposure, Exposure
 
 U16 = numpy.uint16
 U32 = numpy.uint32
@@ -224,6 +224,10 @@ def store(exposures_xml, wfp, dstore, h5tmp):
         assert n == num_assets, (name, n, num_assets)
 
     logging.info('Stored {:_d} assets in {}'.format(n, dstore.filename))
+
+    # check readable around gh3=12396
+    exp = Exposure.read_around(dstore.filename, 12396)
+    assert len(exp.assets), exp
 
 
 def main(exposures_xml, wfp=False):

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -1015,8 +1015,9 @@ class Exposure(object):
                 impact_read_assets(f, start, stop)
                 for gh3, start, stop in slices)
             tagcol = f['tagcol']
-            # tagnames = ['taxonomy', 'ID_0', 'ID_1', 'OCCUPANCY']
-            exp.tagcol = TagCollection(tagcol.tagnames)
+            # revert the tagnames so that taxonomy becomes the first field,
+            # ex. sorted_tagnames = ['taxonomy', 'ID_0', 'ID_1', 'OCCUPANCY']
+            exp.tagcol = TagCollection(sorted(tagcol.tagnames, reverse=True))
         rename = dict(exp.pairs)
         rename['TAXONOMY'] = 'taxonomy'
         for f in ANR_FIELDS:


### PR DESCRIPTION
We want to avoid errors like
```python

File "/mnt/wfp/oq-engine/openquake/commonlib/readinput.py", line 398, in get_mesh_exp
  exposure = get_exposure(oqparam, h5)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
File "/mnt/wfp/oq-engine/openquake/commonlib/readinput.py", line 1141, in get_exposure
  exposure = asset.Exposure.read_around(fnames[0], gh3)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/mnt/wfp/oq-engine/openquake/risklib/asset.py", line 1014, in read_around
  assets_df = pandas.concat(
              ^^^^^^^^^^^^^^
File "/mnt/wfp/venv/lib/python3.11/site-packages/pandas/core/reshape/concat.py", line 372, in concat
  op = _Concatenator(
       ^^^^^^^^^^^^^^
File "/mnt/wfp/venv/lib/python3.11/site-packages/pandas/core/reshape/concat.py", line 426, in __init__
  objs = list(objs)
         ^^^^^^^^^^
File "/mnt/wfp/oq-engine/openquake/risklib/asset.py", line 1015, in <genexpr>
  impact_read_assets(f, start, stop)
File "/mnt/wfp/oq-engine/openquake/risklib/asset.py", line 948, in impact_read_assets
  df = pandas.DataFrame(dic)
       ^^^^^^^^^^^^^^^^^^^^^
File "/mnt/wfp/venv/lib/python3.11/site-packages/pandas/core/frame.py", line 709, in __init__
  mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/mnt/wfp/venv/lib/python3.11/site-packages/pandas/core/internals/construction.py", line 481, in dict_to_mgr
  return arrays_to_mgr(arrays, columns, index, dtype=dtype, typ=typ, consolidate=copy)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/mnt/wfp/venv/lib/python3.11/site-packages/pandas/core/internals/construction.py", line 115, in arrays_to_mgr
  index = _extract_index(arrays)
          ^^^^^^^^^^^^^^^^^^^^^^
File "/mnt/wfp/venv/lib/python3.11/site-packages/pandas/core/internals/construction.py", line 655, in _extract_index
  raise ValueError("All arrays must be of the same length")
ValueError: All arrays must be of the same length
```