### PR TITLE
Added warning for risk_imts missing in the secondary perils

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a warning for risk IMTs not covered as secondary IMTs
   * Optimized build_global_exposure
 
   [Michele Simionato, Paolo Tormene]

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1173,7 +1173,8 @@ class RiskCalculator(HazardCalculator):
         if len(self.crmodel.tmap_df) == 0:
             taxonomies = self.assetcol.tagcol.taxonomy[1:]
             taxidx = {taxo: i for i, taxo in enumerate(taxonomies, 1)}
-            self.crmodel.tmap_df = readinput.taxonomy_mapping(self.oqparam, taxidx)
+            self.crmodel.tmap_df = readinput.taxonomy_mapping(
+                self.oqparam, taxidx)
         with self.monitor('building riskinputs'):
             if self.oqparam.hazard_calculation_id:
                 dstore = self.datastore.parent

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1708,6 +1708,12 @@ class OqParam(valid.ParamSet):
             if any(sec_imt.endswith(imt) for sec_imt in sec_imts):
                 self.raise_invalid('you forgot to set secondary_perils =')
 
+        seco_imts = {sec_imt.split('_')[1] for sec_imt in self.sec_imts}
+        risk_imts = set(self.risk_imtls)
+        for imt in risk_imts - seco_imts:
+            logging.warning(f'The risk functions contain {imt} which is not '
+                            f'in the secondary IMTs {seco_imts}')
+
         risk_perils = sorted(set(getattr(rf, 'peril', 'groundshaking')
                                  for rf in risklist))
         return risk_perils

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -1760,8 +1760,8 @@ class RiskComputer(dict):
                     dic = ast.literal_eval(hdf5.obj_to_json(rf))
                     if getattr(rf, 'retro', False):
                         retro = ast.literal_eval(hdf5.obj_to_json(rf.retro))
-                        dic['openquake.risklib.scientific.VulnerabilityFunction'][
-                            'retro'] = retro
+                        dic['openquake.risklib.scientific.'
+                            'VulnerabilityFunction']['retro'] = retro
                     rfdic['%s#%s#%s' % (rf.peril, lt, rf.id)] = dic
         dic = dict(risk_functions=rfdic, calculation_mode=self.calculation_mode)
         if any(mal for mal in self.minimum_asset_loss.values()):

--- a/openquake/sep/landslide/displacement.py
+++ b/openquake/sep/landslide/displacement.py
@@ -33,11 +33,7 @@ def critical_accel(
     :returns: 
         crit_accel: critical acceleration in g units
     """    
-
     crit_accel = (factor_of_safety - 1) * np.sin(np.arctan(slope))
-    print(factor_of_safety)
-    print(crit_accel)
-    print("crit_accel")
     if np.isscalar(crit_accel):
         return max([crit_accel_threshold, crit_accel])
     else:
@@ -102,7 +98,8 @@ def jibson_2007_model_a(
             accel_ratio == accel_ratio_threshold
     else:
         accel_ratio[accel_ratio > 1.0] = 1.0
-        accel_ratio[accel_ratio <= accel_ratio_threshold] = accel_ratio_threshold
+        accel_ratio[accel_ratio <= accel_ratio_threshold] = \
+            accel_ratio_threshold
 
     pow_1 = (1 - accel_ratio) ** c2
     pow_2 = accel_ratio**c3


### PR DESCRIPTION
The demo `InfrastructureMultiPeril` contains `DispProb` instead of `Disp` in the fragility functions, so such functions are ignored. Now there is at least a warning.