### PR TITLE
Remove also calc_XXX_tmp.hdf5 when deleting a job

### DIFF
--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -65,8 +65,9 @@ def del_calculation(job_id, confirmed=False):
             safeprint(err)
         else:
             if 'success' in resp:
-                if os.path.exists(resp['hdf5path']):
-                    os.remove(resp['hdf5path'])
+                for hdf5path in resp['hdf5paths']:
+                    if os.path.exists(hdf5path):
+                        os.remove(hdf5path)
                 print('Removed %d' % job.id)
             else:
                 print(resp['error'])

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -305,11 +305,12 @@ def del_calc(db, job_id, user, delete_file=True, force=False):
     :param db: a :class:`openquake.commonlib.dbapi.Db` instance
     :param job_id: job ID, can be an integer or a string
     :param user: username
-    :param delete_file: also delete the HDF5 file
+    :param delete_file: also delete the HDF5 file(s)
     :param force: delete even if there are dependent calculations
     :returns: a dict with key "success" and value indicating
         the job id of the calculation or of its ancestor, or key "error"
-        and value describing what went wrong
+        and value describing what went wrong, and a list of paths of files
+        to be removed
     """
     job_id = int(job_id)
     dependent = db(
@@ -343,15 +344,17 @@ def del_calc(db, job_id, user, delete_file=True, force=False):
         return {"error": 'Cannot delete calculation %d: it belongs to '
                 '%s and you are %s' % (job_id, owner, user)}
 
-    fname = path + ".hdf5"
+    fnames = [f'{path}.hdf5', f'{path}_tmp.hdf5']
     # A calculation could fail before it produces a hdf5, or somebody
     # may have canceled the file, so it could not exist
-    if delete_file and os.path.isfile(fname):
-        try:
-            os.remove(fname)
-        except OSError as exc:  # permission error
-            return {"error": 'Could not remove %s: %s' % (fname, exc)}
-    return {"success": str(job_id), "hdf5path": fname}
+    if delete_file:
+        for fname in fnames:
+            if os.path.isfile(fname):
+                try:
+                    os.remove(fname)
+                except OSError as exc:  # permission error
+                    return {"error": 'Could not remove %s: %s' % (fname, exc)}
+    return {"success": str(job_id), "hdf5paths": fnames}
 
 
 def log(db, job_id, timestamp, level, process, message):


### PR DESCRIPTION
I checked that it works both when deleting a calculation via the WebUI using the "Remove" button and when using the command oq engine --delete-calculation XXX