### PR TITLE
Restricted the check on GMF-correlation only to `event_based`

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -537,7 +537,8 @@ class HazardCalculator(BaseCalculator):
         self._read_risk1()
         self._read_risk2()
         self._read_risk3()
-        if (oq.ground_motion_correlation_model and
+        if (oq.calculation_mode == 'event_based' and
+                oq.ground_motion_correlation_model and
                 len(self.sitecol) > oq.max_sites_correl):
             raise ValueError('You cannot use a correlation model with '
                              f'{self.N} sites [{oq.max_sites_correl=}]')


### PR DESCRIPTION
Fixes https://github.com/gem/oq-engine/pull/10669.