### PR TITLE
Fix p20 epistemic uncertainty bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Christopher Brooks]
+  * Fixed bug in ParkerEtAl2020 epistemic uncertainty scaling factors.
+
   [Michele Simionato]
   * Reduced the data transfer in avg_losses (20x for Philippines),
     thus solving an out-of-memory error; also optimized (25% for Philippines)

--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -34,6 +34,13 @@ from openquake.hazardlib.imt import PGA, SA, PGV
 from openquake.hazardlib.gsim.utils_usgs_basin_scaling import \
     _get_z2pt5_usgs_basin_scaling
 
+REGIONS = [None, "AK", "CAM", "Cascadia", "JP", "SA", "TW"]
+
+SAT_REGIONS = [None, "Aleutian", "CAM_N", "CAM_S", "SA_N",
+               "SA_S", "TW_E", "TW_W", "JP_Pac", "JP_Phi"]  
+
+BASINS = [None, "out", "Seattle"]
+
 EPI_ADJS = os.path.join(os.path.dirname(__file__),
                         "parker_2020_epi_adj_table.csv")
 
@@ -462,13 +469,20 @@ class ParkerEtAl2020SInter(GMPE):
         Enable setting regions to prevent messy overriding
         and code duplication.
         """
-        assert region in [None, "AK", "CAM", "Cascadia", "JP", "SA", "TW"]
+        # Check region/sat_region/basin params are valid
+        assert region in REGIONS
+        assert saturation_region in SAT_REGIONS
+        assert basin in BASINS
+
+        # Assign them
         self.region = region
         if saturation_region is None:
             self.saturation_region = region
         else:
             self.saturation_region = saturation_region
         self.basin = basin
+
+        # US23 basin params
         self.m9_basin_term = m9_basin_term
         self.usgs_basin_scaling = usgs_basin_scaling
         # USGS basin scaling and M9 basin term is only applied when the
@@ -485,6 +499,7 @@ class ParkerEtAl2020SInter(GMPE):
                                  'adjustment (i.e. it must have z2pt5 as a '
                                 ' required site parameter).')
 
+        # Epistemic uncertainty scaling
         self.sigma_mu_epsilon = sigma_mu_epsilon
         with open(EPI_ADJS) as f:
             self.epi_adjs_table = pd.read_csv(f.name).set_index('Region')

--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -85,15 +85,15 @@ def _get_sigma_mu_adjustment(sat_region, trt, imt, epi_adjs_table):
 
     # Get period-dependent epistemic standard deviation (equation 27)
     period = imt.period
-    if period < adjs[f'T1_{add}']:
+    if period <= adjs[f'T1_{add}']:
         eps_std = adjs[f'SigEp1_{add}']
-    elif period >= adjs[f'T1_{add}'] and period < adjs[f'T2_{add}']:
-        p1 = adjs[f'SigEp1_{add}'
-                  ] - (adjs[f'SigEp1_{add}'] - adjs[f'SigEp2_{add}'])
+    elif period > adjs[f'T1_{add}'] and period <= adjs[f'T2_{add}']:
+        p1 = adjs[f'SigEp1_{add}'] - (adjs[f'SigEp1_{add}'] - adjs[f'SigEp2_{add}'])
         p2 = (np.log(period/adjs[f'T1_{add}']) / 
               np.log(adjs[f'T2_{add}']/adjs[f'T1_{add}']))
         eps_std = p1 * p2
     else:  # Must be SA with a period larger than or equal to T2
+        assert period > adjs[f'T2_{add}']
         eps_std = adjs[f'SigEp2_{add}']
 
     return eps_std
@@ -462,6 +462,7 @@ class ParkerEtAl2020SInter(GMPE):
         Enable setting regions to prevent messy overriding
         and code duplication.
         """
+        assert region in [None, "AK", "CAM", "Cascadia", "JP", "SA", "TW"]
         self.region = region
         if saturation_region is None:
             self.saturation_region = region
@@ -655,3 +656,4 @@ add_alias('ParkerEtAl2020SSlabJapanPac', ParkerEtAl2020SSlabB,
           region="JP", saturation_region="JP_Pac")
 add_alias('ParkerEtAl2020SSlabJapanPhi', ParkerEtAl2020SSlabB,
           region="JP", saturation_region="JP_Phi")
+

--- a/openquake/hazardlib/gsim/parker_2020.py
+++ b/openquake/hazardlib/gsim/parker_2020.py
@@ -95,7 +95,8 @@ def _get_sigma_mu_adjustment(sat_region, trt, imt, epi_adjs_table):
     if period <= adjs[f'T1_{add}']:
         eps_std = adjs[f'SigEp1_{add}']
     elif period > adjs[f'T1_{add}'] and period <= adjs[f'T2_{add}']:
-        p1 = adjs[f'SigEp1_{add}'] - (adjs[f'SigEp1_{add}'] - adjs[f'SigEp2_{add}'])
+        p1 = adjs[f'SigEp1_{add}'] - (
+            adjs[f'SigEp1_{add}'] - adjs[f'SigEp2_{add}'])
         p2 = (np.log(period/adjs[f'T1_{add}']) / 
               np.log(adjs[f'T2_{add}']/adjs[f'T1_{add}']))
         eps_std = p1 * p2


### PR DESCRIPTION
The conditionals for period vs T1 and T2 were set incorrectly for T = 0.2 (see the small changes). For a period of T = 0.2 s, an `eps_std` of 0 would be returned instead of 0.43 (resulting in no scaling despite specifying a `sigma_mu_epsilon` value, because `np.log(period/adjs[f'T1_{add}'])` when `period=0.2` and `adjs[f"T1_{add}"]=0.2` inherently equals 0.

The fix now correctly results in the expected epistemic uncertainty scaling factors for SA(0.2):

![TrellisPlots](https://github.com/user-attachments/assets/4f26f16b-5590-464f-a7a1-5de3803e8d06)

This fixes this issue reported here - https://github.com/gem/oq-engine/issues/10684

Also some examples for range of periods here - before SA(0.2) would have not been scaled like the other periods due to the conditionals issue fixed here):

![TrellisPlots](https://github.com/user-attachments/assets/7f1115cf-d61e-4b98-b475-cfc17e4c5d55)

Lastly, I added some checks on admitted regions to avoid some vague errors from such typos later in GMM's compute method. 