### PR TITLE
Refactored output splitting in event_based_risk/2

### DIFF
--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -51,7 +51,7 @@ pmap_max_mb = 500
 gmf_data_rows = 40_000_000
 
 # used in event_based_risk
-max_gmvs_chunk = 1_000_000
+max_gmvs_chunk = 10_000_000
 max_assets_chunk = 5_000
 
 # used in AssetCollection.get_aggkeys


### PR DESCRIPTION
```
# before on cole
| calc_1282, maxmem=422.0 GB   | time_sec  | memory_mb | counts    |
|------------------------------+-----------+-----------+-----------|
| total ebr_from_gmfs          | 761_848   | 686.1     | 1_710     |
| computing risk               | 533_877   | 6.0985    | 1_615_213 |
| aggregating losses           | 210_734   | 4_084     | 1_466     |
| reading assets               | 12_954    | 0.0       | 1_983_498 |
| EventBasedRiskCalculator.run | 7_718     | 2_581     | 1         |

# full Pakistan on cole, chunk=10M, 1h54m
| calc_1288, maxmem=351.8 GB   | time_sec  | memory_mb | counts  |
|------------------------------+-----------+-----------+---------|
| total ebr_from_gmfs          | 704_473   | 1_113     | 610     |
| computing risk               | 500_309   | 0.0       | 464_064 |
| aggregating losses           | 197_080   | 3_917     | 366     |
| EventBasedRiskCalculator.run | 6_836     | 2_799     | 1       |
| reading assets               | 3_279     | 3_467     | 366     |
```
This is faster and saving 70 GB of RAM.