### PR TITLE
Speeding up reading assets

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -397,6 +397,11 @@ class Monitor(object):
                 return dset[slc]
             return pickle.loads(dset[()])
 
+    def read_pdcolumns(self, key):
+        tmp = self.filename[:-5] + '_tmp.hdf5'
+        with hdf5.File(tmp, 'r') as f:
+            return f[key].attrs['__pdcolumns__']
+
     def iter(self, genobj, atstop=lambda: None):
         """
         :param genobj: a generator object

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -223,13 +223,11 @@ def event_based_risk(df, crmodel, monitor):
                             int(oq.asset_correlation))
 
     with monitor('reading assets', measuremem=True):
-        dfs = []
-        for id0taxo, s0, s1 in monitor.read('start-stop'):
-            ass = monitor.read('assets', slice(s0, s1)).set_index('ordinal')
-            country = crmodel.countries[id0taxo // TWO24]
-            dfs.append((ass, country))
-    outgen = output_gen(df, dfs, crmodel, rng, monitor)
-    del dfs
+        # saving a lot of memory with respect to a simple read('assets')
+        cols = monitor.read_pdcolumns('assets').split()
+        assdic = {col: monitor.read('assets/' + col) for col in cols}
+    outgen = output_gen(df, assdic, crmodel, rng, monitor)
+    del assdic
     with monitor('aggregating losses', measuremem=True) as agg_mon:
         avg, alt = aggreg(outgen, crmodel, ARK, aggids, rlz_id, oq.ideduc,
                           monitor)
@@ -241,9 +239,10 @@ def event_based_risk(df, crmodel, monitor):
                 out_bytes=out_bytes)
 
 
-def output_gen(df, dfs, crmodel, rng, monitor):
+def output_gen(df, assdic, crmodel, rng, monitor):
     """
     :param df: GMF dataframe (a slice of events)
+    :param assdic: a dictionary column name -> array
     :param crmodel: CompositeRiskModel instance
     :param rng: random number generator
     :param monitor: Monitor instance
@@ -253,7 +252,10 @@ def output_gen(df, dfs, crmodel, rng, monitor):
     fil_mon = monitor('filtering GMFs', measuremem=False)
     sids = df.sid.to_numpy()
     monitor.ctime = 0
-    for adf, country in dfs:
+    for id0taxo, s0, s1 in monitor.read('start-stop'):
+        adf = pandas.DataFrame({col: assdic[col][s0:s1] for col in assdic})
+        adf = adf.set_index('ordinal')
+        country = crmodel.countries[id0taxo // TWO24]
         with fil_mon:
             # *crucial* for the performance of the next step
             gmf_df = df[numpy.isin(sids, adf.site_id.unique())]


### PR DESCRIPTION
This is for Pakistan small on engine192 (6x speedup in read assets):
```
# before
| calc_1295, maxmem=376.5 GB   | time_sec  | memory_mb | counts  |
|------------------------------+-----------+-----------+---------|
| total ebr_from_gmfs          | 77_717    | 725.7     | 752     |
| computing risk               | 37_652    | 0.0       | 423_335 |
| aggregating losses           | 24_768    | 1_626     | 382     |
| reading assets               | 13_725    | 1_439     | 382     |
| reading crmodel              | 882.1     | 301.8     | 370     |
| EventBasedRiskCalculator.run | 723.2     | 1_947     | 1       |

# after
| calc_1294, maxmem=366.7 GB   | time_sec  | memory_mb | counts  |
|------------------------------+-----------+-----------+---------|
| total ebr_from_gmfs          | 67_730    | 509.7     | 752     |
| computing risk               | 38_380    | 0.0       | 423_335 |
| aggregating losses           | 25_648    | 983.2     | 382     |
| reading assets               | 2_103     | 1_701     | 382     |
| reading crmodel              | 899.2     | 301.7     | 370     |
| EventBasedRiskCalculator.run | 670.3     | 1_932     | 1       |
```