### PR TITLE
Refactored sparse matrices

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -196,7 +196,7 @@ def ebr_from_gmfs(slice_by_event, oqparam, dstore, monitor):
         else:
             avg += avg_
         yield dic
-    yield dict(avg=avg)
+    yield dict(avg=avg.tocoo() if hasattr(avg, 'row') else avg)
 
 
 def event_based_risk(df, crmodel, monitor):
@@ -542,8 +542,6 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             # avg_losses are stored as coo matrices or csr matrices
             with self.monitor('saving avg_losses'):
                 coo = dic.pop('avg')
-                if not hasattr(coo, 'row'):  # csr_matrix
-                    coo = coo.tocoo()
                 rlzs, xlts = numpy.divmod(coo.col, self.X)
                 self.avg_losses[coo.row, xlts, rlzs] += coo.data
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -539,7 +539,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                     dset = self.datastore['risk_by_event/' + name]
                     hdf5.extend(dset, alt[name].to_numpy())
         if self.oqparam.avg_losses and 'avg' in dic:
-            # avg_losses are stored as coo matrices or csr matrices
+            # avg_losses are stored as coo matrices
             with self.monitor('saving avg_losses'):
                 coo = dic.pop('avg')
                 rlzs, xlts = numpy.divmod(coo.col, self.X)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -196,7 +196,7 @@ def ebr_from_gmfs(slice_by_event, oqparam, dstore, monitor):
         else:
             avg += avg_
         yield dic
-    yield dict(avg=avg.tocoo() if hasattr(avg, 'row') else avg)
+    yield dict(avg=avg if hasattr(avg, 'col') else avg.tocoo())
 
 
 def event_based_risk(df, crmodel, monitor):


### PR DESCRIPTION
Returning a single sparse matrix instead of X matrices, being X the number of extended loss types.
This improves slightly the memory occupation and the data transfer, at the cost of a slower `saving avg_losses`:
```
# before
| calc_1298, maxmem=243.1 GB   | time_sec  | memory_mb | counts  |
|------------------------------+-----------+-----------+---------|
| total ebr_from_gmfs          | 75_649    | 541.0     | 504     |
| computing risk               | 53_058    | 0.0       | 300_135 |
| aggregating losses           | 21_045    | 1_146     | 258     |
| EventBasedRiskCalculator.run | 943.7     | 1_973     | 1       |
| reading crmodel              | 734.8     | 292.0     | 246     |
| reading assets               | 465.4     | 1_795     | 258     |
| saving avg_losses            | 137.9151  | 2_574     | 246     |

#after
| calc_1301, maxmem=243.5 GB   | time_sec  | memory_mb | counts  |
|------------------------------+-----------+-----------+---------|
| total ebr_from_gmfs          | 75_912    | 560.8     | 504     |
| computing risk               | 53_255    | 0.0       | 300_135 |
| aggregating losses           | 21_151    | 1_443     | 258     |
| EventBasedRiskCalculator.run | 944.3     | 1_964     | 1       |
| reading crmodel              | 741.0     | 292.0     | 246     |
| reading assets               | 435.0     | 1_723     | 258     |
| saving avg_losses            | 161.6104  | 3_370     | 246     |

| task            | sent                                                   | received  |
|-----------------+--------------------------------------------------------+-----------|
| ebr_from_gmfs   | slice_by_event=3.21 MB oqparam=1.18 MB dstore=39.88 KB | 114.18 GB |
| ebr_from_gmfs   | slice_by_event=3.21 MB oqparam=1.18 MB dstore=39.88 KB | 112.43 GB |
```