### PR TITLE
Added `event_based_risk.fast_add` and reduced by half the data transfer in avg_losses

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -549,9 +549,11 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
             # avg_losses are stored as coo matrices
             with self.monitor('saving avg_losses'):
                 coo = dic.pop('avg')
-                rlzs, xlts = numpy.divmod(coo.col, self.X)
-                self.avg_losses[coo.row, xlts, rlzs] += coo.data
-                #fast_add(self.avg_losses, coo.row, coo.col, coo.data, self.X)
+                # the non-numpy approach is 2-3x slower, causing
+                # a big data queue and then running out of memory
+                # rlzs, xlts = numpy.divmod(coo.col, self.X)
+                # self.avg_losses[coo.row, xlts, rlzs] += coo.data
+                fast_add(self.avg_losses, coo.row, coo.col, coo.data, self.X)
 
     def post_execute(self, dummy):
         """


### PR DESCRIPTION
Here is Pakistan small on cole:
```
| task            | sent                                                   | received  |
|-----------------+--------------------------------------------------------+-----------|
| ebr_from_gmfs   | slice_by_event=3.21 MB oqparam=1.18 MB dstore=39.88 KB | 112.43 GB |
| ebr_from_gmfs   | slice_by_event=3.21 MB oqparam=1.18 MB dstore=39.88 KB | 57.2 GB   |


| calc_1304, maxmem=200.0 GB   | time_sec  | memory_mb | counts  |
|------------------------------+-----------+-----------+---------|
| saving avg_losses            | 174.0713  | 1_717     | 246     |
| saving avg_losses            | 78.2422   | 689.0     | 246     |
```
For Pakistan full , the data transfer goes down from  202.58 GB -> 114.98 GB and the memory occupation from 355.7 GB -> 296.8 GB, while "saving avg_losses" goes down from 305.3 s to 135.9s.