### PR TITLE
Fixed the log message to print the pool size instead of num_cores

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Changed the log message to show the pool size instead of num_cores
   * On Windows use as default num_cores
     num_threads/2 if num_threads > 8 else num_threads
   * Extended the aggregation by `site_id` to multiple tags

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -527,7 +527,7 @@ class HazardCalculator(BaseCalculator):
         oq = self.oqparam
         dist = parallel.oq_distribute()
         avail = psutil.virtual_memory().available / 1024**3
-        required = .25 * (1 if dist == 'no' else parallel.Starmap.num_cores)
+        required = .25 * (1 if dist == 'no' else parallel.num_cores)
         if (dist == 'processpool' and avail < required and
                 sys.platform != 'darwin'):
             # macos tells that there is no memory when there is, so we

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -187,7 +187,7 @@ def store_tiles(dstore, csm, sitecol, cmakers):
                      mem_gb, len(light), len(data))
     else:
         logging.info('Required mem_gb = %.2f', req_gb)
-    max_gb = float(config.memory.pmap_max_gb or parallel.Starmap.num_cores/8)
+    max_gb = float(config.memory.pmap_max_gb or parallel.num_cores/8)
     regular = (mem_gb < max_gb or oq.disagg_by_src or
                N < oq.max_sites_disagg or oq.tile_spec)
     if oq.tiling is None:

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -89,7 +89,7 @@ def set_concurrent_tasks_default(calc):
         parallel.Starmap.CT = num_workers * 2
         OqParam.concurrent_tasks.default = num_workers * 2
     else:
-        num_workers = parallel.Starmap.num_cores
+        num_workers = min(parallel.num_cores, parallel.tot_cores)
     if dist == 'no':
         logging.warning('Disabled distribution')
     else:
@@ -307,11 +307,11 @@ def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False, precalc=False
     dist = parallel.oq_distribute()
     if dist == 'slurm':
         # check the total number of required cores
-        tot_cores = parallel.Starmap.num_cores * nodes
+        tot_cores = parallel.num_cores * nodes
         max_cores = int(config.distribution.max_cores)
         if tot_cores > max_cores:
             raise ValueError('You can use at most %d nodes' %
-                             (max_cores // parallel.Starmap.num_cores))
+                             (max_cores // parallel.num_cores))
 
     if concurrent_jobs is None:
         # // 8 is chosen so that the core occupation in cole is decent

--- a/utils/membomb
+++ b/utils/membomb
@@ -34,7 +34,7 @@ def main(n: int = 1):
     Allocate a lot of memory; used to simulate OOM situations
     """
     tot = 0
-    allargs = [(n,) for _ in range(parallel.Starmap.num_cores)]
+    allargs = [(n,) for _ in range(parallel.num_cores)]
     for z in parallel.Starmap(allocate_mem, allargs):
         tot += z.nbytes
     logging.warning('Allocated %.1f GB', tot / 1024**3)


### PR DESCRIPTION
It is more intuitive, especially on Windows where `tot_cores` can be different than the total number of threads.