### PR TITLE
Add `Default` Site Class option

### DIFF
--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -663,15 +663,23 @@ function capitalizeFirstLetter(val) {
                                setTimer();
                            });
 
+            var vs30_original_placeholder = $('input#vs30').attr('placeholder');
             $('select#site_class').on('change', function() {
                 const site_class = $(this).val();
                 const $input_vs30 = $('input#vs30');
                 if (site_class === 'custom') {
                     $input_vs30.prop('disabled', false);
                     $input_vs30.val('');
+                    $input_vs30.attr('placeholder', vs30_original_placeholder);
                 } else {
                     $input_vs30.prop('disabled', true);
-                    $input_vs30.val($(this).val());
+                    if (site_class === 'default') {
+                        $input_vs30.val('');
+                        $input_vs30.attr('placeholder', '');
+                    } else {
+                        $input_vs30.val($(this).val());
+                        $input_vs30.attr('placeholder', vs30_original_placeholder);
+                    }
                 }
             });
 
@@ -693,15 +701,16 @@ function capitalizeFirstLetter(val) {
                         {value: 260, text: 'D - Stiff Soil' },
                         {value: 185, text: 'DE ' },
                         {value: 150, text: 'E - Soft Clay Soil' },
+                        {value: 'default', text: 'Default'},
                         {value: 'custom', text: 'Specify Vs30'},
                     ];
-                    const default_site_class = 'BC';
+                    const preselected_site_class = 'BC';
                     items.forEach(item => {
                         $site_class_select.append(
                             $("<option>", {
                                 value: item.value,
                                 text: item.text,
-                                selected: item.text === default_site_class
+                                selected: item.text === preselected_site_class
                             })
                         );
                     });
@@ -718,10 +727,17 @@ function capitalizeFirstLetter(val) {
             // NOTE: if not in aelo mode, aelo_run_form does not exist, so this can never be triggered
             $("#aelo_run_form").submit(function (event) {
                 $('#submit_aelo_calc').prop('disabled', true);
+                var site_class = $('select#site_class').val();
+                var vs30;
+                if (site_class === 'default') {
+                    vs30 = '260 365 530';
+                } else {
+                    vs30 = $("input#vs30").val();
+                }
                 var formData = {
                     lon: $("#lon").val(),
                     lat: $("#lat").val(),
-                    vs30: parseFloat($("input#vs30").val()),
+                    vs30: vs30,
                     siteid: $("#siteid").val(),
                     asce_version: $("#asce_version").val()
                 };

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -117,7 +117,7 @@ AELO_FORM_LABELS = {
 AELO_FORM_PLACEHOLDERS = {
     'lon': 'max. 5 decimals',
     'lat': 'max. 5 decimals',
-    'vs30': 'float (150 - 3000)',
+    'vs30': 'float [150 - 3000]',
     'siteid': f'max. {settings.MAX_AELO_SITE_NAME_LEN} characters',
     'asce_version': 'ASCE standards',
 }
@@ -1012,7 +1012,11 @@ def aelo_validate(request):
         validation_errs[AELO_FORM_LABELS['lat']] = str(exc)
         invalid_inputs.append('lat')
     try:
-        vs30 = validate_vs30(request.POST.get('vs30'))
+        vs30s_in = sorted([float(val) for val in request.POST.get('vs30').split()])
+        vs30s_out = []
+        for vs30 in vs30s_in:
+            vs30s_out.append(validate_vs30(vs30))
+        vs30 = ' '.join(str(val) for val in vs30s_out)
     except Exception as exc:
         validation_errs[AELO_FORM_LABELS['vs30']] = str(exc)
         invalid_inputs.append('vs30')


### PR DESCRIPTION
When the `Default` Site Class is selected, the Vs30 field is disabled and empty (displaying no placeholder) and the job will use `override_vs30 = 260 365 530`.
I changed the validation on the WebUI side accordingly, in order to accept space-separated vs30 values.
I also modified the placeholder for Vs30, using square brackets insted of round brackets, according to the convention that the extreme values are included in the valid interval.