### PR TITLE
fix nz22 p20 order of args issue in 3.23 backport

### DIFF
--- a/openquake/hazardlib/gsim/nz22/nz_nshm2022_parker.py
+++ b/openquake/hazardlib/gsim/nz22/nz_nshm2022_parker.py
@@ -339,7 +339,7 @@ class NZNSHM2022_ParkerEtAl2020SInter(ParkerEtAl2020SInter):
             )  # backarc term applied to path function for reference rock PGA
             fd = _depth_scaling(trt, C, ctx)
             fd_pga = _depth_scaling(trt, C_PGA, ctx)
-            fb = _get_basin_term(self.region, self.basin, C, ctx, imt, self.basin)
+            fb = _get_basin_term(C, ctx, self.region, imt, self.basin)
             flin = _linear_amplification(self.region, C, ctx.vs30)
             fnl = _non_linear_term(
                 C, imt, ctx.vs30, fp_pga, fm_pga, c0_pga, fd_pga


### PR DESCRIPTION
Fixing issue in 3.23 QA tests (test case 34 for scenario calculator) following backporting of master version of the NZ22 variant of Parker 2022 noticed by @hhalaby. The discussion of the issue and rationale for why the tests were only failing on 3.23 following the backport can be viewed [here](https://github.com/gem/oq-engine/commit/b4af7845dbadcc01a9d034cec8568f387e936d43#r163115904)

