### PR TITLE
add content_type to calc_results entry point

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1236,7 +1236,7 @@ def calc_results(request, calc_id):
             outtypes=outtypes, url=url_with_query, size_mb=result.size_mb)
         response_data.append(datum)
 
-    return HttpResponse(content=json.dumps(response_data))
+    return HttpResponse(content=json.dumps(response_data), content_type=JSON)
 
 
 @require_http_methods(['GET'])


### PR DESCRIPTION
`/v1/calc/<id>/result/list` API entry point doesn't return 'content/json' as http response type: fixed.