### PR TITLE
Add to `oq plot` an optional parameter to save the plot to a PNG file instead of showing it

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -1898,20 +1898,3 @@ class Deduplicate(Sequence):
 
     def __len__(self):
         return len(self.inv)
-
-
-def unique_filename(path):
-    """
-    Return a unique filename by appending a counter if needed.
-    Example: 'plot.png' -> 'plot_1.png' if 'plot.png' exists.
-    """
-    if not os.path.exists(path):
-        return path
-
-    root, ext = os.path.splitext(path)
-    counter = 1
-    new_path = f"{root}_{counter}{ext}"
-    while os.path.exists(new_path):
-        counter += 1
-        new_path = f"{root}_{counter}{ext}"
-    return new_path

--- a/openquake/commands/plot.py
+++ b/openquake/commands/plot.py
@@ -28,8 +28,8 @@ import numpy
 import pandas
 from scipy.stats import linregress
 from shapely.geometry import Polygon, LineString
-from openquake.baselib.general import unique_filename
 from openquake.commonlib import readinput
+from openquake.commonlib.util import unique_filename
 from openquake.hazardlib.geo.utils import PolygonPlotter
 from openquake.hazardlib.contexts import Effect, get_effect_by_mag
 from openquake.hazardlib.source.rupture import build_planar_rupture_from_dict
@@ -1139,9 +1139,10 @@ def plot_csv(fname):
 def main(what,
          calc_id: int = -1,
          others: int = [],
+         *,
+         save_to: str = None,
          webapi=False,
          local=False,
-         to_file=False,
          ):
     """
     Generic plotter for local and remote calculations.
@@ -1149,12 +1150,13 @@ def main(what,
     if what.endswith('.csv'):
         plot_csv(what)
         return
-    if to_file:
-        outfile = unique_filename(f'{what}_{calc_id}.png')
+    if save_to:
+        save_to = unique_filename(save_to)
     if what.startswith(('POINT', 'POLYGON', 'LINESTRING')):
         plt = plot_wkt(what)
-        if to_file:
-            plt.savefig(outfile)
+        if save_to:
+            plt.savefig(save_to, dpi=300)
+            logging.info(f'Plot saved to {save_to}')
         else:
             plt.show()
         return
@@ -1190,8 +1192,9 @@ def main(what,
             xs.append(Extractor(other_id))
     make_figure = globals()['make_figure_' + prefix]
     plt = make_figure(xs, what)
-    if to_file:
-        plt.savefig(outfile)
+    if save_to:
+        plt.savefig(save_to, dpi=300)
+        logging.info(f'Plot saved to {save_to}')
     else:
         plt.show()
 
@@ -1199,6 +1202,6 @@ def main(what,
 main.what = 'what to extract (try examples)'
 main.calc_id = 'computation ID'
 main.others = dict(help='IDs of other computations', nargs='*')
+main.save_to = 'if passed, save the plot to file instead of showing it'
 main.webapi = 'if given, pass through the WebAPI'
 main.local = 'if passed, use the local WebAPI'
-main.to_file = 'if passed, save the plot to file instead of showing it'

--- a/openquake/commonlib/util.py
+++ b/openquake/commonlib/util.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import os
 import numpy
 from openquake.baselib import config, python3compat
 from openquake.commonlib import datastore
@@ -203,3 +204,19 @@ def shared_dir_on():
     :returns: True if a shared_dir has been set in openquake.cfg, else False
     """
     return config.directory.shared_dir
+
+
+def unique_filename(path):
+    """
+    Return a unique filename by appending a counter if needed.
+    Example: 'plot.png' -> 'plot_1.png' if 'plot.png' exists.
+    """
+    if not os.path.exists(path):
+        return path
+    root, ext = os.path.splitext(path)
+    counter = 1
+    new_path = f"{root}_{counter}{ext}"
+    while os.path.exists(new_path):
+        counter += 1
+        new_path = f"{root}_{counter}{ext}"
+    return new_path


### PR DESCRIPTION
The name of the file concatenates the `what` argument and `.png`.

Fixes https://github.com/gem/oq-engine/issues/10760

This is useful for instance when running the oq plot command in a remote machine, so plt.show() would not be visible.