### PR TITLE
Delete part of the 'below_min' AELO warning

### DIFF
--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -94,8 +94,7 @@ AELO_WARNINGS = {
         ' For further information, please refer to the user manual.'),
     'below_min': (
         'The ASCE 7 and/or ASCE 41 parameter values at the site are very low.'
-        ' User may need to increase the values to user-specified minimums'
-        ' (e.g., Ss=0.11g and S1=0.04g).'
+        ' User may need to increase the values to user-specified minimums.'
         ' For further information, please refer to the user manual.'),
 }
 


### PR DESCRIPTION
It was recommended to delete it, as this may be handled differently depending between ASCE 7-16 and 7-22, or for other circumstances.