### PR TITLE
Removed X/Twitter link, updated link to CC BY-NC-SA license

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -83,15 +83,14 @@ Contacts
 ********
 
 - Support forum: https://groups.google.com/g/openquake-users
-- X/Twitter: https://x.com/gem_devs
 
 
 License
 *******
 
 This material is distributed under the Creative Common License
-Attribution-NonCommercial- ShareAlike 3.0 Unported (`CC BY-NC-SA 3.0
-<http://creativecommons.org/licenses/by-nc-sa/3.0/>`__). You
+Attribution-NonCommercial-ShareAlike 4.0 International (`CC BY-NC-SA 4.0
+<https://creativecommons.org/licenses/by-nc-sa/4.0/>`__). You
 can share it with others as long as you provide proper credit, 
 but you cannot change it in any way or use it commercially.
 


### PR DESCRIPTION
Removed X/Twitter link: link was broken, we no longer use X
Updated link to CC BY-NC-SA license: was v3.0 now v4.0