### PR TITLE
IMPACT: add to `impact_run_with_shakemap` the possibility to specify a shakemap id instead of always using the latest one

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -972,12 +972,18 @@ def impact_run_with_shakemap(request):
 
     :param request:
         a `django.http.HttpRequest` object containing a usgs_id and
-        optionally the time of the day ('day', 'night' or 'transit')
+        optionally:
+        the time_event, i.e. the time of the day ('day', 'night' or 'transit')
+        the shakemap_version, the shakemap id in the format returned by
+        the impact_get_shakemap_versions API endpoint
     """
     if request.user.level == 0:
         return HttpResponseForbidden()
     post = dict(usgs_id=request.POST['usgs_id'],
                 use_shakemap='true', approach='use_shakemap_from_usgs')
+    if 'shakemap_version' in request.POST:
+        shakemap_version = request.POST['shakemap_version']
+        post['shakemap_version'] = shakemap_version
     _rup, rupdic, _params, err = impact_validate(post, request.user)
     if err:
         return JsonResponse(err, status=400 if 'invalid_inputs' in err else 500)
@@ -987,6 +993,8 @@ def impact_run_with_shakemap(request):
         post['time_event'] = request.POST['time_event']
     post['approach'] = 'use_shakemap_from_usgs'
     post['use_shakemap'] = 'true'
+    if 'shakemap_version' in request.POST:
+        post['shakemap_version'] = shakemap_version
     for field in IMPACT_FORM_DEFAULTS:
         if field not in post and IMPACT_FORM_DEFAULTS[field]:
             post[field] = IMPACT_FORM_DEFAULTS[field]


### PR DESCRIPTION
I have also updated the example script that can be used to leverage this API endpoint, with an additional call to retrieve all available versions for the given USGS id, and with a modified call to run the calculation using one of the retrieved ids. @catarinaquintela, I can share the script with you.