### PR TITLE
In the test checking that impact fails when SA(0.6) is missing, use a specific shakemap_id instead of usgs_preferred

### DIFF
--- a/openquake/server/tests/test_impact_mode.py
+++ b/openquake/server/tests/test_impact_mode.py
@@ -40,7 +40,7 @@ from openquake.engine.engine import create_jobs
 #       otherwise it would raise:
 #       django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
 
-CALC_RUN_TIMEOUT = 60
+CALC_RUN_TIMEOUT = 120
 
 
 django.setup()

--- a/openquake/server/tests/test_impact_mode.py
+++ b/openquake/server/tests/test_impact_mode.py
@@ -242,7 +242,6 @@ class EngineServerTestCase(django.test.TestCase):
         data = dict(usgs_id='us6000jllz',
                     approach='use_shakemap_from_usgs',
                     shakemap_version=shakemap_version,
-                    use_shakemap=True,
                     lon=37.60602, lat=37.6446,
                     dep=9.0, mag=7.8,
                     rake=0.0, dip=90, strike=51.88112,
@@ -253,7 +252,6 @@ class EngineServerTestCase(django.test.TestCase):
                     truncation_level=3,
                     number_of_ground_motion_fields=2,
                     asset_hazard_distance=15, ses_seed=42,
-                    local_timestamp='2023-02-06 04:17:34+03:00',
                     maximum_distance_stations='', msr='WC1994',
                     description=('us6000jllz: M 7.8 - Pazarcik earthquake,'
                                  ' Kahramanmaras earthquake sequence'))

--- a/openquake/server/tests/test_impact_mode.py
+++ b/openquake/server/tests/test_impact_mode.py
@@ -40,7 +40,7 @@ from openquake.engine.engine import create_jobs
 #       otherwise it would raise:
 #       django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
 
-CALC_RUN_TIMEOUT = 120
+CALC_RUN_TIMEOUT = 60
 
 
 django.setup()

--- a/openquake/server/tests/test_impact_mode.py
+++ b/openquake/server/tests/test_impact_mode.py
@@ -181,8 +181,6 @@ class EngineServerTestCase(django.test.TestCase):
         cls.user1.delete()
         super().tearDownClass()
 
-
-
     def impact_run_then_remove(
             self, endpoint, data, expected_error=None):
         with tempfile.TemporaryDirectory() as email_dir:
@@ -240,19 +238,25 @@ class EngineServerTestCase(django.test.TestCase):
                 'Unable to remove job %s:\n%s' % (job_id, ret))
 
     def test_run_by_usgs_id_then_remove_calc_failure(self):
+        shakemap_version = 'urn:usgs-product:us:shakemap:us6000jllz:1675824364065'
         data = dict(usgs_id='us6000jllz',
                     approach='use_shakemap_from_usgs',
-                    shakemap_version='usgs_preferred',
-                    lon=37.0143, lat=37.2256, dep=10.0, mag=7.8,
-                    rake=0.0, dip=90, strike=0,
-                    time_event='night',
+                    shakemap_version=shakemap_version,
+                    use_shakemap=True,
+                    lon=37.60602, lat=37.6446,
+                    dep=9.0, mag=7.8,
+                    rake=0.0, dip=90, strike=51.88112,
+                    time_event='day',
                     maximum_distance=100,
-                    mosaic_model='MIE',
-                    trt='Active Shallow Crust', truncation_level=3,
+                    mosaic_model='ARB',
+                    trt='TECTONIC_REGION_1',
+                    truncation_level=3,
                     number_of_ground_motion_fields=2,
                     asset_hazard_distance=15, ses_seed=42,
                     local_timestamp='2023-02-06 04:17:34+03:00',
-                    maximum_distance_stations='')
+                    maximum_distance_stations='', msr='WC1994',
+                    description=('us6000jllz: M 7.8 - Pazarcik earthquake,'
+                                 ' Kahramanmaras earthquake sequence'))
         expected_error = 'IMT SA(0.6) is required'
         self.impact_run_then_remove('impact_run', data, expected_error)
 


### PR DESCRIPTION
The most recent 'usgs_preferred' version has SA(0.6), so we need our test to use an older version that doesn't have it.