### PR TITLE
Make it possible to specify the link to the user manual via the local settings

### DIFF
--- a/openquake/server/local_settings.py.aelo_impact
+++ b/openquake/server/local_settings.py.aelo_impact
@@ -20,6 +20,10 @@ WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
 # WEBUI config uncomment and set properly if needed
 # WEBUIURL = 'http://localhost:8800/'
 
+# By default this setting links to the latest engine user manual
+# The following example points to the latest AELO user manual:
+# HELP_URL = 'https://docs.openquake.org/.aelo/latest'
+
 # turn on USE_X_FORWARDED_HOST to expose the webui via a proxy server
 # USE_X_FORWARDED_HOST = True
 # USE_X_FORWARDED_PORT = True

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -234,6 +234,9 @@ MAX_AELO_SITE_NAME_LEN = 256
 
 GOOGLE_ANALYTICS_TOKEN = None
 
+HELP_URL = 'https://docs.openquake.org/oq-engine/latest/manual/'
+
+
 CONTEXT_PROCESSORS = TEMPLATES[0]['OPTIONS']['context_processors']
 
 # OpenQuake Standalone tools (IPT, Taxonomy Glossary)

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -236,7 +236,6 @@ GOOGLE_ANALYTICS_TOKEN = None
 
 HELP_URL = 'https://docs.openquake.org/oq-engine/latest/manual/'
 
-
 CONTEXT_PROCESSORS = TEMPLATES[0]['OPTIONS']['context_processors']
 
 # OpenQuake Standalone tools (IPT, Taxonomy Glossary)

--- a/openquake/server/templates/engine/base.html
+++ b/openquake/server/templates/engine/base.html
@@ -59,11 +59,7 @@
                   </li>
                   {% endif %}
                   <li class="actions">
-                      {% if application_mode == 'AELO' %}
-                      <a href="https://docs.openquake.org/.aelo/latest" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
-                      {% else %}
-                      <a href="https://docs.openquake.org/oq-engine/latest/manual/" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
-                      {% endif %}
+                      <a href="{{ help_url }}" id="help_url" rel="tooltip" target="_blank" title="Help"><img src="{{ STATIC_URL }}img/oq-help.png"></a>
                   </li>
                 </ul>
               </div>

--- a/openquake/server/utils.py
+++ b/openquake/server/utils.py
@@ -133,6 +133,7 @@ def oq_server_context_processor(request):
     context['external_tools'] = settings.EXTERNAL_TOOLS
     context['application_mode'] = settings.APPLICATION_MODE
     context['announcements'] = announcements
+    context['help_url'] = settings.HELP_URL
     if settings.GOOGLE_ANALYTICS_TOKEN is not None:
         context['google_analytics_token'] = settings.GOOGLE_ANALYTICS_TOKEN
     if settings.APPLICATION_MODE == 'AELO':


### PR DESCRIPTION
NOTE: when we update the AELO services, we will need to remember to specify in the corresponding local settings the links to the correct versions of the user manual (otherwise the question mark will point to the engine user manual instead).