### PR TITLE
Fixed the splitting of multifault sources with a single site

### DIFF
--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -307,7 +307,6 @@ def _set_rupids_by_tag(src, allrids, dists, s2i):
         src.rupids_by_tag['off_rupids'] = off_rupids
 
 
-
 # NB: as side effect delete _rupture_idxs,
 # add .hdf5path and possibly .rupids_by_tag
 def save_and_split(mfsources, sectiondict, hdf5path, site1=None,

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -315,7 +315,9 @@ def get_csm(oq, full_lt, dstore=None):
     except (KeyError, TypeError):  # 'NoneType' object is not subscriptable
         sitecol = None
     else:
-        if len(sitecol) > 1:
+        # NB: in AELO we can have multiple vs30 on the same location
+        lonlats = set(zip(sitecol.lons, sitecol.lats))
+        if len(lonlats) > 1:
             sitecol = None
     # must be called *after* _fix_dupl_ids
     fix_geometry_sections(


### PR DESCRIPTION
I will need to add a test with `override_vs30` with multiple values (like the one provided by @ManuelaVillani)