### PR TITLE
Gzipping the avg_losses

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * gzipping the avg_losses reducing the disk space by half or so
   * Added an extractor `losses_by_location`
   * Filtering the assets around the rupture according to the maximum distance
     in scenario calculations

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -488,10 +488,10 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         self.avg_losses = numpy.zeros((self.A, self.X, R), F32)
         for lt in self.xtypes:
             self.datastore.create_dset(
-                'avg_losses-rlzs/' + lt, F32, (self.A, R))
+                'avg_losses-rlzs/' + lt, F32, (self.A, R), 'gzip')
             if S and R > 1:
                 self.datastore.create_dset(
-                    'avg_losses-stats/' + lt, F32, (self.A, S))
+                    'avg_losses-stats/' + lt, F32, (self.A, S), 'gzip')
 
     def execute(self):
         """


### PR DESCRIPTION
Here is an example for Turkey:
```
$ python -m  openquake.engine.impact  us6000jllz --approach use_pnt_rup_from_usgs -u1 -m600

# no gzip
| avg_losses-stats                    | 308.55 MB |
| avg_losses-rlzs                     | 385.69 MB |
| /home/michele/oqdata/calc_1756.hdf5 | 1.05 GB   |

# with gzip
| avg_losses-stats                    | 308.55 MB |
| avg_losses-rlzs                     | 385.69 MB |
| /home/michele/oqdata/calc_1758.hdf5 | 722.01 MB |
```
We save half the space in `avg_losses` since there are many zeros.