### PR TITLE
Removed `export_dir` from the demos

### DIFF
--- a/demos/hazard/AreaSourceClassicalPSHA/job.ini
+++ b/demos/hazard/AreaSourceClassicalPSHA/job.ini
@@ -46,7 +46,6 @@ maximum_distance = 200.0
 
 [output]
 
-export_dir = /tmp
 hazard_maps = true
 uniform_hazard_spectra = true
 poes = 0.1 0.02

--- a/demos/hazard/CharacteristicFaultSourceCase1ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase1ClassicalPSHA/job.ini
@@ -48,7 +48,6 @@ maximum_distance = 200
 
 [output]
 
-export_dir = /tmp
 quantiles =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/CharacteristicFaultSourceCase2ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase2ClassicalPSHA/job.ini
@@ -48,7 +48,6 @@ maximum_distance = 200.0
 
 [output]
 
-export_dir = /tmp
 quantiles =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/CharacteristicFaultSourceCase3ClassicalPSHA/job.ini
+++ b/demos/hazard/CharacteristicFaultSourceCase3ClassicalPSHA/job.ini
@@ -48,7 +48,6 @@ maximum_distance = 200.0
 
 [output]
 
-export_dir = /tmp
 quantiles =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/ComplexFaultSourceClassicalPSHA/job.ini
+++ b/demos/hazard/ComplexFaultSourceClassicalPSHA/job.ini
@@ -48,7 +48,6 @@ maximum_distance = 200.0
 
 [output]
 
-export_dir = /tmp
 quantiles =
 hazard_maps = true
 uniform_hazard_spectra = true

--- a/demos/hazard/Disaggregation/job.ini
+++ b/demos/hazard/Disaggregation/job.ini
@@ -49,4 +49,3 @@ num_epsilon_bins = 3
 
 individual_rlzs = true
 # num_rlzs_disagg = 2
-export_dir = /tmp

--- a/demos/hazard/EventBasedPSHA/job.ini
+++ b/demos/hazard/EventBasedPSHA/job.ini
@@ -45,7 +45,6 @@ ground_motion_correlation_params =
 
 [output]
 
-export_dir = /tmp
 ground_motion_fields = true
 hazard_curves_from_gmfs = true
 hazard_maps = true

--- a/demos/hazard/GMPETablePSHA/job.ini
+++ b/demos/hazard/GMPETablePSHA/job.ini
@@ -32,7 +32,3 @@ truncation_level = 5
 investigation_time = 50.0
 maximum_distance = 400.0
 pointsource_distance = 200
-
-[output]
-
-export_dir = /tmp

--- a/demos/hazard/LogicTreeCase1ClassicalPSHA/job.ini
+++ b/demos/hazard/LogicTreeCase1ClassicalPSHA/job.ini
@@ -38,7 +38,6 @@ maximum_distance = 200.0
 
 [output]
 
-export_dir = /tmp
 individual_rlzs = true
 mean = true
 quantiles = 0.05 0.5 0.95

--- a/demos/hazard/LogicTreeCase2ClassicalPSHA/job.ini
+++ b/demos/hazard/LogicTreeCase2ClassicalPSHA/job.ini
@@ -38,7 +38,6 @@ pointsource_distance = 50
 
 [output]
 
-export_dir = /tmp
 mean = true
 quantiles = 0.05 0.5 0.95
 hazard_maps = true

--- a/demos/hazard/LogicTreeCase3ClassicalPSHA/job.ini
+++ b/demos/hazard/LogicTreeCase3ClassicalPSHA/job.ini
@@ -37,7 +37,6 @@ split_sources = false
 
 [output]
 
-export_dir = /tmp
 max = true
 quantiles = 0.1 0.5 0.9
 hazard_maps = true

--- a/demos/hazard/NonparametricSourcesClassicalPSHA/job.ini
+++ b/demos/hazard/NonparametricSourcesClassicalPSHA/job.ini
@@ -46,7 +46,6 @@ maximum_distance = {'default': 300.}
 
 [output]
 
-export_dir = /tmp
 hazard_maps = True
 uniform_hazard_spectra = False
 poes = 0.002105 0.000404

--- a/demos/hazard/ScenarioCase1/job.ini
+++ b/demos/hazard/ScenarioCase1/job.ini
@@ -30,8 +30,3 @@ gsim = BooreAtkinson2008
 ground_motion_correlation_model = JB2009
 ground_motion_correlation_params = {"vs30_clustering": False}
 number_of_ground_motion_fields = 10
-
-
-[output]
-
-export_dir = /tmp

--- a/demos/hazard/ScenarioCase2/job.ini
+++ b/demos/hazard/ScenarioCase2/job.ini
@@ -30,8 +30,3 @@ gsim = BooreAtkinson2008
 ground_motion_correlation_model = JB2009
 ground_motion_correlation_params = {"vs30_clustering": False}
 number_of_ground_motion_fields = 10
-
-
-[output]
-
-export_dir = /tmp

--- a/demos/hazard/SimpleFaultSourceClassicalPSHA/job.ini
+++ b/demos/hazard/SimpleFaultSourceClassicalPSHA/job.ini
@@ -48,7 +48,6 @@ maximum_distance = 200.0
 
 [output]
 
-export_dir = /tmp
 quantiles =
 uniform_hazard_spectra = true
 poes = 0.1 0.02

--- a/demos/risk/ClassicalDamage/job_hazard.ini
+++ b/demos/risk/ClassicalDamage/job_hazard.ini
@@ -30,4 +30,3 @@ intensity_measure_types_and_levels = {"PGA": [0.005, 0.0075, 0.01,  0.02, 0.03, 
 truncation_level = 3
 investigation_time = 1
 maximum_distance = 200.0
-export_dir = /tmp

--- a/demos/risk/ClassicalDamage/job_risk.ini
+++ b/demos/risk/ClassicalDamage/job_risk.ini
@@ -14,6 +14,3 @@ fragility_file = structural_fragility_model.xml
 [calculation]
 steps_per_interval = 4
 risk_investigation_time = 1
-
-[export]
-export_dir = /tmp

--- a/demos/risk/ClassicalRisk/job_hazard.ini
+++ b/demos/risk/ClassicalRisk/job_hazard.ini
@@ -42,6 +42,3 @@ max = true
 hazard_maps = true
 uniform_hazard_spectra = true
 poes = 0.02, 0.10
-
-[export]
-export_dir = /tmp

--- a/demos/risk/ClassicalRisk/job_risk.ini
+++ b/demos/risk/ClassicalRisk/job_risk.ini
@@ -15,6 +15,3 @@ lrem_steps_per_interval = 1
 
 [outputs]
 conditional_loss_poes = 0.02, 0.10
-
-[export]
-export_dir = /tmp

--- a/demos/risk/EventBasedRisk/job.ini
+++ b/demos/risk/EventBasedRisk/job.ini
@@ -48,6 +48,3 @@ avg_losses = true
 quantiles = 0.15 0.85
 risk_investigation_time = 1
 conditional_loss_poes = 0.0021, 0.000404
-
-[export]
-export_dir = /tmp

--- a/demos/risk/EventBasedRisk/job_eb.ini
+++ b/demos/risk/EventBasedRisk/job_eb.ini
@@ -42,5 +42,4 @@ quantiles = 0.15 0.85
 risk_investigation_time = 1
 
 [export]
-export_dir = /tmp
 individual_rlzs = true

--- a/demos/risk/ScenarioDamage/job_hazard.ini
+++ b/demos/risk/ScenarioDamage/job_hazard.ini
@@ -25,6 +25,3 @@ gsim_logic_tree_file = gsim_logic_tree.xml
 ground_motion_correlation_model =
 ground_motion_correlation_params =
 number_of_ground_motion_fields = 100
-
-[export]
-export_dir = /tmp

--- a/demos/risk/ScenarioDamage/job_risk.ini
+++ b/demos/risk/ScenarioDamage/job_risk.ini
@@ -10,6 +10,3 @@ structural_fragility_file = structural_fragility_model.xml
 
 [consequence]
 consequence_file = {'taxonomy': 'consequences.csv'}
-
-[export]
-export_dir = /tmp/

--- a/demos/risk/ScenarioRisk/job.ini
+++ b/demos/risk/ScenarioRisk/job.ini
@@ -36,6 +36,3 @@ number_of_ground_motion_fields = 100
 [risk_calculation]
 time_event = night
 asset_correlation = 0
-
-[export]
-export_dir = /tmp


### PR DESCRIPTION
Because the sponsor LibertyMutual cannot run the tests on Windows (apparently they lack permissions to write C:\tmp).