### PR TITLE
Don't check the `export_dir` if we are not exporting

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Doing the check on the `export_dir` only if `--exports` is passed
   * Fixed a `NameError: Missing liquefaction:LiqProb in gmf_data`
     when using the TodorovicSilva2022NonParametric model
   * gzipping the avg_losses reducing the disk space by half or so

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -2153,6 +2153,8 @@ class OqParam(valid.ParamSet):
         export_dir={export_dir} must refer to a directory,
         and the user must have the permission to write on it.
         """
+        if not self.exports:  # don't check if we are not exporting
+            return True
         if self.export_dir and not os.path.isabs(self.export_dir):
             self.export_dir = os.path.normpath(
                 os.path.join(self.input_dir, self.export_dir))

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -2153,15 +2153,10 @@ class OqParam(valid.ParamSet):
         export_dir={export_dir} must refer to a directory,
         and the user must have the permission to write on it.
         """
-        if not self.export_dir and not self.exports:
-            # don't check if we are not exporting
+        if not self.exports or not self.exports[0]:  # () or ('',)
+            # we are not exporting anything
             return True
-        elif not self.export_dir:
-            self.export_dir = os.path.expanduser('~')  # home directory
-            logging.info('export_dir not specified. Using export_dir=%s'
-                         % self.export_dir)
-            return True
-        elif not os.path.isabs(self.export_dir):
+        if not os.path.isabs(self.export_dir):
             self.export_dir = os.path.normpath(
                 os.path.join(self.input_dir, self.export_dir))
         if not os.path.exists(self.export_dir):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -2153,16 +2153,17 @@ class OqParam(valid.ParamSet):
         export_dir={export_dir} must refer to a directory,
         and the user must have the permission to write on it.
         """
-        if not self.exports:  # don't check if we are not exporting
+        if not self.export_dir and not self.exports:
+            # don't check if we are not exporting
             return True
-        if self.export_dir and not os.path.isabs(self.export_dir):
-            self.export_dir = os.path.normpath(
-                os.path.join(self.input_dir, self.export_dir))
-        if not self.export_dir:
+        elif not self.export_dir:
             self.export_dir = os.path.expanduser('~')  # home directory
             logging.info('export_dir not specified. Using export_dir=%s'
                          % self.export_dir)
             return True
+        elif not os.path.isabs(self.export_dir):
+            self.export_dir = os.path.normpath(
+                os.path.join(self.input_dir, self.export_dir))
         if not os.path.exists(self.export_dir):
             try:
                 os.makedirs(self.export_dir)


### PR DESCRIPTION
Avoids the error
```
oq engine --run /data/home/martina.caruso/PAPERS/Earthquake_Scenarios/Historical_Events/Jobs_geid/2012_EmiliaRomagna_1-job_hazard_conditioned.ini
ValueError: 
export_dir=/data/home/martina.caruso/PAPERS/Earthquake_Scenarios/Historical_Events/Jobs_geid must refer to a directory,
and the user must have the permission to write on it.
```