### PR TITLE
Discarding sources not starting with source_id

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Changed the Starmap to ensure at least one GB of RAM per thread
+  * Extended the source_id-filtering feature to use .startswith
   * Added a flag "aggregate_exposure" (false by default) to aggregate
     the assets with the same taxonomy on the same hazard site
   * Optimized "building cmakers" and the RateMap in the case of clusters

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -764,7 +764,7 @@ class SourceConverter(RuptureConverter):
         name = striptag(node.tag)
         if name.endswith('Source'):  # source node
             source_id = node['id']
-            if self.source_id and source_id not in self.source_id:
+            if self.source_id and not source_id.startswith(self.source_id):
                 # if source_id is set in the job.ini, discard all other sources
                 return
             elif self.source_nodes and name not in self.source_nodes:

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -733,7 +733,7 @@ class SourceConverter(RuptureConverter):
                  complex_fault_mesh_spacing=None, width_of_mfd_bin=1.0,
                  area_source_discretization=None,
                  minimum_magnitude={'default': 0},
-                 source_id=None, discard_trts=(),
+                 source_id=(), discard_trts=(),
                  floating_x_step=0, floating_y_step=0,
                  source_nodes=(),
                  infer_occur_rates=False):
@@ -744,7 +744,7 @@ class SourceConverter(RuptureConverter):
         self.complex_fault_mesh_spacing = (
             complex_fault_mesh_spacing or rupture_mesh_spacing)
         self.width_of_mfd_bin = width_of_mfd_bin
-        self.source_id = source_id
+        self.source_id = tuple(source_id)
         self.discard_trts = discard_trts
         self.floating_x_step = floating_x_step
         self.floating_y_step = floating_y_step
@@ -753,7 +753,7 @@ class SourceConverter(RuptureConverter):
 
     def convert_node(self, node):
         """
-        Convert the given source node into a hazardlib source, depending
+        Convert the given node into a hazardlib source or group, depending
         on the node tag.
 
         :param node: a node representing a source or a SourceGroup


### PR DESCRIPTION
Supports the third point of https://github.com/gem/oq-engine/issues/10845 (use `source_id = Cascadia NewMadrid`).