### PR TITLE
Fixed hidden exception

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -314,11 +314,11 @@ def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False,
             raise ValueError('You can use at most %d nodes' %
                              (max_cores // parallel.num_cores))
 
-    if concurrent_jobs is None:
-        # // 8 is chosen so that the core occupation in cole is decent
-        concurrent_jobs = parallel.Starmap.CT // 8 or 1
-        if dist in ('slurm', 'zmq'):
-            print(f'{concurrent_jobs=}')
+    if dist in ('slurm', 'zmq'):
+        if concurrent_jobs is None:
+            # // 8 is chosen so that the core occupation in cole is decent
+            concurrent_jobs = parallel.Starmap.CT // 8 or 1
+        print(f'{concurrent_jobs=}')
 
     job_id = jobctxs[0].calc_id
     if precalc:


### PR DESCRIPTION
Avoids the error
```
RuntimeError: The IMT SA(0.6) is required but not in the available set MMI, PGA, SA(0.3), SA(3.0), SA(1.0), please change the risk model otherwise you will have incorrect zero losses for the associated taxonomy strings
```
caused by OQImpact sending an OK message even if the calculation failed.