### PR TITLE
fixing a typo that used the wrong period to assign the seismicity class

### DIFF
--- a/openquake/calculators/postproc/compute_rtgm.py
+++ b/openquake/calculators/postproc/compute_rtgm.py
@@ -509,7 +509,7 @@ def process_sites(dstore, csm, DLLs, ASCE_version):
 def get_seismicity_class(mce_site, vs30):
         if vs30 == 760:
             sa02 = mce_site[mce_site.period==0.2]['SaM'].iloc[0]
-            sa10 = mce_site[mce_site.period==0.2]['SaM'].iloc[0]
+            sa10 = mce_site[mce_site.period==1.0]['SaM'].iloc[0]
             Ss_seismicity = (
                 "Low" if sa02 < 0.25 else
                 "Moderate" if sa02 < 0.5 else

--- a/openquake/calculators/tests/postproc_test.py
+++ b/openquake/calculators/tests/postproc_test.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     rtgmpy = None
 from openquake.baselib.performance import Monitor
-from openquake.baselib import hdf5, writers
+from openquake.baselib import writers
 from openquake.hazardlib.calc.mrd import (
     update_mrd, get_uneven_bins_edges, calc_mean_rate_dist)
 from openquake.hazardlib.contexts import read_cmakers, read_ctx_by_grp
@@ -254,6 +254,7 @@ class PostProcTestCase(CalculatorTestCase):
         fnames = export(('median_spectra', 'csv'), self.calc.datastore)
         for fname in fnames:
             self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname)
+
 
 class SeismicityClassTestCase(unittest.TestCase):
 

--- a/openquake/calculators/tests/postproc_test.py
+++ b/openquake/calculators/tests/postproc_test.py
@@ -17,7 +17,9 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import unittest
 import numpy as np
+import pandas as pd
 import matplotlib.pyplot as plt
 try:
     import rtgmpy
@@ -31,6 +33,7 @@ from openquake.hazardlib.contexts import read_cmakers, read_ctx_by_grp
 from openquake.hazardlib.cross_correlation import BakerJayaram2008
 from openquake.calculators.tests import CalculatorTestCase, strip_calc_id
 from openquake.calculators.export import export
+from openquake.calculators.postproc.compute_rtgm import get_seismicity_class
 from openquake.qa_tests_data.postproc import (
     case_mrd, case_rtgm, case_median_spectrum)
 
@@ -220,7 +223,7 @@ class PostProcTestCase(CalculatorTestCase):
 
         # check string results
         dic07_str = [dic07[k] for k in ['Ss_seismicity', 'S1_seismicity']]
-        assert dic07_str == ['Very High', 'Very High']
+        assert dic07_str == ['Very High', 'High']
 
         asce41 = self.calc.datastore['asce41'][0].decode('ascii')
         dic41 = json.loads(asce41)
@@ -251,3 +254,34 @@ class PostProcTestCase(CalculatorTestCase):
         fnames = export(('median_spectra', 'csv'), self.calc.datastore)
         for fname in fnames:
             self.assertEqualFiles('expected/%s' % strip_calc_id(fname), fname)
+
+class SeismicityClassTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.periods = [0, 0.2, 1.0]
+        self.csid = ['7','7','7']
+
+    def test_get_seismicity_class_case1(self):
+        # testing that both periods are very high
+        SaM = [0.71853975, 1.68876704, 0.6]
+        mce_site = pd.DataFrame({'period': self.periods, 'SaM': SaM,
+                                 'custom_site_id': self.csid})
+        Ss_seismicity, S1_seismicity = get_seismicity_class(mce_site, 760)
+        assert Ss_seismicity == S1_seismicity == 'Very High'
+
+    def test_get_seismicity_class_case2(self):
+        # testing that S1 is high and Ss is very high
+        SaM = [0.7986, 1.902, 0.5637]
+        mce_site = pd.DataFrame({'period': self.periods, 'SaM': SaM,
+                                 'custom_site_id': self.csid})
+        Ss_seismicity, S1_seismicity = get_seismicity_class(mce_site, 760)
+        assert Ss_seismicity == 'Very High'
+        assert S1_seismicity == 'High'
+
+    def test_get_seismicity_class_case3(self):
+        # testing that other vs30 gives nan
+        SaM = [0.7986, 1.902, 0.5637]
+        mce_site = pd.DataFrame({'period': self.periods, 'SaM': SaM,
+                                 'custom_site_id': self.csid})
+        Ss_seismicity, S1_seismicity = get_seismicity_class(mce_site, 530)
+        assert Ss_seismicity == S1_seismicity =='n.a.'

--- a/openquake/commands/compare.py
+++ b/openquake/commands/compare.py
@@ -497,6 +497,7 @@ def compare_asce(dir1: str, dir2: str, atol=1E-3, rtol=1E-3):
     """
     for fname in os.listdir(dir2):
         if fname.endswith('.org'):
+            print(f"Comparing {fname}")
             df1 = read_org_df(os.path.join(dir1, fname))
             df2 = read_org_df(os.path.join(dir2, fname))
             equal = []
@@ -505,7 +506,8 @@ def compare_asce(dir1: str, dir2: str, atol=1E-3, rtol=1E-3):
                                            strip(df2[col].to_numpy()),
                                            col, atol, rtol)
                 equal.append(ok)
-            sys.exit(not all(equal))
+            if not all(equal):
+                sys.exit(1)
 
 
 main = dict(rups=compare_rups,

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -826,9 +826,11 @@ class GPKG2NRMLTestCase(unittest.TestCase):
 @skipIf(rtgmpy is None, 'Missing rtgmpy')
 class RunSiteTestCase(unittest.TestCase):
 
-    def setUp(self):
-        self.mosaic_dir = os.path.dirname(mosaic.__file__)
+    @classmethod
+    def setUpClass(cls):
+        cls.mosaic_dir = os.path.dirname(mosaic.__file__)
         if not os.path.exists('asce'):
+            # create directory in qa_tests_data/mosaic/asce to store the files
             os.makedirs('asce')
 
     def test_runsite_case1(self):

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -828,6 +828,8 @@ class RunSiteTestCase(unittest.TestCase):
 
     def setUp(self):
         self.mosaic_dir = os.path.dirname(mosaic.__file__)
+        if not os.path.exists('asce'):
+            os.makedirs('asce')
 
     def test_runsite_case1(self):
         # tests when there is a lonlat file without vs30 but its given as


### PR DESCRIPTION
For S1 it was using 0.2 but should use 1.0.
I also added more explicit unit tests because the one in test_rtgm includes too much. It changed to compare against wrong results [here](https://github.com/gem/oq-engine/commit/de5a690303ae63535b49257709058acbb10ddab0#diff-600cd0e1d09f60d9349ef32ec54763f22e9eeb188254c66770ae5576772de5adR220-R223) where we overlooked the meaning of the change in class.