### PR TITLE
Introduced `aelo.get_boundaries_file`

### DIFF
--- a/openquake/commands/mosaic.py
+++ b/openquake/commands/mosaic.py
@@ -85,7 +85,7 @@ def from_file(fname, mosaic_dir, concurrent_jobs, asce_version, vs30):
     sites_df = pandas.read_csv(fname)  # header ID,Latitude,Longitude
     lonlats = sites_df[['Longitude', 'Latitude']].to_numpy()
     print('Found %d sites' % len(lonlats))
-    mosaic_df = get_mosaic_df(buffer=0.0)
+    mosaic_df = get_mosaic_df(0.0, mosaic_dir)
     sites_df['model'] = geolocate(lonlats, mosaic_df)
     count_sites_per_model = collections.Counter(sites_df.model)
     print(count_sites_per_model)

--- a/openquake/engine/aelo.py
+++ b/openquake/engine/aelo.py
@@ -54,12 +54,11 @@ def get_boundaries_file(mosaic_dir):
 
 
 @functools.lru_cache
-def get_mosaic_df(buffer):
+def get_mosaic_df(buffer, mosaic_dir=config.directory.mosaic_dir):
     """
     :returns: a DataFrame with the mosaic geometries used in AELO
     """
-    path = get_boundaries_file(config.directory.mosaic_dir or
-                               os.path.dirname(mosaic.__file__))
+    path = get_boundaries_file(mosaic_dir or os.path.dirname(mosaic.__file__))
     logging.info(f'Reading {path}')
     df = readinput.read_geometries(path, 'name', buffer)
     return df


### PR DESCRIPTION
Simpler alternative to specifying `mosaic_boundaries_file` since it is enough to put the file in the mosaic_dir and we won't need to change openquake.cfg. This is useful for the AELO tests in mosaic/.gitlab-ci.yml