### PR TITLE
Turned `onnxruntime` into an optional dependency again

### DIFF
--- a/openquake/baselib/onnx.py
+++ b/openquake/baselib/onnx.py
@@ -19,7 +19,10 @@
 """
 Support for onnxruntime sessions
 """
-import onnxruntime
+try:
+    import onnxruntime
+except ImportError:
+    onnxruntime = None
 
 
 # NB: the engine is already parallelizing, so we must disable the


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/10870.

It must be optional because onnxruntime does not work on all platforms (for instance on debian with Python 3.11).