### PR TITLE
Minor improvement to disagg_source

### DIFF
--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -189,7 +189,7 @@ def get_eps4(eps_edges, truncation_level):
 
 
 # NB: this function is the crucial bit for performance!
-def _disaggregate(ctx, mea, std, cmaker, g, iml2, bin_edges, epsstar, gp,
+def _disaggregate(ctx, mea, std, cmaker, g, iml2, bin_edges, eps4, epsstar, gp,
                   infer_occur_rates, mon1, mon2, mon3):
     # ctx: a recarray of size U for a single site and magnitude bin
     # mea: array of shape (G, M, U)
@@ -197,16 +197,13 @@ def _disaggregate(ctx, mea, std, cmaker, g, iml2, bin_edges, epsstar, gp,
     # cmaker: a ContextMaker instance
     # g: a gsim index
     # iml2: an array of shape (M, P) of logarithmic intensities
-    # eps_bands: an array of E elements obtained from the E+1 eps_edges
-    # bin_edges: a tuple of 5 bin edges (mag, dist, lon, lat, eps)
+    # eps4: a quartet min_eps, max_eps, eps_bands, cum_bands
     # epsstar: a boolean. When True, disaggregation contains eps* results
     # gp: group_probability relevant for mutex sources, otherwise 1
     # returns a 7D-array of shape (D, Lo, La, E, M, P, Z)
 
     with mon1:
-        eps_edges = tuple(bin_edges[-1])  # last edge
-        min_eps, max_eps, eps_bands, cum_bands = get_eps4(
-            eps_edges, cmaker.truncation_level)
+        min_eps, max_eps, eps_bands, cum_bands = eps4
         U, E = len(ctx), len(eps_bands)
         M, P = iml2.shape
         phi_b = cmaker.phi_b
@@ -225,7 +222,7 @@ def _disaggregate(ctx, mea, std, cmaker, g, iml2, bin_edges, epsstar, gp,
             lvls = (iml - mea[g, m]) / std[g, m]
             # Find the index in the epsilons-bins vector where lvls (which are
             # epsilons) should be included
-            idxs = numpy.searchsorted(eps_edges, lvls)
+            idxs = numpy.searchsorted(bin_edges[-1], lvls)
             # Split the epsilons into parts (one for each bin larger than lvls)
             if epsstar:
                 ok = (lvls >= min_eps) & (lvls < max_eps)
@@ -380,6 +377,8 @@ class Disaggregator(object):
                           bin_edges[4])  # eps
         for i, name in enumerate(['Ma', 'D', 'Lo', 'La', 'E']):
             setattr(self, name, len(self.bin_edges[i]) - 1)
+
+        self.eps4 = get_eps4(tuple(self.bin_edges[4]), cmaker.truncation_level)
         self.dist_idx = {}  # magi -> dist_idx
         self.mea, self.std = {}, {}  # magi -> array[G, M, U]
 
@@ -453,7 +452,8 @@ class Disaggregator(object):
         gp = self.src_mutex.get('grp_probability', 1.)
         if not self.src_mutex:
             poes = _disaggregate(self.ctx, mea, std, self.cmaker,
-                                 g, imlog2, self.bin_edges, self.epsstar, gp,
+                                 g, imlog2, self.bin_edges, self.eps4,
+                                 self.epsstar, gp,
                                  self.cmaker.oq.infer_occur_rates,
                                  self.mon1, self.mon2, self.mon3)
             return to_rates(poes)
@@ -465,7 +465,7 @@ class Disaggregator(object):
             mea = self.mea[self.magi][:, :, s1:s2]  # shape (G, M, U)
             std = self.std[self.magi][:, :, s1:s2]  # shape (G, M, U)
             mat = _disaggregate(ctx, mea, std, self.cmaker, g, imlog2,
-                                self.bin_edges, self.epsstar, gp,
+                                self.bin_edges, self.eps4, self.epsstar, gp,
                                 self.cmaker.oq.infer_occur_rates,
                                 self.mon1, self.mon2, self.mon3)
             mats.append(mat)


### PR DESCRIPTION
A bit better than https://github.com/gem/oq-engine/pull/10872 (10% in disagg_mag_dist_eps):
```
| calc_99675, maxmem=2.4 GB                        | time_sec  | memory_mb | counts |
|--------------------------------------------------+-----------+-----------+--------|
| ClassicalCalculator.run                          | 348.8     | 2_088     | 1      |
| compute_rtgm.main                                | 345.3     | 1_656     | 1      |
| total disagg_source                              | 335.2     | 1_151     | 5      |
| disagg_mag_dist_eps on site (24.15061, 35.53642) | 235.0     | 1_054     | 5      |
| calc_rmap on site (24.15061, 35.53642)           | 89.2352   | 97.5469   | 5      |
```