### PR TITLE
Fixed running job_haz+job_risk with zmq

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -334,7 +334,7 @@ def _run(jobctxs, dist, job_id, nodes, sbatch, precalc, concurrent_jobs):
         if dist == 'zmq' or (dist == 'slurm' and not sbatch):
             stop_workers(job_id)
 
-    
+
 def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False,
              precalc=False):
     """


### PR DESCRIPTION
Fixed the error caused by `concurrent_job=None` in the demos:
https://github.com/gem/oq-engine/actions/runs/18488500017/job/52676585675#step:7:3486

Also introduce a helper function to make a long function shorter.