### PR TITLE
Fix `ajax_login` behavior in case of invalid credentials

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -251,7 +251,7 @@ def ajax_login(request):
     """
     username = request.POST['username']
     password = request.POST['password']
-    user = authenticate(username=username, password=password)
+    user = authenticate(request=request, username=username, password=password)
     if user is not None:
         if user.is_active:
             login(request, user)


### PR DESCRIPTION
Giving valid credentials the behavior was correct, but otherwise the server returned an error (with 500 status code) instead of a status code 403.

The error occurred while attempting to read the request to log some metadata about the user who performed that request. The Django authenticate() function receives the request as an optional argument, but our recent change in the logging made it required.