### PR TITLE
Using 32 bit in the cluster pmap

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1630,7 +1630,8 @@ class PmapMaker(object):
             pnemap = self._make_src_mutex()
         if self.cluster:
             with self.cmaker.clu_mon:
-                for nocc in range(0, 10):
+                # TODO: reduce 50 to 10 to make the calculation faster
+                for nocc in range(0, 50):
                     prob_n_occ = self.tom.get_probability_n_occurrences(
                         self.tom.occurrence_rate, nocc)
                     if nocc == 0:


### PR DESCRIPTION
Saves half the memory and it is faster. This is relevant for the USA model https://github.com/gem/oq-engine/issues/10845. Here are the figures for the NewMadrid sources:
```
# before
| calc_9, maxmem=91.1 GB     | time_sec  | memory_mb | counts |
|----------------------------+-----------+-----------+--------|
| total classical            | 1_335     | 111.1611  | 373    |
| cluster loop               | 1_026     | 133.5488  | 373    |
| total postclassical        | 137.8401  | 64.7656   | 10     |
| reading rates              | 136.7811  | 64.7070   | 10     |
| get_poes                   | 85.5447   | 0.0       | 48_667 |
| computing mean_std         | 82.5112   | 0.0       | 1_068  |
| ClassicalCalculator.run    | 73.8808   | 19.9531   | 1      |

# after
| calc_13, maxmem=90.3 GB    | time_sec  | memory_mb | counts |
|----------------------------+-----------+-----------+--------|
| total classical            | 1_094     | 94.7139   | 373    |
| cluster loop               | 788.8     | 66.8057   | 373    |
| total postclassical        | 140.3747  | 60.4805   | 10     |
| reading rates              | 139.3147  | 60.4219   | 10     |
| get_poes                   | 85.4763   | 0.0       | 48_667 |
| computing mean_std         | 82.4400   | 0.0       | 1_068  |
| ClassicalCalculator.run    | 68.1218   | 19.8008   | 1      |
```
We can improve a lot the performance by using 10 iterations instead of 50 iterations:
```
| calc_10, maxmem=90.3 GB    | time_sec  | memory_mb | counts |
|----------------------------+-----------+-----------+--------|
| total classical            | 357.4     | 95.8340   | 373    |
| total postclassical        | 140.0274  | 77.0625   | 10     |
| reading rates              | 138.9651  | 77.0039   | 10     |
| get_poes                   | 84.7314   | 0.0       | 48_667 |
| computing mean_std         | 82.5726   | 0.0       | 1_068  |
| cluster loop               | 54.2338   | 66.7686   | 373    |
| ClassicalCalculator.run    | 45.2128   | 19.7734   | 1      |
```