### PR TITLE
Optimized the cluster loop

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1630,7 +1630,7 @@ class RmapMaker(object):
             pnemap = self._make_src_mutex()
         if self.cluster:
             with self.cmaker.clu_mon:
-                probs =  F32(self.tom.get_probability_n_occurrences(
+                probs = F32(self.tom.get_probability_n_occurrences(
                     self.tom.occurrence_rate, numpy.arange(20)))
                 array = numpy.full(pnemap.shape, probs[0], dtype=F32)
                 for nocc, probn in enumerate(probs[1:], 1):


### PR DESCRIPTION
With less iterations and using less memory. Here are the figures for usa_small:
```
# before
| calc_3, maxmem=242.1 GB    | time_sec  | memory_mb | counts  |
|----------------------------+-----------+-----------+---------|
| total classical            | 16_854    | 1_336     | 705     |
| cluster loop               | 13_605    | 267.1     | 705     |
| total postclassical        | 1_135     | 48.0391   | 10      |
| reading rates              | 1_133     | 47.9805   | 10      |
| get_poes                   | 750.1     | 0.0       | 103_320 |
| ClassicalCalculator.run    | 485.5     | 803.0     | 1       |

# after
| calc_6, maxmem=305.3 GB    | time_sec  | memory_mb | counts  |
|----------------------------+-----------+-----------+---------|
| total classical            | 7_786     | 1_119     | 705     |
| cluster loop               | 4_293     | 0.0352    | 705     |
| total postclassical        | 1_130     | 0.0       | 10      |
| reading rates              | 1_129     | 0.0       | 10      |
| get_poes                   | 793.5     | 0.0       | 103_320 |
| ClassicalCalculator.run    | 454.8     | 676.3     | 1       |
```