### PR TITLE
Gzipped the _rates dataset and saved 3x the disk space in classical calculations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * gzipped the _rates dataset, saving up to 4x the disk space required in
+    classical calculations, as well as doubling the speed of the postclassical
+
   [Michele Simionato, Antonio Ettorre]
   * Upgraded numpy to version 2.2, including related dependencies such as
     pandas, pyproj, GDAL, fiona, etc
@@ -40,7 +44,6 @@
     the asce_version and vs30 parameters
 
   [Michele Simionato]
-  * Updated the related dependencies to numpy 2+  
   * Changed the Starmap to ensure at least one GB of RAM per thread
   * Extended the source_id-filtering feature to use .startswith
   * Added a flag "aggregate_exposure" (false by default) to aggregate

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -503,7 +503,7 @@ class ClassicalCalculator(base.HazardCalculator):
         self.num_chunks, _N = getters.get_num_chunks_sites(self.datastore)
         # create empty dataframes
         self.datastore.create_df(
-            '_rates', [(n, rates_dt[n]) for n in rates_dt.names])
+            '_rates', [(n, rates_dt[n]) for n in rates_dt.names], GZIP)
         self.datastore.create_dset('_rates/slice_by_idx', getters.slice_dt)
 
     def check_memory(self, N, L, maxw):


### PR DESCRIPTION
And more than doubled the speed in postclassical and reading rates. Here are the figures for half of EUR:
```
# before
 calc_89, maxmem=196.5 GB   | time_sec  | memory_mb | counts      |
|----------------------------+-----------+-----------+-------------|
| total tiling               | 1_061_424 | 851.6     | 293         |
| get_poes                   | 715_757   | 0.0       | 208_352_314 |
| computing mean_std         | 184_711   | 0.0       | 4_183_355   |
| total postclassical        | 171_703   | 151.9805  | 1_774       |
| reading rates              | 140_642   | 98.4570   | 1_774       |
| combine pmaps              | 29_528    | 0.0       | 129_838     |
| planar contexts            | 23_476    | 0.0       | 22_686_298  |
| nonplanar contexts         | 21_143    | 0.0       | 2_114_075   |
| ClassicalCalculator.run    | 11_164    | 2_311     | 1           |
Stored 76.56 GB on /home/michele/oqdata/calc_89.hdf5
#after
| calc_92, maxmem=175.7 GB   | time_sec  | memory_mb | counts      |
|----------------------------+-----------+-----------+-------------|
| total tiling               | 1_028_384 | 852.3     | 294         |
| get_poes                   | 695_190   | 0.0       | 208_472_252 |
| computing mean_std         | 194_706   | 0.0       | 4_185_275   |
| total postclassical        | 86_960    | 148.0273  | 1_774       |
| reading rates              | 56_259    | 95.1758   | 1_774       |
| combine pmaps              | 29_127    | 0.0       | 129_838     |
| planar contexts            | 25_242    | 0.0       | 24_039_544  |
| nonplanar contexts         | 13_980    | 0.0       | 2_021_057   |
| ClassicalCalculator.run    | 10_592    | 2_310     | 1           |
Stored 28.28 GB on /home/michele/oqdata/calc_89.hdf5
```