### PR TITLE
Fixed error for AELO JPN

### DIFF
--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -315,7 +315,8 @@ def notify_job_complete(job_id, notify_to, exc=None):
         logging.error(f'notify_job_complete: {notify_to=} not valid')
 
 
-def _run(jobctxs, dist, job_id, nodes, sbatch, precalc, concurrent_jobs, notify_to):
+def _run(jobctxs, dist, job_id, nodes, sbatch, precalc, concurrent_jobs,
+         notify_to):
     for job in jobctxs:
         dic = {'status': 'executing', 'pid': _PID,
                'start_time': datetime.now(UTC)}
@@ -410,7 +411,8 @@ def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False,
             for job in jobctxs:
                 logs.dbcmd('finish', job.calc_id, 'aborted')
             raise
-    _run(jobctxs, dist, job_id, nodes, sbatch, precalc, concurrent_jobs, notify_to)
+    _run(jobctxs, dist, job_id, nodes, sbatch, precalc, concurrent_jobs,
+         notify_to)
     return jobctxs
 
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -700,7 +700,8 @@ def collect_std(disaggs, Ma, D, M, G):
             zeros = sig[:, :, m, g] == 0
             if zeros.any():
                 magi, dsti = numpy.where(~zeros)
-                sig[zeros, m, g] = sig[magi[0], dsti[0], m, g]
+                if len(magi) and len(dsti):
+                    sig[zeros, m, g] = sig[magi[0], dsti[0], m, g]
     return sig
 
 


### PR DESCRIPTION
The error was
```python
  File "/home/michele/oq-engine/openquake/calculators/postproc/disagg_by_rel_sources.py", line 173, in collect_results
    std4D = disagg.collect_std(dics, shp['mag'], shp['dist'], M, G)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/hazardlib/calc/disagg.py", line 703, in collect_std
    sig[zeros, m, g] = sig[magi[0], dsti[0], m, g]                           ~~~~^^^
IndexError: index 0 is out of bounds for axis 0 with size 0
```