### PR TITLE
Removed calculation_mode=ebrisk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Removed the obsolete ebrisk calculator, since it can be replaced
+    with ground_motion_fields = false
   * Turned LSD into a primary IMT, so that the Youd and ZhangZhao GMPE
     can be used
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -366,7 +366,7 @@ def fast_add(avg_losses, row, col, data, X):
         avg_losses[r, lti, rlz] += d
 
 
-@base.calculators.add('ebrisk', 'scenario_risk', 'event_based_risk')
+@base.calculators.add('scenario_risk', 'event_based_risk')
 class EventBasedRiskCalculator(event_based.EventBasedCalculator):
     """
     Event based risk calculator generating event loss tables
@@ -374,7 +374,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
     core_task = ebrisk
     is_stochastic = True
     precalc = 'event_based'
-    accept_precalc = ['scenario', 'event_based', 'event_based_risk', 'ebrisk']
+    accept_precalc = ['scenario', 'event_based', 'event_based_risk']
 
     def save_tmp(self, monitor):
         """
@@ -415,8 +415,6 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
 
     def pre_execute(self):
         oq = self.oqparam
-        if oq.calculation_mode == 'ebrisk':
-            oq.ground_motion_fields = False
         parent = self.datastore.parent
         if parent:
             self.datastore['full_lt'] = parent['full_lt']
@@ -499,7 +497,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         """
         oq = self.oqparam
         self.gmf_bytes = 0
-        if oq.calculation_mode == 'ebrisk' or 'gmf_data' not in self.datastore:
+        if not oq.ground_motion_fields or 'gmf_data' not in self.datastore:
             # start from ruptures
             if (oq.ground_motion_fields and
                     'gsim_logic_tree' not in oq.inputs and

--- a/openquake/qa_tests_data/event_based_risk/case_1f/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_1f/job.ini
@@ -1,6 +1,6 @@
 [general]
 description = ebrisk
-calculation_mode = ebrisk
+calculation_mode = event_based_risk
 master_seed = 42
 
 [boundaries]
@@ -41,4 +41,4 @@ maximum_distance = 200.0
 investigation_time = 1
 number_of_logic_tree_samples = 0
 ses_per_logic_tree_path = 200
-ground_motion_fields = true
+ground_motion_fields = false

--- a/openquake/qa_tests_data/event_based_risk/case_6c/job_eb.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_6c/job_eb.ini
@@ -1,6 +1,6 @@
 [general]
 description = ebrisk with aggregation by NAME_1
-calculation_mode = ebrisk
+calculation_mode = event_based_risk
 exposure_file = exposure_model.xml
 aggregate_by = NAME_1
 
@@ -33,3 +33,4 @@ investigation_time = 1
 number_of_logic_tree_samples = 0
 ses_per_logic_tree_path = 2000
 conditional_loss_poes = .01
+ground_motion_fields = false

--- a/openquake/qa_tests_data/event_based_risk/case_miriam/job.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_miriam/job.ini
@@ -1,7 +1,7 @@
 [general]
 
 description = Virtual Island - City C, 2 SES, grid=0.1
-calculation_mode = ebrisk
+calculation_mode = event_based_risk
 random_seed = 1024
 ignore_master_seed = true
 
@@ -52,7 +52,7 @@ ses_per_logic_tree_path = 2
 export_dir = /tmp
 # post-process ground motion fields into hazard curves,
 # given the specified `intensity_measure_types_and_levels`
-hazard_curves_from_gmfs = false
+ground_motion_fields = false
 mean = false
 # quantiles = 0.15, 0.5, 0.85
 poes = 0.1, 0.01, 0.02

--- a/openquake/qa_tests_data/event_based_risk/case_miriam/job3.ini
+++ b/openquake/qa_tests_data/event_based_risk/case_miriam/job3.ini
@@ -1,7 +1,8 @@
 [general]
 
 description = Virtual Island Risk with amplification
-calculation_mode = ebrisk
+calculation_mode = event_based_risk
+ground_motion_fields = false
 
 [calculation]
 


### PR DESCRIPTION
But kept the functionality, by simply specifying `ground_motion_fields=false`. Part of https://github.com/gem/oq-engine/issues/10938.