### PR TITLE
remove patchelf on onnxruntime libraries for debian 13 and py 3.11 (an updated system doesn't required the fix)

### DIFF
--- a/install.py
+++ b/install.py
@@ -501,24 +501,6 @@ def install(inst, version, from_fork):
     else:
         oqreal = "%s/bin/oq" % inst.VENV
 
-    if sys.platform == 'linux':
-        try:
-            os_info = platform.freedesktop_os_release()
-            if (sys.version_info[:2] == (3, 11) and
-                os_info['ID'] == 'debian' and
-                os_info['VERSION_ID'] == '13'):
-                print("Fix for python 3.11 and Debian 13")
-                patchelf_ret, _ = subprocess.getstatusoutput('patchelf --help')
-                if patchelf_ret != 0:
-                    sys.exit("'patchelf' command not found, please install it and"
-                             " run engine installation again")
-
-                subprocess.run([os.environ['SHELL'], '-c', 'patchelf --clear-execstack'
-                                ' %s/lib/python3.11/site-packages/onnxruntime'
-                                '/capi/*.so' % inst.VENV])
-        except OSError:
-            print("INFO: linux distribution not detected.")
-
     print("Compiling python/numba modules")
     subprocess.run([oqreal, "--version"])  # compile numba
 


### PR DESCRIPTION
remove patchelf on onnxruntime libraries for debian 13 and py 3.11 (an updated system doesn't required the fix)