### PR TITLE
Added method `SiteCollection.lower_res`

### DIFF
--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -334,6 +334,7 @@ def split_source(src):
 def close_ruptures(ruptures, sites, dist=800.):
     """
     :returns: array of ruptures close to the sites
+    """
     hypos = ruptures['hypo']
     kr = KDTree(spherical_to_cartesian(hypos[:, 0], hypos[:, 1], hypos[:, 2]))
     ks = KDTree(spherical_to_cartesian(sites.lons, sites.lats, sites.depths))

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -902,7 +902,7 @@ class SiteCollection(object):
                  for lon, lat in zip(self.lons, self.lats)}
         latlons = F32([h3_to_geo(h) for h in hexes])  # shape (N, 2)
         return self.from_points(latlons[:, 1], latlons[:, 0])
-        
+
     def geohash(self, length):
         """
         :param length: length of the geohash in the range 1..8

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -162,7 +162,7 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
             SiteCollection.from_points(
                 lons, lats, None, SiteModelParam(), req_params)
 
-        
+
 class SiteCollectionFilterTestCase(unittest.TestCase):
     SITES = SiteCollection([
         Site(location=Point(10, 20, 30), vs30=1.2, vs30measured=True,
@@ -254,7 +254,7 @@ class SiteCollectionFilterTestCase(unittest.TestCase):
         small = self.SITES.lower_res()
         self.assertEqual(len(small), 3)
 
-        
+
 class WithinBBoxTestCase(unittest.TestCase):
     # to understand this test case it is ESSENTIAL to plot sites and
     # bounding boxes; the code in plot_sites.py can get you started


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/10938. The idea is to reduce the sitecol so that the prefiltering of the ruptures can be made fast.