### PR TITLE
Removing Arbitrary Arteta2023 Crustal GMM  Typos

### DIFF
--- a/openquake/hazardlib/gsim/arteta_2023.py
+++ b/openquake/hazardlib/gsim/arteta_2023.py
@@ -41,8 +41,7 @@ def _get_stddevs(C):
 
 def _compute_base_term(C):
     """
-    Returns the base coefficient of the GMPE, which for interface-overlying
-    events is just the coefficient a1 (adjusted regionally)
+    Returns the base coefficient of the GMPE.
     """
     return C["Tetha1"]
 


### PR DESCRIPTION
The GMM's required parameters section has (arbitrary but incorrect) references to subduction interface (e.g. the comment above `DEFINED_FOR_TECTONIC_REGION_TYPE` says this GMM was developed for says subduction interface, but it is defined for ASCR, and the comment above `REQUIRES_RUPTURE_PARAMETERS` is not consistent with the parameters specified).