### PR TITLE
IMPACT: add `No uncertainty` checkbox setting `truncation_level=0` and `number_of_ground_motion_fields=1`

### DIFF
--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -152,6 +152,7 @@ IMPACT_FORM_LABELS = {
     'nodal_plane': 'Nodal plane',
     'msr': 'Magnitude scaling relationship',
     'description': 'Description',
+    'no_uncertainty': 'No uncertainty',
 }
 
 IMPACT_FORM_PLACEHOLDERS = {

--- a/openquake/server/static/js/engine.js
+++ b/openquake/server/static/js/engine.js
@@ -586,6 +586,7 @@ function capitalizeFirstLetter(val) {
             $select.empty();
         }
         $('#time_event').val(impact_form_defaults['time_event']);
+        $('#no_uncertainty').prop('checked', false);
         $('#rupture-map').hide();
         $('#shakemap-image-row').hide();
     }
@@ -854,6 +855,29 @@ function capitalizeFirstLetter(val) {
                         $('input[name="impact_approach"]').prop('disabled', false);
                         set_retrieve_data_btn_txt('initial');
                     });
+                }
+            });
+
+            $('input#no_uncertainty').on('change', function() {
+                if ($(this).is(':checked')) {
+                    $('#number_of_ground_motion_fields').val('1');
+                    $('#truncation_level').val('0')
+                } else {
+                    $('#number_of_ground_motion_fields').val(
+                        impact_form_defaults.number_of_ground_motion_fields);
+                    $('#truncation_level').val(impact_form_defaults.truncation_level)
+                }
+            });
+
+            $('input#number_of_ground_motion_fields').on('input', function() {
+                if ($(this).val() != '1') {
+                    $('input#no_uncertainty').prop('checked', false);
+                }
+            });
+
+            $('input#truncation_level').on('input', function() {
+                if ($(this).val() != '0') {
+                    $('input#no_uncertainty').prop('checked', false);
                 }
             });
 

--- a/openquake/server/templates/engine/includes/impact_run_form.html
+++ b/openquake/server/templates/engine/includes/impact_run_form.html
@@ -21,6 +21,9 @@
                     <option value="transit">Transit</option>
                 </select>
               </div>
+              <div class="impact_form_row impact_time_grp">
+                <label class="impact_time_grp" for"no_uncertainty"><input type="checkbox" id="no_uncertainty" value="no" class="impact_time_grp"> {{ impact_form_labels.no_uncertainty }}</label>
+              </div>
               <div class="impact_form_row">
                 <label for"maximum_distance">{{ impact_form_labels.maximum_distance }}</label>
                 <input class="impact-input" type="text" id="maximum_distance" name="maximum_distance" placeholder="{{ impact_form_placeholders.maximum_distance }}" value="{{ impact_form_defaults.maximum_distance }}" {% if user_level < 2 %}disabled{% endif %}/>


### PR DESCRIPTION
The new checkbox is visible to level 1 and level 2 users.
For the sake of consistency, if either `truncation_level` or `number_of_ground_motion_fields` is edited by the user to a different value with respect to the one set when checking the `No uncertainty` checkbox, the checkbox becomes automatically unchecked.

@VSilva is it ok to have this checkbox available for all workflows?