### PR TITLE
Refined weight for ebrisk calculations

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -70,7 +70,7 @@ def rup_weight(rup):
     # rup['nsites'] is 0 if the ruptures were generated without a sitecol
     # NB: if there was an assetcol, nsites is actually the number of affected
     # assets, as set by close_ruptures
-    return 1 + rup['nsites'] // 100
+    return rup['n_occ'] * (1 + rup['nsites'] // 1000)
 
 # ######################## hcurves_from_gmfs ############################ #
 


### PR DESCRIPTION
Here is the improvement for Timor_Lest on the risk-ci machine (3x for the slowest task):
```
# before/after
| operation-duration | counts |    mean | stddev |     min |      max | slowfac |
|--------------------+--------+---------+--------+---------+----------+---------|
| ebrisk             |    127 | 23.7643 |    63% |  5.2484 | 125.1969 |  5.2683 |
| ebrisk             |    126 | 23.4448 |    23% | 13.4245 |  43.5761 |  1.8587 |
```
The improvement is huge even for Indonesia:
```
| operation-duration | counts | mean  | stddev | min     | max   | slowfac |
|--------------------+--------+-------+--------+---------+-------+---------|
| ebrisk             | 385    | 420.6 | 27%    | 61.1708 | 719.4 | 1.7104  |
```
Part of https://github.com/gem/oq-engine/issues/10938.