### PR TITLE
Reduced the data transfer in event based (sitecol)

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -248,7 +248,7 @@ def _event_based(proxies, cmaker, stations, srcfilter, shr,
     return dic
 
 
-def event_based(rups, cmaker, sitecol, stations, hdf5path, monitor):
+def event_based(rups, cmaker, sids, stations, hdf5path, monitor):
     """
     Compute GMFs and optionally hazard curves
     """
@@ -260,7 +260,12 @@ def event_based(rups, cmaker, sitecol, stations, hdf5path, monitor):
     umon = monitor('updating gmfs', measuremem=False)
     cmaker.scenario = 'scenario' in oq.calculation_mode
     with rmon:
-        sites = sitecol if stations[0] is None else sitecol.complete
+        with hdf5.File(hdf5path) as f:
+            try:
+                complete = f['complete']  # the current dstore
+            except KeyError:
+                complete = f['sitecol']  # the parent dstore
+        sites = complete.filtered(sids) if stations[0] is None else complete
         srcfilter = SourceFilter(sites, oq.maximum_distance(cmaker.trt))
         proxies = get_proxies(hdf5path, rups)
     for block in block_splitter(proxies, 20_000, rup_weight):
@@ -355,7 +360,8 @@ def get_rups_args(oq, sitecol, assetcol, station_data_sites,
         logging.info('%s: sending %d ruptures for trt_smr=%d',
                      model, len(rups), trt_smr)
         for block in block_splitter(rups, maxw * 1.02, rup_weight):
-            args = (block, cmaker, sitecol, station_data_sites, dstore.filename)
+            args = (block, cmaker, sitecol.sids, station_data_sites,
+                    dstore.filename)
             allargs.append(args)
     for trt, mags in oq.mags_by_trt.items():
         oq.mags_by_trt[trt] = sorted(mags)
@@ -511,7 +517,7 @@ class EventBasedCalculator(base.HazardCalculator):
     """
     core_task = event_based
     is_stochastic = True
-    accept_precalc = ['event_based', 'ebrisk', 'event_based_risk']
+    accept_precalc = ['event_based', 'event_based_risk']
 
     def init(self):
         if self.oqparam.cross_correl.__class__.__name__ == 'GodaAtkinson2009':

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -325,7 +325,7 @@ def _expand3(arrayN3, maxsize):
     return U32(out)
 
 
-def ebrisk(rups, cmaker, sitecol, stations, dstore, monitor):
+def ebrisk(rups, cmaker, sids, stations, dstore, monitor):
     """
     :param rups: list of ruptures with the same trt_smr
     :param cmaker: ContextMaker instance associated to the trt_smr
@@ -346,7 +346,7 @@ def ebrisk(rups, cmaker, sitecol, stations, dstore, monitor):
     assdic = read_assdic(slice(None), monitor)
     for block in general.block_splitter(rups, 20_000, event_based.rup_weight):
         for dic in event_based.event_based(
-                block, cmaker, sitecol, stations, dstore, monitor):
+                block, cmaker, sids, stations, dstore, monitor):
             if len(dic['gmfdata']):
                 gmf_df = pandas.DataFrame(dic['gmfdata'])
                 loss3 = {'aids': [], 'bids': [], 'loss': []}


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/10938. Here are the figures for Timor_Lest on piaf:
```
# before/after
| task            | sent                                                | received  |
|-----------------+-----------------------------------------------------+-----------|
| ebrisk          | sitecol=7.54 GB cmaker=3.24 MB rups=1.61 MB         | 299.44 MB |
| ebrisk          | cmaker=3.24 MB sids=2.73 MB rups=1.61 MB            | 299.44 MB |
```
Notice the reduction factor of 2828 (!) when transferring `sids` instead of the `sitecol`.
We are also faster and use less memory:
```
# before
| calc_786, maxmem=59.4 GB     | time_sec  | memory_mb | counts |
|------------------------------+-----------+-----------+--------|
| total ebrisk                 | 1_551     | 210.3     | 128    |
| computing risk               | 786.4     | 0.0       | 5_203  |
| reading crmodel              | 326.1     | 179.6250  | 128    |
| aggregating losses           | 241.1     | 46.3984   | 128    |
| EventBasedRiskCalculator.run | 111.3421  | 312.1     | 1      |

# after
| calc_787, maxmem=55.9 GB     | time_sec  | memory_mb | counts |
|------------------------------+-----------+-----------+--------|
| total ebrisk                 | 1_976     | 284.1     | 128    |
| computing risk               | 791.3     | 0.0       | 5_203  |
| reading sites and ruptures   | 345.1     | 68.1562   | 128    |
| reading crmodel              | 341.9     | 188.0     | 128    |
| aggregating losses           | 251.6     | 45.0039   | 128    |
| EventBasedRiskCalculator.run | 94.9305   | 362.4     | 1      |
```