### PR TITLE
Add Django setting `ALLOW_DATASTORE_DOWNLOAD = True` by default

### DIFF
--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -144,6 +144,8 @@ LOCKDOWN = False
 # Forbid users to see other users outputs by default
 ACL_ON = True
 
+ALLOW_DATASTORE_DOWNLOAD = True
+
 # Add additional paths (as regular expressions) that don't require
 # authentication.
 AUTH_EXEMPT_URLS = ()

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1751,7 +1751,7 @@ def calc_datastore(request, job_id):
         of the requested artifact, if present, else throws a 404
     """
     user_level = get_user_level(request)
-    if user_level < 2:
+    if user_level < 2 and not settings.ALLOW_DATASTORE_DOWNLOAD:
         return HttpResponseForbidden()
     job = logs.dbcmd('get_job', int(job_id))
     if job is None or not os.path.exists(job.ds_calc_dir + '.hdf5'):


### PR DESCRIPTION
 Level < 2 users can not download the datastore if it is False

NOTE: we need to backport this also to engine-3.24. We also need to set ALLOW_DATASTORE_DOWNLOAD = False in the impact services