### PR TITLE
Extended `csm.get_sources` to accept an `smr` index

### DIFF
--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -172,17 +172,18 @@ class LogicTreeTestCase(CalculatorTestCase):
             self.assertEqualFiles('expected/' + strip_calc_id(fname), fname,
                                   delta=1E-5)
 
-        # test csm.iter_sources and csm.iter_ruptures
-        csm = self.calc.datastore['_csm']
-        smr0, smr1, smr2 = self.calc.full_lt.sm_rlzs
-        source_ids = [src.source_id for src in csm.iter_sources()]
-        assert source_ids == ['2', '1', '3']
+        # test csm.get_sources; there are 3 source model realizations
+        fname = general.gettemp(view('sm_rlzs', self.calc.datastore))
+        self.assertEqualFiles('expected/sm_rlzs.org', fname)
 
-        n0 = sum(1 for rup in csm.iter_ruptures(smr=0))
-        n1 = sum(1 for rup in csm.iter_ruptures(smr=1))
-        n2 = sum(1 for rup in csm.iter_ruptures(smr=2))
-        n = sum(1 for rup in csm.iter_ruptures())
-        assert n0 + n1 + n2 > n  # the same source appears in two sm_rlzs
+        csm = self.calc.datastore['_csm']
+        source_ids = [src.source_id for src in csm.get_sources(0)]
+        assert source_ids == ['2', '1']
+        source_ids = [src.source_id for src in csm.get_sources(1)]
+        assert source_ids == ['1']
+        source_ids = [src.source_id for src in csm.get_sources(2)]
+        assert source_ids == ['3']
+        # NB: the same source '1' appears in two sm_rlzs
 
     def test_case_08(self):
         self.assert_curves_ok(

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -1441,6 +1441,18 @@ def view_branchsets(token, dstore):
     return text_table(enumerate(map(repr, clt.branchsets)),
                       header=['bsno', 'bset'], ext='org')
 
+@view.add('sm_rlzs')
+def view_sm_rlzs(token, dstore):
+    """
+    Show the source model realizations
+    """
+    sm_rlzs = dstore['full_lt'].sm_rlzs
+    header = ['ordinal', 'lt_path', 'value', 'samples', 'weight']
+    def row(rlz):
+        return (rlz.ordinal, '_'.join(rlz.lt_path),
+                rlz.value, rlz.samples, rlz.weight)
+    return text_table(map(row, sm_rlzs), header, ext='org')
+
 
 @view.add('rupture')
 def view_rupture(token, dstore):

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -595,27 +595,20 @@ class CompositeSourceModel:
                     source_id = basename(src)
                     self.code[source_id] = src.code
 
-    def iter_sources(self, smr=None):
+    def get_sources(self, smr=None):
         """
         :param smr:
             yields only the sources associated to the given source model
             realization, or all realizations if smr is None (the default).
         """
+        srcs = []
         for grp in self.src_groups:
             if smr is not None:
                 keep = any(trt_smr % TWO24 == smr for trt_smr in grp.trt_smrs)
                 if not keep:
                     continue
-            yield from grp
-
-    def iter_ruptures(self, smr=None):
-        """
-        :param smr:
-            yields only the ruptures associated to the given source model
-            realization, or all realizations if smr is None (the default).
-        """
-        for src in self.iter_sources(smr):
-            yield from src.iter_ruptures()
+            srcs.extend(grp)
+        return srcs
 
     def get_trt_smrs(self):
         """
@@ -626,23 +619,11 @@ class CompositeSourceModel:
         return [numpy.array(trt_smrs, numpy.uint32) for trt_smrs in keys]
 
     def get_cmakers(self, oq):
+        """
+        :param oq: the OqParam used to build the CompositeSourceModel
+        :returns: a ContextMakerSequence instance
+        """
         return get_cmakers(self.get_trt_smrs(), self.full_lt, oq)
-
-    def get_sources(self, atomic=None):
-        """
-        There are 3 options:
-
-        atomic == None => return all the sources (default)
-        atomic == True => return all the sources in atomic groups
-        atomic == True => return all the sources not in atomic groups
-        """
-        srcs = []
-        for src_group in self.src_groups:
-            if atomic is None:  # get all sources
-                srcs.extend(src_group)
-            elif atomic == src_group.atomic:
-                srcs.extend(src_group)
-        return srcs
 
     def get_basenames(self):
         """

--- a/openquake/qa_tests_data/logictree/case_07/expected/sm_rlzs.org
+++ b/openquake/qa_tests_data/logictree/case_07/expected/sm_rlzs.org
@@ -1,0 +1,5 @@
+| ordinal | lt_path | value                  | samples | weight |
+|---------+---------+------------------------+---------+--------|
+| 0       | b1      | ['source_model_1.xml'] | 402     | 0.4020 |
+| 1       | b2      | ['source_model_2.xml'] | 283     | 0.2830 |
+| 2       | b3      | ['source_model_3.xml'] | 315     | 0.3150 |


### PR DESCRIPTION
Useful for @mmpagani . The source model realizations can be extracted from `full_lt.sm_rlzs`. For instance in the test
```python
(Pdb) self.calc.datastore['full_lt'].sm_rlzs
[<Realization #0 b"['source_model_1.xml']", path=b1, weight=0.402, samples=402>,
 <Realization #1 b"['source_model_2.xml']", path=b2, weight=0.283, samples=283>,
 <Realization #2 b"['source_model_3.xml']", path=b3, weight=0.315, samples=315>]
```