### PR TITLE
Added a method `CompositeSourceModel.set_msparams`

### DIFF
--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -797,6 +797,18 @@ class ClassicalTestCase(CalculatorTestCase):
         # test preclassical without sites, as requested by Richard Styron
         self.run_calc(case_75.__file__, 'pre.ini')
 
+        # reset .msparams to emulate reading csm without preclassical
+        for src in self.calc.csm.get_sources():
+            if src.code == b'F':
+                delattr(src, 'msparams')
+        self.calc.csm.set_msparams()
+
+        # count the ruptures
+        nrup = 0
+        for src in self.calc.csm.get_sources():
+            nrup += sum(1 for rup in src.iter_ruptures())
+        self.assertEqual(nrup, 5)
+
     def test_case_76(self):
         # CanadaSHM6 GMPEs
         self.run_calc(case_76.__file__, 'job.ini')

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -708,6 +708,19 @@ class CompositeSourceModel:
                 # print(src, src.offset, offset)
             src_id += 1
 
+    def set_msparams(self):
+        """
+        Set the `.msparams` attribute on multifault sources, if any
+        """
+        for src in self.get_sources():
+            if src.code == b'F':
+                with hdf5.File(src.hdf5path, 'r') as h5:
+                    secparams = h5['secparams'][:]
+                break
+        for src in self.get_sources():
+            if src.code == b'F':
+                src.set_msparams(secparams)
+
     def get_msr_by_grp(self):
         """
         :returns: a dictionary grp_id -> MSR string


### PR DESCRIPTION
For @mmpagani . If the source model has multi fault sources, you must call `csm.set_msparams()` before calling `.iter_ruptures`. The method is not called automatically because if you want to call `.sample_ruptures` and not `.iter_ruptures`, then there is no need to call `set_msparams`, it would be a waste to call it always. If you read the composite source model from the datastore of a classical calculation, the `.msparams` are already set.