### PR TITLE
Removed misleading "Could not extract extreme GMVs for"

### DIFF
--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -955,7 +955,7 @@ def view_extreme_gmvs(token, dstore):
             if ':' in token:
                 msg = str(exdf.set_index('rup'))
         return msg
-    return msg + '\nCould not extract extreme GMVs for ' + imt0
+    return msg
 
 
 @view.add('mean_rates')


### PR DESCRIPTION
It was happening for the liquefaction demo, talking about "PGV", while the message was meant for "PGA" and "SA".