### PR TITLE
Moved incorrect Nepal and UTF8 location description from AreaSource demo

### DIFF
--- a/demos/hazard/AreaSourceClassicalPSHA/job.ini
+++ b/demos/hazard/AreaSourceClassicalPSHA/job.ini
@@ -1,6 +1,6 @@
 [general]
 
-description = Classical PSHA Area Source demo for Nepal नेपाल
+description = Classical PSHA Area Source demo for Null Island
 calculation_mode = classical
 
 [geometry]

--- a/demos/risk/ScenarioDamage/job_hazard.ini
+++ b/demos/risk/ScenarioDamage/job_hazard.ini
@@ -1,5 +1,5 @@
 [general]
-description = Scenario Hazard Demo (Nepal)
+description = Scenario Hazard Demo (Nepal नेपाल)
 calculation_mode = scenario
 ses_seed = 42
 

--- a/demos/risk/ScenarioDamage/job_risk.ini
+++ b/demos/risk/ScenarioDamage/job_risk.ini
@@ -1,5 +1,5 @@
 [general]
-description = Scenario Damage and Consequences Demo (Nepal)
+description = Scenario Damage and Consequences Demo (Nepal नेपाल)
 calculation_mode = scenario_damage
 
 [boundaries]


### PR DESCRIPTION
Moved incorrect Nepal and UTF8 location description from AreaSource demo to ScenarioDamage
AreaSource demo is in Null Island (0,0) so description was misleading.
ScenarioDamage demo really is in Nepal, so moved the description there (hazard and risk job ini files)