### PR TITLE
Removed puzzling ipt test

### DIFF
--- a/openquake/server/tests/test_public_mode.py
+++ b/openquake/server/tests/test_public_mode.py
@@ -390,10 +390,6 @@ class EngineServerPublicModeTestCase(EngineServerTestCase):
             resp_text_dict = json.loads(resp.content.decode('utf8'))
             self.assertFalse(resp_text_dict['success'])
 
-    def test_ipt_is_accessible(self):
-        resp = self.c.post('/ipt/')
-        self.assertEqual(resp.status_code, 200)
-
 
 @override_settings(ROOT_URLCONF='openquake.server.tests.test_urls')
 class CallbackTest(LiveServerTestCase):


### PR DESCRIPTION
There is an action by Antonio checking that IPT is up, anyway. It is unclear under which conditions the test cause the error
```python
 File "/home/michele/openquake/lib64/python3.12/site-packages/openquakeplatform_ipt/views.py", line 606, in _get_available_gsims
    ret = requests.get('%sv1/available_gsims' % WEBUIURL)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/openquake/lib64/python3.12/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/openquake/lib64/python3.12/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/openquake/lib64/python3.12/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/openquake/lib64/python3.12/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/openquake/lib64/python3.12/site-packages/requests/adapters.py", line 519, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=8800): Max retries exceeded with url: /v1/available_gsims (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fe719ad1760>: Failed to establish a new connection: [Errno 111] Connection refused'))
```
It is not urgent to investigate, so we can just drop the test.