### PR TITLE
Removed confirmation before upgrading the db

### DIFF
--- a/openquake/commands/engine.py
+++ b/openquake/commands/engine.py
@@ -126,7 +126,6 @@ def main(
     if host == '127.0.0.1' and getpass.getuser() != 'openquake':  # no DbServer
         if not os.path.exists(fname):
             upgrade_db = True  # automatically creates the db
-            yes = True
     else:  # DbServer yes
         print(f'Using the DbServer on {host}')
         dbserver.ensure_on()
@@ -139,7 +138,7 @@ def main(
         msg = logs.dbcmd('what_if_I_upgrade', 'read_scripts')
         if msg.startswith('Your database is already updated'):
             pass
-        elif yes or confirm('Proceed? (y/n) '):
+        else:
             logs.dbcmd('upgrade_db')
         if not run:
             sys.exit(0)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/11035. Asking for confirmation was breaking the tests and was a bad idea since if the user has upgraded the engine, he wants to upgrade the db, otherwise nothing would work, there is no point in asking for confirmation. Also, he has to give the command ``--upgrade-db`` anyway in server installations, so the intent is clear. In over 10 years we never broke the database, the changes were always safe additions and there are no reason to suspect the situation will change.