### PR TITLE
Prevent conversion for non-supported IMTs in conversion to geometric mean

### DIFF
--- a/openquake/hazardlib/const.py
+++ b/openquake/hazardlib/const.py
@@ -137,15 +137,15 @@ def apply_conversion(imc, imt):
     """
     C = COEFF[imc]
     C_PGA_PGV = COEFF_PGA_PGV[imc]
-    if imt.string == 'PGA':
+    if imt.name == 'PGA':
         conv_median = C_PGA_PGV[0]
         conv_sigma = C_PGA_PGV[1]
         rstd = C_PGA_PGV[2]
-    elif imt.string == 'PGV':
+    elif imt.name == 'PGV':
         conv_median = C_PGA_PGV[3]
         conv_sigma = C_PGA_PGV[4]
         rstd = C_PGA_PGV[5]
-    else:
+    elif imt.name == "SA":
         T = imt.period
         if imc.name in ('RotD50', 'GREATER_OF_TWO_HORIZONTAL'):
             term1 = C[1] + (C[3]-C[1]) / np.log(C[2]/C[0]) * np.log(T/C[0])
@@ -170,6 +170,11 @@ def apply_conversion(imc, imt):
                 conv_sigma = (C[2] + (C[3]-C[2]) *
                               np.log10(T/0.15) / np.log10(0.8/0.15))
             rstd = C[4]
+    else:
+        conv_median = 1
+        conv_sigma = 0
+        rstd = 1
+    
     return conv_median, conv_sigma, rstd
 
 


### PR DESCRIPTION
Currently the conversion to geometric mean code is applied to all IMTs, whereas it should only be applied to those supported by the relationships currently available in the engine (we use a combination of Beyes and Bommer 2006 and Boore and Kishida 2017, which collectively support PGA, PGV and SA).

This was noticed in the QA tests for a conditional GMPE predicting Arias Intensity (IA), the conversion was still being applied and resulting in divide by zero warnings.