### PR TITLE
Fixed ilabel weights in map_getters

### DIFF
--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -202,7 +202,7 @@ def map_getters(dstore, full_lt=None, disagg=False):
             flt.__dict__.update(attrs)
             flt.gsim_lt = dstore['gsim_lt' + label]
             flt.init()
-            weights.append(full_lt.weights)
+            weights.append(flt.weights)
     fnames = [dstore.filename]
     try:
         scratch_dir = dstore.hdf5.attrs['scratch_dir']


### PR DESCRIPTION
It was a typo :-(
This took me and Kendra days of debugging, the weights management is too complicated and must be refactored.
Also, the `fastmean` algorithm does not work with ilabels yet.
Part of https://github.com/gem/oq-engine/issues/11032