### PR TITLE
Optimized store_rates

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -84,6 +84,7 @@ def _store(rates, num_chunks, h5, mon=None, gzip=GZIP):
         data['rate'].append(ch_rates['rate'])
         idx_start_stop.append((chunk, offset, offset + n))
         offset += n
+    iss = numpy.array(idx_start_stop, getters.slice_dt)
     for key in data:
         dt = data[key][0].dtype
         data[key] = numpy.concatenate(data[key], dtype=dt)
@@ -91,7 +92,6 @@ def _store(rates, num_chunks, h5, mon=None, gzip=GZIP):
     hdf5.extend(h5['_rates/gid'], data['gid'])
     hdf5.extend(h5['_rates/lid'], data['lid'])
     hdf5.extend(h5['_rates/rate'], data['rate'])
-    iss = numpy.array(idx_start_stop, getters.slice_dt)
     hdf5.extend(h5['_rates/slice_by_idx'], iss)
     if newh5:
         fname = h5.filename


### PR DESCRIPTION
By performing fewer large operations on the HDF5 file. Here is the improvement for EUR in the slow tasks CI job:
```
# before/after
EUR#5388: 0 slow tasks, slow_factor=2.6, tot_duration=1808.3
EUR#5459: 0 slow tasks, slow_factor=2.5, tot_duration=1540.5
```
We saved 4.5 minutes, i.e. 15% of the total time, a lot.