### PR TITLE
Slightly different task splitting

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -214,7 +214,8 @@ def classical(grp_keys, tilegetter, cmaker, dstore, monitor):
         result['rmap'] = result['rmap'].to_array(cmaker.gid)
         yield result
     elif len(grps) == 1 and len(grps[0]) >= 3:
-        b0, b1, *blks = split_in_blocks(list(grps[0]), 8)
+        # tested in case_66
+        b0, *blks = split_in_blocks(list(grps[0]), 8)
         t0 = time.time()
         res = hazclassical(b0, sites, cmaker, True)
         dt = time.time() - t0
@@ -222,11 +223,8 @@ def classical(grp_keys, tilegetter, cmaker, dstore, monitor):
         if dt > cmaker.oq.time_per_task:
             for blk in blks:
                 yield hazclassical, blk, sites, cmaker, True
-            yield hazclassical(b1, sites, cmaker, True)
         else:
-            for blk in blks:
-                b1.extend(blk)
-            yield hazclassical(b1, sites, cmaker, True)
+            yield hazclassical(sum(blks, []), sites, cmaker, True)
     else:
         yield hazclassical(grps, sites, cmaker, True)
 

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -765,7 +765,8 @@ class ClassicalTestCase(CalculatorTestCase):
         # check that you can specify both a site and a site model and the
         # engine will automatically get the closest site model parameters
         self.run_calc(case_66.__file__, 'job1.ini',
-                      calculation_mode='preclassical')
+                      calculation_mode='preclassical',
+                      time_per_task='0')
         self.assertEqual(self.calc.sitecol.vs30, [810.])
 
     def test_case_67(self):


### PR DESCRIPTION
This reduces the data transfer and improves the speed. Here are the figures for SAM 3%:
```
# before
| calc_6600, maxmem=159.1 GB | time_sec  | memory_mb | counts    |
|----------------------------+-----------+-----------+-----------|
| total classical            | 42_038    | 85.2930   | 679       |
| get_poes                   | 38_681    | 0.0       | 6_731_012 |
| total hazclassical         | 18_455    | 146.7344  | 300       |
| computing mean_std         | 11_318    | 0.0       | 136_271   |
| ClassicalCalculator.run    | 551.2     | 3_892     | 1         |

# after
| calc_6639, maxmem=160.1 GB | time_sec  | memory_mb | counts    |
|----------------------------+-----------+-----------+-----------|
| total classical            | 42_258    | 64.8438   | 685       |
| get_poes                   | 41_016    | 0.0       | 7_088_637 |
| total hazclassical         | 21_855    | 157.7266  | 336       |
| computing mean_std         | 12_031    | 0.0       | 143_482   |
| ClassicalCalculator.run    | 512.5     | 3_677     | 1         |

# before
| task          | sent                                              | received |
|---------------+---------------------------------------------------+----------|
| classical     | cmaker=1.2 GB tilegetter=34.88 KB dstore=30.96 KB | 15.31 GB |
| hazclassical  | cmaker=2.64 GB sites=106.79 MB grp=41.39 MB       | 10.13 GB |

# after
| task          | sent                                                  | received |
|---------------+-------------------------------------------------------+----------|
| classical     | cmaker=1.25 GB tilegetter=36.52 KB dstore=32.42 KB    | 14.21 GB |
| hazclassical  | cmaker=2.96 GB sites=119.61 MB grp=51.81 MB           | 10.8 GB  |
```