### PR TITLE
IMPACT: Fix UI in case a rupture location is not covered by any mosaic model

### DIFF
--- a/openquake/hazardlib/shakemap/validate.py
+++ b/openquake/hazardlib/shakemap/validate.py
@@ -361,7 +361,12 @@ def impact_validate(POST, user, rupture_file=None, station_data_file=None,
     expo = getattr(AristotleParam, 'exposure_hdf5',
                    os.path.join(MOSAIC_DIR, 'exposure.hdf5'))
     with monitor('get_close_mosaic_models'):
-        mosaic_models = get_close_mosaic_models(rupdic['lon'], rupdic['lat'], 5)
+        try:
+            mosaic_models = get_close_mosaic_models(rupdic['lon'], rupdic['lat'], 5)
+        except ValueError as exc:
+            # e.g. '(-139.0, 35.0) is farther than 5 deg from any mosaic model!'
+            err = {"status": "failed", "error_msg": str(exc)}
+            return rup, rupdic, params, err
     for mosaic_model in mosaic_models:
         trts[mosaic_model] = get_trts_around(mosaic_model, expo)
     rupdic['trts'] = trts


### PR DESCRIPTION
The fact that the coordinates were not covered by any mosaic model appeared in the logs but it was not shown in the user interface (and the user can not see the logs). The button to build the rupture remained in an inconsistent state.
After this fix, the error is presented to the user and the initial state of the button is restored.

<img width="949" height="593" alt="image" src="https://github.com/user-attachments/assets/62f36937-6d5d-487b-a284-89c50d9d1e3f" />
