### PR TITLE
Fixed New Zealand

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -431,7 +431,7 @@ def _get_ctx_planar(cmaker, builder, mag, mrate, magi, planar, sites,
         # into predetermined shape of probs_occur
         # NB: in case_79 zeroctx['probs_occur'] has shape (2, 1, 10)
         # where (2, 1) = (len(planar), len(sites))
-        pmf = tom.get_pmf(planar.wlr[:, 2] * mrate).T
+        pmf = tom.get_pmf(planar.wlr[:, 2] * mrate)
         zeroctx['probs_occur'] = pmf[:, numpy.newaxis, :]
 
     return zeroctx.flatten()  # shape N*U

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -334,8 +334,7 @@ class NegativeBinomialTOM(BaseTOM):
         theta = tau / (tau + mean_rate * self.time_span)
         if isinstance(theta, numpy.ndarray):
             theta = theta[:, numpy.newaxis]  # shape (n, 1)
-        pmf = scipy.stats.nbinom.pmf(self.x, tau, theta).T
-        # shape (n_max,) if mean_rate is maxrate, else shape (n_max, n)
+        pmf = scipy.stats.nbinom.pmf(self.x, tau, theta)
         return pmf
 
     def get_probability_no_exceedance(self, mean_rate, poes):


### PR DESCRIPTION
Broken by https://github.com/gem/oq-engine/pull/11193 with error
```python
  File "/home/michele/oq-engine/openquake/hazardlib/contexts.py", line 169, in concat
    [shp] = list(set(ctx.probs_occur.shape[1] for ctx in ctxs))
    ^^^^^
ValueError: too many values to unpack (expected 1)
```
Now the size of `probs_occur` is fixed to 10 for the NegativeBinomialTOM, which ensure a good precision and no changes in numbers with respect to before.