### PR TITLE
Add get_x_l_ratio() method to BaseSurface for PFDHA applications

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,7 @@
     along-strike position (x/L) for PFDHA applications
   * Vectorized get_x_l_ratio() implementation using NumPy broadcasting
     for improved performance with large site meshes
-  * Added _get_top_rupture_trace() helper method to extract the top rupture
+  * Added _get_tor() helper method to extract the top rupture
     trace with NaN handling for KiteSurface compatibility
 
   [Christopher Brooks]

--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -251,7 +251,7 @@ class BaseSurface(metaclass=abc.ABCMeta):
             Tuple (x_over_l, l_km) where x_over_l is numpy array in [0,1]
             and l_km is trace length in km.
         """
-        trace = self._get_top_rupture_trace()
+        trace = self._get_tor()
         site_lons = mesh.lons.flatten()
         site_lats = mesh.lats.flatten()
         n_sites = len(site_lons)
@@ -400,7 +400,7 @@ class BaseSurface(metaclass=abc.ABCMeta):
             dep = numpy.min(top_edge.depths)
             return dep
 
-    def _get_top_rupture_trace(self):
+    def _get_tor(self):
         """
         Extract the top rupture trace (top edge) of the rupture surface as a
         2D array of geographic coordinates.

--- a/openquake/hazardlib/tests/geo/surface/base_surface_test.py
+++ b/openquake/hazardlib/tests/geo/surface/base_surface_test.py
@@ -418,7 +418,7 @@ class GetAzimuthClosestPointTestCase(unittest.TestCase):
 
 
 class GetSurfaceTraceTestCase(unittest.TestCase):
-    """Tests for _get_top_rupture_trace()."""
+    """Tests for _get_tor()."""
 
     def test_simple_fault_returns_top_row(self):
         """SimpleFaultSurface: trace should be mesh row 0."""
@@ -428,7 +428,7 @@ class GetSurfaceTraceTestCase(unittest.TestCase):
             lower_seismogenic_depth=10.0, dip=90.0,
             mesh_spacing=0.5
         )
-        result = surface._get_top_rupture_trace()
+        result = surface._get_tor()
         # Must be 2D with shape (N, 2)
         self.assertEqual(result.ndim, 2)
         self.assertEqual(result.shape[1], 2)
@@ -438,8 +438,8 @@ class GetSurfaceTraceTestCase(unittest.TestCase):
         top_depths = surface.mesh[0:1].depths[0, :]
         numpy.testing.assert_allclose(top_depths, 0.0, atol=0.01)
 
-    def test_get_top_rupture_trace(self):
-        """Test _get_top_rupture_trace() with a given fault trace and surface plan.
+    def test_get_tor(self):
+        """Test _get_tor() with a given fault trace and surface plan.
 
         Surface is a 2-column × 2-row rectangular mesh:
             Top edge:    (0.0, 0.0, 0.0) → (0.1, 0.0, 0.0)
@@ -453,7 +453,7 @@ class GetSurfaceTraceTestCase(unittest.TestCase):
                    [(0.0, 0.0, 10.0), (0.1, 0.0, 10.0)]]
         surface = FakeSurface(corners)
 
-        trace = surface._get_top_rupture_trace()
+        trace = surface._get_tor()
 
         # Exact shape: 2 top-edge points, 2 columns (lon, lat)
         self.assertEqual(trace.shape, (2, 2))
@@ -465,8 +465,8 @@ class GetSurfaceTraceTestCase(unittest.TestCase):
         numpy.testing.assert_array_almost_equal(trace[:, 0], expected_lons)
         numpy.testing.assert_array_almost_equal(trace[:, 1], expected_lats)
 
-    def test_get_top_rupture_trace_realistic_fault(self):
-        """Test _get_top_rupture_trace() with a fault geometry.
+    def test_get_tor_realistic_fault(self):
+        """Test _get_tor() with a fault geometry.
         """
         # Fault trace running ~NW-SE for about 30 km:
         #   Point A: (13.30, 42.40)
@@ -480,7 +480,7 @@ class GetSurfaceTraceTestCase(unittest.TestCase):
         ]
         surface = FakeSurface(corners)
 
-        trace = surface._get_top_rupture_trace()
+        trace = surface._get_tor()
 
         self.assertEqual(trace.ndim, 2)
         self.assertEqual(trace.shape[1], 2)


### PR DESCRIPTION
This PR adds support for computing normalized along-strike position (x/L) for Probabilistic Fault Displacement Hazard Assessment (PFDHA) applications.

It includes: 

1.  `_get_surface_trace()`: 
Private helper method that extracts the surface trace (top edge) as a 2D array of geographic coordinates with NaN 
  handling for KiteSurface compatibility.
2. `get_x_l_ratio(mesh)`: It computes the normalized along-strike position (x/L) for each point in the mesh relative to the surface trace
3. Testing suite added to `base_surface_test.py`

Notes:

1. Point-to-polyline projection algorithm finds the nearest trace segment 
  for each site using vectorized distance calculations
2. Returns tuple `(x_over_L, L_km)` where `x_over_L` is a numpy array with 
  values in [0, 1] and `L_km` is the total trace length in kilometers
3. All x/L values are clamped to [0, 1] before return