### PR TITLE
Refined task splitting/6

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -213,7 +213,7 @@ def classical(grp_keys, tilegetter, cmaker, dstore, monitor):
         result = baseclassical(grps, sites, cmaker, remove_zeros=True)
         result['rmap'] = result['rmap'].to_array(cmaker.gid)
         yield result
-    elif len(grps) == 1 and len(grps[0]) >= 3:
+    elif len(grps) == 1 and len(grps[0]) >= 2:
         # tested in case_25
         b0, *blks = _split_src(list(grps[0]), 5)
         rest = sum(blks, [])
@@ -225,9 +225,10 @@ def classical(grp_keys, tilegetter, cmaker, dstore, monitor):
             for blk in _split_src(rest, 4):
                 yield baseclassical, blk, tilegetter, cmaker, True, dstore
         elif dt > cmaker.split_time:
-            odd, even = _split_src(rest, 2)
-            yield baseclassical, odd, tilegetter, cmaker, True, dstore
-            yield baseclassical(even, sites, cmaker, True)
+            b1, *bs = _split_src(rest, 2)  # bs has 0 or 1 elements
+            yield baseclassical, b1, tilegetter, cmaker, True, dstore
+            for b in bs:
+                yield baseclassical(b, sites, cmaker, True)
         else:
             yield baseclassical(rest, sites, cmaker, True)
     else:


### PR DESCRIPTION
Even tasks with 2 big sources are now split (relevant for MEX):
```
# before
| calc_8383, maxmem=193.9 GB | time_sec  | memory_mb | counts    |
|----------------------------+-----------+-----------+-----------|
| total classical            | 152_359   | 132.8164  | 735       |
| get_poes                   | 81_335    | 0.0       | 1_784_254 |
| computing mean_std         | 56_472    | 0.0       | 35_689    |
| total baseclassical        | 12_535    | 99.4297   | 89        |
| planar contexts            | 4_416     | 0.0       | 68_683    |
| ClassicalCalculator.run    | 1_254     | 1_221     | 1         |
# after
| calc_8385, maxmem=193.9 GB | time_sec  | memory_mb | counts    |
|----------------------------+-----------+-----------+-----------|
| total classical            | 120_917   | 103.5977  | 829       |
| get_poes                   | 70_238    | 0.0       | 1_784_454 |
| computing mean_std         | 48_935    | 0.0       | 35_693    |
| total baseclassical        | 21_027    | 100.8242  | 159       |
| planar contexts            | 3_735     | 0.0       | 68_683    |
| ClassicalCalculator.run    | 1_094     | 1_360     | 1         |


# before
| operation-duration | counts | mean     | stddev | min      | max     | slowfac |
|--------------------+--------+----------+--------+----------+---------+---------|
| baseclassical      | 89     | 140.8401 | 45%    | 37.2054  | 258.3   | 1.8341  |
| classical          | 537    | 283.7    | 30%    | 111.3272 | 668.8   | 2.3573  |
# after
| operation-duration | counts | mean     | stddev | min      | max     | slowfac |
|--------------------+--------+----------+--------+----------+---------+---------|
| baseclassical      | 159    | 132.2425 | 41%    | 22.7229  | 247.0   | 1.8680  |
| classical          | 537    | 225.2    | 32%    | 102.1925 | 428.8   | 1.9044  |
```