### PR TITLE
Removed a warning

### DIFF
--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -117,8 +117,7 @@ class CollapseTestCase(unittest.TestCase):
         self.clt = lt.CompositeLogicTree([bs0, bs1])
 
         # setup sitecol, srcfilter, gsims, imtls
-        self.sitecol = site.SiteCollection(
-            [site.Site(Point(0, 0), numpy.array([760.]))])
+        self.sitecol = site.SiteCollection([site.Site(Point(0, 0), 760.)])
         self.gsims = [valid.gsim('ToroEtAl2002')]
         self.imtls = DictArray({'PGA': valid.logscale(.01, 1, 5)})
         self.sg = sourceconverter.SourceGroup(ps.tectonic_region_type, [ps])


### PR DESCRIPTION
This was the warning:
```python
  /home/michele/oq-engine/openquake/hazardlib/site.py:659: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    arr[p][i] = getattr(site, p)
```
Part of https://github.com/gem/oq-engine/issues/10091