### PR TITLE
Fix some more warnings

### DIFF
--- a/openquake/hazardlib/geo/point.py
+++ b/openquake/hazardlib/geo/point.py
@@ -50,7 +50,7 @@ class Point(object):
     EQUALITY_DISTANCE = 1e-3
 
     def __init__(self, longitude, latitude, depth=0.0):
-
+        
         if not depth < geodetic.EARTH_RADIUS:
             raise ValueError("The depth must be less than "
                              "the Earth's radius (6371.0 km)")
@@ -65,9 +65,9 @@ class Point(object):
         if not -90.0 <= latitude <= 90.0:
             raise ValueError("latitude %.6f outside range" % latitude)
 
-        self.depth = float(numpy.asarray(depth).item())
-        self.latitude = float(numpy.asarray(latitude).item())
-        self.longitude = float(numpy.asarray(longitude).item())
+        self.depth = float(depth)
+        self.latitude = float(latitude)
+        self.longitude = float(longitude)
 
     @property
     def x(self):

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -470,9 +470,14 @@ class ParametricProbabilisticRupture(BaseRupture):
             pp = projection_pp(site, normal, dist_to_plane, origin)
             pd, e, idx_nxtp = directp(
                 p0, p1, p2, p3, hypocenter, origin, pp)
+            pd0 = numpy.asarray(pd[0]).item()
+            pd1 = numpy.asarray(pd[1]).item()
+            pd2 = numpy.asarray(pd[2]).item()
+
             pd_geo = origin.point_at(
-                (pd[0] ** 2 + pd[1] ** 2) ** 0.5, -pd[2],
-                numpy.degrees(numpy.arctan2(pd[0], pd[1])))
+                (pd0 * pd0 + pd1 * pd1) ** 0.5,
+                -pd2,
+                numpy.degrees(numpy.arctan2(pd0, pd1)))
 
             # determine the lower bound of E path value
             f1 = geodetic_distance(p0.longitude,


### PR DESCRIPTION
There was an instance of arrays were being passed instead of scalars into instantiation of `Point` objects inside `rupture.py`

<img width="866" height="292" alt="image" src="https://github.com/user-attachments/assets/497c6f3b-6659-45dd-ac9d-5d3f6901d4b7" />
