### PR TITLE
Removed readline dependency in Python 3.13

### DIFF
--- a/openquake/baselib/__init__.py
+++ b/openquake/baselib/__init__.py
@@ -18,7 +18,6 @@
 
 import os
 import sys
-import readline
 import configparser
 
 # use utf8 as default encodings on all platforms (i.e. Windows)
@@ -123,9 +122,6 @@ if config.directory.custom_tmp:
 
 if 'OQ_DISTRIBUTE' not in os.environ:
     os.environ['OQ_DISTRIBUTE'] = config.distribution.oq_distribute
-
-if sys.platform == 'win32':  # fix pdb issue
-    readline.backend = "pyreadline"
 
 # wether the engine was installed as multi_user (linux root) or not
 if sys.platform in 'win32 darwin':

--- a/requirements-py313-linux64.txt
+++ b/requirements-py313-linux64.txt
@@ -61,7 +61,6 @@ https://wheelhouse.openquake.org/v3/py/pycodestyle-2.11.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pycparser-2.22-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pyflakes-3.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pyparsing-3.1.1-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/pyreadline3-3.4.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/python_dateutil-2.8.2-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/python_pam-2.0.2-py3-none-any.whl

--- a/requirements-py313-macos_arm64.txt
+++ b/requirements-py313-macos_arm64.txt
@@ -62,7 +62,6 @@ https://wheelhouse.openquake.org/v3/py/pycodestyle-2.11.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pycparser-2.22-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pyflakes-3.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pyparsing-3.1.1-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/pyreadline3-3.4.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/python_dateutil-2.8.2-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/python_pam-2.0.2-py3-none-any.whl

--- a/requirements-py313-win64.txt
+++ b/requirements-py313-win64.txt
@@ -62,7 +62,6 @@ https://wheelhouse.openquake.org/v3/py/pycodestyle-2.11.1-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pycparser-2.22-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pyflakes-3.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pyparsing-3.1.1-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/pyreadline3-3.4.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/pytest-8.3.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/python_dateutil-2.8.2-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/python_pam-2.0.2-py3-none-any.whl


### PR DESCRIPTION
Python 3.13 rewrite the functionality internally. Not removing it would break Windows.
Supersedes https://github.com/gem/oq-engine/pull/11253.
