### PR TITLE
Made it possible to run risk calculations depending on AvgSA

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made it possible to run risk calculations depending on AvgSA
   * Internal: inferring the slow tasks information from starmap_info
   * Removed numpy.random.seed in the engine code base
   * The NegativeBinomialTOM can now be applied to all parametric sources

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1754,7 +1754,7 @@ class OqParam(valid.ParamSet):
         for imt in risk_imts - seco_imts:
             # LSD is considered a primary IMT because it is directly
             # computed by two GMPEs, Youd and Zang, Zhao
-            if imt.startswith(('PGA', 'PGV', 'SA', 'MMI', 'LSD')):
+            if imt.startswith(('AvgSA', 'PGA', 'PGV', 'SA', 'MMI', 'LSD')):
                 pass  # ground shaking IMT
             else:
                 raise ValueError(f'The risk functions contain {imt} which is '


### PR DESCRIPTION
Solves an issue raised on the mailing list (https://groups.google.com/g/openquake-users/c/MyZ2ZDBXhic/m/wyjV5Ib6BQAJ). A test is being added in the oq-risk-tests