### PR TITLE
tiny PR to fix y label on classical hazard plot

### DIFF
--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -341,7 +341,7 @@ def make_hmap_png(hmap, lons, lats):
     ax.set_title('hmap for IMT=%(imt)s, poe=%(poe)s\ncalculation %(calc_id)d,'
                  'inv_time=%(inv_time)dy' % hmap)
     ax.set_xlabel('Longitude')
-    ax.set_xlabel('Latitude')
+    ax.set_ylabel('Latitude')
     coll = ax.scatter(lons, lats, c=hmap['array'], cmap='jet')
     plt.colorbar(coll)
     bio = io.BytesIO()


### PR DESCRIPTION
This is a small PR that corrects the axis labels for the plot shown in the webui for classical hazard jobs. The current code labels the y-axis as "longitude" (see image)

<img width="573" height="454" alt="Screenshot 2026-03-04 at 9 34 35 AM" src="https://github.com/user-attachments/assets/c4711bdf-5918-4cd8-b155-a0867e96077e" />
