### PR TITLE
Replace `shutil.move` with `shutil.copy2`, to avoid a permission error on Windows

### DIFF
--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -223,6 +223,11 @@ def store(request_files, ini, calc_id):
         # NB: TemporaryUploadedFile Django objects are not sortable
         for input_file in input_files:
             new_path = os.path.join(calc_dir, input_file.name)
+            # Using shutil.copy2, Django deletes the temporary file
+            # when the request ends. With shutil.move it would
+            # attempt to delete it immediately when it is still in
+            # use by the Django process, which would raise an
+            # exception on Windows.
             shutil.copy2(input_file.temporary_file_path(), new_path)
             if input_file.name.endswith(ini):
                 inifiles.append(new_path)


### PR DESCRIPTION
This should prevent errors like:
```python
Traceback (most recent call last):
  File "C:\Users\iklab\AppData\Roaming\Python\Python311\site-packages\openquake\server\views.py", line 1483, in submit_job
    job_ini = store(request_files, ini, job.calc_id)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\iklab\AppData\Roaming\Python\Python311\site-packages\openquake\server\views.py", line 224, in store
    shutil.move(input_file.temporary_file_path(), new_path)
  File "C:\Users\iklab\AppData\Local\Programs\OpenQuake Engine\python3\Lib\shutil.py", line 846, in move
    os.unlink(src)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\iklab\\AppData\\Local\\Temp\\_o1kbw_5.upload'
```

We checked with @vot4anto on a Windows machine that this actually fixes the issue.

Changing `shutil.move` to `shutil.copy2`, Django deletes the temporary file when the request ends, instead of attempting to delete it immediately when it is still in use by the Django process.