### PR TITLE
Improved error message when all assets are filtered out

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved error message when all assets are filtered out
   * Fixed a bug when prefiltering sources around the poles
   * Made it possible to run risk calculations depending on AvgSA
   * Internal: inferring the slow tasks information from starmap_info

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -467,6 +467,9 @@ class RuptureFilter(object):
         dists = get_distances(self.rup, mesh, 'rrup')
         return dists < self.dist, dists
 
+    def __repr__(self):
+        return '<%s mag=%.1f dist=%.0f>' % (self.__class__.__name__,
+                                            self.rup.mag, self.dist)
 
 class SourceFilter(object):
     """

--- a/openquake/risklib/asset.py
+++ b/openquake/risklib/asset.py
@@ -30,6 +30,7 @@ from openquake.baselib import hdf5, general, config, performance
 from openquake.baselib.node import Node, context
 from openquake.baselib.python3compat import encode, decode
 from openquake.hazardlib import valid, nrml, geo, InvalidFile
+from openquake.hazardlib.calc.filters import FilteredAway
 from openquake.hazardlib.geo.utils import SiteAssociationError
 
 U8 = numpy.uint8
@@ -1095,6 +1096,8 @@ class Exposure(object):
         exp.exposures = [os.path.splitext(os.path.basename(f))[0]
                          for f in fnames]
         assets_df = pandas.concat(dfs)
+        if rupfilter and len(assets_df) == 0:
+            raise FilteredAway('No assets within %r' % rupfilter)
         del dfs  # save memory
         exp.build_mesh(assets_df)
         return exp


### PR DESCRIPTION
As requested in the mailing list: https://groups.google.com/g/openquake-users/c/fCVdvvlWrK8/m/pt1cN25GCQAJ
Now the error is
```python
  File "/home/michele/oq-engine/openquake/risklib/asset.py", line 1100, in read_all
    raise FilteredAway('No assets within %r' % rupfilter)
openquake.hazardlib.calc.filters.FilteredAway: No assets within <RuptureFilter mag=0.1 dist=0>
```