### PR TITLE
Fix the `add_borders` function to plot also the seas

### DIFF
--- a/openquake/calculators/postproc/plots.py
+++ b/openquake/calculators/postproc/plots.py
@@ -21,7 +21,7 @@ import os
 import base64
 import numpy
 # import descartes
-from shapely.geometry import MultiPolygon, Polygon, box
+from shapely.geometry import Polygon, box
 from openquake.commonlib import readinput, datastore
 from openquake.hmtk.plotting.patch import PolygonPatch
 
@@ -65,10 +65,10 @@ def adjust_limits(ax, xlim, ylim, padding=1):
 
 def add_borders(
         ax, read_df=readinput.read_countries_df,
-        facecolor='#D6D6C2',   # warm muted land color
-        edgecolor='#A0A0A0',   # slightly darker border
-        linewidth=0.5, alpha=1.0, zorder=0,
-        sea_color='#AED6F1'):  # soft blue sea
+        facecolor='#F5F5F2',   # Very light off-white/grey
+        edgecolor='#D0D0D0',   # Faint grey for borders
+        linewidth=0.4, alpha=1.0, zorder=0,
+        sea_color='#E0F2F7'):  # Pale blue
     """
     Draw filled land regions clipped to the current viewport,
     with seas colored via the axes background.
@@ -82,66 +82,73 @@ def add_borders(
     geometries = df.geometry.values
     sindex = df.sindex
     ax.set_facecolor(sea_color)
-    patch_collection = None
+    # We store the collection in a list to make it mutable inside the closure
+    container = {'coll': None}
 
     def _polygon_to_path(polygon):
         """Convert a Shapely Polygon to a matplotlib Path (with holes)."""
+        if polygon.is_empty:
+            return None
         vertices = []
         codes = []
-        # Exterior ring
-        coords = numpy.array(polygon.exterior.coords)
-        vertices.append(coords)
+        # Exterior
+        ext_coords = numpy.array(polygon.exterior.coords)
+        vertices.append(ext_coords)
         codes.append(
-            [Path.MOVETO] + [Path.LINETO] * (len(coords) - 2) + [Path.CLOSEPOLY]
-        )
-        # Interior rings (holes)
+            [Path.MOVETO] + [Path.LINETO] * (len(ext_coords) - 2)
+            + [Path.CLOSEPOLY])
+        # Interiors
         for interior in polygon.interiors:
-            coords = numpy.array(interior.coords)
-            vertices.append(coords)
+            int_coords = numpy.array(interior.coords)
+            vertices.append(int_coords)
             codes.append(
-                [Path.MOVETO] + [Path.LINETO] * (len(coords) - 2) + [Path.CLOSEPOLY]
-            )
-        return Path(
-            numpy.concatenate(vertices),
-            numpy.concatenate(codes)
-        )
+                [Path.MOVETO] + [Path.LINETO] * (len(int_coords) - 2)
+                + [Path.CLOSEPOLY])
+        return Path(numpy.concatenate(vertices), numpy.concatenate(codes))
 
-    def redraw():
-        nonlocal patch_collection
+    def redraw(event_ax=None):
+        if container['coll'] is not None:
+            container['coll'].remove()
+            container['coll'] = None
+
         xmin, xmax = ax.get_xlim()
         ymin, ymax = ax.get_ylim()
         viewport = box(xmin, ymin, xmax, ymax)
+        # Spatial index filter for speed
         idx = list(sindex.intersection((xmin, ymin, xmax, ymax)))
-        patches = []
+        paths = []
+
         for geom in geometries[idx]:
             try:
                 clipped = geom.intersection(viewport)
+                if clipped.is_empty:
+                    continue
+                # Normalize to iterable parts
+                parts = clipped.geoms if hasattr(clipped, 'geoms') else [clipped]
+                for part in parts:
+                    if isinstance(part, Polygon):
+                        path = _polygon_to_path(part)
+                        if path:
+                            paths.append(path)
             except Exception:
                 continue
-            if clipped.is_empty:
-                continue
-            if isinstance(clipped, MultiPolygon):
-                parts = clipped.geoms
-            elif isinstance(clipped, Polygon):
-                parts = [clipped]
-            else:
-                continue
-            for part in parts:
-                path = _polygon_to_path(part)
-                patches.append(PathPatch(path))
 
-        if patch_collection is not None:
-            patch_collection.remove()
-        patch_collection = PatchCollection(
-            patches, facecolor=facecolor, edgecolor=edgecolor,
-            linewidth=linewidth, alpha=alpha, zorder=zorder)
-        ax.add_collection(patch_collection)
+        new_coll = PatchCollection(
+            [PathPatch(p) for p in paths],
+            facecolor=facecolor,
+            edgecolor=edgecolor,
+            linewidth=linewidth,
+            alpha=alpha,
+            zorder=zorder
+        )
+
+        ax.add_collection(new_coll)
+        container['coll'] = new_coll
         ax.figure.canvas.draw_idle()
 
     # Connect viewport change callbacks
-    ax.callbacks.connect('xlim_changed', lambda ax: redraw())
-    ax.callbacks.connect('ylim_changed', lambda ax: redraw())
-
+    ax.callbacks.connect('xlim_changed', redraw)
+    ax.callbacks.connect('ylim_changed', redraw)
     # Initial draw
     redraw()
 


### PR DESCRIPTION
In a recent optimization I went too far and replaced polygon patches with a single line collection. It drew polygon outlines as line segments. However, filling requires proper Path objects fed into PathPatch, which support both fill color and edge color. With this fix I am making sure polygons are drawn correctly and holes are kept transparent, showing the sea color through them.

<img width="672" height="682" alt="image" src="https://github.com/user-attachments/assets/3409210b-5267-4617-a476-0b52e6bf1eeb" />