### PR TITLE
Removed `general.chdir`

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -41,7 +41,6 @@ import subprocess
 import collections
 import multiprocessing
 from importlib.metadata import version, PackageNotFoundError
-from contextlib import contextmanager
 from collections.abc import Mapping, Container, Sequence, MutableSequence
 import numpy
 import pandas
@@ -1823,21 +1822,6 @@ def sqrscale(x_min, x_max, n):
                          (x_max, x_min))
     delta = numpy.sqrt(x_max - x_min) / (n - 1)
     return x_min + (delta * numpy.arange(n))**2
-
-
-# NB: this is present in contextlib in Python 3.11, but
-# we still support Python 3.9, so it cannot be removed yet
-@contextmanager
-def chdir(path):
-    """
-    Context manager to temporarily change the CWD
-    """
-    oldpwd = os.getcwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(oldpwd)
 
 
 def smart_concat(arrays):

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path
 from unittest import skipIf
 import unittest.mock as mock
-from contextlib import redirect_stdout
+from contextlib import redirect_stdout, chdir
 import shutil
 import pathlib
 import zipfile
@@ -33,7 +33,7 @@ import unittest
 import numpy
 
 from openquake.baselib.general import encode
-from openquake.baselib.general import gettemp, chdir
+from openquake.baselib.general import gettemp
 from openquake.baselib import parallel, sap
 from openquake.baselib.hdf5 import read_csv
 from openquake.baselib.tests.flake8_test import check_newlines


### PR DESCRIPTION
Since Python 3.11 there is contextlib.chdir