### PR TITLE
Fixed `maximum_rupture_depth` error for JPN

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -335,7 +335,7 @@ def get_allargs(oq, sitecol, assetcol, sec_perils, station_data_sites, dstore):
     logging.info(f'Read {len(allrups):_d} ruptures')
     rup_id = os.environ.get('OQ_RUPTURE')
     if rup_id is not None:
-        rup_id = U32(rup_id.split(','))
+        rup_id = I64(rup_id.split(','))
         allrups = allrups[numpy.isin(allrups['id'], rup_id)]
 
     # NB: it is faster to filter a huge number of ruptures

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -355,7 +355,9 @@ def get_allargs(oq, sitecol, assetcol, sec_perils, station_data_sites, dstore):
     for model, trt_smr in pairs:
         ok = (filrups['model'] == model) & (filrups['trt_smr'] == trt_smr)
         if oq.maximum_rupture_depth:
-            trt = trts[model.decode('ascii')][trt_smr // TWO24]
+            amodel = model.decode('ascii')
+            trt_array = trts.get(amodel) or trts.get('???')
+            trt = trt_array[trt_smr // TWO24]
             maxdep = getdefault(oq.maximum_rupture_depth, trt)
             ok &= hypo_deps <= maxdep
         rups = filrups[ok]

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -356,7 +356,7 @@ def get_allargs(oq, sitecol, assetcol, sec_perils, station_data_sites, dstore):
         ok = (filrups['model'] == model) & (filrups['trt_smr'] == trt_smr)
         if oq.maximum_rupture_depth:
             amodel = model.decode('ascii')
-            trt_array = trts.get(amodel) or trts.get('???')
+            trt_array = trts.get(amodel, trts.get('???'))
             trt = trt_array[trt_smr // TWO24]
             maxdep = getdefault(oq.maximum_rupture_depth, trt)
             ok &= hypo_deps <= maxdep

--- a/openquake/calculators/postproc/debug_rupture.py
+++ b/openquake/calculators/postproc/debug_rupture.py
@@ -33,7 +33,7 @@ def main(calc_id: int, rup_id: str):
     An utility to debug event based calculations
     $ python -m openquake.calculators.postproc.debug <calc_id> <rup1>,<rup2>
     """
-    rup_ids = numpy.uint32(rup_id.split(','))
+    rup_ids = numpy.uint64(rup_id.split(','))
     parent = datastore.read(calc_id)
     oq = parent['oqparam']
     try:


### PR DESCRIPTION
Reported by Anirudh:
```python
$ oq engine --run /home/risk/global_risk_model/East_Asia/Jobs/job_JPN.ini -p truncation_level_between=1 -p truncation_level_within=3 -p truncated_mvn=True -p maximum_rupture_depth=60
  File "/home/michele/oq-engine/openquake/calculators/event_based.py", line 866, in execute
    smap = starmap_from_rups(
           ^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/calculators/event_based.py", line 469, in starmap_from_rups
    allargs = get_allargs(
              ^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/calculators/event_based.py", line 358, in get_allargs
    trt = trts[model.decode('ascii')][trt_smr // TWO24]
          ~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'JPN'
```