### PR TITLE
Add a 'mode' param to `check_required_imts` so it returns a list of filtered imts unless the mode is 'strict'

### DIFF
--- a/openquake/commands/shakemap2gmfs.py
+++ b/openquake/commands/shakemap2gmfs.py
@@ -27,7 +27,7 @@ from openquake.calculators.base import calculators, store_gmfs
 # see qa_tests_data/scenario/case_21
 def main(id, site_model='', *, num_gmfs: int = 1, random_seed: int = 42,
          trunclevel: float = 3, spatialcorr='yes', crosscorr='yes',
-         cholesky_limit: int = 10_000):
+         cholesky_limit: int = 10_000, imt_mode='warn'):
     """
     Given a shakemap ID and a path to a site_model.csv file build a
     GMFs array corresponding to num_gmfs events. The user can pass
@@ -55,7 +55,7 @@ def main(id, site_model='', *, num_gmfs: int = 1, random_seed: int = 42,
         calc = calculators(oq, log.calc_id)
         sites = get_site_collection(oq) if site_model else None
         sitecol, shakemap, disc, filtered_imts = get_sitecol_shakemap(
-            dic, imts, sites, imt_mode='warn')
+            dic, imts, sites, imt_mode=imt_mode)
         if set(imts) != set(filtered_imts):
             print(f"Considering only imts: {filtered_imts}")
             imts = filtered_imts
@@ -85,3 +85,4 @@ main.trunclevel = 'Truncation level'
 main.spatialcorr = 'Spatial correlation'
 main.crosscorr = 'Cross correlation among IMTs'
 main.cholesky_limit = 'Cholesky Limit'
+main.imt_mode = 'if "strict", raise an error in case expected imts are missing'

--- a/openquake/commands/shakemap2gmfs.py
+++ b/openquake/commands/shakemap2gmfs.py
@@ -54,12 +54,11 @@ def main(id, site_model='', *, num_gmfs: int = 1, random_seed: int = 42,
         oq = log.get_oqparam()
         calc = calculators(oq, log.calc_id)
         sites = get_site_collection(oq) if site_model else None
-        try:
-            sitecol, shakemap, disc = get_sitecol_shakemap(dic, imts, sites)
-        except RuntimeError as err:
-            assert str(err).startswith('The IMT SA(0.6) is required'), err
-            imts = ['PGA', 'SA(0.3)', 'SA(1.0)']
-            sitecol, shakemap, disc = get_sitecol_shakemap(dic, imts, sites)
+        sitecol, shakemap, disc, filtered_imts = get_sitecol_shakemap(
+            dic, imts, sites, imt_mode='warn')
+        if set(imts) != set(filtered_imts):
+            print(f"Considering only imts: {filtered_imts}")
+            imts = filtered_imts
         if not os.path.exists(fname):
             numpy.save(fname, shakemap)
             print(f'Saved {fname}')

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1255,7 +1255,7 @@ def assoc_to_shakemap(oq, haz_sitecol, assetcol):
         uridict = {'kind': 'file_npy', 'fname': oq.inputs['shakemap']}
     else:
         uridict = oq.shakemap_uri
-    sitecol, shakemap, discarded, _ = get_sitecol_shakemap(
+    sitecol, shakemap, discarded, *_ = get_sitecol_shakemap(
         uridict, oq.risk_imtls, haz_sitecol,
         oq.asset_hazard_distance['default'])
     assetcol.reduce_also(sitecol)

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -51,7 +51,8 @@ from shapely.validation import make_valid, explain_validity
 from openquake.baselib import config, hdf5, parallel, InvalidFile
 from openquake.baselib.performance import Monitor
 from openquake.baselib.general import (
-    random_filter, countby, get_duplicates, check_extension, gettemp, AccumDict)
+    random_filter, countby, get_duplicates, check_extension, gettemp,
+    AccumDict)
 from openquake.baselib.general import decode
 from openquake.baselib.node import Node
 from openquake.hazardlib.const import StdDev
@@ -1091,10 +1092,10 @@ def read_consdict(oqparam, limit_states, perils):
                 raise InvalidFile('Unknown consequence %s in %s' %
                                   (consequence, fnames))
             consdict['%s_by_%s' % (consequence, by)] = df[
-                    df.consequence==consequence]
+                df.consequence == consequence]
     return consdict
 
-    
+
 def get_exposure(oqparam, h5=None):
     """
     Read the full exposure in memory and build a list of
@@ -1192,7 +1193,8 @@ def get_station_data(oqparam, sitecol, duplicates_strategy='error'):
         an :class:`openquake.commonlib.oqvalidation.OqParam` instance
     :param sitecol:
         the hazard site collection
-    :param duplicates_strategy: either 'error', 'keep_first', 'keep_last', 'avg'
+    :param duplicates_strategy:
+        either 'error', 'keep_first', 'keep_last', 'avg'
     :returns: station_data, observed_imts
     """
     if parallel.oq_distribute() == 'zmq':
@@ -1253,7 +1255,7 @@ def assoc_to_shakemap(oq, haz_sitecol, assetcol):
         uridict = {'kind': 'file_npy', 'fname': oq.inputs['shakemap']}
     else:
         uridict = oq.shakemap_uri
-    sitecol, shakemap, discarded = get_sitecol_shakemap(
+    sitecol, shakemap, discarded, _ = get_sitecol_shakemap(
         uridict, oq.risk_imtls, haz_sitecol,
         oq.asset_hazard_distance['default'])
     assetcol.reduce_also(sitecol)
@@ -1821,7 +1823,8 @@ def read_source_models(fnames, hdf5path='', **converterparams):
     """
     :param fnames: a list of source model files
     :param hdf5path: auxiliary .hdf5 file used to store the multifault sources
-    :param converterparams: a dictionary of parameters like rupture_mesh_spacing
+    :param converterparams:
+        a dictionary of parameters like rupture_mesh_spacing
     :returns: a list of SourceModel instances
     """
     converter = sourceconverter.SourceConverter()

--- a/openquake/hazardlib/shakemap/maps.py
+++ b/openquake/hazardlib/shakemap/maps.py
@@ -65,7 +65,9 @@ def get_sitecol_shapefile(uridict, required_imts, sitecol=None,
             site.SiteCollection.from_usgs_shakemap(shakemap),
             shakemap, [], filtered_imts)
 
-    return geo.utils.assoc_to_polygons(polygons, shakemap, sitecol, assoc_mode)
+    return (
+        *geo.utils.assoc_to_polygons(polygons, shakemap, sitecol, assoc_mode),
+        filtered_imts)
 
 
 @get_sitecol_shakemap.add('usgs_xml', 'usgs_id', 'file_npy')
@@ -95,7 +97,8 @@ def get_sitecol_usgs(uridict, required_imts, sitecol=None,
         return (site.SiteCollection.from_usgs_shakemap(shakemap),
                 shakemap, [], filtered_imts)
 
-    return geo.utils.assoc(shakemap, sitecol, assoc_dist, assoc_mode)
+    return (*geo.utils.assoc(shakemap, sitecol, assoc_dist, assoc_mode),
+            filtered_imts)
 
 
 def filter_unused_imts(shakemap, required_imts,
@@ -132,9 +135,10 @@ def check_required_imts(required_imts, available_imts, mode='strict'):
     :returns: set of filtered imts (depending on mode)
     :raises RuntimeError: if required imts are missing and mode is 'strict'
     """
-    required_imts = set(required_imts)
-    missing = required_imts - available_imts
-    filtered_imts = required_imts - missing
+    available_imts = set(available_imts)
+    missing = set(required_imts) - available_imts
+    # preserving the original order of the required imts
+    filtered_imts = [imt for imt in required_imts if imt in available_imts]
     if missing:
         msg = ('The imts %s are required but not in the available set %s, '
                'please change the risk model otherwise you will have '

--- a/openquake/hazardlib/shakemap/maps.py
+++ b/openquake/hazardlib/shakemap/maps.py
@@ -17,6 +17,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy
+import logging
 
 from openquake.baselib.general import CallableDict
 from openquake.hazardlib import geo, site
@@ -29,24 +30,28 @@ get_sitecol_shakemap = CallableDict(keyfunc=lambda dic: dic['kind'])
 
 @get_sitecol_shakemap.add('shapefile')
 def get_sitecol_shapefile(uridict, required_imts, sitecol=None,
-                          assoc_dist=None, mode='filter'):
+                          assoc_dist=None, assoc_mode='filter',
+                          imt_mode='strict'):
     """
     :param uridict: a dictionary specifying the ShakeMap resource
     :param imts: required IMTs as a list of strings
     :param sitecol: SiteCollection used to reduce the shakemap
     :param assoc_dist: unused for shapefiles
-    :param mode: 'strict', 'warn' or 'filter'
-    :returns: filtered site collection, filtered shakemap, discarded
+    :param assoc_mode: 'strict', 'warn' or 'filter'
+    :param imt_mode: 'strict', 'warn' or 'filter'
+    :returns: (filtered site collection, filtered shakemap, discarded,
+        filtered_imts)
     """
     polygons, shakemap = get_array(**uridict)
 
     available_imts = set(shakemap['val'].dtype.names)
 
-    check_required_imts(required_imts, available_imts)
+    filtered_imts = check_required_imts(
+        required_imts, available_imts, imt_mode)
 
     # build a copy of the ShakeMap with only the relevant IMTs
     shakemap = filter_unused_imts(
-        shakemap, required_imts, site_fields=['vs30'])
+        shakemap, filtered_imts, site_fields=['vs30'])
 
     if sitecol is None:
         # use centroids of polygons to generate sitecol
@@ -56,35 +61,41 @@ def get_sitecol_shapefile(uridict, required_imts, sitecol=None,
                                        ('lat', numpy.float32)])
         for name in ('lon', 'lat'):
             shakemap[name] = centroids[name]
-        return site.SiteCollection.from_usgs_shakemap(shakemap), shakemap, []
+        return (
+            site.SiteCollection.from_usgs_shakemap(shakemap),
+            shakemap, [], filtered_imts)
 
-    return geo.utils.assoc_to_polygons(polygons, shakemap, sitecol, mode)
+    return geo.utils.assoc_to_polygons(polygons, shakemap, sitecol, assoc_mode)
 
 
 @get_sitecol_shakemap.add('usgs_xml', 'usgs_id', 'file_npy')
 def get_sitecol_usgs(uridict, required_imts, sitecol=None,
-                     assoc_dist=None, mode='warn'):
+                     assoc_dist=None, assoc_mode='warn', imt_mode='strict'):
     """
     :param uridict: a dictionary specifying the ShakeMap resource
     :param imts: required IMTs as a list of strings
     :param sitecol: SiteCollection used to reduce the shakemap
     :param assoc_dist: the maximum distance for association
-    :param mode: 'strict', 'warn' or 'filter'
-    :returns: filtered site collection, filtered shakemap, discarded
+    :param assoc_mode: 'strict', 'warn' or 'filter'
+    :param imt_mode: 'strict', 'warn' or 'filter'
+    :returns: (filtered site collection, filtered shakemap, discarded,
+        filtered_imts)
     """
     shakemap = get_array(**uridict)
 
     available_imts = set(shakemap['val'].dtype.names)
 
-    check_required_imts(required_imts, available_imts)
+    filtered_imts = check_required_imts(
+        required_imts, available_imts, imt_mode)
 
     # build a copy of the ShakeMap with only the relevant IMTs
-    shakemap = filter_unused_imts(shakemap, required_imts)
+    shakemap = filter_unused_imts(shakemap, filtered_imts)
 
     if sitecol is None:
-        return site.SiteCollection.from_usgs_shakemap(shakemap), shakemap, []
+        return (site.SiteCollection.from_usgs_shakemap(shakemap),
+                shakemap, [], filtered_imts)
 
-    return geo.utils.assoc(shakemap, sitecol, assoc_dist, mode)
+    return geo.utils.assoc(shakemap, sitecol, assoc_dist, assoc_mode)
 
 
 def filter_unused_imts(shakemap, required_imts,
@@ -111,21 +122,29 @@ def filter_unused_imts(shakemap, required_imts,
     return data
 
 
-def check_required_imts(required_imts, available_imts):
+def check_required_imts(required_imts, available_imts, mode='strict'):
     """
     Check if the list of required imts is present in the list of available imts
 
     :param required_imts: list of strings of required imts
     :param available_imts: set of available imts
-    :raises RuntimeError: if required imts are not present
+    :param mode: 'strict', 'warn', or 'filter'
+    :returns: set of filtered imts (depending on mode)
+    :raises RuntimeError: if required imts are missing and mode is 'strict'
     """
-    missing = set(required_imts) - available_imts
+    required_imts = set(required_imts)
+    missing = required_imts - available_imts
+    filtered_imts = required_imts - missing
     if missing:
-        msg = ('The IMT %s is required but not in the available set %s, '
+        msg = ('The imts %s are required but not in the available set %s, '
                'please change the risk model otherwise you will have '
                'incorrect zero losses for the associated taxonomy strings' %
-               (missing.pop(), ', '.join(available_imts)))
-        raise RuntimeError(msg)
+               (missing, ', '.join(available_imts)))
+        if mode == 'strict':
+            raise RuntimeError(msg)
+        elif mode == 'warn':
+            logging.warning(msg)
+    return filtered_imts
 
 
 def apply_bounding_box(sitecol, bbox):

--- a/openquake/hazardlib/tests/shakemap/shakemap_test.py
+++ b/openquake/hazardlib/tests/shakemap/shakemap_test.py
@@ -190,4 +190,4 @@ class ShakemapTestCase(unittest.TestCase):
         uridict = dict(kind='usgs_xml', grid_url=f, uncertainty_url=None)
         with self.assertRaises(RuntimeError) as ctx:
             get_sitecol_shakemap(uridict, ['PGA', 'SA(0.6)', 'SA(1.0)'])
-        self.assertIn("The IMT SA(0.6) is required", str(ctx.exception))
+        self.assertIn("The imts {'SA(0.6)'} are required", str(ctx.exception))

--- a/openquake/server/tests/test_impact_mode.py
+++ b/openquake/server/tests/test_impact_mode.py
@@ -366,7 +366,7 @@ class ImpactModeTestCase(django.test.TestCase):
                     maximum_distance_stations='', msr='WC1994',
                     description=('us6000jllz: M 7.8 - Pazarcik earthquake,'
                                  ' Kahramanmaras earthquake sequence'))
-        expected_error = 'IMT SA(0.6) is required'
+        expected_error = "The imts {'SA(0.6)'} are required"
         self.impact_run_then_remove('impact_run', data, expected_error)
 
     def test_run_by_usgs_id_then_remove_calc_success(self):


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/11363

The ShakeMap was downloaded twice because for the given rupture identifier the first call to get_sitecol_shakemap raised a RuntimeError complaining about the missing SA(0.6), that was silently trapped, then a second call to get_sitecol_shakemap was performed passing a reduced list of imts and re-downloading the ShakeMap.
I modified that function, adding a 'imt_mode' argument that makes the function return a filtered list of imts unless the default 'strict' mode is used.

