### PR TITLE
Storing `num_paths` as a string if there are more than `sys.maxsize` paths

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -84,8 +84,8 @@ def sanitize(value):
     elif isinstance(value, (list, tuple)):
         if value and isinstance(value[0], str):
             return encode(value)
-    elif isinstance(value, int) and value > sys.maxsize:
-        return float(value)
+    elif isinstance(value, int) and value > sys.maxsize:  # ~9E18
+        return str(value)
     return value
 
 


### PR DESCRIPTION
Avoid this error reported by Guillaume:
```python
  File "/home/b94678/Code/Python-envs/oqenv/lib/python3.12/site-packages/openquake/baselib/hdf5.py", line 444, in save_attrs
    raise TypeError(
TypeError: Could not store attribute num_paths=2521985101184504872188522645603212457210133186965075752999740290784127892938689227183012637472652663652205003123097066619044852836936853700778040084920853014428771270573810740215272612971464418818213344423175081395478191970706707204625734342062520691619966853832313636701668078959758662804173795059508545581808076039773588297987984610647765156576959789488095816824439252095539049283036637848094212224142482496648883423049093972769480018676464247915677666326892049021249809786102329082712012059179030414394045: int too large to convert to float
```
We can still run OOM.