### PR TITLE
Made creating the SES for ZAF fast

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1723,7 +1723,7 @@ def get_checksum32(oqparam, h5=None):
     :param oqparam: an OqParam instance
     """
     ini = oqparam.to_ini().encode('utf8')
-    ifiles = oqparam._input_files
+    ifiles = list(oqparam._input_files)
     gpkg = os.path.join(config.directory.mosaic_dir, 'mosaic.gpkg')
     if os.path.exists(gpkg):
         ifiles.append(gpkg)

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -102,7 +102,8 @@ class MultiPointSource(ParametricSeismicSource):
         :meth:`openquake.hazardlib.source.base.BaseSeismicSource.count_ruptures`
         for description of parameters and return value.
         """
-        return (len(self.get_annual_occurrence_rates()) *
+        src = next(iter(self))  # assume the number of mags is constant
+        return (len(self) * len(src.get_annual_occurrence_rates()) *
                 len(self.nodal_plane_distribution.data) *
                 len(self.hypocenter_distribution.data))
 

--- a/openquake/hazardlib/source_group.py
+++ b/openquake/hazardlib/source_group.py
@@ -395,6 +395,10 @@ class CompositeSourceModel:
         mags = AccumDict(accum=set())  # trt -> mags
         for sg in self.src_groups:
             for src in sg:
+                if src.code == b'M':
+                    # fast lane for MultiPointSources, assuming thet have
+                    # all the same magstrs
+                    src = next(iter(src))
                 mags[sg.trt].update(src.get_magstrs())
         out = {}
         for trt in mags:


### PR DESCRIPTION
It was slow due to the multiplication of MultiPointSources caused by the logic tree. Closes https://github.com/gem/oq-engine/issues/11369.
The solution was to add a fast lane for `count_ruptures` and `get_magstrs`.
Here are the numbers on my machine:
```
$ oq run ZAF/in/job_vs30.ini -p calculation_mode=event_based \
  ground_motion_fields=false number_of_logic_tree_samples=50 \
  ses_per_logic_tree_path=50 -s 100
# before/after
| ncalls    | cumtime | path                                             |
|-----------+---------+--------------------------------------------------|
| 1         | 220.604 | readinput.py:992(get_composite_source_model)     |
| 1         | 39.628  | readinput.py:992(get_composite_source_model)     |
```
The speedup is 10x on the real calculation on engine192, from 91 minutes to 9m30s in `get_composite_source_model`
