### PR TITLE
Not calling the view `extreme_gmvs` in global SES calculations

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -942,7 +942,8 @@ class EventBasedCalculator(base.HazardCalculator):
         # check seed dependency unless the number of GMFs is huge
         imt0 = list(oq.imtls)[0]
         size = self.datastore.getsize(f'gmf_data/{imt0}')
-        if 'gmf_data' in self.datastore and size < 4E9:
+        if ('gmf_data' in self.datastore and size < 4E6 and
+                'filtered_ruptures' not in self.datastore):
             logging.info('Checking stored GMFs')
             msg = views.view('extreme_gmvs', self.datastore)
             logging.info(msg)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -943,6 +943,7 @@ class EventBasedCalculator(base.HazardCalculator):
         imt0 = list(oq.imtls)[0]
         size = self.datastore.getsize(f'gmf_data/{imt0}')
         if ('gmf_data' in self.datastore and size < 4E6 and
+                # not event based from parent, i.e. global SES
                 'filtered_ruptures' not in self.datastore):
             logging.info('Checking stored GMFs')
             msg = views.view('extreme_gmvs', self.datastore)

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -46,7 +46,7 @@ from openquake.risklib.scientific import (
 from openquake.baselib.writers import build_header, scientificformat
 from openquake.calculators.getters import (
     get_ebrupture, MapGetter, get_rmap_gb)
-from openquake.calculators.base import get_model_lts, get_weights
+from openquake.calculators.base import get_weights
 from openquake.calculators.extract import extract
 
 TWO24 = 2**24
@@ -935,7 +935,7 @@ def binning_error(values, eids, nbins=10):
 
 class GmpeExtractor(object):
     def __init__(self, dstore):
-        _, full_lt = get_model_lts(dstore)[-1]
+        full_lt = dstore['full_lt']
         self.trt_by = full_lt.trt_by
         self.gsim_by_trt = full_lt.gsim_by_trt
         self.rlzs = full_lt.get_realizations()

--- a/openquake/calculators/views.py
+++ b/openquake/calculators/views.py
@@ -967,7 +967,10 @@ def view_extreme_gmvs(token, dstore):
         msg += ('Your results are expected to have a large dependency '
                 'from the rupture seed: %d%%' % (err * 100))
     if imt0 == 'PGA':
-        rups = dstore['ruptures'][:]
+        try:
+            rups = dstore['filtered_ruptures'][:]
+        except KeyError:
+            rups = dstore['ruptures'][:]
         rupdict = dict(zip(rups['id'], rups))
         gmpe = GmpeExtractor(dstore)
         df = pandas.DataFrame({'imt': gmvs, 'sid': sids}, eids)


### PR DESCRIPTION
Otherwise 80+ GB of RAM and a lot of time will be wasted, plus an error like
```python
  File "/home/michele/oq-engine/openquake/calculators/event_based.py", line 938, in post_execute
    msg = views.view('extreme_gmvs', self.datastore)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/baselib/general.py", line 772, in __call__
    return self[key](obj, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/calculators/views.py", line 986, in view_extreme_gmvs
    extreme_df['gmpe'] = gmpe.extract(trt_smrs, ev['rlz_id'])
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/calculators/views.py", line 946, in extract
    trt = self.trt_by(trt_smr)
          ^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/hazardlib/logictree.py", line 1150, in trt_by
    return self.trts[trt_smr // TWO24]
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^
IndexError: index 8 is out of bounds for axis 0 with size 2
```
may happen since the `GmpeExtractor` is buggy in the global SES case.