### PR TITLE
Kwargs were unused in some mgmpe modules

### DIFF
--- a/openquake/hazardlib/gsim/mgmpe/cb14_basin_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/cb14_basin_term.py
@@ -69,8 +69,8 @@ class CB14BasinTerm(GMPE):
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
     def __init__(self, gmpe_name, **kwargs):
-        self.gmpe = registry[gmpe_name]()
-        self.set_parameters()    
+        self.gmpe = registry[gmpe_name](**kwargs)
+        self.set_parameters()
 
         # Need z2pt5 in req site params to ensure in ctx site col 
         if 'z2pt5' not in self.gmpe.REQUIRES_SITES_PARAMETERS:

--- a/openquake/hazardlib/gsim/mgmpe/cy14_site_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/cy14_site_term.py
@@ -63,7 +63,7 @@ class CY14SiteTerm(GMPE):
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
     def __init__(self, gmpe_name, **kwargs):
-        self.gmpe = registry[gmpe_name]()
+        self.gmpe = registry[gmpe_name](**kwargs)
         self.set_parameters()
         #
         # Check if this GMPE has the necessary requirements

--- a/openquake/hazardlib/gsim/mgmpe/m9_basin_term.py
+++ b/openquake/hazardlib/gsim/mgmpe/m9_basin_term.py
@@ -73,8 +73,8 @@ class M9BasinTerm(GMPE):
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
     def __init__(self, gmpe_name, **kwargs):
-        self.gmpe = registry[gmpe_name]()
-        self.set_parameters()    
+        self.gmpe = registry[gmpe_name](**kwargs)
+        self.set_parameters()
         
         # Need z2pt5 in req site params to ensure in ctx site col 
         if 'z2pt5' not in self.gmpe.REQUIRES_SITES_PARAMETERS:

--- a/openquake/hazardlib/gsim/mgmpe/split_sigma_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/split_sigma_gmpe.py
@@ -79,9 +79,9 @@ class SplitSigmaGMPE(GMPE):
     DEFINED_FOR_TECTONIC_REGION_TYPE = ''
     DEFINED_FOR_REFERENCE_VELOCITY = None
 
-    def __init__(self, gmpe_name, within_absolute=None, between_absolute=None):
+    def __init__(self, gmpe_name, within_absolute=None, between_absolute=None, **kwargs):
         # Create the original GMPE
-        self.gmpe = registry[gmpe_name]()
+        self.gmpe = registry[gmpe_name](**kwargs)
         self.set_parameters()
 
         # Set options for obtaining within and between stds


### PR DESCRIPTION
Small fixes to make sure they are used as expected when instantiating underlying GMMs