### PR TITLE
In the standard get_outputs template show the buttons to download datastore and job.zip only to advanced users

### DIFF
--- a/openquake/server/templates/engine/get_outputs.html
+++ b/openquake/server/templates/engine/get_outputs.html
@@ -111,11 +111,17 @@
               {% endif %} {# end if AELO #}
             </div>
             <div class="outputs-general-btns-right">
+              {% if user_level >= 2 %}
               <div id="my-datastore">
                 <a href="{{ oq_engine_server_url }}/v1/calc/{{ calc_id }}/datastore"
                    title="Size: {{ size_mb }} MB" class="btn btn-sm">
                   Download hdf5 datastore</a>
               </div>
+              <div id="my-job" class="bottom-right-btns">
+                <a href="{{ oq_engine_server_url }}/v1/calc/{{ calc_id }}/job_zip" class="btn btn-sm">
+                  Download job.zip</a>
+              </div>
+              {% endif %} {# end if user_level >= 2 #}
             </div>
           </div>
         </div>

--- a/openquake/server/templates/engine/get_outputs_impact.html
+++ b/openquake/server/templates/engine/get_outputs_impact.html
@@ -71,7 +71,7 @@
                 <a href="{{ oq_engine_server_url }}/v1/calc/{{ calc_id }}/job_zip" class="btn btn-sm">
                   Download job.zip</a>
               </div>
-              {% endif %}
+              {% endif %} {# end if user_level >= 2 #}
             </div>
           </div>
         </div>


### PR DESCRIPTION
The API already has checks on the user level.
The button to download the job.zip was present only in the template used in impact.
The button to download the datastore was present also in the standard template, but it was displayed also to users for whom pressing the button would be useless.