### PR TITLE
Logging and storing the engine version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Logging and storing the engine version and not the DbServer version
+
   [Matteo Nastasi]
   * Integrate Christopher Brooks PAPERS script to run calculation
     starting from hypothetical ruptures into engine as new API

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -209,7 +209,7 @@ def save_version_checksum(oq, dstore):
     Store the engine version and other attributes in the root dataset
     """
     attrs = dstore['/'].attrs
-    attrs['engine_version'] = logs.dbcmd('engine_version')
+    attrs['engine_version'] = general.engine_version()
     if os.environ.get('OQ_APPLICATION_MODE') == 'AELO':
         attrs['aelo_version'] = get_aelo_version()
     attrs['date'] = datetime.now().isoformat()[:19]

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -390,7 +390,7 @@ def run_jobs(jobctxs, concurrent_jobs=None, nodes=1, sbatch=False,
                 job = logs.dbcmd('get_job', hc_id)
                 ppath = job.ds_calc_dir + '.hdf5'
                 if os.path.exists(ppath):
-                    version = logs.dbcmd('engine_version')
+                    version = general.engine_version()
                     with h5py.File(ppath, 'r') as f:
                         prev_version = f.attrs['engine_version']
                         if prev_version != version:
@@ -743,7 +743,7 @@ def check_obsolete_version(calculation_mode='WebUI'):
         # avoid flooding our API server with requests from CI systems
         return
 
-    version = logs.dbcmd('engine_version')
+    version = general.engine_version()
     logging.info('Using engine version %s', version)
     headers = {'User-Agent': 'OpenQuake Engine %s;%s;%s;%s' %
                (version, calculation_mode, platform.platform(),


### PR DESCRIPTION
Going back to the situation of 4 years ago (https://github.com/gem/oq-engine/pull/7924), since now git has finally fixed their bug forbidding the extraction of the git version for generic users. Closes https://github.com/gem/oq-engine/issues/11376
