### PR TITLE
Getting a good error message for duplicate rupture IDs

### DIFF
--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -23,7 +23,7 @@ import numpy
 
 from openquake.baselib import performance, parallel, hdf5, general, config
 from openquake.hazardlib.source import rupture
-from openquake.hazardlib import map_array, geo
+from openquake.hazardlib import map_array, geo, nrml
 from openquake.hazardlib.source.rupture import get_events
 from openquake.commonlib import util, readinput, datastore
 
@@ -122,6 +122,14 @@ def gmvs_to_poes(df, imtls, ses_per_logic_tree_path):
 
 # ################## utilities for event_based calculators ################ #
 
+def check_duplicates(rup_array, source_info):
+  rupids, counts = numpy.unique(rup_array['id'], return_counts=1)
+  rupid = rupids[counts > 1][0]
+  dupl = rup_array[rup_array['id'] == rupid][['id', 'mag', 'source_id']]
+  _source_ids = source_info['id'][dupl['source_id']]
+  breakpoint()
+  return
+            
 def get_model_lts(h5):
     """
     :returns: (model, full_lt) pairs
@@ -233,7 +241,11 @@ class RuptureImporter(object):
         rup_array = rup_array[geom_id]
         nr = len(rup_array)
         rupids = numpy.unique(rup_array['id'])
-        assert len(rupids) == nr, 'rup_id not unique!'
+        if len(rupids) < nr:
+            # rup_id not unique
+            check_duplicates(rup_array, self.datastore['source_info'][:])
+            raise nrml.DuplicatedID
+
         rup_array['geom_id'] = geom_id
         n_occ = rup_array['n_occ']
         self.check_overflow(n_occ.sum())  # check the number of events

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -129,7 +129,7 @@ def get_first_duplicate(rup_array, source_info):
     rupids, counts = numpy.unique(rup_array['id'], return_counts=1)
     rupid = rupids[counts > 1][0]
     dupl = rup_array[rup_array['id'] == rupid][
-       ['id', 'seed', 'source_id', 'trt_smr', 'code', 'n_occ', 'mag',
+       ['id', 'source_id', 'trt_smr', 'code', 'n_occ', 'mag',
         'occurrence_rate', 'model']]
     source_id = source_info['source_id'][dupl['source_id'][0]]
     return dupl, source_id

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -122,14 +122,19 @@ def gmvs_to_poes(df, imtls, ses_per_logic_tree_path):
 
 # ################## utilities for event_based calculators ################ #
 
-def check_duplicates(rup_array, source_info):
-  rupids, counts = numpy.unique(rup_array['id'], return_counts=1)
-  rupid = rupids[counts > 1][0]
-  dupl = rup_array[rup_array['id'] == rupid][['id', 'mag', 'source_id']]
-  _source_ids = source_info['id'][dupl['source_id']]
-  breakpoint()
-  return
-            
+def get_first_duplicate(rup_array, source_info):
+    """
+    :returns: (duplicate rup_array, source_id)
+    """
+    rupids, counts = numpy.unique(rup_array['id'], return_counts=1)
+    rupid = rupids[counts > 1][0]
+    dupl = rup_array[rup_array['id'] == rupid][
+       ['id', 'seed', 'source_id', 'trt_smr', 'code', 'n_occ', 'mag',
+        'occurrence_rate', 'model']]
+    source_id = source_info['source_id'][dupl['source_id'][0]]
+    return dupl, source_id
+
+
 def get_model_lts(h5):
     """
     :returns: (model, full_lt) pairs
@@ -243,8 +248,11 @@ class RuptureImporter(object):
         rupids = numpy.unique(rup_array['id'])
         if len(rupids) < nr:
             # rup_id not unique
-            check_duplicates(rup_array, self.datastore['source_info'][:])
-            raise nrml.DuplicatedID
+            from openquake.calculators.views import text_table
+            dupl, source_id = get_first_duplicate(
+                rup_array, self.datastore['source_info'][:])
+            msg = f'{source_id=}\n{text_table(dupl, ext="org")}'
+            raise nrml.DuplicatedID(msg)
 
         rup_array['geom_id'] = geom_id
         n_occ = rup_array['n_occ']


### PR DESCRIPTION
For USA:
```
openquake.hazardlib.nrml.DuplicatedID: source_id=b'asc-grid!model'
| id               | source_id | trt_smr | code | n_occ | mag    | occurrence_rate | model |
|------------------+-----------+---------+------+-------+--------+-----------------+-------|
| 1_454_925_655_631| 1_355     | 0       | 153  | 1     | 5.8500 | 6.945E-07       | MEX   |
| 1_454_925_655_631| 1_355     | 0       | 153  | 1     | 6.6500 | 1.532E-06       | OPA   |
```
The bug will be fixed in a different PR. The problem is that 2 different ruptures from two different models
end up with the same ID.