### PR TITLE
Add an epistemic uncertainty for aspect ratio in the SSC logic tree

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ 
+  [Christopher Brooks]
+  * Added new epistemic uncertainties in the source model logic tree
+    for the rupture aspect ratio (`setAspectRatioAbsolute` and
+    `setAspectRatioRelative`). Unit tests added and a QA test in
+    logictree/case_32.
+
   [Michele Simionato, Paolo Tormene]
   * Updated build_exposure_hdf5 to work with the 2026 Global Risk Model
 

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -267,8 +267,6 @@ class ClassicalTestCase(CalculatorTestCase):
 
     def test_case_11(self):
         # Check grid-adjusted GMPE
-        self.run_calc(case_11.__file__, 'job.ini',
-                      calculation_mode='classical')
         self.assert_curves_ok(
             ['hazard_curve-mean-PGA.csv',
              'hazard_curve-mean-SA(0.5).csv',

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -33,9 +33,9 @@ from openquake.qa_tests_data.logictree import (
     case_01, case_02, case_03, case_04, case_05, case_06, case_07, case_08,
     case_09, case_10, case_11, case_12, case_13, case_14, case_15, case_16,
     case_17, case_18, case_19, case_20, case_21, case_22, case_23, case_28,
-    case_30, case_31, case_36, case_39, case_45, case_46, case_52, case_56,
-    case_58, case_59, case_67, case_68, case_71, case_73, case_79, case_80,
-    case_83, case_84)
+    case_30, case_31, case_32, case_36, case_39, case_45, case_46, case_52,
+    case_56, case_58, case_59, case_67, case_68, case_71, case_73, case_79,
+    case_80, case_83, case_84)
 
 ae = numpy.testing.assert_equal
 aac = numpy.testing.assert_allclose
@@ -533,6 +533,12 @@ hazard_uhs-std.csv
         # source specific logic tree
         self.assert_curves_ok(['hazard_curve-mean-PGA.csv',
                                'hazard_curve-std-PGA.csv'], case_31.__file__)
+
+    def test_case_32(self):
+        # Test aspect ratio epistemic uncertainties
+        self.assert_curves_ok(
+            ['hazard_curve-mean-PGA.csv'], 
+             case_32.__file__)                            
 
     def test_case_36(self):
         # test with advanced applyToSources and disordered gsim_logic_tree

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1400,13 +1400,7 @@ class BranchSetApplyUncertaintyTestCase(unittest.TestCase):
         self.assertEqual(inc_point_source.mfd.bin_width, 0.1)
         self.assertEqual(inc_point_source.mfd.occurrence_rates[0], 0.05)
         self.assertEqual(inc_point_source.mfd.occurrence_rates[1], 0.01)
-
-    def test_set_msr_absolute(self):
-        new_msr = openquake.hazardlib.scalerel.WC1994()
-        lt.apply_uncertainty('setMSRAbsolute', self.point_source, new_msr)
-        self.assertIsInstance(
-            self.point_source.magnitude_scaling_relationship,
-            openquake.hazardlib.scalerel.WC1994)
+        
 
     def test_set_lower_seismogenic_depth_absolute(self):
         lt.apply_uncertainty(

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1400,7 +1400,13 @@ class BranchSetApplyUncertaintyTestCase(unittest.TestCase):
         self.assertEqual(inc_point_source.mfd.bin_width, 0.1)
         self.assertEqual(inc_point_source.mfd.occurrence_rates[0], 0.05)
         self.assertEqual(inc_point_source.mfd.occurrence_rates[1], 0.01)
-        
+
+    def test_set_msr_absolute(self):
+        new_msr = openquake.hazardlib.scalerel.WC1994()
+        lt.apply_uncertainty('setMSRAbsolute', self.point_source, new_msr)
+        self.assertIsInstance(
+            self.point_source.magnitude_scaling_relationship,
+            openquake.hazardlib.scalerel.WC1994)
 
     def test_set_lower_seismogenic_depth_absolute(self):
         lt.apply_uncertainty(

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1401,96 +1401,126 @@ class BranchSetApplyUncertaintyTestCase(unittest.TestCase):
         self.assertEqual(inc_point_source.mfd.occurrence_rates[0], 0.05)
         self.assertEqual(inc_point_source.mfd.occurrence_rates[1], 0.01)
 
-    ### AC MFD UNCERTAINTIES ### 
-    def _make_ac_point_source(self):
-        # Make point source with the AC MFD
-        source = deepcopy(self.point_source)
-        source.mfd = AlternativeCharacteristicMFD(
-            min_mag=4.0, max_mag=7.5, bin_width=0.2,
-            b_GR=0.8, b_AC=0.3, gamma=0.96,
-            delta_m_AC=1.0, total_rate=5.0)
-        return source
+    def test_set_msr_absolute(self):
+        new_msr = openquake.hazardlib.scalerel.WC1994()
+        lt.apply_uncertainty('setMSRAbsolute', self.point_source, new_msr)
+        self.assertIsInstance(
+            self.point_source.magnitude_scaling_relationship,
+            openquake.hazardlib.scalerel.WC1994)
+
+    def test_set_lower_seismogenic_depth_absolute(self):
+        lt.apply_uncertainty(
+            'setLowerSeismDepthAbsolute', self.point_source, 15.0)
+        self.assertAlmostEqual(
+            self.point_source.lower_seismogenic_depth, 15.0)
+
+    def test_set_upper_seismogenic_depth_absolute(self):
+        lt.apply_uncertainty(
+            'setUpperSeismDepthAbsolute', self.point_source, 5.0)
+        self.assertAlmostEqual(
+            self.point_source.upper_seismogenic_depth, 5.0)
+
+    def test_aspect_ratio_absolute_uncertainty(self):
+        lt.apply_uncertainty(
+            'setAspectRatioAbsolute', self.point_source, 2.0)
+        self.assertAlmostEqual(self.point_source.rupture_aspect_ratio, 2.0)
+
+    def test_aspect_ratio_relative_uncertainty(self):
+        lt.apply_uncertainty(
+            'setAspectRatioRelative', self.point_source, 0.5)
+        self.assertAlmostEqual(self.point_source.rupture_aspect_ratio, 1.5)
+
+
+class BranchSetApplyACMFDUncertaintyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.source = openquake.hazardlib.source.PointSource(
+            source_id='point', name='point',
+            tectonic_region_type=
+            openquake.hazardlib.const.TRT.ACTIVE_SHALLOW_CRUST,
+            mfd=AlternativeCharacteristicMFD(
+                min_mag=4.0, max_mag=7.5, bin_width=0.2,
+                b_GR=0.8, b_AC=0.3, gamma=0.96,
+                delta_m_AC=1.0, total_rate=5.0),
+            nodal_plane_distribution=PMF(
+                [(1, openquake.hazardlib.geo.NodalPlane(0.0, 90.0, 0.0))]
+            ),
+            hypocenter_distribution=PMF([(1, 10)]),
+            upper_seismogenic_depth=0.0, lower_seismogenic_depth=10.0,
+            magnitude_scaling_relationship=
+            openquake.hazardlib.scalerel.PeerMSR(),
+            rupture_aspect_ratio=1, location=openquake.hazardlib.geo.Point(
+                5, 6),
+            rupture_mesh_spacing=1.0,
+            temporal_occurrence_model=PoissonTOM(50.)
+        )
 
     def test_ac_mfd_b_ac_absolute(self):
-        # Make point source with the MFD
-        source = self._make_ac_point_source()
-        # Apply the absolute b_AC uncertainty
-        lt.apply_uncertainty('bACAbsolute', source, 0.5)
-        # b_GR should now be 0.5
-        self.assertEqual(source.mfd.b_AC, 0.5)
+        lt.apply_uncertainty('bACAbsolute', self.source, 0.5)
+        self.assertEqual(self.source.mfd.b_AC, 0.5)
         # b_GR should be unchanged
-        self.assertEqual(source.mfd.b_GR, 0.8)
+        self.assertEqual(self.source.mfd.b_GR, 0.8)
 
     def test_ac_mfd_b_ac_relative(self):
-        # Make point source with the MFD
-        source = self._make_ac_point_source()
-        # Get original TMR
-        old_tmr = source.mfd._get_total_moment_rate()
-        # Apply the relative b_C uncertainty
-        lt.apply_uncertainty('bACRelative', source, 0.1)
-        self.assertAlmostEqual(source.mfd.b_AC, 0.4)
+        old_tmr = self.source.mfd._get_total_moment_rate()
+        lt.apply_uncertainty('bACRelative', self.source, 0.1)
+        self.assertAlmostEqual(self.source.mfd.b_AC, 0.4)
         # TMR should be preserved
         self.assertAlmostEqual(
-            source.mfd._get_total_moment_rate(), old_tmr, delta=old_tmr * 1E-8)
+            self.source.mfd._get_total_moment_rate(), old_tmr,
+            delta=old_tmr * 1E-8)
         # b_GR should be unchanged
-        self.assertEqual(source.mfd.b_GR, 0.8)
+        self.assertEqual(self.source.mfd.b_GR, 0.8)
+
+    def test_ac_mfd_b_gr_absolute(self):
+        lt.apply_uncertainty('bGRAbsolute', self.source, 1.0)
+        self.assertEqual(self.source.mfd.b_GR, 1.0)
+        # b_AC should be unchanged
+        self.assertEqual(self.source.mfd.b_AC, 0.3)
 
     def test_ac_mfd_b_gr_relative(self):
-        # Make point source with the MFD
-        source = self._make_ac_point_source()
-        # Get original TMR
-        old_tmr = source.mfd._get_total_moment_rate()
-        # Apply relative b_GR uncertainty
-        lt.apply_uncertainty('bGRRelative', source, -0.1)
-        self.assertAlmostEqual(source.mfd.b_GR, 0.7)
+        old_tmr = self.source.mfd._get_total_moment_rate()
+        lt.apply_uncertainty('bGRRelative', self.source, -0.1)
+        self.assertAlmostEqual(self.source.mfd.b_GR, 0.7)
         # TMR should be preserved
         self.assertAlmostEqual(
-            source.mfd._get_total_moment_rate(), old_tmr, delta=old_tmr * 1E-8)
+            self.source.mfd._get_total_moment_rate(), old_tmr,
+            delta=old_tmr * 1E-8)
         # b_AC should be unchanged
-        self.assertEqual(source.mfd.b_AC, 0.3)
+        self.assertEqual(self.source.mfd.b_AC, 0.3)
 
-    def test_ac_mfd_max_max_gr_absolute(self):
-        # Make point source with the MFD
-        source = self._make_ac_point_source()
-        # Apply absolute max_mag uncertainty
-        lt.apply_uncertainty('maxMagGRAbsolute', source, 8.0)
-        self.assertEqual(source.mfd.max_mag, 8.0)
+    def test_ac_mfd_max_mag_gr_absolute(self):
+        lt.apply_uncertainty('maxMagGRAbsolute', self.source, 8.0)
+        self.assertEqual(self.source.mfd.max_mag, 8.0)
         # Other parameters should be unchanged
-        self.assertEqual(source.mfd.b_GR, 0.8)
-        self.assertEqual(source.mfd.b_AC, 0.3)
-        self.assertEqual(source.mfd.delta_m_AC, 1.0)
+        self.assertEqual(self.source.mfd.b_GR, 0.8)
+        self.assertEqual(self.source.mfd.b_AC, 0.3)
+        self.assertEqual(self.source.mfd.delta_m_AC, 1.0)
 
     def test_ac_mfd_max_mag_and_delta_mag_ac_relative(self):
-        # Make point source with the MFD
-        source = self._make_ac_point_source()
-        # Get original TMR
-        old_tmr = source.mfd._get_total_moment_rate()
-        # Apply relative max_mag and delta_m_AC uncertainty
+        old_tmr = self.source.mfd._get_total_moment_rate()
         lt.apply_uncertainty(
-            'maxMagAndDeltaMagACRelative', source, (0.5, 0.2))
-        self.assertAlmostEqual(source.mfd.max_mag, 8.0)
-        self.assertAlmostEqual(source.mfd.delta_m_AC, 1.2)
+            'maxMagAndDeltaMagACRelative', self.source, (0.5, 0.2))
+        self.assertAlmostEqual(self.source.mfd.max_mag, 8.0)
+        self.assertAlmostEqual(self.source.mfd.delta_m_AC, 1.2)
         # TMR should be preserved
         self.assertAlmostEqual(
-            source.mfd._get_total_moment_rate(), old_tmr, delta=old_tmr * 1E-8)
+            self.source.mfd._get_total_moment_rate(), old_tmr,
+            delta=old_tmr * 1E-8)
         # b-values should be unchanged
-        self.assertEqual(source.mfd.b_GR, 0.8)
-        self.assertEqual(source.mfd.b_AC, 0.3)
+        self.assertEqual(self.source.mfd.b_GR, 0.8)
+        self.assertEqual(self.source.mfd.b_AC, 0.3)
 
     def test_ac_mfd_max_mag_and_delta_mag_ac_relative_no_balance(self):
-        # Make point source with the MFD
-        source = self._make_ac_point_source()
-        old_total_rate = source.mfd.total_rate
-        # Apply relative max_mag and delta_m_AC without moment balance
+        old_total_rate = self.source.mfd.total_rate
         lt.apply_uncertainty(
-            'maxMagAndDeltaMagACRelativeNoMoBalance', source, (0.5, 0.2))
-        self.assertAlmostEqual(source.mfd.max_mag, 8.0)
-        self.assertAlmostEqual(source.mfd.delta_m_AC, 1.2)
+            'maxMagAndDeltaMagACRelativeNoMoBalance', self.source, (0.5, 0.2))
+        self.assertAlmostEqual(self.source.mfd.max_mag, 8.0)
+        self.assertAlmostEqual(self.source.mfd.delta_m_AC, 1.2)
         # total_rate should NOT have been rescaled
-        self.assertEqual(source.mfd.total_rate, old_total_rate)
+        self.assertEqual(self.source.mfd.total_rate, old_total_rate)
         # b-values should be unchanged
-        self.assertEqual(source.mfd.b_GR, 0.8)
-        self.assertEqual(source.mfd.b_AC, 0.3)
+        self.assertEqual(self.source.mfd.b_GR, 0.8)
+        self.assertEqual(self.source.mfd.b_AC, 0.3)
 
 
 class BranchSetApplyGeometryUncertaintyTestCase(unittest.TestCase):

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -395,6 +395,16 @@ def _setMSR(utype, source, value):
     source.modify('set_msr', dict(new_msr=msr))
 
 
+@apply_uncertainty.add('setAspectRatioAbsolute')
+def _set_aspect_ratio_absolute(utype, source, value):
+    source.modify('set_aspect_ratio', dict(aspect_ratio=value))
+
+
+@apply_uncertainty.add('setAspectRatioRelative')
+def _set_aspect_ratio_relative(utype, source, value):
+    source.modify('adjust_aspect_ratio', dict(increment=value))
+
+
 @apply_uncertainty.add('recomputeMmax')
 def _recompute_mmax_absolute(utype, source, value):
     epsilon = value
@@ -408,7 +418,7 @@ def _setLSD(utype, source, value):
 
 @apply_uncertainty.add('setUpperSeismDepthAbsolute')
 def _setUSD(utype, source, value):
-    source.modify('set_upper_seismogenic_depth', dict(lsd=float(value)))
+    source.modify('set_upper_seismogenic_depth', dict(usd=float(value)))
 
 
 @apply_uncertainty.add('dummy')  # do nothing

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -38,8 +38,13 @@ class AreaSource(ParametricSeismicSource):
     :class:`~openquake.hazardlib.source.point.PointSource`.
     """
     code = b'A'
-    MODIFICATIONS = {'set_geometry', 'set_lower_seismogenic_depth',
-                     'set_upper_seismogenic_depth'}
+    MODIFICATIONS = {
+        'adjust_aspect_ratio',
+        'set_aspect_ratio',
+        'set_geometry',
+        'set_lower_seismogenic_depth',
+        'set_upper_seismogenic_depth',
+    }
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -44,6 +44,7 @@ class AreaSource(ParametricSeismicSource):
         'set_geometry',
         'set_lower_seismogenic_depth',
         'set_upper_seismogenic_depth',
+        'set_msr',
     }
 
     def __init__(self, source_id, name, tectonic_region_type,

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -463,6 +463,9 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
         :param float aspect_ratio:
             New value of the rupture aspect ratio (must be positive)
         """
+        if not aspect_ratio > 0:
+            raise ValueError('rupture aspect ratio must be positive, got %s'
+                             % aspect_ratio)
         self.rupture_aspect_ratio = aspect_ratio
 
     def modify_adjust_aspect_ratio(self, increment):
@@ -472,7 +475,12 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
         :param float increment:
             Value by which to increase or decrease the rupture aspect ratio
         """
-        self.rupture_aspect_ratio += increment
+        new_ratio = self.rupture_aspect_ratio + increment
+        if not new_ratio > 0:
+            raise ValueError(
+                'increment %s would result in a non-positive rupture aspect '
+                'ratio (%s)' % (increment, new_ratio))
+        self.rupture_aspect_ratio = new_ratio
 
     def modify_set_slip_rate(self, slip_rate: float):
         """

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -456,6 +456,24 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
         """
         self.magnitude_scaling_relationship = new_msr
 
+    def modify_set_aspect_ratio(self, aspect_ratio):
+        """
+        Replaces the rupture aspect ratio with the given value
+
+        :param float aspect_ratio:
+            New value of the rupture aspect ratio (must be positive)
+        """
+        self.rupture_aspect_ratio = aspect_ratio
+
+    def modify_adjust_aspect_ratio(self, increment):
+        """
+        Adjusts the rupture aspect ratio by an incremental value
+
+        :param float increment:
+            Value by which to increase or decrease the rupture aspect ratio
+        """
+        self.rupture_aspect_ratio += increment
+
     def modify_set_slip_rate(self, slip_rate: float):
         """
         Updates the slip rate assigned to the source
@@ -467,7 +485,7 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
 
     def modify_set_mmax_truncatedGR(self, mmax: float):
         """
-        Updates the mmax assigned. This works on for parametric MFDs.s
+        Updates the mmax assigned. This works on for parametric MFDs.
 
         :param mmax:
             The value of the new maximum magnitude

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -52,7 +52,10 @@ class CharacteristicFaultSource(ParametricSeismicSource):
     as a LiteralNode object.
     """
     code = b'X'
-    MODIFICATIONS = {'set_geometry', 'adjust_mfd_from_slip'}
+    MODIFICATIONS = {
+        'adjust_mfd_from_slip',
+        'set_geometry',
+    }
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, temporal_occurrence_model, surface, rake,

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -152,6 +152,7 @@ class ComplexFaultSource(ParametricSeismicSource):
         'adjust_mfd_from_slip',
         'set_aspect_ratio',
         'set_geometry',
+        'set_msr',
     }
 
     def __init__(self, source_id, name, tectonic_region_type, mfd,

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -147,7 +147,12 @@ class ComplexFaultSource(ParametricSeismicSource):
     """
     code = b'C'
     # a slice of the rupture_slices, thus splitting the source
-    MODIFICATIONS = {'set_geometry', 'adjust_mfd_from_slip'}
+    MODIFICATIONS = {
+        'adjust_aspect_ratio',
+        'adjust_mfd_from_slip',
+        'set_aspect_ratio',
+        'set_geometry',
+    }
 
     def __init__(self, source_id, name, tectonic_region_type, mfd,
                  rupture_mesh_spacing, magnitude_scaling_relationship,

--- a/openquake/hazardlib/source/kite_fault.py
+++ b/openquake/hazardlib/source/kite_fault.py
@@ -86,7 +86,11 @@ class KiteFaultSource(ParametricSeismicSource):
     Kite fault source
     """
     code = b'K'
-    MODIFICATIONS = {'adjust_mfd_from_slip'}
+    MODIFICATIONS = {
+        'adjust_aspect_ratio',
+        'adjust_mfd_from_slip',
+        'set_aspect_ratio',
+    }
 
     def __init__(self, source_id, name, tectonic_region_type, mfd,
                  rupture_mesh_spacing, magnitude_scaling_relationship,

--- a/openquake/hazardlib/source/kite_fault.py
+++ b/openquake/hazardlib/source/kite_fault.py
@@ -90,6 +90,7 @@ class KiteFaultSource(ParametricSeismicSource):
         'adjust_aspect_ratio',
         'adjust_mfd_from_slip',
         'set_aspect_ratio',
+        'set_msr',
     }
 
     def __init__(self, source_id, name, tectonic_region_type, mfd,

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -51,6 +51,7 @@ class MultiPointSource(ParametricSeismicSource):
         'set_aspect_ratio',
         'set_lower_seismogenic_depth',
         'set_upper_seismogenic_depth',
+        'set_msr',
     }
 
     def __init__(self, source_id, name, tectonic_region_type,

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -46,8 +46,12 @@ class MultiPointSource(ParametricSeismicSource):
     lower_seismogenic_depth, nodal_plane_distribution, hypocenter_distribution
     """
     code = b'M'
-    MODIFICATIONS = {'set_lower_seismogenic_depth',
-                     'set_upper_seismogenic_depth'}
+    MODIFICATIONS = {
+        'adjust_aspect_ratio',
+        'set_aspect_ratio',
+        'set_lower_seismogenic_depth',
+        'set_upper_seismogenic_depth',
+    }
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, magnitude_scaling_relationship, rupture_aspect_ratio,

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -112,8 +112,12 @@ class PointSource(ParametricSeismicSource):
         than upper seismogenic depth or deeper than lower seismogenic depth.
     """
     code = b'P'
-    MODIFICATIONS = {'set_lower_seismogenic_depth',
-                     'set_upper_seismogenic_depth'}
+    MODIFICATIONS = {
+        'adjust_aspect_ratio',
+        'set_aspect_ratio',
+        'set_lower_seismogenic_depth',
+        'set_upper_seismogenic_depth',
+    }
     ps_grid_spacing = 0  # updated in CollapsedPointSource
 
     def __init__(self, source_id, name, tectonic_region_type,

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -117,6 +117,7 @@ class PointSource(ParametricSeismicSource):
         'set_aspect_ratio',
         'set_lower_seismogenic_depth',
         'set_upper_seismogenic_depth',
+        'set_msr',
     }
     ps_grid_spacing = 0  # updated in CollapsedPointSource
 

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -81,11 +81,20 @@ class SimpleFaultSource(ParametricSeismicSource):
         for the lowest magnitude value.
     """
     code = b'S'
-    MODIFICATIONS = {'adjust_dip', 'adjust_mfd_from_slip',
-                     'set_bGR', 'set_dip', 'set_geometry',
-                     'set_lower_seismogenic_depth', 'set_msr',
-                     'set_slip_rate', 'set_mmax_truncatedGR',
-                     'recompute_mmax'}
+    MODIFICATIONS = {
+        'adjust_aspect_ratio',
+        'adjust_dip',
+        'adjust_mfd_from_slip',
+        'recompute_mmax',
+        'set_aspect_ratio',
+        'set_bGR',
+        'set_dip',
+        'set_geometry',
+        'set_lower_seismogenic_depth',
+        'set_mmax_truncatedGR',
+        'set_msr',
+        'set_slip_rate',
+    }
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/qa_tests_data/logictree/README.md
+++ b/openquake/qa_tests_data/logictree/README.md
@@ -30,6 +30,7 @@
 | case\_28\_bis      | Test missing z1pt0                                                         |
 | case\_30           | IMT-dependent weights, International Date Line                             |
 | case\_31           | Source Specific Logic Tree                                                 |
+| case\_32           | Tests setAspectRatioAbsolute and setAspectRatioRelative                    |
 | case\_36           | Advanced applyToSources                                                    |
 | case\_39           | 0-IMT-weights, pointsource distance=0 and ruptures collapsing              |
 | case\_45           | MMI with disagg\_by\_src and sampling                                      |

--- a/openquake/qa_tests_data/logictree/case_32/expected/hazard_curve-mean-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_32/expected/hazard_curve-mean-PGA.csv
@@ -1,0 +1,3 @@
+#,,,,,,,,"generated_by='OpenQuake engine 3.26.0-git92acae053f', start_date='2026-04-23T10:59:07', checksum=123547269, kind='mean', investigation_time=50.0, imt='PGA'"
+lon,lat,depth,poe-0.0100000,poe-0.0500000,poe-0.1000000,poe-0.2000000,poe-0.5000000,poe-1.0000000
+0.50000,-0.50000,0.00000,9.090291E-02,3.176836E-02,7.299312E-03,6.174751E-04,0.000000E+00,0.000000E+00

--- a/openquake/qa_tests_data/logictree/case_32/gsim_logic_tree.xml
+++ b/openquake/qa_tests_data/logictree/case_32/gsim_logic_tree.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="gmpeModel" branchSetID="bs1"
+                                applyToTectonicRegionType="Active Shallow Crust">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>ChiouYoungs2014</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/logictree/case_32/job.ini
+++ b/openquake/qa_tests_data/logictree/case_32/job.ini
@@ -1,0 +1,38 @@
+[general]
+
+description = Test aspect ratio epistemic uncertainties
+calculation_mode = classical
+random_seed = 23
+
+[geometry]
+
+sites = 0.5 -0.5
+
+[logic_tree]
+
+number_of_logic_tree_samples = 0
+
+[erf]
+
+rupture_mesh_spacing = 5.0
+width_of_mfd_bin = 0.1
+
+[site_params]
+
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 2.5
+reference_depth_to_1pt0km_per_sec = 50.0
+
+[calculation]
+
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gsim_logic_tree.xml
+investigation_time = 50.0
+intensity_measure_types_and_levels = {"PGA": [0.01, 0.05, 0.1, 0.2, 0.5, 1.0]}
+truncation_level = 3.0
+maximum_distance = 200.0
+
+[output]
+
+mean = true

--- a/openquake/qa_tests_data/logictree/case_32/source_model.xml
+++ b/openquake/qa_tests_data/logictree/case_32/source_model.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+      xmlns:gml="http://www.opengis.net/gml">
+    <sourceModel name="Simple Fault Source Model for Aspect Ratio Test">
+        <simpleFaultSource id="1" name="Simple Fault Source"
+                           tectonicRegion="Active Shallow Crust">
+            <simpleFaultGeometry>
+                <gml:LineString>
+                    <gml:posList>
+                        1.0 -0.5 1.4 0.0 1.4 0.3
+                    </gml:posList>
+                </gml:LineString>
+                <dip>30.0</dip>
+                <upperSeismoDepth>8.0</upperSeismoDepth>
+                <lowerSeismoDepth>20.0</lowerSeismoDepth>
+            </simpleFaultGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.0</ruptAspectRatio>
+            <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
+                                      minMag="6.5" maxMag="7.5"/>
+            <rake>90.0</rake>
+        </simpleFaultSource>
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/logictree/case_32/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/logictree/case_32/source_model_logic_tree.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>source_model.xml</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+        <logicTreeBranchingLevel branchingLevelID="bl2">
+            <logicTreeBranchSet uncertaintyType="setAspectRatioAbsolute"
+                                branchSetID="bs2">
+                <logicTreeBranch branchID="b21">
+                    <uncertaintyModel>1.0</uncertaintyModel>
+                    <uncertaintyWeight>0.5</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="b22">
+                    <uncertaintyModel>2.0</uncertaintyModel>
+                    <uncertaintyWeight>0.5</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+        <logicTreeBranchingLevel branchingLevelID="bl3">
+            <logicTreeBranchSet uncertaintyType="setAspectRatioRelative"
+                                branchSetID="bs3">
+                <logicTreeBranch branchID="b31">
+                    <uncertaintyModel>-0.5</uncertaintyModel>
+                    <uncertaintyWeight>0.5</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="b32">
+                    <uncertaintyModel>0.5</uncertaintyModel>
+                    <uncertaintyWeight>0.5</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>


### PR DESCRIPTION
I add in this PR a capability to apply either an absolute or relative aspect ratio to permit additional simplification of an SSC logic tree.

I add a QA test (logictree/case_32) and some unit tests too (in `logic_tree_tests.py`.

** Other **
I also moved the AC MFD epistemic uncertainty unit tests located here in `logic_tree_tests.py` into a separate class because they are long and class specific epistemic uncertainties.

Other some basic unit tests (I think) were missing for setting an MSR and the seismogenic depth uncertainties (only tested in QA tests), so I added some simple unit tests for these too. 

The absolute MSR epistemic uncertainty (dict of mag scaling relationships) was previously only supported for simple fault sources, but I think it makes sense to be able to use this uncertainty type in some other types too (still skip characteristic faults given inherently does not make sense here). The new unit tests for setting an MSR in `logic_tree_tests.py` test this on a point source.