### PR TITLE
Add an epistemic uncertainty for setting a relative seismogenic depth

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,7 @@
   [Christopher Brooks]
+  * Add a relative epistemic uncertainty for seismogenic depths in the
+    source model logic tree. Some unit tests added and a QA test in
+    logictree/case_33.
   * Add ability to specify reference z1pt4 (like for z1pt0, z2pt5 etc.) in
     the job file.
   

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -544,7 +544,7 @@ hazard_uhs-std.csv
         # Test seismogenic depth epistemic uncertainties
         self.assert_curves_ok(
             ['hazard_curve-mean-PGA.csv'], 
-             case_32.__file__)    
+             case_33.__file__)    
 
     def test_case_36(self):
         # test with advanced applyToSources and disordered gsim_logic_tree

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -33,9 +33,9 @@ from openquake.qa_tests_data.logictree import (
     case_01, case_02, case_03, case_04, case_05, case_06, case_07, case_08,
     case_09, case_10, case_11, case_12, case_13, case_14, case_15, case_16,
     case_17, case_18, case_19, case_20, case_21, case_22, case_23, case_28,
-    case_30, case_31, case_32, case_36, case_39, case_45, case_46, case_52,
-    case_56, case_58, case_59, case_67, case_68, case_71, case_73, case_79,
-    case_80, case_83, case_84)
+    case_30, case_31, case_32, case_33, case_36, case_39, case_45, case_46,
+    case_52, case_56, case_58, case_59, case_67, case_68, case_71, case_73,
+    case_79, case_80, case_83, case_84)
 
 ae = numpy.testing.assert_equal
 aac = numpy.testing.assert_allclose
@@ -539,6 +539,12 @@ hazard_uhs-std.csv
         self.assert_curves_ok(
             ['hazard_curve-mean-PGA.csv'], 
              case_32.__file__)                            
+
+    def test_case_33(self):
+        # Test seismogenic depth epistemic uncertainties
+        self.assert_curves_ok(
+            ['hazard_curve-mean-PGA.csv'], 
+             case_32.__file__)    
 
     def test_case_36(self):
         # test with advanced applyToSources and disordered gsim_logic_tree

--- a/openquake/commonlib/tests/logictree_test.py
+++ b/openquake/commonlib/tests/logictree_test.py
@@ -1420,6 +1420,18 @@ class BranchSetApplyUncertaintyTestCase(unittest.TestCase):
         self.assertAlmostEqual(
             self.point_source.upper_seismogenic_depth, 5.0)
 
+    def test_set_lower_seismogenic_depth_relative(self):
+        lt.apply_uncertainty(
+            'setLowerSeismDepthRelative', self.point_source, 3.0)
+        self.assertAlmostEqual(
+            self.point_source.lower_seismogenic_depth, 13.0)
+
+    def test_set_upper_seismogenic_depth_relative(self):
+        lt.apply_uncertainty(
+            'setUpperSeismDepthRelative', self.point_source, 2.0)
+        self.assertAlmostEqual(
+            self.point_source.upper_seismogenic_depth, 2.0)
+
     def test_aspect_ratio_absolute_uncertainty(self):
         lt.apply_uncertainty(
             'setAspectRatioAbsolute', self.point_source, 2.0)

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -22,7 +22,7 @@ import operator
 import itertools
 import numpy
 
-from openquake.baselib.general import CallableDict, BASE183, int_to_base183
+from openquake.baselib.general import CallableDict, BASE183
 from openquake.baselib.node import Node
 from openquake.hazardlib import geo, nrml
 from openquake.hazardlib.sourceconverter import (
@@ -902,10 +902,10 @@ class Realization(object):
 
 def add_path(bset, bsno, brno, num_prev, tot, paths):
     base = BASE183
-    if brno + len(bset.branches) >= len(BASE183) ** 2:
+    if brno + len(bset.branches) >= len(BASE183):
         brno = 0
     for br in bset.branches:
-        br.short_id = int_to_base183(brno, base)
+        br.short_id = base[brno]
         path = ['*'] * tot
         path[bsno] = br.id
         paths.append(''.join(path))

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -22,7 +22,7 @@ import operator
 import itertools
 import numpy
 
-from openquake.baselib.general import CallableDict, BASE183
+from openquake.baselib.general import CallableDict, BASE183, int_to_base183
 from openquake.baselib.node import Node
 from openquake.hazardlib import geo, nrml
 from openquake.hazardlib.sourceconverter import (
@@ -419,6 +419,16 @@ def _setLSD(utype, source, value):
 @apply_uncertainty.add('setUpperSeismDepthAbsolute')
 def _setUSD(utype, source, value):
     source.modify('set_upper_seismogenic_depth', dict(usd=float(value)))
+
+
+@apply_uncertainty.add('setLowerSeismDepthRelative')
+def _setLSDRelative(utype, source, value):
+    source.modify('adjust_lower_seismogenic_depth', dict(increment=float(value)))
+
+
+@apply_uncertainty.add('setUpperSeismDepthRelative')
+def _setUSDRelative(utype, source, value):
+    source.modify('adjust_upper_seismogenic_depth', dict(increment=float(value)))
 
 
 @apply_uncertainty.add('dummy')  # do nothing
@@ -892,10 +902,10 @@ class Realization(object):
 
 def add_path(bset, bsno, brno, num_prev, tot, paths):
     base = BASE183
-    if brno + len(bset.branches) >= len(BASE183):
+    if brno + len(bset.branches) >= len(BASE183) ** 2:
         brno = 0
     for br in bset.branches:
-        br.short_id = base[brno]
+        br.short_id = int_to_base183(brno, base)
         path = ['*'] * tot
         path[bsno] = br.id
         paths.append(''.join(path))

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -40,12 +40,12 @@ class AreaSource(ParametricSeismicSource):
     code = b'A'
     MODIFICATIONS = {
         'adjust_aspect_ratio',
-        'adjust_lower_seismogenic_depth',
-        'adjust_upper_seismogenic_depth',
         'set_aspect_ratio',
         'set_geometry',
         'set_lower_seismogenic_depth',
         'set_upper_seismogenic_depth',
+        'adjust_lower_seismogenic_depth',
+        'adjust_upper_seismogenic_depth',
         'set_msr',
     }
 

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -40,6 +40,8 @@ class AreaSource(ParametricSeismicSource):
     code = b'A'
     MODIFICATIONS = {
         'adjust_aspect_ratio',
+        'adjust_lower_seismogenic_depth',
+        'adjust_upper_seismogenic_depth',
         'set_aspect_ratio',
         'set_geometry',
         'set_lower_seismogenic_depth',
@@ -82,12 +84,32 @@ class AreaSource(ParametricSeismicSource):
         """
         self.lower_seismogenic_depth = lsd
 
+    def modify_adjust_lower_seismogenic_depth(self, increment):
+        """
+        Modifies the lower seismogenic depth by adding an increment
+
+        :param float increment:
+            Value (in km) by which to increase or decrease the lower
+            seismogenic depth
+        """
+        self.lower_seismogenic_depth += increment
+
     def modify_set_upper_seismogenic_depth(self, usd):
         """
         Modifies the current source geometry by replacing the original
         upper seismogenic depth with the passed depth
         """
         self.upper_seismogenic_depth = usd
+
+    def modify_adjust_upper_seismogenic_depth(self, increment):
+        """
+        Modifies the upper seismogenic depth by adding an increment
+
+        :param float increment:
+            Value (in km) by which to increase or decrease the upper
+            seismogenic depth
+        """
+        self.upper_seismogenic_depth += increment
 
     def iter_ruptures(self, **kwargs):
         """

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -48,11 +48,11 @@ class MultiPointSource(ParametricSeismicSource):
     code = b'M'
     MODIFICATIONS = {
         'adjust_aspect_ratio',
-        'adjust_lower_seismogenic_depth',
-        'adjust_upper_seismogenic_depth',
         'set_aspect_ratio',
         'set_lower_seismogenic_depth',
         'set_upper_seismogenic_depth',
+        'adjust_lower_seismogenic_depth',
+        'adjust_upper_seismogenic_depth',
         'set_msr',
     }
 

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -48,6 +48,8 @@ class MultiPointSource(ParametricSeismicSource):
     code = b'M'
     MODIFICATIONS = {
         'adjust_aspect_ratio',
+        'adjust_lower_seismogenic_depth',
+        'adjust_upper_seismogenic_depth',
         'set_aspect_ratio',
         'set_lower_seismogenic_depth',
         'set_upper_seismogenic_depth',
@@ -119,12 +121,32 @@ class MultiPointSource(ParametricSeismicSource):
         """
         self.lower_seismogenic_depth = lsd
 
+    def modify_adjust_lower_seismogenic_depth(self, increment):
+        """
+        Modifies the lower seismogenic depth by adding an increment
+
+        :param float increment:
+            Value (in km) by which to increase or decrease the lower
+            seismogenic depth
+        """
+        self.lower_seismogenic_depth += increment
+
     def modify_set_upper_seismogenic_depth(self, usd):
         """
         Modifies the current source geometry by replacing the original
         upper seismogenic depth with the passed depth
         """
         self.upper_seismogenic_depth = usd
+
+    def modify_adjust_upper_seismogenic_depth(self, increment):
+        """
+        Modifies the upper seismogenic depth by adding an increment
+
+        :param float increment:
+            Value (in km) by which to increase or decrease the upper
+            seismogenic depth
+        """
+        self.upper_seismogenic_depth += increment
 
     def get_bounding_box(self, maxdist):
         """

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -114,11 +114,11 @@ class PointSource(ParametricSeismicSource):
     code = b'P'
     MODIFICATIONS = {
         'adjust_aspect_ratio',
-        'adjust_lower_seismogenic_depth',
-        'adjust_upper_seismogenic_depth',
         'set_aspect_ratio',
         'set_lower_seismogenic_depth',
         'set_upper_seismogenic_depth',
+        'adjust_lower_seismogenic_depth',
+        'adjust_upper_seismogenic_depth',
         'set_msr',
     }
     ps_grid_spacing = 0  # updated in CollapsedPointSource

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -114,6 +114,8 @@ class PointSource(ParametricSeismicSource):
     code = b'P'
     MODIFICATIONS = {
         'adjust_aspect_ratio',
+        'adjust_lower_seismogenic_depth',
+        'adjust_upper_seismogenic_depth',
         'set_aspect_ratio',
         'set_lower_seismogenic_depth',
         'set_upper_seismogenic_depth',
@@ -303,12 +305,32 @@ class PointSource(ParametricSeismicSource):
         """
         self.lower_seismogenic_depth = lsd
 
+    def modify_adjust_lower_seismogenic_depth(self, increment):
+        """
+        Modifies the lower seismogenic depth by adding an increment
+
+        :param float increment:
+            Value (in km) by which to increase or decrease the lower
+            seismogenic depth
+        """
+        self.lower_seismogenic_depth += increment
+
     def modify_set_upper_seismogenic_depth(self, usd):
         """
         Modifies the current source geometry by replacing the original
         upper seismogenic depth with the passed depth
         """
         self.upper_seismogenic_depth = usd
+
+    def modify_adjust_upper_seismogenic_depth(self, increment):
+        """
+        Modifies the upper seismogenic depth by adding an increment
+
+        :param float increment:
+            Value (in km) by which to increase or decrease the upper
+            seismogenic depth
+        """
+        self.upper_seismogenic_depth += increment
 
     @property
     def polygon(self):

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -84,6 +84,7 @@ class SimpleFaultSource(ParametricSeismicSource):
     MODIFICATIONS = {
         'adjust_aspect_ratio',
         'adjust_dip',
+        'adjust_lower_seismogenic_depth',
         'adjust_mfd_from_slip',
         'recompute_mmax',
         'set_aspect_ratio',
@@ -325,6 +326,20 @@ class SimpleFaultSource(ParametricSeismicSource):
         :param float lsd:
             New value of the lsd [km]
         """
+        SimpleFaultSurface.check_fault_data(
+            self.fault_trace, self.upper_seismogenic_depth, lsd,
+            self.dip, self.rupture_mesh_spacing)
+        self.lower_seismogenic_depth = lsd
+
+    def modify_adjust_lower_seismogenic_depth(self, increment):
+        """
+        Modifies the lower seismogenic depth by adding an increment
+
+        :param float increment:
+            Value (in km) by which to increase or decrease the lower
+            seismogenic depth
+        """
+        lsd = self.lower_seismogenic_depth + increment
         SimpleFaultSurface.check_fault_data(
             self.fault_trace, self.upper_seismogenic_depth, lsd,
             self.dip, self.rupture_mesh_spacing)

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -84,7 +84,6 @@ class SimpleFaultSource(ParametricSeismicSource):
     MODIFICATIONS = {
         'adjust_aspect_ratio',
         'adjust_dip',
-        'adjust_lower_seismogenic_depth',
         'adjust_mfd_from_slip',
         'recompute_mmax',
         'set_aspect_ratio',
@@ -92,6 +91,7 @@ class SimpleFaultSource(ParametricSeismicSource):
         'set_dip',
         'set_geometry',
         'set_lower_seismogenic_depth',
+        'adjust_lower_seismogenic_depth',
         'set_mmax_truncatedGR',
         'set_msr',
         'set_slip_rate',

--- a/openquake/qa_tests_data/logictree/README.md
+++ b/openquake/qa_tests_data/logictree/README.md
@@ -31,6 +31,7 @@
 | case\_30           | IMT-dependent weights, International Date Line                             |
 | case\_31           | Source Specific Logic Tree                                                 |
 | case\_32           | Tests setAspectRatioAbsolute and setAspectRatioRelative                    |
+| case\_33           | Tests setLowerSeismDepthRelative and setLowerSeismDepthAbsolute            |
 | case\_36           | Advanced applyToSources                                                    |
 | case\_39           | 0-IMT-weights, pointsource distance=0 and ruptures collapsing              |
 | case\_45           | MMI with disagg\_by\_src and sampling                                      |

--- a/openquake/qa_tests_data/logictree/case_33/expected/hazard_curve-mean-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_33/expected/hazard_curve-mean-PGA.csv
@@ -1,0 +1,3 @@
+#,,,,,,,,"generated_by='OpenQuake engine 3.26.0-git9d0f6184f1', start_date='2026-04-24T12:17:05', checksum=927507297, kind='mean', investigation_time=50.0, imt='PGA'"
+lon,lat,depth,poe-0.0100000,poe-0.0500000,poe-0.1000000,poe-0.2000000,poe-0.5000000,poe-1.0000000
+0.50000,-0.50000,0.00000,8.928332E-02,2.642012E-02,5.522685E-03,4.139664E-04,0.000000E+00,0.000000E+00

--- a/openquake/qa_tests_data/logictree/case_33/gsim_logic_tree.xml
+++ b/openquake/qa_tests_data/logictree/case_33/gsim_logic_tree.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="gmpeModel" branchSetID="bs1"
+                                applyToTectonicRegionType="Active Shallow Crust">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>ChiouYoungs2014</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/logictree/case_33/job.ini
+++ b/openquake/qa_tests_data/logictree/case_33/job.ini
@@ -1,0 +1,38 @@
+[general]
+
+description = Tests relative and absolute seismogenic depth uncertainties
+calculation_mode = classical
+random_seed = 23
+
+[geometry]
+
+sites = 0.5 -0.5
+
+[logic_tree]
+
+number_of_logic_tree_samples = 0
+
+[erf]
+
+rupture_mesh_spacing = 5.0
+width_of_mfd_bin = 0.1
+
+[site_params]
+
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 2.5
+reference_depth_to_1pt0km_per_sec = 50.0
+
+[calculation]
+
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gsim_logic_tree.xml
+investigation_time = 50.0
+intensity_measure_types_and_levels = {"PGA": [0.01, 0.05, 0.1, 0.2, 0.5, 1.0]}
+truncation_level = 3.0
+maximum_distance = 200.0
+
+[output]
+
+mean = true

--- a/openquake/qa_tests_data/logictree/case_33/realizations_2027.csv
+++ b/openquake/qa_tests_data/logictree/case_33/realizations_2027.csv
@@ -1,0 +1,11 @@
+#,,"generated_by='OpenQuake engine 3.26.0-git9d0f6184f1', start_date='2026-04-24T12:17:05', checksum=927507297"
+rlz_id,branch_path,weight
+0,AAA~A,1.1108889e-01
+1,AAB~A,1.1112222e-01
+2,AAC~A,1.1108889e-01
+3,ABA~A,1.1112222e-01
+4,ABB~A,1.1115556e-01
+5,ABC~A,1.1112222e-01
+6,ACA~A,1.1108889e-01
+7,ACB~A,1.1112222e-01
+8,ACC~A,1.1108889e-01

--- a/openquake/qa_tests_data/logictree/case_33/source_model.xml
+++ b/openquake/qa_tests_data/logictree/case_33/source_model.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+      xmlns:gml="http://www.opengis.net/gml">
+    <sourceModel name="Test source">
+        <simpleFaultSource id="1" name="Simple Fault Source"
+                           tectonicRegion="Active Shallow Crust">
+            <simpleFaultGeometry>
+                <gml:LineString>
+                    <gml:posList>
+                        1.0 -0.5 1.4 0.0 1.4 0.3
+                    </gml:posList>
+                </gml:LineString>
+                <dip>30.0</dip>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>15.0</lowerSeismoDepth>
+            </simpleFaultGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.0</ruptAspectRatio>
+            <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
+                                      minMag="6.5" maxMag="7.5"/>
+            <rake>90.0</rake>
+        </simpleFaultSource>
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/logictree/case_33/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/logictree/case_33/source_model_logic_tree.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>source_model.xml</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+        <logicTreeBranchingLevel branchingLevelID="bl2">
+            <logicTreeBranchSet uncertaintyType="setLowerSeismDepthAbsolute"
+                                branchSetID="bs2">
+                <logicTreeBranch branchID="b21">
+                    <uncertaintyModel>10.0</uncertaintyModel>
+                    <uncertaintyWeight>0.3333</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="b22">
+                    <uncertaintyModel>15.0</uncertaintyModel>
+                    <uncertaintyWeight>0.3334</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="b23">
+                    <uncertaintyModel>20.0</uncertaintyModel>
+                    <uncertaintyWeight>0.3333</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+        <logicTreeBranchingLevel branchingLevelID="bl3">
+            <logicTreeBranchSet uncertaintyType="setLowerSeismDepthRelative"
+                                branchSetID="bs3">
+                <logicTreeBranch branchID="b31">
+                    <uncertaintyModel>-5.0</uncertaintyModel>
+                    <uncertaintyWeight>0.3333</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="b32">
+                    <uncertaintyModel>0.0</uncertaintyModel>
+                    <uncertaintyWeight>0.3334</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="b33">
+                    <uncertaintyModel>5.0</uncertaintyModel>
+                    <uncertaintyWeight>0.3333</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>


### PR DESCRIPTION
The existing capability was only supporting absolute uncertainties. The uncertainty is as expected applicable only to simple faults, area sources and point sources.

A new QA test (logictree/case_33) and unit tests are added.