### PR TITLE
Add the MSR required for the BC Hydro NVA source zone

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Christopher Brooks]
+  * Add the magnitude-scaling relationship used in the Northern
+    Volcanic Arc (NVA) source zone of the BC Hydro SSC logic tree.
   * Add the NIED 2025 sigma model to the `MorikawaFujiwara2013` GSIM
     and some unit tests.
   * Add ability to specify sentinel (-999) z_ref values when using the
@@ -14,7 +16,7 @@
   * Added parameter `rupture_id` to be used with `rupture_model_file`
     to run scenarios starting from a SES.hdf5 file
 
- 
+
   [Christopher Brooks]
   * Added new epistemic uncertainties in the source model logic tree
     for the rupture aspect ratio (`setAspectRatioAbsolute` and

--- a/openquake/hazardlib/scalerel/bchydro_nva_msr.py
+++ b/openquake/hazardlib/scalerel/bchydro_nva_msr.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2026, GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+"""
+Module :mod:`openquake.hazardlib.scalerel.bchydro_nva_msr` implements
+:class:`BCHydroNVAMSR`.
+"""
+import numpy as np
+from openquake.hazardlib.scalerel.base import BaseMSR
+
+
+class BCHydroNVAMSR(BaseMSR):
+    """
+    Magnitude-area scaling relationship for the BC Hydro Northern
+    Volcanic Arc (NVA) source zone.
+
+    Formula: A = exp(2.095 * Mw - 7.883)
+
+    where A is rupture area in km^2.
+    """
+
+    def get_median_area(self, mag, rake):
+        """
+        Return median rupture area (km²) for the given magnitude.
+
+        NOTE: Rake is not used because the relationship is
+        style-of-faulting independent.
+        """
+        return np.exp(2.095 * mag - 7.883)

--- a/openquake/hazardlib/scalerel/bchydro_nva_msr.py
+++ b/openquake/hazardlib/scalerel/bchydro_nva_msr.py
@@ -26,9 +26,9 @@ from openquake.hazardlib.scalerel.base import BaseMSR
 class BCHydroNVAMSR(BaseMSR):
     """
     Magnitude-area scaling relationship for the BC Hydro Northern
-    Volcanic Arc (NVA) source zone.
+    Volcanic Arc (NVA) source zone:
 
-    Formula: A = exp(2.095 * Mw - 7.883)
+    A = exp(2.095 * Mw - 7.883)
 
     where A is rupture area in km^2.
     """

--- a/openquake/hazardlib/tests/scalerel/bchydro_nva_msr_test.py
+++ b/openquake/hazardlib/tests/scalerel/bchydro_nva_msr_test.py
@@ -1,0 +1,39 @@
+# The Hazard Library
+# Copyright (C) 2026 GEM Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import unittest
+import numpy as np
+
+from openquake.hazardlib.scalerel.bchydro_nva_msr import BCHydroNVAMSR
+
+
+class BCHydroNVAMSRTestCase(unittest.TestCase):
+    """
+    Tests for the BC Hydro NVA magnitude-area scaling relationship.
+    
+    Expected values:
+        Mw 5.0 ~= 13   km^2
+        Mw 6.0 ~= 109  km^2
+        Mw 7.0 ~= 882  km^2
+        Mw 7.5 ~= 2514 km^2
+        Mw 8.0 ~= 7165 km^2
+    """
+
+    def test_median_area(self):
+        msr = BCHydroNVAMSR()
+        mags = np.array([5.0, 6.0, 7.0, 7.5, 8.0])
+        expected = np.exp(2.095 * mags - 7.883)
+        got = np.array([msr.get_median_area(m, 90) for m in mags])
+        np.testing.assert_allclose(got, expected, rtol=1e-10)


### PR DESCRIPTION
Add the MSR for the NVA source zone of the BC Hydro model, and a small unit test on expected values.