### PR TITLE
Spawning less damage tasks

### DIFF
--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -169,13 +169,15 @@ class DamageCalculator(EventBasedRiskCalculator):
         for gmf_df in gmf_dfs:
             smap.submit((gmf_df, oq, self.datastore))
         csqidx = {dc: i + 1 for i, dc in enumerate(self.crmodel.get_dmg_csq())}
-        for dd_dict, dmgcsq in smap:
-            df = _dframe(dd_dict, csqidx, oq.loss_types)
+        dd_dict = general.AccumDict(accum=0)
+        for dd, dmgcsq in smap:
+            dd_dict += dd
             self.dmgcsq += dmgcsq
-            with self.monitor('saving risk_by_event', measuremem=True):
-                for name in df.columns:
-                    dset = self.datastore['risk_by_event/' + name]
-                    hdf5.extend(dset, df[name].to_numpy())
+        df = _dframe(dd_dict, csqidx, oq.loss_types)
+        with self.monitor('saving risk_by_event', measuremem=True):
+            for name in df.columns:
+                dset = self.datastore['risk_by_event/' + name]
+                hdf5.extend(dset, df[name].to_numpy())
         return 1
 
     def post_execute(self, dummy):

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -180,29 +180,16 @@ class DamageCalculator(EventBasedRiskCalculator):
         smap, gmf_dfs = calc.starmap_from_gmfs(
             damage_from_gmfs, oq, self.datastore, self._monitor)
         smap.monitor.save('aggids', aggids)
-        smap.monitor.save('assets', self.assetcol.to_dframe('id'))
+        smap.monitor.save('assets', self.assetcol.to_dframe('ordinal'))
         smap.monitor.save('crmodel', self.crmodel)
         for gmf_df in gmf_dfs:
             smap.submit((gmf_df, oq, self.datastore))
-        return smap.reduce(self.combine)
-
-    def combine(self, acc, res):
-        """
-        :param acc:
-            unused
-        :param res:
-            DataFrame with fields (event_id, agg_id, loss_id, dmg1 ...)
-            plus array with damages and consequences of shape (A, Dc)
-
-        Combine the results and grows risk_by_event with fields
-        (event_id, agg_id, loss_id) and (dmg_0, dmg_1, dmg_2, ...)
-        """
-        df, dmgcsq = res
-        self.dmgcsq += dmgcsq
-        with self.monitor('saving risk_by_event', measuremem=True):
-            for name in df.columns:
-                dset = self.datastore['risk_by_event/' + name]
-                hdf5.extend(dset, df[name].to_numpy())
+        for df, dmgcsq in smap:
+            self.dmgcsq += dmgcsq
+            with self.monitor('saving risk_by_event', measuremem=True):
+                for name in df.columns:
+                    dset = self.datastore['risk_by_event/' + name]
+                    hdf5.extend(dset, df[name].to_numpy())
         return 1
 
     def post_execute(self, dummy):

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -46,10 +46,10 @@ def zero_dmgcsq(A, R, L, crmodel):
     return numpy.zeros((P, A, R, L, Dc), F32)
 
 
-def damage_from_gmfs(gmf_df, oqparam, dstore, monitor):
+def damage_from_gmfs(df, oq, dstore, monitor):
     """
-    :param gmf_df: a DataFrame of GMFs
-    :param oqparam: OqParam instance
+    :param df: a DataFrame of GMFs
+    :param oq: OqParam instance
     :param dstore: DataStore instance from which to read the GMFs
     :param monitor: a Monitor instance
     :returns: a dictionary of arrays, the output of event_based_damage
@@ -58,28 +58,12 @@ def damage_from_gmfs(gmf_df, oqparam, dstore, monitor):
         assetcol = dstore['assetcol']
         crmodel = monitor.read('crmodel')
         aggids = monitor.read('aggids')
-        if oqparam.R > 1:
+        if oq.R > 1:
             # i.e. case_9 in scenario_damage
             rlzs = dstore['events']['rlz_id']
         else:
             rlzs = None
-    with monitor('calc_damage', measuremem=True):
-        dd_dict, dmgcsq = calc_damage(
-            gmf_df, oqparam, assetcol, crmodel, aggids, rlzs)
-    csqidx = {dc: i + 1 for i, dc in enumerate(crmodel.get_dmg_csq())}
-    return _dframe(dd_dict, csqidx, oqparam.loss_types), dmgcsq
 
-
-def calc_damage(df, oq, assetcol, crmodel, aggids, rlzs=None):
-    """
-    :param df: a DataFrame of GMFs with fields sid, eid, imt, ...
-    :param oq: parameters coming from the job.ini
-    :param assetcol: AssetCollection instance
-    :param crmodel: CompositeRiskModel instance
-    :param aggids: array of aggregation indices
-    :param rlzs: array of realization indices (or None for single rlz)
-    :returns: (damages (eid, kid) -> LDc, dmgcsq)
-    """
     dmgcsq = zero_dmgcsq(len(assetcol), oq.R, oq.L, crmodel)
     P, _A, R, L, Dc = dmgcsq.shape
     D = len(crmodel.damage_states)
@@ -184,7 +168,9 @@ class DamageCalculator(EventBasedRiskCalculator):
         smap.monitor.save('crmodel', self.crmodel)
         for gmf_df in gmf_dfs:
             smap.submit((gmf_df, oq, self.datastore))
-        for df, dmgcsq in smap:
+        csqidx = {dc: i + 1 for i, dc in enumerate(self.crmodel.get_dmg_csq())}
+        for dd_dict, dmgcsq in smap:
+            df = _dframe(dd_dict, csqidx, oq.loss_types)
             self.dmgcsq += dmgcsq
             with self.monitor('saving risk_by_event', measuremem=True):
                 for name in df.columns:

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -511,7 +511,7 @@ def starmap_from_gmfs(task_func, oq, dstore, mon):
         expected_outputs = count_outputs(data['eid'], slices, maxw, w)
         logging.info('Expected outputs = %d', expected_outputs)
     gmf_dfs = []
-    for gmfslices in general.block_splitter(slices, maxw, w):
+    for gmfslices in general.block_splitter(slices, 2*maxw, w):
         dfs = []
         for gmfslice in gmfslices:
             slc = slice(gmfslice[0], gmfslice[1])

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -511,7 +511,7 @@ def starmap_from_gmfs(task_func, oq, dstore, mon):
         expected_outputs = count_outputs(data['eid'], slices, maxw, w)
         logging.info('Expected outputs = %d', expected_outputs)
     gmf_dfs = []
-    for gmfslices in general.block_splitter(slices, 2*maxw, w):
+    for gmfslices in general.block_splitter(slices, 2.1*maxw, w):
         dfs = []
         for gmfslice in gmfslices:
             slc = slice(gmfslice[0], gmfslice[1])


### PR DESCRIPTION
Thus tripling the speed:
```
| calc_13175, maxmem=237.8 GB | time_sec | memory_mb | counts |
|-----------------------------+----------+-----------+--------|
| total damage_from_gmfs      | 178_091  | 159.3594  | 187    |
| DamageCalculator.run        | 1_074    | 754.5     | 1      |
```
We are still very inefficient.