### PR TITLE
100x speedup in PAPERS (scenario_damage)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -20,7 +20,6 @@
   * Added parameter `rupture_id` to be used with `rupture_model_file`
     to run scenarios starting from a SES.hdf5 file
 
-
   [Christopher Brooks]
   * Added new epistemic uncertainties in the source model logic tree
     for the rupture aspect ratio (`setAspectRatioAbsolute` and

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Changed the distribution in damage calculations to split in blocks
+    of assets, with a huge performance benefit for large scenarios
+
   [Christopher Brooks]
   * Add the magnitude-scaling relationship used in the Northern
     Volcanic Arc (NVA) source zone of the BC Hydro SSC logic tree.
@@ -10,7 +14,7 @@
     logictree/case_33.
   * Add ability to specify reference z1pt4 (like for z1pt0, z2pt5 etc.) in
     the job file.
-  
+
   [Michele Simionato]
   * Internal: added an utility `hdf5.reduce_file` to reduce HDF5 files
   * Added parameter `rupture_id` to be used with `rupture_model_file`

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -20,10 +20,9 @@ import logging
 import numpy
 import pandas
 
-from openquake.baselib import hdf5, general
+from openquake.baselib import hdf5, general, parallel
 from openquake.hazardlib.stats import compute_stats2, mean_curve
 from openquake.risklib import scientific, connectivity
-from openquake.commonlib import calc
 from openquake.calculators import base
 from openquake.calculators.event_based_risk import EventBasedRiskCalculator
 from openquake.calculators.post_risk import (
@@ -46,32 +45,30 @@ def zero_dmgcsq(A, R, L, crmodel):
     return numpy.zeros((P, A, R, L, Dc), F32)
 
 
-def damage_from_gmfs(df, oq, dstore, monitor):
+def damage_from_gmfs(df, assetcol, oq, rlzs, monitor):
     """
     :param df: a DataFrame of GMFs
+    :param assetcol: DataStore instance from which to read the GMFs
     :param oq: OqParam instance
-    :param dstore: DataStore instance from which to read the GMFs
+    :param rlzs: E realizations or None
     :param monitor: a Monitor instance
     :returns: a dictionary of arrays, the output of event_based_damage
     """
-    with dstore, monitor('reading data', measuremem=True):
-        assetcol = dstore['assetcol']
+    with monitor('reading data', measuremem=True):
         crmodel = monitor.read('crmodel')
         aggids = monitor.read('aggids')
-        if oq.R > 1:
-            # i.e. case_9 in scenario_damage
-            rlzs = dstore['events']['rlz_id']
-        else:
-            rlzs = None
 
     dmgcsq = zero_dmgcsq(len(assetcol), oq.R, oq.L, crmodel)
     P, _A, R, L, Dc = dmgcsq.shape
     D = len(crmodel.damage_states)
     dd_dict = general.AccumDict(accum=numpy.zeros((L, Dc), F32))  # eid, kid
+    ordinals = []
+    idx = {o: i for i, o in enumerate(assetcol['ordinal'])}
     for sid, asset_df in assetcol.to_dframe().groupby('site_id'):
         # working one site at the time
         gmf_df = df[df.sid == sid]
         if len(gmf_df) == 0:
+            ordinals.append(asset_df.ordinal.to_numpy())
             continue
         eids = gmf_df.eid.to_numpy()
         E = len(eids)
@@ -81,15 +78,17 @@ def damage_from_gmfs(df, oq, dstore, monitor):
         else:
             rng = None
         for taxo, adf in asset_df.groupby('taxonomy'):
+            A = len(adf)
             ords = adf.ordinal.to_numpy()
-            A = len(ords)
+            idxs = [idx[o] for o in ords]
+            ordinals.append(ords)
             rc = scientific.RiskComputer(crmodel, taxo)
             dd5 = rc.get_dd5(adf, gmf_df, rng, Dc-D, crmodel)  # (A, E, L, Dc)
             if R == 1:  # possibly because of collect_rlzs
-                dmgcsq[:, ords, 0] += dd5.sum(axis=2)
-            else:
+                dmgcsq[:, idxs, 0] += dd5.sum(axis=2)
+            else:  # use rlzs
                 for e, rlz in enumerate(rlzs[eids]):
-                    dmgcsq[:, ords, rlz] += dd5[:, :, e]
+                    dmgcsq[:, idxs, rlz] += dd5[:, :, e]
             if P > 1:
                 dd4 = numpy.empty(dd5.shape[1:])
                 for li in range(L):
@@ -107,7 +106,7 @@ def damage_from_gmfs(df, oq, dstore, monitor):
                     for kids in aggids:
                         for a, o in enumerate(ords):
                             dd_dict[eid, kids[o]] += dd4[a, e]
-    return dd_dict, dmgcsq
+    return dd_dict, dmgcsq, numpy.concatenate(ordinals, dtype=U32)
 
 
 def _dframe(dd_dic, csqidx, loss_types):
@@ -161,18 +160,28 @@ class DamageCalculator(EventBasedRiskCalculator):
             aggids, _ = self.assetcol.build_aggids(oq.aggregate_by)
         else:
             aggids = 0
-        smap, gmf_dfs = calc.starmap_from_gmfs(
-            damage_from_gmfs, oq, self.datastore, self._monitor)
+        gmf_df = self.datastore.read_df('gmf_data')
+        if oq.R > 1:
+            # i.e. case_9 in scenario_damage
+            rlzs = self.datastore['events']['rlz_id']
+        else:
+            rlzs = None
+        self.datastore.swmr_on()
+        smap =  parallel.Starmap(damage_from_gmfs, h5=self.datastore)
         smap.monitor.save('aggids', aggids)
-        smap.monitor.save('assets', self.assetcol.to_dframe('ordinal'))
         smap.monitor.save('crmodel', self.crmodel)
-        for gmf_df in gmf_dfs:
-            smap.submit((gmf_df, oq, self.datastore))
+        ct = oq.concurrent_tasks or 1
+        sids = self.assetcol['site_id']
+        for t in range(ct):
+            gmf_tile = gmf_df[gmf_df.sid % ct == t]
+            asset_tile = self.assetcol.new(self.assetcol.array[sids % ct == t])
+            if len(asset_tile):
+                smap.submit((gmf_tile, asset_tile, oq, rlzs))
         csqidx = {dc: i + 1 for i, dc in enumerate(self.crmodel.get_dmg_csq())}
         dd_dict = general.AccumDict(accum=0)
-        for dd, dmgcsq in smap:
-            dd_dict += dd
-            self.dmgcsq += dmgcsq
+        for ddd, dmgcsq, ords in smap:
+            dd_dict += ddd
+            self.dmgcsq[:, ords] += dmgcsq
         df = _dframe(dd_dict, csqidx, oq.loss_types)
         with self.monitor('saving risk_by_event', measuremem=True):
             for name in df.columns:

--- a/openquake/calculators/event_based_damage.py
+++ b/openquake/calculators/event_based_damage.py
@@ -62,13 +62,11 @@ def damage_from_gmfs(df, assetcol, oq, rlzs, monitor):
     P, _A, R, L, Dc = dmgcsq.shape
     D = len(crmodel.damage_states)
     dd_dict = general.AccumDict(accum=numpy.zeros((L, Dc), F32))  # eid, kid
-    ordinals = []
     idx = {o: i for i, o in enumerate(assetcol['ordinal'])}
     for sid, asset_df in assetcol.to_dframe().groupby('site_id'):
         # working one site at the time
         gmf_df = df[df.sid == sid]
         if len(gmf_df) == 0:
-            ordinals.append(asset_df.ordinal.to_numpy())
             continue
         eids = gmf_df.eid.to_numpy()
         E = len(eids)
@@ -81,7 +79,6 @@ def damage_from_gmfs(df, assetcol, oq, rlzs, monitor):
             A = len(adf)
             ords = adf.ordinal.to_numpy()
             idxs = [idx[o] for o in ords]
-            ordinals.append(ords)
             rc = scientific.RiskComputer(crmodel, taxo)
             dd5 = rc.get_dd5(adf, gmf_df, rng, Dc-D, crmodel)  # (A, E, L, Dc)
             if R == 1:  # possibly because of collect_rlzs
@@ -106,7 +103,7 @@ def damage_from_gmfs(df, assetcol, oq, rlzs, monitor):
                     for kids in aggids:
                         for a, o in enumerate(ords):
                             dd_dict[eid, kids[o]] += dd4[a, e]
-    return dd_dict, dmgcsq, numpy.concatenate(ordinals, dtype=U32)
+    return dd_dict, dmgcsq, assetcol['ordinal']
 
 
 def _dframe(dd_dic, csqidx, loss_types):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -133,16 +133,13 @@ def build_alt(loss2, xtypes):
     return pandas.DataFrame(dic)
 
 
-def ebr_from_gmfs(gmf_df, oqparam, dstore, monitor):
+def ebr_from_gmfs(gmf_df, oqparam, monitor):
     """
     :param gmf_df: DataFrame of GMFs
     :param oqparam: OqParam instance
-    :param dstore: DataStore instance from which to read the GMFs
     :param monitor: a Monitor instance
     :yields: dictionary of arrays, the output of event_based_risk
     """
-    if dstore.parent:
-        dstore.parent.open('r')
     with monitor('reading crmodel', measuremem=True):
         crmodel = monitor.read('crmodel')
         R = 1 if oqparam.collect_rlzs else len(monitor.read('weights'))
@@ -509,7 +506,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                 ebr_from_gmfs, oq, self.datastore, self._monitor)
             self.save_tmp(smap.monitor)
             for gmf_df in gmf_dfs:
-                smap.submit((gmf_df, oq, self.datastore))
+                smap.submit((gmf_df, oq))
             smap.reduce(self.agg_dicts)
 
         if self.parent_events:

--- a/openquake/commonlib/calc.py
+++ b/openquake/commonlib/calc.py
@@ -511,7 +511,7 @@ def starmap_from_gmfs(task_func, oq, dstore, mon):
         expected_outputs = count_outputs(data['eid'], slices, maxw, w)
         logging.info('Expected outputs = %d', expected_outputs)
     gmf_dfs = []
-    for gmfslices in general.block_splitter(slices, 2.1*maxw, w):
+    for gmfslices in general.block_splitter(slices, maxw, w):
         dfs = []
         for gmfslice in gmfslices:
             slc = slice(gmfslice[0], gmfslice[1])

--- a/openquake/qa_tests_data/scenario_damage/case_17/job_no_time_event.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_17/job_no_time_event.ini
@@ -7,7 +7,6 @@ random_seed = 113
 sites_csv = sitemesh.csv
 gmfs_csv = gmf.csv
 asset_hazard_distance = 150
-custom_site_id = true
 
 [Exposure model]
 exposure_file = exposure_model.xml

--- a/openquake/qa_tests_data/scenario_damage/case_17/job_time_event_day.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_17/job_time_event_day.ini
@@ -7,7 +7,6 @@ random_seed = 113
 sites_csv = sitemesh.csv
 gmfs_csv = gmf.csv
 asset_hazard_distance = 150
-custom_site_id = true
 
 [Exposure model]
 exposure_file = exposure_model.xml

--- a/openquake/qa_tests_data/scenario_damage/case_18/job.ini
+++ b/openquake/qa_tests_data/scenario_damage/case_18/job.ini
@@ -7,7 +7,6 @@ random_seed = 113
 sites_csv = sitemesh.csv
 gmfs_csv = gmf.csv
 asset_hazard_distance = 150
-custom_site_id = true
 
 [Exposure model]
 exposure_file = exposure_model.xml


### PR DESCRIPTION
Supersedes https://github.com/gem/oq-engine/pull/11419. Here is the speedup for a PAPERS calculation with 4 GMMs, 250 GMFs, 1_274_108 assets, 9_972 sites:
```
# before/after
| calc_13170, maxmem=236.1 GB | time_sec | memory_mb | counts      |
|-----------------------------+----------+-----------+-------------|
| total damage_from_gmfs      | 533_777  | 209.1     | 467         |
| total damage_from_gmfs      | 5_275    | 23.512    | 384         |
```
The memory occupation goes down to 109.5 GB and the data transfer down 142x:
```
| task             | sent                                                | received  |
|------------------+-----------------------------------------------------+-----------|
| damage_from_gmfs | oqparam=1.12 MB gmfslices=172.82 KB dstore=76.16 KB | 62.06 GB  |
| damage_from_gmfs | gmf_tile=257.5 MB assetcol=219.31 MB oq=945 KB      | 447.11 MB |
```