### PR TITLE
Add ability to specify a distribution of hypocentres in a simple fault source

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Christopher Brooks]
+  * Added ability to specify a distribution of hypocenters within a
+    simple fault source. Tested in classical/case_28 and unit tests.
   * Added the BCHydro adjusted versions of the original NGA GMMs (median
     scaling and single station sigma) and some unit tests.
   

--- a/openquake/baselib/tests/flake8_test.py
+++ b/openquake/baselib/tests/flake8_test.py
@@ -52,8 +52,8 @@ def _long_funcs(module, maxlen):
         if isinstance(node, ast.FunctionDef):
             dotname = '%s.%s' % (module.__name__, node.name)
             args = node.args.args
-            if len(args) > 15:
-                raise SyntaxError('%s has more than 15 arguments: %s'
+            if len(args) > 16:
+                raise SyntaxError('%s has more than 16 arguments: %s'
                                   % (dotname, [a.arg for a in args]))
             doc = ast.get_docstring(node)
             # Adjust start line to skip the docstring if present

--- a/openquake/baselib/tests/flake8_test.py
+++ b/openquake/baselib/tests/flake8_test.py
@@ -52,8 +52,8 @@ def _long_funcs(module, maxlen):
         if isinstance(node, ast.FunctionDef):
             dotname = '%s.%s' % (module.__name__, node.name)
             args = node.args.args
-            if len(args) > 16:
-                raise SyntaxError('%s has more than 16 arguments: %s'
+            if len(args) > 15:
+                raise SyntaxError('%s has more than 15 arguments: %s'
                                   % (dotname, [a.arg for a in args]))
             doc = ast.get_docstring(node)
             # Adjust start line to skip the docstring if present

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -420,7 +420,7 @@ class ClassicalTestCase(CalculatorTestCase):
                           source_model_logic_tree_file=(
                               'source_model_logic_tree_depth_error.xml'))
 
-        self.assertIn('hypo_depth_list entry 25.0 km is outside the '
+        self.assertIn('hypo_depth_list 25.0 km is outside the '
                       'seismogenic zone [0.0, 20.0] km', str(ctx.exception))
 
     def test_case_29(self):  # non parametric source with 2 KiteSurfaces

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -34,14 +34,14 @@ from openquake.calculators.tests import CalculatorTestCase
 from openquake.qa_tests_data.classical import (
     case_01, case_02, case_03, case_04, case_05, case_06, case_07, case_08,
     case_09, case_10, case_11, case_12, case_13, case_18, case_22, case_23,
-    case_24, case_25, case_26, case_27, case_29, case_32, case_33, case_34,
-    case_35, case_36, case_37, case_38, case_39, case_40, case_41, case_42,
-    case_43, case_44, case_47, case_48, case_49, case_50, case_51, case_53,
-    case_54, case_55, case_57, case_60, case_61, case_62, case_63, case_64,
-    case_65, case_66, case_67, case_68, case_69, case_70, case_71, case_72,
-    case_74, case_75, case_76, case_77, case_78, case_80, case_81, case_82,
-    case_83, case_84, case_85, case_86, case_87, case_88, case_89, case_90,
-    case_91, case_92, case_93, case_94)
+    case_24, case_25, case_26, case_27, case_28, case_29, case_32, case_33,
+    case_34, case_35, case_36, case_37, case_38, case_39, case_40, case_41,
+    case_42, case_43, case_44, case_47, case_48, case_49, case_50, case_51,
+    case_53, case_54, case_55, case_57, case_60, case_61, case_62, case_63,
+    case_64, case_65, case_66, case_67, case_68, case_69, case_70, case_71,
+    case_72, case_74, case_75, case_76, case_77, case_78, case_80, case_81,
+    case_82, case_83, case_84, case_85, case_86, case_87, case_88, case_89,
+    case_90, case_91, case_92, case_93, case_94)
 
 ae = numpy.testing.assert_equal
 aac = numpy.testing.assert_allclose
@@ -402,6 +402,19 @@ class ClassicalTestCase(CalculatorTestCase):
         rel = view('relevant_sources:PGV', self.calc.datastore)
         fname = general.gettemp(text_table(rel, ext='org'))
         self.assertEqualFiles('expected/rel_source.org', fname)
+
+    def test_case_28(self):
+        # Simple fault with hypoDepthDist
+        self.assert_curves_ok(["hazard_curve-mean-PGA.csv"], case_28.__file__)
+
+        # Depth outside seismogenic zone must be rejected
+        with self.assertRaises(ValueError) as ctx:
+            self.run_calc(case_28.__file__, 'job.ini',
+                          source_model_logic_tree_file=(
+                              'source_model_logic_tree_depth_error.xml'))
+            
+        self.assertIn('hypo_depth_list entry 25.0 km is outside the '
+                      'seismogenic zone [0.0, 20.0] km', str(ctx.exception))
 
     def test_case_29(self):  # non parametric source with 2 KiteSurfaces
         check = False

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -407,12 +407,19 @@ class ClassicalTestCase(CalculatorTestCase):
         # Simple fault with hypoDepthDist
         self.assert_curves_ok(["hazard_curve-mean-PGA.csv"], case_28.__file__)
 
+        # Same depth distribution but hypocentre fixed at 2/3 downdip
+        self.assert_curves_ok(
+            ["hazard_curve-mean-PGA_fixed_dip_frac.csv"],
+            case_28.__file__,
+            source_model_logic_tree_file=(
+                'source_model_logic_tree_fixed_dip_frac.xml'))
+
         # Depth outside seismogenic zone must be rejected
         with self.assertRaises(ValueError) as ctx:
             self.run_calc(case_28.__file__, 'job.ini',
                           source_model_logic_tree_file=(
                               'source_model_logic_tree_depth_error.xml'))
-            
+
         self.assertIn('hypo_depth_list entry 25.0 km is outside the '
                       'seismogenic zone [0.0, 20.0] km', str(ctx.exception))
 

--- a/openquake/commonlib/tests/source_test.py
+++ b/openquake/commonlib/tests/source_test.py
@@ -168,8 +168,9 @@ class NrmlSourceToHazardlibTestCase(unittest.TestCase):
                  geo.Point(-122.03880, 37.87710)]),
             dip=45.0,
             rake=30.0,
-            hypo_slip_list=[numpy.array([[0.25, 0.25, 0.3], [0.75, 0.75, 0.7]]),
-                            numpy.array([[90, 0.7], [135, 0.3]])])
+            hypo_data=source.HypoData(
+                hypo_list=numpy.array([[0.25, 0.25, 0.3], [0.75, 0.75, 0.7]]),
+                slip_list=numpy.array([[90, 0.7], [135, 0.3]])))
         return simple
 
     @property

--- a/openquake/hazardlib/source/__init__.py
+++ b/openquake/hazardlib/source/__init__.py
@@ -27,7 +27,7 @@ from openquake.hazardlib.source.rupture import (  # noqa
 from openquake.hazardlib.source.base import BaseSeismicSource
 from openquake.hazardlib.source.point import PointSource  # noqa
 from openquake.hazardlib.source.area import AreaSource  # noqa
-from openquake.hazardlib.source.simple_fault import SimpleFaultSource  # noqa
+from openquake.hazardlib.source.simple_fault import SimpleFaultSource, HypoData  # noqa
 from openquake.hazardlib.source.complex_fault import ComplexFaultSource, MINWEIGHT  # noqa
 from openquake.hazardlib.source.characteristic import CharacteristicFaultSource  # noqa
 from openquake.hazardlib.source.non_parametric import NonParametricSeismicSource   # noqa

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -175,14 +175,16 @@ class SimpleFaultSource(ParametricSeismicSource):
         sin_dip = math.sin(math.radians(self.dip))
         down_dip_delta = self.rupture_mesh_spacing * sin_dip
         
-        top_depth_dd = (self.upper_seismogenic_depth
-                         + first_row * down_dip_delta) # Down dip
+        top_depth_dd = (
+            self.upper_seismogenic_depth + first_row * down_dip_delta)
         
-        bot_depth_dd = (self.upper_seismogenic_depth
-                         + (first_row + rup_rows - 1) * down_dip_delta) # Down dips
+        bot_depth_dd = (
+            self.upper_seismogenic_depth +
+            (first_row + rup_rows - 1) * down_dip_delta) # Down dips
         
         rup_depth_dd = bot_depth_dd - top_depth_dd
 
+        # Check
         hypos = []
         for prob, depth in self.hypo_depth_list:
             if top_depth_dd <= depth <= bot_depth_dd:

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -177,13 +177,13 @@ class SimpleFaultSource(ParametricSeismicSource):
         for _wei, depth, fdf in self.hypo_depth_list:
             if not (upper_seismogenic_depth <= depth <= lower_seismogenic_depth):
                 raise ValueError(
-                    f'hypo_depth_list entry {depth} km is outside the '
+                    f'hypo_depth_list {depth} km is outside the '
                     f'seismogenic zone [{upper_seismogenic_depth}, '
                     f'{lower_seismogenic_depth}] km')
             if fdf is not None and not (0.0 < fdf <= 1.0):
                 raise ValueError(
-                    f'hypo_depth_list fixedDipFrac {fdf} for depth {depth} km'
-                    f' must be in the range (0, 1]')
+                    f'hypo_depth_list fixedDipFrac {fdf} for depth {depth} km '
+                    f'must be in the range [0, 1]')
 
         if 1 in cols_rows:
             raise ValueError('mesh spacing %s is too high to represent '
@@ -196,12 +196,7 @@ class SimpleFaultSource(ParametricSeismicSource):
         for a given floating rupture.
 
         Depths outside [rup_top_depth, rup_bot_depth] are discarded and
-        the remaining weights are renormalised to sum to 1. Where a
-        fixedDipFrac is set on an entry it is used directly; otherwise
-        the fraction is computed from the depth position within the
-        rupture. Entries sharing the same dip_frac are collapsed into one
-        pair so that a uniform fixedDipFrac yields a single hypocentre
-        per floating rupture.
+        the remaining weights are renormalised to sum to 1. 
 
         An error is raised if none of the hypo depths are within the
         depth range of a given floating rup.

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -78,13 +78,14 @@ class SimpleFaultSource(ParametricSeismicSource):
             :param slip_list:
                 Array describing the rupture slip direction, which desribes the
                 rupture propagation direction on the rupture surface. Each line
-                represents a rupture slip direction and the corresponding weight.
-                Example 1: one single rupture slip direction with angle 90 degree
-                will be described by the following array[(90, 1.0)]. Example 2:
-                two possible rupture slip directions are admitted for a rupture.
-                One slip direction is at 90 degree with a weight of 0.7, the
-                other one is at 135 degree with a weight of 0.3. The numpy array
-                would be entered as numpy.array([[90, 0.7], [135, 0.3]]).
+                represents a rupture slip direction and the corresponding
+                weight. Example 1: one single rupture slip direction with
+                angle 90 degree will be described by the following array[(90,
+                1.0)]. Example 2: two possible rupture slip directions are
+                admitted for a rupture. One slip direction is at 90 degree
+                with a weight of 0.7, the other one is at 135 degree with a
+                weight of 0.3. The numpy array would be entered as
+                numpy.array([[90, 0.7], [135, 0.3]]).
 
         Alternative approach 2 is described by hypo_depth_list:
 

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -72,9 +72,10 @@ class SimpleFaultSource(ParametricSeismicSource):
         weight of 0.3. The numpy array would be entered as numpy.array(
         [[90, 0.7], [135, 0.3]]).
     :param hypo_depth_list:
-        List of (probability, depth_km) describing a hypocentre depth distribution.
-        All depths must lie within [upper_seismogenic_depth, lower_seismogenic_depth]
-        or an error is raised. Cannot be combined with hypo_list or slip_list.
+        List of (probability, depth) describing a hypocentre depth distribution.
+        All depths must lie within seismogenic depth range or an error is raised.
+        Also, it cannot be combined with hypo_list or slip_list argument with an
+        error being raised if so.
 
     See also :class:`openquake.hazardlib.source.base.ParametricSeismicSource`
     for description of other parameters.
@@ -160,33 +161,39 @@ class SimpleFaultSource(ParametricSeismicSource):
 
     def _hypo_list_from_depths(self, first_row, rup_rows):
         """
-        Convert the absolute depth distribution to rupture-relative
-        (along_strike, down_dip, weight) triples for a specific floating
+        Convert the hypo depth distribution to rupture-relative
+        (along_strike, down_dip, weight)for a given floating
         rupture position on the fault plane.
 
-        Depths outside [rup_top_depth, rup_bot_depth] are discarded and the
-        remaining weights are renormalised to sum to 1. Raises ValueError if
-        no depths land within the rupture.
+        Depths outside [rup_top_depth, rup_bot_depth] are discarded
+        and the remaining weights are renormalised to sum to 1.
+        
+        An error is raised if none of the hypo depths are within the
+        rupture depth range.
         """
+        # Get down-dip seismo depth range for given floating position
         sin_dip = math.sin(math.radians(self.dip))
-        rup_top_depth = (self.upper_seismogenic_depth
-                         + first_row * self.rupture_mesh_spacing * sin_dip)
-        rup_bot_depth = (self.upper_seismogenic_depth
-                         + (first_row + rup_rows - 1)
-                         * self.rupture_mesh_spacing * sin_dip)
-        rup_depth_width = rup_bot_depth - rup_top_depth
+        down_dip_delta = self.rupture_mesh_spacing * sin_dip
+        
+        top_depth_dd = (self.upper_seismogenic_depth
+                         + first_row * down_dip_delta) # Down dip
+        
+        bot_depth_dd = (self.upper_seismogenic_depth
+                         + (first_row + rup_rows - 1) * down_dip_delta) # Down dips
+        
+        rup_depth_dd = bot_depth_dd - top_depth_dd
 
         hypos = []
         for prob, depth in self.hypo_depth_list:
-            if rup_top_depth <= depth <= rup_bot_depth:
-                dip_frac = ((depth - rup_top_depth) / rup_depth_width
-                            if rup_depth_width > 0 else 0.5)
+            if top_depth_dd <= depth <= bot_depth_dd:
+                dip_frac = ((depth - top_depth_dd) / rup_depth_dd
+                            if rup_depth_dd > 0 else 0.5)
                 hypos.append((0.5, dip_frac, prob))
 
         if not hypos:
             raise ValueError(
                 f'No hypo_depth_list entries fall within the floating rupture '
-                f'depth range [{rup_top_depth:.2f}, {rup_bot_depth:.2f}] km')
+                f'depth range [{top_depth_dd:.2f}, {bot_depth_dd:.2f}] km')
 
         total = sum(h[2] for h in hypos)
         return [(h[0], h[1], h[2] / total) for h in hypos]
@@ -194,8 +201,8 @@ class SimpleFaultSource(ParametricSeismicSource):
     def _iter_ruptures_hypo_depth(self, surface, occurrence_rate, mag,
                                    first_row, rup_rows):
         """
-        Yield ruptures for one floating position using the absolute depth
-        distribution in hypo_depth_list.
+        Yield ruptures for given floating position on fault surface using
+        the absolute depth distribution in hypo_depth_list.
         """
         for strike_frac, dip_frac, w in self._hypo_list_from_depths(
                 first_row, rup_rows):
@@ -208,7 +215,8 @@ class SimpleFaultSource(ParametricSeismicSource):
 
     def _iter_ruptures_hypo_slip(self, surface, occurrence_rate, mag):
         """
-        Yield ruptures for one floating position using hypo_list and slip_list.
+        Yield ruptures for given floating position on fault surface using
+        hypo_list and slip_list.
         """
         for hypo in self.hypo_list:
             for slip in self.slip_list:
@@ -262,6 +270,7 @@ class SimpleFaultSource(ParametricSeismicSource):
                             surface, occurrence_rate, mag)
                         
                     else:
+                        # Regular version using surf centroid
                         yield ParametricProbabilisticRupture(
                             mag, self.rake, self.tectonic_region_type,
                             mesh.get_middle_point(), surface, occurrence_rate,

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -71,6 +71,10 @@ class SimpleFaultSource(ParametricSeismicSource):
         degree with a weight of 0.7, the other one is at 135 degree with a
         weight of 0.3. The numpy array would be entered as numpy.array(
         [[90, 0.7], [135, 0.3]]).
+    :param hypo_depth_list:
+        List of (probability, depth_km) describing a hypocentre depth distribution.
+        All depths must lie within [upper_seismogenic_depth, lower_seismogenic_depth]
+        or an error is raised. Cannot be combined with hypo_list or slip_list.
 
     See also :class:`openquake.hazardlib.source.base.ParametricSeismicSource`
     for description of other parameters.
@@ -99,11 +103,14 @@ class SimpleFaultSource(ParametricSeismicSource):
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,
-                 magnitude_scaling_relationship, rupture_aspect_ratio,
+                 magnitude_scaling_relationship,
+                 rupture_aspect_ratio,
                  temporal_occurrence_model,
                  # simple fault specific parameters
                  upper_seismogenic_depth, lower_seismogenic_depth,
-                 fault_trace, dip, rake, hypo_slip_list=()):
+                 fault_trace, dip, rake,
+                 hypo_slip_list=(),
+                 hypo_depth_list=()):
         super().__init__(
             source_id, name, tectonic_region_type, mfd, rupture_mesh_spacing,
             magnitude_scaling_relationship, rupture_aspect_ratio,
@@ -134,10 +141,83 @@ class SimpleFaultSource(ParametricSeismicSource):
             raise ValueError('hypo_list and slip_list have to be both given '
                              'or neither given')
 
+        if hypo_depth_list and (len(self.hypo_list) or len(self.slip_list)):
+            raise ValueError(
+                'hypo_depth_list and hypo_list/slip_list cannot be used together'
+                )
+        self.hypo_depth_list = tuple(hypo_depth_list)
+        for _, depth in self.hypo_depth_list:
+            if not (upper_seismogenic_depth <= depth <= lower_seismogenic_depth):
+                raise ValueError(
+                    f'hypo_depth_list entry {depth} km is outside the '
+                    f'seismogenic zone [{upper_seismogenic_depth}, '
+                    f'{lower_seismogenic_depth}] km')
+
         if 1 in cols_rows:
             raise ValueError('mesh spacing %s is too high to represent '
                              'ruptures of magnitude %s' %
                              (rupture_mesh_spacing, min_mag))
+
+    def _hypo_list_from_depths(self, first_row, rup_rows):
+        """
+        Convert the absolute depth distribution to rupture-relative
+        (along_strike, down_dip, weight) triples for a specific floating
+        rupture position on the fault plane.
+
+        Depths outside [rup_top_depth, rup_bot_depth] are discarded and the
+        remaining weights are renormalised to sum to 1. Raises ValueError if
+        no depths land within the rupture.
+        """
+        sin_dip = math.sin(math.radians(self.dip))
+        rup_top_depth = (self.upper_seismogenic_depth
+                         + first_row * self.rupture_mesh_spacing * sin_dip)
+        rup_bot_depth = (self.upper_seismogenic_depth
+                         + (first_row + rup_rows - 1)
+                         * self.rupture_mesh_spacing * sin_dip)
+        rup_depth_width = rup_bot_depth - rup_top_depth
+
+        hypos = []
+        for prob, depth in self.hypo_depth_list:
+            if rup_top_depth <= depth <= rup_bot_depth:
+                dip_frac = ((depth - rup_top_depth) / rup_depth_width
+                            if rup_depth_width > 0 else 0.5)
+                hypos.append((0.5, dip_frac, prob))
+
+        if not hypos:
+            raise ValueError(
+                f'No hypo_depth_list entries fall within the floating rupture '
+                f'depth range [{rup_top_depth:.2f}, {rup_bot_depth:.2f}] km')
+
+        total = sum(h[2] for h in hypos)
+        return [(h[0], h[1], h[2] / total) for h in hypos]
+
+    def _iter_ruptures_hypo_depth(self, surface, occurrence_rate, mag,
+                                   first_row, rup_rows):
+        """
+        Yield ruptures for one floating position using the absolute depth
+        distribution in hypo_depth_list.
+        """
+        for strike_frac, dip_frac, w in self._hypo_list_from_depths(
+                first_row, rup_rows):
+            hypo = surface.get_hypo_location(
+                self.rupture_mesh_spacing, (strike_frac, dip_frac))
+            yield ParametricProbabilisticRupture(
+                mag, self.rake, self.tectonic_region_type,
+                hypo, surface, occurrence_rate * w,
+                self.temporal_occurrence_model)
+
+    def _iter_ruptures_hypo_slip(self, surface, occurrence_rate, mag):
+        """
+        Yield ruptures for one floating position using hypo_list and slip_list.
+        """
+        for hypo in self.hypo_list:
+            for slip in self.slip_list:
+                hypocenter = surface.get_hypo_location(
+                    self.rupture_mesh_spacing, hypo[:2])
+                yield ParametricProbabilisticRupture(
+                    mag, self.rake, self.tectonic_region_type,
+                    hypocenter, surface, occurrence_rate * hypo[2] * slip[1],
+                    self.temporal_occurrence_model, slip[0])
 
     def iter_ruptures(self, **kwargs):
         """
@@ -171,32 +251,21 @@ class SimpleFaultSource(ParametricSeismicSource):
                 for first_col in range(num_rup_along_length)[::step]:
                     mesh = whole_fault_mesh[first_row: first_row + rup_rows,
                                             first_col: first_col + rup_cols]
-
-                    if not len(self.hypo_list) and not len(self.slip_list):
-
-                        hypocenter = mesh.get_middle_point()
-                        occurrence_rate_hypo = occurrence_rate
-                        surface = SimpleFaultSurface(mesh)
-
+                    surface = SimpleFaultSurface(mesh)
+                    
+                    if self.hypo_depth_list:
+                        yield from self._iter_ruptures_hypo_depth(
+                            surface, occurrence_rate, mag, first_row, rup_rows)
+                        
+                    elif len(self.hypo_list) and len(self.slip_list):
+                        yield from self._iter_ruptures_hypo_slip(
+                            surface, occurrence_rate, mag)
+                        
+                    else:
                         yield ParametricProbabilisticRupture(
                             mag, self.rake, self.tectonic_region_type,
-                            hypocenter, surface, occurrence_rate_hypo,
+                            mesh.get_middle_point(), surface, occurrence_rate,
                             self.temporal_occurrence_model)
-                    else:
-                        for hypo in self.hypo_list:
-                            for slip in self.slip_list:
-                                surface = SimpleFaultSurface(mesh)
-                                hypocenter = surface.get_hypo_location(
-                                    self.rupture_mesh_spacing, hypo[:2])
-                                occurrence_rate_hypo = occurrence_rate * \
-                                    hypo[2] * slip[1]
-                                rupture_slip_direction = slip[0]
-
-                                yield ParametricProbabilisticRupture(
-                                    mag, self.rake, self.tectonic_region_type,
-                                    hypocenter, surface, occurrence_rate_hypo,
-                                    self.temporal_occurrence_model,
-                                    rupture_slip_direction)
 
     def get_fault_surface_area(self):
         """
@@ -230,7 +299,7 @@ class SimpleFaultSource(ParametricSeismicSource):
         fault_length = float((mesh_cols - 1) * self.rupture_mesh_spacing)
         fault_width = float((mesh_rows - 1) * self.rupture_mesh_spacing)
         self._nr = []
-        n_hypo = len(self.hypo_list) or 1
+        n_hypo = len(self.hypo_depth_list) or len(self.hypo_list) or 1
         n_slip = len(self.slip_list) or 1
         for (mag, mag_occ_rate) in self.get_annual_occurrence_rates():
             if mag_occ_rate == 0:

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -176,7 +176,7 @@ class SimpleFaultSource(ParametricSeismicSource):
         An error is raised if none of the hypo depths are within the
         depth range of a given floating rup.
         """
-        # Get down-dip seismo depth range for given floated rup
+        # Compute top and bottom depth of this floating rupture
         sin_dip = math.sin(math.radians(self.dip))
         down_dip_delta = self.rupture_mesh_spacing * sin_dip
         top_depth = (

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -146,7 +146,13 @@ class SimpleFaultSource(ParametricSeismicSource):
             raise ValueError(
                 'hypo_depth_list and hypo_list/slip_list cannot be used together'
                 )
+        
         self.hypo_depth_list = tuple(hypo_depth_list)
+        if self.hypo_depth_list:
+            total = sum(p for p, _ in self.hypo_depth_list)
+            if abs(total - 1.0) > 1e-7:
+                raise ValueError(
+                    f'hypo_depth_list probabilities sum to {total}, expected 1.0')
         for _, depth in self.hypo_depth_list:
             if not (upper_seismogenic_depth <= depth <= lower_seismogenic_depth):
                 raise ValueError(

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -19,12 +19,18 @@ Module :mod:`openquake.hazardlib.source.simple_fault` defines
 """
 import copy
 import math
+from collections import namedtuple
 from openquake.baselib.general import round
 from openquake.hazardlib import mfd
 from openquake.hazardlib.source.base import ParametricSeismicSource
 from openquake.hazardlib.geo.surface.simple_fault import SimpleFaultSurface
 from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib.source.rupture import ParametricProbabilisticRupture
+
+
+# Grouping all the "extra" hypo depth options to reduce num args in class
+HypoData = namedtuple('HypoData', ['hypo_list', 'slip_list', 'depth_list'],
+                      defaults=[(), (), ()])
 
 
 class SimpleFaultSource(ParametricSeismicSource):
@@ -46,36 +52,48 @@ class SimpleFaultSource(ParametricSeismicSource):
         the direction of hanging wall relative to the foot wall.
     :param rupture_slip_direction:
         Angle describing rupture propagation direction in decimal degrees.
-    :param hypo_list:
-        Array describing the relative position of the hypocentre on the rupture
-        surface. Each line represents a hypocentral position defined in terms
-        of the relative distance along strike and dip (from the upper, left
-        corner of the fault surface i.e. the corner which results from the
-        projection at depth of the first vertex of the fault trace) and the
-        corresponding weight. Example 1: one single hypocentral position at the
-        center of the rupture will be described by the following
-        array[(0.5, 0.5, 1.0)]. Example 2: two possible hypocenters are
-        admitted for a rupture. One hypocentre is located along the strike at
-        1/4 of the fault length and at 1/4 of the fault width along the dip and
-        occurs with a weight of 0.3, the other one is at 3/4 of fault length
-        along strike and at 3/4 of fault width along strike with a weight of
-        0.7. The numpy array would be entered as
-        numpy.array([[0.25, 0.25, 0.3], [0.75, 0.75, 0.7]]).
-    :param slip_list:
-        Array describing the rupture slip direction, which desribes the rupture
-        propagation direction on the rupture surface. Each line represents a
-        rupture slip direction and the corresponding weight. Example 1: one
-        single rupture slip direction with angle 90 degree will be described
-        by the following array[(90, 1.0)]. Example 2: two possible rupture slip
-        directions are admitted for a rupture. One slip direction is at 90
-        degree with a weight of 0.7, the other one is at 135 degree with a
-        weight of 0.3. The numpy array would be entered as numpy.array(
-        [[90, 0.7], [135, 0.3]]).
-    :param hypo_depth_list:
-        List of (probability, depth) describing a hypocentre depth distribution.
-        All depths must lie within seismogenic depth range or an error is raised.
-        Also, it cannot be combined with hypo_list or slip_list argument with an
-        error being raised if so.
+    :param HypoData:
+        Instance used to group the input arguments for the two alternative ways
+        of specifying the hypocentres within a SimpleFaultSource.
+
+        Alternative approach 1 is described by hypo_list and slip_list:
+    
+            :param hypo_list:
+                Array describing the relative position of the hypocentre on the
+                rupture surface. Each line represents a hypocentral position
+                defined in terms of the relative distance along strike and dip
+                (from the upper, left corner of the fault surface i.e. the
+                corner which results from the projection at depth of the first
+                vertex of the fault trace) and the corresponding weight.
+                Example 1: one single hypocentral position at the center of the
+                rupture will be described by the following array[(0.5, 0.5,
+                1.0)]. Example 2: two possible hypocenters are admitted for a
+                rupture. One hypocentre is located along the strike at 1/4 of
+                the fault length and at 1/4 of the fault width along the dip and
+                occurs with a weight of 0.3, the other one is at 3/4 of fault
+                length along strike and at 3/4 of fault width along strike with
+                a weight of 0.7. The numpy array would be entered as
+                numpy.array([[0.25, 0.25, 0.3], [0.75, 0.75, 0.7]]).
+
+            :param slip_list:
+                Array describing the rupture slip direction, which desribes the
+                rupture propagation direction on the rupture surface. Each line
+                represents a rupture slip direction and the corresponding weight.
+                Example 1: one single rupture slip direction with angle 90 degree
+                will be described by the following array[(90, 1.0)]. Example 2:
+                two possible rupture slip directions are admitted for a rupture.
+                One slip direction is at 90 degree with a weight of 0.7, the
+                other one is at 135 degree with a weight of 0.3. The numpy array
+                would be entered as numpy.array([[90, 0.7], [135, 0.3]]).
+
+        Alternative approach 2 is described by hypo_depth_list:
+
+            :param hypo_depth_list:
+                List of (probability, depth) describing a hypocentre depth
+                distribution. All depths must lie within seismogenic depth range
+                or an error is raised. Also, it cannot be combined with
+                hypo_list or slip_list argument with an error being raised if
+                so.
 
     See also :class:`openquake.hazardlib.source.base.ParametricSeismicSource`
     for description of other parameters.
@@ -110,8 +128,7 @@ class SimpleFaultSource(ParametricSeismicSource):
                  # simple fault specific parameters
                  upper_seismogenic_depth, lower_seismogenic_depth,
                  fault_trace, dip, rake,
-                 hypo_slip_list=(),
-                 hypo_depth_list=()):
+                 hypo_data=None):
         super().__init__(
             source_id, name, tectonic_region_type, mfd, rupture_mesh_spacing,
             magnitude_scaling_relationship, rupture_aspect_ratio,
@@ -130,24 +147,24 @@ class SimpleFaultSource(ParametricSeismicSource):
         min_mag, _max_mag = self.mfd.get_min_max_mag()
         cols_rows = self._get_rupture_dimensions(float('inf'), float('inf'),
                                                  min_mag)
-        if hypo_slip_list:
-            self.hypo_list = hypo_slip_list[0]
-            self.slip_list = hypo_slip_list[1]
+        if hypo_data is not None:
+            self.hypo_list = hypo_data.hypo_list
+            self.slip_list = hypo_data.slip_list
+            self.hypo_depth_list = tuple(hypo_data.depth_list)
         else:
             self.hypo_list = ()
             self.slip_list = ()
+            self.hypo_depth_list = ()
 
         if (len(self.hypo_list) and not len(self.slip_list) or
            not len(self.hypo_list) and len(self.slip_list)):
             raise ValueError('hypo_list and slip_list have to be both given '
                              'or neither given')
 
-        if hypo_depth_list and (len(self.hypo_list) or len(self.slip_list)):
+        if self.hypo_depth_list and (len(self.hypo_list) or len(self.slip_list)):
             raise ValueError(
                 'hypo_depth_list and hypo_list/slip_list cannot be used together'
                 )
-        
-        self.hypo_depth_list = tuple(hypo_depth_list)
         if self.hypo_depth_list:
             total = sum(p for p, _ in self.hypo_depth_list)
             if abs(total - 1.0) > 1e-7:
@@ -193,7 +210,7 @@ class SimpleFaultSource(ParametricSeismicSource):
             if top_depth <= depth <= bot_depth:
                 dip_frac = (depth - top_depth) / rup_depth_delta
                 hypos.append((dip_frac, prob))
-
+                
         if not hypos:
             raise ValueError(
                 f'No hypo_depth_list depths fall in depth range of floated '

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -162,7 +162,7 @@ class SimpleFaultSource(ParametricSeismicSource):
     def _hypo_list_from_depths(self, first_row, rup_rows):
         """
         Convert the hypo depth distribution to (dip_frac, weight) pairs
-        for a given floating rupture. Along-strike fraction is always 0.5.
+        for a given floating rupture.
 
         Depths outside [rup_top_depth, rup_bot_depth] are discarded
         and the remaining weights are renormalised to sum to 1.
@@ -194,6 +194,7 @@ class SimpleFaultSource(ParametricSeismicSource):
                 f'rupture [{top_depth:.2f}, {bot_depth:.2f}] km')
 
         total = sum(h[1] for h in hypos)
+
         return [(h[0], h[1] / total) for h in hypos]  # Renormalise weights
 
     def _iter_ruptures_hypo_depth(self, surface, occurrence_rate, mag,
@@ -204,9 +205,11 @@ class SimpleFaultSource(ParametricSeismicSource):
         """
         # Iter over the depths in the hypo depth dist
         for dip_frac, w in self._hypo_list_from_depths(first_row, rup_rows):
+
             # Use the down-dip fraction to get the hypo on given floating rup
             hypo = surface.get_hypo_location(
                 self.rupture_mesh_spacing, (0.5, dip_frac))
+            
             # Make the rup
             yield ParametricProbabilisticRupture(
                 mag, self.rake, self.tectonic_region_type,

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -95,7 +95,7 @@ class SimpleFaultSource(ParametricSeismicSource):
                 (None if not set) and overrides the computed down-dip fraction
                 for that depth if provided. All depths must lie within the
                 seismogenic depth range or an error is raised. Cannot be
-                combined with hypo_list or slip_list.
+                combined with alternative approach 1 (hypo_list/slip_list).
 
     See also :class:`openquake.hazardlib.source.base.ParametricSeismicSource`
     for description of other parameters.

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -218,16 +218,16 @@ class SimpleFaultSource(ParametricSeismicSource):
         bot_depth = (
             self.upper_seismogenic_depth +
             (first_row + rup_rows - 1) * down_dip_delta)
-        rup_depth_delta = bot_depth - top_depth
+        rup_depth_range = bot_depth - top_depth
 
-        # Only keep hypocentres inside this depth range
+        # Keep hypocentres inside given floating rupture's depth range
         weight_by_frac = {}
         for prob, depth, fdf in self.hypo_depth_list:
             if top_depth <= depth <= bot_depth:
-                # Either assign the fixedDepFrac or compute it
-                # using the depth delta for given floating rup
+                # Use fixedDipFrac if provided and otherwise compute from depth
                 dip_frac = (fdf if fdf is not None
-                            else (depth - top_depth) / rup_depth_delta)
+                            else (depth - top_depth) / rup_depth_range)
+                # Collapse depths with the same fraction summing their weights
                 weight_by_frac[dip_frac] = (
                     weight_by_frac.get(dip_frac, 0.0) + prob)
 
@@ -236,10 +236,9 @@ class SimpleFaultSource(ParametricSeismicSource):
                 f'No hypo_depth_list depths fall in depth range of floated '
                 f'rupture [{top_depth:.2f}, {bot_depth:.2f}] km')
 
-        total = sum(weight_by_frac.values()) # Sum weights of retained deps
+        total = sum(weight_by_frac.values())
 
-        return [(frac, w / total # Return retained depths situated in given rup
-                 ) for frac, w in weight_by_frac.items()]
+        return [(frac, w / total) for frac, w in weight_by_frac.items()]
 
     def _iter_ruptures_hypo_depth(self, surface, occurrence_rate, mag,
                                    first_row, rup_rows):

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -161,44 +161,40 @@ class SimpleFaultSource(ParametricSeismicSource):
 
     def _hypo_list_from_depths(self, first_row, rup_rows):
         """
-        Convert the hypo depth distribution to rupture-relative
-        (along_strike, down_dip, weight)for a given floating
-        rupture position on the fault plane.
+        Convert the hypo depth distribution to (dip_frac, weight) pairs
+        for a given floating rupture. Along-strike fraction is always 0.5.
 
         Depths outside [rup_top_depth, rup_bot_depth] are discarded
         and the remaining weights are renormalised to sum to 1.
         
         An error is raised if none of the hypo depths are within the
-        rupture depth range.
+        depth range of a given floating rup.
         """
-        # Get down-dip seismo depth range for given floating position
+        # Get down-dip seismo depth range for given floated rup
         sin_dip = math.sin(math.radians(self.dip))
         down_dip_delta = self.rupture_mesh_spacing * sin_dip
-        
-        top_depth_dd = (
-            self.upper_seismogenic_depth + first_row * down_dip_delta)
-        
-        bot_depth_dd = (
+        top_depth = (
             self.upper_seismogenic_depth +
-            (first_row + rup_rows - 1) * down_dip_delta) # Down dips
-        
-        rup_depth_dd = bot_depth_dd - top_depth_dd
+            first_row * down_dip_delta)
+        bot_depth = (
+            self.upper_seismogenic_depth +
+            (first_row + rup_rows - 1) * down_dip_delta)
+        rup_depth_delta = bot_depth - top_depth
 
-        # Check
+        # Only keep the hypocentres inside this depth range
         hypos = []
         for prob, depth in self.hypo_depth_list:
-            if top_depth_dd <= depth <= bot_depth_dd:
-                dip_frac = ((depth - top_depth_dd) / rup_depth_dd
-                            if rup_depth_dd > 0 else 0.5)
-                hypos.append((0.5, dip_frac, prob))
+            if top_depth <= depth <= bot_depth:
+                dip_frac = (depth - top_depth) / rup_depth_delta
+                hypos.append((dip_frac, prob))
 
         if not hypos:
             raise ValueError(
-                f'No hypo_depth_list entries fall within the floating rupture '
-                f'depth range [{top_depth_dd:.2f}, {bot_depth_dd:.2f}] km')
+                f'No hypo_depth_list depths fall in depth range of floated '
+                f'rupture [{top_depth:.2f}, {bot_depth:.2f}] km')
 
-        total = sum(h[2] for h in hypos)
-        return [(h[0], h[1], h[2] / total) for h in hypos]
+        total = sum(h[1] for h in hypos)
+        return [(h[0], h[1] / total) for h in hypos]  # Renormalise weights
 
     def _iter_ruptures_hypo_depth(self, surface, occurrence_rate, mag,
                                    first_row, rup_rows):
@@ -206,10 +202,12 @@ class SimpleFaultSource(ParametricSeismicSource):
         Yield ruptures for given floating position on fault surface using
         the absolute depth distribution in hypo_depth_list.
         """
-        for strike_frac, dip_frac, w in self._hypo_list_from_depths(
-                first_row, rup_rows):
+        # Iter over the depths in the hypo depth dist
+        for dip_frac, w in self._hypo_list_from_depths(first_row, rup_rows):
+            # Use the down-dip fraction to get the hypo on given floating rup
             hypo = surface.get_hypo_location(
-                self.rupture_mesh_spacing, (strike_frac, dip_frac))
+                self.rupture_mesh_spacing, (0.5, dip_frac))
+            # Make the rup
             yield ParametricProbabilisticRupture(
                 mag, self.rake, self.tectonic_region_type,
                 hypo, surface, occurrence_rate * w,

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -90,11 +90,12 @@ class SimpleFaultSource(ParametricSeismicSource):
         Alternative approach 2 is described by hypo_depth_list:
 
             :param hypo_depth_list:
-                List of (probability, depth) describing a hypocentre depth
-                distribution. All depths must lie within seismogenic depth range
-                or an error is raised. Also, it cannot be combined with
-                hypo_list or slip_list argument with an error being raised if
-                so.
+                List of (probability, depth, fixed_dip_frac) describing a
+                hypocentre depth distribution. fixed_dip_frac is optional
+                (None if not set) and overrides the computed down-dip fraction
+                for that depth if provided. All depths must lie within the
+                seismogenic depth range or an error is raised. Cannot be
+                combined with hypo_list or slip_list.
 
     See also :class:`openquake.hazardlib.source.base.ParametricSeismicSource`
     for description of other parameters.
@@ -151,7 +152,9 @@ class SimpleFaultSource(ParametricSeismicSource):
         if hypo_data is not None:
             self.hypo_list = hypo_data.hypo_list
             self.slip_list = hypo_data.slip_list
-            self.hypo_depth_list = tuple(hypo_data.depth_list)
+            self.hypo_depth_list = tuple(
+                e if len(e) == 3 else (e[0], e[1], None)
+                for e in hypo_data.depth_list)
         else:
             self.hypo_list = ()
             self.slip_list = ()
@@ -167,16 +170,20 @@ class SimpleFaultSource(ParametricSeismicSource):
                 'hypo_depth_list and hypo_list/slip_list cannot be used together'
                 )
         if self.hypo_depth_list:
-            total = sum(p for p, _ in self.hypo_depth_list)
+            total = sum(wei for wei, _depth, _fdf in self.hypo_depth_list)
             if abs(total - 1.0) > 1e-7:
                 raise ValueError(
                     f'hypo_depth_list probabilities sum to {total}, expected 1.0')
-        for _, depth in self.hypo_depth_list:
+        for _wei, depth, fdf in self.hypo_depth_list:
             if not (upper_seismogenic_depth <= depth <= lower_seismogenic_depth):
                 raise ValueError(
                     f'hypo_depth_list entry {depth} km is outside the '
                     f'seismogenic zone [{upper_seismogenic_depth}, '
                     f'{lower_seismogenic_depth}] km')
+            if fdf is not None and not (0.0 < fdf <= 1.0):
+                raise ValueError(
+                    f'hypo_depth_list fixedDipFrac {fdf} for depth {depth} km'
+                    f' must be in the range (0, 1]')
 
         if 1 in cols_rows:
             raise ValueError('mesh spacing %s is too high to represent '
@@ -188,9 +195,14 @@ class SimpleFaultSource(ParametricSeismicSource):
         Convert the hypo depth distribution to (dip_frac, weight) pairs
         for a given floating rupture.
 
-        Depths outside [rup_top_depth, rup_bot_depth] are discarded
-        and the remaining weights are renormalised to sum to 1.
-        
+        Depths outside [rup_top_depth, rup_bot_depth] are discarded and
+        the remaining weights are renormalised to sum to 1. Where a
+        fixedDipFrac is set on an entry it is used directly; otherwise
+        the fraction is computed from the depth position within the
+        rupture. Entries sharing the same dip_frac are collapsed into one
+        pair so that a uniform fixedDipFrac yields a single hypocentre
+        per floating rupture.
+
         An error is raised if none of the hypo depths are within the
         depth range of a given floating rup.
         """
@@ -205,21 +217,23 @@ class SimpleFaultSource(ParametricSeismicSource):
             (first_row + rup_rows - 1) * down_dip_delta)
         rup_depth_delta = bot_depth - top_depth
 
-        # Only keep the hypocentres inside this depth range
-        hypos = []
-        for prob, depth in self.hypo_depth_list:
+        # Only keep hypocentres inside this depth range; resolve dip_frac
+        weight_by_frac = {}
+        for prob, depth, fdf in self.hypo_depth_list:
             if top_depth <= depth <= bot_depth:
-                dip_frac = (depth - top_depth) / rup_depth_delta
-                hypos.append((dip_frac, prob))
-                
-        if not hypos:
+                dip_frac = (fdf if fdf is not None
+                            else (depth - top_depth) / rup_depth_delta)
+                weight_by_frac[dip_frac] = (
+                    weight_by_frac.get(dip_frac, 0.0) + prob)
+
+        if not weight_by_frac:
             raise ValueError(
                 f'No hypo_depth_list depths fall in depth range of floated '
                 f'rupture [{top_depth:.2f}, {bot_depth:.2f}] km')
 
-        total = sum(h[1] for h in hypos)
-
-        return [(h[0], h[1] / total) for h in hypos]  # Renormalise weights
+        total = sum(weight_by_frac.values())
+        return [(frac, w / total)
+                for frac, w in weight_by_frac.items()]
 
     def _iter_ruptures_hypo_depth(self, surface, occurrence_rate, mag,
                                    first_row, rup_rows):

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -217,10 +217,12 @@ class SimpleFaultSource(ParametricSeismicSource):
             (first_row + rup_rows - 1) * down_dip_delta)
         rup_depth_delta = bot_depth - top_depth
 
-        # Only keep hypocentres inside this depth range; resolve dip_frac
+        # Only keep hypocentres inside this depth range
         weight_by_frac = {}
         for prob, depth, fdf in self.hypo_depth_list:
             if top_depth <= depth <= bot_depth:
+                # Either assign the fixedDepFrac or compute it
+                # using the depth delta for given floating rup
                 dip_frac = (fdf if fdf is not None
                             else (depth - top_depth) / rup_depth_delta)
                 weight_by_frac[dip_frac] = (

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -198,7 +198,15 @@ class SimpleFaultSource(ParametricSeismicSource):
         Depths outside [rup_top_depth, rup_bot_depth] are discarded and
         the remaining weights are renormalised to sum to 1. 
 
-        An error is raised if none of the hypo depths are within the
+        If fixedDipFrac is specified in the hypoDepthDist then it is
+        assigned to the corresponding depth instead of a fraction computed
+        using the floating rupture's depth range.
+
+        NOTE: Depths that resolve to the same dip_frac (whether from
+        fixedDipFrac or coincidental computed equality) are collapsed into
+        one pair with their weights summed.
+
+        NOTE: An error is raised if none of the hypo depths are within the
         depth range of a given floating rup.
         """
         # Compute top and bottom depth of this floating rupture
@@ -228,9 +236,10 @@ class SimpleFaultSource(ParametricSeismicSource):
                 f'No hypo_depth_list depths fall in depth range of floated '
                 f'rupture [{top_depth:.2f}, {bot_depth:.2f}] km')
 
-        total = sum(weight_by_frac.values())
-        return [(frac, w / total)
-                for frac, w in weight_by_frac.items()]
+        total = sum(weight_by_frac.values()) # Sum weights of retained deps
+
+        return [(frac, w / total # Return retained depths situated in given rup
+                 ) for frac, w in weight_by_frac.items()]
 
     def _iter_ruptures_hypo_depth(self, surface, occurrence_rate, mag,
                                    first_row, rup_rows):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -759,6 +759,11 @@ class SourceConverter(RuptureConverter):
                 slip_list = valid.slip_list(node.slipList)
             except AttributeError:
                 slip_list = ()
+            try:
+                hypo_depth_list = [(hd['probability'], hd['depth'])
+                                   for hd in node.hypoDepthDist]
+            except AttributeError:
+                hypo_depth_list = ()
             simple = source.SimpleFaultSource(
                 node['id'], node['name'],
                 node.attrib.get('tectonicRegion'),
@@ -766,7 +771,8 @@ class SourceConverter(RuptureConverter):
                 msr, get_aspect_ratio(node), self.get_tom(node),
                 ~geom.upperSeismoDepth, ~geom.lowerSeismoDepth,
                 fault_trace, ~geom.dip, ~node.rake,
-                [hypo_list, slip_list])
+                [hypo_list, slip_list],
+                hypo_depth_list=hypo_depth_list)
         return simple
 
     def convert_kiteFaultSource(self, node):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -771,8 +771,7 @@ class SourceConverter(RuptureConverter):
                 msr, get_aspect_ratio(node), self.get_tom(node),
                 ~geom.upperSeismoDepth, ~geom.lowerSeismoDepth,
                 fault_trace, ~geom.dip, ~node.rake,
-                [hypo_list, slip_list],
-                hypo_depth_list=hypo_depth_list)
+                source.HypoData(hypo_list, slip_list, hypo_depth_list))
         return simple
 
     def convert_kiteFaultSource(self, node):

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -760,8 +760,14 @@ class SourceConverter(RuptureConverter):
             except AttributeError:
                 slip_list = ()
             try:
-                hypo_depth_list = [(hd['probability'], hd['depth'])
-                                   for hd in node.hypoDepthDist]
+                hypo_depth_list = [
+                    (hd['probability'], hd['depth'],
+                     # Optional override of dip frac computed on
+                     # floating rup by floating rup basis within
+                     # in SimpleFaultSource._hypo_list_from_depths
+                     float(hd.attrib['fixedDipFrac'])
+                     if 'fixedDipFrac' in hd.attrib else None)
+                    for hd in node.hypoDepthDist]
             except AttributeError:
                 hypo_depth_list = ()
             simple = source.SimpleFaultSource(

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -404,6 +404,25 @@ def build_slip_list_node(slip_list):
     return sliplist
 
 
+def build_hypo_depth_dist_simple_fault(hypo_depth_list):
+    """
+    Returns Node of a hypocentral depth distribution used
+    in a SimpleFaultSource.
+
+    :param hypo_depth_list:
+        List of (probability, depth, fixed_dip_frac_or_None).
+    :returns:
+        A hypoDepthDist Node with optional fixedDipFrac attribute.
+    """
+    nodes = []
+    for prob, depth, fdf in hypo_depth_list:
+        attribs = {'probability': prob, 'depth': depth}
+        if fdf is not None:
+            attribs['fixedDipFrac'] = fdf
+        nodes.append(Node('hypoDepth', attribs))
+    return Node('hypoDepthDist', nodes=nodes)
+
+
 def get_fault_source_nodes(source):
     """
     Returns list of nodes of attributes common to all fault source classes
@@ -428,10 +447,14 @@ def get_fault_source_nodes(source):
     source_nodes.append(obj_to_node(source.mfd))
     # Parse Rake
     source_nodes.append(Node("rake", text=source.rake))
+    # Parse alternative ways to specify hypocentre if required
     if len(getattr(source, 'hypo_list', [])):
         source_nodes.append(build_hypo_list_node(source.hypo_list))
     if len(getattr(source, 'slip_list', [])):
         source_nodes.append(build_slip_list_node(source.slip_list))
+    if getattr(source, 'hypo_depth_list', ()):
+        source_nodes.append(
+            build_hypo_depth_dist_simple_fault(source.hypo_depth_list))
     return source_nodes
 
 

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -18,7 +18,7 @@ import unittest
 import numpy
 from copy import deepcopy
 from openquake.hazardlib.const import TRT
-from openquake.hazardlib.source.simple_fault import SimpleFaultSource
+from openquake.hazardlib.source.simple_fault import SimpleFaultSource, HypoData
 from openquake.hazardlib.source.rupture import ParametricProbabilisticRupture
 from openquake.hazardlib.mfd import TruncatedGRMFD, EvenlyDiscretizedMFD
 import openquake.hazardlib.mfd.evenly_discretized as mfdeven
@@ -467,7 +467,8 @@ class HypoLocSlipRupture(unittest.TestCase):
                                 self.upper_seismogenic_depth,
                                 self.lower_seismogenic_depth,
                                 self.fault_trace, self.dip,
-                                self.rake, [hypo_list, slip_list])
+                                self.rake,
+                                HypoData(hypo_list=hypo_list, slip_list=slip_list))
 
         for rup, i in zip(src.iter_ruptures(), range(1000)):
             self.assertAlmostEqual(
@@ -488,7 +489,7 @@ class HypoLocSlipRupture(unittest.TestCase):
                                 1., self.src_tom, self.upper_seismogenic_depth,
                                 self.lower_seismogenic_depth,
                                 self.fault_trace, dip, self.rake,
-                                [hypo_list, slip_list])
+                                HypoData(hypo_list=hypo_list, slip_list=slip_list))
         for rup, i in zip(src.iter_ruptures(), range(1000)):
             self.assertAlmostEqual(rup.hypocenter.longitude, LON2[i], delta=0.1)
             self.assertAlmostEqual(rup.hypocenter.latitude, LAT2[i], delta=0.1)
@@ -550,7 +551,8 @@ class HypoLocSlipRupture(unittest.TestCase):
                                 self.upper_seismogenic_depth,
                                 self.lower_seismogenic_depth,
                                 self.fault_trace, self.dip,
-                                self.rake, [hypo_list, slip_list])
+                                self.rake,
+                                HypoData(hypo_list=hypo_list, slip_list=slip_list))
 
         slip = [90., 0., 90., 0.]
         rate = [0.1, 0.3, 0.15, 0.45]
@@ -644,8 +646,7 @@ class HypoDepthListTestCase(unittest.TestCase):
             self.upper_seismogenic_depth,
             self.lower_seismogenic_depth,
             self.fault_trace, self.dip, self.rake,
-            hypo_depth_list=hypo_depth_list
-            )
+            HypoData(depth_list=hypo_depth_list))
 
     def test_valid_hypo_depth_list(self):
         src = self._make_source([(0.5, 5.0), (0.5, 15.0)])
@@ -683,8 +684,8 @@ class HypoDepthListTestCase(unittest.TestCase):
                 self.src_mfd, self.mesh_spacing, WC1994(), 1.5, self.src_tom,
                 self.upper_seismogenic_depth, self.lower_seismogenic_depth,
                 self.fault_trace, self.dip, self.rake,
-                hypo_slip_list=[hypo_list, slip_list],
-                hypo_depth_list=[(1.0, 10.0)])
+                HypoData(hypo_list=hypo_list, slip_list=slip_list,
+                         depth_list=[(1.0, 10.0)]))
         self.assertEqual(
             str(ar.exception),
             'hypo_depth_list and hypo_list/slip_list cannot be used together')

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -702,7 +702,7 @@ class HypoDepthListTestCase(unittest.TestCase):
         self.assertAlmostEqual(result[0][0], 2 / 3, places=10)
 
     def test_same_fixed_dip_frac_collapses(self):
-        # Depths sharing a fixedDipFrac collapse to one pair; weights summed.
+        # Depths sharing a fixedDipFrac collapse to 1 pair with weights summed
         src = self._make_source([(0.3, 5.0, 2 / 3), (0.7, 10.0, 2 / 3)])
         result = src._hypo_list_from_depths(first_row=0, rup_rows=24)
         self.assertEqual(len(result), 1)

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -664,7 +664,7 @@ class HypoDepthListTestCase(unittest.TestCase):
             with self.assertRaises(ValueError) as ar:
                 self._make_source([(1.0, depth)])
             self.assertIn(
-                f'hypo_depth_list entry {label} km is outside the '
+                f'hypo_depth_list {label} km is outside the '
                 'seismogenic zone [0.0, 20.0] km',
                 str(ar.exception))
 
@@ -687,7 +687,7 @@ class HypoDepthListTestCase(unittest.TestCase):
         for bad_fdf in (0.0, 1.5):
             with self.assertRaises(ValueError) as ar:
                 self._make_source([(1.0, 10.0, bad_fdf)])
-            self.assertIn('must be in the range (0, 1]', str(ar.exception))
+            self.assertIn('must be in the range [0, 1]', str(ar.exception))
 
     def test_fixed_dip_frac_overrides_computed_fraction(self):
         # depth=10 without fixedDipFrac maps to ~0.502 for this rupture;

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -27,6 +27,7 @@ import openquake.hazardlib.tom as tom
 from openquake.hazardlib.scalerel import PeerMSR, WC1994
 from openquake.hazardlib.geo import Point, Line
 from openquake.hazardlib.tom import PoissonTOM
+from openquake.hazardlib.sourcewriter import build_hypo_depth_dist_simple_fault
 
 
 from openquake.hazardlib.tests import assert_angles_equal, assert_pickleable
@@ -707,3 +708,11 @@ class HypoDepthListTestCase(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertAlmostEqual(result[0][0], 2 / 3, places=10)
         self.assertAlmostEqual(result[0][1], 1.0, places=10)
+
+    def test_hypo_depth_dist_xml_roundtrip(self):
+        # fixedDipFrac is written to XML when set and omitted when None
+        node = build_hypo_depth_dist_simple_fault(
+            [(0.5, 5.0, 2 / 3), (0.5, 10.0, None)])
+        entries = list(node)
+        self.assertAlmostEqual(entries[0].attrib['fixedDipFrac'], 2 / 3)
+        self.assertNotIn('fixedDipFrac', entries[1].attrib)

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -511,7 +511,7 @@ class HypoLocSlipRupture(unittest.TestCase):
                                 self.upper_seismogenic_depth,
                                 self.lower_seismogenic_depth,
                                 self.fault_trace, self.dip, self.rake,
-                                [hypo_list, slip_list])
+                                HypoData(hypo_list=hypo_list, slip_list=slip_list))
 
         lon = [0.0954, 0.2544, 0.1272, 0.2862, 0.159, 0.3279, 0.1908, 0.3696,
                0.2226, 0.4114, 0.2544, 0.4531, 0.2862, 0.4949, 0.3279, 0.5366,

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -660,13 +660,13 @@ class HypoDepthListTestCase(unittest.TestCase):
             'hypo_depth_list probabilities sum to 0.8, expected 1.0')
 
     def test_depth_outside_seismogenic_zone(self):
-        for depth, label in [(-1.0, '-1.0'), (25.0, '25.0')]:
+        for depth in (-1.0, 25.0):
             with self.assertRaises(ValueError) as ar:
                 self._make_source([(1.0, depth)])
-            self.assertIn(
-                f'hypo_depth_list {label} km is outside the '
-                'seismogenic zone [0.0, 20.0] km',
-                str(ar.exception))
+            self.assertEqual(
+                str(ar.exception),
+                f'hypo_depth_list {depth} km is outside the '
+                f'seismogenic zone [0.0, 20.0] km')
 
     def test_combined_with_hypo_list_raises(self):
         hypo_list = numpy.array([[0.5, 0.5, 1.0]])
@@ -687,7 +687,10 @@ class HypoDepthListTestCase(unittest.TestCase):
         for bad_fdf in (0.0, 1.5):
             with self.assertRaises(ValueError) as ar:
                 self._make_source([(1.0, 10.0, bad_fdf)])
-            self.assertIn('must be in the range [0, 1]', str(ar.exception))
+            self.assertEqual(
+                str(ar.exception),
+                f'hypo_depth_list fixedDipFrac {bad_fdf} for depth 10.0 km '
+                f'must be in the range [0, 1]')
 
     def test_fixed_dip_frac_overrides_computed_fraction(self):
         # depth=10 without fixedDipFrac maps to ~0.502 for this rupture;

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -626,9 +626,6 @@ class ModifySimpleFaultTestCase(_BaseFaultSourceTestCase):
 
 
 class HypoDepthListTestCase(unittest.TestCase):
-    # dip=60°, mesh_spacing=1 km, USD=0, LSD=20 km.
-    # At M=7.5 the rupture spans the full seismogenic depth (one floating
-    # position along width), so first_row=0, rup_rows=24 covers all depths.
 
     def setUp(self):
         self.src_mfd = mfdeven.EvenlyDiscretizedMFD(7.5, 1., [1.])

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -626,6 +626,9 @@ class ModifySimpleFaultTestCase(_BaseFaultSourceTestCase):
 
 
 class HypoDepthListTestCase(unittest.TestCase):
+    # dip=60°, mesh_spacing=1 km, USD=0, LSD=20 km.
+    # At M=7.5 the rupture spans the full seismogenic depth (one floating
+    # position along width), so first_row=0, rup_rows=24 covers all depths.
 
     def setUp(self):
         self.src_mfd = mfdeven.EvenlyDiscretizedMFD(7.5, 1., [1.])
@@ -659,21 +662,14 @@ class HypoDepthListTestCase(unittest.TestCase):
             str(ar.exception),
             'hypo_depth_list probabilities sum to 0.8, expected 1.0')
 
-    def test_depth_above_upper_seismogenic_depth(self):
-        with self.assertRaises(ValueError) as ar:
-            self._make_source([(1.0, -1.0)])
-        self.assertEqual(
-            str(ar.exception),
-            'hypo_depth_list entry -1.0 km is outside the '
-            'seismogenic zone [0.0, 20.0] km')
-
-    def test_depth_below_lower_seismogenic_depth(self):
-        with self.assertRaises(ValueError) as ar:
-            self._make_source([(1.0, 25.0)])
-        self.assertEqual(
-            str(ar.exception),
-            'hypo_depth_list entry 25.0 km is outside the '
-            'seismogenic zone [0.0, 20.0] km')
+    def test_depth_outside_seismogenic_zone(self):
+        for depth, label in [(-1.0, '-1.0'), (25.0, '25.0')]:
+            with self.assertRaises(ValueError) as ar:
+                self._make_source([(1.0, depth)])
+            self.assertIn(
+                f'hypo_depth_list entry {label} km is outside the '
+                'seismogenic zone [0.0, 20.0] km',
+                str(ar.exception))
 
     def test_combined_with_hypo_list_raises(self):
         hypo_list = numpy.array([[0.5, 0.5, 1.0]])
@@ -689,3 +685,25 @@ class HypoDepthListTestCase(unittest.TestCase):
         self.assertEqual(
             str(ar.exception),
             'hypo_depth_list and hypo_list/slip_list cannot be used together')
+
+    def test_fixed_dip_frac_out_of_range_raises(self):
+        for bad_fdf in (0.0, 1.5):
+            with self.assertRaises(ValueError) as ar:
+                self._make_source([(1.0, 10.0, bad_fdf)])
+            self.assertIn('must be in the range (0, 1]', str(ar.exception))
+
+    def test_fixed_dip_frac_overrides_computed_fraction(self):
+        # depth=10 without fixedDipFrac maps to ~0.502 for this rupture;
+        # with fixedDipFrac=2/3 the returned fraction must be exactly 2/3.
+        src = self._make_source([(1.0, 10.0, 2 / 3)])
+        result = src._hypo_list_from_depths(first_row=0, rup_rows=24)
+        self.assertEqual(len(result), 1)
+        self.assertAlmostEqual(result[0][0], 2 / 3, places=10)
+
+    def test_same_fixed_dip_frac_collapses(self):
+        # Depths sharing a fixedDipFrac collapse to one pair; weights summed.
+        src = self._make_source([(0.3, 5.0, 2 / 3), (0.7, 10.0, 2 / 3)])
+        result = src._hypo_list_from_depths(first_row=0, rup_rows=24)
+        self.assertEqual(len(result), 1)
+        self.assertAlmostEqual(result[0][0], 2 / 3, places=10)
+        self.assertAlmostEqual(result[0][1], 1.0, places=10)

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -618,6 +618,73 @@ class ModifySimpleFaultTestCase(_BaseFaultSourceTestCase):
         self.assertEqual(str(ar.exception), "dip must be between 0.0 and 90.0")
 
     def test_modify_set_dip(self):
-        new_fault = deepcopy(self.fault) 
+        new_fault = deepcopy(self.fault)
         new_fault.modify_set_dip(72.0)
         self.assertAlmostEqual(new_fault.dip, 72.0)
+
+
+class HypoDepthListTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.src_mfd = mfdeven.EvenlyDiscretizedMFD(7.5, 1., [1.])
+        self.src_tom = tom.PoissonTOM(50)
+        self.upper_seismogenic_depth = 0.
+        self.lower_seismogenic_depth = 20.
+        self.dip = 60.
+        self.rake = 90.
+        self.mesh_spacing = 1.
+        self.fault_trace = Line([Point(0.0, 0.0), Point(1.0, 0.0)])
+
+    def _make_source(self, hypo_depth_list):
+        return SimpleFaultSource(
+            'test', 'test',
+            TRT.ACTIVE_SHALLOW_CRUST,
+            self.src_mfd,
+            self.mesh_spacing, WC1994(), 1.5, self.src_tom,
+            self.upper_seismogenic_depth,
+            self.lower_seismogenic_depth,
+            self.fault_trace, self.dip, self.rake,
+            hypo_depth_list=hypo_depth_list
+            )
+
+    def test_valid_hypo_depth_list(self):
+        src = self._make_source([(0.5, 5.0), (0.5, 15.0)])
+        self.assertEqual(len(src.hypo_depth_list), 2)
+
+    def test_weights_not_summing_to_one(self):
+        with self.assertRaises(ValueError) as ar:
+            self._make_source([(0.3, 5.0), (0.5, 15.0)])
+        self.assertEqual(
+            str(ar.exception),
+            'hypo_depth_list probabilities sum to 0.8, expected 1.0')
+
+    def test_depth_above_upper_seismogenic_depth(self):
+        with self.assertRaises(ValueError) as ar:
+            self._make_source([(1.0, -1.0)])
+        self.assertEqual(
+            str(ar.exception),
+            'hypo_depth_list entry -1.0 km is outside the '
+            'seismogenic zone [0.0, 20.0] km')
+
+    def test_depth_below_lower_seismogenic_depth(self):
+        with self.assertRaises(ValueError) as ar:
+            self._make_source([(1.0, 25.0)])
+        self.assertEqual(
+            str(ar.exception),
+            'hypo_depth_list entry 25.0 km is outside the '
+            'seismogenic zone [0.0, 20.0] km')
+
+    def test_combined_with_hypo_list_raises(self):
+        hypo_list = numpy.array([[0.5, 0.5, 1.0]])
+        slip_list = numpy.array([[90., 1.0]])
+        with self.assertRaises(ValueError) as ar:
+            SimpleFaultSource(
+                'test', 'test', TRT.ACTIVE_SHALLOW_CRUST,
+                self.src_mfd, self.mesh_spacing, WC1994(), 1.5, self.src_tom,
+                self.upper_seismogenic_depth, self.lower_seismogenic_depth,
+                self.fault_trace, self.dip, self.rake,
+                hypo_slip_list=[hypo_list, slip_list],
+                hypo_depth_list=[(1.0, 10.0)])
+        self.assertEqual(
+            str(ar.exception),
+            'hypo_depth_list and hypo_list/slip_list cannot be used together')

--- a/openquake/qa_tests_data/classical/README.md
+++ b/openquake/qa_tests_data/classical/README.md
@@ -21,6 +21,7 @@
 |case\_25|Test negative depths|
 |case\_26|Test YoungsCoppersmith1985MFD|
 |case\_27|Nankai mutex model, including disaggregation|
+|case\_28|Test hypoDepthDist with a simple fault source|
 |case\_29|Non-parametric source with one rupture represente by 2 kite surfaces|
 |case\_32|Source Specific Logic Tree|
 |case\_33|Directivity|

--- a/openquake/qa_tests_data/classical/case_28/expected/hazard_curve-mean-PGA.csv
+++ b/openquake/qa_tests_data/classical/case_28/expected/hazard_curve-mean-PGA.csv
@@ -1,0 +1,3 @@
+#,,,,,,,,"generated_by='OpenQuake engine 3.26.0-git643dd0471e', start_date='2026-04-29T15:08:28', checksum=3950370653, kind='mean', investigation_time=50.0, imt='PGA'"
+lon,lat,depth,poe-0.0100000,poe-0.0500000,poe-0.1000000,poe-0.2000000,poe-0.5000000,poe-1.0000000
+0.50000,-0.50000,0.00000,9.004363E-02,2.824788E-02,5.823125E-03,4.064307E-04,0.000000E+00,0.000000E+00

--- a/openquake/qa_tests_data/classical/case_28/expected/hazard_curve-mean-PGA_fixed_dip_frac.csv
+++ b/openquake/qa_tests_data/classical/case_28/expected/hazard_curve-mean-PGA_fixed_dip_frac.csv
@@ -1,0 +1,3 @@
+#,,,,,,,,"generated_by='OpenQuake engine 3.26.0-git688c75fed6', start_date='2026-04-29T19:40:18', checksum=2540768029, kind='mean', investigation_time=50.0, imt='PGA'"
+lon,lat,depth,poe-0.0100000,poe-0.0500000,poe-0.1000000,poe-0.2000000,poe-0.5000000,poe-1.0000000
+0.50000,-0.50000,0.00000,9.004363E-02,2.824788E-02,5.823125E-03,4.064307E-04,0.000000E+00,0.000000E+00

--- a/openquake/qa_tests_data/classical/case_28/gsim_logic_tree.xml
+++ b/openquake/qa_tests_data/classical/case_28/gsim_logic_tree.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="gmpeModel" branchSetID="bs1"
+                                applyToTectonicRegionType="Active Shallow Crust">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>ChiouYoungs2014</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_28/job.ini
+++ b/openquake/qa_tests_data/classical/case_28/job.ini
@@ -1,0 +1,38 @@
+[general]
+
+description = Simple fault source with hypoDepthDist
+calculation_mode = classical
+random_seed = 23
+
+[geometry]
+
+sites = 0.5 -0.5
+
+[logic_tree]
+
+number_of_logic_tree_samples = 0
+
+[erf]
+
+rupture_mesh_spacing = 5.0
+width_of_mfd_bin = 0.1
+
+[site_params]
+
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 2.5
+reference_depth_to_1pt0km_per_sec = 50.0
+
+[calculation]
+
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gsim_logic_tree.xml
+investigation_time = 50.0
+intensity_measure_types_and_levels = {"PGA": [0.01, 0.05, 0.1, 0.2, 0.5, 1.0]}
+truncation_level = 3.0
+maximum_distance = 200.0
+
+[output]
+
+mean = true

--- a/openquake/qa_tests_data/classical/case_28/source_model.xml
+++ b/openquake/qa_tests_data/classical/case_28/source_model.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+      xmlns:gml="http://www.opengis.net/gml">
+    <sourceModel name="Simple fault with hypoDepthDist">
+
+        <simpleFaultSource id="1" name="Simple Fault Source"
+                           tectonicRegion="Active Shallow Crust">
+            <simpleFaultGeometry>
+                <gml:LineString>
+                    <gml:posList>
+                        1.0 -0.5 1.4 0.0 1.4 0.3
+                    </gml:posList>
+                </gml:LineString>
+                <dip>60.0</dip>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>20.0</lowerSeismoDepth>
+            </simpleFaultGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.5</ruptAspectRatio>
+            <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
+                                      minMag="6.5" maxMag="7.5"/>
+            <rake>90.0</rake>
+            <hypoDepthDist>
+                <hypoDepth depth="5.0"  probability="0.25"/>
+                <hypoDepth depth="10.0" probability="0.50"/>
+                <hypoDepth depth="15.0" probability="0.25"/>
+            </hypoDepthDist>
+        </simpleFaultSource>
+
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_28/source_model_depth_error.xml
+++ b/openquake/qa_tests_data/classical/case_28/source_model_depth_error.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+      xmlns:gml="http://www.opengis.net/gml">
+    <sourceModel name="Simple fault with out-of-range hypoDepthDist">
+
+        <simpleFaultSource id="1" name="Simple Fault Source"
+                           tectonicRegion="Active Shallow Crust">
+            <simpleFaultGeometry>
+                <gml:LineString>
+                    <gml:posList>
+                        1.0 -0.5 1.4 0.0 1.4 0.3
+                    </gml:posList>
+                </gml:LineString>
+                <dip>60.0</dip>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>20.0</lowerSeismoDepth>
+            </simpleFaultGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.5</ruptAspectRatio>
+            <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
+                                      minMag="6.5" maxMag="7.5"/>
+            <rake>90.0</rake>
+            <hypoDepthDist>
+                <hypoDepth depth="5.0"  probability="0.5"/>
+                <hypoDepth depth="25.0" probability="0.5"/>
+            </hypoDepthDist>
+        </simpleFaultSource>
+
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_28/source_model_fixed_dip_frac.xml
+++ b/openquake/qa_tests_data/classical/case_28/source_model_fixed_dip_frac.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+      xmlns:gml="http://www.opengis.net/gml">
+    <sourceModel name="Simple fault with hypoDepthDist and fixedDipFrac">
+
+        <simpleFaultSource id="1" name="Simple Fault Source"
+                           tectonicRegion="Active Shallow Crust">
+            <simpleFaultGeometry>
+                <gml:LineString>
+                    <gml:posList>
+                        1.0 -0.5 1.4 0.0 1.4 0.3
+                    </gml:posList>
+                </gml:LineString>
+                <dip>60.0</dip>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>20.0</lowerSeismoDepth>
+            </simpleFaultGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.5</ruptAspectRatio>
+            <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
+                                      minMag="6.5" maxMag="7.5"/>
+            <rake>90.0</rake>
+            <hypoDepthDist>
+                <hypoDepth depth="5.0"  probability="0.25" fixedDipFrac="0.6667"/>
+                <hypoDepth depth="10.0" probability="0.50" fixedDipFrac="0.6667"/>
+                <hypoDepth depth="15.0" probability="0.25" fixedDipFrac="0.6667"/>
+            </hypoDepthDist>
+        </simpleFaultSource>
+
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_28/source_model_fixed_dip_frac.xml
+++ b/openquake/qa_tests_data/classical/case_28/source_model_fixed_dip_frac.xml
@@ -20,8 +20,10 @@
             <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
                                       minMag="6.5" maxMag="7.5"/>
             <rake>90.0</rake>
-            <hypoDepthDist>
-                <hypoDepth depth="5.0"  probability="0.25" fixedDipFrac="0.6667"/>
+            <hypoDepthDist>,
+                <!-- The fixedDipFrac is optional and here tells the engine -->
+                <!-- to use this fraction instead of computing it --> 
+                <hypoDepth depth="5.0"  probability="0.25" fixedDipFrac="0.6667"/> 
                 <hypoDepth depth="10.0" probability="0.50" fixedDipFrac="0.6667"/>
                 <hypoDepth depth="15.0" probability="0.25" fixedDipFrac="0.6667"/>
             </hypoDepthDist>

--- a/openquake/qa_tests_data/classical/case_28/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/classical/case_28/source_model_logic_tree.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>source_model.xml</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_28/source_model_logic_tree_depth_error.xml
+++ b/openquake/qa_tests_data/classical/case_28/source_model_logic_tree_depth_error.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>source_model_depth_error.xml</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_28/source_model_logic_tree_fixed_dip_frac.xml
+++ b/openquake/qa_tests_data/classical/case_28/source_model_logic_tree_fixed_dip_frac.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>source_model_fixed_dip_frac.xml</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>


### PR DESCRIPTION
Currently a PMF of hypo depths can only be specified for distributed seismicity but we need this capability for simple faults too for BCHydro SSC. 

When iterating over the floated ruptures the depth range of the given floating rupture is computed and then only the hypocentres within this depth range are retained, with the associated weights of the remaining depths renormalised. The computed down-dip fractions are then used to construct the hypocentres within the rupture object.

An optional value of `fixedDepFrac` permits a manual specification of the down-dip fraction used for assigning each hypocenter to the given floating rup, but if not present (optional column in `hypoDepthDist`) this is computed on the fly using the given floating rup (in this case the depths are still used to filter out against the given floating rup's depth range and then the ratio is fixed using the provided overriding value):

<img width="574" height="135" alt="{2EBD1ECB-A3E3-48F8-ABA9-6C8900DD03B0}" src="https://github.com/user-attachments/assets/cfc7c351-57ac-49a0-a44c-f95b2f7bc134" />

For testing I add a QA test (classical/case_28) and some simple unit tests.

I split the existing `iter_rups` for clarity into helper functions for each hypocentre approach (centroid, hypo_depth_list, slip_list).