### PR TITLE
improve pyproject to manage 'openquake' namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ version = {attr = "openquake.baselib.__version__"}
 "openquake" = ["openquake.cfg", "README.md", "LICENSE", "CONTRIBUTORS.txt"]
 
 [tool.setuptools.packages.find]
+namespaces = true
 where = ["."]
 include = ["openquake.*"]
 exclude = [


### PR DESCRIPTION
These small changes want to enforce the proper packaging management of 'openquake' namespace.