### PR TITLE
Force the ASCE standards to be selected before picking a corresponding site class

### DIFF
--- a/openquake/server/static/js/aelo.js
+++ b/openquake/server/static/js/aelo.js
@@ -53,7 +53,7 @@ window.initAeloForm = function() {
             site_class_select.prop('disabled', true);
             site_class_select.append($('<option>', {
                 value: '',
-                text: '-- 2. Select ASCE standard first --',
+                text: '-- 2. Select ASCE standards first --',
                 selected: true,
                 disabled: true
             }));

--- a/openquake/server/static/js/aelo.js
+++ b/openquake/server/static/js/aelo.js
@@ -18,11 +18,12 @@ window.initAeloForm = function() {
     // NOTE: avoiding to call it DEFAULT_SITE_CLASS to avoid confusion with the 'default' one
     const PRESELECTED_SITE_CLASS = 'BC';
 
-    var vs30_original_placeholder;
+    var vs30_original_placeholder = $('input#vs30').attr('placeholder');
     $('select#site_class').on('change', function() {
         const site_class = $(this).val();
         const input_vs30 = $('input#vs30');
         const asce_version = $("#asce_version").val();
+        if (!site_class) return;
         if (site_class === 'custom') {
             input_vs30.prop('disabled', false);
             input_vs30.val('');
@@ -44,37 +45,40 @@ window.initAeloForm = function() {
         const asce_version = $(this).val();
         const site_class_select = $('select#site_class');
         const input_vs30 = $('input#vs30');
+
         site_class_select.empty();
+
+        if (!asce_version) {
+            // If no ASCE version is selected, lock the dropdowns back down
+            site_class_select.prop('disabled', true);
+            site_class_select.append($('<option>', {
+                value: '',
+                text: '-- 2. Select ASCE standard first --',
+                selected: true,
+                disabled: true
+            }));
+            input_vs30.val('').prop('disabled', true);
+            return;
+        }
+
+        // Otherwise, enable Site Class and show its own placeholder
+        site_class_select.prop('disabled', false);
+
         if (asce_version === 'ASCE7-16') {
             site_class_select.append($('<option>', {
                 value: PRESELECTED_SITE_CLASS,
                 text: window.AELO.site_classes[asce_version][PRESELECTED_SITE_CLASS]['display_name']}));
-            input_vs30.val(window.AELO.site_classes[asce_version][PRESELECTED_SITE_CLASS]['vs30']);
         } else if (asce_version === 'ASCE7-22') {
             for (const site_class of Object.keys(window.AELO.site_classes[asce_version])) {
                 site_class_select.append(
                     $("<option>", {
                         value: site_class,
-                        text: window.AELO.site_classes[asce_version][site_class]['display_name'],
-                        selected: site_class === PRESELECTED_SITE_CLASS
+                        text: window.AELO.site_classes[asce_version][site_class]['display_name']
                     })
                 );
             }
         }
-        const site_class = site_class_select.val();
-        if (site_class === 'custom') {
-            input_vs30.prop('disabled', false);
-            input_vs30.val('');
-        } else {
-            input_vs30.prop('disabled', true);
-            if (site_class === 'default') {
-                input_vs30.val('');
-            } else {
-                const site_class = site_class_select.val();
-                input_vs30.val(window.AELO.site_classes[asce_version][site_class]['vs30']);
-                check_vs30_below_200();
-            }
-        }
+        site_class_select.val(PRESELECTED_SITE_CLASS).change();
     });
 
     const vs30_below_200_warning = `

--- a/openquake/server/templates/engine/includes/aelo_form.html
+++ b/openquake/server/templates/engine/includes/aelo_form.html
@@ -34,18 +34,19 @@
                 <tbody>
                   <tr>
                     <td>
-                        <select class="aelo-select" name="asce_version" id="asce_version">
-                        {% for asce_version, asce_version_label in asce_versions.items %}
-                        {% if asce_version == default_asce_version %}
-                        <option value="{{ asce_version }}" selected>{{ asce_version_label }}</option>
-                        {% else %}
-                        <option value="{{ asce_version }}">{{ asce_version_label }}</option>
-                        {% endif %}
-                        {% endfor %}
+                        <select class="aelo-select" name="asce_version" id="asce_version" required>
+                          <option value="" selected disabled>-- 1. Select ASCE standards --</option>
+                          {% for asce_version, asce_version_label in asce_versions.items %}
+                            <option value="{{ asce_version }}">{{ asce_version_label }}</option>
+                          {% endfor %}
                         </select>
                     </td>
-                    <td><select class="aelo-select" name="site_class" id="site_class"><option value="BC">B-C boundary</option></select></td>
-                    <td><span class="vs30"><input class="aelo-input" type="text" id="vs30" name="vs30" value='760' placeholder="{{ aelo_form_placeholders.vs30 }}" disabled/></span></td>
+                    <td>
+                      <select class="aelo-select" name="site_class" id="site_class" disabled required>
+                        <option value="" selected disabled>-- 2. Select ASCE standards first --</option>
+                      </select>
+                    </td>
+                    <td><span class="vs30"><input class="aelo-input" type="text" id="vs30" name="vs30" value="" placeholder="{{ aelo_form_placeholders.vs30 }}" disabled required/></span></td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
I kept the rest of the chain logic unchanged (besides removing some duplication in the code): when the user selects the ASCE standards, the corresponding default site class is automatically pre-selected and the corresponding Vs30 value is set.

<img width="912" height="232" alt="image" src="https://github.com/user-attachments/assets/49e73617-425b-4644-a86c-d185890ad11c" />
