### PR TITLE
Extended the rupture exporter to export the model field, when needed

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -693,16 +693,13 @@ class EventBasedCalculator(base.HazardCalculator):
                 eff_ruptures += dic['eff_ruptures']
             with mon:
                 self.nruptures += len(rup_array)
-                ok = slice(None)
                 if len(self.mosaic_df):
                     # tested in global_ses
                     rup_array['model'] = geolocate(
                         rup_array['hypo'], self.mosaic_df)
-                    if 'geometry' not in oq.inputs:
-                        ok = in_mosaic(rup_array)
                 # NB: the ruptures will we reordered and resaved later
-                hdf5.extend(self.datastore['ruptures'], rup_array[ok])
-                hdf5.extend(self.datastore['rupgeoms'], geom[ok])
+                hdf5.extend(self.datastore['ruptures'], rup_array)
+                hdf5.extend(self.datastore['rupgeoms'], geom)
         t1 = time.time()
         logging.info(f'Generated {tot_ruptures} ruptures in {t1 - t0} seconds')
         if len(self.datastore['ruptures']) == 0:

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1669,6 +1669,8 @@ def extract_rupture_info(dstore, what):
               ('mag', F32), ('centroid_lon', F32), ('centroid_lat', F32),
               ('centroid_depth', F32), ('trt', '<S50'),
               ('strike', F32), ('dip', F32), ('rake', F32)]
+    if multi_model:
+        dtlist.append(('model', '<S3'))
     rows = []
     boundaries = []
     allrups = dstore['ruptures'][:]

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1665,11 +1665,12 @@ def extract_rupture_info(dstore, what):
     except KeyError:  # scenario
         source_id = None
     multi_model = isinstance(source_id, Group)
+    multi_lt = isinstance(dstore['full_lt'], Group)
     dtlist = [('rup_id', I64), ('source_id', '<S75'), ('multiplicity', U32),
               ('mag', F32), ('centroid_lon', F32), ('centroid_lat', F32),
               ('centroid_depth', F32), ('trt', '<S50'),
               ('strike', F32), ('dip', F32), ('rake', F32)]
-    if multi_model:
+    if multi_lt:
         dtlist.append(('model', '<S3'))
     rows = []
     boundaries = []
@@ -1708,10 +1709,12 @@ def extract_rupture_info(dstore, what):
                                           ', '.join(coordset))
                     else:  # good polygon
                         boundaries.append('POLYGON((%s))' % ', '.join(coords))
-                rows.append(
-                    (r['rup_id'], srcid, r['multiplicity'],
-                     r['mag'], r['lon'], r['lat'], r['depth'],
-                     trt, r['strike'], r['dip'], r['rake']))
+                row = [r['rup_id'], srcid, r['multiplicity'],
+                       r['mag'], r['lon'], r['lat'], r['depth'],
+                       trt, r['strike'], r['dip'], r['rake']]
+                if multi_lt:
+                    row.append(r['model'])
+                rows.append(tuple(row))
     arr = numpy.array(rows, dtlist)
     geoms = gzip.compress('\n'.join(boundaries).encode('utf-8'))
     return ArrayWrapper(arr, dict(investigation_time=oq.investigation_time,

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1580,7 +1580,8 @@ class RuptureData(object):
         self.params = sorted(self.cmaker.REQUIRES_RUPTURE_PARAMETERS -
                              set('mag strike dip rake hypo_depth'.split()))
         self.dt = numpy.dtype([
-            ('rup_id', I64), ('source_id', SOURCE_ID), ('multiplicity', U32),
+            ('rup_id', I64), ('source_id', SOURCE_ID),
+            ('model', '<S3'), ('multiplicity', U32),
             ('occurrence_rate', F64),
             ('mag', F32), ('lon', F32), ('lat', F32), ('depth', F32),
             ('strike', F32), ('dip', F32), ('rake', F32),
@@ -1604,7 +1605,7 @@ class RuptureData(object):
             except AttributeError:  # for nonparametric sources
                 rate = numpy.nan
             data.append(
-                (ebr.id, ebr.source_id, ebr.n_occ, rate,
+                (ebr.id, ebr.source_id, ebr.model, ebr.n_occ, rate,
                  rup.mag, point.x, point.y, point.z, rup.surface.get_strike(),
                  rup.surface.get_dip(), rup.rake, boundaries) + ruptparams)
         return numpy.array(data, self.dt)

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -747,17 +747,19 @@ class EBRupture(object):
     :param int n_occ: number of occurrences of the rupture
     :param int64 id: rupture ID
     :param int e0: initial event ID (default 0)
+    :param str model: mosaic model (default "???")
     :param seed: rupture seed to be set (default "NA")
     """
 
     def __init__(self, rupture, source_id=0, trt_smr=0, n_occ=1, id=0,
-                 e0=0, seed='NA'):
+                 e0=0, model='???', seed='NA'):
         self.rupture = rupture
         self.source_id = source_id
         self.trt_smr = trt_smr
         self.n_occ = n_occ
         self.id = id
         self.e0 = e0
+        self.model = model
         self.seed = seed
 
     @property

--- a/openquake/qa_tests_data/mosaic/workflow.py
+++ b/openquake/qa_tests_data/mosaic/workflow.py
@@ -142,7 +142,8 @@ def ses(mosaic_dir, out='global_ses.hdf5', models=['ALL'],
         models = MODELS
     for model in models:
         base = os.path.abspath(os.path.join(mosaic_dir, model))
-        assert os.path.exists(base), base
+        if not os.path.exists(base):
+            raise RuntimeError(r'Missing repository {base}')
         ini = os.path.join(base, 'in', 'job_vs30.ini')
         if os.path.exists(ini):
             ext = '_vs30.ini'


### PR DESCRIPTION
When exporting from a SES.hdf5 file. Also, not discarding the ruptures outside the mosaic at saving time, only at reading time.