### PR TITLE
Revert the mapping COUNTRY_CODE to Taiwan -> TWN

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -160,7 +160,11 @@ def get_closest_country(lon, lat, buffer_radius):
         lon, lat, buffer_radius, countries_df)
     if not close_countries:
         return '???'
-    return close_countries[0]
+    # close_countries are ordered by ascending distance
+    closest_country = close_countries[0]
+    if closest_country in ALIASES:
+        closest_country = ALIASES[closest_country]
+    return closest_country
 
 
 # used in extract_fom_zip

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -153,7 +153,7 @@ def get_closest_country(lon, lat, buffer_radius):
         coordinates (i.e. degrees), and it defines how far from
         the point the buffer should extend in all directions,
         creating a circular buffer region around the point
-    :returns: the closest country or '???'
+    :returns: the iso3 code of the closest country or '???'
     """
     countries_df = read_countries_df()
     close_countries = geo.utils.geolocate_within_buffer(
@@ -161,10 +161,7 @@ def get_closest_country(lon, lat, buffer_radius):
     if not close_countries:
         return '???'
     # close_countries are ordered by ascending distance
-    closest_country = close_countries[0]
-    if closest_country in ALIASES:
-        closest_country = ALIASES[closest_country]
-    return closest_country
+    return close_countries[0]
 
 
 # used in extract_fom_zip

--- a/openquake/hazardlib/countries.py
+++ b/openquake/hazardlib/countries.py
@@ -267,7 +267,7 @@ Suriname,SUR
 Sweden,SWE
 Switzerland,CHE
 Syria,SYR
-Taiwan,TEM
+Taiwan,TWN
 Tajikistan,TJK
 Tanzania,TZA
 Thailand,THA


### PR DESCRIPTION
Oq-impact was failing for Taiwan because of the recent change TWN -> TEM.
Is Taiwan the only case in which we need to use a 3-letter code that is not the ISO code of the country, but an acronym of the corresponding earthquake model?