### PR TITLE
Extended use_rates to work also with IMT-dependent weights

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Extended use_rates to work also with IMT-dependent weights
+
   [Christopher Brooks]
   * Fix exporting of ruptures with surfaces defined using a `GriddedSurface`
 

--- a/openquake/calculators/classical.py
+++ b/openquake/calculators/classical.py
@@ -525,7 +525,7 @@ class ClassicalCalculator(base.HazardCalculator):
         if oq.hazard_calculation_id:
             logging.info('Reading from parent calculation')
             parent = self.datastore.parent
-            self.full_lt = parent['full_lt'].init()
+            self.full_lt = parent['full_lt']
             self.csm = read_csm(parent, self.full_lt)
             self.datastore['source_info'] = parent['source_info'][:]
             oq.mags_by_trt = {

--- a/openquake/calculators/getters.py
+++ b/openquake/calculators/getters.py
@@ -367,14 +367,16 @@ class MapGetter(object):
         M = self.M
         L1 = self.L // M
         means = MapArray(U32(self.sids), M, L1).fill(0)
+        gweights = self.gweights[0]
+        imt_dep_weights = gweights.shape[1] > 1
         for sid in self.sids:
-            rates = self.array[self.sid2idx[sid]]  # shape (L, G)
             if len(self.ilabels):
                 gweights = self.gweights[self.ilabels[sid]]
-            else:
-                gweights = self.gweights[0]
+            rates = self.array[self.sid2idx[sid]]  # shape (L, G)
             sidx = means.sidx[sid]
-            means.array[sidx] = (rates @ gweights).reshape((M, L1))
+            for m in range(M):
+                means.array[sidx, m] = rates[m*L1: m*L1+L1] @ gweights[
+                    :, m if imt_dep_weights else -1]
         means.array[:] = to_probs(means.array)
         return means
 

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1004,9 +1004,6 @@ def get_full_lt(oqparam):
     full_lt = logictree.FullLogicTree(source_model_lt, gsim_lt, oversampling)
     p = full_lt.source_model_lt.num_paths * gsim_lt.get_num_paths()
 
-    if full_lt.gsim_lt.has_imt_weights() and oqparam.use_rates:
-        raise ValueError('use_rates=true cannot be used with imtWeight')
-
     if oqparam.number_of_logic_tree_samples:
         if (oqparam.oversampling == 'forbid' and
                 oqparam.number_of_logic_tree_samples >= p

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1929,6 +1929,8 @@ def get_cmakers(all_trt_smrs, full_lt, oq):
     :returns: list of ContextMakers associated to the given src_groups
     """
     from openquake.hazardlib.site_amplification import AmplFunction
+    if not hasattr(full_lt, 'weights'):
+        full_lt.init()
     unique_trt_smrs, inverse = get_unique_inverse(all_trt_smrs)
     if 'amplification' in oq.inputs and oq.amplification_method == 'kernel':
         df = AmplFunction.read_df(oq.inputs['amplification'])

--- a/openquake/hazardlib/gsim_lt.py
+++ b/openquake/hazardlib/gsim_lt.py
@@ -319,7 +319,7 @@ class GsimLogicTree(object):
         """
         :returns: True if the logic tree has IMT-dependend weights
         """
-        return len(self.branches[0].weight.dic) > 1
+        return any(len(br.weight.dic) > 1 for br in self.branches)
 
     def check_imts(self, imts):
         """

--- a/openquake/qa_tests_data/classical/case_39/job.ini
+++ b/openquake/qa_tests_data/classical/case_39/job.ini
@@ -1,7 +1,8 @@
 [general]
 
-description = Test checking of IMT-dependent weights with unsupported IMTs
+description = Test IMT-dependent weights with use_rates
 calculation_mode = classical
+use_rates = true
 random_seed = 1
 
 [geometry]


### PR DESCRIPTION
So that we can run CND with full enumeration, even if there are 7_864_320 realizations.