### PR TITLE
MF13 PH corr zone adjustment

### DIFF
--- a/openquake/hazardlib/gsim/morikawa_fujiwara_2013.py
+++ b/openquake/hazardlib/gsim/morikawa_fujiwara_2013.py
@@ -266,10 +266,6 @@ def _get_magnitude_term_3(trt, region, C, rrup, mw1prime, mw1, hypo_z,
     apply_ph = hypo_z < 80 # Only apply to shallower events
     if php_nshm:
         # Suppress PH adjustment for events inside PHP zones 4 or 5
-        # NOTE: NIED apply the PH correction to zone 3 too, but we
-        # obtain a much better match to their results when ommitting
-        # zone 3 here. This difference in implementation has been approved
-        # by NIED (direct communication with A. Iwaki and N. Morikawa).
         in_php = (php_nshm['zone_04'] | php_nshm['zone_05'])
         apply_ph = apply_ph & ~in_php
 

--- a/openquake/hazardlib/gsim/morikawa_fujiwara_2013.py
+++ b/openquake/hazardlib/gsim/morikawa_fujiwara_2013.py
@@ -265,9 +265,11 @@ def _get_magnitude_term_3(trt, region, C, rrup, mw1prime, mw1, hypo_z,
     # Must be SW (i.e., PHP) so apply additional PHP corr
     apply_ph = hypo_z < 80 # Only apply to shallower events
     if php_nshm:
-        # Suppress PH adjustment for events inside PHP zones 3, 4 or 5
-        in_php = (php_nshm['zone_03'] | php_nshm['zone_04']
-                  | php_nshm['zone_05'])
+        # Suppress PH adjustment for events inside PHP zones 4 or 5
+        # NOTE: NIED state they apply to zone 3 too, but this might
+        # not be the case in their actual implementation given the
+        # matches are significantly better here if omitting zone 3
+        in_php = (php_nshm['zone_04'] | php_nshm['zone_05'])
         apply_ph = apply_ph & ~in_php
 
     tmp[apply_ph] += C['PH']

--- a/openquake/hazardlib/gsim/morikawa_fujiwara_2013.py
+++ b/openquake/hazardlib/gsim/morikawa_fujiwara_2013.py
@@ -266,9 +266,10 @@ def _get_magnitude_term_3(trt, region, C, rrup, mw1prime, mw1, hypo_z,
     apply_ph = hypo_z < 80 # Only apply to shallower events
     if php_nshm:
         # Suppress PH adjustment for events inside PHP zones 4 or 5
-        # NOTE: NIED state they apply to zone 3 too, but this might
-        # not be the case in their actual implementation given the
-        # matches are significantly better here if omitting zone 3
+        # NOTE: NIED apply the PH correction to zone 3 too, but we
+        # obtain a much better match to their results when ommitting
+        # zone 3 here. This difference in implementation has been approved
+        # by NIED (direct communication with A. Iwaki and N. Morikawa).
         in_php = (php_nshm['zone_04'] | php_nshm['zone_05'])
         apply_ph = apply_ph & ~in_php
 


### PR DESCRIPTION
In our internal checks of the OQ implementation of the NIED model we see much better matches if omitting events in zone 3 from the `PH` correction, even though the NIED documentation states it should be applied to zones 3, 4 and 5.

UPDATE: NIED have confirmed the initial statement of application to zone 3 was incorrect, so the PR is correct implementation.