### PR TITLE
Use IMMUTABLE="YES" in read_geometries

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1841,7 +1841,7 @@ def read_geometries(fname, name):
     """
     codes = []
     geoms = []
-    with fiona.open(fname) as f:
+    with fiona.open(fname, IMMUTABLE="YES") as f:
         crs = f.crs
         for feature in f:
             props = feature["properties"]


### PR DESCRIPTION
To avoid the warning
```
CPLE_AppDefined:attempt to write a readonly database: this file is a WAL-enabled database.
It cannot be opened because it is presumably read-only or in a read-only directory.
Retrying with IMMUTABLE=YES open option
```
on cole.