### PR TITLE
Enabling WAL mode in sqlite

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -393,7 +393,6 @@ class File(h5py.File):
             if is_array and len(value) and isinstance(value[0], str):
                 dt = vstr
             elif is_array:
-                assert len(value), f'Empty array for {key}/{name}'
                 dt = value.dtype
             else:
                 dt = value

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -393,6 +393,7 @@ class File(h5py.File):
             if is_array and len(value) and isinstance(value[0], str):
                 dt = vstr
             elif is_array:
+                assert len(value), f'Empty array for {key}/{name}'
                 dt = value.dtype
             else:
                 dt = value

--- a/openquake/commonlib/datastore.py
+++ b/openquake/commonlib/datastore.py
@@ -20,6 +20,7 @@ import io
 import os
 import re
 import gzip
+import logging
 import collections
 import numpy
 import h5py
@@ -388,6 +389,9 @@ class DataStore(collections.abc.MutableMapping):
         for field in str_fields:
             typedic[field] = hdf5.vstr
         df = hdf5.read_csv(fname, typedic, renamedict, dframe=True)
+        if len(df) == 0:
+            logging.warning(f"Empty {fname}")
+            return
         if extra:
             for col, val in extra.items():
                 df[col] = val

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -310,7 +310,7 @@ class Db(object):
                 os.makedirs(dname)
             self.local.conn = self.connect(*self.args, **self.kw)
             # set WAL mode to avoid OperationalError: database is locked
-            self.local.conn.execute('PRAGMA journal_mode=WAL')
+            self.local.conn.execute('PRAGMA journal_mode = WAL')
             # honor ON DELETE CASCADE
             self.local.conn.execute('PRAGMA foreign_keys = ON')
             return self.local.conn

--- a/openquake/commonlib/dbapi.py
+++ b/openquake/commonlib/dbapi.py
@@ -309,7 +309,9 @@ class Db(object):
             if dname and not os.path.exists(dname):
                 os.makedirs(dname)
             self.local.conn = self.connect(*self.args, **self.kw)
-            #  honor ON DELETE CASCADE
+            # set WAL mode to avoid OperationalError: database is locked
+            self.local.conn.execute('PRAGMA journal_mode=WAL')
+            # honor ON DELETE CASCADE
             self.local.conn.execute('PRAGMA foreign_keys = ON')
             return self.local.conn
 

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -736,7 +736,7 @@ def run_workflow(workflow_toml, params, concurrent_jobs=None, nodes=1,
                zip(names[mask], calc_dset[:][mask])
                if name not in expected_failures}
         with wfjob:
-            logging.warning(f'The following jobs failed unexpectedly: {dic}')
+            logging.error(f'The following jobs failed unexpectedly: {dic}')
     return wfjob.calc_id
 
 


### PR DESCRIPTION
Avoids the error
```python
sqlite3.OperationalError: database is locked:
UPDATE job SET size_mb=? WHERE id=? (112.52585029602051, 14335)
```
when there are too many concurrent readers and writers. Also managed `import_csv` for no data.