### PR TITLE
Let `oq reset` also remove files left over by `PRAGMA journal_mode = WAL`

### DIFF
--- a/openquake/commands/reset.py
+++ b/openquake/commands/reset.py
@@ -55,6 +55,12 @@ def main(yes=False):
             # remove the database
             os.remove(dbpath)
             print('Removed %s' % dbpath)
+            # remove also files left over by PRAGMA journal_mode = WAL
+            for suffix in ('-wal', '-shm'):
+                leftover = dbpath + suffix
+                if os.path.exists(leftover):
+                    os.remove(leftover)
+                    print('Removed %s' % leftover)
 
 
 main.yes = 'confirmation'


### PR DESCRIPTION
`oq reset` removes all calculations, then removes the dbserver file.
Before https://github.com/gem/oq-engine/pull/11476/changes#diff-73acb9265b54a578df58faebb8d6b1872d555a482ecd60519cde3a78e380a67eR312-R314, setting `PRAGMA journal_mode = WAL`, SQLite used a rollback journal, which is always cleaned up on close.
WAL mode leaves behind `-wal` and `-shm` files even after the connection closes. So after reset removes the db, those two files remain in oqdata, making the directory non-empty and causing restore to exit.
Now I am making sure also those leftover files are removed, if they are found.