### PR TITLE
Saved memory in the rupture sampling algorithm for fault sources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
   [Thuany Costa de Lima]
   * Added Bayless and Somerville (2024) GMM for Australia:
-    BaylessSomerville2024Cratonic and BaylessSomerville2024NonCratonic. 
-    
+    BaylessSomerville2024Cratonic and BaylessSomerville2024NonCratonic.
+
   [Michele Simionato]
+  * Saved memory in the rupture sampling algorithm for fault sources
+    (simple, complex, characteristic)
   * Extended use_rates to work also with IMT-dependent weights
 
   [Christopher Brooks]

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -105,12 +105,12 @@ def poisson_sample(src, eff_num_ses, seed):
                     hypo, sfc, src.occur_rates[i], tom)
                 yield rup, rupids[i], num_occ
         else:  # simple or complex fault
-            iruptures = src.iter_ruptures()
+            iruptures = src.iter_ruptures()  # not kept in memory
             rates = numpy.concatenate(list(src.iter_ruptures(rates=True)))
             occurs = rng.poisson(rates * tom.time_span * eff_num_ses)
             # NB: the algorithm could be smarter, since we are looping
-            # over all ruptures just to discard most of them, but
-            # it is efficient enough
+            # over all ruptures just to discard most of them, but it is
+            # efficient enough, since only the rates are kept in memory
             for rup, rupid, num_occ in zip(iruptures, rupids, occurs):
                 if num_occ:
                     yield rup, rupid, num_occ

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -108,6 +108,9 @@ def poisson_sample(src, eff_num_ses, seed):
             iruptures = src.iter_ruptures()
             rates = numpy.concatenate(list(src.iter_ruptures(rates=True)))
             occurs = rng.poisson(rates * tom.time_span * eff_num_ses)
+            # NB: the algorithm could be smarter, since we are looping
+            # over all ruptures just to discard most of them, but
+            # it is efficient enough
             for rup, rupid, num_occ in zip(iruptures, rupids, occurs):
                 if num_occ:
                     yield rup, rupid, num_occ

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -105,10 +105,10 @@ def poisson_sample(src, eff_num_ses, seed):
                     hypo, sfc, src.occur_rates[i], tom)
                 yield rup, rupids[i], num_occ
         else:  # simple or complex fault
-            ruptures = list(src.iter_ruptures())
-            rates = numpy.array([rup.occurrence_rate for rup in ruptures])
+            iruptures = src.iter_ruptures()
+            rates = numpy.concatenate(list(src.iter_ruptures(rates=True)))
             occurs = rng.poisson(rates * tom.time_span * eff_num_ses)
-            for rup, rupid, num_occ in zip(ruptures, rupids, occurs):
+            for rup, rupid, num_occ in zip(iruptures, rupids, occurs):
                 if num_occ:
                     yield rup, rupid, num_occ
         return

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -17,6 +17,7 @@
 Module :mod:`openquake.hazardlib.source.characteristic` defines
 :class:`CharacteristicFaultSource`.
 """
+import numpy
 from openquake.hazardlib.source.base import ParametricSeismicSource
 from openquake.hazardlib.geo import NodalPlane
 from openquake.hazardlib.source.rupture import ParametricProbabilisticRupture
@@ -94,8 +95,12 @@ class CharacteristicFaultSource(ParametricSeismicSource):
         rupture with a surface always equal to the given surface.
         """
         step = kwargs.get('step', 1)
+        only_rates = kwargs.get('rates')
         hypocenter = self.surface.get_middle_point()
         for mag, occ_rate in self.get_annual_occurrence_rates()[::step]:
+            if only_rates:
+                yield numpy.full(1, occ_rate)
+                continue
             yield ParametricProbabilisticRupture(
                 mag, self.rake, self.tectonic_region_type, hypocenter,
                 self.surface, occ_rate, self.temporal_occurrence_model)

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -192,7 +192,7 @@ class ComplexFaultSource(ParametricSeismicSource):
         checks and the `count` flag, when True the function
         """
         step = kwargs.get('step', 1)
-        only_count = kwargs.get('count', False)
+        only_rates = kwargs.get('rates', False)
         eps_ar_low = kwargs.get('eps_low', None)
         eps_ar_upp = kwargs.get('eps_upp', None)
         num_bins = kwargs.get('num_bins', None)
@@ -211,6 +211,7 @@ class ComplexFaultSource(ParametricSeismicSource):
         # Loop over the range of magnitudes admitted
         rupture_counter = []
         for mag, mag_occ_rate in self.get_annual_occurrence_rates():
+            rates = []
 
             # Computing rupture parameters
             rupture_area = msr.get_median_area(mag, self.rake)
@@ -228,8 +229,7 @@ class ComplexFaultSource(ParametricSeismicSource):
             assert numpy.abs(1.0 - numpy.sum(pmf)) < 1e-5
 
             # Loop over the rupture lengths
-            tmp = 0.0
-            tmp_num_rups = 0
+            num_rups = 0
             for rupture_length, wei in zip(rup_lens, pmf):
 
                 # Generate rupture slices
@@ -238,50 +238,31 @@ class ComplexFaultSource(ParametricSeismicSource):
 
                 # Compute occurrence rate for each rupture
                 occurrence_rate = mag_occ_rate / len(rupture_slices) * wei
-                tmp += occurrence_rate * len(rupture_slices)
 
-                # Just counting the ruptures
-                if only_count:
-                    tmp_num_rups += len(rupture_slices)
+                if only_rates:
+                    rates.extend([occurrence_rate]* len(rupture_slices[::step]))
                     continue
 
                 for rupture_slice in rupture_slices[::step]:
-
-                    # Create the mesh of the rupture from the mesh of the
-                    # complex fault
+                    # Create the surface of the rupture
                     mesh = whole_fault_mesh[rupture_slice]
+                    surface = ComplexFaultSurface(mesh)
 
                     # XXX: use surface centroid as rupture's hypocenter
                     # XXX: instead of point with middle index
                     hypocenter = mesh.get_middle_point()
-                    try:
-                        surface = ComplexFaultSurface(mesh)
-                    except ValueError as e:
-                        raise ValueError("Invalid source with id=%s. %s" % (
-                            self.source_id, str(e)))
 
                     # Create the rupture
                     rup = ParametricProbabilisticRupture(
-                        mag,
-                        self.rake,
-                        self.tectonic_region_type,
-                        hypocenter,
-                        surface,
-                        occurrence_rate,
-                        self.temporal_occurrence_model
-                    )
+                        mag, self.rake, self.tectonic_region_type,
+                        hypocenter, surface, occurrence_rate,
+                        self.temporal_occurrence_model)
                     rup.mag_occ_rate = mag_occ_rate
                     yield rup
 
-            # Checking rates
-            if not only_count:
-                assert numpy.abs(mag_occ_rate - tmp) < 1e-5, mag_occ_rate - tmp
-
-            rupture_counter.append(tmp_num_rups)
-
-        # Just return the number of ruptures per magnitude bin
-        if only_count:
-            yield numpy.array(rupture_counter)
+            rupture_counter.append(num_rups)
+            if only_rates:
+                yield numpy.array(rates)
 
     def count_ruptures(self):
         """
@@ -289,8 +270,8 @@ class ComplexFaultSource(ParametricSeismicSource):
         `openquake.hazardlib.source.base.BaseSeismicSource.count_ruptures`.
         """
         if not hasattr(self, '_nr'):
-            self._nr = list(self.iter_ruptures(count=True))[0]
-            self._num_ruptures = numpy.sum(self._nr)
+            self._nr = [len(r) for r in self.iter_ruptures(rates=True)]
+            self._num_ruptures = sum(self._nr)
         return self._num_ruptures
 
     def modify_set_geometry(self, edges, spacing):

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -209,7 +209,6 @@ class ComplexFaultSource(ParametricSeismicSource):
         msr = self.magnitude_scaling_relationship
 
         # Loop over the range of magnitudes admitted
-        rupture_counter = []
         for mag, mag_occ_rate in self.get_annual_occurrence_rates():
             rates = []
 
@@ -229,7 +228,6 @@ class ComplexFaultSource(ParametricSeismicSource):
             assert numpy.abs(1.0 - numpy.sum(pmf)) < 1e-5
 
             # Loop over the rupture lengths
-            num_rups = 0
             for rupture_length, wei in zip(rup_lens, pmf):
 
                 # Generate rupture slices
@@ -260,7 +258,6 @@ class ComplexFaultSource(ParametricSeismicSource):
                     rup.mag_occ_rate = mag_occ_rate
                     yield rup
 
-            rupture_counter.append(num_rups)
             if only_rates:
                 yield numpy.array(rates)
 

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -101,9 +101,10 @@ class SimpleFaultSource(ParametricSeismicSource):
     for description of other parameters.
 
     :raises ValueError:
-        If :meth:`~openquake.hazardlib.geo.surface.simple_fault.SimpleFaultSurface.check_fault_data`
-        fails, if rake value is invalid and if rupture mesh spacing is too high
-        for the lowest magnitude value.
+        If :meth:`~openquake.hazardlib.geo.surface.simple_fault.
+        SimpleFaultSurface.check_fault_data` fails, if rake value is
+        invalid and if rupture mesh spacing is too high for the lowest
+        magnitude value.
     """
     code = b'S'
     MODIFICATIONS = {
@@ -121,7 +122,6 @@ class SimpleFaultSource(ParametricSeismicSource):
         'set_msr',
         'set_slip_rate',
     }
-
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,
                  magnitude_scaling_relationship,
@@ -165,17 +165,17 @@ class SimpleFaultSource(ParametricSeismicSource):
             raise ValueError('hypo_list and slip_list have to be both given '
                              'or neither given')
 
-        if self.hypo_depth_list and (len(self.hypo_list) or len(self.slip_list)):
-            raise ValueError(
-                'hypo_depth_list and hypo_list/slip_list cannot be used together'
-                )
+        if self.hypo_depth_list and (
+                len(self.hypo_list) or len(self.slip_list)):
+            raise ValueError('hypo_depth_list and hypo_list/slip_list cannot '
+                             'be used together')
         if self.hypo_depth_list:
             total = sum(wei for wei, _depth, _fdf in self.hypo_depth_list)
             if abs(total - 1.0) > 1e-7:
-                raise ValueError(
-                    f'hypo_depth_list probabilities sum to {total}, expected 1.0')
+                raise ValueError('hypo_depth_list probabilities sum to '
+                                 f'{total}, expected 1.0')
         for _wei, depth, fdf in self.hypo_depth_list:
-            if not (upper_seismogenic_depth <= depth <= lower_seismogenic_depth):
+            if not upper_seismogenic_depth <= depth <= lower_seismogenic_depth:
                 raise ValueError(
                     f'hypo_depth_list {depth} km is outside the '
                     f'seismogenic zone [{upper_seismogenic_depth}, '

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -20,6 +20,7 @@ Module :mod:`openquake.hazardlib.source.simple_fault` defines
 import copy
 import math
 from collections import namedtuple
+import numpy
 from openquake.baselib.general import round
 from openquake.hazardlib import mfd
 from openquake.hazardlib.source.base import ParametricSeismicSource
@@ -286,6 +287,9 @@ class SimpleFaultSource(ParametricSeismicSource):
         divided by the number of ruptures that can be placed in a fault.
         """
         step = kwargs.get('step', 1)
+        only_rates = kwargs.get('rates')
+        n_hypo = len(self.hypo_depth_list) or len(self.hypo_list) or 1
+        n_slip = len(self.slip_list) or 1
         whole_fault_surface = SimpleFaultSurface.from_fault_data(
             self.fault_trace, self.upper_seismogenic_depth,
             self.lower_seismogenic_depth, self.dip, self.rupture_mesh_spacing)
@@ -301,6 +305,9 @@ class SimpleFaultSource(ParametricSeismicSource):
             num_rup_along_width = mesh_rows - rup_rows + 1
             num_rup = num_rup_along_length * num_rup_along_width
             occurrence_rate = mag_occ_rate / float(num_rup)
+            if only_rates:
+                yield numpy.full(num_rup * n_hypo * n_slip, occurrence_rate)
+                continue
             for first_row in range(num_rup_along_width)[::step]:
                 for first_col in range(num_rup_along_length)[::step]:
                     mesh = whole_fault_mesh[first_row: first_row + rup_rows,


### PR DESCRIPTION
This is crucial for the CHN model where we have a huge simple fault source called "HimalayanThrust" consuming 9+ GB of RAM per core with `rupture_mesh_spacing=2`:
```
# before/after
| calc_18486, maxmem=11.9 GB | time_sec | memory_mb | counts |
|----------------------------+----------+-----------+--------|
| total sample_ruptures      | 27.8629  | 9_397     | 1      |
| total sample_ruptures      | 23.9637  | 576.5     | 1      |
```
The memory saving is 16x, and we are also a bit faster.