### PR TITLE
fix numba issue in ebr ruptures with kite surfaces

### DIFF
--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -155,7 +155,8 @@ def get_ebr(rec, geom, trt):
                 for array in arrays])
         else:
             # assume KiteSurfaces
-            surface.__init__([geo.KiteSurface(RectangularMesh(*array))
+            surface.__init__([geo.KiteSurface(
+                RectangularMesh(F32(array[0]), F32(array[1]), F32(array[2])))
                               for array in arrays])
 
     elif surface_cls is geo.GriddedSurface:


### PR DESCRIPTION
Force lon/lat/depths in mesh to F32 to prevent numba decorator rejecting it when reconstructing a rupture with a kite surface from a CSV. Previously the following error was observed by risk team when using GEESE rups:

<img width="287" height="340" alt="{D213270E-CC9D-4278-830A-DEBFD46D46AE}" src="https://github.com/user-attachments/assets/ede4e4d3-7602-4207-aeb2-3ece0acb7cf5" />


