### PR TITLE
Using absolute paths for hazard_calculation_id

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -194,7 +194,8 @@ def fix_hc_id(oq):
             oq.hazard_calculation_id, int):
         # there is nothing to fix
         return oq.hazard_calculation_id
-    path = os.path.join(oq.base_path, oq.hazard_calculation_id)
+    path = os.path.abspath(os.path.normpath(
+        os.path.join(oq.base_path, oq.hazard_calculation_id)))
     if path.endswith('.hdf5'):
         oq.hazard_calculation_id = path
     elif path.endswith('.ini'):

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -194,8 +194,10 @@ def fix_hc_id(oq):
             oq.hazard_calculation_id, int):
         # there is nothing to fix
         return oq.hazard_calculation_id
-    path = os.path.abspath(os.path.normpath(
-        os.path.join(oq.base_path, oq.hazard_calculation_id)))
+    path = oq.hazard_calculation_id
+    if not os.path.isabs(path):
+        path = os.path.abspath(os.path.normpath(
+            os.path.join(oq.base_path, oq.hazard_calculation_id)))
     if path.endswith('.hdf5'):
         oq.hazard_calculation_id = path
     elif path.endswith('.ini'):

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1627,8 +1627,11 @@ class OqParam(valid.ParamSet):
         super().validate()
         self.check_source_model()
         if isinstance(self.hazard_calculation_id, str):
-            path = os.path.abspath(os.path.normpath(
-                os.path.join(self.base_path, self.hazard_calculation_id)))
+            path = self.hazard_calculation_id
+            if not os.path.isabs(path):
+                path = os.path.abspath(os.path.normpath(
+                    os.path.join(self.base_path, self.hazard_calculation_id)))
+            os.path.exists(path), path
             self.hazard_calculation_id = path
         if 'post_loss_amplification' in self.inputs:
             df = pandas.read_csv(self.inputs['post_loss_amplification'])

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -1626,6 +1626,10 @@ class OqParam(valid.ParamSet):
         """
         super().validate()
         self.check_source_model()
+        if isinstance(self.hazard_calculation_id, str):
+            path = os.path.abspath(os.path.normpath(
+                os.path.join(self.base_path, self.hazard_calculation_id)))
+            self.hazard_calculation_id = path
         if 'post_loss_amplification' in self.inputs:
             df = pandas.read_csv(self.inputs['post_loss_amplification'])
             check_increasing(df, 'return_period', 'pla_factor')

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -706,7 +706,8 @@ def run_workflow(workflow_toml, params, concurrent_jobs=None, nodes=1,
             if wf_no == 0:  # at first step
                 kw = wf.inis[0].copy()
                 kw.update(calculation_mode='workflow')
-                dstore['oqparam'] = OqParam(**kw)
+                with wfjob:
+                    dstore['oqparam'] = OqParam(**kw)
             failed, calcs, new, new_names = 0, [], [], []
             for name, ini in zip(wf.names, wf.inis):
                 idx = name2idx[name]

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -721,9 +721,10 @@ def run_workflow(workflow_toml, params, concurrent_jobs=None, nodes=1,
                     new_names.append(name)
             if new:
                 one_job = concurrent_jobs == 1 or len(wf.names) == 1
-                jobs = create_jobs(new, log_level=logging.INFO if
-                                   one_job else logging.WARNING,
-                                   workflow_id=wfjob.calc_id)
+                with wfjob:
+                    jobs = create_jobs(new, log_level=logging.INFO if
+                                       one_job else logging.WARNING,
+                                       workflow_id=wfjob.calc_id)
                 run_jobs(jobs, concurrent_jobs, nodes, sbatch, notify_to)
                 for job, name in zip(jobs, new_names):
                     rec = job.get_job()

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -507,7 +507,8 @@ class _Workflow:
             for key, val in dic.items():
                 if isinstance(val, str) and val.endswith(
                         ('.ini', '.hdf5', '.sqlite')):
-                    dic[key] = path = os.path.join(self.workflow_dir, val)
+                    dic[key] = path = os.path.abspath(
+                        os.path.join(self.workflow_dir, val))
                     if 'out' in key and not os.path.exists(path):
                         open(path, 'w').close()  # touch the file
 


### PR DESCRIPTION
Without this fix, we could have something like `hazard_calculation_id =  ../../global_risk_model/Africa/Jobs/../SES_michele.hdf5'` corresponding to a non-existing file, depending of the location where the GRM calculation was started. Also, improved the logging in workflow calculations.