### PR TITLE
Restored the generation of `aggcurves` in the global risk model

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Implemented a workflow to run the 2026 Global Risk Model
+
   [Thuany Costa de Lima]
   * Fix Allen (2022) depth truncation bug: hypocentral depth is now
     clamped to [10, 500] km before evaluating the cubic log-depth

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -61,7 +61,7 @@ def fix_investigation_time(oq, dstore):
                     oq.investigation_time * R)
         elif dstore.parent:
             oqp = dstore.parent['oqparam']
-            if isinstance(oqp, h5py.Group):  # in GRM compurations
+            if isinstance(oqp, h5py.Group):  # in GRM computations
                 first = list(oqp)[0]
                 oqp = dstore.parent[f'oqparam/{first}']  # get the first model
                 # the product investigation_time * ses_per_logic_tree_path

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -61,7 +61,7 @@ def fix_investigation_time(oq, dstore):
                     oq.investigation_time * R)
         elif dstore.parent:
             oqp = dstore.parent['oqparam']
-            if isinstance(oqp, h5py.Group):
+            if isinstance(oqp, h5py.Group):  # in GRM compurations
                 first = list(oqp)[0]
                 oqp = dstore.parent[f'oqparam/{first}']  # get the first model
                 # the product investigation_time * ses_per_logic_tree_path

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -20,6 +20,7 @@ import os
 import getpass
 import logging
 import itertools
+import h5py
 import numpy
 import pandas
 
@@ -58,7 +59,13 @@ def fix_investigation_time(oq, dstore):
                 oq.investigation_time = inv_time
                 oq.ses_per_logic_tree_path = eff_time / (oq.investigation_time * R)
         elif dstore.parent:
-            oq.from_parent(dstore.parent)
+            oqp = dstore.parent['oqparam']
+            if isinstance(oq, h5py.Group):
+                for name in oqp:
+                    if name[-3:] == oq.mosaic_model:
+                        oq.investigation_time = oqp[name].investigation_time
+    if oq.investigation_time is None:
+        assert oq.calculation_mode.startswith('scenario'), 'no investigation_time'
     return R
 
 

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -62,7 +62,8 @@ def fix_investigation_time(oq, dstore):
         elif dstore.parent:
             oqp = dstore.parent['oqparam']
             if isinstance(oqp, h5py.Group):
-                oqp = oqp[list(oqp)[0]]['oqparam']  # get the first model
+                first = list(oqp)[0][-3:]
+                oqp = oqp[f'oqparam/{first}']  # get the first model
                 # the product investigation_time * ses_per_logic_tree_path
                 # will be the same for all models
             oq.investigation_time = oqp.investigation_time

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -57,10 +57,11 @@ def fix_investigation_time(oq, dstore):
             eff_time = attrs['effective_time']
             if inv_time:  # is zero in scenarios
                 oq.investigation_time = inv_time
-                oq.ses_per_logic_tree_path = eff_time / (oq.investigation_time * R)
+                oq.ses_per_logic_tree_path = eff_time / (
+                    oq.investigation_time * R)
         elif dstore.parent:
             oqp = dstore.parent['oqparam']
-            if isinstance(oq, h5py.Group):
+            if isinstance(oqp, h5py.Group):
                 for name in oqp:
                     if name[-3:] == oq.mosaic_model:
                         oq.investigation_time = oqp[name].investigation_time

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -62,7 +62,7 @@ def fix_investigation_time(oq, dstore):
         elif dstore.parent:
             oqp = dstore.parent['oqparam']
             if isinstance(oqp, h5py.Group):
-                oqp = oqp[list(oqp)[0]]  # get the first mosaic model
+                oqp = oqp[list(oqp)[0]]['oqparam']  # get the first model
                 # the product investigation_time * ses_per_logic_tree_path
                 # will be the same for all models
             oq.investigation_time = oqp.investigation_time

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -45,17 +45,20 @@ class FakeBuilder:
 
 def fix_investigation_time(oq, dstore):
     """
-    If starting from GMFs, fix oq.investigation_time.
+    If starting from GMFs or ruptures, fix oq.investigation_time.
     :returns: the number of hazard realizations
     """
     R = oq.number_of_logic_tree_samples or len(dstore['weights'])
-    if 'gmfs' in oq.inputs and not oq.investigation_time:
-        attrs = dstore['gmf_data'].attrs
-        inv_time = attrs['investigation_time']
-        eff_time = attrs['effective_time']
-        if inv_time:  # is zero in scenarios
-            oq.investigation_time = inv_time
-            oq.ses_per_logic_tree_path = eff_time / (oq.investigation_time * R)
+    if oq.investigation_time is None:
+        if 'gmfs' in oq.inputs:
+            attrs = dstore['gmf_data'].attrs
+            inv_time = attrs['investigation_time']
+            eff_time = attrs['effective_time']
+            if inv_time:  # is zero in scenarios
+                oq.investigation_time = inv_time
+                oq.ses_per_logic_tree_path = eff_time / (oq.investigation_time * R)
+        elif dstore.parent:
+            oq.from_parent(dstore.parent)
     return R
 
 

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -62,7 +62,7 @@ def fix_investigation_time(oq, dstore):
         elif dstore.parent:
             oqp = dstore.parent['oqparam']
             if isinstance(oqp, h5py.Group):
-                oqp = oqp[next(oqp)]  # get the first mosaic model
+                oqp = oqp[list(oqp)[0]]  # get the first mosaic model
                 # the product investigation_time * ses_per_logic_tree_path
                 # will be the same for all models
             oq.investigation_time = oqp.investigation_time

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -62,8 +62,8 @@ def fix_investigation_time(oq, dstore):
         elif dstore.parent:
             oqp = dstore.parent['oqparam']
             if isinstance(oqp, h5py.Group):
-                first = list(oqp)[0][-3:]
-                oqp = oqp[f'oqparam/{first}']  # get the first model
+                first = list(oqp)[0]
+                oqp = dstore.parent[f'oqparam/{first}']  # get the first model
                 # the product investigation_time * ses_per_logic_tree_path
                 # will be the same for all models
             oq.investigation_time = oqp.investigation_time

--- a/openquake/calculators/post_risk.py
+++ b/openquake/calculators/post_risk.py
@@ -62,9 +62,11 @@ def fix_investigation_time(oq, dstore):
         elif dstore.parent:
             oqp = dstore.parent['oqparam']
             if isinstance(oqp, h5py.Group):
-                for name in oqp:
-                    if name[-3:] == oq.mosaic_model:
-                        oq.investigation_time = oqp[name].investigation_time
+                oqp = oqp[next(oqp)]  # get the first mosaic model
+                # the product investigation_time * ses_per_logic_tree_path
+                # will be the same for all models
+            oq.investigation_time = oqp.investigation_time
+            oq.ses_per_logic_tree_path = oqp.ses_per_logic_tree_path
     if oq.investigation_time is None:
         assert oq.calculation_mode.startswith('scenario'), 'no investigation_time'
     return R
@@ -552,6 +554,8 @@ class PostRiskCalculator(base.RiskCalculator):
         R = fix_investigation_time(oq, self.datastore)
         if oq.investigation_time:
             eff_time = oq.investigation_time * oq.ses_per_logic_tree_path * R
+        else:
+            eff_time = 0
 
         if 'reinsurance' in oq.inputs:
             logging.warning('Reinsurance calculations are still experimental')
@@ -586,7 +590,7 @@ class PostRiskCalculator(base.RiskCalculator):
             self.datastore.create_df('reinsurance_by_policy', rbp)
             self.datastore.create_df('reinsurance-risk_by_event', rbe)
 
-        if oq.investigation_time and oq.return_periods != [0]:
+        if eff_time and oq.return_periods != [0]:
             # setting return_periods = 0 disable loss curves
             if eff_time < 2:
                 logging.warning(

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -2562,8 +2562,6 @@ class OqParam(valid.ParamSet):
         """
         :returns: updated instance with missing parameters copied from oqparent
         """
-        if not oqparent:
-            return self
         params = {name: value for name, value in
                   vars(oqparent).items()
                   if name not in vars(self)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -2562,6 +2562,8 @@ class OqParam(valid.ParamSet):
         """
         :returns: updated instance with missing parameters copied from oqparent
         """
+        if not oqparent:
+            return self
         params = {name: value for name, value in
                   vars(oqparent).items()
                   if name not in vars(self)


### PR DESCRIPTION
It was off due to `oq.investigation_time` being None.