### PR TITLE
Fix another rup surface bug

### DIFF
--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -31,10 +31,9 @@ F32 = numpy.float32
 
 
 def _get_finite_mesh(mesh):
-    ok = numpy.isfinite(mesh.lons.flat)
+    ok = numpy.isfinite(mesh.lons)
     if numpy.all(ok):
         return mesh
-    ok = numpy.reshape(ok, mesh.lons.shape)
     return Mesh(mesh.lons[ok], mesh.lats[ok], mesh.depths[ok])
 
 


### PR DESCRIPTION
The following was reported by risk team:

<img width="289" height="98" alt="{B9659DE0-9E24-45ED-9255-392B2304289B}" src="https://github.com/user-attachments/assets/14db10c9-6062-42e4-8b1a-6f54b9a33105" />

The fix is simple - in numpy 2.x we can just use isinfite on the original array so the flattening is not required.