### PR TITLE
Fixed the error "cannot pickle sqlite3.Cursor"

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -188,6 +188,7 @@ import time
 import socket
 import signal
 import pickle
+import sqlite3
 import getpass
 import inspect
 import logging
@@ -455,6 +456,9 @@ class Result(object):
             _etype, exc, tb = sys.exc_info()
             res = Result(exc, mon, ''.join(traceback.format_tb(tb)))
         else:
+            if isinstance(val, sqlite3.Cursor):
+                # happens when the DbServer performs an UPDATE command
+                val = val.lastrowid
             res = Result(val, mon)
         return res
 

--- a/openquake/server/db/actions.py
+++ b/openquake/server/db/actions.py
@@ -399,8 +399,13 @@ def log(db, job_id, timestamp, level, process, message):
     :param message:
         message to store in the log record
     """
-    db('INSERT INTO log (job_id, timestamp, level, process, message) '
-       'VALUES (?X)', (job_id, timestamp, level, process, message))
+    try:
+        db('INSERT INTO log (job_id, timestamp, level, process, message) '
+           'VALUES (?X)', (job_id, timestamp, level, process, message))
+    except Exception as exc:
+        # not so serious to break the calculation
+        print(exc)
+
 
 
 def get_log(db, job_id):

--- a/openquake/server/dbserver.py
+++ b/openquake/server/dbserver.py
@@ -61,9 +61,11 @@ class DbServer(object):
                 try:
                     func = getattr(actions, cmd)
                 except AttributeError:  # SQL string
-                    sock.send(p.safely_call(self.db, (cmd,) + args))
+                    res = p.safely_call(self.db, (cmd,) + args)
+                    sock.send(res)
                 else:  # action
-                    sock.send(p.safely_call(func, (self.db,) + args))
+                    res = p.safely_call(func, (self.db,) + args)
+                    sock.send(res)
 
     def start(self):
         """


### PR DESCRIPTION
It happened only with cache=true in the lines
```python
                logging.info(f"Already calculated, {old_job_id=}")
                self.datastore = datastore.read(old_job_id)
                logs.dbcmd(
                    "UPDATE job SET ds_calc_dir = ?x WHERE id=?x",
                    self.datastore.filename[:-5], calc_id)  # strip .hdf5
```
because in presence of a DbServer the update query returns a `sqlite3.Cursor` object which is not pickleable.
Also, if the database is locked, just don't log; we do not want to break the calculation in DbServer mode (we still want to break it with a local db since errors should never pass silently).