### PR TITLE
Introduced a limit on the number of ruptures per source fragment

### DIFF
--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -98,7 +98,7 @@ def _filter_mag(srcs, min_mag):
     mmag = getdefault(min_mag, srcs[0].tectonic_region_type)
     out = [src for src in srcs if src.get_mags()[-1] >= mmag]
     for ss in out:
-        if ss.num_ruptures > 100_000:
+        if ss.num_ruptures > 10_000:
             raise RuntimeError('%s has too many ruptures' % ss)
     return out
 

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -98,7 +98,8 @@ def _filter_mag(srcs, min_mag):
     mmag = getdefault(min_mag, srcs[0].tectonic_region_type)
     out = [src for src in srcs if src.get_mags()[-1] >= mmag]
     for ss in out:
-        ss.num_ruptures
+        if ss.num_ruptures > 100_000:
+            raise RuntimeError('%s has too many ruptures' % ss)
     return out
 
 

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -35,6 +35,7 @@ from openquake.hazardlib.scalerel.point import PointMSR
 from openquake.commonlib import readinput
 from openquake.calculators import base
 
+MAX_NUM_RUPTURES = 27_000  # so that the drouet calculation runs
 U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
@@ -98,7 +99,7 @@ def _filter_mag(srcs, min_mag):
     mmag = getdefault(min_mag, srcs[0].tectonic_region_type)
     out = [src for src in srcs if src.get_mags()[-1] >= mmag]
     for ss in out:
-        if ss.num_ruptures > 10_000:
+        if ss.num_ruptures > MAX_NUM_RUPTURES:
             raise RuntimeError('%s has too many ruptures' % ss)
     return out
 

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1306,7 +1306,7 @@ class ContextMaker(object):
             # may happen for CollapsedPointSources
             return EPS
         src.nsites = len(sites)
-        step = 1 if src.code in b'pP' else 4
+        step = 1 if src.code in b'pP' else max(src.num_ruptures // 10, 4)
         C = sum(len(ctx) for ctx in self.get_ctxs(src, sites, step=step))
         src.dt = time.time() - t0
         if not C:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1306,7 +1306,7 @@ class ContextMaker(object):
             # may happen for CollapsedPointSources
             return EPS
         src.nsites = len(sites)
-        step = 1 if src.code in b'pP' else max(src.num_ruptures // 10, 4)
+        step = 1 if src.code in b'pP' else max(src.num_ruptures // 100, 4)
         C = sum(len(ctx) for ctx in self.get_ctxs(src, sites, step=step))
         src.dt = time.time() - t0
         if not C:

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -375,8 +375,8 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         String representation of a source, displaying the source class name
         and the source id.
         """
-        return '<%s %s, weight=%.1f>' % (
-            self.__class__.__name__, self.source_id, self.weight)
+        return '<%s %s, rups=%d>' % (
+            self.__class__.__name__, self.source_id, self.num_ruptures)
 
 
 class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):


### PR DESCRIPTION
For the moment set to 27,000. To be refined. The goal is to stop the hazard scientists from producing too many ruptures and breaking cole/piaf with out of memory errors (like CHN with a simple fault rupture requiring 9.5 GB per core with `rupture_mesh_spacing=2`).
```
<SimpleFaultSource HimalayanThrust.0, rups=51906> [6.]
<SimpleFaultSource HimalayanThrust.1, rups=51865> [6.1]
<SimpleFaultSource HimalayanThrust.2, rups=50560> [6.2]
<SimpleFaultSource HimalayanThrust.3, rups=50520> [6.3]
<SimpleFaultSource HimalayanThrust.4, rups=49218> [6.4]
<SimpleFaultSource HimalayanThrust.5, rups=49179> [6.5]
<SimpleFaultSource HimalayanThrust.6, rups=47880> [6.6]
<SimpleFaultSource HimalayanThrust.7, rups=46546> [6.7]
<SimpleFaultSource HimalayanThrust.8, rups=45252> [6.8]
<SimpleFaultSource HimalayanThrust.9, rups=43925> [6.9]
<SimpleFaultSource HimalayanThrust.10, rups=42602> [7.]
<SimpleFaultSource HimalayanThrust.11, rups=41250> [7.1]
<SimpleFaultSource HimalayanThrust.12, rups=39936> [7.2]
<SimpleFaultSource HimalayanThrust.13, rups=37350> [7.3]
<SimpleFaultSource HimalayanThrust.14, rups=36018> [7.4]
<SimpleFaultSource HimalayanThrust.15, rups=33426> [7.5]
<SimpleFaultSource HimalayanThrust.16, rups=30850> [7.6]
<SimpleFaultSource HimalayanThrust.17, rups=28290> [7.7]
<SimpleFaultSource HimalayanThrust.18, rups=24500> [7.8]
<SimpleFaultSource HimalayanThrust.19, rups=20723> [7.9]
<SimpleFaultSource HimalayanThrust.20, rups=16982> [8.]
<SimpleFaultSource HimalayanThrust.21, rups=13255> [8.1]
<SimpleFaultSource HimalayanThrust.22, rups=8379> [8.2]
<SimpleFaultSource HimalayanThrust.23, rups=2378> [8.3]
<SimpleFaultSource HimalayanThrust.24, rups=1170> [8.4]
<SimpleFaultSource HimalayanThrust.25, rups=1145> [8.5]
<SimpleFaultSource HimalayanThrust.26, rups=1113> [8.6]
<SimpleFaultSource HimalayanThrust.27, rups=1072> [8.7]
<SimpleFaultSource HimalayanThrust.28, rups=1022> [8.8]
<SimpleFaultSource HimalayanThrust.29, rups=958> [8.9]
<SimpleFaultSource HimalayanThrust.30, rups=879> [9.]
```
Also speeding up preclassical by increasing the step for sources producing tons of ruptures:
```
Received 1 * 10.72 KB in 600 seconds [unpik=0.00s] from preclassical
Received 1 * 10.72 KB in 95 seconds [unpik=0.00s] from preclassical
```
NB: the slow tasks slightly improve with this change.
```
# ALS
| operation-duration | counts | mean    | stddev | min    | max     | slowfac |
|--------------------+--------+---------+--------+--------+---------+---------|
| baseclassical      | 58     | 14.1653 | 43%    | 6.4006 | 39.0399 | 2.7560  |
| classical          | 293    | 25.7069 | 47%    | 6.1010 | 90.2208 | 3.5096  |
# after
| baseclassical      | 71     | 14.9000 | 38%    | 7.3372 | 39.6252  | 2.6594  |
| classical          | 293    | 26.7432 | 47%    | 6.4596 | 100.6121 | 3.7622  |

# USA
| operation-duration | counts | mean    | stddev | min     | max     | slowfac |
|--------------------+--------+---------+--------+---------+---------+---------|
| baseclassical      | 7      | 59.3587 | 23%    | 38.2861 | 83.5328 | 1.4073  |
| classical          | 1_294  | 40.4784 | 102%   | 3.3656  | 218.2   | 5.3896  |
# after
| baseclassical      | 10     | 54.2096 | 27%    | 26.7649 | 84.3963 | 1.5569  |
| classical          | 1_292  | 44.4763 | 100%   | 3.7016  | 220.1   | 4.9498  |

# SAM
| operation-duration | counts | mean    | stddev | min     | max    | slowfac |
|--------------------+--------+---------+--------+---------+--------+---------|
| classical          | 267    | 93.7977 | 37%    | 25.2751 | 270.1  | 2.8793  |
# after
| baseclassical      | 2      | 63.2520 | 20%    | 50.5589 | 75.9451 | 1.2007  |
| classical          | 267    | 95.1032 | 35%    | 27.3856 | 281.1   | 2.9558  |

# NZL
| operation-duration | counts | mean    | stddev | min     | max      | slowfac |
|--------------------+--------+---------+--------+---------+----------+---------|
| baseclassical      | 77     | 44.0603 | 11%    | 27.0282 | 54.3900  | 1.2344  |
| classical          | 305    | 63.1098 | 46%    | 7.0303  | 129.0446 | 2.0448  |
# after
| baseclassical      | 75     | 45.0593 | 10%    | 35.1554 | 52.7451  | 1.1706  |
| classical          | 305    | 63.3083 | 46%    | 7.0740  | 119.6201 | 1.8895  |
```