### PR TITLE
Revert the changes that made `timezonefinder` required also on Windows

### DIFF
--- a/openquake/hazardlib/shakemap/parsers.py
+++ b/openquake/hazardlib/shakemap/parsers.py
@@ -37,7 +37,6 @@ from collections import defaultdict
 from xml.parsers.expat import ExpatError
 from datetime import datetime
 from zoneinfo import ZoneInfo
-from timezonefinder import TimezoneFinder
 
 from shapely.geometry import shape, Point, Polygon
 import pandas as pd
@@ -470,7 +469,12 @@ def utc_to_local_time(utc_timestamp, lon, lat):
     Convert a timestamp '%Y-%m-%dT%H:%M:%S.%fZ' into a datetime object
     """
     utc_time = datetime.strptime(utc_timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
-    timezone_str = TimezoneFinder().timezone_at(lng=lon, lat=lat)
+    try:
+        from timezonefinder import TimezoneFinder
+    except ImportError:
+        timezone_str = None
+    else:
+        timezone_str = TimezoneFinder().timezone_at(lng=lon, lat=lat)
     if timezone_str is None:
         logging.warning('Could not determine the timezone. Using the UTC time')
         return utc_time

--- a/openquake/hazardlib/tests/shakemap/parsers_test.py
+++ b/openquake/hazardlib/tests/shakemap/parsers_test.py
@@ -29,6 +29,14 @@ user = User(level=2, testdir=os.path.join(os.path.dirname(__file__), 'data'))
 
 
 class ShakemapParsersTestCase(unittest.TestCase):
+    @classmethod
+    def setUp(cls):
+        try:
+            import timezonefinder
+        except ImportError:
+            raise unittest.SkipTest('Missing timezonefinder')
+        else:
+            del timezonefinder
 
     def test_utc_to_local_time(self):
         loctime = utc_to_local_time('2011-01-01T12:00:00.0Z', 10., 45.)

--- a/openquake/hazardlib/tests/shakemap/validate_test.py
+++ b/openquake/hazardlib/tests/shakemap/validate_test.py
@@ -37,6 +37,14 @@ user = User(level=2, testdir=os.path.join(os.path.dirname(__file__), 'data'))
 
 
 class ImpactValidateTestCase(unittest.TestCase):
+    @classmethod
+    def setUp(cls):
+        try:
+            import timezonefinder
+        except ImportError:
+            raise unittest.SkipTest('Missing timezonefinder')
+        else:
+            del timezonefinder
 
     def test_1(self):
         POST = {'usgs_id': 'us6000jllz', 'approach': 'use_shakemap_from_usgs'}

--- a/openquake/server/apps.py
+++ b/openquake/server/apps.py
@@ -54,6 +54,16 @@ class ServerConfig(AppConfig):
             raise ValueError(
                 f'Invalid application mode: "{settings.APPLICATION_MODE}".'
                 f' It must be one of {settings.APPLICATION_MODES}')
+        if settings.APPLICATION_MODE == 'IMPACT':
+            try:
+                # NOTE: optional dependency needed for IMPACT
+                from timezonefinder import TimezoneFinder  # noqa
+            except ImportError:
+                raise ImportError(
+                    'The python package "timezonefinder" is not installed.'
+                    ' It is required in order to convert the UTC time to'
+                    ' the local time of the event. You can install it'
+                    ' running: pip install timezonefinder==6.5.2')
         if (settings.LOCKDOWN and 'django_pam.auth.backends.PAMBackend'
                 not in settings.AUTHENTICATION_BACKENDS):
             # check essential constants are defined

--- a/openquake/server/apps.py
+++ b/openquake/server/apps.py
@@ -62,8 +62,7 @@ class ServerConfig(AppConfig):
                 raise ImportError(
                     'The python package "timezonefinder" is not installed.'
                     ' It is required in order to convert the UTC time to'
-                    ' the local time of the event. You can install it'
-                    ' running: pip install timezonefinder==6.5.2')
+                    ' the local time of the event.')
         if (settings.LOCKDOWN and 'django_pam.auth.backends.PAMBackend'
                 not in settings.AUTHENTICATION_BACKENDS):
             # check essential constants are defined


### PR DESCRIPTION
This reverts commit 0f88cc57db961536f4b69b59b41b388abb0ae384.

Fixes https://github.com/gem/oq-engine/issues/11503