### PR TITLE
Update the script to build the hdf5 getting the correct values for the secondary perils

### DIFF
--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -71,8 +71,7 @@ jobs:
           pip install pyshp pytest flake8 ruff https://wheelhouse.openquake.org/v3/py/rtgmpy-1.0.1-py3-none-any.whl
           oq engine --upgrade-db
           ruff check openquake
-          # FIXME: temporarily switching to an updated hdf5
-          curl https://downloads.openquake.org/test_data/exposure_partial_03jun2026.hdf5 -o openquake/qa_tests_data/mosaic/exposure.hdf5
+          curl https://downloads.openquake.org/test_data/exposure.hdf5 -o openquake/qa_tests_data/mosaic/exposure.hdf5
           pytest -xs --doctest-modules --disable-warnings --color=yes --durations=8 openquake/{sep,hmtk,risklib,commonlib,baselib,hazardlib}
           pytest -xs --doctest-modules --disable-warnings --color=yes --durations=8 openquake/calculators -k classical
           pytest --doctest-modules doc/contributing/*.rst
@@ -109,8 +108,7 @@ jobs:
           pip install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl
           pip install pytest-playwright
           playwright install
-          # FIXME: temporarily switching to an updated hdf5
-          curl https://downloads.openquake.org/test_data/exposure_partial_03jun2026.hdf5 -o openquake/qa_tests_data/mosaic/exposure.hdf5; ln -s openquake/qa_tests_data/mosaic/exposure.hdf5
+          curl https://downloads.openquake.org/test_data/exposure.hdf5 -o openquake/qa_tests_data/mosaic/exposure.hdf5; ln -s openquake/qa_tests_data/mosaic/exposure.hdf5
           OQ_APPLICATION_MODE=PUBLIC pytest -vx openquake/server/tests/test_public_mode.py
           OQ_APPLICATION_MODE=RESTRICTED pytest -vx openquake/server/tests/test_restricted_mode.py
           OQ_APPLICATION_MODE=READ_ONLY pytest -vx openquake/server/tests/test_read_only_mode.py

--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -71,7 +71,8 @@ jobs:
           pip install pyshp pytest flake8 ruff https://wheelhouse.openquake.org/v3/py/rtgmpy-1.0.1-py3-none-any.whl
           oq engine --upgrade-db
           ruff check openquake
-          curl https://downloads.openquake.org/test_data/exposure.hdf5 -o openquake/qa_tests_data/mosaic/exposure.hdf5
+          # FIXME: temporarily switching to an updated hdf5
+          curl https://downloads.openquake.org/test_data/exposure_partial_03jun2026.hdf5 -o openquake/qa_tests_data/mosaic/exposure.hdf5
           pytest -xs --doctest-modules --disable-warnings --color=yes --durations=8 openquake/{sep,hmtk,risklib,commonlib,baselib,hazardlib}
           pytest -xs --doctest-modules --disable-warnings --color=yes --durations=8 openquake/calculators -k classical
           pytest --doctest-modules doc/contributing/*.rst
@@ -108,7 +109,8 @@ jobs:
           pip install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl
           pip install pytest-playwright
           playwright install
-          curl https://downloads.openquake.org/test_data/exposure.hdf5 -o openquake/qa_tests_data/mosaic/exposure.hdf5; ln -s openquake/qa_tests_data/mosaic/exposure.hdf5
+          # FIXME: temporarily switching to an updated hdf5
+          curl https://downloads.openquake.org/test_data/exposure_partial_03jun2026.hdf5 -o openquake/qa_tests_data/mosaic/exposure.hdf5; ln -s openquake/qa_tests_data/mosaic/exposure.hdf5
           OQ_APPLICATION_MODE=PUBLIC pytest -vx openquake/server/tests/test_public_mode.py
           OQ_APPLICATION_MODE=RESTRICTED pytest -vx openquake/server/tests/test_restricted_mode.py
           OQ_APPLICATION_MODE=READ_ONLY pytest -vx openquake/server/tests/test_read_only_mode.py

--- a/openquake/engine/build_exposure_hdf5.py
+++ b/openquake/engine/build_exposure_hdf5.py
@@ -139,16 +139,16 @@ def build_site_model(grm_dir):
     dfs = []
     # NOTE: assuming the site-models repository is cloned inside the grm_dir
     site_models_dir = os.path.join(grm_dir, 'site-models')
-    for cwd, dirs, files in os.walk(site_models_dir):
-        # skip os.walk subtrees that don't belong to a known region
-        if not any(cwd == os.path.join(site_models_dir, region) or
-                   cwd.startswith(os.path.join(site_models_dir, region, ''))
-                   for region in REGIONS):
+    for region in REGIONS:
+        impact_dir = os.path.join(site_models_dir, region, 'Impact')
+        if not os.path.isdir(impact_dir):
+            logging.warning(
+                f'Folder "{impact_dir}" was not found. Skipping')
             continue
-        for f in files:
+        for f in os.listdir(impact_dir):
             if re.fullmatch(r'Site_model_[A-Z]{3}\.csv', f):
                 print('Reading %s' % f)
-                df = pandas.read_csv(os.path.join(cwd, f))
+                df = pandas.read_csv(os.path.join(impact_dir, f))
                 if factor < 1:
                     df = general.random_filter(df, factor*10)
                 if len(df):

--- a/openquake/engine/build_exposure_hdf5.py
+++ b/openquake/engine/build_exposure_hdf5.py
@@ -142,9 +142,8 @@ def build_site_model(grm_dir):
     for region in REGIONS:
         impact_dir = os.path.join(site_models_dir, region, 'Impact')
         if not os.path.isdir(impact_dir):
-            logging.warning(
-                f'Folder "{impact_dir}" was not found. Skipping')
-            continue
+            raise FileNotFoundError(
+                f'Folder "{impact_dir}" was not found.')
         for f in os.listdir(impact_dir):
             if re.fullmatch(r'Site_model_[A-Z]{3}\.csv', f):
                 print('Reading %s' % f)

--- a/openquake/engine/tests/impact3/aggrisk_tags.org
+++ b/openquake/engine/tests/impact3/aggrisk_tags.org
@@ -1,2157 +1,2157 @@
-| ID_0    | loss_type       | value         | lossmea    | q05        | q50        | q95         | ID         | NAME                             |
-|---------+-----------------+---------------+------------+------------+------------+-------------+------------+----------------------------------|
-| ESP     | contents        | 149_429_824   | 876_718    | 0.1021     | 18_979     | 4_805_502   | nan        | nan                              |
-| ESP     | structural      | 805_206_784   | 11_330_594 | 344_177    | 3_954_232  | 39_577_646  | nan        | nan                              |
-| ESP     | occupants       | 8_093         | 0.5429     | 4.529E-06  | 0.0207     | 2.6665      | nan        | nan                              |
-| ESP     | area            | 671_804       | 4_952      | 4.921E-04  | 280.6      | 17_909      | nan        | nan                              |
-| ESP     | number          | 3_228         | 31.6678    | 2.621E-06  | 1.5945     | 126.9500    | nan        | nan                              |
-| ESP     | residents       | 10_677        | 77.1858    | 5.591E-06  | 4.9003     | 284.0       | nan        | nan                              |
-| ESP     | affectedpop     | 10_677        | 109.6337   | 5.591E-06  | 10.5797    | 471.6       | nan        | nan                              |
-| ESP     | injured         | 8_093         | 1.6852     | 4.575E-06  | 0.1810     | 6.3688      | nan        | nan                              |
-| ESP     | embodied_carbon | 238_997       | 3_270      | 90.7563    | 1_025      | 12_182      | nan        | nan                              |
-| MAR     | contents        | 46_109_520    | 25_954     | 8.343E-04  | 0.4656     | 100_878     | nan        | nan                              |
-| MAR     | structural      | 239_964_512   | 804_539    | 7_502      | 294_604    | 3_486_578   | nan        | nan                              |
-| MAR     | occupants       | 26_523        | 0.4509     | 1.602E-06  | 2.681E-05  | 2.1112      | nan        | nan                              |
-| MAR     | area            | 740_323       | 521.2      | 4.108E-05  | 0.1479     | 2_664       | nan        | nan                              |
-| MAR     | number          | 7_678         | 5.8526     | 2.367E-07  | 0.0011     | 31.2373     | nan        | nan                              |
-| MAR     | residents       | 32_599        | 31.3660    | 1.998E-06  | 0.0045     | 183.3       | nan        | nan                              |
-| MAR     | affectedpop     | 32_599        | 48.2336    | 1.998E-06  | 0.0491     | 299.7       | nan        | nan                              |
-| MAR     | injured         | 26_523        | 0.7468     | 1.602E-06  | 2.679E-05  | 3.9313      | nan        | nan                              |
-| MAR     | embodied_carbon | 294_368       | 826.1      | 8.7327     | 166.5499   | 4_060       | nan        | nan                              |
-| PRT     | contents        | 247_515_312   | 3_090_031  | 1_218      | 1_159_598  | 11_587_372  | nan        | nan                              |
-| PRT     | structural      | 1_199_247_616 | 62_937_424 | 15_183_550 | 44_890_262 | 152_464_640 | nan        | nan                              |
-| PRT     | occupants       | 9_373         | 1.8438     | 0.0144     | 0.8306     | 6.7033      | nan        | nan                              |
-| PRT     | area            | 998_570       | 15_470     | 139.6203   | 5_663      | 51_061      | nan        | nan                              |
-| PRT     | number          | 3_908         | 91.5981    | 0.3927     | 27.2935    | 309.5       | nan        | nan                              |
-| PRT     | residents       | 11_754        | 245.9      | 1.6029     | 92.8628    | 961.6       | nan        | nan                              |
-| PRT     | affectedpop     | 11_754        | 370.8      | 3.8640     | 159.0930   | 1_451       | nan        | nan                              |
-| PRT     | injured         | 9_373         | 4.4845     | 0.0380     | 1.5164     | 16.5730     | nan        | nan                              |
-| PRT     | embodied_carbon | 338_861       | 17_072     | 3_816      | 13_095     | 42_627      | nan        | nan                              |
-| *total* | affectedpop     | 55_030        | 528.7      | 3.8641     | 169.7218   | 2_222       | nan        | nan                              |
-| *total* | area            | 2_410_697     | 20_943     | 139.6208   | 5_943      | 71_634      | nan        | nan                              |
-| *total* | contents        | 443_054_656   | 3_992_703  | 1_218      | 1_178_578  | 16_493_752  | nan        | nan                              |
-| *total* | embodied_carbon | 872_226       | 21_168     | 3_916      | 14_286     | 58_869      | nan        | nan                              |
-| *total* | injured         | 43_989        | 6.9165     | 0.0380     | 1.6974     | 26.8732     | nan        | nan                              |
-| *total* | number          | 14_813        | 129.1184   | 0.3927     | 28.8891    | 467.7       | nan        | nan                              |
-| *total* | occupants       | 43_989        | 2.8376     | 0.0144     | 0.8513     | 11.4810     | nan        | nan                              |
-| *total* | residents       | 55_030        | 354.5      | 1.6029     | 97.7676    | 1_429       | nan        | nan                              |
-| *total* | structural      | 2_244_419_072 | 75_072_557 | 15_535_229 | 49_139_098 | 195_528_864 | nan        | nan                              |
-| nan     | contents        | 344_085       | 1_388      | 0.0        | 0.0017     | 3_095       | 1001       | Division No.  1                  |
-| nan     | structural      | 1_654_183     | 56_870     | 8_880      | 47_368     | 150_886     | 1001       | Division No.  1                  |
-| nan     | occupants       | 21.6707       | 2.630E-05  | 6.099E-08  | 1.471E-07  | 1.471E-07   | 1001       | Division No.  1                  |
-| nan     | area            | 1_566         | 0.4419     | 4.151E-06  | 1.244E-05  | 1.244E-05   | 1001       | Division No.  1                  |
-| nan     | number          | 7.8334        | 0.0030     | 9.565E-09  | 6.976E-08  | 6.976E-08   | 1001       | Division No.  1                  |
-| nan     | residents       | 11.0390       | 0.0071     | 0.0        | 1.104E-07  | 1.104E-07   | 1001       | Division No.  1                  |
-| nan     | affectedpop     | 11.0390       | 0.0139     | 0.0        | 1.104E-07  | 0.0045      | 1001       | Division No.  1                  |
-| nan     | injured         | 21.6707       | 1.413E-04  | 6.099E-08  | 1.471E-07  | 1.471E-07   | 1001       | Division No.  1                  |
-| nan     | embodied_carbon | 567.8         | 16.6903    | 2.3735     | 12.3570    | 47.5906     | 1001       | Division No.  1                  |
-| nan     | contents        | 102_118       | 69.5708    | 0.0        | 0.0010     | 0.0010      | 1003       | Division No.  3                  |
-| nan     | structural      | 408_472       | 19_258     | 0.0        | 11_695     | 51_869      | 1003       | Division No.  3                  |
-| nan     | occupants       | 8.8537        | 2.395E-06  | 0.0        | 8.854E-08  | 8.854E-08   | 1003       | Division No.  3                  |
-| nan     | area            | 398.1         | 0.0222     | 0.0        | 3.981E-06  | 3.981E-06   | 1003       | Division No.  3                  |
-| nan     | number          | 1.1232        | 6.275E-05  | 0.0        | 1.123E-08  | 1.123E-08   | 1003       | Division No.  3                  |
-| nan     | injured         | 8.8537        | 1.984E-05  | 0.0        | 8.854E-08  | 8.854E-08   | 1003       | Division No.  3                  |
-| nan     | embodied_carbon | 172.4963      | 10.7237    | 0.0        | 7.6504     | 25.2777     | 1003       | Division No.  3                  |
-| nan     | contents        | 361_985       | 23_133     | 0.0        | 0.0028     | 260_848     | 1004       | Division No.  4                  |
-| nan     | structural      | 2_051_247     | 215_184    | 837.5      | 27_253     | 1_526_054   | 1004       | Division No.  4                  |
-| nan     | occupants       | 12.0779       | 0.0588     | 2.786E-08  | 0.0017     | 0.5096      | 1004       | Division No.  4                  |
-| nan     | area            | 1_799         | 152.4609   | 3.975E-06  | 4.3905     | 1_231       | 1004       | Division No.  4                  |
-| nan     | number          | 10.9037       | 0.9637     | 1.909E-08  | 0.0281     | 7.8955      | 1004       | Division No.  4                  |
-| nan     | residents       | 21.8605       | 2.0407     | 5.043E-08  | 0.0870     | 15.5299     | 1004       | Division No.  4                  |
-| nan     | affectedpop     | 21.8605       | 2.4844     | 5.043E-08  | 0.3040     | 16.1693     | 1004       | Division No.  4                  |
-| nan     | injured         | 12.0779       | 0.0366     | 2.786E-08  | 0.0011     | 0.2827      | 1004       | Division No.  4                  |
-| nan     | embodied_carbon | 591.5         | 54.0632    | 0.2723     | 7.1121     | 399.9       | 1004       | Division No.  4                  |
-| nan     | contents        | 63_188        | 1_154      | 0.0        | 3.306E-04  | 3_124       | 1006       | Division No.  6                  |
-| nan     | structural      | 358_069       | 22_456     | 0.0        | 11_795     | 59_818      | 1006       | Division No.  6                  |
-| nan     | occupants       | 2.3538        | 4.422E-04  | 0.0        | 2.354E-08  | 0.0018      | 1006       | Division No.  6                  |
-| nan     | area            | 285.5         | 7.3724     | 0.0        | 0.0368     | 30.6068     | 1006       | Division No.  6                  |
-| nan     | number          | 1.7063        | 0.0529     | 0.0        | 1.983E-04  | 0.2223      | 1006       | Division No.  6                  |
-| nan     | residents       | 4.3524        | 0.1072     | 0.0        | 6.777E-04  | 0.4739      | 1006       | Division No.  6                  |
-| nan     | affectedpop     | 4.3524        | 0.1553     | 0.0        | 0.0011     | 0.6970      | 1006       | Division No.  6                  |
-| nan     | injured         | 2.3538        | 0.0020     | 0.0        | 2.354E-08  | 0.0085      | 1006       | Division No.  6                  |
-| nan     | embodied_carbon | 88.2577       | 5.0148     | 0.0        | 2.3439     | 15.1045     | 1006       | Division No.  6                  |
-| nan     | contents        | 31_096        | 806.7      | 0.0        | 3.110E-04  | 2_385       | 1007       | Division No.  7                  |
-| nan     | structural      | 176_212       | 9_203      | 0.0        | 387.0      | 49_042      | 1007       | Division No.  7                  |
-| nan     | occupants       | 0.4476        | 1.340E-04  | 0.0        | 4.476E-09  | 5.973E-04   | 1007       | Division No.  7                  |
-| nan     | area            | 154.5716      | 6.1106     | 0.0        | 1.546E-06  | 26.9813     | 1007       | Division No.  7                  |
-| nan     | number          | 0.9918        | 0.0392     | 0.0        | 9.918E-09  | 0.1731      | 1007       | Division No.  7                  |
-| nan     | residents       | 0.8102        | 0.0384     | 0.0        | 8.102E-09  | 0.1859      | 1007       | Division No.  7                  |
-| nan     | affectedpop     | 0.8102        | 0.0536     | 0.0        | 8.102E-09  | 0.2890      | 1007       | Division No.  7                  |
-| nan     | injured         | 0.4476        | 6.596E-04  | 0.0        | 4.476E-09  | 0.0031      | 1007       | Division No.  7                  |
-| nan     | embodied_carbon | 49.3157       | 2.6747     | 0.0        | 0.1034     | 12.6832     | 1007       | Division No.  7                  |
-| nan     | contents        | 321_680       | 7_352      | 0.0        | 0.0028     | 39_702      | 1008       | Division No.  8                  |
-| nan     | structural      | 1_822_852     | 67_471     | 282.1      | 5_998      | 246_388     | 1008       | Division No.  8                  |
-| nan     | occupants       | 6.5532        | 0.0015     | 1.291E-08  | 6.553E-08  | 0.0096      | 1008       | Division No.  8                  |
-| nan     | area            | 1_599         | 42.8549    | 2.079E-06  | 0.0206     | 206.7       | 1008       | Division No.  8                  |
-| nan     | number          | 9.9244        | 0.2654     | 9.983E-09  | 9.897E-05  | 1.0465      | 1008       | Division No.  8                  |
-| nan     | residents       | 11.8601       | 0.4042     | 2.336E-08  | 2.350E-04  | 2.0105      | 1008       | Division No.  8                  |
-| nan     | affectedpop     | 11.8601       | 0.5483     | 2.336E-08  | 2.481E-04  | 2.4950      | 1008       | Division No.  8                  |
-| nan     | injured         | 6.5532        | 0.0072     | 1.291E-08  | 6.553E-08  | 0.0367      | 1008       | Division No.  8                  |
-| nan     | embodied_carbon | 550.6         | 22.3045    | 0.0907     | 1.7718     | 85.4577     | 1008       | Division No.  8                  |
-| nan     | contents        | 2_601_728     | 72_119     | 3.491E-04  | 0.0236     | 68_181      | 1009       | Leiria                           |
-| nan     | structural      | 14_679_383    | 726_423    | 19_289     | 144_780    | 3_936_881   | 1009       | Leiria                           |
-| nan     | occupants       | 68.2679       | 0.0218     | 8.535E-08  | 6.827E-07  | 0.1323      | 1009       | Leiria                           |
-| nan     | area            | 9_924         | 332.6      | 7.528E-06  | 0.4262     | 1_663       | 1009       | Leiria                           |
-| nan     | number          | 69.0849       | 2.3894     | 3.235E-08  | 0.0023     | 11.9226     | 1009       | Leiria                           |
-| nan     | residents       | 120.2857      | 4.7897     | 9.811E-08  | 0.0112     | 26.9919     | 1009       | Leiria                           |
-| nan     | affectedpop     | 120.2857      | 6.6732     | 1.139E-07  | 0.0362     | 41.3921     | 1009       | Leiria                           |
-| nan     | injured         | 68.2679       | 0.0909     | 8.535E-08  | 6.827E-07  | 0.4769      | 1009       | Leiria                           |
-| nan     | embodied_carbon | 3_506         | 167.5608   | 2.1468     | 31.3481    | 740.9       | 1009       | Leiria                           |
-| nan     | contents        | 1_976_803     | 15_257     | 0.0022     | 0.0115     | 89_434      | 101        | Hanumangarh                      |
-| nan     | structural      | 10_631_079    | 406_427    | 12_370     | 243_363    | 1_570_834   | 101        | Hanumangarh                      |
-| nan     | occupants       | 109.4221      | 0.0117     | 2.547E-07  | 1.094E-06  | 0.0657      | 101        | Hanumangarh                      |
-| nan     | area            | 9_525         | 89.1190    | 2.298E-05  | 0.3590     | 475.3       | 101        | Hanumangarh                      |
-| nan     | number          | 32.4502       | 0.4638     | 8.987E-08  | 0.0024     | 2.5774      | 101        | Hanumangarh                      |
-| nan     | residents       | 135.1385      | 1.7684     | 2.957E-07  | 0.0059     | 10.4813     | 101        | Hanumangarh                      |
-| nan     | affectedpop     | 135.1385      | 2.4411     | 2.975E-07  | 0.0094     | 15.2192     | 101        | Hanumangarh                      |
-| nan     | injured         | 109.4221      | 0.0339     | 2.547E-07  | 1.094E-06  | 0.2008      | 101        | Hanumangarh                      |
-| nan     | embodied_carbon | 3_185         | 130.7125   | 3.7336     | 77.9875    | 441.5       | 101        | Hanumangarh                      |
-| nan     | contents        | 63_108        | 171.4722   | 0.0        | 6.311E-04  | 6.311E-04   | 1010       | Division No. 10                  |
-| nan     | structural      | 357_613       | 6_989      | 0.0        | 1_927      | 26_381      | 1010       | Division No. 10                  |
-| nan     | occupants       | 2.1918        | 2.218E-04  | 0.0        | 2.192E-08  | 2.192E-08   | 1010       | Division No. 10                  |
-| nan     | area            | 313.7         | 1.1002     | 0.0        | 3.137E-06  | 0.3189      | 1010       | Division No. 10                  |
-| nan     | number          | 2.0129        | 0.0071     | 0.0        | 2.013E-08  | 0.0020      | 1010       | Division No. 10                  |
-| nan     | residents       | 3.9672        | 0.0160     | 0.0        | 3.967E-08  | 0.0062      | 1010       | Division No. 10                  |
-| nan     | affectedpop     | 3.9672        | 0.0274     | 0.0        | 3.967E-08  | 0.0588      | 1010       | Division No. 10                  |
-| nan     | injured         | 2.1918        | 2.598E-04  | 0.0        | 2.192E-08  | 2.192E-08   | 1010       | Division No. 10                  |
-| nan     | embodied_carbon | 93.8909       | 1.3876     | 0.0        | 0.2989     | 5.2488      | 1010       | Division No. 10                  |
-| nan     | contents        | 61_186        | 64.7960    | 0.0        | 5.538E-04  | 5.538E-04   | 1012       | Óbidos                           |
-| nan     | structural      | 337_042       | 3_336      | 0.0        | 1_859      | 10_043      | 1012       | Óbidos                           |
-| nan     | occupants       | 2.1480        | 3.955E-07  | 0.0        | 1.594E-08  | 1.594E-08   | 1012       | Óbidos                           |
-| nan     | area            | 297.9         | 0.0156     | 0.0        | 2.753E-06  | 2.753E-06   | 1012       | Óbidos                           |
-| nan     | number          | 2.1084        | 1.131E-04  | 0.0        | 2.000E-08  | 2.000E-08   | 1012       | Óbidos                           |
-| nan     | residents       | 2.8855        | 1.945E-04  | 0.0        | 2.886E-08  | 2.886E-08   | 1012       | Óbidos                           |
-| nan     | affectedpop     | 2.8855        | 4.947E-04  | 0.0        | 2.886E-08  | 2.886E-08   | 1012       | Óbidos                           |
-| nan     | injured         | 2.1480        | 3.569E-06  | 0.0        | 1.594E-08  | 1.594E-08   | 1012       | Óbidos                           |
-| nan     | embodied_carbon | 92.2654       | 1.7657     | 0.0        | 1.1167     | 5.0253      | 1012       | Óbidos                           |
-| nan     | contents        | 346_716       | 3_517      | 0.0        | 0.0035     | 0.0035      | 1014       | Peniche                          |
-| nan     | structural      | 1_964_724     | 70_732     | 0.0        | 13_968     | 143_510     | 1014       | Peniche                          |
-| nan     | occupants       | 7.0052        | 0.0028     | 0.0        | 7.005E-08  | 7.005E-08   | 1014       | Peniche                          |
-| nan     | area            | 1_567         | 21.6364    | 0.0        | 1.567E-05  | 1.7876      | 1014       | Peniche                          |
-| nan     | number          | 10.0534       | 0.1388     | 0.0        | 1.005E-07  | 0.0115      | 1014       | Peniche                          |
-| nan     | residents       | 12.9554       | 0.2202     | 0.0        | 1.296E-07  | 0.0232      | 1014       | Peniche                          |
-| nan     | affectedpop     | 12.9554       | 0.3224     | 0.0        | 1.296E-07  | 0.2118      | 1014       | Peniche                          |
-| nan     | injured         | 7.0052        | 0.0033     | 0.0        | 7.005E-08  | 7.005E-08   | 1014       | Peniche                          |
-| nan     | embodied_carbon | 468.9         | 12.3198    | 0.0        | 2.0324     | 27.6283     | 1014       | Peniche                          |
-| nan     | contents        | 2_437_501     | 43_875     | 0.0032     | 0.0235     | 374_298     | 1015       | Pombal                           |
-| nan     | structural      | 13_765_536    | 537_944    | 15_597     | 196_339    | 1_980_498   | 1015       | Pombal                           |
-| nan     | occupants       | 78.7829       | 0.0083     | 1.482E-07  | 7.641E-07  | 0.0368      | 1015       | Pombal                           |
-| nan     | area            | 12_086        | 201.4      | 3.078E-05  | 1.198E-04  | 1_014       | 1015       | Pombal                           |
-| nan     | number          | 83.3780       | 1.2942     | 2.115E-07  | 8.315E-07  | 6.5108      | 1015       | Pombal                           |
-| nan     | residents       | 138.3052      | 2.3768     | 2.683E-07  | 1.383E-06  | 10.8133     | 1015       | Pombal                           |
-| nan     | affectedpop     | 138.3052      | 3.2238     | 2.683E-07  | 9.307E-04  | 15.8565     | 1015       | Pombal                           |
-| nan     | injured         | 78.7829       | 0.0406     | 9.688E-08  | 7.641E-07  | 0.1803      | 1015       | Pombal                           |
-| nan     | embodied_carbon | 3_814         | 149.4704   | 3.2551     | 44.9467    | 605.3       | 1015       | Pombal                           |
-| nan     | contents        | 526_396       | 25_348     | 0.0        | 0.0053     | 354_642     | 1016       | Porto de Mós                     |
-| nan     | structural      | 2_982_912     | 220_652    | 0.0        | 10_545     | 1_191_771   | 1016       | Porto de Mós                     |
-| nan     | occupants       | 20.1401       | 0.0116     | 0.0        | 2.014E-07  | 0.0758      | 1016       | Porto de Mós                     |
-| nan     | area            | 2_617         | 161.9693   | 0.0        | 2.617E-05  | 1_055       | 1016       | Porto de Mós                     |
-| nan     | number          | 19.0069       | 1.1765     | 0.0        | 1.901E-07  | 7.6671      | 1016       | Porto de Mós                     |
-| nan     | residents       | 36.4525       | 2.6337     | 0.0        | 3.645E-07  | 17.9214     | 1016       | Porto de Mós                     |
-| nan     | affectedpop     | 36.4525       | 3.3418     | 0.0        | 3.645E-07  | 23.1700     | 1016       | Porto de Mós                     |
-| nan     | injured         | 20.1401       | 0.0514     | 0.0        | 2.014E-07  | 0.3384      | 1016       | Porto de Mós                     |
-| nan     | embodied_carbon | 948.8         | 75.9180    | 0.0        | 3.5524     | 504.1       | 1016       | Porto de Mós                     |
-| nan     | contents        | 196_590       | 9_125      | 8.814E-26  | 0.0017     | 134_066     | 102        | Jaipur                           |
-| nan     | structural      | 1_114_012     | 55_644     | 377.6      | 6_611      | 315_821     | 102        | Jaipur                           |
-| nan     | occupants       | 8.7083        | 0.0046     | 9.342E-09  | 8.708E-08  | 0.0288      | 102        | Jaipur                           |
-| nan     | area            | 977.2         | 39.7340    | 1.354E-06  | 9.772E-06  | 267.3       | 102        | Jaipur                           |
-| nan     | number          | 3.0630        | 0.0609     | 9.834E-09  | 3.063E-08  | 0.3816      | 102        | Jaipur                           |
-| nan     | residents       | 15.7591       | 0.8193     | 1.691E-08  | 1.576E-07  | 5.4190      | 102        | Jaipur                           |
-| nan     | affectedpop     | 15.7591       | 1.0414     | 1.691E-08  | 1.576E-07  | 7.2877      | 102        | Jaipur                           |
-| nan     | injured         | 8.7083        | 0.0157     | 9.342E-09  | 8.708E-08  | 0.1000      | 102        | Jaipur                           |
-| nan     | embodied_carbon | 337.4         | 17.9382    | 0.2016     | 2.3624     | 90.5881     | 102        | Jaipur                           |
-| nan     | contents        | 1_513_318     | 52_336     | 4.151E-04  | 0.0025     | 361_319     | 103        | Jaisalmer                        |
-| nan     | structural      | 3_744_997     | 185_555    | 3_562      | 90_440     | 827_517     | 103        | Jaisalmer                        |
-| nan     | occupants       | 21.6845       | 0.0124     | 5.977E-08  | 2.168E-07  | 0.0495      | 103        | Jaisalmer                        |
-| nan     | area            | 4_668         | 42.6324    | 5.902E-06  | 4.668E-05  | 299.5       | 103        | Jaisalmer                        |
-| nan     | number          | 13.3830       | 0.2326     | 3.309E-08  | 1.338E-07  | 1.3013      | 103        | Jaisalmer                        |
-| nan     | residents       | 14.3658       | 0.4456     | 0.0        | 1.437E-07  | 2.2686      | 103        | Jaisalmer                        |
-| nan     | affectedpop     | 14.3658       | 0.5422     | 0.0        | 1.437E-07  | 3.2200      | 103        | Jaisalmer                        |
-| nan     | injured         | 21.6845       | 0.0099     | 5.977E-08  | 2.168E-07  | 0.0458      | 103        | Jaisalmer                        |
-| nan     | embodied_carbon | 1_317         | 68.8608    | 1.5843     | 33.4462    | 302.6       | 103        | Jaisalmer                        |
-| nan     | contents        | 1_123_217     | 1_924      | 0.0        | 0.0015     | 3_331       | 105        | Jhalawar                         |
-| nan     | structural      | 4_610_390     | 43_027     | 0.0        | 27_652     | 106_630     | 105        | Jhalawar                         |
-| nan     | occupants       | 85.6806       | 0.0040     | 0.0        | 1.611E-07  | 0.0104      | 105        | Jhalawar                         |
-| nan     | area            | 3_370         | 5.7818     | 0.0        | 7.749E-06  | 14.5918     | 105        | Jhalawar                         |
-| nan     | number          | 9.8769        | 0.0420     | 0.0        | 4.287E-08  | 0.1060      | 105        | Jhalawar                         |
-| nan     | residents       | 4.6653        | 0.1134     | 0.0        | 4.665E-08  | 0.3447      | 105        | Jhalawar                         |
-| nan     | affectedpop     | 4.6653        | 0.1438     | 0.0        | 4.665E-08  | 0.6224      | 105        | Jhalawar                         |
-| nan     | injured         | 85.6806       | 0.0022     | 0.0        | 1.611E-07  | 0.0062      | 105        | Jhalawar                         |
-| nan     | embodied_carbon | 1_501         | 13.2364    | 0.0        | 9.4193     | 34.7901     | 105        | Jhalawar                         |
-| nan     | contents        | 438_600       | 172.1637   | 0.0        | 0.0033     | 3.9067      | 107        | Jodhpur                          |
-| nan     | structural      | 2_312_676     | 67_953     | 0.0        | 46_752     | 244_366     | 107        | Jodhpur                          |
-| nan     | occupants       | 27.3857       | 2.787E-05  | 0.0        | 2.739E-07  | 2.739E-07   | 107        | Jodhpur                          |
-| nan     | area            | 1_877         | 0.3632     | 0.0        | 1.877E-05  | 0.1537      | 107        | Jodhpur                          |
-| nan     | number          | 12.7002       | 0.0026     | 0.0        | 1.270E-07  | 0.0011      | 107        | Jodhpur                          |
-| nan     | residents       | 26.5009       | 0.0077     | 0.0        | 2.650E-07  | 0.0027      | 107        | Jodhpur                          |
-| nan     | affectedpop     | 26.5009       | 0.0171     | 0.0        | 2.650E-07  | 0.0324      | 107        | Jodhpur                          |
-| nan     | injured         | 27.3857       | 1.281E-04  | 0.0        | 2.739E-07  | 2.739E-07   | 107        | Jodhpur                          |
-| nan     | embodied_carbon | 623.8         | 18.7031    | 0.0        | 13.8490    | 64.8155     | 107        | Jodhpur                          |
-| nan     | contents        | 3_918_363     | 66_743     | 0.0        | 0.0392     | 3_414       | 108        | Karauli                          |
-| nan     | structural      | 22_204_056    | 1_062_511  | 0.0        | 33_091     | 11_421_565  | 108        | Karauli                          |
-| nan     | occupants       | 131.0966      | 0.0453     | 0.0        | 1.311E-06  | 0.4289      | 108        | Karauli                          |
-| nan     | area            | 19_477        | 887.4      | 0.0        | 1.948E-04  | 8_347       | 108        | Karauli                          |
-| nan     | number          | 124.9789      | 5.6944     | 0.0        | 1.250E-06  | 53.5573     | 108        | Karauli                          |
-| nan     | residents       | 237.3         | 12.4940    | 0.0        | 2.373E-06  | 120.1171    | 108        | Karauli                          |
-| nan     | affectedpop     | 237.3         | 15.7055    | 0.0        | 2.373E-06  | 151.7498    | 108        | Karauli                          |
-| nan     | injured         | 131.0966      | 0.2165     | 0.0        | 1.311E-06  | 2.0523      | 108        | Karauli                          |
-| nan     | embodied_carbon | 7_058         | 380.8      | 0.0        | 9.5279     | 2_816       | 108        | Karauli                          |
-| nan     | contents        | 4_320_605     | 32_992     | 0.0        | 0.0084     | 76_716      | 109        | Kota                             |
-| nan     | structural      | 24_452_584    | 1_039_424  | 0.0        | 621_766    | 3_808_363   | 109        | Kota                             |
-| nan     | occupants       | 214.5         | 0.0260     | 0.0        | 2.145E-06  | 0.0725      | 109        | Kota                             |
-| nan     | area            | 21_457        | 289.1      | 0.0        | 2.146E-04  | 1_096       | 109        | Kota                             |
-| nan     | number          | 39.3597       | 1.2959     | 0.0        | 3.936E-07  | 6.0589      | 109        | Kota                             |
-| nan     | residents       | 385.3         | 5.5062     | 0.0        | 3.853E-06  | 22.0324     | 109        | Kota                             |
-| nan     | affectedpop     | 385.3         | 8.2481     | 0.0        | 3.125E-05  | 42.9471     | 109        | Kota                             |
-| nan     | injured         | 214.5         | 0.0862     | 0.0        | 2.145E-06  | 0.2931      | 109        | Kota                             |
-| nan     | embodied_carbon | 7_153         | 323.8      | 0.0        | 187.2      | 966.7       | 109        | Kota                             |
-| nan     | contents        | 323_498       | 11.2325    | 0.0        | 5.999E-04  | 5.999E-04   | 1101       | Kings                            |
-| nan     | structural      | 1_293_991     | 8_920      | 0.0        | 5_220      | 31_366      | 1101       | Kings                            |
-| nan     | occupants       | 32.4674       | 5.574E-08  | 0.0        | 6.021E-08  | 6.021E-08   | 1101       | Kings                            |
-| nan     | area            | 1_135         | 1.949E-06  | 0.0        | 2.105E-06  | 2.105E-06   | 1101       | Kings                            |
-| nan     | number          | 2.9178        | 9.136E-09  | 0.0        | 9.870E-09  | 9.870E-09   | 1101       | Kings                            |
-| nan     | injured         | 32.4674       | 5.574E-08  | 0.0        | 6.021E-08  | 6.021E-08   | 1101       | Kings                            |
-| nan     | embodied_carbon | 533.1         | 5.4447     | 0.0        | 3.6519     | 15.9196     | 1101       | Kings                            |
-| nan     | contents        | 2_081_289     | 107_126    | 0.0        | 0.0380     | 712_920     | 1103       | Prince                           |
-| nan     | structural      | 4_941_015     | 488_542    | 3_348      | 251_755    | 1_606_675   | 1103       | Prince                           |
-| nan     | occupants       | 18.0250       | 0.0553     | 8.990E-08  | 1.802E-07  | 0.4545      | 1103       | Prince                           |
-| nan     | area            | 6_288         | 144.4682   | 1.404E-05  | 0.1522     | 1_157       | 1103       | Prince                           |
-| nan     | number          | 17.3359       | 0.9088     | 8.329E-08  | 8.355E-04  | 7.4225      | 1103       | Prince                           |
-| nan     | residents       | 16.3521       | 1.8316     | 0.0        | 1.635E-07  | 14.4423     | 1103       | Prince                           |
-| nan     | affectedpop     | 16.3521       | 2.2144     | 0.0        | 0.0089     | 15.3405     | 1103       | Prince                           |
-| nan     | injured         | 18.0250       | 0.0327     | 8.990E-08  | 1.802E-07  | 0.2597      | 1103       | Prince                           |
-| nan     | embodied_carbon | 1_718         | 156.8579   | 0.7818     | 91.3323    | 549.0       | 1103       | Prince                           |
-| nan     | contents        | 252_481       | 732.0      | 0.0        | 5.516E-04  | 6_143       | 1104       | ACEH TENGGARA Regency            |
-| nan     | structural      | 1_145_151     | 32_405     | 2_227      | 17_177     | 116_950     | 1104       | ACEH TENGGARA Regency            |
-| nan     | occupants       | 21.2309       | 0.0013     | 7.351E-09  | 2.725E-08  | 0.0057      | 1104       | ACEH TENGGARA Regency            |
-| nan     | area            | 1_071         | 6.4653     | 1.291E-06  | 0.1718     | 30.5028     | 1104       | ACEH TENGGARA Regency            |
-| nan     | number          | 4.4554        | 0.0470     | 9.377E-09  | 0.0012     | 0.2216      | 1104       | ACEH TENGGARA Regency            |
-| nan     | residents       | 4.9320        | 0.1164     | 1.330E-08  | 0.0020     | 0.5609      | 1104       | ACEH TENGGARA Regency            |
-| nan     | affectedpop     | 4.9320        | 0.2739     | 1.330E-08  | 0.0082     | 1.4077      | 1104       | ACEH TENGGARA Regency            |
-| nan     | injured         | 21.2309       | 0.0018     | 7.351E-09  | 2.725E-08  | 0.0080      | 1104       | ACEH TENGGARA Regency            |
-| nan     | embodied_carbon | 410.8         | 6.0461     | 0.2810     | 2.8007     | 18.5765     | 1104       | ACEH TENGGARA Regency            |
-| nan     | contents        | 653_901       | 27_238     | 0.0        | 0.0        | 33.0694     | 1105       | ACEH TIMUR Regency               |
-| nan     | structural      | 3_705_441     | 204_684    | 4_563      | 19_630     | 1_728_678   | 1105       | ACEH TIMUR Regency               |
-| nan     | occupants       | 32.1308       | 0.0160     | 3.213E-07  | 3.213E-07  | 0.1156      | 1105       | ACEH TIMUR Regency               |
-| nan     | area            | 2_500         | 117.0500   | 2.500E-05  | 1.0735     | 828.1       | 1105       | ACEH TIMUR Regency               |
-| nan     | number          | 12.0053       | 0.5620     | 1.201E-07  | 0.0052     | 3.9761      | 1105       | ACEH TIMUR Regency               |
-| nan     | residents       | 59.4249       | 3.0839     | 5.942E-07  | 0.0255     | 23.3695     | 1105       | ACEH TIMUR Regency               |
-| nan     | affectedpop     | 59.4249       | 3.7501     | 5.942E-07  | 0.0255     | 30.5607     | 1105       | ACEH TIMUR Regency               |
-| nan     | injured         | 32.1308       | 0.0608     | 3.213E-07  | 3.213E-07  | 0.4428      | 1105       | ACEH TIMUR Regency               |
-| nan     | embodied_carbon | 907.2         | 50.7273    | 1.1222     | 5.0151     | 233.1       | 1105       | ACEH TIMUR Regency               |
-| nan     | contents        | 6_359_240     | 17_485     | 3.833E-07  | 0.3660     | 109_270     | 1106       | ACEH TENGAH Regency              |
-| nan     | structural      | 29_747_242    | 1_159_146  | 418_343    | 917_801    | 3_046_332   | 1106       | ACEH TENGAH Regency              |
-| nan     | occupants       | 550.0         | 0.0106     | 1.621E-06  | 1.709E-06  | 0.0354      | 1106       | ACEH TENGAH Regency              |
-| nan     | area            | 20_945        | 52.2606    | 9.268E-05  | 1.018E-04  | 167.5976    | 1106       | ACEH TENGAH Regency              |
-| nan     | number          | 34.0087       | 0.1024     | 8.083E-08  | 1.153E-07  | 0.7048      | 1106       | ACEH TENGAH Regency              |
-| nan     | residents       | 266.7         | 2.5955     | 2.503E-06  | 2.667E-06  | 13.6650     | 1106       | ACEH TENGAH Regency              |
-| nan     | affectedpop     | 266.7         | 7.8024     | 2.503E-06  | 0.0378     | 55.7156     | 1106       | ACEH TENGAH Regency              |
-| nan     | injured         | 550.0         | 0.0280     | 1.621E-06  | 1.709E-06  | 0.0998      | 1106       | ACEH TENGAH Regency              |
-| nan     | embodied_carbon | 8_122         | 179.7197   | 52.2016    | 147.6042   | 476.3       | 1106       | ACEH TENGAH Regency              |
-| nan     | contents        | 1_378_162     | 21_139     | 5.957E-21  | 446.8      | 74_605      | 1107       | AFŞİN                            |
-| nan     | structural      | 7_266_306     | 757_181    | 36_318     | 538_143    | 1_978_342   | 1107       | AFŞİN                            |
-| nan     | occupants       | 85.5149       | 0.0575     | 1.006E-07  | 8.551E-07  | 0.2501      | 1107       | AFŞİN                            |
-| nan     | area            | 5_043         | 123.5505   | 9.585E-06  | 1.9622     | 500.8       | 1107       | AFŞİN                            |
-| nan     | number          | 11.1499       | 0.2337     | 4.187E-08  | 0.0035     | 1.4174      | 1107       | AFŞİN                            |
-| nan     | residents       | 103.5445      | 5.2189     | 1.861E-07  | 0.2001     | 26.3074     | 1107       | AFŞİN                            |
-| nan     | affectedpop     | 103.5445      | 12.4982    | 1.861E-07  | 2.6509     | 56.2763     | 1107       | AFŞİN                            |
-| nan     | injured         | 85.5149       | 0.0699     | 1.006E-07  | 8.551E-07  | 0.2973      | 1107       | AFŞİN                            |
-| nan     | embodied_carbon | 1_652         | 134.8554   | 3.8778     | 85.6647    | 375.8       | 1107       | AFŞİN                            |
-| nan     | contents        | 199_685       | 17_124     | 0.0        | 0.0020     | 199_685     | 1108       | ACEH BESAR Regency               |
-| nan     | structural      | 1_131_549     | 142_247    | 1_466      | 8_283      | 887_754     | 1108       | ACEH BESAR Regency               |
-| nan     | occupants       | 7.7836        | 0.0107     | 7.784E-08  | 7.784E-08  | 0.0681      | 1108       | ACEH BESAR Regency               |
-| nan     | area            | 992.6         | 112.5610   | 9.926E-06  | 0.2778     | 714.7       | 1108       | ACEH BESAR Regency               |
-| nan     | number          | 1.5158        | 0.1719     | 1.516E-08  | 4.242E-04  | 1.0914      | 1108       | ACEH BESAR Regency               |
-| nan     | residents       | 14.0912       | 1.8353     | 1.409E-07  | 0.0088     | 11.1417     | 1108       | ACEH BESAR Regency               |
-| nan     | affectedpop     | 14.0912       | 2.2410     | 1.409E-07  | 0.0396     | 12.2972     | 1108       | ACEH BESAR Regency               |
-| nan     | injured         | 7.7836        | 0.0360     | 7.784E-08  | 7.784E-08  | 0.2243      | 1108       | ACEH BESAR Regency               |
-| nan     | embodied_carbon | 360.4         | 49.5672    | 0.4846     | 2.7307     | 336.4       | 1108       | ACEH BESAR Regency               |
-| nan     | contents        | 403_430       | 8_014      | 6.930E-04  | 15.1138    | 46_301      | 1109       | PIDIE Regency                    |
-| nan     | structural      | 1_757_566     | 97_184     | 21_672     | 67_006     | 295_386     | 1109       | PIDIE Regency                    |
-| nan     | occupants       | 26.4253       | 0.0019     | 1.756E-07  | 2.643E-07  | 0.0112      | 1109       | PIDIE Regency                    |
-| nan     | area            | 1_738         | 19.1848    | 1.061E-05  | 0.1587     | 104.6219    | 1109       | PIDIE Regency                    |
-| nan     | number          | 9.2739        | 0.1484     | 4.355E-08  | 0.0010     | 0.8395      | 1109       | PIDIE Regency                    |
-| nan     | residents       | 15.8558       | 0.2368     | 3.284E-08  | 7.144E-04  | 1.3685      | 1109       | PIDIE Regency                    |
-| nan     | affectedpop     | 15.8558       | 0.3269     | 3.284E-08  | 0.0018     | 1.8440      | 1109       | PIDIE Regency                    |
-| nan     | injured         | 26.4253       | 0.0098     | 1.756E-07  | 2.643E-07  | 0.0531      | 1109       | PIDIE Regency                    |
-| nan     | embodied_carbon | 597.0         | 33.9677    | 8.2899     | 25.0507    | 75.6228     | 1109       | PIDIE Regency                    |
-| nan     | contents        | 1_047_387     | 2_690      | 0.0        | 0.0066     | 194.3       | 111        | Pali                             |
-| nan     | structural      | 5_935_193     | 236_495    | 0.0        | 189_937    | 586_809     | 111        | Pali                             |
-| nan     | occupants       | 46.7590       | 0.0028     | 0.0        | 4.676E-07  | 0.0104      | 111        | Pali                             |
-| nan     | area            | 5_206         | 13.5296    | 0.0        | 5.206E-05  | 47.9825     | 111        | Pali                             |
-| nan     | number          | 29.7535       | 0.0966     | 0.0        | 2.975E-07  | 0.3419      | 111        | Pali                             |
-| nan     | residents       | 84.6314       | 0.2678     | 0.0        | 8.463E-07  | 1.1521      | 111        | Pali                             |
-| nan     | affectedpop     | 84.6314       | 0.5822     | 0.0        | 8.463E-07  | 3.6122      | 111        | Pali                             |
-| nan     | injured         | 46.7590       | 0.0041     | 0.0        | 4.676E-07  | 0.0148      | 111        | Pali                             |
-| nan     | embodied_carbon | 1_560         | 46.6490    | 0.0        | 34.8745    | 113.3319    | 111        | Pali                             |
-| nan     | contents        | 3_312_181     | 114_532    | 0.0078     | 0.0255     | 759_931     | 1110       | BIREUEN Regency                  |
-| nan     | structural      | 18_209_268    | 1_288_416  | 54_137     | 635_044    | 4_436_223   | 1110       | BIREUEN Regency                  |
-| nan     | occupants       | 125.9962      | 0.0761     | 5.605E-07  | 0.0069     | 0.3554      | 1110       | BIREUEN Regency                  |
-| nan     | area            | 12_362        | 591.8      | 1.236E-04  | 58.2054    | 2_675       | 1110       | BIREUEN Regency                  |
-| nan     | number          | 62.2592       | 1.7945     | 6.226E-07  | 0.1692     | 8.7749      | 1110       | BIREUEN Regency                  |
-| nan     | residents       | 179.2351      | 11.9791    | 1.792E-06  | 1.4418     | 50.5636     | 1110       | BIREUEN Regency                  |
-| nan     | affectedpop     | 179.2351      | 15.8525    | 1.792E-06  | 3.2866     | 58.5352     | 1110       | BIREUEN Regency                  |
-| nan     | injured         | 125.9962      | 0.2762     | 1.260E-06  | 0.0429     | 1.1597      | 1110       | BIREUEN Regency                  |
-| nan     | embodied_carbon | 4_396         | 314.4      | 13.6242    | 112.0736   | 1_126       | 1110       | BIREUEN Regency                  |
-| nan     | contents        | 38_760_636    | 94_638     | 0.0116     | 318.7      | 565_109     | 1111       | ACEH UTARA Regency               |
-| nan     | structural      | 216_213_520   | 13_450_030 | 3_842_935  | 12_023_646 | 31_133_514  | 1111       | ACEH UTARA Regency               |
-| nan     | occupants       | 1_807         | 0.0423     | 1.671E-05  | 1.687E-05  | 0.1959      | 1111       | ACEH UTARA Regency               |
-| nan     | area            | 146_472       | 304.9      | 0.0014     | 7.8729     | 1_597       | 1111       | ACEH UTARA Regency               |
-| nan     | number          | 153.0254      | 0.7743     | 1.385E-06  | 0.0340     | 4.7636      | 1111       | ACEH UTARA Regency               |
-| nan     | residents       | 3_093         | 13.5373    | 3.087E-05  | 0.2612     | 85.5962     | 1111       | ACEH UTARA Regency               |
-| nan     | affectedpop     | 3_093         | 49.5611    | 3.090E-05  | 0.9448     | 319.9       | 1111       | ACEH UTARA Regency               |
-| nan     | injured         | 1_807         | 0.1357     | 1.681E-05  | 1.647E-04  | 0.7780      | 1111       | ACEH UTARA Regency               |
-| nan     | embodied_carbon | 47_387        | 2_740      | 738.1      | 2_533      | 6_322       | 1111       | ACEH UTARA Regency               |
-| nan     | contents        | 890_993       | 24_206     | 3.449E-04  | 0.0075     | 134_710     | 1113       | AKÇAABAT                         |
-| nan     | structural      | 5_048_961     | 362_102    | 65_397     | 199_942    | 1_302_391   | 1113       | AKÇAABAT                         |
-| nan     | occupants       | 37.8525       | 0.0089     | 3.147E-07  | 6.548E-04  | 0.0586      | 1113       | AKÇAABAT                         |
-| nan     | area            | 4_026         | 101.0810   | 3.376E-05  | 12.7573    | 604.4       | 1113       | AKÇAABAT                         |
-| nan     | number          | 17.9619       | 0.3704     | 1.696E-07  | 0.0400     | 1.9792      | 1113       | AKÇAABAT                         |
-| nan     | residents       | 70.0061       | 1.9330     | 5.820E-07  | 0.2521     | 11.1920     | 1113       | AKÇAABAT                         |
-| nan     | affectedpop     | 70.0061       | 2.9727     | 5.820E-07  | 0.5288     | 13.2603     | 1113       | AKÇAABAT                         |
-| nan     | injured         | 37.8525       | 0.0340     | 3.147E-07  | 0.0038     | 0.2188      | 1113       | AKÇAABAT                         |
-| nan     | embodied_carbon | 1_257         | 81.0078    | 12.0651    | 36.9318    | 310.5       | 1113       | AKÇAABAT                         |
-| nan     | contents        | 1_038_030     | 3_237      | 0.0        | 3.615E-04  | 36_133      | 1114       | AKÇADAĞ                          |
-| nan     | structural      | 4_212_379     | 20_964     | 65.3780    | 1_190      | 117_563     | 1114       | AKÇADAĞ                          |
-| nan     | occupants       | 77.9471       | 9.390E-04  | 1.138E-08  | 1.138E-08  | 0.0061      | 1114       | AKÇADAĞ                          |
-| nan     | area            | 3_068         | 12.2195    | 1.382E-06  | 1.382E-06  | 79.5307     | 1114       | AKÇADAĞ                          |
-| nan     | number          | 7.1224        | 0.0888     | 1.004E-08  | 1.004E-08  | 0.5777      | 1114       | AKÇADAĞ                          |
-| nan     | residents       | 2.1053        | 0.2146     | 2.105E-08  | 2.105E-08  | 1.3989      | 1114       | AKÇADAĞ                          |
-| nan     | affectedpop     | 2.1053        | 0.2646     | 2.105E-08  | 2.105E-08  | 1.6542      | 1114       | AKÇADAĞ                          |
-| nan     | injured         | 77.9471       | 0.0041     | 1.138E-08  | 1.138E-08  | 0.0267      | 1114       | AKÇADAĞ                          |
-| nan     | embodied_carbon | 1_421         | 4.7118     | 0.0144     | 0.2760     | 31.5223     | 1114       | AKÇADAĞ                          |
-| nan     | contents        | 3_611_628     | 40_552     | 0.0        | 0.0196     | 120_521     | 1116       | AKÇAKOCA                         |
-| nan     | structural      | 20_465_890    | 1_069_928  | 195_680    | 882_572    | 2_518_256   | 1116       | AKÇAKOCA                         |
-| nan     | occupants       | 182.4         | 0.0034     | 8.346E-07  | 1.824E-06  | 0.0162      | 1116       | AKÇAKOCA                         |
-| nan     | area            | 13_810        | 33.1148    | 6.318E-05  | 1.381E-04  | 124.6821    | 1116       | AKÇAKOCA                         |
-| nan     | number          | 40.0722       | 0.0539     | 4.100E-08  | 4.007E-07  | 0.3265      | 1116       | AKÇAKOCA                         |
-| nan     | residents       | 337.4         | 1.2534     | 1.544E-06  | 3.374E-06  | 4.4911      | 1116       | AKÇAKOCA                         |
-| nan     | affectedpop     | 337.4         | 3.2089     | 1.544E-06  | 3.374E-06  | 21.0200     | 1116       | AKÇAKOCA                         |
-| nan     | injured         | 182.4         | 0.0154     | 8.346E-07  | 1.824E-06  | 0.0659      | 1116       | AKÇAKOCA                         |
-| nan     | embodied_carbon | 4_311         | 238.3      | 64.9278    | 188.5      | 543.6       | 1116       | AKÇAKOCA                         |
-| nan     | contents        | 249_844       | 270.8      | 0.0        | 0.0025     | 18.9034     | 112        | Rajsamand                        |
-| nan     | structural      | 1_415_785     | 35_702     | 0.0        | 18_115     | 161_934     | 112        | Rajsamand                        |
-| nan     | occupants       | 6.0779        | 4.618E-08  | 0.0        | 6.078E-08  | 6.078E-08   | 112        | Rajsamand                        |
-| nan     | area            | 1_242         | 0.0193     | 0.0        | 1.242E-05  | 0.0103      | 112        | Rajsamand                        |
-| nan     | number          | 9.0213        | 1.401E-04  | 0.0        | 9.021E-08  | 7.465E-05   | 112        | Rajsamand                        |
-| nan     | residents       | 11.0009       | 1.758E-04  | 0.0        | 1.100E-07  | 9.088E-05   | 112        | Rajsamand                        |
-| nan     | affectedpop     | 11.0009       | 0.0017     | 0.0        | 1.100E-07  | 0.0050      | 112        | Rajsamand                        |
-| nan     | injured         | 6.0779        | 5.199E-07  | 0.0        | 6.078E-08  | 6.078E-08   | 112        | Rajsamand                        |
-| nan     | embodied_carbon | 372.0         | 7.7929     | 0.0        | 3.7497     | 32.7491     | 112        | Rajsamand                        |
-| nan     | contents        | 83_095        | 40.7047    | 0.0        | 8.309E-04  | 0.0065      | 113        | Sawai Madhopur                   |
-| nan     | structural      | 470_873       | 11_055     | 0.0        | 7_466      | 34_819      | 113        | Sawai Madhopur                   |
-| nan     | occupants       | 3.3529        | 7.208E-06  | 0.0        | 3.353E-08  | 3.353E-08   | 113        | Sawai Madhopur                   |
-| nan     | area            | 413.0         | 0.1019     | 0.0        | 4.130E-06  | 4.130E-06   | 113        | Sawai Madhopur                   |
-| nan     | number          | 3.0004        | 7.406E-04  | 0.0        | 3.000E-08  | 3.000E-08   | 113        | Sawai Madhopur                   |
-| nan     | residents       | 6.0685        | 0.0021     | 0.0        | 6.069E-08  | 6.069E-08   | 113        | Sawai Madhopur                   |
-| nan     | affectedpop     | 6.0685        | 0.0044     | 0.0        | 6.069E-08  | 6.069E-08   | 113        | Sawai Madhopur                   |
-| nan     | injured         | 3.3529        | 3.288E-05  | 0.0        | 3.353E-08  | 3.353E-08   | 113        | Sawai Madhopur                   |
-| nan     | embodied_carbon | 123.7333      | 2.4409     | 0.0        | 1.5490     | 7.8973      | 113        | Sawai Madhopur                   |
-| nan     | contents        | 22_185        | 337.8      | 0.0        | 6.834E-32  | 1_786       | 114        | Sikar                            |
-| nan     | structural      | 88_742        | 7_342      | 0.0        | 5_210      | 22_169      | 114        | Sikar                            |
-| nan     | occupants       | 2.4529        | 1.927E-08  | 0.0        | 2.453E-08  | 2.453E-08   | 114        | Sikar                            |
-| nan     | area            | 97.3048       | 0.0014     | 0.0        | 9.730E-07  | 9.730E-07   | 114        | Sikar                            |
-| nan     | number          | 0.4484        | 6.295E-06  | 0.0        | 4.484E-09  | 4.484E-09   | 114        | Sikar                            |
-| nan     | injured         | 2.4529        | 1.261E-06  | 0.0        | 2.453E-08  | 2.453E-08   | 114        | Sikar                            |
-| nan     | embodied_carbon | 42.1214       | 2.8821     | 0.0        | 1.8871     | 9.4533      | 114        | Sikar                            |
-| nan     | contents        | 569_609       | 10_738     | 0.0        | 0.0046     | 88_309      | 115        | Sirohi                           |
-| nan     | structural      | 3_091_922     | 198_275    | 0.0        | 42_907     | 1_151_167   | 115        | Sirohi                           |
-| nan     | occupants       | 28.3062       | 0.0098     | 0.0        | 2.831E-07  | 0.0584      | 115        | Sirohi                           |
-| nan     | area            | 2_784         | 124.4217   | 0.0        | 0.0522     | 864.0       | 115        | Sirohi                           |
-| nan     | number          | 14.6142       | 0.6977     | 0.0        | 3.430E-04  | 5.5917      | 115        | Sirohi                           |
-| nan     | residents       | 35.1046       | 1.9930     | 0.0        | 9.583E-04  | 12.8516     | 115        | Sirohi                           |
-| nan     | affectedpop     | 35.1046       | 2.6361     | 0.0        | 0.0054     | 17.2167     | 115        | Sirohi                           |
-| nan     | injured         | 28.3062       | 0.0351     | 0.0        | 2.831E-07  | 0.2179      | 115        | Sirohi                           |
-| nan     | embodied_carbon | 918.3         | 54.0786    | 0.0        | 9.8184     | 418.8       | 115        | Sirohi                           |
-| nan     | contents        | 3_489_842     | 78_190     | 0.0        | 0.0349     | 30_246      | 117        | Udaipur                          |
-| nan     | structural      | 19_775_772    | 821_855    | 0.0        | 86_226     | 2_750_779   | 117        | Udaipur                          |
-| nan     | occupants       | 104.9875      | 0.0310     | 0.0        | 1.050E-06  | 0.1124      | 117        | Udaipur                          |
-| nan     | area            | 17_347        | 513.6      | 0.0        | 1.735E-04  | 1_748       | 117        | Udaipur                          |
-| nan     | number          | 125.8819      | 3.7241     | 0.0        | 1.259E-06  | 12.6615     | 117        | Udaipur                          |
-| nan     | residents       | 190.0         | 6.6643     | 0.0        | 1.900E-06  | 27.2215     | 117        | Udaipur                          |
-| nan     | affectedpop     | 190.0         | 8.6253     | 0.0        | 1.900E-06  | 46.0258     | 117        | Udaipur                          |
-| nan     | injured         | 104.9875      | 0.1284     | 0.0        | 1.050E-06  | 0.4808      | 117        | Udaipur                          |
-| nan     | embodied_carbon | 6_283         | 248.6      | 0.0        | 29.2428    | 817.7       | 117        | Udaipur                          |
-| nan     | contents        | 497_838       | 4_977      | 2.770E-04  | 0.0040     | 4.1642      | 118        | Agra                             |
-| nan     | structural      | 2_821_076     | 123_706    | 14.2221    | 7_313      | 595_020     | 118        | Agra                             |
-| nan     | occupants       | 15.6593       | 0.0059     | 1.123E-08  | 1.566E-07  | 0.0411      | 118        | Agra                             |
-| nan     | area            | 2_475         | 85.7880    | 1.377E-06  | 2.475E-05  | 477.2       | 118        | Agra                             |
-| nan     | number          | 15.9955       | 0.5530     | 1.000E-08  | 1.600E-07  | 3.0622      | 118        | Agra                             |
-| nan     | residents       | 28.3432       | 1.2163     | 2.034E-08  | 2.834E-07  | 7.0758      | 118        | Agra                             |
-| nan     | affectedpop     | 28.3432       | 1.6206     | 2.034E-08  | 2.834E-07  | 10.0798     | 118        | Agra                             |
-| nan     | injured         | 15.6593       | 0.0209     | 1.123E-08  | 1.566E-07  | 0.1178      | 118        | Agra                             |
-| nan     | embodied_carbon | 861.3         | 43.5487    | 0.0035     | 2.0358     | 238.6       | 118        | Agra                             |
-| nan     | contents        | 139_273       | 1_618      | 0.0        | 8.298E-04  | 20.7648     | 119        | Aligarh                          |
-| nan     | structural      | 789_213       | 26_899     | 0.0        | 7_391      | 110_321     | 119        | Aligarh                          |
-| nan     | occupants       | 4.1421        | 8.457E-04  | 0.0        | 4.142E-08  | 0.0024      | 119        | Aligarh                          |
-| nan     | area            | 692.3         | 12.2668    | 0.0        | 6.923E-06  | 42.6347     | 119        | Aligarh                          |
-| nan     | number          | 5.0288        | 0.0891     | 0.0        | 5.029E-08  | 0.3097      | 119        | Aligarh                          |
-| nan     | residents       | 7.4968        | 0.1451     | 0.0        | 7.497E-08  | 0.5669      | 119        | Aligarh                          |
-| nan     | affectedpop     | 7.4968        | 0.2177     | 0.0        | 7.497E-08  | 1.1094      | 119        | Aligarh                          |
-| nan     | injured         | 4.1421        | 0.0027     | 0.0        | 4.142E-08  | 0.0100      | 119        | Aligarh                          |
-| nan     | embodied_carbon | 215.5         | 7.0266     | 0.0        | 1.2399     | 25.1888     | 119        | Aligarh                          |
-| nan     | contents        | 34_314        | 775.1      | 0.0        | 1.920E-18  | 2_243       | 1206       | Lunenburg                        |
-| nan     | structural      | 194_444       | 12_607     | 0.0        | 5_409      | 30_649      | 1206       | Lunenburg                        |
-| nan     | occupants       | 0.4579        | 4.150E-04  | 0.0        | 4.579E-09  | 3.540E-04   | 1206       | Lunenburg                        |
-| nan     | area            | 170.5652      | 5.2388     | 0.0        | 1.706E-06  | 4.4490      | 1206       | Lunenburg                        |
-| nan     | number          | 1.2390        | 0.0381     | 0.0        | 1.239E-08  | 0.0323      | 1206       | Lunenburg                        |
-| nan     | residents       | 0.8288        | 0.0307     | 0.0        | 8.288E-09  | 0.0404      | 1206       | Lunenburg                        |
-| nan     | affectedpop     | 0.8288        | 0.0414     | 0.0        | 8.288E-09  | 0.1437      | 1206       | Lunenburg                        |
-| nan     | injured         | 0.4579        | 5.672E-04  | 0.0        | 4.579E-09  | 5.050E-04   | 1206       | Lunenburg                        |
-| nan     | embodied_carbon | 51.0967       | 2.7556     | 0.0        | 0.7484     | 6.1671      | 1206       | Lunenburg                        |
-| nan     | contents        | 33_484        | 17.7772    | 0.0        | 3.348E-04  | 3.348E-04   | 1207       | Kings                            |
-| nan     | structural      | 189_744       | 2_814      | 0.0        | 742.4      | 12_374      | 1207       | Kings                            |
-| nan     | occupants       | 0.9547        | 1.692E-06  | 0.0        | 9.547E-09  | 9.547E-09   | 1207       | Kings                            |
-| nan     | area            | 151.3108      | 0.0402     | 0.0        | 1.513E-06  | 1.513E-06   | 1207       | Kings                            |
-| nan     | number          | 0.9709        | 2.581E-04  | 0.0        | 9.709E-09  | 9.709E-09   | 1207       | Kings                            |
-| nan     | residents       | 1.7663        | 5.226E-04  | 0.0        | 1.766E-08  | 1.766E-08   | 1207       | Kings                            |
-| nan     | affectedpop     | 1.7663        | 9.798E-04  | 0.0        | 1.766E-08  | 1.766E-08   | 1207       | Kings                            |
-| nan     | injured         | 0.9547        | 9.639E-06  | 0.0        | 9.547E-09  | 9.547E-09   | 1207       | Kings                            |
-| nan     | embodied_carbon | 45.2897       | 0.6572     | 0.0        | 0.1755     | 3.1446      | 1207       | Kings                            |
-| nan     | contents        | 31_829        | 29.8545    | 0.0        | 3.183E-04  | 3.183E-04   | 1211       | Cumberland                       |
-| nan     | structural      | 180_365       | 1_082      | 0.0        | 276.5      | 3_398       | 1211       | Cumberland                       |
-| nan     | occupants       | 0.7745        | 6.127E-09  | 0.0        | 7.745E-09  | 7.745E-09   | 1211       | Cumberland                       |
-| nan     | area            | 158.2146      | 2.707E-05  | 0.0        | 1.582E-06  | 1.582E-06   | 1211       | Cumberland                       |
-| nan     | number          | 1.0152        | 1.737E-07  | 0.0        | 1.015E-08  | 1.015E-08   | 1211       | Cumberland                       |
-| nan     | residents       | 1.4018        | 3.296E-07  | 0.0        | 1.402E-08  | 1.402E-08   | 1211       | Cumberland                       |
-| nan     | affectedpop     | 1.4018        | 2.371E-06  | 0.0        | 1.402E-08  | 1.402E-08   | 1211       | Cumberland                       |
-| nan     | injured         | 0.7745        | 6.127E-09  | 0.0        | 7.745E-09  | 7.745E-09   | 1211       | Cumberland                       |
-| nan     | embodied_carbon | 47.3560       | 0.6565     | 0.0        | 0.2301     | 2.0911      | 1211       | Cumberland                       |
-| nan     | contents        | 407_392       | 6_355      | 0.0        | 0.0041     | 9.0725      | 1213       | Guysborough                      |
-| nan     | structural      | 2_308_556     | 150_556    | 0.0        | 10_633     | 558_441     | 1213       | Guysborough                      |
-| nan     | occupants       | 7.0498        | 0.0024     | 0.0        | 7.050E-08  | 0.0084      | 1213       | Guysborough                      |
-| nan     | area            | 2_025         | 91.3348    | 0.0        | 2.025E-05  | 315.6       | 1213       | Guysborough                      |
-| nan     | number          | 12.9941       | 0.5861     | 0.0        | 1.299E-07  | 2.0254      | 1213       | Guysborough                      |
-| nan     | residents       | 12.7600       | 0.6574     | 0.0        | 1.276E-07  | 2.6336      | 1213       | Guysborough                      |
-| nan     | affectedpop     | 12.7600       | 0.8507     | 0.0        | 1.276E-07  | 4.1707      | 1213       | Guysborough                      |
-| nan     | injured         | 7.0498        | 0.0115     | 0.0        | 7.050E-08  | 0.0432      | 1213       | Guysborough                      |
-| nan     | embodied_carbon | 733.8         | 45.4075    | 0.0        | 3.3787     | 187.0       | 1213       | Guysborough                      |
-| nan     | contents        | 26_822        | 449.1      | 0.0        | 5.271E-21  | 3.3345      | 1214       | Antigonish                       |
-| nan     | structural      | 107_289       | 6_871      | 0.0        | 2_438      | 29_065      | 1214       | Antigonish                       |
-| nan     | occupants       | 1.2900        | 3.638E-04  | 0.0        | 1.290E-08  | 0.0023      | 1214       | Antigonish                       |
-| nan     | area            | 78.4277       | 2.4161     | 0.0        | 7.843E-07  | 14.9403     | 1214       | Antigonish                       |
-| nan     | number          | 0.3964        | 0.0122     | 0.0        | 3.964E-09  | 0.0755      | 1214       | Antigonish                       |
-| nan     | injured         | 1.2900        | 0.0017     | 0.0        | 1.290E-08  | 0.0108      | 1214       | Antigonish                       |
-| nan     | embodied_carbon | 40.5399       | 2.3457     | 0.0        | 0.7735     | 10.9731     | 1214       | Antigonish                       |
-| nan     | contents        | 275_327       | 441.7      | 0.0        | 3.257E-04  | 393.1       | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | structural      | 1_366_168     | 22_678     | 0.0        | 10_222     | 137_141     | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | occupants       | 21.4360       | 3.243E-04  | 0.0        | 8.144E-08  | 0.0034      | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | area            | 1_244         | 7.1081     | 0.0        | 7.899E-06  | 74.2639     | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | number          | 5.0022        | 0.0455     | 0.0        | 4.054E-08  | 0.4765      | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | residents       | 14.7409       | 0.0897     | 0.0        | 1.474E-07  | 0.9469      | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | affectedpop     | 14.7409       | 0.1149     | 0.0        | 1.474E-07  | 1.1745      | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | injured         | 21.4360       | 0.0016     | 0.0        | 8.144E-08  | 0.0163      | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | embodied_carbon | 418.2         | 6.7220     | 0.0        | 4.9397     | 28.0499     | 1301       | KEPULAUAN MENTAWAI Regency       |
-| nan     | contents        | 17_660        | 1_241      | 0.0        | 1.766E-04  | 16_334      | 1302       | Charlotte                        |
-| nan     | structural      | 70_639        | 7_198      | 0.0        | 1_222      | 49_056      | 1302       | Charlotte                        |
-| nan     | occupants       | 2.2100        | 0.0015     | 0.0        | 2.210E-08  | 0.0123      | 1302       | Charlotte                        |
-| nan     | area            | 68.8489       | 5.1287     | 0.0        | 6.885E-07  | 40.8920     | 1302       | Charlotte                        |
-| nan     | number          | 0.3478        | 0.0259     | 0.0        | 3.478E-09  | 0.2066      | 1302       | Charlotte                        |
-| nan     | injured         | 2.2100        | 0.0067     | 0.0        | 2.210E-08  | 0.0532      | 1302       | Charlotte                        |
-| nan     | embodied_carbon | 35.5889       | 3.4385     | 0.0        | 0.5226     | 20.2958     | 1302       | Charlotte                        |
-| nan     | contents        | 384_932       | 7_064      | 0.0        | 0.0028     | 83_379      | 1303       | Sunbury                          |
-| nan     | structural      | 1_911_118     | 89_852     | 0.0        | 24_767     | 527_573     | 1303       | Sunbury                          |
-| nan     | occupants       | 25.3145       | 0.0055     | 0.0        | 2.088E-07  | 0.0481      | 1303       | Sunbury                          |
-| nan     | area            | 1_763         | 39.8587    | 0.0        | 1.763E-05  | 350.3       | 1303       | Sunbury                          |
-| nan     | number          | 8.1975        | 0.0622     | 0.0        | 8.198E-08  | 0.5343      | 1303       | Sunbury                          |
-| nan     | residents       | 19.6597       | 0.9074     | 0.0        | 1.966E-07  | 7.5886      | 1303       | Sunbury                          |
-| nan     | affectedpop     | 19.6597       | 1.0576     | 0.0        | 1.966E-07  | 7.9841      | 1303       | Sunbury                          |
-| nan     | injured         | 25.3145       | 0.0183     | 0.0        | 2.531E-07  | 0.1568      | 1303       | Sunbury                          |
-| nan     | embodied_carbon | 641.7         | 29.5330    | 0.0        | 7.0939     | 167.3372    | 1303       | Sunbury                          |
-| nan     | contents        | 1_757_137     | 40_229     | 0.0        | 0.0089     | 40_762      | 1304       | Queens                           |
-| nan     | structural      | 9_848_565     | 409_202    | 0.0        | 41_959     | 2_875_974   | 1304       | Queens                           |
-| nan     | occupants       | 83.8402       | 0.0287     | 0.0        | 7.717E-07  | 0.2718      | 1304       | Queens                           |
-| nan     | area            | 6_660         | 197.5      | 0.0        | 6.314E-05  | 1_830       | 1304       | Queens                           |
-| nan     | number          | 10.0590       | 0.3254     | 0.0        | 8.127E-08  | 3.0636      | 1304       | Queens                           |
-| nan     | residents       | 145.0706      | 5.1215     | 0.0        | 1.427E-06  | 48.1379     | 1304       | Queens                           |
-| nan     | affectedpop     | 145.0706      | 6.3815     | 0.0        | 1.427E-06  | 57.0090     | 1304       | Queens                           |
-| nan     | injured         | 83.8402       | 0.0980     | 0.0        | 7.717E-07  | 0.9133      | 1304       | Queens                           |
-| nan     | embodied_carbon | 2_236         | 97.9753    | 0.0        | 16.6070    | 719.0       | 1304       | Queens                           |
-| nan     | contents        | 2_803_063     | 104_706    | 0.0        | 0.0270     | 344.7       | 1305       | Kings                            |
-| nan     | structural      | 15_573_714    | 707_711    | 0.0        | 86_375     | 5_385_176   | 1305       | Kings                            |
-| nan     | occupants       | 147.1963      | 0.0481     | 0.0        | 1.472E-06  | 0.2587      | 1305       | Kings                            |
-| nan     | area            | 13_734        | 503.1      | 0.0        | 1.373E-04  | 2_695       | 1305       | Kings                            |
-| nan     | number          | 97.3543       | 3.6525     | 0.0        | 9.735E-07  | 19.5763     | 1305       | Kings                            |
-| nan     | residents       | 242.1         | 10.2002    | 0.0        | 2.421E-06  | 72.7754     | 1305       | Kings                            |
-| nan     | affectedpop     | 242.1         | 11.7912    | 0.0        | 2.421E-06  | 100.4375    | 1305       | Kings                            |
-| nan     | injured         | 147.1963      | 0.2080     | 0.0        | 1.472E-06  | 1.1805      | 1305       | Kings                            |
-| nan     | embodied_carbon | 5_031         | 258.8      | 0.0        | 28.5967    | 2_222       | 1305       | Kings                            |
-| nan     | contents        | 1_608_180     | 61_923     | 0.0        | 0.0159     | 867_167     | 1306       | PADANG PARIAMAN Regency          |
-| nan     | structural      | 8_840_568     | 369_860    | 125.4203   | 52_399     | 2_761_313   | 1306       | PADANG PARIAMAN Regency          |
-| nan     | occupants       | 64.7726       | 0.0202     | 1.970E-08  | 6.477E-07  | 0.1840      | 1306       | PADANG PARIAMAN Regency          |
-| nan     | area            | 6_008         | 216.8      | 6.901E-07  | 6.008E-05  | 2_008       | 1306       | PADANG PARIAMAN Regency          |
-| nan     | number          | 39.7619       | 1.5538     | 1.989E-11  | 3.976E-07  | 14.5903     | 1306       | PADANG PARIAMAN Regency          |
-| nan     | residents       | 95.6668       | 4.3548     | 0.0        | 9.567E-07  | 42.4393     | 1306       | PADANG PARIAMAN Regency          |
-| nan     | affectedpop     | 95.6668       | 5.4304     | 0.0        | 9.567E-07  | 52.8152     | 1306       | PADANG PARIAMAN Regency          |
-| nan     | injured         | 64.7726       | 0.0835     | 1.970E-08  | 6.477E-07  | 0.7986      | 1306       | PADANG PARIAMAN Regency          |
-| nan     | embodied_carbon | 2_140         | 111.5787   | 0.0261     | 12.6086    | 813.6       | 1306       | PADANG PARIAMAN Regency          |
-| nan     | contents        | 878_734       | 641.9      | 0.0        | 0.0063     | 1_357       | 1307       | Westmorland                      |
-| nan     | structural      | 4_195_051     | 100_026    | 0.0        | 65_531     | 299_132     | 1307       | Westmorland                      |
-| nan     | occupants       | 54.2495       | 7.180E-05  | 0.0        | 5.338E-07  | 5.425E-07   | 1307       | Westmorland                      |
-| nan     | area            | 3_863         | 0.8695     | 0.0        | 3.725E-05  | 0.5909      | 1307       | Westmorland                      |
-| nan     | number          | 22.0107       | 0.0046     | 0.0        | 2.100E-07  | 0.0028      | 1307       | Westmorland                      |
-| nan     | residents       | 29.4540       | 0.0204     | 0.0        | 2.789E-07  | 0.0087      | 1307       | Westmorland                      |
-| nan     | affectedpop     | 29.4540       | 0.0523     | 0.0        | 2.789E-07  | 0.0301      | 1307       | Westmorland                      |
-| nan     | injured         | 54.2495       | 2.985E-04  | 0.0        | 5.338E-07  | 5.425E-07   | 1307       | Westmorland                      |
-| nan     | embodied_carbon | 1_402         | 35.8276    | 0.0        | 24.9107    | 104.2405    | 1307       | Westmorland                      |
-| nan     | contents        | 1_555_652     | 25_252     | 0.0        | 8.478E-04  | 34_321      | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | structural      | 8_794_474     | 451_240    | 1_239      | 206_147    | 2_234_030   | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | occupants       | 75.4115       | 0.0500     | 1.937E-08  | 6.118E-07  | 0.1503      | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | area            | 5_937         | 147.3959   | 3.664E-07  | 5.937E-05  | 859.4       | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | number          | 14.1222       | 0.3537     | 1.035E-09  | 1.412E-07  | 2.7005      | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | residents       | 135.8871      | 4.3617     | 0.0        | 1.359E-06  | 23.7107     | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | affectedpop     | 135.8871      | 6.3391     | 0.0        | 0.0019     | 44.1462     | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | injured         | 75.4115       | 0.0670     | 1.937E-08  | 6.118E-07  | 0.4039      | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | embodied_carbon | 1_852         | 67.2067    | 0.2797     | 16.1469    | 404.6       | 1308       | LIMA PULUH KOTA Regency          |
-| nan     | contents        | 52_446        | 623.9      | 0.0        | 0.0        | 3_007       | 1309       | Northumberland                   |
-| nan     | structural      | 297_192       | 16_225     | 0.0        | 5_421      | 93_956      | 1309       | Northumberland                   |
-| nan     | occupants       | 2.7861        | 0.0013     | 0.0        | 2.786E-08  | 0.0110      | 1309       | Northumberland                   |
-| nan     | area            | 260.7         | 4.2281     | 0.0        | 2.607E-06  | 34.9263     | 1309       | Northumberland                   |
-| nan     | number          | 1.8937        | 0.0307     | 0.0        | 1.894E-08  | 0.2537      | 1309       | Northumberland                   |
-| nan     | residents       | 5.0431        | 0.1261     | 0.0        | 5.043E-08  | 1.0903      | 1309       | Northumberland                   |
-| nan     | affectedpop     | 5.0431        | 0.2740     | 0.0        | 5.043E-08  | 2.4157      | 1309       | Northumberland                   |
-| nan     | injured         | 2.7861        | 0.0018     | 0.0        | 2.786E-08  | 0.0154      | 1309       | Northumberland                   |
-| nan     | embodied_carbon | 78.0954       | 3.0797     | 0.0        | 0.7120     | 17.5107     | 1309       | Northumberland                   |
-| nan     | contents        | 606_976       | 33_807     | 0.0        | 8.104E-04  | 516_011     | 1310       | York                             |
-| nan     | structural      | 3_304_473     | 173_586    | 0.0        | 20_175     | 1_075_614   | 1310       | York                             |
-| nan     | occupants       | 29.6168       | 0.0094     | 0.0        | 2.962E-07  | 0.0962      | 1310       | York                             |
-| nan     | area            | 2_930         | 116.3830   | 0.0        | 2.930E-05  | 1_192       | 1310       | York                             |
-| nan     | number          | 20.4463       | 0.8454     | 0.0        | 2.045E-07  | 8.6614      | 1310       | York                             |
-| nan     | residents       | 40.8847       | 2.1871     | 0.0        | 4.088E-07  | 22.3018     | 1310       | York                             |
-| nan     | affectedpop     | 40.8847       | 2.8590     | 0.0        | 4.088E-07  | 27.9688     | 1310       | York                             |
-| nan     | injured         | 29.6168       | 0.0419     | 0.0        | 2.962E-07  | 0.4259      | 1310       | York                             |
-| nan     | embodied_carbon | 1_096         | 62.5762    | 0.0        | 7.5527     | 581.1       | 1310       | York                             |
-| nan     | contents        | 126_163       | 309.7      | 0.0        | 9.584E-04  | 0.0013      | 1311       | DHARMAS RAYA Regency             |
-| nan     | structural      | 504_654       | 18_441     | 0.0        | 6_919      | 90_785      | 1311       | DHARMAS RAYA Regency             |
-| nan     | occupants       | 13.4938       | 0.0013     | 0.0        | 1.349E-07  | 0.0136      | 1311       | DHARMAS RAYA Regency             |
-| nan     | area            | 491.9         | 5.2637     | 0.0        | 4.919E-06  | 53.9284     | 1311       | DHARMAS RAYA Regency             |
-| nan     | number          | 2.3193        | 0.0266     | 0.0        | 2.319E-08  | 0.2725      | 1311       | DHARMAS RAYA Regency             |
-| nan     | injured         | 13.4938       | 0.0059     | 0.0        | 1.349E-07  | 0.0600      | 1311       | DHARMAS RAYA Regency             |
-| nan     | embodied_carbon | 236.2         | 10.1931    | 0.0        | 4.6778     | 43.5343     | 1311       | DHARMAS RAYA Regency             |
-| nan     | contents        | 766_645       | 725.6      | 0.0        | 0.0077     | 0.0077      | 1312       | Victoria                         |
-| nan     | structural      | 3_066_578     | 155_241    | 0.0        | 130_505    | 427_168     | 1312       | Victoria                         |
-| nan     | occupants       | 95.9885       | 6.812E-07  | 0.0        | 9.599E-07  | 9.599E-07   | 1312       | Victoria                         |
-| nan     | area            | 2_242         | 0.0018     | 0.0        | 2.242E-05  | 2.242E-05   | 1312       | Victoria                         |
-| nan     | number          | 5.3521        | 4.311E-06  | 0.0        | 5.352E-08  | 5.352E-08   | 1312       | Victoria                         |
-| nan     | injured         | 95.9885       | 1.566E-06  | 0.0        | 9.599E-07  | 9.599E-07   | 1312       | Victoria                         |
-| nan     | embodied_carbon | 1_051         | 43.8573    | 0.0        | 36.5965    | 125.8674    | 1312       | Victoria                         |
-| nan     | contents        | 120_831       | 1_627      | 0.0        | 4.925E-04  | 925.1       | 1313       | Madawaska                        |
-| nan     | structural      | 684_709       | 26_634     | 0.0        | 9_767      | 119_467     | 1313       | Madawaska                        |
-| nan     | occupants       | 3.7069        | 0.0011     | 0.0        | 3.707E-08  | 0.0091      | 1313       | Madawaska                        |
-| nan     | area            | 462.0         | 9.1253     | 0.0        | 4.620E-06  | 58.5523     | 1313       | Madawaska                        |
-| nan     | number          | 2.8923        | 0.0491     | 0.0        | 2.892E-08  | 0.3260      | 1313       | Madawaska                        |
-| nan     | residents       | 6.8557        | 0.1697     | 0.0        | 6.856E-08  | 1.2520      | 1313       | Madawaska                        |
-| nan     | affectedpop     | 6.8557        | 0.2505     | 0.0        | 6.856E-08  | 1.9235      | 1313       | Madawaska                        |
-| nan     | injured         | 3.7069        | 0.0031     | 0.0        | 3.707E-08  | 0.0185      | 1313       | Madawaska                        |
-| nan     | embodied_carbon | 101.3097      | 3.0863     | 0.0        | 1.0043     | 18.8161     | 1313       | Madawaska                        |
-| nan     | contents        | 749_716       | 292.9      | 0.0        | 0.0069     | 218.0       | 1314       | Restigouche                      |
-| nan     | structural      | 4_248_388     | 109_605    | 0.0        | 51_566     | 446_019     | 1314       | Restigouche                      |
-| nan     | occupants       | 34.1724       | 2.495E-05  | 0.0        | 3.417E-07  | 3.417E-07   | 1314       | Restigouche                      |
-| nan     | area            | 3_727         | 0.4353     | 0.0        | 3.727E-05  | 0.6290      | 1314       | Restigouche                      |
-| nan     | number          | 26.9391       | 0.0032     | 0.0        | 2.694E-07  | 0.0046      | 1314       | Restigouche                      |
-| nan     | residents       | 61.8501       | 0.0094     | 0.0        | 6.185E-07  | 0.0104      | 1314       | Restigouche                      |
-| nan     | affectedpop     | 61.8501       | 0.0324     | 0.0        | 6.185E-07  | 0.0982      | 1314       | Restigouche                      |
-| nan     | injured         | 34.1724       | 1.279E-04  | 0.0        | 3.417E-07  | 3.417E-07   | 1314       | Restigouche                      |
-| nan     | embodied_carbon | 1_116         | 26.3548    | 0.0        | 11.1578    | 109.8794    | 1314       | Restigouche                      |
-| nan     | contents        | 1_071_417     | 12_675     | 0.0        | 7.480E-12  | 412.6       | 1315       | Gloucester                       |
-| nan     | structural      | 5_151_568     | 215_820    | 0.0        | 109_178    | 797_013     | 1315       | Gloucester                       |
-| nan     | occupants       | 190.5         | 0.0063     | 0.0        | 1.685E-06  | 0.0228      | 1315       | Gloucester                       |
-| nan     | area            | 3_600         | 58.1047    | 0.0        | 3.600E-05  | 218.8       | 1315       | Gloucester                       |
-| nan     | number          | 16.7886       | 0.4200     | 0.0        | 1.679E-07  | 1.5893      | 1315       | Gloucester                       |
-| nan     | residents       | 40.8136       | 1.3625     | 0.0        | 4.081E-07  | 6.4142      | 1315       | Gloucester                       |
-| nan     | affectedpop     | 40.8136       | 1.6928     | 0.0        | 4.081E-07  | 10.7199     | 1315       | Gloucester                       |
-| nan     | injured         | 190.5         | 0.0274     | 0.0        | 1.905E-06  | 0.1105      | 1315       | Gloucester                       |
-| nan     | embodied_carbon | 1_394         | 56.7759    | 0.0        | 29.5985    | 192.1       | 1315       | Gloucester                       |
-| nan     | contents        | 2_362_993     | 529.3      | 0.0        | 0.0229     | 4_477       | 1316       | ERMENEK                          |
-| nan     | structural      | 13_270_940    | 160_609    | 0.0        | 133_069    | 659_177     | 1316       | ERMENEK                          |
-| nan     | occupants       | 97.2816       | 6.168E-07  | 0.0        | 9.728E-07  | 9.728E-07   | 1316       | ERMENEK                          |
-| nan     | area            | 8_990         | 0.3134     | 0.0        | 8.990E-05  | 8.990E-05   | 1316       | ERMENEK                          |
-| nan     | number          | 9.3478        | 3.441E-04  | 0.0        | 9.348E-08  | 9.348E-08   | 1316       | ERMENEK                          |
-| nan     | residents       | 169.6907      | 0.0138     | 0.0        | 1.697E-06  | 1.697E-06   | 1316       | ERMENEK                          |
-| nan     | affectedpop     | 169.6907      | 0.0706     | 0.0        | 1.697E-06  | 1.697E-06   | 1316       | ERMENEK                          |
-| nan     | injured         | 97.2816       | 1.249E-04  | 0.0        | 9.728E-07  | 9.728E-07   | 1316       | ERMENEK                          |
-| nan     | embodied_carbon | 2_700         | 51.1878    | 0.0        | 50.8678    | 192.2       | 1316       | ERMENEK                          |
-| nan     | contents        | 4_903_542     | 38_120     | 0.0        | 0.0401     | 19_984      | 1317       | Vila Nova de Gaia                |
-| nan     | structural      | 27_555_132    | 573_379    | 0.0        | 217_139    | 1_200_041   | 1317       | Vila Nova de Gaia                |
-| nan     | occupants       | 332.2         | 0.0233     | 0.0        | 3.322E-06  | 0.0600      | 1317       | Vila Nova de Gaia                |
-| nan     | area            | 24_237        | 238.4      | 0.0        | 7.897E-04  | 423.1       | 1317       | Vila Nova de Gaia                |
-| nan     | number          | 137.7322      | 1.5612     | 0.0        | 2.213E-06  | 2.8066      | 1317       | Vila Nova de Gaia                |
-| nan     | residents       | 395.3         | 4.0164     | 0.0        | 1.811E-05  | 8.4171      | 1317       | Vila Nova de Gaia                |
-| nan     | affectedpop     | 395.3         | 5.7194     | 0.0        | 0.0043     | 18.4609     | 1317       | Vila Nova de Gaia                |
-| nan     | injured         | 332.2         | 0.0709     | 0.0        | 3.322E-06  | 0.1289      | 1317       | Vila Nova de Gaia                |
-| nan     | embodied_carbon | 7_570         | 137.0472   | 0.0        | 42.6374    | 315.2       | 1317       | Vila Nova de Gaia                |
-| nan     | contents        | 756_461       | 3_440      | 0.0        | 0.0016     | 1_756       | 1318       | MERKEZ                           |
-| nan     | structural      | 4_286_611     | 170_128    | 0.0        | 121_779    | 511_374     | 1318       | MERKEZ                           |
-| nan     | occupants       | 45.1950       | 0.0025     | 0.0        | 4.520E-07  | 0.0220      | 1318       | MERKEZ                           |
-| nan     | area            | 3_760         | 21.1366    | 0.0        | 3.760E-05  | 198.0       | 1318       | MERKEZ                           |
-| nan     | number          | 8.4402        | 0.1271     | 0.0        | 8.440E-08  | 1.1447      | 1318       | MERKEZ                           |
-| nan     | residents       | 81.8012       | 0.6092     | 0.0        | 8.180E-07  | 5.1832      | 1318       | MERKEZ                           |
-| nan     | affectedpop     | 81.8012       | 1.0578     | 0.0        | 8.180E-07  | 7.0867      | 1318       | MERKEZ                           |
-| nan     | injured         | 45.1950       | 0.0102     | 0.0        | 4.520E-07  | 0.0986      | 1318       | MERKEZ                           |
-| nan     | embodied_carbon | 1_158         | 33.7710    | 0.0        | 21.8496    | 127.0903    | 1318       | MERKEZ                           |
-| nan     | contents        | 983_167       | 11_364     | 0.0        | 0.0097     | 6_042       | 1401       | MERKEZ                           |
-| nan     | structural      | 5_571_281     | 211_870    | 0.0        | 52_873     | 813_500     | 1401       | MERKEZ                           |
-| nan     | occupants       | 21.2990       | 0.0065     | 0.0        | 2.130E-07  | 0.0106      | 1401       | MERKEZ                           |
-| nan     | area            | 4_443         | 46.6383    | 0.0        | 4.443E-05  | 77.2781     | 1401       | MERKEZ                           |
-| nan     | number          | 28.5719       | 0.3005     | 0.0        | 2.857E-07  | 0.5016      | 1401       | MERKEZ                           |
-| nan     | residents       | 39.3910       | 0.5302     | 0.0        | 3.939E-07  | 1.3039      | 1401       | MERKEZ                           |
-| nan     | affectedpop     | 39.3910       | 1.0067     | 0.0        | 3.939E-07  | 5.0873      | 1401       | MERKEZ                           |
-| nan     | injured         | 21.2990       | 0.0077     | 0.0        | 2.130E-07  | 0.0133      | 1401       | MERKEZ                           |
-| nan     | embodied_carbon | 1_330         | 42.5579    | 0.0        | 8.0580     | 165.3277    | 1401       | MERKEZ                           |
-| nan     | contents        | 81_028        | 1_664      | 0.0        | 8.103E-04  | 0.4497      | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | structural      | 459_161       | 16_087     | 0.0        | 855.4      | 64_314      | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | occupants       | 4.1644        | 0.0013     | 0.0        | 4.164E-08  | 0.0045      | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | area            | 402.8         | 11.6599    | 0.0        | 4.028E-06  | 39.8988     | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | number          | 1.9339        | 0.0560     | 0.0        | 1.934E-08  | 0.1916      | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | residents       | 7.5373        | 0.2418     | 0.0        | 7.537E-08  | 0.9117      | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | affectedpop     | 7.5373        | 0.3107     | 0.0        | 7.537E-08  | 1.4058      | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | injured         | 4.1644        | 0.0049     | 0.0        | 4.164E-08  | 0.0177      | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | embodied_carbon | 146.1464      | 5.4619     | 0.0        | 0.2843     | 22.3053     | 1403       | INDRAGIRI HILIR Regency          |
-| nan     | contents        | 11_733_957    | 12_791     | 7.033E-10  | 0.1162     | 5_519       | 1405       | SIAK Regency                     |
-| nan     | structural      | 38_603_568    | 2_877_283  | 231_462    | 2_309_651  | 6_948_936   | 1405       | SIAK Regency                     |
-| nan     | occupants       | 138.8419      | 0.0150     | 6.611E-07  | 1.388E-06  | 0.0802      | 1405       | SIAK Regency                     |
-| nan     | area            | 45_658        | 72.1357    | 6.341E-05  | 0.0587     | 262.2       | 1405       | SIAK Regency                     |
-| nan     | number          | 72.7933       | 0.0910     | 5.747E-08  | 8.968E-05  | 0.3438      | 1405       | SIAK Regency                     |
-| nan     | residents       | 131.6443      | 2.0682     | 0.0        | 0.0012     | 11.3058     | 1405       | SIAK Regency                     |
-| nan     | affectedpop     | 131.6443      | 5.1385     | 0.0        | 0.0075     | 34.9438     | 1405       | SIAK Regency                     |
-| nan     | injured         | 138.8419      | 0.0239     | 6.611E-07  | 1.388E-06  | 0.1093      | 1405       | SIAK Regency                     |
-| nan     | embodied_carbon | 17_752        | 1_165      | 35.5486    | 912.2      | 2_978       | 1405       | SIAK Regency                     |
-| nan     | contents        | 66_719        | 905.6      | 0.0        | 2.489E-04  | 0.6457      | 1406       | KAMPAR Regency                   |
-| nan     | structural      | 336_602       | 16_712     | 315.5      | 5_094      | 53_181      | 1406       | KAMPAR Regency                   |
-| nan     | occupants       | 4.1217        | 0.0010     | 2.000E-08  | 4.122E-08  | 0.0060      | 1406       | KAMPAR Regency                   |
-| nan     | area            | 305.0         | 7.4766     | 9.702E-07  | 0.0058     | 33.5163     | 1406       | KAMPAR Regency                   |
-| nan     | number          | 1.4456        | 0.0358     | 4.471E-09  | 2.652E-05  | 0.1609      | 1406       | KAMPAR Regency                   |
-| nan     | residents       | 3.8403        | 0.1475     | 0.0        | 3.840E-08  | 0.7502      | 1406       | KAMPAR Regency                   |
-| nan     | affectedpop     | 3.8403        | 0.1891     | 0.0        | 3.840E-08  | 1.0934      | 1406       | KAMPAR Regency                   |
-| nan     | injured         | 4.1217        | 0.0033     | 2.000E-08  | 4.122E-08  | 0.0146      | 1406       | KAMPAR Regency                   |
-| nan     | embodied_carbon | 117.4533      | 5.5686     | 0.1028     | 1.7323     | 17.6865     | 1406       | KAMPAR Regency                   |
-| nan     | contents        | 1_716_786     | 87_143     | 0.0        | 0.0168     | 1_164_138   | 1407       | İMRANLI                          |
-| nan     | structural      | 9_661_124     | 1_085_580  | 6_802      | 51_726     | 8_481_427   | 1407       | İMRANLI                          |
-| nan     | occupants       | 42.1603       | 0.2669     | 2.430E-08  | 4.216E-07  | 1.9700      | 1407       | İMRANLI                          |
-| nan     | area            | 8_510         | 916.2      | 1.772E-06  | 8.510E-05  | 6_770       | 1407       | İMRANLI                          |
-| nan     | number          | 53.7693       | 5.8777     | 2.998E-09  | 5.377E-07  | 43.4389     | 1407       | İMRANLI                          |
-| nan     | residents       | 71.9104       | 9.0668     | 0.0        | 7.191E-07  | 62.8719     | 1407       | İMRANLI                          |
-| nan     | affectedpop     | 71.9104       | 11.1916    | 0.0        | 7.191E-07  | 67.0888     | 1407       | İMRANLI                          |
-| nan     | injured         | 42.1603       | 0.1580     | 2.430E-08  | 4.216E-07  | 1.1270      | 1407       | İMRANLI                          |
-| nan     | embodied_carbon | 2_711         | 361.5      | 1.6400     | 13.0419    | 2_480       | 1407       | İMRANLI                          |
-| nan     | contents        | 304_402       | 8_466      | 0.0        | 0.0030     | 5.8168      | 1408       | BENGKALIS Regency                |
-| nan     | structural      | 1_724_946     | 80_613     | 0.0        | 11_398     | 602_093     | 1408       | BENGKALIS Regency                |
-| nan     | occupants       | 13.4161       | 0.0039     | 0.0        | 1.342E-07  | 0.0180      | 1408       | BENGKALIS Regency                |
-| nan     | area            | 1_513         | 47.3383    | 0.0        | 1.513E-05  | 217.0       | 1408       | BENGKALIS Regency                |
-| nan     | number          | 10.9912       | 0.3439     | 0.0        | 1.099E-07  | 1.5764      | 1408       | BENGKALIS Regency                |
-| nan     | residents       | 24.2828       | 0.9210     | 0.0        | 2.428E-07  | 4.8203      | 1408       | BENGKALIS Regency                |
-| nan     | affectedpop     | 24.2828       | 1.2563     | 0.0        | 5.244E-04  | 7.7150      | 1408       | BENGKALIS Regency                |
-| nan     | injured         | 13.4161       | 0.0176     | 0.0        | 1.342E-07  | 0.0861      | 1408       | BENGKALIS Regency                |
-| nan     | embodied_carbon | 548.7         | 22.6286    | 0.0        | 3.7923     | 95.7838     | 1408       | BENGKALIS Regency                |
-| nan     | contents        | 170_072       | 1_537      | 0.0        | 0.0015     | 0.0017      | 1409       | İNCESU                           |
-| nan     | structural      | 937_112       | 31_005     | 277.8      | 17_028     | 81_336      | 1409       | İNCESU                           |
-| nan     | occupants       | 4.9603        | 5.991E-04  | 1.130E-08  | 4.960E-08  | 8.258E-04   | 1409       | İNCESU                           |
-| nan     | area            | 828.3         | 3.5637     | 6.230E-07  | 8.283E-06  | 1.5533      | 1409       | İNCESU                           |
-| nan     | number          | 5.2020        | 0.0225     | 2.871E-09  | 5.202E-08  | 0.0077      | 1409       | İNCESU                           |
-| nan     | residents       | 6.9320        | 0.0461     | 0.0        | 6.932E-08  | 0.0174      | 1409       | İNCESU                           |
-| nan     | affectedpop     | 6.9320        | 0.1118     | 0.0        | 6.932E-08  | 0.1479      | 1409       | İNCESU                           |
-| nan     | injured         | 4.9603        | 7.166E-04  | 1.130E-08  | 4.960E-08  | 0.0010      | 1409       | İNCESU                           |
-| nan     | embodied_carbon | 256.2         | 6.7932     | 0.1003     | 3.3663     | 18.0802     | 1409       | İNCESU                           |
-| nan     | contents        | 1_879_335     | 1_763      | 0.0        | 0.0063     | 1_800       | 1410       | İNEBOLU                          |
-| nan     | structural      | 10_649_564    | 284_991    | 4_306      | 214_507    | 775_928     | 1410       | İNEBOLU                          |
-| nan     | occupants       | 78.2888       | 3.727E-05  | 1.703E-07  | 7.829E-07  | 7.829E-07   | 1410       | İNEBOLU                          |
-| nan     | area            | 8_492         | 0.8072     | 2.500E-05  | 8.492E-05  | 0.2998      | 1410       | İNEBOLU                          |
-| nan     | number          | 21.1056       | 0.0041     | 5.066E-08  | 2.111E-07  | 2.535E-04   | 1410       | İNEBOLU                          |
-| nan     | residents       | 144.7892      | 0.0224     | 3.150E-07  | 1.448E-06  | 0.0347      | 1410       | İNEBOLU                          |
-| nan     | affectedpop     | 144.7892      | 0.1531     | 3.150E-07  | 1.448E-06  | 0.6744      | 1410       | İNEBOLU                          |
-| nan     | injured         | 78.2888       | 2.037E-04  | 1.703E-07  | 7.829E-07  | 7.829E-07   | 1410       | İNEBOLU                          |
-| nan     | embodied_carbon | 2_550         | 94.5797    | 0.9435     | 79.2260    | 222.4       | 1410       | İNEBOLU                          |
-| nan     | contents        | 579_231       | 13_032     | 0.0        | 0.0047     | 11_265      | 1411       | İNEGÖL                           |
-| nan     | structural      | 3_101_870     | 163_194    | 0.0        | 13_727     | 1_053_278   | 1411       | İNEGÖL                           |
-| nan     | occupants       | 8.8453        | 0.0035     | 0.0        | 7.692E-08  | 0.0307      | 1411       | İNEGÖL                           |
-| nan     | area            | 2_763         | 115.7031   | 0.0        | 2.341E-05  | 1_002       | 1411       | İNEGÖL                           |
-| nan     | number          | 17.9692       | 0.8405     | 0.0        | 1.701E-07  | 7.2777      | 1411       | İNEGÖL                           |
-| nan     | residents       | 13.9226       | 0.7598     | 0.0        | 1.392E-07  | 7.1771      | 1411       | İNEGÖL                           |
-| nan     | affectedpop     | 13.9226       | 0.9046     | 0.0        | 1.392E-07  | 9.1133      | 1411       | İNEGÖL                           |
-| nan     | injured         | 8.8453        | 0.0153     | 0.0        | 7.692E-08  | 0.1366      | 1411       | İNEGÖL                           |
-| nan     | embodied_carbon | 1_032         | 42.5314    | 0.0        | 4.6597     | 294.7       | 1411       | İNEGÖL                           |
-| nan     | contents        | 385_802       | 8_652      | 0.0        | 0.0023     | 443.4       | 1413       | İSKENDERUN                       |
-| nan     | structural      | 2_186_211     | 90_383     | 0.0        | 10_697     | 794_291     | 1413       | İSKENDERUN                       |
-| nan     | occupants       | 6.0832        | 0.0018     | 0.0        | 6.083E-08  | 0.0125      | 1413       | İSKENDERUN                       |
-| nan     | area            | 1_918         | 59.7955    | 0.0        | 1.918E-05  | 419.6       | 1413       | İSKENDERUN                       |
-| nan     | number          | 13.9304       | 0.4344     | 0.0        | 1.393E-07  | 3.0480      | 1413       | İSKENDERUN                       |
-| nan     | residents       | 11.0102       | 0.4075     | 0.0        | 1.101E-07  | 3.1288      | 1413       | İSKENDERUN                       |
-| nan     | affectedpop     | 11.0102       | 0.5329     | 0.0        | 1.101E-07  | 4.4731      | 1413       | İSKENDERUN                       |
-| nan     | injured         | 6.0832        | 0.0079     | 0.0        | 6.083E-08  | 0.0573      | 1413       | İSKENDERUN                       |
-| nan     | embodied_carbon | 678.1         | 32.4396    | 0.0        | 3.8828     | 212.2       | 1413       | İSKENDERUN                       |
-| nan     | contents        | 1_066_374     | 9_103      | 0.0        | 0.0097     | 93_823      | 1414       | İSKİLİP                          |
-| nan     | structural      | 6_042_787     | 145_061    | 29_463     | 114_683    | 419_096     | 1414       | İSKİLİP                          |
-| nan     | occupants       | 49.1475       | 0.0019     | 4.497E-07  | 4.915E-07  | 0.0103      | 1414       | İSKİLİP                          |
-| nan     | area            | 5_301         | 26.9937    | 4.673E-05  | 0.4736     | 139.7846    | 1414       | İSKİLİP                          |
-| nan     | number          | 8.1335        | 0.1614     | 4.779E-08  | 0.0025     | 0.9903      | 1414       | İSKİLİP                          |
-| nan     | residents       | 88.9532       | 0.4125     | 8.140E-07  | 0.0058     | 2.0024      | 1414       | İSKİLİP                          |
-| nan     | affectedpop     | 88.9532       | 0.5578     | 8.140E-07  | 0.0101     | 2.3592      | 1414       | İSKİLİP                          |
-| nan     | injured         | 49.1475       | 0.0080     | 4.497E-07  | 3.149E-06  | 0.0429      | 1414       | İSKİLİP                          |
-| nan     | embodied_carbon | 1_631         | 58.1174    | 16.5201    | 50.5060    | 151.4527    | 1414       | İSKİLİP                          |
-| nan     | contents        | 81_578        | 6.845E-04  | 0.0        | 8.158E-04  | 8.158E-04   | 1416       | İSPİR                            |
-| nan     | structural      | 462_278       | 11_181     | 0.0        | 3_340      | 56_187      | 1416       | İSPİR                            |
-| nan     | occupants       | 1.6666        | 2.932E-07  | 0.0        | 1.667E-08  | 1.667E-08   | 1416       | İSPİR                            |
-| nan     | area            | 311.9         | 0.0420     | 0.0        | 3.119E-06  | 3.119E-06   | 1416       | İSPİR                            |
-| nan     | number          | 2.0015        | 2.694E-04  | 0.0        | 2.001E-08  | 2.001E-08   | 1416       | İSPİR                            |
-| nan     | residents       | 3.0824        | 4.592E-04  | 0.0        | 3.082E-08  | 3.082E-08   | 1416       | İSPİR                            |
-| nan     | affectedpop     | 3.0824        | 0.0017     | 0.0        | 3.082E-08  | 5.458E-04   | 1416       | İSPİR                            |
-| nan     | injured         | 1.6666        | 6.759E-06  | 0.0        | 1.667E-08  | 1.667E-08   | 1416       | İSPİR                            |
-| nan     | embodied_carbon | 93.3620       | 2.2732     | 0.0        | 0.6545     | 11.8719     | 1416       | İSPİR                            |
-| nan     | contents        | 176_246       | 342.3      | 2.806E-22  | 0.0012     | 5.6178      | 1418       | İVRİNDİ                          |
-| nan     | structural      | 998_728       | 29_178     | 644.3      | 23_431     | 69_233      | 1418       | İVRİNDİ                          |
-| nan     | occupants       | 3.9811        | 4.707E-04  | 1.550E-08  | 3.981E-08  | 8.548E-04   | 1418       | İVRİNDİ                          |
-| nan     | area            | 796.4         | 2.9642     | 2.741E-06  | 7.964E-06  | 5.2240      | 1418       | İVRİNDİ                          |
-| nan     | number          | 5.0040        | 0.0212     | 1.991E-08  | 5.004E-08  | 0.0375      | 1418       | İVRİNDİ                          |
-| nan     | residents       | 7.3636        | 0.0411     | 2.867E-08  | 7.364E-08  | 0.1038      | 1418       | İVRİNDİ                          |
-| nan     | affectedpop     | 7.3636        | 0.0788     | 2.867E-08  | 7.364E-08  | 0.4095      | 1418       | İVRİNDİ                          |
-| nan     | injured         | 3.9811        | 6.618E-04  | 1.550E-08  | 3.981E-08  | 0.0013      | 1418       | İVRİNDİ                          |
-| nan     | embodied_carbon | 238.6         | 5.7576     | 0.4811     | 4.4225     | 12.9966     | 1418       | İVRİNDİ                          |
-| nan     | contents        | 482_157       | 1_876      | 0.0        | 0.0041     | 19.9398     | 1419       | Torres Novas                     |
-| nan     | structural      | 2_732_221     | 23_850     | 0.0        | 7_471      | 105_537     | 1419       | Torres Novas                     |
-| nan     | occupants       | 9.7031        | 5.358E-04  | 0.0        | 9.703E-08  | 0.0028      | 1419       | Torres Novas                     |
-| nan     | area            | 2_179         | 7.3469     | 0.0        | 2.179E-05  | 38.2807     | 1419       | Torres Novas                     |
-| nan     | number          | 13.4592       | 0.0353     | 0.0        | 1.346E-07  | 0.1838      | 1419       | Torres Novas                     |
-| nan     | residents       | 17.9465       | 0.1067     | 0.0        | 1.795E-07  | 0.5886      | 1419       | Torres Novas                     |
-| nan     | affectedpop     | 17.9465       | 0.1406     | 0.0        | 1.795E-07  | 0.8888      | 1419       | Torres Novas                     |
-| nan     | injured         | 9.7031        | 0.0021     | 0.0        | 9.703E-08  | 0.0111      | 1419       | Torres Novas                     |
-| nan     | embodied_carbon | 672.6         | 10.2525    | 0.0        | 4.3038     | 48.4490     | 1419       | Torres Novas                     |
-| nan     | contents        | 1_881_476     | 36_991     | 0.0014     | 0.0160     | 158_121     | 1421       | KADIKÖY                          |
-| nan     | structural      | 10_578_802    | 641_875    | 1_618      | 49_517     | 4_415_322   | 1421       | KADIKÖY                          |
-| nan     | occupants       | 37.8025       | 0.0380     | 3.894E-08  | 3.780E-07  | 0.2268      | 1421       | KADIKÖY                          |
-| nan     | area            | 9_299         | 405.6      | 6.982E-06  | 1.6205     | 2_775       | 1421       | KADIKÖY                          |
-| nan     | number          | 59.9063       | 2.6219     | 4.949E-08  | 0.0118     | 17.8030     | 1421       | KADIKÖY                          |
-| nan     | residents       | 62.9429       | 3.1617     | 7.048E-08  | 0.0172     | 18.5465     | 1421       | KADIKÖY                          |
-| nan     | affectedpop     | 62.9429       | 4.0979     | 7.048E-08  | 0.0447     | 22.4979     | 1421       | KADIKÖY                          |
-| nan     | injured         | 37.8025       | 0.0556     | 3.894E-08  | 2.921E-04  | 0.3212      | 1421       | KADIKÖY                          |
-| nan     | embodied_carbon | 2_990         | 182.9      | 0.4194     | 13.5228    | 1_202       | 1421       | KADIKÖY                          |
-| nan     | contents        | 19_986_150    | 316_747    | 0.0        | 0.0038     | 1_481_731   | 1502       | MERANGIN Regency                 |
-| nan     | structural      | 38_546_808    | 3_891_762  | 874_297    | 3_455_463  | 8_483_318   | 1502       | MERANGIN Regency                 |
-| nan     | occupants       | 62.0331       | 0.0063     | 5.128E-07  | 6.203E-07  | 0.0455      | 1502       | MERANGIN Regency                 |
-| nan     | area            | 55_111        | 156.4996   | 5.325E-04  | 5.511E-04  | 1_041       | 1502       | MERANGIN Regency                 |
-| nan     | number          | 102.7684      | 0.9469     | 9.080E-07  | 1.028E-06  | 6.6354      | 1502       | MERANGIN Regency                 |
-| nan     | residents       | 19.4629       | 1.7219     | 0.0        | 1.946E-07  | 12.2937     | 1502       | MERANGIN Regency                 |
-| nan     | affectedpop     | 19.4629       | 2.2041     | 0.0        | 1.134E-05  | 14.5764     | 1502       | MERANGIN Regency                 |
-| nan     | injured         | 62.0331       | 0.0305     | 5.128E-07  | 6.203E-07  | 0.2139      | 1502       | MERANGIN Regency                 |
-| nan     | embodied_carbon | 15_033        | 1_371      | 290.3      | 1_154      | 3_161       | 1502       | MERANGIN Regency                 |
-| nan     | contents        | 2_777_515     | 59_028     | 0.0        | 0.0270     | 818_544     | 1503       | SAROLANGUN Regency               |
-| nan     | structural      | 15_616_754    | 998_823    | 0.0        | 328_961    | 6_251_832   | 1503       | SAROLANGUN Regency               |
-| nan     | occupants       | 102.3050      | 0.0265     | 0.0        | 1.023E-06  | 0.2085      | 1503       | SAROLANGUN Regency               |
-| nan     | area            | 10_574        | 313.3      | 0.0        | 0.2039     | 2_458       | 1503       | SAROLANGUN Regency               |
-| nan     | number          | 76.1845       | 2.2749     | 0.0        | 0.0015     | 17.8559     | 1503       | SAROLANGUN Regency               |
-| nan     | residents       | 173.7858      | 6.0235     | 0.0        | 0.0038     | 44.7506     | 1503       | SAROLANGUN Regency               |
-| nan     | affectedpop     | 173.7858      | 7.4444     | 0.0        | 0.0148     | 49.0301     | 1503       | SAROLANGUN Regency               |
-| nan     | injured         | 102.3050      | 0.1163     | 0.0        | 1.023E-06  | 0.8892      | 1503       | SAROLANGUN Regency               |
-| nan     | embodied_carbon | 3_261         | 209.6      | 0.0        | 62.1328    | 1_243       | 1503       | SAROLANGUN Regency               |
-| nan     | contents        | 190_336       | 12_339     | 0.0        | 2.418E-09  | 102_240     | 1504       | BATANG HARI Regency              |
-| nan     | structural      | 761_343       | 78_987     | 30_773     | 72_789     | 179_684     | 1504       | BATANG HARI Regency              |
-| nan     | occupants       | 20.5970       | 0.0011     | 2.060E-07  | 2.060E-07  | 0.0050      | 1504       | BATANG HARI Regency              |
-| nan     | area            | 556.5         | 1.3637     | 5.565E-06  | 5.565E-06  | 6.0500      | 1504       | BATANG HARI Regency              |
-| nan     | number          | 1.1622        | 0.0028     | 1.162E-08  | 1.162E-08  | 0.0126      | 1504       | BATANG HARI Regency              |
-| nan     | injured         | 20.5970       | 0.0023     | 2.060E-07  | 2.060E-07  | 0.0104      | 1504       | BATANG HARI Regency              |
-| nan     | embodied_carbon | 261.5         | 22.5937    | 8.8727     | 20.4315    | 52.3037     | 1504       | BATANG HARI Regency              |
-| nan     | contents        | 31_479        | 33.5354    | 0.0        | 3.148E-04  | 3.148E-04   | 1505       | MUARO JAMBI Regency              |
-| nan     | structural      | 178_381       | 2_040      | 0.0        | 448.3      | 11_357      | 1505       | MUARO JAMBI Regency              |
-| nan     | occupants       | 0.8543        | 5.639E-07  | 0.0        | 8.543E-09  | 8.543E-09   | 1505       | MUARO JAMBI Regency              |
-| nan     | area            | 156.4746      | 0.0259     | 0.0        | 1.565E-06  | 1.565E-06   | 1505       | MUARO JAMBI Regency              |
-| nan     | number          | 1.0040        | 1.663E-04  | 0.0        | 1.004E-08  | 1.004E-08   | 1505       | MUARO JAMBI Regency              |
-| nan     | residents       | 1.5462        | 2.629E-04  | 0.0        | 1.546E-08  | 1.546E-08   | 1505       | MUARO JAMBI Regency              |
-| nan     | affectedpop     | 1.5462        | 2.995E-04  | 0.0        | 1.546E-08  | 1.546E-08   | 1505       | MUARO JAMBI Regency              |
-| nan     | injured         | 0.8543        | 4.850E-06  | 0.0        | 8.543E-09  | 8.543E-09   | 1505       | MUARO JAMBI Regency              |
-| nan     | embodied_carbon | 46.8352       | 1.0984     | 0.0        | 0.3508     | 5.6066      | 1505       | MUARO JAMBI Regency              |
-| nan     | contents        | 53_858        | 3_917      | 0.0        | 5.386E-04  | 43_840      | 1506       | TANJUNG JABUNG TIMUR Regency     |
-| nan     | structural      | 215_433       | 23_321     | 0.0        | 4_344      | 139_542     | 1506       | TANJUNG JABUNG TIMUR Regency     |
-| nan     | occupants       | 5.1856        | 0.0029     | 0.0        | 5.186E-08  | 0.0197      | 1506       | TANJUNG JABUNG TIMUR Regency     |
-| nan     | area            | 157.4799      | 11.8524    | 0.0        | 1.575E-06  | 78.2298     | 1506       | TANJUNG JABUNG TIMUR Regency     |
-| nan     | number          | 2.1014        | 0.1582     | 0.0        | 2.101E-08  | 1.0439      | 1506       | TANJUNG JABUNG TIMUR Regency     |
-| nan     | injured         | 5.1856        | 0.0142     | 0.0        | 5.186E-08  | 0.0934      | 1506       | TANJUNG JABUNG TIMUR Regency     |
-| nan     | embodied_carbon | 81.3410       | 8.7353     | 0.0        | 1.4611     | 45.8167     | 1506       | TANJUNG JABUNG TIMUR Regency     |
-| nan     | contents        | 433_754       | 950.4      | 0.0        | 0.0043     | 497.9       | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | structural      | 2_457_940     | 164_736    | 0.0        | 118_556    | 347_237     | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | occupants       | 17.3282       | 0.0014     | 0.0        | 1.733E-07  | 1.733E-07   | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | area            | 1_659         | 13.0456    | 0.0        | 1.659E-05  | 7.3559      | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | number          | 7.9635        | 0.0626     | 0.0        | 7.964E-08  | 0.0353      | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | residents       | 32.0476       | 0.3482     | 0.0        | 3.205E-07  | 0.1422      | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | affectedpop     | 32.0476       | 0.6045     | 0.0        | 3.205E-07  | 0.7770      | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | injured         | 17.3282       | 0.0055     | 0.0        | 1.733E-07  | 0.0032      | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | embodied_carbon | 497.3         | 27.6858    | 0.0        | 18.6169    | 63.9222     | 1507       | TANJUNG JABUNG BARAT Regency     |
-| nan     | contents        | 13_420_574    | 1_341      | 0.1312     | 0.1339     | 5_268       | 1508       | TEBO Regency                     |
-| nan     | structural      | 41_028_040    | 3_454_193  | 730_512    | 2_580_662  | 8_151_540   | 1508       | TEBO Regency                     |
-| nan     | occupants       | 50.7205       | 6.728E-04  | 3.838E-07  | 5.072E-07  | 5.072E-07   | 1508       | TEBO Regency                     |
-| nan     | area            | 50_667        | 14.0979    | 4.952E-04  | 5.067E-04  | 2.7942      | 1508       | TEBO Regency                     |
-| nan     | number          | 91.6139       | 0.0397     | 8.543E-07  | 9.161E-07  | 0.0135      | 1508       | TEBO Regency                     |
-| nan     | residents       | 22.8175       | 0.1260     | 6.348E-08  | 2.282E-07  | 0.0492      | 1508       | TEBO Regency                     |
-| nan     | affectedpop     | 22.8175       | 0.2387     | 6.348E-08  | 2.282E-07  | 0.2388      | 1508       | TEBO Regency                     |
-| nan     | injured         | 50.7205       | 0.0023     | 3.838E-07  | 5.072E-07  | 9.166E-04   | 1508       | TEBO Regency                     |
-| nan     | embodied_carbon | 20_295        | 1_563      | 260.5      | 1_118      | 3_738       | 1508       | TEBO Regency                     |
-| nan     | contents        | 4_355_949     | 14_411     | 0.0        | 0.0387     | 13_659      | 1510       | MALAZGİRT                        |
-| nan     | structural      | 23_871_168    | 1_317_054  | 0.0        | 1_051_930  | 3_843_867   | 1510       | MALAZGİRT                        |
-| nan     | occupants       | 224.6         | 0.0035     | 0.0        | 1.772E-06  | 0.0080      | 1510       | MALAZGİRT                        |
-| nan     | area            | 16_217        | 30.4203    | 0.0        | 1.479E-04  | 115.8792    | 1510       | MALAZGİRT                        |
-| nan     | number          | 75.0435       | 0.1461     | 0.0        | 7.102E-07  | 0.5564      | 1510       | MALAZGİRT                        |
-| nan     | residents       | 327.7         | 0.8265     | 0.0        | 3.277E-06  | 2.7891      | 1510       | MALAZGİRT                        |
-| nan     | affectedpop     | 327.7         | 2.4115     | 0.0        | 3.277E-06  | 15.9615     | 1510       | MALAZGİRT                        |
-| nan     | injured         | 224.6         | 0.0142     | 0.0        | 1.772E-06  | 0.0576      | 1510       | MALAZGİRT                        |
-| nan     | embodied_carbon | 5_052         | 206.3      | 0.0        | 154.9494   | 618.7       | 1510       | MALAZGİRT                        |
-| nan     | contents        | 2_147_131     | 1_098      | 0.0        | 0.0028     | 4_578       | 1511       | MALKARA                          |
-| nan     | structural      | 12_167_076    | 645_893    | 258_263    | 575_821    | 1_126_820   | 1511       | MALKARA                          |
-| nan     | occupants       | 109.0583      | 8.003E-04  | 9.952E-07  | 1.091E-06  | 1.091E-06   | 1511       | MALKARA                          |
-| nan     | area            | 9_703         | 7.8061     | 8.455E-05  | 9.703E-05  | 17.6904     | 1511       | MALKARA                          |
-| nan     | number          | 18.9029       | 0.0178     | 1.291E-07  | 1.890E-07  | 0.0435      | 1511       | MALKARA                          |
-| nan     | residents       | 201.7         | 0.2280     | 1.840E-06  | 2.017E-06  | 0.3250      | 1511       | MALKARA                          |
-| nan     | affectedpop     | 201.7         | 0.6213     | 1.840E-06  | 2.017E-06  | 1.7996      | 1511       | MALKARA                          |
-| nan     | injured         | 109.0583      | 0.0027     | 9.952E-07  | 1.091E-06  | 0.0024      | 1511       | MALKARA                          |
-| nan     | embodied_carbon | 2_911         | 114.5275   | 43.1009    | 100.2341   | 209.6       | 1511       | MALKARA                          |
-| nan     | contents        | 1_402_109     | 31_213     | 5.234E-18  | 0.0011     | 11_826      | 1512       | MANAVGAT                         |
-| nan     | structural      | 7_827_816     | 537_951    | 3_957      | 276_943    | 1_572_848   | 1512       | MANAVGAT                         |
-| nan     | occupants       | 75.0667       | 0.0307     | 3.560E-08  | 4.390E-07  | 0.0840      | 1512       | MANAVGAT                         |
-| nan     | area            | 5_298         | 120.9107   | 4.129E-06  | 0.2406     | 328.5       | 1512       | MANAVGAT                         |
-| nan     | number          | 37.9939       | 0.8783     | 2.999E-08  | 0.0017     | 2.3862      | 1512       | MANAVGAT                         |
-| nan     | residents       | 81.1916       | 2.5159     | 6.584E-08  | 0.0040     | 9.0661      | 1512       | MANAVGAT                         |
-| nan     | affectedpop     | 81.1916       | 4.7738     | 6.584E-08  | 0.0144     | 24.5055     | 1512       | MANAVGAT                         |
-| nan     | injured         | 75.0667       | 0.0423     | 3.560E-08  | 4.390E-07  | 0.1181      | 1512       | MANAVGAT                         |
-| nan     | embodied_carbon | 1_614         | 89.1517    | 1.8077     | 39.8170    | 296.5       | 1512       | MANAVGAT                         |
-| nan     | contents        | 29_444        | 307.8      | 0.0        | 2.944E-04  | 0.0012      | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | structural      | 166_848       | 5_259      | 0.0        | 175.0700   | 43_095      | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | occupants       | 0.5743        | 1.697E-04  | 0.0        | 5.743E-09  | 0.0012      | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | area            | 146.3577      | 4.0029     | 0.0        | 1.464E-06  | 29.1249     | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | number          | 0.7027        | 0.0192     | 0.0        | 7.027E-09  | 0.1398      | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | residents       | 1.0388        | 0.0322     | 0.0        | 1.039E-08  | 0.2503      | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | affectedpop     | 1.0388        | 0.0405     | 0.0        | 1.039E-08  | 0.3537      | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | injured         | 0.5743        | 6.430E-04  | 0.0        | 5.743E-09  | 0.0048      | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | embodied_carbon | 53.1079       | 1.5782     | 0.0        | 0.0573     | 12.4151     | 1601       | OGAN KOMERING ULU Regency        |
-| nan     | contents        | 52_522        | 91.2615    | 0.0        | 2.997E-04  | 6.236E-04   | 1602       | SARIKAYA                         |
-| nan     | structural      | 297_623       | 3_700      | 0.0        | 745.6      | 12_680      | 1602       | SARIKAYA                         |
-| nan     | occupants       | 1.4100        | 6.661E-05  | 0.0        | 8.502E-09  | 1.410E-08   | 1602       | SARIKAYA                         |
-| nan     | area            | 261.1         | 1.5992     | 0.0        | 1.490E-06  | 1.4767      | 1602       | SARIKAYA                         |
-| nan     | number          | 1.7702        | 0.0103     | 0.0        | 9.559E-09  | 0.0100      | 1602       | SARIKAYA                         |
-| nan     | residents       | 2.5542        | 0.0195     | 0.0        | 1.539E-08  | 0.0290      | 1602       | SARIKAYA                         |
-| nan     | affectedpop     | 2.5542        | 0.0279     | 0.0        | 1.539E-08  | 0.1203      | 1602       | SARIKAYA                         |
-| nan     | injured         | 1.4100        | 3.317E-04  | 0.0        | 8.502E-09  | 3.106E-04   | 1602       | SARIKAYA                         |
-| nan     | embodied_carbon | 89.8284       | 1.1506     | 0.0        | 0.2604     | 2.8147      | 1602       | SARIKAYA                         |
-| nan     | contents        | 506_161       | 3_092      | 0.0        | 0.0051     | 0.0051      | 1603       | MUARA ENIM Regency               |
-| nan     | structural      | 2_809_736     | 70_422     | 0.0        | 10_311     | 282_812     | 1603       | MUARA ENIM Regency               |
-| nan     | occupants       | 3.6124        | 4.782E-04  | 0.0        | 3.612E-08  | 0.0025      | 1603       | MUARA ENIM Regency               |
-| nan     | area            | 2_478         | 36.5365    | 0.0        | 2.478E-05  | 177.9286    | 1603       | MUARA ENIM Regency               |
-| nan     | number          | 18.8350       | 0.2739     | 0.0        | 1.884E-07  | 1.3182      | 1603       | MUARA ENIM Regency               |
-| nan     | residents       | 6.4192        | 0.1202     | 0.0        | 6.419E-08  | 0.7020      | 1603       | MUARA ENIM Regency               |
-| nan     | affectedpop     | 6.4192        | 0.1809     | 0.0        | 6.419E-08  | 1.2647      | 1603       | MUARA ENIM Regency               |
-| nan     | injured         | 3.6124        | 0.0023     | 0.0        | 3.612E-08  | 0.0124      | 1603       | MUARA ENIM Regency               |
-| nan     | embodied_carbon | 919.7         | 22.3458    | 0.0        | 3.5525     | 103.1910    | 1603       | MUARA ENIM Regency               |
-| nan     | contents        | 214_833       | 2_953      | 0.0        | 2.772E-04  | 18_583      | 1604       | LAHAT Regency                    |
-| nan     | structural      | 905_530       | 41_032     | 0.0        | 27_898     | 147_117     | 1604       | LAHAT Regency                    |
-| nan     | occupants       | 7.4510        | 1.101E-06  | 0.0        | 1.131E-08  | 1.131E-08   | 1604       | LAHAT Regency                    |
-| nan     | area            | 936.7         | 0.0513     | 0.0        | 7.627E-06  | 7.627E-06   | 1604       | LAHAT Regency                    |
-| nan     | number          | 4.2781        | 3.241E-04  | 0.0        | 3.881E-08  | 3.881E-08   | 1604       | LAHAT Regency                    |
-| nan     | residents       | 1.0220        | 2.798E-04  | 0.0        | 1.022E-08  | 1.022E-08   | 1604       | LAHAT Regency                    |
-| nan     | affectedpop     | 1.0220        | 6.042E-04  | 0.0        | 1.022E-08  | 1.022E-08   | 1604       | LAHAT Regency                    |
-| nan     | injured         | 7.4510        | 5.810E-06  | 0.0        | 1.131E-08  | 1.131E-08   | 1604       | LAHAT Regency                    |
-| nan     | embodied_carbon | 387.3         | 15.4578    | 0.0        | 10.4101    | 56.7961     | 1604       | LAHAT Regency                    |
-| nan     | contents        | 124_357       | 1_419      | 0.0        | 0.0        | 1_019       | 1605       | MUSI RAWAS Regency               |
-| nan     | structural      | 497_427       | 27_942     | 0.0        | 21_690     | 110_190     | 1605       | MUSI RAWAS Regency               |
-| nan     | occupants       | 0.6169        | 4.159E-09  | 0.0        | 6.169E-09  | 6.169E-09   | 1605       | MUSI RAWAS Regency               |
-| nan     | area            | 545.4         | 0.4850     | 0.0        | 5.454E-06  | 5.454E-06   | 1605       | MUSI RAWAS Regency               |
-| nan     | number          | 2.5135        | 0.0022     | 0.0        | 2.513E-08  | 2.513E-08   | 1605       | MUSI RAWAS Regency               |
-| nan     | injured         | 0.6169        | 1.688E-05  | 0.0        | 6.169E-09  | 6.169E-09   | 1605       | MUSI RAWAS Regency               |
-| nan     | embodied_carbon | 236.1         | 10.7381    | 0.0        | 8.0243     | 44.7752     | 1605       | MUSI RAWAS Regency               |
-| nan     | contents        | 130_703       | 969.3      | 0.0        | 6.100E-04  | 766.3       | 1606       | MUSI BANYUASIN Regency           |
-| nan     | structural      | 624_472       | 28_475     | 0.0        | 12_550     | 74_199      | 1606       | MUSI BANYUASIN Regency           |
-| nan     | occupants       | 2.4443        | 3.713E-04  | 0.0        | 2.444E-08  | 2.444E-08   | 1606       | MUSI BANYUASIN Regency           |
-| nan     | area            | 608.9         | 2.5476     | 0.0        | 6.089E-06  | 0.5222      | 1606       | MUSI BANYUASIN Regency           |
-| nan     | number          | 3.3544        | 0.0163     | 0.0        | 3.354E-08  | 0.0034      | 1606       | MUSI BANYUASIN Regency           |
-| nan     | residents       | 2.7815        | 0.0259     | 0.0        | 2.782E-08  | 0.0040      | 1606       | MUSI BANYUASIN Regency           |
-| nan     | affectedpop     | 2.7815        | 0.0375     | 0.0        | 2.782E-08  | 0.0375      | 1606       | MUSI BANYUASIN Regency           |
-| nan     | injured         | 2.4443        | 4.393E-04  | 0.0        | 2.444E-08  | 9.646E-06   | 1606       | MUSI BANYUASIN Regency           |
-| nan     | embodied_carbon | 223.1         | 9.7632     | 0.0        | 4.3909     | 29.3855     | 1606       | MUSI BANYUASIN Regency           |
-| nan     | contents        | 705_219       | 10_130     | 0.0        | 0.0053     | 47.9281     | 1607       | BANYU ASIN Regency               |
-| nan     | structural      | 3_711_284     | 146_031    | 0.0        | 10_494     | 538_362     | 1607       | BANYU ASIN Regency               |
-| nan     | occupants       | 24.4252       | 0.0020     | 0.0        | 5.885E-08  | 0.0100      | 1607       | BANYU ASIN Regency               |
-| nan     | area            | 3_322         | 96.7087    | 0.0        | 2.656E-05  | 481.9       | 1607       | BANYU ASIN Regency               |
-| nan     | number          | 20.8127       | 0.7025     | 0.0        | 1.929E-07  | 3.5002      | 1607       | BANYU ASIN Regency               |
-| nan     | residents       | 10.6531       | 0.4591     | 0.0        | 1.065E-07  | 2.5867      | 1607       | BANYU ASIN Regency               |
-| nan     | affectedpop     | 10.6531       | 0.6112     | 0.0        | 1.065E-07  | 3.9158      | 1607       | BANYU ASIN Regency               |
-| nan     | injured         | 24.4252       | 0.0089     | 0.0        | 5.885E-08  | 0.0468      | 1607       | BANYU ASIN Regency               |
-| nan     | embodied_carbon | 1_137         | 39.4685    | 0.0        | 3.0422     | 101.1036    | 1607       | BANYU ASIN Regency               |
-| nan     | contents        | 109_282       | 1_818      | 0.0        | 0.0011     | 0.0011      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | structural      | 619_266       | 14_210     | 0.0        | 856.5      | 53_071      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | occupants       | 2.9945        | 0.0037     | 0.0        | 2.994E-08  | 0.0111      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | area            | 543.2         | 8.9485     | 0.0        | 5.432E-06  | 26.9335     | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | number          | 3.9459        | 0.0650     | 0.0        | 3.946E-08  | 0.1956      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | residents       | 5.4186        | 0.1034     | 0.0        | 5.419E-08  | 0.3628      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | affectedpop     | 5.4186        | 0.1345     | 0.0        | 5.419E-08  | 0.6656      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | injured         | 2.9945        | 0.0020     | 0.0        | 2.994E-08  | 0.0068      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | embodied_carbon | 173.4097      | 3.8282     | 0.0        | 0.2195     | 13.9996     | 1608       | OGAN KOMERING ULU SELATAN Regenc |
-| nan     | contents        | 4_278_704     | 19_487     | 0.0        | 0.0408     | 97_554      | 1609       | SAVUR                            |
-| nan     | structural      | 24_116_548    | 946_737    | 0.0        | 797_435    | 2_353_688   | 1609       | SAVUR                            |
-| nan     | occupants       | 136.7498      | 0.0079     | 0.0        | 1.367E-06  | 0.0503      | 1609       | SAVUR                            |
-| nan     | area            | 16_290        | 77.5491    | 0.0        | 1.629E-04  | 377.5       | 1609       | SAVUR                            |
-| nan     | number          | 76.7309       | 0.2876     | 0.0        | 7.673E-07  | 0.5938      | 1609       | SAVUR                            |
-| nan     | residents       | 250.8         | 1.6728     | 0.0        | 2.508E-06  | 8.1945      | 1609       | SAVUR                            |
-| nan     | affectedpop     | 250.8         | 2.7134     | 0.0        | 2.508E-06  | 8.7808      | 1609       | SAVUR                            |
-| nan     | injured         | 136.7498      | 0.0288     | 0.0        | 1.367E-06  | 0.1644      | 1609       | SAVUR                            |
-| nan     | embodied_carbon | 4_963         | 148.2356   | 0.0        | 121.4330   | 396.4       | 1609       | SAVUR                            |
-| nan     | contents        | 84_946        | 21.2485    | 0.0        | 8.495E-04  | 8.495E-04   | 1610       | SEBEN                            |
-| nan     | structural      | 339_783       | 12_565     | 0.0        | 9_657      | 41_991      | 1610       | SEBEN                            |
-| nan     | occupants       | 8.8376        | 5.756E-08  | 0.0        | 8.838E-08  | 8.838E-08   | 1610       | SEBEN                            |
-| nan     | area            | 331.2         | 2.030E-04  | 0.0        | 3.312E-06  | 3.312E-06   | 1610       | SEBEN                            |
-| nan     | number          | 1.5261        | 9.354E-07  | 0.0        | 1.526E-08  | 1.526E-08   | 1610       | SEBEN                            |
-| nan     | injured         | 8.8376        | 2.297E-07  | 0.0        | 8.838E-08  | 8.838E-08   | 1610       | SEBEN                            |
-| nan     | embodied_carbon | 155.1623      | 4.8306     | 0.0        | 3.7558     | 15.8891     | 1610       | SEBEN                            |
-| nan     | contents        | 16_977        | 610.0      | 0.0        | 1.698E-04  | 76.4966     | 1701       | BENGKULU SELATAN Regency         |
-| nan     | structural      | 96_201        | 5_933      | 0.0        | 202.1      | 53_706      | 1701       | BENGKULU SELATAN Regency         |
-| nan     | occupants       | 0.3237        | 9.785E-04  | 0.0        | 3.237E-09  | 0.0065      | 1701       | BENGKULU SELATAN Regency         |
-| nan     | area            | 84.3871       | 4.1755     | 0.0        | 8.439E-07  | 27.4905     | 1701       | BENGKULU SELATAN Regency         |
-| nan     | number          | 0.5415        | 0.0268     | 0.0        | 5.415E-09  | 0.1764      | 1701       | BENGKULU SELATAN Regency         |
-| nan     | residents       | 0.5824        | 0.0328     | 0.0        | 5.824E-09  | 0.2418      | 1701       | BENGKULU SELATAN Regency         |
-| nan     | affectedpop     | 0.5824        | 0.0408     | 0.0        | 5.824E-09  | 0.3331      | 1701       | BENGKULU SELATAN Regency         |
-| nan     | injured         | 0.3237        | 5.774E-04  | 0.0        | 3.237E-09  | 0.0040      | 1701       | BENGKULU SELATAN Regency         |
-| nan     | embodied_carbon | 26.9248       | 1.5071     | 0.0        | 0.0471     | 13.1093     | 1701       | BENGKULU SELATAN Regency         |
-| nan     | contents        | 287_937       | 4_859      | 0.0        | 0.0029     | 24_839      | 1703       | BENGKULU UTARA Regency           |
-| nan     | structural      | 1_424_670     | 43_650     | 0.0        | 9_002      | 141_433     | 1703       | BENGKULU UTARA Regency           |
-| nan     | occupants       | 13.7688       | 0.0014     | 0.0        | 1.377E-07  | 0.0020      | 1703       | BENGKULU UTARA Regency           |
-| nan     | area            | 1_176         | 15.4723    | 0.0        | 1.176E-05  | 34.9837     | 1703       | BENGKULU UTARA Regency           |
-| nan     | number          | 7.0740        | 0.1039     | 0.0        | 7.074E-08  | 0.2441      | 1703       | BENGKULU UTARA Regency           |
-| nan     | residents       | 7.2415        | 0.1734     | 0.0        | 7.241E-08  | 0.5956      | 1703       | BENGKULU UTARA Regency           |
-| nan     | affectedpop     | 7.2415        | 0.2234     | 0.0        | 7.241E-08  | 1.0816      | 1703       | BENGKULU UTARA Regency           |
-| nan     | injured         | 13.7688       | 0.0040     | 0.0        | 1.377E-07  | 0.0101      | 1703       | BENGKULU UTARA Regency           |
-| nan     | embodied_carbon | 426.2         | 13.3140    | 0.0        | 3.6200     | 40.0108     | 1703       | BENGKULU UTARA Regency           |
-| nan     | contents        | 24_764        | 190.1      | 0.0        | 0.0        | 709.1       | 1704       | KAUR Regency                     |
-| nan     | structural      | 99_055        | 5_973      | 0.0        | 4_695      | 21_243      | 1704       | KAUR Regency                     |
-| nan     | occupants       | 0.9990        | 7.254E-09  | 0.0        | 9.990E-09  | 9.990E-09   | 1704       | KAUR Regency                     |
-| nan     | area            | 108.6128      | 0.0175     | 0.0        | 1.086E-06  | 1.086E-06   | 1704       | KAUR Regency                     |
-| nan     | number          | 0.5005        | 8.065E-05  | 0.0        | 5.005E-09  | 5.005E-09   | 1704       | KAUR Regency                     |
-| nan     | injured         | 0.9990        | 5.635E-06  | 0.0        | 9.990E-09  | 9.990E-09   | 1704       | KAUR Regency                     |
-| nan     | embodied_carbon | 47.0161       | 2.3192     | 0.0        | 1.6279     | 8.0392      | 1704       | KAUR Regency                     |
-| nan     | contents        | 145_450       | 4_844      | 0.0        | 6.263E-04  | 1_162       | 1706       | ÜNYE                             |
-| nan     | structural      | 824_217       | 67_200     | 0.0        | 2_087      | 545_112     | 1706       | ÜNYE                             |
-| nan     | occupants       | 2.4255        | 0.0015     | 0.0        | 2.425E-08  | 0.0126      | 1706       | ÜNYE                             |
-| nan     | area            | 723.0         | 49.0603    | 0.0        | 7.230E-06  | 424.2       | 1706       | ÜNYE                             |
-| nan     | number          | 4.9881        | 0.3402     | 0.0        | 4.988E-08  | 2.9394      | 1706       | ÜNYE                             |
-| nan     | residents       | 4.3897        | 0.3428     | 0.0        | 4.390E-08  | 2.9583      | 1706       | ÜNYE                             |
-| nan     | affectedpop     | 4.3897        | 0.4187     | 0.0        | 4.390E-08  | 3.4588      | 1706       | ÜNYE                             |
-| nan     | injured         | 2.4255        | 0.0065     | 0.0        | 2.425E-08  | 0.0560      | 1706       | ÜNYE                             |
-| nan     | embodied_carbon | 244.2         | 20.7402    | 0.0        | 0.6119     | 168.4662    | 1706       | ÜNYE                             |
-| nan     | contents        | 589_665       | 17_433     | 0.0        | 0.0058     | 781.0       | 1708       | ÜSKÜDAR                          |
-| nan     | structural      | 3_150_370     | 149_965    | 0.0        | 14_810     | 822_316     | 1708       | ÜSKÜDAR                          |
-| nan     | occupants       | 24.0649       | 0.0045     | 0.0        | 2.406E-07  | 0.0279      | 1708       | ÜSKÜDAR                          |
-| nan     | area            | 2_549         | 96.3709    | 0.0        | 2.549E-05  | 594.8       | 1708       | ÜSKÜDAR                          |
-| nan     | number          | 17.5603       | 0.6998     | 0.0        | 1.756E-07  | 4.3207      | 1708       | ÜSKÜDAR                          |
-| nan     | residents       | 19.8870       | 1.0487     | 0.0        | 1.989E-07  | 6.9975      | 1708       | ÜSKÜDAR                          |
-| nan     | affectedpop     | 19.8870       | 1.3523     | 0.0        | 1.989E-07  | 9.6571      | 1708       | ÜSKÜDAR                          |
-| nan     | injured         | 24.0649       | 0.0202     | 0.0        | 2.406E-07  | 0.1271      | 1708       | ÜSKÜDAR                          |
-| nan     | embodied_carbon | 948.6         | 53.7372    | 0.0        | 6.4077     | 293.5       | 1708       | ÜSKÜDAR                          |
-| nan     | contents        | 352_739       | 1_020      | 0.0        | 0.0        | 0.0406      | 1710       | Sabrosa                          |
-| nan     | structural      | 1_410_955     | 42_653     | 0.0        | 34_582     | 158_845     | 1710       | Sabrosa                          |
-| nan     | occupants       | 30.9800       | 3.292E-07  | 0.0        | 3.098E-07  | 3.098E-07   | 1710       | Sabrosa                          |
-| nan     | area            | 1_375         | 0.1897     | 0.0        | 1.375E-05  | 1.375E-05   | 1710       | Sabrosa                          |
-| nan     | number          | 2.0098        | 2.772E-04  | 0.0        | 2.010E-08  | 2.010E-08   | 1710       | Sabrosa                          |
-| nan     | injured         | 30.9800       | 1.399E-04  | 0.0        | 3.098E-07  | 3.098E-07   | 1710       | Sabrosa                          |
-| nan     | embodied_carbon | 647.5         | 22.6612    | 0.0        | 19.5195    | 75.1990     | 1710       | Sabrosa                          |
-| nan     | contents        | 31_691        | 1_267      | 0.0        | 3.169E-04  | 59.4178     | 1711       | Santa Marta de Penaguião         |
-| nan     | structural      | 179_580       | 16_214     | 0.0        | 384.5      | 112_878     | 1711       | Santa Marta de Penaguião         |
-| nan     | occupants       | 0.6481        | 0.0032     | 0.0        | 6.481E-09  | 0.0241      | 1711       | Santa Marta de Penaguião         |
-| nan     | area            | 157.5267      | 12.6015    | 0.0        | 1.575E-06  | 96.1144     | 1711       | Santa Marta de Penaguião         |
-| nan     | number          | 1.0108        | 0.0809     | 0.0        | 1.011E-08  | 0.6167      | 1711       | Santa Marta de Penaguião         |
-| nan     | residents       | 1.1737        | 0.1070     | 0.0        | 1.174E-08  | 0.8169      | 1711       | Santa Marta de Penaguião         |
-| nan     | affectedpop     | 1.1737        | 0.1301     | 0.0        | 1.174E-08  | 0.9464      | 1711       | Santa Marta de Penaguião         |
-| nan     | injured         | 0.6481        | 0.0019     | 0.0        | 6.481E-09  | 0.0141      | 1711       | Santa Marta de Penaguião         |
-| nan     | embodied_carbon | 50.2585       | 3.9943     | 0.0        | 0.0892     | 25.2823     | 1711       | Santa Marta de Penaguião         |
-| nan     | contents        | 564_663       | 6_457      | 0.0        | 0.0044     | 1_354       | 1712       | VEZİRKÖPRÜ                       |
-| nan     | structural      | 3_199_757     | 74_335     | 0.0        | 26_809     | 173_900     | 1712       | VEZİRKÖPRÜ                       |
-| nan     | occupants       | 8.9209        | 0.0048     | 0.0        | 7.011E-08  | 0.0091      | 1712       | VEZİRKÖPRÜ                       |
-| nan     | area            | 2_807         | 22.6053    | 0.0        | 2.214E-05  | 40.0423     | 1712       | VEZİRKÖPRÜ                       |
-| nan     | number          | 17.8409       | 0.1606     | 0.0        | 1.488E-07  | 0.2908      | 1712       | VEZİRKÖPRÜ                       |
-| nan     | residents       | 16.1477       | 0.1503     | 0.0        | 1.304E-07  | 0.3224      | 1712       | VEZİRKÖPRÜ                       |
-| nan     | affectedpop     | 16.1477       | 0.1993     | 0.0        | 1.615E-07  | 0.6033      | 1712       | VEZİRKÖPRÜ                       |
-| nan     | injured         | 8.9209        | 0.0029     | 0.0        | 7.011E-08  | 0.0058      | 1712       | VEZİRKÖPRÜ                       |
-| nan     | embodied_carbon | 859.9         | 17.4605    | 0.0        | 5.2259     | 38.8566     | 1712       | VEZİRKÖPRÜ                       |
-| nan     | contents        | 162_918       | 838.3      | 0.0        | 7.918E-04  | 44.3308     | 1713       | VİRANŞEHİR                       |
-| nan     | structural      | 840_802       | 30_314     | 0.0        | 9_172      | 157_073     | 1713       | VİRANŞEHİR                       |
-| nan     | occupants       | 10.9554       | 2.450E-04  | 0.0        | 1.057E-07  | 0.0026      | 1713       | VİRANŞEHİR                       |
-| nan     | area            | 756.8         | 9.5182     | 0.0        | 7.568E-06  | 103.5356    | 1713       | VİRANŞEHİR                       |
-| nan     | number          | 4.8604        | 0.0613     | 0.0        | 4.860E-08  | 0.6644      | 1713       | VİRANŞEHİR                       |
-| nan     | residents       | 4.5882        | 0.0648     | 0.0        | 4.588E-08  | 0.6810      | 1713       | VİRANŞEHİR                       |
-| nan     | affectedpop     | 4.5882        | 0.0811     | 0.0        | 4.588E-08  | 0.7645      | 1713       | VİRANŞEHİR                       |
-| nan     | injured         | 10.9554       | 0.0011     | 0.0        | 1.057E-07  | 0.0121      | 1713       | VİRANŞEHİR                       |
-| nan     | embodied_carbon | 268.6         | 8.6345     | 0.0        | 2.7074     | 46.5588     | 1713       | VİRANŞEHİR                       |
-| nan     | contents        | 2_759_053     | 2_816      | 0.0        | 0.0011     | 0.0298      | 1714       | VİZE                             |
-| nan     | structural      | 15_522_105    | 333_722    | 0.0        | 141_922    | 965_832     | 1714       | VİZE                             |
-| nan     | occupants       | 55.2217       | 4.749E-04  | 0.0        | 5.522E-07  | 8.349E-05   | 1714       | VİZE                             |
-| nan     | area            | 10_489        | 11.2992    | 0.0        | 1.049E-04  | 3.7675      | 1714       | VİZE                             |
-| nan     | number          | 75.1177       | 0.0776     | 0.0        | 7.512E-07  | 0.0242      | 1714       | VİZE                             |
-| nan     | residents       | 94.7895       | 0.1386     | 0.0        | 9.479E-07  | 0.0543      | 1714       | VİZE                             |
-| nan     | affectedpop     | 94.7895       | 0.3121     | 0.0        | 9.479E-07  | 0.1276      | 1714       | VİZE                             |
-| nan     | injured         | 55.2217       | 0.0022     | 0.0        | 5.522E-07  | 8.858E-04   | 1714       | VİZE                             |
-| nan     | embodied_carbon | 3_129         | 57.9048    | 0.0        | 23.0536    | 167.8159    | 1714       | VİZE                             |
-| nan     | contents        | 18_881        | 70.5585    | 0.0        | 1.888E-04  | 1.888E-04   | 1801       | LAMPUNG BARAT Regency            |
-| nan     | structural      | 75_523        | 1_826      | 0.0        | 1_012      | 6_148       | 1801       | LAMPUNG BARAT Regency            |
-| nan     | occupants       | 5.4900        | 4.137E-08  | 0.0        | 5.490E-08  | 5.490E-08   | 1801       | LAMPUNG BARAT Regency            |
-| nan     | area            | 73.6094       | 5.547E-07  | 0.0        | 7.361E-07  | 7.361E-07   | 1801       | LAMPUNG BARAT Regency            |
-| nan     | number          | 0.3393        | 2.557E-09  | 0.0        | 3.393E-09  | 3.393E-09   | 1801       | LAMPUNG BARAT Regency            |
-| nan     | injured         | 5.4900        | 4.137E-08  | 0.0        | 5.490E-08  | 5.490E-08   | 1801       | LAMPUNG BARAT Regency            |
-| nan     | embodied_carbon | 34.4900       | 1.2817     | 0.0        | 0.9047     | 3.6320      | 1801       | LAMPUNG BARAT Regency            |
-| nan     | contents        | 28_510        | 14.9154    | 0.0        | 2.851E-04  | 0.5028      | 1802       | TANGGAMUS Regency                |
-| nan     | structural      | 161_556       | 7_040      | 0.0        | 3_041      | 35_853      | 1802       | TANGGAMUS Regency                |
-| nan     | occupants       | 0.6776        | 1.748E-04  | 0.0        | 6.776E-09  | 0.0018      | 1802       | TANGGAMUS Regency                |
-| nan     | area            | 141.7160      | 1.2555     | 0.0        | 1.417E-06  | 12.5218     | 1802       | TANGGAMUS Regency                |
-| nan     | number          | 1.0294        | 0.0091     | 0.0        | 1.029E-08  | 0.0910      | 1802       | TANGGAMUS Regency                |
-| nan     | residents       | 1.2263        | 0.0170     | 0.0        | 1.226E-08  | 0.1837      | 1802       | TANGGAMUS Regency                |
-| nan     | affectedpop     | 1.2263        | 0.0411     | 0.0        | 1.226E-08  | 0.4640      | 1802       | TANGGAMUS Regency                |
-| nan     | injured         | 0.6776        | 2.437E-04  | 0.0        | 6.776E-09  | 0.0025      | 1802       | TANGGAMUS Regency                |
-| nan     | embodied_carbon | 42.4547       | 1.2473     | 0.0        | 0.4135     | 7.0774      | 1802       | TANGGAMUS Regency                |
-| nan     | contents        | 277_863       | 17_492     | 0.0        | 0.0028     | 184_267     | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | structural      | 1_574_556     | 195_286    | 0.0        | 3_148      | 1_440_316   | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | occupants       | 5.2492        | 0.0350     | 0.0        | 5.249E-08  | 0.2696      | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | area            | 1_381         | 150.1824   | 0.0        | 1.381E-05  | 1_162       | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | number          | 8.8626        | 0.9637     | 0.0        | 8.863E-08  | 7.4564      | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | residents       | 9.5002        | 1.1769     | 0.0        | 9.500E-08  | 8.6263      | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | affectedpop     | 9.5002        | 1.3707     | 0.0        | 9.500E-08  | 9.0057      | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | injured         | 5.2492        | 0.0209     | 0.0        | 5.249E-08  | 0.1574      | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | embodied_carbon | 447.7         | 52.2960    | 0.0        | 0.7458     | 401.6       | 1803       | LAMPUNG SELATAN Regency          |
-| nan     | contents        | 1_664_573     | 26_276     | 0.0        | 4.611E-15  | 76_197      | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | structural      | 9_432_583     | 685_381    | 0.0        | 34_734     | 5_467_336   | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | occupants       | 40.6585       | 0.0180     | 0.0        | 4.066E-07  | 0.1457      | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | area            | 8_274         | 395.5      | 0.0        | 8.274E-05  | 3_179       | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | number          | 60.1036       | 2.8727     | 0.0        | 6.010E-07  | 23.0902     | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | residents       | 73.5892       | 4.3078     | 0.0        | 7.359E-07  | 34.6698     | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | affectedpop     | 73.5892       | 5.8050     | 0.0        | 7.359E-07  | 45.2822     | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | injured         | 40.6585       | 0.0816     | 0.0        | 4.066E-07  | 0.6527      | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | embodied_carbon | 3_000         | 195.7      | 0.0        | 11.6091    | 1_579       | 1804       | LAMPUNG TIMUR Regency            |
-| nan     | contents        | 51_680        | 1_668      | 0.0        | 3.154E-04  | 19_652      | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | structural      | 292_856       | 12_824     | 0.0        | 819.5      | 86_951      | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | occupants       | 1.2645        | 4.318E-04  | 0.0        | 1.264E-08  | 0.0030      | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | area            | 256.9         | 10.0869    | 0.0        | 2.569E-06  | 92.8546     | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | number          | 1.7333        | 0.0684     | 0.0        | 1.733E-08  | 0.6464      | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | residents       | 2.2885        | 0.1045     | 0.0        | 2.288E-08  | 0.8088      | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | affectedpop     | 2.2885        | 0.1328     | 0.0        | 2.289E-08  | 0.9402      | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | injured         | 1.2645        | 0.0020     | 0.0        | 1.264E-08  | 0.0143      | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | embodied_carbon | 60.2859       | 2.8064     | 0.0        | 0.1424     | 13.5522     | 1805       | LAMPUNG TENGAH Regency           |
-| nan     | contents        | 62_226        | 2_346      | 0.0        | 3.173E-04  | 31_570      | 1806       | LAMPUNG UTARA Regency            |
-| nan     | structural      | 352_619       | 15_913     | 0.0        | 895.2      | 122_073     | 1806       | LAMPUNG UTARA Regency            |
-| nan     | occupants       | 1.1408        | 0.0023     | 0.0        | 1.141E-08  | 0.0275      | 1806       | LAMPUNG UTARA Regency            |
-| nan     | area            | 309.3         | 11.8727    | 0.0        | 3.093E-06  | 111.3852    | 1806       | LAMPUNG UTARA Regency            |
-| nan     | number          | 1.9848        | 0.0762     | 0.0        | 1.985E-08  | 0.7148      | 1806       | LAMPUNG UTARA Regency            |
-| nan     | residents       | 2.0648        | 0.0937     | 0.0        | 2.065E-08  | 0.9154      | 1806       | LAMPUNG UTARA Regency            |
-| nan     | affectedpop     | 2.0648        | 0.1126     | 0.0        | 1.206E-04  | 1.0327      | 1806       | LAMPUNG UTARA Regency            |
-| nan     | injured         | 1.1408        | 0.0017     | 0.0        | 1.141E-08  | 0.0165      | 1806       | LAMPUNG UTARA Regency            |
-| nan     | embodied_carbon | 98.6861       | 4.5943     | 0.0        | 0.2274     | 46.2582     | 1806       | LAMPUNG UTARA Regency            |
-| nan     | contents        | 145_587       | 3_038      | 0.0        | 6.635E-04  | 4_353       | 1807       | WAY KANAN Regency                |
-| nan     | structural      | 824_987       | 21_443     | 0.0        | 3_233      | 111_055     | 1807       | WAY KANAN Regency                |
-| nan     | occupants       | 2.9427        | 5.850E-04  | 0.0        | 2.566E-08  | 0.0039      | 1807       | WAY KANAN Regency                |
-| nan     | area            | 723.7         | 14.1430    | 0.0        | 7.237E-06  | 96.9752     | 1807       | WAY KANAN Regency                |
-| nan     | number          | 4.1739        | 0.0904     | 0.0        | 4.174E-08  | 0.6574      | 1807       | WAY KANAN Regency                |
-| nan     | residents       | 5.3261        | 0.1236     | 0.0        | 5.326E-08  | 0.9497      | 1807       | WAY KANAN Regency                |
-| nan     | affectedpop     | 5.3261        | 0.1534     | 0.0        | 5.326E-08  | 1.2743      | 1807       | WAY KANAN Regency                |
-| nan     | injured         | 2.9427        | 0.0024     | 0.0        | 2.566E-08  | 0.0177      | 1807       | WAY KANAN Regency                |
-| nan     | embodied_carbon | 243.3         | 6.8357     | 0.0        | 1.2317     | 36.0672     | 1807       | WAY KANAN Regency                |
-| nan     | contents        | 197_943       | 9_657      | 0.0        | 0.0017     | 65_961      | 1808       | TULANGBAWANG Regency             |
-| nan     | structural      | 1_121_677     | 63_563     | 0.0        | 5_209      | 360_071     | 1808       | TULANGBAWANG Regency             |
-| nan     | occupants       | 5.2783        | 0.0024     | 0.0        | 5.278E-08  | 0.0160      | 1808       | TULANGBAWANG Regency             |
-| nan     | area            | 983.9         | 47.7879    | 0.0        | 1.152E-04  | 309.8       | 1808       | TULANGBAWANG Regency             |
-| nan     | number          | 7.0139        | 0.3429     | 0.0        | 7.462E-07  | 2.2505      | 1808       | TULANGBAWANG Regency             |
-| nan     | residents       | 9.5534        | 0.5026     | 0.0        | 9.562E-07  | 3.8281      | 1808       | TULANGBAWANG Regency             |
-| nan     | affectedpop     | 9.5534        | 0.5791     | 0.0        | 3.974E-04  | 5.0261      | 1808       | TULANGBAWANG Regency             |
-| nan     | injured         | 5.2783        | 0.0103     | 0.0        | 5.278E-08  | 0.0720      | 1808       | TULANGBAWANG Regency             |
-| nan     | embodied_carbon | 314.1         | 17.9942    | 0.0        | 1.5648     | 101.1277    | 1808       | TULANGBAWANG Regency             |
-| nan     | contents        | 83_400        | 2_790      | 0.0        | 8.340E-04  | 1.0093      | 1809       | PESAWARAN Regency                |
-| nan     | structural      | 472_599       | 38_599     | 0.0        | 1_680      | 414_145     | 1809       | PESAWARAN Regency                |
-| nan     | occupants       | 2.5835        | 0.0016     | 0.0        | 2.583E-08  | 0.0174      | 1809       | PESAWARAN Regency                |
-| nan     | area            | 414.6         | 28.2538    | 0.0        | 4.146E-06  | 298.5       | 1809       | PESAWARAN Regency                |
-| nan     | number          | 3.0114        | 0.2052     | 0.0        | 3.011E-08  | 2.1685      | 1809       | PESAWARAN Regency                |
-| nan     | residents       | 4.6763        | 0.3444     | 0.0        | 4.676E-08  | 3.7067      | 1809       | PESAWARAN Regency                |
-| nan     | affectedpop     | 4.6763        | 0.3825     | 0.0        | 4.676E-08  | 4.1165      | 1809       | PESAWARAN Regency                |
-| nan     | injured         | 2.5835        | 0.0070     | 0.0        | 2.583E-08  | 0.0745      | 1809       | PESAWARAN Regency                |
-| nan     | embodied_carbon | 132.3400      | 10.3774    | 0.0        | 0.4948     | 94.5205     | 1809       | PESAWARAN Regency                |
-| nan     | contents        | 201_407       | 1_585      | 0.0        | 0.0016     | 816.3       | 1810       | PRINGSEWU Regency                |
-| nan     | structural      | 1_141_306     | 20_376     | 0.0        | 1_671      | 168_157     | 1810       | PRINGSEWU Regency                |
-| nan     | occupants       | 4.0693        | 6.459E-04  | 0.0        | 4.069E-08  | 0.0062      | 1810       | PRINGSEWU Regency                |
-| nan     | area            | 1_001         | 15.2019    | 0.0        | 1.001E-05  | 135.1234    | 1810       | PRINGSEWU Regency                |
-| nan     | number          | 6.0737        | 0.0849     | 0.0        | 6.074E-08  | 0.6488      | 1810       | PRINGSEWU Regency                |
-| nan     | residents       | 7.3656        | 0.1420     | 0.0        | 7.366E-08  | 1.3690      | 1810       | PRINGSEWU Regency                |
-| nan     | affectedpop     | 7.3656        | 0.1805     | 0.0        | 7.366E-08  | 1.6314      | 1810       | PRINGSEWU Regency                |
-| nan     | injured         | 4.0693        | 0.0027     | 0.0        | 4.069E-08  | 0.0264      | 1810       | PRINGSEWU Regency                |
-| nan     | embodied_carbon | 353.5         | 6.7958     | 0.0        | 0.4864     | 38.7041     | 1810       | PRINGSEWU Regency                |
-| nan     | contents        | 107_648       | 8_154      | 0.0        | 0.0011     | 92_383      | 1811       | MESUJI Regency                   |
-| nan     | structural      | 610_006       | 57_667     | 0.0        | 1_766      | 595_539     | 1811       | MESUJI Regency                   |
-| nan     | occupants       | 1.3702        | 0.0010     | 0.0        | 1.370E-08  | 0.0124      | 1811       | MESUJI Regency                   |
-| nan     | area            | 535.1         | 43.0011    | 0.0        | 5.351E-06  | 516.9       | 1811       | MESUJI Regency                   |
-| nan     | number          | 3.8869        | 0.3124     | 0.0        | 3.887E-08  | 3.7546      | 1811       | MESUJI Regency                   |
-| nan     | residents       | 2.4808        | 0.2164     | 0.0        | 2.481E-08  | 2.4337      | 1811       | MESUJI Regency                   |
-| nan     | affectedpop     | 2.4808        | 0.2472     | 0.0        | 2.481E-08  | 2.4620      | 1811       | MESUJI Regency                   |
-| nan     | injured         | 1.3702        | 0.0044     | 0.0        | 1.370E-08  | 0.0518      | 1811       | MESUJI Regency                   |
-| nan     | embodied_carbon | 54.8471       | 4.8224     | 0.0        | 0.1663     | 53.4667     | 1811       | MESUJI Regency                   |
-| nan     | contents        | 210_973       | 3_905      | 0.0        | 0.0012     | 0.0021      | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | structural      | 1_195_514     | 29_023     | 0.0        | 1_501      | 162_667     | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | occupants       | 4.7036        | 0.0033     | 0.0        | 4.704E-08  | 0.0187      | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | area            | 1_049         | 19.5598    | 0.0        | 1.049E-05  | 101.5891    | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | number          | 6.0864        | 0.1189     | 0.0        | 6.086E-08  | 0.6360      | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | residents       | 8.5139        | 0.1741     | 0.0        | 8.514E-08  | 0.9785      | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | affectedpop     | 8.5139        | 0.2227     | 0.0        | 8.514E-08  | 1.5492      | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | injured         | 4.7036        | 0.0035     | 0.0        | 4.704E-08  | 0.0187      | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | embodied_carbon | 361.9         | 8.4972     | 0.0        | 0.4423     | 45.6840     | 1812       | TULANGBAWANG BARAT Regency       |
-| nan     | contents        | 276_811       | 20_444     | 0.0        | 0.0028     | 214_055     | 1814       | KARATAY                          |
-| nan     | structural      | 1_568_594     | 95_097     | 0.0        | 6_238      | 757_417     | 1814       | KARATAY                          |
-| nan     | occupants       | 8.9633        | 0.0043     | 0.0        | 8.963E-08  | 0.0313      | 1814       | KARATAY                          |
-| nan     | area            | 1_376         | 71.3138    | 0.0        | 1.376E-05  | 515.7       | 1814       | KARATAY                          |
-| nan     | number          | 9.9949        | 0.5180     | 0.0        | 9.995E-08  | 3.7463      | 1814       | KARATAY                          |
-| nan     | residents       | 16.2232       | 0.8973     | 0.0        | 1.622E-07  | 7.4811      | 1814       | KARATAY                          |
-| nan     | affectedpop     | 16.2232       | 1.0267     | 0.0        | 1.622E-07  | 9.8225      | 1814       | KARATAY                          |
-| nan     | injured         | 8.9633        | 0.0186     | 0.0        | 8.963E-08  | 0.1406      | 1814       | KARATAY                          |
-| nan     | embodied_carbon | 498.9         | 30.0768    | 0.0        | 2.0681     | 248.5       | 1814       | KARATAY                          |
-| nan     | contents        | 512_225       | 10_615     | 0.0        | 0.0051     | 0.0051      | 1815       | KAHRAMANKAZAN                    |
-| nan     | structural      | 2_902_611     | 126_129    | 0.0        | 8_047      | 576_160     | 1815       | KAHRAMANKAZAN                    |
-| nan     | occupants       | 8.8416        | 0.0029     | 0.0        | 8.842E-08  | 0.0108      | 1815       | KAHRAMANKAZAN                    |
-| nan     | area            | 2_546         | 89.4919    | 0.0        | 2.546E-05  | 331.3       | 1815       | KAHRAMANKAZAN                    |
-| nan     | number          | 18.4951       | 0.6501     | 0.0        | 1.850E-07  | 2.4064      | 1815       | KAHRAMANKAZAN                    |
-| nan     | residents       | 16.0072       | 0.6263     | 0.0        | 1.601E-07  | 2.9064      | 1815       | KAHRAMANKAZAN                    |
-| nan     | affectedpop     | 16.0072       | 0.7560     | 0.0        | 1.601E-07  | 4.7263      | 1815       | KAHRAMANKAZAN                    |
-| nan     | injured         | 8.8416        | 0.0126     | 0.0        | 8.842E-08  | 0.0517      | 1815       | KAHRAMANKAZAN                    |
-| nan     | embodied_carbon | 812.8         | 35.2620    | 0.0        | 2.3471     | 141.7966    | 1815       | KAHRAMANKAZAN                    |
-| nan     | contents        | 105_014       | 1_827      | 0.0        | 6.190E-04  | 22_056      | 1816       | São Pedro do Sul                 |
-| nan     | structural      | 595_075       | 8_742      | 0.0        | 1_388      | 31_343      | 1816       | São Pedro do Sul                 |
-| nan     | occupants       | 1.7195        | 1.396E-04  | 0.0        | 1.720E-08  | 4.473E-04   | 1816       | São Pedro do Sul                 |
-| nan     | area            | 522.0         | 3.8347     | 0.0        | 5.220E-06  | 12.0619     | 1816       | São Pedro do Sul                 |
-| nan     | number          | 3.0033        | 0.0191     | 0.0        | 3.003E-08  | 0.0793      | 1816       | São Pedro do Sul                 |
-| nan     | residents       | 3.1126        | 0.0217     | 0.0        | 3.113E-08  | 0.0920      | 1816       | São Pedro do Sul                 |
-| nan     | affectedpop     | 3.1126        | 0.0354     | 0.0        | 3.113E-08  | 0.1800      | 1816       | São Pedro do Sul                 |
-| nan     | injured         | 1.7195        | 3.868E-04  | 0.0        | 1.720E-08  | 0.0018      | 1816       | São Pedro do Sul                 |
-| nan     | embodied_carbon | 169.8598      | 2.5645     | 0.0        | 0.3967     | 9.7549      | 1816       | São Pedro do Sul                 |
-| nan     | contents        | 363_800       | 10_694     | 0.0        | 0.0014     | 114_878     | 1817       | KIZILIRMAK                       |
-| nan     | structural      | 1_898_547     | 94_813     | 0.0        | 25_910     | 635_363     | 1817       | KIZILIRMAK                       |
-| nan     | occupants       | 22.8002       | 0.0023     | 0.0        | 2.280E-07  | 0.0172      | 1817       | KIZILIRMAK                       |
-| nan     | area            | 1_704         | 53.4821    | 0.0        | 1.704E-05  | 410.3       | 1817       | KIZILIRMAK                       |
-| nan     | number          | 6.4109        | 0.2071     | 0.0        | 6.411E-08  | 1.5320      | 1817       | KIZILIRMAK                       |
-| nan     | residents       | 9.3574        | 0.4374     | 0.0        | 9.357E-08  | 2.9569      | 1817       | KIZILIRMAK                       |
-| nan     | affectedpop     | 9.3574        | 0.5732     | 0.0        | 4.487E-04  | 3.4013      | 1817       | KIZILIRMAK                       |
-| nan     | injured         | 22.8002       | 0.0089     | 0.0        | 2.280E-07  | 0.0604      | 1817       | KIZILIRMAK                       |
-| nan     | embodied_carbon | 636.1         | 32.0958    | 0.0        | 9.2475     | 176.8669    | 1817       | KIZILIRMAK                       |
-| nan     | contents        | 189_087       | 3_858      | 0.0        | 0.0019     | 0.0019      | 1818       | KOCAALİ                          |
-| nan     | structural      | 1_071_490     | 14_903     | 0.0        | 1_333      | 95_282      | 1818       | KOCAALİ                          |
-| nan     | occupants       | 3.0622        | 1.834E-04  | 0.0        | 3.062E-08  | 9.777E-04   | 1818       | KOCAALİ                          |
-| nan     | area            | 939.9         | 7.6121     | 0.0        | 9.399E-06  | 39.7829     | 1818       | KOCAALİ                          |
-| nan     | number          | 6.0311        | 0.0488     | 0.0        | 6.031E-08  | 0.2553      | 1818       | KOCAALİ                          |
-| nan     | residents       | 5.5444        | 0.0570     | 0.0        | 5.544E-08  | 0.3435      | 1818       | KOCAALİ                          |
-| nan     | affectedpop     | 5.5444        | 0.0908     | 0.0        | 5.544E-08  | 0.6915      | 1818       | KOCAALİ                          |
-| nan     | injured         | 3.0622        | 9.613E-04  | 0.0        | 3.062E-08  | 0.0056      | 1818       | KOCAALİ                          |
-| nan     | embodied_carbon | 340.6         | 4.7912     | 0.0        | 0.3837     | 33.2748     | 1818       | KOCAALİ                          |
-| nan     | contents        | 30_214        | 538.4      | 0.0        | 3.021E-04  | 3.021E-04   | 1820       | KOVANCILAR                       |
-| nan     | structural      | 171_211       | 5_261      | 0.0        | 726.7      | 11_574      | 1820       | KOVANCILAR                       |
-| nan     | occupants       | 0.6514        | 2.558E-04  | 0.0        | 6.514E-09  | 6.514E-09   | 1820       | KOVANCILAR                       |
-| nan     | area            | 150.1854      | 2.0123     | 0.0        | 1.502E-06  | 0.1028      | 1820       | KOVANCILAR                       |
-| nan     | number          | 0.9637        | 0.0129     | 0.0        | 9.637E-09  | 6.597E-04   | 1820       | KOVANCILAR                       |
-| nan     | residents       | 1.1794        | 0.0183     | 0.0        | 1.179E-08  | 0.0012      | 1820       | KOVANCILAR                       |
-| nan     | affectedpop     | 1.1794        | 0.0247     | 0.0        | 1.179E-08  | 0.0126      | 1820       | KOVANCILAR                       |
-| nan     | injured         | 0.6514        | 2.993E-04  | 0.0        | 6.514E-09  | 6.514E-09   | 1820       | KOVANCILAR                       |
-| nan     | embodied_carbon | 44.9528       | 1.1320     | 0.0        | 0.1097     | 2.4456      | 1820       | KOVANCILAR                       |
-| nan     | contents        | 27_594        | 200.9      | 0.0        | 1.679E-17  | 3.0597      | 1821       | KÖRFEZ                           |
-| nan     | structural      | 156_368       | 10_129     | 0.0        | 3_093      | 24_233      | 1821       | KÖRFEZ                           |
-| nan     | occupants       | 0.5824        | 6.052E-04  | 0.0        | 5.824E-09  | 6.318E-04   | 1821       | KÖRFEZ                           |
-| nan     | area            | 137.1645      | 4.8194     | 0.0        | 1.372E-06  | 5.0360      | 1821       | KÖRFEZ                           |
-| nan     | number          | 0.9964        | 0.0350     | 0.0        | 9.964E-09  | 0.0366      | 1821       | KÖRFEZ                           |
-| nan     | residents       | 1.0541        | 0.0411     | 0.0        | 1.054E-08  | 0.0705      | 1821       | KÖRFEZ                           |
-| nan     | affectedpop     | 1.0541        | 0.0489     | 0.0        | 1.054E-08  | 0.2291      | 1821       | KÖRFEZ                           |
-| nan     | injured         | 0.5824        | 8.242E-04  | 0.0        | 5.824E-09  | 8.968E-04   | 1821       | KÖRFEZ                           |
-| nan     | embodied_carbon | 41.0913       | 2.2153     | 0.0        | 0.4196     | 5.0673      | 1821       | KÖRFEZ                           |
-| nan     | contents        | 122_664       | 23.9653    | 0.0        | 8.814E-04  | 0.0012      | 1822       | KÖSE                             |
-| nan     | structural      | 490_658       | 16_190     | 0.0        | 9_746      | 58_577      | 1822       | KÖSE                             |
-| nan     | occupants       | 14.0905       | 9.790E-08  | 0.0        | 1.409E-07  | 1.409E-07   | 1822       | KÖSE                             |
-| nan     | area            | 521.2         | 0.0144     | 0.0        | 5.212E-06  | 5.212E-06   | 1822       | KÖSE                             |
-| nan     | number          | 1.5110        | 3.317E-05  | 0.0        | 1.511E-08  | 1.511E-08   | 1822       | KÖSE                             |
-| nan     | injured         | 14.0905       | 9.071E-06  | 0.0        | 1.409E-07  | 1.409E-07   | 1822       | KÖSE                             |
-| nan     | embodied_carbon | 230.6         | 7.0415     | 0.0        | 4.4007     | 23.8215     | 1822       | KÖSE                             |
-| nan     | contents        | 913_965       | 14_807     | 0.0        | 0.0058     | 9_632       | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | structural      | 4_696_457     | 122_199    | 0.0        | 9_228      | 300_019     | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | occupants       | 41.5007       | 0.0048     | 0.0        | 1.778E-07  | 0.0100      | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | area            | 3_234         | 64.4969    | 0.0        | 2.444E-05  | 163.0682    | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | number          | 13.8998       | 0.3145     | 0.0        | 1.209E-07  | 1.0151      | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | residents       | 29.5915       | 0.9113     | 0.0        | 2.959E-07  | 1.8739      | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | affectedpop     | 29.5915       | 1.0598     | 0.0        | 2.959E-07  | 3.0607      | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | injured         | 41.5007       | 0.0180     | 0.0        | 1.778E-07  | 0.0389      | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | embodied_carbon | 1_226         | 30.0975    | 0.0        | 2.3619     | 96.8061     | 1823       | KÜÇÜKÇEKMECE                     |
-| nan     | contents        | 659_031       | 1_081      | 0.0        | 0.0047     | 4_350       | 1824       | Vouzela                          |
-| nan     | structural      | 3_423_410     | 92_795     | 0.0        | 69_790     | 257_981     | 1824       | Vouzela                          |
-| nan     | occupants       | 21.6558       | 4.692E-05  | 0.0        | 2.166E-07  | 2.166E-07   | 1824       | Vouzela                          |
-| nan     | area            | 3_076         | 0.6497     | 0.0        | 3.076E-05  | 3.076E-05   | 1824       | Vouzela                          |
-| nan     | number          | 18.1198       | 0.0028     | 0.0        | 1.812E-07  | 1.812E-07   | 1824       | Vouzela                          |
-| nan     | residents       | 19.1245       | 0.0042     | 0.0        | 1.912E-07  | 1.912E-07   | 1824       | Vouzela                          |
-| nan     | affectedpop     | 19.1245       | 0.0125     | 0.0        | 1.912E-07  | 1.912E-07   | 1824       | Vouzela                          |
-| nan     | injured         | 21.6558       | 2.282E-04  | 0.0        | 2.166E-07  | 2.166E-07   | 1824       | Vouzela                          |
-| nan     | embodied_carbon | 1_046         | 30.0681    | 0.0        | 23.7352    | 83.7721     | 1824       | Vouzela                          |
-| nan     | contents        | 31_325        | 3_619      | 0.0        | 3.132E-04  | 30_382      | 201        | Katihar                          |
-| nan     | structural      | 177_507       | 20_691     | 0.0        | 821.6      | 119_272     | 201        | Katihar                          |
-| nan     | occupants       | 0.8433        | 6.031E-04  | 0.0        | 8.433E-09  | 0.0043      | 201        | Katihar                          |
-| nan     | area            | 155.7081      | 14.7650    | 0.0        | 1.557E-06  | 104.7135    | 201        | Katihar                          |
-| nan     | number          | 0.9991        | 0.0947     | 0.0        | 9.991E-09  | 0.6719      | 201        | Katihar                          |
-| nan     | residents       | 1.5263        | 0.1650     | 0.0        | 1.526E-08  | 1.1329      | 201        | Katihar                          |
-| nan     | affectedpop     | 1.5263        | 0.2037     | 0.0        | 1.526E-08  | 1.2772      | 201        | Katihar                          |
-| nan     | injured         | 0.8433        | 0.0029     | 0.0        | 8.433E-09  | 0.0200      | 201        | Katihar                          |
-| nan     | embodied_carbon | 56.4238       | 5.4501     | 0.0        | 0.2629     | 25.8490     | 201        | Katihar                          |
-| nan     | contents        | 683_916       | 529.2      | 5.633E-04  | 0.0068     | 0.0068      | 202        | Khagaria                         |
-| nan     | structural      | 3_781_642     | 49_660     | 1_870      | 23_083     | 253_393     | 202        | Khagaria                         |
-| nan     | occupants       | 15.0134       | 1.379E-07  | 5.374E-08  | 1.501E-07  | 1.501E-07   | 202        | Khagaria                         |
-| nan     | area            | 3_339         | 5.772E-04  | 2.196E-06  | 3.339E-05  | 3.339E-05   | 202        | Khagaria                         |
-| nan     | number          | 21.0458       | 3.700E-06  | 1.028E-08  | 2.105E-07  | 2.105E-07   | 202        | Khagaria                         |
-| nan     | residents       | 17.4488       | 4.363E-06  | 0.0        | 1.745E-07  | 1.745E-07   | 202        | Khagaria                         |
-| nan     | affectedpop     | 17.4488       | 3.435E-05  | 0.0        | 1.745E-07  | 1.745E-07   | 202        | Khagaria                         |
-| nan     | injured         | 15.0134       | 1.647E-07  | 5.374E-08  | 1.501E-07  | 1.501E-07   | 202        | Khagaria                         |
-| nan     | embodied_carbon | 1_037         | 28.4468    | 1.8141     | 16.6351    | 135.1292    | 202        | Khagaria                         |
-| nan     | contents        | 47_813        | 81.3202    | 0.0        | 4.781E-04  | 4.781E-04   | 206        | Madhubani                        |
-| nan     | structural      | 191_251       | 16_968     | 0.0        | 14_160     | 41_688      | 206        | Madhubani                        |
-| nan     | occupants       | 5.0763        | 3.642E-06  | 0.0        | 5.076E-08  | 5.076E-08   | 206        | Madhubani                        |
-| nan     | area            | 186.4         | 0.0163     | 0.0        | 1.864E-06  | 1.864E-06   | 206        | Madhubani                        |
-| nan     | number          | 0.4442        | 3.885E-05  | 0.0        | 4.442E-09  | 4.442E-09   | 206        | Madhubani                        |
-| nan     | injured         | 5.0763        | 1.816E-05  | 0.0        | 5.076E-08  | 5.076E-08   | 206        | Madhubani                        |
-| nan     | embodied_carbon | 87.4231       | 6.4942     | 0.0        | 5.4251     | 17.9676     | 206        | Madhubani                        |
-| nan     | contents        | 295_967       | 1_525      | 7.069E-35  | 0.0027     | 86.8757     | 209        | Nalanda                          |
-| nan     | structural      | 1_639_422     | 47_034     | 266.8      | 17_622     | 148_260     | 209        | Nalanda                          |
-| nan     | occupants       | 6.6186        | 0.0011     | 3.376E-09  | 6.619E-08  | 0.0038      | 209        | Nalanda                          |
-| nan     | area            | 1_447         | 9.1055     | 1.494E-06  | 1.447E-05  | 35.0960     | 209        | Nalanda                          |
-| nan     | number          | 10.0055       | 0.0832     | 9.583E-09  | 1.001E-07  | 0.3280      | 209        | Nalanda                          |
-| nan     | residents       | 8.3600        | 0.0466     | 6.114E-09  | 8.360E-08  | 0.0835      | 209        | Nalanda                          |
-| nan     | affectedpop     | 8.3600        | 0.1093     | 6.114E-09  | 8.360E-08  | 0.3842      | 209        | Nalanda                          |
-| nan     | injured         | 6.6186        | 0.0036     | 3.376E-09  | 6.619E-08  | 0.0172      | 209        | Nalanda                          |
-| nan     | embodied_carbon | 452.3         | 11.6427    | 0.0358     | 4.0161     | 40.4434     | 209        | Nalanda                          |
-| nan     | contents        | 1_570_596     | 5_373      | 0.0        | 0.0157     | 60_045      | 210        | Nawada                           |
-| nan     | structural      | 8_900_045     | 194_076    | 0.0        | 39_435     | 1_376_293   | 210        | Nawada                           |
-| nan     | occupants       | 26.6759       | 6.498E-04  | 0.0        | 2.668E-07  | 0.0071      | 210        | Nawada                           |
-| nan     | area            | 7_807         | 25.4149    | 0.0        | 7.807E-05  | 273.2       | 210        | Nawada                           |
-| nan     | number          | 50.0952       | 0.1631     | 0.0        | 5.010E-07  | 1.7529      | 210        | Nawada                           |
-| nan     | residents       | 48.2802       | 0.1652     | 0.0        | 4.828E-07  | 1.7541      | 210        | Nawada                           |
-| nan     | affectedpop     | 48.2802       | 0.1905     | 0.0        | 4.828E-07  | 1.8309      | 210        | Nawada                           |
-| nan     | injured         | 26.6759       | 0.0030     | 0.0        | 2.668E-07  | 0.0322      | 210        | Nawada                           |
-| nan     | embodied_carbon | 2_343         | 52.9618    | 0.0        | 9.6624     | 334.6       | 210        | Nawada                           |
-| nan     | contents        | 180_481       | 15_476     | 0.0        | 0.0013     | 125_414     | 211        | Pashchim Champaran               |
-| nan     | structural      | 1_022_722     | 126_326    | 989.9      | 21_093     | 632_111     | 211        | Pashchim Champaran               |
-| nan     | occupants       | 4.6342        | 0.0214     | 3.406E-08  | 3.002E-04  | 0.1421      | 211        | Pashchim Champaran               |
-| nan     | area            | 897.1         | 93.7914    | 6.234E-06  | 6.0995     | 457.8       | 211        | Pashchim Champaran               |
-| nan     | number          | 5.9884        | 0.6307     | 4.000E-08  | 0.0439     | 2.9378      | 211        | Pashchim Champaran               |
-| nan     | residents       | 8.3876        | 1.0074     | 6.165E-08  | 0.0774     | 4.9939      | 211        | Pashchim Champaran               |
-| nan     | affectedpop     | 8.3876        | 1.2891     | 6.165E-08  | 0.1686     | 5.5287      | 211        | Pashchim Champaran               |
-| nan     | injured         | 4.6342        | 0.0182     | 3.406E-08  | 0.0014     | 0.0881      | 211        | Pashchim Champaran               |
-| nan     | embodied_carbon | 298.1         | 36.3638    | 0.2215     | 6.0661     | 177.3427    | 211        | Pashchim Champaran               |
-| nan     | contents        | 113_292       | 5_021      | 0.0        | 8.254E-04  | 42_847      | 213        | Purbi Champaran                  |
-| nan     | structural      | 641_992       | 39_707     | 135.2999   | 2_229      | 206_651     | 213        | Purbi Champaran                  |
-| nan     | occupants       | 2.4460        | 0.0076     | 6.255E-09  | 2.446E-08  | 0.0513      | 213        | Purbi Champaran                  |
-| nan     | area            | 563.2         | 27.8028    | 1.528E-06  | 0.0200     | 157.2389    | 213        | Purbi Champaran                  |
-| nan     | number          | 3.9613        | 0.1975     | 9.808E-09  | 1.288E-04  | 1.1402      | 213        | Purbi Champaran                  |
-| nan     | residents       | 4.4270        | 0.2464     | 1.132E-08  | 1.481E-04  | 1.5043      | 213        | Purbi Champaran                  |
-| nan     | affectedpop     | 4.4270        | 0.3071     | 1.132E-08  | 7.925E-04  | 1.9537      | 213        | Purbi Champaran                  |
-| nan     | injured         | 2.4460        | 0.0048     | 6.255E-09  | 2.446E-08  | 0.0289      | 213        | Purbi Champaran                  |
-| nan     | embodied_carbon | 179.7468      | 10.2205    | 0.0327     | 0.6177     | 53.0563     | 213        | Purbi Champaran                  |
-| nan     | contents        | 39_500        | 188.3      | 0.0        | 3.449E-07  | 70.7095     | 301        | Sonitpur                         |
-| nan     | structural      | 157_999       | 11_445     | 0.0        | 7_423      | 38_550      | 301        | Sonitpur                         |
-| nan     | occupants       | 2.3600        | 2.904E-04  | 0.0        | 2.360E-08  | 1.039E-04   | 301        | Sonitpur                         |
-| nan     | area            | 153.9952      | 0.6558     | 0.0        | 1.540E-06  | 0.5836      | 301        | Sonitpur                         |
-| nan     | number          | 0.3255        | 0.0014     | 0.0        | 3.255E-09  | 0.0012      | 301        | Sonitpur                         |
-| nan     | injured         | 2.3600        | 3.461E-04  | 0.0        | 2.360E-08  | 3.246E-04   | 301        | Sonitpur                         |
-| nan     | embodied_carbon | 66.8527       | 4.1234     | 0.0        | 2.8039     | 13.6596     | 301        | Sonitpur                         |
-| nan     | contents        | 4_212_693     | 34_445     | 0.0        | 0.0350     | 69_256      | 302        | Tinsukia                         |
-| nan     | structural      | 23_089_098    | 814_489    | 0.0        | 146_014    | 4_555_729   | 302        | Tinsukia                         |
-| nan     | occupants       | 265.1         | 0.0542     | 0.0        | 2.364E-06  | 0.4064      | 302        | Tinsukia                         |
-| nan     | area            | 20_437        | 451.7      | 0.0        | 1.914E-04  | 3_362       | 302        | Tinsukia                         |
-| nan     | number          | 127.3476      | 3.2469     | 0.0        | 1.253E-06  | 24.3387     | 302        | Tinsukia                         |
-| nan     | residents       | 404.8         | 12.1596    | 0.0        | 4.048E-06  | 101.8722    | 302        | Tinsukia                         |
-| nan     | affectedpop     | 404.8         | 16.2107    | 0.0        | 4.048E-06  | 150.3372    | 302        | Tinsukia                         |
-| nan     | injured         | 265.1         | 0.2344     | 0.0        | 2.364E-06  | 1.8519      | 302        | Tinsukia                         |
-| nan     | embodied_carbon | 7_353         | 259.4      | 0.0        | 58.9622    | 1_653       | 302        | Tinsukia                         |
-| nan     | contents        | 2_794_246     | 7_158      | 0.0        | 0.0055     | 37_069      | 303        | 24 Paraganas North               |
-| nan     | structural      | 12_132_778    | 228_856    | 0.0        | 104_856    | 993_616     | 303        | 24 Paraganas North               |
-| nan     | occupants       | 231.0         | 0.0117     | 0.0        | 7.464E-07  | 0.0871      | 303        | 24 Paraganas North               |
-| nan     | area            | 8_686         | 49.2003    | 0.0        | 3.178E-05  | 331.6       | 303        | 24 Paraganas North               |
-| nan     | number          | 31.2931       | 0.3432     | 0.0        | 1.979E-07  | 2.3904      | 303        | 24 Paraganas North               |
-| nan     | residents       | 34.6998       | 1.0000     | 0.0        | 3.470E-07  | 7.2103      | 303        | 24 Paraganas North               |
-| nan     | affectedpop     | 34.6998       | 1.5396     | 0.0        | 9.381E-04  | 10.7433     | 303        | 24 Paraganas North               |
-| nan     | injured         | 231.0         | 0.0169     | 0.0        | 7.464E-07  | 0.1135      | 303        | 24 Paraganas North               |
-| nan     | embodied_carbon | 3_711         | 45.0796    | 0.0        | 18.8069    | 202.5       | 303        | 24 Paraganas North               |
-| nan     | contents        | 31_933        | 1_757      | 0.0        | 3.193E-04  | 17_106      | 305        | Bankura                          |
-| nan     | structural      | 180_955       | 14_184     | 0.0        | 394.7      | 76_871      | 305        | Bankura                          |
-| nan     | occupants       | 0.8308        | 0.0036     | 0.0        | 8.308E-09  | 0.0342      | 305        | Bankura                          |
-| nan     | area            | 158.7322      | 11.4054    | 0.0        | 1.587E-06  | 107.0806    | 305        | Bankura                          |
-| nan     | number          | 1.0185        | 0.0732     | 0.0        | 1.018E-08  | 0.6871      | 305        | Bankura                          |
-| nan     | residents       | 1.5028        | 0.1196     | 0.0        | 1.503E-08  | 1.1411      | 305        | Bankura                          |
-| nan     | affectedpop     | 1.5028        | 0.1431     | 0.0        | 1.503E-08  | 1.2885      | 305        | Bankura                          |
-| nan     | injured         | 0.8308        | 0.0021     | 0.0        | 8.308E-09  | 0.0199      | 305        | Bankura                          |
-| nan     | embodied_carbon | 50.6431       | 4.1409     | 0.0        | 0.0918     | 44.8089     | 305        | Bankura                          |
-| nan     | contents        | 233_416       | 2_361      | 0.0        | 0.0011     | 108.9016    | 306        | Purba Bardhaman                  |
-| nan     | structural      | 1_144_644     | 49_629     | 0.0        | 18_360     | 256_645     | 306        | Purba Bardhaman                  |
-| nan     | occupants       | 15.4956       | 0.0031     | 0.0        | 1.384E-07  | 0.0171      | 306        | Purba Bardhaman                  |
-| nan     | area            | 1_046         | 15.1881    | 0.0        | 8.451E-06  | 135.8033    | 306        | Purba Bardhaman                  |
-| nan     | number          | 4.9719        | 0.0727     | 0.0        | 3.998E-08  | 0.7037      | 306        | Purba Bardhaman                  |
-| nan     | residents       | 9.0470        | 0.2428     | 0.0        | 9.047E-08  | 2.2188      | 306        | Purba Bardhaman                  |
-| nan     | affectedpop     | 9.0470        | 0.3625     | 0.0        | 9.047E-08  | 2.6345      | 306        | Purba Bardhaman                  |
-| nan     | injured         | 15.4956       | 0.0057     | 0.0        | 1.384E-07  | 0.0496      | 306        | Purba Bardhaman                  |
-| nan     | embodied_carbon | 389.7         | 14.3016    | 0.0        | 6.6808     | 75.3281     | 306        | Purba Bardhaman                  |
-| nan     | contents        | 1_193_401     | 2_841      | 1.262E-04  | 0.0094     | 7_516       | 307        | Birbhum                          |
-| nan     | structural      | 6_368_020     | 191_888    | 95.0361    | 145_698    | 576_441     | 307        | Birbhum                          |
-| nan     | occupants       | 54.1495       | 5.953E-04  | 1.131E-08  | 5.247E-07  | 0.0017      | 307        | Birbhum                          |
-| nan     | area            | 5_788         | 8.0035     | 4.920E-07  | 5.630E-05  | 19.0194     | 307        | Birbhum                          |
-| nan     | number          | 35.4939       | 0.0474     | 6.564E-09  | 3.449E-07  | 0.1163      | 307        | Birbhum                          |
-| nan     | residents       | 56.4040       | 0.1105     | 0.0        | 5.436E-07  | 0.2878      | 307        | Birbhum                          |
-| nan     | affectedpop     | 56.4040       | 0.1652     | 0.0        | 5.640E-07  | 0.5716      | 307        | Birbhum                          |
-| nan     | injured         | 54.1495       | 0.0028     | 1.131E-08  | 5.299E-07  | 0.0079      | 307        | Birbhum                          |
-| nan     | embodied_carbon | 1_900         | 57.5106    | 0.0257     | 39.7568    | 185.7       | 307        | Birbhum                          |
-| nan     | contents        | 2_542_273     | 12_618     | 0.0        | 0.0164     | 31_169      | 308        | Coochbehar                       |
-| nan     | structural      | 9_312_110     | 302_921    | 0.0        | 152_278    | 861_547     | 308        | Coochbehar                       |
-| nan     | occupants       | 85.0239       | 0.0102     | 0.0        | 7.879E-07  | 0.0505      | 308        | Coochbehar                       |
-| nan     | area            | 8_991         | 80.2892    | 0.0        | 8.850E-05  | 362.0       | 308        | Coochbehar                       |
-| nan     | number          | 43.0878       | 0.5702     | 0.0        | 4.206E-07  | 2.5939      | 308        | Coochbehar                       |
-| nan     | residents       | 81.2327       | 1.6812     | 0.0        | 8.123E-07  | 9.0903      | 308        | Coochbehar                       |
-| nan     | affectedpop     | 81.2327       | 2.2134     | 0.0        | 8.123E-07  | 16.1541     | 308        | Coochbehar                       |
-| nan     | injured         | 85.0239       | 0.0329     | 0.0        | 7.920E-07  | 0.1667      | 308        | Coochbehar                       |
-| nan     | embodied_carbon | 3_097         | 100.5490   | 0.0        | 55.0856    | 308.1       | 308        | Coochbehar                       |
-| nan     | contents        | 329_375       | 12_117     | 0.0        | 0.0030     | 4_496       | 309        | Darjeeling                       |
-| nan     | structural      | 1_825_067     | 81_923     | 0.0        | 9_980      | 581_577     | 309        | Darjeeling                       |
-| nan     | occupants       | 13.6299       | 0.0040     | 0.0        | 1.363E-07  | 0.0430      | 309        | Darjeeling                       |
-| nan     | area            | 1_611         | 53.8074    | 0.0        | 1.611E-05  | 571.3       | 309        | Darjeeling                       |
-| nan     | number          | 11.2009       | 0.3904     | 0.0        | 1.120E-07  | 4.1489      | 309        | Darjeeling                       |
-| nan     | residents       | 22.0994       | 0.9357     | 0.0        | 2.210E-07  | 10.2467     | 309        | Darjeeling                       |
-| nan     | affectedpop     | 22.0994       | 1.2112     | 0.0        | 2.210E-07  | 13.4355     | 309        | Darjeeling                       |
-| nan     | injured         | 13.6299       | 0.0180     | 0.0        | 1.363E-07  | 0.1928      | 309        | Darjeeling                       |
-| nan     | embodied_carbon | 590.9         | 29.9980    | 0.0        | 4.2061     | 282.4       | 309        | Darjeeling                       |
-| nan     | contents        | 17_402        | 156.2936   | 0.0        | 0.0        | 1_023       | 310        | Dinajpur Dakshin                 |
-| nan     | structural      | 69_610        | 3_913      | 0.0        | 2_311      | 16_548      | 310        | Dinajpur Dakshin                 |
-| nan     | occupants       | 3.1400        | 1.976E-08  | 0.0        | 3.140E-08  | 3.140E-08   | 310        | Dinajpur Dakshin                 |
-| nan     | area            | 76.3263       | 0.0130     | 0.0        | 7.633E-07  | 7.633E-07   | 310        | Dinajpur Dakshin                 |
-| nan     | number          | 0.3518        | 5.977E-05  | 0.0        | 3.518E-09  | 3.518E-09   | 310        | Dinajpur Dakshin                 |
-| nan     | injured         | 3.1400        | 1.934E-05  | 0.0        | 3.140E-08  | 3.140E-08   | 310        | Dinajpur Dakshin                 |
-| nan     | embodied_carbon | 33.0408       | 1.5048     | 0.0        | 0.8338     | 5.8421      | 310        | Dinajpur Dakshin                 |
-| nan     | contents        | 99_663        | 110.7882   | 0.0        | 3.160E-04  | 0.0194      | 311        | Dinajpur Uttar                   |
-| nan     | structural      | 564_757       | 11_007     | 0.0        | 6_415      | 30_801      | 311        | Dinajpur Uttar                   |
-| nan     | occupants       | 2.8434        | 4.174E-05  | 0.0        | 2.843E-08  | 2.843E-08   | 311        | Dinajpur Uttar                   |
-| nan     | area            | 495.4         | 0.5331     | 0.0        | 4.954E-06  | 0.0119      | 311        | Dinajpur Uttar                   |
-| nan     | number          | 1.5246        | 8.164E-04  | 0.0        | 1.525E-08  | 1.820E-05   | 311        | Dinajpur Uttar                   |
-| nan     | residents       | 5.1445        | 0.0106     | 0.0        | 5.144E-08  | 1.476E-04   | 311        | Dinajpur Uttar                   |
-| nan     | affectedpop     | 5.1445        | 0.0251     | 0.0        | 5.144E-08  | 9.154E-04   | 311        | Dinajpur Uttar                   |
-| nan     | injured         | 2.8434        | 1.267E-04  | 0.0        | 2.843E-08  | 2.843E-08   | 311        | Dinajpur Uttar                   |
-| nan     | embodied_carbon | 148.5405      | 2.1890     | 0.0        | 1.1806     | 6.4829      | 311        | Dinajpur Uttar                   |
-| nan     | contents        | 1_070_039     | 11_596     | 0.0        | 0.0099     | 69_645      | 312        | Hooghly                          |
-| nan     | structural      | 5_827_472     | 162_940    | 0.0        | 52_521     | 918_452     | 312        | Hooghly                          |
-| nan     | occupants       | 53.9320       | 0.0116     | 0.0        | 5.393E-07  | 0.0669      | 312        | Hooghly                          |
-| nan     | area            | 5_203         | 60.9601    | 0.0        | 5.203E-05  | 503.2       | 312        | Hooghly                          |
-| nan     | number          | 34.1601       | 0.3966     | 0.0        | 3.416E-07  | 3.2315      | 312        | Hooghly                          |
-| nan     | residents       | 72.3564       | 0.9416     | 0.0        | 7.236E-07  | 7.4372      | 312        | Hooghly                          |
-| nan     | affectedpop     | 72.3564       | 1.1971     | 0.0        | 7.236E-07  | 9.0454      | 312        | Hooghly                          |
-| nan     | injured         | 53.9320       | 0.0175     | 0.0        | 5.393E-07  | 0.1344      | 312        | Hooghly                          |
-| nan     | embodied_carbon | 1_660         | 54.5564    | 0.0        | 20.8316    | 282.6       | 312        | Hooghly                          |
-| nan     | contents        | 1_944_459     | 15_375     | 0.0        | 0.0178     | 17_979      | 313        | Howrah                           |
-| nan     | structural      | 10_767_553    | 279_610    | 0.0        | 91_894     | 1_276_180   | 313        | Howrah                           |
-| nan     | occupants       | 92.3295       | 0.0063     | 0.0        | 7.175E-07  | 0.0285      | 313        | Howrah                           |
-| nan     | area            | 9_504         | 76.9628    | 0.0        | 8.962E-05  | 402.9       | 313        | Howrah                           |
-| nan     | number          | 63.2854       | 0.5039     | 0.0        | 6.215E-07  | 2.6279      | 313        | Howrah                           |
-| nan     | residents       | 127.2377      | 1.2079     | 0.0        | 1.272E-06  | 6.9808      | 313        | Howrah                           |
-| nan     | affectedpop     | 127.2377      | 1.8499     | 0.0        | 1.272E-06  | 12.8768     | 313        | Howrah                           |
-| nan     | injured         | 92.3295       | 0.0203     | 0.0        | 7.175E-07  | 0.1105      | 313        | Howrah                           |
-| nan     | embodied_carbon | 3_073         | 69.7229    | 0.0        | 17.3969    | 325.1       | 313        | Howrah                           |
-| nan     | contents        | 208_060       | 535.5      | 0.0        | 0.0017     | 0.0021      | 401        | Datia                            |
-| nan     | structural      | 896_696       | 27_737     | 0.0        | 10_818     | 115_569     | 401        | Datia                            |
-| nan     | occupants       | 18.5046       | 0.0015     | 0.0        | 1.850E-07  | 0.0092      | 401        | Datia                            |
-| nan     | area            | 852.6         | 4.6508     | 0.0        | 8.526E-06  | 29.3682     | 401        | Datia                            |
-| nan     | number          | 4.6262        | 0.0336     | 0.0        | 4.626E-08  | 0.2133      | 401        | Datia                            |
-| nan     | residents       | 1.4551        | 0.0399     | 0.0        | 1.455E-08  | 0.2968      | 401        | Datia                            |
-| nan     | affectedpop     | 1.4551        | 0.0502     | 0.0        | 1.455E-08  | 0.4525      | 401        | Datia                            |
-| nan     | injured         | 18.5046       | 8.562E-04  | 0.0        | 1.850E-07  | 0.0053      | 401        | Datia                            |
-| nan     | embodied_carbon | 347.2         | 8.7326     | 0.0        | 3.6962     | 35.2633     | 401        | Datia                            |
-| nan     | contents        | 2_007_762     | 3_936      | 0.0        | 0.0041     | 1_248       | 402        | Dewas                            |
-| nan     | structural      | 8_718_749     | 328_338    | 0.0        | 295_568    | 1_191_072   | 402        | Dewas                            |
-| nan     | occupants       | 134.0586      | 0.0016     | 0.0        | 1.270E-06  | 1.341E-06   | 402        | Dewas                            |
-| nan     | area            | 6_285         | 11.8405    | 0.0        | 4.707E-05  | 0.8321      | 402        | Dewas                            |
-| nan     | number          | 17.4366       | 0.0739     | 0.0        | 1.012E-07  | 0.0053      | 402        | Dewas                            |
-| nan     | residents       | 13.0611       | 0.1102     | 0.0        | 1.306E-07  | 0.0093      | 402        | Dewas                            |
-| nan     | affectedpop     | 13.0611       | 0.1504     | 0.0        | 1.306E-07  | 0.1119      | 402        | Dewas                            |
-| nan     | injured         | 134.0586      | 0.0021     | 0.0        | 1.270E-06  | 1.341E-06   | 402        | Dewas                            |
-| nan     | embodied_carbon | 2_669         | 86.9308    | 0.0        | 75.1564    | 357.7       | 402        | Dewas                            |
-| nan     | contents        | 470_021       | 882.0      | 0.0        | 8.873E-04  | 5.4887      | 405        | East Nimar                       |
-| nan     | structural      | 2_515_574     | 85_463     | 0.0        | 61_462     | 229_945     | 405        | East Nimar                       |
-| nan     | occupants       | 13.8077       | 9.462E-04  | 0.0        | 1.381E-07  | 6.440E-04   | 405        | East Nimar                       |
-| nan     | area            | 2_241         | 8.8803     | 0.0        | 2.241E-05  | 7.1553      | 405        | East Nimar                       |
-| nan     | number          | 14.7462       | 0.0634     | 0.0        | 1.475E-07  | 0.0520      | 405        | East Nimar                       |
-| nan     | residents       | 11.1474       | 0.0678     | 0.0        | 1.115E-07  | 0.0438      | 405        | East Nimar                       |
-| nan     | affectedpop     | 11.1474       | 0.1352     | 0.0        | 1.115E-07  | 0.2529      | 405        | East Nimar                       |
-| nan     | injured         | 13.8077       | 0.0014     | 0.0        | 1.381E-07  | 9.017E-04   | 405        | East Nimar                       |
-| nan     | embodied_carbon | 717.6         | 17.9370    | 0.0        | 11.8254    | 48.2196     | 405        | East Nimar                       |
-| nan     | contents        | 5_703         | 24.1633    | 0.0        | 5.703E-05  | 5.703E-05   | 407        | Gwalior                          |
-| nan     | structural      | 22_811        | 987.1      | 0.0        | 506.5      | 4_544       | 407        | Gwalior                          |
-| nan     | occupants       | 0.9700        | 9.646E-05  | 0.0        | 9.700E-09  | 3.492E-05   | 407        | Gwalior                          |
-| nan     | area            | 22.2327       | 0.0764     | 0.0        | 2.223E-07  | 0.0581      | 407        | Gwalior                          |
-| nan     | number          | 0.1025        | 3.521E-04  | 0.0        | 1.025E-09  | 2.679E-04   | 407        | Gwalior                          |
-| nan     | injured         | 0.9700        | 1.139E-04  | 0.0        | 9.700E-09  | 4.437E-05   | 407        | Gwalior                          |
-| nan     | embodied_carbon | 9.6263        | 0.3203     | 0.0        | 0.1662     | 1.6076      | 407        | Gwalior                          |
-| nan     | contents        | 432_934       | 3_320      | 0.0        | 0.0024     | 270.6       | 408        | Harda                            |
-| nan     | structural      | 2_453_292     | 45_841     | 0.0        | 8_737      | 270_139     | 408        | Harda                            |
-| nan     | occupants       | 8.7727        | 9.577E-04  | 0.0        | 6.607E-08  | 0.0087      | 408        | Harda                            |
-| nan     | area            | 2_152         | 22.7470    | 0.0        | 2.046E-05  | 176.7577    | 408        | Harda                            |
-| nan     | number          | 12.8435       | 0.1269     | 0.0        | 1.234E-07  | 0.9197      | 408        | Harda                            |
-| nan     | residents       | 15.8756       | 0.2123     | 0.0        | 1.508E-07  | 1.8962      | 408        | Harda                            |
-| nan     | affectedpop     | 15.8756       | 0.2750     | 0.0        | 1.508E-07  | 2.6008      | 408        | Harda                            |
-| nan     | injured         | 8.7727        | 0.0040     | 0.0        | 6.607E-08  | 0.0355      | 408        | Harda                            |
-| nan     | embodied_carbon | 708.4         | 13.3524    | 0.0        | 3.7659     | 74.5634     | 408        | Harda                            |
-| nan     | contents        | 389_521       | 10_006     | 0.0        | 0.0039     | 905.1       | 410        | Indore                           |
-| nan     | structural      | 2_207_290     | 85_973     | 0.0        | 5_490      | 342_637     | 410        | Indore                           |
-| nan     | occupants       | 6.7657        | 0.0020     | 0.0        | 6.766E-08  | 0.0122      | 410        | Indore                           |
-| nan     | area            | 1_936         | 62.5282    | 0.0        | 1.936E-05  | 371.5       | 410        | Indore                           |
-| nan     | number          | 14.0646       | 0.4542     | 0.0        | 1.406E-07  | 2.6986      | 410        | Indore                           |
-| nan     | residents       | 12.2452       | 0.4394     | 0.0        | 1.225E-07  | 3.1471      | 410        | Indore                           |
-| nan     | affectedpop     | 12.2452       | 0.5220     | 0.0        | 1.225E-07  | 4.7566      | 410        | Indore                           |
-| nan     | injured         | 6.7657        | 0.0088     | 0.0        | 6.766E-08  | 0.0569      | 410        | Indore                           |
-| nan     | embodied_carbon | 624.1         | 25.1566    | 0.0        | 1.6145     | 148.2027    | 410        | Indore                           |
-| nan     | contents        | 27_572        | 1_348      | 0.0        | 1.440E-09  | 15_297      | 411        | Jabalpur                         |
-| nan     | structural      | 156_239       | 10_617     | 0.0        | 393.7      | 113_028     | 411        | Jabalpur                         |
-| nan     | occupants       | 0.5334        | 2.882E-04  | 0.0        | 5.334E-09  | 0.0021      | 411        | Jabalpur                         |
-| nan     | area            | 137.0517      | 7.9348     | 0.0        | 1.371E-06  | 58.7887     | 411        | Jabalpur                         |
-| nan     | number          | 0.9955        | 0.0576     | 0.0        | 9.955E-09  | 0.4270      | 411        | Jabalpur                         |
-| nan     | residents       | 0.9655        | 0.0616     | 0.0        | 9.655E-09  | 0.4996      | 411        | Jabalpur                         |
-| nan     | affectedpop     | 0.9655        | 0.0721     | 0.0        | 9.655E-09  | 0.6354      | 411        | Jabalpur                         |
-| nan     | injured         | 0.5334        | 0.0012     | 0.0        | 5.334E-09  | 0.0095      | 411        | Jabalpur                         |
-| nan     | embodied_carbon | 43.7529       | 2.9019     | 0.0        | 0.1145     | 27.3795     | 411        | Jabalpur                         |
-| nan     | contents        | 32_437        | 893.4      | 0.0        | 3.244E-04  | 7_672       | 412        | Jhabua                           |
-| nan     | structural      | 183_810       | 8_336      | 0.0        | 167.7227   | 88_623      | 412        | Jhabua                           |
-| nan     | occupants       | 0.4709        | 1.771E-04  | 0.0        | 4.709E-09  | 0.0026      | 412        | Jhabua                           |
-| nan     | area            | 161.2371      | 7.9759     | 0.0        | 1.612E-06  | 115.0658    | 412        | Jhabua                           |
-| nan     | number          | 1.0346        | 0.0512     | 0.0        | 1.035E-08  | 0.7383      | 412        | Jhabua                           |
-| nan     | residents       | 0.8523        | 0.0455     | 0.0        | 8.523E-09  | 0.6633      | 412        | Jhabua                           |
-| nan     | affectedpop     | 0.8523        | 0.0513     | 0.0        | 8.523E-09  | 0.7347      | 412        | Jhabua                           |
-| nan     | injured         | 0.4709        | 8.199E-04  | 0.0        | 4.709E-09  | 0.0118      | 412        | Jhabua                           |
-| nan     | embodied_carbon | 58.4272       | 3.1388     | 0.0        | 0.0473     | 27.8439     | 412        | Jhabua                           |
-| nan     | contents        | 61_274        | 77.6199    | 0.0        | 6.127E-04  | 6.127E-04   | 501        | Adilabad                         |
-| nan     | structural      | 347_217       | 7_762      | 0.0        | 1_564      | 36_238      | 501        | Adilabad                         |
-| nan     | occupants       | 1.2600        | 1.102E-04  | 0.0        | 1.260E-08  | 1.334E-04   | 501        | Adilabad                         |
-| nan     | area            | 304.6         | 0.9242     | 0.0        | 3.046E-06  | 1.2704      | 501        | Adilabad                         |
-| nan     | number          | 1.9543        | 0.0059     | 0.0        | 1.954E-08  | 0.0082      | 501        | Adilabad                         |
-| nan     | residents       | 2.2800        | 0.0098     | 0.0        | 2.280E-08  | 0.0176      | 501        | Adilabad                         |
-| nan     | affectedpop     | 2.2800        | 0.0248     | 0.0        | 2.280E-08  | 0.1083      | 501        | Adilabad                         |
-| nan     | injured         | 1.2600        | 1.314E-04  | 0.0        | 1.260E-08  | 1.695E-04   | 501        | Adilabad                         |
-| nan     | embodied_carbon | 91.1614       | 1.5770     | 0.0        | 0.2339     | 6.8225      | 501        | Adilabad                         |
-| nan     | contents        | 1_342_213     | 29_695     | 9.948E-13  | 0.0119     | 940.0       | 503        | Chittoor                         |
-| nan     | structural      | 7_560_317     | 289_306    | 8_611      | 59_175     | 784_579     | 503        | Chittoor                         |
-| nan     | occupants       | 37.9473       | 0.0094     | 1.234E-08  | 3.795E-07  | 0.0169      | 503        | Chittoor                         |
-| nan     | area            | 6_038         | 155.1349   | 5.646E-06  | 0.0298     | 347.0       | 503        | Chittoor                         |
-| nan     | number          | 43.6028       | 1.1269     | 4.101E-08  | 2.162E-04  | 2.5205      | 503        | Chittoor                         |
-| nan     | residents       | 65.9162       | 2.0198     | 2.280E-08  | 2.212E-04  | 4.9918      | 503        | Chittoor                         |
-| nan     | affectedpop     | 65.9162       | 2.5358     | 2.280E-08  | 0.0023     | 9.4411      | 503        | Chittoor                         |
-| nan     | injured         | 37.9473       | 0.0397     | 1.234E-08  | 3.795E-07  | 0.0852      | 503        | Chittoor                         |
-| nan     | embodied_carbon | 2_151         | 81.1058    | 1.0017     | 15.8024    | 204.5       | 503        | Chittoor                         |
-| nan     | contents        | 2_880_514     | 24_099     | 8.935E-04  | 0.0269     | 116_807     | 504        | Y.S.R.                           |
-| nan     | structural      | 16_322_907    | 731_439    | 1_633      | 554_334    | 1_467_345   | 504        | Y.S.R.                           |
-| nan     | occupants       | 111.5704      | 0.0083     | 3.348E-08  | 1.116E-06  | 0.0203      | 504        | Y.S.R.                           |
-| nan     | area            | 14_318        | 103.8721   | 8.275E-06  | 0.0216     | 379.4       | 504        | Y.S.R.                           |
-| nan     | number          | 24.7422       | 0.4046     | 5.868E-08  | 1.378E-04  | 2.7975      | 504        | Y.S.R.                           |
-| nan     | residents       | 201.9         | 1.5413     | 6.061E-08  | 1.307E-04  | 4.8538      | 504        | Y.S.R.                           |
-| nan     | affectedpop     | 201.9         | 2.1909     | 6.061E-08  | 0.0015     | 6.5168      | 504        | Y.S.R.                           |
-| nan     | injured         | 111.5704      | 0.0266     | 3.348E-08  | 1.116E-06  | 0.0882      | 504        | Y.S.R.                           |
-| nan     | embodied_carbon | 4_319         | 138.7893   | 0.3477     | 94.8724    | 314.2       | 504        | Y.S.R.                           |
-| nan     | contents        | 257_366       | 66.7957    | 0.0        | 0.0023     | 10.2265     | 505        | East Godavari                    |
-| nan     | structural      | 1_458_412     | 51_497     | 0.0        | 40_951     | 112_345     | 505        | East Godavari                    |
-| nan     | occupants       | 2.8662        | 1.124E-05  | 0.0        | 2.866E-08  | 2.866E-08   | 505        | East Godavari                    |
-| nan     | area            | 1_279         | 0.5676     | 0.0        | 1.279E-05  | 0.0959      | 505        | East Godavari                    |
-| nan     | number          | 6.4823        | 0.0028     | 0.0        | 6.482E-08  | 6.688E-04   | 505        | East Godavari                    |
-| nan     | residents       | 5.1832        | 0.0034     | 0.0        | 5.183E-08  | 5.460E-04   | 505        | East Godavari                    |
-| nan     | affectedpop     | 5.1832        | 0.0115     | 0.0        | 5.183E-08  | 0.0029      | 505        | East Godavari                    |
-| nan     | injured         | 2.8662        | 5.044E-05  | 0.0        | 2.866E-08  | 2.866E-08   | 505        | East Godavari                    |
-| nan     | embodied_carbon | 383.5         | 10.4842    | 0.0        | 8.1232     | 22.7626     | 505        | East Godavari                    |
-| nan     | contents        | 45_417        | 750.6      | 0.0        | 2.775E-04  | 5_043       | 506        | Guntur                           |
-| nan     | structural      | 257_365       | 11_941     | 46.5268    | 3_356      | 79_501      | 506        | Guntur                           |
-| nan     | occupants       | 0.6118        | 1.731E-04  | 1.949E-09  | 6.118E-09  | 0.0015      | 506        | Guntur                           |
-| nan     | area            | 225.8         | 5.7778     | 8.784E-07  | 2.258E-06  | 53.0844     | 506        | Guntur                           |
-| nan     | number          | 1.6399        | 0.0420     | 6.381E-09  | 1.640E-08  | 0.3856      | 506        | Guntur                           |
-| nan     | residents       | 1.1090        | 0.0387     | 3.544E-09  | 1.109E-08  | 0.3626      | 506        | Guntur                           |
-| nan     | affectedpop     | 1.1090        | 0.0555     | 3.544E-09  | 2.468E-05  | 0.4651      | 506        | Guntur                           |
-| nan     | injured         | 0.6118        | 7.281E-04  | 1.949E-09  | 6.118E-09  | 0.0077      | 506        | Guntur                           |
-| nan     | embodied_carbon | 70.3458       | 3.0573     | 0.0135     | 0.6158     | 19.8336     | 506        | Guntur                           |
-| nan     | contents        | 73_285        | 1_033      | 0.0        | 7.328E-04  | 98.4103     | 507        | Hyderabad                        |
-| nan     | structural      | 415_280       | 14_460     | 0.0        | 1_701      | 76_076      | 507        | Hyderabad                        |
-| nan     | occupants       | 0.8732        | 1.894E-04  | 0.0        | 8.732E-09  | 6.170E-04   | 507        | Hyderabad                        |
-| nan     | area            | 364.3         | 7.0079     | 0.0        | 3.643E-06  | 31.6230     | 507        | Hyderabad                        |
-| nan     | number          | 2.4543        | 0.0501     | 0.0        | 2.454E-08  | 0.2295      | 507        | Hyderabad                        |
-| nan     | residents       | 1.5800        | 0.0333     | 0.0        | 1.580E-08  | 0.1590      | 507        | Hyderabad                        |
-| nan     | affectedpop     | 1.5800        | 0.0488     | 0.0        | 1.580E-08  | 0.2486      | 507        | Hyderabad                        |
-| nan     | injured         | 0.8732        | 6.119E-04  | 0.0        | 8.732E-09  | 0.0029      | 507        | Hyderabad                        |
-| nan     | embodied_carbon | 117.7554      | 3.8081     | 0.0        | 0.3608     | 19.7094     | 507        | Hyderabad                        |
-| nan     | contents        | 812_011       | 25_694     | 3.023E-04  | 0.0064     | 134_897     | 509        | Khammam                          |
-| nan     | structural      | 4_601_397     | 355_479    | 370.9      | 27_628     | 1_824_446   | 509        | Khammam                          |
-| nan     | occupants       | 15.9760       | 0.0094     | 6.582E-09  | 1.598E-07  | 0.0599      | 509        | Khammam                          |
-| nan     | area            | 4_036         | 257.7      | 1.547E-06  | 0.1134     | 1_630       | 509        | Khammam                          |
-| nan     | number          | 29.0576       | 1.8721     | 9.927E-09  | 8.235E-04  | 11.8397     | 509        | Khammam                          |
-| nan     | residents       | 28.9154       | 2.1689     | 1.191E-08  | 8.463E-04  | 13.4104     | 509        | Khammam                          |
-| nan     | affectedpop     | 28.9154       | 2.8367     | 1.191E-08  | 0.0026     | 15.9380     | 509        | Khammam                          |
-| nan     | injured         | 15.9760       | 0.0421     | 6.582E-09  | 1.598E-07  | 0.2613      | 509        | Khammam                          |
-| nan     | embodied_carbon | 1_408         | 102.4609   | 0.2957     | 9.3349     | 511.0       | 509        | Khammam                          |
-| nan     | contents        | 156_655       | 3_450      | 0.0        | 0.0016     | 9_152       | 511        | Kurnool                          |
-| nan     | structural      | 887_709       | 45_243     | 0.0        | 1_826      | 323_515     | 511        | Kurnool                          |
-| nan     | occupants       | 2.1631        | 6.415E-04  | 0.0        | 2.163E-08  | 0.0040      | 511        | Kurnool                          |
-| nan     | area            | 778.7         | 30.4203    | 0.0        | 7.787E-06  | 188.9       | 511        | Kurnool                          |
-| nan     | number          | 4.9966        | 0.1952     | 0.0        | 4.997E-08  | 1.2123      | 511        | Kurnool                          |
-| nan     | residents       | 3.9150        | 0.1838     | 0.0        | 3.915E-08  | 1.1985      | 511        | Kurnool                          |
-| nan     | affectedpop     | 3.9150        | 0.2498     | 0.0        | 3.915E-08  | 1.7258      | 511        | Kurnool                          |
-| nan     | injured         | 2.1631        | 0.0031     | 0.0        | 2.163E-08  | 0.0199      | 511        | Kurnool                          |
-| nan     | embodied_carbon | 282.2         | 16.1755    | 0.0        | 0.5430     | 100.5425    | 511        | Kurnool                          |
-| nan     | contents        | 84_950        | 1_170      | 0.0        | 8.495E-04  | 1.2677      | 601        | Yanam                            |
-| nan     | structural      | 481_386       | 10_426     | 0.0        | 992.9      | 41_270      | 601        | Yanam                            |
-| nan     | occupants       | 1.7672        | 2.557E-04  | 0.0        | 1.767E-08  | 9.739E-04   | 601        | Yanam                            |
-| nan     | area            | 422.3         | 5.7409     | 0.0        | 4.223E-06  | 21.4453     | 601        | Yanam                            |
-| nan     | number          | 2.0275        | 0.0276     | 0.0        | 2.027E-08  | 0.1030      | 601        | Yanam                            |
-| nan     | residents       | 3.1990        | 0.0504     | 0.0        | 3.199E-08  | 0.1981      | 601        | Yanam                            |
-| nan     | affectedpop     | 3.1990        | 0.0700     | 0.0        | 3.199E-08  | 0.3255      | 601        | Yanam                            |
-| nan     | injured         | 1.7672        | 9.959E-04  | 0.0        | 1.767E-08  | 0.0039      | 601        | Yanam                            |
-| nan     | embodied_carbon | 134.8824      | 2.4082     | 0.0        | 0.2792     | 10.3141     | 601        | Yanam                            |
-| nan     | contents        | 350_692       | 2_156      | 0.0        | 0.0029     | 0.0035      | 602        | South Andamans                   |
-| nan     | structural      | 1_886_549     | 41_411     | 0.0        | 18_453     | 126_919     | 602        | South Andamans                   |
-| nan     | occupants       | 11.1231       | 6.356E-04  | 0.0        | 1.112E-07  | 3.700E-04   | 602        | South Andamans                   |
-| nan     | area            | 1_678         | 5.5118     | 0.0        | 1.678E-05  | 3.3999      | 602        | South Andamans                   |
-| nan     | number          | 10.3438       | 0.0354     | 0.0        | 1.034E-07  | 0.0218      | 602        | South Andamans                   |
-| nan     | residents       | 12.3837       | 0.0518     | 0.0        | 1.238E-07  | 0.0518      | 602        | South Andamans                   |
-| nan     | affectedpop     | 12.3837       | 0.1081     | 0.0        | 1.238E-07  | 0.3366      | 602        | South Andamans                   |
-| nan     | injured         | 11.1231       | 7.515E-04  | 0.0        | 1.112E-07  | 4.681E-04   | 602        | South Andamans                   |
-| nan     | embodied_carbon | 542.2         | 11.5887    | 0.0        | 5.7370     | 36.0457     | 602        | South Andamans                   |
-| nan     | contents        | 2_673_214     | 24_429     | 2.958E-24  | 0.0136     | 67_232      | 603        | Nicobars                         |
-| nan     | structural      | 13_852_013    | 534_742    | 8_386      | 302_588    | 1_984_901   | 603        | Nicobars                         |
-| nan     | occupants       | 125.1724      | 0.0353     | 5.678E-08  | 1.252E-06  | 0.1573      | 603        | Nicobars                         |
-| nan     | area            | 9_522         | 111.8568   | 6.177E-06  | 1.4069     | 484.1       | 603        | Nicobars                         |
-| nan     | number          | 33.2953       | 0.3616     | 7.057E-08  | 0.0040     | 2.2728      | 603        | Nicobars                         |
-| nan     | residents       | 108.2295      | 2.3215     | 1.031E-07  | 0.0226     | 12.7020     | 603        | Nicobars                         |
-| nan     | affectedpop     | 108.2295      | 4.2503     | 1.031E-07  | 0.1177     | 30.5818     | 603        | Nicobars                         |
-| nan     | injured         | 125.1724      | 0.0342     | 5.678E-08  | 1.252E-06  | 0.1631      | 603        | Nicobars                         |
-| nan     | embodied_carbon | 3_202         | 101.7848   | 0.8879     | 46.3207    | 304.9       | 603        | Nicobars                         |
-| nan     | contents        | 179_847       | 7_356      | 0.0        | 0.0014     | 36_413      | 604        | Nuh                              |
-| nan     | structural      | 953_778       | 54_139     | 0.0        | 14_743     | 211_571     | 604        | Nuh                              |
-| nan     | occupants       | 8.6916        | 0.0021     | 0.0        | 8.692E-08  | 0.0116      | 604        | Nuh                              |
-| nan     | area            | 851.9         | 29.8636    | 0.0        | 8.519E-06  | 160.6640    | 604        | Nuh                              |
-| nan     | number          | 5.4302        | 0.2168     | 0.0        | 5.430E-08  | 1.1671      | 604        | Nuh                              |
-| nan     | residents       | 9.7404        | 0.4966     | 0.0        | 9.740E-08  | 2.9256      | 604        | Nuh                              |
-| nan     | affectedpop     | 9.7404        | 0.6742     | 0.0        | 9.740E-08  | 4.2486      | 604        | Nuh                              |
-| nan     | injured         | 8.6916        | 0.0096     | 0.0        | 8.692E-08  | 0.0535      | 604        | Nuh                              |
-| nan     | embodied_carbon | 325.2         | 18.5224    | 0.0        | 5.3944     | 75.5190     | 604        | Nuh                              |
-| nan     | contents        | 103_499       | 77.6160    | 0.0        | 0.0010     | 0.0010      | 605        | Barnala                          |
-| nan     | structural      | 413_995       | 11_334     | 0.0        | 7_377      | 30_000      | 605        | Barnala                          |
-| nan     | area            | 403.5         | 4.572E-04  | 0.0        | 4.035E-06  | 4.035E-06   | 605        | Barnala                          |
-| nan     | number          | 1.8594        | 2.107E-06  | 0.0        | 1.859E-08  | 1.859E-08   | 605        | Barnala                          |
-| nan     | embodied_carbon | 174.6602      | 7.3430     | 0.0        | 5.9985     | 17.3613     | 605        | Barnala                          |
-| nan     | contents        | 260_096       | 46.5560    | 0.0        | 0.0026     | 0.0026      | 606        | Khunti                           |
-| nan     | structural      | 863_036       | 33_724     | 0.0        | 23_543     | 88_171      | 606        | Khunti                           |
-| nan     | occupants       | 13.1752       | 4.972E-05  | 0.0        | 1.318E-07  | 1.318E-07   | 606        | Khunti                           |
-| nan     | area            | 1_015         | 0.1410     | 0.0        | 1.015E-05  | 1.015E-05   | 606        | Khunti                           |
-| nan     | number          | 2.4583        | 3.077E-04  | 0.0        | 2.458E-08  | 2.458E-08   | 606        | Khunti                           |
-| nan     | residents       | 0.7694        | 7.985E-05  | 0.0        | 7.694E-09  | 7.694E-09   | 606        | Khunti                           |
-| nan     | affectedpop     | 0.7694        | 1.226E-04  | 0.0        | 7.694E-09  | 7.694E-09   | 606        | Khunti                           |
-| nan     | injured         | 13.1752       | 6.590E-05  | 0.0        | 1.318E-07  | 1.318E-07   | 606        | Khunti                           |
-| nan     | embodied_carbon | 393.2         | 14.5612    | 0.0        | 10.2194    | 36.1496     | 606        | Khunti                           |
-| nan     | contents        | 31_488        | 741.0      | 0.0        | 2.134E-20  | 1_170       | 610        | Ariyalur                         |
-| nan     | structural      | 125_951       | 8_146      | 0.0        | 6_602      | 20_725      | 610        | Ariyalur                         |
-| nan     | occupants       | 3.1200        | 4.682E-05  | 0.0        | 3.120E-08  | 3.120E-08   | 610        | Ariyalur                         |
-| nan     | area            | 122.7594      | 0.0914     | 0.0        | 1.228E-06  | 0.0930      | 610        | Ariyalur                         |
-| nan     | number          | 0.2563        | 1.907E-04  | 0.0        | 2.563E-09  | 1.941E-04   | 610        | Ariyalur                         |
-| nan     | injured         | 3.1200        | 1.029E-04  | 0.0        | 3.120E-08  | 3.120E-08   | 610        | Ariyalur                         |
-| nan     | embodied_carbon | 57.6895       | 3.0252     | 0.0        | 2.4737     | 7.8233      | 610        | Ariyalur                         |
-| nan     | contents        | 709_522       | 4_312      | 0.0        | 0.0039     | 25.9933     | 611        | Arwal                            |
-| nan     | structural      | 4_020_627     | 78_538     | 0.0        | 37_972     | 258_785     | 611        | Arwal                            |
-| nan     | occupants       | 15.6746       | 5.722E-04  | 0.0        | 1.567E-07  | 0.0015      | 611        | Arwal                            |
-| nan     | area            | 3_527         | 25.7792    | 0.0        | 3.527E-05  | 68.1381     | 611        | Arwal                            |
-| nan     | number          | 17.0976       | 0.1806     | 0.0        | 1.710E-07  | 0.4777      | 611        | Arwal                            |
-| nan     | residents       | 28.3689       | 0.1360     | 0.0        | 2.837E-07  | 0.4447      | 611        | Arwal                            |
-| nan     | affectedpop     | 28.3689       | 0.2085     | 0.0        | 2.837E-07  | 0.8977      | 611        | Arwal                            |
-| nan     | injured         | 15.6746       | 0.0026     | 0.0        | 1.567E-07  | 0.0076      | 611        | Arwal                            |
-| nan     | embodied_carbon | 1_183         | 28.0316    | 0.0        | 15.7644    | 73.9003     | 611        | Arwal                            |
-| nan     | contents        | 71_046        | 2_228      | 0.0        | 7.105E-04  | 8_631       | 612        | Chirang                          |
-| nan     | structural      | 402_592       | 22_525     | 0.0        | 1_422      | 216_789     | 612        | Chirang                          |
-| nan     | occupants       | 0.3914        | 1.554E-04  | 0.0        | 3.914E-09  | 0.0013      | 612        | Chirang                          |
-| nan     | area            | 353.2         | 16.5471    | 0.0        | 3.532E-06  | 133.4030    | 612        | Chirang                          |
-| nan     | number          | 2.4969        | 0.1202     | 0.0        | 2.497E-08  | 0.9690      | 612        | Chirang                          |
-| nan     | residents       | 0.7119        | 0.0340     | 0.0        | 7.119E-09  | 0.2901      | 612        | Chirang                          |
-| nan     | affectedpop     | 0.7119        | 0.0402     | 0.0        | 7.119E-09  | 0.3571      | 612        | Chirang                          |
-| nan     | injured         | 0.3914        | 6.800E-04  | 0.0        | 3.914E-09  | 0.0056      | 612        | Chirang                          |
-| nan     | embodied_carbon | 117.4089      | 6.8778     | 0.0        | 0.4668     | 65.5124     | 612        | Chirang                          |
-| nan     | contents        | 137_876       | 2_902      | 0.0        | 2.790E-04  | 0.0014      | 613        | Peren                            |
-| nan     | structural      | 781_298       | 28_287     | 0.0        | 3_306      | 78_416      | 613        | Peren                            |
-| nan     | occupants       | 3.3845        | 7.772E-04  | 0.0        | 3.385E-08  | 0.0023      | 613        | Peren                            |
-| nan     | area            | 685.3         | 16.6029    | 0.0        | 6.853E-06  | 48.2799     | 613        | Peren                            |
-| nan     | number          | 4.9784        | 0.1206     | 0.0        | 4.978E-08  | 0.3507      | 613        | Peren                            |
-| nan     | residents       | 6.1262        | 0.1840     | 0.0        | 6.126E-08  | 0.6451      | 613        | Peren                            |
-| nan     | affectedpop     | 6.1262        | 0.2647     | 0.0        | 6.126E-08  | 1.1266      | 613        | Peren                            |
-| nan     | injured         | 3.3845        | 0.0035     | 0.0        | 3.385E-08  | 0.0113      | 613        | Peren                            |
-| nan     | embodied_carbon | 250.6         | 9.2631     | 0.0        | 1.1325     | 28.0025     | 613        | Peren                            |
-| nan     | contents        | 27_851        | 38.6510    | 0.0        | 2.785E-04  | 0.0097      | 614        | Kiphire                          |
-| nan     | structural      | 157_823       | 2_140      | 0.0        | 1_156      | 9_544       | 614        | Kiphire                          |
-| nan     | occupants       | 0.6402        | 9.440E-09  | 0.0        | 6.402E-09  | 6.402E-09   | 614        | Kiphire                          |
-| nan     | area            | 138.4412      | 0.0015     | 0.0        | 1.384E-06  | 1.384E-06   | 614        | Kiphire                          |
-| nan     | number          | 1.0056        | 1.066E-05  | 0.0        | 1.006E-08  | 1.006E-08   | 614        | Kiphire                          |
-| nan     | residents       | 1.1588        | 1.249E-05  | 0.0        | 1.159E-08  | 1.159E-08   | 614        | Kiphire                          |
-| nan     | affectedpop     | 1.1588        | 5.089E-05  | 0.0        | 1.159E-08  | 1.159E-08   | 614        | Kiphire                          |
-| nan     | injured         | 0.6402        | 1.413E-07  | 0.0        | 6.402E-09  | 6.402E-09   | 614        | Kiphire                          |
-| nan     | embodied_carbon | 41.4737       | 1.0791     | 0.0        | 0.7018     | 4.2493      | 614        | Kiphire                          |
-| nan     | contents        | 553_823       | 36_319     | 0.0        | 0.0055     | 441_626     | 615        | Longleng                         |
-| nan     | structural      | 3_119_043     | 172_587    | 0.0        | 20_669     | 1_054_053   | 615        | Longleng                         |
-| nan     | occupants       | 22.2860       | 0.0100     | 0.0        | 2.229E-07  | 0.0872      | 615        | Longleng                         |
-| nan     | area            | 2_741         | 129.1067   | 0.0        | 2.741E-05  | 1_114       | 615        | Longleng                         |
-| nan     | number          | 19.7709       | 0.9504     | 0.0        | 1.977E-07  | 8.1987      | 615        | Longleng                         |
-| nan     | residents       | 39.1412       | 2.2498     | 0.0        | 3.914E-07  | 19.4799     | 615        | Longleng                         |
-| nan     | affectedpop     | 39.1412       | 2.9062     | 0.0        | 0.0043     | 23.9047     | 615        | Longleng                         |
-| nan     | injured         | 22.2860       | 0.0448     | 0.0        | 2.229E-07  | 0.3847      | 615        | Longleng                         |
-| nan     | embodied_carbon | 970.0         | 69.1976    | 0.0        | 7.9573     | 519.7       | 615        | Longleng                         |
-| nan     | contents        | 205_319       | 874.0      | 0.0        | 0.0013     | 2_072       | 702        | Kalimpong                        |
-| nan     | structural      | 821_278       | 65_182     | 0.0        | 44_576     | 178_981     | 702        | Kalimpong                        |
-| nan     | occupants       | 10.2863       | 8.523E-08  | 0.0        | 1.029E-07  | 1.029E-07   | 702        | Kalimpong                        |
-| nan     | area            | 837.0         | 0.1274     | 0.0        | 8.370E-06  | 8.370E-06   | 702        | Kalimpong                        |
-| nan     | number          | 2.7300        | 5.833E-04  | 0.0        | 2.730E-08  | 2.730E-08   | 702        | Kalimpong                        |
-| nan     | injured         | 10.2863       | 5.337E-05  | 0.0        | 1.029E-07  | 1.029E-07   | 702        | Kalimpong                        |
-| nan     | embodied_carbon | 380.7         | 25.3364    | 0.0        | 17.1904    | 71.1317     | 702        | Kalimpong                        |
-| nan     | contents        | 33_324        | 536.5      | 0.0        | 3.157E-33  | 2_602       | 704        | Paschim Bardhaman                |
-| nan     | structural      | 133_295       | 12_814     | 0.0        | 8_509      | 40_649      | 704        | Paschim Bardhaman                |
-| nan     | occupants       | 1.2200        | 1.015E-08  | 0.0        | 1.220E-08  | 1.220E-08   | 704        | Paschim Bardhaman                |
-| nan     | area            | 129.9173      | 0.0464     | 0.0        | 1.299E-06  | 1.299E-06   | 704        | Paschim Bardhaman                |
-| nan     | number          | 0.5987        | 2.138E-04  | 0.0        | 5.987E-09  | 5.987E-09   | 704        | Paschim Bardhaman                |
-| nan     | injured         | 1.2200        | 1.417E-05  | 0.0        | 1.220E-08  | 1.220E-08   | 704        | Paschim Bardhaman                |
-| nan     | embodied_carbon | 56.2378       | 4.4802     | 0.0        | 2.7974     | 15.2698     | 704        | Paschim Bardhaman                |
-| nan     | contents        | 3_778_145     | 268_591    | 0.0        | 0.0378     | 3_752_914   | 705        | Biswanath                        |
-| nan     | structural      | 21_409_488    | 1_970_432  | 0.0        | 77_529     | 13_481_124  | 705        | Biswanath                        |
-| nan     | occupants       | 144.1277      | 0.1094     | 0.0        | 1.441E-06  | 1.1380      | 705        | Biswanath                        |
-| nan     | area            | 14_446        | 1_176      | 0.0        | 1.445E-04  | 12_201      | 705        | Biswanath                        |
-| nan     | number          | 104.9380      | 8.5411     | 0.0        | 1.049E-06  | 88.6311     | 705        | Biswanath                        |
-| nan     | residents       | 266.6         | 24.5781    | 0.0        | 2.666E-06  | 238.6       | 705        | Biswanath                        |
-| nan     | affectedpop     | 266.6         | 29.7214    | 0.0        | 2.666E-06  | 252.3       | 705        | Biswanath                        |
-| nan     | injured         | 144.1277      | 0.4777     | 0.0        | 1.441E-06  | 4.8195      | 705        | Biswanath                        |
-| nan     | embodied_carbon | 5_238         | 493.8      | 0.0        | 19.7373    | 4_286       | 705        | Biswanath                        |
-| nan     | contents        | 256_701       | 2_406      | 3.131E-04  | 0.0023     | 30_902      | 706        | Majuli                           |
-| nan     | structural      | 1_454_639     | 53_832     | 621.8      | 34_398     | 250_796     | 706        | Majuli                           |
-| nan     | occupants       | 10.5937       | 8.135E-04  | 1.087E-08  | 1.059E-07  | 0.0059      | 706        | Majuli                           |
-| nan     | area            | 1_276         | 15.0228    | 2.962E-06  | 1.276E-05  | 111.4088    | 706        | Majuli                           |
-| nan     | number          | 9.0050        | 0.0970     | 1.998E-08  | 9.005E-08  | 0.7149      | 706        | Majuli                           |
-| nan     | residents       | 19.1741       | 0.2133     | 3.936E-08  | 1.917E-07  | 1.5345      | 706        | Majuli                           |
-| nan     | affectedpop     | 19.1741       | 0.2616     | 3.936E-08  | 1.917E-07  | 1.7045      | 706        | Majuli                           |
-| nan     | injured         | 10.5937       | 0.0038     | 2.175E-08  | 1.059E-07  | 0.0274      | 706        | Majuli                           |
-| nan     | embodied_carbon | 385.2         | 13.0567    | 0.1510     | 7.7384     | 53.8662     | 706        | Majuli                           |
-| nan     | contents        | 554_840       | 15_887     | 0.0        | 0.0055     | 9.2700      | 707        | South Salmara Mancachar          |
-| nan     | structural      | 3_144_092     | 184_282    | 0.0        | 12_577     | 1_240_961   | 707        | South Salmara Mancachar          |
-| nan     | occupants       | 17.1672       | 0.0086     | 0.0        | 1.717E-07  | 0.0872      | 707        | South Salmara Mancachar          |
-| nan     | area            | 2_758         | 148.3233   | 0.0        | 2.758E-05  | 1_497       | 707        | South Salmara Mancachar          |
-| nan     | number          | 20.0339       | 1.0774     | 0.0        | 2.003E-07  | 10.8722     | 707        | South Salmara Mancachar          |
-| nan     | residents       | 31.0722       | 1.9387     | 0.0        | 3.107E-07  | 19.6355     | 707        | South Salmara Mancachar          |
-| nan     | affectedpop     | 31.0722       | 2.4431     | 0.0        | 3.107E-07  | 23.5503     | 707        | South Salmara Mancachar          |
-| nan     | injured         | 17.1672       | 0.0380     | 0.0        | 1.717E-07  | 0.3813      | 707        | South Salmara Mancachar          |
-| nan     | embodied_carbon | 1_000         | 73.8032    | 0.0        | 4.1669     | 618.1       | 707        | South Salmara Mancachar          |
-| nan     | contents        | 308_213       | 17_106     | 0.0        | 1.746E-21  | 130_802     | 709        | Hojai                            |
-| nan     | structural      | 1_232_850     | 137_416    | 0.0        | 82_063     | 477_605     | 709        | Hojai                            |
-| nan     | occupants       | 0.8863        | 3.411E-08  | 0.0        | 8.863E-09  | 8.863E-09   | 709        | Hojai                            |
-| nan     | area            | 1_352         | 1.0728     | 0.0        | 1.352E-05  | 0.7530      | 709        | Hojai                            |
-| nan     | number          | 6.2295        | 0.0049     | 0.0        | 6.230E-08  | 0.0035      | 709        | Hojai                            |
-| nan     | injured         | 0.8863        | 2.189E-05  | 0.0        | 8.863E-09  | 3.067E-07   | 709        | Hojai                            |
-| nan     | embodied_carbon | 585.1         | 55.8281    | 0.0        | 31.0495    | 202.4       | 709        | Hojai                            |
-| nan     | contents        | 413_590       | 34.5248    | 0.0        | 3.135E-04  | 3.135E-04   | 711        | Reguengos de Monsaraz            |
-| nan     | structural      | 1_706_614     | 2_796      | 0.0        | 863.9      | 12_451      | 711        | Reguengos de Monsaraz            |
-| nan     | occupants       | 33.1251       | 2.707E-06  | 0.0        | 4.449E-09  | 4.449E-09   | 711        | Reguengos de Monsaraz            |
-| nan     | area            | 1_646         | 0.1263     | 0.0        | 1.558E-06  | 1.558E-06   | 711        | Reguengos de Monsaraz            |
-| nan     | number          | 3.1779        | 8.108E-04  | 0.0        | 1.000E-08  | 1.000E-08   | 711        | Reguengos de Monsaraz            |
-| nan     | residents       | 0.8053        | 6.732E-04  | 0.0        | 8.053E-09  | 8.053E-09   | 711        | Reguengos de Monsaraz            |
-| nan     | affectedpop     | 0.8053        | 7.411E-04  | 0.0        | 8.053E-09  | 8.053E-09   | 711        | Reguengos de Monsaraz            |
-| nan     | injured         | 33.1251       | 1.449E-05  | 0.0        | 4.449E-09  | 4.449E-09   | 711        | Reguengos de Monsaraz            |
-| nan     | embodied_carbon | 748.3         | 0.7391     | 0.0        | 0.2142     | 3.4690      | 711        | Reguengos de Monsaraz            |
-| nan     | contents        | 802_492       | 44_416     | 0.0        | 0.0041     | 380_966     | 712        | Kangpokpi                        |
-| nan     | structural      | 3_889_798     | 356_332    | 0.0        | 27_059     | 2_277_915   | 712        | Kangpokpi                        |
-| nan     | occupants       | 48.0186       | 0.1040     | 0.0        | 6.047E-04  | 0.7606      | 712        | Kangpokpi                        |
-| nan     | area            | 3_566         | 274.1      | 0.0        | 2.6418     | 1_978       | 712        | Kangpokpi                        |
-| nan     | number          | 15.5970       | 1.7455     | 0.0        | 0.0140     | 12.6791     | 712        | Kangpokpi                        |
-| nan     | residents       | 23.1499       | 3.3985     | 0.0        | 2.315E-07  | 22.8115     | 712        | Kangpokpi                        |
-| nan     | affectedpop     | 23.1499       | 4.1389     | 0.0        | 0.0122     | 23.0036     | 712        | Kangpokpi                        |
-| nan     | injured         | 48.0186       | 0.0689     | 0.0        | 0.0028     | 0.4206      | 712        | Kangpokpi                        |
-| nan     | embodied_carbon | 1_376         | 99.6584    | 0.0        | 7.5858     | 638.8       | 712        | Kangpokpi                        |
-| nan     | contents        | 879_271       | 44_861     | 1.540E-35  | 0.0051     | 311_080     | 801        | Australian Capital Territory     |
-| nan     | structural      | 4_982_535     | 421_637    | 52_879     | 173_580    | 1_621_283   | 801        | Australian Capital Territory     |
-| nan     | occupants       | 32.9778       | 0.0146     | 1.481E-07  | 3.298E-07  | 0.0715      | 801        | Australian Capital Territory     |
-| nan     | area            | 3_973         | 187.2      | 3.973E-05  | 4.9794     | 919.7       | 801        | Australian Capital Territory     |
-| nan     | number          | 11.0323       | 0.2825     | 1.103E-07  | 0.0076     | 1.4028      | 801        | Australian Capital Territory     |
-| nan     | residents       | 60.9903       | 2.7062     | 6.099E-07  | 0.1328     | 12.2305     | 801        | Australian Capital Territory     |
-| nan     | affectedpop     | 60.9903       | 3.6297     | 6.099E-07  | 0.3977     | 14.5229     | 801        | Australian Capital Territory     |
-| nan     | injured         | 32.9778       | 0.0496     | 3.298E-07  | 0.0021     | 0.2373      | 801        | Australian Capital Territory     |
-| nan     | embodied_carbon | 1_276         | 126.0222   | 11.7951    | 48.1645    | 512.4       | 801        | Australian Capital Territory     |
-| nan     | contents        | 141_727       | 1_782      | 0.0        | 0.0014     | 28_751      | 803        | Aljezur                          |
-| nan     | structural      | 803_122       | 51_704     | 5_045      | 20_977     | 190_882     | 803        | Aljezur                          |
-| nan     | occupants       | 3.3261        | 2.569E-04  | 3.326E-08  | 3.326E-08  | 0.0015      | 803        | Aljezur                          |
-| nan     | area            | 704.5         | 16.1702    | 7.045E-06  | 7.045E-06  | 98.5747     | 803        | Aljezur                          |
-| nan     | number          | 4.9859        | 0.1040     | 4.986E-08  | 4.986E-08  | 0.6326      | 803        | Aljezur                          |
-| nan     | residents       | 6.0202        | 0.0715     | 6.020E-08  | 6.020E-08  | 0.4046      | 803        | Aljezur                          |
-| nan     | affectedpop     | 6.0202        | 0.1000     | 6.020E-08  | 1.592E-04  | 0.4714      | 803        | Aljezur                          |
-| nan     | injured         | 3.3261        | 0.0012     | 3.326E-08  | 3.326E-08  | 0.0071      | 803        | Aljezur                          |
-| nan     | embodied_carbon | 220.8         | 12.8296    | 1.1274     | 4.6806     | 45.1669     | 803        | Aljezur                          |
-| nan     | contents        | 125_496       | 5_068      | 0.0        | 0.0013     | 7_328       | 804        | Castro Marim                     |
-| nan     | structural      | 711_144       | 73_733     | 0.0        | 2_869      | 657_435     | 804        | Castro Marim                     |
-| nan     | occupants       | 2.3156        | 0.0122     | 0.0        | 2.316E-08  | 0.1173      | 804        | Castro Marim                     |
-| nan     | area            | 623.8         | 53.6730    | 0.0        | 6.238E-06  | 517.6       | 804        | Castro Marim                     |
-| nan     | number          | 4.0028        | 0.3444     | 0.0        | 4.003E-08  | 3.3213      | 804        | Castro Marim                     |
-| nan     | residents       | 4.1911        | 0.3994     | 0.0        | 4.191E-08  | 3.7197      | 804        | Castro Marim                     |
-| nan     | affectedpop     | 4.1911        | 0.4750     | 0.0        | 8.026E-05  | 3.9423      | 804        | Castro Marim                     |
-| nan     | injured         | 2.3156        | 0.0071     | 0.0        | 2.316E-08  | 0.0670      | 804        | Castro Marim                     |
-| nan     | embodied_carbon | 199.0         | 18.9580    | 0.0        | 0.7215     | 177.3308    | 804        | Castro Marim                     |
-| nan     | contents        | 256_379       | 1_441      | 0.0        | 3.605E-04  | 103.8253    | 805        | Faro                             |
-| nan     | structural      | 1_452_814     | 36_889     | 0.0        | 20_749     | 131_297     | 805        | Faro                             |
-| nan     | occupants       | 9.7359        | 6.356E-04  | 0.0        | 6.504E-08  | 0.0044      | 805        | Faro                             |
-| nan     | area            | 980.3         | 4.0317     | 0.0        | 9.803E-06  | 41.4377     | 805        | Faro                             |
-| nan     | number          | 5.0464        | 0.0255     | 0.0        | 5.046E-08  | 0.3010      | 805        | Faro                             |
-| nan     | residents       | 18.0069       | 0.1037     | 0.0        | 1.801E-07  | 0.8589      | 805        | Faro                             |
-| nan     | affectedpop     | 18.0069       | 0.2492     | 0.0        | 1.801E-07  | 1.3724      | 805        | Faro                             |
-| nan     | injured         | 9.7359        | 0.0015     | 0.0        | 9.736E-08  | 0.0149      | 805        | Faro                             |
-| nan     | embodied_carbon | 296.6         | 4.9682     | 0.0        | 2.3797     | 23.3014     | 805        | Faro                             |
-| nan     | contents        | 784_756       | 35_432     | 3.616E-16  | 0.0076     | 156_780     | 806        | Lagoa                            |
-| nan     | structural      | 4_446_953     | 191_882    | 12_377     | 71_966     | 683_924     | 806        | Lagoa                            |
-| nan     | occupants       | 29.0013       | 0.0121     | 2.745E-07  | 6.045E-04  | 0.0717      | 806        | Lagoa                            |
-| nan     | area            | 3_901         | 64.4614    | 3.416E-05  | 4.2743     | 367.6       | 806        | Lagoa                            |
-| nan     | number          | 27.6520       | 0.4102     | 2.454E-07  | 0.0213     | 2.3537      | 806        | Lagoa                            |
-| nan     | residents       | 52.4954       | 0.4825     | 4.968E-07  | 0.0731     | 2.2880      | 806        | Lagoa                            |
-| nan     | affectedpop     | 52.4954       | 0.7532     | 5.250E-07  | 0.2738     | 2.8166      | 806        | Lagoa                            |
-| nan     | injured         | 29.0013       | 0.0083     | 2.745E-07  | 7.824E-04  | 0.0417      | 806        | Lagoa                            |
-| nan     | embodied_carbon | 1_178         | 69.2141    | 5.8380     | 30.5189    | 230.5       | 806        | Lagoa                            |
-| nan     | contents        | 688_402       | 5_097      | 0.0        | 1.252E-06  | 32_385      | 807        | Lagos                            |
-| nan     | structural      | 2_753_607     | 49_290     | 15_143     | 44_356     | 95_858      | 807        | Lagos                            |
-| nan     | occupants       | 72.3023       | 4.129E-04  | 1.201E-07  | 1.201E-07  | 0.0011      | 807        | Lagos                            |
-| nan     | area            | 2_415         | 0.7072     | 4.013E-06  | 4.013E-06  | 2.2255      | 807        | Lagos                            |
-| nan     | number          | 10.6901       | 0.0015     | 8.381E-09  | 8.381E-09  | 0.0046      | 807        | Lagos                            |
-| nan     | injured         | 72.3023       | 9.391E-04  | 1.201E-07  | 1.201E-07  | 0.0031      | 807        | Lagos                            |
-| nan     | embodied_carbon | 1_060         | 17.2167    | 5.1721     | 14.8274    | 34.7184     | 807        | Lagos                            |
-| nan     | contents        | 3_549_587     | 53_674     | 0.0015     | 23.2587    | 269_880     | 808        | Loulé                            |
-| nan     | structural      | 16_444_001    | 591_621    | 20_075     | 190_328    | 2_251_066   | 808        | Loulé                            |
-| nan     | occupants       | 182.8         | 0.0207     | 2.702E-07  | 0.0046     | 0.0899      | 808        | Loulé                            |
-| nan     | area            | 13_789        | 330.6      | 6.353E-05  | 66.0535    | 1_477       | 808        | Loulé                            |
-| nan     | number          | 49.5347       | 1.5773     | 3.250E-07  | 0.1591     | 6.6864      | 808        | Loulé                            |
-| nan     | residents       | 68.1863       | 4.2587     | 6.819E-07  | 1.0677     | 18.1566     | 808        | Loulé                            |
-| nan     | affectedpop     | 68.1863       | 5.4336     | 2.492E-04  | 1.8159     | 20.5144     | 808        | Loulé                            |
-| nan     | injured         | 182.8         | 0.0799     | 3.235E-07  | 0.0180     | 0.3529      | 808        | Loulé                            |
-| nan     | embodied_carbon | 5_477         | 163.7180   | 8.1150     | 57.1753    | 641.5       | 808        | Loulé                            |
-| nan     | contents        | 62_656        | 3_054      | 0.0        | 6.266E-04  | 10_726      | 809        | Monchique                        |
-| nan     | structural      | 355_052       | 34_325     | 0.0        | 1_428      | 257_414     | 809        | Monchique                        |
-| nan     | occupants       | 1.3442        | 8.147E-04  | 0.0        | 1.344E-08  | 0.0061      | 809        | Monchique                        |
-| nan     | area            | 311.4         | 24.8879    | 0.0        | 3.114E-06  | 184.7       | 809        | Monchique                        |
-| nan     | number          | 1.9985        | 0.1597     | 0.0        | 1.999E-08  | 1.1852      | 809        | Monchique                        |
-| nan     | residents       | 2.4329        | 0.2183     | 0.0        | 2.433E-08  | 1.6252      | 809        | Monchique                        |
-| nan     | affectedpop     | 2.4329        | 0.2691     | 0.0        | 2.433E-08  | 1.8931      | 809        | Monchique                        |
-| nan     | injured         | 1.3442        | 0.0039     | 0.0        | 1.344E-08  | 0.0284      | 809        | Monchique                        |
-| nan     | embodied_carbon | 112.8567      | 10.6166    | 0.0        | 0.4563     | 67.0703     | 809        | Monchique                        |
-| nan     | contents        | 351_759       | 0.0020     | 0.0        | 0.0035     | 0.0035      | 810        | Olhão                            |
-| nan     | structural      | 1_692_971     | 12_114     | 0.0        | 6_938      | 46_835      | 810        | Olhão                            |
-| nan     | occupants       | 19.7159       | 1.115E-07  | 0.0        | 1.972E-07  | 1.972E-07   | 810        | Olhão                            |
-| nan     | area            | 1_408         | 7.961E-06  | 0.0        | 1.408E-05  | 1.408E-05   | 810        | Olhão                            |
-| nan     | number          | 7.9393        | 4.490E-08  | 0.0        | 7.939E-08  | 7.939E-08   | 810        | Olhão                            |
-| nan     | residents       | 7.1483        | 4.043E-08  | 0.0        | 7.148E-08  | 7.148E-08   | 810        | Olhão                            |
-| nan     | affectedpop     | 7.1483        | 4.043E-08  | 0.0        | 7.148E-08  | 7.148E-08   | 810        | Olhão                            |
-| nan     | injured         | 19.7159       | 1.115E-07  | 0.0        | 1.972E-07  | 1.972E-07   | 810        | Olhão                            |
-| nan     | embodied_carbon | 528.3         | 8.0457     | 0.0        | 6.0743     | 26.1263     | 810        | Olhão                            |
-| nan     | contents        | 224_854       | 11_593     | 5.012E-25  | 6.487E-04  | 72_575      | 811        | Portimão                         |
-| nan     | structural      | 1_274_169     | 171_430    | 25_940     | 90_568     | 614_067     | 811        | Portimão                         |
-| nan     | occupants       | 7.4632        | 0.0128     | 6.617E-08  | 6.493E-04  | 0.0924      | 811        | Portimão                         |
-| nan     | area            | 1_016         | 72.1600    | 1.016E-05  | 5.3150     | 386.9       | 811        | Portimão                         |
-| nan     | number          | 5.4688        | 0.3999     | 5.469E-08  | 0.0288     | 1.9631      | 811        | Portimão                         |
-| nan     | residents       | 13.8024       | 1.2497     | 1.380E-07  | 0.1861     | 7.4456      | 811        | Portimão                         |
-| nan     | affectedpop     | 13.8024       | 2.0442     | 1.380E-07  | 0.6631     | 9.9077      | 811        | Portimão                         |
-| nan     | injured         | 7.4632        | 0.0203     | 6.617E-08  | 0.0018     | 0.1271      | 811        | Portimão                         |
-| nan     | embodied_carbon | 307.6         | 34.0372    | 2.3142     | 14.6505    | 172.0592    | 811        | Portimão                         |
-| nan     | contents        | 104_582       | 1_705      | 1.484E-42  | 8.294E-04  | 20_848      | 815        | Vila do Bispo                    |
-| nan     | structural      | 592_634       | 36_004     | 6_756      | 21_967     | 109_373     | 815        | Vila do Bispo                    |
-| nan     | occupants       | 2.0453        | 0.0011     | 2.045E-08  | 2.045E-08  | 0.0069      | 815        | Vila do Bispo                    |
-| nan     | area            | 519.9         | 5.6706     | 5.199E-06  | 0.1384     | 35.2724     | 815        | Vila do Bispo                    |
-| nan     | number          | 3.5113        | 0.0287     | 3.511E-08  | 6.644E-04  | 0.1694      | 815        | Vila do Bispo                    |
-| nan     | residents       | 3.7033        | 0.0995     | 3.703E-08  | 0.0025     | 0.6643      | 815        | Vila do Bispo                    |
-| nan     | affectedpop     | 3.7033        | 0.1973     | 3.703E-08  | 0.0268     | 1.0234      | 815        | Vila do Bispo                    |
-| nan     | injured         | 2.0453        | 0.0015     | 2.045E-08  | 2.045E-08  | 0.0099      | 815        | Vila do Bispo                    |
-| nan     | embodied_carbon | 155.7590      | 7.9418     | 1.1742     | 3.9875     | 27.0387     | 815        | Vila do Bispo                    |
-| nan     | contents        | 87_388        | 1_082      | 0.0        | 4.552E-28  | 6_489       | 816        | Vila Real de Santo António       |
-| nan     | structural      | 349_552       | 30_142     | 0.0        | 20_445     | 96_649      | 816        | Vila Real de Santo António       |
-| nan     | occupants       | 11.6400       | 3.785E-07  | 0.0        | 1.164E-07  | 1.164E-07   | 816        | Vila Real de Santo António       |
-| nan     | area            | 340.7         | 0.1280     | 0.0        | 3.407E-06  | 3.407E-06   | 816        | Vila Real de Santo António       |
-| nan     | number          | 1.5700        | 5.901E-04  | 0.0        | 1.570E-08  | 1.570E-08   | 816        | Vila Real de Santo António       |
-| nan     | injured         | 11.6400       | 1.382E-04  | 0.0        | 1.164E-07  | 1.164E-07   | 816        | Vila Real de Santo António       |
-| nan     | embodied_carbon | 147.4725      | 10.4697    | 0.0        | 6.9404     | 37.6442     | 816        | Vila Real de Santo António       |
-| nan     | contents        | 473_072       | 4_801      | 0.0        | 0.0032     | 140.7755    | 901        | Aguiar da Beira                  |
-| nan     | structural      | 2_680_741     | 80_892     | 0.0        | 13_000     | 518_945     | 901        | Aguiar da Beira                  |
-| nan     | occupants       | 5.8651        | 0.0072     | 0.0        | 5.865E-08  | 0.0572      | 901        | Aguiar da Beira                  |
-| nan     | area            | 2_352         | 43.1572    | 0.0        | 2.352E-05  | 459.1       | 901        | Aguiar da Beira                  |
-| nan     | number          | 15.7155       | 0.3120     | 0.0        | 1.572E-07  | 3.0279      | 901        | Aguiar da Beira                  |
-| nan     | residents       | 10.6183       | 0.1933     | 0.0        | 1.062E-07  | 2.0697      | 901        | Aguiar da Beira                  |
-| nan     | affectedpop     | 10.6183       | 0.2304     | 0.0        | 1.062E-07  | 2.5270      | 901        | Aguiar da Beira                  |
-| nan     | injured         | 5.8651        | 0.0039     | 0.0        | 5.865E-08  | 0.0419      | 901        | Aguiar da Beira                  |
-| nan     | embodied_carbon | 718.5         | 19.5956    | 0.0        | 2.2117     | 199.8       | 901        | Aguiar da Beira                  |
-| nan     | contents        | 247_064       | 6_233      | 0.0        | 0.0019     | 41_466      | 902        | Almeida                          |
-| nan     | structural      | 1_400_031     | 86_922     | 0.0        | 9_194      | 676_606     | 902        | Almeida                          |
-| nan     | occupants       | 2.7543        | 0.0012     | 0.0        | 2.754E-08  | 0.0113      | 902        | Almeida                          |
-| nan     | area            | 1_228         | 55.6590    | 0.0        | 1.228E-05  | 524.1       | 902        | Almeida                          |
-| nan     | number          | 8.1037        | 0.3610     | 0.0        | 8.104E-08  | 3.3904      | 902        | Almeida                          |
-| nan     | residents       | 4.9859        | 0.2804     | 0.0        | 4.986E-08  | 2.6771      | 902        | Almeida                          |
-| nan     | affectedpop     | 4.9859        | 0.3523     | 0.0        | 4.986E-08  | 3.3155      | 902        | Almeida                          |
-| nan     | injured         | 2.7543        | 0.0049     | 0.0        | 2.754E-08  | 0.0462      | 902        | Almeida                          |
-| nan     | embodied_carbon | 395.8         | 24.8746    | 0.0        | 1.5709     | 240.2       | 902        | Almeida                          |
-| nan     | contents        | 385_380       | 13_763     | 0.0        | 0.0025     | 193_386     | 903        | Celorico da Beira                |
-| nan     | structural      | 2_087_304     | 122_779    | 0.0        | 15_408     | 987_086     | 903        | Celorico da Beira                |
-| nan     | occupants       | 11.3510       | 0.0042     | 0.0        | 1.135E-07  | 0.0361      | 903        | Celorico da Beira                |
-| nan     | area            | 1_854         | 87.9920    | 0.0        | 1.854E-05  | 715.9       | 903        | Celorico da Beira                |
-| nan     | number          | 11.2335       | 0.6171     | 0.0        | 1.123E-07  | 4.9537      | 903        | Celorico da Beira                |
-| nan     | residents       | 14.8415       | 0.8900     | 0.0        | 1.484E-07  | 7.1316      | 903        | Celorico da Beira                |
-| nan     | affectedpop     | 14.8415       | 1.0446     | 0.0        | 1.484E-07  | 8.1304      | 903        | Celorico da Beira                |
-| nan     | injured         | 11.3510       | 0.0178     | 0.0        | 1.135E-07  | 0.1447      | 903        | Celorico da Beira                |
-| nan     | embodied_carbon | 654.3         | 34.7151    | 0.0        | 5.4844     | 298.6       | 903        | Celorico da Beira                |
-| nan     | contents        | 248_629       | 14_947     | 0.0        | 0.0020     | 207_207     | 906        | Gouveia                          |
-| nan     | structural      | 1_327_316     | 107_976    | 0.0        | 16_729     | 902_172     | 906        | Gouveia                          |
-| nan     | occupants       | 2.8414        | 0.0016     | 0.0        | 2.841E-08  | 0.0162      | 906        | Gouveia                          |
-| nan     | area            | 1_207         | 65.5878    | 0.0        | 1.207E-05  | 668.0       | 906        | Gouveia                          |
-| nan     | number          | 8.1993        | 0.4764     | 0.0        | 8.199E-08  | 4.8520      | 906        | Gouveia                          |
-| nan     | residents       | 4.6631        | 0.3420     | 0.0        | 4.663E-08  | 3.5024      | 906        | Gouveia                          |
-| nan     | affectedpop     | 4.6631        | 0.4041     | 0.0        | 4.663E-08  | 3.9635      | 906        | Gouveia                          |
-| nan     | injured         | 2.8414        | 0.0069     | 0.0        | 2.841E-08  | 0.0698      | 906        | Gouveia                          |
-| nan     | embodied_carbon | 452.8         | 36.2980    | 0.0        | 6.3562     | 344.5       | 906        | Gouveia                          |
-| nan     | contents        | 2_609_836     | 47_400     | 1.419E-04  | 0.0206     | 302_470     | 907        | Guarda                           |
-| nan     | structural      | 13_760_139    | 734_869    | 1_353      | 192_432    | 4_521_688   | 907        | Guarda                           |
-| nan     | occupants       | 89.0610       | 0.0250     | 1.490E-08  | 8.906E-07  | 0.1961      | 907        | Guarda                           |
-| nan     | area            | 9_418         | 308.2      | 1.141E-06  | 0.5267     | 2_184       | 907        | Guarda                           |
-| nan     | number          | 25.3995       | 0.4278     | 5.738E-09  | 4.230E-04  | 2.5794      | 907        | Guarda                           |
-| nan     | residents       | 80.1758       | 4.0124     | 3.217E-09  | 8.018E-07  | 32.3858     | 907        | Guarda                           |
-| nan     | affectedpop     | 80.1758       | 5.1121     | 3.217E-09  | 0.0038     | 40.9296     | 907        | Guarda                           |
-| nan     | injured         | 89.0610       | 0.0802     | 1.663E-08  | 8.906E-07  | 0.6181      | 907        | Guarda                           |
-| nan     | embodied_carbon | 3_485         | 171.7107   | 0.3191     | 43.4168    | 1_046       | 907        | Guarda                           |
-| nan     | contents        | 2_331_353     | 1_345      | 0.0        | 1.093E-04  | 0.1256      | 909        | Mêda                             |
-| nan     | structural      | 13_192_789    | 521_368    | 0.0        | 420_658    | 1_193_500   | 909        | Mêda                             |
-| nan     | occupants       | 55.4850       | 8.955E-04  | 0.0        | 5.549E-07  | 5.549E-07   | 909        | Mêda                             |
-| nan     | area            | 11_582        | 18.8574    | 0.0        | 1.158E-04  | 2.2896      | 909        | Mêda                             |
-| nan     | number          | 55.4926       | 0.0905     | 0.0        | 5.549E-07  | 0.0110      | 909        | Mêda                             |
-| nan     | residents       | 96.2618       | 0.2182     | 0.0        | 9.626E-07  | 0.0192      | 909        | Mêda                             |
-| nan     | affectedpop     | 96.2618       | 0.3722     | 0.0        | 9.626E-07  | 0.0283      | 909        | Mêda                             |
-| nan     | injured         | 55.4850       | 0.0035     | 0.0        | 5.549E-07  | 5.549E-07   | 909        | Mêda                             |
-| nan     | embodied_carbon | 3_479         | 105.4064   | 0.0        | 78.5782    | 242.6       | 909        | Mêda                             |
-| nan     | contents        | 31_826        | 691.2      | 0.0        | 3.183E-04  | 0.4801      | 910        | Pinhel                           |
-| nan     | structural      | 127_303       | 4_811      | 0.0        | 1_415      | 29_270      | 910        | Pinhel                           |
-| nan     | occupants       | 11.3249       | 4.057E-04  | 0.0        | 1.132E-07  | 0.0017      | 910        | Pinhel                           |
-| nan     | area            | 124.0767      | 2.0668     | 0.0        | 1.241E-06  | 8.3066      | 910        | Pinhel                           |
-| nan     | number          | 1.2407        | 0.0276     | 0.0        | 1.241E-08  | 0.1108      | 910        | Pinhel                           |
-| nan     | injured         | 11.3249       | 0.0020     | 0.0        | 1.132E-07  | 0.0087      | 910        | Pinhel                           |
-| nan     | embodied_carbon | 61.8122       | 2.8373     | 0.0        | 0.9253     | 10.0233     | 910        | Pinhel                           |
-| nan     | contents        | 3_186_681     | 22_387     | 0.0        | 0.0312     | 67_907      | 911        | Sabugal                          |
-| nan     | structural      | 18_057_864    | 953_680    | 0.0        | 496_051    | 5_225_027   | 911        | Sabugal                          |
-| nan     | occupants       | 61.9774       | 0.0033     | 0.0        | 6.198E-07  | 0.0265      | 911        | Sabugal                          |
-| nan     | area            | 15_840        | 217.9      | 0.0        | 1.584E-04  | 2_006       | 911        | Sabugal                          |
-| nan     | number          | 81.6981       | 1.3753     | 0.0        | 8.170E-07  | 12.7644     | 911        | Sabugal                          |
-| nan     | residents       | 112.1730      | 0.8941     | 0.0        | 1.122E-06  | 7.5744      | 911        | Sabugal                          |
-| nan     | affectedpop     | 112.1730      | 1.4618     | 0.0        | 1.122E-06  | 11.1816     | 911        | Sabugal                          |
-| nan     | injured         | 61.9774       | 0.0156     | 0.0        | 6.198E-07  | 0.1357      | 911        | Sabugal                          |
-| nan     | embodied_carbon | 4_948         | 220.6      | 0.0        | 93.1167    | 1_112       | 911        | Sabugal                          |
-| nan     | contents        | 406_553       | 10_176     | 0.0        | 0.0026     | 32_080      | 912        | Seia                             |
-| nan     | structural      | 2_303_804     | 129_748    | 0.0        | 17_754     | 529_248     | 912        | Seia                             |
-| nan     | occupants       | 3.7958        | 0.0028     | 0.0        | 3.796E-08  | 0.0179      | 912        | Seia                             |
-| nan     | area            | 2_021         | 85.5747    | 0.0        | 2.021E-05  | 418.7       | 912        | Seia                             |
-| nan     | number          | 7.0954        | 0.1809     | 0.0        | 7.095E-08  | 1.0515      | 912        | Seia                             |
-| nan     | residents       | 6.8686        | 0.2466     | 0.0        | 6.869E-08  | 1.2932      | 912        | Seia                             |
-| nan     | affectedpop     | 6.8686        | 0.3298     | 0.0        | 5.450E-04  | 1.6965      | 912        | Seia                             |
-| nan     | injured         | 3.7958        | 0.0046     | 0.0        | 3.796E-08  | 0.0234      | 912        | Seia                             |
-| nan     | embodied_carbon | 691.0         | 39.4467    | 0.0        | 4.3556     | 198.8       | 912        | Seia                             |
-| nan     | contents        | 157_591       | 1_418      | 0.0        | 0.0013     | 17_832      | 913        | Trancoso                         |
-| nan     | structural      | 893_017       | 19_376     | 0.0        | 10_462     | 72_888      | 913        | Trancoso                         |
-| nan     | occupants       | 1.8818        | 1.094E-04  | 0.0        | 1.882E-08  | 3.244E-04   | 913        | Trancoso                         |
-| nan     | area            | 783.3         | 2.6389     | 0.0        | 7.833E-06  | 6.8855      | 913        | Trancoso                         |
-| nan     | number          | 5.1400        | 0.0172     | 0.0        | 5.140E-08  | 0.0442      | 913        | Trancoso                         |
-| nan     | residents       | 3.4069        | 0.0193     | 0.0        | 3.407E-08  | 0.0579      | 913        | Trancoso                         |
-| nan     | affectedpop     | 3.4069        | 0.0404     | 0.0        | 3.407E-08  | 0.2166      | 913        | Trancoso                         |
-| nan     | injured         | 1.8818        | 3.016E-04  | 0.0        | 1.882E-08  | 9.280E-04   | 913        | Trancoso                         |
-| nan     | embodied_carbon | 237.0         | 3.8981     | 0.0        | 1.6846     | 19.2603     | 913        | Trancoso                         |
-| nan     | contents        | 46_404        | 161.2294   | 0.0        | 0.0        | 1.2522      | 914        | Vila Nova de Foz Côa             |
-| nan     | structural      | 185_616       | 8_809      | 0.0        | 9_480      | 28_553      | 914        | Vila Nova de Foz Côa             |
-| nan     | occupants       | 3.9400        | 9.262E-07  | 0.0        | 3.940E-08  | 3.940E-08   | 914        | Vila Nova de Foz Côa             |
-| nan     | area            | 180.9         | 0.0113     | 0.0        | 1.809E-06  | 1.809E-06   | 914        | Vila Nova de Foz Côa             |
-| nan     | number          | 0.2551        | 1.590E-05  | 0.0        | 2.551E-09  | 2.551E-09   | 914        | Vila Nova de Foz Côa             |
-| nan     | injured         | 3.9400        | 5.118E-06  | 0.0        | 3.940E-08  | 3.940E-08   | 914        | Vila Nova de Foz Côa             |
-| nan     | embodied_carbon | 85.1853       | 3.3269     | 0.0        | 3.3938     | 11.4000     | 914        | Vila Nova de Foz Côa             |
-| nan     | contents        | 6_938_479     | 1_569      | 0.0        | 0.0026     | 57.6275     | ES-AN      | Andalucía                        |
-| nan     | structural      | 29_724_676    | 158_917    | 0.0        | 46_607     | 867_471     | ES-AN      | Andalucía                        |
-| nan     | occupants       | 1_313         | 0.0025     | 0.0        | 4.593E-07  | 1.005E-05   | ES-AN      | Andalucía                        |
-| nan     | area            | 22_220        | 3.9059     | 0.0        | 7.773E-06  | 4.8750      | ES-AN      | Andalucía                        |
-| nan     | number          | 58.9959       | 0.0091     | 0.0        | 3.001E-08  | 0.0025      | ES-AN      | Andalucía                        |
-| nan     | injured         | 1_313         | 0.0093     | 0.0        | 4.593E-07  | 0.0039      | ES-AN      | Andalucía                        |
-| nan     | embodied_carbon | 10_399        | 42.4636    | 0.0        | 9.8124     | 229.5       | ES-AN      | Andalucía                        |
-| nan     | contents        | 467_701       | 4_714      | 0.0        | 7.127E-04  | 7_607       | ES-CL      | Castilla y León                  |
-| nan     | structural      | 1_870_803     | 147_929    | 0.0        | 102_884    | 459_788     | ES-CL      | Castilla y León                  |
-| nan     | occupants       | 61.1757       | 0.0362     | 0.0        | 5.092E-07  | 0.1649      | ES-CL      | Castilla y León                  |
-| nan     | area            | 1_361         | 30.2605    | 0.0        | 1.361E-05  | 164.7563    | ES-CL      | Castilla y León                  |
-| nan     | number          | 3.3284        | 0.0788     | 0.0        | 3.328E-08  | 0.5863      | ES-CL      | Castilla y León                  |
-| nan     | injured         | 61.1757       | 0.0393     | 0.0        | 5.092E-07  | 0.2463      | ES-CL      | Castilla y León                  |
-| nan     | embodied_carbon | 611.2         | 36.0724    | 0.0        | 20.0699    | 133.9437    | ES-CL      | Castilla y León                  |
-| nan     | contents        | 278_911       | 1.542E-04  | 0.0        | 0.0014     | 0.0028      | ES-CM      | Castilla-La Mancha               |
-| nan     | structural      | 1_115_644     | 1_594      | 0.0        | 2_067      | 42_476      | ES-CM      | Castilla-La Mancha               |
-| nan     | occupants       | 41.0237       | 1.081E-05  | 0.0        | 1.891E-07  | 4.102E-07   | ES-CM      | Castilla-La Mancha               |
-| nan     | area            | 845.7         | 0.0145     | 0.0        | 3.899E-06  | 8.457E-06   | ES-CM      | Castilla-La Mancha               |
-| nan     | number          | 3.9987        | 6.375E-05  | 0.0        | 1.999E-08  | 3.999E-08   | ES-CM      | Castilla-La Mancha               |
-| nan     | injured         | 41.0237       | 2.938E-05  | 0.0        | 1.891E-07  | 4.102E-07   | ES-CM      | Castilla-La Mancha               |
-| nan     | embodied_carbon | 404.5         | 0.4110     | 0.0        | 0.8462     | 9.2926      | ES-CM      | Castilla-La Mancha               |
-| nan     | contents        | 1_213_906     | 6_718      | 4.055E-04  | 0.0091     | 34_308      | ES-EX      | Extremadura                      |
-| nan     | structural      | 6_142_196     | 231_579    | 1_578      | 143_038    | 854_753     | ES-EX      | Extremadura                      |
-| nan     | occupants       | 237.7         | 0.0151     | 6.969E-08  | 2.198E-06  | 0.0908      | ES-EX      | Extremadura                      |
-| nan     | area            | 4_426         | 21.9525    | 1.298E-06  | 4.296E-05  | 157.8878    | ES-EX      | Extremadura                      |
-| nan     | number          | 16.9921       | 0.0969     | 1.953E-09  | 1.599E-07  | 0.7579      | ES-EX      | Extremadura                      |
-| nan     | injured         | 237.7         | 0.0436     | 6.969E-08  | 2.198E-06  | 0.3041      | ES-EX      | Extremadura                      |
-| nan     | embodied_carbon | 1_946         | 62.2951    | 0.5750     | 35.6905    | 217.8       | ES-EX      | Extremadura                      |
-| nan     | contents        | 1_833_411     | 24_251     | 0.0014     | 0.0098     | 229_467     | ES-GA      | Galicia                          |
-| nan     | structural      | 7_387_210     | 393_733    | 3_757      | 182_908    | 1_467_270   | ES-GA      | Galicia                          |
-| nan     | occupants       | 268.4         | 0.0603     | 1.934E-07  | 2.246E-06  | 0.2970      | ES-GA      | Galicia                          |
-| nan     | area            | 5_596         | 93.0119    | 4.033E-06  | 0.1237     | 514.5       | ES-GA      | Galicia                          |
-| nan     | number          | 16.9968       | 0.2991     | 1.999E-08  | 5.424E-04  | 1.4241      | ES-GA      | Galicia                          |
-| nan     | injured         | 268.4         | 0.1690     | 1.934E-07  | 2.247E-06  | 0.9177      | ES-GA      | Galicia                          |
-| nan     | embodied_carbon | 2_670         | 117.9122   | 1.4822     | 46.7247    | 476.5       | ES-GA      | Galicia                          |
-| nan     | contents        | 5_229_771     | 1_617      | 0.0        | 0.0016     | 150.4010    | ESP.1.2_1  | Cádiz                            |
-| nan     | structural      | 29_599_560    | 165_346    | 0.0        | 105_846    | 665_192     | ESP.1.2_1  | Cádiz                            |
-| nan     | occupants       | 337.2         | 0.0013     | 0.0        | 4.827E-07  | 2.837E-04   | ESP.1.2_1  | Cádiz                            |
-| nan     | area            | 24_093        | 7.4130     | 0.0        | 3.096E-05  | 7.7592      | ESP.1.2_1  | Cádiz                            |
-| nan     | number          | 82.9993       | 0.0310     | 0.0        | 1.999E-08  | 0.0172      | ESP.1.2_1  | Cádiz                            |
-| nan     | residents       | 596.7         | 0.2687     | 0.0        | 8.602E-07  | 0.3877      | ESP.1.2_1  | Cádiz                            |
-| nan     | affectedpop     | 596.7         | 0.6675     | 0.0        | 8.602E-07  | 3.3689      | ESP.1.2_1  | Cádiz                            |
-| nan     | injured         | 337.2         | 0.0041     | 0.0        | 4.827E-07  | 0.0042      | ESP.1.2_1  | Cádiz                            |
-| nan     | embodied_carbon | 8_176         | 22.9988    | 0.0        | 10.7801    | 96.8185     | ESP.1.2_1  | Cádiz                            |
-| nan     | contents        | 13_807_168    | 3_679      | 0.0        | 0.0        | 577.1       | ESP.1.3_1  | Córdoba                          |
-| nan     | structural      | 55_913_532    | 71_783     | 0.0        | 0.0        | 724_495     | ESP.1.3_1  | Córdoba                          |
-| nan     | occupants       | 495.5         | 1.766E-04  | 0.0        | 0.0        | 4.492E-06   | ESP.1.3_1  | Córdoba                          |
-| nan     | area            | 52_438        | 2.1612     | 0.0        | 0.0        | 4.1536      | ESP.1.3_1  | Córdoba                          |
-| nan     | number          | 216.0         | 0.0078     | 0.0        | 0.0        | 0.0210      | ESP.1.3_1  | Córdoba                          |
-| nan     | residents       | 751.6         | 0.0408     | 0.0        | 0.0        | 0.1094      | ESP.1.3_1  | Córdoba                          |
-| nan     | affectedpop     | 751.6         | 0.1025     | 0.0        | 0.0        | 0.2919      | ESP.1.3_1  | Córdoba                          |
-| nan     | injured         | 495.5         | 8.476E-04  | 0.0        | 0.0        | 8.106E-04   | ESP.1.3_1  | Córdoba                          |
-| nan     | embodied_carbon | 17_322        | 18.8850    | 0.0        | 0.0        | 196.8       | ESP.1.3_1  | Córdoba                          |
-| nan     | contents        | 6_236_232     | 95.3367    | 0.0        | 0.0013     | 0.0537      | ESP.1.4_1  | Granada                          |
-| nan     | structural      | 35_338_644    | 16_304     | 0.0        | 12_065     | 172_135     | ESP.1.4_1  | Granada                          |
-| nan     | occupants       | 259.5         | 3.012E-04  | 0.0        | 1.430E-07  | 7.504E-04   | ESP.1.4_1  | Granada                          |
-| nan     | area            | 28_761        | 1.8423     | 0.0        | 1.509E-05  | 7.7076      | ESP.1.4_1  | Granada                          |
-| nan     | number          | 222.0         | 0.0128     | 0.0        | 6.928E-08  | 0.0511      | ESP.1.4_1  | Granada                          |
-| nan     | residents       | 459.1         | 0.0466     | 0.0        | 2.547E-07  | 0.1378      | ESP.1.4_1  | Granada                          |
-| nan     | affectedpop     | 459.1         | 0.0968     | 0.0        | 2.547E-07  | 0.4067      | ESP.1.4_1  | Granada                          |
-| nan     | injured         | 259.5         | 7.437E-04  | 0.0        | 1.430E-07  | 0.0030      | ESP.1.4_1  | Granada                          |
-| nan     | embodied_carbon | 10_496        | 3.5879     | 0.0        | 1.8362     | 39.6251     | ESP.1.4_1  | Granada                          |
-| nan     | contents        | 11_026_765    | 2_593      | 3.501E-04  | 0.0017     | 1_509       | ESP.1.5_1  | Huelva                           |
-| nan     | structural      | 62_260_884    | 236_618    | 245.0      | 6_801      | 631_995     | ESP.1.5_1  | Huelva                           |
-| nan     | occupants       | 529.6         | 0.0164     | 2.230E-08  | 8.965E-08  | 9.252E-05   | ESP.1.5_1  | Huelva                           |
-| nan     | area            | 48_359        | 83.4012    | 1.804E-06  | 8.815E-06  | 34.2556     | ESP.1.5_1  | Huelva                           |
-| nan     | number          | 248.1         | 0.4210     | 1.000E-08  | 4.003E-08  | 0.1820      | ESP.1.5_1  | Huelva                           |
-| nan     | residents       | 938.6         | 2.0208     | 3.896E-08  | 1.560E-07  | 0.9326      | ESP.1.5_1  | Huelva                           |
-| nan     | affectedpop     | 938.6         | 2.9290     | 3.896E-08  | 1.560E-07  | 1.6286      | ESP.1.5_1  | Huelva                           |
-| nan     | injured         | 529.6         | 0.0384     | 2.230E-08  | 8.965E-08  | 0.0067      | ESP.1.5_1  | Huelva                           |
-| nan     | embodied_carbon | 18_162        | 63.5341    | 0.0875     | 3.4889     | 209.4       | ESP.1.5_1  | Huelva                           |
-| nan     | contents        | 4_304_812     | 351.4      | 0.0        | 0.0        | 0.5377      | ESP.1.6_1  | Jaén                             |
-| nan     | structural      | 23_573_592    | 50_888     | 0.0        | 0.0        | 414_592     | ESP.1.6_1  | Jaén                             |
-| nan     | occupants       | 161.9422      | 1.624E-04  | 0.0        | 0.0        | 1.375E-06   | ESP.1.6_1  | Jaén                             |
-| nan     | area            | 19_263        | 0.8572     | 0.0        | 0.0        | 1.3550      | ESP.1.6_1  | Jaén                             |
-| nan     | number          | 96.3660       | 0.0034     | 0.0        | 0.0        | 0.0034      | ESP.1.6_1  | Jaén                             |
-| nan     | residents       | 271.1         | 0.0328     | 0.0        | 0.0        | 0.0422      | ESP.1.6_1  | Jaén                             |
-| nan     | affectedpop     | 271.1         | 0.1314     | 0.0        | 0.0        | 0.4243      | ESP.1.6_1  | Jaén                             |
-| nan     | injured         | 161.9422      | 2.994E-04  | 0.0        | 0.0        | 2.946E-04   | ESP.1.6_1  | Jaén                             |
-| nan     | embodied_carbon | 6_417         | 6.1044     | 0.0        | 0.0        | 51.9853     | ESP.1.6_1  | Jaén                             |
-| nan     | contents        | 20_201_060    | 1_871      | 0.0        | 1.106E-29  | 7_073       | ESP.1.7_1  | Málaga                           |
-| nan     | structural      | 113_926_664   | 271_883    | 0.0        | 41_649     | 1_582_351   | ESP.1.7_1  | Málaga                           |
-| nan     | occupants       | 1_262         | 0.0012     | 0.0        | 3.480E-07  | 8.725E-06   | ESP.1.7_1  | Málaga                           |
-| nan     | area            | 91_342        | 3.4103     | 0.0        | 2.349E-05  | 1.1848      | ESP.1.7_1  | Málaga                           |
-| nan     | number          | 276.5         | 0.0100     | 0.0        | 9.995E-09  | 0.0072      | ESP.1.7_1  | Málaga                           |
-| nan     | residents       | 2_189         | 0.1603     | 0.0        | 6.202E-07  | 0.3211      | ESP.1.7_1  | Málaga                           |
-| nan     | affectedpop     | 2_189         | 0.7010     | 0.0        | 6.202E-07  | 4.6686      | ESP.1.7_1  | Málaga                           |
-| nan     | injured         | 1_262         | 0.0017     | 0.0        | 3.480E-07  | 4.609E-05   | ESP.1.7_1  | Málaga                           |
-| nan     | embodied_carbon | 29_989        | 47.6280    | 0.0        | 7.4310     | 260.7       | ESP.1.7_1  | Málaga                           |
-| nan     | contents        | 9_565_985     | 5_275      | 0.0        | 0.0032     | 1_112       | ESP.1.8_1  | Sevilla                          |
-| nan     | structural      | 53_985_052    | 285_224    | 0.0        | 242_627    | 1_132_207   | ESP.1.8_1  | Sevilla                          |
-| nan     | occupants       | 612.2         | 0.0044     | 0.0        | 1.434E-06  | 0.0286      | ESP.1.8_1  | Sevilla                          |
-| nan     | area            | 45_009        | 16.4730    | 0.0        | 9.692E-05  | 68.9029     | ESP.1.8_1  | Sevilla                          |
-| nan     | number          | 124.2651      | 0.0428     | 0.0        | 5.029E-08  | 0.0694      | ESP.1.8_1  | Sevilla                          |
-| nan     | residents       | 1_077         | 0.7897     | 0.0        | 2.504E-06  | 6.6726      | ESP.1.8_1  | Sevilla                          |
-| nan     | affectedpop     | 1_077         | 2.8963     | 0.0        | 2.531E-06  | 19.3864     | ESP.1.8_1  | Sevilla                          |
-| nan     | injured         | 612.2         | 0.0083     | 0.0        | 1.385E-06  | 0.0328      | ESP.1.8_1  | Sevilla                          |
-| nan     | embodied_carbon | 15_178        | 47.9888    | 0.0        | 19.5226    | 220.8       | ESP.1.8_1  | Sevilla                          |
-| nan     | contents        | 14_641_219    | 243_460    | 0.0186     | 53.0047    | 523_608     | ESP.11.1_1 | Badajoz                          |
-| nan     | structural      | 82_917_144    | 2_746_164  | 95_284     | 635_541    | 7_305_336   | ESP.11.1_1 | Badajoz                          |
-| nan     | occupants       | 672.2         | 0.1191     | 9.593E-07  | 5.682E-06  | 0.7320      | ESP.11.1_1 | Badajoz                          |
-| nan     | area            | 73_590        | 1_510      | 1.035E-04  | 3.2887     | 4_952       | ESP.11.1_1 | Badajoz                          |
-| nan     | number          | 582.6         | 14.2729    | 6.905E-07  | 0.0164     | 47.6819     | ESP.11.1_1 | Badajoz                          |
-| nan     | residents       | 1_177         | 27.0059    | 1.683E-06  | 0.1507     | 80.4349     | ESP.11.1_1 | Badajoz                          |
-| nan     | affectedpop     | 1_177         | 36.3526    | 1.683E-06  | 1.2119     | 141.4737    | ESP.11.1_1 | Badajoz                          |
-| nan     | injured         | 672.2         | 0.4771     | 9.593E-07  | 0.0012     | 1.5093      | ESP.11.1_1 | Badajoz                          |
-| nan     | embodied_carbon | 26_615        | 799.4      | 22.3481    | 147.3050   | 2_711       | ESP.11.1_1 | Badajoz                          |
-| nan     | contents        | 8_998_204     | 259_787    | 0.0068     | 291.6      | 2_025_499   | ESP.11.2_1 | Cáceres                          |
-| nan     | structural      | 50_466_888    | 2_377_717  | 54_901     | 556_846    | 8_800_704   | ESP.11.2_1 | Cáceres                          |
-| nan     | occupants       | 282.9         | 0.1037     | 4.788E-07  | 0.0021     | 0.5241      | ESP.11.2_1 | Cáceres                          |
-| nan     | area            | 45_134        | 1_378      | 7.208E-05  | 31.1120    | 5_827       | ESP.11.2_1 | Cáceres                          |
-| nan     | number          | 205.3         | 6.7406     | 2.548E-07  | 0.1666     | 29.4173     | ESP.11.2_1 | Cáceres                          |
-| nan     | residents       | 486.3         | 17.4334    | 8.358E-07  | 0.4995     | 72.6305     | ESP.11.2_1 | Cáceres                          |
-| nan     | affectedpop     | 486.3         | 23.3272    | 8.358E-07  | 1.3049     | 94.1281     | ESP.11.2_1 | Cáceres                          |
-| nan     | injured         | 282.9         | 0.3453     | 4.788E-07  | 0.0081     | 1.4326      | ESP.11.2_1 | Cáceres                          |
-| nan     | embodied_carbon | 16_469        | 777.6      | 14.0877    | 167.2688   | 2_850       | ESP.11.2_1 | Cáceres                          |
-| nan     | contents        | 4_418_335     | 3_258      | 0.0        | 0.0440     | 57.5491     | ESP.12.1_1 | A Coruña                         |
-| nan     | structural      | 25_001_092    | 424_498    | 0.0        | 77_737     | 1_632_459   | ESP.12.1_1 | A Coruña                         |
-| nan     | occupants       | 132.1895      | 0.0202     | 0.0        | 1.320E-06  | 0.0543      | ESP.12.1_1 | A Coruña                         |
-| nan     | area            | 19_248        | 159.0520   | 0.0        | 1.920E-04  | 419.3       | ESP.12.1_1 | A Coruña                         |
-| nan     | number          | 96.0354       | 0.7917     | 0.0        | 9.600E-07  | 2.0967      | ESP.12.1_1 | A Coruña                         |
-| nan     | residents       | 235.3         | 2.5412     | 0.0        | 2.353E-06  | 8.8171      | ESP.12.1_1 | A Coruña                         |
-| nan     | affectedpop     | 235.3         | 3.9639     | 0.0        | 2.353E-06  | 20.0471     | ESP.12.1_1 | A Coruña                         |
-| nan     | injured         | 132.1895      | 0.0476     | 0.0        | 1.320E-06  | 0.1479      | ESP.12.1_1 | A Coruña                         |
-| nan     | embodied_carbon | 7_264         | 134.9299   | 0.0        | 24.5817    | 511.0       | ESP.12.1_1 | A Coruña                         |
-| nan     | contents        | 19_411        | 221.2      | 0.0        | 1.941E-04  | 4.295E-04   | ESP.12.2_1 | Lugo                             |
-| nan     | structural      | 109_994       | 4_826      | 0.0        | 127.8506   | 25_446      | ESP.12.2_1 | Lugo                             |
-| nan     | occupants       | 0.5880        | 1.554E-04  | 0.0        | 5.880E-09  | 7.851E-04   | ESP.12.2_1 | Lugo                             |
-| nan     | area            | 99.9950       | 3.4765     | 0.0        | 9.999E-07  | 17.4587     | ESP.12.2_1 | Lugo                             |
-| nan     | number          | 0.9999        | 0.0348     | 0.0        | 9.999E-09  | 0.1746      | ESP.12.2_1 | Lugo                             |
-| nan     | residents       | 1.0270        | 0.0412     | 0.0        | 1.027E-08  | 0.2357      | ESP.12.2_1 | Lugo                             |
-| nan     | affectedpop     | 1.0270        | 0.0531     | 0.0        | 1.027E-08  | 0.3662      | ESP.12.2_1 | Lugo                             |
-| nan     | injured         | 0.5880        | 7.444E-04  | 0.0        | 5.880E-09  | 0.0040      | ESP.12.2_1 | Lugo                             |
-| nan     | embodied_carbon | 37.7048       | 1.3260     | 0.0        | 0.0394     | 7.4476      | ESP.12.2_1 | Lugo                             |
-| nan     | contents        | 3_269_786     | 51_339     | 0.0016     | 0.0563     | 310_845     | ESP.12.3_1 | Ourense                          |
-| nan     | structural      | 18_528_804    | 596_332    | 2_322      | 110_980    | 3_142_445   | ESP.12.3_1 | Ourense                          |
-| nan     | occupants       | 91.7700       | 0.0317     | 4.040E-08  | 7.966E-07  | 0.1873      | ESP.12.3_1 | Ourense                          |
-| nan     | area            | 16_753        | 358.3      | 7.903E-06  | 0.6181     | 2_187       | ESP.12.3_1 | Ourense                          |
-| nan     | number          | 79.0186       | 1.3999     | 6.000E-08  | 0.0033     | 11.7909     | ESP.12.3_1 | Ourense                          |
-| nan     | residents       | 160.3856      | 4.2432     | 7.057E-08  | 0.0073     | 26.1352     | ESP.12.3_1 | Ourense                          |
-| nan     | affectedpop     | 160.3856      | 5.6836     | 7.057E-08  | 0.0357     | 34.0203     | ESP.12.3_1 | Ourense                          |
-| nan     | injured         | 91.7700       | 0.0822     | 4.040E-08  | 7.063E-06  | 0.5050      | ESP.12.3_1 | Ourense                          |
-| nan     | embodied_carbon | 5_961         | 184.8      | 0.8204     | 31.2507    | 1_018       | ESP.12.3_1 | Ourense                          |
-| nan     | contents        | 14_162_123    | 209_452    | 0.0083     | 0.5384     | 1_409_930   | ESP.12.4_1 | Pontevedra                       |
-| nan     | structural      | 80_252_016    | 2_274_734  | 12_654     | 595_530    | 9_381_329   | ESP.12.4_1 | Pontevedra                       |
-| nan     | occupants       | 599.1         | 0.0970     | 3.669E-07  | 4.839E-06  | 0.5797      | ESP.12.4_1 | Pontevedra                       |
-| nan     | area            | 63_429        | 910.6      | 4.394E-05  | 29.6939    | 3_893       | ESP.12.4_1 | Pontevedra                       |
-| nan     | number          | 255.4         | 4.5586     | 2.304E-07  | 0.1795     | 18.3371     | ESP.12.4_1 | Pontevedra                       |
-| nan     | residents       | 1_064         | 17.2828    | 6.935E-07  | 0.5963     | 90.4749     | ESP.12.4_1 | Pontevedra                       |
-| nan     | affectedpop     | 1_064         | 24.9969    | 6.935E-07  | 1.2230     | 144.0531    | ESP.12.4_1 | Pontevedra                       |
-| nan     | injured         | 599.1         | 0.3208     | 3.669E-07  | 0.0112     | 1.3814      | ESP.12.4_1 | Pontevedra                       |
-| nan     | embodied_carbon | 21_932        | 645.7      | 4.9886     | 162.6271   | 2_720       | ESP.12.4_1 | Pontevedra                       |
-| nan     | contents        | 1_397_288     | 12.2991    | 0.0        | 5.126E-04  | 0.0808      | ESP.4.2_1  | Ciudad Real                      |
-| nan     | structural      | 7_912_958     | 3_255      | 0.0        | 3_545      | 37_142      | ESP.4.2_1  | Ciudad Real                      |
-| nan     | occupants       | 62.4916       | 4.712E-06  | 0.0        | 2.252E-08  | 5.782E-07   | ESP.4.2_1  | Ciudad Real                      |
-| nan     | area            | 7_012         | 0.0228     | 0.0        | 2.532E-06  | 0.0309      | ESP.4.2_1  | Ciudad Real                      |
-| nan     | number          | 51.9985       | 1.170E-04  | 0.0        | 1.123E-08  | 1.547E-04   | ESP.4.2_1  | Ciudad Real                      |
-| nan     | residents       | 109.4650      | 5.709E-04  | 0.0        | 3.937E-08  | 6.109E-04   | ESP.4.2_1  | Ciudad Real                      |
-| nan     | affectedpop     | 109.4650      | 0.0020     | 0.0        | 3.937E-08  | 0.0022      | ESP.4.2_1  | Ciudad Real                      |
-| nan     | injured         | 62.4916       | 8.336E-06  | 0.0        | 2.252E-08  | 5.825E-07   | ESP.4.2_1  | Ciudad Real                      |
-| nan     | embodied_carbon | 2_333         | 0.8564     | 0.0        | 0.7389     | 11.4093     | ESP.4.2_1  | Ciudad Real                      |
-| nan     | contents        | 9_195_523     | 0.0086     | 0.0        | 0.0326     | 0.0893      | ESP.4.5_1  | Toledo                           |
-| nan     | structural      | 52_107_960    | 18_625     | 0.0        | 61_057     | 321_131     | ESP.4.5_1  | Toledo                           |
-| nan     | occupants       | 316.1         | 1.430E-04  | 0.0        | 1.364E-06  | 3.161E-06   | ESP.4.5_1  | Toledo                           |
-| nan     | area            | 43_046        | 2.2692     | 0.0        | 2.225E-04  | 3.6490      | ESP.4.5_1  | Toledo                           |
-| nan     | number          | 272.4         | 0.0114     | 0.0        | 1.526E-06  | 0.0188      | ESP.4.5_1  | Toledo                           |
-| nan     | residents       | 558.3         | 0.0439     | 0.0        | 2.885E-06  | 0.0485      | ESP.4.5_1  | Toledo                           |
-| nan     | affectedpop     | 558.3         | 0.0897     | 0.0        | 2.885E-06  | 0.1229      | ESP.4.5_1  | Toledo                           |
-| nan     | injured         | 316.1         | 7.917E-04  | 0.0        | 1.364E-06  | 3.161E-06   | ESP.4.5_1  | Toledo                           |
-| nan     | embodied_carbon | 15_277        | 6.0432     | 0.0        | 17.7826    | 110.0183    | ESP.4.5_1  | Toledo                           |
-| nan     | contents        | 6_787_001     | 1_422      | 0.0        | 1.941E-04  | 19_400      | ESP.5.1_1  | Ávila                            |
-| nan     | structural      | 38_409_200    | 19_045     | 0.0        | 161.1342   | 106_862     | ESP.5.1_1  | Ávila                            |
-| nan     | occupants       | 157.0417      | 1.474E-04  | 0.0        | 4.427E-09  | 2.179E-04   | ESP.5.1_1  | Ávila                            |
-| nan     | area            | 34_020        | 3.5677     | 0.0        | 1.000E-06  | 6.4226      | ESP.5.1_1  | Ávila                            |
-| nan     | number          | 150.3550      | 0.0323     | 0.0        | 1.000E-08  | 0.0642      | ESP.5.1_1  | Ávila                            |
-| nan     | residents       | 274.0         | 0.0331     | 0.0        | 7.734E-09  | 0.0707      | ESP.5.1_1  | Ávila                            |
-| nan     | affectedpop     | 274.0         | 0.0450     | 0.0        | 7.734E-09  | 0.1324      | ESP.5.1_1  | Ávila                            |
-| nan     | injured         | 157.0417      | 5.910E-04  | 0.0        | 4.427E-09  | 0.0012      | ESP.5.1_1  | Ávila                            |
-| nan     | embodied_carbon | 12_323        | 6.0875     | 0.0        | 0.0508     | 36.1820     | ESP.5.1_1  | Ávila                            |
-| nan     | contents        | 4_443_185     | 43_264     | 0.0019     | 0.1882     | 351_560     | ESP.5.5_1  | Salamanca                        |
-| nan     | structural      | 23_249_750    | 726_346    | 3_013      | 319_030    | 3_399_489   | ESP.5.5_1  | Salamanca                        |
-| nan     | occupants       | 158.2843      | 0.0277     | 6.948E-08  | 1.431E-06  | 0.1605      | ESP.5.5_1  | Salamanca                        |
-| nan     | area            | 21_225        | 290.9      | 9.826E-06  | 0.3254     | 1_824       | ESP.5.5_1  | Salamanca                        |
-| nan     | number          | 137.6805      | 2.1458     | 6.000E-08  | 0.0029     | 13.4478     | ESP.5.5_1  | Salamanca                        |
-| nan     | residents       | 257.9         | 4.4986     | 1.214E-07  | 0.0046     | 28.5786     | ESP.5.5_1  | Salamanca                        |
-| nan     | affectedpop     | 257.9         | 6.6962     | 1.214E-07  | 0.0211     | 40.2632     | ESP.5.5_1  | Salamanca                        |
-| nan     | injured         | 158.2843      | 0.0818     | 6.948E-08  | 1.432E-06  | 0.5140      | ESP.5.5_1  | Salamanca                        |
-| nan     | embodied_carbon | 7_328         | 205.9      | 0.8481     | 80.0893    | 1_040       | ESP.5.5_1  | Salamanca                        |
-| nan     | contents        | 663_985       | 11_769     | 0.0        | 0.0033     | 64_829      | ESP.5.9_1  | Zamora                           |
-| nan     | structural      | 3_544_999     | 106_201    | 0.0        | 9_128      | 833_067     | ESP.5.9_1  | Zamora                           |
-| nan     | occupants       | 16.3706       | 0.0051     | 0.0        | 1.448E-07  | 0.0421      | ESP.5.9_1  | Zamora                           |
-| nan     | area            | 3_288         | 71.3951    | 0.0        | 3.000E-05  | 571.0       | ESP.5.9_1  | Zamora                           |
-| nan     | number          | 26.2042       | 0.6667     | 0.0        | 2.600E-07  | 5.7091      | ESP.5.9_1  | Zamora                           |
-| nan     | residents       | 25.2938       | 0.7001     | 0.0        | 2.529E-07  | 5.6867      | ESP.5.9_1  | Zamora                           |
-| nan     | affectedpop     | 25.2938       | 0.8934     | 0.0        | 5.424E-04  | 6.9442      | ESP.5.9_1  | Zamora                           |
-| nan     | injured         | 16.3706       | 0.0127     | 0.0        | 1.448E-07  | 0.1002      | ESP.5.9_1  | Zamora                           |
-| nan     | embodied_carbon | 1_213         | 37.3190    | 0.0        | 3.3148     | 235.9       | ESP.5.9_1  | Zamora                           |
-| nan     | contents        | 329_565       | 3.485E-04  | 0.0        | 0.0033     | 0.0033      | ESP.8.1_1  | Madrid                           |
-| nan     | structural      | 1_867_533     | 1_053      | 0.0        | 4_790      | 26_003      | ESP.8.1_1  | Madrid                           |
-| nan     | occupants       | 24.6275       | 1.493E-05  | 0.0        | 2.463E-07  | 2.463E-07   | ESP.8.1_1  | Madrid                           |
-| nan     | area            | 1_245         | 0.0371     | 0.0        | 1.245E-05  | 0.5149      | ESP.8.1_1  | Madrid                           |
-| nan     | number          | 3.0001        | 8.932E-05  | 0.0        | 3.000E-08  | 0.0012      | ESP.8.1_1  | Madrid                           |
-| nan     | residents       | 43.8915       | 0.0023     | 0.0        | 4.389E-07  | 0.0424      | ESP.8.1_1  | Madrid                           |
-| nan     | affectedpop     | 43.8915       | 0.0056     | 0.0        | 4.389E-07  | 0.1702      | ESP.8.1_1  | Madrid                           |
-| nan     | injured         | 24.6275       | 3.165E-05  | 0.0        | 2.463E-07  | 5.730E-05   | ESP.8.1_1  | Madrid                           |
-| nan     | embodied_carbon | 470.7         | 0.2868     | 0.0        | 1.3268     | 7.1108      | ESP.8.1_1  | Madrid                           |
-| nan     | contents        | 5_720_314     | 803.3      | 0.0        | 0.0010     | 4_081       | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | structural      | 29_190_636    | 40_449     | 0.0        | 5_435      | 248_193     | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | occupants       | 2_747         | 0.0261     | 0.0        | 5.821E-07  | 0.0454      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | area            | 94_760        | 16.3837    | 0.0        | 1.474E-05  | 46.8011     | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | number          | 1_082         | 0.2323     | 0.0        | 1.500E-07  | 1.2450      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | residents       | 3_416         | 0.8805     | 0.0        | 4.385E-07  | 6.0859      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | affectedpop     | 3_416         | 1.3485     | 0.0        | 4.385E-07  | 8.3477      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | injured         | 2_747         | 0.0209     | 0.0        | 5.821E-07  | 0.1252      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | embodied_carbon | 40_653        | 36.6724    | 0.0        | 3.3264     | 200.8       | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
-| nan     | contents        | 208_395       | 0.0018     | 0.0        | 1.208E-04  | 4.958E-04   | MA-02      | Al-Sharq                         |
-| nan     | structural      | 1_160_732     | 74.0622    | 0.0        | 192.9      | 1_528       | MA-02      | Al-Sharq                         |
-| nan     | occupants       | 117.2093      | 4.060E-05  | 0.0        | 1.739E-07  | 5.960E-07   | MA-02      | Al-Sharq                         |
-| nan     | area            | 3_551         | 0.0185     | 0.0        | 4.929E-06  | 0.0012      | MA-02      | Al-Sharq                         |
-| nan     | number          | 38.0032       | 2.131E-04  | 0.0        | 6.000E-08  | 1.765E-05   | MA-02      | Al-Sharq                         |
-| nan     | residents       | 153.7799      | 7.638E-04  | 0.0        | 2.494E-07  | 7.303E-05   | MA-02      | Al-Sharq                         |
-| nan     | affectedpop     | 153.7799      | 0.0014     | 0.0        | 2.536E-07  | 0.0023      | MA-02      | Al-Sharq                         |
-| nan     | injured         | 117.2093      | 6.007E-05  | 0.0        | 1.739E-07  | 5.960E-07   | MA-02      | Al-Sharq                         |
-| nan     | embodied_carbon | 1_055         | 0.1734     | 0.0        | 0.4265     | 3.6684      | MA-02      | Al-Sharq                         |
-| nan     | contents        | 4_990_356     | 350.7      | 0.0        | 0.0        | 306.8       | MA-03      | Fez-Meknes                       |
-| nan     | structural      | 25_645_198    | 54_429     | 0.0        | 0.8927     | 286_185     | MA-03      | Fez-Meknes                       |
-| nan     | occupants       | 3_236         | 0.0112     | 0.0        | 3.619E-09  | 0.0039      | MA-03      | Fez-Meknes                       |
-| nan     | area            | 79_484        | 9.2471     | 0.0        | 7.835E-08  | 5.6930      | MA-03      | Fez-Meknes                       |
-| nan     | number          | 859.8         | 0.1171     | 0.0        | 9.936E-09  | 0.0514      | MA-03      | Fez-Meknes                       |
-| nan     | residents       | 3_555         | 0.5712     | 0.0        | 0.0        | 0.2621      | MA-03      | Fez-Meknes                       |
-| nan     | affectedpop     | 3_555         | 0.8239     | 0.0        | 0.0        | 0.8987      | MA-03      | Fez-Meknes                       |
-| nan     | injured         | 3_236         | 0.0152     | 0.0        | 3.619E-09  | 0.0048      | MA-03      | Fez-Meknes                       |
-| nan     | embodied_carbon | 31_095        | 43.7286    | 0.0        | 5.141E-04  | 217.7       | MA-03      | Fez-Meknes                       |
-| nan     | contents        | 6_847_760     | 1_697      | 0.0        | 0.0044     | 952.2       | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | structural      | 33_139_916    | 185_881    | 0.0        | 83_706     | 714_512     | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | occupants       | 4_161         | 0.0646     | 0.0        | 3.687E-06  | 0.1353      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | area            | 97_854        | 37.7874    | 0.0        | 9.709E-05  | 110.7973    | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | number          | 845.9         | 0.5041     | 0.0        | 3.189E-07  | 1.2993      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | residents       | 4_132         | 2.8955     | 0.0        | 4.815E-06  | 11.1454     | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | affectedpop     | 4_132         | 5.6500     | 0.0        | 5.008E-06  | 25.4120     | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | injured         | 4_161         | 0.0676     | 0.0        | 3.687E-06  | 0.2337      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | embodied_carbon | 40_888        | 148.0638   | 0.0        | 54.0647    | 699.4       | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
-| nan     | contents        | 2_874_461     | 1_565      | 0.0        | 2.990E-04  | 4_464       | MA-05      | Béni Mellal-Khénifra             |
-| nan     | structural      | 15_000_907    | 40_600     | 0.0        | 2_911      | 218_127     | MA-05      | Béni Mellal-Khénifra             |
-| nan     | occupants       | 1_512         | 0.0077     | 0.0        | 6.249E-07  | 0.0248      | MA-05      | Béni Mellal-Khénifra             |
-| nan     | area            | 43_962        | 5.6577     | 0.0        | 1.425E-05  | 12.5619     | MA-05      | Béni Mellal-Khénifra             |
-| nan     | number          | 385.9         | 0.0610     | 0.0        | 7.834E-08  | 0.1947      | MA-05      | Béni Mellal-Khénifra             |
-| nan     | residents       | 1_795         | 0.4362     | 0.0        | 6.775E-07  | 1.1623      | MA-05      | Béni Mellal-Khénifra             |
-| nan     | affectedpop     | 1_795         | 0.8826     | 0.0        | 6.775E-07  | 2.7444      | MA-05      | Béni Mellal-Khénifra             |
-| nan     | injured         | 1_512         | 0.0102     | 0.0        | 6.249E-07  | 0.0239      | MA-05      | Béni Mellal-Khénifra             |
-| nan     | embodied_carbon | 15_900        | 23.2014    | 0.0        | 2.5545     | 132.8354    | MA-05      | Béni Mellal-Khénifra             |
-| nan     | contents        | 11_230_778    | 14_038     | 2.659E-04  | 0.0914     | 36_227      | MA-06      | Casablanca-Settat                |
-| nan     | structural      | 59_852_696    | 307_684    | 3_770      | 121_519    | 1_231_459   | MA-06      | Casablanca-Settat                |
-| nan     | occupants       | 6_317         | 0.1039     | 7.295E-07  | 1.882E-05  | 0.4328      | MA-06      | Casablanca-Settat                |
-| nan     | area            | 182_153       | 254.3      | 2.027E-05  | 0.0198     | 945.7       | MA-06      | Casablanca-Settat                |
-| nan     | number          | 1_944         | 2.6526     | 9.572E-08  | 7.839E-05  | 8.9450      | MA-06      | Casablanca-Settat                |
-| nan     | residents       | 8_358         | 14.2585    | 1.030E-06  | 0.0011     | 59.2055     | MA-06      | Casablanca-Settat                |
-| nan     | affectedpop     | 8_358         | 21.9091    | 1.030E-06  | 0.0236     | 104.6990    | MA-06      | Casablanca-Settat                |
-| nan     | injured         | 6_317         | 0.3512     | 7.295E-07  | 1.895E-05  | 1.4065      | MA-06      | Casablanca-Settat                |
-| nan     | embodied_carbon | 73_188        | 378.9      | 4.9645     | 124.7396   | 1_589       | MA-06      | Casablanca-Settat                |
-| nan     | contents        | 8_591_734     | 6_251      | 0.0        | 0.0088     | 14_182      | MA-07      | Marrakech-Safi                   |
-| nan     | structural      | 46_802_080    | 112_753    | 0.0        | 21_420     | 441_163     | MA-07      | Marrakech-Safi                   |
-| nan     | occupants       | 4_800         | 0.1386     | 0.0        | 3.683E-06  | 0.6825      | MA-07      | Marrakech-Safi                   |
-| nan     | area            | 142_210       | 152.9798   | 0.0        | 3.505E-04  | 390.0       | MA-07      | Marrakech-Safi                   |
-| nan     | number          | 1_531         | 1.6635     | 0.0        | 3.224E-06  | 2.4116      | MA-07      | Marrakech-Safi                   |
-| nan     | residents       | 6_545         | 8.7669     | 0.0        | 1.358E-05  | 20.3407     | MA-07      | Marrakech-Safi                   |
-| nan     | affectedpop     | 6_545         | 12.3705    | 0.0        | 0.0028     | 38.1406     | MA-07      | Marrakech-Safi                   |
-| nan     | injured         | 4_800         | 0.2062     | 0.0        | 5.104E-06  | 0.5280      | MA-07      | Marrakech-Safi                   |
-| nan     | embodied_carbon | 56_023        | 149.6377   | 0.0        | 25.3925    | 550.6       | MA-07      | Marrakech-Safi                   |
-| nan     | contents        | 1_471_714     | 61.9861    | 0.0        | 0.0        | 0.0086      | MA-08      | Drâa-Tafilalet                   |
-| nan     | structural      | 7_774_754     | 4_868      | 0.0        | 0.0        | 34_462      | MA-08      | Drâa-Tafilalet                   |
-| nan     | occupants       | 973.7         | 0.0191     | 0.0        | 0.0        | 6.861E-06   | MA-08      | Drâa-Tafilalet                   |
-| nan     | area            | 26_782        | 7.0443     | 0.0        | 0.0        | 0.9802      | MA-08      | Drâa-Tafilalet                   |
-| nan     | number          | 274.6         | 0.1133     | 0.0        | 0.0        | 0.0052      | MA-08      | Drâa-Tafilalet                   |
-| nan     | residents       | 1_334         | 0.5904     | 0.0        | 0.0        | 0.0576      | MA-08      | Drâa-Tafilalet                   |
-| nan     | affectedpop     | 1_334         | 0.8320     | 0.0        | 0.0        | 0.1545      | MA-08      | Drâa-Tafilalet                   |
-| nan     | injured         | 973.7         | 0.0122     | 0.0        | 0.0        | 6.866E-06   | MA-08      | Drâa-Tafilalet                   |
-| nan     | embodied_carbon | 10_707        | 4.9985     | 0.0        | 0.0        | 39.5403     | MA-08      | Drâa-Tafilalet                   |
-| nan     | contents        | 3_740_797     | 1_184      | 0.0        | 3.435E-04  | 1_826       | MA-09      | Souss-Massa                      |
-| nan     | structural      | 19_200_756    | 57_429     | 0.0        | 908.1      | 286_989     | MA-09      | Souss-Massa                      |
-| nan     | occupants       | 2_428         | 0.0791     | 0.0        | 6.685E-07  | 0.3224      | MA-09      | Souss-Massa                      |
-| nan     | area            | 62_029        | 37.4730    | 0.0        | 1.678E-05  | 130.4320    | MA-09      | Souss-Massa                      |
-| nan     | number          | 643.1         | 0.5039     | 0.0        | 8.062E-08  | 1.1659      | MA-09      | Souss-Massa                      |
-| nan     | residents       | 3_088         | 2.9489     | 0.0        | 9.960E-07  | 11.0017     | MA-09      | Souss-Massa                      |
-| nan     | affectedpop     | 3_088         | 4.3875     | 0.0        | 1.003E-06  | 18.9459     | MA-09      | Souss-Massa                      |
-| nan     | injured         | 2_428         | 0.0628     | 0.0        | 6.685E-07  | 0.2903      | MA-09      | Souss-Massa                      |
-| nan     | embodied_carbon | 22_507        | 40.1585    | 0.0        | 1.7441     | 204.9       | MA-09      | Souss-Massa                      |
-| nan     | contents        | 433_212       | 2.8003     | 0.0        | 7.403E-04  | 0.0016      | MA-10      | Guelmim-Wadi Noun                |
-| nan     | structural      | 2_196_849     | 372.5      | 0.0        | 1_112      | 8_660       | MA-10      | Guelmim-Wadi Noun                |
-| nan     | occupants       | 231.2         | 5.571E-04  | 0.0        | 6.274E-07  | 0.0030      | MA-10      | Guelmim-Wadi Noun                |
-| nan     | area            | 7_539         | 0.2802     | 0.0        | 1.210E-05  | 1.9554      | MA-10      | Guelmim-Wadi Noun                |
-| nan     | number          | 73.9674       | 0.0045     | 0.0        | 9.180E-08  | 0.0198      | MA-10      | Guelmim-Wadi Noun                |
-| nan     | residents       | 221.4         | 0.0172     | 0.0        | 3.667E-07  | 0.0659      | MA-10      | Guelmim-Wadi Noun                |
-| nan     | affectedpop     | 221.4         | 0.0280     | 0.0        | 3.667E-07  | 0.2171      | MA-10      | Guelmim-Wadi Noun                |
-| nan     | injured         | 231.2         | 3.821E-04  | 0.0        | 6.274E-07  | 0.0019      | MA-10      | Guelmim-Wadi Noun                |
-| nan     | embodied_carbon | 2_351         | 0.5174     | 0.0        | 1.8661     | 11.1166     | MA-10      | Guelmim-Wadi Noun                |
-| nan     | affectedpop     | 55_030        | 528.7      | 2.977E-04  | 15.3058    | 3_190       | *total*    | *total*                          |
-| nan     | area            | 2_407_935     | 20_943     | 0.0036     | 247.3      | 124_990     | *total*    | *total*                          |
-| nan     | contents        | 442_346_176   | 3_992_703  | 0.2028     | 1_151      | 23_655_130  | *total*    | *total*                          |
-| nan     | embodied_carbon | 870_944       | 21_168     | 1_661      | 10_274     | 83_871      | *total*    | *total*                          |
-| nan     | injured         | 43_954        | 6.9165     | 3.016E-05  | 0.0955     | 39.5400     | *total*    | *total*                          |
-| nan     | number          | 14_807        | 129.1184   | 7.758E-06  | 0.9568     | 778.4       | *total*    | *total*                          |
-| nan     | occupants       | 43_954        | 2.8376     | 2.917E-05  | 0.0182     | 16.5694     | *total*    | *total*                          |
-| nan     | residents       | 55_030        | 354.5      | 4.907E-05  | 5.1532     | 2_095       | *total*    | *total*                          |
-| nan     | structural      | 2_241_584_896 | 75_072_556 | 7_221_533  | 39_494_392 | 287_014_464 | *total*    | *total*                          |
+| ID_0    | loss_type       | value         | lossmea    | q05       | q50        | q95         | ID         | NAME                             |
+|---------+-----------------+---------------+------------+-----------+------------+-------------+------------+----------------------------------|
+| ESP     | contents        | 149_429_824   | 705_577    | 0.0531    | 10_287     | 4_346_094   | nan        | nan                              |
+| ESP     | structural      | 805_206_784   | 6_779_806  | 239_981   | 3_019_563  | 29_575_773  | nan        | nan                              |
+| ESP     | occupants       | 8_093         | 0.3464     | 2.761E-06 | 0.0099     | 2.1874      | nan        | nan                              |
+| ESP     | area            | 671_804       | 2_953      | 2.982E-04 | 144.8379   | 13_218      | nan        | nan                              |
+| ESP     | number          | 3_228         | 19.7570    | 8.494E-07 | 0.6517     | 83.0697     | nan        | nan                              |
+| ESP     | residents       | 10_677        | 46.1807    | 3.179E-06 | 2.4423     | 206.0       | nan        | nan                              |
+| ESP     | affectedpop     | 10_677        | 63.9917    | 3.179E-06 | 5.9416     | 279.7       | nan        | nan                              |
+| ESP     | injured         | 8_093         | 1.0204     | 2.761E-06 | 0.0402     | 5.2599      | nan        | nan                              |
+| ESP     | embodied_carbon | 238_997       | 2_010      | 52.0566   | 830.9      | 8_856       | nan        | nan                              |
+| MAR     | contents        | 46_109_520    | 11_311     | 1.983E-04 | 0.0476     | 33_880      | nan        | nan                              |
+| MAR     | structural      | 239_964_512   | 475_315    | 1_065     | 174_762    | 1_873_340   | nan        | nan                              |
+| MAR     | occupants       | 26_523        | 0.1348     | 6.521E-07 | 2.537E-05  | 0.8291      | nan        | nan                              |
+| MAR     | area            | 740_323       | 174.8070   | 1.757E-05 | 9.078E-04  | 619.7       | nan        | nan                              |
+| MAR     | number          | 7_678         | 2.2019     | 5.261E-08 | 9.165E-06  | 5.7771      | nan        | nan                              |
+| MAR     | residents       | 32_599        | 11.5196    | 9.976E-07 | 4.042E-05  | 40.6329     | nan        | nan                              |
+| MAR     | affectedpop     | 32_599        | 18.2187    | 9.976E-07 | 6.086E-04  | 73.3965     | nan        | nan                              |
+| MAR     | injured         | 26_523        | 0.2876     | 6.521E-07 | 2.537E-05  | 0.8900      | nan        | nan                              |
+| MAR     | embodied_carbon | 294_368       | 457.4      | 1.2262    | 148.8819   | 1_906       | nan        | nan                              |
+| PRT     | contents        | 247_515_312   | 1_703_729  | 1.9893    | 256_296    | 7_260_582   | nan        | nan                              |
+| PRT     | structural      | 1_199_247_616 | 38_214_040 | 9_388_530 | 25_322_788 | 99_286_225  | nan        | nan                              |
+| PRT     | occupants       | 9_373         | 0.9500     | 3.274E-05 | 0.2078     | 3.7736      | nan        | nan                              |
+| PRT     | area            | 998_570       | 7_698      | 8.1549    | 1_572      | 26_890      | nan        | nan                              |
+| PRT     | number          | 3_908         | 47.2279    | 0.0115    | 8.4166     | 154.7875    | nan        | nan                              |
+| PRT     | residents       | 11_754        | 120.9848   | 0.1412    | 28.9357    | 443.3       | nan        | nan                              |
+| PRT     | affectedpop     | 11_754        | 176.9220   | 0.7715    | 49.2145    | 618.6       | nan        | nan                              |
+| PRT     | injured         | 9_373         | 2.2417     | 0.0024    | 0.5971     | 8.4398      | nan        | nan                              |
+| PRT     | embodied_carbon | 338_861       | 10_257     | 2_261     | 7_124      | 26_339      | nan        | nan                              |
+| *total* | affectedpop     | 55_030        | 259.1      | 0.7715    | 55.1567    | 971.7       | nan        | nan                              |
+| *total* | area            | 2_410_697     | 10_826     | 8.1552    | 1_717      | 40_728      | nan        | nan                              |
+| *total* | contents        | 443_054_656   | 2_420_616  | 2.0426    | 266_582    | 11_640_557  | nan        | nan                              |
+| *total* | embodied_carbon | 872_226       | 12_725     | 2_314     | 8_104      | 37_101      | nan        | nan                              |
+| *total* | injured         | 43_989        | 3.5497     | 0.0024    | 0.6374     | 14.5897     | nan        | nan                              |
+| *total* | number          | 14_813        | 69.1867    | 0.0115    | 9.0683     | 243.6       | nan        | nan                              |
+| *total* | occupants       | 43_989        | 1.4311     | 3.615E-05 | 0.2177     | 6.7901      | nan        | nan                              |
+| *total* | residents       | 55_030        | 178.6852   | 0.1412    | 31.3780    | 690.0       | nan        | nan                              |
+| *total* | structural      | 2_244_419_072 | 45_469_161 | 9_629_576 | 28_517_113 | 130_735_337 | nan        | nan                              |
+| nan     | contents        | 344_085       | 364.0      | 0.0       | 0.0017     | 32.1974     | 1001       | Division No.  1                  |
+| nan     | structural      | 1_654_183     | 42_160     | 0.0       | 31_154     | 116_946     | 1001       | Division No.  1                  |
+| nan     | occupants       | 21.6707       | 5.510E-05  | 0.0       | 1.471E-07  | 1.471E-07   | 1001       | Division No.  1                  |
+| nan     | area            | 1_566         | 0.8173     | 0.0       | 1.244E-05  | 1.244E-05   | 1001       | Division No.  1                  |
+| nan     | number          | 7.8334        | 0.0059     | 0.0       | 6.976E-08  | 6.976E-08   | 1001       | Division No.  1                  |
+| nan     | residents       | 11.0390       | 0.0178     | 0.0       | 1.104E-07  | 1.104E-07   | 1001       | Division No.  1                  |
+| nan     | affectedpop     | 11.0390       | 0.0521     | 0.0       | 1.104E-07  | 1.104E-07   | 1001       | Division No.  1                  |
+| nan     | injured         | 21.6707       | 2.498E-04  | 0.0       | 1.471E-07  | 1.471E-07   | 1001       | Division No.  1                  |
+| nan     | embodied_carbon | 567.8         | 12.2348    | 0.0       | 8.5023     | 38.3112     | 1001       | Division No.  1                  |
+| nan     | contents        | 102_118       | 47.7424    | 0.0       | 0.0010     | 0.2519      | 1003       | Division No.  3                  |
+| nan     | structural      | 408_472       | 12_781     | 0.0       | 9_083      | 39_897      | 1003       | Division No.  3                  |
+| nan     | occupants       | 8.8537        | 6.856E-08  | 0.0       | 8.854E-08  | 8.854E-08   | 1003       | Division No.  3                  |
+| nan     | area            | 398.1         | 0.0016     | 0.0       | 3.981E-06  | 3.981E-06   | 1003       | Division No.  3                  |
+| nan     | number          | 1.1232        | 4.507E-06  | 0.0       | 1.123E-08  | 1.123E-08   | 1003       | Division No.  3                  |
+| nan     | injured         | 8.8537        | 1.452E-06  | 0.0       | 8.854E-08  | 8.854E-08   | 1003       | Division No.  3                  |
+| nan     | embodied_carbon | 172.4963      | 7.5732     | 0.0       | 6.2236     | 21.4941     | 1003       | Division No.  3                  |
+| nan     | contents        | 361_985       | 5_489      | 0.0       | 0.0028     | 0.0036      | 1004       | Division No.  4                  |
+| nan     | structural      | 2_051_247     | 54_971     | 0.0       | 4_839      | 280_561     | 1004       | Division No.  4                  |
+| nan     | occupants       | 12.0779       | 0.0131     | 0.0       | 1.208E-07  | 0.0669      | 1004       | Division No.  4                  |
+| nan     | area            | 1_799         | 37.8555    | 0.0       | 1.799E-05  | 169.0399    | 1004       | Division No.  4                  |
+| nan     | number          | 10.9037       | 0.2322     | 0.0       | 1.090E-07  | 1.0784      | 1004       | Division No.  4                  |
+| nan     | residents       | 21.8605       | 0.5603     | 0.0       | 2.186E-07  | 2.8921      | 1004       | Division No.  4                  |
+| nan     | affectedpop     | 21.8605       | 0.7959     | 0.0       | 2.186E-07  | 5.0228      | 1004       | Division No.  4                  |
+| nan     | injured         | 12.0779       | 0.0097     | 0.0       | 1.208E-07  | 0.0460      | 1004       | Division No.  4                  |
+| nan     | embodied_carbon | 591.5         | 16.0112    | 0.0       | 1.3000     | 73.0940     | 1004       | Division No.  4                  |
+| nan     | contents        | 63_188        | 269.7      | 0.0       | 3.013E-04  | 168.5561    | 1006       | Division No.  6                  |
+| nan     | structural      | 358_069       | 18_679     | 314.9     | 8_615      | 57_591      | 1006       | Division No.  6                  |
+| nan     | occupants       | 2.3538        | 3.383E-04  | 8.666E-09 | 2.354E-08  | 0.0029      | 1006       | Division No.  6                  |
+| nan     | area            | 285.5         | 5.6788     | 1.362E-06 | 2.855E-06  | 48.4940     | 1006       | Division No.  6                  |
+| nan     | number          | 1.7063        | 0.0409     | 7.173E-09 | 1.706E-08  | 0.3517      | 1006       | Division No.  6                  |
+| nan     | residents       | 4.3524        | 0.0783     | 1.602E-08 | 4.352E-08  | 0.7083      | 1006       | Division No.  6                  |
+| nan     | affectedpop     | 4.3524        | 0.1038     | 1.602E-08 | 4.352E-08  | 0.9152      | 1006       | Division No.  6                  |
+| nan     | injured         | 2.3538        | 0.0015     | 8.666E-09 | 2.354E-08  | 0.0130      | 1006       | Division No.  6                  |
+| nan     | embodied_carbon | 88.2577       | 4.1390     | 0.0820    | 1.5437     | 15.6466     | 1006       | Division No.  6                  |
+| nan     | contents        | 31_096        | 58.1330    | 0.0       | 3.110E-04  | 3.110E-04   | 1007       | Division No.  7                  |
+| nan     | structural      | 176_212       | 2_102      | 0.0       | 260.2      | 14_306      | 1007       | Division No.  7                  |
+| nan     | occupants       | 0.4476        | 1.931E-05  | 0.0       | 4.476E-09  | 1.309E-04   | 1007       | Division No.  7                  |
+| nan     | area            | 154.5716      | 0.9392     | 0.0       | 1.546E-06  | 5.8712      | 1007       | Division No.  7                  |
+| nan     | number          | 0.9918        | 0.0060     | 0.0       | 9.918E-09  | 0.0377      | 1007       | Division No.  7                  |
+| nan     | residents       | 0.8102        | 0.0064     | 0.0       | 8.102E-09  | 0.0457      | 1007       | Division No.  7                  |
+| nan     | affectedpop     | 0.8102        | 0.0111     | 0.0       | 8.102E-09  | 0.0947      | 1007       | Division No.  7                  |
+| nan     | injured         | 0.4476        | 1.071E-04  | 0.0       | 4.476E-09  | 7.439E-04   | 1007       | Division No.  7                  |
+| nan     | embodied_carbon | 49.3157       | 0.6079     | 0.0       | 0.0676     | 3.5097      | 1007       | Division No.  7                  |
+| nan     | contents        | 321_680       | 708.4      | 0.0       | 0.0028     | 0.0032      | 1008       | Division No.  8                  |
+| nan     | structural      | 1_822_852     | 17_709     | 0.0       | 3_823      | 103_734     | 1008       | Division No.  8                  |
+| nan     | occupants       | 6.5532        | 2.610E-04  | 0.0       | 6.553E-08  | 0.0017      | 1008       | Division No.  8                  |
+| nan     | area            | 1_599         | 7.1005     | 0.0       | 1.599E-05  | 34.3790     | 1008       | Division No.  8                  |
+| nan     | number          | 9.9244        | 0.0433     | 0.0       | 9.924E-08  | 0.3723      | 1008       | Division No.  8                  |
+| nan     | residents       | 11.8601       | 0.0741     | 0.0       | 1.186E-07  | 0.4146      | 1008       | Division No.  8                  |
+| nan     | affectedpop     | 11.8601       | 0.1209     | 0.0       | 1.186E-07  | 1.2325      | 1008       | Division No.  8                  |
+| nan     | injured         | 6.5532        | 0.0013     | 0.0       | 6.553E-08  | 0.0075      | 1008       | Division No.  8                  |
+| nan     | embodied_carbon | 550.6         | 5.8413     | 0.0       | 1.0875     | 46.8788     | 1008       | Division No.  8                  |
+| nan     | contents        | 2_601_728     | 84_564     | 8.128E-09 | 0.0036     | 60_812      | 1009       | Leiria                           |
+| nan     | structural      | 14_679_383    | 570_025    | 205.5     | 86_226     | 2_255_640   | 1009       | Leiria                           |
+| nan     | occupants       | 68.2679       | 0.0178     | 8.540E-09 | 6.827E-07  | 0.1248      | 1009       | Leiria                           |
+| nan     | area            | 9_924         | 284.1      | 1.335E-06 | 9.924E-05  | 2_055       | 1009       | Leiria                           |
+| nan     | number          | 69.0849       | 2.0544     | 8.565E-09 | 6.908E-07  | 14.9306     | 1009       | Leiria                           |
+| nan     | residents       | 120.2857      | 4.3545     | 1.582E-08 | 1.203E-06  | 32.0426     | 1009       | Leiria                           |
+| nan     | affectedpop     | 120.2857      | 6.2896     | 1.582E-08 | 6.687E-04  | 45.8792     | 1009       | Leiria                           |
+| nan     | injured         | 68.2679       | 0.0791     | 8.540E-09 | 6.827E-07  | 0.5746      | 1009       | Leiria                           |
+| nan     | embodied_carbon | 3_506         | 130.6450   | 0.0726    | 17.0897    | 613.2       | 1009       | Leiria                           |
+| nan     | contents        | 1_976_803     | 2_045      | 0.0       | 0.0080     | 36.0444     | 101        | Hanumangarh                      |
+| nan     | structural      | 10_631_079    | 184_768    | 0.0       | 143_148    | 542_723     | 101        | Hanumangarh                      |
+| nan     | occupants       | 109.4221      | 0.0016     | 0.0       | 7.317E-07  | 0.0093      | 101        | Hanumangarh                      |
+| nan     | area            | 9_525         | 12.1140    | 0.0       | 7.026E-05  | 58.5385     | 101        | Hanumangarh                      |
+| nan     | number          | 32.4502       | 0.0633     | 0.0       | 2.154E-07  | 0.2975      | 101        | Hanumangarh                      |
+| nan     | residents       | 135.1385      | 0.2631     | 0.0       | 1.056E-06  | 1.3099      | 101        | Hanumangarh                      |
+| nan     | affectedpop     | 135.1385      | 0.4447     | 0.0       | 1.114E-06  | 2.6713      | 101        | Hanumangarh                      |
+| nan     | injured         | 109.4221      | 0.0050     | 0.0       | 7.317E-07  | 0.0254      | 101        | Hanumangarh                      |
+| nan     | embodied_carbon | 3_185         | 60.1327    | 0.0       | 44.4532    | 160.6060    | 101        | Hanumangarh                      |
+| nan     | contents        | 63_108        | 11.8680    | 0.0       | 6.311E-04  | 6.311E-04   | 1010       | Division No. 10                  |
+| nan     | structural      | 357_613       | 5_366      | 0.0       | 1_440      | 15_962      | 1010       | Division No. 10                  |
+| nan     | occupants       | 2.1918        | 1.402E-04  | 0.0       | 2.192E-08  | 2.192E-08   | 1010       | Division No. 10                  |
+| nan     | area            | 313.7         | 0.6924     | 0.0       | 3.137E-06  | 0.0055      | 1010       | Division No. 10                  |
+| nan     | number          | 2.0129        | 0.0044     | 0.0       | 2.013E-08  | 3.529E-05   | 1010       | Division No. 10                  |
+| nan     | residents       | 3.9672        | 0.0133     | 0.0       | 3.967E-08  | 7.583E-05   | 1010       | Division No. 10                  |
+| nan     | affectedpop     | 3.9672        | 0.0301     | 0.0       | 3.967E-08  | 0.0044      | 1010       | Division No. 10                  |
+| nan     | injured         | 2.1918        | 1.674E-04  | 0.0       | 2.192E-08  | 2.192E-08   | 1010       | Division No. 10                  |
+| nan     | embodied_carbon | 93.8909       | 1.2002     | 0.0       | 0.2137     | 2.9642      | 1010       | Division No. 10                  |
+| nan     | contents        | 61_186        | 75.9591    | 0.0       | 5.538E-04  | 5.538E-04   | 1012       | Óbidos                           |
+| nan     | structural      | 337_042       | 2_959      | 0.0       | 1_558      | 11_525      | 1012       | Óbidos                           |
+| nan     | occupants       | 2.1480        | 4.291E-07  | 0.0       | 1.594E-08  | 1.594E-08   | 1012       | Óbidos                           |
+| nan     | area            | 297.9         | 0.0146     | 0.0       | 2.753E-06  | 2.753E-06   | 1012       | Óbidos                           |
+| nan     | number          | 2.1084        | 1.064E-04  | 0.0       | 2.000E-08  | 2.000E-08   | 1012       | Óbidos                           |
+| nan     | residents       | 2.8855        | 1.912E-04  | 0.0       | 2.886E-08  | 2.886E-08   | 1012       | Óbidos                           |
+| nan     | affectedpop     | 2.8855        | 4.958E-04  | 0.0       | 2.886E-08  | 2.886E-08   | 1012       | Óbidos                           |
+| nan     | injured         | 2.1480        | 3.482E-06  | 0.0       | 1.594E-08  | 1.594E-08   | 1012       | Óbidos                           |
+| nan     | embodied_carbon | 92.2654       | 1.5380     | 0.0       | 0.9607     | 5.6653      | 1012       | Óbidos                           |
+| nan     | contents        | 346_716       | 1_053      | 0.0       | 0.0035     | 0.0035      | 1014       | Peniche                          |
+| nan     | structural      | 1_964_724     | 39_495     | 0.0       | 12_271     | 115_484     | 1014       | Peniche                          |
+| nan     | occupants       | 7.0052        | 8.248E-04  | 0.0       | 7.005E-08  | 7.005E-08   | 1014       | Peniche                          |
+| nan     | area            | 1_567         | 6.3343     | 0.0       | 1.567E-05  | 0.5949      | 1014       | Peniche                          |
+| nan     | number          | 10.0534       | 0.0406     | 0.0       | 1.005E-07  | 0.0038      | 1014       | Peniche                          |
+| nan     | residents       | 12.9554       | 0.0631     | 0.0       | 1.296E-07  | 0.0064      | 1014       | Peniche                          |
+| nan     | affectedpop     | 12.9554       | 0.0966     | 0.0       | 1.296E-07  | 0.0827      | 1014       | Peniche                          |
+| nan     | injured         | 7.0052        | 9.674E-04  | 0.0       | 7.005E-08  | 7.005E-08   | 1014       | Peniche                          |
+| nan     | embodied_carbon | 468.9         | 7.1666     | 0.0       | 1.7594     | 21.8237     | 1014       | Peniche                          |
+| nan     | contents        | 2_437_501     | 40_353     | 6.247E-04 | 0.0215     | 220_709     | 1015       | Pombal                           |
+| nan     | structural      | 13_765_536    | 334_735    | 1_258     | 101_229    | 1_408_826   | 1015       | Pombal                           |
+| nan     | occupants       | 78.7829       | 0.0047     | 1.213E-08 | 7.641E-07  | 0.0273      | 1015       | Pombal                           |
+| nan     | area            | 12_086        | 118.3501   | 3.105E-06 | 1.198E-04  | 754.8       | 1015       | Pombal                           |
+| nan     | number          | 83.3780       | 0.7596     | 1.993E-08 | 8.315E-07  | 4.8437      | 1015       | Pombal                           |
+| nan     | residents       | 138.3052      | 1.3145     | 2.196E-08 | 1.383E-06  | 7.0937      | 1015       | Pombal                           |
+| nan     | affectedpop     | 138.3052      | 1.6990     | 2.196E-08 | 1.383E-06  | 9.2479      | 1015       | Pombal                           |
+| nan     | injured         | 78.7829       | 0.0229     | 1.213E-08 | 7.641E-07  | 0.1261      | 1015       | Pombal                           |
+| nan     | embodied_carbon | 3_814         | 91.2162    | 0.3087    | 22.0053    | 449.5       | 1015       | Pombal                           |
+| nan     | contents        | 526_396       | 3_687      | 0.0       | 8.316E-14  | 0.0053      | 1016       | Porto de Mós                     |
+| nan     | structural      | 2_982_912     | 50_714     | 0.0       | 10_477     | 157_905     | 1016       | Porto de Mós                     |
+| nan     | occupants       | 20.1401       | 0.0018     | 0.0       | 2.014E-07  | 0.0059      | 1016       | Porto de Mós                     |
+| nan     | area            | 2_617         | 25.7381    | 0.0       | 2.617E-05  | 81.2180     | 1016       | Porto de Mós                     |
+| nan     | number          | 19.0069       | 0.1870     | 0.0       | 1.901E-07  | 0.5900      | 1016       | Porto de Mós                     |
+| nan     | residents       | 36.4525       | 0.4356     | 0.0       | 3.645E-07  | 1.7646      | 1016       | Porto de Mós                     |
+| nan     | affectedpop     | 36.4525       | 0.6537     | 0.0       | 3.645E-07  | 3.6496      | 1016       | Porto de Mós                     |
+| nan     | injured         | 20.1401       | 0.0084     | 0.0       | 2.014E-07  | 0.0307      | 1016       | Porto de Mós                     |
+| nan     | embodied_carbon | 948.8         | 16.4549    | 0.0       | 3.5313     | 52.4468     | 1016       | Porto de Mós                     |
+| nan     | contents        | 196_590       | 1_376      | 0.0       | 5.508E-04  | 0.0130      | 102        | Jaipur                           |
+| nan     | structural      | 1_114_012     | 35_371     | 0.0       | 4_523      | 193_197     | 102        | Jaipur                           |
+| nan     | occupants       | 8.7083        | 0.0022     | 0.0       | 7.664E-08  | 0.0204      | 102        | Jaipur                           |
+| nan     | area            | 977.2         | 19.2759    | 0.0       | 8.418E-06  | 198.0       | 102        | Jaipur                           |
+| nan     | number          | 3.0630        | 0.0295     | 0.0       | 2.080E-08  | 0.2158      | 102        | Jaipur                           |
+| nan     | residents       | 15.7591       | 0.4129     | 0.0       | 1.407E-07  | 4.3871      | 102        | Jaipur                           |
+| nan     | affectedpop     | 15.7591       | 0.5572     | 0.0       | 1.407E-07  | 5.0640      | 102        | Jaipur                           |
+| nan     | injured         | 8.7083        | 0.0077     | 0.0       | 7.664E-08  | 0.0770      | 102        | Jaipur                           |
+| nan     | embodied_carbon | 337.4         | 9.9746     | 0.0       | 1.6324     | 70.4454     | 102        | Jaipur                           |
+| nan     | contents        | 1_513_318     | 57_851     | 0.0       | 0.0025     | 509_910     | 103        | Jaisalmer                        |
+| nan     | structural      | 3_744_997     | 144_723    | 1_672     | 95_870     | 478_700     | 103        | Jaisalmer                        |
+| nan     | occupants       | 21.6845       | 0.0030     | 3.628E-08 | 1.806E-07  | 0.0020      | 103        | Jaisalmer                        |
+| nan     | area            | 4_668         | 18.5453    | 1.171E-06 | 4.568E-05  | 19.6633     | 103        | Jaisalmer                        |
+| nan     | number          | 13.3830       | 0.0768     | 3.682E-09 | 1.292E-07  | 0.1204      | 103        | Jaisalmer                        |
+| nan     | residents       | 14.3658       | 0.1264     | 0.0       | 1.437E-07  | 0.1887      | 103        | Jaisalmer                        |
+| nan     | affectedpop     | 14.3658       | 0.1546     | 0.0       | 1.437E-07  | 0.3938      | 103        | Jaisalmer                        |
+| nan     | injured         | 21.6845       | 0.0033     | 2.698E-08 | 1.806E-07  | 0.0063      | 103        | Jaisalmer                        |
+| nan     | embodied_carbon | 1_317         | 52.7006    | 0.6886    | 34.6686    | 169.3753    | 103        | Jaisalmer                        |
+| nan     | contents        | 1_123_217     | 947.6      | 0.0       | 8.199E-04  | 34.2757     | 105        | Jhalawar                         |
+| nan     | structural      | 4_610_390     | 30_238     | 0.0       | 17_779     | 98_336      | 105        | Jhalawar                         |
+| nan     | occupants       | 85.6806       | 0.0035     | 0.0       | 1.611E-07  | 0.0189      | 105        | Jhalawar                         |
+| nan     | area            | 3_370         | 5.0308     | 0.0       | 7.749E-06  | 27.0157     | 105        | Jhalawar                         |
+| nan     | number          | 9.8769        | 0.0365     | 0.0       | 4.287E-08  | 0.1962      | 105        | Jhalawar                         |
+| nan     | residents       | 4.6653        | 0.0995     | 0.0       | 4.665E-08  | 0.6131      | 105        | Jhalawar                         |
+| nan     | affectedpop     | 4.6653        | 0.1276     | 0.0       | 4.665E-08  | 1.0095      | 105        | Jhalawar                         |
+| nan     | injured         | 85.6806       | 0.0019     | 0.0       | 1.611E-07  | 0.0112      | 105        | Jhalawar                         |
+| nan     | embodied_carbon | 1_501         | 9.4463     | 0.0       | 5.6891     | 31.9195     | 105        | Jhalawar                         |
+| nan     | contents        | 438_600       | 20.5941    | 0.0       | 0.0010     | 0.0044      | 107        | Jodhpur                          |
+| nan     | structural      | 2_312_676     | 34_085     | 0.0       | 19_500     | 104_602     | 107        | Jodhpur                          |
+| nan     | occupants       | 27.3857       | 1.577E-05  | 0.0       | 1.433E-07  | 2.739E-07   | 107        | Jodhpur                          |
+| nan     | area            | 1_877         | 0.1873     | 0.0       | 1.514E-05  | 1.877E-05   | 107        | Jodhpur                          |
+| nan     | number          | 12.7002       | 0.0014     | 0.0       | 1.100E-07  | 1.270E-07   | 107        | Jodhpur                          |
+| nan     | residents       | 26.5009       | 0.0043     | 0.0       | 2.650E-07  | 2.650E-07   | 107        | Jodhpur                          |
+| nan     | affectedpop     | 26.5009       | 0.0084     | 0.0       | 2.650E-07  | 2.650E-07   | 107        | Jodhpur                          |
+| nan     | injured         | 27.3857       | 7.007E-05  | 0.0       | 1.433E-07  | 2.739E-07   | 107        | Jodhpur                          |
+| nan     | embodied_carbon | 623.8         | 10.0553    | 0.0       | 6.4327     | 30.2380     | 107        | Jodhpur                          |
+| nan     | contents        | 3_918_363     | 127_909    | 0.0       | 0.0392     | 0.0392      | 108        | Karauli                          |
+| nan     | structural      | 22_204_056    | 905_630    | 0.0       | 14_877     | 2_936_136   | 108        | Karauli                          |
+| nan     | occupants       | 131.0966      | 0.0338     | 0.0       | 1.311E-06  | 0.0902      | 108        | Karauli                          |
+| nan     | area            | 19_477        | 670.9      | 0.0       | 1.948E-04  | 1_750       | 108        | Karauli                          |
+| nan     | number          | 124.9789      | 4.3052     | 0.0       | 1.250E-06  | 11.2277     | 108        | Karauli                          |
+| nan     | residents       | 237.3         | 8.9036     | 0.0       | 2.373E-06  | 29.6676     | 108        | Karauli                          |
+| nan     | affectedpop     | 237.3         | 10.4672    | 0.0       | 2.373E-06  | 52.5560     | 108        | Karauli                          |
+| nan     | injured         | 131.0966      | 0.1602     | 0.0       | 1.311E-06  | 0.4824      | 108        | Karauli                          |
+| nan     | embodied_carbon | 7_058         | 286.4      | 0.0       | 4.0787     | 727.9       | 108        | Karauli                          |
+| nan     | contents        | 4_320_605     | 30_730     | 0.0       | 0.0083     | 152_574     | 109        | Kota                             |
+| nan     | structural      | 24_452_584    | 604_123    | 0.0       | 289_316    | 3_221_146   | 109        | Kota                             |
+| nan     | occupants       | 214.5         | 0.0116     | 0.0       | 2.090E-06  | 0.1026      | 109        | Kota                             |
+| nan     | area            | 21_457        | 164.9799   | 0.0       | 2.083E-04  | 1_779       | 109        | Kota                             |
+| nan     | number          | 39.3597       | 0.9654     | 0.0       | 3.636E-07  | 2.9204      | 109        | Kota                             |
+| nan     | residents       | 385.3         | 2.7625     | 0.0       | 3.658E-06  | 26.7183     | 109        | Kota                             |
+| nan     | affectedpop     | 385.3         | 4.2722     | 0.0       | 3.754E-06  | 41.8682     | 109        | Kota                             |
+| nan     | injured         | 214.5         | 0.0441     | 0.0       | 2.090E-06  | 0.4584      | 109        | Kota                             |
+| nan     | embodied_carbon | 7_153         | 183.8      | 0.0       | 86.6356    | 969.7       | 109        | Kota                             |
+| nan     | contents        | 323_498       | 44.9735    | 0.0       | 5.999E-04  | 5.999E-04   | 1101       | Kings                            |
+| nan     | structural      | 1_293_991     | 5_675      | 0.0       | 3_856      | 17_859      | 1101       | Kings                            |
+| nan     | occupants       | 32.4674       | 4.829E-08  | 0.0       | 6.021E-08  | 6.021E-08   | 1101       | Kings                            |
+| nan     | area            | 1_135         | 1.688E-06  | 0.0       | 2.105E-06  | 2.105E-06   | 1101       | Kings                            |
+| nan     | number          | 2.9178        | 7.915E-09  | 0.0       | 9.870E-09  | 9.870E-09   | 1101       | Kings                            |
+| nan     | injured         | 32.4674       | 4.829E-08  | 0.0       | 6.021E-08  | 6.021E-08   | 1101       | Kings                            |
+| nan     | embodied_carbon | 533.1         | 3.6562     | 0.0       | 2.9758     | 10.5048     | 1101       | Kings                            |
+| nan     | contents        | 2_081_289     | 126_878    | 0.0       | 0.0028     | 968_672     | 1103       | Prince                           |
+| nan     | structural      | 4_941_015     | 396_696    | 0.0       | 202_937    | 1_715_889   | 1103       | Prince                           |
+| nan     | occupants       | 18.0250       | 0.0473     | 0.0       | 1.802E-07  | 0.4262      | 1103       | Prince                           |
+| nan     | area            | 6_288         | 132.2563   | 0.0       | 6.288E-05  | 1_104       | 1103       | Prince                           |
+| nan     | number          | 17.3359       | 0.7926     | 0.0       | 1.734E-07  | 6.9676      | 1103       | Prince                           |
+| nan     | residents       | 16.3521       | 1.5658     | 0.0       | 1.635E-07  | 13.7835     | 1103       | Prince                           |
+| nan     | affectedpop     | 16.3521       | 1.9106     | 0.0       | 1.635E-07  | 14.9430     | 1103       | Prince                           |
+| nan     | injured         | 18.0250       | 0.0286     | 0.0       | 1.802E-07  | 0.2458      | 1103       | Prince                           |
+| nan     | embodied_carbon | 1_718         | 121.0278   | 0.0       | 69.7843    | 485.7       | 1103       | Prince                           |
+| nan     | contents        | 252_481       | 271.0      | 0.0       | 2.597E-04  | 374.7       | 1104       | ACEH TENGGARA Regency            |
+| nan     | structural      | 1_145_151     | 16_273     | 0.0       | 11_738     | 44_754      | 1104       | ACEH TENGGARA Regency            |
+| nan     | occupants       | 21.2309       | 3.279E-04  | 0.0       | 2.725E-08  | 9.798E-04   | 1104       | ACEH TENGGARA Regency            |
+| nan     | area            | 1_071         | 1.8392     | 0.0       | 7.379E-04  | 4.8338      | 1104       | ACEH TENGGARA Regency            |
+| nan     | number          | 4.4554        | 0.0134     | 0.0       | 5.360E-06  | 0.0351      | 1104       | ACEH TENGGARA Regency            |
+| nan     | residents       | 4.9320        | 0.0282     | 0.0       | 8.538E-06  | 0.0937      | 1104       | ACEH TENGGARA Regency            |
+| nan     | affectedpop     | 4.9320        | 0.0617     | 0.0       | 1.911E-04  | 0.3166      | 1104       | ACEH TENGGARA Regency            |
+| nan     | injured         | 21.2309       | 4.536E-04  | 0.0       | 2.725E-08  | 0.0014      | 1104       | ACEH TENGGARA Regency            |
+| nan     | embodied_carbon | 410.8         | 2.6119     | 0.0       | 1.7247     | 7.9904      | 1104       | ACEH TENGGARA Regency            |
+| nan     | contents        | 653_901       | 22_387     | 0.0       | 1.391E-11  | 2_992       | 1105       | ACEH TIMUR Regency               |
+| nan     | structural      | 3_705_441     | 176_532    | 0.0       | 15_102     | 872_674     | 1105       | ACEH TIMUR Regency               |
+| nan     | occupants       | 32.1308       | 0.0127     | 0.0       | 3.213E-07  | 0.0530      | 1105       | ACEH TIMUR Regency               |
+| nan     | area            | 2_500         | 92.2872    | 0.0       | 0.2189     | 380.5       | 1105       | ACEH TIMUR Regency               |
+| nan     | number          | 12.0053       | 0.4431     | 0.0       | 0.0011     | 1.8269      | 1105       | ACEH TIMUR Regency               |
+| nan     | residents       | 59.4249       | 2.5201     | 0.0       | 0.0053     | 10.9883     | 1105       | ACEH TIMUR Regency               |
+| nan     | affectedpop     | 59.4249       | 3.3001     | 0.0       | 0.0053     | 16.0213     | 1105       | ACEH TIMUR Regency               |
+| nan     | injured         | 32.1308       | 0.0488     | 0.0       | 3.213E-07  | 0.2077      | 1105       | ACEH TIMUR Regency               |
+| nan     | embodied_carbon | 907.2         | 44.7594    | 0.0       | 3.8786     | 220.6       | 1105       | ACEH TIMUR Regency               |
+| nan     | contents        | 6_359_240     | 2_790      | 3.084E-04 | 0.0235     | 24_764      | 1106       | ACEH TENGAH Regency              |
+| nan     | structural      | 29_747_242    | 691_887    | 30_517    | 589_146    | 1_527_494   | 1106       | ACEH TENGAH Regency              |
+| nan     | occupants       | 550.0         | 9.312E-04  | 3.557E-07 | 1.709E-06  | 1.709E-06   | 1106       | ACEH TENGAH Regency              |
+| nan     | area            | 20_945        | 4.6364     | 1.208E-05 | 1.018E-04  | 7.5039      | 1106       | ACEH TENGAH Regency              |
+| nan     | number          | 34.0087       | 0.0190     | 3.943E-08 | 1.153E-07  | 0.0064      | 1106       | ACEH TENGAH Regency              |
+| nan     | residents       | 266.7         | 0.1999     | 1.639E-07 | 2.667E-06  | 0.8832      | 1106       | ACEH TENGAH Regency              |
+| nan     | affectedpop     | 266.7         | 0.9130     | 1.639E-07 | 2.667E-06  | 4.3848      | 1106       | ACEH TENGAH Regency              |
+| nan     | injured         | 550.0         | 0.0018     | 3.557E-07 | 1.709E-06  | 1.709E-06   | 1106       | ACEH TENGAH Regency              |
+| nan     | embodied_carbon | 8_122         | 98.3199    | 7.1096    | 84.0349    | 230.0       | 1106       | ACEH TENGAH Regency              |
+| nan     | contents        | 1_378_162     | 9_838      | 0.0       | 0.1251     | 38_379      | 1107       | AFŞİN                            |
+| nan     | structural      | 7_266_306     | 484_874    | 0.0       | 323_432    | 1_774_283   | 1107       | AFŞİN                            |
+| nan     | occupants       | 85.5149       | 0.0217     | 0.0       | 8.551E-07  | 0.2020      | 1107       | AFŞİN                            |
+| nan     | area            | 5_043         | 49.4715    | 0.0       | 1.843E-04  | 377.0       | 1107       | AFŞİN                            |
+| nan     | number          | 11.1499       | 0.1461     | 0.0       | 1.084E-06  | 0.3923      | 1107       | AFŞİN                            |
+| nan     | residents       | 103.5445      | 2.3010     | 0.0       | 0.0052     | 19.1016     | 1107       | AFŞİN                            |
+| nan     | affectedpop     | 103.5445      | 6.4184     | 0.0       | 0.0474     | 42.6273     | 1107       | AFŞİN                            |
+| nan     | injured         | 85.5149       | 0.0269     | 0.0       | 8.551E-07  | 0.2228      | 1107       | AFŞİN                            |
+| nan     | embodied_carbon | 1_652         | 79.4199    | 0.0       | 45.6150    | 303.5       | 1107       | AFŞİN                            |
+| nan     | contents        | 199_685       | 4_973      | 0.0       | 0.0020     | 0.0851      | 1108       | ACEH BESAR Regency               |
+| nan     | structural      | 1_131_549     | 58_464     | 223.5     | 4_153      | 143_827     | 1108       | ACEH BESAR Regency               |
+| nan     | occupants       | 7.7836        | 0.0035     | 7.784E-08 | 7.784E-08  | 0.0092      | 1108       | ACEH BESAR Regency               |
+| nan     | area            | 992.6         | 36.7911    | 9.926E-06 | 9.926E-06  | 97.1220     | 1108       | ACEH BESAR Regency               |
+| nan     | number          | 1.5158        | 0.0562     | 1.516E-08 | 1.516E-08  | 0.1483      | 1108       | ACEH BESAR Regency               |
+| nan     | residents       | 14.0912       | 0.6073     | 1.409E-07 | 1.409E-07  | 2.1101      | 1108       | ACEH BESAR Regency               |
+| nan     | affectedpop     | 14.0912       | 0.7824     | 1.409E-07 | 2.682E-05  | 3.6382      | 1108       | ACEH BESAR Regency               |
+| nan     | injured         | 7.7836        | 0.0119     | 7.784E-08 | 7.784E-08  | 0.0355      | 1108       | ACEH BESAR Regency               |
+| nan     | embodied_carbon | 360.4         | 16.6271    | 0.0740    | 1.4102     | 50.1722     | 1108       | ACEH BESAR Regency               |
+| nan     | contents        | 403_430       | 6_162      | 6.930E-04 | 0.0032     | 44_921      | 1109       | PIDIE Regency                    |
+| nan     | structural      | 1_757_566     | 74_039     | 9_650     | 42_593     | 204_056     | 1109       | PIDIE Regency                    |
+| nan     | occupants       | 26.4253       | 0.0012     | 1.061E-07 | 2.643E-07  | 0.0030      | 1109       | PIDIE Regency                    |
+| nan     | area            | 1_738         | 11.4622    | 5.797E-06 | 1.738E-05  | 31.8564     | 1109       | PIDIE Regency                    |
+| nan     | number          | 9.2739        | 0.0921     | 3.247E-08 | 9.274E-08  | 0.2487      | 1109       | PIDIE Regency                    |
+| nan     | residents       | 15.8558       | 0.1396     | 3.284E-08 | 1.586E-07  | 0.4941      | 1109       | PIDIE Regency                    |
+| nan     | affectedpop     | 15.8558       | 0.1879     | 3.284E-08 | 1.586E-07  | 0.8332      | 1109       | PIDIE Regency                    |
+| nan     | injured         | 26.4253       | 0.0059     | 1.061E-07 | 2.643E-07  | 0.0154      | 1109       | PIDIE Regency                    |
+| nan     | embodied_carbon | 597.0         | 26.3494    | 3.2570    | 16.0325    | 64.4320     | 1109       | PIDIE Regency                    |
+| nan     | contents        | 1_047_387     | 1_697      | 0.0       | 0.0066     | 435.9       | 111        | Pali                             |
+| nan     | structural      | 5_935_193     | 201_211    | 0.0       | 146_826    | 554_993     | 111        | Pali                             |
+| nan     | occupants       | 46.7590       | 0.0030     | 0.0       | 4.676E-07  | 0.0094      | 111        | Pali                             |
+| nan     | area            | 5_206         | 14.2257    | 0.0       | 5.206E-05  | 43.0390     | 111        | Pali                             |
+| nan     | number          | 29.7535       | 0.1013     | 0.0       | 2.975E-07  | 0.3066      | 111        | Pali                             |
+| nan     | residents       | 84.6314       | 0.2695     | 0.0       | 8.463E-07  | 1.0558      | 111        | Pali                             |
+| nan     | affectedpop     | 84.6314       | 0.5763     | 0.0       | 8.463E-07  | 3.4093      | 111        | Pali                             |
+| nan     | injured         | 46.7590       | 0.0044     | 0.0       | 4.676E-07  | 0.0137      | 111        | Pali                             |
+| nan     | embodied_carbon | 1_560         | 40.2091    | 0.0       | 27.4643    | 115.8823    | 111        | Pali                             |
+| nan     | contents        | 3_312_181     | 31_561     | 4.236E-04 | 0.0247     | 31_638      | 1110       | BIREUEN Regency                  |
+| nan     | structural      | 18_209_268    | 659_236    | 27_697    | 148_098    | 3_684_538   | 1110       | BIREUEN Regency                  |
+| nan     | occupants       | 125.9962      | 0.0427     | 5.605E-07 | 1.260E-06  | 0.2581      | 1110       | BIREUEN Regency                  |
+| nan     | area            | 12_362        | 344.8      | 6.191E-05 | 7.1510     | 1_802       | 1110       | BIREUEN Regency                  |
+| nan     | number          | 62.2592       | 1.1754     | 2.400E-07 | 0.0089     | 3.3032      | 1110       | BIREUEN Regency                  |
+| nan     | residents       | 179.2351      | 6.6087     | 1.037E-06 | 0.1787     | 41.0292     | 1110       | BIREUEN Regency                  |
+| nan     | affectedpop     | 179.2351      | 8.4949     | 1.037E-06 | 0.6008     | 52.7332     | 1110       | BIREUEN Regency                  |
+| nan     | injured         | 125.9962      | 0.1585     | 5.605E-07 | 0.0033     | 0.8697      | 1110       | BIREUEN Regency                  |
+| nan     | embodied_carbon | 4_396         | 180.0      | 5.8386    | 35.8021    | 1_041       | 1110       | BIREUEN Regency                  |
+| nan     | contents        | 38_760_636    | 47_506     | 0.0019    | 0.3653     | 196_777     | 1111       | ACEH UTARA Regency               |
+| nan     | structural      | 216_213_520   | 8_034_720  | 106_583   | 6_381_865  | 19_451_364  | 1111       | ACEH UTARA Regency               |
+| nan     | occupants       | 1_807         | 0.0148     | 7.944E-07 | 1.687E-05  | 0.0666      | 1111       | ACEH UTARA Regency               |
+| nan     | area            | 146_472       | 105.4091   | 0.0014    | 0.0886     | 521.1       | 1111       | ACEH UTARA Regency               |
+| nan     | number          | 153.0254      | 0.3052     | 1.065E-06 | 4.198E-04  | 1.6020      | 1111       | ACEH UTARA Regency               |
+| nan     | residents       | 3_093         | 3.6428     | 3.022E-05 | 0.0029     | 13.6918     | 1111       | ACEH UTARA Regency               |
+| nan     | affectedpop     | 3_093         | 11.1968    | 3.022E-05 | 0.0255     | 40.6500     | 1111       | ACEH UTARA Regency               |
+| nan     | injured         | 1_807         | 0.0469     | 7.944E-07 | 1.687E-05  | 0.2591      | 1111       | ACEH UTARA Regency               |
+| nan     | embodied_carbon | 47_387        | 1_613      | 22.6170   | 1_247      | 3_934       | 1111       | ACEH UTARA Regency               |
+| nan     | contents        | 890_993       | 4_716      | 8.969E-19 | 0.0086     | 5_299       | 1113       | AKÇAABAT                         |
+| nan     | structural      | 5_048_961     | 201_188    | 1_731     | 132_007    | 747_535     | 1113       | AKÇAABAT                         |
+| nan     | occupants       | 37.8525       | 0.0029     | 6.384E-08 | 3.785E-07  | 0.0239      | 1113       | AKÇAABAT                         |
+| nan     | area            | 4_026         | 32.7365    | 6.498E-06 | 4.026E-05  | 292.9       | 1113       | AKÇAABAT                         |
+| nan     | number          | 17.9619       | 0.1146     | 1.000E-08 | 1.796E-07  | 0.9922      | 1113       | AKÇAABAT                         |
+| nan     | residents       | 70.0061       | 0.6099     | 1.181E-07 | 7.001E-07  | 5.3143      | 1113       | AKÇAABAT                         |
+| nan     | affectedpop     | 70.0061       | 0.8567     | 1.181E-07 | 0.0017     | 8.3495      | 1113       | AKÇAABAT                         |
+| nan     | injured         | 37.8525       | 0.0109     | 6.384E-08 | 3.785E-07  | 0.0929      | 1113       | AKÇAABAT                         |
+| nan     | embodied_carbon | 1_257         | 41.9643    | 0.5429    | 23.1898    | 167.9542    | 1113       | AKÇAABAT                         |
+| nan     | contents        | 1_038_030     | 947.2      | 0.0       | 3.615E-04  | 3.616E-04   | 1114       | AKÇADAĞ                          |
+| nan     | structural      | 4_212_379     | 7_887      | 0.0       | 1_130      | 49_137      | 1114       | AKÇADAĞ                          |
+| nan     | occupants       | 77.9471       | 2.888E-04  | 0.0       | 1.138E-08  | 0.0012      | 1114       | AKÇADAĞ                          |
+| nan     | area            | 3_068         | 3.8047     | 0.0       | 1.382E-06  | 14.9889     | 1114       | AKÇADAĞ                          |
+| nan     | number          | 7.1224        | 0.0276     | 0.0       | 1.004E-08  | 0.1089      | 1114       | AKÇADAĞ                          |
+| nan     | residents       | 2.1053        | 0.0709     | 0.0       | 2.105E-08  | 0.3227      | 1114       | AKÇADAĞ                          |
+| nan     | affectedpop     | 2.1053        | 0.1000     | 0.0       | 2.105E-08  | 0.5391      | 1114       | AKÇADAĞ                          |
+| nan     | injured         | 77.9471       | 0.0013     | 0.0       | 1.138E-08  | 0.0056      | 1114       | AKÇADAĞ                          |
+| nan     | embodied_carbon | 1_421         | 1.7193     | 0.0       | 0.2599     | 7.9001      | 1114       | AKÇADAĞ                          |
+| nan     | contents        | 3_611_628     | 10_172     | 0.0       | 0.0196     | 27_315      | 1116       | AKÇAKOCA                         |
+| nan     | structural      | 20_465_890    | 683_595    | 101_014   | 534_795    | 1_488_636   | 1116       | AKÇAKOCA                         |
+| nan     | occupants       | 182.4         | 0.0020     | 8.346E-07 | 1.824E-06  | 1.824E-06   | 1116       | AKÇAKOCA                         |
+| nan     | area            | 13_810        | 14.7216    | 6.318E-05 | 1.381E-04  | 2.8897      | 1116       | AKÇAKOCA                         |
+| nan     | number          | 40.0722       | 0.0688     | 4.100E-08 | 4.007E-07  | 0.0138      | 1116       | AKÇAKOCA                         |
+| nan     | residents       | 337.4         | 0.5923     | 1.544E-06 | 3.374E-06  | 0.1431      | 1116       | AKÇAKOCA                         |
+| nan     | affectedpop     | 337.4         | 1.6344     | 1.544E-06 | 3.374E-06  | 1.2796      | 1116       | AKÇAKOCA                         |
+| nan     | injured         | 182.4         | 0.0078     | 8.346E-07 | 1.824E-06  | 1.824E-06   | 1116       | AKÇAKOCA                         |
+| nan     | embodied_carbon | 4_311         | 152.1252   | 34.9259   | 123.3446   | 306.4       | 1116       | AKÇAKOCA                         |
+| nan     | contents        | 249_844       | 136.7996   | 0.0       | 0.0025     | 0.0025      | 112        | Rajsamand                        |
+| nan     | structural      | 1_415_785     | 30_164     | 0.0       | 11_018     | 99_905      | 112        | Rajsamand                        |
+| nan     | occupants       | 6.0779        | 2.980E-05  | 0.0       | 6.078E-08  | 6.078E-08   | 112        | Rajsamand                        |
+| nan     | area            | 1_242         | 0.7101     | 0.0       | 1.242E-05  | 1.242E-05   | 112        | Rajsamand                        |
+| nan     | number          | 9.0213        | 0.0052     | 0.0       | 9.021E-08  | 9.021E-08   | 112        | Rajsamand                        |
+| nan     | residents       | 11.0009       | 0.0096     | 0.0       | 1.100E-07  | 1.100E-07   | 112        | Rajsamand                        |
+| nan     | affectedpop     | 11.0009       | 0.0268     | 0.0       | 1.100E-07  | 1.100E-07   | 112        | Rajsamand                        |
+| nan     | injured         | 6.0779        | 1.377E-04  | 0.0       | 6.078E-08  | 6.078E-08   | 112        | Rajsamand                        |
+| nan     | embodied_carbon | 372.0         | 6.5846     | 0.0       | 2.2498     | 22.5464     | 112        | Rajsamand                        |
+| nan     | contents        | 83_095        | 37.1895    | 0.0       | 8.309E-04  | 8.310E-04   | 113        | Sawai Madhopur                   |
+| nan     | structural      | 470_873       | 8_263      | 0.0       | 4_540      | 26_320      | 113        | Sawai Madhopur                   |
+| nan     | occupants       | 3.3529        | 2.353E-08  | 0.0       | 3.353E-08  | 3.353E-08   | 113        | Sawai Madhopur                   |
+| nan     | area            | 413.0         | 0.0030     | 0.0       | 4.130E-06  | 4.130E-06   | 113        | Sawai Madhopur                   |
+| nan     | number          | 3.0004        | 2.163E-05  | 0.0       | 3.000E-08  | 3.000E-08   | 113        | Sawai Madhopur                   |
+| nan     | residents       | 6.0685        | 4.385E-05  | 0.0       | 6.068E-08  | 6.069E-08   | 113        | Sawai Madhopur                   |
+| nan     | affectedpop     | 6.0685        | 4.412E-04  | 0.0       | 6.068E-08  | 6.069E-08   | 113        | Sawai Madhopur                   |
+| nan     | injured         | 3.3529        | 3.531E-08  | 0.0       | 3.353E-08  | 3.353E-08   | 113        | Sawai Madhopur                   |
+| nan     | embodied_carbon | 123.7333      | 1.8215     | 0.0       | 0.9258     | 6.2394      | 113        | Sawai Madhopur                   |
+| nan     | contents        | 22_185        | 64.3744    | 0.0       | 0.0        | 270.7       | 114        | Sikar                            |
+| nan     | structural      | 88_742        | 4_605      | 0.0       | 2_208      | 14_911      | 114        | Sikar                            |
+| nan     | occupants       | 2.4529        | 1.737E-08  | 0.0       | 2.453E-08  | 2.453E-08   | 114        | Sikar                            |
+| nan     | area            | 97.3048       | 0.0124     | 0.0       | 9.730E-07  | 9.730E-07   | 114        | Sikar                            |
+| nan     | number          | 0.4484        | 5.699E-05  | 0.0       | 4.484E-09  | 4.484E-09   | 114        | Sikar                            |
+| nan     | injured         | 2.4529        | 9.840E-06  | 0.0       | 2.453E-08  | 2.453E-08   | 114        | Sikar                            |
+| nan     | embodied_carbon | 42.1214       | 1.7346     | 0.0       | 0.7830     | 6.1275      | 114        | Sikar                            |
+| nan     | contents        | 569_609       | 5_222      | 0.0       | 0.0017     | 7_866       | 115        | Sirohi                           |
+| nan     | structural      | 3_091_922     | 72_099     | 0.0       | 22_112     | 277_963     | 115        | Sirohi                           |
+| nan     | occupants       | 28.3062       | 0.0028     | 0.0       | 1.472E-07  | 0.0066      | 115        | Sirohi                           |
+| nan     | area            | 2_784         | 30.1375    | 0.0       | 2.784E-05  | 61.1242     | 115        | Sirohi                           |
+| nan     | number          | 14.6142       | 0.1305     | 0.0       | 1.461E-07  | 0.2985      | 115        | Sirohi                           |
+| nan     | residents       | 35.1046       | 0.5390     | 0.0       | 3.510E-07  | 1.5114      | 115        | Sirohi                           |
+| nan     | affectedpop     | 35.1046       | 0.7311     | 0.0       | 3.510E-07  | 2.6887      | 115        | Sirohi                           |
+| nan     | injured         | 28.3062       | 0.0099     | 0.0       | 2.363E-07  | 0.0252      | 115        | Sirohi                           |
+| nan     | embodied_carbon | 918.3         | 18.3980    | 0.0       | 6.7476     | 74.1949     | 115        | Sirohi                           |
+| nan     | contents        | 3_489_842     | 151_513    | 0.0       | 0.0349     | 27_426      | 117        | Udaipur                          |
+| nan     | structural      | 19_775_772    | 592_957    | 0.0       | 52_977     | 5_058_227   | 117        | Udaipur                          |
+| nan     | occupants       | 104.9875      | 0.0212     | 0.0       | 1.050E-06  | 0.1870      | 117        | Udaipur                          |
+| nan     | area            | 17_347        | 349.9      | 0.0       | 1.735E-04  | 2_954       | 117        | Udaipur                          |
+| nan     | number          | 125.8819      | 2.5364     | 0.0       | 1.259E-06  | 21.4040     | 117        | Udaipur                          |
+| nan     | residents       | 190.0         | 4.8401     | 0.0       | 1.900E-06  | 43.8809     | 117        | Udaipur                          |
+| nan     | affectedpop     | 190.0         | 7.0351     | 0.0       | 1.900E-06  | 67.9115     | 117        | Udaipur                          |
+| nan     | injured         | 104.9875      | 0.0905     | 0.0       | 1.050E-06  | 0.7875      | 117        | Udaipur                          |
+| nan     | embodied_carbon | 6_283         | 185.5      | 0.0       | 17.6689    | 1_616       | 117        | Udaipur                          |
+| nan     | contents        | 497_838       | 5_305      | 0.0       | 0.0040     | 0.0050      | 118        | Agra                             |
+| nan     | structural      | 2_821_076     | 38_303     | 0.0       | 5_400      | 158_974     | 118        | Agra                             |
+| nan     | occupants       | 15.6593       | 0.0023     | 0.0       | 1.454E-07  | 0.0096      | 118        | Agra                             |
+| nan     | area            | 2_475         | 18.2245    | 0.0       | 2.337E-05  | 56.2765     | 118        | Agra                             |
+| nan     | number          | 15.9955       | 0.1191     | 0.0       | 1.500E-07  | 0.3444      | 118        | Agra                             |
+| nan     | residents       | 28.3432       | 0.2684     | 0.0       | 2.631E-07  | 0.9906      | 118        | Agra                             |
+| nan     | affectedpop     | 28.3432       | 0.4004     | 0.0       | 2.834E-07  | 1.7094      | 118        | Agra                             |
+| nan     | injured         | 15.6593       | 0.0047     | 0.0       | 1.454E-07  | 0.0156      | 118        | Agra                             |
+| nan     | embodied_carbon | 861.3         | 12.2622    | 0.0       | 1.4626     | 43.4697     | 118        | Agra                             |
+| nan     | contents        | 139_273       | 202.9      | 0.0       | 0.0        | 0.0014      | 119        | Aligarh                          |
+| nan     | structural      | 789_213       | 7_506      | 0.0       | 2_246      | 22_253      | 119        | Aligarh                          |
+| nan     | occupants       | 4.1421        | 9.913E-05  | 0.0       | 4.142E-08  | 4.142E-08   | 119        | Aligarh                          |
+| nan     | area            | 692.3         | 1.6345     | 0.0       | 6.923E-06  | 0.8754      | 119        | Aligarh                          |
+| nan     | number          | 5.0288        | 0.0119     | 0.0       | 5.029E-08  | 0.0064      | 119        | Aligarh                          |
+| nan     | residents       | 7.4968        | 0.0193     | 0.0       | 7.497E-08  | 0.0085      | 119        | Aligarh                          |
+| nan     | affectedpop     | 7.4968        | 0.0307     | 0.0       | 7.497E-08  | 0.0261      | 119        | Aligarh                          |
+| nan     | injured         | 4.1421        | 3.547E-04  | 0.0       | 4.142E-08  | 1.580E-04   | 119        | Aligarh                          |
+| nan     | embodied_carbon | 215.5         | 1.6366     | 0.0       | 0.3310     | 4.4481      | 119        | Aligarh                          |
+| nan     | contents        | 34_314        | 647.9      | 0.0       | 3.431E-04  | 0.2517      | 1206       | Lunenburg                        |
+| nan     | structural      | 194_444       | 6_229      | 0.0       | 2_378      | 45_698      | 1206       | Lunenburg                        |
+| nan     | occupants       | 0.4579        | 1.004E-04  | 0.0       | 4.579E-09  | 9.739E-04   | 1206       | Lunenburg                        |
+| nan     | area            | 170.5652      | 1.2663     | 0.0       | 1.706E-06  | 12.2340     | 1206       | Lunenburg                        |
+| nan     | number          | 1.2390        | 0.0092     | 0.0       | 1.239E-08  | 0.0889      | 1206       | Lunenburg                        |
+| nan     | residents       | 0.8288        | 0.0098     | 0.0       | 8.288E-09  | 0.1025      | 1206       | Lunenburg                        |
+| nan     | affectedpop     | 0.8288        | 0.0226     | 0.0       | 8.288E-09  | 0.2744      | 1206       | Lunenburg                        |
+| nan     | injured         | 0.4579        | 1.400E-04  | 0.0       | 4.579E-09  | 0.0014      | 1206       | Lunenburg                        |
+| nan     | embodied_carbon | 51.0967       | 1.1037     | 0.0       | 0.2844     | 8.1830      | 1206       | Lunenburg                        |
+| nan     | contents        | 33_484        | 0.0249     | 0.0       | 3.348E-04  | 3.348E-04   | 1207       | Kings                            |
+| nan     | structural      | 189_744       | 901.3      | 0.0       | 348.2      | 4_414       | 1207       | Kings                            |
+| nan     | occupants       | 0.9547        | 5.846E-08  | 0.0       | 9.547E-09  | 9.547E-09   | 1207       | Kings                            |
+| nan     | area            | 151.3108      | 0.0011     | 0.0       | 1.513E-06  | 1.513E-06   | 1207       | Kings                            |
+| nan     | number          | 0.9709        | 7.090E-06  | 0.0       | 9.709E-09  | 9.709E-09   | 1207       | Kings                            |
+| nan     | residents       | 1.7663        | 1.540E-05  | 0.0       | 1.766E-08  | 1.766E-08   | 1207       | Kings                            |
+| nan     | affectedpop     | 1.7663        | 3.799E-05  | 0.0       | 1.766E-08  | 1.766E-08   | 1207       | Kings                            |
+| nan     | injured         | 0.9547        | 2.891E-07  | 0.0       | 9.547E-09  | 9.547E-09   | 1207       | Kings                            |
+| nan     | embodied_carbon | 45.2897       | 0.2117     | 0.0       | 0.0749     | 1.1095      | 1207       | Kings                            |
+| nan     | contents        | 31_829        | 5.9639     | 0.0       | 3.183E-04  | 3.183E-04   | 1211       | Cumberland                       |
+| nan     | structural      | 180_365       | 700.6      | 0.0       | 205.3      | 2_876       | 1211       | Cumberland                       |
+| nan     | occupants       | 0.7745        | 5.242E-08  | 0.0       | 7.745E-09  | 7.745E-09   | 1211       | Cumberland                       |
+| nan     | area            | 158.2146      | 0.0024     | 0.0       | 1.582E-06  | 1.582E-06   | 1211       | Cumberland                       |
+| nan     | number          | 1.0152        | 1.520E-05  | 0.0       | 1.015E-08  | 1.015E-08   | 1211       | Cumberland                       |
+| nan     | residents       | 1.4018        | 2.505E-05  | 0.0       | 1.402E-08  | 1.402E-08   | 1211       | Cumberland                       |
+| nan     | affectedpop     | 1.4018        | 4.954E-05  | 0.0       | 1.402E-08  | 1.402E-08   | 1211       | Cumberland                       |
+| nan     | injured         | 0.7745        | 4.076E-07  | 0.0       | 7.745E-09  | 7.745E-09   | 1211       | Cumberland                       |
+| nan     | embodied_carbon | 47.3560       | 0.4411     | 0.0       | 0.1754     | 1.7725      | 1211       | Cumberland                       |
+| nan     | contents        | 407_392       | 534.3      | 0.0       | 0.0041     | 0.0041      | 1213       | Guysborough                      |
+| nan     | structural      | 2_308_556     | 46_901     | 0.0       | 4_044      | 130_507     | 1213       | Guysborough                      |
+| nan     | occupants       | 7.0498        | 5.198E-04  | 0.0       | 7.050E-08  | 7.351E-04   | 1213       | Guysborough                      |
+| nan     | area            | 2_025         | 21.5002    | 0.0       | 2.025E-05  | 41.6291     | 1213       | Guysborough                      |
+| nan     | number          | 12.9941       | 0.1380     | 0.0       | 1.299E-07  | 0.2671      | 1213       | Guysborough                      |
+| nan     | residents       | 12.7600       | 0.1709     | 0.0       | 1.276E-07  | 0.3990      | 1213       | Guysborough                      |
+| nan     | affectedpop     | 12.7600       | 0.2722     | 0.0       | 1.276E-07  | 0.9096      | 1213       | Guysborough                      |
+| nan     | injured         | 7.0498        | 0.0029     | 0.0       | 7.050E-08  | 0.0066      | 1213       | Guysborough                      |
+| nan     | embodied_carbon | 733.8         | 13.9518    | 0.0       | 1.2011     | 38.0856     | 1213       | Guysborough                      |
+| nan     | contents        | 26_822        | 531.0      | 0.0       | 0.0        | 2.682E-04   | 1214       | Antigonish                       |
+| nan     | structural      | 107_289       | 4_956      | 0.0       | 1_436      | 12_879      | 1214       | Antigonish                       |
+| nan     | occupants       | 1.2900        | 2.760E-04  | 0.0       | 1.290E-08  | 3.398E-04   | 1214       | Antigonish                       |
+| nan     | area            | 78.4277       | 1.8243     | 0.0       | 7.843E-07  | 2.2060      | 1214       | Antigonish                       |
+| nan     | number          | 0.3964        | 0.0092     | 0.0       | 3.964E-09  | 0.0111      | 1214       | Antigonish                       |
+| nan     | injured         | 1.2900        | 0.0012     | 0.0       | 1.290E-08  | 0.0018      | 1214       | Antigonish                       |
+| nan     | embodied_carbon | 40.5399       | 1.5833     | 0.0       | 0.4601     | 3.8308      | 1214       | Antigonish                       |
+| nan     | contents        | 275_327       | 186.4      | 0.0       | 3.257E-04  | 0.0016      | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | structural      | 1_366_168     | 6_504      | 0.0       | 4_322      | 20_871      | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | occupants       | 21.4360       | 2.364E-05  | 0.0       | 8.144E-08  | 8.144E-08   | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | area            | 1_244         | 0.5180     | 0.0       | 7.899E-06  | 0.1186      | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | number          | 5.0022        | 0.0033     | 0.0       | 4.054E-08  | 7.610E-04   | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | residents       | 14.7409       | 0.0073     | 0.0       | 1.474E-07  | 0.0014      | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | affectedpop     | 14.7409       | 0.0119     | 0.0       | 1.474E-07  | 0.0054      | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | injured         | 21.4360       | 1.219E-04  | 0.0       | 8.144E-08  | 8.144E-08   | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | embodied_carbon | 418.2         | 2.7452     | 0.0       | 2.4357     | 8.8267      | 1301       | KEPULAUAN MENTAWAI Regency       |
+| nan     | contents        | 17_660        | 23.0980    | 0.0       | 1.766E-04  | 1.766E-04   | 1302       | Charlotte                        |
+| nan     | structural      | 70_639        | 1_769      | 0.0       | 842.4      | 3_267       | 1302       | Charlotte                        |
+| nan     | occupants       | 2.2100        | 1.825E-04  | 0.0       | 2.210E-08  | 2.210E-08   | 1302       | Charlotte                        |
+| nan     | area            | 68.8489       | 0.6104     | 0.0       | 6.885E-07  | 0.1031      | 1302       | Charlotte                        |
+| nan     | number          | 0.3478        | 0.0031     | 0.0       | 3.478E-09  | 5.208E-04   | 1302       | Charlotte                        |
+| nan     | injured         | 2.2100        | 8.312E-04  | 0.0       | 2.210E-08  | 1.060E-04   | 1302       | Charlotte                        |
+| nan     | embodied_carbon | 35.5889       | 0.8848     | 0.0       | 0.3579     | 1.3683      | 1302       | Charlotte                        |
+| nan     | contents        | 384_932       | 795.3      | 0.0       | 0.0015     | 0.3026      | 1303       | Sunbury                          |
+| nan     | structural      | 1_911_118     | 35_071     | 0.0       | 10_921     | 108_033     | 1303       | Sunbury                          |
+| nan     | occupants       | 25.3145       | 0.0011     | 0.0       | 1.580E-07  | 4.133E-04   | 1303       | Sunbury                          |
+| nan     | area            | 1_763         | 8.2468     | 0.0       | 8.177E-06  | 4.9870      | 1303       | Sunbury                          |
+| nan     | number          | 8.1975        | 0.0131     | 0.0       | 3.892E-08  | 0.0078      | 1303       | Sunbury                          |
+| nan     | residents       | 19.6597       | 0.1980     | 0.0       | 8.713E-08  | 0.2018      | 1303       | Sunbury                          |
+| nan     | affectedpop     | 19.6597       | 0.2489     | 0.0       | 8.713E-08  | 0.5010      | 1303       | Sunbury                          |
+| nan     | injured         | 25.3145       | 0.0038     | 0.0       | 1.580E-07  | 0.0032      | 1303       | Sunbury                          |
+| nan     | embodied_carbon | 641.7         | 10.6390    | 0.0       | 3.0987     | 34.6125     | 1303       | Sunbury                          |
+| nan     | contents        | 1_757_137     | 8_440      | 0.0       | 0.0079     | 0.2927      | 1304       | Queens                           |
+| nan     | structural      | 9_848_565     | 128_634    | 0.0       | 34_828     | 437_925     | 1304       | Queens                           |
+| nan     | occupants       | 83.8402       | 0.0054     | 0.0       | 4.338E-07  | 0.0053      | 1304       | Queens                           |
+| nan     | area            | 6_660         | 38.8580    | 0.0       | 3.350E-05  | 74.8675     | 1304       | Queens                           |
+| nan     | number          | 10.0590       | 0.0706     | 0.0       | 5.004E-08  | 0.2302      | 1304       | Queens                           |
+| nan     | residents       | 145.0706      | 1.0819     | 0.0       | 7.024E-07  | 1.7722      | 1304       | Queens                           |
+| nan     | affectedpop     | 145.0706      | 1.5493     | 0.0       | 7.024E-07  | 4.0394      | 1304       | Queens                           |
+| nan     | injured         | 83.8402       | 0.0197     | 0.0       | 4.338E-07  | 0.0271      | 1304       | Queens                           |
+| nan     | embodied_carbon | 2_236         | 34.3672    | 0.0       | 14.6436    | 99.5627     | 1304       | Queens                           |
+| nan     | contents        | 2_803_063     | 27_709     | 0.0       | 0.0270     | 0.0280      | 1305       | Kings                            |
+| nan     | structural      | 15_573_714    | 544_141    | 0.0       | 75_296     | 2_482_351   | 1305       | Kings                            |
+| nan     | occupants       | 147.1963      | 0.0332     | 0.0       | 1.472E-06  | 0.1939      | 1305       | Kings                            |
+| nan     | area            | 13_734        | 346.9      | 0.0       | 1.373E-04  | 2_014       | 1305       | Kings                            |
+| nan     | number          | 97.3543       | 2.5194     | 0.0       | 9.735E-07  | 14.6263     | 1305       | Kings                            |
+| nan     | residents       | 242.1         | 7.7014     | 0.0       | 2.421E-06  | 51.5579     | 1305       | Kings                            |
+| nan     | affectedpop     | 242.1         | 10.1256    | 0.0       | 2.421E-06  | 81.6033     | 1305       | Kings                            |
+| nan     | injured         | 147.1963      | 0.1483     | 0.0       | 1.472E-06  | 0.9220      | 1305       | Kings                            |
+| nan     | embodied_carbon | 5_031         | 182.5      | 0.0       | 24.8546    | 1_187       | 1305       | Kings                            |
+| nan     | contents        | 1_608_180     | 11_536     | 0.0       | 0.0146     | 60.1148     | 1306       | PADANG PARIAMAN Regency          |
+| nan     | structural      | 8_840_568     | 176_859    | 0.0       | 37_557     | 460_078     | 1306       | PADANG PARIAMAN Regency          |
+| nan     | occupants       | 64.7726       | 0.0082     | 0.0       | 6.117E-07  | 0.0190      | 1306       | PADANG PARIAMAN Regency          |
+| nan     | area            | 6_008         | 81.6436    | 0.0       | 5.524E-05  | 210.4       | 1306       | PADANG PARIAMAN Regency          |
+| nan     | number          | 39.7619       | 0.5813     | 0.0       | 3.671E-07  | 1.5263      | 1306       | PADANG PARIAMAN Regency          |
+| nan     | residents       | 95.6668       | 1.5948     | 0.0       | 8.901E-07  | 4.9108      | 1306       | PADANG PARIAMAN Regency          |
+| nan     | affectedpop     | 95.6668       | 1.9704     | 0.0       | 8.901E-07  | 5.2769      | 1306       | PADANG PARIAMAN Regency          |
+| nan     | injured         | 64.7726       | 0.0308     | 0.0       | 6.095E-07  | 0.0945      | 1306       | PADANG PARIAMAN Regency          |
+| nan     | embodied_carbon | 2_140         | 45.8924    | 0.0       | 9.0678     | 158.6098    | 1306       | PADANG PARIAMAN Regency          |
+| nan     | contents        | 878_734       | 73.3846    | 0.0       | 0.0050     | 1.3034      | 1307       | Westmorland                      |
+| nan     | structural      | 4_195_051     | 51_194     | 0.0       | 26_031     | 172_788     | 1307       | Westmorland                      |
+| nan     | occupants       | 54.2495       | 1.349E-06  | 0.0       | 4.382E-07  | 5.425E-07   | 1307       | Westmorland                      |
+| nan     | area            | 3_863         | 0.1116     | 0.0       | 2.516E-05  | 0.0610      | 1307       | Westmorland                      |
+| nan     | number          | 22.0107       | 7.652E-04  | 0.0       | 1.222E-07  | 3.185E-04   | 1307       | Westmorland                      |
+| nan     | residents       | 29.4540       | 0.0022     | 0.0       | 1.732E-07  | 9.398E-04   | 1307       | Westmorland                      |
+| nan     | affectedpop     | 29.4540       | 0.0121     | 0.0       | 1.732E-07  | 0.0011      | 1307       | Westmorland                      |
+| nan     | injured         | 54.2495       | 3.255E-05  | 0.0       | 4.382E-07  | 5.425E-07   | 1307       | Westmorland                      |
+| nan     | embodied_carbon | 1_402         | 19.7894    | 0.0       | 11.5824    | 71.0966     | 1307       | Westmorland                      |
+| nan     | contents        | 1_555_652     | 10_430     | 0.0       | 8.478E-04  | 40_381      | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | structural      | 8_794_474     | 204_391    | 0.0       | 17_285     | 1_014_790   | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | occupants       | 75.4115       | 0.0102     | 0.0       | 1.905E-07  | 0.0633      | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | area            | 5_937         | 39.5608    | 0.0       | 1.358E-05  | 275.2       | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | number          | 14.1222       | 0.1367     | 0.0       | 7.024E-08  | 1.0338      | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | residents       | 135.8871      | 1.3326     | 0.0       | 3.164E-07  | 8.4882      | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | affectedpop     | 135.8871      | 2.6487     | 0.0       | 3.164E-07  | 17.8948     | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | injured         | 75.4115       | 0.0196     | 0.0       | 1.905E-07  | 0.1554      | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | embodied_carbon | 1_852         | 27.0734    | 0.0       | 2.4112     | 158.3520    | 1308       | LIMA PULUH KOTA Regency          |
+| nan     | contents        | 52_446        | 22.7047    | 0.0       | 0.0        | 0.0838      | 1309       | Northumberland                   |
+| nan     | structural      | 297_192       | 5_122      | 0.0       | 3_488      | 18_227      | 1309       | Northumberland                   |
+| nan     | occupants       | 2.7861        | 4.565E-05  | 0.0       | 2.786E-08  | 2.786E-08   | 1309       | Northumberland                   |
+| nan     | area            | 260.7         | 0.1689     | 0.0       | 2.607E-06  | 0.4176      | 1309       | Northumberland                   |
+| nan     | number          | 1.8937        | 0.0012     | 0.0       | 1.894E-08  | 0.0030      | 1309       | Northumberland                   |
+| nan     | residents       | 5.0431        | 0.0039     | 0.0       | 5.043E-08  | 0.0081      | 1309       | Northumberland                   |
+| nan     | affectedpop     | 5.0431        | 0.0093     | 0.0       | 5.043E-08  | 0.0390      | 1309       | Northumberland                   |
+| nan     | injured         | 2.7861        | 6.275E-05  | 0.0       | 2.786E-08  | 2.786E-08   | 1309       | Northumberland                   |
+| nan     | embodied_carbon | 78.0954       | 0.7996     | 0.0       | 0.4301     | 3.3917      | 1309       | Northumberland                   |
+| nan     | contents        | 606_976       | 3_330      | 0.0       | 0.0053     | 0.0061      | 1310       | York                             |
+| nan     | structural      | 3_304_473     | 83_471     | 0.0       | 15_562     | 135_644     | 1310       | York                             |
+| nan     | occupants       | 29.6168       | 0.0032     | 0.0       | 2.962E-07  | 0.0027      | 1310       | York                             |
+| nan     | area            | 2_930         | 40.4108    | 0.0       | 2.930E-05  | 35.4533     | 1310       | York                             |
+| nan     | number          | 20.4463       | 0.2935     | 0.0       | 2.045E-07  | 0.2575      | 1310       | York                             |
+| nan     | residents       | 40.8847       | 0.7367     | 0.0       | 4.088E-07  | 0.8498      | 1310       | York                             |
+| nan     | affectedpop     | 40.8847       | 0.9557     | 0.0       | 4.088E-07  | 2.0075      | 1310       | York                             |
+| nan     | injured         | 29.6168       | 0.0144     | 0.0       | 2.962E-07  | 0.0155      | 1310       | York                             |
+| nan     | embodied_carbon | 1_096         | 27.0377    | 0.0       | 6.1072     | 46.1330     | 1310       | York                             |
+| nan     | contents        | 126_163       | 566.3      | 0.0       | 9.584E-04  | 0.0013      | 1311       | Carleton                         |
+| nan     | structural      | 504_654       | 10_400     | 0.0       | 5_921      | 28_833      | 1311       | Carleton                         |
+| nan     | occupants       | 13.4938       | 4.522E-04  | 0.0       | 1.349E-07  | 3.670E-04   | 1311       | Carleton                         |
+| nan     | area            | 491.9         | 1.8277     | 0.0       | 4.919E-06  | 1.5777      | 1311       | Carleton                         |
+| nan     | number          | 2.3193        | 0.0092     | 0.0       | 2.319E-08  | 0.0080      | 1311       | Carleton                         |
+| nan     | injured         | 13.4938       | 0.0020     | 0.0       | 1.349E-07  | 0.0022      | 1311       | Carleton                         |
+| nan     | embodied_carbon | 236.2         | 6.3864     | 0.0       | 4.7779     | 17.3429     | 1311       | Carleton                         |
+| nan     | contents        | 766_645       | 120.2310   | 0.0       | 0.0077     | 0.0077      | 1312       | Victoria                         |
+| nan     | structural      | 3_066_578     | 126_224    | 0.0       | 115_956    | 359_083     | 1312       | Victoria                         |
+| nan     | occupants       | 95.9885       | 6.122E-07  | 0.0       | 9.599E-07  | 9.599E-07   | 1312       | Victoria                         |
+| nan     | area            | 2_242         | 3.747E-05  | 0.0       | 2.242E-05  | 2.242E-05   | 1312       | Victoria                         |
+| nan     | number          | 5.3521        | 8.946E-08  | 0.0       | 5.352E-08  | 5.352E-08   | 1312       | Victoria                         |
+| nan     | injured         | 95.9885       | 6.122E-07  | 0.0       | 9.599E-07  | 9.599E-07   | 1312       | Victoria                         |
+| nan     | embodied_carbon | 1_051         | 36.2220    | 0.0       | 31.7821    | 112.5245    | 1312       | Victoria                         |
+| nan     | contents        | 120_831       | 96.7323    | 0.0       | 4.925E-04  | 0.0394      | 1313       | Madawaska                        |
+| nan     | structural      | 684_709       | 11_897     | 0.0       | 5_958      | 37_904      | 1313       | Madawaska                        |
+| nan     | occupants       | 3.7069        | 2.237E-04  | 0.0       | 2.083E-08  | 7.473E-04   | 1313       | Madawaska                        |
+| nan     | area            | 462.0         | 1.5507     | 0.0       | 4.620E-06  | 6.8672      | 1313       | Madawaska                        |
+| nan     | number          | 2.8923        | 0.0090     | 0.0       | 2.892E-08  | 0.0357      | 1313       | Madawaska                        |
+| nan     | residents       | 6.8557        | 0.0302     | 0.0       | 6.856E-08  | 0.1452      | 1313       | Madawaska                        |
+| nan     | affectedpop     | 6.8557        | 0.0586     | 0.0       | 6.856E-08  | 0.2685      | 1313       | Madawaska                        |
+| nan     | injured         | 3.7069        | 5.249E-04  | 0.0       | 2.083E-08  | 0.0025      | 1313       | Madawaska                        |
+| nan     | embodied_carbon | 101.3097      | 1.4395     | 0.0       | 0.5962     | 5.0022      | 1313       | Madawaska                        |
+| nan     | contents        | 749_716       | 213.0      | 0.0       | 0.0069     | 2.8968      | 1314       | Restigouche                      |
+| nan     | structural      | 4_248_388     | 49_539     | 0.0       | 32_217     | 190_196     | 1314       | Restigouche                      |
+| nan     | occupants       | 34.1724       | 2.762E-05  | 0.0       | 3.167E-07  | 3.417E-07   | 1314       | Restigouche                      |
+| nan     | area            | 3_727         | 0.3464     | 0.0       | 3.453E-05  | 3.727E-05   | 1314       | Restigouche                      |
+| nan     | number          | 26.9391       | 0.0025     | 0.0       | 2.495E-07  | 2.694E-07   | 1314       | Restigouche                      |
+| nan     | residents       | 61.8501       | 0.0077     | 0.0       | 5.732E-07  | 6.185E-07   | 1314       | Restigouche                      |
+| nan     | affectedpop     | 61.8501       | 0.0129     | 0.0       | 5.732E-07  | 6.185E-07   | 1314       | Restigouche                      |
+| nan     | injured         | 34.1724       | 1.296E-04  | 0.0       | 3.167E-07  | 3.417E-07   | 1314       | Restigouche                      |
+| nan     | embodied_carbon | 1_116         | 11.2736    | 0.0       | 7.0271     | 42.7752     | 1314       | Restigouche                      |
+| nan     | contents        | 1_071_417     | 10_197     | 0.0       | 0.0052     | 28.8678     | 1315       | Gloucester                       |
+| nan     | structural      | 5_151_568     | 164_076    | 0.0       | 103_664    | 426_144     | 1315       | Gloucester                       |
+| nan     | occupants       | 190.5         | 0.0041     | 0.0       | 1.685E-06  | 0.0077      | 1315       | Gloucester                       |
+| nan     | area            | 3_600         | 38.4676    | 0.0       | 3.600E-05  | 81.0147     | 1315       | Gloucester                       |
+| nan     | number          | 16.7886       | 0.2784     | 0.0       | 1.679E-07  | 0.6192      | 1315       | Gloucester                       |
+| nan     | residents       | 40.8136       | 0.8930     | 0.0       | 4.081E-07  | 2.5773      | 1315       | Gloucester                       |
+| nan     | affectedpop     | 40.8136       | 1.1297     | 0.0       | 4.081E-07  | 5.0690      | 1315       | Gloucester                       |
+| nan     | injured         | 190.5         | 0.0180     | 0.0       | 1.685E-06  | 0.0427      | 1315       | Gloucester                       |
+| nan     | embodied_carbon | 1_394         | 39.5098    | 0.0       | 27.4141    | 94.3814     | 1315       | Gloucester                       |
+| nan     | contents        | 2_362_993     | 1_045      | 0.0       | 0.0229     | 45.5918     | 1316       | ERMENEK                          |
+| nan     | structural      | 13_270_940    | 149_161    | 0.0       | 92_090     | 550_209     | 1316       | ERMENEK                          |
+| nan     | occupants       | 97.2816       | 8.679E-07  | 0.0       | 9.175E-07  | 9.728E-07   | 1316       | ERMENEK                          |
+| nan     | area            | 8_990         | 0.1369     | 0.0       | 8.761E-05  | 8.990E-05   | 1316       | ERMENEK                          |
+| nan     | number          | 9.3478        | 2.286E-04  | 0.0       | 8.961E-08  | 9.348E-08   | 1316       | ERMENEK                          |
+| nan     | residents       | 169.6907      | 3.439E-04  | 0.0       | 1.697E-06  | 1.697E-06   | 1316       | ERMENEK                          |
+| nan     | affectedpop     | 169.6907      | 0.0043     | 0.0       | 1.697E-06  | 1.697E-06   | 1316       | ERMENEK                          |
+| nan     | injured         | 97.2816       | 7.449E-05  | 0.0       | 9.175E-07  | 9.728E-07   | 1316       | ERMENEK                          |
+| nan     | embodied_carbon | 2_700         | 48.2388    | 0.0       | 37.4707    | 167.5666    | 1316       | ERMENEK                          |
+| nan     | contents        | 4_903_542     | 34_100     | 0.0       | 0.0349     | 564.7       | 1317       | Vila Nova de Gaia                |
+| nan     | structural      | 27_555_132    | 508_692    | 0.0       | 133_483    | 2_664_586   | 1317       | Vila Nova de Gaia                |
+| nan     | occupants       | 332.2         | 0.0174     | 0.0       | 2.132E-06  | 0.1144      | 1317       | Vila Nova de Gaia                |
+| nan     | area            | 24_237        | 271.5      | 0.0       | 1.929E-04  | 1_936       | 1317       | Vila Nova de Gaia                |
+| nan     | number          | 137.7322      | 1.7456     | 0.0       | 1.126E-06  | 12.6291     | 1317       | Vila Nova de Gaia                |
+| nan     | residents       | 395.3         | 4.6100     | 0.0       | 3.163E-06  | 36.6895     | 1317       | Vila Nova de Gaia                |
+| nan     | affectedpop     | 395.3         | 6.5435     | 0.0       | 3.194E-06  | 60.3028     | 1317       | Vila Nova de Gaia                |
+| nan     | injured         | 332.2         | 0.0783     | 0.0       | 2.184E-06  | 0.5823      | 1317       | Vila Nova de Gaia                |
+| nan     | embodied_carbon | 7_570         | 156.9131   | 0.0       | 23.2211    | 949.9       | 1317       | Vila Nova de Gaia                |
+| nan     | contents        | 756_461       | 3_581      | 0.0       | 0.0016     | 612.6       | 1318       | MERKEZ                           |
+| nan     | structural      | 4_286_611     | 123_516    | 0.0       | 89_829     | 363_435     | 1318       | MERKEZ                           |
+| nan     | occupants       | 45.1950       | 8.423E-04  | 0.0       | 4.234E-07  | 0.0087      | 1318       | MERKEZ                           |
+| nan     | area            | 3_760         | 7.2088     | 0.0       | 3.446E-05  | 77.9527     | 1318       | MERKEZ                           |
+| nan     | number          | 8.4402        | 0.0429     | 0.0       | 6.422E-08  | 0.5229      | 1318       | MERKEZ                           |
+| nan     | residents       | 81.8012       | 0.2338     | 0.0       | 7.664E-07  | 2.2954      | 1318       | MERKEZ                           |
+| nan     | affectedpop     | 81.8012       | 0.5213     | 0.0       | 7.664E-07  | 3.6041      | 1318       | MERKEZ                           |
+| nan     | injured         | 45.1950       | 0.0037     | 0.0       | 4.234E-07  | 0.0411      | 1318       | MERKEZ                           |
+| nan     | embodied_carbon | 1_158         | 24.0487    | 0.0       | 14.9527    | 73.6447     | 1318       | MERKEZ                           |
+| nan     | contents        | 983_167       | 6_413      | 0.0       | 0.0097     | 0.1528      | 1401       | MERKEZ                           |
+| nan     | structural      | 5_571_281     | 58_394     | 0.0       | 25_323     | 212_331     | 1401       | MERKEZ                           |
+| nan     | occupants       | 21.2990       | 1.803E-04  | 0.0       | 2.130E-07  | 1.078E-05   | 1401       | MERKEZ                           |
+| nan     | area            | 4_443         | 1.3865     | 0.0       | 4.443E-05  | 0.2095      | 1401       | MERKEZ                           |
+| nan     | number          | 28.5719       | 0.0090     | 0.0       | 2.857E-07  | 0.0015      | 1401       | MERKEZ                           |
+| nan     | residents       | 39.3910       | 0.0191     | 0.0       | 3.939E-07  | 9.841E-04   | 1401       | MERKEZ                           |
+| nan     | affectedpop     | 39.3910       | 0.0640     | 0.0       | 3.939E-07  | 0.0260      | 1401       | MERKEZ                           |
+| nan     | injured         | 21.2990       | 2.194E-04  | 0.0       | 2.130E-07  | 1.498E-05   | 1401       | MERKEZ                           |
+| nan     | embodied_carbon | 1_330         | 9.8465     | 0.0       | 3.5485     | 38.5371     | 1401       | MERKEZ                           |
+| nan     | contents        | 81_028        | 626.3      | 0.0       | 0.0        | 8.103E-04   | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | structural      | 459_161       | 7_343      | 0.0       | 880.4      | 10_951      | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | occupants       | 4.1644        | 4.465E-04  | 0.0       | 4.164E-08  | 5.605E-04   | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | area            | 402.8         | 4.2961     | 0.0       | 4.028E-06  | 5.2537      | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | number          | 1.9339        | 0.0206     | 0.0       | 1.934E-08  | 0.0252      | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | residents       | 7.5373        | 0.0918     | 0.0       | 7.537E-08  | 0.0996      | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | affectedpop     | 7.5373        | 0.1191     | 0.0       | 7.537E-08  | 0.1672      | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | injured         | 4.1644        | 0.0018     | 0.0       | 4.164E-08  | 0.0023      | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | embodied_carbon | 146.1464      | 2.5575     | 0.0       | 0.2801     | 3.1224      | 1403       | INDRAGIRI HILIR Regency          |
+| nan     | contents        | 11_733_957    | 4_283      | 0.0116    | 0.1046     | 6_242       | 1405       | SIAK Regency                     |
+| nan     | structural      | 38_603_568    | 2_269_920  | 160_842   | 1_633_943  | 5_631_967   | 1405       | SIAK Regency                     |
+| nan     | occupants       | 138.8419      | 0.0082     | 6.611E-07 | 1.388E-06  | 0.0577      | 1405       | SIAK Regency                     |
+| nan     | area            | 45_658        | 32.1111    | 6.341E-05 | 4.566E-04  | 193.8       | 1405       | SIAK Regency                     |
+| nan     | number          | 72.7933       | 0.0408     | 5.747E-08 | 7.279E-07  | 0.2609      | 1405       | SIAK Regency                     |
+| nan     | residents       | 131.6443      | 1.1856     | 0.0       | 1.316E-06  | 8.2549      | 1405       | SIAK Regency                     |
+| nan     | affectedpop     | 131.6443      | 3.3192     | 0.0       | 0.0023     | 27.6486     | 1405       | SIAK Regency                     |
+| nan     | injured         | 138.8419      | 0.0121     | 6.611E-07 | 1.388E-06  | 0.0784      | 1405       | SIAK Regency                     |
+| nan     | embodied_carbon | 17_752        | 920.5      | 23.4217   | 552.5      | 2_607       | 1405       | SIAK Regency                     |
+| nan     | contents        | 66_719        | 63.6528    | 0.0       | 2.489E-04  | 6.672E-04   | 1406       | KAMPAR Regency                   |
+| nan     | structural      | 336_602       | 6_950      | 511.4     | 3_742      | 29_169      | 1406       | KAMPAR Regency                   |
+| nan     | occupants       | 4.1217        | 2.306E-04  | 2.000E-08 | 4.122E-08  | 0.0012      | 1406       | KAMPAR Regency                   |
+| nan     | area            | 305.0         | 1.9492     | 9.702E-07 | 3.050E-06  | 7.1642      | 1406       | KAMPAR Regency                   |
+| nan     | number          | 1.4456        | 0.0093     | 4.471E-09 | 1.446E-08  | 0.0344      | 1406       | KAMPAR Regency                   |
+| nan     | residents       | 3.8403        | 0.0411     | 0.0       | 3.840E-08  | 0.1578      | 1406       | KAMPAR Regency                   |
+| nan     | affectedpop     | 3.8403        | 0.0602     | 0.0       | 3.840E-08  | 0.2686      | 1406       | KAMPAR Regency                   |
+| nan     | injured         | 4.1217        | 8.426E-04  | 2.000E-08 | 4.122E-08  | 0.0032      | 1406       | KAMPAR Regency                   |
+| nan     | embodied_carbon | 117.4533      | 2.2860     | 0.1681    | 1.1528     | 8.6142      | 1406       | KAMPAR Regency                   |
+| nan     | contents        | 1_716_786     | 111_971    | 0.0       | 0.0168     | 1_622_368   | 1407       | İMRANLI                          |
+| nan     | structural      | 9_661_124     | 759_034    | 5_333     | 31_067     | 6_285_011   | 1407       | İMRANLI                          |
+| nan     | occupants       | 42.1603       | 0.1739     | 2.430E-08 | 4.216E-07  | 1.6290      | 1407       | İMRANLI                          |
+| nan     | area            | 8_510         | 597.1      | 1.772E-06 | 8.510E-05  | 5_596       | 1407       | İMRANLI                          |
+| nan     | number          | 53.7693       | 3.8311     | 2.998E-09 | 5.377E-07  | 35.9083     | 1407       | İMRANLI                          |
+| nan     | residents       | 71.9104       | 5.6162     | 0.0       | 7.191E-07  | 54.4269     | 1407       | İMRANLI                          |
+| nan     | affectedpop     | 71.9104       | 6.5193     | 0.0       | 7.191E-07  | 61.5444     | 1407       | İMRANLI                          |
+| nan     | injured         | 42.1603       | 0.1008     | 2.430E-08 | 4.216E-07  | 0.9481      | 1407       | İMRANLI                          |
+| nan     | embodied_carbon | 2_711         | 220.8      | 1.2872    | 7.3846     | 2_209       | 1407       | İMRANLI                          |
+| nan     | contents        | 304_402       | 15_833     | 0.0       | 0.0030     | 225_029     | 1408       | BENGKALIS Regency                |
+| nan     | structural      | 1_724_946     | 112_212    | 0.0       | 6_435      | 1_217_002   | 1408       | BENGKALIS Regency                |
+| nan     | occupants       | 13.4161       | 0.0053     | 0.0       | 1.342E-07  | 0.0694      | 1408       | BENGKALIS Regency                |
+| nan     | area            | 1_513         | 64.7394    | 0.0       | 1.513E-05  | 836.8       | 1408       | BENGKALIS Regency                |
+| nan     | number          | 10.9912       | 0.4703     | 0.0       | 1.099E-07  | 6.0787      | 1408       | BENGKALIS Regency                |
+| nan     | residents       | 24.2828       | 1.1975     | 0.0       | 2.428E-07  | 15.5943     | 1408       | BENGKALIS Regency                |
+| nan     | affectedpop     | 24.2828       | 1.4909     | 0.0       | 2.428E-07  | 18.6157     | 1408       | BENGKALIS Regency                |
+| nan     | injured         | 13.4161       | 0.0235     | 0.0       | 1.342E-07  | 0.3034      | 1408       | BENGKALIS Regency                |
+| nan     | embodied_carbon | 548.7         | 22.5011    | 0.0       | 2.1403     | 185.9       | 1408       | BENGKALIS Regency                |
+| nan     | contents        | 170_072       | 92.6675    | 0.0       | 0.0015     | 0.0017      | 1409       | İNCESU                           |
+| nan     | structural      | 937_112       | 15_878     | 0.0       | 7_076      | 43_700      | 1409       | İNCESU                           |
+| nan     | occupants       | 4.9603        | 2.123E-04  | 0.0       | 4.960E-08  | 8.993E-05   | 1409       | İNCESU                           |
+| nan     | area            | 828.3         | 0.7450     | 0.0       | 8.283E-06  | 0.3935      | 1409       | İNCESU                           |
+| nan     | number          | 5.2020        | 0.0043     | 0.0       | 5.202E-08  | 0.0025      | 1409       | İNCESU                           |
+| nan     | residents       | 6.9320        | 0.0059     | 0.0       | 6.932E-08  | 4.798E-04   | 1409       | İNCESU                           |
+| nan     | affectedpop     | 6.9320        | 0.0169     | 0.0       | 6.932E-08  | 0.0120      | 1409       | İNCESU                           |
+| nan     | injured         | 4.9603        | 2.506E-04  | 0.0       | 4.960E-08  | 1.143E-04   | 1409       | İNCESU                           |
+| nan     | embodied_carbon | 256.2         | 3.4772     | 0.0       | 1.5420     | 9.7646      | 1409       | İNCESU                           |
+| nan     | contents        | 1_879_335     | 522.8      | 0.0       | 0.0055     | 0.0188      | 1410       | İNEBOLU                          |
+| nan     | structural      | 10_649_564    | 176_637    | 0.0       | 111_136    | 557_811     | 1410       | İNEBOLU                          |
+| nan     | occupants       | 78.2888       | 1.934E-05  | 0.0       | 7.829E-07  | 7.829E-07   | 1410       | İNEBOLU                          |
+| nan     | area            | 8_492         | 0.4330     | 0.0       | 8.492E-05  | 8.492E-05   | 1410       | İNEBOLU                          |
+| nan     | number          | 21.1056       | 0.0024     | 0.0       | 2.111E-07  | 2.111E-07   | 1410       | İNEBOLU                          |
+| nan     | residents       | 144.7892      | 0.0107     | 0.0       | 1.448E-06  | 1.448E-06   | 1410       | İNEBOLU                          |
+| nan     | affectedpop     | 144.7892      | 0.0615     | 0.0       | 1.448E-06  | 0.0137      | 1410       | İNEBOLU                          |
+| nan     | injured         | 78.2888       | 1.048E-04  | 0.0       | 7.829E-07  | 7.829E-07   | 1410       | İNEBOLU                          |
+| nan     | embodied_carbon | 2_550         | 61.8791    | 0.0       | 47.8049    | 167.9767    | 1410       | İNEBOLU                          |
+| nan     | contents        | 579_231       | 389.1      | 0.0       | 0.0047     | 0.0047      | 1411       | İNEGÖL                           |
+| nan     | structural      | 3_101_870     | 38_387     | 0.0       | 8_844      | 84_887      | 1411       | İNEGÖL                           |
+| nan     | occupants       | 8.8453        | 5.975E-04  | 0.0       | 7.692E-08  | 0.0013      | 1411       | İNEGÖL                           |
+| nan     | area            | 2_763         | 19.9389    | 0.0       | 2.341E-05  | 41.0208     | 1411       | İNEGÖL                           |
+| nan     | number          | 17.9692       | 0.1448     | 0.0       | 1.701E-07  | 0.2980      | 1411       | İNEGÖL                           |
+| nan     | residents       | 13.9226       | 0.1481     | 0.0       | 1.392E-07  | 0.3796      | 1411       | İNEGÖL                           |
+| nan     | affectedpop     | 13.9226       | 0.2152     | 0.0       | 1.392E-07  | 0.8573      | 1411       | İNEGÖL                           |
+| nan     | injured         | 8.8453        | 0.0028     | 0.0       | 7.692E-08  | 0.0068      | 1411       | İNEGÖL                           |
+| nan     | embodied_carbon | 1_032         | 12.7285    | 0.0       | 2.9598     | 30.7817     | 1411       | İNEGÖL                           |
+| nan     | contents        | 385_802       | 5_141      | 0.0       | 0.0039     | 0.0039      | 1413       | İSKENDERUN                       |
+| nan     | structural      | 2_186_211     | 46_072     | 0.0       | 5_012      | 50_385      | 1413       | İSKENDERUN                       |
+| nan     | occupants       | 6.0832        | 8.307E-04  | 0.0       | 6.083E-08  | 6.083E-08   | 1413       | İSKENDERUN                       |
+| nan     | area            | 1_918         | 28.4101    | 0.0       | 1.918E-05  | 9.5378      | 1413       | İSKENDERUN                       |
+| nan     | number          | 13.9304       | 0.2064     | 0.0       | 1.393E-07  | 0.0693      | 1413       | İSKENDERUN                       |
+| nan     | residents       | 11.0102       | 0.1876     | 0.0       | 1.101E-07  | 0.0705      | 1413       | İSKENDERUN                       |
+| nan     | affectedpop     | 11.0102       | 0.2319     | 0.0       | 1.101E-07  | 0.1923      | 1413       | İSKENDERUN                       |
+| nan     | injured         | 6.0832        | 0.0037     | 0.0       | 6.083E-08  | 0.0015      | 1413       | İSKENDERUN                       |
+| nan     | embodied_carbon | 678.1         | 12.8756    | 0.0       | 1.9230     | 18.5424     | 1413       | İSKENDERUN                       |
+| nan     | contents        | 1_066_374     | 2_011      | 9.893E-25 | 0.0013     | 15_918      | 1414       | İSKİLİP                          |
+| nan     | structural      | 6_042_787     | 116_627    | 999.2     | 92_984     | 289_597     | 1414       | İSKİLİP                          |
+| nan     | occupants       | 49.1475       | 7.655E-04  | 1.852E-08 | 4.915E-07  | 0.0040      | 1414       | İSKİLİP                          |
+| nan     | area            | 5_301         | 10.9541    | 4.901E-06 | 5.301E-05  | 56.1852     | 1414       | İSKİLİP                          |
+| nan     | number          | 8.1335        | 0.0653     | 2.353E-08 | 8.134E-08  | 0.2817      | 1414       | İSKİLİP                          |
+| nan     | residents       | 88.9532       | 0.1669     | 5.552E-08 | 8.895E-07  | 0.7772      | 1414       | İSKİLİP                          |
+| nan     | affectedpop     | 88.9532       | 0.2388     | 5.552E-08 | 1.528E-04  | 1.2437      | 1414       | İSKİLİP                          |
+| nan     | injured         | 49.1475       | 0.0032     | 3.068E-08 | 4.915E-07  | 0.0147      | 1414       | İSKİLİP                          |
+| nan     | embodied_carbon | 1_631         | 48.5032    | 0.3252    | 43.6702    | 108.5923    | 1414       | İSKİLİP                          |
+| nan     | contents        | 81_578        | 8.7048     | 0.0       | 8.158E-04  | 8.158E-04   | 1416       | İSPİR                            |
+| nan     | structural      | 462_278       | 4_400      | 0.0       | 768.0      | 19_592      | 1416       | İSPİR                            |
+| nan     | occupants       | 1.6666        | 1.913E-07  | 0.0       | 1.667E-08  | 1.667E-08   | 1416       | İSPİR                            |
+| nan     | area            | 311.9         | 0.0060     | 0.0       | 3.119E-06  | 3.119E-06   | 1416       | İSPİR                            |
+| nan     | number          | 2.0015        | 3.823E-05  | 0.0       | 2.001E-08  | 2.001E-08   | 1416       | İSPİR                            |
+| nan     | residents       | 3.0824        | 6.828E-05  | 0.0       | 3.082E-08  | 3.082E-08   | 1416       | İSPİR                            |
+| nan     | affectedpop     | 3.0824        | 1.811E-04  | 0.0       | 3.082E-08  | 3.082E-08   | 1416       | İSPİR                            |
+| nan     | injured         | 1.6666        | 1.217E-06  | 0.0       | 1.667E-08  | 1.667E-08   | 1416       | İSPİR                            |
+| nan     | embodied_carbon | 93.3620       | 0.8899     | 0.0       | 0.1414     | 4.0378      | 1416       | İSPİR                            |
+| nan     | contents        | 176_246       | 697.4      | 0.0       | 0.0012     | 26.2091     | 1418       | İVRİNDİ                          |
+| nan     | structural      | 998_728       | 25_461     | 31.8004   | 14_207     | 70_257      | 1418       | İVRİNDİ                          |
+| nan     | occupants       | 3.9811        | 5.759E-04  | 8.152E-09 | 3.981E-08  | 0.0019      | 1418       | İVRİNDİ                          |
+| nan     | area            | 796.4         | 3.4810     | 2.097E-06 | 7.964E-06  | 11.7288     | 1418       | İVRİNDİ                          |
+| nan     | number          | 5.0040        | 0.0252     | 1.007E-08 | 5.004E-08  | 0.0847      | 1418       | İVRİNDİ                          |
+| nan     | residents       | 7.3636        | 0.0513     | 1.508E-08 | 7.364E-08  | 0.2193      | 1418       | İVRİNDİ                          |
+| nan     | affectedpop     | 7.3636        | 0.0987     | 1.508E-08 | 7.364E-08  | 0.6935      | 1418       | İVRİNDİ                          |
+| nan     | injured         | 3.9811        | 7.967E-04  | 8.152E-09 | 3.981E-08  | 0.0027      | 1418       | İVRİNDİ                          |
+| nan     | embodied_carbon | 238.6         | 5.1573     | 0.0267    | 2.4695     | 13.7855     | 1418       | İVRİNDİ                          |
+| nan     | contents        | 482_157       | 1_366      | 0.0       | 0.0041     | 0.0048      | 1419       | Torres Novas                     |
+| nan     | structural      | 2_732_221     | 20_274     | 0.0       | 6_136      | 69_198      | 1419       | Torres Novas                     |
+| nan     | occupants       | 9.7031        | 3.927E-04  | 0.0       | 9.703E-08  | 7.412E-04   | 1419       | Torres Novas                     |
+| nan     | area            | 2_179         | 5.3941     | 0.0       | 2.179E-05  | 10.0365     | 1419       | Torres Novas                     |
+| nan     | number          | 13.4592       | 0.0259     | 0.0       | 1.346E-07  | 0.0482      | 1419       | Torres Novas                     |
+| nan     | residents       | 17.9465       | 0.0743     | 0.0       | 1.795E-07  | 0.1487      | 1419       | Torres Novas                     |
+| nan     | affectedpop     | 17.9465       | 0.0893     | 0.0       | 1.795E-07  | 0.2552      | 1419       | Torres Novas                     |
+| nan     | injured         | 9.7031        | 0.0015     | 0.0       | 9.703E-08  | 0.0030      | 1419       | Torres Novas                     |
+| nan     | embodied_carbon | 672.6         | 8.6900     | 0.0       | 3.8333     | 33.1983     | 1419       | Torres Novas                     |
+| nan     | contents        | 1_881_476     | 52_896     | 0.0       | 0.0160     | 250_612     | 1421       | KADIKÖY                          |
+| nan     | structural      | 10_578_802    | 472_272    | 0.0       | 48_665     | 2_427_984   | 1421       | KADIKÖY                          |
+| nan     | occupants       | 37.8025       | 0.0367     | 0.0       | 3.780E-07  | 0.3054      | 1421       | KADIKÖY                          |
+| nan     | area            | 9_299         | 320.2      | 0.0       | 0.2924     | 1_866       | 1421       | KADIKÖY                          |
+| nan     | number          | 59.9063       | 2.0667     | 0.0       | 0.0019     | 12.3317     | 1421       | KADIKÖY                          |
+| nan     | residents       | 62.9429       | 2.6465     | 0.0       | 0.0019     | 17.9185     | 1421       | KADIKÖY                          |
+| nan     | affectedpop     | 62.9429       | 3.3856     | 0.0       | 0.0149     | 20.6739     | 1421       | KADIKÖY                          |
+| nan     | injured         | 37.8025       | 0.0463     | 0.0       | 3.780E-07  | 0.3221      | 1421       | KADIKÖY                          |
+| nan     | embodied_carbon | 2_990         | 126.9012   | 0.0       | 13.0062    | 703.7       | 1421       | KADIKÖY                          |
+| nan     | contents        | 19_986_150    | 81_925     | 0.0       | 0.1961     | 375_254     | 1502       | MERANGIN Regency                 |
+| nan     | structural      | 38_546_808    | 2_683_508  | 2_852     | 2_155_977  | 6_025_561   | 1502       | MERANGIN Regency                 |
+| nan     | occupants       | 62.0331       | 0.0059     | 1.075E-07 | 6.203E-07  | 0.0694      | 1502       | MERANGIN Regency                 |
+| nan     | area            | 55_111        | 159.4045   | 1.865E-05 | 5.511E-04  | 1_578       | 1502       | MERANGIN Regency                 |
+| nan     | number          | 102.7684      | 0.9090     | 1.197E-07 | 1.028E-06  | 10.1245     | 1502       | MERANGIN Regency                 |
+| nan     | residents       | 19.4629       | 1.5207     | 0.0       | 1.946E-07  | 17.3058     | 1502       | MERANGIN Regency                 |
+| nan     | affectedpop     | 19.4629       | 1.7417     | 0.0       | 1.946E-07  | 18.2298     | 1502       | MERANGIN Regency                 |
+| nan     | injured         | 62.0331       | 0.0282     | 1.075E-07 | 6.203E-07  | 0.3158      | 1502       | MERANGIN Regency                 |
+| nan     | embodied_carbon | 15_033        | 914.0      | 0.8344    | 734.4      | 2_139       | 1502       | MERANGIN Regency                 |
+| nan     | contents        | 2_777_515     | 13_851     | 0.0       | 0.0270     | 3_918       | 1503       | SAROLANGUN Regency               |
+| nan     | structural      | 15_616_754    | 583_214    | 0.0       | 300_654    | 1_995_513   | 1503       | SAROLANGUN Regency               |
+| nan     | occupants       | 102.3050      | 0.0088     | 0.0       | 1.023E-06  | 0.0568      | 1503       | SAROLANGUN Regency               |
+| nan     | area            | 10_574        | 104.5966   | 0.0       | 1.057E-04  | 667.8       | 1503       | SAROLANGUN Regency               |
+| nan     | number          | 76.1845       | 0.7598     | 0.0       | 7.618E-07  | 4.8507      | 1503       | SAROLANGUN Regency               |
+| nan     | residents       | 173.7858      | 2.2443     | 0.0       | 1.738E-06  | 14.8766     | 1503       | SAROLANGUN Regency               |
+| nan     | affectedpop     | 173.7858      | 3.4120     | 0.0       | 0.0037     | 22.0735     | 1503       | SAROLANGUN Regency               |
+| nan     | injured         | 102.3050      | 0.0410     | 0.0       | 1.023E-06  | 0.2644      | 1503       | SAROLANGUN Regency               |
+| nan     | embodied_carbon | 3_261         | 110.5454   | 0.0       | 53.5485    | 385.4       | 1503       | SAROLANGUN Regency               |
+| nan     | contents        | 190_336       | 8_848      | 0.0       | 6.143E-27  | 102_592     | 1504       | BATANG HARI Regency              |
+| nan     | structural      | 761_343       | 63_782     | 0.0       | 59_466     | 157_062     | 1504       | BATANG HARI Regency              |
+| nan     | occupants       | 20.5970       | 6.161E-04  | 0.0       | 2.060E-07  | 0.0033      | 1504       | BATANG HARI Regency              |
+| nan     | area            | 556.5         | 0.7704     | 0.0       | 5.565E-06  | 4.0262      | 1504       | BATANG HARI Regency              |
+| nan     | number          | 1.1622        | 0.0016     | 0.0       | 1.162E-08  | 0.0084      | 1504       | BATANG HARI Regency              |
+| nan     | injured         | 20.5970       | 0.0013     | 0.0       | 2.060E-07  | 0.0069      | 1504       | BATANG HARI Regency              |
+| nan     | embodied_carbon | 261.5         | 18.6808    | 0.0       | 16.0516    | 47.3445     | 1504       | BATANG HARI Regency              |
+| nan     | contents        | 31_479        | 34.5039    | 0.0       | 3.148E-04  | 3.148E-04   | 1505       | MUARO JAMBI Regency              |
+| nan     | structural      | 178_381       | 1_036      | 0.0       | 340.2      | 3_058       | 1505       | MUARO JAMBI Regency              |
+| nan     | occupants       | 0.8543        | 7.623E-09  | 0.0       | 8.543E-09  | 8.543E-09   | 1505       | MUARO JAMBI Regency              |
+| nan     | area            | 156.4746      | 2.482E-05  | 0.0       | 1.565E-06  | 1.565E-06   | 1505       | MUARO JAMBI Regency              |
+| nan     | number          | 1.0040        | 1.593E-07  | 0.0       | 1.004E-08  | 1.004E-08   | 1505       | MUARO JAMBI Regency              |
+| nan     | residents       | 1.5462        | 3.349E-07  | 0.0       | 1.546E-08  | 1.546E-08   | 1505       | MUARO JAMBI Regency              |
+| nan     | affectedpop     | 1.5462        | 2.084E-06  | 0.0       | 1.546E-08  | 1.546E-08   | 1505       | MUARO JAMBI Regency              |
+| nan     | injured         | 0.8543        | 7.623E-09  | 0.0       | 8.543E-09  | 8.543E-09   | 1505       | MUARO JAMBI Regency              |
+| nan     | embodied_carbon | 46.8352       | 0.6423     | 0.0       | 0.2748     | 1.8357      | 1505       | MUARO JAMBI Regency              |
+| nan     | contents        | 53_858        | 3_953      | 0.0       | 5.386E-04  | 53_848      | 1506       | TANJUNG JABUNG TIMUR Regency     |
+| nan     | structural      | 215_433       | 17_741     | 0.0       | 3_169      | 113_207     | 1506       | TANJUNG JABUNG TIMUR Regency     |
+| nan     | occupants       | 5.1856        | 0.0027     | 0.0       | 5.186E-08  | 0.0266      | 1506       | TANJUNG JABUNG TIMUR Regency     |
+| nan     | area            | 157.4799      | 10.7657    | 0.0       | 1.575E-06  | 106.0836    | 1506       | TANJUNG JABUNG TIMUR Regency     |
+| nan     | number          | 2.1014        | 0.1437     | 0.0       | 2.101E-08  | 1.4156      | 1506       | TANJUNG JABUNG TIMUR Regency     |
+| nan     | injured         | 5.1856        | 0.0126     | 0.0       | 5.186E-08  | 0.1234      | 1506       | TANJUNG JABUNG TIMUR Regency     |
+| nan     | embodied_carbon | 81.3410       | 6.8686     | 0.0       | 1.0888     | 53.9655     | 1506       | TANJUNG JABUNG TIMUR Regency     |
+| nan     | contents        | 433_754       | 1_109      | 0.0       | 0.0043     | 1_420       | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | structural      | 2_457_940     | 132_974    | 0.0       | 90_991     | 484_415     | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | occupants       | 17.3282       | 3.160E-04  | 0.0       | 1.733E-07  | 0.0024      | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | area            | 1_659         | 3.0246     | 0.0       | 1.659E-05  | 22.4883     | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | number          | 7.9635        | 0.0145     | 0.0       | 7.964E-08  | 0.1080      | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | residents       | 32.0476       | 0.0897     | 0.0       | 3.205E-07  | 0.5947      | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | affectedpop     | 32.0476       | 0.3225     | 0.0       | 3.205E-07  | 2.9391      | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | injured         | 17.3282       | 0.0013     | 0.0       | 1.733E-07  | 0.0098      | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | embodied_carbon | 497.3         | 21.0609    | 0.0       | 13.4636    | 77.8849     | 1507       | TANJUNG JABUNG BARAT Regency     |
+| nan     | contents        | 13_420_574    | 1_143      | 0.0019    | 0.1339     | 6_955       | 1508       | TEBO Regency                     |
+| nan     | structural      | 41_028_040    | 2_091_986  | 32_588    | 1_355_973  | 6_212_046   | 1508       | TEBO Regency                     |
+| nan     | occupants       | 50.7205       | 2.694E-04  | 1.524E-07 | 5.072E-07  | 5.072E-07   | 1508       | TEBO Regency                     |
+| nan     | area            | 50_667        | 3.5319     | 1.361E-05 | 5.067E-04  | 2.0566      | 1508       | TEBO Regency                     |
+| nan     | number          | 91.6139       | 0.0146     | 7.533E-08 | 9.161E-07  | 0.0100      | 1508       | TEBO Regency                     |
+| nan     | residents       | 22.8175       | 0.0689     | 6.348E-08 | 2.282E-07  | 0.0396      | 1508       | TEBO Regency                     |
+| nan     | affectedpop     | 22.8175       | 0.1771     | 6.348E-08 | 2.282E-07  | 0.1840      | 1508       | TEBO Regency                     |
+| nan     | injured         | 50.7205       | 0.0011     | 1.295E-07 | 5.072E-07  | 5.408E-04   | 1508       | TEBO Regency                     |
+| nan     | embodied_carbon | 20_295        | 933.6      | 7.3581    | 571.8      | 2_680       | 1508       | TEBO Regency                     |
+| nan     | contents        | 4_355_949     | 6_580      | 0.0       | 2.934E-05  | 1_373       | 1510       | MALAZGİRT                        |
+| nan     | structural      | 23_871_168    | 1_063_061  | 0.0       | 935_407    | 2_285_631   | 1510       | MALAZGİRT                        |
+| nan     | occupants       | 224.6         | 5.515E-04  | 0.0       | 1.772E-06  | 1.772E-06   | 1510       | MALAZGİRT                        |
+| nan     | area            | 16_217        | 5.4891     | 0.0       | 1.479E-04  | 10.3424     | 1510       | MALAZGİRT                        |
+| nan     | number          | 75.0435       | 0.0264     | 0.0       | 7.102E-07  | 0.0497      | 1510       | MALAZGİRT                        |
+| nan     | residents       | 327.7         | 0.1847     | 0.0       | 3.277E-06  | 0.2297      | 1510       | MALAZGİRT                        |
+| nan     | affectedpop     | 327.7         | 0.6299     | 0.0       | 3.277E-06  | 0.6420      | 1510       | MALAZGİRT                        |
+| nan     | injured         | 224.6         | 0.0022     | 0.0       | 1.772E-06  | 1.772E-06   | 1510       | MALAZGİRT                        |
+| nan     | embodied_carbon | 5_052         | 165.8365   | 0.0       | 140.4046   | 370.2       | 1510       | MALAZGİRT                        |
+| nan     | contents        | 2_147_131     | 1_489      | 0.0       | 0.0187     | 547.8       | 1511       | MALKARA                          |
+| nan     | structural      | 12_167_076    | 502_773    | 131_618   | 410_630    | 1_201_901   | 1511       | MALKARA                          |
+| nan     | occupants       | 109.0583      | 7.294E-04  | 9.952E-07 | 1.091E-06  | 1.091E-06   | 1511       | MALKARA                          |
+| nan     | area            | 9_703         | 7.7994     | 8.455E-05 | 9.703E-05  | 29.5230     | 1511       | MALKARA                          |
+| nan     | number          | 18.9029       | 0.0186     | 1.291E-07 | 1.890E-07  | 0.0642      | 1511       | MALKARA                          |
+| nan     | residents       | 201.7         | 0.2208     | 1.840E-06 | 2.017E-06  | 0.7213      | 1511       | MALKARA                          |
+| nan     | affectedpop     | 201.7         | 0.6372     | 1.840E-06 | 2.017E-06  | 2.9707      | 1511       | MALKARA                          |
+| nan     | injured         | 109.0583      | 0.0028     | 9.952E-07 | 1.091E-06  | 0.0096      | 1511       | MALKARA                          |
+| nan     | embodied_carbon | 2_911         | 88.3867    | 20.5298   | 67.4074    | 208.2       | 1511       | MALKARA                          |
+| nan     | contents        | 1_402_109     | 14_159     | 0.0       | 0.0011     | 743.7       | 1512       | MANAVGAT                         |
+| nan     | structural      | 7_827_816     | 416_032    | 1_040     | 148_488    | 1_467_610   | 1512       | MANAVGAT                         |
+| nan     | occupants       | 75.0667       | 0.0244     | 3.560E-08 | 4.390E-07  | 0.0680      | 1512       | MANAVGAT                         |
+| nan     | area            | 5_298         | 96.0816    | 4.129E-06 | 5.092E-05  | 266.4       | 1512       | MANAVGAT                         |
+| nan     | number          | 37.9939       | 0.6979     | 2.999E-08 | 3.699E-07  | 1.9353      | 1512       | MANAVGAT                         |
+| nan     | residents       | 81.1916       | 1.9959     | 6.584E-08 | 8.119E-07  | 7.4638      | 1512       | MANAVGAT                         |
+| nan     | affectedpop     | 81.1916       | 3.2924     | 6.584E-08 | 8.119E-07  | 21.4226     | 1512       | MANAVGAT                         |
+| nan     | injured         | 75.0667       | 0.0335     | 3.560E-08 | 4.390E-07  | 0.0958      | 1512       | MANAVGAT                         |
+| nan     | embodied_carbon | 1_614         | 62.7934    | 0.5471    | 16.0928    | 204.3       | 1512       | MANAVGAT                         |
+| nan     | contents        | 29_444        | 298.4      | 0.0       | 0.0        | 2.944E-04   | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | structural      | 166_848       | 2_407      | 0.0       | 0.0        | 3_147       | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | occupants       | 0.5743        | 7.480E-05  | 0.0       | 0.0        | 1.050E-05   | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | area            | 146.3577      | 1.7787     | 0.0       | 0.0        | 1.1226      | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | number          | 0.7027        | 0.0085     | 0.0       | 0.0        | 0.0054      | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | residents       | 1.0388        | 0.0133     | 0.0       | 0.0        | 0.0080      | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | affectedpop     | 1.0388        | 0.0147     | 0.0       | 0.0        | 0.0117      | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | injured         | 0.5743        | 2.766E-04  | 0.0       | 0.0        | 1.804E-04   | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | embodied_carbon | 53.1079       | 0.7414     | 0.0       | 0.0        | 1.0065      | 1601       | OGAN KOMERING ULU Regency        |
+| nan     | contents        | 52_522        | 163.9153   | 0.0       | 2.255E-04  | 5.252E-04   | 1602       | SARIKAYA                         |
+| nan     | structural      | 297_623       | 3_049      | 0.0       | 424.9      | 5_937       | 1602       | SARIKAYA                         |
+| nan     | occupants       | 1.4100        | 6.859E-05  | 0.0       | 5.598E-09  | 1.410E-08   | 1602       | SARIKAYA                         |
+| nan     | area            | 261.1         | 1.5928     | 0.0       | 1.121E-06  | 0.1258      | 1602       | SARIKAYA                         |
+| nan     | number          | 1.7702        | 0.0103     | 0.0       | 8.143E-09  | 8.073E-04   | 1602       | SARIKAYA                         |
+| nan     | residents       | 2.5542        | 0.0184     | 0.0       | 1.015E-08  | 0.0014      | 1602       | SARIKAYA                         |
+| nan     | affectedpop     | 2.5542        | 0.0225     | 0.0       | 1.015E-08  | 0.0093      | 1602       | SARIKAYA                         |
+| nan     | injured         | 1.4100        | 3.164E-04  | 0.0       | 5.598E-09  | 1.410E-08   | 1602       | SARIKAYA                         |
+| nan     | embodied_carbon | 89.8284       | 0.9762     | 0.0       | 0.1496     | 2.0221      | 1602       | SARIKAYA                         |
+| nan     | contents        | 506_161       | 2_556      | 0.0       | 0.0        | 0.0051      | 1603       | MUARA ENIM Regency               |
+| nan     | structural      | 2_809_736     | 42_259     | 0.0       | 4_021      | 73_568      | 1603       | MUARA ENIM Regency               |
+| nan     | occupants       | 3.6124        | 2.764E-04  | 0.0       | 3.612E-08  | 3.556E-05   | 1603       | MUARA ENIM Regency               |
+| nan     | area            | 2_478         | 21.0564    | 0.0       | 2.478E-05  | 16.2563     | 1603       | MUARA ENIM Regency               |
+| nan     | number          | 18.8350       | 0.1584     | 0.0       | 1.884E-07  | 0.1193      | 1603       | MUARA ENIM Regency               |
+| nan     | residents       | 6.4192        | 0.0659     | 0.0       | 6.419E-08  | 0.0592      | 1603       | MUARA ENIM Regency               |
+| nan     | affectedpop     | 6.4192        | 0.0891     | 0.0       | 6.419E-08  | 0.1565      | 1603       | MUARA ENIM Regency               |
+| nan     | injured         | 3.6124        | 0.0013     | 0.0       | 3.612E-08  | 0.0012      | 1603       | MUARA ENIM Regency               |
+| nan     | embodied_carbon | 919.7         | 11.3160    | 0.0       | 1.3601     | 25.6841     | 1603       | MUARA ENIM Regency               |
+| nan     | contents        | 214_833       | 655.9      | 0.0       | 2.772E-04  | 253.3       | 1604       | LAHAT Regency                    |
+| nan     | structural      | 905_530       | 26_588     | 0.0       | 13_655     | 125_710     | 1604       | LAHAT Regency                    |
+| nan     | occupants       | 7.4510        | 3.948E-07  | 0.0       | 5.663E-09  | 1.131E-08   | 1604       | LAHAT Regency                    |
+| nan     | area            | 936.7         | 0.0128     | 0.0       | 6.249E-06  | 7.627E-06   | 1604       | LAHAT Regency                    |
+| nan     | number          | 4.2781        | 8.747E-05  | 0.0       | 2.880E-08  | 3.881E-08   | 1604       | LAHAT Regency                    |
+| nan     | residents       | 1.0220        | 1.065E-04  | 0.0       | 1.022E-08  | 1.022E-08   | 1604       | LAHAT Regency                    |
+| nan     | affectedpop     | 1.0220        | 2.136E-04  | 0.0       | 1.022E-08  | 1.022E-08   | 1604       | LAHAT Regency                    |
+| nan     | injured         | 7.4510        | 1.800E-06  | 0.0       | 5.663E-09  | 1.131E-08   | 1604       | LAHAT Regency                    |
+| nan     | embodied_carbon | 387.3         | 9.9895     | 0.0       | 4.5721     | 49.9267     | 1604       | LAHAT Regency                    |
+| nan     | contents        | 124_357       | 63.1881    | 0.0       | 0.0        | 0.0012      | 1605       | MUSI RAWAS Regency               |
+| nan     | structural      | 497_427       | 17_832     | 0.0       | 14_716     | 61_913      | 1605       | MUSI RAWAS Regency               |
+| nan     | occupants       | 0.6169        | 3.635E-09  | 0.0       | 6.169E-09  | 6.169E-09   | 1605       | MUSI RAWAS Regency               |
+| nan     | area            | 545.4         | 0.0016     | 0.0       | 5.454E-06  | 5.454E-06   | 1605       | MUSI RAWAS Regency               |
+| nan     | number          | 2.5135        | 7.414E-06  | 0.0       | 2.513E-08  | 2.513E-08   | 1605       | MUSI RAWAS Regency               |
+| nan     | injured         | 0.6169        | 7.365E-08  | 0.0       | 6.169E-09  | 6.169E-09   | 1605       | MUSI RAWAS Regency               |
+| nan     | embodied_carbon | 236.1         | 6.7815     | 0.0       | 5.2404     | 24.6109     | 1605       | MUSI RAWAS Regency               |
+| nan     | contents        | 130_703       | 416.7      | 0.0       | 6.100E-04  | 0.5616      | 1606       | MUSI BANYUASIN Regency           |
+| nan     | structural      | 624_472       | 11_498     | 0.0       | 6_186      | 40_918      | 1606       | MUSI BANYUASIN Regency           |
+| nan     | occupants       | 2.4443        | 8.521E-05  | 0.0       | 1.537E-08  | 2.444E-08   | 1606       | MUSI BANYUASIN Regency           |
+| nan     | area            | 608.9         | 0.6420     | 0.0       | 3.057E-06  | 6.089E-06   | 1606       | MUSI BANYUASIN Regency           |
+| nan     | number          | 3.3544        | 0.0040     | 0.0       | 1.945E-08  | 3.354E-08   | 1606       | MUSI BANYUASIN Regency           |
+| nan     | residents       | 2.7815        | 0.0072     | 0.0       | 2.782E-08  | 2.782E-08   | 1606       | MUSI BANYUASIN Regency           |
+| nan     | affectedpop     | 2.7815        | 0.0124     | 0.0       | 2.782E-08  | 1.671E-04   | 1606       | MUSI BANYUASIN Regency           |
+| nan     | injured         | 2.4443        | 1.070E-04  | 0.0       | 1.537E-08  | 2.444E-08   | 1606       | MUSI BANYUASIN Regency           |
+| nan     | embodied_carbon | 223.1         | 3.9644     | 0.0       | 2.0477     | 15.9232     | 1606       | MUSI BANYUASIN Regency           |
+| nan     | contents        | 705_219       | 4_333      | 0.0       | 0.0        | 0.0053      | 1607       | BANYU ASIN Regency               |
+| nan     | structural      | 3_711_284     | 39_898     | 0.0       | 4_107      | 85_006      | 1607       | BANYU ASIN Regency               |
+| nan     | occupants       | 24.4252       | 4.791E-04  | 0.0       | 5.885E-08  | 2.304E-04   | 1607       | BANYU ASIN Regency               |
+| nan     | area            | 3_322         | 24.0204    | 0.0       | 2.656E-05  | 22.9695     | 1607       | BANYU ASIN Regency               |
+| nan     | number          | 20.8127       | 0.1745     | 0.0       | 1.929E-07  | 0.1669      | 1607       | BANYU ASIN Regency               |
+| nan     | residents       | 10.6531       | 0.1053     | 0.0       | 1.065E-07  | 0.1312      | 1607       | BANYU ASIN Regency               |
+| nan     | affectedpop     | 10.6531       | 0.1313     | 0.0       | 1.065E-07  | 0.3303      | 1607       | BANYU ASIN Regency               |
+| nan     | injured         | 24.4252       | 0.0022     | 0.0       | 5.885E-08  | 0.0026      | 1607       | BANYU ASIN Regency               |
+| nan     | embodied_carbon | 1_137         | 11.0703    | 0.0       | 1.1627     | 25.0823     | 1607       | BANYU ASIN Regency               |
+| nan     | contents        | 109_282       | 1_137      | 0.0       | 0.0        | 0.0011      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | structural      | 619_266       | 10_112     | 0.0       | 0.0        | 20_745      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | occupants       | 2.9945        | 0.0028     | 0.0       | 0.0        | 0.0035      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | area            | 543.2         | 6.9279     | 0.0       | 0.0        | 8.5661      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | number          | 3.9459        | 0.0503     | 0.0       | 0.0        | 0.0622      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | residents       | 5.4186        | 0.0776     | 0.0       | 0.0        | 0.1159      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | affectedpop     | 5.4186        | 0.0968     | 0.0       | 0.0        | 0.2497      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | injured         | 2.9945        | 0.0016     | 0.0       | 0.0        | 0.0022      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | embodied_carbon | 173.4097      | 2.9278     | 0.0       | 0.0        | 6.2772      | 1608       | OGAN KOMERING ULU SELATAN Regenc |
+| nan     | contents        | 4_278_704     | 7_166      | 0.0       | 0.0020     | 1_826       | 1609       | SAVUR                            |
+| nan     | structural      | 24_116_548    | 693_347    | 0.0       | 635_751    | 1_528_048   | 1609       | SAVUR                            |
+| nan     | occupants       | 136.7498      | 0.0022     | 0.0       | 1.316E-06  | 0.0044      | 1609       | SAVUR                            |
+| nan     | area            | 16_290        | 23.1910    | 0.0       | 1.606E-04  | 113.4943    | 1609       | SAVUR                            |
+| nan     | number          | 76.7309       | 0.0881     | 0.0       | 7.558E-07  | 0.1871      | 1609       | SAVUR                            |
+| nan     | residents       | 250.8         | 0.5162     | 0.0       | 2.412E-06  | 1.0038      | 1609       | SAVUR                            |
+| nan     | affectedpop     | 250.8         | 1.1805     | 0.0       | 2.412E-06  | 1.8754      | 1609       | SAVUR                            |
+| nan     | injured         | 136.7498      | 0.0084     | 0.0       | 1.356E-06  | 0.0239      | 1609       | SAVUR                            |
+| nan     | embodied_carbon | 4_963         | 108.0759   | 0.0       | 93.3781    | 257.7       | 1609       | SAVUR                            |
+| nan     | contents        | 84_946        | 15.8744    | 0.0       | 8.495E-04  | 8.495E-04   | 1610       | SEBEN                            |
+| nan     | structural      | 339_783       | 9_208      | 0.0       | 7_722      | 34_171      | 1610       | SEBEN                            |
+| nan     | occupants       | 8.8376        | 4.864E-08  | 0.0       | 8.838E-08  | 8.838E-08   | 1610       | SEBEN                            |
+| nan     | area            | 331.2         | 8.079E-06  | 0.0       | 3.312E-06  | 3.312E-06   | 1610       | SEBEN                            |
+| nan     | number          | 1.5261        | 3.723E-08  | 0.0       | 1.526E-08  | 1.526E-08   | 1610       | SEBEN                            |
+| nan     | injured         | 8.8376        | 4.864E-08  | 0.0       | 8.838E-08  | 8.838E-08   | 1610       | SEBEN                            |
+| nan     | embodied_carbon | 155.1623      | 3.5800     | 0.0       | 2.8220     | 12.6879     | 1610       | SEBEN                            |
+| nan     | contents        | 16_977        | 304.5      | 0.0       | 1.698E-04  | 1.698E-04   | 1701       | BENGKULU SELATAN Regency         |
+| nan     | structural      | 96_201        | 2_891      | 0.0       | 136.1373   | 13_583      | 1701       | BENGKULU SELATAN Regency         |
+| nan     | occupants       | 0.3237        | 3.912E-04  | 0.0       | 3.237E-09  | 0.0016      | 1701       | BENGKULU SELATAN Regency         |
+| nan     | area            | 84.3871       | 1.6663     | 0.0       | 8.439E-07  | 6.8733      | 1701       | BENGKULU SELATAN Regency         |
+| nan     | number          | 0.5415        | 0.0107     | 0.0       | 5.415E-09  | 0.0441      | 1701       | BENGKULU SELATAN Regency         |
+| nan     | residents       | 0.5824        | 0.0146     | 0.0       | 5.824E-09  | 0.0698      | 1701       | BENGKULU SELATAN Regency         |
+| nan     | affectedpop     | 0.5824        | 0.0216     | 0.0       | 5.824E-09  | 0.1324      | 1701       | BENGKULU SELATAN Regency         |
+| nan     | injured         | 0.3237        | 2.441E-04  | 0.0       | 3.237E-09  | 0.0011      | 1701       | BENGKULU SELATAN Regency         |
+| nan     | embodied_carbon | 26.9248       | 0.7301     | 0.0       | 0.0304     | 3.7195      | 1701       | BENGKULU SELATAN Regency         |
+| nan     | contents        | 287_937       | 1_222      | 0.0       | 0.0023     | 0.0029      | 1703       | BENGKULU UTARA Regency           |
+| nan     | structural      | 1_424_670     | 21_816     | 0.0       | 5_128      | 58_625      | 1703       | BENGKULU UTARA Regency           |
+| nan     | occupants       | 13.7688       | 0.0010     | 0.0       | 1.377E-07  | 1.370E-04   | 1703       | BENGKULU UTARA Regency           |
+| nan     | area            | 1_176         | 6.6564     | 0.0       | 1.176E-05  | 3.5847      | 1703       | BENGKULU UTARA Regency           |
+| nan     | number          | 7.0740        | 0.0433     | 0.0       | 7.074E-08  | 0.0254      | 1703       | BENGKULU UTARA Regency           |
+| nan     | residents       | 7.2415        | 0.0666     | 0.0       | 7.241E-08  | 0.0651      | 1703       | BENGKULU UTARA Regency           |
+| nan     | affectedpop     | 7.2415        | 0.0908     | 0.0       | 7.241E-08  | 0.1649      | 1703       | BENGKULU UTARA Regency           |
+| nan     | injured         | 13.7688       | 0.0021     | 0.0       | 1.377E-07  | 0.0012      | 1703       | BENGKULU UTARA Regency           |
+| nan     | embodied_carbon | 426.2         | 6.8391     | 0.0       | 2.2721     | 18.1681     | 1703       | BENGKULU UTARA Regency           |
+| nan     | contents        | 24_764        | 84.3090    | 0.0       | 0.0        | 2.476E-04   | 1704       | KAUR Regency                     |
+| nan     | structural      | 99_055        | 3_938      | 0.0       | 3_573      | 10_044      | 1704       | KAUR Regency                     |
+| nan     | occupants       | 0.9990        | 6.769E-09  | 0.0       | 9.990E-09  | 9.990E-09   | 1704       | KAUR Regency                     |
+| nan     | area            | 108.6128      | 0.0067     | 0.0       | 1.086E-06  | 1.086E-06   | 1704       | KAUR Regency                     |
+| nan     | number          | 0.5005        | 3.085E-05  | 0.0       | 5.005E-09  | 5.005E-09   | 1704       | KAUR Regency                     |
+| nan     | injured         | 0.9990        | 2.266E-06  | 0.0       | 9.990E-09  | 9.990E-09   | 1704       | KAUR Regency                     |
+| nan     | embodied_carbon | 47.0161       | 1.4801     | 0.0       | 1.2757     | 3.8539      | 1704       | KAUR Regency                     |
+| nan     | contents        | 145_450       | 2_388      | 0.0       | 0.0        | 0.0015      | 1706       | ÜNYE                             |
+| nan     | structural      | 824_217       | 16_976     | 0.0       | 0.0        | 20_414      | 1706       | ÜNYE                             |
+| nan     | occupants       | 2.4255        | 3.581E-04  | 0.0       | 0.0        | 7.413E-05   | 1706       | ÜNYE                             |
+| nan     | area            | 723.0         | 12.1228    | 0.0       | 0.0        | 4.4861      | 1706       | ÜNYE                             |
+| nan     | number          | 4.9881        | 0.0840     | 0.0       | 0.0        | 0.0320      | 1706       | ÜNYE                             |
+| nan     | residents       | 4.3897        | 0.0841     | 0.0       | 0.0        | 0.0415      | 1706       | ÜNYE                             |
+| nan     | affectedpop     | 4.3897        | 0.1004     | 0.0       | 0.0        | 0.1072      | 1706       | ÜNYE                             |
+| nan     | injured         | 2.4255        | 0.0016     | 0.0       | 0.0        | 7.751E-04   | 1706       | ÜNYE                             |
+| nan     | embodied_carbon | 244.2         | 5.2645     | 0.0       | 0.0        | 6.0267      | 1706       | ÜNYE                             |
+| nan     | contents        | 589_665       | 22_427     | 0.0       | 0.0058     | 112_172     | 1708       | ÜSKÜDAR                          |
+| nan     | structural      | 3_150_370     | 74_106     | 0.0       | 5_602      | 592_504     | 1708       | ÜSKÜDAR                          |
+| nan     | occupants       | 24.0649       | 0.0037     | 0.0       | 2.381E-07  | 0.0532      | 1708       | ÜSKÜDAR                          |
+| nan     | area            | 2_549         | 77.7451    | 0.0       | 2.488E-05  | 1_131       | 1708       | ÜSKÜDAR                          |
+| nan     | number          | 17.5603       | 0.5647     | 0.0       | 1.712E-07  | 8.2150      | 1708       | ÜSKÜDAR                          |
+| nan     | residents       | 19.8870       | 0.8062     | 0.0       | 1.941E-07  | 12.2226     | 1708       | ÜSKÜDAR                          |
+| nan     | affectedpop     | 19.8870       | 0.9258     | 0.0       | 1.941E-07  | 14.6543     | 1708       | ÜSKÜDAR                          |
+| nan     | injured         | 24.0649       | 0.0158     | 0.0       | 2.381E-07  | 0.2326      | 1708       | ÜSKÜDAR                          |
+| nan     | embodied_carbon | 948.6         | 40.4557    | 0.0       | 2.8833     | 657.2       | 1708       | ÜSKÜDAR                          |
+| nan     | contents        | 352_739       | 995.3      | 0.0       | 0.0        | 0.3264      | 1710       | Sabrosa                          |
+| nan     | structural      | 1_410_955     | 33_125     | 0.0       | 31_124     | 141_798     | 1710       | Sabrosa                          |
+| nan     | occupants       | 30.9800       | 2.348E-06  | 0.0       | 3.098E-07  | 3.098E-07   | 1710       | Sabrosa                          |
+| nan     | area            | 1_375         | 0.0793     | 0.0       | 1.375E-05  | 1.375E-05   | 1710       | Sabrosa                          |
+| nan     | number          | 2.0098        | 1.159E-04  | 0.0       | 2.010E-08  | 2.010E-08   | 1710       | Sabrosa                          |
+| nan     | injured         | 30.9800       | 5.527E-05  | 0.0       | 3.098E-07  | 3.098E-07   | 1710       | Sabrosa                          |
+| nan     | embodied_carbon | 647.5         | 17.5128    | 0.0       | 17.8310    | 70.5377     | 1710       | Sabrosa                          |
+| nan     | contents        | 31_691        | 1_532      | 0.0       | 3.169E-04  | 29_591      | 1711       | Santa Marta de Penaguião         |
+| nan     | structural      | 179_580       | 9_902      | 0.0       | 133.9644   | 146_730     | 1711       | Santa Marta de Penaguião         |
+| nan     | occupants       | 0.6481        | 0.0021     | 0.0       | 6.481E-09  | 0.0342      | 1711       | Santa Marta de Penaguião         |
+| nan     | area            | 157.5267      | 8.2626     | 0.0       | 1.575E-06  | 136.2167    | 1711       | Santa Marta de Penaguião         |
+| nan     | number          | 1.0108        | 0.0530     | 0.0       | 1.011E-08  | 0.8741      | 1711       | Santa Marta de Penaguião         |
+| nan     | residents       | 1.1737        | 0.0647     | 0.0       | 1.174E-08  | 1.0721      | 1711       | Santa Marta de Penaguião         |
+| nan     | affectedpop     | 1.1737        | 0.0692     | 0.0       | 1.174E-08  | 1.1214      | 1711       | Santa Marta de Penaguião         |
+| nan     | injured         | 0.6481        | 0.0012     | 0.0       | 6.481E-09  | 0.0195      | 1711       | Santa Marta de Penaguião         |
+| nan     | embodied_carbon | 50.2585       | 2.7743     | 0.0       | 0.0284     | 39.8785     | 1711       | Santa Marta de Penaguião         |
+| nan     | contents        | 564_663       | 2_180      | 0.0       | 0.0024     | 13.0878     | 1712       | VEZİRKÖPRÜ                       |
+| nan     | structural      | 3_199_757     | 39_808     | 0.0       | 16_706     | 150_706     | 1712       | VEZİRKÖPRÜ                       |
+| nan     | occupants       | 8.9209        | 0.0030     | 0.0       | 3.935E-08  | 0.0015      | 1712       | VEZİRKÖPRÜ                       |
+| nan     | area            | 2_807         | 13.9747    | 0.0       | 1.213E-05  | 6.7376      | 1712       | VEZİRKÖPRÜ                       |
+| nan     | number          | 17.8409       | 0.0975     | 0.0       | 7.785E-08  | 0.0473      | 1712       | VEZİRKÖPRÜ                       |
+| nan     | residents       | 16.1477       | 0.0988     | 0.0       | 7.123E-08  | 0.0503      | 1712       | VEZİRKÖPRÜ                       |
+| nan     | affectedpop     | 16.1477       | 0.1367     | 0.0       | 7.123E-08  | 0.1649      | 1712       | VEZİRKÖPRÜ                       |
+| nan     | injured         | 8.9209        | 0.0019     | 0.0       | 3.935E-08  | 9.346E-04   | 1712       | VEZİRKÖPRÜ                       |
+| nan     | embodied_carbon | 859.9         | 10.0182    | 0.0       | 3.2576     | 29.8083     | 1712       | VEZİRKÖPRÜ                       |
+| nan     | contents        | 162_918       | 196.9      | 0.0       | 0.0013     | 0.2748      | 1713       | VİRANŞEHİR                       |
+| nan     | structural      | 840_802       | 12_428     | 0.0       | 8_348      | 36_531      | 1713       | VİRANŞEHİR                       |
+| nan     | occupants       | 10.9554       | 3.086E-05  | 0.0       | 1.096E-07  | 2.402E-04   | 1713       | VİRANŞEHİR                       |
+| nan     | area            | 756.8         | 1.2301     | 0.0       | 7.568E-06  | 9.4328      | 1713       | VİRANŞEHİR                       |
+| nan     | number          | 4.8604        | 0.0079     | 0.0       | 4.860E-08  | 0.0605      | 1713       | VİRANŞEHİR                       |
+| nan     | residents       | 4.5882        | 0.0096     | 0.0       | 4.588E-08  | 0.0807      | 1713       | VİRANŞEHİR                       |
+| nan     | affectedpop     | 4.5882        | 0.0159     | 0.0       | 4.588E-08  | 0.1514      | 1713       | VİRANŞEHİR                       |
+| nan     | injured         | 10.9554       | 1.616E-04  | 0.0       | 1.096E-07  | 0.0013      | 1713       | VİRANŞEHİR                       |
+| nan     | embodied_carbon | 268.6         | 3.7131     | 0.0       | 2.4229     | 11.3732     | 1713       | VİRANŞEHİR                       |
+| nan     | contents        | 2_759_053     | 331.8      | 0.0       | 0.0276     | 0.0276      | 1714       | VİZE                             |
+| nan     | structural      | 15_522_105    | 182_280    | 0.0       | 114_034    | 640_474     | 1714       | VİZE                             |
+| nan     | occupants       | 55.2217       | 9.844E-05  | 0.0       | 5.522E-07  | 5.522E-07   | 1714       | VİZE                             |
+| nan     | area            | 10_489        | 2.6037     | 0.0       | 1.049E-04  | 0.2551      | 1714       | VİZE                             |
+| nan     | number          | 75.1177       | 0.0173     | 0.0       | 7.512E-07  | 0.0016      | 1714       | VİZE                             |
+| nan     | residents       | 94.7895       | 0.0288     | 0.0       | 9.479E-07  | 0.0026      | 1714       | VİZE                             |
+| nan     | affectedpop     | 94.7895       | 0.0491     | 0.0       | 9.479E-07  | 0.0102      | 1714       | VİZE                             |
+| nan     | injured         | 55.2217       | 4.924E-04  | 0.0       | 5.522E-07  | 5.522E-07   | 1714       | VİZE                             |
+| nan     | embodied_carbon | 3_129         | 30.5666    | 0.0       | 18.0480    | 107.2330    | 1714       | VİZE                             |
+| nan     | contents        | 18_881        | 9.704E-05  | 0.0       | 1.888E-04  | 1.888E-04   | 1801       | LAMPUNG BARAT Regency            |
+| nan     | structural      | 75_523        | 1_008      | 0.0       | 537.2      | 6_643       | 1801       | LAMPUNG BARAT Regency            |
+| nan     | occupants       | 5.4900        | 3.089E-08  | 0.0       | 5.490E-08  | 5.490E-08   | 1801       | LAMPUNG BARAT Regency            |
+| nan     | area            | 73.6094       | 4.142E-07  | 0.0       | 7.361E-07  | 7.361E-07   | 1801       | LAMPUNG BARAT Regency            |
+| nan     | number          | 0.3393        | 1.909E-09  | 0.0       | 3.393E-09  | 3.393E-09   | 1801       | LAMPUNG BARAT Regency            |
+| nan     | injured         | 5.4900        | 3.089E-08  | 0.0       | 5.490E-08  | 5.490E-08   | 1801       | LAMPUNG BARAT Regency            |
+| nan     | embodied_carbon | 34.4900       | 0.7221     | 0.0       | 0.5590     | 3.9391      | 1801       | LAMPUNG BARAT Regency            |
+| nan     | contents        | 28_510        | 77.8260    | 0.0       | 0.0        | 0.0248      | 1802       | TANGGAMUS Regency                |
+| nan     | structural      | 161_556       | 4_752      | 0.0       | 3_275      | 13_653      | 1802       | TANGGAMUS Regency                |
+| nan     | occupants       | 0.6776        | 8.189E-05  | 0.0       | 6.776E-09  | 7.898E-05   | 1802       | TANGGAMUS Regency                |
+| nan     | area            | 141.7160      | 0.5864     | 0.0       | 1.417E-06  | 0.5567      | 1802       | TANGGAMUS Regency                |
+| nan     | number          | 1.0294        | 0.0043     | 0.0       | 1.029E-08  | 0.0040      | 1802       | TANGGAMUS Regency                |
+| nan     | residents       | 1.2263        | 0.0075     | 0.0       | 1.226E-08  | 0.0050      | 1802       | TANGGAMUS Regency                |
+| nan     | affectedpop     | 1.2263        | 0.0164     | 0.0       | 1.226E-08  | 0.0290      | 1802       | TANGGAMUS Regency                |
+| nan     | injured         | 0.6776        | 1.136E-04  | 0.0       | 6.776E-09  | 1.105E-04   | 1802       | TANGGAMUS Regency                |
+| nan     | embodied_carbon | 42.4547       | 0.8033     | 0.0       | 0.4498     | 2.3600      | 1802       | TANGGAMUS Regency                |
+| nan     | contents        | 277_863       | 3_994      | 0.0       | 0.0028     | 0.0028      | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | structural      | 1_574_556     | 24_918     | 0.0       | 1_708      | 24_170      | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | occupants       | 5.2492        | 0.0056     | 0.0       | 5.249E-08  | 9.989E-04   | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | area            | 1_381         | 23.4660    | 0.0       | 1.381E-05  | 4.0483      | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | number          | 8.8626        | 0.1506     | 0.0       | 8.863E-08  | 0.0260      | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | residents       | 9.5002        | 0.1977     | 0.0       | 9.500E-08  | 0.0497      | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | affectedpop     | 9.5002        | 0.2497     | 0.0       | 9.500E-08  | 0.1745      | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | injured         | 5.2492        | 0.0034     | 0.0       | 5.249E-08  | 6.346E-04   | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | embodied_carbon | 447.7         | 9.0478     | 0.0       | 0.3866     | 6.5724      | 1803       | LAMPUNG SELATAN Regency          |
+| nan     | contents        | 1_664_573     | 1_536      | 0.0       | 0.0166     | 0.0166      | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | structural      | 9_432_583     | 120_052    | 0.0       | 20_931     | 220_781     | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | occupants       | 40.6585       | 0.0030     | 0.0       | 4.066E-07  | 4.066E-07   | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | area            | 8_274         | 66.6268    | 0.0       | 8.274E-05  | 46.5076     | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | number          | 60.1036       | 0.4840     | 0.0       | 6.010E-07  | 0.3378      | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | residents       | 73.5892       | 0.7194     | 0.0       | 7.359E-07  | 0.5299      | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | affectedpop     | 73.5892       | 0.9691     | 0.0       | 7.359E-07  | 1.4498      | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | injured         | 40.6585       | 0.0137     | 0.0       | 4.066E-07  | 0.0114      | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | embodied_carbon | 3_000         | 36.4400    | 0.0       | 6.8419     | 69.4923     | 1804       | LAMPUNG TIMUR Regency            |
+| nan     | contents        | 51_680        | 1_636      | 0.0       | 3.154E-04  | 20_138      | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | structural      | 292_856       | 15_216     | 0.0       | 258.8      | 113_132     | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | occupants       | 1.2645        | 4.856E-04  | 0.0       | 6.529E-09  | 0.0040      | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | area            | 256.9         | 10.6326    | 0.0       | 1.568E-06  | 95.2522     | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | number          | 1.7333        | 0.0728     | 0.0       | 1.006E-08  | 0.6897      | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | residents       | 2.2885        | 0.1094     | 0.0       | 1.181E-08  | 0.9836      | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | affectedpop     | 2.2885        | 0.1239     | 0.0       | 1.181E-08  | 1.0369      | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | injured         | 1.2645        | 0.0021     | 0.0       | 6.529E-09  | 0.0179      | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | embodied_carbon | 60.2859       | 2.8798     | 0.0       | 0.0410     | 14.8295     | 1805       | LAMPUNG TENGAH Regency           |
+| nan     | contents        | 62_226        | 652.7      | 0.0       | 3.173E-04  | 6.223E-04   | 1806       | LAMPUNG UTARA Regency            |
+| nan     | structural      | 352_619       | 11_671     | 0.0       | 927.5      | 64_279      | 1806       | LAMPUNG UTARA Regency            |
+| nan     | occupants       | 1.1408        | 0.0014     | 0.0       | 1.141E-08  | 0.0075      | 1806       | LAMPUNG UTARA Regency            |
+| nan     | area            | 309.3         | 6.7960     | 0.0       | 3.093E-06  | 33.9957     | 1806       | LAMPUNG UTARA Regency            |
+| nan     | number          | 1.9848        | 0.0436     | 0.0       | 1.985E-08  | 0.2181      | 1806       | LAMPUNG UTARA Regency            |
+| nan     | residents       | 2.0648        | 0.0586     | 0.0       | 2.065E-08  | 0.3186      | 1806       | LAMPUNG UTARA Regency            |
+| nan     | affectedpop     | 2.0648        | 0.0828     | 0.0       | 2.065E-08  | 0.4777      | 1806       | LAMPUNG UTARA Regency            |
+| nan     | injured         | 1.1408        | 9.993E-04  | 0.0       | 1.141E-08  | 0.0052      | 1806       | LAMPUNG UTARA Regency            |
+| nan     | embodied_carbon | 98.6861       | 2.8030     | 0.0       | 0.2332     | 17.4627     | 1806       | LAMPUNG UTARA Regency            |
+| nan     | contents        | 145_587       | 440.6      | 0.0       | 5.712E-04  | 21.3282     | 1807       | WAY KANAN Regency                |
+| nan     | structural      | 824_987       | 9_163      | 0.0       | 2_028      | 54_190      | 1807       | WAY KANAN Regency                |
+| nan     | occupants       | 2.9427        | 1.788E-04  | 0.0       | 1.610E-08  | 0.0012      | 1807       | WAY KANAN Regency                |
+| nan     | area            | 723.7         | 4.3990     | 0.0       | 3.939E-06  | 29.9763     | 1807       | WAY KANAN Regency                |
+| nan     | number          | 4.1739        | 0.0290     | 0.0       | 2.590E-08  | 0.1486      | 1807       | WAY KANAN Regency                |
+| nan     | residents       | 5.3261        | 0.0409     | 0.0       | 2.912E-08  | 0.2754      | 1807       | WAY KANAN Regency                |
+| nan     | affectedpop     | 5.3261        | 0.0560     | 0.0       | 2.912E-08  | 0.4318      | 1807       | WAY KANAN Regency                |
+| nan     | injured         | 2.9427        | 7.840E-04  | 0.0       | 1.610E-08  | 0.0054      | 1807       | WAY KANAN Regency                |
+| nan     | embodied_carbon | 243.3         | 3.0320     | 0.0       | 0.8324     | 15.9661     | 1807       | WAY KANAN Regency                |
+| nan     | contents        | 197_943       | 1_058      | 0.0       | 3.165E-04  | 0.1363      | 1808       | TULANGBAWANG Regency             |
+| nan     | structural      | 1_121_677     | 29_964     | 0.0       | 3_087      | 61_422      | 1808       | TULANGBAWANG Regency             |
+| nan     | occupants       | 5.2783        | 9.533E-04  | 0.0       | 5.278E-08  | 0.0012      | 1808       | TULANGBAWANG Regency             |
+| nan     | area            | 983.9         | 19.6702    | 0.0       | 9.839E-06  | 35.9047     | 1808       | TULANGBAWANG Regency             |
+| nan     | number          | 7.0139        | 0.1407     | 0.0       | 7.014E-08  | 0.2310      | 1808       | TULANGBAWANG Regency             |
+| nan     | residents       | 9.5534        | 0.2249     | 0.0       | 9.553E-08  | 0.3641      | 1808       | TULANGBAWANG Regency             |
+| nan     | affectedpop     | 9.5534        | 0.2910     | 0.0       | 9.553E-08  | 0.5319      | 1808       | TULANGBAWANG Regency             |
+| nan     | injured         | 5.2783        | 0.0043     | 0.0       | 5.278E-08  | 0.0060      | 1808       | TULANGBAWANG Regency             |
+| nan     | embodied_carbon | 314.1         | 7.1996     | 0.0       | 0.9003     | 19.0814     | 1808       | TULANGBAWANG Regency             |
+| nan     | contents        | 83_400        | 394.6      | 0.0       | 0.0        | 8.340E-04   | 1809       | PESAWARAN Regency                |
+| nan     | structural      | 472_599       | 9_626      | 0.0       | 1_529      | 31_621      | 1809       | PESAWARAN Regency                |
+| nan     | occupants       | 2.5835        | 2.600E-04  | 0.0       | 2.583E-08  | 7.632E-04   | 1809       | PESAWARAN Regency                |
+| nan     | area            | 414.6         | 4.6026     | 0.0       | 4.146E-06  | 13.0695     | 1809       | PESAWARAN Regency                |
+| nan     | number          | 3.0114        | 0.0334     | 0.0       | 3.011E-08  | 0.0949      | 1809       | PESAWARAN Regency                |
+| nan     | residents       | 4.6763        | 0.0669     | 0.0       | 4.676E-08  | 0.2283      | 1809       | PESAWARAN Regency                |
+| nan     | affectedpop     | 4.6763        | 0.1081     | 0.0       | 4.676E-08  | 0.4679      | 1809       | PESAWARAN Regency                |
+| nan     | injured         | 2.5835        | 0.0013     | 0.0       | 2.583E-08  | 0.0040      | 1809       | PESAWARAN Regency                |
+| nan     | embodied_carbon | 132.3400      | 2.7665     | 0.0       | 0.4528     | 9.7340      | 1809       | PESAWARAN Regency                |
+| nan     | contents        | 201_407       | 2_054      | 0.0       | 0.0016     | 0.0020      | 1810       | PRINGSEWU Regency                |
+| nan     | structural      | 1_141_306     | 18_451     | 0.0       | 972.4      | 79_457      | 1810       | PRINGSEWU Regency                |
+| nan     | occupants       | 4.0693        | 4.723E-04  | 0.0       | 2.946E-08  | 0.0012      | 1810       | PRINGSEWU Regency                |
+| nan     | area            | 1_001         | 14.2830    | 0.0       | 7.842E-06  | 32.9264     | 1810       | PRINGSEWU Regency                |
+| nan     | number          | 6.0737        | 0.0877     | 0.0       | 5.032E-08  | 0.2112      | 1810       | PRINGSEWU Regency                |
+| nan     | residents       | 7.3656        | 0.1168     | 0.0       | 5.333E-08  | 0.3297      | 1810       | PRINGSEWU Regency                |
+| nan     | affectedpop     | 7.3656        | 0.1468     | 0.0       | 5.333E-08  | 0.6675      | 1810       | PRINGSEWU Regency                |
+| nan     | injured         | 4.0693        | 0.0021     | 0.0       | 2.946E-08  | 0.0056      | 1810       | PRINGSEWU Regency                |
+| nan     | embodied_carbon | 353.5         | 6.8329     | 0.0       | 0.2746     | 25.2905     | 1810       | PRINGSEWU Regency                |
+| nan     | contents        | 107_648       | 678.8      | 0.0       | 0.0011     | 0.0011      | 1811       | MESUJI Regency                   |
+| nan     | structural      | 610_006       | 5_686      | 0.0       | 1_699      | 8_750       | 1811       | MESUJI Regency                   |
+| nan     | occupants       | 1.3702        | 5.886E-05  | 0.0       | 1.370E-08  | 1.370E-08   | 1811       | MESUJI Regency                   |
+| nan     | area            | 535.1         | 2.5369     | 0.0       | 5.351E-06  | 1.1486      | 1811       | MESUJI Regency                   |
+| nan     | number          | 3.8869        | 0.0184     | 0.0       | 3.887E-08  | 0.0083      | 1811       | MESUJI Regency                   |
+| nan     | residents       | 2.4808        | 0.0152     | 0.0       | 2.481E-08  | 0.0055      | 1811       | MESUJI Regency                   |
+| nan     | affectedpop     | 2.4808        | 0.0229     | 0.0       | 2.481E-08  | 0.0171      | 1811       | MESUJI Regency                   |
+| nan     | injured         | 1.3702        | 2.807E-04  | 0.0       | 1.370E-08  | 1.304E-04   | 1811       | MESUJI Regency                   |
+| nan     | embodied_carbon | 54.8471       | 0.4657     | 0.0       | 0.1604     | 0.9071      | 1811       | MESUJI Regency                   |
+| nan     | contents        | 210_973       | 711.1      | 0.0       | 4.832E-24  | 0.0021      | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | structural      | 1_195_514     | 8_794      | 0.0       | 1_213      | 19_096      | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | occupants       | 4.7036        | 8.998E-04  | 0.0       | 4.704E-08  | 7.316E-04   | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | area            | 1_049         | 5.1107     | 0.0       | 1.049E-05  | 5.9741      | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | number          | 6.0864        | 0.0316     | 0.0       | 6.086E-08  | 0.0353      | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | residents       | 8.5139        | 0.0472     | 0.0       | 8.514E-08  | 0.0504      | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | affectedpop     | 8.5139        | 0.0667     | 0.0       | 8.514E-08  | 0.0889      | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | injured         | 4.7036        | 9.098E-04  | 0.0       | 4.704E-08  | 0.0011      | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | embodied_carbon | 361.9         | 2.5790     | 0.0       | 0.3549     | 5.7626      | 1812       | TULANGBAWANG BARAT Regency       |
+| nan     | contents        | 276_811       | 4_799      | 0.0       | 2.670E-17  | 0.0028      | 1814       | KARATAY                          |
+| nan     | structural      | 1_568_594     | 50_546     | 0.0       | 4_577      | 43_684      | 1814       | KARATAY                          |
+| nan     | occupants       | 8.9633        | 0.0017     | 0.0       | 8.963E-08  | 1.265E-04   | 1814       | KARATAY                          |
+| nan     | area            | 1_376         | 28.5315    | 0.0       | 1.376E-05  | 9.7759      | 1814       | KARATAY                          |
+| nan     | number          | 9.9949        | 0.2073     | 0.0       | 9.995E-08  | 0.0710      | 1814       | KARATAY                          |
+| nan     | residents       | 16.2232       | 0.3904     | 0.0       | 1.622E-07  | 0.1567      | 1814       | KARATAY                          |
+| nan     | affectedpop     | 16.2232       | 0.4968     | 0.0       | 1.622E-07  | 0.4107      | 1814       | KARATAY                          |
+| nan     | injured         | 8.9633        | 0.0076     | 0.0       | 8.963E-08  | 0.0032      | 1814       | KARATAY                          |
+| nan     | embodied_carbon | 498.9         | 15.8789    | 0.0       | 1.5375     | 13.4577     | 1814       | KARATAY                          |
+| nan     | contents        | 512_225       | 10_855     | 0.0       | 0.0031     | 0.0051      | 1815       | KAHRAMANKAZAN                    |
+| nan     | structural      | 2_902_611     | 88_534     | 0.0       | 7_604      | 346_188     | 1815       | KAHRAMANKAZAN                    |
+| nan     | occupants       | 8.8416        | 0.0020     | 0.0       | 8.842E-08  | 0.0070      | 1815       | KAHRAMANKAZAN                    |
+| nan     | area            | 2_546         | 63.2676    | 0.0       | 2.546E-05  | 214.3       | 1815       | KAHRAMANKAZAN                    |
+| nan     | number          | 18.4951       | 0.4596     | 0.0       | 1.850E-07  | 1.5563      | 1815       | KAHRAMANKAZAN                    |
+| nan     | residents       | 16.0072       | 0.4739     | 0.0       | 1.601E-07  | 1.9467      | 1815       | KAHRAMANKAZAN                    |
+| nan     | affectedpop     | 16.0072       | 0.6298     | 0.0       | 1.601E-07  | 3.3884      | 1815       | KAHRAMANKAZAN                    |
+| nan     | injured         | 8.8416        | 0.0092     | 0.0       | 8.842E-08  | 0.0343      | 1815       | KAHRAMANKAZAN                    |
+| nan     | embodied_carbon | 812.8         | 26.0352    | 0.0       | 2.1985     | 86.5120     | 1815       | KAHRAMANKAZAN                    |
+| nan     | contents        | 105_014       | 570.9      | 0.0       | 6.190E-04  | 0.0011      | 1816       | São Pedro do Sul                 |
+| nan     | structural      | 595_075       | 5_529      | 0.0       | 922.9      | 9_499       | 1816       | São Pedro do Sul                 |
+| nan     | occupants       | 1.7195        | 8.662E-05  | 0.0       | 1.230E-08  | 4.129E-05   | 1816       | São Pedro do Sul                 |
+| nan     | area            | 522.0         | 2.4980     | 0.0       | 3.077E-06  | 2.0901      | 1816       | São Pedro do Sul                 |
+| nan     | number          | 3.0033        | 0.0124     | 0.0       | 1.974E-08  | 0.0100      | 1816       | São Pedro do Sul                 |
+| nan     | residents       | 3.1126        | 0.0129     | 0.0       | 2.227E-08  | 0.0094      | 1816       | São Pedro do Sul                 |
+| nan     | affectedpop     | 3.1126        | 0.0178     | 0.0       | 2.227E-08  | 0.0152      | 1816       | São Pedro do Sul                 |
+| nan     | injured         | 1.7195        | 2.423E-04  | 0.0       | 1.230E-08  | 1.975E-04   | 1816       | São Pedro do Sul                 |
+| nan     | embodied_carbon | 169.8598      | 1.6423     | 0.0       | 0.2739     | 2.7618      | 1816       | São Pedro do Sul                 |
+| nan     | contents        | 363_800       | 1_410      | 0.0       | 0.0014     | 16.7231     | 1817       | KIZILIRMAK                       |
+| nan     | structural      | 1_898_547     | 33_117     | 0.0       | 20_406     | 136_929     | 1817       | KIZILIRMAK                       |
+| nan     | occupants       | 22.8002       | 3.273E-04  | 0.0       | 1.763E-07  | 0.0015      | 1817       | KIZILIRMAK                       |
+| nan     | area            | 1_704         | 8.1710     | 0.0       | 1.322E-05  | 44.2714     | 1817       | KIZILIRMAK                       |
+| nan     | number          | 6.4109        | 0.0377     | 0.0       | 5.854E-08  | 0.1120      | 1817       | KIZILIRMAK                       |
+| nan     | residents       | 9.3574        | 0.0793     | 0.0       | 9.357E-08  | 0.4229      | 1817       | KIZILIRMAK                       |
+| nan     | affectedpop     | 9.3574        | 0.1233     | 0.0       | 9.357E-08  | 0.8557      | 1817       | KIZILIRMAK                       |
+| nan     | injured         | 22.8002       | 0.0014     | 0.0       | 1.763E-07  | 0.0073      | 1817       | KIZILIRMAK                       |
+| nan     | embodied_carbon | 636.1         | 10.8850    | 0.0       | 7.1345     | 39.9365     | 1817       | KIZILIRMAK                       |
+| nan     | contents        | 189_087       | 2_421      | 0.0       | 0.0019     | 0.0019      | 1818       | KOCAALİ                          |
+| nan     | structural      | 1_071_490     | 24_527     | 0.0       | 678.6      | 17_470      | 1818       | KOCAALİ                          |
+| nan     | occupants       | 3.0622        | 3.862E-04  | 0.0       | 3.062E-08  | 3.062E-08   | 1818       | KOCAALİ                          |
+| nan     | area            | 939.9         | 15.6282    | 0.0       | 9.399E-06  | 2.5503      | 1818       | KOCAALİ                          |
+| nan     | number          | 6.0311        | 0.1003     | 0.0       | 6.031E-08  | 0.0164      | 1818       | KOCAALİ                          |
+| nan     | residents       | 5.5444        | 0.1028     | 0.0       | 5.544E-08  | 0.0194      | 1818       | KOCAALİ                          |
+| nan     | affectedpop     | 5.5444        | 0.1236     | 0.0       | 5.544E-08  | 0.0634      | 1818       | KOCAALİ                          |
+| nan     | injured         | 3.0622        | 0.0018     | 0.0       | 3.062E-08  | 3.096E-04   | 1818       | KOCAALİ                          |
+| nan     | embodied_carbon | 340.6         | 7.2427     | 0.0       | 0.1850     | 5.6312      | 1818       | KOCAALİ                          |
+| nan     | contents        | 30_214        | 1_074      | 0.0       | 0.0        | 0.4492      | 1820       | KOVANCILAR                       |
+| nan     | structural      | 171_211       | 4_439      | 0.0       | 271.0      | 26_260      | 1820       | KOVANCILAR                       |
+| nan     | occupants       | 0.6514        | 2.185E-04  | 0.0       | 6.514E-09  | 3.563E-04   | 1820       | KOVANCILAR                       |
+| nan     | area            | 150.1854      | 1.7109     | 0.0       | 1.502E-06  | 2.7820      | 1820       | KOVANCILAR                       |
+| nan     | number          | 0.9637        | 0.0110     | 0.0       | 9.637E-09  | 0.0179      | 1820       | KOVANCILAR                       |
+| nan     | residents       | 1.1794        | 0.0187     | 0.0       | 1.179E-08  | 0.0427      | 1820       | KOVANCILAR                       |
+| nan     | affectedpop     | 1.1794        | 0.0334     | 0.0       | 1.179E-08  | 0.1640      | 1820       | KOVANCILAR                       |
+| nan     | injured         | 0.6514        | 2.588E-04  | 0.0       | 6.514E-09  | 4.423E-04   | 1820       | KOVANCILAR                       |
+| nan     | embodied_carbon | 44.9528       | 1.0899     | 0.0       | 0.0365     | 5.5549      | 1820       | KOVANCILAR                       |
+| nan     | contents        | 27_594        | 109.2054   | 0.0       | 0.0        | 0.0099      | 1821       | KÖRFEZ                           |
+| nan     | structural      | 156_368       | 4_559      | 0.0       | 2_450      | 9_430       | 1821       | KÖRFEZ                           |
+| nan     | occupants       | 0.5824        | 1.000E-04  | 0.0       | 5.824E-09  | 5.824E-09   | 1821       | KÖRFEZ                           |
+| nan     | area            | 137.1645      | 0.8057     | 0.0       | 1.372E-06  | 0.1371      | 1821       | KÖRFEZ                           |
+| nan     | number          | 0.9964        | 0.0059     | 0.0       | 9.964E-09  | 9.957E-04   | 1821       | KÖRFEZ                           |
+| nan     | residents       | 1.0541        | 0.0080     | 0.0       | 1.054E-08  | 0.0011      | 1821       | KÖRFEZ                           |
+| nan     | affectedpop     | 1.0541        | 0.0151     | 0.0       | 1.054E-08  | 0.0044      | 1821       | KÖRFEZ                           |
+| nan     | injured         | 0.5824        | 1.376E-04  | 0.0       | 5.824E-09  | 5.824E-09   | 1821       | KÖRFEZ                           |
+| nan     | embodied_carbon | 41.0913       | 0.8063     | 0.0       | 0.3153     | 1.6690      | 1821       | KÖRFEZ                           |
+| nan     | contents        | 122_664       | 12.4979    | 0.0       | 3.453E-04  | 0.0012      | 1822       | KÖSE                             |
+| nan     | structural      | 490_658       | 11_438     | 0.0       | 6_675      | 38_488      | 1822       | KÖSE                             |
+| nan     | occupants       | 14.0905       | 7.343E-08  | 0.0       | 5.374E-08  | 1.409E-07   | 1822       | KÖSE                             |
+| nan     | area            | 521.2         | 0.0228     | 0.0       | 1.346E-06  | 5.212E-06   | 1822       | KÖSE                             |
+| nan     | number          | 1.5110        | 5.250E-05  | 0.0       | 6.203E-09  | 1.511E-08   | 1822       | KÖSE                             |
+| nan     | injured         | 14.0905       | 1.487E-05  | 0.0       | 5.374E-08  | 1.409E-07   | 1822       | KÖSE                             |
+| nan     | embodied_carbon | 230.6         | 5.1222     | 0.0       | 2.7907     | 16.2356     | 1822       | KÖSE                             |
+| nan     | contents        | 913_965       | 1_590      | 0.0       | 0.0010     | 2_816       | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | structural      | 4_696_457     | 30_182     | 0.0       | 5_869      | 56_743      | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | occupants       | 41.5007       | 9.014E-04  | 0.0       | 1.530E-07  | 2.601E-04   | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | area            | 3_234         | 13.0019    | 0.0       | 2.232E-05  | 15.1235     | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | number          | 13.8998       | 0.0645     | 0.0       | 1.097E-07  | 0.0788      | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | residents       | 29.5915       | 0.1879     | 0.0       | 2.830E-07  | 0.2064      | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | affectedpop     | 29.5915       | 0.2395     | 0.0       | 2.830E-07  | 0.2968      | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | injured         | 41.5007       | 0.0036     | 0.0       | 1.530E-07  | 0.0036      | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | embodied_carbon | 1_226         | 6.6470     | 0.0       | 1.6297     | 13.7585     | 1823       | KÜÇÜKÇEKMECE                     |
+| nan     | contents        | 659_031       | 94.9201    | 0.0       | 0.0047     | 0.0066      | 1824       | Vouzela                          |
+| nan     | structural      | 3_423_410     | 45_013     | 0.0       | 42_967     | 127_425     | 1824       | Vouzela                          |
+| nan     | occupants       | 21.6558       | 7.595E-07  | 0.0       | 1.109E-07  | 2.166E-07   | 1824       | Vouzela                          |
+| nan     | area            | 3_076         | 0.0120     | 0.0       | 2.348E-05  | 3.076E-05   | 1824       | Vouzela                          |
+| nan     | number          | 18.1198       | 6.155E-05  | 0.0       | 1.706E-07  | 1.812E-07   | 1824       | Vouzela                          |
+| nan     | residents       | 19.1245       | 9.348E-05  | 0.0       | 1.912E-07  | 1.912E-07   | 1824       | Vouzela                          |
+| nan     | affectedpop     | 19.1245       | 5.013E-04  | 0.0       | 1.912E-07  | 1.912E-07   | 1824       | Vouzela                          |
+| nan     | injured         | 21.6558       | 3.837E-06  | 0.0       | 1.109E-07  | 2.166E-07   | 1824       | Vouzela                          |
+| nan     | embodied_carbon | 1_046         | 15.3447    | 0.0       | 13.1627    | 46.9692     | 1824       | Vouzela                          |
+| nan     | contents        | 31_325        | 599.9      | 0.0       | 3.132E-04  | 0.0075      | 201        | Katihar                          |
+| nan     | structural      | 177_507       | 13_333     | 0.0       | 514.3      | 110_958     | 201        | Katihar                          |
+| nan     | occupants       | 0.8433        | 3.722E-04  | 0.0       | 8.433E-09  | 0.0030      | 201        | Katihar                          |
+| nan     | area            | 155.7081      | 9.0968     | 0.0       | 1.557E-06  | 71.3690     | 201        | Katihar                          |
+| nan     | number          | 0.9991        | 0.0584     | 0.0       | 9.991E-09  | 0.4579      | 201        | Katihar                          |
+| nan     | residents       | 1.5263        | 0.1033     | 0.0       | 1.526E-08  | 0.8208      | 201        | Katihar                          |
+| nan     | affectedpop     | 1.5263        | 0.1349     | 0.0       | 1.526E-08  | 1.0211      | 201        | Katihar                          |
+| nan     | injured         | 0.8433        | 0.0018     | 0.0       | 8.433E-09  | 0.0141      | 201        | Katihar                          |
+| nan     | embodied_carbon | 56.4238       | 3.5955     | 0.0       | 0.1576     | 16.5767     | 201        | Katihar                          |
+| nan     | contents        | 683_916       | 522.6      | 0.0       | 0.0068     | 0.0068      | 202        | Khagaria                         |
+| nan     | structural      | 3_781_642     | 20_758     | 0.0       | 13_213     | 70_256      | 202        | Khagaria                         |
+| nan     | occupants       | 15.0134       | 1.258E-07  | 0.0       | 1.501E-07  | 1.501E-07   | 202        | Khagaria                         |
+| nan     | area            | 3_339         | 0.0011     | 0.0       | 3.339E-05  | 3.339E-05   | 202        | Khagaria                         |
+| nan     | number          | 21.0458       | 7.073E-06  | 0.0       | 2.105E-07  | 2.105E-07   | 202        | Khagaria                         |
+| nan     | residents       | 17.4488       | 8.483E-06  | 0.0       | 1.745E-07  | 1.745E-07   | 202        | Khagaria                         |
+| nan     | affectedpop     | 17.4488       | 5.289E-05  | 0.0       | 1.745E-07  | 1.745E-07   | 202        | Khagaria                         |
+| nan     | injured         | 15.0134       | 1.258E-07  | 0.0       | 1.501E-07  | 1.501E-07   | 202        | Khagaria                         |
+| nan     | embodied_carbon | 1_037         | 13.9132    | 0.0       | 10.0467    | 43.8558     | 202        | Khagaria                         |
+| nan     | contents        | 47_813        | 31.7641    | 0.0       | 4.781E-04  | 4.781E-04   | 206        | Madhubani                        |
+| nan     | structural      | 191_251       | 9_652      | 0.0       | 6_619      | 28_044      | 206        | Madhubani                        |
+| nan     | occupants       | 5.0763        | 3.700E-08  | 0.0       | 5.076E-08  | 5.076E-08   | 206        | Madhubani                        |
+| nan     | area            | 186.4         | 1.172E-04  | 0.0       | 1.864E-06  | 1.864E-06   | 206        | Madhubani                        |
+| nan     | number          | 0.4442        | 2.793E-07  | 0.0       | 4.442E-09  | 4.442E-09   | 206        | Madhubani                        |
+| nan     | injured         | 5.0763        | 3.700E-08  | 0.0       | 5.076E-08  | 5.076E-08   | 206        | Madhubani                        |
+| nan     | embodied_carbon | 87.4231       | 3.6119     | 0.0       | 2.4701     | 10.7948     | 206        | Madhubani                        |
+| nan     | contents        | 295_967       | 1_218      | 0.0       | 0.0030     | 3.6619      | 209        | Nalanda                          |
+| nan     | structural      | 1_639_422     | 26_085     | 0.0       | 12_227     | 88_874      | 209        | Nalanda                          |
+| nan     | occupants       | 6.6186        | 3.396E-04  | 0.0       | 6.619E-08  | 4.503E-04   | 209        | Nalanda                          |
+| nan     | area            | 1_447         | 2.9579     | 0.0       | 1.447E-05  | 4.4236      | 209        | Nalanda                          |
+| nan     | number          | 10.0055       | 0.0252     | 0.0       | 1.001E-07  | 0.0402      | 209        | Nalanda                          |
+| nan     | residents       | 8.3600        | 0.0158     | 0.0       | 8.360E-08  | 0.0150      | 209        | Nalanda                          |
+| nan     | affectedpop     | 8.3600        | 0.0318     | 0.0       | 8.360E-08  | 0.0880      | 209        | Nalanda                          |
+| nan     | injured         | 6.6186        | 0.0010     | 0.0       | 6.619E-08  | 0.0020      | 209        | Nalanda                          |
+| nan     | embodied_carbon | 452.3         | 6.2374     | 0.0       | 2.5988     | 20.3312     | 209        | Nalanda                          |
+| nan     | contents        | 1_570_596     | 2_100      | 0.0       | 0.0157     | 0.2096      | 210        | Nawada                           |
+| nan     | structural      | 8_900_045     | 89_490     | 0.0       | 22_469     | 329_706     | 210        | Nawada                           |
+| nan     | occupants       | 26.6759       | 2.122E-04  | 0.0       | 2.668E-07  | 4.563E-04   | 210        | Nawada                           |
+| nan     | area            | 7_807         | 8.2608     | 0.0       | 7.807E-05  | 17.4616     | 210        | Nawada                           |
+| nan     | number          | 50.0952       | 0.0530     | 0.0       | 5.010E-07  | 0.1120      | 210        | Nawada                           |
+| nan     | residents       | 48.2802       | 0.0546     | 0.0       | 4.828E-07  | 0.1545      | 210        | Nawada                           |
+| nan     | affectedpop     | 48.2802       | 0.0684     | 0.0       | 4.828E-07  | 0.2959      | 210        | Nawada                           |
+| nan     | injured         | 26.6759       | 9.884E-04  | 0.0       | 2.668E-07  | 0.0025      | 210        | Nawada                           |
+| nan     | embodied_carbon | 2_343         | 22.4106    | 0.0       | 5.4738     | 85.6739     | 210        | Nawada                           |
+| nan     | contents        | 180_481       | 10_965     | 0.0       | 0.0013     | 122_652     | 211        | Pashchim Champaran               |
+| nan     | structural      | 1_022_722     | 80_665     | 527.7     | 5_716      | 617_054     | 211        | Pashchim Champaran               |
+| nan     | occupants       | 4.6342        | 0.0172     | 1.228E-08 | 4.634E-08  | 0.1470      | 211        | Pashchim Champaran               |
+| nan     | area            | 897.1         | 58.4221    | 2.737E-06 | 0.1880     | 443.1       | 211        | Pashchim Champaran               |
+| nan     | number          | 5.9884        | 0.3814     | 1.988E-08 | 0.0014     | 2.8447      | 211        | Pashchim Champaran               |
+| nan     | residents       | 8.3876        | 0.6460     | 2.223E-08 | 0.0015     | 4.9066      | 211        | Pashchim Champaran               |
+| nan     | affectedpop     | 8.3876        | 0.8013     | 2.223E-08 | 0.0044     | 5.6139      | 211        | Pashchim Champaran               |
+| nan     | injured         | 4.6342        | 0.0114     | 1.228E-08 | 4.634E-08  | 0.0856      | 211        | Pashchim Champaran               |
+| nan     | embodied_carbon | 298.1         | 22.6618    | 0.1407    | 1.7439     | 166.9484    | 211        | Pashchim Champaran               |
+| nan     | contents        | 113_292       | 2_439      | 3.028E-19 | 8.254E-04  | 16_739      | 213        | Purbi Champaran                  |
+| nan     | structural      | 641_992       | 28_887     | 163.0427  | 1_843      | 107_396     | 213        | Purbi Champaran                  |
+| nan     | occupants       | 2.4460        | 0.0040     | 6.255E-09 | 2.446E-08  | 0.0125      | 213        | Purbi Champaran                  |
+| nan     | area            | 563.2         | 19.9796    | 1.528E-06 | 0.0090     | 80.8718     | 213        | Purbi Champaran                  |
+| nan     | number          | 3.9613        | 0.1378     | 9.808E-09 | 6.518E-05  | 0.5227      | 213        | Purbi Champaran                  |
+| nan     | residents       | 4.4270        | 0.1817     | 1.132E-08 | 7.233E-05  | 0.6927      | 213        | Purbi Champaran                  |
+| nan     | affectedpop     | 4.4270        | 0.2426     | 1.132E-08 | 5.486E-04  | 0.8358      | 213        | Purbi Champaran                  |
+| nan     | injured         | 2.4460        | 0.0034     | 6.255E-09 | 2.446E-08  | 0.0120      | 213        | Purbi Champaran                  |
+| nan     | embodied_carbon | 179.7468      | 7.9615     | 0.0402    | 0.5171     | 32.3743     | 213        | Purbi Champaran                  |
+| nan     | contents        | 39_500        | 12.3937    | 0.0       | 0.0        | 10.3630     | 301        | Sonitpur                         |
+| nan     | structural      | 157_999       | 6_125      | 0.0       | 0.0        | 27_783      | 301        | Sonitpur                         |
+| nan     | occupants       | 2.3600        | 2.291E-05  | 0.0       | 0.0        | 2.360E-08   | 301        | Sonitpur                         |
+| nan     | area            | 153.9952      | 0.0564     | 0.0       | 0.0        | 0.0169      | 301        | Sonitpur                         |
+| nan     | number          | 0.3255        | 1.193E-04  | 0.0       | 0.0        | 3.565E-05   | 301        | Sonitpur                         |
+| nan     | injured         | 2.3600        | 2.979E-05  | 0.0       | 0.0        | 2.360E-08   | 301        | Sonitpur                         |
+| nan     | embodied_carbon | 66.8527       | 2.1489     | 0.0       | 0.0        | 9.6458      | 301        | Sonitpur                         |
+| nan     | contents        | 4_212_693     | 18_085     | 0.0       | 0.0328     | 17_023      | 302        | Tinsukia                         |
+| nan     | structural      | 23_089_098    | 385_934    | 0.0       | 120_063    | 1_258_827   | 302        | Tinsukia                         |
+| nan     | occupants       | 265.1         | 0.0231     | 0.0       | 2.214E-06  | 0.0424      | 302        | Tinsukia                         |
+| nan     | area            | 20_437        | 188.5      | 0.0       | 1.759E-04  | 347.8       | 302        | Tinsukia                         |
+| nan     | number          | 127.3476      | 1.3649     | 0.0       | 1.130E-06  | 2.5261      | 302        | Tinsukia                         |
+| nan     | residents       | 404.8         | 5.2141     | 0.0       | 3.775E-06  | 13.4822     | 302        | Tinsukia                         |
+| nan     | affectedpop     | 404.8         | 7.0191     | 0.0       | 3.775E-06  | 26.8005     | 302        | Tinsukia                         |
+| nan     | injured         | 265.1         | 0.1000     | 0.0       | 2.214E-06  | 0.2420      | 302        | Tinsukia                         |
+| nan     | embodied_carbon | 7_353         | 120.3207   | 0.0       | 42.0278    | 361.1       | 302        | Tinsukia                         |
+| nan     | contents        | 2_794_246     | 1_463      | 0.0       | 0.0055     | 31.3973     | 303        | 24 Paraganas North               |
+| nan     | structural      | 12_132_778    | 106_608    | 0.0       | 71_966     | 383_008     | 303        | 24 Paraganas North               |
+| nan     | occupants       | 231.0         | 0.0016     | 0.0       | 6.449E-07  | 0.0034      | 303        | 24 Paraganas North               |
+| nan     | area            | 8_686         | 7.4820     | 0.0       | 2.988E-05  | 14.8108     | 303        | 24 Paraganas North               |
+| nan     | number          | 31.2931       | 0.0498     | 0.0       | 1.888E-07  | 0.1065      | 303        | 24 Paraganas North               |
+| nan     | residents       | 34.6998       | 0.1576     | 0.0       | 3.125E-07  | 0.3383      | 303        | 24 Paraganas North               |
+| nan     | affectedpop     | 34.6998       | 0.3090     | 0.0       | 3.125E-07  | 1.5486      | 303        | 24 Paraganas North               |
+| nan     | injured         | 231.0         | 0.0026     | 0.0       | 6.449E-07  | 0.0050      | 303        | 24 Paraganas North               |
+| nan     | embodied_carbon | 3_711         | 21.1253    | 0.0       | 14.5428    | 72.0255     | 303        | 24 Paraganas North               |
+| nan     | contents        | 31_933        | 340.3      | 0.0       | 0.0        | 3.193E-04   | 305        | Bankura                          |
+| nan     | structural      | 180_955       | 3_098      | 0.0       | 204.1      | 11_568      | 305        | Bankura                          |
+| nan     | occupants       | 0.8308        | 5.180E-04  | 0.0       | 8.308E-09  | 0.0018      | 305        | Bankura                          |
+| nan     | area            | 158.7322      | 1.6172     | 0.0       | 1.587E-06  | 5.4560      | 305        | Bankura                          |
+| nan     | number          | 1.0185        | 0.0104     | 0.0       | 1.018E-08  | 0.0350      | 305        | Bankura                          |
+| nan     | residents       | 1.5028        | 0.0210     | 0.0       | 1.503E-08  | 0.0812      | 305        | Bankura                          |
+| nan     | affectedpop     | 1.5028        | 0.0376     | 0.0       | 1.503E-08  | 0.1834      | 305        | Bankura                          |
+| nan     | injured         | 0.8308        | 3.422E-04  | 0.0       | 8.308E-09  | 0.0013      | 305        | Bankura                          |
+| nan     | embodied_carbon | 50.6431       | 0.8237     | 0.0       | 0.0453     | 3.4634      | 305        | Bankura                          |
+| nan     | contents        | 233_416       | 732.9      | 0.0       | 0.0011     | 0.0923      | 306        | Purba Bardhaman                  |
+| nan     | structural      | 1_144_644     | 23_675     | 0.0       | 12_287     | 103_954     | 306        | Purba Bardhaman                  |
+| nan     | occupants       | 15.4956       | 0.0019     | 0.0       | 1.050E-07  | 0.0044      | 306        | Purba Bardhaman                  |
+| nan     | area            | 1_046         | 4.4679     | 0.0       | 8.379E-06  | 17.8867     | 306        | Purba Bardhaman                  |
+| nan     | number          | 4.9719        | 0.0212     | 0.0       | 3.974E-08  | 0.0854      | 306        | Purba Bardhaman                  |
+| nan     | residents       | 9.0470        | 0.0563     | 0.0       | 6.059E-08  | 0.3497      | 306        | Purba Bardhaman                  |
+| nan     | affectedpop     | 9.0470        | 0.1414     | 0.0       | 9.047E-08  | 1.2187      | 306        | Purba Bardhaman                  |
+| nan     | injured         | 15.4956       | 0.0026     | 0.0       | 1.043E-07  | 0.0067      | 306        | Purba Bardhaman                  |
+| nan     | embodied_carbon | 389.7         | 7.1308     | 0.0       | 4.2583     | 24.0988     | 306        | Purba Bardhaman                  |
+| nan     | contents        | 1_193_401     | 824.2      | 0.0       | 0.0088     | 50.7597     | 307        | Birbhum                          |
+| nan     | structural      | 6_368_020     | 124_341    | 0.0       | 77_481     | 448_653     | 307        | Birbhum                          |
+| nan     | occupants       | 54.1495       | 3.945E-04  | 0.0       | 2.949E-07  | 0.0020      | 307        | Birbhum                          |
+| nan     | area            | 5_788         | 5.1211     | 0.0       | 4.553E-05  | 22.3425     | 307        | Birbhum                          |
+| nan     | number          | 35.4939       | 0.0325     | 0.0       | 3.248E-07  | 0.1484      | 307        | Birbhum                          |
+| nan     | residents       | 56.4040       | 0.0720     | 0.0       | 5.131E-07  | 0.1167      | 307        | Birbhum                          |
+| nan     | affectedpop     | 56.4040       | 0.0984     | 0.0       | 5.131E-07  | 0.2093      | 307        | Birbhum                          |
+| nan     | injured         | 54.1495       | 0.0018     | 0.0       | 2.951E-07  | 0.0105      | 307        | Birbhum                          |
+| nan     | embodied_carbon | 1_900         | 37.2661    | 0.0       | 22.6762    | 140.2921    | 307        | Birbhum                          |
+| nan     | contents        | 2_542_273     | 17_903     | 0.0       | 0.0125     | 712.5       | 308        | Coochbehar                       |
+| nan     | structural      | 9_312_110     | 283_344    | 0.0       | 86_651     | 801_278     | 308        | Coochbehar                       |
+| nan     | occupants       | 85.0239       | 0.0115     | 0.0       | 7.237E-07  | 0.0897      | 308        | Coochbehar                       |
+| nan     | area            | 8_991         | 103.2388   | 0.0       | 5.382E-05  | 273.8       | 308        | Coochbehar                       |
+| nan     | number          | 43.0878       | 0.7359     | 0.0       | 3.558E-07  | 1.5306      | 308        | Coochbehar                       |
+| nan     | residents       | 81.2327       | 2.1401     | 0.0       | 7.210E-07  | 6.4645      | 308        | Coochbehar                       |
+| nan     | affectedpop     | 81.2327       | 2.6917     | 0.0       | 7.210E-07  | 8.1047      | 308        | Coochbehar                       |
+| nan     | injured         | 85.0239       | 0.0415     | 0.0       | 7.237E-07  | 0.1230      | 308        | Coochbehar                       |
+| nan     | embodied_carbon | 3_097         | 73.0918    | 0.0       | 28.3213    | 288.3       | 308        | Coochbehar                       |
+| nan     | contents        | 329_375       | 2_509      | 0.0       | 2.483E-04  | 2.3950      | 309        | Darjeeling                       |
+| nan     | structural      | 1_825_067     | 25_694     | 0.0       | 3_544      | 80_477      | 309        | Darjeeling                       |
+| nan     | occupants       | 13.6299       | 0.0010     | 0.0       | 1.221E-07  | 0.0020      | 309        | Darjeeling                       |
+| nan     | area            | 1_611         | 13.9782    | 0.0       | 1.514E-05  | 26.4956     | 309        | Darjeeling                       |
+| nan     | number          | 11.2009       | 0.1015     | 0.0       | 1.100E-07  | 0.1925      | 309        | Darjeeling                       |
+| nan     | residents       | 22.0994       | 0.2558     | 0.0       | 2.210E-07  | 0.6393      | 309        | Darjeeling                       |
+| nan     | affectedpop     | 22.0994       | 0.3695     | 0.0       | 2.210E-07  | 1.4278      | 309        | Darjeeling                       |
+| nan     | injured         | 13.6299       | 0.0048     | 0.0       | 1.221E-07  | 0.0108      | 309        | Darjeeling                       |
+| nan     | embodied_carbon | 590.9         | 10.6281    | 0.0       | 1.6200     | 28.1124     | 309        | Darjeeling                       |
+| nan     | contents        | 17_402        | 34.3439    | 0.0       | 0.0        | 241.0       | 310        | Dinajpur Dakshin                 |
+| nan     | structural      | 69_610        | 2_433      | 0.0       | 1_463      | 9_181       | 310        | Dinajpur Dakshin                 |
+| nan     | occupants       | 3.1400        | 1.643E-08  | 0.0       | 3.140E-08  | 3.140E-08   | 310        | Dinajpur Dakshin                 |
+| nan     | area            | 76.3263       | 9.133E-05  | 0.0       | 7.633E-07  | 7.633E-07   | 310        | Dinajpur Dakshin                 |
+| nan     | number          | 0.3518        | 4.210E-07  | 0.0       | 3.518E-09  | 3.518E-09   | 310        | Dinajpur Dakshin                 |
+| nan     | injured         | 3.1400        | 1.822E-07  | 0.0       | 3.140E-08  | 3.140E-08   | 310        | Dinajpur Dakshin                 |
+| nan     | embodied_carbon | 33.0408       | 0.9346     | 0.0       | 0.5382     | 3.6023      | 310        | Dinajpur Dakshin                 |
+| nan     | contents        | 99_663        | 3.8274     | 0.0       | 3.160E-04  | 9.966E-04   | 311        | Dinajpur Uttar                   |
+| nan     | structural      | 564_757       | 5_394      | 0.0       | 749.7      | 24_305      | 311        | Dinajpur Uttar                   |
+| nan     | occupants       | 2.8434        | 9.357E-07  | 0.0       | 5.234E-09  | 2.843E-08   | 311        | Dinajpur Uttar                   |
+| nan     | area            | 495.4         | 0.0266     | 0.0       | 1.571E-06  | 4.954E-06   | 311        | Dinajpur Uttar                   |
+| nan     | number          | 1.5246        | 4.707E-05  | 0.0       | 1.008E-08  | 1.525E-08   | 311        | Dinajpur Uttar                   |
+| nan     | residents       | 5.1445        | 4.604E-04  | 0.0       | 9.473E-09  | 5.144E-08   | 311        | Dinajpur Uttar                   |
+| nan     | affectedpop     | 5.1445        | 0.0023     | 0.0       | 9.473E-09  | 5.144E-08   | 311        | Dinajpur Uttar                   |
+| nan     | injured         | 2.8434        | 6.065E-06  | 0.0       | 5.234E-09  | 2.843E-08   | 311        | Dinajpur Uttar                   |
+| nan     | embodied_carbon | 148.5405      | 1.0589     | 0.0       | 0.1848     | 4.8212      | 311        | Dinajpur Uttar                   |
+| nan     | contents        | 1_070_039     | 1_968      | 0.0       | 0.0068     | 250.1       | 312        | Hooghly                          |
+| nan     | structural      | 5_827_472     | 57_059     | 0.0       | 23_150     | 230_597     | 312        | Hooghly                          |
+| nan     | occupants       | 53.9320       | 0.0025     | 0.0       | 3.774E-07  | 0.0105      | 312        | Hooghly                          |
+| nan     | area            | 5_203         | 13.4637    | 0.0       | 3.728E-05  | 53.2233     | 312        | Hooghly                          |
+| nan     | number          | 34.1601       | 0.0879     | 0.0       | 2.543E-07  | 0.3539      | 312        | Hooghly                          |
+| nan     | residents       | 72.3564       | 0.2233     | 0.0       | 5.403E-07  | 1.2324      | 312        | Hooghly                          |
+| nan     | affectedpop     | 72.3564       | 0.3211     | 0.0       | 5.403E-07  | 1.8204      | 312        | Hooghly                          |
+| nan     | injured         | 53.9320       | 0.0040     | 0.0       | 3.774E-07  | 0.0176      | 312        | Hooghly                          |
+| nan     | embodied_carbon | 1_660         | 20.8788    | 0.0       | 10.4568    | 92.3638     | 312        | Hooghly                          |
+| nan     | contents        | 1_944_459     | 3_950      | 0.0       | 0.0141     | 2.2889      | 313        | Howrah                           |
+| nan     | structural      | 10_767_553    | 152_833    | 0.0       | 76_040     | 439_524     | 313        | Howrah                           |
+| nan     | occupants       | 92.3295       | 0.0020     | 0.0       | 7.093E-07  | 3.647E-04   | 313        | Howrah                           |
+| nan     | area            | 9_504         | 23.2860    | 0.0       | 8.962E-05  | 7.7850      | 313        | Howrah                           |
+| nan     | number          | 63.2854       | 0.1531     | 0.0       | 6.215E-07  | 0.0515      | 313        | Howrah                           |
+| nan     | residents       | 127.2377      | 0.3569     | 0.0       | 1.272E-06  | 0.1397      | 313        | Howrah                           |
+| nan     | affectedpop     | 127.2377      | 0.5208     | 0.0       | 1.272E-06  | 0.8938      | 313        | Howrah                           |
+| nan     | injured         | 92.3295       | 0.0061     | 0.0       | 7.093E-07  | 0.0021      | 313        | Howrah                           |
+| nan     | embodied_carbon | 3_073         | 33.8301    | 0.0       | 13.9540    | 97.7045     | 313        | Howrah                           |
+| nan     | contents        | 208_060       | 472.9      | 0.0       | 0.0017     | 0.0021      | 401        | Datia                            |
+| nan     | structural      | 896_696       | 20_925     | 0.0       | 6_964      | 80_208      | 401        | Datia                            |
+| nan     | occupants       | 18.5046       | 0.0012     | 0.0       | 1.770E-07  | 0.0027      | 401        | Datia                            |
+| nan     | area            | 852.6         | 3.9284     | 0.0       | 6.604E-06  | 8.5957      | 401        | Datia                            |
+| nan     | number          | 4.6262        | 0.0285     | 0.0       | 3.230E-08  | 0.0624      | 401        | Datia                            |
+| nan     | residents       | 1.4551        | 0.0337     | 0.0       | 0.0        | 0.1574      | 401        | Datia                            |
+| nan     | affectedpop     | 1.4551        | 0.0419     | 0.0       | 0.0        | 0.2668      | 401        | Datia                            |
+| nan     | injured         | 18.5046       | 6.705E-04  | 0.0       | 1.770E-07  | 0.0017      | 401        | Datia                            |
+| nan     | embodied_carbon | 347.2         | 6.7749     | 0.0       | 2.6633     | 25.9867     | 401        | Datia                            |
+| nan     | contents        | 2_007_762     | 1_233      | 0.0       | 0.0041     | 0.2011      | 402        | Dewas                            |
+| nan     | structural      | 8_718_749     | 236_726    | 0.0       | 60_632     | 988_044     | 402        | Dewas                            |
+| nan     | occupants       | 134.0586      | 8.348E-04  | 0.0       | 7.063E-08  | 1.341E-06   | 402        | Dewas                            |
+| nan     | area            | 6_285         | 5.7503     | 0.0       | 1.578E-05  | 1.9071      | 402        | Dewas                            |
+| nan     | number          | 17.4366       | 0.0350     | 0.0       | 1.012E-07  | 0.0122      | 402        | Dewas                            |
+| nan     | residents       | 13.0611       | 0.0650     | 0.0       | 1.306E-07  | 0.0250      | 402        | Dewas                            |
+| nan     | affectedpop     | 13.0611       | 0.1395     | 0.0       | 1.306E-07  | 0.2249      | 402        | Dewas                            |
+| nan     | injured         | 134.0586      | 0.0012     | 0.0       | 7.063E-08  | 1.341E-06   | 402        | Dewas                            |
+| nan     | embodied_carbon | 2_669         | 62.8135    | 0.0       | 8.5719     | 300.4       | 402        | Dewas                            |
+| nan     | contents        | 470_021       | 98.8955    | 0.0       | 8.873E-04  | 2.3379      | 405        | East Nimar                       |
+| nan     | structural      | 2_515_574     | 62_539     | 0.0       | 37_714     | 155_263     | 405        | East Nimar                       |
+| nan     | occupants       | 13.8077       | 8.481E-04  | 0.0       | 1.381E-07  | 1.381E-07   | 405        | East Nimar                       |
+| nan     | area            | 2_241         | 8.7513     | 0.0       | 2.241E-05  | 0.8905      | 405        | East Nimar                       |
+| nan     | number          | 14.7462       | 0.0634     | 0.0       | 1.475E-07  | 0.0065      | 405        | East Nimar                       |
+| nan     | residents       | 11.1474       | 0.0760     | 0.0       | 1.115E-07  | 0.0052      | 405        | East Nimar                       |
+| nan     | affectedpop     | 11.1474       | 0.1497     | 0.0       | 1.115E-07  | 0.0165      | 405        | East Nimar                       |
+| nan     | injured         | 13.8077       | 0.0012     | 0.0       | 1.381E-07  | 1.381E-07   | 405        | East Nimar                       |
+| nan     | embodied_carbon | 717.6         | 13.0591    | 0.0       | 6.9160     | 30.3493     | 405        | East Nimar                       |
+| nan     | contents        | 5_703         | 21.6294    | 0.0       | 5.703E-05  | 5.703E-05   | 407        | Gwalior                          |
+| nan     | structural      | 22_811        | 598.1      | 0.0       | 211.5      | 2_457       | 407        | Gwalior                          |
+| nan     | occupants       | 0.9700        | 1.077E-04  | 0.0       | 9.700E-09  | 9.700E-09   | 407        | Gwalior                          |
+| nan     | area            | 22.2327       | 0.0840     | 0.0       | 2.223E-07  | 2.223E-07   | 407        | Gwalior                          |
+| nan     | number          | 0.1025        | 3.873E-04  | 0.0       | 1.025E-09  | 1.025E-09   | 407        | Gwalior                          |
+| nan     | injured         | 0.9700        | 1.256E-04  | 0.0       | 9.700E-09  | 9.700E-09   | 407        | Gwalior                          |
+| nan     | embodied_carbon | 9.6263        | 0.1984     | 0.0       | 0.0752     | 0.7691      | 407        | Gwalior                          |
+| nan     | contents        | 432_934       | 1_385      | 0.0       | 0.0013     | 37.7384     | 408        | Harda                            |
+| nan     | structural      | 2_453_292     | 26_392     | 0.0       | 6_672      | 97_248      | 408        | Harda                            |
+| nan     | occupants       | 8.7727        | 6.859E-04  | 0.0       | 2.603E-08  | 0.0019      | 408        | Harda                            |
+| nan     | area            | 2_152         | 14.7344    | 0.0       | 9.449E-06  | 34.9640     | 408        | Harda                            |
+| nan     | number          | 12.8435       | 0.0776     | 0.0       | 5.317E-08  | 0.1679      | 408        | Harda                            |
+| nan     | residents       | 15.8756       | 0.1431     | 0.0       | 7.524E-08  | 0.3801      | 408        | Harda                            |
+| nan     | affectedpop     | 15.8756       | 0.1851     | 0.0       | 7.524E-08  | 0.6344      | 408        | Harda                            |
+| nan     | injured         | 8.7727        | 0.0027     | 0.0       | 2.603E-08  | 0.0076      | 408        | Harda                            |
+| nan     | embodied_carbon | 708.4         | 8.7466     | 0.0       | 1.7781     | 39.6133     | 408        | Harda                            |
+| nan     | contents        | 389_521       | 8_295      | 0.0       | 0.0039     | 1.5560      | 410        | Indore                           |
+| nan     | structural      | 2_207_290     | 25_731     | 0.0       | 3_279      | 28_443      | 410        | Indore                           |
+| nan     | occupants       | 6.7657        | 5.117E-04  | 0.0       | 6.766E-08  | 6.766E-08   | 410        | Indore                           |
+| nan     | area            | 1_936         | 15.7881    | 0.0       | 1.936E-05  | 2.5173      | 410        | Indore                           |
+| nan     | number          | 14.0646       | 0.1147     | 0.0       | 1.406E-07  | 0.0183      | 410        | Indore                           |
+| nan     | residents       | 12.2452       | 0.1229     | 0.0       | 1.225E-07  | 0.0162      | 410        | Indore                           |
+| nan     | affectedpop     | 12.2452       | 0.1678     | 0.0       | 1.225E-07  | 0.0487      | 410        | Indore                           |
+| nan     | injured         | 6.7657        | 0.0023     | 0.0       | 6.766E-08  | 2.309E-04   | 410        | Indore                           |
+| nan     | embodied_carbon | 624.1         | 6.1823     | 0.0       | 0.9403     | 8.3457      | 410        | Indore                           |
+| nan     | contents        | 27_572        | 142.8802   | 0.0       | 2.757E-04  | 2.757E-04   | 411        | Jabalpur                         |
+| nan     | structural      | 156_239       | 2_801      | 0.0       | 280.8      | 12_218      | 411        | Jabalpur                         |
+| nan     | occupants       | 0.5334        | 5.808E-05  | 0.0       | 5.334E-09  | 1.786E-04   | 411        | Jabalpur                         |
+| nan     | area            | 137.0517      | 1.6052     | 0.0       | 1.371E-06  | 4.9048      | 411        | Jabalpur                         |
+| nan     | number          | 0.9955        | 0.0117     | 0.0       | 9.955E-09  | 0.0356      | 411        | Jabalpur                         |
+| nan     | residents       | 0.9655        | 0.0141     | 0.0       | 9.655E-09  | 0.0538      | 411        | Jabalpur                         |
+| nan     | affectedpop     | 0.9655        | 0.0200     | 0.0       | 9.655E-09  | 0.1092      | 411        | Jabalpur                         |
+| nan     | injured         | 0.5334        | 2.656E-04  | 0.0       | 5.334E-09  | 9.320E-04   | 411        | Jabalpur                         |
+| nan     | embodied_carbon | 43.7529       | 0.7673     | 0.0       | 0.0808     | 3.6526      | 411        | Jabalpur                         |
+| nan     | contents        | 32_437        | 139.7528   | 0.0       | 3.244E-04  | 3.244E-04   | 412        | Jhabua                           |
+| nan     | structural      | 183_810       | 1_514      | 0.0       | 114.0771   | 1_402       | 412        | Jhabua                           |
+| nan     | occupants       | 0.4709        | 2.111E-05  | 0.0       | 4.709E-09  | 4.709E-09   | 412        | Jhabua                           |
+| nan     | area            | 161.2371      | 0.9659     | 0.0       | 1.612E-06  | 0.0192      | 412        | Jhabua                           |
+| nan     | number          | 1.0346        | 0.0062     | 0.0       | 1.035E-08  | 1.235E-04   | 412        | Jhabua                           |
+| nan     | residents       | 0.8523        | 0.0059     | 0.0       | 8.523E-09  | 1.014E-04   | 412        | Jhabua                           |
+| nan     | affectedpop     | 0.8523        | 0.0081     | 0.0       | 8.523E-09  | 5.754E-04   | 412        | Jhabua                           |
+| nan     | injured         | 0.4709        | 1.039E-04  | 0.0       | 4.709E-09  | 4.709E-09   | 412        | Jhabua                           |
+| nan     | embodied_carbon | 58.4272       | 0.5005     | 0.0       | 0.0312     | 0.4576      | 412        | Jhabua                           |
+| nan     | contents        | 61_274        | 3.796E-04  | 0.0       | 6.127E-04  | 6.127E-04   | 501        | Adilabad                         |
+| nan     | structural      | 347_217       | 2_532      | 0.0       | 1_379      | 8_860       | 501        | Adilabad                         |
+| nan     | occupants       | 1.2600        | 8.695E-06  | 0.0       | 1.260E-08  | 1.260E-08   | 501        | Adilabad                         |
+| nan     | area            | 304.6         | 0.0752     | 0.0       | 3.046E-06  | 3.046E-06   | 501        | Adilabad                         |
+| nan     | number          | 1.9543        | 4.822E-04  | 0.0       | 1.954E-08  | 1.954E-08   | 501        | Adilabad                         |
+| nan     | residents       | 2.2800        | 8.113E-04  | 0.0       | 2.280E-08  | 2.280E-08   | 501        | Adilabad                         |
+| nan     | affectedpop     | 2.2800        | 0.0019     | 0.0       | 2.280E-08  | 2.280E-08   | 501        | Adilabad                         |
+| nan     | injured         | 1.2600        | 1.032E-05  | 0.0       | 1.260E-08  | 1.260E-08   | 501        | Adilabad                         |
+| nan     | embodied_carbon | 91.1614       | 0.4445     | 0.0       | 0.2042     | 1.6169      | 501        | Adilabad                         |
+| nan     | contents        | 1_342_213     | 2_421      | 0.0       | 0.0116     | 0.0926      | 503        | Chittoor                         |
+| nan     | structural      | 7_560_317     | 119_142    | 0.0       | 34_707     | 159_187     | 503        | Chittoor                         |
+| nan     | occupants       | 37.9473       | 0.0038     | 0.0       | 3.671E-07  | 0.0012      | 503        | Chittoor                         |
+| nan     | area            | 6_038         | 63.1011    | 0.0       | 6.038E-05  | 24.7853     | 503        | Chittoor                         |
+| nan     | number          | 43.6028       | 0.4584     | 0.0       | 4.360E-07  | 0.1800      | 503        | Chittoor                         |
+| nan     | residents       | 65.9162       | 0.8866     | 0.0       | 6.592E-07  | 0.3783      | 503        | Chittoor                         |
+| nan     | affectedpop     | 65.9162       | 1.1694     | 0.0       | 6.592E-07  | 0.9921      | 503        | Chittoor                         |
+| nan     | injured         | 37.9473       | 0.0167     | 0.0       | 3.795E-07  | 0.0082      | 503        | Chittoor                         |
+| nan     | embodied_carbon | 2_151         | 40.3781    | 0.0       | 7.8854     | 43.4416     | 503        | Chittoor                         |
+| nan     | contents        | 2_880_514     | 1_320      | 5.687E-39 | 0.0035     | 197.7       | 504        | Y.S.R.                           |
+| nan     | structural      | 16_322_907    | 394_670    | 382.5     | 368_712    | 1_009_458   | 504        | Y.S.R.                           |
+| nan     | occupants       | 111.5704      | 6.983E-04  | 1.333E-08 | 1.096E-06  | 0.0012      | 504        | Y.S.R.                           |
+| nan     | area            | 14_318        | 16.5246    | 4.441E-06 | 1.432E-04  | 46.6551     | 504        | Y.S.R.                           |
+| nan     | number          | 24.7422       | 0.1106     | 2.850E-08 | 2.474E-07  | 0.2922      | 504        | Y.S.R.                           |
+| nan     | residents       | 201.9         | 0.1891     | 2.413E-08 | 2.019E-06  | 0.7653      | 504        | Y.S.R.                           |
+| nan     | affectedpop     | 201.9         | 0.3712     | 2.413E-08 | 2.019E-06  | 1.3232      | 504        | Y.S.R.                           |
+| nan     | injured         | 111.5704      | 0.0032     | 1.333E-08 | 1.096E-06  | 0.0071      | 504        | Y.S.R.                           |
+| nan     | embodied_carbon | 4_319         | 70.3233    | 0.0788    | 58.9545    | 214.5       | 504        | Y.S.R.                           |
+| nan     | contents        | 257_366       | 319.0      | 0.0       | 2.775E-04  | 49.2743     | 505        | East Godavari                    |
+| nan     | structural      | 1_458_412     | 39_271     | 0.0       | 30_032     | 142_103     | 505        | East Godavari                    |
+| nan     | occupants       | 2.8662        | 8.657E-06  | 0.0       | 2.866E-08  | 2.866E-08   | 505        | East Godavari                    |
+| nan     | area            | 1_279         | 0.5554     | 0.0       | 1.279E-05  | 1.1449      | 505        | East Godavari                    |
+| nan     | number          | 6.4823        | 0.0027     | 0.0       | 6.482E-08  | 0.0055      | 505        | East Godavari                    |
+| nan     | residents       | 5.1832        | 0.0030     | 0.0       | 5.183E-08  | 0.0044      | 505        | East Godavari                    |
+| nan     | affectedpop     | 5.1832        | 0.0096     | 0.0       | 5.183E-08  | 0.0146      | 505        | East Godavari                    |
+| nan     | injured         | 2.8662        | 4.366E-05  | 0.0       | 2.866E-08  | 2.866E-08   | 505        | East Godavari                    |
+| nan     | embodied_carbon | 383.5         | 7.9658     | 0.0       | 5.6041     | 32.0734     | 505        | East Godavari                    |
+| nan     | contents        | 45_417        | 310.0      | 0.0       | 2.775E-04  | 340.2       | 506        | Guntur                           |
+| nan     | structural      | 257_365       | 7_396      | 0.0       | 1_868      | 42_304      | 506        | Guntur                           |
+| nan     | occupants       | 0.6118        | 1.008E-04  | 0.0       | 6.118E-09  | 0.0012      | 506        | Guntur                           |
+| nan     | area            | 225.8         | 3.0797     | 0.0       | 2.258E-06  | 21.3817     | 506        | Guntur                           |
+| nan     | number          | 1.6399        | 0.0224     | 0.0       | 1.640E-08  | 0.1553      | 506        | Guntur                           |
+| nan     | residents       | 1.1090        | 0.0202     | 0.0       | 1.109E-08  | 0.1176      | 506        | Guntur                           |
+| nan     | affectedpop     | 1.1090        | 0.0298     | 0.0       | 1.109E-08  | 0.2063      | 506        | Guntur                           |
+| nan     | injured         | 0.6118        | 3.765E-04  | 0.0       | 6.118E-09  | 0.0020      | 506        | Guntur                           |
+| nan     | embodied_carbon | 70.3458       | 1.6307     | 0.0       | 0.3716     | 8.8391      | 506        | Guntur                           |
+| nan     | contents        | 73_285        | 389.4      | 0.0       | 7.328E-04  | 7.328E-04   | 507        | Hyderabad                        |
+| nan     | structural      | 415_280       | 5_676      | 0.0       | 986.8      | 12_867      | 507        | Hyderabad                        |
+| nan     | occupants       | 0.8732        | 7.638E-05  | 0.0       | 8.732E-09  | 1.323E-05   | 507        | Hyderabad                        |
+| nan     | area            | 364.3         | 2.4504     | 0.0       | 3.643E-06  | 1.2466      | 507        | Hyderabad                        |
+| nan     | number          | 2.4543        | 0.0174     | 0.0       | 2.454E-08  | 0.0091      | 507        | Hyderabad                        |
+| nan     | residents       | 1.5800        | 0.0115     | 0.0       | 1.580E-08  | 0.0068      | 507        | Hyderabad                        |
+| nan     | affectedpop     | 1.5800        | 0.0160     | 0.0       | 1.580E-08  | 0.0171      | 507        | Hyderabad                        |
+| nan     | injured         | 0.8732        | 2.131E-04  | 0.0       | 8.732E-09  | 1.324E-04   | 507        | Hyderabad                        |
+| nan     | embodied_carbon | 117.7554      | 1.4050     | 0.0       | 0.2063     | 2.8889      | 507        | Hyderabad                        |
+| nan     | contents        | 812_011       | 2_849      | 0.0       | 0.0058     | 0.0652      | 509        | Khammam                          |
+| nan     | structural      | 4_601_397     | 138_699    | 0.0       | 18_316     | 743_936     | 509        | Khammam                          |
+| nan     | occupants       | 15.9760       | 0.0029     | 0.0       | 1.532E-07  | 0.0141      | 509        | Khammam                          |
+| nan     | area            | 4_036         | 79.8081    | 0.0       | 4.036E-05  | 383.7       | 509        | Khammam                          |
+| nan     | number          | 29.0576       | 0.5797     | 0.0       | 2.906E-07  | 2.7870      | 509        | Khammam                          |
+| nan     | residents       | 28.9154       | 0.6988     | 0.0       | 2.892E-07  | 3.6772      | 509        | Khammam                          |
+| nan     | affectedpop     | 28.9154       | 0.9621     | 0.0       | 0.0020     | 5.8926      | 509        | Khammam                          |
+| nan     | injured         | 15.9760       | 0.0132     | 0.0       | 1.532E-07  | 0.0666      | 509        | Khammam                          |
+| nan     | embodied_carbon | 1_408         | 40.4484    | 0.0       | 6.0288     | 178.2703    | 509        | Khammam                          |
+| nan     | contents        | 156_655       | 1_280      | 0.0       | 0.0016     | 0.0016      | 511        | Kurnool                          |
+| nan     | structural      | 887_709       | 22_785     | 0.0       | 1_581      | 70_820      | 511        | Kurnool                          |
+| nan     | occupants       | 2.1631        | 3.212E-04  | 0.0       | 2.163E-08  | 7.423E-04   | 511        | Kurnool                          |
+| nan     | area            | 778.7         | 15.2834    | 0.0       | 7.787E-06  | 35.7097     | 511        | Kurnool                          |
+| nan     | number          | 4.9966        | 0.0981     | 0.0       | 4.997E-08  | 0.2291      | 511        | Kurnool                          |
+| nan     | residents       | 3.9150        | 0.0846     | 0.0       | 3.915E-08  | 0.2603      | 511        | Kurnool                          |
+| nan     | affectedpop     | 3.9150        | 0.1035     | 0.0       | 3.915E-08  | 0.5147      | 511        | Kurnool                          |
+| nan     | injured         | 2.1631        | 0.0015     | 0.0       | 2.163E-08  | 0.0042      | 511        | Kurnool                          |
+| nan     | embodied_carbon | 282.2         | 6.6272     | 0.0       | 0.4597     | 25.0154     | 511        | Kurnool                          |
+| nan     | contents        | 84_950        | 143.9198   | 0.0       | 0.0        | 8.495E-04   | 601        | Yanam                            |
+| nan     | structural      | 481_386       | 3_326      | 0.0       | 370.3      | 12_676      | 601        | Yanam                            |
+| nan     | occupants       | 1.7672        | 1.016E-04  | 0.0       | 1.767E-08  | 2.433E-04   | 601        | Yanam                            |
+| nan     | area            | 422.3         | 2.3048     | 0.0       | 4.223E-06  | 5.4026      | 601        | Yanam                            |
+| nan     | number          | 2.0275        | 0.0111     | 0.0       | 2.027E-08  | 0.0259      | 601        | Yanam                            |
+| nan     | residents       | 3.1990        | 0.0206     | 0.0       | 3.199E-08  | 0.0411      | 601        | Yanam                            |
+| nan     | affectedpop     | 3.1990        | 0.0296     | 0.0       | 3.199E-08  | 0.0688      | 601        | Yanam                            |
+| nan     | injured         | 1.7672        | 4.033E-04  | 0.0       | 1.767E-08  | 9.451E-04   | 601        | Yanam                            |
+| nan     | embodied_carbon | 134.8824      | 1.0495     | 0.0       | 0.1035     | 3.4300      | 601        | Yanam                            |
+| nan     | contents        | 350_692       | 86.7709    | 0.0       | 0.0025     | 0.0035      | 602        | South Andamans                   |
+| nan     | structural      | 1_886_549     | 26_460     | 0.0       | 10_269     | 79_184      | 602        | South Andamans                   |
+| nan     | occupants       | 11.1231       | 3.493E-04  | 0.0       | 9.221E-08  | 1.112E-07   | 602        | South Andamans                   |
+| nan     | area            | 1_678         | 2.5194     | 0.0       | 1.443E-05  | 0.1849      | 602        | South Andamans                   |
+| nan     | number          | 10.3438       | 0.0162     | 0.0       | 9.258E-08  | 0.0012      | 602        | South Andamans                   |
+| nan     | residents       | 12.3837       | 0.0310     | 0.0       | 1.238E-07  | 0.0017      | 602        | South Andamans                   |
+| nan     | affectedpop     | 12.3837       | 0.0669     | 0.0       | 1.238E-07  | 0.0293      | 602        | South Andamans                   |
+| nan     | injured         | 11.1231       | 4.150E-04  | 0.0       | 9.221E-08  | 1.112E-07   | 602        | South Andamans                   |
+| nan     | embodied_carbon | 542.2         | 8.0401     | 0.0       | 4.5834     | 24.9419     | 602        | South Andamans                   |
+| nan     | contents        | 2_673_214     | 6_962      | 0.0011    | 0.0094     | 758.4       | 603        | Nicobars                         |
+| nan     | structural      | 13_852_013    | 329_585    | 2_083     | 160_632    | 1_538_850   | 603        | Nicobars                         |
+| nan     | occupants       | 125.1724      | 0.0168     | 3.486E-08 | 1.088E-06  | 0.1285      | 603        | Nicobars                         |
+| nan     | area            | 9_522         | 53.6598    | 4.103E-06 | 7.494E-05  | 552.1       | 603        | Nicobars                         |
+| nan     | number          | 33.2953       | 0.2165     | 2.981E-08 | 2.323E-07  | 1.1552      | 603        | Nicobars                         |
+| nan     | residents       | 108.2295      | 1.1548     | 6.447E-08 | 9.792E-07  | 9.6971      | 603        | Nicobars                         |
+| nan     | affectedpop     | 108.2295      | 2.3971     | 6.447E-08 | 0.0012     | 15.0668     | 603        | Nicobars                         |
+| nan     | injured         | 125.1724      | 0.0166     | 3.486E-08 | 1.088E-06  | 0.1666      | 603        | Nicobars                         |
+| nan     | embodied_carbon | 3_202         | 61.2297    | 0.5056    | 30.4881    | 297.6       | 603        | Nicobars                         |
+| nan     | contents        | 179_847       | 8_073      | 0.0       | 0.0014     | 91_428      | 604        | Nuh                              |
+| nan     | structural      | 953_778       | 43_164     | 0.0       | 8_127      | 366_822     | 604        | Nuh                              |
+| nan     | occupants       | 8.6916        | 0.0015     | 0.0       | 8.692E-08  | 0.0155      | 604        | Nuh                              |
+| nan     | area            | 851.9         | 21.3653    | 0.0       | 8.519E-06  | 215.3       | 604        | Nuh                              |
+| nan     | number          | 5.4302        | 0.1551     | 0.0       | 5.430E-08  | 1.5636      | 604        | Nuh                              |
+| nan     | residents       | 9.7404        | 0.3781     | 0.0       | 9.740E-08  | 3.7958      | 604        | Nuh                              |
+| nan     | affectedpop     | 9.7404        | 0.5485     | 0.0       | 9.740E-08  | 5.2092      | 604        | Nuh                              |
+| nan     | injured         | 8.6916        | 0.0071     | 0.0       | 8.692E-08  | 0.0704      | 604        | Nuh                              |
+| nan     | embodied_carbon | 325.2         | 13.1902    | 0.0       | 2.9572     | 97.9073     | 604        | Nuh                              |
+| nan     | contents        | 103_499       | 19.4401    | 0.0       | 0.0010     | 0.0010      | 605        | Barnala                          |
+| nan     | structural      | 413_995       | 5_751      | 0.0       | 3_549      | 15_185      | 605        | Barnala                          |
+| nan     | area            | 403.5         | 2.986E-06  | 0.0       | 4.035E-06  | 4.035E-06   | 605        | Barnala                          |
+| nan     | number          | 1.8594        | 1.376E-08  | 0.0       | 1.859E-08  | 1.859E-08   | 605        | Barnala                          |
+| nan     | embodied_carbon | 174.6602      | 4.1505     | 0.0       | 3.2905     | 10.1036     | 605        | Barnala                          |
+| nan     | contents        | 260_096       | 42.7899    | 0.0       | 0.0026     | 0.0026      | 606        | Khunti                           |
+| nan     | structural      | 863_036       | 22_125     | 0.0       | 15_416     | 83_643      | 606        | Khunti                           |
+| nan     | occupants       | 13.1752       | 3.412E-05  | 0.0       | 1.318E-07  | 1.318E-07   | 606        | Khunti                           |
+| nan     | area            | 1_015         | 0.0951     | 0.0       | 1.015E-05  | 1.015E-05   | 606        | Khunti                           |
+| nan     | number          | 2.4583        | 2.022E-04  | 0.0       | 2.458E-08  | 2.458E-08   | 606        | Khunti                           |
+| nan     | residents       | 0.7694        | 4.993E-05  | 0.0       | 7.694E-09  | 7.694E-09   | 606        | Khunti                           |
+| nan     | affectedpop     | 0.7694        | 1.023E-04  | 0.0       | 7.694E-09  | 7.694E-09   | 606        | Khunti                           |
+| nan     | injured         | 13.1752       | 4.593E-05  | 0.0       | 1.318E-07  | 1.318E-07   | 606        | Khunti                           |
+| nan     | embodied_carbon | 393.2         | 9.7654     | 0.0       | 6.7635     | 35.8294     | 606        | Khunti                           |
+| nan     | contents        | 31_488        | 493.2      | 0.0       | 1.258E-42  | 6.2090      | 610        | Ariyalur                         |
+| nan     | structural      | 125_951       | 7_948      | 0.0       | 7_294      | 18_959      | 610        | Ariyalur                         |
+| nan     | occupants       | 3.1200        | 5.248E-05  | 0.0       | 3.120E-08  | 3.120E-08   | 610        | Ariyalur                         |
+| nan     | area            | 122.7594      | 0.1013     | 0.0       | 1.228E-06  | 0.0903      | 610        | Ariyalur                         |
+| nan     | number          | 0.2563        | 2.116E-04  | 0.0       | 2.563E-09  | 1.885E-04   | 610        | Ariyalur                         |
+| nan     | injured         | 3.1200        | 1.143E-04  | 0.0       | 3.120E-08  | 3.120E-08   | 610        | Ariyalur                         |
+| nan     | embodied_carbon | 57.6895       | 3.0517     | 0.0       | 2.5557     | 7.9409      | 610        | Ariyalur                         |
+| nan     | contents        | 709_522       | 1_611      | 0.0       | 0.0032     | 3.9267      | 611        | Arwal                            |
+| nan     | structural      | 4_020_627     | 55_849     | 0.0       | 25_209     | 258_812     | 611        | Arwal                            |
+| nan     | occupants       | 15.6746       | 4.204E-04  | 0.0       | 1.131E-07  | 0.0019      | 611        | Arwal                            |
+| nan     | area            | 3_527         | 17.7937    | 0.0       | 3.325E-05  | 75.8354     | 611        | Arwal                            |
+| nan     | number          | 17.0976       | 0.1215     | 0.0       | 1.613E-07  | 0.4798      | 611        | Arwal                            |
+| nan     | residents       | 28.3689       | 0.0966     | 0.0       | 2.709E-07  | 0.4875      | 611        | Arwal                            |
+| nan     | affectedpop     | 28.3689       | 0.1395     | 0.0       | 2.709E-07  | 0.9291      | 611        | Arwal                            |
+| nan     | injured         | 15.6746       | 0.0019     | 0.0       | 1.131E-07  | 0.0086      | 611        | Arwal                            |
+| nan     | embodied_carbon | 1_183         | 20.9486    | 0.0       | 11.5999    | 71.3429     | 611        | Arwal                            |
+| nan     | contents        | 71_046        | 244.4      | 0.0       | 5.480E-04  | 7.105E-04   | 612        | Chirang                          |
+| nan     | structural      | 402_592       | 2_845      | 0.0       | 630.5      | 3_636       | 612        | Chirang                          |
+| nan     | occupants       | 0.3914        | 1.103E-05  | 0.0       | 2.767E-09  | 3.914E-09   | 612        | Chirang                          |
+| nan     | area            | 353.2         | 1.1874     | 0.0       | 2.724E-06  | 0.1742      | 612        | Chirang                          |
+| nan     | number          | 2.4969        | 0.0086     | 0.0       | 1.979E-08  | 0.0013      | 612        | Chirang                          |
+| nan     | residents       | 0.7119        | 0.0026     | 0.0       | 5.010E-09  | 3.221E-04   | 612        | Chirang                          |
+| nan     | affectedpop     | 0.7119        | 0.0033     | 0.0       | 5.010E-09  | 8.930E-04   | 612        | Chirang                          |
+| nan     | injured         | 0.3914        | 4.921E-05  | 0.0       | 2.767E-09  | 3.914E-09   | 612        | Chirang                          |
+| nan     | embodied_carbon | 117.4089      | 0.8508     | 0.0       | 0.1818     | 1.1186      | 612        | Chirang                          |
+| nan     | contents        | 137_876       | 737.8      | 0.0       | 0.0014     | 0.0014      | 613        | Peren                            |
+| nan     | structural      | 781_298       | 8_539      | 0.0       | 1_669      | 12_668      | 613        | Peren                            |
+| nan     | occupants       | 3.3845        | 1.967E-04  | 0.0       | 3.385E-08  | 3.385E-08   | 613        | Peren                            |
+| nan     | area            | 685.3         | 4.2226     | 0.0       | 6.853E-06  | 1.6579      | 613        | Peren                            |
+| nan     | number          | 4.9784        | 0.0307     | 0.0       | 4.978E-08  | 0.0120      | 613        | Peren                            |
+| nan     | residents       | 6.1262        | 0.0449     | 0.0       | 6.126E-08  | 0.0169      | 613        | Peren                            |
+| nan     | affectedpop     | 6.1262        | 0.0587     | 0.0       | 6.126E-08  | 0.0507      | 613        | Peren                            |
+| nan     | injured         | 3.3845        | 8.815E-04  | 0.0       | 3.385E-08  | 4.084E-04   | 613        | Peren                            |
+| nan     | embodied_carbon | 250.6         | 2.5344     | 0.0       | 0.5576     | 4.4507      | 613        | Peren                            |
+| nan     | contents        | 27_851        | 5.5641     | 0.0       | 2.785E-04  | 2.785E-04   | 614        | Kiphire                          |
+| nan     | structural      | 157_823       | 960.8      | 0.0       | 623.9      | 2_430       | 614        | Kiphire                          |
+| nan     | occupants       | 0.6402        | 1.806E-08  | 0.0       | 6.402E-09  | 6.402E-09   | 614        | Kiphire                          |
+| nan     | area            | 138.4412      | 6.596E-04  | 0.0       | 1.384E-06  | 1.384E-06   | 614        | Kiphire                          |
+| nan     | number          | 1.0056        | 4.791E-06  | 0.0       | 1.006E-08  | 1.006E-08   | 614        | Kiphire                          |
+| nan     | residents       | 1.1588        | 6.259E-06  | 0.0       | 1.159E-08  | 1.159E-08   | 614        | Kiphire                          |
+| nan     | affectedpop     | 1.1588        | 2.310E-05  | 0.0       | 1.159E-08  | 1.159E-08   | 614        | Kiphire                          |
+| nan     | injured         | 0.6402        | 1.256E-07  | 0.0       | 6.402E-09  | 6.402E-09   | 614        | Kiphire                          |
+| nan     | embodied_carbon | 41.4737       | 0.5354     | 0.0       | 0.3900     | 1.2910      | 614        | Kiphire                          |
+| nan     | contents        | 553_823       | 8_264      | 0.0       | 0.0055     | 0.0830      | 615        | Longleng                         |
+| nan     | structural      | 3_119_043     | 71_545     | 0.0       | 8_182      | 107_948     | 615        | Longleng                         |
+| nan     | occupants       | 22.2860       | 0.0037     | 0.0       | 2.229E-07  | 0.0022      | 615        | Longleng                         |
+| nan     | area            | 2_741         | 47.5061    | 0.0       | 2.741E-05  | 32.3363     | 615        | Longleng                         |
+| nan     | number          | 19.7709       | 0.3499     | 0.0       | 1.977E-07  | 0.2360      | 615        | Longleng                         |
+| nan     | residents       | 39.1412       | 0.8066     | 0.0       | 3.914E-07  | 0.7356      | 615        | Longleng                         |
+| nan     | affectedpop     | 39.1412       | 1.0131     | 0.0       | 3.914E-07  | 1.6865      | 615        | Longleng                         |
+| nan     | injured         | 22.2860       | 0.0164     | 0.0       | 2.229E-07  | 0.0135      | 615        | Longleng                         |
+| nan     | embodied_carbon | 970.0         | 23.5436    | 0.0       | 3.0523     | 36.8508     | 615        | Longleng                         |
+| nan     | contents        | 205_319       | 1_665      | 0.0       | 0.0013     | 6_029       | 702        | Kalimpong                        |
+| nan     | structural      | 821_278       | 52_755     | 0.0       | 44_428     | 143_918     | 702        | Kalimpong                        |
+| nan     | occupants       | 10.2863       | 1.074E-07  | 0.0       | 1.029E-07  | 1.029E-07   | 702        | Kalimpong                        |
+| nan     | area            | 837.0         | 0.1651     | 0.0       | 8.370E-06  | 8.370E-06   | 702        | Kalimpong                        |
+| nan     | number          | 2.7300        | 7.511E-04  | 0.0       | 2.730E-08  | 2.730E-08   | 702        | Kalimpong                        |
+| nan     | injured         | 10.2863       | 6.415E-05  | 0.0       | 1.029E-07  | 1.029E-07   | 702        | Kalimpong                        |
+| nan     | embodied_carbon | 380.7         | 19.7920    | 0.0       | 16.5875    | 54.2978     | 702        | Kalimpong                        |
+| nan     | contents        | 33_324        | 512.7      | 0.0       | 6.441E-36  | 5_569       | 704        | Paschim Bardhaman                |
+| nan     | structural      | 133_295       | 9_555      | 0.0       | 6_542      | 36_398      | 704        | Paschim Bardhaman                |
+| nan     | occupants       | 1.2200        | 1.074E-07  | 0.0       | 1.220E-08  | 1.220E-08   | 704        | Paschim Bardhaman                |
+| nan     | area            | 129.9173      | 0.0555     | 0.0       | 1.299E-06  | 1.299E-06   | 704        | Paschim Bardhaman                |
+| nan     | number          | 0.5987        | 2.559E-04  | 0.0       | 5.987E-09  | 5.987E-09   | 704        | Paschim Bardhaman                |
+| nan     | injured         | 1.2200        | 1.553E-05  | 0.0       | 1.220E-08  | 1.220E-08   | 704        | Paschim Bardhaman                |
+| nan     | embodied_carbon | 56.2378       | 3.2137     | 0.0       | 2.0475     | 13.0630     | 704        | Paschim Bardhaman                |
+| nan     | contents        | 3_778_145     | 144_790    | 0.0       | 0.0378     | 306_022     | 705        | Biswanath                        |
+| nan     | structural      | 21_409_488    | 1_056_541  | 0.0       | 75_798     | 2_660_014   | 705        | Biswanath                        |
+| nan     | occupants       | 144.1277      | 0.0524     | 0.0       | 1.441E-06  | 0.0788      | 705        | Biswanath                        |
+| nan     | area            | 14_446        | 567.5      | 0.0       | 1.445E-04  | 842.0       | 705        | Biswanath                        |
+| nan     | number          | 104.9380      | 4.1225     | 0.0       | 1.049E-06  | 6.1165      | 705        | Biswanath                        |
+| nan     | residents       | 266.6         | 11.5024    | 0.0       | 2.666E-06  | 23.2460     | 705        | Biswanath                        |
+| nan     | affectedpop     | 266.6         | 13.7089    | 0.0       | 2.666E-06  | 43.3146     | 705        | Biswanath                        |
+| nan     | injured         | 144.1277      | 0.2288     | 0.0       | 1.441E-06  | 0.3972      | 705        | Biswanath                        |
+| nan     | embodied_carbon | 5_238         | 252.9      | 0.0       | 19.2425    | 613.8       | 705        | Biswanath                        |
+| nan     | contents        | 256_701       | 911.9      | 3.131E-04 | 0.0023     | 454.4       | 706        | Majuli                           |
+| nan     | structural      | 1_454_639     | 37_535     | 166.0809  | 19_281     | 193_553     | 706        | Majuli                           |
+| nan     | occupants       | 10.5937       | 2.203E-04  | 1.087E-08 | 1.059E-07  | 8.266E-04   | 706        | Majuli                           |
+| nan     | area            | 1_276         | 4.2617     | 1.556E-06 | 1.276E-05  | 15.4566     | 706        | Majuli                           |
+| nan     | number          | 9.0050        | 0.0274     | 9.986E-09 | 9.005E-08  | 0.0992      | 706        | Majuli                           |
+| nan     | residents       | 19.1741       | 0.0633     | 1.967E-08 | 1.917E-07  | 0.2689      | 706        | Majuli                           |
+| nan     | affectedpop     | 19.1741       | 0.0981     | 1.967E-08 | 1.917E-07  | 0.4654      | 706        | Majuli                           |
+| nan     | injured         | 10.5937       | 0.0011     | 1.087E-08 | 1.059E-07  | 0.0044      | 706        | Majuli                           |
+| nan     | embodied_carbon | 385.2         | 8.4547     | 0.0396    | 4.2315     | 39.1516     | 706        | Majuli                           |
+| nan     | contents        | 554_840       | 3_190      | 0.0       | 0.0        | 0.0055      | 707        | South Salmara Mancachar          |
+| nan     | structural      | 3_144_092     | 92_063     | 0.0       | 9_463      | 427_867     | 707        | South Salmara Mancachar          |
+| nan     | occupants       | 17.1672       | 0.0029     | 0.0       | 1.717E-07  | 0.0132      | 707        | South Salmara Mancachar          |
+| nan     | area            | 2_758         | 51.2353    | 0.0       | 2.758E-05  | 226.3       | 707        | South Salmara Mancachar          |
+| nan     | number          | 20.0339       | 0.3722     | 0.0       | 2.003E-07  | 1.6436      | 707        | South Salmara Mancachar          |
+| nan     | residents       | 31.0722       | 0.7589     | 0.0       | 3.107E-07  | 3.6899      | 707        | South Salmara Mancachar          |
+| nan     | affectedpop     | 31.0722       | 1.1813     | 0.0       | 3.107E-07  | 6.4543      | 707        | South Salmara Mancachar          |
+| nan     | injured         | 17.1672       | 0.0140     | 0.0       | 1.717E-07  | 0.0650      | 707        | South Salmara Mancachar          |
+| nan     | embodied_carbon | 1_000         | 28.5907    | 0.0       | 3.1084     | 130.3266    | 707        | South Salmara Mancachar          |
+| nan     | contents        | 308_213       | 10_355     | 0.0       | 0.0        | 55_233      | 709        | Hojai                            |
+| nan     | structural      | 1_232_850     | 89_307     | 0.0       | 68_313     | 281_902     | 709        | Hojai                            |
+| nan     | occupants       | 0.8863        | 7.297E-09  | 0.0       | 8.863E-09  | 8.863E-09   | 709        | Hojai                            |
+| nan     | area            | 1_352         | 0.1246     | 0.0       | 1.352E-05  | 1.352E-05   | 709        | Hojai                            |
+| nan     | number          | 6.2295        | 5.744E-04  | 0.0       | 6.230E-08  | 6.230E-08   | 709        | Hojai                            |
+| nan     | injured         | 0.8863        | 2.705E-06  | 0.0       | 8.863E-09  | 8.863E-09   | 709        | Hojai                            |
+| nan     | embodied_carbon | 585.1         | 34.0035    | 0.0       | 25.5361    | 101.2145    | 709        | Hojai                            |
+| nan     | contents        | 413_590       | 5.8899     | 0.0       | 3.135E-04  | 3.135E-04   | 711        | Reguengos de Monsaraz            |
+| nan     | structural      | 1_706_614     | 1_398      | 0.0       | 720.1      | 2_952       | 711        | Reguengos de Monsaraz            |
+| nan     | occupants       | 33.1251       | 5.293E-07  | 0.0       | 4.449E-09  | 4.449E-09   | 711        | Reguengos de Monsaraz            |
+| nan     | area            | 1_646         | 0.0245     | 0.0       | 1.558E-06  | 1.558E-06   | 711        | Reguengos de Monsaraz            |
+| nan     | number          | 3.1779        | 1.574E-04  | 0.0       | 1.000E-08  | 1.000E-08   | 711        | Reguengos de Monsaraz            |
+| nan     | residents       | 0.8053        | 1.318E-04  | 0.0       | 8.053E-09  | 8.053E-09   | 711        | Reguengos de Monsaraz            |
+| nan     | affectedpop     | 0.8053        | 1.417E-04  | 0.0       | 8.053E-09  | 8.053E-09   | 711        | Reguengos de Monsaraz            |
+| nan     | injured         | 33.1251       | 2.820E-06  | 0.0       | 4.449E-09  | 4.449E-09   | 711        | Reguengos de Monsaraz            |
+| nan     | embodied_carbon | 748.3         | 0.3597     | 0.0       | 0.1762     | 0.7547      | 711        | Reguengos de Monsaraz            |
+| nan     | contents        | 802_492       | 17_636     | 0.0       | 0.0043     | 68_195      | 712        | Kangpokpi                        |
+| nan     | structural      | 3_889_798     | 213_783    | 0.0       | 11_087     | 1_418_124   | 712        | Kangpokpi                        |
+| nan     | occupants       | 48.0186       | 0.0681     | 0.0       | 1.496E-07  | 0.6302      | 712        | Kangpokpi                        |
+| nan     | area            | 3_566         | 179.1390   | 0.0       | 0.0351     | 1_457       | 712        | Kangpokpi                        |
+| nan     | number          | 15.5970       | 1.1420     | 0.0       | 1.774E-04  | 9.3512      | 712        | Kangpokpi                        |
+| nan     | residents       | 23.1499       | 2.2643     | 0.0       | 2.315E-07  | 19.7962     | 712        | Kangpokpi                        |
+| nan     | affectedpop     | 23.1499       | 2.8125     | 0.0       | 2.315E-07  | 21.3358     | 712        | Kangpokpi                        |
+| nan     | injured         | 48.0186       | 0.0447     | 0.0       | 1.496E-07  | 0.3287      | 712        | Kangpokpi                        |
+| nan     | embodied_carbon | 1_376         | 71.3463    | 0.0       | 3.4420     | 620.2       | 712        | Kangpokpi                        |
+| nan     | contents        | 879_271       | 12_603     | 0.0       | 0.0051     | 21_155      | 801        | Australian Capital Territory     |
+| nan     | structural      | 4_982_535     | 279_244    | 22_028    | 107_195    | 1_087_930   | 801        | Australian Capital Territory     |
+| nan     | occupants       | 32.9778       | 0.0096     | 1.481E-07 | 3.298E-07  | 0.0639      | 801        | Australian Capital Territory     |
+| nan     | area            | 3_973         | 123.2679   | 1.667E-05 | 0.2473     | 819.9       | 801        | Australian Capital Territory     |
+| nan     | number          | 11.0323       | 0.1879     | 3.028E-08 | 3.777E-04  | 1.2512      | 801        | Australian Capital Territory     |
+| nan     | residents       | 60.9903       | 1.7480     | 2.740E-07 | 0.0092     | 11.1550     | 801        | Australian Capital Territory     |
+| nan     | affectedpop     | 60.9903       | 2.3322     | 2.740E-07 | 0.0324     | 13.4851     | 801        | Australian Capital Territory     |
+| nan     | injured         | 32.9778       | 0.0325     | 1.481E-07 | 3.298E-07  | 0.2134      | 801        | Australian Capital Territory     |
+| nan     | embodied_carbon | 1_276         | 82.8052    | 6.5035    | 29.8521    | 493.0       | 801        | Australian Capital Territory     |
+| nan     | contents        | 141_727       | 1_749      | 0.0       | 0.0014     | 2_218       | 803        | Aljezur                          |
+| nan     | structural      | 803_122       | 33_379     | 0.0       | 18_743     | 129_110     | 803        | Aljezur                          |
+| nan     | occupants       | 3.3261        | 1.198E-04  | 0.0       | 3.326E-08  | 7.040E-04   | 803        | Aljezur                          |
+| nan     | area            | 704.5         | 7.8520     | 0.0       | 7.045E-06  | 45.4989     | 803        | Aljezur                          |
+| nan     | number          | 4.9859        | 0.0505     | 0.0       | 4.986E-08  | 0.2920      | 803        | Aljezur                          |
+| nan     | residents       | 6.0202        | 0.0329     | 0.0       | 6.020E-08  | 0.2072      | 803        | Aljezur                          |
+| nan     | affectedpop     | 6.0202        | 0.0470     | 0.0       | 6.020E-08  | 0.2877      | 803        | Aljezur                          |
+| nan     | injured         | 3.3261        | 5.850E-04  | 0.0       | 3.326E-08  | 0.0035      | 803        | Aljezur                          |
+| nan     | embodied_carbon | 220.8         | 8.2959     | 0.0       | 4.0861     | 26.0437     | 803        | Aljezur                          |
+| nan     | contents        | 125_496       | 4_285      | 0.0       | 0.0013     | 1_623       | 804        | Castro Marim                     |
+| nan     | structural      | 711_144       | 67_008     | 0.0       | 1_903      | 310_009     | 804        | Castro Marim                     |
+| nan     | occupants       | 2.3156        | 0.0110     | 0.0       | 2.316E-08  | 0.0510      | 804        | Castro Marim                     |
+| nan     | area            | 623.8         | 48.5043    | 0.0       | 6.238E-06  | 224.5       | 804        | Castro Marim                     |
+| nan     | number          | 4.0028        | 0.3112     | 0.0       | 4.003E-08  | 1.4407      | 804        | Castro Marim                     |
+| nan     | residents       | 4.1911        | 0.4005     | 0.0       | 4.191E-08  | 1.8959      | 804        | Castro Marim                     |
+| nan     | affectedpop     | 4.1911        | 0.5510     | 0.0       | 4.191E-08  | 2.5444      | 804        | Castro Marim                     |
+| nan     | injured         | 2.3156        | 0.0067     | 0.0       | 2.316E-08  | 0.0313      | 804        | Castro Marim                     |
+| nan     | embodied_carbon | 199.0         | 19.4347    | 0.0       | 0.4529     | 76.2538     | 804        | Castro Marim                     |
+| nan     | contents        | 256_379       | 22.5314    | 0.0       | 8.912E-04  | 0.0026      | 805        | Faro                             |
+| nan     | structural      | 1_452_814     | 15_029     | 0.0       | 10_053     | 47_529      | 805        | Faro                             |
+| nan     | occupants       | 9.7359        | 1.390E-05  | 0.0       | 6.504E-08  | 9.736E-08   | 805        | Faro                             |
+| nan     | area            | 980.3         | 0.1648     | 0.0       | 6.395E-06  | 0.0945      | 805        | Faro                             |
+| nan     | number          | 5.0464        | 0.0011     | 0.0       | 3.071E-08  | 4.951E-04   | 805        | Faro                             |
+| nan     | residents       | 18.0069       | 0.0045     | 0.0       | 1.203E-07  | 0.0022      | 805        | Faro                             |
+| nan     | affectedpop     | 18.0069       | 0.0204     | 0.0       | 1.203E-07  | 0.0398      | 805        | Faro                             |
+| nan     | injured         | 9.7359        | 5.810E-05  | 0.0       | 6.504E-08  | 9.736E-08   | 805        | Faro                             |
+| nan     | embodied_carbon | 296.6         | 1.7022     | 0.0       | 0.9998     | 5.9991      | 805        | Faro                             |
+| nan     | contents        | 784_756       | 10_639     | 0.0       | 0.0066     | 95_267      | 806        | Lagoa                            |
+| nan     | structural      | 4_446_953     | 143_421    | 5_881     | 73_543     | 602_773     | 806        | Lagoa                            |
+| nan     | occupants       | 29.0013       | 0.0096     | 5.717E-09 | 4.055E-06  | 0.0890      | 806        | Lagoa                            |
+| nan     | area            | 3_901         | 49.9078    | 5.959E-06 | 0.2670     | 474.8       | 806        | Lagoa                            |
+| nan     | number          | 27.6520       | 0.3137     | 3.645E-08 | 0.0015     | 2.9016      | 806        | Lagoa                            |
+| nan     | residents       | 52.4954       | 0.3536     | 3.855E-08 | 0.0028     | 2.8155      | 806        | Lagoa                            |
+| nan     | affectedpop     | 52.4954       | 0.4740     | 4.864E-07 | 0.0171     | 2.8157      | 806        | Lagoa                            |
+| nan     | injured         | 29.0013       | 0.0061     | 5.717E-09 | 2.900E-07  | 0.0532      | 806        | Lagoa                            |
+| nan     | embodied_carbon | 1_178         | 51.5807    | 0.7900    | 33.2093    | 178.6101    | 806        | Lagoa                            |
+| nan     | contents        | 688_402       | 5_728      | 0.0       | 1.801E-09  | 32_316      | 807        | Lagos                            |
+| nan     | structural      | 2_753_607     | 42_710     | 12_591    | 34_583     | 81_483      | 807        | Lagos                            |
+| nan     | occupants       | 72.3023       | 5.141E-04  | 1.201E-07 | 1.201E-07  | 1.201E-07   | 807        | Lagos                            |
+| nan     | area            | 2_415         | 0.8627     | 4.013E-06 | 4.013E-06  | 1.0558      | 807        | Lagos                            |
+| nan     | number          | 10.6901       | 0.0018     | 8.381E-09 | 8.381E-09  | 0.0022      | 807        | Lagos                            |
+| nan     | injured         | 72.3023       | 0.0011     | 1.201E-07 | 1.201E-07  | 0.0015      | 807        | Lagos                            |
+| nan     | embodied_carbon | 1_060         | 14.6000    | 4.5687    | 11.7195    | 28.5245     | 807        | Lagos                            |
+| nan     | contents        | 3_549_587     | 9_572      | 4.755E-04 | 0.0092     | 40_093      | 808        | Loulé                            |
+| nan     | structural      | 16_444_001    | 164_275    | 5_346     | 43_282     | 746_960     | 808        | Loulé                            |
+| nan     | occupants       | 182.8         | 0.0047     | 1.489E-07 | 3.687E-07  | 0.0302      | 808        | Loulé                            |
+| nan     | area            | 13_789        | 76.6085    | 2.428E-05 | 1.9318     | 443.5       | 808        | Loulé                            |
+| nan     | number          | 49.5347       | 0.3859     | 9.529E-08 | 0.0123     | 2.0614      | 808        | Loulé                            |
+| nan     | residents       | 68.1863       | 1.0495     | 2.753E-07 | 0.0266     | 5.9854      | 808        | Loulé                            |
+| nan     | affectedpop     | 68.1863       | 1.4811     | 2.753E-07 | 0.0407     | 7.9898      | 808        | Loulé                            |
+| nan     | injured         | 182.8         | 0.0191     | 1.489E-07 | 3.687E-07  | 0.1172      | 808        | Loulé                            |
+| nan     | embodied_carbon | 5_477         | 55.7524    | 1.5703    | 14.4991    | 249.4       | 808        | Loulé                            |
+| nan     | contents        | 62_656        | 168.2075   | 0.0       | 6.266E-04  | 6.266E-04   | 809        | Monchique                        |
+| nan     | structural      | 355_052       | 4_901      | 0.0       | 539.2      | 9_483       | 809        | Monchique                        |
+| nan     | occupants       | 1.3442        | 9.205E-05  | 0.0       | 1.344E-08  | 1.344E-08   | 809        | Monchique                        |
+| nan     | area            | 311.4         | 2.8566     | 0.0       | 3.114E-06  | 2.2504      | 809        | Monchique                        |
+| nan     | number          | 1.9985        | 0.0183     | 0.0       | 1.999E-08  | 0.0144      | 809        | Monchique                        |
+| nan     | residents       | 2.4329        | 0.0262     | 0.0       | 2.433E-08  | 0.0262      | 809        | Monchique                        |
+| nan     | affectedpop     | 2.4329        | 0.0363     | 0.0       | 2.433E-08  | 0.0716      | 809        | Monchique                        |
+| nan     | injured         | 1.3442        | 4.561E-04  | 0.0       | 1.344E-08  | 4.626E-04   | 809        | Monchique                        |
+| nan     | embodied_carbon | 112.8567      | 1.6050     | 0.0       | 0.1572     | 3.2306      | 809        | Monchique                        |
+| nan     | contents        | 351_759       | 0.0014     | 0.0       | 0.0        | 0.0035      | 810        | Olhão                            |
+| nan     | structural      | 1_692_971     | 5_023      | 0.0       | 0.0        | 15_611      | 810        | Olhão                            |
+| nan     | occupants       | 19.7159       | 7.952E-08  | 0.0       | 0.0        | 1.972E-07   | 810        | Olhão                            |
+| nan     | area            | 1_408         | 5.677E-06  | 0.0       | 0.0        | 1.408E-05   | 810        | Olhão                            |
+| nan     | number          | 7.9393        | 3.202E-08  | 0.0       | 0.0        | 7.939E-08   | 810        | Olhão                            |
+| nan     | residents       | 7.1483        | 2.883E-08  | 0.0       | 0.0        | 7.148E-08   | 810        | Olhão                            |
+| nan     | affectedpop     | 7.1483        | 2.883E-08  | 0.0       | 0.0        | 7.148E-08   | 810        | Olhão                            |
+| nan     | injured         | 19.7159       | 7.952E-08  | 0.0       | 0.0        | 1.972E-07   | 810        | Olhão                            |
+| nan     | embodied_carbon | 528.3         | 3.7941     | 0.0       | 0.0        | 11.9021     | 810        | Olhão                            |
+| nan     | contents        | 224_854       | 4_026      | 0.0       | 3.446E-04  | 7_534       | 811        | Portimão                         |
+| nan     | structural      | 1_274_169     | 103_090    | 16_477    | 62_069     | 328_162     | 811        | Portimão                         |
+| nan     | occupants       | 7.4632        | 0.0050     | 5.891E-08 | 9.845E-06  | 0.0385      | 811        | Portimão                         |
+| nan     | area            | 1_016         | 28.3197    | 8.604E-06 | 0.4849     | 163.1059    | 811        | Portimão                         |
+| nan     | number          | 5.4688        | 0.1538     | 4.470E-08 | 0.0035     | 0.8238      | 811        | Portimão                         |
+| nan     | residents       | 13.8024       | 0.5342     | 1.224E-07 | 0.0122     | 3.8541      | 811        | Portimão                         |
+| nan     | affectedpop     | 13.8024       | 1.0497     | 1.224E-07 | 0.1250     | 7.2153      | 811        | Portimão                         |
+| nan     | injured         | 7.4632        | 0.0081     | 5.891E-08 | 3.493E-05  | 0.0541      | 811        | Portimão                         |
+| nan     | embodied_carbon | 307.6         | 18.8713    | 1.3356    | 7.6974     | 66.0978     | 811        | Portimão                         |
+| nan     | contents        | 104_582       | 466.1      | 0.0       | 8.294E-04  | 494.7       | 815        | Vila do Bispo                    |
+| nan     | structural      | 592_634       | 22_640     | 5_677     | 15_937     | 78_893      | 815        | Vila do Bispo                    |
+| nan     | occupants       | 2.0453        | 5.551E-04  | 1.291E-08 | 2.045E-08  | 0.0025      | 815        | Vila do Bispo                    |
+| nan     | area            | 519.9         | 2.7899     | 4.123E-06 | 5.199E-06  | 12.1190     | 815        | Vila do Bispo                    |
+| nan     | number          | 3.5113        | 0.0137     | 2.995E-08 | 3.511E-08  | 0.0582      | 815        | Vila do Bispo                    |
+| nan     | residents       | 3.7033        | 0.0478     | 2.337E-08 | 3.703E-08  | 0.2793      | 815        | Vila do Bispo                    |
+| nan     | affectedpop     | 3.7033        | 0.0826     | 2.337E-08 | 3.703E-08  | 0.6543      | 815        | Vila do Bispo                    |
+| nan     | injured         | 2.0453        | 7.756E-04  | 1.291E-08 | 2.045E-08  | 0.0035      | 815        | Vila do Bispo                    |
+| nan     | embodied_carbon | 155.7590      | 4.5666     | 0.9413    | 2.9512     | 18.7096     | 815        | Vila do Bispo                    |
+| nan     | contents        | 87_388        | 362.4      | 0.0       | 0.0        | 1_154       | 816        | Vila Real de Santo António       |
+| nan     | structural      | 349_552       | 27_949     | 0.0       | 16_656     | 72_698      | 816        | Vila Real de Santo António       |
+| nan     | occupants       | 11.6400       | 9.137E-08  | 0.0       | 1.164E-07  | 1.164E-07   | 816        | Vila Real de Santo António       |
+| nan     | area            | 340.7         | 0.0171     | 0.0       | 3.407E-06  | 3.407E-06   | 816        | Vila Real de Santo António       |
+| nan     | number          | 1.5700        | 7.896E-05  | 0.0       | 1.570E-08  | 1.570E-08   | 816        | Vila Real de Santo António       |
+| nan     | injured         | 11.6400       | 1.984E-05  | 0.0       | 1.164E-07  | 1.164E-07   | 816        | Vila Real de Santo António       |
+| nan     | embodied_carbon | 147.4725      | 9.8202     | 0.0       | 5.5598     | 24.5532     | 816        | Vila Real de Santo António       |
+| nan     | contents        | 473_072       | 3_898      | 0.0       | 0.0032     | 0.0047      | 901        | Aguiar da Beira                  |
+| nan     | structural      | 2_680_741     | 27_218     | 0.0       | 5_786      | 66_132      | 901        | Aguiar da Beira                  |
+| nan     | occupants       | 5.8651        | 0.0020     | 0.0       | 4.182E-08  | 0.0035      | 901        | Aguiar da Beira                  |
+| nan     | area            | 2_352         | 11.9348    | 0.0       | 1.612E-05  | 20.3465     | 901        | Aguiar da Beira                  |
+| nan     | number          | 15.7155       | 0.0865     | 0.0       | 1.034E-07  | 0.1478      | 901        | Aguiar da Beira                  |
+| nan     | residents       | 10.6183       | 0.0554     | 0.0       | 7.572E-08  | 0.1152      | 901        | Aguiar da Beira                  |
+| nan     | affectedpop     | 10.6183       | 0.0728     | 0.0       | 7.572E-08  | 0.2293      | 901        | Aguiar da Beira                  |
+| nan     | injured         | 5.8651        | 0.0011     | 0.0       | 4.182E-08  | 0.0022      | 901        | Aguiar da Beira                  |
+| nan     | embodied_carbon | 718.5         | 6.5474     | 0.0       | 0.8346     | 17.6634     | 901        | Aguiar da Beira                  |
+| nan     | contents        | 247_064       | 306.3      | 0.0       | 0.0019     | 0.0025      | 902        | Almeida                          |
+| nan     | structural      | 1_400_031     | 10_907     | 0.0       | 3_477      | 29_160      | 902        | Almeida                          |
+| nan     | occupants       | 2.7543        | 7.137E-05  | 0.0       | 2.754E-08  | 2.754E-08   | 902        | Almeida                          |
+| nan     | area            | 1_228         | 3.2152     | 0.0       | 1.228E-05  | 0.9314      | 902        | Almeida                          |
+| nan     | number          | 8.1037        | 0.0209     | 0.0       | 8.104E-08  | 0.0061      | 902        | Almeida                          |
+| nan     | residents       | 4.9859        | 0.0167     | 0.0       | 4.986E-08  | 0.0043      | 902        | Almeida                          |
+| nan     | affectedpop     | 4.9859        | 0.0239     | 0.0       | 4.986E-08  | 0.0166      | 902        | Almeida                          |
+| nan     | injured         | 2.7543        | 2.858E-04  | 0.0       | 2.754E-08  | 2.754E-08   | 902        | Almeida                          |
+| nan     | embodied_carbon | 395.8         | 2.2418     | 0.0       | 0.4755     | 6.3632      | 902        | Almeida                          |
+| nan     | contents        | 385_380       | 3_061      | 0.0       | 0.0019     | 0.0039      | 903        | Celorico da Beira                |
+| nan     | structural      | 2_087_304     | 34_992     | 0.0       | 6_506      | 114_601     | 903        | Celorico da Beira                |
+| nan     | occupants       | 11.3510       | 9.727E-04  | 0.0       | 7.989E-08  | 0.0027      | 903        | Celorico da Beira                |
+| nan     | area            | 1_854         | 19.5503    | 0.0       | 1.191E-05  | 53.0304     | 903        | Celorico da Beira                |
+| nan     | number          | 11.2335       | 0.1222     | 0.0       | 8.053E-08  | 0.3350      | 903        | Celorico da Beira                |
+| nan     | residents       | 14.8415       | 0.2042     | 0.0       | 8.759E-08  | 0.6721      | 903        | Celorico da Beira                |
+| nan     | affectedpop     | 14.8415       | 0.2640     | 0.0       | 8.759E-08  | 1.1884      | 903        | Celorico da Beira                |
+| nan     | injured         | 11.3510       | 0.0041     | 0.0       | 7.989E-08  | 0.0122      | 903        | Celorico da Beira                |
+| nan     | embodied_carbon | 654.3         | 11.0847    | 0.0       | 2.2034     | 36.1846     | 903        | Celorico da Beira                |
+| nan     | contents        | 248_629       | 1_268      | 0.0       | 0.0020     | 8.9593      | 906        | Gouveia                          |
+| nan     | structural      | 1_327_316     | 33_478     | 0.0       | 7_801      | 80_526      | 906        | Gouveia                          |
+| nan     | occupants       | 2.8414        | 3.318E-04  | 0.0       | 2.841E-08  | 5.608E-04   | 906        | Gouveia                          |
+| nan     | area            | 1_207         | 13.9031    | 0.0       | 1.207E-05  | 23.0452     | 906        | Gouveia                          |
+| nan     | number          | 8.1993        | 0.1010     | 0.0       | 8.199E-08  | 0.1674      | 906        | Gouveia                          |
+| nan     | residents       | 4.6631        | 0.0775     | 0.0       | 4.663E-08  | 0.1687      | 906        | Gouveia                          |
+| nan     | affectedpop     | 4.6631        | 0.1037     | 0.0       | 4.663E-08  | 0.3629      | 906        | Gouveia                          |
+| nan     | injured         | 2.8414        | 0.0015     | 0.0       | 2.841E-08  | 0.0030      | 906        | Gouveia                          |
+| nan     | embodied_carbon | 452.8         | 8.7424     | 0.0       | 2.6184     | 29.9043     | 906        | Gouveia                          |
+| nan     | contents        | 2_609_836     | 19_590     | 0.0       | 0.0171     | 16_948      | 907        | Guarda                           |
+| nan     | structural      | 13_760_139    | 331_408    | 357.1     | 128_991    | 1_457_617   | 907        | Guarda                           |
+| nan     | occupants       | 89.0610       | 0.0099     | 1.731E-09 | 8.377E-07  | 0.0556      | 907        | Guarda                           |
+| nan     | area            | 9_418         | 116.5142   | 4.148E-07 | 8.186E-05  | 679.5       | 907        | Guarda                           |
+| nan     | number          | 25.3995       | 0.1087     | 2.096E-09 | 2.250E-07  | 0.6187      | 907        | Guarda                           |
+| nan     | residents       | 80.1758       | 1.7060     | 0.0       | 7.346E-07  | 11.1454     | 907        | Guarda                           |
+| nan     | affectedpop     | 80.1758       | 2.2948     | 0.0       | 7.481E-07  | 17.9465     | 907        | Guarda                           |
+| nan     | injured         | 89.0610       | 0.0318     | 1.731E-09 | 8.450E-07  | 0.1934      | 907        | Guarda                           |
+| nan     | embodied_carbon | 3_485         | 82.6166    | 0.0846    | 33.5384    | 344.2       | 907        | Guarda                           |
+| nan     | contents        | 2_331_353     | 193.5      | 0.0       | 1.093E-04  | 0.0233      | 909        | Mêda                             |
+| nan     | structural      | 13_192_789    | 331_559    | 0.0       | 271_541    | 1_246_136   | 909        | Mêda                             |
+| nan     | occupants       | 55.4850       | 8.531E-05  | 0.0       | 5.318E-07  | 5.549E-07   | 909        | Mêda                             |
+| nan     | area            | 11_582        | 2.0577     | 0.0       | 1.153E-04  | 3.5052      | 909        | Mêda                             |
+| nan     | number          | 55.4926       | 0.0099     | 0.0       | 5.538E-07  | 0.0168      | 909        | Mêda                             |
+| nan     | residents       | 96.2618       | 0.0217     | 0.0       | 9.626E-07  | 0.0294      | 909        | Mêda                             |
+| nan     | affectedpop     | 96.2618       | 0.0850     | 0.0       | 9.626E-07  | 0.0552      | 909        | Mêda                             |
+| nan     | injured         | 55.4850       | 3.395E-04  | 0.0       | 5.318E-07  | 5.549E-07   | 909        | Mêda                             |
+| nan     | embodied_carbon | 3_479         | 67.6443    | 0.0       | 49.7237    | 260.9       | 909        | Mêda                             |
+| nan     | contents        | 31_826        | 45.8091    | 0.0       | 3.183E-04  | 3.183E-04   | 910        | Pinhel                           |
+| nan     | structural      | 127_303       | 1_984      | 0.0       | 781.5      | 7_198       | 910        | Pinhel                           |
+| nan     | occupants       | 11.3249       | 5.035E-05  | 0.0       | 1.132E-07  | 6.543E-07   | 910        | Pinhel                           |
+| nan     | area            | 124.0767      | 0.3000     | 0.0       | 1.241E-06  | 0.4372      | 910        | Pinhel                           |
+| nan     | number          | 1.2407        | 0.0040     | 0.0       | 1.241E-08  | 0.0058      | 910        | Pinhel                           |
+| nan     | injured         | 11.3249       | 3.015E-04  | 0.0       | 1.132E-07  | 5.442E-04   | 910        | Pinhel                           |
+| nan     | embodied_carbon | 61.8122       | 1.1044     | 0.0       | 0.5970     | 3.6582      | 910        | Pinhel                           |
+| nan     | contents        | 3_186_681     | 4_231      | 0.0       | 0.0064     | 0.0319      | 911        | Sabugal                          |
+| nan     | structural      | 18_057_864    | 311_426    | 0.0       | 244_407    | 941_192     | 911        | Sabugal                          |
+| nan     | occupants       | 61.9774       | 2.912E-04  | 0.0       | 6.159E-07  | 6.198E-07   | 911        | Sabugal                          |
+| nan     | area            | 15_840        | 14.4461    | 0.0       | 1.553E-04  | 2.9696      | 911        | Sabugal                          |
+| nan     | number          | 81.6981       | 0.0880     | 0.0       | 7.973E-07  | 0.0191      | 911        | Sabugal                          |
+| nan     | residents       | 112.1730      | 0.0725     | 0.0       | 1.115E-06  | 0.0103      | 911        | Sabugal                          |
+| nan     | affectedpop     | 112.1730      | 0.1151     | 0.0       | 1.122E-06  | 0.0445      | 911        | Sabugal                          |
+| nan     | injured         | 61.9774       | 0.0013     | 0.0       | 6.159E-07  | 2.426E-05   | 911        | Sabugal                          |
+| nan     | embodied_carbon | 4_948         | 64.0046    | 0.0       | 44.6660    | 198.4       | 911        | Sabugal                          |
+| nan     | contents        | 406_553       | 4_209      | 0.0       | 0.0015     | 4_187       | 912        | Seia                             |
+| nan     | structural      | 2_303_804     | 45_385     | 0.0       | 10_828     | 162_998     | 912        | Seia                             |
+| nan     | occupants       | 3.7958        | 0.0010     | 0.0       | 3.796E-08  | 0.0050      | 912        | Seia                             |
+| nan     | area            | 2_021         | 20.8738    | 0.0       | 2.021E-05  | 91.2775     | 912        | Seia                             |
+| nan     | number          | 7.0954        | 0.0543     | 0.0       | 7.095E-08  | 0.2062      | 912        | Seia                             |
+| nan     | residents       | 6.8686        | 0.0698     | 0.0       | 6.869E-08  | 0.3299      | 912        | Seia                             |
+| nan     | affectedpop     | 6.8686        | 0.1012     | 0.0       | 6.869E-08  | 0.6513      | 912        | Seia                             |
+| nan     | injured         | 3.7958        | 0.0013     | 0.0       | 3.796E-08  | 0.0054      | 912        | Seia                             |
+| nan     | embodied_carbon | 691.0         | 12.7957    | 0.0       | 2.7107     | 57.1195     | 912        | Seia                             |
+| nan     | contents        | 157_591       | 955.4      | 0.0       | 0.0010     | 0.0166      | 913        | Trancoso                         |
+| nan     | structural      | 893_017       | 12_090     | 0.0       | 3_995      | 37_490      | 913        | Trancoso                         |
+| nan     | occupants       | 1.8818        | 1.137E-04  | 0.0       | 1.441E-08  | 2.456E-04   | 913        | Trancoso                         |
+| nan     | area            | 783.3         | 3.6385     | 0.0       | 6.544E-06  | 11.0252     | 913        | Trancoso                         |
+| nan     | number          | 5.1400        | 0.0234     | 0.0       | 4.312E-08  | 0.0780      | 913        | Trancoso                         |
+| nan     | residents       | 3.4069        | 0.0238     | 0.0       | 2.608E-08  | 0.0982      | 913        | Trancoso                         |
+| nan     | affectedpop     | 3.4069        | 0.0302     | 0.0       | 2.683E-08  | 0.1483      | 913        | Trancoso                         |
+| nan     | injured         | 1.8818        | 4.166E-04  | 0.0       | 1.441E-08  | 0.0014      | 913        | Trancoso                         |
+| nan     | embodied_carbon | 237.0         | 2.5950     | 0.0       | 0.6474     | 6.9959      | 913        | Trancoso                         |
+| nan     | contents        | 46_404        | 3.8940     | 0.0       | 0.0        | 2.4111      | 914        | Vila Nova de Foz Côa             |
+| nan     | structural      | 185_616       | 7_307      | 0.0       | 7_449      | 27_086      | 914        | Vila Nova de Foz Côa             |
+| nan     | occupants       | 3.9400        | 9.892E-07  | 0.0       | 3.940E-08  | 3.940E-08   | 914        | Vila Nova de Foz Côa             |
+| nan     | area            | 180.9         | 0.0044     | 0.0       | 1.809E-06  | 1.809E-06   | 914        | Vila Nova de Foz Côa             |
+| nan     | number          | 0.2551        | 6.160E-06  | 0.0       | 2.551E-09  | 2.551E-09   | 914        | Vila Nova de Foz Côa             |
+| nan     | injured         | 3.9400        | 2.795E-06  | 0.0       | 3.940E-08  | 3.940E-08   | 914        | Vila Nova de Foz Côa             |
+| nan     | embodied_carbon | 85.1853       | 2.7567     | 0.0       | 2.6688     | 10.2400     | 914        | Vila Nova de Foz Côa             |
+| nan     | contents        | 6_938_479     | 196.2      | 0.0       | 0.0018     | 0.3244      | ES-AN      | Andalucía                        |
+| nan     | structural      | 29_724_676    | 85_806     | 0.0       | 39_740     | 668_716     | ES-AN      | Andalucía                        |
+| nan     | occupants       | 1_313         | 0.0010     | 0.0       | 3.165E-07  | 9.131E-06   | ES-AN      | Andalucía                        |
+| nan     | area            | 22_220        | 1.5670     | 0.0       | 5.356E-06  | 1.3503      | ES-AN      | Andalucía                        |
+| nan     | number          | 58.9959       | 0.0046     | 0.0       | 2.997E-08  | 0.0029      | ES-AN      | Andalucía                        |
+| nan     | injured         | 1_313         | 0.0037     | 0.0       | 3.165E-07  | 9.721E-06   | ES-AN      | Andalucía                        |
+| nan     | embodied_carbon | 10_399        | 23.1087    | 0.0       | 8.9700     | 177.2475    | ES-AN      | Andalucía                        |
+| nan     | contents        | 467_701       | 1_152      | 0.0       | 7.127E-04  | 7_655       | ES-CL      | Castilla y León                  |
+| nan     | structural      | 1_870_803     | 79_229     | 0.0       | 43_773     | 352_396     | ES-CL      | Castilla y León                  |
+| nan     | occupants       | 61.1757       | 0.0113     | 0.0       | 3.401E-07  | 0.0723      | ES-CL      | Castilla y León                  |
+| nan     | area            | 1_361         | 9.3062     | 0.0       | 7.566E-06  | 52.6968     | ES-CL      | Castilla y León                  |
+| nan     | number          | 3.3284        | 0.0245     | 0.0       | 2.164E-08  | 0.1030      | ES-CL      | Castilla y León                  |
+| nan     | injured         | 61.1757       | 0.0119     | 0.0       | 3.401E-07  | 0.0617      | ES-CL      | Castilla y León                  |
+| nan     | embodied_carbon | 611.2         | 18.2445    | 0.0       | 8.8001     | 79.1859     | ES-CL      | Castilla y León                  |
+| nan     | contents        | 278_911       | 1.248E-04  | 0.0       | 0.0        | 0.0022      | ES-CM      | Castilla-La Mancha               |
+| nan     | structural      | 1_115_644     | 1_087      | 0.0       | 0.0        | 23_271      | ES-CM      | Castilla-La Mancha               |
+| nan     | occupants       | 41.0237       | 1.051E-06  | 0.0       | 0.0        | 4.102E-07   | ES-CM      | Castilla-La Mancha               |
+| nan     | area            | 845.7         | 0.0016     | 0.0       | 0.0        | 8.457E-06   | ES-CM      | Castilla-La Mancha               |
+| nan     | number          | 3.9987        | 7.224E-06  | 0.0       | 0.0        | 3.999E-08   | ES-CM      | Castilla-La Mancha               |
+| nan     | injured         | 41.0237       | 4.009E-06  | 0.0       | 0.0        | 4.102E-07   | ES-CM      | Castilla-La Mancha               |
+| nan     | embodied_carbon | 404.5         | 0.2912     | 0.0       | 0.0        | 5.6570      | ES-CM      | Castilla-La Mancha               |
+| nan     | contents        | 1_213_906     | 11_321     | 4.055E-04 | 0.0082     | 112_595     | ES-EX      | Extremadura                      |
+| nan     | structural      | 6_142_196     | 170_320    | 1_587     | 125_363    | 479_280     | ES-EX      | Extremadura                      |
+| nan     | occupants       | 237.7         | 0.0100     | 6.969E-08 | 2.007E-06  | 0.0300      | ES-EX      | Extremadura                      |
+| nan     | area            | 4_426         | 9.2024     | 1.298E-06 | 3.938E-05  | 47.7044     | ES-EX      | Extremadura                      |
+| nan     | number          | 16.9921       | 0.0343     | 3.707E-09 | 1.399E-07  | 0.2562      | ES-EX      | Extremadura                      |
+| nan     | injured         | 237.7         | 0.0190     | 6.969E-08 | 2.045E-06  | 0.1077      | ES-EX      | Extremadura                      |
+| nan     | embodied_carbon | 1_946         | 45.4832    | 0.5646    | 31.9126    | 128.7469    | ES-EX      | Extremadura                      |
+| nan     | contents        | 1_833_411     | 22_604     | 0.0       | 0.0082     | 147_458     | ES-GA      | Galicia                          |
+| nan     | structural      | 7_387_210     | 300_101    | 0.0       | 115_462    | 1_468_129   | ES-GA      | Galicia                          |
+| nan     | occupants       | 268.4         | 0.0722     | 0.0       | 1.726E-06  | 0.3788      | ES-GA      | Galicia                          |
+| nan     | area            | 5_596         | 72.5918    | 0.0       | 3.600E-05  | 367.8       | ES-GA      | Galicia                          |
+| nan     | number          | 16.9968       | 0.1515     | 0.0       | 1.061E-07  | 0.7797      | ES-GA      | Galicia                          |
+| nan     | injured         | 268.4         | 0.1361     | 0.0       | 1.726E-06  | 0.7174      | ES-GA      | Galicia                          |
+| nan     | embodied_carbon | 2_670         | 85.4467    | 0.0       | 25.5390    | 376.5       | ES-GA      | Galicia                          |
+| nan     | contents        | 5_229_771     | 706.5      | 0.0       | 3.911E-06  | 234.0       | ESP.1.2_1  | Cádiz                            |
+| nan     | structural      | 29_599_560    | 105_088    | 0.0       | 4_482      | 539_057     | ESP.1.2_1  | Cádiz                            |
+| nan     | occupants       | 337.2         | 2.123E-04  | 0.0       | 2.059E-08  | 2.383E-06   | ESP.1.2_1  | Cádiz                            |
+| nan     | area            | 24_093        | 1.3379     | 0.0       | 1.622E-06  | 2.1009      | ESP.1.2_1  | Cádiz                            |
+| nan     | number          | 82.9993       | 0.0050     | 0.0       | 1.012E-08  | 0.0019      | ESP.1.2_1  | Cádiz                            |
+| nan     | residents       | 596.7         | 0.0553     | 0.0       | 3.605E-08  | 0.0869      | ESP.1.2_1  | Cádiz                            |
+| nan     | affectedpop     | 596.7         | 0.2250     | 0.0       | 3.605E-08  | 1.2099      | ESP.1.2_1  | Cádiz                            |
+| nan     | injured         | 337.2         | 7.506E-04  | 0.0       | 2.059E-08  | 2.600E-06   | ESP.1.2_1  | Cádiz                            |
+| nan     | embodied_carbon | 8_176         | 13.9244    | 0.0       | 0.3129     | 80.1350     | ESP.1.2_1  | Cádiz                            |
+| nan     | contents        | 13_807_168    | 2_341      | 0.0       | 0.0        | 227.7       | ESP.1.3_1  | Córdoba                          |
+| nan     | structural      | 55_913_532    | 45_065     | 0.0       | 0.0        | 294_992     | ESP.1.3_1  | Córdoba                          |
+| nan     | occupants       | 495.5         | 5.810E-04  | 0.0       | 0.0        | 2.870E-06   | ESP.1.3_1  | Córdoba                          |
+| nan     | area            | 52_438        | 5.3140     | 0.0       | 0.0        | 0.0279      | ESP.1.3_1  | Córdoba                          |
+| nan     | number          | 216.0         | 0.0265     | 0.0       | 0.0        | 1.474E-04   | ESP.1.3_1  | Córdoba                          |
+| nan     | residents       | 751.6         | 0.1354     | 0.0       | 0.0        | 0.0045      | ESP.1.3_1  | Córdoba                          |
+| nan     | affectedpop     | 751.6         | 0.2285     | 0.0       | 0.0        | 0.0921      | ESP.1.3_1  | Córdoba                          |
+| nan     | injured         | 495.5         | 0.0026     | 0.0       | 0.0        | 3.178E-06   | ESP.1.3_1  | Córdoba                          |
+| nan     | embodied_carbon | 17_322        | 12.7266    | 0.0       | 0.0        | 72.8498     | ESP.1.3_1  | Córdoba                          |
+| nan     | contents        | 6_236_232     | 0.1138     | 0.0       | 0.0109     | 0.0479      | ESP.1.4_1  | Granada                          |
+| nan     | structural      | 35_338_644    | 7_644      | 2_335     | 36_887     | 165_825     | ESP.1.4_1  | Granada                          |
+| nan     | occupants       | 259.5         | 4.381E-06  | 1.407E-08 | 5.118E-07  | 1.943E-06   | ESP.1.4_1  | Granada                          |
+| nan     | area            | 28_761        | 0.1320     | 1.431E-06 | 7.383E-05  | 2.0643      | ESP.1.4_1  | Granada                          |
+| nan     | number          | 222.0         | 7.408E-04  | 7.949E-09 | 3.782E-07  | 0.0115      | ESP.1.4_1  | Granada                          |
+| nan     | residents       | 459.1         | 0.0025     | 2.507E-08 | 1.266E-06  | 0.0807      | ESP.1.4_1  | Granada                          |
+| nan     | affectedpop     | 459.1         | 0.0082     | 2.507E-08 | 3.036E-06  | 0.2429      | ESP.1.4_1  | Granada                          |
+| nan     | injured         | 259.5         | 4.463E-05  | 1.407E-08 | 5.118E-07  | 8.027E-04   | ESP.1.4_1  | Granada                          |
+| nan     | embodied_carbon | 10_496        | 1.4868     | 0.3516    | 4.3567     | 27.8350     | ESP.1.4_1  | Granada                          |
+| nan     | contents        | 11_026_765    | 320.8      | 0.0       | 0.0024     | 0.4547      | ESP.1.5_1  | Huelva                           |
+| nan     | structural      | 62_260_884    | 107_602    | 0.0       | 5_248      | 486_336     | ESP.1.5_1  | Huelva                           |
+| nan     | occupants       | 529.6         | 5.184E-04  | 0.0       | 1.156E-07  | 8.762E-05   | ESP.1.5_1  | Huelva                           |
+| nan     | area            | 48_359        | 3.7621     | 0.0       | 1.037E-05  | 3.1418      | ESP.1.5_1  | Huelva                           |
+| nan     | number          | 248.1         | 0.0197     | 0.0       | 6.005E-08  | 0.0159      | ESP.1.5_1  | Huelva                           |
+| nan     | residents       | 938.6         | 0.0931     | 0.0       | 2.132E-07  | 0.0847      | ESP.1.5_1  | Huelva                           |
+| nan     | affectedpop     | 938.6         | 0.2230     | 0.0       | 2.132E-07  | 0.2089      | ESP.1.5_1  | Huelva                           |
+| nan     | injured         | 529.6         | 0.0019     | 0.0       | 1.156E-07  | 0.0012      | ESP.1.5_1  | Huelva                           |
+| nan     | embodied_carbon | 18_162        | 35.5449    | 0.0       | 2.6663     | 161.9224    | ESP.1.5_1  | Huelva                           |
+| nan     | contents        | 4_304_812     | 211.0      | 0.0       | 0.0054     | 0.0248      | ESP.1.6_1  | Jaén                             |
+| nan     | structural      | 23_573_592    | 22_523     | 0.0       | 96_238     | 358_201     | ESP.1.6_1  | Jaén                             |
+| nan     | occupants       | 161.9422      | 2.161E-05  | 0.0       | 4.453E-07  | 1.269E-06   | ESP.1.6_1  | Jaén                             |
+| nan     | area            | 19_263        | 0.2014     | 0.0       | 5.736E-05  | 0.9736      | ESP.1.6_1  | Jaén                             |
+| nan     | number          | 96.3660       | 0.0018     | 0.0       | 2.577E-07  | 0.0022      | ESP.1.6_1  | Jaén                             |
+| nan     | residents       | 271.1         | 0.0038     | 0.0       | 7.156E-07  | 0.0225      | ESP.1.6_1  | Jaén                             |
+| nan     | affectedpop     | 271.1         | 0.0133     | 0.0       | 8.024E-07  | 0.1948      | ESP.1.6_1  | Jaén                             |
+| nan     | injured         | 161.9422      | 6.148E-05  | 0.0       | 4.533E-07  | 3.531E-04   | ESP.1.6_1  | Jaén                             |
+| nan     | embodied_carbon | 6_417         | 2.5473     | 0.0       | 9.4886     | 34.4897     | ESP.1.6_1  | Jaén                             |
+| nan     | contents        | 20_201_060    | 463.2      | 0.0       | 0.0066     | 13_406      | ESP.1.7_1  | Málaga                           |
+| nan     | structural      | 113_926_664   | 108_957    | 0.0       | 153_616    | 972_911     | ESP.1.7_1  | Málaga                           |
+| nan     | occupants       | 1_262         | 1.123E-04  | 0.0       | 1.297E-06  | 6.667E-06   | ESP.1.7_1  | Málaga                           |
+| nan     | area            | 91_342        | 0.3361     | 0.0       | 8.772E-05  | 0.9820      | ESP.1.7_1  | Málaga                           |
+| nan     | number          | 276.5         | 6.324E-04  | 0.0       | 5.787E-08  | 0.0044      | ESP.1.7_1  | Málaga                           |
+| nan     | residents       | 2_189         | 0.0278     | 0.0       | 2.271E-06  | 0.0725      | ESP.1.7_1  | Málaga                           |
+| nan     | affectedpop     | 2_189         | 0.1615     | 0.0       | 2.305E-06  | 1.2124      | ESP.1.7_1  | Málaga                           |
+| nan     | injured         | 1_262         | 1.811E-04  | 0.0       | 1.297E-06  | 1.038E-04   | ESP.1.7_1  | Málaga                           |
+| nan     | embodied_carbon | 29_989        | 17.8193    | 0.0       | 20.1979    | 198.9       | ESP.1.7_1  | Málaga                           |
+| nan     | contents        | 9_565_985     | 1_265      | 0.0       | 1.332E-19  | 5_879       | ESP.1.8_1  | Sevilla                          |
+| nan     | structural      | 53_985_052    | 129_102    | 0.0       | 2_926      | 629_817     | ESP.1.8_1  | Sevilla                          |
+| nan     | occupants       | 612.2         | 6.492E-04  | 0.0       | 5.794E-08  | 3.687E-05   | ESP.1.8_1  | Sevilla                          |
+| nan     | area            | 45_009        | 4.1732     | 0.0       | 4.147E-06  | 2.4090      | ESP.1.8_1  | Sevilla                          |
+| nan     | number          | 124.2651      | 0.0288     | 0.0       | 1.000E-08  | 0.0063      | ESP.1.8_1  | Sevilla                          |
+| nan     | residents       | 1_077         | 0.1382     | 0.0       | 1.033E-07  | 0.1530      | ESP.1.8_1  | Sevilla                          |
+| nan     | affectedpop     | 1_077         | 0.4346     | 0.0       | 1.034E-07  | 1.5715      | ESP.1.8_1  | Sevilla                          |
+| nan     | injured         | 612.2         | 0.0019     | 0.0       | 5.794E-08  | 3.561E-04   | ESP.1.8_1  | Sevilla                          |
+| nan     | embodied_carbon | 15_178        | 22.8153    | 0.0       | 1.2406     | 114.7644    | ESP.1.8_1  | Sevilla                          |
+| nan     | contents        | 14_641_219    | 186_331    | 0.0062    | 0.4668     | 80_481      | ESP.11.1_1 | Badajoz                          |
+| nan     | structural      | 82_917_144    | 1_698_882  | 57_526    | 450_348    | 4_023_479   | ESP.11.1_1 | Badajoz                          |
+| nan     | occupants       | 672.2         | 0.0765     | 5.744E-07 | 5.366E-06  | 0.1327      | ESP.11.1_1 | Badajoz                          |
+| nan     | area            | 73_590        | 1_021      | 5.280E-05 | 0.1837     | 1_626       | ESP.11.1_1 | Badajoz                          |
+| nan     | number          | 582.6         | 9.8473     | 1.548E-07 | 8.818E-04  | 14.1911     | ESP.11.1_1 | Badajoz                          |
+| nan     | residents       | 1_177         | 18.0677    | 9.709E-07 | 0.0055     | 46.8844     | ESP.11.1_1 | Badajoz                          |
+| nan     | affectedpop     | 1_177         | 23.6129    | 9.709E-07 | 0.0728     | 91.2001     | ESP.11.1_1 | Badajoz                          |
+| nan     | injured         | 672.2         | 0.3176     | 5.744E-07 | 5.493E-06  | 0.5277      | ESP.11.1_1 | Badajoz                          |
+| nan     | embodied_carbon | 26_615        | 530.3      | 15.5698   | 87.9895    | 1_205       | ESP.11.1_1 | Badajoz                          |
+| nan     | contents        | 8_998_204     | 119_145    | 0.0057    | 0.2652     | 743_055     | ESP.11.2_1 | Cáceres                          |
+| nan     | structural      | 50_466_888    | 1_100_055  | 19_598    | 400_148    | 4_547_955   | ESP.11.2_1 | Cáceres                          |
+| nan     | occupants       | 282.9         | 0.0409     | 3.326E-07 | 2.686E-06  | 0.1557      | ESP.11.2_1 | Cáceres                          |
+| nan     | area            | 45_134        | 579.0      | 4.022E-05 | 6.1686     | 2_628       | ESP.11.2_1 | Cáceres                          |
+| nan     | number          | 205.3         | 2.8628     | 1.409E-07 | 0.0303     | 13.1525     | ESP.11.2_1 | Cáceres                          |
+| nan     | residents       | 486.3         | 7.7942     | 5.415E-07 | 0.0980     | 36.0113     | ESP.11.2_1 | Cáceres                          |
+| nan     | affectedpop     | 486.3         | 11.4187    | 5.755E-07 | 0.4170     | 49.7135     | ESP.11.2_1 | Cáceres                          |
+| nan     | injured         | 282.9         | 0.1488     | 3.326E-07 | 5.012E-04  | 0.6854      | ESP.11.2_1 | Cáceres                          |
+| nan     | embodied_carbon | 16_469        | 334.7      | 6.7450    | 113.2347   | 1_225       | ESP.11.2_1 | Cáceres                          |
+| nan     | contents        | 4_418_335     | 219_193    | 0.0       | 0.0        | 1_683_355   | ESP.12.1_1 | A Coruña                         |
+| nan     | structural      | 25_001_092    | 739_736    | 0.0       | 1_249      | 8_845_454   | ESP.12.1_1 | A Coruña                         |
+| nan     | occupants       | 132.1895      | 0.0530     | 0.0       | 1.600E-09  | 0.5103      | ESP.12.1_1 | A Coruña                         |
+| nan     | area            | 19_248        | 413.5      | 0.0       | 4.784E-07  | 3_981       | ESP.12.1_1 | A Coruña                         |
+| nan     | number          | 96.0354       | 2.0661     | 0.0       | 3.365E-10  | 19.9066     | ESP.12.1_1 | A Coruña                         |
+| nan     | residents       | 235.3         | 6.2281     | 0.0       | 0.0        | 65.6240     | ESP.12.1_1 | A Coruña                         |
+| nan     | affectedpop     | 235.3         | 8.4374     | 0.0       | 0.0        | 100.6746    | ESP.12.1_1 | A Coruña                         |
+| nan     | injured         | 132.1895      | 0.1196     | 0.0       | 1.600E-09  | 1.2005      | ESP.12.1_1 | A Coruña                         |
+| nan     | embodied_carbon | 7_264         | 245.6      | 0.0       | 0.6247     | 2_543       | ESP.12.1_1 | A Coruña                         |
+| nan     | contents        | 19_411        | 96.9824    | 0.0       | 1.941E-04  | 1.941E-04   | ESP.12.2_1 | Lugo                             |
+| nan     | structural      | 109_994       | 1_123      | 0.0       | 70.9864    | 4_233       | ESP.12.2_1 | Lugo                             |
+| nan     | occupants       | 0.5880        | 2.740E-05  | 0.0       | 5.880E-09  | 2.496E-06   | ESP.12.2_1 | Lugo                             |
+| nan     | area            | 99.9950       | 0.6231     | 0.0       | 9.999E-07  | 1.1062      | ESP.12.2_1 | Lugo                             |
+| nan     | number          | 0.9999        | 0.0062     | 0.0       | 9.999E-09  | 0.0111      | ESP.12.2_1 | Lugo                             |
+| nan     | residents       | 1.0270        | 0.0078     | 0.0       | 1.027E-08  | 0.0176      | ESP.12.2_1 | Lugo                             |
+| nan     | affectedpop     | 1.0270        | 0.0113     | 0.0       | 1.027E-08  | 0.0451      | ESP.12.2_1 | Lugo                             |
+| nan     | injured         | 0.5880        | 1.377E-04  | 0.0       | 5.880E-09  | 3.076E-04   | ESP.12.2_1 | Lugo                             |
+| nan     | embodied_carbon | 37.7048       | 0.3909     | 0.0       | 0.0209     | 1.4046      | ESP.12.2_1 | Lugo                             |
+| nan     | contents        | 3_269_786     | 28_872     | 7.764E-04 | 0.0163     | 217_642     | ESP.12.3_1 | Ourense                          |
+| nan     | structural      | 18_528_804    | 315_633    | 907.9     | 77_305     | 1_660_772   | ESP.12.3_1 | Ourense                          |
+| nan     | occupants       | 91.7700       | 0.0148     | 2.045E-08 | 5.701E-07  | 0.1161      | ESP.12.3_1 | Ourense                          |
+| nan     | area            | 16_753        | 176.1670   | 4.000E-06 | 0.1515     | 1_367       | ESP.12.3_1 | Ourense                          |
+| nan     | number          | 79.0186       | 0.7723     | 2.000E-08 | 2.146E-04  | 3.7255      | ESP.12.3_1 | Ourense                          |
+| nan     | residents       | 160.3856      | 2.0492     | 3.572E-08 | 0.0014     | 15.7569     | ESP.12.3_1 | Ourense                          |
+| nan     | affectedpop     | 160.3856      | 2.7230     | 3.572E-08 | 0.0030     | 21.9262     | ESP.12.3_1 | Ourense                          |
+| nan     | injured         | 91.7700       | 0.0397     | 2.045E-08 | 5.738E-07  | 0.3160      | ESP.12.3_1 | Ourense                          |
+| nan     | embodied_carbon | 5_961         | 102.6081   | 0.5368    | 20.7331    | 519.3       | ESP.12.3_1 | Ourense                          |
+| nan     | contents        | 14_162_123    | 77_351     | 0.0       | 1.9727     | 303_950     | ESP.12.4_1 | Pontevedra                       |
+| nan     | structural      | 80_252_016    | 1_311_431  | 0.0       | 312_697    | 5_814_890   | ESP.12.4_1 | Pontevedra                       |
+| nan     | occupants       | 599.1         | 0.0500     | 0.0       | 2.737E-06  | 0.3494      | ESP.12.4_1 | Pontevedra                       |
+| nan     | area            | 63_429        | 492.4      | 0.0       | 1.0687     | 3_119       | ESP.12.4_1 | Pontevedra                       |
+| nan     | number          | 255.4         | 2.6721     | 0.0       | 0.0053     | 15.5415     | ESP.12.4_1 | Pontevedra                       |
+| nan     | residents       | 1_064         | 9.2666     | 0.0       | 0.0164     | 55.5488     | ESP.12.4_1 | Pontevedra                       |
+| nan     | affectedpop     | 1_064         | 13.3170    | 0.0       | 0.0445     | 80.6574     | ESP.12.4_1 | Pontevedra                       |
+| nan     | injured         | 599.1         | 0.1729     | 0.0       | 2.957E-06  | 0.9897      | ESP.12.4_1 | Pontevedra                       |
+| nan     | embodied_carbon | 21_932        | 388.6      | 0.0       | 89.6235    | 1_764       | ESP.12.4_1 | Pontevedra                       |
+| nan     | contents        | 1_397_288     | 0.1025     | 0.0       | 0.0029     | 0.0103      | ESP.4.2_1  | Ciudad Real                      |
+| nan     | structural      | 7_912_958     | 2_556      | 0.0       | 8_484      | 65_803      | ESP.4.2_1  | Ciudad Real                      |
+| nan     | occupants       | 62.4916       | 4.669E-05  | 0.0       | 1.277E-07  | 1.162E-04   | ESP.4.2_1  | Ciudad Real                      |
+| nan     | area            | 7_012         | 0.2894     | 0.0       | 1.364E-05  | 2.2503      | ESP.4.2_1  | Ciudad Real                      |
+| nan     | number          | 51.9985       | 0.0015     | 0.0       | 5.640E-08  | 0.0125      | ESP.4.2_1  | Ciudad Real                      |
+| nan     | residents       | 109.4650      | 0.0054     | 0.0       | 2.251E-07  | 0.0406      | ESP.4.2_1  | Ciudad Real                      |
+| nan     | affectedpop     | 109.4650      | 0.0100     | 0.0       | 2.251E-07  | 0.2272      | ESP.4.2_1  | Ciudad Real                      |
+| nan     | injured         | 62.4916       | 1.115E-04  | 0.0       | 1.277E-07  | 4.241E-04   | ESP.4.2_1  | Ciudad Real                      |
+| nan     | embodied_carbon | 2_333         | 0.7877     | 0.0       | 1.8226     | 18.4464     | ESP.4.2_1  | Ciudad Real                      |
+| nan     | contents        | 9_195_523     | 0.0039     | 0.0       | 7.255E-05  | 0.0618      | ESP.4.5_1  | Toledo                           |
+| nan     | structural      | 52_107_960    | 6_054      | 0.0       | 178.6390   | 89_582      | ESP.4.5_1  | Toledo                           |
+| nan     | occupants       | 316.1         | 1.088E-05  | 0.0       | 3.081E-09  | 2.020E-06   | ESP.4.5_1  | Toledo                           |
+| nan     | area            | 43_046        | 0.1667     | 0.0       | 3.738E-07  | 3.469E-04   | ESP.4.5_1  | Toledo                           |
+| nan     | number          | 272.4         | 8.925E-04  | 0.0       | 2.076E-09  | 2.281E-06   | ESP.4.5_1  | Toledo                           |
+| nan     | residents       | 558.3         | 0.0031     | 0.0       | 5.382E-09  | 4.498E-06   | ESP.4.5_1  | Toledo                           |
+| nan     | affectedpop     | 558.3         | 0.0060     | 0.0       | 5.382E-09  | 4.498E-06   | ESP.4.5_1  | Toledo                           |
+| nan     | injured         | 316.1         | 5.616E-05  | 0.0       | 3.081E-09  | 2.021E-06   | ESP.4.5_1  | Toledo                           |
+| nan     | embodied_carbon | 15_277        | 1.9151     | 0.0       | 0.0562     | 28.5722     | ESP.4.5_1  | Toledo                           |
+| nan     | contents        | 6_787_001     | 15.9107    | 0.0       | 0.0        | 0.0167      | ESP.5.1_1  | Ávila                            |
+| nan     | structural      | 38_409_200    | 7_784      | 0.0       | 30.9374    | 49_978      | ESP.5.1_1  | Ávila                            |
+| nan     | occupants       | 157.0417      | 1.777E-05  | 0.0       | 4.427E-09  | 4.194E-07   | ESP.5.1_1  | Ávila                            |
+| nan     | area            | 34_020        | 0.5699     | 0.0       | 1.000E-06  | 0.1079      | ESP.5.1_1  | Ávila                            |
+| nan     | number          | 150.3550      | 0.0055     | 0.0       | 1.000E-08  | 0.0011      | ESP.5.1_1  | Ávila                            |
+| nan     | residents       | 274.0         | 0.0053     | 0.0       | 7.734E-09  | 0.0012      | ESP.5.1_1  | Ávila                            |
+| nan     | affectedpop     | 274.0         | 0.0078     | 0.0       | 7.734E-09  | 0.0058      | ESP.5.1_1  | Ávila                            |
+| nan     | injured         | 157.0417      | 9.106E-05  | 0.0       | 4.427E-09  | 1.167E-06   | ESP.5.1_1  | Ávila                            |
+| nan     | embodied_carbon | 12_323        | 2.3438     | 0.0       | 0.0090     | 15.8942     | ESP.5.1_1  | Ávila                            |
+| nan     | contents        | 4_443_185     | 30_456     | 0.0       | 0.0160     | 168_530     | ESP.5.5_1  | Salamanca                        |
+| nan     | structural      | 23_249_750    | 397_777    | 0.0       | 106_966    | 2_102_249   | ESP.5.5_1  | Salamanca                        |
+| nan     | occupants       | 158.2843      | 0.0129     | 0.0       | 7.262E-07  | 0.0839      | ESP.5.5_1  | Salamanca                        |
+| nan     | area            | 21_225        | 141.9312   | 0.0       | 1.151E-04  | 1_111       | ESP.5.5_1  | Salamanca                        |
+| nan     | number          | 137.6805      | 1.0304     | 0.0       | 8.598E-07  | 7.7785      | ESP.5.5_1  | Salamanca                        |
+| nan     | residents       | 257.9         | 2.0852     | 0.0       | 1.353E-06  | 17.5692     | ESP.5.5_1  | Salamanca                        |
+| nan     | affectedpop     | 257.9         | 2.8479     | 0.0       | 9.861E-06  | 22.8913     | ESP.5.5_1  | Salamanca                        |
+| nan     | injured         | 158.2843      | 0.0396     | 0.0       | 7.267E-07  | 0.3177      | ESP.5.5_1  | Salamanca                        |
+| nan     | embodied_carbon | 7_328         | 109.1362   | 0.0       | 25.8337    | 632.2       | ESP.5.5_1  | Salamanca                        |
+| nan     | contents        | 663_985       | 3_536      | 0.0       | 0.0037     | 1.0310      | ESP.5.9_1  | Zamora                           |
+| nan     | structural      | 3_544_999     | 35_824     | 0.0       | 5_726      | 192_685     | ESP.5.9_1  | Zamora                           |
+| nan     | occupants       | 16.3706       | 0.0014     | 0.0       | 9.171E-08  | 0.0044      | ESP.5.9_1  | Zamora                           |
+| nan     | area            | 3_288         | 20.0954    | 0.0       | 2.400E-05  | 70.0560     | ESP.5.9_1  | Zamora                           |
+| nan     | number          | 26.2042       | 0.1940     | 0.0       | 2.300E-07  | 0.5813      | ESP.5.9_1  | Zamora                           |
+| nan     | residents       | 25.2938       | 0.2118     | 0.0       | 2.023E-07  | 0.8955      | ESP.5.9_1  | Zamora                           |
+| nan     | affectedpop     | 25.2938       | 0.3055     | 0.0       | 2.023E-07  | 1.8082      | ESP.5.9_1  | Zamora                           |
+| nan     | injured         | 16.3706       | 0.0037     | 0.0       | 1.158E-07  | 0.0152      | ESP.5.9_1  | Zamora                           |
+| nan     | embodied_carbon | 1_213         | 14.0046    | 0.0       | 2.1907     | 60.1003     | ESP.5.9_1  | Zamora                           |
+| nan     | contents        | 329_565       | 2.018E-04  | 0.0       | 0.0        | 0.0033      | ESP.8.1_1  | Madrid                           |
+| nan     | structural      | 1_867_533     | 427.6      | 0.0       | 0.0        | 9_163       | ESP.8.1_1  | Madrid                           |
+| nan     | occupants       | 24.6275       | 4.567E-08  | 0.0       | 0.0        | 2.463E-07   | ESP.8.1_1  | Madrid                           |
+| nan     | area            | 1_245         | 3.765E-04  | 0.0       | 0.0        | 1.245E-05   | ESP.8.1_1  | Madrid                           |
+| nan     | number          | 3.0001        | 9.072E-07  | 0.0       | 0.0        | 3.000E-08   | ESP.8.1_1  | Madrid                           |
+| nan     | residents       | 43.8915       | 3.188E-05  | 0.0       | 0.0        | 4.389E-07   | ESP.8.1_1  | Madrid                           |
+| nan     | affectedpop     | 43.8915       | 1.073E-04  | 0.0       | 0.0        | 4.389E-07   | ESP.8.1_1  | Madrid                           |
+| nan     | injured         | 24.6275       | 5.381E-07  | 0.0       | 0.0        | 2.463E-07   | ESP.8.1_1  | Madrid                           |
+| nan     | embodied_carbon | 470.7         | 0.1199     | 0.0       | 0.0        | 2.5955      | ESP.8.1_1  | Madrid                           |
+| nan     | contents        | 5_720_314     | 118.1716   | 0.0       | 3.335E-04  | 0.0309      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | structural      | 29_190_636    | 26_845     | 0.0       | 448.5      | 220_133     | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | occupants       | 2_747         | 0.0063     | 0.0       | 3.134E-07  | 0.0033      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | area            | 94_760        | 4.0528     | 0.0       | 1.500E-05  | 3.3102      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | number          | 1_082         | 0.0615     | 0.0       | 9.982E-08  | 0.0358      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | residents       | 3_416         | 0.2416     | 0.0       | 3.732E-07  | 0.1280      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | affectedpop     | 3_416         | 0.4013     | 0.0       | 3.732E-07  | 0.4307      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | injured         | 2_747         | 0.0052     | 0.0       | 3.134E-07  | 0.0035      | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | embodied_carbon | 40_653        | 20.8050    | 0.0       | 1.4496     | 151.9938    | MA-01      | Tangier-Tetouan-Al-Hoceïma       |
+| nan     | contents        | 208_395       | 1.4338     | 0.0       | 4.236E-05  | 3.433E-04   | MA-02      | Al-Sharq                         |
+| nan     | structural      | 1_160_732     | 37.5040    | 0.0       | 19.1787    | 897.8       | MA-02      | Al-Sharq                         |
+| nan     | occupants       | 117.2093      | 2.500E-05  | 0.0       | 5.573E-08  | 1.224E-05   | MA-02      | Al-Sharq                         |
+| nan     | area            | 3_551         | 0.0128     | 0.0       | 2.000E-06  | 0.0549      | MA-02      | Al-Sharq                         |
+| nan     | number          | 38.0032       | 1.798E-04  | 0.0       | 2.000E-08  | 5.488E-04   | MA-02      | Al-Sharq                         |
+| nan     | residents       | 153.7799      | 0.0011     | 0.0       | 8.313E-08  | 0.0024      | MA-02      | Al-Sharq                         |
+| nan     | affectedpop     | 153.7799      | 0.0021     | 0.0       | 8.313E-08  | 0.0064      | MA-02      | Al-Sharq                         |
+| nan     | injured         | 117.2093      | 2.053E-05  | 0.0       | 5.573E-08  | 3.639E-07   | MA-02      | Al-Sharq                         |
+| nan     | embodied_carbon | 1_055         | 0.0962     | 0.0       | 0.0087     | 2.1741      | MA-02      | Al-Sharq                         |
+| nan     | contents        | 4_990_356     | 187.2      | 0.0       | 0.0        | 1.7035      | MA-03      | Fez-Meknes                       |
+| nan     | structural      | 25_645_198    | 30_335     | 0.0       | 0.0        | 229_118     | MA-03      | Fez-Meknes                       |
+| nan     | occupants       | 3_236         | 0.0017     | 0.0       | 0.0        | 7.214E-04   | MA-03      | Fez-Meknes                       |
+| nan     | area            | 79_484        | 2.0710     | 0.0       | 0.0        | 2.3207      | MA-03      | Fez-Meknes                       |
+| nan     | number          | 859.8         | 0.0257     | 0.0       | 0.0        | 0.0208      | MA-03      | Fez-Meknes                       |
+| nan     | residents       | 3_555         | 0.1312     | 0.0       | 3.036E-06  | 0.6587      | MA-03      | Fez-Meknes                       |
+| nan     | affectedpop     | 3_555         | 0.2546     | 0.0       | 3.036E-06  | 1.6852      | MA-03      | Fez-Meknes                       |
+| nan     | injured         | 3_236         | 0.0034     | 0.0       | 0.0        | 0.0017      | MA-03      | Fez-Meknes                       |
+| nan     | embodied_carbon | 31_095        | 24.5621    | 0.0       | 0.0        | 174.0908    | MA-03      | Fez-Meknes                       |
+| nan     | contents        | 6_847_760     | 3_876      | 0.0       | 0.0017     | 10_612      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | structural      | 33_139_916    | 111_009    | 0.0       | 37_860     | 494_635     | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | occupants       | 4_161         | 0.0159     | 0.0       | 2.292E-06  | 0.0163      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | area            | 97_854        | 11.3305    | 0.0       | 3.909E-05  | 10.7843     | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | number          | 845.9         | 0.1421     | 0.0       | 1.650E-07  | 0.1564      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | residents       | 4_132         | 0.7268     | 0.0       | 1.753E-06  | 0.9111      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | affectedpop     | 4_132         | 1.3873     | 0.0       | 1.755E-06  | 1.7081      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | injured         | 4_161         | 0.0224     | 0.0       | 2.292E-06  | 0.0231      | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | embodied_carbon | 40_888        | 88.4173    | 0.0       | 29.6567    | 417.3       | MA-04      | Al-Rabat-Salé-Al-Kénitra         |
+| nan     | contents        | 2_874_461     | 251.7      | 0.0       | 6.135E-04  | 541.6       | MA-05      | Béni Mellal-Khénifra             |
+| nan     | structural      | 15_000_907    | 25_112     | 0.0       | 1_695      | 137_397     | MA-05      | Béni Mellal-Khénifra             |
+| nan     | occupants       | 1_512         | 0.0029     | 0.0       | 4.777E-07  | 0.0084      | MA-05      | Béni Mellal-Khénifra             |
+| nan     | area            | 43_962        | 2.3176     | 0.0       | 6.812E-06  | 5.3515      | MA-05      | Béni Mellal-Khénifra             |
+| nan     | number          | 385.9         | 0.0214     | 0.0       | 5.143E-08  | 0.0523      | MA-05      | Béni Mellal-Khénifra             |
+| nan     | residents       | 1_795         | 0.2505     | 0.0       | 6.037E-07  | 1.1463      | MA-05      | Béni Mellal-Khénifra             |
+| nan     | affectedpop     | 1_795         | 0.8136     | 0.0       | 6.037E-07  | 2.9515      | MA-05      | Béni Mellal-Khénifra             |
+| nan     | injured         | 1_512         | 0.0040     | 0.0       | 4.777E-07  | 0.0078      | MA-05      | Béni Mellal-Khénifra             |
+| nan     | embodied_carbon | 15_900        | 14.7113    | 0.0       | 2.9022     | 85.9630     | MA-05      | Béni Mellal-Khénifra             |
+| nan     | contents        | 11_230_778    | 5_110      | 1.753E-04 | 0.0300     | 14_810      | MA-06      | Casablanca-Settat                |
+| nan     | structural      | 59_852_696    | 197_922    | 1_011     | 87_558     | 772_257     | MA-06      | Casablanca-Settat                |
+| nan     | occupants       | 6_317         | 0.0464     | 6.523E-07 | 1.662E-05  | 0.1701      | MA-06      | Casablanca-Settat                |
+| nan     | area            | 182_153       | 101.3918   | 1.743E-05 | 5.105E-04  | 229.1       | MA-06      | Casablanca-Settat                |
+| nan     | number          | 1_944         | 1.2863     | 3.000E-08 | 5.453E-06  | 2.7075      | MA-06      | Casablanca-Settat                |
+| nan     | residents       | 8_358         | 6.7637     | 9.701E-07 | 2.364E-05  | 13.5958     | MA-06      | Casablanca-Settat                |
+| nan     | affectedpop     | 8_358         | 10.2391    | 9.701E-07 | 7.108E-05  | 35.1885     | MA-06      | Casablanca-Settat                |
+| nan     | injured         | 6_317         | 0.1752     | 6.523E-07 | 1.662E-05  | 0.4597      | MA-06      | Casablanca-Settat                |
+| nan     | embodied_carbon | 73_188        | 223.3      | 1.0641    | 90.2829    | 753.1       | MA-06      | Casablanca-Settat                |
+| nan     | contents        | 8_591_734     | 1_433      | 0.0       | 0.0052     | 1.8445      | MA-07      | Marrakech-Safi                   |
+| nan     | structural      | 46_802_080    | 49_777     | 0.0       | 19_848     | 183_916     | MA-07      | Marrakech-Safi                   |
+| nan     | occupants       | 4_800         | 0.0470     | 0.0       | 2.176E-06  | 0.0930      | MA-07      | Marrakech-Safi                   |
+| nan     | area            | 142_210       | 46.4343    | 0.0       | 7.387E-05  | 63.2418     | MA-07      | Marrakech-Safi                   |
+| nan     | number          | 1_531         | 0.5741     | 0.0       | 7.335E-07  | 0.7266      | MA-07      | Marrakech-Safi                   |
+| nan     | residents       | 6_545         | 2.8377     | 0.0       | 2.916E-06  | 4.5425      | MA-07      | Marrakech-Safi                   |
+| nan     | affectedpop     | 6_545         | 4.0938     | 0.0       | 1.091E-05  | 9.6814      | MA-07      | Marrakech-Safi                   |
+| nan     | injured         | 4_800         | 0.0657     | 0.0       | 2.176E-06  | 0.1009      | MA-07      | Marrakech-Safi                   |
+| nan     | embodied_carbon | 56_023        | 62.6468    | 0.0       | 19.8965    | 246.3       | MA-07      | Marrakech-Safi                   |
+| nan     | contents        | 1_471_714     | 23.1669    | 0.0       | 0.0021     | 0.0086      | MA-08      | Drâa-Tafilalet                   |
+| nan     | structural      | 7_774_754     | 2_136      | 0.0       | 5_453      | 28_953      | MA-08      | Drâa-Tafilalet                   |
+| nan     | occupants       | 973.7         | 0.0013     | 0.0       | 1.473E-06  | 8.475E-05   | MA-08      | Drâa-Tafilalet                   |
+| nan     | area            | 26_782        | 1.0332     | 0.0       | 3.780E-05  | 0.1049      | MA-08      | Drâa-Tafilalet                   |
+| nan     | number          | 274.6         | 0.0124     | 0.0       | 3.933E-07  | 0.0010      | MA-08      | Drâa-Tafilalet                   |
+| nan     | residents       | 1_334         | 0.0592     | 0.0       | 1.970E-06  | 2.279E-04   | MA-08      | Drâa-Tafilalet                   |
+| nan     | affectedpop     | 1_334         | 0.0727     | 0.0       | 1.970E-06  | 8.608E-04   | MA-08      | Drâa-Tafilalet                   |
+| nan     | injured         | 973.7         | 0.0013     | 0.0       | 1.473E-06  | 5.530E-06   | MA-08      | Drâa-Tafilalet                   |
+| nan     | embodied_carbon | 10_707        | 2.5855     | 0.0       | 6.9964     | 28.8316     | MA-08      | Drâa-Tafilalet                   |
+| nan     | contents        | 3_740_797     | 310.0      | 0.0       | 9.218E-42  | 0.5171      | MA-09      | Souss-Massa                      |
+| nan     | structural      | 19_200_756    | 32_048     | 0.0       | 71.8808    | 215_289     | MA-09      | Souss-Massa                      |
+| nan     | occupants       | 2_428         | 0.0132     | 0.0       | 1.307E-07  | 9.266E-04   | MA-09      | Souss-Massa                      |
+| nan     | area            | 62_029        | 6.1411     | 0.0       | 6.475E-06  | 0.7887      | MA-09      | Souss-Massa                      |
+| nan     | number          | 643.1         | 0.0779     | 0.0       | 5.944E-09  | 0.0054      | MA-09      | Souss-Massa                      |
+| nan     | residents       | 3_088         | 0.5064     | 0.0       | 2.252E-07  | 0.0588      | MA-09      | Souss-Massa                      |
+| nan     | affectedpop     | 3_088         | 0.9520     | 0.0       | 2.252E-07  | 0.3456      | MA-09      | Souss-Massa                      |
+| nan     | injured         | 2_428         | 0.0103     | 0.0       | 1.307E-07  | 5.990E-04   | MA-09      | Souss-Massa                      |
+| nan     | embodied_carbon | 22_507        | 20.1313    | 0.0       | 0.0400     | 130.6767    | MA-09      | Souss-Massa                      |
+| nan     | contents        | 433_212       | 0.2374     | 0.0       | 4.575E-05  | 0.0011      | MA-10      | Guelmim-Wadi Noun                |
+| nan     | structural      | 2_196_849     | 93.5174    | 0.0       | 52.1692    | 2_492       | MA-10      | Guelmim-Wadi Noun                |
+| nan     | occupants       | 231.2         | 4.443E-05  | 0.0       | 6.424E-08  | 8.883E-07   | MA-10      | Guelmim-Wadi Noun                |
+| nan     | area            | 7_539         | 0.0220     | 0.0       | 2.160E-06  | 1.599E-05   | MA-10      | Guelmim-Wadi Noun                |
+| nan     | number          | 73.9674       | 3.606E-04  | 0.0       | 3.164E-08  | 1.899E-07   | MA-10      | Guelmim-Wadi Noun                |
+| nan     | residents       | 221.4         | 0.0014     | 0.0       | 9.087E-08  | 5.149E-07   | MA-10      | Guelmim-Wadi Noun                |
+| nan     | affectedpop     | 221.4         | 0.0021     | 0.0       | 9.087E-08  | 5.247E-07   | MA-10      | Guelmim-Wadi Noun                |
+| nan     | injured         | 231.2         | 2.948E-05  | 0.0       | 6.424E-08  | 8.883E-07   | MA-10      | Guelmim-Wadi Noun                |
+| nan     | embodied_carbon | 2_351         | 0.1354     | 0.0       | 0.0252     | 3.7855      | MA-10      | Guelmim-Wadi Noun                |
+| nan     | affectedpop     | 55_030        | 259.1      | 3.925E-05 | 1.4633     | 1_480       | *total*    | *total*                          |
+| nan     | area            | 2_407_935     | 10_826     | 0.0019    | 18.4957    | 56_035      | *total*    | *total*                          |
+| nan     | contents        | 442_346_176   | 2_420_616  | 0.0325    | 4.6213     | 9_622_286   | *total*    | *total*                          |
+| nan     | embodied_carbon | 870_944       | 12_725     | 171.4459  | 5_946      | 47_820      | *total*    | *total*                          |
+| nan     | injured         | 43_954        | 3.5497     | 7.099E-06 | 0.0040     | 17.3885     | *total*    | *total*                          |
+| nan     | number          | 14_807        | 69.1867    | 2.638E-06 | 0.0684     | 318.7       | *total*    | *total*                          |
+| nan     | occupants       | 43_954        | 1.4311     | 7.119E-06 | 1.296E-04  | 8.2573      | *total*    | *total*                          |
+| nan     | residents       | 55_030        | 178.6852   | 3.877E-05 | 0.3680     | 929.2       | *total*    | *total*                          |
+| nan     | structural      | 2_241_584_896 | 45_469_162 | 771_325   | 23_570_363 | 162_208_112 | *total*    | *total*                          |


### PR DESCRIPTION
I made a mistake in the loop collecting site model data, therefore some variables were overwritten by values read from files with the same name format, that exist in different folders.
The result was that the variables for the secondary perils were collected, but contained unexpected zeros.
I regenerated the partial hdf5 and I am testing the updated file here. If tests are green, I will replace the old file with the new one and I will restore the action yml of this branch.