### PR TITLE
Restored group splitting in `build_events_from_sources`

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -672,7 +672,7 @@ class EventBasedCalculator(base.HazardCalculator):
         Prefilter the composite source model and store the source_info
         """
         oq = self.oqparam
-        self.counting_ruptures()
+        maxw = self.counting_ruptures()
         eff_ruptures = AccumDict(accum=0)  # grp_id => potential ruptures
         source_data = AccumDict(accum=[])
         allargs = []
@@ -688,7 +688,9 @@ class EventBasedCalculator(base.HazardCalculator):
             param['ses_seed'] = oq.ses_seed
             param['magdist'] = cmaker.maximum_distance
             mfs = [src for src in sg if src.code == b'F']
-            if mfs:
+            if sg.atomic:
+                allargs.append((sg, param))
+            elif mfs:
                 # send one multifault source at the time
                 # tested in event_based case_29
                 for mf in mfs:
@@ -697,7 +699,9 @@ class EventBasedCalculator(base.HazardCalculator):
                 if others:
                     allargs.append((others, param))
             else:
-                allargs.append((sg, param))
+                for block in block_splitter(
+                        sg.sources, maxw, lambda src: src.num_ruptures):
+                    allargs.append((block, param))
         self.datastore.swmr_on()
         smap = parallel.Starmap(
             sample_ruptures, allargs, h5=self.datastore.hdf5)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -700,7 +700,7 @@ class EventBasedCalculator(base.HazardCalculator):
                     allargs.append((others, param))
             else:
                 for block in block_splitter(
-                        sg.sources, maxw, lambda src: src.num_ruptures):
+                        sg.sources, maxw, lambda src: src.weight):
                     allargs.append((block, param))
         self.datastore.swmr_on()
         smap = parallel.Starmap(


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/11517. Reduces the terrible slow tasks when computing the global SES.