### PR TITLE
Restored multifault splitting

### DIFF
--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -232,6 +232,7 @@ class MultiFaultSource(BaseSeismicSource):
                 self.probs_occur[slc],
                 self.mags[slc],
                 self.rakes[slc],
+                self.faults,
                 self.investigation_time,
                 self.infer_occur_rates)
             src.hdf5path = self.hdf5path

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -47,12 +47,12 @@ source_info_dt = numpy.dtype([
 
 
 # NB: blocksize is chosen so that event_based/case_35 works
-def split_mps(sources, blocksize=1000):
+def splitMF(sources, blocksize=1000):
     """
     Split the MultiPointSources to avoid oceanic sources with 160M ruptures
     hanging during rupture sampling
     """    
-    split_mps = []
+    splitMF = []
     for src in sources:
         if src.code == b'M' and len(src) > blocksize:
             for i, slc in enumerate(general.gen_slices(0, len(src), blocksize)):
@@ -73,16 +73,16 @@ def split_mps(sources, blocksize=1000):
                 segment.trt_smr = src.trt_smr
                 segment.samples = src.samples
                 segment.smweight = src.smweight
-                split_mps.append(segment)
-        #elif src.code == b'F':
-        #    for segment in src:
-        #        segment.trt_smr = src.trt_smr
-        #        segment.samples = src.samples
-        #        segment.smweight = src.smweight
-        #        split_mps.append(segment)
+                splitMF.append(segment)
+        elif src.code == b'F':
+            for segment in src:
+                segment.trt_smr = src.trt_smr
+                segment.samples = src.samples
+                segment.smweight = src.smweight
+                splitMF.append(segment)
         else:
-            split_mps.append(src)
-    sources[:] = split_mps
+            splitMF.append(src)
+    sources[:] = splitMF
 
 
 def check_unique(ids, msg='', strict=True):
@@ -559,7 +559,7 @@ def _get_csm(oq, full_lt, groups, event_based):
     atomic = []
     acc = general.AccumDict(accum=[])
     for grp in groups:
-        split_mps(grp.sources)
+        splitMF(grp.sources)
         if grp and grp.atomic:
             atomic.append(grp)
         elif grp:


### PR DESCRIPTION
After the change in https://github.com/gem/oq-engine/pull/11517, to avoid slow tasks in USA and MIE. The difference is abysmal:
```
# before/after
| operation-duration | counts | mean    | stddev | min    | max     | slowfac |
|--------------------+--------+---------+--------+--------+---------+---------|
| sample_ruptures    | 93     | 33.4120 | 648%   | 2.3529 | 2_107   | 63.0548 |
| sample_ruptures    | 491    |  2.8933 | 201%   | 0.3074 | 58.9103 | 20.3611 |

$ oq show slow_sources 3640 # terrible multifault
| source_id         | code | calc_time | num_ruptures |
|-------------------+------+-----------+--------------|
| emme26_gem_faults | F    |     2_107 | 715_597      |
| 2!add_sub_deep@1  | M    |   52.4090 | 688_000      |
| 2!add_sub_deep@0  | M    |   49.7563 | 688_000      |
| 5!add_sub_deep@0  | M    |   32.5629 | 420_000      |
| 5!add_sub_deep@1  | M    |   29.4391 | 395_640      |
| 15:999@0          | M    |   20.1502 | 456_000      |
```