### PR TITLE
spherical_to_cartesian numpy f32 fix + fix bug in check_aki_richards_convention

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Christopher Brooks]
+  * Fix a bug observed in the Aki and Richard's convention check in
+    complex faults.
+
   [Michele Simionato]
   * Optimized reading and sampling multiFaultSources
   * Saved memory in classical calculations with large sources affecting many

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -298,7 +298,7 @@ class Mesh(object):
         :returns: an array of shape (N, 3) with the cartesian coordinates
         """
         return geo_utils.spherical_to_cartesian(
-            self.lons.flat, self.lats.flat, self.depths.flat)
+            self.lons.ravel(), self.lats.ravel(), self.depths.ravel())
 
     def __iter__(self):
         """

--- a/openquake/hazardlib/geo/multiline.py
+++ b/openquake/hazardlib/geo/multiline.py
@@ -198,6 +198,8 @@ class MultiLine(object):
         """
         :returns: L arrays of shape (N, 2) or a single array (L, N, 2)
         """
+        lons = np.asarray(lons, dtype=np.float64)
+        lats = np.asarray(lats, dtype=np.float64)
         nsegs = [len(ln) - 1 for ln in self.lines]  # segments per line
         if len(set(nsegs)) == 1:
             # fast lane, when the number of segments is constant

--- a/openquake/hazardlib/geo/surface/complex_fault.py
+++ b/openquake/hazardlib/geo/surface/complex_fault.py
@@ -145,7 +145,7 @@ class ComplexFaultSurface(BaseSurface):
         ul, ur, bl, br = spherical_to_cartesian(
             [ul.longitude, u1.longitude, bl.longitude, b1.longitude],
             [ul.latitude, u1.latitude, bl.latitude, b1.latitude],
-            [ul.depth, b1.depth, bl.depth, b1.depth])
+            [ul.depth, u1.depth, bl.depth, b1.depth])
 
         top_edge = ur - ul
         left_edge = bl - ul


### PR DESCRIPTION
After a lot of digging, the `TypeError: loop of ufunc does not support argument 0 of type float which has no callable radians method` in `spherical_to_cartesian` error observed by risk team when using some rupture CSVs turns out to have a simple fix - in numpy 2.x, `array.flat` passed to a ufunc produces a `dtype=object` array, so replacing `.flat` with `.ravel()` in `Mesh.xyz` does the trick.

IMPORTANT
There was also a bug in `check_aki_richards_convention` where the bottom-left depth was used twice instead of bottom-left and upper-left, incorrectly causing QA test `logictree/case_20` to fail under F32 precision (we are back to F32, but the error still existed and has been fixed).