### PR TITLE
Fix a dict key issue in station data compilation

### DIFF
--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1078,7 +1078,8 @@ def get_composite_source_model(oqparam, dstore=None):
     :param dstore:
          an open datastore where to save the source info
     """
-    if 'source_model_logic_tree' in oqparam.inputs:
+    if ('source_model_logic_tree' in oqparam.inputs and not
+        oqparam.inputs['source_model_logic_tree'].endswith(".py")):
         logging.info('Reading %s', oqparam.inputs['source_model_logic_tree'])
     elif 'source_model' in oqparam.inputs:
         logging.info('Reading %s', oqparam.inputs['source_model'])
@@ -1304,8 +1305,8 @@ def get_station_data(oqparam, sitecol, duplicates_strategy='error'):
     sitecol.extend(lons, lats)
     logging.info('Extended complete site collection from %d to %d sites',
                  nsites, len(sitecol.complete))
-    dic = {(lo, la): sid
-           for lo, la, sid in sitecol.complete[['lon', 'lat', 'sids']]}
+    dic = {(lo, la): sid # lons/lats arrays for const. of keys with sids dict
+           for lo, la, sid in zip(lons, lats, sitecol.complete['sids'])}
     sids = U32([dic[lon, lat] for lon, lat in zip(lons, lats, strict=True)])
 
     # Identify the columns with IM values

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1304,9 +1304,11 @@ def get_station_data(oqparam, sitecol, duplicates_strategy='error'):
     sitecol.extend(lons, lats)
     logging.info('Extended complete site collection from %d to %d sites',
                  nsites, len(sitecol.complete))
-    dic = {(lo, la): sid # lons/lats arrays for const. of keys with sids dict
-           for lo, la, sid in zip(lons, lats, sitecol.complete['sids'])}
-    sids = U32([dic[lon, lat] for lon, lat in zip(lons, lats, strict=True)])
+    # rnd5 matches the precision sitecol.extend uses for deduplication
+    dic = {(round(float(lo), 5), round(float(la), 5)): sid
+           for lo, la, sid in sitecol.complete[['lon', 'lat', 'sids']]}
+    sids = U32([dic[round(float(lon), 5), round(float(lat), 5)]
+                for lon, lat in zip(lons, lats, strict=True)])
 
     # Identify the columns with IM values
     # Replace replace() with removesuffix() for pandas ≥ 1.4

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1304,7 +1304,7 @@ def get_station_data(oqparam, sitecol, duplicates_strategy='error'):
     sitecol.extend(lons, lats)
     logging.info('Extended complete site collection from %d to %d sites',
                  nsites, len(sitecol.complete))
-    # rnd5 matches the precision sitecol.extend uses for deduplication
+    # 5dp matches the precision sitecol.extend uses for deduplication
     dic = {(round(float(lo), 5), round(float(la), 5)): sid
            for lo, la, sid in sitecol.complete[['lon', 'lat', 'sids']]}
     sids = U32([dic[round(float(lon), 5), round(float(lat), 5)]

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -1078,8 +1078,7 @@ def get_composite_source_model(oqparam, dstore=None):
     :param dstore:
          an open datastore where to save the source info
     """
-    if ('source_model_logic_tree' in oqparam.inputs and not
-        oqparam.inputs['source_model_logic_tree'].endswith(".py")):
+    if 'source_model_logic_tree' in oqparam.inputs:
         logging.info('Reading %s', oqparam.inputs['source_model_logic_tree'])
     elif 'source_model' in oqparam.inputs:
         logging.info('Reading %s', oqparam.inputs['source_model'])

--- a/openquake/qa_tests_data/scenario_damage/case_19/expected/aggrisk.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_19/expected/aggrisk.csv
@@ -1,3 +1,3 @@
-#,,,,,"generated_by='OpenQuake engine 3.26.0-gitd60b0b61c2', start_date='2026-06-08T15:43:24', checksum=2404281722"
+#,,,,,"generated_by='OpenQuake engine 3.26.0-git411209cf9f', start_date='2026-05-09T02:55:39', checksum=3484533368, investigation_time=None, risk_investigation_time=None"
 loss_type,no_damage,slight,moderate,extensive,complete
-structural,1.48162E+02,3.89767E+01,3.96798E+00,6.61579E-01,2.31318E-01
+structural,5.39505E+01,3.54395E+01,3.15420E+01,2.28753E+01,4.81928E+01

--- a/openquake/qa_tests_data/scenario_damage/case_19/expected/aggrisk.csv
+++ b/openquake/qa_tests_data/scenario_damage/case_19/expected/aggrisk.csv
@@ -1,3 +1,3 @@
-#,,,,,"generated_by='OpenQuake engine 3.26.0-git411209cf9f', start_date='2026-05-09T02:55:39', checksum=3484533368, investigation_time=None, risk_investigation_time=None"
+#,,,,,"generated_by='OpenQuake engine 3.26.0-gitd60b0b61c2', start_date='2026-06-08T15:43:24', checksum=2404281722"
 loss_type,no_damage,slight,moderate,extensive,complete
-structural,5.39505E+01,3.54395E+01,3.15420E+01,2.28753E+01,4.81928E+01
+structural,1.48162E+02,3.89767E+01,3.96798E+00,6.61579E-01,2.31318E-01


### PR DESCRIPTION
Inconsistent use of lons/lats arrays and the same coords from the site collection was generating a key error. 

This fixes https://github.com/gem/oq-engine/issues/11515, I also noticed it in GEESE recently.