### PR TITLE
Fixed missing weight in AvgPoeGMPE, breaking the exporters

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed missing weight in AvgPoeGMPE breaking the realization exporter
+
   [Christopher Brooks]
   * Fix a bug observed in the Aki and Richard's convention check in
     complex faults.

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -767,6 +767,9 @@ class ClassicalTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/hcurve_PGA.csv', f1)
         self.assertEqualFiles('expected/hcurve_SA.csv', f2)
 
+        # test for https://github.com/gem/oq-engine/issues/11512
+        export(('realizations', 'csv'), self.calc.datastore)
+
         # checking missing region
         with self.assertRaises(InvalidFile) as ctx:
             self.run_calc(case_57.__file__, 'job_wrong.ini')

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -180,7 +180,12 @@ class MetaGSIM(abc.ABCMeta):
 
     def __call__(cls, **kwargs):
         mixture_model = kwargs.pop('mixture_model', None)
-        self = type.__call__(cls, **kwargs)
+        if 'weight' in kwargs:  # AvgPoeGMPE
+            w = kwargs.pop('weight')
+            self = type.__call__(cls, **kwargs)
+            kwargs['weight'] = w
+        else:
+            self = type.__call__(cls, **kwargs)
         self.kwargs = kwargs
         self._toml = toml.dumps({cls.__name__: fix_toml(kwargs)}).strip()
         if hasattr(self, 'gmpe_table'):

--- a/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
+++ b/openquake/hazardlib/gsim/mgmpe/avg_poe_gmpe.py
@@ -82,7 +82,7 @@ class AvgPoeGMPE(GMPE):
         def_for_stddevs = []
         for branchid, branchparams in kwargs.items():
             [(gsim_name, params)] = branchparams.items()
-            weights.append(params.pop('weight'))
+            weights.append(params['weight'])
             gsim = registry[gsim_name](**params)
             rd.update(gsim.REQUIRES_DISTANCES)
             rsp.update(gsim.REQUIRES_SITES_PARAMETERS)


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/11512. Notice that engine-3.25 is unaffected, the problem is only in master.