### PR TITLE
Fix Nowicki Jessee landcover coefficient assignment

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Catarina Costa]
+  * Fixed landcover coefficient assignment on Nowicki Jessee landslide model
+
   [Michele Simionato]
   * Fixed missing weight in AvgPoeGMPE breaking the realization exporter
 

--- a/openquake/sep/landslide/probability.py
+++ b/openquake/sep/landslide/probability.py
@@ -123,11 +123,10 @@ def nowicki_jessee_2018(
     else:
         lithology_coeff = np.array([coeff_table_lith.get(lith, -0.66) for lith in lithology])
 
-    if isinstance(landcover, int):   
-        landcover = str(landcover)
-        landcover_coeff = coeff_table_cov.get(landcover, -1.08)
+    if np.isscalar(landcover):   
+        landcover_coeff = coeff_table_cov.get(str(int(landcover)), -1.08)
     else:
-        landcover_coeff = np.array([coeff_table_cov.get(str(lc), -1.08) for lc in landcover])
+        landcover_coeff = np.array([coeff_table_cov.get(str(int(lc)), -1.08) for lc in landcover])
 
     pgv = np.clip(pgv, MIN_HAZARD, None)
     Xg = (


### PR DESCRIPTION
The landcover coefficient in the Nowicki Jessee model was being incorrectly assigned to the default value.

The issue occurred because the landcover input was converted to a string after being read as a float. For example, a landcover value of 60 in sitemodel.csv was parsed as the float 60.0 and then converted to the string "60.0". Since the landcover_values dictionary uses keys such as "60", the lookup failed and the default coefficient was used instead.

The bug was identified following a user report on the OpenQuake Users mailing list:
https://groups.google.com/g/openquake-users/c/yc2BfQEQtRA
