### PR TITLE
Using the colon convention when splitting multifault sources

### DIFF
--- a/openquake/hazardlib/source/multi_fault.py
+++ b/openquake/hazardlib/source/multi_fault.py
@@ -214,7 +214,7 @@ class MultiFaultSource(BaseSeismicSource):
             yield self.source_id, slice(0, len(self.mags))
             return
         for i, slc in enumerate(gen_slices(0, len(self.mags), BLOCKSIZE)):
-            yield '%s-%d' % (self.source_id, i), slc
+            yield '%s:%d' % (self.source_id, i), slc
 
     def __iter__(self):
         if len(self.mags) <= BLOCKSIZE or hasattr(self, 'rupids_by_tag'):


### PR DESCRIPTION
This fixes the AELO tests for CEA, broken by https://github.com/gem/oq-engine/pull/11522.