### PR TITLE
Refactored `set_trt_smr`

### DIFF
--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1202,7 +1202,7 @@ class FullLogicTree(object):
                      if set(sm_rlz.lt_path) & brids)
 
     # NB: called by reduce_groups with source_id
-    def set_trt_smr(self, srcs, source_id=None, smr=None):
+    def set_trt_smr(self, srcs, source_id):
         """
         :param srcs: source objects
         :param source_id: base source ID
@@ -1216,14 +1216,11 @@ class FullLogicTree(object):
             srcid = valid.corename(src)
             if source_id and srcid != source_id:
                 continue  # filter
-            if self.trti == {'*': 0}:  # passed gsim=XXX in the job.ini
-                trti = 0
-            else:
-                trti = self.trti[src.tectonic_region_type]
-            if smr is None and ';' in src.source_id:
-                # assume <base_id>;<smr>
-                smr = _get_smr(src.source_id)
-            if smr is None:  # called by .reduce_groups in disagg_by_src
+            trti = self.trti[src.tectonic_region_type]
+            if ';' in src.source_id:
+                # assume <base_id>;<smr> like in logictree/case_05
+                src.trt_smr = trti * TWO24 + _get_smr(src.source_id)
+            else:  # regular case
                 srcid = srcid.split('@')[0]
                 try:
                     # check if ambiguous source ID
@@ -1238,9 +1235,7 @@ class FullLogicTree(object):
                 tup = tuple(trti * TWO24 + sm_rlz.ordinal
                             for sm_rlz in self.sm_rlzs
                             if set(sm_rlz.lt_path) & brids)
-            else:  # called by source_reader
-                tup = trti * TWO24 + smr
-            src.trt_smr = tup  # realizations impacted by the source
+                src.trt_smr = tup  # realizations impacted by the source
             out.append(src)
         return out
 

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1201,13 +1201,11 @@ class FullLogicTree(object):
                      for sm_rlz in self.sm_rlzs
                      if set(sm_rlz.lt_path) & brids)
 
-    # NB: called by the source_reader with smr and by
-    # .reduce_groups with source_id
+    # NB: called by reduce_groups with source_id
     def set_trt_smr(self, srcs, source_id=None, smr=None):
         """
         :param srcs: source objects
         :param source_id: base source ID
-        :param srm: source model realization index
         :returns: list of sources with the same base source ID
         """
         if not self.trti:  # empty gsim_lt

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -295,7 +295,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
                 if hasattr(rup, 'occurrence_rate'):
                     # defined only for poissonian sources
                     # needed to get convergency of the frequency to the rate
-                    # tested only in oq-risk-tests etna0
+                    # tested in case_83_eb
                     rup.occurrence_rate *= smweight
                 ebr = EBRupture(rup, self.id, trt_smr, num_occ, rupid,
                                 seed=rupid + TWO30 * self.id + ses_seed)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -33,17 +33,23 @@ from openquake.hazardlib.lt import apply_uncertainties
 from openquake.hazardlib.valid import basename
 
 TWO24 = 2**24
+U32 = numpy.uint32
+F32 = numpy.float32
 bybranch = operator.attrgetter('branch')
 checksum = operator.attrgetter('checksum')
+sampling_dt = numpy.dtype([
+    ('samples', U32),
+    ('smweight', F32),
+    ('trt_smr', U32)])
 source_info_dt = numpy.dtype([
     ('source_id', hdf5.vstr),          # 0
     ('grp_id', numpy.uint16),          # 1
     ('code', (numpy.bytes_, 1)),       # 2
-    ('calc_time', numpy.float32),      # 3
+    ('calc_time', F32),                # 3
     ('num_ctxs', numpy.uint64),        # 4
     ('est_ctxs', numpy.uint64),        # 5
-    ('num_ruptures', numpy.uint32),    # 6
-    ('weight', numpy.float32),         # 7
+    ('num_ruptures', U32),             # 6
+    ('weight', F32),                   # 7
 ])
 
 
@@ -497,12 +503,11 @@ def _build_groups(full_lt, smdict):
             sg = apply_uncertainties(bset_values, src_group)
             dt[rlz.ordinal] += time.time() - t0
             for src in sg:
-                src.trt_smr = trti * TWO24 + rlz.ordinal
-            for src in sg:
                 # the smweight is used in event based sampling:
                 # see oq-risk-tests etna or case_83_eb
                 src.smweight = rlz.weight
                 src.samples = rlz.samples
+                src.trt_smr = trti * TWO24 + rlz.ordinal
             groups.append(sg)
 
         # check applyToSources

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -468,7 +468,7 @@ def _build_groups(full_lt, smdict):
     smlt_dir = os.path.dirname(smlt_file)
     groups = []
     R = len(full_lt.sm_rlzs)
-    dt = numpy.zeros((2, R))
+    dt = numpy.zeros(R)
     for rlz in full_lt.sm_rlzs:
         if rlz.ordinal % 10 == 0:
             logging.info('Building source groups for rlz'
@@ -494,16 +494,13 @@ def _build_groups(full_lt, smdict):
             # (<maxMagGRAbsolute(3, applyToSources=['second'])>, 7.5)
             t0 = time.time()
             sg = apply_uncertainties(bset_values, src_group)
-            t1 = time.time()
+            dt[rlz.ordinal] += time.time() - t0
             if full_lt.trti == {'*': 0}:  # passed gsim=XXX in the job.ini
                 trti = 0
             else:
                 trti = full_lt.trti[sg.trt]
             for src in sg:
                 src.trt_smr = trti * TWO24 + rlz.ordinal
-            t2 = time.time()
-            dt[0, rlz.ordinal] += t1 - t0
-            dt[1, rlz.ordinal] += t2 - t1
             for src in sg:
                 # the smweight is used in event based sampling:
                 # see oq-risk-tests etna
@@ -522,8 +519,7 @@ def _build_groups(full_lt, smdict):
                     " please fix applyToSources in %s or the "
                     "source model(s) %s" % (srcid, smlt_file,
                                             rlz.value[0].split()))
-    logging.info('Seconds in [apply_uncertainties, set_trt_smr]: %s',
-                 numpy.round(dt.sum(axis=1), 2))
+    logging.info(f'Seconds in apply_uncertainties: {dt.sum():.2f}')
     return groups
 
 

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -504,8 +504,8 @@ def _build_groups(full_lt, smdict):
             dt[rlz.ordinal] += time.time() - t0
             for src in sg:
                 # the smweight is used in event based sampling:
-                # see oq-risk-tests etna or case_83_eb
-                src.smweight = rlz.weight
+                # see oq-risk-tests etna0 for full enum, else case_83_eb
+                src.smweight = rlz.weight if full_lt.num_samples else 1/R
                 src.samples = rlz.samples
                 src.trt_smr = trti * TWO24 + rlz.ordinal
             groups.append(sg)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -487,6 +487,7 @@ def _build_groups(full_lt, smdict):
                     (value, common, rlz.value))
             src_groups.extend(extra)
         for src_group in src_groups:
+            trti = 0 if full_lt.trti=={'*': 0} else full_lt.trti[src_group.trt]
             # an example of bsetvalues is in LogicTreeCase2ClassicalPSHA:
             # (<abGRAbsolute(3, applyToSources=['first'])>, (4.6, 1.1))
             # (<abGRAbsolute(3, applyToSources=['second'])>, (3.3, 1.0))
@@ -495,10 +496,6 @@ def _build_groups(full_lt, smdict):
             t0 = time.time()
             sg = apply_uncertainties(bset_values, src_group)
             dt[rlz.ordinal] += time.time() - t0
-            if full_lt.trti == {'*': 0}:  # passed gsim=XXX in the job.ini
-                trti = 0
-            else:
-                trti = full_lt.trti[sg.trt]
             for src in sg:
                 src.trt_smr = trti * TWO24 + rlz.ordinal
             for src in sg:

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -32,6 +32,7 @@ from openquake.hazardlib.source.multi_fault import save_and_split
 from openquake.hazardlib.lt import apply_uncertainties
 from openquake.hazardlib.valid import basename
 
+TWO24 = 2**24
 bybranch = operator.attrgetter('branch')
 checksum = operator.attrgetter('checksum')
 source_info_dt = numpy.dtype([
@@ -494,7 +495,12 @@ def _build_groups(full_lt, smdict):
             t0 = time.time()
             sg = apply_uncertainties(bset_values, src_group)
             t1 = time.time()
-            full_lt.set_trt_smr(sg, smr=rlz.ordinal)
+            if full_lt.trti == {'*': 0}:  # passed gsim=XXX in the job.ini
+                trti = 0
+            else:
+                trti = full_lt.trti[sg.trt]
+            for src in sg:
+                src.trt_smr = trti * TWO24 + rlz.ordinal
             t2 = time.time()
             dt[0, rlz.ordinal] += t1 - t0
             dt[1, rlz.ordinal] += t2 - t1

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -500,10 +500,9 @@ def _build_groups(full_lt, smdict):
                 src.trt_smr = trti * TWO24 + rlz.ordinal
             for src in sg:
                 # the smweight is used in event based sampling:
-                # see oq-risk-tests etna
-                src.smweight = rlz.weight if full_lt.num_samples else 1/R
-                if rlz.samples > 1:
-                    src.samples = rlz.samples
+                # see oq-risk-tests etna or case_83_eb
+                src.smweight = rlz.weight
+                src.samples = rlz.samples
             groups.append(sg)
 
         # check applyToSources


### PR DESCRIPTION
Calling it only in `disagg_by_rel_sources`. This is part of https://github.com/gem/oq-engine/issues/11541, since the final goal is to remove the source copies which are still generated in `apply_uncertainties` (slow and using lots of memory).