### PR TITLE
Optimized `get_composite_source_model` for identical sources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
   * Avoided copying sources when building the CompositeSourceModel,
-    thus reducing the memory occupation by 75% for preclassical NZL
+    thus reducing the memory occupation and time by 75% for NZL
 
   [Paolo Tormene, Michele Simionato]
   * Implemented secondary perils for ShakeMap calculations

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -598,12 +598,6 @@ number_of_logic_tree_samples:
   Example: *number_of_logic_tree_samples = 0*.
   Default: 0
 
-optimize_same_id_sources:
-  Tell the engine that sources with the same ID are identical, without needing
-  to check, thus saving time when building the composite source model.
-  Example: *optimize_same_id_sources = true*
-  Default: False
-
 oversampling:
   When equal to "forbid" raise an error if tot_samples > num_paths in classical
   calculations; when equal to "tolerate" do not raise the error (the default).
@@ -1187,7 +1181,6 @@ class OqParam(valid.ParamSet):
     number_of_logic_tree_samples = valid.Param(valid.positiveint, 0)
     num_epsilon_bins = valid.Param(valid.positiveint, 1)
     num_rlzs_disagg = valid.Param(valid.positiveint, 0)
-    optimize_same_id_sources = valid.Param(valid.boolean, False)
     oversampling = valid.Param(valid.Choice('forbid', 'tolerate'), 'tolerate')
     poes = valid.Param(valid.probabilities, [])
     poes_disagg = valid.Param(valid.probabilities, [])

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -598,6 +598,12 @@ number_of_logic_tree_samples:
   Example: *number_of_logic_tree_samples = 0*.
   Default: 0
 
+optimize_same_id_sources:
+  Tell the engine that sources with the same ID are identical, without needing
+  to check, thus saving time when building the composite source model.
+  Example: *optimize_same_id_sources = true*
+  Default: False
+
 oversampling:
   When equal to "forbid" raise an error if tot_samples > num_paths in classical
   calculations; when equal to "tolerate" do not raise the error (the default).
@@ -1181,8 +1187,8 @@ class OqParam(valid.ParamSet):
     number_of_logic_tree_samples = valid.Param(valid.positiveint, 0)
     num_epsilon_bins = valid.Param(valid.positiveint, 1)
     num_rlzs_disagg = valid.Param(valid.positiveint, 0)
-    oversampling = valid.Param(
-        valid.Choice('forbid', 'tolerate'), 'tolerate')
+    optimize_same_id_sources = valid.Param(valid.boolean, False)
+    oversampling = valid.Param(valid.Choice('forbid', 'tolerate'), 'tolerate')
     poes = valid.Param(valid.probabilities, [])
     poes_disagg = valid.Param(valid.probabilities, [])
     pointsource_distance = valid.Param(valid.floatdict, {'default': PSDIST})

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -284,7 +284,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         seed = self.serial(ses_seed)
         sample = poisson_sample if is_poissonian(self) else timedep_sample
         ebrs = []
-        for i, (samples, smweight, trt_smr) in enumerate(self.sampling):
+        for i, (trt_smr, samples, smweight) in enumerate(self.sampling):
             for rup, rid, num_occ in sample(self, num_ses*samples, seed + i):
                 rupid = rid + i * self.num_ruptures
                 if hasattr(rup, 'occurrence_rate'):

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -543,9 +543,15 @@ def reduce_sources(sources_with_same_id, full_lt, event_based):
     :param sources_with_same_id: a list of sources with the same source_id
     :returns: a list of truly unique sources
     """
+    # first reduce identical sources having the same id(src)
+    # tested in LogictreeTestCase.test_case_08, where <PoinstSource 2>
+    # appears 3 times
+    unique = {}
+    for src in sources_with_same_id:
+        unique[id(src)] = src
     out = []
-    add_checksums(sources_with_same_id)
-    for srcs in general.groupby(sources_with_same_id, checksum).values():
+    add_checksums(unique.values())
+    for srcs in general.groupby(unique.values(), checksum).values():
         # NB: the simplest test featuring the same source in two
         # different source models is logictree/case_01
         src = srcs[0]

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -303,20 +303,6 @@ def get_csm(oq, full_lt, dstore=None):
     return build_csm(oq, full_lt, smdict, dstore)
 
 
-def log_num_mul(groups):
-    """
-    Logging the total number of sources and the total multiplicity
-    """
-    num = 0
-    mul = 0
-    for grp in groups:
-        for src in grp:
-            print(src)
-            num += 1
-            mul += len(src.sampling)
-    logging.info(f'tot_num_sources={num:_d}, tot_multiplicity={mul:_d}')
-
-
 def build_csm(oq, full_lt, smdict, dstore):
     """
     Applies uncertainties, builds the source groups and returns
@@ -326,7 +312,6 @@ def build_csm(oq, full_lt, smdict, dstore):
     with mon:
         groups = _build_groups(full_lt, smdict)  # fast
     logging.info(mon)
-    log_num_mul(groups)
 
     logging.info('Building CompositeSourceModel')
     is_event_based = oq.calculation_mode.startswith(('event_based', 'ebrisk'))
@@ -334,7 +319,6 @@ def build_csm(oq, full_lt, smdict, dstore):
     with mon:
         csm = _build_csm(oq, full_lt, groups, is_event_based)
     logging.info(mon)
-    log_num_mul(csm.src_groups)
 
     out = []
     probs = []
@@ -379,6 +363,7 @@ def build_csm(oq, full_lt, smdict, dstore):
     return csm
 
 
+# called by reduce_sources
 def add_checksums(srcs):
     """
     Build and attach a checksum to each source
@@ -551,11 +536,14 @@ def _build_groups(full_lt, smdict):
     return groups
 
 
-def reduce_sources(sources_with_same_id, full_lt, event_based):
+def reduce_sources(sources_with_same_id, full_lt, event_based, opt_same_id):
     """
     :param sources_with_same_id: a list of sources with the same source_id
     :returns: a list of truly unique sources, ordered by trt_smr
     """
+    if opt_same_id:
+        # assume sources with the same id are identical, so get the first only
+        return [sources_with_same_id[0]]
     out = []
     add_checksums(sources_with_same_id)
     for srcs in general.groupby(sources_with_same_id, checksum).values():
@@ -587,7 +575,9 @@ def _build_csm(oq, full_lt, groups, event_based):
     # 3. reorder the sources by source_id
     atomic = []
     acc = general.AccumDict(accum=[])
+    changes = 0
     for grp in groups:
+        changes += grp.changes
         for src in grp:
             if isinstance(src.sampling, list):
                 src.sampling = numpy.concatenate(
@@ -602,13 +592,16 @@ def _build_csm(oq, full_lt, groups, event_based):
             atomic.append(grp)
         elif grp:
             acc[grp.trt].extend(grp)
+    if oq.optimize_same_id_sources:
+        assert not changes, 'optimize_same_id_sources cannot work!'
     key = operator.attrgetter('source_id', 'code')
     src_groups = []
     for trt in acc:
         lst = []
         for srcs in general.groupby(acc[trt], key).values():
             if len(srcs) > 1:  # reduce_sources is ultra-fast
-                srcs = reduce_sources(srcs, full_lt, event_based)
+                srcs = reduce_sources(srcs, full_lt, event_based,
+                                      oq.optimize_same_id_sources)
             lst.extend(srcs)
         for sources in general.groupby(lst, trt_smrs).values():
             for grp in split_by_tom(sources):
@@ -619,4 +612,5 @@ def _build_csm(oq, full_lt, groups, event_based):
     # split multipoint and sort by source_id
     for sg in src_groups:
         sg.sources.sort(key=operator.attrgetter('source_id'))
-    return CompositeSourceModel(oq, full_lt, src_groups)
+    csm = CompositeSourceModel(oq, full_lt, src_groups)
+    return csm

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -171,20 +171,24 @@ def read_source_model(fname, branch, converter, applied, sample, monitor):
     return {fname: sm}
 
 
-# NB: in classical this is called after reduce_sources, so ";" is not
-# added if the same source appears multiple times, len(srcs) == 1
-# in event based instead identical sources can appear multiple times
-# but will have different seeds and produce different rupture sets
-def _fix_dupl_ids(src_groups):
+# NB:this is called after reduce_sources, so ";" is notadded
+# if the same source appears multiple times, i.e. len(srcs) == 1
+def add_semicolons(src_groups):
+    """
+    Add semicolons to differentiate different sources with the same source_id
+    and then sort the sources in each group by extended source_id
+    """
     sources = general.AccumDict(accum=[])
     for sg in src_groups:
-        for src in sg.sources:
+        for src in sg:
             sources[src.source_id].append(src)
     for src_id, srcs in sources.items():
         if len(srcs) > 1:
             # happens in logictree/case_01/rup.ini
             for i, src in enumerate(srcs):
                 src.source_id = '%s;%d' % (src.source_id, i)
+    for sg in src_groups:
+        sg.sources.sort(key=operator.attrgetter('source_id'))
 
 
 def check_branchID(branchID):
@@ -352,7 +356,7 @@ def build_csm(oq, full_lt, smdict, dstore):
         lonlats = set(zip(sitecol.lons, sitecol.lats))
         if len(lonlats) > 1:
             sitecol = None
-    # must be called *after* _fix_dupl_ids
+    # must be called *after* add_semicolons
     t0 = time.time()
     secparams = fix_geometry_sections(
         smdict, csm.src_groups, dstore.tempname if dstore else '',
@@ -375,7 +379,7 @@ def add_checksums(srcs):
         src.checksum = zlib.adler32(pickle.dumps(dic, protocol=4))
 
 
-# called before _fix_dupl_ids
+# called before add_semicolons
 def find_false_duplicates(smdict):
     """
     Discriminate different sources with same ID (false duplicates)
@@ -529,11 +533,6 @@ def _build_groups(full_lt, smdict):
                     " please fix applyToSources in %s or the "
                     "source model(s) %s" % (srcid, smlt_file,
                                             rlz.value[0].split()))
-    # checking the changes
-    changes = sum(sg.changes for sg in groups)
-    if changes:
-        logging.info('Applied {:_d} changes to {:_d} source groups'.
-                     format(changes, len(groups)))
     return groups
 
 
@@ -568,12 +567,10 @@ def split_by_tom(sources):
 
 
 def _build_csm(oq, full_lt, groups, event_based):
-    # 1. extract a single source from multiple sources with the same ID
-    # 2. regroup the sources in non-atomic groups by TRT
-    # 3. reorder the sources by source_id
-    atomic = []
     acc = general.AccumDict(accum=[])
+    atomic = []
     changes = 0
+    # concatenate sampling records, split MF sources, single out atomic groups
     for grp in groups:
         changes += grp.changes
         for src in grp:
@@ -581,7 +578,7 @@ def _build_csm(oq, full_lt, groups, event_based):
                 src.sampling = numpy.concatenate(
                     src.sampling, dtype=sampling_dt)
             else:
-                # already concatenated at the previous iteration,
+                # already concatenated at the previous iteration;
                 # happens for sources belonging to multiple groups,
                 # such as <AreaSource 002> in classical case_10
                 pass
@@ -590,7 +587,12 @@ def _build_csm(oq, full_lt, groups, event_based):
             atomic.append(grp)
         elif grp:
             acc[grp.trt].extend(grp)
+    if changes:
+        logging.info(f'Applied {changes:_d} changes to '
+                     f'{len(groups):_d} source groups')
 
+    # reduce identical sources by concatenating the sampling records,
+    # then regroup by trt_smrs
     key = operator.attrgetter('source_id', 'code')
     src_groups = []
     for trt in acc:
@@ -603,10 +605,7 @@ def _build_csm(oq, full_lt, groups, event_based):
             for grp in split_by_tom(sources):
                 src_groups.append(sourceconverter.SourceGroup(trt, grp))
     src_groups.extend(atomic)
-    _fix_dupl_ids(src_groups)
 
-    # split multipoint and sort by source_id
-    for sg in src_groups:
-        sg.sources.sort(key=operator.attrgetter('source_id'))
+    add_semicolons(src_groups)
     csm = CompositeSourceModel(oq, full_lt, src_groups)
     return csm

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -38,9 +38,10 @@ F32 = numpy.float32
 bybranch = operator.attrgetter('branch')
 checksum = operator.attrgetter('checksum')
 sampling_dt = numpy.dtype([
+    ('trt_smr', U32),
     ('samples', U32),
-    ('smweight', F32),
-    ('trt_smr', U32)])
+    ('smweight', F32)])
+
 source_info_dt = numpy.dtype([
     ('source_id', hdf5.vstr),          # 0
     ('grp_id', numpy.uint16),          # 1
@@ -57,7 +58,7 @@ def sampling(samples, smweight, trt_smr):
     """
     :returns: a structured array (samples, smweight, trt_smr) of length 1
     """
-    return numpy.array([(samples, smweight, trt_smr)], sampling_dt)
+    return numpy.array([(trt_smr, samples, smweight)], sampling_dt)
 
 
 # NB: blocksize is chosen so that event_based/case_35 works
@@ -543,6 +544,12 @@ def reduce_sources(sources_with_same_id, full_lt, event_based, opt_same_id):
     """
     if opt_same_id:
         # assume sources with the same id are identical, so get the first only
+        sampl = numpy.concatenate([s.sampling for s in sources_with_same_id],
+                                  dtype=sampling_dt)
+        src = sources_with_same_id[0]
+        src.sampling = numpy.unique(sampl)
+        return [src]
+
         return [sources_with_same_id[0]]
     out = []
     add_checksums(sources_with_same_id)

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -303,6 +303,20 @@ def get_csm(oq, full_lt, dstore=None):
     return build_csm(oq, full_lt, smdict, dstore)
 
 
+def log_num_mul(groups):
+    """
+    Logging the total number of sources and the total multiplicity
+    """
+    num = 0
+    mul = 0
+    for grp in groups:
+        for src in grp:
+            print(src)
+            num += 1
+            mul += len(src.sampling)
+    logging.info(f'tot_num_sources={num:_d}, tot_multiplicity={mul:_d}')
+
+
 def build_csm(oq, full_lt, smdict, dstore):
     """
     Applies uncertainties, builds the source groups and returns
@@ -312,19 +326,15 @@ def build_csm(oq, full_lt, smdict, dstore):
     with mon:
         groups = _build_groups(full_lt, smdict)  # fast
     logging.info(mon)
-
-    # checking the changes
-    changes = sum(sg.changes for sg in groups)
-    if changes:
-        logging.info('Applied {:_d} changes to {:_d} source groups'.
-                     format(changes, len(groups)))
+    log_num_mul(groups)
 
     logging.info('Building CompositeSourceModel')
     is_event_based = oq.calculation_mode.startswith(('event_based', 'ebrisk'))
-    mon = performance.Monitor('_get_csm', measuremem=True)
+    mon = performance.Monitor('_build_csm', measuremem=True)
     with mon:
-        csm = _get_csm(oq, full_lt, groups, is_event_based)
+        csm = _build_csm(oq, full_lt, groups, is_event_based)
     logging.info(mon)
+    log_num_mul(csm.src_groups)
 
     out = []
     probs = []
@@ -347,7 +357,7 @@ def build_csm(oq, full_lt, smdict, dstore):
         lst = [('grp_id', int), ('probability', float)]
         dstore.create_dset('grp_probability', numpy.array(probs, lst))
 
-    # split multifault sources if there is a single site
+    # add rupids_by_tag to multifault sources if there is a single site
     try:
         sitecol = dstore['sitecol']
     except (KeyError, TypeError):  # 'NoneType' object is not subscriptable
@@ -516,8 +526,10 @@ def _build_groups(full_lt, smdict):
                 sampl = sampling(
                     rlz.samples, smweight, trti * TWO24 + rlz.ordinal)
                 if src.sampling is None:
+                    # the first time
                     src.sampling = [sampl]
                 else:
+                    # if the same source belongs to multiple realizations
                     src.sampling.append(sampl)
             groups.append(sg)
 
@@ -531,6 +543,11 @@ def _build_groups(full_lt, smdict):
                     " please fix applyToSources in %s or the "
                     "source model(s) %s" % (srcid, smlt_file,
                                             rlz.value[0].split()))
+    # checking the changes
+    changes = sum(sg.changes for sg in groups)
+    if changes:
+        logging.info('Applied {:_d} changes to {:_d} source groups'.
+                     format(changes, len(groups)))
     return groups
 
 
@@ -564,7 +581,7 @@ def split_by_tom(sources):
     return general.groupby(sources, key).values()
 
 
-def _get_csm(oq, full_lt, groups, event_based):
+def _build_csm(oq, full_lt, groups, event_based):
     # 1. extract a single source from multiple sources with the same ID
     # 2. regroup the sources in non-atomic groups by TRT
     # 3. reorder the sources by source_id

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -171,7 +171,7 @@ def read_source_model(fname, branch, converter, applied, sample, monitor):
     return {fname: sm}
 
 
-# NB:this is called after reduce_sources, so ";" is notadded
+# NB:this is called after reduce_sources, so ";" is not added
 # if the same source appears multiple times, i.e. len(srcs) == 1
 def add_semicolons(src_groups):
     """
@@ -189,6 +189,8 @@ def add_semicolons(src_groups):
                 src.source_id = '%s;%d' % (src.source_id, i)
     for sg in src_groups:
         sg.sources.sort(key=operator.attrgetter('source_id'))
+    # tested in logictree/case_05 with 9 variations of
+    # AreaSource 1 and SimpleFaultSource 2
 
 
 def check_branchID(branchID):

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -555,10 +555,9 @@ def reduce_sources(sources_with_same_id, full_lt, event_based):
         # NB: the simplest test featuring the same source in two
         # different source models is logictree/case_01
         src = srcs[0]
-        if len(srcs) > 1 and len(src.sampling) == 1:
+        if len(srcs) > 1:
+            assert len(src.sampling) == 1, src  # sanity check
             src.sampling = numpy.concatenate([s.sampling for s in srcs])
-            # NB: len(src.sampling) can be > 1 already due to the operation
-            # in _build_csm (see for instance classical case_10)
         out.append(src)
     return out
 

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -541,20 +541,19 @@ def _build_groups(full_lt, smdict):
 def reduce_sources(sources_with_same_id, full_lt, event_based):
     """
     :param sources_with_same_id: a list of sources with the same source_id
-    :returns: a list of truly unique sources, ordered by trt_smr
+    :returns: a list of truly unique sources
     """
     out = []
     add_checksums(sources_with_same_id)
     for srcs in general.groupby(sources_with_same_id, checksum).values():
-        # duplicate sources: same id, same checksum
-        # the simplest test featuring the same source in two
-        # source models is logictree/case_01
+        # NB: the simplest test featuring the same source in two
+        # different source models is logictree/case_01
         src = srcs[0]
         if len(srcs) > 1 and len(src.sampling) == 1:
-            # happens in logictree/case_07
             src.sampling = numpy.concatenate([s.sampling for s in srcs])
+            # NB: len(src.sampling) can be > 1 already due to the operation
+            # in _build_csm (see for instance classical case_10)
         out.append(src)
-    out.sort(key=operator.attrgetter('trt_smrs'))
     return out
 
 

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -537,20 +537,11 @@ def _build_groups(full_lt, smdict):
     return groups
 
 
-def reduce_sources(sources_with_same_id, full_lt, event_based, opt_same_id):
+def reduce_sources(sources_with_same_id, full_lt, event_based):
     """
     :param sources_with_same_id: a list of sources with the same source_id
     :returns: a list of truly unique sources, ordered by trt_smr
     """
-    if opt_same_id:
-        # assume sources with the same id are identical, so get the first only
-        sampl = numpy.concatenate([s.sampling for s in sources_with_same_id],
-                                  dtype=sampling_dt)
-        src = sources_with_same_id[0]
-        src.sampling = numpy.unique(sampl)
-        return [src]
-
-        return [sources_with_same_id[0]]
     out = []
     add_checksums(sources_with_same_id)
     for srcs in general.groupby(sources_with_same_id, checksum).values():
@@ -599,16 +590,14 @@ def _build_csm(oq, full_lt, groups, event_based):
             atomic.append(grp)
         elif grp:
             acc[grp.trt].extend(grp)
-    if oq.optimize_same_id_sources:
-        assert not changes, 'optimize_same_id_sources cannot work!'
+
     key = operator.attrgetter('source_id', 'code')
     src_groups = []
     for trt in acc:
         lst = []
         for srcs in general.groupby(acc[trt], key).values():
             if len(srcs) > 1:  # reduce_sources is ultra-fast
-                srcs = reduce_sources(srcs, full_lt, event_based,
-                                      oq.optimize_same_id_sources)
+                srcs = reduce_sources(srcs, full_lt, event_based)
             lst.extend(srcs)
         for sources in general.groupby(lst, trt_smrs).values():
             for grp in split_by_tom(sources):

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -34,7 +34,7 @@ def _get_model_nankai():
     for i, src in enumerate(group):
         src.id = i
         src.grp_id = 0
-        src.sampling = numpy.array([(1, 1, 0)], sampling_dt)
+        src.sampling = numpy.array([(0, 1, 1)], sampling_dt)
         # src.num_ruptures = src.count_ruptures()
     aae([src.mutex_weight for src in group],
         [0.0125, 0.0125, 0.0125, 0.0125, 0.1625, 0.1625, 0.0125, 0.0125,

--- a/openquake/hazardlib/tests/source/base_test.py
+++ b/openquake/hazardlib/tests/source/base_test.py
@@ -145,7 +145,7 @@ class SampleRupturesTestCase(unittest.TestCase):
         <hypoDepth depth="4" probability="1"/>
       </hypoDepthDist>
     </pointSource>''')
-        ps.sampling = numpy.array([(1, 1, 0)], sampling_dt)
+        ps.sampling = numpy.array([(0, 1, 1)], sampling_dt)
         mags_rates = list(ps.get_annual_occurrence_rates())
         mags, rates = zip(*mags_rates)
         ebrs = list(ps.sample_ruptures(num_ses=100, ses_seed=42))

--- a/openquake/qa_tests_data/logictree/case_07/job.ini
+++ b/openquake/qa_tests_data/logictree/case_07/job.ini
@@ -7,6 +7,7 @@ disagg_by_src = true
 use_rates = true
 postproc_func = disagg_by_rel_sources.main
 postproc_args = {'imts': ['PGA'], 'imls_by_sid': {0: [.1]}}
+optimize_same_id_sources = true
 
 [geometry]
 

--- a/openquake/qa_tests_data/logictree/case_83/job_eb.ini
+++ b/openquake/qa_tests_data/logictree/case_83/job_eb.ini
@@ -2,6 +2,7 @@
 
 description = 2x2 extendModel
 calculation_mode = event_based
+optimize_same_id_sources = true
 
 [geometry]
 


### PR DESCRIPTION
More than doubling the speed in the case of the NZL model for event based:
```
| before/after           | time_sec | memory_mb | counts |
|------------------------+----------+-----------+--------|
| composite source model |    750.4 | 4_445     |      1 |
| composite source model |    322.9 | 4_342     |      1 |
```