### PR TITLE
Change `export_avg_gmf_csv` to consider only sites that were not discarded

### DIFF
--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -538,18 +538,14 @@ def export_avg_gmf_csv(ekey, dstore):
     oq = dstore['oqparam']
     if dstore.parent:
         sitecol = dstore.parent['sitecol']
-        if 'complete' in dstore.parent:
-            sitecol.complete = dstore.parent['complete']
     else:
         sitecol = dstore['sitecol']
-        if 'complete' in dstore:
-            sitecol.complete = dstore['complete']
     if 'custom_site_id' in sitecol.array.dtype.names:
-        dic = dict(custom_site_id=decode(sitecol.complete.custom_site_id))
+        dic = dict(custom_site_id=decode(sitecol.custom_site_id))
     else:
-        dic = dict(site_id=sitecol.complete.sids)
-    dic['lon'] = sitecol.complete.lons
-    dic['lat'] = sitecol.complete.lats
+        dic = dict(site_id=sitecol.sids)
+    dic['lon'] = sitecol.lons
+    dic['lat'] = sitecol.lats
     data = dstore['avg_gmf'][:]  # shape (2, N, C)
     imts = list(oq.imtls)
     for m, imt in enumerate(oq.all_imts()):


### PR DESCRIPTION
Running a oq-impact calculation for us7000srb1 using the small (sampled) exposure, trying to export `avg_gmf` raises an error. It is due to a mismatch between the size of the full site collection and the shape of the exported `avg_gmf`, that contains data only for the filtered sites that are close enough to any asset.
I am changing the exporter to consider only sites that were not discarded, thus fixing the mismatch.