### PR TITLE
Fixed slow tasks in AELO

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Fixed the slow tasks in AELO, due to accidental disabling of the filtering
+
   [Savas Ceylan]
   * Added EdwardsFah2013Foreland3Bars, BindiEtAl2011Rhypo,
     ECOS2009VariableDepth and ECOS2009FixedDepth GSIMs with

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -35,8 +35,7 @@ from openquake.hazardlib.scalerel.point import PointMSR
 from openquake.commonlib import readinput
 from openquake.calculators import base
 
-# MAX_NUM_RUPTURES = 52_000  # to support HimalayanThrust in CHN
-MAX_NUM_RUPTURES = 72_000  # to support SFS-active_417 in MIE
+MAX_NUM_RUPTURES = 52_000  # to support HimalayanThrust in CHN
 U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
@@ -102,7 +101,7 @@ def _filter_mag(srcs, min_mag, strict):
     mmag = getdefault(min_mag, srcs[0].tectonic_region_type)
     out = [src for src in srcs if src.get_mags()[-1] >= mmag]
     for ss in out:
-        if (ss.num_ruptures > MAX_NUM_RUPTURES and strict and
+        if (ss.nsites and ss.num_ruptures > MAX_NUM_RUPTURES and strict and
             ss.code in b'FSCNXK'):  # only for fault sources
             raise RuntimeError('%s has too many ruptures' % ss)
     return out

--- a/openquake/calculators/preclassical.py
+++ b/openquake/calculators/preclassical.py
@@ -35,7 +35,8 @@ from openquake.hazardlib.scalerel.point import PointMSR
 from openquake.commonlib import readinput
 from openquake.calculators import base
 
-MAX_NUM_RUPTURES = 52_000  # to support HimalayanThrust in CHN
+# MAX_NUM_RUPTURES = 52_000  # to support HimalayanThrust in CHN
+MAX_NUM_RUPTURES = 72_000  # to support SFS-active_417 in MIE
 U16 = numpy.uint16
 U32 = numpy.uint32
 F32 = numpy.float32
@@ -320,6 +321,8 @@ class PreClassicalCalculator(base.HazardCalculator):
             sf = SourceFilter(lowres, oq.maximum_distance)
             sf.multiplier = len(sites) / len(lowres)
             logging.debug('Reducing %d->%d sites', len(sites), len(lowres))
+        elif sites:
+            sf = SourceFilter(sites, oq.maximum_distance)
         else:
             sf = SourceFilter(None)
         atomic_sources = []

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1318,6 +1318,9 @@ class ContextMaker(object):
             C *= step
         src.nctxs = C * srcfilter.multiplier
         weight = src.nctxs / N
+        if self.oq.disagg_by_src and src.code in 'pPAM':
+            print(src)
+            weight /= 10.
         return weight
 
     def set_weight(self, sources, srcfilter):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1318,9 +1318,10 @@ class ContextMaker(object):
             C *= step
         src.nctxs = C * srcfilter.multiplier
         weight = src.nctxs / N
-        if self.oq.disagg_by_src and src.code in 'pPAM':
-            print(src)
-            weight /= 10.
+        #if (N <= self.oq.max_sites_disagg or self.oq.disagg_by_src
+        #    ) and src.code in 'pPAM':
+        #    print(src)
+        #    weight /= 10.
         return weight
 
     def set_weight(self, sources, srcfilter):

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1318,10 +1318,6 @@ class ContextMaker(object):
             C *= step
         src.nctxs = C * srcfilter.multiplier
         weight = src.nctxs / N
-        #if (N <= self.oq.max_sites_disagg or self.oq.disagg_by_src
-        #    ) and src.code in 'pPAM':
-        #    print(src)
-        #    weight /= 10.
         return weight
 
     def set_weight(self, sources, srcfilter):

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -598,6 +598,8 @@ def _build_csm(oq, full_lt, groups, event_based):
             atomic.append(grp)
         elif grp:
             acc[grp.trt].extend(grp)
+    if atomic:
+        logging.info('Found %d atomic groups', len(atomic))
     if changes:
         logging.info(f'Applied {changes:_d} changes to '
                      f'{len(groups):_d} source groups')

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -106,7 +106,7 @@ def rounded_unique(mags, idxs):
     mag_idxs = [(mag, ' '.join(idx)) for mag, idx in zip(mags, idxs)]
     dupl = extract_dupl(mag_idxs)
     if dupl:
-        logging.error('the pair (mag=%s, idxs=%s) is duplicated' % dupl[0])
+        logging.warning('the pair (mag=%s, idxs=%s) is duplicated' % dupl[0])
     return mags
 
 


### PR DESCRIPTION
The SourceFiltering was disabled causing a wrong source weight. The improvement in MIE is 6x, for half  a hour to 5 minutes (on cassidy)!
```
# before/after
| operation-duration | counts | mean      | stddev | min       | max       | slowfac |
|--------------------+--------+-----------+--------+-----------+-----------+---------|
| classical_disagg   | 66     | 63.6615   | 314%   | 6.0377    | 1_473     | 23.143  |
| classical_disagg   | 66     | 87.2948   | 84%    | 8.7713    | 231.0     | 2.6467  |
```