### PR TITLE
Fix a minor bug in add_semicolons with identical sources

### DIFF
--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -185,6 +185,7 @@ def add_semicolons(src_groups):
         for src in sg:
             sources[src.source_id].append(src)
     for src_id, srcs in sources.items():
+        srcs = get_unique(srcs)
         if len(srcs) > 1:
             # happens in logictree/case_01/rup.ini
             for i, src in enumerate(srcs):
@@ -540,6 +541,16 @@ def _build_groups(full_lt, smdict):
     return groups
 
 
+def get_unique(sources):
+    """
+    :returns: remove redundant identical sources
+    """
+    unique = {}
+    for src in sources:
+        unique[id(src)] = src
+    return unique.values()
+
+    
 def reduce_sources(sources_with_same_id, full_lt, event_based):
     """
     :param sources_with_same_id: a list of sources with the same source_id
@@ -550,14 +561,12 @@ def reduce_sources(sources_with_same_id, full_lt, event_based):
     # first reduce identical sources having the same id(src)
     # tested in LogictreeTestCase.test_case_08, where <PoinstSource 2>
     # appears 3 times
-    unique = {}
-    for src in sources_with_same_id:
-        unique[id(src)] = src
+    unique = get_unique(sources_with_same_id)
     out = []
-    add_checksums(unique.values())
+    add_checksums(unique)
     # in LogicTreeCase2ClassicalPSHA there 81 unique sources
     # grouped in 9 groups of 9 sources each with the same checksum
-    for srcs in general.groupby(unique.values(), checksum).values():
+    for srcs in general.groupby(unique, checksum).values():
         # NB: the simplest test featuring the same source in two
         # different source models is logictree/case_01
         src = srcs[0]


### PR DESCRIPTION
It was causing the error in KOR:
```
$ oq run GRM.toml -k KOR 
Building ruptures from 454 groups
tot_weight=99_512_547, max_weight=310_976, num_sources=56_677

  File "/home/michele/oq-engine/openquake/calculators/event_based.py", line 749, in build_events_from_sources
    imp.import_rups_events(self.datastore.getitem('ruptures')[()])
  File "/home/michele/oq-engine/openquake/commonlib/calc.py", line 257, in import_rups_events
    raise nrml.DuplicatedID(msg)
openquake.hazardlib.nrml.DuplicatedID:
source_id=b'PLE_ANNKI:00101;0;1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;1
8;19;20;21;22;23;24;25;26;27;28;29;30;31;32;33;34;35;36;37;38;39;40;41;42;43;44;
45;46;47;48;49;50;51;52;53;54;55;56;57;58;59;60;61;62;63;64;65;66;67;68;69;70;71;
72;73;74;75;76;77;78;79;80;81;82;83;84;85;86;87;88;89;90;91;92;93;94;95;96;97;98;
99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;
120;121;122;123;124;125;126;127;128;129;130;131;132;133;134;135;136;137;138;139;
140;141;142;143;144;145;146;147;148;149;150;151;152;153;154;155;156;157;158;159;
160;161;162;163;164;165;166;167;168;169;170;171;172;173;174;175;176;177;178;179;
180;181;182;183;184;185;186;187;188;189;190;191;192;193;194;195;196;197;198;199;
200;201;202;203;204;205;206;207;208'
```
Caused by the recent refactorings in the source_reader.
With this fix the semicolons are not added, however the DuplicatedID error is still there and will be fixed in a separate PR.