### PR TITLE
Removed `smweight`

### DIFF
--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -1327,7 +1327,7 @@ def extract_damages_stats_npz(dstore, what):
 @extract.add('event_based_mfd')
 def extract_mfd(dstore, what):
     """
-    Compare n_occ/eff_time with occurrence_rate.
+    The number of ruptures / eff_time per magnitude.
     Example: http://127.0.0.1:8800/v1/calc/30/extract/event_based_mfd?
     """
     oq = datastore.get_oq(dstore)
@@ -1339,11 +1339,10 @@ def extract_mfd(dstore, what):
         rup_df = dstore.read_df('filtered_ruptures', 'id')
     rup_df = rup_df[['mag', 'n_occ', 'occurrence_rate']]
     rup_df.mag = numpy.round(rup_df.mag, 1)
-    dic = dict(mag=[], freq=[], occ_rate=[])
+    dic = dict(mag=[], freq=[])
     for mag, df in rup_df.groupby('mag'):
         dic['mag'].append(mag)
         dic['freq'].append(df.n_occ.sum() / eff_time)
-        dic['occ_rate'].append(df.occurrence_rate.sum())
     return ArrayWrapper((), {k: numpy.array(v) for k, v in dic.items()})
 
 

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -97,14 +97,13 @@ class LogictreeTestCase(CalculatorTestCase):
         self.assertEqualFiles('expected/mfd.csv', f, delta=1E-6)
 
         # check that the occurrence rates are the expected ones
-        # NB: in engine < 3.17 this check fails
         [src] = self.calc.csm.get_sources()
         occrates = src.mfd.occurrence_rates
         aac(occrates, [1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0])
         df = self.calc.datastore.read_df('ruptures', 'id')[
             ['mag', 'occurrence_rate']]
         gb = df.groupby('mag').sum()
-        aac(occrates, gb.occurrence_rate, atol=2E-7)
+        aac(gb.occurrence_rate / src.multiplicity, occrates, atol=2E-7)
 
     def test_case_02(self):
         self.run_calc(case_02.__file__, 'job.ini')
@@ -776,10 +775,10 @@ hazard_uhs-std.csv
 
         df = view('event_based_mfd', self.calc.datastore)
         self.assertEqual(str(df), '''\
-      freq  occ_rate
-mag                 
-4.0  2.725     2.795
-4.5  1.578     1.614''')
+      freq
+mag       
+4.0  2.725
+4.5  1.578''')
 
     def test_case_84(self):
         # test maxMagGRRelativeNoMoBalance

--- a/openquake/hazardlib/__init__.py
+++ b/openquake/hazardlib/__init__.py
@@ -304,7 +304,6 @@ class Input(object):
                 src.grp_id = grp_id
                 src.trt_smr = grp_id
                 src.samples = num_rlzs
-                src.smweight = 1. / num_rlzs
                 idx += 1
                 if hasattr(src, 'trt_smrs'):
                     trt_smrs.append(src.trt_smrs)

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -121,7 +121,7 @@ def sample_cluster(group, num_ses, ses_seed):
     sampling = unique_sampling(group)
     seed = group[0].serial(ses_seed)
     offset = 0
-    for trt_smr, samples, _smweight in sampling:
+    for trt_smr, samples in sampling:
         for src in group:
             src.offset = offset
             offset += src.num_ruptures

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -301,11 +301,6 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         for i, (trt_smr, samples, smweight) in enumerate(self.sampling):
             for rup, rid, num_occ in sample(self, num_ses*samples, seed + i):
                 rupid = rid + i * self.num_ruptures
-                if hasattr(rup, 'occurrence_rate'):
-                    # defined only for poissonian sources
-                    # needed to get convergency of the frequency to the rate
-                    # tested in case_83_eb
-                    rup.occurrence_rate *= smweight
                 ebr = EBRupture(rup, self.id, trt_smr, num_occ, rupid,
                                 seed=rupid + TWO30 * self.id + ses_seed)
                 ebrs.append(ebr)

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -222,7 +222,6 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
     _num_ruptures = 0  # set by the engine
     seed = None  # set by the engine
     samples = 1  # set by the engine
-    smweight = 1.  # set by the engine
     dt = 0  # set by the engine
 
     @abc.abstractproperty
@@ -298,7 +297,7 @@ class BaseSeismicSource(metaclass=abc.ABCMeta):
         seed = self.serial(ses_seed)
         sample = poisson_sample if is_poissonian(self) else timedep_sample
         ebrs = []
-        for i, (trt_smr, samples, smweight) in enumerate(self.sampling):
+        for i, (trt_smr, samples) in enumerate(self.sampling):
             for rup, rid, num_occ in sample(self, num_ses*samples, seed + i):
                 rupid = rid + i * self.num_ruptures
                 ebr = EBRupture(rup, self.id, trt_smr, num_occ, rupid,

--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -40,8 +40,7 @@ bybranch = operator.attrgetter('branch')
 checksum = operator.attrgetter('checksum')
 sampling_dt = numpy.dtype([
     ('trt_smr', U32),
-    ('samples', U32),
-    ('smweight', F32)])
+    ('samples', U32)])
 
 source_info_dt = numpy.dtype([
     ('source_id', hdf5.vstr),          # 0
@@ -56,11 +55,11 @@ source_info_dt = numpy.dtype([
 ])
 
 
-def sampling(samples, smweight, trt_smr):
+def sampling(samples, trt_smr):
     """
-    :returns: a structured array (samples, smweight, trt_smr) of length 1
+    :returns: a structured array (trt_smr, samples) of length 1
     """
-    return numpy.array([(trt_smr, samples, smweight)], sampling_dt)
+    return numpy.array([(trt_smr, samples)], sampling_dt)
 
 
 # NB: blocksize is chosen so that event_based/case_35 works
@@ -490,7 +489,6 @@ def _build_groups(full_lt, smdict):
     smlt_file = full_lt.source_model_lt.filename
     smlt_dir = os.path.dirname(smlt_file)
     groups = []
-    R = len(full_lt.sm_rlzs)
     for rlz in full_lt.sm_rlzs:
         if rlz.ordinal % 100 == 0:
             logging.info('Building source groups for rlz'
@@ -508,7 +506,6 @@ def _build_groups(full_lt, smdict):
                     '%s contains source(s) %s already present in %s' %
                     (value, common, rlz.value))
             src_groups.extend(extra)
-        smweight = rlz.weight if full_lt.num_samples else 1/R
         for src_group in src_groups:
             trti = 0 if full_lt.trti=={'*': 0} else full_lt.trti[src_group.trt]
             # an example of bsetvalues is in LogicTreeCase2ClassicalPSHA:
@@ -518,8 +515,7 @@ def _build_groups(full_lt, smdict):
             # (<maxMagGRAbsolute(3, applyToSources=['second'])>, 7.5)
             sg = apply_uncertainties(bset_values, src_group)
             for src in sg:  # tested in case_83_eb
-                sampl = sampling(
-                    rlz.samples, smweight, trti * TWO24 + rlz.ordinal)
+                sampl = sampling(rlz.samples, trti * TWO24 + rlz.ordinal)
                 if src.sampling is None:
                     # the first time
                     src.sampling = [sampl]


### PR DESCRIPTION
It was there only for debugging purposes. Now the stored occurrence rates are the real ones, not multiplied by smweight.