### PR TITLE
Disabled check on IMT-dependent weights with strict=false

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Introduced `strict` flag to disable checks which are possibly too strict
   * Internal: storing the real `occurrence_rate` in the `ruptures` dataset,
     not multiplied by `smweight`
   * Fixed the slow tasks in AELO, due to accidental disabling of the filtering

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -902,8 +902,8 @@ def get_gsim_lt(oqparam, trts=()):
                 raise CorrelationButNoInterIntraStdDevs(gmfcorr, gsim)
     imt_dep_w = any(len(branch.weight.dic) > 1 for branch in gsim_lt.branches)
     if oqparam.number_of_logic_tree_samples and imt_dep_w:
-        if oqparam.calculation_mode.startswith(('classical',
-                                                'disaggregation')):
+        if oqparam.strict and oqparam.calculation_mode.startswith(
+                ('classical', 'disaggregation')):
             raise InvalidFile(
                 f'{oqparam.inputs["gsim_logic_tree"]}: IMT-dependent weights '
                 'in the GMM logic tree require full enumeration')


### PR DESCRIPTION
While it is possible to run CND classical with full enumeration (over 7 million realizations) it is impossible to run the disaggregation, since the disaggregation matrix would run out of memory. Therefore the only why to run disaggregation is to use sampling with few realizations and ignore the IMT-dependent weights check by setting `strict=false`.