### PR TITLE
Split multifaults even if .faults is set

### DIFF
--- a/openquake/hazardlib/source_reader.py
+++ b/openquake/hazardlib/source_reader.py
@@ -63,7 +63,7 @@ def sampling(samples, trt_smr):
 
 
 # NB: blocksize is chosen so that event_based/case_35 works
-def splitMF(sources, blocksize=1000):
+def splitMF(sources, disagg_by_src, blocksize=1000):
     """
     Split the MultiPointSources to avoid oceanic sources with 160M ruptures
     hanging during rupture sampling
@@ -88,7 +88,7 @@ def splitMF(sources, blocksize=1000):
                     temporal_occurrence_model=src.temporal_occurrence_model)
                 segment.sampling = src.sampling
                 splits.append(segment)
-        elif src.code == b'F' and not src.faults:
+        elif src.code == b'F' and not disagg_by_src:
             # use the colon convention only in absence of kendra-splitting
             for segment in src:
                 segment.sampling = src.sampling
@@ -588,7 +588,7 @@ def _build_csm(oq, full_lt, groups, event_based):
                 # happens for sources belonging to multiple groups,
                 # such as <AreaSource 002> in classical case_10
                 pass
-        splitMF(grp.sources)
+        splitMF(grp.sources, oq.disagg_by_src)
         if grp and grp.atomic:
             atomic.append(grp)
         elif grp:


### PR DESCRIPTION
Unless `disagg_by_src` is set. Addresses the slow tasks in MIE and TUR. Part of https://github.com/gem/oq-engine/issues/11559.
