### PR TITLE
Fixed the exporters `aggexp_tags` and `aggrisk_tags`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed the exporters `aggexp_tags` and `aggrisk_tags`
   * Reduced the number of tasks and the memory consumption in event_based_risk
   * Optimized rupture sampling for sources with high multiplicity
   * Internal: storing `occ_by_trt_smr` in the SES.hdf5 file

--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1911,8 +1911,10 @@ def expose_outputs(dstore, owner=USER, status='complete', calc_id=None):
     calcmode = oq.calculation_mode
     dskeys = set(dstore) & exportable  # exportable datastore keys
     dskeys.add('fullreport')
-    _, full_lt = get_model_lts(dstore)[-1]
-    R = full_lt.get_num_paths()
+    try:
+        R = len(dstore['weights'])
+    except KeyError:
+        R = 1
     if R > 1:
         dskeys.add('realizations')
     hdf5 = dstore.hdf5

--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -628,11 +628,10 @@ def export_aggexp_tags_csv(ekey, dstore):
     :param dstore: datastore object
     """
     oq = dstore['oqparam']
-    fulldf, slices = aggexp_tags(dstore)
+    dfs = aggexp_tags(dstore)
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     fnames = []
-    for aggby, slc in zip(oq.aggregate_by, slices):
-        df = fulldf[slc]
+    for aggby, df in zip(oq.aggregate_by, dfs):
         fname = dstore.export_path('%s-%s.csv' % (ekey[0], '-'.join(aggby)))
         writer.save(df, fname, comment=dstore.metadata)
         fnames.append(fname)

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -817,7 +817,7 @@ def extract_agg_curves(dstore, what):
 
 def aggexp_tags(dstore):
     """
-    Read agg_values and returns a datastore with fields like::
+    Read agg_values and returns datastores with fields like::
 
             policy taxonomy  number  nonstructural  structural  area
      agg_id
@@ -828,7 +828,6 @@ def aggexp_tags(dstore):
     aggkey = dstore['assetcol/tagcol'].get_aggkey(oq.aggregate_by)
     ags = U32([key[0] for key in aggkey])
     dfs = []
-    slices = []
     for ag, start, stop in performance.idx_start_stop(ags):
         lines = numpy.array([
             line.decode('utf8') for line in dstore['agg_keys'][start:stop]])
@@ -841,9 +840,9 @@ def aggexp_tags(dstore):
             dic[kfield] = ks[:, i]
         for name in values.dtype.names:
             dic[name] = okvalues[name]
-        dfs.append(pandas.DataFrame(dic))
-        slices.append(slice(start, stop))
-    return pandas.concat(dfs).set_index('agg_id'), slices
+        df = pandas.DataFrame(dic).set_index('agg_id')
+        dfs.append(df)
+    return dfs
 
 
 @extract.add('aggexp_tags')
@@ -852,7 +851,7 @@ def extract_aggexp_tags(dstore, what):
     Aggregate the exposure values (one for each loss type) by tag. Use it as
     /extract/aggexp_tags?
     """
-    return aggexp_tags(dstore)[0]
+    return aggexp_tags(dstore)
 
 
 @extract.add('mmi_tags')
@@ -904,7 +903,7 @@ def extract_aggrisk_tags(dstore, what):
     aggrdf = dstore.read_df('aggrisk')
     aggrdf.loss *= ws[aggrdf.rlz_id]
     del aggrdf['rlz_id']
-    adf = aggrdf.groupby(['agg_id', 'loss_id']).sum().reset_index()
+    aggdf = aggrdf.groupby(['agg_id', 'loss_id']).sum().reset_index()
     if 'aggrisk_quantiles' in dstore:
         # normally there are two quantiles 0.05, 0.95
         qdf = dstore.read_df('aggrisk_quantiles', ['agg_id', 'loss_id'])
@@ -913,19 +912,13 @@ def extract_aggrisk_tags(dstore, what):
         qdf = ()
         qfields = []
 
-    fulldf, slices = aggexp_tags(dstore)
+    dfs = aggexp_tags(dstore)
     outs = []
-    for aggby, slc in zip(oq.aggregate_by, slices):
-        df = fulldf[slc]
+    for aggby, df in zip(oq.aggregate_by, dfs):
+        adf = aggdf[numpy.isin(aggdf.agg_id, df.index)]
         acc = general.AccumDict(accum=[])
         for agg_id, loss_id, loss in zip(
                 adf.agg_id, adf.loss_id, adf.loss):
-            if agg_id < slc.start or agg_id >= slc.stop:
-                continue
-            try:
-                df.loc[agg_id]
-            except KeyError:
-                continue
             lt = LOSSTYPE[loss_id]
             if lt in oq.loss_types:
                 for kfield, key in zip(aggby, df.loc[agg_id][aggby]):

--- a/openquake/commands/importcalc.py
+++ b/openquake/commands/importcalc.py
@@ -37,6 +37,7 @@ def main(calc_id):
     try:
         calc_id = int(calc_id)
     except ValueError:  # assume calc_id is a pathname
+        calc_id = os.path.abspath(calc_id)
         remote = False
         fname = os.path.join(datadir, os.path.basename(calc_id))
         if fname != calc_id:

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -317,7 +317,7 @@ class RunShowExportTestCase(unittest.TestCase):
 
         with Print.patch() as p:
             sap.runline(f'openquake.commands show slow_sources {self.calc_id}')
-        self.assertIn('source_id | code | calc_time | num_ctxs', str(p))
+        self.assertIn('source_id | code | calc_time | weight | mul', str(p))
 
     def test_show_attrs(self):
         with Print.patch() as p:

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -520,7 +520,7 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
                           dict(truncation_level=truncation_level,
                                imtls={str(imt): np.array([0.])
                                       for imt in imts}))
-    cmaker.scenario = True
+    cmaker.oq.calculation_mode = 'scenario'
     ebr = EBRupture(
         rupture, source_id=0, trt_smr=0, n_occ=realizations, id=0, e0=0)
     ebr.seed = seed

--- a/openquake/hazardlib/tests/gsim/can15/nbcc_aa13_test.py
+++ b/openquake/hazardlib/tests/gsim/can15/nbcc_aa13_test.py
@@ -53,7 +53,7 @@ class NBCC2015_AA13TestCase(unittest.TestCase):
         for trt in gsim_lt.values:
             rbg = {gsim: U32([g]) for g, gsim in enumerate(gsim_lt.values[trt])}
             cmaker = contexts.ContextMaker(trt, rbg, param)
-            cmaker.scenario = True
+            cmaker.oq.calculation_mode = "scenario"
             ebr.n_occ = len(cmaker.gsims)
             gc = gmf.GmfComputer(ebr, inp.sitecol, cmaker)
             gmfdata = pandas.DataFrame(gc.compute_all())


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/11570. Also a couple of fixes to `oq importcalc`. Having re-run Europe on brennan we have now consistent results for Albania:
```python
>>> ds=o.read(99978731)
>>> aggexp=ds.read_df('aggexp_tags-OCCUPANCY', 'calc').loc['riskALB']
>>> aggrisk=ds.read_df('aggrisk-OCCUPANCY', 'calc').loc['riskALB']
>>> aggexp
        OCCUPANCY         number  ...  occupants_transit  occupants_avg
calc                              ...                                  
riskALB       COM   36319.101562  ...       1.546370e+05   3.596190e+05
riskALB       IND   18098.900391  ...       1.800340e+04   3.669110e+04
riskALB       RES  652205.000000  ...       1.719960e+06   1.789720e+06

[3 rows x 11 columns]
>>> aggrisk
                   loss_type OCCUPANCY    loss_value  loss_ratio
calc                                                            
riskALB             contents       COM  8.065960e+05    0.000902
riskALB           structural       COM  5.325220e+06    0.001279
riskALB        occupants_avg       COM  2.207500e+00    0.000006
riskALB  structural+contents       COM  6.131820e+06    0.001212
riskALB                 area       COM  8.817260e+03    0.001085
riskALB               number       COM  4.096480e+01    0.001128
riskALB              injured       COM  1.332670e+01    0.000037
riskALB      embodied_carbon       COM  4.489190e+03    0.001200
riskALB             contents       IND  6.003910e+05    0.000609
riskALB           structural       IND  3.214050e+06    0.001355
riskALB        occupants_avg       IND  1.436520e-01    0.000004
riskALB  structural+contents       IND  3.814440e+06    0.001136
riskALB                 area       IND  4.436520e+03    0.000778
riskALB               number       IND  1.404270e+01    0.000776
riskALB              injured       IND  9.773410e-01    0.000027
riskALB      embodied_carbon       IND  2.190400e+03    0.001080
riskALB             contents       RES  3.610020e+06    0.000833
riskALB           structural       RES  3.233270e+07    0.001322
riskALB        occupants_avg       RES  1.004850e+01    0.000006
riskALB  structural+contents       RES  3.594270e+07    0.001248
riskALB                 area       RES  6.586090e+04    0.000964
riskALB               number       RES  7.608580e+02    0.001167
riskALB            residents       RES  3.109340e+03    0.001122
riskALB          affectedpop       RES  4.186680e+03    0.001511
riskALB              injured       RES  6.022780e+01    0.000034
riskALB      embodied_carbon       RES  2.538670e+04    0.001090
```