### PR TITLE
Speedup simple faults with hypo depth distribution

### DIFF
--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -423,6 +423,14 @@ class ClassicalTestCase(CalculatorTestCase):
         self.assertIn('hypo_depth_list 25.0 km is outside the '
                       'seismogenic zone [0.0, 20.0] km', str(ctx.exception))
 
+        # Event-based on the same source goes through simple_fault
+        # iter_ruptures(rates=True), where per-rupture rates must be
+        # weighted by the renormalised hypo_depth weights so poisson
+        # sampling totals match the source's true annual rate
+        self.run_calc(case_28.__file__, 'job_event_based.ini')
+        self.assertEqual(len(self.calc.datastore['ruptures']), 89)
+        self.assertEqual(len(self.calc.datastore['events']), 96)
+
     def test_case_29(self):  # non parametric source with 2 KiteSurfaces
         check = False
 

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -288,7 +288,6 @@ class SimpleFaultSource(ParametricSeismicSource):
         """
         step = kwargs.get('step', 1)
         only_rates = kwargs.get('rates')
-        n_hypo = len(self.hypo_depth_list) or len(self.hypo_list) or 1
         n_slip = len(self.slip_list) or 1
         whole_fault_surface = SimpleFaultSurface.from_fault_data(
             self.fault_trace, self.upper_seismogenic_depth,
@@ -306,7 +305,24 @@ class SimpleFaultSource(ParametricSeismicSource):
             num_rup = num_rup_along_length * num_rup_along_width
             occurrence_rate = mag_occ_rate / float(num_rup)
             if only_rates:
-                yield numpy.full(num_rup * n_hypo * n_slip, occurrence_rate)
+                if self.hypo_depth_list:
+                    # Match _iter_ruptures_hypo_depth exactly - per (first_row,
+                    # first_col) yield one rate per (dip_frac, w) pair from
+                    # _hypo_list_from_depths, which filters by the float's
+                    # depth range and collapses entries with equal dip_frac
+                    n_cols = len(range(num_rup_along_length)[::step])
+                    parts = []
+                    for first_row in range(num_rup_along_width)[::step]:
+                        weights = numpy.array(
+                            [w for _, w in self._hypo_list_from_depths(
+                                first_row, rup_rows)]
+                                )
+                        parts.append(numpy.tile(weights, n_cols))
+                    yield numpy.concatenate(parts) * occurrence_rate
+                else:
+                    n_hypo = len(self.hypo_list) or 1
+                    yield numpy.full(
+                        num_rup * n_hypo * n_slip, occurrence_rate)
                 continue
             for first_row in range(num_rup_along_width)[::step]:
                 for first_col in range(num_rup_along_length)[::step]:
@@ -361,7 +377,6 @@ class SimpleFaultSource(ParametricSeismicSource):
         fault_length = float((mesh_cols - 1) * self.rupture_mesh_spacing)
         fault_width = float((mesh_rows - 1) * self.rupture_mesh_spacing)
         self._nr = []
-        n_hypo = len(self.hypo_depth_list) or len(self.hypo_list) or 1
         n_slip = len(self.slip_list) or 1
         for (mag, mag_occ_rate) in self.get_annual_occurrence_rates():
             if mag_occ_rate == 0:
@@ -370,8 +385,20 @@ class SimpleFaultSource(ParametricSeismicSource):
                 fault_length, fault_width, mag)
             num_rup_along_length = mesh_cols - rup_cols + 1
             num_rup_along_width = mesh_rows - rup_rows + 1
-            self._nr.append(num_rup_along_length * num_rup_along_width *
-                            n_hypo * n_slip)
+            if self.hypo_depth_list:
+                # _hypo_list_from_depths filters by each float's depth range
+                # and collapses entries with equal dip_frac (e.g. when the
+                # fixedDipFrac is constant), so the real per-float count
+                # depends on first_row
+                n_hypo_total = sum(
+                    len(self._hypo_list_from_depths(first_row, rup_rows))
+                    for first_row in range(num_rup_along_width)
+                    )
+                self._nr.append(num_rup_along_length * n_hypo_total * n_slip)
+            else:
+                n_hypo = len(self.hypo_list) or 1
+                self._nr.append(num_rup_along_length * num_rup_along_width *
+                                n_hypo * n_slip)
         counts = sum(self._nr)
         return counts
 

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -388,8 +388,8 @@ class SimpleFaultSource(ParametricSeismicSource):
             if self.hypo_depth_list:
                 # _hypo_list_from_depths filters by each float's depth range
                 # and collapses entries with equal dip_frac (e.g. when the
-                # fixedDipFrac is constant), so the real per-float count
-                # depends on first_row
+                # fixedDipFrac is constant over the depth entries), so the
+                # real per-float count depends on first_row
                 n_hypo_total = sum(
                     len(self._hypo_list_from_depths(first_row, rup_rows))
                     for first_row in range(num_rup_along_width)

--- a/openquake/qa_tests_data/classical/case_28/job_event_based.ini
+++ b/openquake/qa_tests_data/classical/case_28/job_event_based.ini
@@ -1,0 +1,44 @@
+[general]
+
+description = Simple fault source with hypoDepthDist (event based)
+calculation_mode = event_based
+random_seed = 23
+ses_seed = 24
+
+[geometry]
+
+sites = 0.5 -0.5
+
+[logic_tree]
+
+number_of_logic_tree_samples = 0
+
+[erf]
+
+rupture_mesh_spacing = 5.0
+width_of_mfd_bin = 0.1
+
+[site_params]
+
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 2.5
+reference_depth_to_1pt0km_per_sec = 50.0
+
+[calculation]
+
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gsim_logic_tree.xml
+investigation_time = 50000.0
+intensity_measure_types = PGA
+truncation_level = 3.0
+maximum_distance = 200.0
+minimum_intensity = 0.001
+
+[event_based_params]
+
+ses_per_logic_tree_path = 1
+
+[output]
+
+ground_motion_fields = true


### PR DESCRIPTION
There was an inconsistency when using `hypoDepthDist` with simple faults between `count_ruptures` and `iter_ruptures`  (`count_ruptures` was reporting more ruptures than actually had to be worked on so more memory was being allocated than necessary I think - there is a slight speedup in the BC Hydro implementation tests but nothing substantial). 

The initial implementation within the classical was correct (hence the results don't change), but now a potential bottleneck is resolved.

Also, there was a bug when using `only_rates` (event-based) relating to incorrect weights being assigned when depth entries are filtered out. I add a test that actually checks this (added to existing tests for use of `hypoDepthDist` on simple faults (classical/case_28).