### PR TITLE
Fixed CND with use_rates=true

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Fixed a bug with IMT-dependent weights being not normalized, breaking
+    the CND model with use_rates=true
+
   [Paolo Tormene]
   * Added exporter for `exposure_by_liquefaction_lse` and
     `exposure_by_landslide_lse` (Exposure grouped by Region and by

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1301,7 +1301,7 @@ class FullLogicTree(object):
         tot_weight = sum(rlz.weight for rlz in rlzs)
         if (tot_weight != 1).any():
             for rlz in rlzs:
-                rlz.weight = rlz.weight / tot_weight
+                rlz.weight /= tot_weight
         return rlzs
 
     def get_rlzs_by_gsim_dic(self):

--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -1103,6 +1103,7 @@ class FullLogicTree(object):
         logging.info('Building {:_d} realizations'.format(R))
         self.weights = ws = numpy.array(  # shape (R, 1) or (R, M+1)
             [rlz.weight for rlz in self.get_realizations()])
+        numpy.testing.assert_allclose(ws.sum(axis=0), 1)
         self.gsim_lt.wget.weights = ws
         return self
 
@@ -1296,8 +1297,9 @@ class FullLogicTree(object):
                     rlzs[i] = LtRealization(i, smpath, gsim_rlz, weight)
                     i += 1
         # rescale the weights if not one, see case_52
-        tot_weight = sum(rlz.weight for rlz in rlzs)[-1]
-        if tot_weight != 1.:
+        # and logictree/case_30 for IMT-dependent weights
+        tot_weight = sum(rlz.weight for rlz in rlzs)
+        if (tot_weight != 1).any():
             for rlz in rlzs:
                 rlz.weight = rlz.weight / tot_weight
         return rlzs


### PR DESCRIPTION
Closes https://github.com/gem/oq-engine/issues/11561. The issue was IMT-dependent weights being not normalized to 1.