### PR TITLE
Restore IMT-dependent weights with sampling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,15 +1,7 @@
-  [Michele Simionato]
-  * Fixed a bug with IMT-dependent weights being not normalized, breaking
-    the CND model with use_rates=true
-
   [Paolo Tormene]
   * Fixed a unit-scaling bug in GMF calculations; acceleration IMTs are
     converted to g as before, while velocity measures (PGV) preserve their
     native cm/s units.
-
-  [Michele Simionato]
-  * Fixed a bug with IMT-dependent weights being not normalized, breaking
-    the CND model with use_rates=true
 
   [Paolo Tormene]
   * Added exporter for `exposure_by_liquefaction_lse` and
@@ -184,7 +176,6 @@
   [Michele Simionato]
   * Added variable `keep_trt` to select a branchset in the gsim logic tree
   * Filtering the sites around the rupture also in scenario_damage
-  * Forbidded IMT-dependent weights for classical calculations with sampling
   * Extended `oq shakemap2gmfs` to work without a site model file
 
   [Christopher Brooks]

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -523,10 +523,9 @@ hazard_uhs-std.csv
                                    'hazard_curve-SA(1.0).csv'],
                                   case_30.__file__)
 
-        # IMT-dependent weights with sampling
-        with self.assertRaises(InvalidFile):
-            self.run_calc(case_30.__file__, 'job.ini',
-                          number_of_logic_tree_samples='10')
+        # IMT-dependent weights with sampling is valid
+        self.run_calc(case_30.__file__, 'job.ini',
+                      number_of_logic_tree_samples='10')
 
     def test_case_31(self):
         # source specific logic tree

--- a/openquake/commonlib/readinput.py
+++ b/openquake/commonlib/readinput.py
@@ -902,17 +902,9 @@ def get_gsim_lt(oqparam, trts=()):
                 raise CorrelationButNoInterIntraStdDevs(gmfcorr, gsim)
     imt_dep_w = any(len(branch.weight.dic) > 1 for branch in gsim_lt.branches)
     if oqparam.number_of_logic_tree_samples and imt_dep_w:
-        if oqparam.strict and oqparam.calculation_mode.startswith(
-                ('classical', 'disaggregation')):
-            raise InvalidFile(
-                f'{oqparam.inputs["gsim_logic_tree"]}: IMT-dependent weights '
-                'in the GMM logic tree require full enumeration')
-        else:
-            logging.error(
-                'IMT-dependent weights in the logic tree cannot work '
-                'with sampling, because they would produce different '
-                'GMPE paths for each IMT that cannot be combined; '
-                'using the default weights')
+        logging.warning(
+            'IMT-dependent weights in the logic tree are ignored '
+            'when sampling; using the default weights')
         for branch in gsim_lt.branches:
             for k, w in sorted(branch.weight.dic.items()):
                 if k != 'weight':


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/11350. It must be possible to run IMT-dependent weights with sampling, otherwise the disaggregation for Canada (with 7 millions of realizations) would be impossible. So, I am reverting to the previous behavior, against @CB-quakemodel desires ;-)