### PR TITLE
Added a test of GDAL opening a grid.asc file

### DIFF
--- a/.github/workflows/macos_arm_install.yml
+++ b/.github/workflows/macos_arm_install.yml
@@ -97,6 +97,34 @@ jobs:
           pytest openquake/baselib/tests/pyproj_wheel_test.py
           pytest openquake/hazardlib/tests/pyproj_wheel_test.py
 
+      - name: Run tests for hazardlib, sep, commands, engine, hmtk, risklib, commonlib and baselib to test installation
+        if: always()
+        run: |
+          curl -O https://downloads.openquake.org/test_data/exposure.hdf5
+          source ~/openquake/bin/activate
+          cd openquake
+          pytest --doctest-modules --disable-warnings --color=yes --durations=10 sep hazardlib commands engine hmtk risklib commonlib baselib
+          cd ..
+
+      - name: Run tests for calculators to test installation
+        if: always()
+        run: |
+          source ~/openquake/bin/activate
+          pytest --doctest-modules --disable-warnings --color=yes --durations=10 openquake/calculators
+
+      - name: Run tests for the engine server in public mode to test installation
+        if: always()
+        run: |
+          source ~/openquake/bin/activate
+          pip3 install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl
+          OQ_APPLICATION_MODE=PUBLIC pytest -v openquake/server/tests/test_public_mode.py
+
+      - name: Run tests for the engine server in read-only mode to test installation
+        if: always()
+        run: |
+          source ~/openquake/bin/activate
+          pip3 install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl
+          OQ_APPLICATION_MODE=READ_ONLY pytest -v openquake/server/tests/test_read_only_mode.py
       - name: Run test to start OQ-WebUI in public mode to test installation
         if: always()
         run: |
@@ -127,32 +155,3 @@ jobs:
           oq info venv
           oq info cfg
           bin/run-demos.sh demos/ openquake/qa_tests_data/
-      - name: Run tests for calculators to test installation
-        if: always()
-        run: |
-          source ~/openquake/bin/activate
-          pytest --doctest-modules --disable-warnings --color=yes --durations=10 openquake/calculators
-
-      - name: Run tests for hazardlib, sep, commands, engine, hmtk, risklib, commonlib and baselib to test installation
-        if: always()
-        run: |
-          curl -O https://downloads.openquake.org/test_data/exposure.hdf5
-          source ~/openquake/bin/activate
-          cd openquake
-          pytest --doctest-modules --disable-warnings --color=yes --durations=10 hazardlib sep commands engine hmtk risklib commonlib baselib
-          cd ..
-
-
-      - name: Run tests for the engine server in public mode to test installation
-        if: always()
-        run: |
-          source ~/openquake/bin/activate
-          pip3 install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl
-          OQ_APPLICATION_MODE=PUBLIC pytest -v openquake/server/tests/test_public_mode.py
-
-      - name: Run tests for the engine server in read-only mode to test installation
-        if: always()
-        run: |
-          source ~/openquake/bin/activate
-          pip3 install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl
-          OQ_APPLICATION_MODE=READ_ONLY pytest -v openquake/server/tests/test_read_only_mode.py

--- a/.github/workflows/macos_arm_install.yml
+++ b/.github/workflows/macos_arm_install.yml
@@ -89,7 +89,15 @@ jobs:
           pip3 install pytest pyshp flake8
           oq engine --upgrade-db
           sleep 5
-
+      
+      - name: Run demos to test installation
+        run: |
+          set -x
+          source ~/openquake/bin/activate
+          oq info venv
+          oq info cfg
+          bin/run-demos.sh demos/ openquake/qa_tests_data/
+          
       - name: Test importing pyproj and hazardlib in both orders, to check the pyproj wheel
         if: always()
         run: |
@@ -125,6 +133,7 @@ jobs:
           source ~/openquake/bin/activate
           pip3 install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl
           OQ_APPLICATION_MODE=READ_ONLY pytest -v openquake/server/tests/test_read_only_mode.py
+          
       - name: Run test to start OQ-WebUI in public mode to test installation
         if: always()
         run: |
@@ -147,11 +156,3 @@ jobs:
           sleep 5
           echo "curl.exe -X HEAD -I --fail http://127.0.0.1:8800/taxonomy/"
           curl -X HEAD -I --fail http://127.0.0.1:8800/taxonomy/
-
-      - name: Run demos to test installation
-        run: |
-          set -x
-          source ~/openquake/bin/activate
-          oq info venv
-          oq info cfg
-          bin/run-demos.sh demos/ openquake/qa_tests_data/

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -129,15 +129,6 @@ jobs:
           Write-Host "curl.exe -X HEAD -I --fail http://127.0.0.1:8800/taxonomy/"
           curl.exe -X HEAD -I --fail http://127.0.0.1:8800/taxonomy/
           ping 127.0.0.1 -n 6 > null
-      - name: Run tests for calculators
-        if: always() && env.to_run == 0
-        run: |
-          C:\Users\runneradmin\openquake\Scripts\activate.ps1
-          oq --version
-          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' engine --upgrade-db}
-          cd D:\a\oq-engine\oq-engine
-          pytest --doctest-modules --disable-warnings --color=yes --durations=10 openquake/calculators
-
       - name: Run tests for hazardlib, sep, commands, engine, hmtk, risklib, commonlib and baselib to test installation
         if: always() && env.to_run == 0
         run: |
@@ -147,6 +138,15 @@ jobs:
           sleep 10
           cd D:\a\oq-engine\oq-engine\openquake
           pytest --doctest-modules --disable-warnings --color=yes --durations=10 hazardlib sep commands engine hmtk risklib commonlib baselib
+
+      - name: Run tests for calculators
+        if: always() && env.to_run == 0
+        run: |
+          C:\Users\runneradmin\openquake\Scripts\activate.ps1
+          oq --version
+          Start-Job -ScriptBlock{& 'C:\Users\runneradmin\openquake\Scripts\oq.exe' engine --upgrade-db}
+          cd D:\a\oq-engine\oq-engine
+          pytest --doctest-modules --disable-warnings --color=yes --durations=10 openquake/calculators
 
       - name: Run tests for the engine server in public mode to test installation
         if: always() && env.to_run == 0

--- a/doc/getting-started/installation-instructions/index.rst
+++ b/doc/getting-started/installation-instructions/index.rst
@@ -66,6 +66,11 @@ and for Mac, it would be::
 	$ pip install -r https://github.com/gem/oq-engine/raw/master/requirements-py311-macos.txt openquake.engine
 	```
 
+If you have a previous installation of the engine it is a good idea to
+pass ``--force-reinstall`` to ``pip``: this solves potential issues with
+geospatial libraries, like using using the old version of proj instead
+of the new one.
+
 Cloud
 -----
 

--- a/doc/getting-started/installation-instructions/macos.rst
+++ b/doc/getting-started/installation-instructions/macos.rst
@@ -16,9 +16,9 @@ Requirements are:
 We recommend using a Linux server for large calculations such as
 national or regional-scale models.
 
-**Intel-based MacOS**  are not supported.
+**Intel-based MacOS** is no longer supported.
 
-**Please note** that  OpenQuake Engine cannot be installed on any macOS version lower than macOS Sequoia 15.7.
+**Please note** that  OpenQuake Engine cannot be installed on any macOS version lower than macOS Sequoia 15.
 
 Installation Procedure of Python 3
 ----------------------------------

--- a/doc/getting-started/installation-instructions/macos.rst
+++ b/doc/getting-started/installation-instructions/macos.rst
@@ -17,6 +17,7 @@ We recommend using a Linux server for large calculations such as
 national or regional-scale models.
 
 **Intel-based MacOS**  are not supported.
+
 **Please note** that  OpenQuake Engine cannot be installed on any macOS version lower than macOS Sequoia 15.7.
 
 Installation Procedure of Python 3

--- a/doc/getting-started/installation-instructions/macos.rst
+++ b/doc/getting-started/installation-instructions/macos.rst
@@ -9,6 +9,7 @@ Requirements
 Requirements are:
 
 -  macOS Sequoia 15.7 or macOS 26 Tahoe 26.4
+-  ARM-based Apple Silicon CPU (M1 - M5)
 -  at least 16 GB of RAM
 -  4 GB of free disk space
 -  Python 3.12

--- a/doc/getting-started/installation-instructions/macos.rst
+++ b/doc/getting-started/installation-instructions/macos.rst
@@ -8,7 +8,7 @@ Requirements
 
 Requirements are:
 
--  macOS Sequoia 15.7 or macOS Sonoma 14.6
+-  macOS Sequoia 15.7 or macOS 26 Tahoe 26.4
 -  at least 16 GB of RAM
 -  4 GB of free disk space
 -  Python 3.12
@@ -17,6 +17,7 @@ We recommend using a Linux server for large calculations such as
 national or regional-scale models.
 
 **Intel-based MacOS**  are not supported.
+**Please note** that  OpenQuake Engine cannot be installed on any macOS version lower than macOS Sequoia 15.7.
 
 Installation Procedure of Python 3
 ----------------------------------

--- a/install.py
+++ b/install.py
@@ -481,6 +481,7 @@ def install(inst, version, from_fork):
             "-m",
             "pip",
             "install",
+            "--force-reinstall",
             "--trusted-host",
             "wheelhouse.openquake.org",
             "--trusted-host",

--- a/install.py
+++ b/install.py
@@ -78,14 +78,13 @@ if PYVER < (3, 11, 0):
 
 # check macOS
 if sys.platform == "darwin":
-    try:
-        mac_version_str = platform.mac_ver()[0]
-        major_version = int(mac_version_str.split(".")[0])
-        if major_version < 15:
-            sys.exit(
-                f"Error: macOS {mac_version_str} is not supported. "
-                "Version 15 or higher is required."
-            )
+    mac_version_str = platform.mac_ver()[0]
+    major_version = int(mac_version_str.split(".")[0])
+    if major_version < 15:
+        sys.exit(
+            f"Error: macOS {mac_version_str} is not supported. "
+            "Version 15 or higher is required."
+        )
 
 CDIR = os.path.dirname(os.path.abspath(__file__))
 REMOVE_VENV = """Found pre-existing venv %s

--- a/install.py
+++ b/install.py
@@ -75,6 +75,18 @@ if PYVER < (3, 11, 0):
     sys.exit(
         "Error: you need at least Python 3.11, but you have %s"
         % ".".join(map(str, sys.version_info)))
+
+# check macOS
+if sys.platform == "darwin":
+    try:
+        mac_version_str = platform.mac_ver()[0]
+        major_version = int(mac_version_str.split(".")[0])
+        if major_version < 15:
+            sys.exit(
+                f"Error: macOS {mac_version_str} is not supported. "
+                "Version 15 or higher is required."
+            )
+
 CDIR = os.path.dirname(os.path.abspath(__file__))
 REMOVE_VENV = """Found pre-existing venv %s
 If you proceeed you will have to reinstall manually any software other

--- a/openquake/sep/tests/data/grid.asc
+++ b/openquake/sep/tests/data/grid.asc
@@ -1,0 +1,10 @@
+ncols         3
+nrows         4
+xllcorner     500000.0
+yllcorner     520000.0
+cellsize      10.0
+NODATA_value  -9999
+1.5 2.5 0.0
+3.5 4.5 -9999
+0.5 1.0 2.0
+2.0 3.0 4.0

--- a/openquake/sep/tests/test_utils.py
+++ b/openquake/sep/tests/test_utils.py
@@ -21,9 +21,10 @@ from openquake.sep.utils import (
 BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), "data")
 test_dem = os.path.join(BASE_DATA_PATH, "dem_small.tif")
 test_relief = os.path.join(BASE_DATA_PATH, "relief_out.tif")
+test_grid = os.path.join(BASE_DATA_PATH, "grid.asc")
 
 
-class testUtils(unittest.TestCase):
+class TestUtils(unittest.TestCase):
     def test_slope_angle_to_gradient_1(self):
         assert slope_angle_to_gradient(0, unit="degree") == 0.0
 
@@ -45,7 +46,7 @@ class testUtils(unittest.TestCase):
         )
 
 
-class test_array_funcs_super_simple(unittest.TestCase):
+class Test_array_funcs_super_simple(unittest.TestCase):
     def setUp(self):
         self.array = np.arange(25).reshape((5, 5))
 
@@ -233,25 +234,27 @@ class test_array_funcs_super_simple(unittest.TestCase):
 
 
 @unittest.skipIf(gdal is None, "GDAL not always installed correctly")
-class test_make_local_relief_raster(unittest.TestCase):
+class Test_make_local_relief_raster(unittest.TestCase):
     def setUp(self):
         self.test_relief_raster = gdal.Open(test_relief)
         _outfile_handler, outfile = tempfile.mkstemp(suffix=".tiff")
         self.lrr = make_local_relief_raster(
-            test_dem, 5, outfile=outfile, write=False, trim=False
-        )
+            test_dem, 5, outfile=outfile, write=False, trim=False)
 
     def test_make_local_relief_raster_geo_transform(self):
         np.testing.assert_allclose(
             self.lrr.GetGeoTransform(),
-            self.test_relief_raster.GetGeoTransform(),
-        )
+            self.test_relief_raster.GetGeoTransform())
 
     def test_make_2d_local_relief_raster_array_vals(self):
         np.testing.assert_array_almost_equal(
             self.lrr.GetRasterBand(1).ReadAsArray(),
-            self.test_relief_raster.GetRasterBand(1).ReadAsArray(),
-        )
+            self.test_relief_raster.GetRasterBand(1).ReadAsArray())
+
+    def test_grid_asc(self):
+        raster = gdal.Open(test_grid)
+        lon, lon_delta, _, lat, _, lat_delta = raster.GetGeoTransform()
+        print(raster.ReadAsArray())
 
     def tearDown(self):
         # NOTE: On Windows, trying to remove the temporary outfile raises

--- a/openquake/sep/utils.py
+++ b/openquake/sep/utils.py
@@ -9,11 +9,11 @@ import pyproj as pj
 from osgeo import gdal
 from numpy.lib.stride_tricks import as_strided
 
-
 # Set PROJ_DATA (proj == 9.0.1) to dir containing proj.db to avoid:
 # 'ERROR 1: PROJ: proj_create_from_name: Cannot find proj.db'
 if "PROJ_DATA" not in os.environ:
     os.environ["PROJ_DATA"] = pj.datadir.get_data_dir()
+gdal.UseExceptions()
 
 
 def sample_raster_at_points(
@@ -141,10 +141,7 @@ def rolling_array_operation(
     """
     if window_size % 2 != 1:
         raise ValueError(
-            "window_size should be an odd integer; {} passed".format(
-                window_size
-            )
-        )
+            f"window_size should be an odd integer; {window_size} passed")
 
     window_rad = window_size // 2
 

--- a/requirements-py311-linux64.txt
+++ b/requirements-py311-linux64.txt
@@ -18,7 +18,7 @@ https://wheelhouse.openquake.org/v3/linux/py311/onnxruntime-1.23.2-cp311-cp311-m
 https://wheelhouse.openquake.org/v3/linux/py311/pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
-https://wheelhouse.openquake.org/v3/linux/py311/pyogrio-0.11.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py311/pyogrio-0.12.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/pyproj-3.7.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/pyzmq-26.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/scipy-1.15.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -45,7 +45,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py311-linux64.txt
+++ b/requirements-py311-linux64.txt
@@ -6,7 +6,7 @@ https://wheelhouse.openquake.org/v3/linux/py311/cffi-1.17.1-cp311-cp311-manylinu
 https://wheelhouse.openquake.org/v3/linux/py311/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/contourpy-1.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/fiona-1.10.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-https://wheelhouse.openquake.org/v3/linux/py311/gdal-3.10.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py311/gdal-3.13.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/h3-4.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/h5py-3.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py311/kiwisolver-1.4.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

--- a/requirements-py311-macos_arm64.txt
+++ b/requirements-py311-macos_arm64.txt
@@ -17,7 +17,7 @@ https://wheelhouse.openquake.org/v3/macos/arm64/py311/onnxruntime-1.23.2-cp311-c
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/pandas-2.2.3-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py311/pyogrio-0.11.1-cp311-cp311-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py311/pyogrio-0.12.1-cp311-cp311-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/pyproj-3.7.2-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/pyzmq-26.0.3-cp311-cp311-macosx_10_15_universal2.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl
@@ -44,7 +44,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py311-macos_arm64.txt
+++ b/requirements-py311-macos_arm64.txt
@@ -5,7 +5,7 @@
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/contourpy-1.3.2-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/fiona-1.10.1-cp311-cp311-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py311/gdal-3.10.3-cp311-cp311-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py311/gdal-3.13.1-cp311-cp311-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/h3-4.4.1-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/h5py-3.13.0-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/kiwisolver-1.4.5-cp311-cp311-macosx_11_0_arm64.whl

--- a/requirements-py311-macos_arm64.txt
+++ b/requirements-py311-macos_arm64.txt
@@ -4,7 +4,7 @@
 #
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/contourpy-1.3.2-cp311-cp311-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py311/fiona-1.10.1-cp311-cp311-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py312/fiona-1.10.1-cp312-cp312-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/gdal-3.13.1-cp311-cp311-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/h3-4.4.1-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/h5py-3.13.0-cp311-cp311-macosx_11_0_arm64.whl
@@ -18,7 +18,7 @@ https://wheelhouse.openquake.org/v3/macos/arm64/py311/pandas-2.2.3-cp311-cp311-m
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/pyogrio-0.12.1-cp311-cp311-macosx_14_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py311/pyproj-3.7.2-cp311-cp311-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py311/pyproj-3.7.2-cp311-cp311-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/pyzmq-26.0.3-cp311-cp311-macosx_10_15_universal2.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/setproctitle-1.3.7-cp311-cp311-macosx_11_0_arm64.whl

--- a/requirements-py311-macos_arm64.txt
+++ b/requirements-py311-macos_arm64.txt
@@ -4,7 +4,7 @@
 #
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/contourpy-1.3.2-cp311-cp311-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py312/fiona-1.10.1-cp312-cp312-macosx_14_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py311/fiona-1.10.1-cp311-cp311-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/gdal-3.13.1-cp311-cp311-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/h3-4.4.1-cp311-cp311-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py311/h5py-3.13.0-cp311-cp311-macosx_11_0_arm64.whl

--- a/requirements-py311-win64.txt
+++ b/requirements-py311-win64.txt
@@ -4,7 +4,7 @@
 https://wheelhouse.openquake.org/v3/windows/py311/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/contourpy-1.3.2-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/fiona-1.10.1-cp311-cp311-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py311/gdal-3.13.1-cp311-cp311-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py311/gdal-3.10.2-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/h3-4.4.1-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/h5py-3.13.0-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/kiwisolver-1.4.5-cp311-cp311-win_amd64.whl
@@ -43,7 +43,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py311-win64.txt
+++ b/requirements-py311-win64.txt
@@ -4,7 +4,7 @@
 https://wheelhouse.openquake.org/v3/windows/py311/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/contourpy-1.3.2-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/fiona-1.10.1-cp311-cp311-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py311/gdal-3.10.2-cp311-cp311-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py311/gdal-3.13.1-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/h3-4.4.1-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/h5py-3.13.0-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/kiwisolver-1.4.5-cp311-cp311-win_amd64.whl
@@ -43,7 +43,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py311-win64.txt
+++ b/requirements-py311-win64.txt
@@ -4,7 +4,7 @@
 https://wheelhouse.openquake.org/v3/windows/py311/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/contourpy-1.3.2-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/fiona-1.10.1-cp311-cp311-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py311/gdal-3.10.2-cp311-cp311-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py311/gdal-3.11.4-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/h3-4.4.1-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/h5py-3.13.0-cp311-cp311-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py311/kiwisolver-1.4.5-cp311-cp311-win_amd64.whl

--- a/requirements-py312-linux64.txt
+++ b/requirements-py312-linux64.txt
@@ -18,7 +18,7 @@ https://wheelhouse.openquake.org/v3/linux/py312/onnxruntime-1.23.2-cp312-cp312-m
 https://wheelhouse.openquake.org/v3/linux/py312/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
-https://wheelhouse.openquake.org/v3/linux/py312/pyogrio-0.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py312/pyogrio-0.12.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/pyproj-3.7.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/pyzmq-26.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -45,7 +45,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py312-linux64.txt
+++ b/requirements-py312-linux64.txt
@@ -6,7 +6,7 @@ https://wheelhouse.openquake.org/v3/linux/py312/cffi-1.17.1-cp312-cp312-manylinu
 https://wheelhouse.openquake.org/v3/linux/py312/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/contourpy-1.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/fiona-1.10.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-https://wheelhouse.openquake.org/v3/linux/py312/gdal-3.10.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py312/gdal-3.13.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/h3-4.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/h5py-3.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py312/kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

--- a/requirements-py312-macos_arm64.txt
+++ b/requirements-py312-macos_arm64.txt
@@ -5,7 +5,7 @@
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/contourpy-1.3.2-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/fiona-1.10.1-cp312-cp312-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py312/gdal-3.10.3-cp312-cp312-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py312/gdal-3.13.1-cp312-cp312-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/h3-4.4.1-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/h5py-3.13.0-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/kiwisolver-1.4.7-cp312-cp312-macosx_11_0_arm64.whl

--- a/requirements-py312-macos_arm64.txt
+++ b/requirements-py312-macos_arm64.txt
@@ -4,7 +4,7 @@
 #
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/contourpy-1.3.2-cp312-cp312-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py312/fiona-1.10.1-cp312-cp312-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py312/fiona-1.10.1-cp312-cp312-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/gdal-3.13.1-cp312-cp312-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/h3-4.4.1-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/h5py-3.13.0-cp312-cp312-macosx_11_0_arm64.whl
@@ -18,7 +18,7 @@ https://wheelhouse.openquake.org/v3/macos/arm64/py312/pandas-2.2.3-cp312-cp312-m
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/pyogrio-0.12.1-cp312-cp312-macosx_14_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py312/pyproj-3.7.2-cp312-cp312-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py312/pyproj-3.7.2-cp312-cp312-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/pyzmq-26.2.0-cp312-cp312-macosx_10_15_universal2.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl

--- a/requirements-py312-macos_arm64.txt
+++ b/requirements-py312-macos_arm64.txt
@@ -17,7 +17,7 @@ https://wheelhouse.openquake.org/v3/macos/arm64/py312/onnxruntime-1.23.2-cp312-c
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py312/pyogrio-0.11.1-cp312-cp312-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py312/pyogrio-0.12.1-cp312-cp312-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/pyproj-3.7.2-cp312-cp312-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/pyzmq-26.2.0-cp312-cp312-macosx_10_15_universal2.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py312/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl
@@ -44,7 +44,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py312-win64.txt
+++ b/requirements-py312-win64.txt
@@ -4,7 +4,7 @@
 https://wheelhouse.openquake.org/v3/windows/py312/charset_normalizer-3.4.0-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/contourpy-1.3.2-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/fiona-1.10.1-cp312-cp312-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py312/gdal-3.13.1-cp312-cp312-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py312/gdal-3.10.2-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/h3-4.4.1-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/h5py-3.13.0-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/kiwisolver-1.4.7-cp312-cp312-win_amd64.whl
@@ -43,7 +43,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py312-win64.txt
+++ b/requirements-py312-win64.txt
@@ -4,7 +4,7 @@
 https://wheelhouse.openquake.org/v3/windows/py312/charset_normalizer-3.4.0-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/contourpy-1.3.2-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/fiona-1.10.1-cp312-cp312-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py312/gdal-3.10.2-cp312-cp312-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py312/gdal-3.11.4-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/h3-4.4.1-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/h5py-3.13.0-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/kiwisolver-1.4.7-cp312-cp312-win_amd64.whl

--- a/requirements-py312-win64.txt
+++ b/requirements-py312-win64.txt
@@ -4,7 +4,7 @@
 https://wheelhouse.openquake.org/v3/windows/py312/charset_normalizer-3.4.0-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/contourpy-1.3.2-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/fiona-1.10.1-cp312-cp312-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py312/gdal-3.10.2-cp312-cp312-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py312/gdal-3.13.1-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/h3-4.4.1-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/h5py-3.13.0-cp312-cp312-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py312/kiwisolver-1.4.7-cp312-cp312-win_amd64.whl
@@ -43,7 +43,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py313-linux64.txt
+++ b/requirements-py313-linux64.txt
@@ -5,7 +5,7 @@ https://wheelhouse.openquake.org/v3/linux/py313/cffi-1.17.1-cp313-cp313-manylinu
 https://wheelhouse.openquake.org/v3/linux/py313/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/contourpy-1.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/fiona-1.10.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-https://wheelhouse.openquake.org/v3/linux/py313/gdal-3.10.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py313/gdal-3.13.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/h3-4.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/h5py-3.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

--- a/requirements-py313-linux64.txt
+++ b/requirements-py313-linux64.txt
@@ -17,7 +17,7 @@ https://wheelhouse.openquake.org/v3/linux/py313/onnxruntime-1.23.2-cp313-cp313-m
 https://wheelhouse.openquake.org/v3/linux/py313/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
-https://wheelhouse.openquake.org/v3/linux/py313/pyogrio-0.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py313/pyogrio-0.12.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/pyproj-3.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/pyzmq-26.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 https://wheelhouse.openquake.org/v3/linux/py313/scipy-1.15.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -44,7 +44,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py313-macos_arm64.txt
+++ b/requirements-py313-macos_arm64.txt
@@ -18,7 +18,7 @@ https://wheelhouse.openquake.org/v3/macos/arm64/py313/onnxruntime-1.23.2-cp313-c
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py313/pyogrio-0.11.1-cp313-cp313-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py313/pyogrio-0.12.1-cp313-cp313-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/pyproj-3.7.2-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/pyzmq-26.2.0-cp313-cp313-macosx_10_15_universal2.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/scipy-1.15.3-cp313-cp313-macosx_12_0_arm64.whl
@@ -45,7 +45,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py313-macos_arm64.txt
+++ b/requirements-py313-macos_arm64.txt
@@ -6,7 +6,7 @@ https://wheelhouse.openquake.org/v3/macos/arm64/py313/cffi-1.17.1-cp313-cp313-ma
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/charset_normalizer-3.4.0-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/contourpy-1.3.2-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/fiona-1.10.1-cp313-cp313-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py313/gdal-3.10.3-cp313-cp313-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py313/gdal-3.13.1-cp313-cp313-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/h3-4.4.1-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/h5py-3.13.0-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/kiwisolver-1.4.7-cp313-cp313-macosx_11_0_arm64.whl

--- a/requirements-py313-macos_arm64.txt
+++ b/requirements-py313-macos_arm64.txt
@@ -5,7 +5,7 @@
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/charset_normalizer-3.4.0-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/contourpy-1.3.2-cp313-cp313-macosx_11_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py313/fiona-1.10.1-cp313-cp313-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py313/fiona-1.10.1-cp313-cp313-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/gdal-3.13.1-cp313-cp313-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/h3-4.4.1-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/h5py-3.13.0-cp313-cp313-macosx_11_0_arm64.whl
@@ -19,7 +19,7 @@ https://wheelhouse.openquake.org/v3/macos/arm64/py313/pandas-2.2.3-cp313-cp313-m
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/pyogrio-0.12.1-cp313-cp313-macosx_14_0_arm64.whl
-https://wheelhouse.openquake.org/v3/macos/arm64/py313/pyproj-3.7.2-cp313-cp313-macosx_11_0_arm64.whl
+https://wheelhouse.openquake.org/v3/macos/arm64/py313/pyproj-3.7.2-cp313-cp313-macosx_14_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/pyzmq-26.2.0-cp313-cp313-macosx_10_15_universal2.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/scipy-1.15.3-cp313-cp313-macosx_12_0_arm64.whl
 https://wheelhouse.openquake.org/v3/macos/arm64/py313/setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl

--- a/requirements-py313-win64.txt
+++ b/requirements-py313-win64.txt
@@ -5,7 +5,7 @@ https://wheelhouse.openquake.org/v3/windows/py313/cffi-1.17.1-cp313-cp313-win_am
 https://wheelhouse.openquake.org/v3/windows/py313/charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/contourpy-1.3.2-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/fiona-1.10.1-cp313-cp313-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py313/gdal-3.13.1-cp313-cp313-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py313/gdal-3.10.2-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/h3-4.4.1-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/h5py-3.13.0-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/kiwisolver-1.4.7-cp313-cp313-win_amd64.whl
@@ -45,7 +45,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py313-win64.txt
+++ b/requirements-py313-win64.txt
@@ -5,7 +5,7 @@ https://wheelhouse.openquake.org/v3/windows/py313/cffi-1.17.1-cp313-cp313-win_am
 https://wheelhouse.openquake.org/v3/windows/py313/charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/contourpy-1.3.2-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/fiona-1.10.1-cp313-cp313-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py313/gdal-3.10.2-cp313-cp313-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py313/gdal-3.13.1-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/h3-4.4.1-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/h5py-3.13.0-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/kiwisolver-1.4.7-cp313-cp313-win_amd64.whl
@@ -45,7 +45,7 @@ https://wheelhouse.openquake.org/v3/py/docutils-0.20.1-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flake8-6.1.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/flatbuffers-25.12.19-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/fonttools-4.60.2-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/py/geopandas-1.1.3-py3-none-any.whl
+https://wheelhouse.openquake.org/v3/py/geopandas-1.1.4-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/humanfriendly-10.0-py2.py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/idna-3.15-py3-none-any.whl
 https://wheelhouse.openquake.org/v3/py/importlib_metadata-7.0.0-py3-none-any.whl

--- a/requirements-py313-win64.txt
+++ b/requirements-py313-win64.txt
@@ -5,7 +5,7 @@ https://wheelhouse.openquake.org/v3/windows/py313/cffi-1.17.1-cp313-cp313-win_am
 https://wheelhouse.openquake.org/v3/windows/py313/charset_normalizer-3.4.0-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/contourpy-1.3.2-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/fiona-1.10.1-cp313-cp313-win_amd64.whl
-https://wheelhouse.openquake.org/v3/windows/py313/gdal-3.10.2-cp313-cp313-win_amd64.whl
+https://wheelhouse.openquake.org/v3/windows/py313/gdal-3.11.4-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/h3-4.4.1-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/h5py-3.13.0-cp313-cp313-win_amd64.whl
 https://wheelhouse.openquake.org/v3/windows/py313/kiwisolver-1.4.7-cp313-cp313-win_amd64.whl


### PR DESCRIPTION
The GDAL wheel provided by @vot4anto cannot open an ESRI .asc file: that breaks IPT in the Volcano example:
```python
ERROR: openquakeplatform_ipt.test.examples_test.IptExamplesTest.ConfigurationFile_92_4_test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/oq-platform-ipt/openquakeplatform_ipt/test/examples_test.py", line 476, in generated
    res = zip_diff(exp_filename, zipfile, True)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/oq-platform-ipt/openquakeplatform_ipt/test/examples_test.py", line 218, in zip_diff
    z2 = zipfile.ZipFile(open(filename2, "rb"))
                         ^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/gem-oq-moon-download/Volcano.zip'
```
My guess is a missing AAIGrid driver. Here I add a test, engine side, which actually gives a proper error message and not a confusing one.