### PR TITLE
Reduced `max_assets_chunk` to reduce the memory occupation

### DIFF
--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -282,11 +282,11 @@ def _event_based_risk(gmf_df, gen_adf, crmodel, monitor):
         countries = ["?"]  # assume a single contry
     for id0taxo, assetdf in gen_adf:
         with fil_mon:
+            # filtering is *crucial* for the performance of the next step
             adf = assetdf[numpy.isin(assetdf.site_id, haz_sids)]
+            if len(adf) == 0:
+                continue
             gdf = gmf_df[numpy.isin(gmf_df.sid, adf.site_id)]
-        if len(adf) == 0:
-            # *crucial* for the performance of the next step
-            continue
         # passing the contry is crucial for impact_test,
         # where the exposure contains multiple countries
         country = countries[id0taxo // TWO24]

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -169,8 +169,8 @@ def ebr_from_gmfs(gmf_df, oqparam, monitor):
     """
     with monitor('reading crmodel', measuremem=True):
         crmodel = monitor.read('crmodel')
-    assdf = monitor.read('assets')
-    items = ((id0taxo, assdf[s0:s1].set_index('ordinal'))
+    items = ((id0taxo, monitor.read('assets', slice(s0, s1)).
+              set_index('ordinal'))
              for id0taxo, s0, s1 in monitor.read('start-stop'))
     dic = _event_based_risk(gmf_df, items, crmodel, monitor)
     return dic

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -318,6 +318,8 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     oq.ground_motion_fields = True
     with monitor('reading crmodel', measuremem=True):
         crmodel = monitor.read('crmodel')
+        pairs = [(idx0taxo, slice(s0, s1))
+                 for idx0taxo, s0, s1 in monitor.read('start-stop')]
     # NB: the assets are read more times than needed; this is on purpose;
     # the slowdown is minor, while the memory saving is massive, since only
     # one taxonomy at the time is read inside _event_based_risk
@@ -326,9 +328,8 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         if len(dic['gmfdata']):
             times = dic['times']  # rup_id, time, weight
             gmf_df = pandas.DataFrame(dic['gmfdata'])
-            items = ((id0taxo, monitor.read(
-                'assets', slc=slice(s0, s1)).set_index('ordinal'))
-                     for id0taxo, s0, s1 in monitor.read('start-stop'))
+            items = ((id0taxo, monitor.read('assets', slc).
+                      set_index('ordinal')) for id0taxo, slc in pairs)
             t0 = time.time()
             res = _event_based_risk(gmf_df, items, crmodel, monitor)
             dt = time.time() - t0

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -275,23 +275,23 @@ def _event_based_risk(gdf, gen_adf, crmodel, monitor):
     risk_mon = monitor('computing risk', measuremem=False)
     fil_mon = monitor('filtering GMFs', measuremem=False)
     agg_mon = monitor('aggregating losses', measuremem=False)
-    sids = gdf.sid.to_numpy()
+    haz_sids = gdf.sid.unique()
     try:
         countries = monitor.read('countries')
     except KeyError:  # no ID_0 in the exposure
         countries = ["?"]  # assume a single contry
-    for id0taxo, adf in gen_adf:
+    for id0taxo, assetdf in gen_adf:
+        with fil_mon:
+            adf = assetdf[numpy.isin(assetdf.site_id, haz_sids)]
+        if len(adf) == 0:
+            # *crucial* for the performance of the next step
+            continue
         # passing the contry is crucial for impact_test,
         # where the exposure contains multiple countries
         country = countries[id0taxo // TWO24]
-        with fil_mon:
-            # *crucial* for the performance of the next step
-            gmf_df = gdf[numpy.isin(sids, adf.site_id.unique())]
-        if len(gmf_df) == 0:  # common enough
-            continue
         with risk_mon:
             [out] = crmodel.get_outputs(
-                adf, gmf_df, crmodel.oqparam._sec_losses, rng, country)
+                adf, gdf, crmodel.oqparam._sec_losses, rng, country)
         with agg_mon:
             aggreg(out, aggids, rlz_id, oq, loss2, loss3)
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -176,54 +176,6 @@ def ebr_from_gmfs(gmf_df, oqparam, monitor):
     return dic
 
 
-def _event_based_risk(df, gen_adf, crmodel, monitor):
-    oq = crmodel.oqparam
-    R = 1 if oq.collect_rlzs else len(monitor.read('weights'))
-    X = len(oq.ext_loss_types) + oq.ideduc
-    loss3 = {'aids': [], 'bids': [], 'loss': []}
-    loss2 = general.AccumDict(accum=numpy.zeros((X, 2)))  # u8idx->array
-    if os.environ.get('OQ_DEBUG_SITE'):
-        print(df)
-
-    aggids = monitor.read('aggids')
-    rlz_id = monitor.read('rlz_id')
-    if oq.ignore_master_seed or oq.ignore_covs:
-        rng = None
-    else:
-        rng = MultiEventRNG(oq.master_seed, df.eid.unique(),
-                            int(oq.asset_correlation))
-    risk_mon = monitor('computing risk', measuremem=False)
-    fil_mon = monitor('filtering GMFs', measuremem=False)
-    agg_mon = monitor('aggregating losses', measuremem=False)
-    sids = df.sid.to_numpy()
-    try:
-        countries = monitor.read('countries')
-    except KeyError:  # no ID_0 in the exposure
-        countries = ["?"]  # assume a single contry
-    for id0taxo, adf in gen_adf:
-        # passing the contry is crucial for impact_test,
-        # where the exposure contains multiple countries
-        country = countries[id0taxo // TWO24]
-        with fil_mon:
-            # *crucial* for the performance of the next step
-            gmf_df = df[numpy.isin(sids, adf.site_id.unique())]
-        if len(gmf_df) == 0:  # common enough
-            continue
-        with risk_mon:
-            [out] = crmodel.get_outputs(
-                adf, gmf_df, crmodel.oqparam._sec_losses, rng, country)
-        with agg_mon:
-            aggreg(out, aggids, rlz_id, oq, loss2, loss3)
-
-    dic = dict(gmf_bytes=df.memory_usage().sum())
-    xtypes = oq.ext_loss_types
-    if oq.ideduc:
-        xtypes.append('claim')
-    dic['alt'] = build_alt(loss2, xtypes)
-    dic['avg'] = build_avg(loss3, oq.A, R*X)
-    return dic
-
-
 def aggreg(out, aggids, rlz_id, oq, loss2, loss3):
     """
     Update loss2 and loss3
@@ -304,15 +256,63 @@ def set_oqparam(oq, assetcol, dstore):
     oq.A = assetcol['ordinal'].max() + 1
 
 
+def _event_based_risk(gdf, gen_adf, crmodel, monitor):
+    oq = crmodel.oqparam
+    R = 1 if oq.collect_rlzs else len(monitor.read('weights'))
+    X = len(oq.ext_loss_types) + oq.ideduc
+    loss3 = {'aids': [], 'bids': [], 'loss': []}
+    loss2 = general.AccumDict(accum=numpy.zeros((X, 2)))  # u8idx->array
+    if os.environ.get('OQ_DEBUG_SITE'):
+        print(gdf)
+
+    aggids = monitor.read('aggids')
+    rlz_id = monitor.read('rlz_id')
+    if oq.ignore_master_seed or oq.ignore_covs:
+        rng = None
+    else:
+        rng = MultiEventRNG(oq.master_seed, gdf.eid.unique(),
+                            int(oq.asset_correlation))
+    risk_mon = monitor('computing risk', measuremem=False)
+    fil_mon = monitor('filtering GMFs', measuremem=False)
+    agg_mon = monitor('aggregating losses', measuremem=False)
+    sids = gdf.sid.to_numpy()
+    try:
+        countries = monitor.read('countries')
+    except KeyError:  # no ID_0 in the exposure
+        countries = ["?"]  # assume a single contry
+    for id0taxo, adf in gen_adf:
+        # passing the contry is crucial for impact_test,
+        # where the exposure contains multiple countries
+        country = countries[id0taxo // TWO24]
+        with fil_mon:
+            # *crucial* for the performance of the next step
+            gmf_df = gdf[numpy.isin(sids, adf.site_id.unique())]
+        if len(gmf_df) == 0:  # common enough
+            continue
+        with risk_mon:
+            [out] = crmodel.get_outputs(
+                adf, gmf_df, crmodel.oqparam._sec_losses, rng, country)
+        with agg_mon:
+            aggreg(out, aggids, rlz_id, oq, loss2, loss3)
+
+    dic = dict(gmf_bytes=gdf.memory_usage().sum())
+    xtypes = oq.ext_loss_types
+    if oq.ideduc:
+        xtypes.append('claim')
+    dic['alt'] = build_alt(loss2, xtypes)
+    dic['avg'] = build_avg(loss3, oq.A, R*X)
+    return dic
+
+
 def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     """
     :param rups: list of ruptures with the same trt_smr
-    :param cmaker: ContextMaker instance associated to the trt_smr
+    :param cmakers: ContextMaker instances associated to each trt_smr
     :param sids: array of site indices
     :param secperils: list of secondary peril instances
     :param hdf5path: path to the ses.hdf5 file
     :param monitor: a Monitor instance
-    :yields: dictionaries with keys 'avg' and 'alt'
+    :yields: dictionaries with keys 'avg', 'alt' and times
     """
     oq = cmakers[0].oq
     oq.ground_motion_fields = True

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -256,26 +256,26 @@ def set_oqparam(oq, assetcol, dstore):
     oq.A = assetcol['ordinal'].max() + 1
 
 
-def _event_based_risk(gdf, gen_adf, crmodel, monitor):
+def _event_based_risk(gmf_df, gen_adf, crmodel, monitor):
     oq = crmodel.oqparam
     R = 1 if oq.collect_rlzs else len(monitor.read('weights'))
     X = len(oq.ext_loss_types) + oq.ideduc
     loss3 = {'aids': [], 'bids': [], 'loss': []}
     loss2 = general.AccumDict(accum=numpy.zeros((X, 2)))  # u8idx->array
     if os.environ.get('OQ_DEBUG_SITE'):
-        print(gdf)
+        print(gmf_df)
 
     aggids = monitor.read('aggids')
     rlz_id = monitor.read('rlz_id')
     if oq.ignore_master_seed or oq.ignore_covs:
         rng = None
     else:
-        rng = MultiEventRNG(oq.master_seed, gdf.eid.unique(),
+        rng = MultiEventRNG(oq.master_seed, gmf_df.eid.unique(),
                             int(oq.asset_correlation))
     risk_mon = monitor('computing risk', measuremem=False)
     fil_mon = monitor('filtering GMFs', measuremem=False)
     agg_mon = monitor('aggregating losses', measuremem=False)
-    haz_sids = gdf.sid.unique()
+    haz_sids = gmf_df.sid.unique()
     try:
         countries = monitor.read('countries')
     except KeyError:  # no ID_0 in the exposure
@@ -283,6 +283,7 @@ def _event_based_risk(gdf, gen_adf, crmodel, monitor):
     for id0taxo, assetdf in gen_adf:
         with fil_mon:
             adf = assetdf[numpy.isin(assetdf.site_id, haz_sids)]
+            gdf = gmf_df[numpy.isin(gmf_df.sid, adf.site_id)]
         if len(adf) == 0:
             # *crucial* for the performance of the next step
             continue

--- a/openquake/engine/openquake.cfg
+++ b/openquake/engine/openquake.cfg
@@ -56,7 +56,7 @@ max_ruptures_chunk = 5000
 max_gmvs_chunk = 10_000_000
 
 # this has impact on the memory occupation
-max_assets_chunk = 5_000
+max_assets_chunk = 2_000
 
 # used in AssetCollection.get_aggkeys
 max_aggregations = 100_000


### PR DESCRIPTION
Plus other minor changes. The effect is minor oin Taiwan:
```
# master
$ OQ_SAMPLE_ASSETS=.01 oq engine --run job_Taiwan.ini --hc ../SES.hdf5 
| calc_13, maxmem=183.6 GB     | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total ebrisk                 | 9_554    | 554.8     | 2_001   |
| computing risk               | 4_716    | 0.0       | 118_293 |
| reading sites                | 1_208    | 184.3     | 188     |
| reading ruptures             | 826.4    | 0.0       | 2_047   |
| EventBasedRiskCalculator.run | 537.2    | 691.2     | 1       |
| reading crmodel              | 501.9    | 369.0     | 188     |

| operation-duration | counts | mean    | stddev | min    | max    | slowfac |
|--------------------+--------+---------+--------+--------+--------+---------|
| ebrisk             | 188    | 50.9786 | 94%    | 9.1446 | 448.2  | 8.7914  |

# more_mem
$ OQ_SAMPLE_ASSETS=.01 oq engine --run job_Taiwan.ini --hc ../SES.hdf5 
| calc_14, maxmem=183.6 GB     | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total ebrisk                 | 9_204    | 554.7     | 2_001   |
| computing risk               | 4_720    | 0.0       | 118_292 |
| reading sites                | 888.1    | 184.2     | 188     |
| reading ruptures             | 723.0    | 0.0       | 2_047   |
| EventBasedRiskCalculator.run | 534.6    | 711.1     | 1       |
| reading crmodel              | 502.6    | 369.0     | 188     |

| operation-duration | counts | mean    | stddev | min    | max    | slowfac |
|--------------------+--------+---------+--------+--------+--------+---------|
| ebrisk             | 188    | 49.1032 | 99%    | 9.2018 | 446.7  | 9.0977  |
```
The improvement is in reading from the datastore since we are reading a bit less thanks to the introduction of
```python
pairs = [(idx0taxo, slice(s0, s1))
                 for idx0taxo, s0, s1 in monitor.read('start-stop')]
```
moved outside the loop.