### PR TITLE
Fix a zero division warning in hazardlib test

### DIFF
--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -227,7 +227,11 @@ class MixtureModelGMPETestCase(unittest.TestCase):
                                 -15.22535996, -16.23988897, -17.94685518,
                                 -19.36079032, -20.57460101, -21.64201335])
         expected = numpy.around(expected, 5)
-        hcm_lnpga = numpy.around(numpy.log(hcm["PGA"].flatten()), 5)
+        # Tail POEs underflow the F32 output of _get_poes to 0, giving
+        # log(0) = -inf so use np.errstate to ignore related runtime div
+        # by zero warning
+        with numpy.errstate(divide='ignore'):
+            hcm_lnpga = numpy.around(numpy.log(hcm["PGA"].flatten()), 5)
         rel_diff = ((hcm_lnpga / expected) - 1.0)
         okdiff = rel_diff[numpy.isfinite(rel_diff)]
         assert (okdiff < .03).all()

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -227,9 +227,9 @@ class MixtureModelGMPETestCase(unittest.TestCase):
                                 -15.22535996, -16.23988897, -17.94685518,
                                 -19.36079032, -20.57460101, -21.64201335])
         expected = numpy.around(expected, 5)
-        # Tail POEs underflow the F32 output of _get_poes to 0, giving
-        # log(0) = -inf so use np.errstate to ignore related runtime div
-        # by zero warning
+        # Very small tail POEs underflow the F32 output of _get_poes to 0
+        # giving log(0) = -inf so use np.errstate to ignore related runtime
+        # div by zero warning given it's harmless
         with numpy.errstate(divide='ignore'):
             hcm_lnpga = numpy.around(numpy.log(hcm["PGA"].flatten()), 5)
         rel_diff = ((hcm_lnpga / expected) - 1.0)


### PR DESCRIPTION
The extremely small PoEs for the highest IMTLs were floored to `-inf` at F32 precision within `_get_poes` hence resulting in a "false" divide by zero warning in ` MixtureModelGMPETestCase`. The "fix" is just to hide the warning using `np.errstate` given it's harmless.

Addresses https://github.com/gem/oq-engine/issues/11592