### PR TITLE
Reduced slow tasks and memory consumption in East_Asia

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Optimized ebrisk calculations by using larger GMF arrays
   * Saving memory when running several jobs together with a pool
   * Fixed a bug with IMT-dependent weights being not normalized, breaking
     the CND model with use_rates=true

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -319,6 +319,25 @@ def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,
         yield ws
 
 
+def genconcat(dframes, size=512*1024**2):
+    """
+    Yield concatenated dataframes of size < 512 MB
+    """
+    dfs = []
+    nbytes = 0
+    for df in dframes:
+        nbytes += df.memory_usage().sum()
+        if nbytes > size:
+            yield pandas.concat(dfs)
+            nbytes = 0
+            dfs = []
+        else:
+            dfs.append(df)
+    if dfs:
+        yield pandas.concat(dfs)
+        
+    
+
 def split_in_slices(number, num_slices):
     """
     :param number: a positive number to split in slices

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -319,10 +319,11 @@ def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,
         yield ws
 
 
-def genconcat(dframes, size_mb=512):
+def genconcat(dframes, size_mb=1024):
     """
     :param dframes: iterator over dataframes
-    :yields: concatenated dataframes of size ~512 MB
+    :param size_mb: yielding when cum_size > size_mb
+    :yields: concatenated dataframes around ~size_mb
     """
     dfs = []
     size = 0

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -319,18 +319,23 @@ def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,
         yield ws
 
 
-def genconcat(dframes, size=512*1024**2):
+def genconcat(dframes, size_mb=512):
     """
     :paran dframes: iterator over dataframes
     Yield concatenated dataframes of size < 512 MB
     """
     dfs = []
-    nbytes = 0
+    size = 0
     for df in dframes:
-        nbytes += df.memory_usage().sum()
-        if nbytes > size:
-            yield pandas.concat(dfs)
-            nbytes = 0
+        mb = df.memory_usage().sum() / 1024**2
+        size += mb
+        if size > size_mb:
+            if dfs:
+                yield pandas.concat(dfs)
+            else:
+                print(f'There is a large gmf_df of {mb:.0f} MB')
+                yield df
+            size = 0
             dfs = []
         else:
             dfs.append(df)

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -333,8 +333,8 @@ def genconcat(dframes, size_mb=512):
             print(f'There is a gmf_df of {mb:.0f} MB')
             yield df
         elif size + mb > size_mb:
-            yield pandas.concat(dfs[:-1])
-            dfs = [dfs[-1]]
+            yield pandas.concat(dfs)
+            dfs = [df]
             size = mb
         else:
             dfs.append(df)

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -321,6 +321,7 @@ def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,
 
 def genconcat(dframes, size=512*1024**2):
     """
+    :paran dframes: iterator over dataframes
     Yield concatenated dataframes of size < 512 MB
     """
     dfs = []

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -321,8 +321,8 @@ def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,
 
 def genconcat(dframes, size_mb=512):
     """
-    :paran dframes: iterator over dataframes
-    Yield concatenated dataframes of size < 512 MB
+    :param dframes: iterator over dataframes
+    :yields: concatenated dataframes of size ~512 MB
     """
     dfs = []
     size = 0
@@ -330,10 +330,10 @@ def genconcat(dframes, size_mb=512):
         mb = df.memory_usage().sum() / 1024**2
         size += mb
         if size > size_mb:
-            if dfs:
+            if len(dfs) > 1:
                 yield pandas.concat(dfs)
             else:
-                print(f'There is a large gmf_df of {mb:.0f} MB')
+                print(f'There is a gmf_df of {mb:.0f} MB')
                 yield df
             size = 0
             dfs = []

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -319,7 +319,7 @@ def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,
         yield ws
 
 
-def genconcat(dframes, size_mb=512):
+def concatenated(dframes, size_mb=512):
     """
     :param dframes: iterator over dataframes
     :param size_mb: yielding when cum_size > size_mb

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -319,7 +319,7 @@ def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,
         yield ws
 
 
-def genconcat(dframes, size_mb=1024):
+def genconcat(dframes, size_mb=512):
     """
     :param dframes: iterator over dataframes
     :param size_mb: yielding when cum_size > size_mb
@@ -329,17 +329,16 @@ def genconcat(dframes, size_mb=1024):
     size = 0
     for df in dframes:
         mb = df.memory_usage().sum() / 1024**2
-        size += mb
-        if size > size_mb:
-            if len(dfs) > 1:
-                yield pandas.concat(dfs)
-            else:
-                print(f'There is a gmf_df of {mb:.0f} MB')
-                yield df
-            size = 0
-            dfs = []
+        if mb > size_mb:
+            print(f'There is a gmf_df of {mb:.0f} MB')
+            yield df
+        elif size + mb > size_mb:
+            yield pandas.concat(dfs[:-1])
+            dfs = [dfs[-1]]
+            size = mb
         else:
             dfs.append(df)
+            size += mb
     if dfs:
         yield pandas.concat(dfs)
         

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -418,7 +418,7 @@ def get_allargs(oq, sitecol, assetcol, sec_perils, dstore):
         cmaker.min_mag = getdefault(oqparam.minimum_magnitude, trt)
         logging.debug('%s: sending %d ruptures for trt_smr=%d',
                       model, len(rups), trt_smr)
-        for rupblock in block_splitter(rups, maxw, rup_weight):
+        for rupblock in block_splitter(rups, maxw/4, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
     allargs = _collect(allargs, maxw*2, sitecol.sids, sec_perils, dstore)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -239,7 +239,7 @@ def _event_based(proxies, cmaker, sec_perils, srcfilter, cmon, umon):
         return dict(gmfdata={}, times=times, sig_eps=())
 
     gmfdata = pandas.concat(alldata)  # ~40 MB
-    dic = dict(gmfdata={k: gmfdata[k].to_numpy() for k in gmfdata.columns},
+    dic = dict(gmfdata=gmfdata,
                times=times, sig_eps=numpy.concatenate(sig_eps, dtype=se_dt))
     if oq.mea_tau_phi:
         mtpdata = numpy.concatenate(mea_tau_phi, dtype=GmfComputer.mtp_dt)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -421,7 +421,7 @@ def get_allargs(oq, sitecol, assetcol, sec_perils, dstore):
         for rupblock in block_splitter(rups, maxw, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
-    allargs = _collect(allargs, maxw*2, sitecol.sids, sec_perils, dstore)
+    allargs = _collect(allargs, maxw, sitecol.sids, sec_perils, dstore)
     for oqp in oq_by.values():
         for trt, mags in oqp.mags_by_trt.items():
             oqp.mags_by_trt[trt] = sorted(mags)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -421,7 +421,7 @@ def get_allargs(oq, sitecol, assetcol, sec_perils, dstore):
         for rupblock in block_splitter(rups, maxw, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
-    allargs = _collect(allargs, maxw, sitecol.sids, sec_perils, dstore)
+    allargs = _collect(allargs, maxw*2, sitecol.sids, sec_perils, dstore)
     for oqp in oq_by.values():
         for trt, mags in oqp.mags_by_trt.items():
             oqp.mags_by_trt[trt] = sorted(mags)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -326,7 +326,7 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     dfs = (dic['gmfdata'] for dic in event_based.event_based(
         allrups, cmakers, sids, secperils, hdf5path, monitor)
            if len(dic['gmfdata']))
-    for gmf_df in general.genconcat(dfs):
+    for gmf_df in general.concatenated(dfs):
         items = ((id0taxo, monitor.read('assets', slc).
                   set_index('ordinal')) for id0taxo, slc in pairs)
         res = _event_based_risk(gmf_df, items, crmodel, monitor)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -327,11 +327,10 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         allrups, cmakers, sids, secperils, hdf5path, monitor)
            if len(dic['gmfdata']))
     for gmf_df in general.genconcat(dfs):
-        if len(gmf_df):
-            items = ((id0taxo, monitor.read('assets', slc).
-                      set_index('ordinal')) for id0taxo, slc in pairs)
-            res = _event_based_risk(gmf_df, items, crmodel, monitor)
-            yield res
+        items = ((id0taxo, monitor.read('assets', slc).
+                  set_index('ordinal')) for id0taxo, slc in pairs)
+        res = _event_based_risk(gmf_df, items, crmodel, monitor)
+        yield res
 
 
 @performance.compile("(f4[:,:,:], i4[:], i4[:], f4[:], i8)")

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import os.path
 import logging
 import operator
@@ -324,18 +323,14 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     # NB: the assets are read more times than needed; this is on purpose;
     # the slowdown is minor, while the memory saving is massive, since only
     # one taxonomy at the time is read inside _event_based_risk
-    for dic in event_based.event_based(
-            allrups, cmakers, sids, secperils, hdf5path, monitor):
-        if len(dic['gmfdata']):
-            times = dic['times']  # rup_id, time, weight
-            gmf_df = pandas.DataFrame(dic['gmfdata'])
+    dfs = (dic['gmf_data'] for dic in event_based.event_based(
+        allrups, cmakers, sids, secperils, hdf5path, monitor)
+           if 'gmf_data' in dic)
+    for gmf_df in general.genconcat(dfs):
+        if len(gmf_df):
             items = ((id0taxo, monitor.read('assets', slc).
                       set_index('ordinal')) for id0taxo, slc in pairs)
-            t0 = time.time()
             res = _event_based_risk(gmf_df, items, crmodel, monitor)
-            dt = time.time() - t0
-            times['time'] += dt / len(times)
-            res['times'] = times
             yield res
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -318,8 +318,8 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     oq.ground_motion_fields = True
     with monitor('reading crmodel', measuremem=True):
         crmodel = monitor.read('crmodel')
-        pairs = [(idx0taxo, slice(s0, s1))
-                 for idx0taxo, s0, s1 in monitor.read('start-stop')]
+    pairs = [(idx0taxo, slice(s0, s1))
+             for idx0taxo, s0, s1 in monitor.read('start-stop')]
     dfs = (dic['gmfdata'] for dic in event_based.event_based(
         allrups, cmakers, sids, secperils, hdf5path, monitor)
            if len(dic['gmfdata']))

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -323,9 +323,9 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     # NB: the assets are read more times than needed; this is on purpose;
     # the slowdown is minor, while the memory saving is massive, since only
     # one taxonomy at the time is read inside _event_based_risk
-    dfs = (dic['gmf_data'] for dic in event_based.event_based(
+    dfs = (dic['gmfdata'] for dic in event_based.event_based(
         allrups, cmakers, sids, secperils, hdf5path, monitor)
-           if 'gmf_data' in dic)
+           if len(dic['gmfdata']))
     for gmf_df in general.genconcat(dfs):
         if len(gmf_df):
             items = ((id0taxo, monitor.read('assets', slc).

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -295,7 +295,7 @@ def _event_based_risk(gmf_df, gen_adf, crmodel, monitor):
         with agg_mon:
             aggreg(out, aggids, rlz_id, oq, loss2, loss3)
 
-    dic = dict(gmf_bytes=gdf.memory_usage().sum())
+    dic = dict(gmf_bytes=gmf_df.memory_usage().sum())
     xtypes = oq.ext_loss_types
     if oq.ideduc:
         xtypes.append('claim')

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -327,6 +327,7 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         allrups, cmakers, sids, secperils, hdf5path, monitor)
            if len(dic['gmfdata']))
     for gmf_df in general.genconcat(dfs):
+        print(gmf_df.memory_usage().sum())
         items = ((id0taxo, monitor.read('assets', slc).
                   set_index('ordinal')) for id0taxo, slc in pairs)
         res = _event_based_risk(gmf_df, items, crmodel, monitor)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -327,7 +327,6 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         allrups, cmakers, sids, secperils, hdf5path, monitor)
            if len(dic['gmfdata']))
     for gmf_df in general.genconcat(dfs):
-        print(gmf_df.memory_usage().sum())
         items = ((id0taxo, monitor.read('assets', slc).
                   set_index('ordinal')) for id0taxo, slc in pairs)
         res = _event_based_risk(gmf_df, items, crmodel, monitor)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -320,13 +320,15 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         crmodel = monitor.read('crmodel')
         pairs = [(idx0taxo, slice(s0, s1))
                  for idx0taxo, s0, s1 in monitor.read('start-stop')]
-    # NB: the assets are read more times than needed; this is on purpose;
-    # the slowdown is minor, while the memory saving is massive, since only
-    # one taxonomy at the time is read inside _event_based_risk
     dfs = (dic['gmfdata'] for dic in event_based.event_based(
         allrups, cmakers, sids, secperils, hdf5path, monitor)
            if len(dic['gmfdata']))
+    # NB: it is essential to concatenate the small dataframes to have
+    # long arrays (around 512 MB) and hence a good performance
     for gmf_df in general.concatenated(dfs):
+        # NB: the assets are read more times than needed; this is on purpose;
+        # the slowdown is minor, while the memory saving is massive, since
+        # only one taxonomy at the time is read inside _event_based_risk
         items = ((id0taxo, monitor.read('assets', slc).
                   set_index('ordinal')) for id0taxo, slc in pairs)
         res = _event_based_risk(gmf_df, items, crmodel, monitor)


### PR DESCRIPTION
Part of https://github.com/gem/oq-engine/issues/11559. Here are the figures for Japan on engine192:
```
# before
| calc_12, maxmem=299.5 GB     | time_sec | memory_mb | counts    |
|------------------------------+----------+-----------+-----------|
| total ebrisk                 | 487_498  | 895.1     | 1_879     |
| computing risk               | 426_721  | 0.0       | 401_537   |
| aggregating losses           | 25_695   | 0.0       | 401_537   |
| EventBasedRiskCalculator.run | 12_305   | 1_721     | 1         |

# after
| calc_40, maxmem=307.4 GB     | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total ebrisk                 | 468_774  | 1_105     | 276     |
| computing risk               | 420_695  | 0.0       | 278_725 |
| aggregating losses           | 24_908   | 0.0       | 278_725 |
| EventBasedRiskCalculator.run | 12_412   | 1_827     | 1       |
```
The improvement is really minor for Japan since the slow tasks are the same:
```
| operation-duration | counts | mean  | stddev |   min | max    | slowfac |
|--------------------+--------+-------+--------+-------+--------+---------|
| ebrisk             |    159 | 3_058 |    87% | 323.5 | 12_059 |  3.9436 |
| ebrisk             |    157 | 2_976 |    89% | 288.6 | 12_182 |  4.0935 |
```
However, in small calculations, we can double the speed of the risk part, for instance for slovenia.zip:
```
| calc_7973, maxmem=9.8 GB     | time_sec | memory_mb | counts |
|------------------------------+----------+-----------+--------|
| computing risk               | 22.4886  | 0.0       | 4_407  |
| computing risk               | 12.8242  | 0.0       | 2_227  |
```
Taiwan is even better, 3x for the slowest task:
```
| operation-duration | counts | mean   | stddev | min     | max     | slowfac |
|--------------------+--------+--------+--------+---------+---------+---------|
| ebrisk             | 185    | 416.1  | 45%    | 43.1735 | 1_620   | 3.8938  |
| ebrisk             | 166    | 395.2  | 23%    | 40.1724 | 596.8   | 1.5099  |
```
Also, there is a substantial memory saving on small machines: on cassidy Japan runs using ~72 GB or RAM, while before it was going OOM.