### PR TITLE
Reduced slow tasks in Japan

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -319,7 +319,7 @@ def block_splitter(items, max_weight, weight=lambda item: 1, key=nokey,
         yield ws
 
 
-def concatenated(dframes, size_mb=300):
+def concatenated(dframes, size_mb):
     """
     :param dframes: iterator over dataframes
     :param size_mb: yielding when cum_size > size_mb

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -330,7 +330,6 @@ def concatenated(dframes, size_mb):
     for df in dframes:
         mb = df.memory_usage().sum() / 1024**2
         if mb > size_mb:
-            print(f'There is a gmf_df of {mb:.0f} MB')
             yield df
         elif size + mb > size_mb:
             yield pandas.concat(dfs)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -421,7 +421,7 @@ def get_allargs(oq, sitecol, assetcol, sec_perils, dstore):
         for rupblock in block_splitter(rups, maxw/4, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
-    allargs = _collect(allargs, maxw*1.5, sitecol.sids, sec_perils, dstore)
+    allargs = _collect(allargs, maxw, sitecol.sids, sec_perils, dstore)
     for oqp in oq_by.values():
         for trt, mags in oqp.mags_by_trt.items():
             oqp.mags_by_trt[trt] = sorted(mags)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -421,7 +421,7 @@ def get_allargs(oq, sitecol, assetcol, sec_perils, dstore):
         for rupblock in block_splitter(rups, maxw/4, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
-    allargs = _collect(allargs, maxw, sitecol.sids, sec_perils, dstore)
+    allargs = _collect(allargs, maxw*2, sitecol.sids, sec_perils, dstore)
     for oqp in oq_by.values():
         for trt, mags in oqp.mags_by_trt.items():
             oqp.mags_by_trt[trt] = sorted(mags)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -334,9 +334,10 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         gmf_mb = gmf_df.memory_usage().sum() / 1024**2
         if gmf_mb > GMF_MB:
             print(f'{gmf_mb=:.1f}')
-            mod2 = gmf_df.eid % 2
-            yield  _event_based_risk(gmf_df[mod2==0], pairs, crmodel, monitor)
-            yield  _event_based_risk, gmf_df[mod2==1], pairs, crmodel
+            mod3 = gmf_df.eid % 3
+            yield _event_based_risk(gmf_df[mod3==0], pairs, crmodel, monitor)
+            yield _event_based_risk, gmf_df[mod3==1], pairs, crmodel
+            yield _event_based_risk, gmf_df[mod3==2], pairs, crmodel
         else:
             yield _event_based_risk(gmf_df, pairs, crmodel, monitor)
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -335,8 +335,8 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         if gmf_mb > GMF_MB:
             print(f'{gmf_mb=:.1f}')
             mod2 = gmf_df.eid % 2
-            yield  _event_based_risk, gmf_df[mod2==0], pairs, crmodel
-            yield  _event_based_risk(gmf_df[mod2==1], pairs, crmodel, monitor)
+            yield  _event_based_risk(gmf_df[mod2==0], pairs, crmodel, monitor)
+            yield  _event_based_risk, gmf_df[mod2==1], pairs, crmodel
         else:
             yield _event_based_risk(gmf_df, pairs, crmodel, monitor)
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -168,10 +168,9 @@ def ebr_from_gmfs(gmf_df, oqparam, monitor):
     """
     with monitor('reading crmodel', measuremem=True):
         crmodel = monitor.read('crmodel')
-    items = ((id0taxo, monitor.read('assets', slice(s0, s1)).
-              set_index('ordinal'))
-             for id0taxo, s0, s1 in monitor.read('start-stop'))
-    dic = _event_based_risk(gmf_df, items, crmodel, monitor)
+    pairs = [(id0taxo, slice(s0, s1))
+             for id0taxo, s0, s1 in monitor.read('start-stop')]
+    dic = _event_based_risk(gmf_df, pairs, crmodel, monitor)
     return dic
 
 
@@ -255,7 +254,7 @@ def set_oqparam(oq, assetcol, dstore):
     oq.A = assetcol['ordinal'].max() + 1
 
 
-def _event_based_risk(gmf_df, gen_adf, crmodel, monitor):
+def _event_based_risk(gmf_df, pairs, crmodel, monitor):
     oq = crmodel.oqparam
     R = 1 if oq.collect_rlzs else len(monitor.read('weights'))
     X = len(oq.ext_loss_types) + oq.ideduc
@@ -266,6 +265,8 @@ def _event_based_risk(gmf_df, gen_adf, crmodel, monitor):
 
     aggids = monitor.read('aggids')
     rlz_id = monitor.read('rlz_id')
+    items = ((id0taxo, monitor.read('assets', slc).
+              set_index('ordinal')) for id0taxo, slc in pairs)
     if oq.ignore_master_seed or oq.ignore_covs:
         rng = None
     else:
@@ -279,7 +280,7 @@ def _event_based_risk(gmf_df, gen_adf, crmodel, monitor):
         countries = monitor.read('countries')
     except KeyError:  # no ID_0 in the exposure
         countries = ["?"]  # assume a single contry
-    for id0taxo, assetdf in gen_adf:
+    for id0taxo, assetdf in items:
         with fil_mon:
             # filtering is *crucial* for the performance of the next step
             adf = assetdf[numpy.isin(assetdf.site_id, haz_sids)]
@@ -329,9 +330,7 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         # NB: the assets are read more times than needed; this is on purpose;
         # the slowdown is minor, while the memory saving is massive, since
         # only one taxonomy at the time is read inside _event_based_risk
-        items = ((id0taxo, monitor.read('assets', slc).
-                  set_index('ordinal')) for id0taxo, slc in pairs)
-        res = _event_based_risk(gmf_df, items, crmodel, monitor)
+        res = _event_based_risk(gmf_df, pairs, crmodel, monitor)
         yield res
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,6 +42,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
+GMF_MB = 300
 get_n_occ = operator.itemgetter(1)
 
 
@@ -326,12 +327,12 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
            if len(dic['gmfdata']))
     # NB: it is essential to concatenate the small dataframes to have
     # long arrays (around 512 MB) and hence a good performance
-    for gmf_df in general.concatenated(dfs):
+    for gmf_df in general.concatenated(dfs, GMF_MB):
         # NB: the assets are read more times than needed; this is on purpose;
         # the slowdown is minor, while the memory saving is massive, since
         # only one taxonomy at the time is read inside _event_based_risk
         size_mb = gmf_df.memory_usage().sum() / 1024**2
-        if size_mb > 100:
+        if size_mb > GMF_MB:
             print(f'{size_mb=:.1f}')
             yield  _event_based_risk, gmf_df, pairs, crmodel
         else:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -326,7 +326,7 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         allrups, cmakers, sids, secperils, hdf5path, monitor)
            if len(dic['gmfdata']))
     # NB: it is essential to concatenate the small dataframes to have
-    # long arrays (around 512 MB) and hence a good performance
+    # long arrays (around GMF_MB) and hence a good performance
     for gmf_df in general.concatenated(dfs, GMF_MB):
         # NB: the assets are read more times than needed; this is on purpose;
         # the slowdown is minor, while the memory saving is massive, since

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -334,7 +334,9 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         gmf_mb = gmf_df.memory_usage().sum() / 1024**2
         if gmf_mb > GMF_MB:
             print(f'{gmf_mb=:.1f}')
-            yield  _event_based_risk, gmf_df, pairs, crmodel
+            mod2 = gmf_df.eid % 2
+            yield  _event_based_risk, gmf_df[mod2==0], pairs, crmodel
+            yield  _event_based_risk(gmf_df[mod2==1], pairs, crmodel, monitor)
         else:
             yield _event_based_risk(gmf_df, pairs, crmodel, monitor)
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -331,9 +331,9 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         # NB: the assets are read more times than needed; this is on purpose;
         # the slowdown is minor, while the memory saving is massive, since
         # only one taxonomy at the time is read inside _event_based_risk
-        size_mb = gmf_df.memory_usage().sum() / 1024**2
-        if size_mb > GMF_MB:
-            print(f'{size_mb=:.1f}')
+        gmf_mb = gmf_df.memory_usage().sum() / 1024**2
+        if gmf_mb > GMF_MB:
+            print(f'{gmf_mb=:.1f}')
             yield  _event_based_risk, gmf_df, pairs, crmodel
         else:
             yield _event_based_risk(gmf_df, pairs, crmodel, monitor)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -493,6 +493,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                     'No GMFs were generated, perhaps they were '
                     'all below the minimum_intensity threshold')
                 return 1
+            self.datastore['/'].attrs['gmf_bytes'] = self.gmf_bytes
             logging.info(
                 'Produced %s of GMFs', general.humansize(self.gmf_bytes))
         else:  # start from GMFs

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -259,7 +259,7 @@ def event_based_risk(gmf_df, pairs, crmodel, monitor):
     """
     Aggregate the losses for all assets for the given event slice
 
-    :returns: dictionary alt, avg
+    :returns: dictionary with keys 'alt', 'avg', 'gmf_bytes'
     """
     oq = crmodel.oqparam
     R = 1 if oq.collect_rlzs else len(monitor.read('weights'))

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -256,6 +256,11 @@ def set_oqparam(oq, assetcol, dstore):
 
 
 def event_based_risk(gmf_df, pairs, crmodel, monitor):
+    """
+    Aggregate the losses for all assets for the given event slice
+
+    :returns: dictionary alt, avg
+    """
     oq = crmodel.oqparam
     R = 1 if oq.collect_rlzs else len(monitor.read('weights'))
     X = len(oq.ext_loss_types) + oq.ideduc

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,7 +42,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
-GMF_MB = 300
+GMF_MB = 600
 get_n_occ = operator.itemgetter(1)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,7 +42,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
-GMF_MB = 450
+GMF_MB = 300
 get_n_occ = operator.itemgetter(1)
 
 
@@ -334,10 +334,9 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         gmf_mb = gmf_df.memory_usage().sum() / 1024**2
         if gmf_mb > GMF_MB:
             print(f'{gmf_mb=:.1f}')
-            mod3 = gmf_df.eid % 3
-            yield _event_based_risk(gmf_df[mod3==0], pairs, crmodel, monitor)
-            yield _event_based_risk, gmf_df[mod3==1], pairs, crmodel
-            yield _event_based_risk, gmf_df[mod3==2], pairs, crmodel
+            mod2 = gmf_df.eid % 2
+            yield _event_based_risk, gmf_df[mod2==1], pairs, crmodel
+            yield _event_based_risk(gmf_df[mod2==0], pairs, crmodel, monitor)
         else:
             yield _event_based_risk(gmf_df, pairs, crmodel, monitor)
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -171,7 +171,7 @@ def ebr_from_gmfs(gmf_df, oqparam, monitor):
         crmodel = monitor.read('crmodel')
     pairs = [(id0taxo, slice(s0, s1))
              for id0taxo, s0, s1 in monitor.read('start-stop')]
-    dic = _event_based_risk(gmf_df, pairs, crmodel, monitor)
+    dic = event_based_risk(gmf_df, pairs, crmodel, monitor)
     return dic
 
 
@@ -255,7 +255,7 @@ def set_oqparam(oq, assetcol, dstore):
     oq.A = assetcol['ordinal'].max() + 1
 
 
-def _event_based_risk(gmf_df, pairs, crmodel, monitor):
+def event_based_risk(gmf_df, pairs, crmodel, monitor):
     oq = crmodel.oqparam
     R = 1 if oq.collect_rlzs else len(monitor.read('weights'))
     X = len(oq.ext_loss_types) + oq.ideduc
@@ -330,15 +330,15 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     for gmf_df in general.concatenated(dfs, GMF_MB):
         # NB: the assets are read more times than needed; this is on purpose;
         # the slowdown is minor, while the memory saving is massive, since
-        # only one taxonomy at the time is read inside _event_based_risk
+        # only one taxonomy at the time is read inside event_based_risk
         gmf_mb = gmf_df.memory_usage().sum() / 1024**2
         if gmf_mb > GMF_MB:
             print(f'{gmf_mb=:.1f}')
             mod2 = gmf_df.eid % 2
-            yield _event_based_risk, gmf_df[mod2==1], pairs, crmodel
-            yield _event_based_risk(gmf_df[mod2==0], pairs, crmodel, monitor)
+            yield event_based_risk, gmf_df[mod2==1], pairs, crmodel
+            yield event_based_risk(gmf_df[mod2==0], pairs, crmodel, monitor)
         else:
-            yield _event_based_risk(gmf_df, pairs, crmodel, monitor)
+            yield event_based_risk(gmf_df, pairs, crmodel, monitor)
 
 
 @performance.compile("(f4[:,:,:], i4[:], i4[:], f4[:], i8)")

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,7 +42,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
-GMF_MB = 600
+GMF_MB = 450
 get_n_occ = operator.itemgetter(1)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -330,8 +330,12 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         # NB: the assets are read more times than needed; this is on purpose;
         # the slowdown is minor, while the memory saving is massive, since
         # only one taxonomy at the time is read inside _event_based_risk
-        res = _event_based_risk(gmf_df, pairs, crmodel, monitor)
-        yield res
+        size_mb = gmf_df.memory_usage().sum() / 1024**2
+        if size_mb > 100:
+            print(f'{size_mb=:.1f}')
+            yield  _event_based_risk, gmf_df, pairs, crmodel
+        else:
+            yield _event_based_risk(gmf_df, pairs, crmodel, monitor)
 
 
 @performance.compile("(f4[:,:,:], i4[:], i4[:], f4[:], i8)")


### PR DESCRIPTION
The run time of EastAsia went down from 6 hours to 4 hours, even if there are slow tasks. Part of https://github.com/gem/oq-engine/issues/11559. Here are the figures for Japan on piaf:
```
| calc_99979079, maxmem=145.6 GB | time_sec | memory_mb | counts  |
|--------------------------------+----------+-----------+---------|
| computing risk                 | 415_214  | 0.0       | 136_041 |
| total ebrisk                   | 338_129  | 913.0     | 377     |
| total event_based_risk         | 118_711  | 278.6     | 102     |
| aggregating losses             | 24_086   | 0.0       | 136_041 |
| EventBasedRiskCalculator.run   | 13_899   | 1_727     | 1       |

| operation-duration | counts | mean  | stddev |   min | max    | slowfac |
|--------------------+--------+-------+--------+-------+--------+---------|
| event_based_risk   |    102 | 1_164 |    31% | 335.7 | 2_380  |  2.0446 |
| ebrisk             |     63 | 5_355 |    63% | 679.1 | 13_645 |  2.5480 |

| taskname        | mean    | std     | min    | max     |
|-----------------+---------+---------+--------+---------|
| ebrisk          | 7_251   | 1_937   | 5_111  | 13_645  |
```
Before it was worse both on time and memory:
````
| calc_99979038, maxmem=177.4 GB | time_sec | memory_mb | counts  |
|--------------------------------+----------+-----------+---------|
| total ebrisk                   | 463_939  | 394.2     | 292     |
| computing risk                 | 421_604  | 0.0       | 103_761 |
| aggregating losses             | 24_534   | 0.0       | 103_761 |
| EventBasedRiskCalculator.run   | 21_489   | 1_683     | 1       |

| operation-duration | counts | mean    | stddev | min    | max     | slowfac |
|--------------------+--------+---------+--------+--------+---------+---------|
| ebrisk             | 85     | 5_447   | 83%    | 527.2  | 20_182  | 3.7050  |
````