### PR TITLE
Fix PGV period handling in the JB2009 spatial correlation model

### DIFF
--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -137,13 +137,13 @@ def jbcorrelation(sites_or_distances, imt, vs30_clustering=False):
     if period < 1:
         if not vs30_clustering:
             # case 1, eq. (17)
-            b = 8.5 + 17.2 * imt.period
+            b = 8.5 + 17.2 * period
         else:
             # case 2, eq. (18)
-            b = 40.7 - 15.0 * imt.period
+            b = 40.7 - 15.0 * period
     else:
         # both cases, eq. (19)
-        b = 22.0 + 3.7 * imt.period
+        b = 22.0 + 3.7 * period
 
     # eq. (20)
     return numpy.exp((- 3.0 / b) * distances)

--- a/openquake/hazardlib/tests/correlation_test.py
+++ b/openquake/hazardlib/tests/correlation_test.py
@@ -17,7 +17,7 @@ import unittest
 
 import numpy
 
-from openquake.hazardlib.imt import SA, PGA
+from openquake.hazardlib.imt import SA, PGA, PGV
 from openquake.hazardlib.correlation import JB2009CorrelationModel, \
                                             HM2018CorrelationModel
 from openquake.hazardlib.site import Site, SiteCollection
@@ -99,6 +99,21 @@ class JB2009CorrelationMatrixTestCase(unittest.TestCase):
         corma = cormo._get_correlation_matrix(self.SITECOL, sa)
         corma2 = cormo._get_correlation_matrix(self.SITECOL, pga)
         self.assertTrue((corma == corma2).all())
+
+    def test_pgv(self):
+        sa = SA(period=1.0, damping=5)
+        pgv = PGV()
+
+        for vs30_clustering in (False, True):
+            cormo = JB2009CorrelationModel(
+                vs30_clustering=vs30_clustering)
+
+            corma = cormo._get_correlation_matrix(
+                self.SITECOL, sa)
+            corma2 = cormo._get_correlation_matrix(
+                self.SITECOL, pgv)
+
+            self.assertTrue((corma == corma2).all())
 
 
 class JB2009LowerTriangleCorrelationMatrixTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

This pull request fixes the treatment of PGV in the Jayaram and Baker (2009) spatial correlation model.

The implementation defines a local `period` variable so that PGV is treated as equivalent to `SA(1.0)`. However, the equations used to calculate the correlation range parameter `b` currently reference `imt.period`.

Since `PGV().period` defaults to `0.0`, the current implementation results in `b = 22.0` rather than the intended `b = 25.7`.

## Changes

- Replaced `imt.period` with the local `period` variable in the three equations used to calculate `b`.
- Added a dedicated PGV regression test.
- Added coverage for the equivalence of the JB2009 correlation matrices for `PGV()` and `SA(1.0)`, both with and without Vs30 clustering.

Fixes #11597