### PR TITLE
Removed ebr_from_gmfs

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -344,7 +344,7 @@ def _filter_rups(oq, sitecol, assetcol, trts, dstore):
             totw += rup_weight(rups).sum()
             nsites += rups['nsites'].sum()
             affected = max(affected, rups['nsites'].max())
-    logging.info('Affected assets/sites ~%.0f per rupture, max=%.0f',
+    logging.info('Affected sites ~%.0f per rupture, max=%.0f',
                  nsites / len(filrups), affected)
     maxw = totw / (oq.concurrent_tasks or 1)
     logging.info(f'{round(maxw)=}')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -344,7 +344,7 @@ def _filter_rups(oq, sitecol, assetcol, trts, dstore):
             totw += rup_weight(rups).sum()
             nsites += rups['nsites'].sum()
             affected = max(affected, rups['nsites'].max())
-    logging.info('Affected sites ~%.0f per rupture, max=%.0f',
+    logging.info('Affected assets/sites ~%.0f per rupture, max=%.0f',
                  nsites / len(filrups), affected)
     maxw = totw / (oq.concurrent_tasks or 1)
     logging.info(f'{round(maxw)=}')

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -167,11 +167,7 @@ def ebr_from_gmfs(gmf_df, oqparam, monitor):
     :param monitor: a Monitor instance
     :yields: dictionary of arrays, the output of event_based_risk
     """
-    with monitor('reading crmodel', measuremem=True):
-        crmodel = monitor.read('crmodel')
-    pairs = [(id0taxo, slice(s0, s1))
-             for id0taxo, s0, s1 in monitor.read('start-stop')]
-    dic = event_based_risk(gmf_df, pairs, crmodel, monitor)
+    dic = event_based_risk(gmf_df, monitor)
     return dic
 
 
@@ -255,12 +251,17 @@ def set_oqparam(oq, assetcol, dstore):
     oq.A = assetcol['ordinal'].max() + 1
 
 
-def event_based_risk(gmf_df, pairs, crmodel, monitor):
+def event_based_risk(gmf_df, monitor):
     """
     Aggregate the losses for all assets for the given event slice
 
     :returns: dictionary with keys 'alt', 'avg', 'gmf_bytes'
     """
+    with monitor('reading crmodel', measuremem=True):
+        crmodel = monitor.read('crmodel')
+    pairs = [(id0taxo, slice(s0, s1))
+             for id0taxo, s0, s1 in monitor.read('start-stop')]
+
     oq = crmodel.oqparam
     R = 1 if oq.collect_rlzs else len(monitor.read('weights'))
     X = len(oq.ext_loss_types) + oq.ideduc
@@ -323,10 +324,6 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     """
     oq = cmakers[0].oq
     oq.ground_motion_fields = True
-    with monitor('reading crmodel', measuremem=True):
-        crmodel = monitor.read('crmodel')
-    pairs = [(idx0taxo, slice(s0, s1))
-             for idx0taxo, s0, s1 in monitor.read('start-stop')]
     dfs = (dic['gmfdata'] for dic in event_based.event_based(
         allrups, cmakers, sids, secperils, hdf5path, monitor)
            if len(dic['gmfdata']))
@@ -340,10 +337,10 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         if gmf_mb > GMF_MB:
             print(f'{gmf_mb=:.1f}')
             mod2 = gmf_df.eid % 2
-            yield event_based_risk, gmf_df[mod2==1], pairs, crmodel
-            yield event_based_risk(gmf_df[mod2==0], pairs, crmodel, monitor)
+            yield event_based_risk, gmf_df[mod2==1]
+            yield event_based_risk(gmf_df[mod2==0], monitor)
         else:
-            yield event_based_risk(gmf_df, pairs, crmodel, monitor)
+            yield event_based_risk(gmf_df, monitor)
 
 
 @performance.compile("(f4[:,:,:], i4[:], i4[:], f4[:], i8)")

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -160,17 +160,6 @@ def build_alt(loss2, xtypes):
     return pandas.DataFrame(dic)
 
 
-def ebr_from_gmfs(gmf_df, oqparam, monitor):
-    """
-    :param gmf_df: DataFrame of GMFs
-    :param oqparam: OqParam instance
-    :param monitor: a Monitor instance
-    :yields: dictionary of arrays, the output of event_based_risk
-    """
-    dic = event_based_risk(gmf_df, monitor)
-    return dic
-
-
 def aggreg(out, aggids, rlz_id, oq, loss2, loss3):
     """
     Update loss2 and loss3
@@ -500,10 +489,10 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
                 'Produced %s of GMFs', general.humansize(self.gmf_bytes))
         else:  # start from GMFs
             smap, gmf_dfs = starmap_from_gmfs(
-                ebr_from_gmfs, oq, self.datastore, self._monitor)
+                event_based_risk, oq, self.datastore, self._monitor)
             self.save_tmp(smap.monitor)
             for gmf_df in gmf_dfs:
-                smap.submit((gmf_df, oq))
+                smap.submit((gmf_df,))
             smap.reduce(self.agg_dicts)
 
         if self.parent_events:

--- a/openquake/commands/tests/commands_test.py
+++ b/openquake/commands/tests/commands_test.py
@@ -623,7 +623,7 @@ Source Loss Table'''.splitlines())
         # refactoring of the monitoring and it happened several times)
         with read(log.calc_id) as dstore:
             perf = str(view('performance', dstore))
-            self.assertIn('total ebr_from_gmfs', perf)
+            self.assertIn('total event_based_risk', perf)
 
     def test_oqdata(self):
         # the that the environment variable OQ_DATADIR is honored


### PR DESCRIPTION
Since we have `event_based_risk`. This reduces a bit the data transfer via `crmodel` and the memory occupation.