### PR TITLE
Sending the avg_losses by region

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -418,7 +418,7 @@ def get_allargs(oq, sitecol, sec_perils, dstore):
         for rupblock in block_splitter(rups, maxw/4, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
-    allargs = _collect(allargs, maxw*2, sitecol.sids, sec_perils, dstore)
+    allargs = _collect(allargs, maxw, sitecol.sids, sec_perils, dstore)
     for oqp in oq_by.values():
         for trt, mags in oqp.mags_by_trt.items():
             oqp.mags_by_trt[trt] = sorted(mags)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -418,7 +418,7 @@ def get_allargs(oq, sitecol, sec_perils, dstore):
         for rupblock in block_splitter(rups, maxw/4, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
-    allargs = _collect(allargs, maxw, sitecol.sids, sec_perils, dstore)
+    allargs = _collect(allargs, maxw*2, sitecol.sids, sec_perils, dstore)
     for oqp in oq_by.values():
         for trt, mags in oqp.mags_by_trt.items():
             oqp.mags_by_trt[trt] = sorted(mags)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -343,7 +343,7 @@ def _filter_rups(oq, sitecol, trts, dstore):
             affected = max(affected, rups['nsites'].max())
     logging.info('Affected sites ~%.0f per rupture, max=%.0f',
                  nsites / len(filrups), affected)
-    maxw = min(totw / (oq.concurrent_tasks or 1), 1E8)
+    maxw = min(totw / (oq.concurrent_tasks or 1), 50_000_000)
     logging.info(f'{round(maxw)=:_d}')
     return filrups, maxw, acc
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -337,6 +337,7 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
         # the slowdown is minor, while the memory saving is massive, since
         # only one taxonomy at the time is read inside event_based_risk
         gmf_mb = gmf_df.memory_usage().sum() / 1024**2
+        print(f'{gmf_mb=}')
         if gmf_mb > GMF_MB:
             # print(f'{gmf_mb=:.1f}')
             mod2 = gmf_df.eid % 2

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -266,7 +266,6 @@ def event_based_risk(gmf_df, monitor):
     xtypes = oq.xtypes
     R = 1 if oq.collect_rlzs else len(monitor.read('weights'))
     X = len(xtypes)
-    loss3 = {'aids': [], 'bids': [], 'loss': []}
     loss2 = general.AccumDict(accum=numpy.zeros((X, 2)))  # u8idx->array
     if os.environ.get('OQ_DEBUG_SITE'):
         print(gmf_df)
@@ -290,6 +289,7 @@ def event_based_risk(gmf_df, monitor):
         countries = ["?"]  # assume a single contry
     for id01, adf_ in items:
         id0, id1 = numpy.divmod(id01, TWO16)
+        loss3 = {'aids': [], 'bids': [], 'loss': []}
         for taxo in adf_.taxonomy.unique():
             with fil_mon:
                 # filtering is *crucial* for the performance of the next step
@@ -305,11 +305,11 @@ def event_based_risk(gmf_df, monitor):
                     adf, gdf, crmodel.oqparam._sec_losses, rng, country)
             with agg_mon:
                 aggreg(out, aggids, rlz_id, oq, loss2, loss3)
+        yield dict(avg=build_avg(loss3, oq.A, R*X))
 
-    dic = dict(gmf_bytes=gmf_df.memory_usage().sum())
-    dic['alt'] = build_alt(loss2, xtypes)
-    dic['avg'] = build_avg(loss3, oq.A, R*X)
-    return dic
+    dic = dict(gmf_bytes=gmf_df.memory_usage().sum(),
+               alt=build_alt(loss2, xtypes))
+    yield dic
 
 
 def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
@@ -338,9 +338,9 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
             # print(f'{gmf_mb=:.1f}')
             mod2 = gmf_df.eid % 2
             yield event_based_risk, gmf_df[mod2==1]
-            yield event_based_risk(gmf_df[mod2==0], monitor)
+            yield from event_based_risk(gmf_df[mod2==0], monitor)
         else:
-            yield event_based_risk(gmf_df, monitor)
+            yield from event_based_risk(gmf_df, monitor)
 
 
 @performance.compile("(f4[:,:,:], i4[:], i4[:], f4[:], i8)")
@@ -532,16 +532,16 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         times = dic.pop('times', None)
         if times is not None:
             hdf5.extend(self.datastore['ruptimes'], times)
-
-        with self.monitor('saving risk_by_event'):
-            alt = dic.pop('alt')
-            for name in alt.columns:
-                dset = self.datastore['risk_by_event/' + name]
-                hdf5.extend(dset, alt[name].to_numpy())
-        if self.oqparam.avg_losses:
+        alt = dic.pop('alt', None)
+        if alt is not None:
+            with self.monitor('saving risk_by_event'):
+                for name in alt.columns:
+                    dset = self.datastore['risk_by_event/' + name]
+                    hdf5.extend(dset, alt[name].to_numpy())
+        coo = dic.pop('avg', None)
+        if coo is not None and self.oqparam.avg_losses:
             # avg_losses are stored as coo matrices
             with self.monitor('saving avg_losses'):
-                coo = dic.pop('avg')
                 # the non-numpy approach is 2-3x slower, causing
                 # a big data queue and then running out of memory
                 # rlzs, xlts = numpy.divmod(coo.col, self.X)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -322,7 +322,7 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     :param secperils: list of secondary peril instances
     :param hdf5path: path to the ses.hdf5 file
     :param monitor: a Monitor instance
-    :yields: dictionaries with keys 'avg', 'alt' and times
+    :yields: dictionaries with keys 'avg', 'alt' and 'gmfbytes'
     """
     oq = cmakers[0].oq
     oq.ground_motion_fields = True

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -305,11 +305,11 @@ def event_based_risk(gmf_df, monitor):
                     adf, gdf, crmodel.oqparam._sec_losses, rng, country)
             with agg_mon:
                 aggreg(out, aggids, rlz_id, oq, loss2, loss3)
-        yield dict(avg=build_avg(loss3, oq.A, R*X))
+        avg = build_avg(loss3, oq.A, R*X)
+        yield dict(avg=avg)
 
-    dic = dict(gmf_bytes=gmf_df.memory_usage().sum(),
-               alt=build_alt(loss2, xtypes))
-    yield dic
+    alt = build_alt(loss2, xtypes)
+    yield dict(alt=alt, gmf_bytes=gmf_df.memory_usage().sum())
 
 
 def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,7 +42,6 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
-GMF_MB = 500
 get_n_occ = operator.itemgetter(1)
 
 
@@ -327,24 +326,13 @@ def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
     """
     oq = cmakers[0].oq
     oq.ground_motion_fields = True
-    dfs = (dic['gmfdata'] for dic in event_based.event_based(
+    dfs = [dic['gmfdata'] for dic in event_based.event_based(
         allrups, cmakers, sids, secperils, hdf5path, monitor)
-           if len(dic['gmfdata']))
-    # NB: it is essential to concatenate the small dataframes to have
-    # long arrays (around GMF_MB) and hence a good performance
-    for gmf_df in general.concatenated(dfs, GMF_MB):
-        # NB: the assets are read more times than needed; this is on purpose;
-        # the slowdown is minor, while the memory saving is massive, since
-        # only one taxonomy at the time is read inside event_based_risk
-        gmf_mb = gmf_df.memory_usage().sum() / 1024**2
-        print(f'{gmf_mb=}')
-        if gmf_mb > GMF_MB:
-            # print(f'{gmf_mb=:.1f}')
-            mod2 = gmf_df.eid % 2
-            yield event_based_risk, gmf_df[mod2==1]
-            yield from event_based_risk(gmf_df[mod2==0], monitor)
-        else:
-            yield from event_based_risk(gmf_df, monitor)
+           if len(dic['gmfdata'])]
+    if dfs:
+        # NB: it is essential to concatenate the small dataframes to have
+        # long arrays (around GMF_MB) and hence a good performance
+        yield from event_based_risk(pandas.concat(dfs), monitor)
 
 
 @performance.compile("(f4[:,:,:], i4[:], i4[:], f4[:], i8)")

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -299,7 +299,10 @@ def event_based_risk(gmf_df, monitor):
                     continue
             # passing the contry is crucial for impact_test,
             # where the exposure contains multiple countries
-            country = countries[id0]
+            try:
+                country = countries[id0]
+            except IndexError:
+                raise IndexError(f'Index {id0} not in {countries}')
             with risk_mon:
                 [out] = crmodel.get_outputs(
                     adf, gdf, crmodel.oqparam._sec_losses, rng, country)


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/11614. Step towards distributing by region. Here are the figures for Taiwan:
```
| calc_41, maxmem=173.5 GB     | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| total ebrisk                 | 46_412   | 28.9015   | 3_864   |
| computing risk               | 40_345   | 0.0       | 193_536 |
| aggregating losses           | 2_678    | 0.0       | 193_536 |
| EventBasedRiskCalculator.run | 695.5    | 783.5     | 1       |

| operation-duration | counts | mean   | stddev | min     | max    | slowfac |
|--------------------+--------+--------+--------+---------+--------+---------|
| ebrisk             | 168    | 276.3  | 22%    | 29.2324 | 604.1  | 2.1867  |
```