### PR TITLE
Epistemic uncertainty for hypoDepthDist

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato, Christopher Brooks]
+  * Added absolute epistemic uncertainty for hypoDepthDist for both
+    simple faults and background sources. QA test in logictree/case_29
+  
   [Michele Simionato]
   * Fine tuned memory consumption and slow tasks in ebrisk
   * Changed the event_based_risk calculator to split the assets by region

--- a/openquake/calculators/tests/logictree_test.py
+++ b/openquake/calculators/tests/logictree_test.py
@@ -33,9 +33,9 @@ from openquake.qa_tests_data.logictree import (
     case_01, case_02, case_03, case_04, case_05, case_06, case_07, case_08,
     case_09, case_10, case_11, case_12, case_13, case_14, case_15, case_16,
     case_17, case_18, case_19, case_20, case_21, case_22, case_23, case_28,
-    case_30, case_31, case_32, case_33, case_36, case_39, case_45, case_46,
-    case_52, case_56, case_58, case_59, case_67, case_68, case_71, case_73,
-    case_79, case_80, case_83, case_84)
+    case_29, case_30, case_31, case_32, case_33, case_36, case_39, case_45,
+    case_46, case_52, case_56, case_58, case_59, case_67, case_68, case_71,
+    case_73, case_79, case_80, case_83, case_84)
 
 ae = numpy.testing.assert_equal
 aac = numpy.testing.assert_allclose
@@ -514,6 +514,12 @@ hazard_uhs-std.csv
             self.run_calc(case_28.__file__, 'job_wrong.ini')
         self.assertIn('reference_depth_to_1pt0km_per_sec not specified',
                       str(ctx.exception))
+
+    def test_case_29(self):
+        # Simple fault source and area source with epistemic uncertainty
+        # on hypoDepthDist
+        self.assert_curves_ok(['hazard_curve-mean-PGA.csv'],
+                              case_29.__file__)
 
     def test_case_30(self):
         # point on the international data line

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -83,6 +83,15 @@ def abGR(utype, node, filename):
             node, filename, 'expected a pair of floats separated by space')
 
 
+@parse_uncertainty.add('setHypoDepthDistribution')
+def setHypoDepthDistribution(utype, node, filename):
+    try:
+        return [n.attrib for n in node.hypoDepthDist]
+    except ValueError:
+        raise LogicTreeError(
+            node, filename, 'expected a hypoDepthDist')
+
+
 @parse_uncertainty.add('maxMagAndDeltaMagACRelative',
                        'maxMagAndDeltaMagACRelativeNoMoBalance')
 def maxMagAndDeltaMagAC(utype, node, filename):
@@ -429,6 +438,11 @@ def _setLSDRelative(utype, source, value):
 @apply_uncertainty.add('setUpperSeismDepthRelative')
 def _setUSDRelative(utype, source, value):
     source.modify('adjust_upper_seismogenic_depth', dict(increment=float(value)))
+
+
+@apply_uncertainty.add('setHypoDepthDistribution')
+def _set_hypo_depth_dist_absolute(utype, source, value):
+    source.modify('set_hypo_depth_dist', dict(hdd=value))
 
 
 @apply_uncertainty.add('dummy')  # do nothing

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -47,7 +47,7 @@ class AreaSource(ParametricSeismicSource):
         'adjust_lower_seismogenic_depth',
         'adjust_upper_seismogenic_depth',
         'set_msr',
-        'set_hypo_depth_distribution',
+        'set_hypo_depth_dist',
     }
 
     def __init__(self, source_id, name, tectonic_region_type,

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -47,6 +47,7 @@ class AreaSource(ParametricSeismicSource):
         'adjust_lower_seismogenic_depth',
         'adjust_upper_seismogenic_depth',
         'set_msr',
+        'set_hypo_depth_distribution',
     }
 
     def __init__(self, source_id, name, tectonic_region_type,

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -548,6 +548,20 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
         """
         self.slip_rate = slip_rate
 
+    def modify_set_hypo_depth_dist(self, hdd: list):
+        """
+        Updates the hypoDepthDist assigned to the source
+
+        :param hdd:
+            List of dictionaries where each dictionary contains
+            the keys of probability and depth, and also potentially
+            of down-dip fraction to place the hypocentre.
+        """
+        self.hypo_depth_list = [(
+            dic['probability'], dic['depth'],
+            float(dic['fixedDipFrac']) if 'fixedDipFrac' in dic else None
+            ) for dic in hdd]
+
     def modify_set_mmax_truncatedGR(self, mmax: float):
         """
         Updates the mmax assigned. This works on for parametric MFDs.

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -550,17 +550,32 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
 
     def modify_set_hypo_depth_dist(self, hdd: list):
         """
-        Updates the hypoDepthDist assigned to the source
+        Updates the hypoDepthDist assigned to the source.
 
         :param hdd:
             List of dictionaries where each dictionary contains
             the keys of probability and depth, and also potentially
             of down-dip fraction to place the hypocentre.
         """
-        self.hypo_depth_list = [(
-            dic['probability'], dic['depth'],
+        # Get fixedDipFrac values if any
+        fracs = tuple(
             float(dic['fixedDipFrac']) if 'fixedDipFrac' in dic else None
-            ) for dic in hdd]
+            for dic in hdd)
+        
+        if hasattr(self, 'hypocenter_distribution'):
+            # Distributed typologies (MPS, PS, area) - rebuild the PMF
+            pmf = PMF([(dic['probability'], dic['depth']) for dic in hdd])
+            if any(f is not None for f in fracs):
+                pmf.hypo_dip_fracs = fracs
+                self.hypo_dip_fracs = fracs
+            else:
+                self.hypo_dip_fracs = None
+            self.hypocenter_distribution = pmf
+        else:
+            # Simple Faults - rebuild the hypo_depth_list
+            self.hypo_depth_list = [
+                (dic['probability'], dic['depth'], frac)
+                for dic, frac in zip(hdd, fracs)]
 
     def modify_set_mmax_truncatedGR(self, mmax: float):
         """

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -56,6 +56,7 @@ class MultiPointSource(ParametricSeismicSource):
         'adjust_lower_seismogenic_depth',
         'adjust_upper_seismogenic_depth',
         'set_msr',
+        'set_hypo_depth_dist',
     }
 
     def __init__(self, source_id, name, tectonic_region_type,

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -138,6 +138,7 @@ class PointSource(ParametricSeismicSource):
         'adjust_lower_seismogenic_depth',
         'adjust_upper_seismogenic_depth',
         'set_msr',
+        'set_hypo_depth_dist',
     }
     ps_grid_spacing = 0  # updated in CollapsedPointSource
 

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -122,6 +122,7 @@ class SimpleFaultSource(ParametricSeismicSource):
         'set_mmax_truncatedGR',
         'set_msr',
         'set_slip_rate',
+        'set_hypo_depth_dist',
     }
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/hazardlib/tests/lt_test.py
+++ b/openquake/hazardlib/tests/lt_test.py
@@ -504,3 +504,126 @@ class CompositeLogicTreeTestCase(unittest.TestCase):
         cnt = collections.Counter(paths)
         assert cnt == {'A': 64, 'B': 36}
 
+
+class SetHypoDepthDistUncertaintyTestCase(unittest.TestCase):
+    """
+    Tests for setHypoDepthDistribution epistemic uncertainty.
+    """
+    # fixedDipFrac arrives as str from the LT parser
+    HDD_WITH_FDF = [
+        dict(probability=0.25, depth=5.0, fixedDipFrac='0.4'),
+        dict(probability=0.75, depth=10.0, fixedDipFrac='0.6')]
+    HDD_NO_FDF = [
+        dict(probability=0.5, depth=7.0),
+        dict(probability=0.5, depth=12.0)]
+
+    SIMPLE_FAULT = '''\
+    <simpleFaultSource id="1" name="sf"
+        tectonicRegion="Active Shallow Crust">
+      <simpleFaultGeometry>
+        <gml:LineString><gml:posList>0 0 1 0</gml:posList></gml:LineString>
+        <dip>60</dip>
+        <upperSeismoDepth>0</upperSeismoDepth>
+        <lowerSeismoDepth>20</lowerSeismoDepth>
+      </simpleFaultGeometry>
+      <magScaleRel>WC1994</magScaleRel>
+      <ruptAspectRatio>1.5</ruptAspectRatio>
+      <truncGutenbergRichterMFD aValue="3" bValue="0.9"
+                                minMag="5" maxMag="6"/>
+      <rake>90</rake>
+    </simpleFaultSource>'''
+
+    POINT_LIKE = {
+        'point': '''\
+    <pointSource id="2" name="ps"
+        tectonicRegion="Active Shallow Crust">
+      <pointGeometry>
+        <gml:Point><gml:pos>0 0</gml:pos></gml:Point>
+        <upperSeismoDepth>0</upperSeismoDepth>
+        <lowerSeismoDepth>20</lowerSeismoDepth>
+      </pointGeometry>
+      <magScaleRel>WC1994</magScaleRel>
+      <ruptAspectRatio>1.5</ruptAspectRatio>
+      <truncGutenbergRichterMFD aValue="3" bValue="0.9"
+                                minMag="5" maxMag="6"/>
+      <nodalPlaneDist>
+        <nodalPlane probability="1" strike="0" dip="90" rake="0"/>
+      </nodalPlaneDist>
+      <hypoDepthDist>
+        <hypoDepth depth="8" probability="1"/>
+      </hypoDepthDist>
+    </pointSource>''',
+        'area': '''\
+    <areaSource id="3" name="ar"
+        tectonicRegion="Active Shallow Crust">
+      <areaGeometry discretization="10">
+        <gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>
+          0 0 1 0 1 1 0 1
+        </gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>
+        <upperSeismoDepth>0</upperSeismoDepth>
+        <lowerSeismoDepth>20</lowerSeismoDepth>
+      </areaGeometry>
+      <magScaleRel>WC1994</magScaleRel>
+      <ruptAspectRatio>1.5</ruptAspectRatio>
+      <truncGutenbergRichterMFD aValue="3" bValue="0.9"
+                                minMag="5" maxMag="6"/>
+      <nodalPlaneDist>
+        <nodalPlane probability="1" strike="0" dip="90" rake="0"/>
+      </nodalPlaneDist>
+      <hypoDepthDist>
+        <hypoDepth depth="8" probability="1"/>
+      </hypoDepthDist>
+    </areaSource>''',
+        'multi_point': '''\
+    <multiPointSource id="4" name="mp"
+        tectonicRegion="Active Shallow Crust">
+      <multiPointGeometry>
+        <gml:posList>0 0 0 1</gml:posList>
+        <upperSeismoDepth>0</upperSeismoDepth>
+        <lowerSeismoDepth>20</lowerSeismoDepth>
+      </multiPointGeometry>
+      <magScaleRel>WC1994</magScaleRel>
+      <ruptAspectRatio>1.5</ruptAspectRatio>
+      <multiMFD kind="truncGutenbergRichterMFD" size="2">
+        <a_val>3 3</a_val>
+        <b_val>0.9</b_val>
+        <min_mag>5</min_mag>
+        <max_mag>6</max_mag>
+      </multiMFD>
+      <nodalPlaneDist>
+        <nodalPlane probability="1" strike="0" dip="90" rake="0"/>
+      </nodalPlaneDist>
+      <hypoDepthDist>
+        <hypoDepth depth="8" probability="1"/>
+      </hypoDepthDist>
+    </multiPointSource>'''}
+
+    def test_apply_to_simple_fault(self):
+        src = nrml.get(self.SIMPLE_FAULT)
+        lt.apply_uncertainty(
+            'setHypoDepthDistribution', src, self.HDD_WITH_FDF)
+        self.assertEqual(
+            src.hypo_depth_list,
+            [(0.25, 5.0, 0.4), (0.75, 10.0, 0.6)])
+        lt.apply_uncertainty(
+            'setHypoDepthDistribution', src, self.HDD_NO_FDF)
+        self.assertEqual(
+            src.hypo_depth_list,
+            [(0.5, 7.0, None), (0.5, 12.0, None)])
+
+    def test_apply_to_point_like(self):
+        for kind, xml in self.POINT_LIKE.items():
+            src = nrml.get(xml)
+            lt.apply_uncertainty(
+                'setHypoDepthDistribution', src, self.HDD_WITH_FDF)
+            self.assertEqual(src.hypocenter_distribution.data,
+                             [(0.25, 5.0), (0.75, 10.0)], msg=kind)
+            self.assertEqual(src.hypo_dip_fracs, (0.4, 0.6), msg=kind)
+            self.assertEqual(
+                src.hypocenter_distribution.hypo_dip_fracs,
+                (0.4, 0.6), msg=kind)
+            lt.apply_uncertainty(
+                'setHypoDepthDistribution', src, self.HDD_NO_FDF)
+            self.assertEqual(src.hypocenter_distribution.data,
+                             [(0.5, 7.0), (0.5, 12.0)], msg=kind)
+            self.assertIsNone(src.hypo_dip_fracs, msg=kind)

--- a/openquake/qa_tests_data/logictree/README.md
+++ b/openquake/qa_tests_data/logictree/README.md
@@ -28,6 +28,7 @@
 | case\_23           | Arctic region and IDL (no bounding box)                                    |
 | case\_28           | Test collapse\_gsim\_logic\_tree                                           |
 | case\_28\_bis      | Test missing z1pt0                                                         |
+| case\_29           | Set hypo depth dist epistemic uncertainty                                  |
 | case\_30           | IMT-dependent weights, International Date Line                             |
 | case\_31           | Source Specific Logic Tree                                                 |
 | case\_32           | Tests setAspectRatioAbsolute and setAspectRatioRelative                    |

--- a/openquake/qa_tests_data/logictree/case_29/expected/hazard_curve-mean-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_29/expected/hazard_curve-mean-PGA.csv
@@ -1,0 +1,3 @@
+#,,,,,,,,"generated_by='OpenQuake engine 3.27.0-git145f3f7b3f', start_date='2026-07-15T11:20:15', checksum=2674772872, kind='mean', investigation_time=50.0, imt='PGA'"
+lon,lat,depth,poe-0.0100000,poe-0.0500000,poe-0.1000000,poe-0.2000000,poe-0.5000000,poe-1.0000000
+0.50000,-0.50000,0.00000,9.004363E-02,2.824788E-02,5.823126E-03,4.064306E-04,0.000000E+00,0.000000E+00

--- a/openquake/qa_tests_data/logictree/case_29/expected/hazard_curve-mean-PGA.csv
+++ b/openquake/qa_tests_data/logictree/case_29/expected/hazard_curve-mean-PGA.csv
@@ -1,3 +1,3 @@
-#,,,,,,,,"generated_by='OpenQuake engine 3.27.0-git145f3f7b3f', start_date='2026-07-15T11:20:15', checksum=2674772872, kind='mean', investigation_time=50.0, imt='PGA'"
+#,,,,,,,,"generated_by='OpenQuake engine 3.27.0-gitd3044b0e6a', start_date='2026-07-15T11:39:34', checksum=3753769382, kind='mean', investigation_time=50.0, imt='PGA'"
 lon,lat,depth,poe-0.0100000,poe-0.0500000,poe-0.1000000,poe-0.2000000,poe-0.5000000,poe-1.0000000
-0.50000,-0.50000,0.00000,9.004363E-02,2.824788E-02,5.823126E-03,4.064306E-04,0.000000E+00,0.000000E+00
+0.50000,-0.50000,0.00000,9.811708E-01,9.401511E-01,7.777091E-01,3.713670E-01,2.738217E-02,6.889134E-04

--- a/openquake/qa_tests_data/logictree/case_29/expected/hazard_curve-mean-PGA_old.csv
+++ b/openquake/qa_tests_data/logictree/case_29/expected/hazard_curve-mean-PGA_old.csv
@@ -1,0 +1,3 @@
+#,,,,,,,,"generated_by='OpenQuake engine 3.26.0-git643dd0471e', start_date='2026-04-29T15:08:28', checksum=3950370653, kind='mean', investigation_time=50.0, imt='PGA'"
+lon,lat,depth,poe-0.0100000,poe-0.0500000,poe-0.1000000,poe-0.2000000,poe-0.5000000,poe-1.0000000
+0.50000,-0.50000,0.00000,9.004363E-02,2.824788E-02,5.823125E-03,4.064307E-04,0.000000E+00,0.000000E+00

--- a/openquake/qa_tests_data/logictree/case_29/expected/hazard_curve-mean-PGA_old.csv
+++ b/openquake/qa_tests_data/logictree/case_29/expected/hazard_curve-mean-PGA_old.csv
@@ -1,3 +1,0 @@
-#,,,,,,,,"generated_by='OpenQuake engine 3.26.0-git643dd0471e', start_date='2026-04-29T15:08:28', checksum=3950370653, kind='mean', investigation_time=50.0, imt='PGA'"
-lon,lat,depth,poe-0.0100000,poe-0.0500000,poe-0.1000000,poe-0.2000000,poe-0.5000000,poe-1.0000000
-0.50000,-0.50000,0.00000,9.004363E-02,2.824788E-02,5.823125E-03,4.064307E-04,0.000000E+00,0.000000E+00

--- a/openquake/qa_tests_data/logictree/case_29/gsim_logic_tree.xml
+++ b/openquake/qa_tests_data/logictree/case_29/gsim_logic_tree.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="gmpeModel" branchSetID="bs1"
+                                applyToTectonicRegionType="Active Shallow Crust">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>ChiouYoungs2014</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/logictree/case_29/job.ini
+++ b/openquake/qa_tests_data/logictree/case_29/job.ini
@@ -1,0 +1,38 @@
+[general]
+
+description = Simple fault source with hypoDepthDist
+calculation_mode = classical
+random_seed = 23
+
+[geometry]
+
+sites = 0.5 -0.5
+
+[logic_tree]
+
+number_of_logic_tree_samples = 0
+
+[erf]
+
+rupture_mesh_spacing = 5.0
+width_of_mfd_bin = 0.1
+
+[site_params]
+
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 2.5
+reference_depth_to_1pt0km_per_sec = 50.0
+
+[calculation]
+
+source_model_logic_tree_file = source_model_logic_tree.xml
+gsim_logic_tree_file = gsim_logic_tree.xml
+investigation_time = 50.0
+intensity_measure_types_and_levels = {"PGA": [0.01, 0.05, 0.1, 0.2, 0.5, 1.0]}
+truncation_level = 3.0
+maximum_distance = 200.0
+
+[output]
+
+mean = true

--- a/openquake/qa_tests_data/logictree/case_29/job.ini
+++ b/openquake/qa_tests_data/logictree/case_29/job.ini
@@ -1,6 +1,6 @@
 [general]
 
-description = Simple fault source with epistemic uncertainty on hypoDepthDist
+description = Epistemic uncertainty on hypoDepthDist
 calculation_mode = classical
 random_seed = 23
 

--- a/openquake/qa_tests_data/logictree/case_29/job.ini
+++ b/openquake/qa_tests_data/logictree/case_29/job.ini
@@ -1,6 +1,6 @@
 [general]
 
-description = Simple fault source with hypoDepthDist
+description = Simple fault source with epistemic uncertainty on hypoDepthDist
 calculation_mode = classical
 random_seed = 23
 

--- a/openquake/qa_tests_data/logictree/case_29/source_model.xml
+++ b/openquake/qa_tests_data/logictree/case_29/source_model.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+      xmlns:gml="http://www.opengis.net/gml">
+    <sourceModel name="Simple fault with hypoDepthDist">
+
+        <simpleFaultSource id="1" name="Simple Fault Source"
+                           tectonicRegion="Active Shallow Crust">
+            <simpleFaultGeometry>
+                <gml:LineString>
+                    <gml:posList>
+                        1.0 -0.5 1.4 0.0 1.4 0.3
+                    </gml:posList>
+                </gml:LineString>
+                <dip>60.0</dip>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>20.0</lowerSeismoDepth>
+            </simpleFaultGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.5</ruptAspectRatio>
+            <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
+                                      minMag="6.5" maxMag="7.5"/>
+            <rake>90.0</rake>
+            <hypoDepthDist>
+                <hypoDepth depth="5.0"  probability="0.25"/>
+                <hypoDepth depth="10.0" probability="0.50"/>
+                <hypoDepth depth="15.0" probability="0.25"/>
+            </hypoDepthDist>
+        </simpleFaultSource>
+
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/logictree/case_29/source_model.xml
+++ b/openquake/qa_tests_data/logictree/case_29/source_model.xml
@@ -20,11 +20,6 @@
             <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
                                       minMag="6.5" maxMag="7.5"/>
             <rake>90.0</rake>
-            <hypoDepthDist>
-                <hypoDepth depth="5.0"  probability="0.25"/>
-                <hypoDepth depth="10.0" probability="0.50"/>
-                <hypoDepth depth="15.0" probability="0.25"/>
-            </hypoDepthDist>
         </simpleFaultSource>
 
     </sourceModel>

--- a/openquake/qa_tests_data/logictree/case_29/source_model.xml
+++ b/openquake/qa_tests_data/logictree/case_29/source_model.xml
@@ -1,26 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
-<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.5"
       xmlns:gml="http://www.opengis.net/gml">
-    <sourceModel name="Simple fault with hypoDepthDist">
+    <sourceModel name="One of each hypoDepthDist-supporting source type">
+        <sourceGroup tectonicRegion="Active Shallow Crust">
 
-        <simpleFaultSource id="1" name="Simple Fault Source"
-                           tectonicRegion="Active Shallow Crust">
-            <simpleFaultGeometry>
-                <gml:LineString>
-                    <gml:posList>
-                        1.0 -0.5 1.4 0.0 1.4 0.3
-                    </gml:posList>
-                </gml:LineString>
-                <dip>60.0</dip>
-                <upperSeismoDepth>0.0</upperSeismoDepth>
-                <lowerSeismoDepth>20.0</lowerSeismoDepth>
-            </simpleFaultGeometry>
-            <magScaleRel>WC1994</magScaleRel>
-            <ruptAspectRatio>1.5</ruptAspectRatio>
-            <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
-                                      minMag="6.5" maxMag="7.5"/>
-            <rake>90.0</rake>
-        </simpleFaultSource>
+            <simpleFaultSource id="1" name="Simple Fault Source">
+                <simpleFaultGeometry>
+                    <gml:LineString>
+                        <gml:posList>
+                            1.0 -0.5 1.4 0.0 1.4 0.3
+                        </gml:posList>
+                    </gml:LineString>
+                    <dip>60.0</dip>
+                    <upperSeismoDepth>0.0</upperSeismoDepth>
+                    <lowerSeismoDepth>20.0</lowerSeismoDepth>
+                </simpleFaultGeometry>
+                <magScaleRel>WC1994</magScaleRel>
+                <ruptAspectRatio>1.5</ruptAspectRatio>
+                <truncGutenbergRichterMFD aValue="3.2" bValue="0.9"
+                                          minMag="6.5" maxMag="7.5"/>
+                <rake>90.0</rake>
+            </simpleFaultSource>
 
+            <pointSource id="2" name="Point Source">
+                <pointGeometry>
+                    <gml:Point>
+                        <gml:pos>0.4 -0.4</gml:pos>
+                    </gml:Point>
+                    <upperSeismoDepth>0.0</upperSeismoDepth>
+                    <lowerSeismoDepth>20.0</lowerSeismoDepth>
+                </pointGeometry>
+                <magScaleRel>WC1994</magScaleRel>
+                <ruptAspectRatio>1.5</ruptAspectRatio>
+                <truncGutenbergRichterMFD aValue="3.0" bValue="0.9"
+                                          minMag="5.0" maxMag="6.5"/>
+                <nodalPlaneDist>
+                    <nodalPlane probability="1.0" strike="0.0"
+                                dip="90.0" rake="0.0"/>
+                </nodalPlaneDist>
+                <hypoDepthDist>
+                    <hypoDepth depth="8.0" probability="1.0"/>
+                </hypoDepthDist>
+            </pointSource>
+
+            <areaSource id="3" name="Area Source">
+                <areaGeometry discretization="10.0">
+                    <gml:Polygon>
+                        <gml:exterior>
+                            <gml:LinearRing>
+                                <gml:posList>
+                                    0.3 -0.6 0.7 -0.6 0.7 -0.3 0.3 -0.3
+                                </gml:posList>
+                            </gml:LinearRing>
+                        </gml:exterior>
+                    </gml:Polygon>
+                    <upperSeismoDepth>0.0</upperSeismoDepth>
+                    <lowerSeismoDepth>20.0</lowerSeismoDepth>
+                </areaGeometry>
+                <magScaleRel>WC1994</magScaleRel>
+                <ruptAspectRatio>1.5</ruptAspectRatio>
+                <truncGutenbergRichterMFD aValue="2.5" bValue="0.9"
+                                          minMag="5.0" maxMag="6.5"/>
+                <nodalPlaneDist>
+                    <nodalPlane probability="1.0" strike="0.0"
+                                dip="90.0" rake="0.0"/>
+                </nodalPlaneDist>
+                <hypoDepthDist>
+                    <hypoDepth depth="8.0" probability="1.0"/>
+                </hypoDepthDist>
+            </areaSource>
+
+            <multiPointSource id="4" name="MultiPoint Source">
+                <multiPointGeometry>
+                    <gml:posList>0.6 -0.6 0.6 -0.4</gml:posList>
+                    <upperSeismoDepth>0.0</upperSeismoDepth>
+                    <lowerSeismoDepth>20.0</lowerSeismoDepth>
+                </multiPointGeometry>
+                <magScaleRel>WC1994</magScaleRel>
+                <ruptAspectRatio>1.5</ruptAspectRatio>
+                <multiMFD kind="truncGutenbergRichterMFD" size="2">
+                    <a_val>2.8 2.8</a_val>
+                    <b_val>0.9</b_val>
+                    <min_mag>5.0</min_mag>
+                    <max_mag>6.5</max_mag>
+                </multiMFD>
+                <nodalPlaneDist>
+                    <nodalPlane probability="1.0" strike="0.0"
+                                dip="90.0" rake="0.0"/>
+                </nodalPlaneDist>
+                <hypoDepthDist>
+                    <hypoDepth depth="8.0" probability="1.0"/>
+                </hypoDepthDist>
+            </multiPointSource>
+
+        </sourceGroup>
     </sourceModel>
 </nrml>

--- a/openquake/qa_tests_data/logictree/case_29/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/logictree/case_29/source_model_logic_tree.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.4">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchingLevel branchingLevelID="bl1">
+            <logicTreeBranchSet uncertaintyType="sourceModel"
+                                branchSetID="bs1">
+                <logicTreeBranch branchID="b1">
+                    <uncertaintyModel>source_model.xml</uncertaintyModel>
+                    <uncertaintyWeight>1.0</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
+        </logicTreeBranchingLevel>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/logictree/case_29/source_model_logic_tree.xml
+++ b/openquake/qa_tests_data/logictree/case_29/source_model_logic_tree.xml
@@ -2,14 +2,34 @@
 <nrml xmlns:gml="http://www.opengis.net/gml"
       xmlns="http://openquake.org/xmlns/nrml/0.4">
     <logicTree logicTreeID="lt1">
-        <logicTreeBranchingLevel branchingLevelID="bl1">
             <logicTreeBranchSet uncertaintyType="sourceModel"
                                 branchSetID="bs1">
-                <logicTreeBranch branchID="b1">
+                <logicTreeBranch branchID="b1_0">
                     <uncertaintyModel>source_model.xml</uncertaintyModel>
                     <uncertaintyWeight>1.0</uncertaintyWeight>
                 </logicTreeBranch>
             </logicTreeBranchSet>
-        </logicTreeBranchingLevel>
+            <logicTreeBranchSet uncertaintyType="setHypoDepthDistribution"
+                                branchSetID="bs2">
+                <logicTreeBranch branchID="b2_0">
+                    <uncertaintyModel>
+                        <hypoDepthDist>
+                            <hypoDepth depth="5.0"  probability="0.25" fixedDipFrac="0.667"/>
+                            <hypoDepth depth="10.0" probability="0.50" fixedDipFrac="0.667"/>
+                            <hypoDepth depth="15.0" probability="0.25" fixedDipFrac="0.667"/>
+                        </hypoDepthDist>
+                    </uncertaintyModel>
+                    <uncertaintyWeight>0.5</uncertaintyWeight>
+                </logicTreeBranch>
+                <logicTreeBranch branchID="b2_1">
+                    <uncertaintyModel>
+                        <hypoDepthDist>
+                            <hypoDepth depth="7.0"  probability="0.50"/>
+                            <hypoDepth depth="12.0" probability="0.50"/>
+                        </hypoDepthDist>
+                    </uncertaintyModel>
+                    <uncertaintyWeight>0.5</uncertaintyWeight>
+                </logicTreeBranch>
+            </logicTreeBranchSet>
     </logicTree>
 </nrml>


### PR DESCRIPTION
Add ability to specify epistemic uncertainties on hypocentral depth dist in background sources and simple fault sources (the source typologies that support this feature already). It's an absolute uncertainty - we are setting different distributions in each branchset.

New unit test in `logictree/case_29` and some unit tests.