### PR TITLE
filter hypoDepthDist in distributed sources by lower seismogenic depth

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+  [Christopher Brooks]
+  * Added filtering of hypoDepthDist in area, multi-point and point
+    sources to only depths within seismogenic depth range and then
+    renormalise the distribution. QA test in classical/case_45
+
   [Michele Simionato, Christopher Brooks]
   * Added absolute epistemic uncertainty for hypoDepthDist for both
     simple faults and background sources. QA test in logictree/case_29

--- a/openquake/calculators/tests/classical_test.py
+++ b/openquake/calculators/tests/classical_test.py
@@ -36,12 +36,12 @@ from openquake.qa_tests_data.classical import (
     case_09, case_10, case_11, case_12, case_13, case_18, case_22, case_23,
     case_24, case_25, case_26, case_27, case_28, case_29, case_30, case_31,
     case_32, case_33, case_34, case_35, case_36, case_37, case_38, case_39,
-    case_40, case_41, case_42, case_43, case_44, case_47, case_48, case_49,
-    case_50, case_51, case_53, case_54, case_55, case_57, case_60, case_61,
-    case_62, case_63, case_64, case_65, case_66, case_67, case_68, case_69,
-    case_70, case_71, case_72, case_74, case_75, case_76, case_77, case_78,
-    case_80, case_81, case_82, case_83, case_84, case_85, case_86, case_87,
-    case_88, case_89, case_90, case_91, case_92, case_93, case_94)
+    case_40, case_41, case_42, case_43, case_44, case_45, case_47, case_48,
+    case_49, case_50, case_51, case_53, case_54, case_55, case_57, case_60,
+    case_61, case_62, case_63, case_64, case_65, case_66, case_67, case_68,
+    case_69, case_70, case_71, case_72, case_74, case_75, case_76, case_77,
+    case_78, case_80, case_81, case_82, case_83, case_84, case_85, case_86,
+    case_87, case_88, case_89, case_90, case_91, case_92, case_93, case_94)
 
 ae = numpy.testing.assert_equal
 aac = numpy.testing.assert_allclose
@@ -633,6 +633,11 @@ class ClassicalTestCase(CalculatorTestCase):
         self.assert_curves_ok(["hazard_curve-mean-PGA.csv"], case_44.__file__,
                               shift_hypo='false')
 
+    def test_case_45(self):
+        # Test use of setLowerSeismDepthAbsolute on area, mps and point sources
+        self.assert_curves_ok(['hazard_curve-mean-PGA.csv'],
+                              case_45.__file__)
+        
     def test_case_47(self):
         # Mixture Model for Sigma using PEER (2018) Test Case 2.5b
         self.assert_curves_ok(["hazard_curve-rlz-000-PGA.csv",
@@ -1198,3 +1203,4 @@ class ClassicalTestCase(CalculatorTestCase):
             'hazard_curve-mean-PGA.csv',
             'hazard_curve-mean-SA(0.5).csv'],
             case_94.__file__)
+

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -84,9 +84,14 @@ class AreaSource(ParametricSeismicSource):
     def modify_set_lower_seismogenic_depth(self, lsd):
         """
         Modifies the current source geometry by replacing the original
-        lower seismogenic depth with the passed depth
+        lower seismogenic depth with the passed depth.
+
+        Hypocenter depths deeper than the new LSD are dropped and the
+        remaining probabilities are renormalised (see
+        ParamatricSeismicSource._shrink_hypo_depths_to_lsd).
         """
         self.lower_seismogenic_depth = lsd
+        self._shrink_hypo_depths_to_lsd(lsd)
 
     def modify_adjust_lower_seismogenic_depth(self, increment):
         """

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -577,6 +577,33 @@ class ParametricSeismicSource(BaseSeismicSource, metaclass=abc.ABCMeta):
                 (dic['probability'], dic['depth'], frac)
                 for dic, frac in zip(hdd, fracs)]
 
+    def _shrink_hypo_depths_to_lsd(self, lsd: float):
+        """
+        Drop depths deeper than lsd from a hypocenter_distribution,
+        renormalise the surviving probabilities, and trim any matching
+        entries in hypo_dip_fracs.
+
+        Called by modify_set_lower_seismogenic_depth on the
+        distributed source typologies (point/area/multi-point) so
+        that a shrunk LSD does not leave orphan hypo depths that would
+        later fail within the PointSource instantiation.
+        """
+        hdd = self.hypocenter_distribution
+        fracs = getattr(hdd, 'hypo_dip_fracs', None)
+        keep = [(i, prob, depth) for i, (prob, depth) in enumerate(hdd.data)
+                if depth <= lsd]
+        if not keep:
+            raise ValueError(
+                f'No hypocenter depths remain at or above the new '
+                f'lower_seismogenic_depth={lsd}')
+        total = sum(prob for _, prob, _ in keep)
+        new_hdd = PMF([(prob / total, depth) for _, prob, depth in keep])
+        if fracs is not None:
+            new_fracs = tuple(fracs[i] for i, _, _ in keep)
+            new_hdd.hypo_dip_fracs = new_fracs
+            self.hypo_dip_fracs = new_fracs
+        self.hypocenter_distribution = new_hdd
+
     def modify_set_mmax_truncatedGR(self, mmax: float):
         """
         Updates the mmax assigned. This works on for parametric MFDs.

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -119,9 +119,14 @@ class MultiPointSource(ParametricSeismicSource):
     def modify_set_lower_seismogenic_depth(self, lsd):
         """
         Modifies the current source geometry by replacing the original
-        lower seismogenic depth with the passed depth
+        lower seismogenic depth with the passed depth.
+
+        Hypocenter depths deeper than the new LSD are dropped and the
+        remaining probabilities are renormalised (see
+        ``_shrink_hypo_depths_to_lsd``).
         """
         self.lower_seismogenic_depth = lsd
+        self._shrink_hypo_depths_to_lsd(lsd)
 
     def modify_adjust_lower_seismogenic_depth(self, increment):
         """

--- a/openquake/hazardlib/source/multi_point.py
+++ b/openquake/hazardlib/source/multi_point.py
@@ -123,7 +123,7 @@ class MultiPointSource(ParametricSeismicSource):
 
         Hypocenter depths deeper than the new LSD are dropped and the
         remaining probabilities are renormalised (see
-        ``_shrink_hypo_depths_to_lsd``).
+        ParamatricSeismicSource._shrink_hypo_depths_to_lsd).
         """
         self.lower_seismogenic_depth = lsd
         self._shrink_hypo_depths_to_lsd(lsd)

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -335,9 +335,14 @@ class PointSource(ParametricSeismicSource):
     def modify_set_lower_seismogenic_depth(self, lsd):
         """
         Modifies the current source geometry by replacing the original
-        lower seismogenic depth with the passed depth
+        lower seismogenic depth with the passed depth.
+
+        Hypocenter depths deeper than the new LSD are dropped and the
+        remaining probabilities are renormalised (see
+        ParamatricSeismicSource._shrink_hypo_depths_to_lsd).
         """
         self.lower_seismogenic_depth = lsd
+        self._shrink_hypo_depths_to_lsd(lsd)
 
     def modify_adjust_lower_seismogenic_depth(self, increment):
         """

--- a/openquake/hazardlib/tests/source/area_test.py
+++ b/openquake/hazardlib/tests/source/area_test.py
@@ -122,3 +122,18 @@ class AreaSourceDipFracsTestCase(unittest.TestCase):
             self.assertIsNone(ps.hypo_dip_fracs)
 
 
+class AreaSourceModifyLSDTestCase(unittest.TestCase):
+
+    def test_lsd_shrink_filters_and_renormalises_hypos(self):
+        hdd = PMF([(0.2, 4.0), (0.5, 8.0), (0.3, 12.0)])
+        hdd.hypo_dip_fracs = (0.5, 0.6, 0.7)
+        polygon = Polygon([Point(0, 0), Point(0, 1), Point(1, 1), Point(1, 0)])
+        src = make_area_source(polygon, 50.0, hypocenter_distribution=hdd,
+                               lower_seismogenic_depth=15.0)
+        src.modify_set_lower_seismogenic_depth(10.0)
+        data = src.hypocenter_distribution.data
+        self.assertEqual([d for _, d in data], [4.0, 8.0])
+        self.assertAlmostEqual(data[0][0], 0.2 / 0.7)
+        self.assertEqual(src.hypo_dip_fracs, (0.5, 0.6))
+
+

--- a/openquake/hazardlib/tests/source/multi_point_test.py
+++ b/openquake/hazardlib/tests/source/multi_point_test.py
@@ -98,3 +98,18 @@ multiPointSource{id='mp1', name='multi point source'}
                                mmfd, PeerMSR(), 1.0, 0, 20, npd, hd, mesh)
         for ps in mps:
             self.assertEqual(ps.hypo_dip_fracs, fracs)
+
+    def test_lsd_shrink_filters_and_renormalises_hypos(self):
+        hd = PMF([(0.2, 4.0), (0.5, 8.0), (0.3, 12.0)])
+        hd.hypo_dip_fracs = (0.5, 0.6, 0.7)
+        npd = PMF([(1, NodalPlane(0, 60, 90))])
+        mesh = Mesh(numpy.array([0., 1.]), numpy.array([0., 0.]))
+        mmfd = MultiMFD('incrementalMFD', size=2, min_mag=[4.5],
+                        bin_width=[1.0], occurRates=[[0.1], [0.2]])
+        mps = MultiPointSource('mp3', 'test', 'Active Shallow Crust',
+                               mmfd, PeerMSR(), 1.0, 0, 15, npd, hd, mesh)
+        mps.modify_set_lower_seismogenic_depth(10.0)
+        data = mps.hypocenter_distribution.data
+        self.assertEqual([d for _, d in data], [4.0, 8.0])
+        self.assertAlmostEqual(data[0][0], 0.2 / 0.7)
+        self.assertEqual(mps.hypo_dip_fracs, (0.5, 0.6))

--- a/openquake/hazardlib/tests/source/point_test.py
+++ b/openquake/hazardlib/tests/source/point_test.py
@@ -481,3 +481,19 @@ class PointSourceDipFracsTestCase(unittest.TestCase):
         pla_cen = list(src_cen.get_planar().values())[0][0]
         pla_off = list(src_off.get_planar().values())[0][0]
         self.assertFalse(numpy.array_equal(pla_cen, pla_off))
+
+
+class PointSourceModifyLSDTestCase(unittest.TestCase):
+
+    def test_lsd_shrink_filters_and_renormalises_hypos(self):
+        hdd = PMF([(0.2, 4.0), (0.5, 8.0), (0.3, 12.0)])
+        hdd.hypo_dip_fracs = (0.5, 0.6, 0.7)
+        src = make_point_source(
+            upper_seismogenic_depth=0.0, lower_seismogenic_depth=15.0,
+            hypocenter_distribution=hdd,
+            nodal_plane_distribution=PMF([(1, NodalPlane(0, 60, 90))]))
+        src.modify_set_lower_seismogenic_depth(10.0)
+        data = src.hypocenter_distribution.data
+        self.assertEqual([d for _, d in data], [4.0, 8.0])
+        self.assertAlmostEqual(data[0][0], 0.2 / 0.7)
+        self.assertEqual(src.hypo_dip_fracs, (0.5, 0.6))

--- a/openquake/qa_tests_data/classical/README.md
+++ b/openquake/qa_tests_data/classical/README.md
@@ -38,6 +38,7 @@
 |case\_42|Split/filter a long complex fault source with maxdist=1000 km|
 |case\_43|Test for ps grid spacing|
 |case\_44|Test for shift hypo feature|
+|case\_45|Test setLowerSeismDepthAbsolute drops hypoDepthDist entries below the new LSD in distributed sources
 |case\_47|Mixture Model for Sigma using PEER (2018) Test Case 2.5b|
 |case\_48|Precise test of pointsource distance|
 |case\_49|Test the use of the convolution method to amplify the motion|

--- a/openquake/qa_tests_data/classical/case_45/expected/hazard_curve-mean-PGA.csv
+++ b/openquake/qa_tests_data/classical/case_45/expected/hazard_curve-mean-PGA.csv
@@ -1,0 +1,3 @@
+#,,,,,,,"generated_by='OpenQuake engine 3.27.0-git1cae0b8e4c', start_date='2026-07-16T14:44:55', checksum=879168694, kind='mean', investigation_time=1.0, imt='PGA'"
+lon,lat,depth,poe-0.0010000,poe-0.0056234,poe-0.0316228,poe-0.1778279,poe-1.0000000
+0.00000,0.00000,0.00000,3.822053E-02,2.622649E-02,5.226927E-03,2.414504E-04,1.582940E-07

--- a/openquake/qa_tests_data/classical/case_45/gmcLT.xml
+++ b/openquake/qa_tests_data/classical/case_45/gmcLT.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.5">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchSet uncertaintyType="gmpeModel" branchSetID="bs1"
+                            applyToTectonicRegionType="Active Shallow Crust">
+            <logicTreeBranch branchID="b1">
+                <uncertaintyModel>BooreAtkinson2008</uncertaintyModel>
+                <uncertaintyWeight>1.0</uncertaintyWeight>
+            </logicTreeBranch>
+        </logicTreeBranchSet>
+    </logicTree>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_45/job.ini
+++ b/openquake/qa_tests_data/classical/case_45/job.ini
@@ -1,0 +1,29 @@
+[general]
+description = Shrink hypoDepthDist entries in distributed sources to with LSD
+calculation_mode = classical
+random_seed = 1
+
+[geometry]
+sites = 0.0 0.0
+
+[logic_tree]
+number_of_logic_tree_samples = 0
+
+[erf]
+rupture_mesh_spacing = 5.0
+width_of_mfd_bin = 0.2
+area_source_discretization = 25.0
+
+[site_params]
+reference_vs30_type = measured
+reference_vs30_value = 760.0
+reference_depth_to_2pt5km_per_sec = 0.607
+reference_depth_to_1pt0km_per_sec = 48.0
+
+[calculation]
+source_model_logic_tree_file = sscLT.xml
+gsim_logic_tree_file = gmcLT.xml
+investigation_time = 1.0
+intensity_measure_types_and_levels = {"PGA": logscale(0.001, 1.0, 5)}
+truncation_level = 3
+maximum_distance = 200.0

--- a/openquake/qa_tests_data/classical/case_45/source_model.xml
+++ b/openquake/qa_tests_data/classical/case_45/source_model.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+      xmlns:gml="http://www.opengis.net/gml">
+    <sourceModel name="LSD-filter test">
+        <areaSource id="area1" name="Area with deep hypos"
+                    tectonicRegion="Active Shallow Crust">
+            <areaGeometry>
+                <gml:Polygon>
+                    <gml:exterior>
+                        <gml:LinearRing>
+                            <gml:posList>
+                                -0.5 -0.5 0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 -0.5
+                            </gml:posList>
+                        </gml:LinearRing>
+                    </gml:exterior>
+                </gml:Polygon>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>20.0</lowerSeismoDepth>
+            </areaGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.0</ruptAspectRatio>
+            <truncGutenbergRichterMFD aValue="3.0" bValue="1.0"
+                                      minMag="5.0" maxMag="6.5"/>
+            <nodalPlaneDist>
+                <nodalPlane strike="0.0" dip="90.0" rake="0.0" probability="1.0"/>
+            </nodalPlaneDist>
+            <hypoDepthDist>
+                <hypoDepth depth="5.0"  probability="0.2"/>
+                <hypoDepth depth="10.0" probability="0.5"/>
+                <hypoDepth depth="15.0" probability="0.3"/>
+            </hypoDepthDist>
+        </areaSource>
+
+        <pointSource id="point1" name="Point with deep hypos"
+                     tectonicRegion="Active Shallow Crust">
+            <pointGeometry>
+                <gml:Point>
+                    <gml:pos>1.0 0.0</gml:pos>
+                </gml:Point>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>20.0</lowerSeismoDepth>
+            </pointGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.0</ruptAspectRatio>
+            <truncGutenbergRichterMFD aValue="3.0" bValue="1.0"
+                                      minMag="5.0" maxMag="6.5"/>
+            <nodalPlaneDist>
+                <nodalPlane strike="0.0" dip="90.0" rake="0.0" probability="1.0"/>
+            </nodalPlaneDist>
+            <hypoDepthDist>
+                <hypoDepth depth="5.0"  probability="0.2"/>
+                <hypoDepth depth="10.0" probability="0.5"/>
+                <hypoDepth depth="15.0" probability="0.3"/>
+            </hypoDepthDist>
+        </pointSource>
+
+        <multiPointSource id="mps1" name="Multi-point with deep hypos"
+                          tectonicRegion="Active Shallow Crust">
+            <multiPointGeometry>
+                <gml:posList>-1.0 0.0 -1.0 0.5</gml:posList>
+                <upperSeismoDepth>0.0</upperSeismoDepth>
+                <lowerSeismoDepth>20.0</lowerSeismoDepth>
+            </multiPointGeometry>
+            <magScaleRel>WC1994</magScaleRel>
+            <ruptAspectRatio>1.0</ruptAspectRatio>
+            <multiMFD kind="truncGutenbergRichterMFD" size="2">
+                <a_val>3.0 3.0</a_val>
+                <b_val>1.0</b_val>
+                <bin_width>0.2</bin_width>
+                <min_mag>5.0</min_mag>
+                <max_mag>6.5</max_mag>
+            </multiMFD>
+            <nodalPlaneDist>
+                <nodalPlane strike="0.0" dip="90.0" rake="0.0" probability="1.0"/>
+            </nodalPlaneDist>
+            <hypoDepthDist>
+                <hypoDepth depth="5.0"  probability="0.2"/>
+                <hypoDepth depth="10.0" probability="0.5"/>
+                <hypoDepth depth="15.0" probability="0.3"/>
+            </hypoDepthDist>
+        </multiPointSource>
+    </sourceModel>
+</nrml>

--- a/openquake/qa_tests_data/classical/case_45/sscLT.xml
+++ b/openquake/qa_tests_data/classical/case_45/sscLT.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nrml xmlns:gml="http://www.opengis.net/gml"
+      xmlns="http://openquake.org/xmlns/nrml/0.5">
+    <logicTree logicTreeID="lt1">
+        <logicTreeBranchSet uncertaintyType="sourceModel" branchSetID="bs1">
+            <logicTreeBranch branchID="b1">
+                <uncertaintyModel>source_model.xml</uncertaintyModel>
+                <uncertaintyWeight>1.0</uncertaintyWeight>
+            </logicTreeBranch>
+        </logicTreeBranchSet>
+
+        <!-- Shrinks LSD below the 10 and 15 km hypo depths on the area, point
+             and multi-point sources, exercising the filter+renormalise path in
+             ParametricSeismicSource._shrink_hypo_depths_to_lsd -->
+        <logicTreeBranchSet uncertaintyType="setLowerSeismDepthAbsolute"
+                            applyToSources="*" branchSetID="bs2">
+            <logicTreeBranch branchID="lsd8">
+                <uncertaintyModel>
+                    <correlated src="area1">8.0</correlated>
+                    <correlated src="point1">8.0</correlated>
+                    <correlated src="mps1">8.0</correlated>
+                </uncertaintyModel>
+                <uncertaintyWeight>1.0</uncertaintyWeight>
+            </logicTreeBranch>
+        </logicTreeBranchSet>
+    </logicTree>
+</nrml>


### PR DESCRIPTION
Needed for BC Hydro but useful in general - we initially filtered the hypoDepthDist for area sources within the builder script, but it's better to do this automatically within the area source itself (which is needed if we don't use the builder script approach)

QA test added (classical/case_45) and also some simple unit tests