### PR TITLE
Update install.py to handle external django apps with server mode

### DIFF
--- a/.github/workflows/devel_server_install.yaml
+++ b/.github/workflows/devel_server_install.yaml
@@ -40,7 +40,7 @@ jobs:
         else
            BRANCH=${{ github.event.inputs.git-ref }}
         fi
-        # Add openquake user
+        # Update system and install utilities
         dnf update -y
         dnf install -y ${{ matrix.python-version }}
         dnf install -y git git-lfs nc procps sudo

--- a/.github/workflows/devel_server_install.yaml
+++ b/.github/workflows/devel_server_install.yaml
@@ -1,5 +1,5 @@
 ---
-name: OQ devel server
+name: Devel Server Installation of OQ on RH OS
 on:
   workflow_dispatch:
     inputs:
@@ -12,16 +12,15 @@ on:
 
 jobs:
   test_ui:
-    name: OQ Devel Server on RH based (fedora container) ${{ matrix.python-version }}
+    name: Test on RH based (fedora container) ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     env:
       GITHUB_DEF_BR:  ${{ github.event.repository.default_branch }}
     strategy:
-      fail-fast: false
       matrix:
         python-version: ["python3.11", "python3.12", "python3.13"]
     container:
-      image: fedora:41
+      image: fedora:44
       options: --privileged
     steps:
     - name: Clone Repository (Master)
@@ -41,7 +40,7 @@ jobs:
         else
            BRANCH=${{ github.event.inputs.git-ref }}
         fi
-        # update system and install utilities
+        # Add openquake user
         dnf update -y
         dnf install -y ${{ matrix.python-version }}
         dnf install -y git git-lfs nc procps sudo
@@ -56,8 +55,10 @@ jobs:
         #
         echo "branch to test: ${BRANCH}"
         cd /__w/oq-engine/oq-engine/
-        eval '$mypython -m pip install -U pip setuptools wheel'
         eval '$mypython install.py --version $BRANCH devel_server'
+        if [[ $EXIT_CODE -ne 0 ]]; then
+                break
+        fi
     - name: Actualize 'default' templates for email notifications
       run: |
         cd /__w/oq-engine/oq-engine/
@@ -68,7 +69,6 @@ jobs:
       run: |
          set -o pipefail
          source /opt/openquake/venv/bin/activate
-         pip freeze
          mkdir -p /var/log/oq-engine/
          chown -R openquake /var/log/oq-engine/
          runuser -l openquake -c '/opt/openquake/venv/bin/oq engine --upgrade-db'

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -95,8 +95,10 @@ jobs:
           # Perform migration after setup local_settings
           /opt/openquake/venv/bin/python3 manage.py migrate
           /opt/openquake/venv/bin/python3 manage.py createuser openquake testuser1@test.com --level 1 --password level_1_password --no-email
-          # START WEBUI
-          runuser -l openquake -c '/opt/openquake/venv/bin/oq webui start 127.0.0.1:8800 -s &'
+          # STOP AND START WEBUI
+          systemctl stop openquake-webui
+          sleep 10
+          systemctl start openquake-webui
           echo "Waiting WEBUI up on port 8800...."
           echo "Test WebUI with curl before to test django"
           while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://127.0.0.1:8800/accounts/login/)" != "200" ]]; do
@@ -133,7 +135,7 @@ jobs:
           fi
           echo " Run a calc using https"
           runuser -l openquake -c '/opt/openquake/venv/bin/oq engine --run https://downloads.openquake.org/jobs/M4_Exercise.zip'
-          sleep 5
+          sleep 10
           status_code=$($CURL_BIN -w "%{http_code}"\
              -d "$DJANGO_TOKEN&username=$YOUR_USER&password=$YOUR_PASS" \
              -G http://127.0.0.1:8800/engine/1/outputs -o /dev/null)
@@ -147,7 +149,7 @@ jobs:
           set -o pipefail
           source /opt/openquake/venv/bin/activate
           echo "Restart WebUI without authentication"
-          runuser -l openquake -c 'pkill oq-webui'
+          systemctl stop openquake-webui
           sleep 5
           runuser -l openquake -c 'OQ_APPLICATION_MODE=PUBLIC /opt/openquake/venv/bin/oq webui start 127.0.0.1:8800 -s &'
           echo "Waiting WEBUI up on port 8800...."

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -1,0 +1,172 @@
+---
+name: Server Installation of OQ
+on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Ref Branch
+        default: master
+        required: true
+      debug_enabled:
+        type: boolean
+        description: "Run the build with tmate debugging enabled"
+        required: false
+        default: false
+  schedule:
+    - cron: "05 11 * * *"
+
+jobs:
+  Sever_Installation:
+    name: Server OQ  Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_DEF_BR: ${{ github.event.repository.default_branch }}
+      GITHUB_REF: ${{ github.ref }}
+      GITHUB_HD_REF: ${{ github.head_ref }}}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - name: Clone Repository (Master)
+        uses: actions/checkout@v6
+        if: github.event.inputs.git-ref == ''
+      - name: Clone Repository (Custom Ref)
+        uses: actions/checkout@v6
+        if: github.event.inputs.git-ref != ''
+        with:
+          ref: ${{ github.event.inputs.git-ref }}
+      - name: Set up Python  ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install OQ Server with ${{ matrix.python-version }}
+        run: |
+          if [ -z ${{ github.event.inputs.git-ref }} ];
+          then
+             BRANCH=master
+          else
+             BRANCH=${{ github.event.inputs.git-ref }}
+          fi
+          sudo -H python install.py --version $BRANCH server
+          if [[ $EXIT_CODE -ne 0 ]]; then
+                break
+          fi
+      - name: Actualize 'default' templates for email notifications
+        run: |
+          pwd
+          for file in openquake/server/templates/registration/*.default.tmpl; do
+            cp -- "$file" "${file%.default.tmpl}"
+          done
+      - name: WebUI and calculation with Auth
+        shell: sudo su root -c "bash --noprofile --norc -e -o pipefail {0}"
+        run: |
+          whoami  # Outputs: root
+          set -o pipefail
+          source /opt/openquake/venv/bin/activate
+          mkdir -p /var/log/oq-engine/
+          chown -R openquake /var/log/oq-engine/
+          runuser -l openquake -c '/opt/openquake/venv/bin/oq engine --upgrade-db'
+          oq --version
+          #
+          echo "Add settings for login and logging on webui before to start"
+          cd /home/runner/work/oq-engine/oq-engine
+          cd openquake/server
+          cat > local_settings.py << EOF
+          APPLICATION_MODE = "RESTRICTED"
+          EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+          EMAIL_HOST = 'smtp.gmail.com'
+          EMAIL_PORT = 587
+          EMAIL_USE_TLS = True
+          EMAIL_HOST_USER = 'admin@reply.com'
+          EMAIL_HOST_PASSWORD = 'polhjuih@'
+          EMAIL_SUPPORT = 'noreply@reply.com'
+          WEBUI_ACCESS_LOG_DIR = '/var/log/oq-engine'
+          EOF
+          echo "DISPLAY content of local_settings"
+          cat local_settings.py
+          # Perform migration after setup local_settings
+          cd /home/runner/work/oq-engine/oq-engine/openquake/server/
+          runuser -l openquake -c 'cd /home/runner/work/oq-engine/oq-engine/openquake/server/ ; /opt/openquake/venv/bin/python3 manage.py migrate'
+          runuser -l openquake -c 'cd /home/runner/work/oq-engine/oq-engine/openquake/server/ ; /opt/openquake/venv/bin/python3 manage.py createuser openquake testuser1@test.com --level 1 --password level_1_password --no-email'
+          # START WEBUI
+          runuser -l openquake -c '/opt/openquake/venv/bin/oq webui start 127.0.0.1:8800 -s &'
+          echo "Waiting WEBUI up on port 8800...."
+          echo "Test WebUI with curl before to test django"
+          while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://127.0.0.1:8800/accounts/login/)" != "200" ]]; do
+            echo "Still waiting WEBUI account login up on port 8800...."
+            sleep 5 # wait for 5 seconds before check again
+          done
+          echo -n "TEST DJANGO LOGIN "
+          LOGIN_URL=http://127.0.0.1:8800/accounts/login/
+          YOUR_USER='openquake'
+          YOUR_PASS='level_1_password'
+          COOKIES=cookies.txt
+          CURL_BIN="curl -s -c $COOKIES -b $COOKIES -e $LOGIN_URL"
+          echo -n "Django Auth: get csrftoken ..."
+          $CURL_BIN $LOGIN_URL -o /dev/null
+          DJANGO_TOKEN="csrfmiddlewaretoken=$(grep csrftoken $COOKIES | sed 's/^.*csrftoken\s*//')"
+          echo " perform login ..."
+          status_code=$($CURL_BIN -w "%{http_code}"\
+             -d "$DJANGO_TOKEN&username=$YOUR_USER&password=$YOUR_PASS" \
+             -X POST $LOGIN_URL -o /dev/null)
+          if [ $status_code != "302" ]; then
+           echo "Unable to login"
+           exit 1
+          fi
+          echo "--------------------"
+          echo "display log of webui"
+          echo "--------------------"
+          cat /var/log/oq-engine/webui-access.log
+          if [ -s /var/log/oq-engine/webui-access.log ]; then
+           # The file is not-empty.
+           cat /var/log/oq-engine/webui-access.log
+          else
+           echo "/var/log/oq-engine/webui-access.log is empty. Something did not work as expected"
+           exit 1
+          fi
+          echo " Run a calc using https"
+          runuser -l openquake -c '/opt/openquake/venv/bin/oq engine --run https://downloads.openquake.org/jobs/M4_Exercise.zip'
+          sleep 5
+          status_code=$($CURL_BIN -w "%{http_code}"\
+             -d "$DJANGO_TOKEN&username=$YOUR_USER&password=$YOUR_PASS" \
+             -G http://127.0.0.1:8800/engine/1/outputs -o /dev/null)
+          if [ $status_code != "200" ]; then
+           echo "Unable to visualize outputs"
+           exit 1
+          fi
+      - name: WebUI on PUBLIC
+        shell: sudo su root -c "bash --noprofile --norc -e -o pipefail {0}"
+        run: |
+          set -o pipefail
+          source /opt/openquake/venv/bin/activate
+          echo "Restart WebUI without authentication"
+          runuser -l openquake -c 'pkill oq-webui'
+          sleep 5
+          runuser -l openquake -c 'OQ_APPLICATION_MODE=PUBLIC /opt/openquake/venv/bin/oq webui start 127.0.0.1:8800 -s &'
+          echo "Waiting WEBUI up on port 8800...."
+          while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://127.0.0.1:8800/engine/)" != "200" ]]; do
+           echo "Still waiting WEBUI on port 8800...."
+           sleep 5 # wait for 5 seconds before check again
+          done
+          echo -n "Test Standalone Tools pages (without authentication)"
+          read status_code redirect_url <<<"$(
+           curl -s -o /dev/null -w "%{http_code} %{redirect_url}" http://127.0.0.1:8800/
+          )"
+          if [ "$status_code" != "301" ] || [ "$redirect_url" != "http://127.0.0.1:8800/engine/" ]; then
+           echo "Unexpected redirect: status=$status_code redirect=$redirect_url"
+           echo "Should redirect to http://127.0.0.1:8800/engine/"
+           exit 1
+          fi
+          status_code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8800/taxonomy/)
+          if [ $status_code != "200" ]; then
+           echo "Unable access the taxonomy standalone app"
+           exit 1
+          fi
+          status_code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8800/ipt/)
+          if [ $status_code != "200" ]; then
+           echo "Unable to access the ipt standalone app"
+           exit 1
+          fi
+          echo " Run a calc using https"
+          runuser -l openquake -c '/opt/openquake/venv/bin/oq engine --run https://downloads.openquake.org/jobs/eb_risk_demo.zip'

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -58,15 +58,12 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Actualize 'default' templates for email notifications
         run: |
-          cd /home/runner/work/oq-engine/oq-engine/
-          ls -lrt openquake/server/templates/registration/*.default.tmpl
-          DEST_DIR="/opt/openquake/venv/lib/python${{ matrix.python-version }}/site-packages/openquake/server/templates/registration"
-          for file in /home/runner/work/oq-engine/oq-engine/openquake/server/templates/registration/*.default.tmpl; do
-            filename=$(basename -- "$file")
-            new_filename="${filename%.default.tmpl}"
-            cp -- "$file" "${DEST_DIR}/${new_filename}"
+          SITE-PKG="/opt/openquake/venv/lib/python${{ matrix.python-version }}/site-packages/"
+          cd ${SITE-PKG}
+          for file in openquake/server/templates/registration/*.default.tmpl; do
+             echo ' cp -- "$file" "${file%.default.tmpl}" '
+             cp -- "$file" "${file%.default.tmpl}"
           done
-          ls -lrt ${DEST_DIR}
       - name: WebUI and calculation with Auth
         shell: sudo su root -c "bash --noprofile --norc -e -o pipefail {0}"
         run: |

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -52,6 +52,10 @@ jobs:
           if [[ $EXIT_CODE -ne 0 ]]; then
                 break
           fi
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 60
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Actualize 'default' templates for email notifications
         run: |
           pwd

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -66,7 +66,6 @@ jobs:
         shell: sudo su root -c "bash --noprofile --norc -e -o pipefail {0}"
         run: |
           whoami  # Outputs: root
-          set -o pipefail
           source /opt/openquake/venv/bin/activate
           mkdir -p /var/log/oq-engine/
           chown -R openquake /var/log/oq-engine/
@@ -74,8 +73,7 @@ jobs:
           oq --version
           #
           echo "Add settings for login and logging on webui before to start"
-          cd /home/runner/work/oq-engine/oq-engine
-          cd openquake/server
+          cd /home/runner/work/oq-engine/oq-engine/openquake/server
           cat > local_settings.py << EOF
           APPLICATION_MODE = "RESTRICTED"
           EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
@@ -90,9 +88,9 @@ jobs:
           echo "DISPLAY content of local_settings"
           cat local_settings.py
           # Perform migration after setup local_settings
-          cd /home/runner/work/oq-engine/oq-engine/openquake/server/
-          runuser -l openquake -c 'cd /home/runner/work/oq-engine/oq-engine/openquake/server/ ; /opt/openquake/venv/bin/python3 manage.py migrate'
-          runuser -l openquake -c 'cd /home/runner/work/oq-engine/oq-engine/openquake/server/ ; /opt/openquake/venv/bin/python3 manage.py createuser openquake testuser1@test.com --level 1 --password level_1_password --no-email'
+          cd /home/runner/work/oq-engine/oq-engine/openquake/server
+          /opt/openquake/venv/bin/python3 ./manage.py migrate
+          /opt/openquake/venv/bin/python3 ./manage.py createuser openquake testuser1@test.com --level 1 --password level_1_password --no-email
           # START WEBUI
           runuser -l openquake -c '/opt/openquake/venv/bin/oq webui start 127.0.0.1:8800 -s &'
           echo "Waiting WEBUI up on port 8800...."

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -76,7 +76,9 @@ jobs:
           oq --version
           #
           echo "Add settings for login and logging on webui before to start"
-          cd /home/runner/work/oq-engine/oq-engine/openquake/server
+          SITE_PKG="/opt/openquake/venv/lib/python${{ matrix.python-version }}/site-packages/"
+          cd  ${SITE_PKG}
+          cd openquake/server
           cat > local_settings.py << EOF
           APPLICATION_MODE = "RESTRICTED"
           EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
@@ -91,7 +93,6 @@ jobs:
           echo "DISPLAY content of local_settings"
           cat local_settings.py
           # Perform migration after setup local_settings
-          cd /home/runner/work/oq-engine/oq-engine/openquake/server
           /opt/openquake/venv/bin/python3 manage.py migrate
           /opt/openquake/venv/bin/python3 manage.py createuser openquake testuser1@test.com --level 1 --password level_1_password --no-email
           # START WEBUI

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -60,10 +60,13 @@ jobs:
         run: |
           cd /home/runner/work/oq-engine/oq-engine/
           ls -lrt openquake/server/templates/registration/*.default.tmpl
+          DEST_DIR="/opt/openquake/venv/lib/${{ matrix.python-version }}/site-packages/openquake/server/templates/registration"
           for file in /home/runner/work/oq-engine/oq-engine/openquake/server/templates/registration/*.default.tmpl; do
-            cp -- "$file" "${file%.default.tmpl}"
+            filename=$(basename -- "$file")
+            new_filename="${filename%.default.tmpl}"
+            cp -- "$file" "${DEST_DIR}/${new_filename}"
           done
-          ls -lrt ./openquake/server/templates/registration/
+          ls -lrt ${DEST_DIR}
       - name: WebUI and calculation with Auth
         shell: sudo su root -c "bash --noprofile --norc -e -o pipefail {0}"
         run: |

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           cd /home/runner/work/oq-engine/oq-engine/
           ls -lrt openquake/server/templates/registration/*.default.tmpl
-          DEST_DIR="/opt/openquake/venv/lib/${{ matrix.python-version }}/site-packages/openquake/server/templates/registration"
+          DEST_DIR="/opt/openquake/venv/lib/python${{ matrix.python-version }}/site-packages/openquake/server/templates/registration"
           for file in /home/runner/work/oq-engine/oq-engine/openquake/server/templates/registration/*.default.tmpl; do
             filename=$(basename -- "$file")
             new_filename="${filename%.default.tmpl}"

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -58,10 +58,12 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Actualize 'default' templates for email notifications
         run: |
-          pwd
-          for file in openquake/server/templates/registration/*.default.tmpl; do
+          cd /home/runner/work/oq-engine/oq-engine/
+          ls -lrt openquake/server/templates/registration/*.default.tmpl
+          for file in /home/runner/work/oq-engine/oq-engine/openquake/server/templates/registration/*.default.tmpl; do
             cp -- "$file" "${file%.default.tmpl}"
           done
+          ls -lrt ./openquake/server/templates/registration/
       - name: WebUI and calculation with Auth
         shell: sudo su root -c "bash --noprofile --norc -e -o pipefail {0}"
         run: |
@@ -89,8 +91,8 @@ jobs:
           cat local_settings.py
           # Perform migration after setup local_settings
           cd /home/runner/work/oq-engine/oq-engine/openquake/server
-          /opt/openquake/venv/bin/python3 ./manage.py migrate
-          /opt/openquake/venv/bin/python3 ./manage.py createuser openquake testuser1@test.com --level 1 --password level_1_password --no-email
+          /opt/openquake/venv/bin/python3 manage.py migrate
+          /opt/openquake/venv/bin/python3 manage.py createuser openquake testuser1@test.com --level 1 --password level_1_password --no-email
           # START WEBUI
           runuser -l openquake -c '/opt/openquake/venv/bin/oq webui start 127.0.0.1:8800 -s &'
           echo "Waiting WEBUI up on port 8800...."

--- a/.github/workflows/server_install.yaml
+++ b/.github/workflows/server_install.yaml
@@ -48,7 +48,7 @@ jobs:
           else
              BRANCH=${{ github.event.inputs.git-ref }}
           fi
-          sudo -H python install.py --version $BRANCH server
+          sudo -H "$(which python3)" install.py --version $BRANCH server
           if [[ $EXIT_CODE -ne 0 ]]; then
                 break
           fi
@@ -58,12 +58,13 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Actualize 'default' templates for email notifications
         run: |
-          SITE-PKG="/opt/openquake/venv/lib/python${{ matrix.python-version }}/site-packages/"
-          cd ${SITE-PKG}
+          SITE_PKG="/opt/openquake/venv/lib/python${{ matrix.python-version }}/site-packages/"
+          cd ${SITE_PKG}
           for file in openquake/server/templates/registration/*.default.tmpl; do
              echo ' cp -- "$file" "${file%.default.tmpl}" '
              cp -- "$file" "${file%.default.tmpl}"
           done
+          ls -lrt ${SITE_PKG}/openquake/server/templates/registration/
       - name: WebUI and calculation with Auth
         shell: sudo su root -c "bash --noprofile --norc -e -o pipefail {0}"
         run: |

--- a/.github/workflows/webui_rh_test.yml
+++ b/.github/workflows/webui_rh_test.yml
@@ -1,5 +1,5 @@
 ---
-name: OQ devel server Test WebUI on RH based OS
+name: OQ devel server
 on:
   workflow_dispatch:
     inputs:
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["python3.11", "python3.12", "python3.13"]
-        req-version: [py312]
     container:
       image: fedora:41
       options: --privileged
@@ -44,7 +43,7 @@ jobs:
         # update system and install utilities
         dnf update -y
         dnf install -y ${{ matrix.python-version }}
-        dnf install -y git git-lfs nc procps
+        dnf install -y git git-lfs nc procps sudo
         # define it
         mypython=${{ matrix.python-version }}
         #run it
@@ -58,9 +57,6 @@ jobs:
         cd /__w/oq-engine/oq-engine/
         eval '$mypython -m pip install -U pip setuptools wheel'
         eval '$mypython install.py --version $BRANCH devel_server'
-        if [[ $EXIT_CODE -ne 0 ]]; then
-                break
-        fi
     - name: Actualize 'default' templates for email notifications
       run: |
         cd /__w/oq-engine/oq-engine/

--- a/.github/workflows/webui_rh_test.yml
+++ b/.github/workflows/webui_rh_test.yml
@@ -1,5 +1,5 @@
 ---
-name: Test WebUI on RH based OS
+name: OQ devel server Test WebUI on RH based OS
 on:
   workflow_dispatch:
     inputs:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test_ui:
-    name: Test on RH based (fedora container)
+    name: Test on RH based (fedora container) OQ devel server ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     env:
       GITHUB_DEF_BR:  ${{ github.event.repository.default_branch }}

--- a/.github/workflows/webui_rh_test.yml
+++ b/.github/workflows/webui_rh_test.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       GITHUB_DEF_BR:  ${{ github.event.repository.default_branch }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["python3.11", "python3.12", "python3.13"]
     container:

--- a/.github/workflows/webui_rh_test.yml
+++ b/.github/workflows/webui_rh_test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test_ui:
-    name: Test on RH based (fedora container) OQ devel server ${{ matrix.python-version }}
+    name: OQ Devel Server on RH based (fedora container) ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     env:
       GITHUB_DEF_BR:  ${{ github.event.repository.default_branch }}

--- a/.github/workflows/webui_rh_test.yml
+++ b/.github/workflows/webui_rh_test.yml
@@ -18,7 +18,7 @@ jobs:
       GITHUB_DEF_BR:  ${{ github.event.repository.default_branch }}
     strategy:
       matrix:
-        python-version: [python3.12]
+        python-version: ["python3.11", "python3.12", "python3.13"]
         req-version: [py312]
     container:
       image: fedora:41
@@ -41,15 +41,12 @@ jobs:
         else
            BRANCH=${{ github.event.inputs.git-ref }}
         fi
-        # Add openquake user
-        useradd -m -u 1000 -s /bin/bash openquake
         # update system and install utilities
         dnf update -y
         dnf install -y ${{ matrix.python-version }}
         dnf install -y git git-lfs nc procps
         # define it
         mypython=${{ matrix.python-version }}
-        reqpython=${{ matrix.req-version }}
         #run it
         eval '$mypython -c "import sys; print(sys.version)"'
         #
@@ -60,39 +57,10 @@ jobs:
         echo "branch to test: ${BRANCH}"
         cd /__w/oq-engine/oq-engine/
         eval '$mypython -m pip install -U pip setuptools wheel'
-        eval '$mypython -m venv /opt/openquake/venv '
-        source /opt/openquake/venv/bin/activate
-        eval '$mypython -m pip install -r "requirements-$reqpython-linux64.txt"'
-        eval '$mypython -m pip install -e . '
-        ## Standalone apps
-        echo "Downloading standalone apps"
-        for app in oq-platform-standalone django-gem-taxonomy oq-platform-ipt oq-platform-taxonomy; do
-            for branch in "$BRANCH" "master" "main"; do
-                TOOLS_BRANCH="$branch"
-                # do not fail on exit code 2 if the branch
-                # does not exist in the app repository
-                set +e
-                git ls-remote --exit-code --heads https://github.com/gem/${app}.git $TOOLS_BRANCH >/dev/null 2>&1
-                EXIT_CODE=$?
-                # set again to fail on exit code not 0
-                set -e
-                if [[ $EXIT_CODE -eq 0 ]]; then
-                    echo "Git branch '$BRANCH' exists in the remote repository"
-                    break
-                fi
-            done
-            if [[ $EXIT_CODE -ne 0 ]]; then
+        eval '$mypython install.py --version $BRANCH devel_server'
+        if [[ $EXIT_CODE -ne 0 ]]; then
                 break
-            fi
-            echo "We need to use the branch $TOOLS_BRANCH for the standalone apps"
-            git clone -b ${TOOLS_BRANCH} --depth=1 https://github.com/gem/${app}.git
-            eval '$mypython -m pip install -e ./${app}'
-        done
-        if [ $EXIT_CODE -ne 0 ]; then
-            echo "No '$branch', nor 'master' or 'main' branch found for '$app' django app; failed"
-            exit 1
         fi
-        deactivate
     - name: Actualize 'default' templates for email notifications
       run: |
         cd /__w/oq-engine/oq-engine/

--- a/install.py
+++ b/install.py
@@ -611,7 +611,7 @@ def install(inst, version, from_fork, novenv, noupgrade):
     if inst in (user, devel):  # create/upgrade the db in the default location
         subprocess.run([oqreal, "engine", "--upgrade-db"])
 
-    errors += postinstall_standalone(inst.VENV)
+    errors += postinstall_standalone(inst)
 
     if (
         inst is server

--- a/install.py
+++ b/install.py
@@ -113,6 +113,7 @@ class server:
         DBPORT,
         DBPATH,
     )
+    USER = "openquake"
 
     @classmethod
     def exit(cls):
@@ -145,6 +146,7 @@ class devel_server:
         DBPORT,
         DBPATH,
     )
+    USER = "openquake"
     exit = server.exit
 
 
@@ -171,6 +173,7 @@ class user:
     DBPATH = os.path.join(OQDATA, "db.sqlite3")
     DBPORT = 1908
     CONFIG = ""
+    USER = None
 
     @classmethod
     def exit(cls):
@@ -274,7 +277,7 @@ def get_requirements_branch(version, inst, from_fork):
         return version
 
 
-def install_or_postinstall_standalone(venv, is_install=True):
+def install_or_postinstall_standalone(inst, is_install=True):
     """
     Install the standalone Django applications if possible or
     run '<app>_postinstall' command if it exists
@@ -332,7 +335,7 @@ def install_or_postinstall_standalone(venv, is_install=True):
                 subprocess.check_call(
                     [os.path.join(inst.VENV, *django_admin),
                      "openquake_engine_postinstall", app['name']],
-                    env=django_env)
+                    env=django_env, user=inst.USER)
             except Exception as exc:
                 # for instance is somebody removed a wheel from the wheelhouse
                 errors.append("%s: error during %s postinstall command execution" % (exc, app['name']))
@@ -340,11 +343,11 @@ def install_or_postinstall_standalone(venv, is_install=True):
     return errors
 
 
-def install_standalone(venv):
-    return install_or_postinstall_standalone(venv, is_install=True)
+def install_standalone(inst):
+    return install_or_postinstall_standalone(inst, is_install=True)
 
-def postinstall_standalone(venv):
-    return install_or_postinstall_standalone(venv, is_install=False)
+def postinstall_standalone(inst):
+    return install_or_postinstall_standalone(inst, is_install=False)
 
 def before_checks(inst, args, usage):
     """
@@ -581,7 +584,7 @@ def install(inst, version, from_fork, novenv, noupgrade):
                 env=custom_env)
         fix_version(commit, inst.VENV)
 
-    errors = install_standalone(inst.VENV)
+    errors = install_standalone(inst)
 
     # create openquake.cfg
     if inst is server or inst is devel_server:

--- a/install.py
+++ b/install.py
@@ -343,9 +343,9 @@ def install_or_postinstall_standalone(inst, is_install=True):
                                'server', 'manage.py')
 
         # Run python manage.py migrate before running app postinstall
-        _run_subprocess(
-            inst,
-            [os.path.join(inst.VENV, *python), mpy, "migrate"])
+#        _run_subprocess(
+#            inst,
+#            [os.path.join(inst.VENV, *python), mpy, "migrate"])
 
         for app in STANDALONE_APP_INFO:
             if not app['name']:

--- a/install.py
+++ b/install.py
@@ -43,7 +43,6 @@ import tempfile
 import argparse
 import platform
 import subprocess
-import site
 from urllib.request import urlopen, Request
 
 try:
@@ -278,6 +277,16 @@ def get_requirements_branch(version, inst, from_fork):
         return version
 
 
+def _run_subprocess(inst, args):
+    # Run subprocess use sudo if inst.USER != None
+    if inst.USER is None:
+        subprocess.check_call(args)
+    else:
+        # user=inst.USER does not appear to work in the same
+        # way as sudo -u $USER
+        subprocess.check_call(['sudo', '-u', inst.USER] + args)
+
+
 def install_or_postinstall_standalone(inst, is_install=True):
     """
     Install the standalone Django applications if possible or
@@ -320,6 +329,24 @@ def install_or_postinstall_standalone(inst, is_install=True):
                 # for instance is somebody removed a wheel from the wheelhouse
                 errors.append("%s: could not install %s" % (exc, app['pkg']))
     else:
+        # Obtain paths for python and manage.py in VENV, we cannot use
+        # site.getsitepackages here since we are not yet running in the venv
+        if sys.platform == "win32":
+            python = ['Scripts', 'python.exe']
+            mpy = os.path.join(inst.VENV, 'lib', 'site-packages',
+                               'openquake', 'server', 'manage.py')
+        else:
+            python = ["bin", "python"]
+            mpy = os.path.join(inst.VENV, 'lib',
+                               f'python{PYVER[0]}.{PYVER[1]}',
+                               'site-packages', 'openquake',
+                               'server', 'manage.py')
+
+        # Run python manage.py migrate before running app postinstall
+        _run_subprocess(
+            inst,
+            [os.path.join(inst.VENV, *python), mpy, "migrate"])
+
         for app in STANDALONE_APP_INFO:
             if not app['name']:
                 continue
@@ -329,24 +356,17 @@ def install_or_postinstall_standalone(inst, is_install=True):
                 #     django_admin = ['Scripts', 'django-admin.exe']
                 # else:
                 #     django_admin = ["bin", "django-admin"]
-                if sys.platform == "win32":
-                    python = ['Scripts', 'python.exe']
-                else:
-                    python = ["bin", "python"]
 
                 # django_env = os.environ.copy()
                 # django_env[
                 #     "DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
 
-                # This returns a list of all site-packages paths for the
-                # current environment
-                site_packages_dirs = site.getsitepackages()
-                manage_path = os.path.join(site_packages_dirs[0],
-                                           'openquake', 'server', 'manage.py')
-                subprocess.check_call(
+                # Run python manage.py postinstall
+                _run_subprocess(
+                    inst,
                     [os.path.join(inst.VENV, *python),
-                        manage_path, "openquake_engine_postinstall",
-                        app['name']], user=inst.USER)
+                        mpy, "openquake_engine_postinstall",
+                        app['name']])
                 # if inst.USER is None:
                 #     subprocess.check_call(
                 #         [os.path.join(inst.VENV, *django_admin),

--- a/install.py
+++ b/install.py
@@ -320,10 +320,16 @@ def install_or_postinstall_standalone(inst, is_install=True):
         pycmd = inst.VENV + "/bin/python3"
 
     STANDALONE_APP_INFO = [
-        {"pkg": "oq-platform-standalone", "name": None},
-        {"pkg": "oq-platform-ipt",       "name": "openquakeplatform_ipt"},
-        {"pkg": "oq-platform-taxonomy",  "name": "openquakeplatform_taxonomy"},
-        {"pkg": "django-gem-taxonomy",   "name": "django_gem_taxonomy"},
+        # All engine Django app need oq-platform-standalone
+        {"pkg": "oq-platform-standalone", "name": None,
+         "ver": "~=2.16.4"},
+        # Django apps to install
+        {"pkg": "oq-platform-ipt",        "name": "openquakeplatform_ipt",
+         "ver": "~=1.21.0"},
+        {"pkg": "oq-platform-taxonomy",   "name": "openquakeplatform_taxonomy",
+         "ver": "~=1.1.0"},
+        {"pkg": "django-gem-taxonomy",    "name": "django_gem_taxonomy",
+         "ver": "~=1.4.4"},
     ]
 
     if is_install:
@@ -336,7 +342,7 @@ def install_or_postinstall_standalone(inst, is_install=True):
                      "--no-index", "--no-cache-dir",
                      "--find-links", WHEELHOUSE_URL,
                      "--find-links", URL_STANDALONE,
-                     app['pkg']]
+                     app['pkg'] + app['ver']]
                 )
             except Exception as exc:
                 # for instance is somebody removed a wheel from the wheelhouse
@@ -359,38 +365,12 @@ def install_or_postinstall_standalone(inst, is_install=True):
                 continue
 
             try:
-                # if sys.platform == "win32":
-                #     django_admin = ['Scripts', 'django-admin.exe']
-                # else:
-                #     django_admin = ["bin", "django-admin"]
-
-                # django_env = os.environ.copy()
-                # django_env[
-                #     "DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
-
                 # Run python manage.py postinstall
                 _run_subprocess(
                     inst,
                     [os.path.join(inst.VENV, *python),
                         inst.MPY, "openquake_engine_postinstall",
                         app['name']])
-                # if inst.USER is None:
-                #     subprocess.check_call(
-                #         [os.path.join(inst.VENV, *django_admin),
-                #          "openquake_engine_postinstall", app['name']],
-                #         env=django_env)
-                # else:
-                #     manage_path = os.path.join(
-                #         'openquake', 'server', 'manage.py')
-                #     # subprocess.check_call(
-                #     #     ["sudo", "-u", inst.USER,
-                #     #      "DJANGO_SETTINGS_MODULE=openquake.server.settings",
-                #     #      os.path.join(inst.VENV, *manage_path),
-                #     #      "openquake_engine_postinstall", app['name']])
-                #     subprocess.check_call(
-                #         [os.path.join(inst.VENV, *python),
-                #          manage_path, "openquake_engine_postinstall",
-                #          app['name']], user=inst.USER)
             except Exception as exc:
                 # for instance is somebody removed a wheel from the wheelhouse
                 errors.append(

--- a/install.py
+++ b/install.py
@@ -722,6 +722,7 @@ if __name__ == "__main__":
     parser.set_defaults(from_fork=False)
     args = parser.parse_args()
     if args.inst:
+        # set inst to the class named as the string args.inst
         inst = globals()[args.inst]
         before_checks(inst, args, parser.format_usage())
         if args.remove:

--- a/install.py
+++ b/install.py
@@ -327,7 +327,7 @@ def install_or_postinstall_standalone(inst, is_install=True):
         {"pkg": "oq-platform-ipt",        "name": "openquakeplatform_ipt",
          "ver": "~=1.21.0"},
         {"pkg": "oq-platform-taxonomy",   "name": "openquakeplatform_taxonomy",
-         "ver": "~=1.1.0"},
+         "ver": "~=1.2.0"},
         {"pkg": "django-gem-taxonomy",    "name": "django_gem_taxonomy",
          "ver": "~=1.4.4"},
     ]

--- a/install.py
+++ b/install.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# vim: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
 #
 # Copyright (C) 2020-2026 GEM Foundation
 #
@@ -114,6 +114,10 @@ class server:
         DBPATH,
     )
     USER = "openquake"
+    MPY = os.path.join(VENV, 'lib',
+                       f'python{PYVER[0]}.{PYVER[1]}',
+                       'site-packages', 'openquake',
+                       'server', 'manage.py')
 
     @classmethod
     def exit(cls):
@@ -148,6 +152,7 @@ class devel_server:
     )
     USER = "openquake"
     exit = server.exit
+    MPY = os.path.join('openquake', 'server', 'manage.py')
 
 
 class user:
@@ -164,10 +169,17 @@ class user:
             VENV = os.path.expanduser("~\\openquake")
             OQ = os.path.join(VENV, "\\Scripts\\oq")
             OQDATA = os.path.expanduser("~\\oqdata")
+        MPY = os.path.join(VENV, 'lib',
+                           'site-packages', 'openquake',
+                           'server', 'manage.py')
     else:
         VENV = os.path.expanduser("~/openquake")
         OQ = os.path.join(VENV, "/bin/oq")
         OQDATA = os.path.expanduser("~/oqdata")
+        MPY = os.path.join(VENV, 'lib',
+                           f'python{PYVER[0]}.{PYVER[1]}',
+                           'site-packages', 'openquake',
+                           'server', 'manage.py')
 
     CFG = os.path.join(VENV, "openquake.cfg")
     DBPATH = os.path.join(OQDATA, "db.sqlite3")
@@ -187,6 +199,7 @@ class devel(user):
     Parameters for a devel installation (same as user)
     """
 
+    MPY = os.path.join('openquake', 'server', 'manage.py')
     exit = user.exit
 
 
@@ -333,19 +346,13 @@ def install_or_postinstall_standalone(inst, is_install=True):
         # site.getsitepackages here since we are not yet running in the venv
         if sys.platform == "win32":
             python = ['Scripts', 'python.exe']
-            mpy = os.path.join(inst.VENV, 'lib', 'site-packages',
-                               'openquake', 'server', 'manage.py')
         else:
             python = ["bin", "python"]
-            mpy = os.path.join(inst.VENV, 'lib',
-                               f'python{PYVER[0]}.{PYVER[1]}',
-                               'site-packages', 'openquake',
-                               'server', 'manage.py')
 
         # Run python manage.py migrate before running app postinstall
-#        _run_subprocess(
-#            inst,
-#            [os.path.join(inst.VENV, *python), mpy, "migrate"])
+        _run_subprocess(
+            inst,
+            [os.path.join(inst.VENV, *python), inst.MPY, "migrate"])
 
         for app in STANDALONE_APP_INFO:
             if not app['name']:
@@ -365,7 +372,7 @@ def install_or_postinstall_standalone(inst, is_install=True):
                 _run_subprocess(
                     inst,
                     [os.path.join(inst.VENV, *python),
-                        mpy, "openquake_engine_postinstall",
+                        inst.MPY, "openquake_engine_postinstall",
                         app['name']])
                 # if inst.USER is None:
                 #     subprocess.check_call(

--- a/install.py
+++ b/install.py
@@ -324,25 +324,40 @@ def install_or_postinstall_standalone(inst, is_install=True):
                 continue
 
             try:
+                # if sys.platform == "win32":
+                #     django_admin = ['Scripts', 'django-admin.exe']
+                # else:
+                #     django_admin = ["bin", "django-admin"]
                 if sys.platform == "win32":
-                    django_admin = ['Scripts', 'django-admin.exe']
+                    python = ['Scripts', 'python.exe']
                 else:
-                    django_admin = ["bin", "django-admin"]
+                    python = ["bin", "python"]
 
-                django_env = os.environ.copy()
-                django_env[
-                    "DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
-                if inst.USER is None:
-                    subprocess.check_call(
-                        [os.path.join(inst.VENV, *django_admin),
-                         "openquake_engine_postinstall", app['name']],
-                        env=django_env)
-                else:
-                    subprocess.check_call(
-                        ["sudo", "-u", inst.USER,
-                         "DJANGO_SETTINGS_MODULE=openquake.server.settings",
-                         os.path.join(inst.VENV, *django_admin),
-                         "openquake_engine_postinstall", app['name']])
+                # django_env = os.environ.copy()
+                # django_env[
+                #     "DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
+                manage_path = os.path.join('openquake', 'server', 'manage.py')
+                subprocess.check_call(
+                    [os.path.join(inst.VENV, *python),
+                        manage_path, "openquake_engine_postinstall",
+                        app['name']], user=inst.USER)
+                # if inst.USER is None:
+                #     subprocess.check_call(
+                #         [os.path.join(inst.VENV, *django_admin),
+                #          "openquake_engine_postinstall", app['name']],
+                #         env=django_env)
+                # else:
+                #     manage_path = os.path.join(
+                #         'openquake', 'server', 'manage.py')
+                #     # subprocess.check_call(
+                #     #     ["sudo", "-u", inst.USER,
+                #     #      "DJANGO_SETTINGS_MODULE=openquake.server.settings",
+                #     #      os.path.join(inst.VENV, *manage_path),
+                #     #      "openquake_engine_postinstall", app['name']])
+                #     subprocess.check_call(
+                #         [os.path.join(inst.VENV, *python),
+                #          manage_path, "openquake_engine_postinstall",
+                #          app['name']], user=inst.USER)
             except Exception as exc:
                 # for instance is somebody removed a wheel from the wheelhouse
                 errors.append(

--- a/install.py
+++ b/install.py
@@ -43,6 +43,7 @@ import tempfile
 import argparse
 import platform
 import subprocess
+import site
 from urllib.request import urlopen, Request
 
 try:
@@ -336,7 +337,12 @@ def install_or_postinstall_standalone(inst, is_install=True):
                 # django_env = os.environ.copy()
                 # django_env[
                 #     "DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
-                manage_path = os.path.join('openquake', 'server', 'manage.py')
+
+                # This returns a list of all site-packages paths for the
+                # current environment
+                site_packages_dirs = site.getsitepackages()
+                manage_path = os.path.join(site_packages_dirs[0],
+                                           'openquake', 'server', 'manage.py')
                 subprocess.check_call(
                     [os.path.join(inst.VENV, *python),
                         manage_path, "openquake_engine_postinstall",

--- a/install.py
+++ b/install.py
@@ -332,13 +332,17 @@ def install_or_postinstall_standalone(inst, is_install=True):
                 django_env = os.environ.copy()
                 django_env[
                     "DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
-                if inst.USER is not None:
-                    django_env["USER"] = inst.USER
-
-                subprocess.check_call(
-                    [os.path.join(inst.VENV, *django_admin),
-                     "openquake_engine_postinstall", app['name']],
-                    env=django_env, user=inst.USER)
+                if inst.USER is None:
+                    subprocess.check_call(
+                        [os.path.join(inst.VENV, *django_admin),
+                         "openquake_engine_postinstall", app['name']],
+                        env=django_env)
+                else:
+                    subprocess.check_call(
+                        ["sudo", "-u", inst.USER,
+                         "DJANGO_SETTINGS_MODULE=openquake.server.settings",
+                         os.path.join(inst.VENV, *django_admin),
+                         "openquake_engine_postinstall", app['name']])
             except Exception as exc:
                 # for instance is somebody removed a wheel from the wheelhouse
                 errors.append(

--- a/install.py
+++ b/install.py
@@ -332,6 +332,8 @@ def install_or_postinstall_standalone(inst, is_install=True):
                 django_env = os.environ.copy()
                 django_env[
                     "DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
+                if inst.USER is not None:
+                    django_env["USER"] = inst.USER
 
                 subprocess.check_call(
                     [os.path.join(inst.VENV, *django_admin),

--- a/install.py
+++ b/install.py
@@ -298,15 +298,15 @@ def install_or_postinstall_standalone(inst, is_install=True):
 
     STANDALONE_APP_INFO = [
         {"pkg": "oq-platform-standalone", "name": None},
-        {"pkg": "oq-platform-ipt",        "name": "openquakeplatform_ipt"},
-        {"pkg": "oq-platform-taxonomy",   "name": "openquakeplatform_taxonomy"},
-        {"pkg": "django-gem-taxonomy",    "name": "django_gem_taxonomy"},
+        {"pkg": "oq-platform-ipt",       "name": "openquakeplatform_ipt"},
+        {"pkg": "oq-platform-taxonomy",  "name": "openquakeplatform_taxonomy"},
+        {"pkg": "django-gem-taxonomy",   "name": "django_gem_taxonomy"},
     ]
 
     if is_install:
         for app in STANDALONE_APP_INFO:
             try:
-                print("Applications " + app['pkg'] + " are not installed yet \n")
+                print(f"Applications {app['pkg']} are not installed yet \n")
 
                 subprocess.check_call(
                     [pycmd, "-m", "pip", "install",
@@ -330,7 +330,8 @@ def install_or_postinstall_standalone(inst, is_install=True):
                     django_admin = ["bin", "django-admin"]
 
                 django_env = os.environ.copy()
-                django_env["DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
+                django_env[
+                    "DJANGO_SETTINGS_MODULE"] = "openquake.server.settings"
 
                 subprocess.check_call(
                     [os.path.join(inst.VENV, *django_admin),
@@ -338,7 +339,9 @@ def install_or_postinstall_standalone(inst, is_install=True):
                     env=django_env, user=inst.USER)
             except Exception as exc:
                 # for instance is somebody removed a wheel from the wheelhouse
-                errors.append("%s: error during %s postinstall command execution" % (exc, app['name']))
+                errors.append(
+                    "%s: error during %s postinstall command execution" % (
+                        exc, app['name']))
 
     return errors
 
@@ -346,8 +349,10 @@ def install_or_postinstall_standalone(inst, is_install=True):
 def install_standalone(inst):
     return install_or_postinstall_standalone(inst, is_install=True)
 
+
 def postinstall_standalone(inst):
     return install_or_postinstall_standalone(inst, is_install=False)
+
 
 def before_checks(inst, args, usage):
     """
@@ -712,8 +717,10 @@ if __name__ == "__main__":
                         help="not use '--upgrade' in pip install calls")
     parser.add_argument("--remove", action="store_true",
                         help="disinstall the engine")
-    parser.add_argument("--version", help="version to install (default stable)")
-    parser.add_argument("--dbport", help="DbServer port (default 1907 or 1908)")
+    parser.add_argument("--version",
+                        help="version to install (default stable)")
+    parser.add_argument("--dbport",
+                        help="DbServer port (default 1907 or 1908)")
     # NOTE: This flag should be set when installing the engine from an action
     #       triggered by a fork
     parser.add_argument(
@@ -728,7 +735,8 @@ if __name__ == "__main__":
         if args.remove:
             remove(inst)
         else:
-            errors = install(inst, args.version, args.from_fork, args.novenv, args.noupgrade)
+            errors = install(inst, args.version, args.from_fork, args.novenv,
+                             args.noupgrade)
             if errors:
                 # NB: even if one of the tools is missing, the engine will work
                 sys.exit('\n'.join(errors))

--- a/openquake/server/management/commands/openquake_engine_postinstall.py
+++ b/openquake/server/management/commands/openquake_engine_postinstall.py
@@ -23,6 +23,7 @@ from django.core.management import call_command, get_commands
 import sys
 from django.core.management.base import BaseCommand
 
+
 class Command(BaseCommand):
     help = ("Command that run a '<app_name>_postinstall' command if it exists")
 
@@ -50,7 +51,8 @@ class Command(BaseCommand):
         if postinstall_cmd not in django_cmds:
             self.stdout.write(
                 self.style.WARNING(
-                    "No 'postinst' action needed for app %s, skipped." % (options['django_app'],))
+                    "No 'postinst' action needed for app %s, skipped." % (
+                        options['django_app'],))
                 )
             sys.exit(0)
 


### PR DESCRIPTION
Add a USER field to all four installation mode classes - for server and server_devel this indicates the user who should own db and other files.  Pass inst to all relevant functions.

Use VENV openquake/server/manage.py rather than django-admin + env vars; in server mode we need to run some commands as root but others as openquake, running sudo while also changing the environment is uncomfortable.   Manage.py already has the correct environment settings and so can be used with sudo more easily.

Run migrations before running app postinstall scripts

Some code cleanup in install_or_postinstall_standalone required.  Not yet tested on Windows/mac.

