### PR TITLE
Extended `oq info job.ini` to display the source model logic tree

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Internal: extended `oq info job.ini` to display the source model logic tree
   * Internal: extended `oq sample` to manage ESRI .asc files
 
   [Michele Simionato, Christopher Brooks]

--- a/openquake/commands/info.py
+++ b/openquake/commands/info.py
@@ -390,7 +390,7 @@ def main(what, report=False):
                 print('Generated', reportwriter.build_report(what))
             else:
                 oq = readinput.get_oqparam(what)
-                ltree = readinput.get_logic_tree(oq)
+                ltree = readinput.get_source_model_lt(oq)
                 size = humansize(oq.get_input_size())
                 print('calculation_mode: %s' % oq.calculation_mode)
                 print('description: %s' % oq.description)
@@ -398,6 +398,7 @@ def main(what, report=False):
                 print('input size: %s' % size)
                 for bset in ltree.branchsets:
                     pprint(bset)
+                lt.print_tree(ltree.branchsets[0])
         if mon.duration > 1:
             print(mon)
     elif what:

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -942,6 +942,41 @@ def dummy_branchset():
     return bset
 
 
+def print_tree(bob, prefix="", is_last=True):
+    """
+    Recursively prints a tree structure using ASCII art.
+
+    :param bob: a branchset or a branch
+    :param prefix: The visual padding/lines accumulated from parent levels.
+    :param is_last: Boolean indicating if this node is the last child
+    """
+    try:
+        id = bob.branch_id  # if branch
+    except AttributeError:
+        id = bob.id  # if branchset
+    print(f"{prefix}{'└── ' if is_last else '├── '}{id}")
+
+    # Update the prefix for the children.
+    # If this node is the last child, its vertical line ends here (add spaces).
+    # Otherwise, extend the vertical line downwards.
+    new_prefix = prefix + ("    " if is_last else "│   ")
+   
+    # Recursively print all branches
+    if hasattr(bob, 'bset') and bob.bset:
+        branches = bob.bset.branches
+    elif hasattr(bob, 'branches'):
+        branches = bob.branches
+    else:
+        branches = []
+    if len(branches) > 3:
+        br1 = copy.copy(branches[1])
+        br1.branch_id = '...'
+        branches = [branches[0], br1, branches[-1]]
+    count = len(branches)
+    for i, branch in enumerate(branches, 1):
+        print_tree(branch, new_prefix, is_last=(i == count))
+
+
 class Realization(object):
     """
     Generic Realization object with attributes value, weight, ordinal, lt_path,


### PR DESCRIPTION
For instance for case_25 one gets
```
└── bs0
    ├── alt12_UBN
    │   ├── 262
    │   │   ├── 262a
    │   │   │   ├── lsd10_NVA_AB_UBS
    │   │   │   ├── lsd15_NVA_AB_UBS
    │   │   │   └── lsd20_NVA_AB_UBS
    │   │   └── 262b
    │   │       ├── lsd10_NVA_AB_UBS
    │   │       ├── lsd15_NVA_AB_UBS
    │   │       └── lsd20_NVA_AB_UBS
    │   └── 70
    │       ├── 70a
    │       │   ├── lsd10_NVA_AB_UBS
    │       │   ├── lsd15_NVA_AB_UBS
    │       │   └── lsd20_NVA_AB_UBS
    │       └── 70b
    │           ├── lsd10_NVA_AB_UBS
    │           ├── lsd15_NVA_AB_UBS
    │           └── lsd20_NVA_AB_UBS
    ├── alt12_AB
    │   ├── 154
    │   │   ├── 154a
    │   │   │   ├── lsd10_NVA_AB_UBS
    │   │   │   ├── lsd15_NVA_AB_UBS
    │   │   │   └── lsd20_NVA_AB_UBS
    │   │   └── 154b
    │   │       ├── lsd10_NVA_AB_UBS
    │   │       ├── lsd15_NVA_AB_UBS
    │   │       └── lsd20_NVA_AB_UBS
    │   └── 52
    │       ├── 52a
    │       │   ├── lsd10_NVA_AB_UBS
    │       │   ├── lsd15_NVA_AB_UBS
    │       │   └── lsd20_NVA_AB_UBS
    │       └── 52b
    │           ├── lsd10_NVA_AB_UBS
    │           ├── lsd15_NVA_AB_UBS
    │           └── lsd20_NVA_AB_UBS
    └── alt3
        └── .
```