### PR TITLE
Added parameter `keep_rupdata`

### DIFF
--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -450,8 +450,8 @@ job_id:
 
 keep_rupdata:
    By default store rupdata only if there are few sites
-   Example: *keep_rupdata = true*.
-   Default: ''
+   Example: *keep_rupdata = false*.
+   Default: true
 
 keep_trt:
    Tectonic region type to consider in the gsim logic tree
@@ -1158,7 +1158,7 @@ class OqParam(valid.ParamSet):
     interest_rate = valid.Param(valid.positivefloat)
     investigation_time = valid.Param(valid.positivefloat, None)
     job_id = valid.Param(valid.positiveint, 0)
-    keep_rupdata = valid.Param(valid.boolean, '')
+    keep_rupdata = valid.Param(valid.boolean, True)
     keep_trt = valid.Param(valid.utf8, '')
     limit_states = valid.Param(valid.namelist, [])
     local_timestamp = valid.Param(valid.local_timestamp, None)

--- a/openquake/commonlib/oqvalidation.py
+++ b/openquake/commonlib/oqvalidation.py
@@ -448,6 +448,11 @@ job_id:
    Example: *job_id = 42*.
    Default: 0 (meaning create a new job)
 
+keep_rupdata:
+   By default store rupdata only if there are few sites
+   Example: *keep_rupdata = true*.
+   Default: ''
+
 keep_trt:
    Tectonic region type to consider in the gsim logic tree
    Example: *keep_trt = Active Shallow Crust*.
@@ -1153,6 +1158,7 @@ class OqParam(valid.ParamSet):
     interest_rate = valid.Param(valid.positivefloat)
     investigation_time = valid.Param(valid.positivefloat, None)
     job_id = valid.Param(valid.positiveint, 0)
+    keep_rupdata = valid.Param(valid.boolean, '')
     keep_trt = valid.Param(valid.utf8, '')
     limit_states = valid.Param(valid.namelist, [])
     local_timestamp = valid.Param(valid.local_timestamp, None)

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -1617,7 +1617,10 @@ class RmapMaker(object):
         dic['rmap'] = pnemap.to_rates()
         dic['rmap'].gid = self.cmaker.gid
         dic['cfactor'] = self.cmaker.cfactor
-        dic['rup_data'] = concat(self.rupdata)
+        if self.oq.keep_rupdata:
+            dic['rup_data'] = concat(self.rupdata)
+        else:
+            dic['rup_data'] = ()
         dic['source_data'] = self.source_data
         dic['task_no'] = self.task_no
         dic['dparam_mb'] = getsizeof(self.cmaker.dparam) / TWO20

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -200,6 +200,7 @@ class Oq(object):
     cross_correl = None
     mea_tau_phi = False
     split_sources = True
+    keep_rupdata = True
     use_rates = False
     with_betw_ratio = None
     infer_occur_rates = False


### PR DESCRIPTION
Must be set to false for the BCHydro calculation, otherwise the data transfer will kill the performance. Here are the figures on brennan for 1000 realizations:
```
| calc_99980617, maxmem=59.4 GB | time_sec | memory_mb | counts    |
|-------------------------------+----------+-----------+-----------|
| total classical_disagg        | 26_093   | 2.3832    | 21_907    |
| computing mean_std            | 10_409   | 0.0       | 424_641   |
| get_poes                      | 8_734    | 0.0       | 8_050_548 |
| total filter_weight           | 2_970    | 16.2344   | 1_668     |
| iter_ruptures                 | 1_185    | 0.0       | 33_718    |
| ClassicalCalculator.run       | 411.1    | 1_821     | 1         |
```
Then regular disaggregation will become impossible, while `disagg_by_src` will work:
```
# disagg_by_src, no ps_grid_spacing
| calc_99980618, maxmem=72.4 GB | time_sec | memory_mb | counts    |
|-------------------------------+----------+-----------+-----------|
| total classical_disagg        | 18_355   | 209.4     | 1_982     |
| get_poes                      | 5_909    | 0.0       | 2_388_331 |
| computing mean_std            | 5_042    | 0.0       | 86_309    |
| total filter_weight           | 4_060    | 2.7930    | 1_126     |
| iter_ruptures                 | 1_181    | 0.0       | 335_935   |
| ClassicalCalculator.run       | 348.1    | 1_533     | 1         |
```