### PR TITLE
Fixed the AELO tests

### DIFF
--- a/openquake/hazardlib/logictree.py
+++ b/openquake/hazardlib/logictree.py
@@ -557,7 +557,9 @@ class SourceModelLogicTree(object):
         lineno = branchset_node.lineno
         for branch_id in app2brs.split():
             if branch_id not in self.branches:
-                if self.branchID:  # the branch cannot be attached
+                if self.source_id or self.branchID:
+                    # the branch cannot be attached, but it is okay since
+                    # this is a reduced logic tree, not the original
                     continue
                 raise LogicTreeError(
                     lineno, self.filename,

--- a/openquake/hazardlib/lt.py
+++ b/openquake/hazardlib/lt.py
@@ -1077,7 +1077,8 @@ def attach_branches(ltree, override=False):
             branchdic[br.branch_id] = br
 
         prev_ids = [pb.branch_id for pb in previous_branches]
-        app2brs = bset.filters.get('applyToBranches', [])
+        app2brs = [brid for brid in bset.filters.get('applyToBranches', [])
+                   if brid in branchdic]
         dummies = []
         next_previous = []
         if app2brs and app2brs != prev_ids:
@@ -1087,12 +1088,7 @@ def attach_branches(ltree, override=False):
                 if brid in branchdic
             }  # bs00 for build4
             for branch_id in app2brs:
-                if branch_id not in branchdic:
-                    raise LogicTreeError(
-                        fname, '?',
-                        f"branch ID {branch_id!r} in applyToBranches "
-                        f"not found")
-                br = branchdic[branch_id]
+                br = branchdic[branch_id]  # the branch_ids are checked before
                 if not br.is_leaf() and not override:
                     raise LogicTreeError(
                         fname, '?',


### PR DESCRIPTION
Broken one week ago by the logic tree refactoring, with error when reducing the logic tree to a specific source:
```python
    smlt = csm.full_lt.source_model_lt.reduce(source_id, num_samples=0)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/hazardlib/logictree.py", line 486, in reduce
    new = self.__class__(self.filename, self.seed, num_samples,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/michele/oq-engine/openquake/hazardlib/logictree.py", line 444, in __init__
    self.parse_tree(tree)
  File "/home/michele/oq-engine/openquake/hazardlib/logictree.py", line 502, in parse_tree
    self.parse_branchset(bsnode, bsno)
  File "/home/michele/oq-engine/openquake/hazardlib/logictree.py", line 562, in parse_branchset
    raise LogicTreeError(
openquake.hazardlib.lt.LogicTreeError: filename '/media/michele/ORICO/AELO2025/EUR/in/ssmLT.xml', line 415:
branch 'fs_SRL_ML' is not yet defined
```