### PR TITLE
Replaced `multiprocessing.pool` with `concurrent.futures.ProcessPoolExecutor`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Internal: switched to ProcessPoolExecutor
   * Extended smlt_branch to work with applyToSources and applyToBranches
   * Changed the `avg_gmf` exporter to export only nonzero values
   * Fixed bug in classical_risk from hazard_curves.csv manifesting as a
@@ -11,7 +12,7 @@
     LTs (tested inside logictree/case_25)
 
   [Michele Simionato]
-  * Fixed a bug in `oq show rlz` showing wrong information for some complex trees
+  * Fixed a bug in `oq show rlz` showing wrong information for some trees
   * Internal: extended `oq info job.ini` to display the source model logic tree
   * Internal: extended `oq sample` to manage ESRI .asc files
 

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -199,7 +199,7 @@ import collections
 from unittest import mock
 import multiprocessing.dummy
 import multiprocessing.shared_memory as shmem
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 import psutil
 import numpy
 
@@ -245,15 +245,10 @@ def no_submit(self, func, args, monitor):
     safely_call(func, args, self.task_no, monitor)
 
 
-@submit.add('processpool')
+@submit.add('processpool', 'threadpool')
 def processpool_submit(self, func, args, monitor):
     return self.pool.submit(
         safely_call, func, args, self.task_no, monitor)
-
-
-@submit.add('threadpool')
-def threadpool_submit(self, func, args, monitor):
-    self.pool.apply_async(safely_call, (func, args, self.task_no, monitor))
 
 
 @submit.add('zmq', 'slurm')
@@ -732,7 +727,7 @@ class Starmap(object):
             # https://codewithoutrules.com/2018/09/04/python-multiprocessing/
             cls.pids = list(cls.pool._processes)
         elif cls.distribute == 'threadpool' and not hasattr(cls, 'pool'):
-            cls.pool = multiprocessing.dummy.Pool(num_cores)
+            cls.pool = ThreadPoolExecutor(num_cores, mp_context, init_worker)
 
         if num_cores > tot_cores:
             logging.warning(f'{num_cores=} but {tot_cores=}')

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -253,8 +253,7 @@ def processpool_submit(self, func, args, monitor):
 
 @submit.add('threadpool')
 def threadpool_submit(self, func, args, monitor):
-    return self.pool.apply_async(
-        safely_call, (func, args, self.task_no, monitor))
+    self.pool.apply_async(safely_call, (func, args, self.task_no, monitor))
 
 
 @submit.add('zmq', 'slurm')

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -199,6 +199,7 @@ import collections
 from unittest import mock
 import multiprocessing.dummy
 import multiprocessing.shared_memory as shmem
+from concurrent.futures import ProcessPoolExecutor
 import psutil
 import numpy
 
@@ -246,12 +247,14 @@ def no_submit(self, func, args, monitor):
 
 @submit.add('processpool')
 def processpool_submit(self, func, args, monitor):
-    self.pool.apply_async(safely_call, (func, args, self.task_no, monitor))
+    return self.pool.submit(
+        safely_call, func, args, self.task_no, monitor)
 
 
 @submit.add('threadpool')
 def threadpool_submit(self, func, args, monitor):
-    self.pool.apply_async(safely_call, (func, args, self.task_no, monitor))
+    return self.pool.apply_async(
+        safely_call, (func, args, self.task_no, monitor))
 
 
 @submit.add('zmq', 'slurm')
@@ -276,7 +279,7 @@ def oq_distribute(task=None):
     return dist
 
 
-def init_workers():
+def init_worker():
     """
     Used to initialize the process pool. Calls setproctitle (if available)
     and sets the flag Starmap.on, so that it is possible to determine if
@@ -711,33 +714,9 @@ class MasterKilled(KeyboardInterrupt):
     """Exception raised when a job is killed manually"""
 
 
-def kill_master(signum, frame):
-    try:
-        pid, wait_status = os.waitpid(-1, os.WNOHANG)
-    except ChildProcessError:  # no children
-        return
-    else:
-        if os.WIFEXITED(wait_status) or os.WIFSTOPPED(
-                wait_status) or os.WIFCONTINUED(wait_status):
-            pass
-        else:
-            raise MasterKilled(f'A worker was killed: {pid=}, {wait_status=}')
-
-
-def enable_sigchld():
-    if hasattr(signal, 'SIGCHLD'):
-        signal.signal(signal.SIGCHLD, kill_master)
-
-
-def disable_sigchld():
-    if hasattr(signal, 'SIGCHLD'):
-        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
-
-
 class Starmap(object):
     on = False
     pids = ()
-    maxtasksperchild = None  # with 1 it hangs on the EUR calculation!
     CT = num_cores * 2
     expected_outputs = 0  # unknown
 
@@ -745,16 +724,14 @@ class Starmap(object):
     def init(cls, distribute=None):
         cls.distribute = distribute or oq_distribute()
         if cls.distribute == 'processpool' and not hasattr(cls, 'pool'):
-            enable_sigchld()
             with sighandler('SIGINT', signal.SIG_IGN):
                 # SIGINT not passed to the workers to reduce traceback
-                cls.pool = mp_context.Pool(
-                    num_cores, init_workers,
-                    maxtasksperchild=cls.maxtasksperchild)
+                cls.pool = ProcessPoolExecutor(
+                    num_cores, mp_context, init_worker)
             # we use spawn to avoid deadlocks with logging, see
             # https://github.com/gem/oq-engine/pull/3923 and
             # https://codewithoutrules.com/2018/09/04/python-multiprocessing/
-            cls.pids = [proc.pid for proc in cls.pool._pool]
+            cls.pids = list(cls.pool._processes)
         elif cls.distribute == 'threadpool' and not hasattr(cls, 'pool'):
             cls.pool = multiprocessing.dummy.Pool(num_cores)
 
@@ -763,17 +740,12 @@ class Starmap(object):
 
     @classmethod
     def shutdown(cls):
-        # shutting down the pool during the runtime causes mysterious
-        # race conditions with errors inside atexit._run_exitfuncs
         if hasattr(cls, 'pool'):
-            cls.pool.close()
-            disable_sigchld()
-            cls.pool.terminate()
-            cls.pool.join()
-            del cls.pool
-            cls.pids = []
-        elif hasattr(cls, 'executor'):
-            cls.executor.shutdown()
+            # shutdown and recreate the executor
+            cls.pool.shutdown()
+            cls.pool = ProcessPoolExecutor(
+                num_cores, mp_context, init_worker)
+            cls.pids = list(cls.pool._processes)
 
     @classmethod
     def apply(cls, task, allargs, concurrent_tasks=None,
@@ -884,7 +856,10 @@ class Starmap(object):
         """
         func = func or self.task_func
         if not hasattr(self, 'socket'):  # setup the PULL socket the first time
-            self.socket = Socket(self.receiver, zmq.PULL, 'bind').__enter__()
+            self.socket = Socket(
+                self.receiver, zmq.PULL, 'bind',
+                starmap=self if self.distribute == 'processpool' else None
+            ).__enter__()
             self.monitor.shared = self._shared
             self.monitor.backurl = 'tcp://%s:%s' % (
                 self.return_ip, self.socket.port)
@@ -903,8 +878,7 @@ class Starmap(object):
                 fname = func.__name__
                 argnames = getargnames(func)[:-1]
             self.sent[fname] += {a: len(p) for a, p in zip(argnames, args)}
-        submit[dist](self, func, args, self.monitor)
-        self.tasks[self.task_no] = None
+        self.tasks[self.task_no] = submit[dist](self, func, args, self.monitor)
         self.task_no += 1
 
     def submit_all(self):
@@ -965,6 +939,15 @@ class Starmap(object):
         for name, shr in self._shared.items():
             logging.debug('Unlinking %s', name)
             shr.unlink()
+
+    # called by the zmq Socket
+    def check_tasks_alive(self):
+        """
+        Raise BrokenProcessPool if any task died abruptly
+        """
+        for task in self.tasks.values():
+            if task.done():
+                task.result(timeout=0)
 
     def _loop(self):
         self.busytime = AccumDict(accum=[])  # pid -> time

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -737,7 +737,6 @@ def disable_sigchld():
 class Starmap(object):
     on = False
     pids = ()
-    running_tasks = []  # currently running tasks
     maxtasksperchild = None  # with 1 it hangs on the EUR calculation!
     CT = num_cores * 2
     expected_outputs = 0  # unknown
@@ -846,7 +845,7 @@ class Starmap(object):
             self.return_ip = get_return_ip(config.dbserver.receiver_host)
             logging.debug(f'{self.return_ip=}')
         self.monitor.backurl = None  # overridden later
-        self.tasks = []  # populated by .submit
+        self.tasks = {}  # populated by .submit
         self.task_no = 0
         self._shared = {}
         self.n_out = 0
@@ -885,7 +884,6 @@ class Starmap(object):
         """
         func = func or self.task_func
         if not hasattr(self, 'socket'):  # setup the PULL socket the first time
-            self.__class__.running_tasks = self.tasks
             self.socket = Socket(self.receiver, zmq.PULL, 'bind').__enter__()
             self.monitor.shared = self._shared
             self.monitor.backurl = 'tcp://%s:%s' % (
@@ -906,7 +904,7 @@ class Starmap(object):
                 argnames = getargnames(func)[:-1]
             self.sent[fname] += {a: len(p) for a, p in zip(argnames, args)}
         submit[dist](self, func, args, self.monitor)
-        self.tasks.append(self.task_no)
+        self.tasks[self.task_no] = None
         self.task_no += 1
 
     def submit_all(self):
@@ -998,7 +996,7 @@ class Starmap(object):
             elif res.msg == 'TASK_ENDED':
                 finished.add(res.mon.task_no)
                 self.busytime += {res.workerid: res.mon.duration}
-                self.tasks.remove(res.mon.task_no)
+                del self.tasks[res.mon.task_no]
                 self._submit_many(1)
                 todo = set(range(self.task_no)) - finished
                 logging.debug('%d tasks todo %s', len(todo),

--- a/openquake/baselib/zeromq.py
+++ b/openquake/baselib/zeromq.py
@@ -93,10 +93,12 @@ class Socket(object):
     :param socket_type: zmq socket type (integer)
     :param mode: default 'bind', accepts also 'connect'
     :param timeout: default 30s, used when polling the underlying socket
+    :param starmap: associated Starmap (the regular case) or None
     """
     # NB: the timeout has to be large since starting a workerpool can be
     # slow due to numba compiling everything, so you have to wait
-    def __init__(self, end_point, socket_type, mode, timeout=60):
+    def __init__(self, end_point, socket_type, mode, timeout=30,
+                 starmap=None):
         assert socket_type in (zmq.REP, zmq.REQ, zmq.PULL, zmq.PUSH)
         assert mode in ('bind', 'connect'), mode
         if mode == 'bind':
@@ -105,6 +107,7 @@ class Socket(object):
         self.socket_type = socket_type
         self.mode = mode
         self.timeout = timeout * 1000  # milliseconds
+        self.starmap = starmap
         self.running = False
 
     def __enter__(self):
@@ -147,14 +150,19 @@ class Socket(object):
 
         1. the flag .running is set to False
         2. SIGTERM is sent
+        3. the underlying task pool is broken
         """
         # works with zmq.REP and zmq.PULL sockets
         self.running = True
         while self.running:
             try:
-                if self.zsocket.poll(self.timeout):
+                got_something = self.zsocket.poll(self.timeout)
+                if got_something:
                     yield self.zsocket.recv_pyobj()
-                elif self.socket_type == zmq.PULL:
+                elif self.starmap:
+                    # possibly raise BrokenProcessPool
+                    self.starmap.check_tasks_alive()
+                if self.socket_type == zmq.PULL:
                     logging.debug('Waiting on %s:%d', self, self.port)
             except zmq.ZMQError:
                 # sending SIGTERM raises ZMQError


### PR DESCRIPTION
The ProcessPoolExecutor is smarter and able to manage broken pools due to terminated processes, typically caused by the OOMKiller. Therefore we don't need to manage SIGCHLD anymore, which is brittle, causes https://github.com/gem/oq-engine/issues/11639 and it is frowned upon by gemini:
```
Using SIGCHLD to monitor process deaths inside a multiprocessing.Pool is highly problematic.
The Pool class internally manages a dynamic group of worker processes and automatically handles
their signals. If your master process intercepts SIGCHLD, it will break the Pool's internal state
machine, causing unexpected crashes or race conditions. Instead, the standard Pythonic way to
handle unexpected worker deaths (like OOM kills) is to switch to concurrent.futures, which natively
exposes process termination.
```