### PR TITLE
Fixed exporters for `mag_dst_eps_sig` and `mean_disagg_by_src`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Fixed the exporters `mag_dst_eps_sig` and `mean_disagg_by_src` for low
+    hazard sites, when such outputs are not computed
   * Internal: switched to ProcessPoolExecutor
   * Extended smlt_branch to work with applyToSources and applyToBranches
   * Changed the `avg_gmf` exporter to export only nonzero values

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -634,11 +634,14 @@ def export_mean_disagg_by_src(ekey, dstore):
     sitecol = dstore['sitecol']
     fnames = []
     for site in sitecol:
-        suffix = '' if len(sitecol) == 1 else f'-{site.id}'
-        aw = dstore[f'mean_disagg_by_src/{site.id}']
+        try:
+            aw = dstore[f'mean_disagg_by_src/{site.id}']
+        except KeyError:  # some sites can be missing, this is normal
+            continue
         df = aw.to_dframe()
         df = df[df.value > 0]  # don't export zeros
         df.rename(columns={'value': 'afoe'}, inplace=True)
+        suffix = '' if len(sitecol) == 1 else f'-{site.id}'
         fname = dstore.export_path('%s%s.csv' % (ekey[0], suffix))
         com = dstore.metadata.copy()
         com['lon'] = site.location.x
@@ -812,7 +815,8 @@ def export_asce(ekey, dstore):
         comment['lat'] = sitecol.lats[s]
         comment['vs30'] = sitecol.vs30[s]
         comment['site_name'] = dstore['oqparam'].description  # 'CCA example'
-        writer.save(dic.items(), fname, header=['parameter', 'value'], comment=comment)
+        writer.save(dic.items(), fname, header=['parameter', 'value'],
+                    comment=comment)
     return [fname]
 
 
@@ -838,8 +842,10 @@ def export_mag_dst_eps_sig(ekey, dstore):
         [site] = sitecol
         return [_export_mde(writer, dstore, ekey[0], site, oq.description)]
     else:
+        oksites = [site for site in sitecol
+                   if f'mag_dst_eps_sig/{site.id}' in dstore]
         return [_export_mde(writer, dstore, ekey[0], site, oq.description,
-                            f'-{site.id}') for site in sitecol]
+                            f'-{site.id}') for site in oksites]
 
 
 @export.add(('trt_gsim', 'csv'))

--- a/openquake/calculators/export/hazard.py
+++ b/openquake/calculators/export/hazard.py
@@ -820,16 +820,22 @@ def export_asce(ekey, dstore):
     return [fname]
 
 
-def _export_mde(writer, dstore, key, site, descr, suffix=''):
-    data = dstore[key + f'/{site.id}'][:]
-    fname = dstore.export_path('%s%s.csv' % (key, suffix))
-    comment = dstore.metadata.copy()
-    comment['lon'] = site.location.x
-    comment['lat'] = site.location.y
-    comment['vs30'] = site.vs30
-    comment['site_name'] = descr  # e.g. 'CCA example'
-    writer.save(data, fname, comment=comment)
-    return fname
+def _export_mde(writer, dstore, key, sites, descr, suffix=''):
+    fnames = []
+    for site in sites:
+        try:
+            data = dstore[key + f'/{site.id}'][:]
+        except KeyError:  # some sites can be missing, this is normal
+            continue
+        fname = dstore.export_path('%s%s.csv' % (key, suffix))
+        comment = dstore.metadata.copy()
+        comment['lon'] = site.location.x
+        comment['lat'] = site.location.y
+        comment['vs30'] = site.vs30
+        comment['site_name'] = descr  # e.g. 'CCA example'
+        writer.save(data, fname, comment=comment)
+        fnames.append(fname)
+    return fnames
 
 
 @export.add(('mag_dst_eps_sig', 'csv'))
@@ -839,13 +845,9 @@ def export_mag_dst_eps_sig(ekey, dstore):
     sitecol = dstore['sitecol']
     writer = writers.CsvWriter(fmt='%.5f')
     if len(site_ids) == 1:
-        [site] = sitecol
-        return [_export_mde(writer, dstore, ekey[0], site, oq.description)]
+        return _export_mde(writer, dstore, ekey[0], sitecol, oq.description)
     else:
-        oksites = [site for site in sitecol
-                   if f'mag_dst_eps_sig/{site.id}' in dstore]
-        return [_export_mde(writer, dstore, ekey[0], site, oq.description,
-                            f'-{site.id}') for site in oksites]
+        return _export_mde(writer, dstore, ekey[0], sitecol, oq.description)
 
 
 @export.add(('trt_gsim', 'csv'))


### PR DESCRIPTION
For some sites  `mag_dst_eps_sig` and `mean_disagg_by_src` are correctly not computed and not stored, but the exporters where trying to export them anyway. This was a pre-existing issue made visible by https://github.com/gem/oq-engine/pull/11622