### PR TITLE
Rewritten multispawn in terms of futures

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -199,7 +199,8 @@ import collections
 from unittest import mock
 import multiprocessing.dummy
 import multiprocessing.shared_memory as shmem
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import (ProcessPoolExecutor, ThreadPoolExecutor,
+                                as_completed)
 import psutil
 import numpy
 
@@ -1097,18 +1098,17 @@ def multispawn(func, allargs, names=(), nprocs=num_cores, logfinish=True):
         names = [f'job#{i}' for i, args in enumerate(allargs, 1)]
     tot = len(allargs)
     assert len(names) == tot, (len(names), tot)
-    p = mp_context.Pool(min(nprocs, tot))
-    n = 0
-    for name in p.imap_unordered(
-            safecall, [(func, args, name)
-                       for args, name in zip(allargs, names)]):
-        n += 1
-        if isinstance(name, BaseException):
-            logging.error(f'{name.name}: {name}')
-        elif logfinish:
-            logging.info('Finished job %s [%d of %d]', name, n, tot)
-    p.close()
-    p.join()  # not using `with Pool` to avoid mysterious atexit errors
+    with ProcessPoolExecutor(min(nprocs, tot), mp_context) as pool:
+        futs = [pool.submit(safecall, (func, args, name))
+                for args, name in zip(allargs, names)]
+        n = 0
+        for fut in as_completed(futs):
+            name = fut.result()
+            n += 1
+            if isinstance(name, BaseException):
+                logging.error(f'{name.name}: {name}')
+            elif logfinish:
+                logging.info('Finished job %s [%d of %d]', name, n, tot)
 
 
 if oq_distribute() == 'slurm':

--- a/openquake/engine/engine.py
+++ b/openquake/engine/engine.py
@@ -339,7 +339,7 @@ def _run(jobctxs, job_id, nodes, sbatch, concurrent_jobs, notify_to):
             w.WorkerMaster(job_id).send_jobs()
             print('oq engine --show-log %d to see the progress' % job_id)
         elif concurrent_jobs > 1:
-            args = [(job,) for job in jobctxs]
+            args = [(job, 1.5) for job in jobctxs]
             names = []
             for job in jobctxs:
                 name = f"{job.params['mosaic_model']}{job.calc_id}"


### PR DESCRIPTION
Continuation of https://github.com/gem/oq-engine/pull/11652. Also reduced a bit the number of concurrent_tasks in case of multi-jobs calculations.