### PR TITLE
Reducing memory in ebrisk calculations

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -737,7 +737,7 @@ class Starmap(object):
     def shutdown(cls):
         if hasattr(cls, 'pool'):
             # shutdown and recreate the executor
-            cls.pool.shutdown()
+            cls.pool.shutdown(wait=False, cancel_futures=True)
             cls.pool = ProcessPoolExecutor(
                 num_cores, mp_context, init_worker)
             cls.pids = list(cls.pool._processes)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -737,6 +737,7 @@ class Starmap(object):
     def shutdown(cls):
         if hasattr(cls, 'pool'):
             # shutdown and recreate the executor
+            logging.info('Shutting down the pool')
             cls.pool.shutdown(wait=False, cancel_futures=True)
             cls.pool = ProcessPoolExecutor(
                 num_cores, mp_context, init_worker)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -415,7 +415,7 @@ def get_allargs(oq, sitecol, sec_perils, dstore):
         cmaker.min_mag = getdefault(oqparam.minimum_magnitude, trt)
         logging.debug('%s: sending %d ruptures for trt_smr=%d',
                       model, len(rups), trt_smr)
-        for rupblock in block_splitter(rups, maxw/8, rup_weight):
+        for rupblock in block_splitter(rups, maxw/5, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
     allargs = _collect(allargs, maxw*2, sitecol.sids, sec_perils, dstore)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -343,7 +343,7 @@ def _filter_rups(oq, sitecol, trts, dstore):
             affected = max(affected, rups['nsites'].max())
     logging.info('Affected sites ~%.0f per rupture, max=%.0f',
                  nsites / len(filrups), affected)
-    maxw = min(totw / (oq.concurrent_tasks or 1), 60_000_000)
+    maxw = min(totw / (oq.concurrent_tasks or 1), 40_000_000)
     logging.info(f'{round(maxw)=:_d}')
     return filrups, maxw, acc
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -415,7 +415,7 @@ def get_allargs(oq, sitecol, sec_perils, dstore):
         cmaker.min_mag = getdefault(oqparam.minimum_magnitude, trt)
         logging.debug('%s: sending %d ruptures for trt_smr=%d',
                       model, len(rups), trt_smr)
-        for rupblock in block_splitter(rups, maxw/4, rup_weight):
+        for rupblock in block_splitter(rups, maxw/8, rup_weight):
             allargs.append((rupblock, cmaker, model))
 
     allargs = _collect(allargs, maxw*2, sitecol.sids, sec_perils, dstore)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -54,6 +54,10 @@ def size_mb(df):
     return df.memory_usage().sum() / 1024**2
 
 
+def affected_assets(df, num_assets):
+    return sum(num_assets[sid].sum() for sid in df.sid)
+
+
 def get_assetdf_startstop(assetcol):
     """
     :param assetcol: an AssetCollection
@@ -321,22 +325,25 @@ def event_based_risk(gmf_df, monitor):
     return dict(avg=avg, alt=alt, gmf_bytes=gmf_df.memory_usage().sum())
 
 
-def ebrisk(allrups, cmakers, sids, secperils, hdf5path, monitor):
+def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
     """
     :param rups: list of ruptures with the same trt_smr
     :param cmakers: ContextMaker instances associated to each trt_smr
     :param sids: array of site indices
     :param secperils: list of secondary peril instances
-    :param hdf5path: path to the ses.hdf5 file
+    :param dstore: a DataStore instance
     :param monitor: a Monitor instance
     :yields: dictionaries with keys 'avg', 'alt' and 'gmfbytes'
     """
     oq = cmakers[0].oq
     oq.ground_motion_fields = True
-    dfs = (dic['gmfdata'] for dic in event_based.event_based(
-        allrups, cmakers, sids, secperils, hdf5path, monitor)
-           if len(dic['gmfdata']))
-    for b, blk in enumerate(general.block_splitter(dfs, GMF2_MB, size_mb)):
+    dfs = [dic['gmfdata'] for dic in event_based.event_based(
+        allrups, cmakers, sids, secperils, dstore, monitor)
+           if len(dic['gmfdata'])]
+    num_assets = general.fast_agg(dstore['assetcol/array']['site_id'])
+    affected = partial(affected_assets, num_assets=num_assets)
+    print('---------------', sum(affected(df) for df in dfs))
+    for b, blk in enumerate(general.block_splitter(dfs, 1E6, affected)):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -341,7 +341,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
         aff = round(sum(num_assets[df.sid].sum() for df in blk))
-        if b == 0 or mb < 2E7:  # don't spawn small tasks
+        if b == 0 or aff < 2E7:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:
             print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {aff=:_d}')

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -337,7 +337,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
            if len(dic['gmfdata']))
     num_assets = monitor.read('num_assets')
     for b, blk in enumerate(general.block_splitter(
-            dfs, 1E8, lambda gmf_df: num_assets[gmf_df.sid].sum())):
+            dfs, 2E8, lambda gmf_df: num_assets[gmf_df.sid].sum())):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -342,7 +342,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
         na = numpy.round([num_assets[df.sid].sum() for df in blk])
-        aff = sum(na)
+        aff = int(na.sum())
         # print(f'{monitor.task_no=}, {na/1E6=}')
         if b == 0 or aff < AE_MIN:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -342,12 +342,12 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
         na = numpy.round([num_assets[df.sid].sum() for df in blk])
-        aff = int(na.sum())
+        ae = int(na.sum())
         # print(f'{monitor.task_no=}, {na/1E6=}')
-        if b == 0 or aff < AE_MIN:  # don't spawn small tasks
+        if b == 0 or ae < AE_MIN:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:
-            print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {aff=:_d}')
+            print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {ae=:_d}')
             yield event_based_risk, pandas.concat(blk)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -345,16 +345,15 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
            if len(dic['gmfdata']))
     num_assets = monitor.read('num_assets')
     affected = partial(affected_assets, num_assets=num_assets)
-    for b, blk in enumerate(general.block_splitter(dfs, 1E6, affected)):
+    for b, blk in enumerate(general.block_splitter(dfs, 1E7, affected)):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
         aff = round(sum(affected(df) for df in blk))
-        print(f'{aff=}')
         if b == 0 or mb < GMF1_MB:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:
-            print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=}')
+            print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {aff=}')
             yield event_based_risk, pandas.concat(blk)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,7 +42,6 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
-GMF_MB = 50
 get_n_occ = operator.itemgetter(1)
 
 
@@ -342,7 +341,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
         aff = round(sum(num_assets[df.sid].sum() for df in blk))
-        if b == 0 or mb < GMF_MB:  # don't spawn small tasks
+        if b == 0 or mb < 2E7:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:
             print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {aff=:_d}')

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -55,7 +55,7 @@ def size_mb(df):
 
 
 def affected_assets(df, num_assets):
-    return sum(num_assets[sid].sum() for sid in df.sid)
+    return sum(num_assets[sid] for sid in df.sid)
 
 
 def get_assetdf_startstop(assetcol):
@@ -337,16 +337,20 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
     """
     oq = cmakers[0].oq
     oq.ground_motion_fields = True
-    dfs = [dic['gmfdata'] for dic in event_based.event_based(
+    dfs = (dic['gmfdata'] for dic in event_based.event_based(
         allrups, cmakers, sids, secperils, dstore, monitor)
-           if len(dic['gmfdata'])]
-    num_assets = general.fast_agg(dstore['assetcol/array']['site_id'])
+           if len(dic['gmfdata']))
+    if dstore.parent:
+        num_assets = general.fast_agg(dstore.parent['assetcol/array']['site_id'])
+    else:
+        num_assets = {sid: 1 for sid in sids}
     affected = partial(affected_assets, num_assets=num_assets)
-    print('---------------', sum(affected(df) for df in dfs))
     for b, blk in enumerate(general.block_splitter(dfs, 1E6, affected)):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
+        aff = round(sum(affected(df) for df in blk))
+        print(f'{aff=}')
         if b == 0 or mb < GMF1_MB:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -54,8 +54,11 @@ def size_mb(df):
     return df.memory_usage().sum() / 1024**2
 
 
-def affected_assets(df, num_assets):
-    return sum(num_assets[sid] for sid in df.sid)
+def affected_assets(gmf_df, num_assets):
+    """
+    :returns: the total number of affected assets multiplied by n_occ
+    """
+    return sum(num_assets[sid] for sid in gmf_df.sid)
 
 
 def get_assetdf_startstop(assetcol):
@@ -340,10 +343,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
     dfs = (dic['gmfdata'] for dic in event_based.event_based(
         allrups, cmakers, sids, secperils, dstore, monitor)
            if len(dic['gmfdata']))
-    if dstore.parent:
-        num_assets = general.fast_agg(dstore.parent['assetcol/array']['site_id'])
-    else:
-        num_assets = {sid: 1 for sid in sids}
+    num_assets = monitor.read('num_assets')
     affected = partial(affected_assets, num_assets=num_assets)
     for b, blk in enumerate(general.block_splitter(dfs, 1E6, affected)):
         # NB: it is essential to concatenate the small dataframes to have
@@ -385,6 +385,7 @@ class EventBasedRiskCalculator(event_based.EventBasedCalculator):
         max_assets_per_region = (iss[:, 2] - iss[:, 1]).max()
         logging.info(f'{max_assets_per_region=:_d}')
         monitor.save('assets', adf)
+        monitor.save('num_assets', general.fast_agg(self.assetcol['site_id']))
         monitor.save('start-stop', iss)
         monitor.save('crmodel', self.crmodel)
         monitor.save('rlz_id', self.rlzs)

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -343,7 +343,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
         mb = round(sum(size_mb(df) for df in blk))
         na = numpy.round([num_assets[df.sid].sum() for df in blk])
         aff = sum(na)
-        print(f'{monitor.task_no=}, {na/1E6=}')
+        # print(f'{monitor.task_no=}, {na/1E6=}')
         if b == 0 or aff < AE_MIN:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -54,13 +54,6 @@ def size_mb(df):
     return df.memory_usage().sum() / 1024**2
 
 
-def affected_assets(gmf_df, num_assets):
-    """
-    :returns: the total number of affected assets multiplied by n_occ
-    """
-    return sum(num_assets[sid] for sid in gmf_df.sid)
-
-
 def get_assetdf_startstop(assetcol):
     """
     :param assetcol: an AssetCollection
@@ -344,12 +337,12 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
         allrups, cmakers, sids, secperils, dstore, monitor)
            if len(dic['gmfdata']))
     num_assets = monitor.read('num_assets')
-    affected = partial(affected_assets, num_assets=num_assets)
-    for b, blk in enumerate(general.block_splitter(dfs, 2E7, affected)):
+    for b, blk in enumerate(general.block_splitter(
+            dfs, 2E7, lambda gmf_df: num_assets[gmf_df.sid].sum())):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
-        aff = round(sum(affected(df) for df in blk))
+        aff = round(sum(num_assets[df.sid].sum() for df in blk))
         if b == 0 or mb < GMF1_MB:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,6 +42,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
+AE_MIN, AE_MAX = 2E7, 2E8
 get_n_occ = operator.itemgetter(1)
 
 
@@ -336,12 +337,14 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
            if len(dic['gmfdata']))
     num_assets = monitor.read('num_assets')
     for b, blk in enumerate(general.block_splitter(
-            dfs, 2E8, lambda gmf_df: num_assets[gmf_df.sid].sum())):
+            dfs, AE_MAX, lambda gmf_df: num_assets[gmf_df.sid].sum())):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
-        aff = round(sum(num_assets[df.sid].sum() for df in blk))
-        if b == 0 or aff < 2E7:  # don't spawn small tasks
+        na = [round(num_assets[df.sid].sum()) for df in blk]
+        aff = sum(na)
+        print(f'{monitor.task_no=}, {na=}')
+        if b == 0 or aff < AE_MIN:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:
             print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {aff=:_d}')

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -345,7 +345,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
            if len(dic['gmfdata']))
     num_assets = monitor.read('num_assets')
     affected = partial(affected_assets, num_assets=num_assets)
-    for b, blk in enumerate(general.block_splitter(dfs, 1E7, affected)):
+    for b, blk in enumerate(general.block_splitter(dfs, 2E7, affected)):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
@@ -353,7 +353,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
         if b == 0 or mb < GMF1_MB:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:
-            print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {aff=}')
+            print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {aff=:_d}')
             yield event_based_risk, pandas.concat(blk)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -341,9 +341,9 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
-        na = [round(num_assets[df.sid].sum()) for df in blk]
+        na = numpy.round([num_assets[df.sid].sum() for df in blk])
         aff = sum(na)
-        print(f'{monitor.task_no=}, {na=}')
+        print(f'{monitor.task_no=}, {na/1E6=}')
         if b == 0 or aff < AE_MIN:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,8 +42,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
-GMF1_MB = 80
-GMF2_MB = 400
+GMF_MB = 50
 get_n_occ = operator.itemgetter(1)
 
 
@@ -338,12 +337,12 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
            if len(dic['gmfdata']))
     num_assets = monitor.read('num_assets')
     for b, blk in enumerate(general.block_splitter(
-            dfs, 2E7, lambda gmf_df: num_assets[gmf_df.sid].sum())):
+            dfs, 5E7, lambda gmf_df: num_assets[gmf_df.sid].sum())):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))
         aff = round(sum(num_assets[df.sid].sum() for df in blk))
-        if b == 0 or mb < GMF1_MB:  # don't spawn small tasks
+        if b == 0 or mb < GMF_MB:  # don't spawn small tasks
             yield event_based_risk(pandas.concat(blk), monitor)
         else:
             print(f'{monitor.calc_id=}, {monitor.task_no=}, {mb=} {aff=:_d}')

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -42,7 +42,7 @@ F64 = numpy.float64
 TWO16 = 2 ** 16
 TWO24 = 2 ** 24
 TWO32 = U64(2 ** 32)
-AE_MIN, AE_MAX = 2E7, 2E8
+AE_MIN, AE_MAX = 2E7, 1E8
 get_n_occ = operator.itemgetter(1)
 
 

--- a/openquake/calculators/event_based_risk.py
+++ b/openquake/calculators/event_based_risk.py
@@ -337,7 +337,7 @@ def ebrisk(allrups, cmakers, sids, secperils, dstore, monitor):
            if len(dic['gmfdata']))
     num_assets = monitor.read('num_assets')
     for b, blk in enumerate(general.block_splitter(
-            dfs, 5E7, lambda gmf_df: num_assets[gmf_df.sid].sum())):
+            dfs, 1E8, lambda gmf_df: num_assets[gmf_df.sid].sum())):
         # NB: it is essential to concatenate the small dataframes to have
         # long arrays (around GMF_MB) and hence a good performance
         mb = round(sum(size_mb(df) for df in blk))


### PR DESCRIPTION
By setting a limit AE_MAX=1E8 on the product (num_assets x num_events). Also reduced the slow tasks. Here are the figures for Japan with 10,000 years on mayfield:
```
# master
| calc_1455, maxmem=??? GB     | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| computing risk               | 37_993   | 0.0       | 166_968 |
| total ebrisk                 | 28_235   | 965.3     | 31      |
| total event_based_risk       | 15_141   | 216.3     | 12      |
| EventBasedRiskCalculator.run | 4_642    | 1_330     | 1       |

# AE_MAX=1E8
| calc_1454, maxmem=??? GB     | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| computing risk               | 44_614   | 0.0       | 320_558 |
| total ebrisk                 | 17_527   | 814.0     | 64      |
| total event_based_risk       | 33_015   | 266.6     | 44      |
| EventBasedRiskCalculator.run | 3_534    | 1_334     | 1       |
```
We are 31% faster because the slow tasks are much better:
```
# master
| operation-duration | counts | mean   | stddev | min    | max    | slowfac |
|--------------------+--------+--------+--------+--------+--------+---------|
| ebrisk             | 17     | 1_655  | 34%    | 657.9  | 2_892  | 1.7476  |
| event_based_risk   | 12     | 1_262  | 26%    | 698.0  | 1_779  | 1.4100  |

# AE_MAX=1E8
| operation-duration | counts | mean   | stddev | min    | max    | slowfac |
|--------------------+--------+--------+--------+--------+--------+---------|
| ebrisk             | 17     | 1_025  | 21%    | 557.2  | 1_387  | 1.3530  |
| event_based_risk   | 44     | 750.3  | 31%    | 248.9  | 1_313  | 1.7502  |
```
Now finally I can run East_Asia on brennan without running out-of-memory.