### PR TITLE
Fix a warning in `extract_aggrisk_tags`

### DIFF
--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -161,7 +161,7 @@ def export_aggrisk_stats(ekey, dstore):
                 else:
                     aggnames.add(aggfield)
         dataf = extract(dstore, 'aggrisk_tags')
-        for tagnames, (start, stop) in dataf.slc.items():
+        for tagnames, (start, stop) in dataf.attrs['slc'].items():
             df = dataf[start:stop]
             for missing in aggnames - set(tagnames):
                 del df[missing]

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -983,7 +983,7 @@ def extract_aggrisk_tags(dstore, what):
         slc[tuple(aggby)] = (start, start + len(df))
         start += len(df)
     totdf = pandas.concat(outs)
-    totdf.slc = slc
+    totdf.attrs['slc'] = slc
     return totdf
 
 


### PR DESCRIPTION
The warning was:

```
UserWarning: Pandas doesn't allow columns to be created via a new attribute name - see https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access
    totdf.slc = slc
```

`slc` is a lookup object that records where each aggregation's rows live inside the final concatenated `totdf`. It is not supposed to be a new column and Pandas complains, assuming it was the purpose. However, the attribute was actually added to the object and it was used in `export_aggrisk_tags`.
I changed the syntax to avoid the warning.