### PR TITLE
Fixed the memory monitoring

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -713,7 +713,6 @@ class MasterKilled(KeyboardInterrupt):
 
 class Starmap(object):
     on = False
-    pids = ()
     CT = num_cores * 2
     expected_outputs = 0  # unknown
 
@@ -1001,7 +1000,7 @@ class Starmap(object):
                     # do not measure the memory on the workers
                     # otherwise memory_rss would double count the shared memory
                     mem_gb = memory_gb()
-                else:
+                elif hasattr(Starmap, 'pool'):
                     mem_gb = memory_gb(Starmap.pool._processes)
                 if self.h5.mode != 'r':
                     res.mon.save_task_info(self.h5, res, name, mem_gb)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -1002,6 +1002,8 @@ class Starmap(object):
                     mem_gb = memory_gb()
                 elif hasattr(Starmap, 'pool'):
                     mem_gb = memory_gb(Starmap.pool._processes)
+                else:
+                    mem_gb = 0
                 if self.h5.mode != 'r':
                     res.mon.save_task_info(self.h5, res, name, mem_gb)
                     res.mon.flush(self.h5)

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -726,7 +726,6 @@ class Starmap(object):
             # we use spawn to avoid deadlocks with logging, see
             # https://github.com/gem/oq-engine/pull/3923 and
             # https://codewithoutrules.com/2018/09/04/python-multiprocessing/
-            cls.pids = list(cls.pool._processes)
         elif cls.distribute == 'threadpool' and not hasattr(cls, 'pool'):
             cls.pool = ThreadPoolExecutor(num_cores, mp_context, init_worker)
 
@@ -739,6 +738,9 @@ class Starmap(object):
             # shutdown and recreate the executor
             logging.info('Shutting down the pool')
             cls.pool.shutdown(wait=False, cancel_futures=True)
+            if cls.pool._processes:
+                for p in cls.pool._processes.values():
+                    p.terminate()
             del cls.pool
 
     @classmethod
@@ -1000,7 +1002,7 @@ class Starmap(object):
                     # otherwise memory_rss would double count the shared memory
                     mem_gb = memory_gb()
                 else:
-                    mem_gb = memory_gb(Starmap.pids)
+                    mem_gb = memory_gb(Starmap.pool._processes)
                 if self.h5.mode != 'r':
                     res.mon.save_task_info(self.h5, res, name, mem_gb)
                     res.mon.flush(self.h5)


### PR DESCRIPTION
Broken by https://github.com/gem/oq-engine/pull/11652, since the `pids` list is empty before submitting tasks (differently from the old pool).