### PR TITLE
Testing engine_pr_test Action - starting from hash 7ef4cbb40fbe80cf19c4012d3ba32ef008d9a739 

### DIFF
--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   calculators:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -42,6 +43,7 @@ jobs:
 
   hazardlib:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -79,6 +81,7 @@ jobs:
 
   server:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -103,6 +106,7 @@ jobs:
           fi
       - name: Server tests
         run: |
+          set -x
           source ~/openquake/bin/activate
           oq engine --upgrade-db
           pip install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl


### PR DESCRIPTION
Branch started from hash 7ef4cbb40fbe80cf19c4012d3ba32ef008d9a739 - tests were green for PT PR [fix_export_asce](https://github.com/gem/oq-engine/tree/refs/heads/fix_export_asce)

Added Timeout and debug changes to engine_pr_workflow.

If the engine_pr_tests run to completion, this suggests the error is not (just) due to a github problem but is a change applied to the engine since the hash.   If not, it suggests the problem is with GH.