### PR TITLE
Limit engine PR tests for 60min.  Install.py ignores --version and loads local requirements files for devel and devel_server modes

### DIFF
--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   calculators:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -42,6 +43,7 @@ jobs:
 
   hazardlib:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -79,6 +81,7 @@ jobs:
 
   server:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -103,6 +106,7 @@ jobs:
           fi
       - name: Server tests
         run: |
+          set -x
           source ~/openquake/bin/activate
           oq engine --upgrade-db
           pip install https://wheelhouse.openquake.org/v3/py/pytest_django-4.9.0-py3-none-any.whl

--- a/.github/workflows/windows_pr_test.yml
+++ b/.github/workflows/windows_pr_test.yml
@@ -10,8 +10,9 @@ on:
   pull_request:
 
 jobs:
-  install_oq:
+  install_oq_test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     env:
       GITHUB_PULL_REQUEST: ${{ github.event.number }}
       GITHUB_DEF_BR: ${{ github.event.repository.default_branch }}

--- a/install.py
+++ b/install.py
@@ -455,9 +455,13 @@ def before_checks(inst, args, usage):
         except subprocess.CalledProcessError:
             raise RuntimeError('install.py must be called from the engine '
                                f'repository, not from {os.getcwd()}')
-        if branch.startswith('engine-') and not args.version:
-            # use version consistent with the branch
-            args.version == branch
+#        if branch.startswith('engine-'):
+        print(f'Devel install on branch {branch}')
+        if args.version:
+            print('WARNING: Ignoring version flag for devel install on branch '
+                  f'{branch}')
+        # use version consistent with the branch, even if --version flag
+        args.version = branch
 
     # check if there is a DbServer running
     if not args.remove:
@@ -596,10 +600,16 @@ def install(inst, version, from_fork, novenv, noupgrade):
         mac = ("_" + platform.machine(),)  # x86_64 or arm64
     else:
         mac = ("",)
-    req = (
-        f"https://raw.githubusercontent.com/gem/oq-engine/{branch}/"
-        "requirements-py%d%d-%s%s.txt" % (PYVER[:2] + PLATFORM[sys.platform]
-                                          + mac))
+    # TODO move this to inst classes
+    if (inst is devel or inst is devel_server):
+        # use local requirements file for devel installs
+        req_pre = CDIR
+    else:
+        # use github for user and server installs
+        req_pre = f'https://raw.githubusercontent.com/gem/oq-engine/{branch}/'
+    req = f"{req_pre}/requirements-py%d%d-%s%s.txt" % \
+          (PYVER[:2] + PLATFORM[sys.platform] + mac)
+
     subprocess.check_call(
         [
             pycmd,


### PR DESCRIPTION
Limit engine PR tests for 60min, use set -x to assist debugging.
  
Install.py ignores --version and loads local requirements files for devel and devel_server modes