### PR TITLE
Remove misplaced set around a horizontal comp definition + add a better guard in set_imts_conv

### DIFF
--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -35,7 +35,7 @@ from openquake.baselib.general import (
 from openquake.baselib.performance import Monitor, split_array, kround0, compile
 from openquake.baselib.general import decode
 from openquake.hazardlib import valid, imt as imt_module, InvalidFile
-from openquake.hazardlib.const import StdDev, OK_COMPONENTS
+from openquake.hazardlib.const import IMC, StdDev, OK_COMPONENTS
 from openquake.hazardlib.tom import NegativeBinomialTOM, PoissonTOM
 from openquake.hazardlib.stats import ndtr, truncnorm_sf
 from openquake.hazardlib.site import SiteCollection, site_param_dt
@@ -711,6 +711,9 @@ class ContextMaker(object):
             imc = gsim.DEFINED_FOR_INTENSITY_MEASURE_COMPONENT
             if not imc:  # for GMPETables
                 continue
+            elif not isinstance(imc, IMC):
+                raise ValueError(f"{gsim.__class__.__name__}'s component "
+                                 f"def. is not an instance of const.IMC.<>")
             elif imc.name == 'GEOMETRIC_MEAN':
                 pass  # nothing to do
             elif imc.name in OK_COMPONENTS:

--- a/openquake/hazardlib/contexts.py
+++ b/openquake/hazardlib/contexts.py
@@ -712,8 +712,10 @@ class ContextMaker(object):
             if not imc:  # for GMPETables
                 continue
             elif not isinstance(imc, IMC):
-                raise ValueError(f"{gsim.__class__.__name__}'s component "
-                                 f"def. is not an instance of const.IMC.<>")
+                raise ValueError(
+                    f"{gsim.__class__.__name__}."
+                    f"DEFINED_FOR_INTENSITY_MEASURE_COMPONENT "
+                    f"is not an instance of const.IMC")
             elif imc.name == 'GEOMETRIC_MEAN':
                 pass  # nothing to do
             elif imc.name in OK_COMPONENTS:

--- a/openquake/hazardlib/gsim/aristeidou_2024.py
+++ b/openquake/hazardlib/gsim/aristeidou_2024.py
@@ -38,6 +38,12 @@ import h5py
 
 ASSET_DIR = pathlib.Path(__file__).resolve().parent / "aristeidou_2024_assets"
 
+COMPONENT_MAPPING = {
+    const.IMC.RotD50: "RotD50",
+    const.IMC.GEOMETRIC_MEAN: "geomean",
+    const.IMC.RotD100: "RotD100",
+}
+
 
 def load_hdf5_to_list(group):
     """
@@ -111,18 +117,21 @@ def _get_style_of_faulting_term(rake):
     return sof
 
 
-def extract_im_names(imts, component_definition):
+def extract_im_names(imts, imc):
     """
     Convert the im strings of openquake to the im naming convention
-    used in the GMM
+    used in the GMM. ``imc`` is the GMM's
+    ``DEFINED_FOR_INTENSITY_MEASURE_COMPONENT`` (a ``const.IMC`` member),
+    looked up in ``COMPONENT_MAPPING`` for the SA / Sa_avg suffix.
     """
+    component_name = COMPONENT_MAPPING[imc]
     im_names = []
     for imt in imts:
         base = imt.name
 
         # 1. Handle Spectral Acceleration and Averages
         if base == "SA" or base.startswith("Sa_avg"):
-            name = f"{base}_{component_definition}({imt.period})"
+            name = f"{base}_{component_name}({imt.period})"
             # i.e. SA_RotD100(1.0)
 
         # 2. Handle Duration and Velocity/Displacement/Acceleration
@@ -144,13 +153,13 @@ def extract_im_names(imts, component_definition):
     return np.array(im_names)
 
 
-def _get_means_stddevs(DATA, imts, means, stddevs, component_definition):
+def _get_means_stddevs(DATA, imts, means, stddevs, imc):
     """
     Extract the means and standard deviations of the requested IMs and
-    horizontal compoent definitions
+    horizontal component definitions
     """
     supported_ims = np.char.decode(DATA["output_ims"], 'UTF-8')
-    im_names = extract_im_names(imts, component_definition)
+    im_names = extract_im_names(imts, imc)
 
     if len(means.shape) == 1:
         means = means.reshape(1, means.shape[0])
@@ -283,8 +292,6 @@ class AristeidouEtAl2024(GMPE):
         "Ztor": [0, 16.23],
     }
 
-    component_definition = "RotD50"
-
     def __init__(self):
         # Load background information about the model from a hdf5 file
         # (i.e., weight, biases, standard devation values, etc.)
@@ -355,7 +362,8 @@ class AristeidouEtAl2024(GMPE):
 
         # Get the means and stddevs at index corresponding to the IM
         mean[:], stddevs = _get_means_stddevs(
-            self.DATA, imts, means, stddevs, self.component_definition)
+            self.DATA, imts, means, stddevs,
+            self.DEFINED_FOR_INTENSITY_MEASURE_COMPONENT)
 
         sig[:] = stddevs[0, :, :]
         tau[:] = stddevs[1, :, :]
@@ -370,8 +378,6 @@ class AristeidouEtAl2024Geomean(AristeidouEtAl2024):
     #: Supported intensity measure components
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.GEOMETRIC_MEAN
 
-    component_definition = "geomean"
-
 
 class AristeidouEtAl2024RotD100(AristeidouEtAl2024):
     #: Supported intensity measure types
@@ -379,5 +385,3 @@ class AristeidouEtAl2024RotD100(AristeidouEtAl2024):
 
     #: Supported intensity measure components
     DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.RotD100
-
-    component_definition = "RotD100"

--- a/openquake/hazardlib/gsim/aristeidou_2024.py
+++ b/openquake/hazardlib/gsim/aristeidou_2024.py
@@ -120,9 +120,7 @@ def _get_style_of_faulting_term(rake):
 def extract_im_names(imts, imc):
     """
     Convert the im strings of openquake to the im naming convention
-    used in the GMM. ``imc`` is the GMM's
-    ``DEFINED_FOR_INTENSITY_MEASURE_COMPONENT`` (a ``const.IMC`` member),
-    looked up in ``COMPONENT_MAPPING`` for the SA / Sa_avg suffix.
+    used in the GMM.
     """
     component_name = COMPONENT_MAPPING[imc]
     im_names = []

--- a/openquake/hazardlib/gsim/aristeidou_2024.py
+++ b/openquake/hazardlib/gsim/aristeidou_2024.py
@@ -254,7 +254,7 @@ class AristeidouEtAl2024(GMPE):
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = {PGA, PGV, PGD, SA, Sa_avg2, Sa_avg3}
 
     #: Supported intensity measure components
-    DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = {const.IMC.RotD50}
+    DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.RotD50
 
     #: Supported standard deviation types
     DEFINED_FOR_STANDARD_DEVIATION_TYPES = {
@@ -368,7 +368,7 @@ class AristeidouEtAl2024Geomean(AristeidouEtAl2024):
         SA, Sa_avg2, Sa_avg3, RSD595, RSD575, FIV3}
 
     #: Supported intensity measure components
-    DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = {const.IMC.GEOMETRIC_MEAN}
+    DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.GEOMETRIC_MEAN
 
     component_definition = "geomean"
 
@@ -378,6 +378,6 @@ class AristeidouEtAl2024RotD100(AristeidouEtAl2024):
     DEFINED_FOR_INTENSITY_MEASURE_TYPES = {SA, Sa_avg2, Sa_avg3}
 
     #: Supported intensity measure components
-    DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = {const.IMC.RotD100}
+    DEFINED_FOR_INTENSITY_MEASURE_COMPONENT = const.IMC.RotD100
 
     component_definition = "RotD100"


### PR DESCRIPTION
Addresses https://github.com/gem/oq-engine/issues/11678

Also a small cleanup to avoid an unnecessary attribute being set on each subclass of same GMM.