### PR TITLE
Minor improvements in get_losses

### DIFF
--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -329,12 +329,20 @@ class VulnerabilityFunction(object):
         covs = not hasattr(self, 'covs') or self.covs.any()
         losses = sampler.get_losses(df, covs)
         ok = losses > minloss
+        losses_ok = losses[ok]
         if self.distribution_name == 'PM':  # special case
-            variances = numpy.zeros(len(losses))
+            variances_ok = numpy.zeros(len(losses_ok))
         else:
-            variances = (losses * df['cov'].to_numpy())**2
-        return pandas.DataFrame(dict(eid=df.eid[ok], aid=df.aid[ok],
-                                     variance=variances[ok], loss=losses[ok]))
+            covs_ok = df['cov'].to_numpy()[ok]
+            variances_ok = (losses_ok * covs_ok) ** 2
+        return pandas.DataFrame(
+            dict(
+                eid=df.eid[ok],
+                aid=df.aid[ok],
+                variance=variances_ok,
+                loss=losses_ok,
+            )
+        )
 
     def strictly_increasing(self):
         """
@@ -858,9 +866,15 @@ class MultiEventRNG(object):
         :returns: array of floats
         """
         corrcache = {}
-        eps = numpy.array([self._get_eps(eid, corrcache) for eid in eids])
-        sigma = numpy.sqrt(numpy.log(1 + covs ** 2))
-        div = numpy.sqrt(1 + covs ** 2)
+        eps = numpy.fromiter(
+            (self._get_eps(eid, corrcache) for eid in eids),
+            dtype=numpy.float64,
+            count=len(eids),
+        )
+        covs2 = covs ** 2
+        covs2_1 = covs2 + 1.0
+        sigma = numpy.sqrt(numpy.log1p(covs2))
+        div = numpy.sqrt(covs2_1)
         return means * numpy.exp(eps * sigma) / div
 
     # NB: asset correlation is ignored


### PR DESCRIPTION
Suggested by gemini. In spite of gemini claims about the ebrisk demo
```
  1. Filtered Entry Variance Computation:
      • Updated scientific.py to filter ok = losses > minloss before computing variances and
      creating the returned pandas.DataFrame.
      • Result: Result DataFrame memory allocation reduced from 745.15 MB down to 320.12 MB.
  2. Efficient Array Operations & numpy.fromiter:
      • Modified scientific.py to use numpy.fromiter when constructing eps, avoiding temporary
      Python list allocations.
      • Reused covs ** 2 and adopted numpy.log1p(covs2) to avoid redundant array power operations
      and duplicate logarithm memory allocations.
      • Result: Epsilon array generation memory allocation dropped from 303.81 MB down to 115.21 MB,
      and intermediate array allocations were reduced by ~230 MB
```
there is no improvement in practice in the big calculations, not in memory not in runtime.