### PR TITLE
Minor improvements to event_based_risk

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -660,7 +660,7 @@ def dumps(dic):
         elif isinstance(v, dict):
             new[k] = dumps(v)
         elif hasattr(v, '__dict__'):
-            new[k] = {cls2dotname(v.__class__): dumps(vars(v))}
+            new[k] = dumps({cls2dotname(v.__class__): vars(v)})
         else:
             new[k] = json.dumps(v)
     return "{%s}" % ','.join('\n"%s": %s' % it for it in new.items())

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -139,31 +139,28 @@ class Sampler(object):
         self.lratios = lratios  # for the PM distribution
         self.cols = cols  # for the PM distribution
 
-    def get_losses(self, rng, df, covs):
-        vals = df['val'].to_numpy()
+    def get_losses(self, rng, dic, covs):
+        vals = dic['val']
         if not rng or not covs:  # fast lane
-            losses = vals * df['mean'].to_numpy()
+            losses = vals * dic['mean']
         else:  # slow lane
-            losses = vals * getattr(self, 'sample' + self.distname)(rng, df)
+            losses = vals * getattr(self, 'sample' + self.distname)(rng, dic)
         return losses
 
-    def sampleLN(self, rng, df):
-        means = df['mean'].to_numpy()
-        covs = df['cov'].to_numpy()
-        eids = df['eid'].to_numpy()
+    def sampleLN(self, rng, dic):
+        means = dic['mean']
+        covs = dic['cov']
+        eids = dic['eid']
         losses = rng.lognormal(eids, means, covs)
         return losses
 
-    def sampleBT(self, rng, df):
-        means = df['mean'].to_numpy()
-        covs = df['cov'].to_numpy()
-        eids = df['eid'].to_numpy()
-        return rng.beta(eids, means, covs)
+    def sampleBT(self, rng, dic):
+        return rng.beta(dic['eid'], dic['mean'], dic['cov'])
 
-    def samplePM(self, rng, df):
-        # in case_1g self.cols = [0, 1, 2, 3, 4, 5, 6], len(df)=4
-        eids = df['eid'].to_numpy()
-        allprobs = numpy.array([df[c] for c in self.cols]).T  # (4, 7)
+    def samplePM(self, rng, dic):
+        # in case_1g self.cols = [0, 1, 2, 3, 4, 5, 6], len(dic)=4
+        eids = dic['eid']
+        allprobs = numpy.array([dic[c] for c in self.cols]).T  # (4, 7)
         pmf = []
         for eid, probs in zip(eids, allprobs):  # probs by asset
             if probs.sum() == 0:  # oq-risk-tests/case_1g
@@ -178,6 +175,9 @@ class Sampler(object):
 #
 # Input models
 #
+def join_dic(ratio_df, asset_df):
+    df = ratio_df.join(asset_df, how='inner')
+    return {col: df[col].to_numpy() for col in df.columns}
 
 
 class VulnerabilityFunction(object):
@@ -318,20 +318,20 @@ class VulnerabilityFunction(object):
             # dataset with fields aid, val and key site_id
         ratio_df = self.interpolate(gmf_df, col)  # really fast
         # dataset with fields eid, mean, cov and key sid
-        df = ratio_df.join(asset_df, how='inner')
+        dic = join_dic(ratio_df, asset_df)
         # df is a dataset with fields eid, mean, cov, aid, val and key sid
         covs = not hasattr(self, 'covs') or self.covs.any()
-        losses = self.sampler.get_losses(rng, df, covs)
+        losses = self.sampler.get_losses(rng, dic, covs)
         ok = losses > minloss
         losses_ok = losses[ok]
         if self.distribution_name == 'PM':  # special case
             variances_ok = numpy.zeros(len(losses_ok))
         else:
-            covs_ok = df['cov'].to_numpy()[ok]
+            covs_ok = dic['cov'][ok]
             variances_ok = (losses_ok * covs_ok) ** 2
         return pandas.DataFrame(
-            dict(eid=df.eid[ok],
-                 aid=df.aid[ok],
+            dict(eid=dic['eid'][ok],
+                 aid=dic['aid'][ok],
                  variance=variances_ok,
                  loss=losses_ok))
 

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -140,11 +140,11 @@ class Sampler(object):
         self.cols = cols  # for the PM distribution
 
     def get_losses(self, rng, dic, covs):
-        vals = dic['val']
         if not rng or not covs:  # fast lane
-            losses = vals * dic['mean']
+            losses = dic['val'] * dic['mean']
         else:  # slow lane
-            losses = vals * getattr(self, 'sample' + self.distname)(rng, dic)
+            sample = getattr(self, 'sample' + self.distname)
+            losses = dic['val'] * sample(rng, dic)
         return losses
 
     def sampleLN(self, rng, dic):
@@ -172,13 +172,15 @@ class Sampler(object):
                     seed=rng.master_seed + eid).rvs())
         return self.lratios[pmf]
 
-#
-# Input models
-#
+
 def join_dic(ratio_df, asset_df):
+    # in the common case df has columns eid mean cov aid val
     df = ratio_df.join(asset_df, how='inner')
     return {col: df[col].to_numpy() for col in df.columns}
 
+#
+# Input models
+#
 
 class VulnerabilityFunction(object):
     dtype = numpy.dtype([('iml', F64), ('loss_ratio', F64), ('cov', F64)])

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -161,8 +161,9 @@ class Sampler(object):
         return rng.beta(eids, means, covs)
 
     def samplePM(self, rng, df):
+        # in case_1g self.cols = [0, 1, 2, 3, 4, 5, 6], len(df)=4
         eids = df['eid'].to_numpy()
-        allprobs = df[self.cols].to_numpy()
+        allprobs = numpy.array([df[c] for c in self.cols]).T  # (4, 7)
         pmf = []
         for eid, probs in zip(eids, allprobs):  # probs by asset
             if probs.sum() == 0:  # oq-risk-tests/case_1g

--- a/openquake/risklib/scientific.py
+++ b/openquake/risklib/scientific.py
@@ -133,35 +133,34 @@ def fine_graining(points, steps):
 
 # sampling functions
 class Sampler(object):
-    def __init__(self, distname, rng, lratios=(), cols=None):
+    def __init__(self, distname, lratios=(), cols=None):
         self.distname = distname
-        self.rng = rng
         self.arange = numpy.arange(len(lratios))  # for the PM distribution
         self.lratios = lratios  # for the PM distribution
         self.cols = cols  # for the PM distribution
 
-    def get_losses(self, df, covs):
+    def get_losses(self, rng, df, covs):
         vals = df['val'].to_numpy()
-        if not self.rng or not covs:  # fast lane
+        if not rng or not covs:  # fast lane
             losses = vals * df['mean'].to_numpy()
         else:  # slow lane
-            losses = vals * getattr(self, 'sample' + self.distname)(df)
+            losses = vals * getattr(self, 'sample' + self.distname)(rng, df)
         return losses
 
-    def sampleLN(self, df):
+    def sampleLN(self, rng, df):
         means = df['mean'].to_numpy()
         covs = df['cov'].to_numpy()
         eids = df['eid'].to_numpy()
-        losses = self.rng.lognormal(eids, means, covs)
+        losses = rng.lognormal(eids, means, covs)
         return losses
 
-    def sampleBT(self, df):
+    def sampleBT(self, rng, df):
         means = df['mean'].to_numpy()
         covs = df['cov'].to_numpy()
         eids = df['eid'].to_numpy()
-        return self.rng.beta(eids, means, covs)
+        return rng.beta(eids, means, covs)
 
-    def samplePM(self, df):
+    def samplePM(self, rng, df):
         eids = df['eid'].to_numpy()
         allprobs = df[self.cols].to_numpy()
         pmf = []
@@ -172,7 +171,7 @@ class Sampler(object):
             else:
                 pmf.append(stats.rv_discrete(
                     name='pmf', values=(self.arange, probs),
-                    seed=self.rng.master_seed + eid).rvs())
+                    seed=rng.master_seed + eid).rvs())
         return self.lratios[pmf]
 
 #
@@ -261,6 +260,7 @@ class VulnerabilityFunction(object):
                                              fill_value="extrapolate")
         self._covs_i1d = interpolate.interp1d(self.imls, self.covs,
                                               fill_value="extrapolate")
+        self.sampler = Sampler(self.distribution_name)
 
     def interpolate(self, gmf_df, col):
         """
@@ -317,17 +317,10 @@ class VulnerabilityFunction(object):
             # dataset with fields aid, val and key site_id
         ratio_df = self.interpolate(gmf_df, col)  # really fast
         # dataset with fields eid, mean, cov and key sid
-        if self.distribution_name == 'PM':  # special case
-            lratios = F64(self.loss_ratios)
-            cols = [col for col in ratio_df.columns if isinstance(col, int)]
-        else:
-            lratios = ()
-            cols = None
         df = ratio_df.join(asset_df, how='inner')
         # df is a dataset with fields eid, mean, cov, aid, val and key sid
-        sampler = Sampler(self.distribution_name, rng, lratios, cols)
         covs = not hasattr(self, 'covs') or self.covs.any()
-        losses = sampler.get_losses(df, covs)
+        losses = self.sampler.get_losses(rng, df, covs)
         ok = losses > minloss
         losses_ok = losses[ok]
         if self.distribution_name == 'PM':  # special case
@@ -336,13 +329,10 @@ class VulnerabilityFunction(object):
             covs_ok = df['cov'].to_numpy()[ok]
             variances_ok = (losses_ok * covs_ok) ** 2
         return pandas.DataFrame(
-            dict(
-                eid=df.eid[ok],
-                aid=df.aid[ok],
-                variance=variances_ok,
-                loss=losses_ok,
-            )
-        )
+            dict(eid=df.eid[ok],
+                 aid=df.aid[ok],
+                 variance=variances_ok,
+                 loss=losses_ok))
 
     def strictly_increasing(self):
         """
@@ -498,6 +488,9 @@ class VulnerabilityFunctionWithPMF(VulnerabilityFunction):
 
     def init(self):
         self._probs_i1d = interpolate.interp1d(self.imls, self.probs)
+        lratios = F64(self.loss_ratios)
+        cols = list(range(len(self.probs)))
+        self.sampler = Sampler(self.distribution_name, lratios, cols)
 
     def __getstate__(self):
         return (self.id, self.imt, self.imls, self.loss_ratios,
@@ -526,7 +519,8 @@ class VulnerabilityFunctionWithPMF(VulnerabilityFunction):
         """
         :param gmvs:
            DataFrame of GMFs
-        :param col:           name of the column to consider
+        :param col:
+           name of the column to consider
         :returns:
            DataFrame of interpolated probabilities
         """

--- a/openquake/risklib/tests/scientific_test.py
+++ b/openquake/risklib/tests/scientific_test.py
@@ -658,7 +658,10 @@ class RiskComputerTestCase(unittest.TestCase):
                      "imls": [0.1, 0.2, 0.3, 0.5, 0.7],
                      "mean_loss_ratios": [0.0035, 0.07, 0.14, 0.28, 0.56],
                      "covs": [0.0, 0.0, 0.0, 0.0, 0.0],
-                     "distribution_name": "LN"}}}}
+                     "distribution_name": "LN",
+                     'sampler': {
+                         'openquake.risklib.scientific.Sampler':
+                         {'distname': 'LN', 'arange': [], 'lratios': []}}}}}}
         gmfs = {'eid': [0, 1],
                 'sid': [0, 0],
                 'PGA': [.23, .31]}


### PR DESCRIPTION
Not much, here are the figures for Taiwan small on engine192:
```
# before/after
| calc_231, maxmem=155.7 GB    | time_sec | memory_mb | counts  |
|------------------------------+----------+-----------+---------|
| computing risk               | 12_540   | 0.0       | 189_491 |
| computing risk               | 11_860   | 0.0       | 190_775 |
```
We save about 1% of the RAM.