### PR TITLE
Fix serialization of non-ASCII characters, still with allow_pickle=False; fix export_exposure_by_lse decoding

### DIFF
--- a/openquake/calculators/export/risk.py
+++ b/openquake/calculators/export/risk.py
@@ -216,6 +216,11 @@ def export_exposure_by_lse(ekey, dstore):
     writer = writers.CsvWriter(fmt=writers.FIVEDIGITS)
     dest = dstore.build_fname(dskey, '', 'csv')
     df = extract(dstore, f'exposure_by_lse?secondary_peril={secondary_peril}')
+    # Decode UTF-8 bytes back to standard strings for Pandas CSV export
+    for col in df.columns:
+        if df[col].dtype.kind == 'S' or df[col].dtype == object:
+            df[col] = df[col].apply(lambda x: x.decode('utf-8')
+                                    if isinstance(x, bytes) else x)
     writer.save(df, dest, df.columns, comment=dstore.metadata)
     return [dest]
 

--- a/openquake/calculators/extract.py
+++ b/openquake/calculators/extract.py
@@ -877,7 +877,12 @@ def ensure_npy_serializable(df):
     for col in df.columns:
         if df[col].dtype != object:
             continue
-        df[col] = df[col].astype('S')
+        # Explicitly encode strings to UTF-8 bytes to handle non-ASCII
+        # characters (e.g., 'é', 'ñ') before casting to the fixed-width byte
+        # string type ('S')
+        df[col] = df[col].apply(
+            lambda x: x.encode('utf-8') if isinstance(x, str) else x
+        ).astype('S')
     return df
 
 


### PR DESCRIPTION
Partially addressing https://github.com/gem/oq-engine/issues/11691

An example of problematic characters is obtained running an impact job for us6000t7zp: M 7.5 - 17 km W of Catia La Mar, Venezuela