### PR TITLE
Use spatial correlation also in impact jobs

### DIFF
--- a/openquake/calculators/base.py
+++ b/openquake/calculators/base.py
@@ -1488,8 +1488,8 @@ def import_ruptures_hdf5(h5, fnames):
             events['rup_id'] += offset
             if fileno == 0:  # first time
                 h5.create_dataset(
-                    'events', (0,), events.dtype, maxshape=(None,), chunks=True,
-                    compression='gzip')
+                    'events', (0,), events.dtype, maxshape=(None,),
+                    chunks=True, compression='gzip')
             hdf5.extend(h5['events'], events)
             arr = f['rupgeoms'][:]
             h5.save_vlen('rupgeoms', list(arr))
@@ -1614,7 +1614,6 @@ def _store_events(E, n, dstore):
         dstore['weights'] = numpy.ones(1)
     return events['id']
 
-    
 
 def create_gmf_data(dstore, prim_imts, sec_imts=(), data=None,
                     N=None, E=None, R=None):
@@ -1798,9 +1797,7 @@ def store_gmfs_from_shakemap(calc, haz_sitecol, assetcol):
                 % ', '.join(oq.imtls))
     else:
         # no MMI intensities, calculation with or without correlation
-        if oq.impact:
-            gmf_dict = {'kind': 'basic'}  # possibly add correlation
-        elif oq.spatial_correlation != 'no' or oq.cross_correlation != 'no':
+        if oq.spatial_correlation != 'no' or oq.cross_correlation != 'no':
             # cross correlation and/or spatial correlation after S&H
             gmf_dict = {'kind': 'Silva&Horspool',
                         'spatialcorr': oq.spatial_correlation,


### PR DESCRIPTION
So far, when calculating the gmfs in impact calculations, we have been using the 'basic' (faster) approach without correlation. We need to use 'Silva&Horspool' instead. This will make the computation heavier and slower. Let's see how this will affect the computational performance. 

I am also running tests here: https://github.com/gem/oq-engine/actions/runs/31259846195
and here: https://github.com/gem/oq-engine/actions/runs/31259857636

I tried on the staging machine using the impact_report branch plus the spatial correlation, and I got the following error after attempting to run an impact job using the ShakeMap with ID `us6000t7zp`:
```
  File "/mnt/impact/oq-engine/openquake/engine/engine.py", line 222, in run_calc
    calc.run(shutdown=True)
  File "/mnt/impact/oq-engine/openquake/calculators/base.py", line 344, in run
    self.pre_execute()
  File "/mnt/impact/oq-engine/openquake/calculators/event_based_risk.py", line 412, in pre_execute
    super().pre_execute()
  File "/mnt/impact/oq-engine/openquake/calculators/base.py", line 743, in pre_execute
    calc.run(remove=False)
  File "/mnt/impact/oq-engine/openquake/calculators/base.py", line 348, in run
    self.result = self.execute()
                  ^^^^^^^^^^^^^^
  File "/mnt/impact/oq-engine/openquake/calculators/event_based.py", line 921, in execute
    base.store_gmfs_from_shakemap(self, self.sitecol, self.assetcol)
  File "/mnt/impact/oq-engine/openquake/calculators/base.py", line 1809, in store_gmfs_from_shakemap
    store_gmfs(calc, sitecol, shakemap, gmf_dict)
  File "/mnt/impact/oq-engine/openquake/calculators/base.py", line 1727, in store_gmfs
    imts, gmfs = to_gmfs(shakemap, gmf_dict, vs30,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/impact/oq-engine/openquake/hazardlib/shakemap/gmfs.py", line 319, in to_gmfs
    gmfs = calculate_gmfs(gmf_dict.pop('kind'), **gmf_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/impact/oq-engine/openquake/baselib/general.py", line 806, in __call__
    return self[key](obj, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/impact/oq-engine/openquake/hazardlib/shakemap/gmfs.py", line 209, in calculate_gmfs_sh
    raise ValueError(CORRELATION_MATRIX_TOO_LARGE % (
ValueError: You have a correlation matrix which is too large: M=5 x N=30608 > 10000.
To avoid that, set a proper `region_grid_spacing` so that your exposure
involves less sites.
```

Using the small (sampled) exposure, I completed the same calculation on my laptop, but the full exposure makes the computation too expensive. For now I will roll back the staging machine to work without spatial correlation, then we will need to further discuss about this.