### PR TITLE
Fix an error in lon array dtype when using gridded surface rupture from a CSV

### DIFF
--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -162,7 +162,7 @@ def get_ebr(rec, geom, trt):
     elif surface_cls is geo.GriddedSurface:
         # fault surface, strike and dip will be computed
         surface.strike = surface.dip = None
-        surface.mesh = Mesh(*mesh)
+        surface.mesh = Mesh(F32(mesh[0]), F32(mesh[1]), F32(mesh[2]))
     else:
         # fault surface, strike and dip will be computed
         surface.strike = surface.dip = None


### PR DESCRIPTION
`TypeError: loop of ufunc does not support argument 0 of type float which has no callable radians method` when loading a rupture from a CSV which uses `GriddedSurface` 

The dtype of the array was `object` so cleanest fix is to set dtype of float32 when constructing the surface (this is now consistent with the other surface types too).