### PR TITLE
Less slow tasks in ebrisk

### DIFF
--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -518,12 +518,23 @@ def run(func, oq, rup0, calc):
             numpy.isin(events['rup_id'], filrups['id'])]
 
     allargs = []
+    #for model, pairs in cmaker_rups.items():
+    #    cmakers, rupss = zip(*pairs)
+    #    allargs.append((rupss, cmakers, calc.sitecol.sids,
+    #                    calc.sec_perils, calc.datastore))
+    nchunks = (oq.concurrent_tasks // len(cmaker_rups) // 2) or 1
     for model, pairs in cmaker_rups.items():
-        for cmaker, rups in pairs:
-            for rupblock in block_splitter(rups, maxw/5, rup_weight):
-                allargs.append((rupblock, cmaker, model))
-    allargs = _collect(allargs, maxw*2, calc.sitecol.sids, calc.sec_perils,
-                       dstore)
+        cmakers, rupss = zip(*pairs)
+        for ch in range(nchunks):
+            cs, rs = [], []
+            for cm, rups in zip(cmakers, rupss):
+                chrups = rups[ch::nchunks]
+                if len(chrups):
+                    cs.append(cm)
+                    rs.append(chrups)
+            if cs:
+                allargs.append((rs, cs, calc.sitecol.sids,
+                                calc.sec_perils, calc.datastore))
     assert len(allargs) < TWO16, len(allargs)
 
     dstore.swmr_on()

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -521,6 +521,7 @@ def run(func, oq, rup0, calc):
     if len(ntasks) > 1:
         logging.info(f'ntasks by model={ntasks}')
     nr = 0
+    no = 0
     for model, pairs in cmaker_rups.items():
         nt = ntasks[model]
         cmakers, rupss = zip(*pairs)
@@ -532,11 +533,13 @@ def run(func, oq, rup0, calc):
                     cs.append(cm)
                     rs.append(chrups)
                     nr += len(chrups)
+                    no += chrups['n_occ'].sum()
             if cs:
                 allargs.append((rs, cs, calc.sitecol.sids,
                                 calc.sec_perils, calc.datastore))
     assert len(allargs) < TWO16, len(allargs)
     assert nr == len(filrups), (nr, len(filrups))  # sanity check
+    assert no == filrups['n_occ'].sum()  # sanity check
 
     dstore.swmr_on()
     smap = parallel.Starmap(func, h5=dstore.hdf5)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -471,7 +471,7 @@ def ntasks_by_model(cmaker_rups, concurrent_tasks):
         totr += rups_by[model]
         totw += sum(rup_weight(rups).sum() for rups in rupss)
 
-    ct = max(concurrent_tasks, totw / 1E8)
+    ct = max(concurrent_tasks, totw / 8E7)
     return {model: int(numpy.ceil(ct * nr / totr))
             for model, nr in rups_by.items()}
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -468,7 +468,7 @@ def ntasks_by_model(cmaker_rups, concurrent_tasks):
     rng = numpy.random.default_rng(42)
     ntasks = rng.multinomial(
         concurrent_tasks, [rups_by[model] / tot for model in rups_by])
-    return {model: int(ntasks[i]) for i, model in enumerate(rups_by)}
+    return {model: int(ntasks[i]) or 1 for i, model in enumerate(rups_by)}
 
 
 def run(func, oq, rup0, calc):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -486,7 +486,7 @@ def ntasks_by_model(cmaker_rups, concurrent_tasks):
     rng = numpy.random.default_rng(42)
     ntasks = rng.multinomial(
         concurrent_tasks, [rups_by[model] / tot for model in rups_by])
-    return ntasks
+    return {model: ntasks[i] for i, model in enumerate(rups_by)}
 
 
 def run(func, oq, rup0, calc):
@@ -532,7 +532,10 @@ def run(func, oq, rup0, calc):
 
     allargs = []
     ntasks = ntasks_by_model(cmaker_rups, oq.concurrent_tasks or 1)
-    for nt, (model, pairs) in zip(ntasks, cmaker_rups.items()):
+    if len(ntasks) > 1:
+        logging.info(f'ntasks by model={ntasks}')
+    for model, pairs in cmaker_rups.items():
+        nt = ntasks[model]
         cmakers, rupss = zip(*pairs)
         for ch in range(nt):
             cs, rs = [], []
@@ -542,14 +545,11 @@ def run(func, oq, rup0, calc):
                     cs.append(cm)
                     rs.append(chrups)
             if cs:
-                if model != '???':
-                    logging.info(f'Producing {nt:_d} tasks for {model}')
                 allargs.append((rs, cs, calc.sitecol.sids,
                                 calc.sec_perils, calc.datastore))
     assert len(allargs) < TWO16, len(allargs)
 
     dstore.swmr_on()
-    breakpoint()
     smap = parallel.Starmap(func, h5=dstore.hdf5)
     if hasattr(calc, 'save_tmp'):
         calc.save_tmp(smap.monitor)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -471,7 +471,7 @@ def ntasks_by_model(cmaker_rups, concurrent_tasks):
         totr += rups_by[model]
         totw += sum(rup_weight(rups).sum() for rups in rupss)
 
-    ct = max(concurrent_tasks, totw / 5E7)
+    ct = max(concurrent_tasks, totw / 1E8)
     rng = numpy.random.default_rng(42)
     ntasks = rng.multinomial(ct, [rups_by[model] / totr for model in rups_by])
     return {model: int(ntasks[i]) or 1 for i, model in enumerate(rups_by)}

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -518,10 +518,6 @@ def run(func, oq, rup0, calc):
             numpy.isin(events['rup_id'], filrups['id'])]
 
     allargs = []
-    #for model, pairs in cmaker_rups.items():
-    #    cmakers, rupss = zip(*pairs)
-    #    allargs.append((rupss, cmakers, calc.sitecol.sids,
-    #                    calc.sec_perils, calc.datastore))
     nchunks = (oq.concurrent_tasks // len(cmaker_rups) // 2) or 1
     for model, pairs in cmaker_rups.items():
         cmakers, rupss = zip(*pairs)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -486,7 +486,7 @@ def ntasks_by_model(cmaker_rups, concurrent_tasks):
     rng = numpy.random.default_rng(42)
     ntasks = rng.multinomial(
         concurrent_tasks, [rups_by[model] / tot for model in rups_by])
-    return {model: ntasks[i] for i, model in enumerate(rups_by)}
+    return {model: int(ntasks[i]) for i, model in enumerate(rups_by)}
 
 
 def run(func, oq, rup0, calc):
@@ -531,7 +531,7 @@ def run(func, oq, rup0, calc):
             numpy.isin(events['rup_id'], filrups['id'])]
 
     allargs = []
-    ntasks = ntasks_by_model(cmaker_rups, oq.concurrent_tasks or 1)
+    ntasks = ntasks_by_model(cmaker_rups, oq.concurrent_tasks // 2 or 1)
     if len(ntasks) > 1:
         logging.info(f'ntasks by model={ntasks}')
     for model, pairs in cmaker_rups.items():

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -520,6 +520,7 @@ def run(func, oq, rup0, calc):
     ntasks = ntasks_by_model(cmaker_rups, oq.concurrent_tasks // 2 or 1)
     if len(ntasks) > 1:
         logging.info(f'ntasks by model={ntasks}')
+    nr = 0
     for model, pairs in cmaker_rups.items():
         nt = ntasks[model]
         cmakers, rupss = zip(*pairs)
@@ -530,10 +531,12 @@ def run(func, oq, rup0, calc):
                 if len(chrups):
                     cs.append(cm)
                     rs.append(chrups)
+                    nr += len(chrups)
             if cs:
                 allargs.append((rs, cs, calc.sitecol.sids,
                                 calc.sec_perils, calc.datastore))
     assert len(allargs) < TWO16, len(allargs)
+    assert nr == len(filrups), (nr, len(filrups))  # sanity check
 
     dstore.swmr_on()
     smap = parallel.Starmap(func, h5=dstore.hdf5)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -459,15 +459,21 @@ def run_conditioned(oq, proxy, full_lt, calc, station_data, station_sites):
 
 
 def ntasks_by_model(cmaker_rups, concurrent_tasks):
+    """
+    :returns: dictionary model->num_tasks
+    """
     rups_by = {}
-    tot = 0
+    totr = 0
+    totw = 0
     for model, pairs in cmaker_rups.items():
         cmakers, rupss = zip(*pairs)
         rups_by[model] = sum(len(rups) for rups in rupss)
-        tot += rups_by[model]
+        totr += rups_by[model]
+        totw += sum(rup_weight(rups).sum() for rups in rupss)
+
+    ct = max(concurrent_tasks, totw / 5E7)
     rng = numpy.random.default_rng(42)
-    ntasks = rng.multinomial(
-        concurrent_tasks, [rups_by[model] / tot for model in rups_by])
+    ntasks = rng.multinomial(ct, [rups_by[model] / totr for model in rups_by])
     return {model: int(ntasks[i]) or 1 for i, model in enumerate(rups_by)}
 
 

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -321,7 +321,6 @@ def _filter_rups(oq, sitecol, trts, dstore):
         logging.info(f'Selected {len(filrups):_d} ruptures')
     else:
         filrups = allrups
-    totw = 0
     nsites = 0
     affected = 0
     acc = {}
@@ -338,14 +337,11 @@ def _filter_rups(oq, sitecol, trts, dstore):
         rups = filrups[ok]
         if len(rups):
             acc[model, trt_smr] = rups
-            totw += rup_weight(rups).sum()
             nsites += rups['nsites'].sum()
             affected = max(affected, rups['nsites'].max())
     logging.info('Affected sites ~%.0f per rupture, max=%.0f',
                  nsites / len(filrups), affected)
-    maxw = min(totw / (oq.concurrent_tasks or 1), 5E7)
-    logging.info(f'{round(maxw)=:_d}')
-    return filrups, maxw, acc
+    return filrups, acc
 
 
 # tested in global_ses_test
@@ -410,20 +406,6 @@ def read_cmaker_rups(oq, rup_acc, dstore):
         for trt, mags in oqp.mags_by_trt.items():
             oqp.mags_by_trt[trt] = sorted(mags)
     return cmaker_rups
-
-
-def _collect(allargs, maxw, sids, sec_perils, dstore):
-    # allargs is a list [(rupblock, cmaker, model) ...]
-    # returns less arguments [(rup_arrays, cmakers, sids, perils, dstore) ...]
-    out = []
-    for triples in block_splitter(allargs, maxw, lambda item: item[0].weight,
-                                  key=lambda item: item[2]):  # by model
-        rupblks, cmakers, models = zip(*triples)
-        allrups = general.WeightedSequence([
-            (numpy.array(rb), rb.weight) for rb in rupblks])
-        out.append((allrups, cmakers, sids, sec_perils, dstore))
-    # the arguments are reduced in event_based_risk_test/case_03 (from 6 to 5)
-    return out
 
 
 def run_conditioned(oq, proxy, full_lt, calc, station_data, station_sites):
@@ -520,7 +502,7 @@ def run(func, oq, rup0, calc):
 
     trts = {model: full_lt.trts for model, full_lt in get_model_lts(dstore)}
     # NB: _filter_rups calls close_ruptures which can raise an error
-    filrups, maxw, acc = _filter_rups(oq, calc.sitecol, trts, dstore)
+    filrups, acc = _filter_rups(oq, calc.sitecol, trts, dstore)
     cmaker_rups = read_cmaker_rups(oq, acc, dstore)
     p = sum(len(pairs) for pairs in cmaker_rups.values())
     logging.info(f'There are {p:_d} pairs cmaker_rups')

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -248,12 +248,10 @@ def event_based(allrups, cmakers, sids, secperils, dstore, monitor):
     """
     Compute GMFs and optionally hazard curves
     """
-    cmaker = cmakers[0]
     rmon = monitor('reading ruptures', measuremem=True)
     smon = monitor('reading sites', measuremem=True)
     cmon = monitor('computing gmfs', measuremem=False)
     umon = monitor('updating gmfs', measuremem=False)
-    maxdist = cmaker.oq.maximum_distance(cmaker.trt)
     with smon:
         with dstore as f:
             try:
@@ -261,11 +259,13 @@ def event_based(allrups, cmakers, sids, secperils, dstore, monitor):
             except KeyError:
                 complete = f['sitecol']
         sites = complete.filtered(sids)
-        srcfilter = SourceFilter(sites, maxdist)
     chunksize = int(config.memory.max_ruptures_chunk)
     for rups, cmaker in zip(allrups, cmakers):
         if not hasattr(cmaker, 'gmf_mon'):  # not already initialized
             cmaker.init_monitoring(monitor)
+        # NB: the maximum distance can vary between TRTs/CMakers
+        maxdist = cmaker.oq.maximum_distance(cmaker.trt)
+        srcfilter = SourceFilter(sites, maxdist)
         with rmon:
             try:
                 proxies = get_proxies(dstore.filename, rups)
@@ -472,7 +472,8 @@ def ntasks_by_model(cmaker_rups, concurrent_tasks):
         totw += sum(rup_weight(rups).sum() for rups in rupss)
 
     ct = max(concurrent_tasks, totw / 1E8)
-    return {model: int(ct * nr / totr) or 1 for model, nr in rups_by.items()}
+    return {model: int(numpy.ceil(ct * nr / totr))
+            for model, nr in rups_by.items()}
 
 
 def run(func, oq, rup0, calc):
@@ -521,7 +522,6 @@ def run(func, oq, rup0, calc):
     if len(ntasks) > 1:
         logging.info(f'ntasks by model={ntasks}')
     nr = 0
-    no = 0
     for model, pairs in cmaker_rups.items():
         nt = ntasks[model]
         cmakers, rupss = zip(*pairs)
@@ -533,13 +533,11 @@ def run(func, oq, rup0, calc):
                     cs.append(cm)
                     rs.append(chrups)
                     nr += len(chrups)
-                    no += chrups['n_occ'].sum()
             if cs:
                 allargs.append((rs, cs, calc.sitecol.sids,
                                 calc.sec_perils, calc.datastore))
     assert len(allargs) < TWO16, len(allargs)
     assert nr == len(filrups), (nr, len(filrups))  # sanity check
-    assert no == filrups['n_occ'].sum()  # sanity check
 
     dstore.swmr_on()
     smap = parallel.Starmap(func, h5=dstore.hdf5)

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -472,9 +472,7 @@ def ntasks_by_model(cmaker_rups, concurrent_tasks):
         totw += sum(rup_weight(rups).sum() for rups in rupss)
 
     ct = max(concurrent_tasks, totw / 1E8)
-    rng = numpy.random.default_rng(42)
-    ntasks = rng.multinomial(ct, [rups_by[model] / totr for model in rups_by])
-    return {model: int(ntasks[i]) or 1 for i, model in enumerate(rups_by)}
+    return {model: int(ct * nr / totr) or 1 for model, nr in rups_by.items()}
 
 
 def run(func, oq, rup0, calc):

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -476,6 +476,19 @@ def run_conditioned(oq, proxy, full_lt, calc, station_data, station_sites):
         hdf5.extend(dstore[f'gmf_data/{col}'], gmf_df[col])
 
 
+def ntasks_by_model(cmaker_rups, concurrent_tasks):
+    rups_by = {}
+    tot = 0
+    for model, pairs in cmaker_rups.items():
+        cmakers, rupss = zip(*pairs)
+        rups_by[model] = sum(len(rups) for rups in rupss)
+        tot += rups_by[model]
+    rng = numpy.random.default_rng(42)
+    ntasks = rng.multinomial(
+        concurrent_tasks, [rups_by[model] / tot for model in rups_by])
+    return ntasks
+
+
 def run(func, oq, rup0, calc):
     """
     Submit the ruptures and apply `func` (event_based or ebrisk)
@@ -518,22 +531,25 @@ def run(func, oq, rup0, calc):
             numpy.isin(events['rup_id'], filrups['id'])]
 
     allargs = []
-    nchunks = (oq.concurrent_tasks // len(cmaker_rups) // 2) or 1
-    for model, pairs in cmaker_rups.items():
+    ntasks = ntasks_by_model(cmaker_rups, oq.concurrent_tasks or 1)
+    for nt, (model, pairs) in zip(ntasks, cmaker_rups.items()):
         cmakers, rupss = zip(*pairs)
-        for ch in range(nchunks):
+        for ch in range(nt):
             cs, rs = [], []
             for cm, rups in zip(cmakers, rupss):
-                chrups = rups[ch::nchunks]
+                chrups = rups[ch::nt]
                 if len(chrups):
                     cs.append(cm)
                     rs.append(chrups)
             if cs:
+                if model != '???':
+                    logging.info(f'Producing {nt:_d} tasks for {model}')
                 allargs.append((rs, cs, calc.sitecol.sids,
                                 calc.sec_perils, calc.datastore))
     assert len(allargs) < TWO16, len(allargs)
 
     dstore.swmr_on()
+    breakpoint()
     smap = parallel.Starmap(func, h5=dstore.hdf5)
     if hasattr(calc, 'save_tmp'):
         calc.save_tmp(smap.monitor)

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -19,7 +19,9 @@
 import io
 import os
 import math
+from unittest import mock
 from unittest.mock import patch
+import numpy
 import pandas
 import numpy.testing
 
@@ -33,7 +35,7 @@ from openquake.commonlib.calc import gmvs_to_poes
 from openquake.calculators.views import view
 from openquake.calculators.export import export
 from openquake.calculators.extract import extract
-from openquake.calculators.event_based import get_mean_curve, compute_avg_gmf
+from openquake.calculators import event_based
 from openquake.calculators.postproc import debug_rupture
 from openquake.calculators.tests import CalculatorTestCase, strip_calc_id
 from openquake.qa_tests_data.event_based import (
@@ -86,13 +88,89 @@ def joint_prob_of_occurrence(gmvs_site_1, gmvs_site_2, gmv, time_span,
 
 class EventBasedTestCase(CalculatorTestCase):
 
+    def test_cmakers_maximum_distance(self):
+        # A task containing multiple CMakers must not lose later GMFs
+
+        class Oq:
+            def maximum_distance(self, trt):
+                return {'short': 10.0, 'long': 100.0}[trt]
+
+        class Cmaker:
+            def __init__(self, trt):
+                self.trt = trt
+                self.oq = Oq()
+
+            def init_monitoring(self, monitor):
+                pass
+
+        class Dstore:
+            filename = 'dummy.hdf5'
+            parent = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def __getitem__(self, key):
+                if key == 'complete':
+                    return self
+                raise KeyError(key)
+
+            def filtered(self, sids):
+                return self
+
+        class SourceFilter:
+            def __init__(self, sites, maxdist):
+                self.maxdist = maxdist
+
+        class Monitor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def __call__(self, *args, **kwargs):
+                return self
+
+        dtype = numpy.dtype([('id', 'i8'), ('distance', 'f4')])
+        rups = [
+            numpy.array([(1, 5.0)], dtype),
+            numpy.array([(2, 50.0)], dtype),
+        ]
+        cmakers = [Cmaker('short'), Cmaker('long')]
+        received = []
+
+        def get_proxies(_filename, rows):
+            return list(rows)
+
+        def fake_event_based(
+                block, cmaker, _sec_perils, srcfilter, _cmon, _umon):
+            for rup in block:
+                if rup['distance'] <= srcfilter.maxdist:
+                    received.append((cmaker.trt, int(rup['id'])))
+            yield {'gmfdata': {}}
+
+        with mock.patch.object(event_based, 'SourceFilter', SourceFilter), \
+                mock.patch.object(event_based, 'get_proxies', get_proxies), \
+                mock.patch.object(
+                    event_based, '_event_based', fake_event_based):
+            for result in event_based.event_based(
+                    rups, cmakers, numpy.array([0]), (), Dstore(), Monitor()):
+                list(result)
+
+        self.assertEqual(received, [('short', 1), ('long', 2)])
+
     def check_avg_gmf(self):
         # checking avg_gmf with a single site
         min_iml = self.calc.oqparam.min_iml
         df = self.calc.datastore.read_df('gmf_data', 'sid')
         weights = self.calc.datastore['weights'][:]
         rlzs = self.calc.datastore['events']['rlz_id']
-        [(_sid, avgstd)] = compute_avg_gmf(df, weights[rlzs], min_iml).items()
+        [(_sid, avgstd)] = event_based.compute_avg_gmf(
+            df, weights[rlzs], min_iml).items()
         avg_gmf = self.calc.datastore['avg_gmf'][:]  # 2, N, M
         aac(avg_gmf[:, 0], avgstd)
 
@@ -107,7 +185,8 @@ class EventBasedTestCase(CalculatorTestCase):
         gmf_df = pandas.DataFrame(dict(eid=eids[ok], gmv_0=gmvs[ok]),
                                   numpy.zeros(E, int)[ok])
         weights = numpy.ones(E)
-        [(_sid, avgstd)] = compute_avg_gmf(gmf_df, weights, min_iml).items()
+        [(_sid, avgstd)] = event_based.compute_avg_gmf(
+            gmf_df, weights, min_iml).items()
         aac(avgstd, [[0.134056], [1.620217]], atol=1E-6)
 
     def test_spatial_correlation(self):
@@ -329,10 +408,12 @@ class EventBasedTestCase(CalculatorTestCase):
                          dic)
 
         fnames = out['hcurves', 'csv']
-        mean_eb = get_mean_curve(self.calc.datastore, 'PGA', slice(None))
+        mean_eb = event_based.get_mean_curve(
+            self.calc.datastore, 'PGA', slice(None))
         for exp, got in zip(expected, fnames):
             self.assertEqualFiles('expected/%s' % exp, got)
-        mean_cl = get_mean_curve(self.calc.cl.datastore, 'PGA', slice(None))
+        mean_cl = event_based.get_mean_curve(
+            self.calc.cl.datastore, 'PGA', slice(None))
         reldiff, _index = max_rel_diff_index(mean_cl, mean_eb, min_value=0.1)
         self.assertLess(reldiff, 0.06)
 


### PR DESCRIPTION
Here is the situation for Japan small:
```
| operation-duration | counts | mean   | stddev | min     | max    | slowfac |
|--------------------+--------+--------+--------+---------+--------+---------|
| ebrisk             | 168    | 191.3  | 56%    | 43.1443 | 454.5  | 2.3755  |
| ebrisk             | 158    | 322.2  | 26%    | 33.1309 | 398.3  | 1.2363  |

# JPN before
| calc_72, maxmem=182.9 GB     | time_sec | memory_mb | counts    |
|------------------------------+----------+-----------+-----------|
| total ebrisk                 | 32_145   | 286.8     | 168       |
| computing risk               | 20_855   | 0.0       | 464_749   |
| filtering GMFs               | 2_055    | 0.0       | 1_097_376 |
| aggregating losses           | 1_918    | 0.0       | 464_749   |
| EventBasedRiskCalculator.run | 772.4    | 676.7     | 1         |

# JPN after
| calc_60, maxmem=207.3 GB     | time_sec | memory_mb | counts    |
|------------------------------+----------+-----------+-----------|
| total ebrisk                 | 51_008   | 340.1     | 162       |
| computing risk               | 38_826   | 0.0       | 947_133   |
| aggregating losses           | 3_814    | 0.0       | 947_133   |
| filtering GMFs               | 2_496    | 0.0       | 1_058_184 |
| EventBasedRiskCalculator.run | 695.5    | 672.2     | 1         |
```