### PR TITLE
Avoid animations/transitions in playwright UI tests…

### DIFF
--- a/openquake/server/tests/conftest.py
+++ b/openquake/server/tests/conftest.py
@@ -124,6 +124,11 @@ def authenticated_page(
         "url": live_server.url,
     }])
     page.goto(f"{live_server.url}/engine/")
+    # Disable animations/transitions to prevent Bootstrap modal backdrop
+    # timeouts
+    page.add_style_tag(
+        content="* {transition: none !important; animation: none !important;}"
+    )
     return page
 
 
@@ -138,4 +143,9 @@ def ui_logged_in_page(
     page.get_by_role("button", name="Log in").click()
 
     page.wait_for_url(f"{live_server.url}/engine/")
+    # Disable animations/transitions to prevent Bootstrap modal backdrop
+    # timeouts
+    page.add_style_tag(
+        content="* {transition: none !important; animation: none !important;}"
+    )
     return page


### PR DESCRIPTION
…to prevent Bootstrap modal backdrop timeouts.

Sometimes (rarely but annoyingly) the Playwright UI tests fail due to race conditions (e.g. https://github.com/gem/oq-engine/actions/runs/32467349360/job/96726683861)
Let's see if this change will prevent those random failures.

See also https://github.com/gem/oq-engine/actions/runs/32583462483