### PR TITLE
docs: fix typo availabe -> available

### DIFF
--- a/doc/user-guide/advanced/working-with-the-dstore.rst
+++ b/doc/user-guide/advanced/working-with-the-dstore.rst
@@ -12,7 +12,7 @@ Reading the datastore with python
 ---------------------------------
 
 Read the datastore for a given calculation id and list
-the availabe datastore keys::
+the available datastore keys::
 
 	>> from openquake.commonlib.datastore import read
 	>> dstore = read(calc_id)


### PR DESCRIPTION
Corrects a single misspelling of `availabe` in `doc/user-guide/advanced/working-with-the-dstore.rst`.

Documentation only, no behaviour change.