### PR TITLE
Filter conditioning IMTs by GMM support

### DIFF
--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -355,9 +355,10 @@ def _gsim_supports_imt(gsim, imt):
             imt.name in {imt_type.__name__ for imt_type in supported})
 
 
-def select_observed_imts(target_imts, observed_imts, gsim, models):
-    """Return station IMTs supported by a GSIM and correlation models."""
-    for model in models:
+def select_observed_imts(
+        target_imts, observed_imts, gsim, correlation_models):
+    """Return station IMTs supported by the GSIM and correlation models."""
+    for model in correlation_models:
         model.validate_imts(target_imts)
 
     selected = []
@@ -366,7 +367,7 @@ def select_observed_imts(target_imts, observed_imts, gsim, models):
             continue
         trial = list(dict.fromkeys([*target_imts, *selected, candidate]))
         try:
-            for model in models:
+            for model in correlation_models:
                 model.validate_imts(trial)
         except ValueError:
             continue
@@ -1141,9 +1142,10 @@ def build_precomputed(rupture, cmaker, inp, compute_covs=True):
     :return: Precomputed(ctx_Y, ctx_D, YY, YD, DY, DD, mtp_args) tuple
     """
     pre = get_precomputed(rupture, cmaker, inp, compute_covs)
-    models = [inp.within_event_model, inp.between_event_model]
+    correlation_models = [
+        inp.within_event_model, inp.between_event_model]
     if isinstance(inp.within_event_model, SpatialCorrelationModel):
-        models.append(inp.separable_cross_imt_model)
+        correlation_models.append(inp.separable_cross_imt_model)
     for g, gsim in enumerate(cmaker.gsims):
         if gsim.DEFINED_FOR_STANDARD_DEVIATION_TYPES == {StdDev.TOTAL}:
             if not (type(gsim).__name__ == "ModifiableGMPE"
@@ -1153,7 +1155,7 @@ def build_precomputed(rupture, cmaker, inp, compute_covs=True):
         # NB: there are relatively few stations, so cm.get_mean_stds([ctx_D])
         # is fast and done sequentially, while ctx_Y is done in parallel
         imts_D = select_observed_imts(
-            inp.imts_Y, inp.imts_D, gsim, models)
+            inp.imts_Y, inp.imts_D, gsim, correlation_models)
         skipped = [imt.string for imt in conditionable_imts(inp.imts_D)
                    if imt not in imts_D]
         if skipped:

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -349,6 +349,31 @@ def conditionable_imts(imts):
     return [imt for imt in imts if imt.string != 'MMI']
 
 
+def _gsim_supports_imt(gsim, imt):
+    supported = gsim.DEFINED_FOR_INTENSITY_MEASURE_TYPES
+    return (supported is None or
+            imt.name in {imt_type.__name__ for imt_type in supported})
+
+
+def select_observed_imts(target_imts, observed_imts, gsim, models):
+    """Return station IMTs supported by a GSIM and correlation models."""
+    for model in models:
+        model.validate_imts(target_imts)
+
+    selected = []
+    for candidate in conditionable_imts(observed_imts):
+        if not _gsim_supports_imt(gsim, candidate):
+            continue
+        trial = list(dict.fromkeys([*target_imts, *selected, candidate]))
+        try:
+            for model in models:
+                model.validate_imts(trial)
+        except ValueError:
+            continue
+        selected.append(candidate)
+    return selected
+
+
 def get_precomputed(rupture, cmaker, inp, compute_covs=True):
     """
     :param compute_covs: build matrices required only for random fields
@@ -477,13 +502,15 @@ class ConditionedGmfComputer(GmfComputer):
         self.rupture = rupture
 
         target_imts = conditionable_imts(self.imts)
+        within_event_model = within_event_model or JayaramBaker2009(clust)
+        between_event_model = between_event_model or GodaAtkinson2009()
+        separable_cross_imt_model = BakerJayaram2008()
 
         self.inp = Input(
             sitecol, station_sitecol,
             target_imts, observed_imts, station_data,
-            within_event_model or JayaramBaker2009(clust),
-            between_event_model or GodaAtkinson2009(),
-            BakerJayaram2008(), self.correlation_context)
+            within_event_model, between_event_model,
+            separable_cross_imt_model, self.correlation_context)
 
     def _compute_mvn(self, mu_Y, cov_WY_WY, cov_BY_BY, E):
         rng = numpy.random.default_rng(self.seed)
@@ -1114,6 +1141,9 @@ def build_precomputed(rupture, cmaker, inp, compute_covs=True):
     :return: Precomputed(ctx_Y, ctx_D, YY, YD, DY, DD, mtp_args) tuple
     """
     pre = get_precomputed(rupture, cmaker, inp, compute_covs)
+    models = [inp.within_event_model, inp.between_event_model]
+    if isinstance(inp.within_event_model, SpatialCorrelationModel):
+        models.append(inp.separable_cross_imt_model)
     for g, gsim in enumerate(cmaker.gsims):
         if gsim.DEFINED_FOR_STANDARD_DEVIATION_TYPES == {StdDev.TOTAL}:
             if not (type(gsim).__name__ == "ModifiableGMPE"
@@ -1122,15 +1152,29 @@ def build_precomputed(rupture, cmaker, inp, compute_covs=True):
 
         # NB: there are relatively few stations, so cm.get_mean_stds([ctx_D])
         # is fast and done sequentially, while ctx_Y is done in parallel
+        imts_D = select_observed_imts(
+            inp.imts_Y, inp.imts_D, gsim, models)
+        skipped = [imt.string for imt in conditionable_imts(inp.imts_D)
+                   if imt not in imts_D]
+        if skipped:
+            logging.info(
+                'Skipping station IMTs unsupported by %s and its '
+                'correlation models: %s', gsim.__class__.__name__,
+                ', '.join(skipped))
+        if not imts_D:
+            raise ValueError(
+                'The station data contains no IMTs supported by '
+                f'{gsim.__class__.__name__} and its correlation models')
+        branch_inp = replace(inp, imts_D=imts_D)
         gdict = {gsim: cmaker.gsims[gsim]}
-        cm_D = cmaker.copy(imtls={im.string: [0] for im in inp.imts_D},
+        cm_D = cmaker.copy(imtls={im.string: [0] for im in imts_D},
                            gsims=gdict)
         mean_stds_D = cm_D.get_mean_stds([pre.ctx_D])
         cm_Y = cmaker.copy(
             imtls={imt.string: [0] for imt in inp.imts_Y}, gsims=gdict)
         mean_stds_Y = cm_Y.get_mean_stds([pre.ctx_Y])  # fast enough
         pre.conditioners.append(Conditioner(
-            g, gsim, inp, mean_stds_Y, mean_stds_D))
+            g, gsim, branch_inp, mean_stds_Y, mean_stds_D))
     return pre
 
 

--- a/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
+++ b/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
@@ -42,7 +42,7 @@ from openquake.hazardlib.calc.conditioned_gmfs import (
     compute_distance_matrix, conditionable_imts, conditioned,
     conditioned_mean_in_chunks, createD,
     compute_within_event_covariance_matrix, get_mean_covs, Input,
-    JointConditioning, StationConditioning)
+    JointConditioning, select_observed_imts, StationConditioning)
 from openquake.hazardlib.tests.calc import \
     _conditioned_gmfs_test_data as test_data
 
@@ -51,6 +51,41 @@ aac = numpy.testing.assert_allclose
 
 def test_pgv_is_conditionable():
     assert conditionable_imts([PGA(), PGV(), MMI()]) == [PGA(), PGV()]
+
+
+def test_observed_imt_support():
+    target = [PGA(), SA(0.3)]
+    observed = [PGA(), PGV(), SA(0.3), MMI()]
+    all_imts = SimpleNamespace(
+        DEFINED_FOR_INTENSITY_MEASURE_TYPES={PGA, PGV, SA})
+    spectral_only = SimpleNamespace(
+        DEFINED_FOR_INTENSITY_MEASURE_TYPES={PGA, SA})
+    models = [DuNing2021(), NoCrossCorrelation()]
+
+    assert select_observed_imts(
+        target, observed, all_imts, models) == observed[:3]
+    assert select_observed_imts(
+        target, observed, spectral_only, models) == [
+            PGA(), SA(0.3)]
+
+
+def test_branch_observed_imts():
+    class PGVGMM(test_data.ZeroMeanGMM):
+        DEFINED_FOR_INTENSITY_MEASURE_TYPES = {PGA, PGV, SA}
+
+    cmaker = simple_cmaker(
+        [PGVGMM(), test_data.ZeroMeanGMM()], [],
+        maximum_distance=test_data.MAX_DIST, truncation_level=0)
+    observed = [PGA(), PGV()]
+    inp = Input(
+        test_data.CASE07_TARGET_SITECOL,
+        test_data.CASE07_STATION_SITECOL,
+        [PGA()], observed, test_data.CASE07_STATION_DATA,
+        DuNing2021(), NoCrossCorrelation(), None)
+
+    pre = build_precomputed(test_data.RUP, cmaker, inp, compute_covs=False)
+    assert pre.conditioners[0].inp.imts_D == observed
+    assert pre.conditioners[1].inp.imts_D == [PGA()]
 
 
 def test_joint_within_covariance():

--- a/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
+++ b/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
@@ -60,12 +60,12 @@ def test_observed_imt_support():
         DEFINED_FOR_INTENSITY_MEASURE_TYPES={PGA, PGV, SA})
     spectral_only = SimpleNamespace(
         DEFINED_FOR_INTENSITY_MEASURE_TYPES={PGA, SA})
-    models = [DuNing2021(), NoCrossCorrelation()]
+    correlation_models = [DuNing2021(), NoCrossCorrelation()]
 
     assert select_observed_imts(
-        target, observed, all_imts, models) == observed[:3]
+        target, observed, all_imts, correlation_models) == observed[:3]
     assert select_observed_imts(
-        target, observed, spectral_only, models) == [
+        target, observed, spectral_only, correlation_models) == [
             PGA(), SA(0.3)]
 
 


### PR DESCRIPTION
Select extra station IMTs separately for each GSIM branch and require compatibility with the selected within- and between-event correlation models. This would keep PGV when the GMM branch supports it and remove it when the GMM branch does not, thus preventing unsupported observations from reaching a GSIM. Should resolve the failing test cases involving PGV in oq-risk-tests and GEESE.