### PR TITLE
Optimise KothaEtAl2020regional spatial lookups

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
   [Christopher Brooks]
   * Optimise the spatial lookups in the KothaEtAl2020regional GSIM by
     performing them once per call of the `compute` method instead of
-    per IMT (the events and sites don't vary with IMT).
+    per IMT (the events and sites don't vary with IMT in `ctx` recarray).
 
   [Anirudh Rao]
   * Add the Du and Ning (2021) within-event joint spatial and cross-IMT

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+  [Christopher Brooks]
+  * Optimise the spatial lookups in the KothaEtAl2020regional GSIM by
+    performing them once per call of the `compute` method instead of
+    per IMT (the events and sites don't vary with IMT).
+
   [Anirudh Rao]
   * Add the Du and Ning (2021) within-event joint spatial and cross-IMT
     correlation model for PGA, SAs at 17 periods, PGV, Ia, CAV, and 

--- a/openquake/hazardlib/gsim/kotha_2020.py
+++ b/openquake/hazardlib/gsim/kotha_2020.py
@@ -37,8 +37,8 @@ from openquake.hazardlib.imt import PGA, PGV, SA, from_string
 from openquake.hazardlib.gsim.nga_east import (get_tau_at_quantile, ITPL,
                                                TAU_EXECUTION, TAU_SETUP)
 
-DATA_FOLDER = os.path.join(os.path.dirname(__file__), 'Kotha_2020')
 
+DATA_FOLDER = os.path.join(os.path.dirname(__file__), 'Kotha_2020')
 
 CONSTANTS = {"Mref": 4.5, "Rref": 30., "Mh": 5.7,
              "h_D10": 4.0, "h_10D20": 8.0, "h_D20": 12.0}

--- a/openquake/hazardlib/gsim/kotha_2020.py
+++ b/openquake/hazardlib/gsim/kotha_2020.py
@@ -27,8 +27,8 @@ Module exports :class:`KothaEtAl2020`,
 import os
 import numpy as np
 from scipy.constants import g
-from shapely.geometry import Point, shape
-from shapely.prepared import prep
+from shapely import contains_xy
+from shapely.geometry import shape
 from openquake.baselib.general import CallableDict
 from openquake.hazardlib.geo.packager import fiona
 from openquake.hazardlib.gsim.base import GMPE, CoeffsTable, add_alias
@@ -38,6 +38,7 @@ from openquake.hazardlib.gsim.nga_east import (get_tau_at_quantile, ITPL,
                                                TAU_EXECUTION, TAU_SETUP)
 
 DATA_FOLDER = os.path.join(os.path.dirname(__file__), 'Kotha_2020')
+
 
 CONSTANTS = {"Mref": 4.5, "Rref": 30., "Mh": 5.7,
              "h_D10": 4.0, "h_10D20": 8.0, "h_D20": 12.0}
@@ -123,6 +124,62 @@ def _get_h(C, hypo_depth):
         np.where(hypo_depth > 20., CONSTANTS["h_D20"], CONSTANTS["h_10D20"]))
 
 
+def _assign_feature_indices(shapes, lons, lats):
+    """
+    Return the index of the containing feature for each (lon, lat) point,
+    or -1 if the point is outside every feature.
+    """
+    # num entries in ctx row
+    n = len(lons)
+
+    # -1 means point is not yet inside any feature
+    assignment = np.full(n, -1)
+
+    # Track which points still need a feature assignment
+    unassigned = np.ones(n, bool)
+    for i, geom in enumerate(shapes):
+
+        # Stop early once every point has been assigned
+        if not unassigned.any():
+            break
+
+        # Only test points that haven't been assigned yet
+        idx = np.flatnonzero(unassigned)
+
+        # Point-in-polygon check against this feature
+        contained = contains_xy(geom, lons[idx], lats[idx])
+
+        # Orig array indices of the points inside this feature
+        hits = idx[contained]
+
+        # Record the feature index and mark those points as assigned
+        assignment[hits] = i
+        unassigned[hits] = False
+
+    return assignment
+
+
+def _lookup_property(feat_idx, props_list, key):
+    """
+    Return each point's value of "key" from its assigned feature's
+    properties, or 0.0 for points outside every feature.
+    """
+    # Set array of zeros (one per input point) - any unassigned point will
+    # end up keeping this zero value and therefore fallback to base coeff
+    out = np.zeros(len(feat_idx))
+
+    # Get the key property from each feature into a flat array
+    values = np.array([p[key] for p in props_list])
+
+    # Get mask marking the points which got assigned to a feature
+    valid = feat_idx >= 0
+
+    # Assign non-zero value to each point inside a feature
+    out[valid] = values[feat_idx[valid]]
+
+    return out
+
+
 get_distance_coefficients = CallableDict()
 
 
@@ -175,7 +232,8 @@ def get_distance_coefficients_2(kind, c3, c3_epsilon, C, imt, sctx):
     return c3_ + c3_epsilon * tau_c3
 
 
-def get_distance_coefficients_3(att, delta_c3_epsilon, C, imt, sctx):
+def get_distance_coefficients_3(att_props, site_feat_idx, delta_c3_epsilon,
+                                C, imt_key):
     """
     Return site-specific coefficient 'C3'. The function retrieves the
     value of delta_c3 and the standard error of delta_c3 from the 'att'
@@ -183,19 +241,9 @@ def get_distance_coefficients_3(att, delta_c3_epsilon, C, imt, sctx):
     added to the generic coefficient 'c3' from the GMPE. A delta_c3_epsilon
     value of +/- 1.6 gives the 95% confidence interval for delta_c3.
     """
-    s = [(Point(lon, lat)) for lon, lat in zip(sctx.lon, sctx.lat)]
-    delta_c3 = np.zeros((len(sctx.lat), 2), dtype=float)
-    for i, feature in enumerate(att):
-        prepared_polygon = prep(shape(feature['geometry']))
-        contained = list(filter(prepared_polygon.contains, s))
-        if contained:
-            ll = np.concatenate([
-                np.where((sctx['lon'] == p.x) &
-                         (sctx['lat'] == p.y))[0] for p in contained])
-            delta_c3[ll, 0] = feature['properties'][str(imt)]
-            delta_c3[ll, 1] = feature['properties'][str(imt)+'_se']
-
-    return C["c3"] + delta_c3[:, 0] + delta_c3_epsilon * delta_c3[:, 1]
+    delta_c3 = _lookup_property(site_feat_idx, att_props, imt_key)
+    delta_c3_se = _lookup_property(site_feat_idx, att_props, imt_key + '_se')
+    return C["c3"] + delta_c3 + delta_c3_epsilon * delta_c3_se
 
 
 def get_distance_term(kind, c3, c3_epsilon, C, ctx, imt):
@@ -222,7 +270,7 @@ def get_magnitude_scaling(C, mag):
                     C["e1"] + C["b3"] * d_m)
 
 
-def get_dl2l(tec, ctx, imt, delta_l2l_epsilon):
+def get_dl2l(tec_props, tec_feat_idx, imt_key, delta_l2l_epsilon):
     """
     Returns rupture source specific delta_l2l values. The method
     retrieves the delta_l2l and standard error of delta_l2l values.
@@ -230,19 +278,9 @@ def get_dl2l(tec, ctx, imt, delta_l2l_epsilon):
     will be included. A delta_l2l_epsilon value of +/- 1.6 gives
     the 95% confidence interval for delta_l2l.
     """
-    f = [(Point(lon, lat)) for lon, lat in zip(ctx.hypo_lon, ctx.hypo_lat)]
-    dl2l = np.zeros((len(ctx.hypo_lon), 2), dtype=float)
-    for i, feature in enumerate(tec):
-        prepared_polygon = prep(shape(feature['geometry']))
-        contained = list(filter(prepared_polygon.contains, f))
-        if contained:
-            ll = np.concatenate([
-                np.where((ctx['hypo_lon'] == p.x) &
-                         (ctx['hypo_lat'] == p.y))[0] for p in contained])
-            dl2l[ll, 0] = feature['properties'][str(imt)]
-            dl2l[ll, 1] = feature['properties'][str(imt)+'_se']
-
-    return dl2l[:, 0] + delta_l2l_epsilon * dl2l[:, 1]
+    dl2l = _lookup_property(tec_feat_idx, tec_props, imt_key)
+    dl2l_se = _lookup_property(tec_feat_idx, tec_props, imt_key + '_se')
+    return dl2l + delta_l2l_epsilon * dl2l_se
 
 
 def get_sigma_mu_adjustment(kind, C, imt, ctx):
@@ -470,6 +508,13 @@ class KothaEtAl2020(GMPE):
         <.base.GroundShakingIntensityModel.compute>`
         for spec of input and result values.
         """
+        # Point-in-polygon assignments do not depend on IMT, so compute them
+        # once per compute call and reuse across all IMTs.
+        if self.kind == 'regional':
+            site_feat_idx = _assign_feature_indices(
+                self.att_shapes, ctx.lon, ctx.lat)
+            tec_feat_idx = _assign_feature_indices(
+                self.tec_shapes, ctx.hypo_lon, ctx.hypo_lat)
         for m, imt in enumerate(imts):
             C = self.COEFFS[imt]
             extra = {}
@@ -487,9 +532,9 @@ class KothaEtAl2020(GMPE):
             else:
                 phi_s2s = None
             if self.kind == 'regional':
-                c3 = get_distance_coefficients_3(self.att,
-                                                 self.delta_c3_epsilon,
-                                                 C, imt, ctx)
+                c3 = get_distance_coefficients_3(
+                    self.att_props, site_feat_idx,
+                    self.delta_c3_epsilon, C, str(imt))
             else:
                 c3 = self.c3
             fp = get_distance_term(self.kind, c3, self.c3_epsilon,
@@ -506,7 +551,8 @@ class KothaEtAl2020(GMPE):
                 mean[m] += self.dl2l[imt]["dl2l"]
 
             elif self.kind == 'regional':
-                dl2l = get_dl2l(self.tec, ctx, imt, self.delta_l2l_epsilon)
+                dl2l = get_dl2l(self.tec_props, tec_feat_idx, str(imt),
+                                self.delta_l2l_epsilon)
                 mean[m] += dl2l
 
             elif self.sigma_mu_epsilon:
@@ -582,12 +628,21 @@ class KothaEtAl2020regional(KothaEtAl2020):
         self.delta_l2l_epsilon = delta_l2l_epsilon
         self.delta_c3_epsilon = delta_c3_epsilon
         self.ergodic = ergodic
+        # Cache geojson feature shapes and properties once. The polygon
+        # geometry does not vary with IMT or ctx, so building shapes here
+        # (and precomputing per-point assignments per compute call) avoids
+        # rebuilding prepared polygons N_imts times per compute.
         attenuation_file = os.path.join(
             DATA_FOLDER, 'kotha_attenuation_regions.geojson')
-        self.att = list(fiona.open(attenuation_file))
+        att = list(fiona.open(attenuation_file))
+        self.att_shapes = [shape(f['geometry']) for f in att]
+        self.att_props = [f['properties'] for f in att]
         tectonic_file = os.path.join(
             DATA_FOLDER, 'kotha_tectonic_regions.geojson')
-        self.tec = list(fiona.open(tectonic_file))
+        tec = list(fiona.open(tectonic_file))
+        self.tec_shapes = [shape(f['geometry']) for f in tec]
+        self.tec_props = [f['properties'] for f in tec]
+
 
 
 class KothaEtAl2020Site(KothaEtAl2020):

--- a/openquake/hazardlib/gsim/kotha_2020.py
+++ b/openquake/hazardlib/gsim/kotha_2020.py
@@ -13,7 +13,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Affero General Public Licensegit push --force-with-lease origin k20_opt
+# You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 """

--- a/openquake/hazardlib/gsim/kotha_2020.py
+++ b/openquake/hazardlib/gsim/kotha_2020.py
@@ -13,7 +13,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Affero General Public License
+# You should have received a copy of the GNU Affero General Public Licensegit push --force-with-lease origin k20_opt
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 """
@@ -236,10 +236,11 @@ def get_distance_coefficients_3(att_props, site_feat_idx, delta_c3_epsilon,
                                 C, imt_key):
     """
     Return site-specific coefficient 'C3'. The function retrieves the
-    value of delta_c3 and the standard error of delta_c3 from the 'att'
-    geojson file depending on the location of site. This delta_c3 is
-    added to the generic coefficient 'c3' from the GMPE. A delta_c3_epsilon
-    value of +/- 1.6 gives the 95% confidence interval for delta_c3.
+    value of delta_c3 and the standard error of delta_c3 from the
+    pre-parsed 'att' properties depending on the location of site. This
+    delta_c3 is added to the generic coefficient 'c3' from the GMPE. A
+    delta_c3_epsilon value of +/- 1.6 gives the 95% confidence interval
+    for delta_c3.
     """
     delta_c3 = _lookup_property(site_feat_idx, att_props, imt_key)
     delta_c3_se = _lookup_property(site_feat_idx, att_props, imt_key + '_se')
@@ -274,7 +275,7 @@ def get_dl2l(tec_props, tec_feat_idx, imt_key, delta_l2l_epsilon):
     """
     Returns rupture source specific delta_l2l values. The method
     retrieves the delta_l2l and standard error of delta_l2l values.
-    if delta_l2l_epsilon is provided, standard error of delta_c3
+    if delta_l2l_epsilon is provided, standard error of delta_l2l
     will be included. A delta_l2l_epsilon value of +/- 1.6 gives
     the 95% confidence interval for delta_l2l.
     """

--- a/openquake/hazardlib/tests/gsim/kotha_2020_test.py
+++ b/openquake/hazardlib/tests/gsim/kotha_2020_test.py
@@ -29,7 +29,8 @@ from openquake.hazardlib.gsim.kotha_2020 import (
     KothaEtAl2020, KothaEtAl2020ESHM20, KothaEtAl2020Site,
     KothaEtAl2020Slope, KothaEtAl2020ESHM20SlopeGeology, KothaEtAl2020regional)
 from openquake.hazardlib.tests.gsim.utils import BaseGSIMTestCase
-from openquake.hazardlib.gsim.kotha_2020 import get_distance_coefficients_3, get_dl2l
+from openquake.hazardlib.gsim.kotha_2020 import (
+    get_distance_coefficients_3, get_dl2l, _assign_feature_indices)
 
 MAX_DISCREP = 0.01
 
@@ -134,32 +135,35 @@ class KothaEtAl2020regionalcoefficientsTestCase(unittest.TestCase):
     # were selected manually. 
     def test_get_distance_coefficients3(self):
         delta_c3_epsilon = 0
-        imt = 'PGA'
+        imt_key = 'PGA'
         f = KothaEtAl2020regional()
-        self.att = f.att
         C = KothaEtAl2020regional.COEFFS[PGA()]
         ## manually selected sites
-        data = [[-4.13, 38.55], [7.74, 46.23], [10.579, 62.477], 
-                [12.34, 45.03], [15.02, 39.80]] 
+        data = [[-4.13, 38.55], [7.74, 46.23], [10.579, 62.477],
+                [12.34, 45.03], [15.02, 39.80]]
         sctx = pd.DataFrame(data, columns=['lon', 'lat'])
         ## values retireved manually from the author provided csv files
-        expected_val = np.array([-0.609876182476899, -0.589902644476899, 
+        expected_val = np.array([-0.609876182476899, -0.589902644476899,
             -0.609876182476899, -0.530099285476899, -1.065428170476899])
-        target = get_distance_coefficients_3(self.att, delta_c3_epsilon, C, imt, sctx)
+        site_feat_idx = _assign_feature_indices(
+            f.att_shapes, sctx.lon.values, sctx.lat.values)
+        target = get_distance_coefficients_3(
+            f.att_props, site_feat_idx, delta_c3_epsilon, C, imt_key)
         np.testing.assert_array_equal(target, expected_val)
 
     def test_get_dl2l_coefficients(self):
         delta_l2l_epsilon = 0
-        imt = 'PGA'
+        imt_key = 'PGA'
         f = KothaEtAl2020regional()
-        self.tec = f.tec
         ## manually selected sites
-        hypo = [[-4.13, 38.55], [7.74, 46.23], [10.579, 62.477], 
+        hypo = [[-4.13, 38.55], [7.74, 46.23], [10.579, 62.477],
                 [12.34, 45.03], [15.02, 39.80]]
         ctx = pd.DataFrame(hypo, columns=['hypo_lon', 'hypo_lat'])
         ## values retireved manually from the author provided csv files
         expected_val = np.array([0., -0.1490727,  0., -0.28239376, -0.2107627 ])
-        dl2l = get_dl2l(self.tec, ctx, imt, delta_l2l_epsilon)            
+        tec_feat_idx = _assign_feature_indices(
+            f.tec_shapes, ctx.hypo_lon.values, ctx.hypo_lat.values)
+        dl2l = get_dl2l(f.tec_props, tec_feat_idx, imt_key, delta_l2l_epsilon)
         np.testing.assert_array_equal(dl2l, expected_val)
     
 


### PR DESCRIPTION
Currently within `KothaEtAl2020regional`, the hypocenter-based and site-based lookups are being performed from scratch per intensity measure within each call of the GSIM's `compute` method, which was becoming computationally costly. The fix proposed here has made previously (practically-speaking) unrunnable calculations for some projects we support complete in only 3 or 4 minutes instead.

This PR modifies this lookup to be once per call of the `compute` method using some helper functions, which is fine given the locations of the events and the sites inherently do not vary with IMT within a single "ctx".

The existing unit tests pass with exactly the same values being observed.