### PR TITLE
Correlation modules refactor #14 – local Kriging

### DIFF
--- a/openquake/hazardlib/correlation_models/circulant_embedding.py
+++ b/openquake/hazardlib/correlation_models/circulant_embedding.py
@@ -85,6 +85,7 @@ class RegularGridLayout:
     spacing: tuple
     site_indices: numpy.ndarray
     crs: int
+    projected_origin: tuple
     maximum_error: float
 
     @classmethod
@@ -124,8 +125,10 @@ class RegularGridLayout:
                 'Sites do not form an axis-aligned regular UTM grid; '
                 f'maximum coordinate error is {errors.max():g} m')
 
-        ix -= ix.min()
-        iy -= iy.min()
+        minimum_x = ix.min()
+        minimum_y = iy.min()
+        ix -= minimum_x
+        iy -= minimum_y
         nx = int(ix.max()) + 1
         ny = int(iy.max()) + 1
         if nx < 2 or ny < 2:
@@ -142,7 +145,58 @@ class RegularGridLayout:
         return cls(
             (ny, nx),
             (float(spacing_y / 1000), float(spacing_x / 1000)),
-            indices, crs, float(errors.max()))
+            indices, crs,
+            (float(y0 + minimum_y * spacing_y),
+             float(x0 + minimum_x * spacing_x)),
+            float(errors.max()))
+
+    def grid_coordinates(self, sites):
+        """Return fractional row and column coordinates for ``sites``."""
+        transformer = Transformer.from_crs(
+            4326, self.crs, always_xy=True)
+        x, y = transformer.transform(sites.lons, sites.lats)
+        origin_y, origin_x = self.projected_origin
+        spacing_y, spacing_x = self.spacing
+        rows = (numpy.asarray(y) - origin_y) / (spacing_y * 1000)
+        columns = (numpy.asarray(x) - origin_x) / (spacing_x * 1000)
+        return rows, columns
+
+    def expanded(self, sites, margin):
+        """Return a grid enlarged around ``sites`` by ``margin`` cells."""
+        if not isinstance(margin, (int, numpy.integer)) or margin < 0:
+            raise ValueError('margin must be a non-negative integer')
+        rows, columns = self.grid_coordinates(sites)
+        rounded_rows = numpy.rint(rows)
+        rounded_columns = numpy.rint(columns)
+        rows = numpy.where(
+            numpy.abs(rows - rounded_rows) <= GRID_TOLERANCE,
+            rounded_rows, rows)
+        columns = numpy.where(
+            numpy.abs(columns - rounded_columns) <= GRID_TOLERANCE,
+            rounded_columns, columns)
+        if not len(rows):
+            return self
+
+        ny, nx = self.grid_shape
+        lower_y = min(0, int(numpy.floor(rows.min())) - margin)
+        lower_x = min(0, int(numpy.floor(columns.min())) - margin)
+        upper_y = max(ny - 1, int(numpy.ceil(rows.max())) + margin)
+        upper_x = max(nx - 1, int(numpy.ceil(columns.max())) + margin)
+        if (lower_y, lower_x, upper_y, upper_x) == (
+                0, 0, ny - 1, nx - 1):
+            return self
+
+        old_rows, old_columns = numpy.divmod(self.site_indices, nx)
+        new_nx = upper_x - lower_x + 1
+        indices = ((old_rows - lower_y) * new_nx +
+                   old_columns - lower_x)
+        spacing_y, spacing_x = self.spacing
+        origin_y, origin_x = self.projected_origin
+        origin = (origin_y + lower_y * spacing_y * 1000,
+                  origin_x + lower_x * spacing_x * 1000)
+        return type(self)(
+            (upper_y - lower_y + 1, new_nx), self.spacing,
+            indices, self.crs, origin, self.maximum_error)
 
     @property
     def occupancy(self):

--- a/openquake/hazardlib/correlation_models/circulant_embedding.py
+++ b/openquake/hazardlib/correlation_models/circulant_embedding.py
@@ -154,7 +154,13 @@ class RegularGridLayout:
         """Return fractional row and column coordinates for ``sites``."""
         transformer = Transformer.from_crs(
             4326, self.crs, always_xy=True)
-        x, y = transformer.transform(sites.lons, sites.lats)
+        if len(sites.lons) == 1:
+            x, y = transformer.transform(
+                float(sites.lons[0]), float(sites.lats[0]))
+            x = numpy.array([x])
+            y = numpy.array([y])
+        else:
+            x, y = transformer.transform(sites.lons, sites.lats)
         origin_y, origin_x = self.projected_origin
         spacing_y, spacing_x = self.spacing
         rows = (numpy.asarray(y) - origin_y) / (spacing_y * 1000)

--- a/openquake/hazardlib/correlation_models/local_kriging.py
+++ b/openquake/hazardlib/correlation_models/local_kriging.py
@@ -16,19 +16,28 @@
 """Local-kriging extension of grid simulation to off-grid stations.
 
 The implementation follows the local-kriging method recommended by Bailey
-et al. (2022). A station value is sampled conditionally on a small regular
-grid neighborhood. Stations in the same grid box are sampled jointly;
-conditional errors belonging to different boxes are treated as independent.
-The latter is the approximation that makes the operation scalable.
+et al. (2022). It extends a simulated regular-grid field to station locations
+in the following steps:
 
-For a spatial-cross-IMT model, the local conditional distribution includes
-every IMT. This preserves cross-IMT covariance within each station and among
-stations occupying the same grid box.
+1. Map the stations to fractional grid coordinates. A station that coincides
+   with a grid cell takes that cell's simulated value exactly.
+2. Group the remaining stations by the grid box containing them and select a
+   ``(2 * order)`` square neighborhood around each box.
+3. For every group, construct the grid covariance ``C_GG``, station-to-grid
+   covariance ``C_SG``, and station covariance ``C_SS``. The conditional
+   distribution has mean ``C_SG C_GG^+ G`` and covariance
+   ``C_SS - C_SG C_GG^+ C_GS``.
+4. Apply the conditional mean to each simulated grid field and add an
+   independent Gaussian draw from the conditional covariance.
 
-Bailey, M. D., Bandyopadhyay, S., Nychka, D. W., Thompson, E. M., and
-Worden, C. B. (2022). Adapting conditional simulation using circulant
-embedding for irregularly spaced spatial data. Stat, 11(1), e446.
-https://doi.org/10.1002/sta4.446
+For a spatial-cross-IMT model, these matrices include every IMT. Stations in
+the same grid box are therefore sampled jointly across sites and IMTs.
+Conditional errors belonging to different boxes are treated as independent;
+this is the approximation that makes the operation scalable.
+
+Bailey, M. D., Bandyopadhyay, S., and Nychka, D. (2022). Adapting conditional
+simulation using circulant embedding for irregularly spaced spatial data.
+Stat, 11(1), e446. https://doi.org/10.1002/sta4.446
 """
 
 from dataclasses import dataclass

--- a/openquake/hazardlib/correlation_models/local_kriging.py
+++ b/openquake/hazardlib/correlation_models/local_kriging.py
@@ -1,0 +1,207 @@
+# The Hazard Library
+# Copyright (C) 2026 GEM Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""Local-kriging extension of grid simulation to off-grid stations.
+
+The implementation follows the local-kriging method recommended by Bailey
+et al. (2022). A station value is sampled conditionally on a small regular
+grid neighborhood. Stations in the same grid box are sampled jointly;
+conditional errors belonging to different boxes are treated as independent.
+The latter is the approximation that makes the operation scalable.
+
+For a spatial-cross-IMT model, the local conditional distribution includes
+every IMT. This preserves cross-IMT covariance within each station and among
+stations occupying the same grid box.
+
+Bailey, M. D., Bandyopadhyay, S., Nychka, D. W., Thompson, E. M., and
+Worden, C. B. (2022). Adapting conditional simulation using circulant
+embedding for irregularly spaced spatial data. Stat, 11(1), e446.
+https://doi.org/10.1002/sta4.446
+"""
+
+from dataclasses import dataclass
+
+import numpy
+
+from openquake.hazardlib.correlation_models.circulant_embedding import (
+    GRID_TOLERANCE, RegularGridLayout)
+
+
+def _distances(first, second):
+    """Return Euclidean distances between two projected point arrays."""
+    differences = first[:, numpy.newaxis] - second[numpy.newaxis, :]
+    return numpy.linalg.norm(differences, axis=-1)
+
+
+def _grid_points(layout, indices):
+    """Return selected grid-cell coordinates in kilometres."""
+    rows, columns = numpy.divmod(indices, layout.grid_shape[1])
+    return numpy.column_stack(
+        (rows * layout.spacing[0], columns * layout.spacing[1]))
+
+
+def _covariance_root(covariance):
+    """Return a real square root of a positive-semidefinite covariance."""
+    covariance = (covariance + covariance.T) / 2
+    eigenvalues, eigenvectors = numpy.linalg.eigh(covariance)
+    scale = max(1.0, float(numpy.abs(eigenvalues).max()))
+    tolerance = len(covariance) * numpy.finfo(float).eps * scale
+    if eigenvalues.min() < -tolerance:
+        raise ValueError(
+            'The local conditional covariance is not positive semidefinite')
+    return eigenvectors * numpy.sqrt(eigenvalues.clip(min=0))
+
+
+def _neighborhood(box, order, shape):
+    """Return flattened cells in a ``(2 * order)`` square neighborhood."""
+    row, column = box
+    rows = numpy.arange(row - order + 1, row + order + 1)
+    columns = numpy.arange(column - order + 1, column + order + 1)
+    if (rows.min() < 0 or columns.min() < 0 or
+            rows.max() >= shape[0] or columns.max() >= shape[1]):
+        raise ValueError(
+            'The correlation grid does not contain the local-kriging '
+            'neighborhood; expand it around the stations first')
+    rr, cc = numpy.meshgrid(rows, columns, indexing='ij')
+    return (rr * shape[1] + cc).reshape(-1)
+
+
+@dataclass(frozen=True)
+class LocalKrigingGroup:
+    """Conditional sampler for stations occupying one grid box."""
+
+    station_indices: numpy.ndarray
+    grid_indices: numpy.ndarray
+    weights: numpy.ndarray
+    conditional_root: numpy.ndarray
+    error_slice: slice
+
+
+def _build_group(model, imts, layout, station_points, station_indices,
+                 box, order, component, context, error_start):
+    """Build one same-grid-box multivariate conditional distribution."""
+    grid_indices = _neighborhood(box, order, layout.grid_shape)
+    grid_points = _grid_points(layout, grid_indices)
+    selected_stations = station_points[station_indices]
+    grid_covariance = model.correlation_block(
+        _distances(grid_points, grid_points), imts,
+        component=component, context=context)
+    cross_covariance = model.correlation_block(
+        _distances(selected_stations, grid_points), imts, imts,
+        component, context)
+    station_covariance = model.correlation_block(
+        _distances(selected_stations, selected_stations), imts,
+        component=component, context=context)
+    inverse = numpy.linalg.pinv(grid_covariance, hermitian=True)
+    weights = cross_covariance @ inverse
+    conditional = station_covariance - weights @ cross_covariance.T
+    root = _covariance_root(conditional)
+    error_stop = error_start + len(conditional)
+    return LocalKrigingGroup(
+        station_indices, grid_indices, weights, root,
+        slice(error_start, error_stop))
+
+
+@dataclass(frozen=True)
+class LocalKrigingFactor:
+    """Map regular-grid fields and local errors to station fields."""
+
+    layout: RegularGridLayout
+    num_imts: int
+    num_stations: int
+    on_grid_stations: numpy.ndarray
+    on_grid_cells: numpy.ndarray
+    groups: tuple
+    error_size: int
+
+    @classmethod
+    def build(cls, model, imts, layout, stations, order=4,
+              component=None, context=None):
+        """Build fourth-order local conditionals by default."""
+        if not isinstance(layout, RegularGridLayout):
+            raise TypeError('layout must be a RegularGridLayout')
+        if not isinstance(order, (int, numpy.integer)) or order < 1:
+            raise ValueError('order must be a positive integer')
+        if not imts:
+            raise ValueError('At least one IMT is required')
+
+        rows, columns = layout.grid_coordinates(stations)
+        rounded_rows = numpy.rint(rows)
+        rounded_columns = numpy.rint(columns)
+        on_grid = (
+            (numpy.abs(rows - rounded_rows) <= GRID_TOLERANCE) &
+            (numpy.abs(columns - rounded_columns) <= GRID_TOLERANCE))
+        on_grid_stations = numpy.flatnonzero(on_grid)
+        on_grid_rows = rounded_rows[on_grid].astype(int)
+        on_grid_columns = rounded_columns[on_grid].astype(int)
+        if (numpy.any(on_grid_rows < 0) or
+                numpy.any(on_grid_rows >= layout.grid_shape[0]) or
+                numpy.any(on_grid_columns < 0) or
+                numpy.any(on_grid_columns >= layout.grid_shape[1])):
+            raise ValueError('An on-grid station lies outside the grid')
+        on_grid_cells = (
+            on_grid_rows * layout.grid_shape[1] + on_grid_columns)
+
+        station_points = numpy.column_stack(
+            (rows * layout.spacing[0], columns * layout.spacing[1]))
+        boxes = {}
+        for station_index in numpy.flatnonzero(~on_grid):
+            box = (int(numpy.floor(rows[station_index])),
+                   int(numpy.floor(columns[station_index])))
+            boxes.setdefault(box, []).append(station_index)
+
+        groups = []
+        error_start = 0
+        for box, indices in sorted(boxes.items()):
+            station_indices = numpy.asarray(indices, dtype=numpy.int64)
+            group = _build_group(
+                model, imts, layout, station_points, station_indices,
+                box, order, component, context, error_start)
+            groups.append(group)
+            error_start = group.error_slice.stop
+        return cls(
+            layout, len(imts), len(rows), on_grid_stations,
+            on_grid_cells, tuple(groups), error_start)
+
+    def apply(self, grid_fields, errors):
+        """Return IMT-major station fields for one or more realizations."""
+        grid_fields = numpy.asarray(grid_fields)
+        errors = numpy.asarray(errors)
+        grid_size = numpy.prod(self.layout.grid_shape)
+        if (grid_fields.ndim != 3 or
+                grid_fields.shape[:2] != (self.num_imts, grid_size)):
+            raise ValueError(
+                'Expected grid fields with shape '
+                f'({self.num_imts}, {grid_size}, E)')
+        num_events = grid_fields.shape[2]
+        if errors.shape != (self.error_size, num_events):
+            raise ValueError(
+                f'Expected local errors with shape '
+                f'({self.error_size}, {num_events})')
+
+        result = numpy.empty(
+            (self.num_imts, self.num_stations, num_events),
+            dtype=numpy.result_type(grid_fields, errors))
+        result[:, self.on_grid_stations] = grid_fields[
+            :, self.on_grid_cells]
+        for group in self.groups:
+            local_grid = grid_fields[:, group.grid_indices].reshape(
+                -1, num_events)
+            local_errors = errors[group.error_slice]
+            values = (group.weights @ local_grid +
+                      group.conditional_root @ local_errors)
+            result[:, group.station_indices] = values.reshape(
+                self.num_imts, len(group.station_indices), num_events)
+        return result

--- a/openquake/hazardlib/tests/correlation_models/circulant_embedding_test.py
+++ b/openquake/hazardlib/tests/correlation_models/circulant_embedding_test.py
@@ -122,6 +122,27 @@ def test_layout():
     assert layout.maximum_error < 1
     assert layout.occupancy == 11 / 12
 
+    rows, columns = layout.grid_coordinates(sites)
+    actual = numpy.rint(rows).astype(int) * 4
+    actual += numpy.rint(columns).astype(int)
+    numpy.testing.assert_array_equal(actual, expected)
+
+
+def test_expanded_layout():
+    sites, _ = geographic_grid((3, 4))
+    layout = RegularGridLayout.from_sites(sites)
+    expanded = layout.expanded(sites, margin=2)
+
+    assert expanded.grid_shape == (7, 8)
+    rows, columns = expanded.grid_coordinates(sites)
+    assert rows.min() > 1.99
+    assert columns.min() > 1.99
+    assert rows.max() < 4.01
+    assert columns.max() < 5.01
+    expected = numpy.rint(rows).astype(int) * 8
+    expected += numpy.rint(columns).astype(int)
+    numpy.testing.assert_array_equal(expanded.site_indices, expected)
+
 
 def test_irregular_layout():
     sites, _ = geographic_grid((3, 4), perturb=0.002)

--- a/openquake/hazardlib/tests/correlation_models/local_kriging_test.py
+++ b/openquake/hazardlib/tests/correlation_models/local_kriging_test.py
@@ -1,0 +1,141 @@
+# The Hazard Library
+# Copyright (C) 2026 GEM Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from types import SimpleNamespace
+
+import numpy
+import pytest
+from pyproj import Transformer
+
+from openquake.hazardlib.correlation_models.base import ResidualComponent
+from openquake.hazardlib.correlation_models.circulant_embedding import (
+    CirculantEmbeddingFactor, RegularGridLayout)
+from openquake.hazardlib.correlation_models.local_kriging import (
+    LocalKrigingFactor)
+from openquake.hazardlib.correlation_models.spatial_cross_imt.du_ning_2021 \
+    import DuNing2021
+from openquake.hazardlib.imt import PGA, SA
+
+
+IMTS = [PGA(), SA(0.3)]
+
+
+def geographic_sites(x, y):
+    """Return geographic sites for projected UTM coordinates."""
+    transformer = Transformer.from_crs(32610, 4326, always_xy=True)
+    x = numpy.asarray(x, dtype=float)
+    y = numpy.asarray(y, dtype=float)
+    if len(x) == 1:
+        lon, lat = transformer.transform(float(x[0]), float(y[0]))
+        lons, lats = numpy.array([lon]), numpy.array([lat])
+    else:
+        lons, lats = transformer.transform(x, y)
+    return SimpleNamespace(lons=numpy.asarray(lons), lats=numpy.asarray(lats))
+
+
+def grid_sites(shape):
+    rows, columns = numpy.indices(shape)
+    return geographic_sites(
+        500_000 + columns.ravel() * 1_000,
+        4_200_000 + rows.ravel() * 1_000)
+
+
+def projected_points(sites):
+    transformer = Transformer.from_crs(4326, 32610, always_xy=True)
+    x, y = transformer.transform(sites.lons, sites.lats)
+    return numpy.column_stack((numpy.asarray(y), numpy.asarray(x))) / 1_000
+
+
+def distances(first, second):
+    differences = first[:, numpy.newaxis] - second[numpy.newaxis, :]
+    return numpy.linalg.norm(differences, axis=-1)
+
+
+def test_exact_local_distribution():
+    # An order-two neighborhood covers this complete 4 x 4 grid. Sampling
+    # two stations in the same box is therefore identical to constructing
+    # their full dense joint covariance with the grid.
+    model = DuNing2021()
+    grid = grid_sites((4, 4))
+    stations = geographic_sites(
+        [501_000, 501_300, 501_700],
+        [4_201_000, 4_201_200, 4_201_800])
+    layout = RegularGridLayout.from_sites(grid)
+    ce = CirculantEmbeddingFactor.build(
+        model, IMTS, layout.grid_shape, layout.spacing,
+        ResidualComponent.WITHIN_EVENT)
+    local = LocalKrigingFactor.build(
+        model, IMTS, layout, stations, order=2,
+        component=ResidualComponent.WITHIN_EVENT)
+
+    total_inputs = ce.input_size + local.error_size
+    basis = numpy.eye(total_inputs)
+    grid_fields = ce.apply(basis[:ce.input_size]).reshape(
+        len(IMTS), -1, total_inputs)
+    station_fields = local.apply(
+        grid_fields, basis[ce.input_size:])
+    applied = numpy.concatenate(
+        (grid_fields.reshape(len(IMTS) * len(grid.lons), total_inputs),
+         station_fields.reshape(
+             len(IMTS) * len(stations.lons), total_inputs)))
+
+    grid_points = projected_points(grid)
+    station_points = projected_points(stations)
+    all_points = numpy.concatenate((grid_points, station_points))
+    full = model.correlation_block(
+        distances(all_points, all_points), IMTS,
+        component=ResidualComponent.WITHIN_EVENT)
+    grid_count = len(grid.lons)
+    indices = numpy.concatenate([
+        numpy.arange(m * len(all_points), m * len(all_points) + grid_count)
+        for m in range(len(IMTS))] + [
+        numpy.arange(m * len(all_points) + grid_count,
+                     (m + 1) * len(all_points))
+        for m in range(len(IMTS))])
+    expected = full[numpy.ix_(indices, indices)]
+    numpy.testing.assert_allclose(
+        applied @ applied.T, expected, atol=2E-12)
+
+
+def test_grid_padding_required():
+    model = DuNing2021()
+    grid = grid_sites((4, 4))
+    edge_station = geographic_sites([500_300], [4_200_400])
+    layout = RegularGridLayout.from_sites(grid)
+
+    with pytest.raises(ValueError, match='expand it'):
+        LocalKrigingFactor.build(
+            model, IMTS, layout, edge_station, order=2)
+
+    expanded = layout.expanded(edge_station, margin=2)
+    factor = LocalKrigingFactor.build(
+        model, IMTS, expanded, edge_station, order=2)
+    assert factor.error_size == len(IMTS)
+    assert factor.groups[0].grid_indices.size == 16
+
+
+def test_input_shapes():
+    model = DuNing2021()
+    grid = grid_sites((4, 4))
+    stations = geographic_sites([501_300], [4_201_200])
+    layout = RegularGridLayout.from_sites(grid)
+    factor = LocalKrigingFactor.build(
+        model, IMTS, layout, stations, order=2)
+
+    with pytest.raises(ValueError, match='Expected grid fields'):
+        factor.apply(numpy.zeros((2, 15, 1)), numpy.zeros((2, 1)))
+    with pytest.raises(ValueError, match='Expected local errors'):
+        factor.apply(numpy.zeros((2, 16, 1)), numpy.zeros((1, 1)))


### PR DESCRIPTION
## Local Kriging for off-grid values

Related to #11230 and #10833. #11734 connects the circulant-embedding implementation introduced in https://github.com/gem/oq-engine/pull/11728 to unconditioned ground-motion field (GMF) generation.

This is the first of two PRs stacked on top of #11734, extending circulant embedding from unconditioned regular-grid fields to station-conditioned GMFs.

Circulant embedding can efficiently simulate a correlated Gaussian field on a regular grid. Seismic station locations, however, might not (and usually will not) coincide exactly with that grid as stations might be located in between our regular grid points, i.e., off-grid. Before a grid realization can be conditioned on station observations, we therefore need corresponding values from the same unconditioned field at the irregular station locations.

This PR implements the local Kriging method described by [Bailey et al. (2022)](https://doi.org/10.1002/sta4.446)[^1] for obtaining those values.

### How local Kriging works

Any stations that coincide with grid cells take the simulated value from that cell exactly. The remaining stations are grouped according to the grid box containing them. For each group, the method selects a small neighborhood of surrounding grid cells for interpolation ("local Kriging"). The figure below illustrates first-order (2 × 2), second-order (4 × 4), and third-order (6 × 6) neighborhood constructions. The default fourth-order construction recommended by Bailey et al. (2022) as implemented in this PR uses an 8 × 8 neighborhood.

<img width="1728" height="831" alt="Kriging" src="https://github.com/user-attachments/assets/d3386506-bbe6-4aeb-9da0-9a08990947ce" />
Figure source: Bailey et al. (2022).<br/><br/>

Let $G$ contain the simulated values at those neighboring grid cells and let $S$ represent the values required at the station locations. Their joint covariance supplies three blocks:

- $C_{GG}$: covariance among the neighboring grid values
- $C_{SG}$: covariance between the stations and the grid neighborhood
- $C_{SS}$: covariance among the stations

A station realization is then obtained as

```math
S = C_{SG}C_{GG}^{+}G + L\epsilon,
```

where

```math
LL^{\mathsf T}
=
C_{SS} - C_{SG}C_{GG}^{+}C_{GS}.
```

The first term interpolates the particular simulated grid realization to the stations. The second adds the residual variation that cannot be inferred from the local grid values.

For a joint spatial-cross-IMT correlation model, these matrices contain every requested IMT. Stations occupying the same grid box are therefore sampled jointly across both locations and IMTs.

Conditional errors belonging to different grid boxes are treated as independent. This is an approximation that keeps the operation local and scalable. The treatment is exact for stations lying on the grid and also becomes equivalent to the usual dense (and typically intractable) construction when the selected neighborhood spans the complete grid.

### In this PR

The regular-grid geometry now retains its projected origin, and can map arbitrary locations to fractional grid coordinates. We now also expand the grid by the padding needed around stations near its boundaries, for the cases where stations are located near the edges of the grid.

A new `LocalKrigingFactor` builds and applies the local conditional transformations. The implementation clearly separates exact on-grid extraction from approximate off-grid sampling and groups nearby stations so their joint covariance is preserved.

This PR does not yet change the conditioned GMF calculation routines. Its purpose is to first establish and verify the irregular-station sampling operation independently before integrating it into conditioned calculations using circulant embedding, which will be done in the following stacked PR.

### Verification

The tests cover grid-coordinate mapping, grid expansion, exact on-grid extraction, input validation, and joint multi-IMT sampling.

The principal verification constructs a small case in which the local neighborhood spans the entire grid. Applying the CE and local-kriging factors in this case must recover the full exact joint grid-and-station covariance. This directly verifies the transformation without sampling uncertainty.

### Reference

[^1]: Bailey, M. D., Bandyopadhyay, S., & Nychka, D. (2022). Adapting conditional simulation using circulant embedding for irregularly spaced spatial data. *Stat*, 11(1), e446. https://doi.org/10.1002/sta4.446