### PR TITLE
Correlation modules refactor #15 – station-conditioned correlated GMFs

### DIFF
--- a/doc/api-reference/openquake.hazardlib.correlation_models.rst
+++ b/doc/api-reference/openquake.hazardlib.correlation_models.rst
@@ -19,6 +19,22 @@ Registry
     :undoc-members:
     :show-inheritance:
 
+Scalable sampling
+-----------------
+
+.. currentmodule:: openquake.hazardlib.correlation_models.circulant_embedding
+
+.. autoclass:: RegularGridLayout
+    :members:
+
+.. autoclass:: CirculantEmbeddingFactor
+    :members:
+
+.. currentmodule:: openquake.hazardlib.correlation_models.local_kriging
+
+.. autoclass:: LocalKrigingFactor
+    :members:
+
 Spatial models
 --------------
 

--- a/doc/underlying-science/conditioning-gmf.rst
+++ b/doc/underlying-science/conditioning-gmf.rst
@@ -1,9 +1,9 @@
 Conditioning Ground Shaking
 ===========================
 
-Given an earthquake rupture model, a site model, and a set of ground shaking intensity models (GSIMs), the OpenQuake scenario calculator simulates a set of ground motion fields (GMFs) at the target sites for the requested set of intensity measure types (IMTs). This set of GMFs can then be used in the :ref:`scenario-damage-intro` and :ref:`scenario-risk-intro` calculators to estimate the distribution of potential damage, economic losses, fatalities, and other consequences. The scenario calculators are useful for simulating both historical and hypothetical earthquakes.
+Given an earthquake rupture model, a site model, and a set of ground shaking intensity models (GSIMs), the OpenQuake engine scenario calculator simulates a set of ground motion fields (GMFs) at the target sites for the requested set of intensity measure types (IMTs). This set of GMFs can then be used in the :ref:`scenario-damage-intro` and :ref:`scenario-risk-intro` calculators to estimate the distribution of potential damage, economic losses, fatalities, and other consequences. The scenario calculators are useful for simulating both historical and hypothetical earthquakes.
 
-For historical events, ground motion recordings and macroseismic intensity data ("ground truth") can provide additional constraints on the ground shaking estimates in the region affected by the earthquake. The U.S. Geological Survey ShakeMap system (Worden et al. 2020; Wald et al. 2022) provides near-real-time estimates of ground shaking for earthquakes conditioned on station and macroseismic data where available. Support to read USGS ShakeMaps and simulate GMFs based on the mean and standard deviation values estimated by the ShakeMap — for peak ground acceleration (PGA) and spectral acceleration (SA) at 0.3s, 1.0s, and 3.0s — was added to the OpenQuake-engine in 2018, and a link to the `scenario_damage` and `scenario_risk` calculators was added based on the methodology described by Silva & Horspool (2019). Further support for reading ShakeMaps from sources other than the USGS, support for MMI, and performance improvements were introduced to the engine in 2021.
+For historical events, ground motion recordings and macroseismic intensity data ("ground truth") can provide additional constraints on the ground shaking estimates in the region affected by the earthquake. The U.S. Geological Survey ShakeMap system (Worden et al. 2020; Wald et al. 2022) provides near-real-time estimates of ground shaking for earthquakes conditioned on station and macroseismic data where available. Support to read USGS ShakeMaps and simulate GMFs based on the mean and standard deviation values estimated by the ShakeMap — for peak ground acceleration (PGA) and spectral acceleration (SA) at 0.3s, 1.0s, and 3.0s — was added to the OpenQuake engine in 2018, and a link to the `scenario_damage` and `scenario_risk` calculators was added based on the methodology described by Silva & Horspool (2019). Further support for reading ShakeMaps from sources other than the USGS, support for MMI, and performance improvements were introduced to the engine in 2021.
 
 Therefore, starting from OpenQuake engine v3.16, it is possible to condition the ground shaking to observations, such as ground motion recordings and macroseismic intensity observations. The implementation is tightly coupled with the existing scenario calculator.
 
@@ -25,14 +25,14 @@ Where `IM` stands for an intensity measure such as peak ground acceleration (PGA
 
 Where `B` stands for the between-event residual (i.e., representing the variability in the ground shaking amongst events with the same characteristics) and `W` refers to the within-event residual (i.e., representing the variability within the same event for sites at the same distance and soil conditions). These residuals typically follow a normal distribution and for the assessment of earthquake damage or losses they can be randomly sampled or numerically integrated using the respective standard deviations associated with each ground motion model.
 
-OpenQuake implementation
-------------------------
+OpenQuake engine implementation
+-------------------------------
 
-The implementation of the conditioning of ground motion fields in the OpenQuake-engine was performed following closely the procedure proposed by Engler et al. (2022). For additional details, readers are referred to the Appendix A and B of Engler et al. (2022). The module in the OpenQuake-engine is similar to the well-established scenario damage or risk calculator in which users have to provide an earthquake rupture, a site model, the list of locations where ground shaking will be calculated, and a single GSIM or a GSIM logic tree. However, for the constraining of the ground shaking, it is necessary to provide additional input files and adjustments to the configuration file as presented in the OpenQuake input files section.
+The implementation of the conditioning of ground motion fields in the OpenQuake engine was performed following closely the procedure proposed by Engler et al. (2022). For additional details, readers are referred to the Appendix A and B of Engler et al. (2022). The module in the OpenQuake engine is similar to the well-established scenario damage or risk calculator in which users have to provide an earthquake rupture, a site model, the list of locations where ground shaking will be calculated, and a single GSIM or a GSIM logic tree. However, for the constraining of the ground shaking, it is necessary to provide additional input files and adjustments to the configuration file as presented in the OpenQuake engine input files section.
 
 The generation of the conditioned cross-spatially correlated ground motion fields was performed in the following steps described below. All variables associated with the target sites (i.e., locations where the ground shaking will be computed) are identified with the subscript “T” while all variables related to the observations at the seismic station are identified with subscript “O”. 
 
-1. The median ground shaking is calculated at the location of the seismic stations considering the set of GMMs selected by the user (and using the library of GMMs of the OpenQuake-engine).
+1. The median ground shaking is calculated at the location of the seismic stations considering the set of GMMs selected by the user (and using the GMM library of the OpenQuake engine).
 
 2. The residuals (:math:`\zeta_{IMO}`) at every station location are computed through the difference between the recorded IM and the median IM from the GMMs.
 
@@ -70,7 +70,7 @@ The generation of the conditioned cross-spatially correlated ground motion field
 
 We can assume that the ground shaking for the various IMs are multivariate random variables, and these two parameters can be used to randomly sample cross-spatially correlated ground motion fields conditioned on the observations.
 
-In addition to the generation of cross-spatially correlated ground motion fields conditioned on data from seismic stations, it is also possible to constrain the resulting ground shaking based on observational data usually characterized using macroseismic intensity. This option can be advantageous for regions with poor seismic networks or when considering older events for which strong motion data might also be limited. This process requires the conversion of macroseismic intensity into ground motion, which will inevitably introduce additional uncertainty. As a result, the ground shaking converted from macroseismic intensity will be represented not only by a single value (as done when a seismic station is used) but by a mean and standard deviation. This variability can be taken from the chosen conversion equation. The incorporation of macroseismic intensity in this procedure has also been implemented within the OpenQuake-engine. Additional details about the mathematical formulation of this procedure can be found in Worden et al. (2018).
+In addition to the generation of cross-spatially correlated ground motion fields conditioned on data from seismic stations, it is also possible to constrain the resulting ground shaking based on observational data usually characterized using macroseismic intensity. This option can be advantageous for regions with poor seismic networks or when considering older events for which strong motion data might also be limited. This process requires the conversion of macroseismic intensity into ground motion, which will inevitably introduce additional uncertainty. As a result, the ground shaking converted from macroseismic intensity will be represented not only by a single value (as done when a seismic station is used) but by a mean and standard deviation. This variability can be taken from the chosen conversion equation. The incorporation of macroseismic intensity in this procedure has also been implemented within the OpenQuake engine. Additional details about the mathematical formulation of this procedure can be found in Worden et al. (2018).
 
 Correlation models
 ------------------
@@ -128,7 +128,7 @@ The partitioned conditional mean is
    \Sigma_{W_YW_D}\Sigma_{W_DW_D}^{+}
    (\zeta_D - T_D\widehat H).
 
-OpenQuake's joint path absorbs the same between-event shift and the
+The OpenQuake engine's joint path absorbs the same between-event shift and the
 within-event kriging adjustment into one regression:
 
 .. math::
@@ -162,9 +162,9 @@ covariance.
 This follows the same broad strategy used by Engler et al. (2025) for
 post-earthquake impact modelling: generate an unconditional within-event
 field with circulant embedding and condition it on the observations through
-kriging. OpenQuake expresses the complete between- and within-event update as
-the joint Matheron substitution above, rather than realizing the conditional
-components in separate stages.
+kriging. The OpenQuake engine expresses the complete between- and within-event
+update as the joint Matheron substitution above, rather than realizing the
+conditional components in separate stages.
 
 Stations that coincide with grid cells share their simulated values exactly.
 Off-grid stations use the fourth-order local-kriging approximation proposed by

--- a/doc/underlying-science/conditioning-gmf.rst
+++ b/doc/underlying-science/conditioning-gmf.rst
@@ -195,4 +195,4 @@ References
 
 - Engler, D. T., Jaiswal, K. S., & Ganesh, M. (2025). Evaluating the impact of uncertainty in ground motion forecasts for post-earthquake impact modeling applications. Earthquake Spectra, 41(1), 524–546. DOI: https://doi.org/10.1177/87552930241283201.
 
-- Bailey, M. D., Bandyopadhyay, S., Nychka, D. W., Thompson, E. M., & Worden, C. B. (2022). Adapting conditional simulation using circulant embedding for irregularly spaced spatial data. Stat, 11(1), e446. DOI: https://doi.org/10.1002/sta4.446.
+- Bailey, M. D., Bandyopadhyay, S., & Nychka, D. (2022). Adapting conditional simulation using circulant embedding for irregularly spaced spatial data. Stat, 11(1), e446. DOI: https://doi.org/10.1002/sta4.446.

--- a/doc/underlying-science/conditioning-gmf.rst
+++ b/doc/underlying-science/conditioning-gmf.rst
@@ -89,8 +89,41 @@ correlation, this is a legacy approximation rather than a direct model of the
 required covariance. A direct joint model bypasses that approximation.
 
 The model library currently has a limited selection for station-conditioned,
-multi-IMT calculations. Loth and Baker (2013), further direct joint models and
-scalable covariance factorizations are priorities for future development.
+multi-IMT calculations. Direct spatial-cross-IMT models should be used when
+available because they provide the complete target-to-observation covariance
+without the separable legacy approximation.
+
+Scalable conditional simulation
+--------------------------------
+
+Direct sampling from the conditional covariance in Step 7 requires a dense
+matrix whose dimensions are the number of targets multiplied by the number of
+IMTs. This is retained as a reference for small calculations but is infeasible
+for realistic regional grids.
+
+For sufficiently large regular grids and compatible joint models, the engine
+therefore uses circulant embedding to generate an unconditional target field
+and Matheron substitution to condition it. Paired unconditional values are
+generated at the target grid and station locations; the difference between
+the observed and simulated station values is then propagated to the target
+field with the same covariance weights used for the conditional mean. This
+applies the conditional-Gaussian transform without forming its dense target
+covariance.
+
+Stations that coincide with grid cells share their simulated values exactly.
+Off-grid stations use the fourth-order local-kriging approximation proposed by
+Bailey et al. (2022). Stations occupying the same grid box are simulated
+jointly across all IMTs, while conditional errors belonging to different grid
+boxes are treated as independent. Regression weights and GMFs are processed
+in batches governed by ``memory.conditioned_gmf_gb``.
+
+``DuNing2021`` is currently enabled for this scalable joint path. Other joint
+models retain dense sampling until their structured embeddings have been
+validated.
+
+The scalable joint path currently supports untruncated Gaussian conditioning.
+Finite truncated multivariate-normal sampling is not available for joint
+spatial-cross-IMT conditioning.
 
 
 References
@@ -103,3 +136,5 @@ References
 - Silva, V., & Horspool, N. (2019). Combining USGS ShakeMaps and the OpenQuake-engine for damage and loss assessment. Earthquake Engineering and Structural Dynamics, 48(6), 634–652. DOI: https://doi.org/10.1002/eqe.3154.
 
 - Engler, D. T., Worden, C. B., Thompson, E. M., & Jaiswal, K. S. (2022). Partitioning Ground Motion Uncertainty When Conditioned on Station Data. Bulletin of the Seismological Society of America, 112(2), 1060–1079. DOI: https://doi.org/10.1785/0120210177.
+
+- Bailey, M. D., Bandyopadhyay, S., Nychka, D. W., Thompson, E. M., & Worden, C. B. (2022). Adapting conditional simulation using circulant embedding for irregularly spaced spatial data. Stat, 11(1), e446. DOI: https://doi.org/10.1002/sta4.446.

--- a/doc/underlying-science/conditioning-gmf.rst
+++ b/doc/underlying-science/conditioning-gmf.rst
@@ -139,8 +139,12 @@ within-event kriging adjustment into one regression:
 
 For nonsingular, or compatible singular, covariance systems these expressions
 are algebraically equivalent. The nominal-bias effect is therefore retained,
-although the joint path does not expose a separately labelled posterior
-between-event field or scalar bias statistic.
+and the small station system also recovers the complete posterior mean and
+covariance of :math:`H`. For each target IMT, the joint path reports the
+posterior normalized between-event mean and standard deviation and the
+target-averaged nominal-bias mean and standard deviation. These values are
+diagnostics: the sampled GMFs still use the complete joint posterior and do
+not retain separate within- and between-event realizations.
 
 Scalable conditional simulation
 --------------------------------

--- a/doc/underlying-science/conditioning-gmf.rst
+++ b/doc/underlying-science/conditioning-gmf.rst
@@ -93,6 +93,55 @@ multi-IMT calculations. Direct spatial-cross-IMT models should be used when
 available because they provide the complete target-to-observation covariance
 without the separable legacy approximation.
 
+Nominal bias in the joint formulation
+-------------------------------------
+
+The partitioned formulation of Engler et al. (2022) first computes the
+posterior distribution of the normalized between-event residual. Let
+:math:`H` denote that residual, let :math:`T_D` and :math:`T_Y` scale it by
+the appropriate GSIM :math:`\tau` values at the observations and targets,
+and let :math:`\zeta_D = y_D - \mu_D`. The posterior mean is
+
+.. math::
+
+   \widehat H = \Sigma_{HH} T_D^{\mathsf T} \Sigma_D^{+} \zeta_D,
+
+where
+
+.. math::
+
+   \Sigma_D = \Sigma_{W_DW_D} +
+              T_D \Sigma_{HH} T_D^{\mathsf T}.
+
+Observation-error variance, when present, is included in
+:math:`\Sigma_{W_DW_D}`. The target-specific shift
+:math:`T_Y\widehat H` is the analogue of the *nominal bias*. The scalar
+``nominal_bias_mean`` reported by the historical implementation is only a
+summary obtained by averaging the corresponding station shifts; the actual
+mean calculation uses the full target term.
+
+The partitioned conditional mean is
+
+.. math::
+
+   \mu_{Y|D} = \mu_Y + T_Y\widehat H +
+   \Sigma_{W_YW_D}\Sigma_{W_DW_D}^{+}
+   (\zeta_D - T_D\widehat H).
+
+OpenQuake's joint path absorbs the same between-event shift and the
+within-event kriging adjustment into one regression:
+
+.. math::
+
+   \mu_{Y|D} = \mu_Y +
+   (\Sigma_{W_YW_D} + T_Y\Sigma_{HH}T_D^{\mathsf T})
+   \Sigma_D^{+}\zeta_D.
+
+For nonsingular, or compatible singular, covariance systems these expressions
+are algebraically equivalent. The nominal-bias effect is therefore retained,
+although the joint path does not expose a separately labelled posterior
+between-event field or scalar bias statistic.
+
 Scalable conditional simulation
 --------------------------------
 
@@ -109,6 +158,13 @@ the observed and simulated station values is then propagated to the target
 field with the same covariance weights used for the conditional mean. This
 applies the conditional-Gaussian transform without forming its dense target
 covariance.
+
+This follows the same broad strategy used by Engler et al. (2025) for
+post-earthquake impact modelling: generate an unconditional within-event
+field with circulant embedding and condition it on the observations through
+kriging. OpenQuake expresses the complete between- and within-event update as
+the joint Matheron substitution above, rather than realizing the conditional
+components in separate stages.
 
 Stations that coincide with grid cells share their simulated values exactly.
 Off-grid stations use the fourth-order local-kriging approximation proposed by
@@ -136,5 +192,7 @@ References
 - Silva, V., & Horspool, N. (2019). Combining USGS ShakeMaps and the OpenQuake-engine for damage and loss assessment. Earthquake Engineering and Structural Dynamics, 48(6), 634–652. DOI: https://doi.org/10.1002/eqe.3154.
 
 - Engler, D. T., Worden, C. B., Thompson, E. M., & Jaiswal, K. S. (2022). Partitioning Ground Motion Uncertainty When Conditioned on Station Data. Bulletin of the Seismological Society of America, 112(2), 1060–1079. DOI: https://doi.org/10.1785/0120210177.
+
+- Engler, D. T., Jaiswal, K. S., & Ganesh, M. (2025). Evaluating the impact of uncertainty in ground motion forecasts for post-earthquake impact modeling applications. Earthquake Spectra, 41(1), 524–546. DOI: https://doi.org/10.1177/87552930241283201.
 
 - Bailey, M. D., Bandyopadhyay, S., Nychka, D. W., Thompson, E. M., & Worden, C. B. (2022). Adapting conditional simulation using circulant embedding for irregularly spaced spatial data. Stat, 11(1), e446. DOI: https://doi.org/10.1002/sta4.446.

--- a/doc/underlying-science/correlation-models.rst
+++ b/doc/underlying-science/correlation-models.rst
@@ -338,9 +338,9 @@ cross-IMT reconstruction used during posterior sampling.
 References
 ----------
 
-* Bailey, M. D., Bandyopadhyay, S., Nychka, D. W., Thompson, E. M., and
-  Worden, C. B. (2022). Adapting conditional simulation using circulant
-  embedding for irregularly spaced spatial data. *Stat*, 11(1), e446.
+* Bailey, M. D., Bandyopadhyay, S., and Nychka, D. (2022). Adapting
+  conditional simulation using circulant embedding for irregularly spaced
+  spatial data. *Stat*, 11(1), e446.
   https://doi.org/10.1002/sta4.446
 * Baker, J. W., and Cornell, C. A. (2006). Correlation of response spectral
   values for multicomponent ground motions. *Bulletin of the Seismological

--- a/doc/underlying-science/correlation-models.rst
+++ b/doc/underlying-science/correlation-models.rst
@@ -198,8 +198,47 @@ The default sampler forms a dense correlation matrix and uses a Cholesky
 factorization. Its memory requirement grows quadratically and its factorization
 cost grows cubically with :math:`MN`. Consequently, a calculation that is
 tractable for one IMT or a small site collection can become infeasible for a
-large multi-IMT field. Structured methods and alternative factorizations are
-needed for substantially larger calculations.
+large multi-IMT field.
+
+Scalable sampling on regular grids
+----------------------------------
+
+For a stationary model evaluated on a regular two-dimensional grid, the
+spatial covariance has repeated block-Toeplitz structure. Circulant embedding
+places that covariance inside a larger periodic block-circulant matrix, whose
+spatial modes can be diagonalized with fast Fourier transforms (FFTs). Only a
+small IMT-by-IMT spectral covariance must then be factorized at each Fourier
+mode. This replaces the dense cubic factorization with operations that scale
+approximately as :math:`MN\log N`.
+
+The engine uses this path automatically for sufficiently large compatible
+models and regular grids. Grid cells may be unoccupied, provided the enclosing
+rectangle is not excessively larger than the requested site collection. The
+periodic embedding is enlarged until its spectrum is positive semidefinite;
+the calculation stops with an explanatory error when that cannot be achieved
+within the supported enlargement.
+
+For station-conditioned fields, OpenQuake combines circulant embedding with
+Matheron substitution. If :math:`U_T` and :math:`U_O` are paired unconditional
+draws at the targets and observations, respectively, a conditional draw is
+
+.. math::
+
+   Y_{T|O} = \mu_T + U_T +
+   \Sigma_{TO}\Sigma_{OO}^{+}(y_O - \mu_O - U_O).
+
+This avoids constructing or factorizing the dense target posterior covariance.
+The target-to-station regression weights are built once in memory-bounded site
+chunks and reused for every realization batch.
+
+Circulant embedding samples directly only on the grid. Observations that
+coincide with grid cells use the same simulated values exactly. Off-grid
+stations follow the local-kriging approximation of Bailey et al. (2022): each
+is sampled conditionally on a fourth-order grid neighborhood, and stations in
+the same grid box are sampled jointly across all IMTs. Conditional errors from
+different grid boxes are assumed independent. The regular-grid field itself
+is exact for the embedded covariance; this conditional-independence assumption
+is the approximation introduced for irregular station locations.
 
 Configuration examples are provided in the User Guide for
 :ref:`scenario hazard <scenario-hazard-params>`,
@@ -266,6 +305,10 @@ cross-IMT reconstruction used during posterior sampling.
 References
 ----------
 
+* Bailey, M. D., Bandyopadhyay, S., Nychka, D. W., Thompson, E. M., and
+  Worden, C. B. (2022). Adapting conditional simulation using circulant
+  embedding for irregularly spaced spatial data. *Stat*, 11(1), e446.
+  https://doi.org/10.1002/sta4.446
 * Baker, J. W., and Cornell, C. A. (2006). Correlation of response spectral
   values for multicomponent ground motions. *Bulletin of the Seismological
   Society of America*, 96(1), 215-227.
@@ -276,6 +319,12 @@ References
 * Bradley, B. A. (2012). Empirical correlations between peak ground velocity
   and spectrum-based intensity measures. *Earthquake Spectra*, 28(1), 17-35.
   https://doi.org/10.1193/1.3675582
+* Chan, G., and Wood, A. T. A. (1999). Simulation of stationary Gaussian
+  vector fields. *Statistics and Computing*, 9, 265-268.
+  https://doi.org/10.1023/A:1008903804954
+* Dietrich, C. R., and Newsam, G. N. (1993). A fast and exact method for
+  multidimensional Gaussian stochastic simulations. *Water Resources
+  Research*, 29(8), 2861-2869. https://doi.org/10.1029/93WR01070
 * Du, W., and Ning, C.-L. (2021). Modeling spatial cross-correlation of
   multiple ground motion intensity measures (SAs, PGA, PGV, Ia, CAV, and
   significant durations) based on principal component and geostatistical

--- a/doc/underlying-science/correlation-models.rst
+++ b/doc/underlying-science/correlation-models.rst
@@ -208,8 +208,39 @@ spatial covariance has repeated block-Toeplitz structure. Circulant embedding
 places that covariance inside a larger periodic block-circulant matrix, whose
 spatial modes can be diagonalized with fast Fourier transforms (FFTs). Only a
 small IMT-by-IMT spectral covariance must then be factorized at each Fourier
-mode. This replaces the dense cubic factorization with operations that scale
-approximately as :math:`MN\log N`.
+mode. If :math:`P` is the number of cells in the embedded grid, constructing
+the factor requires :math:`P` small :math:`M \times M` factorizations and each
+field requires FFTs and small matrix products at those frequencies. For the
+small, fixed number of IMTs typical of a calculation, the work therefore grows
+approximately as :math:`P\log P`, rather than cubically with :math:`MN`, and
+does not require storing a dense :math:`MN \times MN` matrix.
+
+The repeated structure follows from stationarity: covariance depends on the
+separation between two grid cells, rather than on their absolute coordinates.
+Consequently, every row of the spatial covariance is a shifted version of the
+same set of covariance lags. A finite rectangular grid has a block-Toeplitz
+with Toeplitz blocks (BTTB) covariance. Extending and reflecting those lags on
+a larger periodic grid produces a block-circulant with circulant blocks (BCCB)
+covariance while preserving all covariances between cells in the original
+grid.
+
+An FFT changes the spatial representation from grid cells to sinusoidal
+spatial frequencies. In this representation, the large BCCB matrix separates
+into one small :math:`M \times M` spectral covariance matrix for every
+frequency, where :math:`M` is the number of IMTs. OpenQuake computes a square
+root of each of these matrices. To draw a field, it transforms independent
+Gaussian noise to the frequency domain, applies the corresponding spectral
+root, transforms the result back, and retains the original grid. This can be
+viewed as efficiently combining random spatial waves whose amplitudes and
+cross-IMT dependence are prescribed by the correlation model.
+
+The periodic extension must itself be a valid covariance, which means that
+all of its spectral covariance matrices must be positive semidefinite. A valid
+stationary model on the requested grid does not guarantee this for the first
+periodic extension. OpenQuake therefore increases the size of the embedding
+until the condition is met. Once it is met, cropping the simulated periodic
+field recovers the covariance specified by the model on the original grid;
+the embedding does not replace the model with a periodic approximation there.
 
 The engine uses this path automatically for sufficiently large compatible
 models and regular grids. Grid cells may be unoccupied, provided the enclosing

--- a/doc/underlying-science/correlation-models.rst
+++ b/doc/underlying-science/correlation-models.rst
@@ -56,7 +56,7 @@ between-event and within-event correlations.
 Dimensions of correlation
 -------------------------
 
-The OpenQuake hazard library distinguishes three geometric capabilities.
+Hazardlib in the OpenQuake engine distinguishes three geometric capabilities.
 
 Spatial correlation
 *******************
@@ -95,10 +95,10 @@ A direct joint model gives the dependence between any two site-and-IMT pairs:
    \rho_W((s,i),(t,j)) =
    \operatorname{Corr}(\epsilon_{e,s,i}, \epsilon_{e,t,j}).
 
-For :math:`M` IMTs and :math:`N` sites, OpenQuake orders the joint vector by
-IMT, so the correlation matrix has shape :math:`MN \times MN`. Direct joint
-models can also return rectangular blocks between target and observation
-locations. Those blocks are required for station conditioning.
+For :math:`M` IMTs and :math:`N` sites, the OpenQuake engine orders the joint
+vector by IMT, so the correlation matrix has shape :math:`MN \times MN`.
+Direct joint models can also return rectangular blocks between target and
+observation locations. Those blocks are required for station conditioning.
 
 Separate spatial and cross-IMT models are sometimes combined using a separable
 approximation,
@@ -189,10 +189,10 @@ through the site- and IMT-dependent standard deviations:
    \phi_{s,i}\phi_{t,j}\rho_W((s,i),(t,j)).
 
 The equivalent expression for between-event residuals uses :math:`\tau`, while
-total-residual covariance uses :math:`\sigma`. The OpenQuake correlation-model
-interfaces operate primarily on standardized correlations; calculators apply
-the corresponding standard deviations when constructing covariance or
-residual ground motions.
+total-residual covariance uses :math:`\sigma`. The OpenQuake engine
+correlation-model interfaces operate primarily on standardized correlations;
+calculators apply the corresponding standard deviations when constructing
+covariance or residual ground motions.
 
 The default sampler forms a dense correlation matrix and uses a Cholesky
 factorization. Its memory requirement grows quadratically and its factorization
@@ -227,20 +227,21 @@ grid.
 An FFT changes the spatial representation from grid cells to sinusoidal
 spatial frequencies. In this representation, the large BCCB matrix separates
 into one small :math:`M \times M` spectral covariance matrix for every
-frequency, where :math:`M` is the number of IMTs. OpenQuake computes a square
-root of each of these matrices. To draw a field, it transforms independent
-Gaussian noise to the frequency domain, applies the corresponding spectral
-root, transforms the result back, and retains the original grid. This can be
-viewed as efficiently combining random spatial waves whose amplitudes and
-cross-IMT dependence are prescribed by the correlation model.
+frequency, where :math:`M` is the number of IMTs. The OpenQuake engine computes
+a square root of each of these matrices. To draw a field, it transforms
+independent Gaussian noise to the frequency domain, applies the corresponding
+spectral root, transforms the result back, and retains the original grid. This
+can be viewed as efficiently combining random spatial waves whose amplitudes
+and cross-IMT dependence are prescribed by the correlation model.
 
 The periodic extension must itself be a valid covariance, which means that
 all of its spectral covariance matrices must be positive semidefinite. A valid
 stationary model on the requested grid does not guarantee this for the first
-periodic extension. OpenQuake therefore increases the size of the embedding
-until the condition is met. Once it is met, cropping the simulated periodic
-field recovers the covariance specified by the model on the original grid;
-the embedding does not replace the model with a periodic approximation there.
+periodic extension. The OpenQuake engine therefore increases the size of the
+embedding until the condition is met. Once it is met, cropping the simulated
+periodic field recovers the covariance specified by the model on the original
+grid; the embedding does not replace the model with a periodic approximation
+there.
 
 The engine uses this path automatically for sufficiently large compatible
 models and regular grids. Grid cells may be unoccupied, provided the enclosing
@@ -249,9 +250,10 @@ periodic embedding is enlarged until its spectrum is positive semidefinite;
 the calculation stops with an explanatory error when that cannot be achieved
 within the supported enlargement.
 
-For station-conditioned fields, OpenQuake combines circulant embedding with
-Matheron substitution. If :math:`U_T` and :math:`U_O` are paired unconditional
-draws at the targets and observations, respectively, a conditional draw is
+For station-conditioned fields, the OpenQuake engine combines circulant
+embedding with Matheron substitution. If :math:`U_T` and :math:`U_O` are
+paired unconditional draws at the targets and observations, respectively, a
+conditional draw is
 
 .. math::
 
@@ -322,11 +324,11 @@ ShakeMap limitation
 -------------------
 
 The legacy ShakeMap XML workflow supplies median ground motions and marginal
-total standard deviations. For reproducibility, OpenQuake currently retains a
-workflow that applies configured spatial and total-residual cross-IMT models to
-those quantities. Applying a total-residual correlation model in this way does
-not reconstruct the station-conditioned posterior covariance and should not be
-interpreted as exact ShakeMap-consistent sampling.
+total standard deviations. For reproducibility, the OpenQuake engine currently
+retains a workflow that applies configured spatial and total-residual cross-IMT
+models to those quantities. Applying a total-residual correlation model in
+this way does not reconstruct the station-conditioned posterior covariance and
+should not be interpreted as exact ShakeMap-consistent sampling.
 
 `Issue #11706 <https://github.com/gem/oq-engine/issues/11706>`_ tracks a future
 workflow based on richer ShakeMap products. That workflow will need to

--- a/openquake/calculators/event_based.py
+++ b/openquake/calculators/event_based.py
@@ -42,7 +42,8 @@ from openquake.hazardlib.calc.filters import (
 from openquake.hazardlib.calc.gmf import GmfComputer, TRUNCATION_THRESHOLD
 from openquake.hazardlib.calc.conditioned_gmfs import (
     ConditionedGmfComputer, build_precomputed, conditionable_imts,
-    conditioned, use_joint_conditioning, use_joint_gaussian_sampling)
+    conditioned, conditioned_ce, use_circulant_conditioning,
+    use_joint_conditioning, use_joint_gaussian_sampling)
 from openquake.hazardlib.calc.stochastic import get_rup_array, rupture_dt
 from openquake.hazardlib.source.rupture import (
     RuptureProxy, EBRupture, get_ruptures_aw)
@@ -409,6 +410,27 @@ def _conditioned_memory(
         computer, num_stations, G, N, compute_covs, memory_limit):
     """Estimate peak arrays used by conditioned-GMF worker tasks."""
     joint = use_joint_conditioning(computer)
+    if compute_covs and use_circulant_conditioning(computer):
+        M = len(computer.inp.imts_Y)
+        Q = len(computer.inp.imts_D) * num_stations
+        T = M * N
+        weights = T * Q * 8
+        station = 4 * Q * Q * 8
+        one_field = 64 * T
+        per_worker = memory_limit // G
+        available = max(
+            0, per_worker - weights - station - one_field)
+        elements_per_site = M * Q
+        block = available // (6 * 8)
+        block = block // elements_per_site * elements_per_site
+        block = min(T * Q, max(elements_per_site, block))
+        chunks = 6 * block * 8
+        size = G * (weights + station + one_field + chunks)
+        detail = (f'{G=} * ({humansize(weights)} regression weights + '
+                  f'{humansize(station)} stations + '
+                  f'{humansize(one_field)} minimum field workspace + '
+                  f'{humansize(chunks)} chunks)')
+        return (size, detail, 'circulant conditioning workspace', block)
     if compute_covs and joint:
         M = len(computer.inp.imts_Y)
         Q = len(computer.inp.imts_D) * num_stations
@@ -457,6 +479,18 @@ def _conditioned_memory(
     return size, detail, 'target-station matrices', None
 
 
+def _store_conditioned(calc, gmf_df):
+    """Append one conditioned GMF table to the datastore."""
+    dstore = calc.datastore
+    if calc.N >= SLICE_BY_EVENT_NSITES:
+        offset = len(dstore['gmf_data/sid'])
+        sbe = build_slice_by_event(gmf_df.eid.to_numpy(), offset)
+        hdf5.extend(dstore['gmf_data/slice_by_event'], sbe)
+    del gmf_df['rlz']
+    for col in gmf_df.columns:
+        hdf5.extend(dstore[f'gmf_data/{col}'], gmf_df[col])
+
+
 def run_conditioned(oq, proxy, full_lt, calc, station_data, station_sites):
     """Run a conditioned scenario calculation and store the GMFs."""
     dstore = calc.datastore
@@ -468,6 +502,7 @@ def run_conditioned(oq, proxy, full_lt, calc, station_data, station_sites):
     maxdist = oq.maximum_distance(cmaker.trt)
     srcfilter = SourceFilter(calc.sitecol.complete, maxdist)
     sites = srcfilter.get_close_sites(proxy, cmaker.trt)
+    scalable = False
     if sites is None:  # filtered away
         raise FarAwayRupture
     ebr = proxy.to_ebr(cmaker.trt)
@@ -481,6 +516,7 @@ def run_conditioned(oq, proxy, full_lt, calc, station_data, station_sites):
         compute_covs = max(computer.tlw, computer.tlb) > \
             TRUNCATION_THRESHOLD
         joint = use_joint_conditioning(computer)
+        scalable = compute_covs and use_circulant_conditioning(computer)
         if compute_covs and joint and not use_joint_gaussian_sampling(
                 computer):
             raise ValueError(
@@ -506,9 +542,19 @@ def run_conditioned(oq, proxy, full_lt, calc, station_data, station_sites):
     del proxy.geom  # to reduce data transfer
 
     dstore.swmr_on()
-    smap = parallel.Starmap(conditioned, h5=dstore)
+    task = conditioned_ce if scalable else conditioned
+    smap = parallel.Starmap(task, h5=dstore)
     pre = build_precomputed(
-        ebr.rupture, cmaker, computer.inp, compute_covs=compute_covs)
+        ebr.rupture, cmaker, computer.inp,
+        compute_covs=compute_covs and not scalable)
+    if scalable:
+        worker_budget = memory_limit // G
+        for conditioner in pre.conditioners:
+            smap.submit((computer, conditioner, worker_budget))
+        for gmf_df in smap:
+            _store_conditioned(calc, gmf_df)
+        return
+
     shared = dict(DD=pre.DD)
     if pre.YD is not None:
         shared['YD'] = pre.YD
@@ -521,12 +567,7 @@ def run_conditioned(oq, proxy, full_lt, calc, station_data, station_sites):
         smap.submit((computer, conditioner))
     MNEdic = smap.reduce()  # g -> MNE
     gmf_df = computer.compute_all(MNEdic, calc._monitor, calc._monitor)
-    if calc.N >= SLICE_BY_EVENT_NSITES:
-        sbe = build_slice_by_event(gmf_df.eid.to_numpy())
-        hdf5.extend(dstore['gmf_data/slice_by_event'], sbe)
-    del gmf_df['rlz']
-    for col in gmf_df.columns:
-        hdf5.extend(dstore[f'gmf_data/{col}'], gmf_df[col])
+    _store_conditioned(calc, gmf_df)
 
 
 def ntasks_by_model(cmaker_rups, concurrent_tasks):

--- a/openquake/calculators/tests/event_based_test.py
+++ b/openquake/calculators/tests/event_based_test.py
@@ -78,6 +78,20 @@ def test_joint_memory_estimates():
     assert dense_name == 'dense joint conditioning workspace'
     assert dense_block is None
 
+    ce_model = SimpleNamespace(SUPPORTS_CIRCULANT_EMBEDDING=True)
+    scalable = SimpleNamespace(
+        inp=SimpleNamespace(
+            within_event_model=ce_model,
+            imts_Y=range(4), imts_D=range(3)),
+        E=500, N=N)
+    ce_size, _, ce_name, ce_block = event_based._conditioned_memory(
+        scalable, D, G, N, compute_covs=True,
+        memory_limit=8 * 1024 ** 3)
+    assert ce_name == 'circulant conditioning workspace'
+    assert ce_size <= 8 * 1024 ** 3
+    assert ce_size >= T * Q * 8
+    assert ce_block > 0
+
     chunked_size, _, chunked_name, block = (
         event_based._conditioned_memory(
             computer, D, G, N, compute_covs=False, memory_limit=budget))

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -132,7 +132,10 @@ then applies the standard conditional-MVN equations. Expanding that Schur
 complement gives equations (B16) and (B17). It therefore produces the same
 untruncated total Gaussian posterior while also allowing one within-event
 model to correlate every target IMT and site jointly. It does not retain
-separate within- and between-event posterior fields.
+separate within- and between-event posterior realizations. The small station
+system nevertheless recovers the posterior mean and covariance of ``H_D``.
+The joint path logs its mean and standard deviation, together with the
+target-averaged nominal-bias mean and standard deviation, for each target IMT.
 
 The OpenQuake engine also makes the following implementation choices:
 
@@ -636,6 +639,36 @@ class StationConditioning:
     def solve(self, right_hand_side):
         """Apply the precomputed station covariance pseudoinverse."""
         return self.cov_YD_YD_inv @ right_hand_side
+
+    def event_posterior(self):
+        """Return the posterior mean and covariance of normalized ``H``."""
+        cross_covariance = self.cov_HD_HD @ self.T_D.T
+        gain = cross_covariance @ self.cov_YD_YD_inv
+        mean = gain @ self.zeta_D
+        covariance = self.cov_HD_HD - gain @ cross_covariance.T
+        covariance = (covariance + covariance.T) / 2
+        return mean, covariance
+
+
+def log_event_posterior(conditioner, station):
+    """Log between-event and nominal-bias diagnostics by target IMT."""
+    mean, covariance = station.event_posterior()
+    stddev = numpy.sqrt(numpy.diag(covariance).clip(min=0))
+    latent_index = {imt: i for i, imt in enumerate(station.latent_imts)}
+    gsim = (conditioner.gsim.gmpe
+            if hasattr(conditioner.gsim, 'gmpe') else conditioner.gsim)
+    for m, imt in enumerate(conditioner.inp.imts_Y):
+        index = latent_index[imt]
+        tau = numpy.asarray(
+            conditioner.mean_stds_Y[2, 0, m], dtype=numpy.float64)
+        bias_mean = numpy.mean(tau * mean[index])
+        bias_stddev = numpy.sqrt(
+            numpy.mean(tau ** 2 * covariance[index, index]))
+        logging.info(
+            'GSIM: %s, IMT: %s, normalized between-event residual '
+            'mean: %.3f, stddev: %.3f, target-averaged nominal bias '
+            'mean: %.3f, stddev: %.3f', gsim, imt, mean[index],
+            stddev[index], bias_mean, bias_stddev)
 
 
 def build_station_conditioning(inp, mean_stds_D, DD):
@@ -1511,6 +1544,7 @@ def conditioned_ce(computer, conditioner, memory_budget, monitor):
         layout, conditioner.inp.sites_D, conditioner.inp.sites_D)
     station = build_station_conditioning(
         conditioner.inp, conditioner.mean_stds_D, DD)
+    log_event_posterior(conditioner, station)
     sampler = CirculantConditioningSampler.build(
         conditioner.inp, station, order, layout)
     weights = build_ce_weights(
@@ -1559,6 +1593,7 @@ def conditioned_joint(computer, conditioner, monitor, compute_covs):
     with monitor.shared['DD'] as DD:
         station = build_station_conditioning(
             conditioner.inp, conditioner.mean_stds_D, DD)
+    log_event_posterior(conditioner, station)
     if compute_covs:
         with monitor.shared['YD'] as YD:
             with monitor.shared['YY'] as YY:

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -28,6 +28,10 @@ https://usgs.github.io/shakemap/manual4_0/tg_processing.html. Its main
 implementation is in ``shakemap_modules/coremods/model.py`` at
 https://code.usgs.gov/ghsc/esi/shakemap-modules.
 
+The scalable approach also follows the CE-and-kriging strategy used by
+Engler, Jaiswal, and Ganesh (2025), *Earthquake Spectra*, 41(1), 524-546,
+https://doi.org/10.1177/87552930241283201.
+
 Basic model
 ===========
 
@@ -107,6 +111,19 @@ The historical path retains the paper's partitioned calculation. ``createD``
 constructs the terms needed by equations (B8) and (B9),
 ``Conditioner.get_mu_tau_phi`` evaluates (B8) and the mean in (B16), and
 ``_compute_target_covs`` evaluates the two covariance terms in (B17).
+
+The *nominal bias* is not omitted from the joint path. In the partitioned
+formulation it is the target between-event shift ``T_Y @ E[H_D | y_D]``.
+The historical ``nominal_bias_mean`` is only a scalar summary of the related
+station shifts; the full target shift is used in the conditional mean. In the
+joint formulation this shift and the within-event kriging correction are
+absorbed into
+
+``Sigma_Y_YD @ Sigma_YD_YD^+ @ zeta_D``.
+
+Expanding that regression recovers the partitioned nominal-bias and
+within-event terms. Adding a separate nominal bias to the joint posterior
+mean would therefore count the between-event adjustment twice.
 
 The joint path is an algebraic generalization rather than a literal sequence
 of the Appendix B equations. It first integrates the normalized

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -330,10 +330,14 @@ from openquake.hazardlib.calc.gmf import GmfComputer, TRUNCATION_THRESHOLD
 from openquake.hazardlib.const import StdDev
 from openquake.hazardlib.correlation_models.base import (
     ResidualComponent, SpatialCorrelationModel)
+from openquake.hazardlib.correlation_models.circulant_embedding import (
+    CirculantEmbeddingFactor, GRID_TOLERANCE, RegularGridLayout)
 from openquake.hazardlib.correlation_models.cross_imt.baker_jayaram_2008 \
     import BakerJayaram2008
 from openquake.hazardlib.correlation_models.cross_imt.goda_atkinson_2009 \
     import GodaAtkinson2009
+from openquake.hazardlib.correlation_models.local_kriging import (
+    covariance_root, LocalKrigingFactor)
 from openquake.hazardlib.correlation_models.spatial.jayaram_baker_2009 \
     import JayaramBaker2009
 from openquake.hazardlib.geo.geodetic import geodetic_distance
@@ -579,6 +583,7 @@ class StationConditioning:
     full_phi_D: numpy.ndarray
     phi_D: numpy.ndarray
     tau_D: numpy.ndarray
+    observation_stddev: numpy.ndarray
     T_D: numpy.ndarray
     cov_HD_HD: numpy.ndarray
     cov_YD_YD: numpy.ndarray
@@ -643,8 +648,196 @@ def build_station_conditioning(inp, mean_stds_D, DD):
             'covariance matrix')
     return StationConditioning(
         zeta_D, imts_D, latent_imts, valid, observed_imt_indices,
-        full_phi_D, phi_D, tau_D, T_D, cov_HD_HD, cov_YD_YD,
+        full_phi_D, phi_D, tau_D, observation_stddev.reshape(-1)[valid],
+        T_D, cov_HD_HD, cov_YD_YD,
         cov_YD_YD_inv)
+
+
+def _target_grid(inp):
+    """Return the regular target sites after excluding station locations."""
+    is_station = numpy.isin(inp.sites_Y.sids, inp.sites_D.sids)
+    grid_sites = inp.sites_Y.filter(~is_station)
+    if grid_sites is None or len(grid_sites) < 4:
+        raise ValueError(
+            'Circulant conditioning requires at least four non-station '
+            'target grid sites')
+    return grid_sites
+
+
+def _target_locations(inp, layout):
+    """Map target sites to grid cells or matching off-grid stations."""
+    rows, columns = layout.grid_coordinates(inp.sites_Y)
+    rounded_rows = numpy.rint(rows)
+    rounded_columns = numpy.rint(columns)
+    on_grid = (
+        (numpy.abs(rows - rounded_rows) <= GRID_TOLERANCE) &
+        (numpy.abs(columns - rounded_columns) <= GRID_TOLERANCE))
+    on_grid_targets = numpy.flatnonzero(on_grid)
+    grid_cells = (
+        rounded_rows[on_grid].astype(int) * layout.grid_shape[1] +
+        rounded_columns[on_grid].astype(int))
+    if (numpy.any(grid_cells < 0) or
+            numpy.any(grid_cells >= numpy.prod(layout.grid_shape))):
+        raise ValueError('An on-grid target lies outside the CE grid')
+
+    off_grid_targets = numpy.flatnonzero(~on_grid)
+    station_by_sid = {
+        sid: index for index, sid in enumerate(inp.sites_D.sids)}
+    try:
+        station_indices = numpy.array([
+            station_by_sid[inp.sites_Y.sids[index]]
+            for index in off_grid_targets], dtype=numpy.int64)
+    except KeyError as exc:
+        raise ValueError(
+            'An off-grid target does not correspond to a station') from exc
+    return (on_grid_targets, grid_cells, off_grid_targets,
+            station_indices)
+
+
+@dataclass(frozen=True)
+class CirculantConditioningSampler:
+    """Generate paired target and station draws from one joint prior."""
+
+    grid_factor: CirculantEmbeddingFactor
+    station_factor: LocalKrigingFactor
+    target_imt_indices: numpy.ndarray
+    on_grid_targets: numpy.ndarray
+    target_grid_cells: numpy.ndarray
+    off_grid_targets: numpy.ndarray
+    target_station_indices: numpy.ndarray
+    observation_field_indices: numpy.ndarray
+    between_root: numpy.ndarray
+
+    @classmethod
+    def build(cls, inp, station, order=4):
+        """Build the CE and local-kriging factors for one station system."""
+        model = inp.within_event_model
+        if not model.SUPPORTS_CIRCULANT_EMBEDDING:
+            raise ValueError(
+                f'{model.__class__.__name__} is not enabled for '
+                'circulant embedding')
+        layout = RegularGridLayout.from_sites(_target_grid(inp))
+        layout = layout.expanded(inp.sites_D, order)
+        grid_factor = CirculantEmbeddingFactor.build(
+            model, station.latent_imts, layout.grid_shape,
+            layout.spacing, ResidualComponent.WITHIN_EVENT,
+            inp.correlation_context)
+        station_factor = LocalKrigingFactor.build(
+            model, station.latent_imts, layout, inp.sites_D, order,
+            ResidualComponent.WITHIN_EVENT, inp.correlation_context)
+        locations = _target_locations(inp, layout)
+
+        latent_index = {
+            imt: index for index, imt in enumerate(station.latent_imts)}
+        target_imt_indices = numpy.array([
+            latent_index[imt] for imt in inp.imts_Y], dtype=numpy.int64)
+        num_stations = len(inp.sites_D)
+        observation_sites = numpy.tile(
+            numpy.arange(num_stations), len(station.observed_imts))
+        observation_sites = observation_sites[station.observation_mask]
+        observation_fields = (
+            station.observed_imt_indices * num_stations +
+            observation_sites)
+        return cls(
+            grid_factor, station_factor, target_imt_indices,
+            *locations, observation_fields,
+            covariance_root(station.cov_HD_HD))
+
+    def draw_prior(self, rng, mean_stds_Y, station, num_events, cutoff=0):
+        """Draw paired zero-mean target and noisy station prior fields."""
+        white = rng.standard_normal(
+            (self.grid_factor.input_size, num_events))
+        grid_fields = self.grid_factor.apply(white).reshape(
+            self.station_factor.num_imts, -1, num_events)
+        local_errors = rng.standard_normal(
+            (self.station_factor.error_size, num_events))
+        station_fields = self.station_factor.apply(
+            grid_fields, local_errors)
+
+        M = len(self.target_imt_indices)
+        N = mean_stds_Y.shape[-1]
+        within_Y = numpy.empty((M, N, num_events))
+        for m, latent_index in enumerate(self.target_imt_indices):
+            within_Y[m, self.on_grid_targets] = grid_fields[
+                latent_index, self.target_grid_cells]
+            within_Y[m, self.off_grid_targets] = station_fields[
+                latent_index, self.target_station_indices]
+        phi_Y = numpy.asarray(mean_stds_Y[3, 0], dtype=numpy.float64)
+        tau_Y = numpy.asarray(mean_stds_Y[2, 0], dtype=numpy.float64)
+        unconditional_Y = phi_Y[:, :, None] * within_Y
+
+        flat_stations = station_fields.reshape(
+            self.station_factor.num_imts *
+            self.station_factor.num_stations, num_events)
+        unconditional_D = (
+            station.phi_D[:, None] *
+            flat_stations[self.observation_field_indices])
+        H = self.between_root @ rng.standard_normal(
+            (len(self.between_root), num_events))
+        unconditional_Y += (
+            tau_Y[:, :, None] *
+            H[self.target_imt_indices, None, :])
+        unconditional_D += station.T_D @ H
+        unconditional_D += (
+            station.observation_stddev[:, None] *
+            rng.standard_normal(unconditional_D.shape))
+        unconditional_Y = unconditional_Y.reshape(M * N, num_events)
+        if cutoff:
+            unconditional_Y += numpy.sqrt(cutoff) * rng.standard_normal(
+                unconditional_Y.shape)
+        return unconditional_Y, unconditional_D
+
+
+def _layout_distances(layout, first, second):
+    """Return projected distances in kilometres on a CE grid's CRS."""
+    first_rows, first_columns = layout.grid_coordinates(first)
+    second_rows, second_columns = layout.grid_coordinates(second)
+    spacing_y, spacing_x = layout.spacing
+    first_points = numpy.column_stack(
+        (first_rows * spacing_y, first_columns * spacing_x))
+    second_points = numpy.column_stack(
+        (second_rows * spacing_y, second_columns * spacing_x))
+    differences = first_points[:, None] - second_points[numpy.newaxis, :]
+    return numpy.linalg.norm(differences, axis=-1)
+
+
+def condition_ce_prior(inp, mean_stds_Y, station, sampler,
+                       unconditional_Y, unconditional_D,
+                       max_block_elements):
+    """Apply Matheron substitution in bounded target-site chunks."""
+    M = len(inp.imts_Y)
+    N = len(inp.sites_Y)
+    Q = len(station.zeta_D)
+    if unconditional_Y.shape[0] != M * N:
+        raise ValueError('The target prior has an unexpected shape')
+    if unconditional_D.shape[0] != Q:
+        raise ValueError('The station prior has an unexpected shape')
+    num_events = unconditional_Y.shape[1]
+    if unconditional_D.shape[1] != num_events:
+        raise ValueError('Target and station priors must have equal samples')
+
+    chunk_size = max(1, max_block_elements // (M * Q))
+    result = numpy.empty((M, N, num_events), dtype=numpy.float64)
+    prior = unconditional_Y.reshape(M, N, num_events)
+    correction = station.solve(
+        station.zeta_D[:, None] - unconditional_D)
+    layout = sampler.station_factor.layout
+    for start in range(0, N, chunk_size):
+        stop = min(start + chunk_size, N)
+        positions = numpy.arange(start, stop)
+        sites_Y = inp.sites_Y.filtered(positions)
+        chunk_inp = replace(inp, sites_Y=sites_Y)
+        chunk_stats = mean_stds_Y[:, :, :, start:stop]
+        distances = _layout_distances(layout, sites_Y, inp.sites_D)
+        joint = build_joint_conditioning(
+            chunk_inp, chunk_stats, station, None, distances)
+        conditioned = (
+            joint.mu_Y[:, None] +
+            prior[:, start:stop].reshape(-1, num_events) +
+            joint.cov_Y_YD @ correction)
+        result[:, start:stop] = conditioned.reshape(
+            M, stop - start, num_events)
+    return result
 
 
 @dataclass

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -54,9 +54,10 @@ The module has two calculation paths:
   existing finite truncated-normal sampler.
 * A spatial-cross-IMT model forms one joint vector containing every target
   IMT and site. It conditions that vector in a single Gaussian operation,
-  preserving the model's spatial and cross-IMT covariance. Dense sampling
-  is the correctness reference; deterministic posterior means are computed
-  in site chunks. Finite truncated sampling is not yet supported here.
+  preserving the model's spatial and cross-IMT covariance. Dense sampling is
+  retained for small calculations and as the correctness reference. Eligible
+  regular grids use the scalable conditional simulation described below.
+  Finite truncated sampling is not yet supported here.
 
 The joint path stacks all requested target IMTs rather than applying
 Appendix B to one target IMT at a time. Its prior covariance blocks are
@@ -75,6 +76,29 @@ diagonal of ``Sigma_WD_WD``. With ``^+`` denoting a pseudoinverse and
 
 These are the joint form of the mean and covariance in equations (B16) and
 (B17). For one target IMT, ``T_Y`` corresponds to the paper's ``T_Y0``.
+
+Scalable conditional simulation
+================================
+
+Factoring ``Sigma_YY_yD`` is infeasible for a realistic target grid. The
+scalable path instead uses Matheron substitution. It draws paired zero-mean
+values ``U_Y`` and ``U_D`` from the same target-and-station prior and forms
+
+``Y_yD = mu_Y + U_Y + Sigma_Y_YD Sigma_YD_YD^+ (zeta_D - U_D)``.
+
+The large regular target field is generated with circulant embedding. A
+station coinciding with a grid point takes that same simulated value. An
+off-grid station is sampled conditionally on a fourth-order local grid
+neighborhood following Bailey et al. (2022), Stat, 11(1), e446,
+https://doi.org/10.1002/sta4.446. Stations within one grid box are sampled
+jointly across all IMTs. Conditional errors from different boxes are treated
+as independent; this is the documented local-kriging approximation.
+
+The target-to-station regression weights are constructed once in site
+chunks and retained in float64. Realizations are then generated, conditioned,
+converted to GMFs, and returned in memory-bounded batches. This removes the
+dense target covariance and posterior factorization while preserving the
+small station covariance system.
 
 Relationship to the Engler algorithm
 ====================================
@@ -120,8 +144,9 @@ Basic flow
    one Engler posterior per target IMT; the latter first builds one joint
    station system and then the joint target blocks.
 5. With zero truncation, posterior means are repeated for all requested
-   fields. Otherwise, covariance is constructed and residual fields are
-   sampled. The final mean is retained with the fields in ``MNE``.
+   fields. Small random calculations construct and sample the dense
+   covariance. Eligible regular grids instead use paired CE prior fields and
+   Matheron substitution, streaming the resulting GMFs in bounded batches.
 
 Notation and dimensions
 =======================
@@ -324,9 +349,11 @@ from collections import namedtuple
 import psutil
 import numpy
 import pandas
-from openquake.baselib import performance
+from openquake.baselib import config, performance
+from openquake.baselib.general import humansize
 from openquake.hazardlib.truncated_mvn import TruncatedMVN
-from openquake.hazardlib.calc.gmf import GmfComputer, TRUNCATION_THRESHOLD
+from openquake.hazardlib.calc.gmf import (
+    CE_MIN_SITES, GmfComputer, TRUNCATION_THRESHOLD)
 from openquake.hazardlib.const import StdDev
 from openquake.hazardlib.correlation_models.base import (
     ResidualComponent, SpatialCorrelationModel)
@@ -664,6 +691,12 @@ def _target_grid(inp):
     return grid_sites
 
 
+def _conditioning_layout(inp, order):
+    """Fit the target lattice and pad it around the station sites."""
+    layout = RegularGridLayout.from_sites(_target_grid(inp))
+    return layout.expanded(inp.sites_D, order)
+
+
 def _target_locations(inp, layout):
     """Map target sites to grid cells or matching off-grid stations."""
     rows, columns = layout.grid_coordinates(inp.sites_Y)
@@ -673,12 +706,15 @@ def _target_locations(inp, layout):
         (numpy.abs(rows - rounded_rows) <= GRID_TOLERANCE) &
         (numpy.abs(columns - rounded_columns) <= GRID_TOLERANCE))
     on_grid_targets = numpy.flatnonzero(on_grid)
-    grid_cells = (
-        rounded_rows[on_grid].astype(int) * layout.grid_shape[1] +
-        rounded_columns[on_grid].astype(int))
-    if (numpy.any(grid_cells < 0) or
-            numpy.any(grid_cells >= numpy.prod(layout.grid_shape))):
+    on_grid_rows = rounded_rows[on_grid].astype(int)
+    on_grid_columns = rounded_columns[on_grid].astype(int)
+    if (numpy.any(on_grid_rows < 0) or
+            numpy.any(on_grid_rows >= layout.grid_shape[0]) or
+            numpy.any(on_grid_columns < 0) or
+            numpy.any(on_grid_columns >= layout.grid_shape[1])):
         raise ValueError('An on-grid target lies outside the CE grid')
+    grid_cells = (
+        on_grid_rows * layout.grid_shape[1] + on_grid_columns)
 
     off_grid_targets = numpy.flatnonzero(~on_grid)
     station_by_sid = {
@@ -708,16 +744,32 @@ class CirculantConditioningSampler:
     observation_field_indices: numpy.ndarray
     between_root: numpy.ndarray
 
+    @property
+    def nbytes(self):
+        """Return bytes retained by the CE and station factors."""
+        arrays = (
+            self.grid_factor.spectral_root,
+            self.grid_factor.site_indices,
+            self.target_imt_indices,
+            self.on_grid_targets,
+            self.target_grid_cells,
+            self.off_grid_targets,
+            self.target_station_indices,
+            self.observation_field_indices,
+            self.between_root)
+        return (sum(array.nbytes for array in arrays) +
+                self.station_factor.nbytes)
+
     @classmethod
-    def build(cls, inp, station, order=4):
+    def build(cls, inp, station, order=4, layout=None):
         """Build the CE and local-kriging factors for one station system."""
         model = inp.within_event_model
         if not model.SUPPORTS_CIRCULANT_EMBEDDING:
             raise ValueError(
                 f'{model.__class__.__name__} is not enabled for '
                 'circulant embedding')
-        layout = RegularGridLayout.from_sites(_target_grid(inp))
-        layout = layout.expanded(inp.sites_D, order)
+        if layout is None:
+            layout = _conditioning_layout(inp, order)
         grid_factor = CirculantEmbeddingFactor.build(
             model, station.latent_imts, layout.grid_shape,
             layout.spacing, ResidualComponent.WITHIN_EVENT,
@@ -801,26 +853,45 @@ def _layout_distances(layout, first, second):
     return numpy.linalg.norm(differences, axis=-1)
 
 
-def condition_ce_prior(inp, mean_stds_Y, station, sampler,
-                       unconditional_Y, unconditional_D,
-                       max_block_elements):
-    """Apply Matheron substitution in bounded target-site chunks."""
+@dataclass(frozen=True)
+class ConditioningWeights:
+    """Reusable target regression weights for Matheron substitution."""
+
+    mu_Y: numpy.ndarray
+    regression: numpy.ndarray
+    station: StationConditioning
+
+    @property
+    def nbytes(self):
+        station_arrays = (
+            value for value in vars(self.station).values()
+            if isinstance(value, numpy.ndarray))
+        return (self.mu_Y.nbytes + self.regression.nbytes +
+                sum(array.nbytes for array in station_arrays))
+
+    def posterior_mean(self):
+        """Return the conditional mean at all target IMTs and sites."""
+        return self.mu_Y + self.regression @ self.station.zeta_D
+
+    def condition(self, unconditional_Y, unconditional_D):
+        """Apply Matheron substitution to one batch of paired priors."""
+        correction = self.station.zeta_D[:, None] - unconditional_D
+        return (self.mu_Y[:, None] + unconditional_Y +
+                self.regression @ correction)
+
+
+def build_ce_weights(inp, mean_stds_Y, station, sampler,
+                     max_block_elements):
+    """Build target regression weights once in bounded site chunks."""
     M = len(inp.imts_Y)
     N = len(inp.sites_Y)
     Q = len(station.zeta_D)
-    if unconditional_Y.shape[0] != M * N:
-        raise ValueError('The target prior has an unexpected shape')
-    if unconditional_D.shape[0] != Q:
-        raise ValueError('The station prior has an unexpected shape')
-    num_events = unconditional_Y.shape[1]
-    if unconditional_D.shape[1] != num_events:
-        raise ValueError('Target and station priors must have equal samples')
-
-    chunk_size = max(1, max_block_elements // (M * Q))
-    result = numpy.empty((M, N, num_events), dtype=numpy.float64)
-    prior = unconditional_Y.reshape(M, N, num_events)
-    correction = station.solve(
-        station.zeta_D[:, None] - unconditional_D)
+    full_station_values = len(inp.imts_D) * len(inp.sites_D)
+    chunk_size = max(
+        1, max_block_elements // (M * full_station_values))
+    regression = numpy.empty((M, N, Q), dtype=numpy.float64)
+    mu_Y = numpy.asarray(
+        mean_stds_Y[0, 0], dtype=numpy.float64).reshape(-1)
     layout = sampler.station_factor.layout
     for start in range(0, N, chunk_size):
         stop = min(start + chunk_size, N)
@@ -830,14 +901,13 @@ def condition_ce_prior(inp, mean_stds_Y, station, sampler,
         chunk_stats = mean_stds_Y[:, :, :, start:stop]
         distances = _layout_distances(layout, sites_Y, inp.sites_D)
         joint = build_joint_conditioning(
-            chunk_inp, chunk_stats, station, None, distances)
-        conditioned = (
-            joint.mu_Y[:, None] +
-            prior[:, start:stop].reshape(-1, num_events) +
-            joint.cov_Y_YD @ correction)
-        result[:, start:stop] = conditioned.reshape(
-            M, stop - start, num_events)
-    return result
+            chunk_inp, chunk_stats, station, None, distances,
+            check_compatibility=start == 0)
+        regression[:, start:stop] = (
+            joint.cov_Y_YD @ station.cov_YD_YD_inv).reshape(
+                M, stop - start, Q)
+    return ConditioningWeights(
+        mu_Y, regression.reshape(M * N, Q), station)
 
 
 @dataclass
@@ -895,7 +965,9 @@ class JointConditioning:
         return self.posterior_mean()[:, None] + samples
 
 
-def build_joint_conditioning(inp, mean_stds_Y, station, YY, YD):
+def build_joint_conditioning(
+        inp, mean_stds_Y, station, YY, YD,
+        check_compatibility=True):
     """Build a dense all-IMT target prior and target-station block."""
     imts_Y = tuple(inp.imts_Y)
     num_targets = len(inp.sites_Y)
@@ -935,13 +1007,14 @@ def build_joint_conditioning(inp, mean_stds_Y, station, YY, YD):
         cov_YY += T_Y @ station.cov_HD_HD @ T_Y.T
     cov_Y_YD = (cov_WY_WD +
                 T_Y @ station.cov_HD_HD @ station.T_D.T)
-    projected_YD = (cov_Y_YD @ station.cov_YD_YD_inv @
-                    station.cov_YD_YD)
-    if not numpy.allclose(
-            projected_YD, cov_Y_YD, rtol=1E-9, atol=1E-12):
-        raise ValueError(
-            'Target-station covariance is incompatible with the singular '
-            'station covariance matrix')
+    if check_compatibility:
+        projected_YD = (cov_Y_YD @ station.cov_YD_YD_inv @
+                        station.cov_YD_YD)
+        if not numpy.allclose(
+                projected_YD, cov_Y_YD, rtol=1E-9, atol=1E-12):
+            raise ValueError(
+                'Target-station covariance is incompatible with the '
+                'singular station covariance matrix')
     return JointConditioning(mu_Y, cov_YY, cov_Y_YD, station)
 
 
@@ -1383,6 +1456,81 @@ def use_joint_gaussian_sampling(computer):
     """Return whether untruncated joint Gaussian sampling is requested."""
     return (computer.cmaker.oq.truncated_mvn is False or
             (computer.tlw == 99 and computer.tlb == 99))
+
+
+def use_circulant_conditioning(computer):
+    """Return whether the scalable joint conditioning path is eligible."""
+    model = computer.inp.within_event_model
+    return (use_joint_conditioning(computer) and
+            getattr(model, 'SUPPORTS_CIRCULANT_EMBEDDING', False) and
+            getattr(computer, 'N', 0) >= CE_MIN_SITES)
+
+
+def _conditioning_batch_size(computer, sampler, weights, memory_budget):
+    """Bound one conditioned batch by workspace memory and output rows."""
+    fixed = sampler.nbytes + weights.nbytes
+    T = computer.M * computer.N
+    Q = len(weights.station.zeta_D)
+    per_event = (
+        sampler.grid_factor.workspace_bytes_per_realization +
+        32 * T + 24 * Q)
+    available = memory_budget - fixed
+    if available < per_event:
+        required = fixed + per_event
+        raise ValueError(
+            'Circulant conditioning requires at least '
+            f'{humansize(required)} of workspace')
+    memory_events = max(1, available // per_event)
+    output_events = max(
+        1, int(config.memory.max_gmvs_chunk) // computer.N)
+    return min(memory_events, output_events)
+
+
+def conditioned_ce(computer, conditioner, memory_budget, monitor):
+    """Yield scalable station-conditioned GMF tables in bounded batches."""
+    order = 4
+    layout = _conditioning_layout(conditioner.inp, order)
+    DD = _layout_distances(
+        layout, conditioner.inp.sites_D, conditioner.inp.sites_D)
+    station = build_station_conditioning(
+        conditioner.inp, conditioner.mean_stds_D, DD)
+    sampler = CirculantConditioningSampler.build(
+        conditioner.inp, station, order, layout)
+    weights = build_ce_weights(
+        conditioner.inp, conditioner.mean_stds_Y, station, sampler,
+        computer.conditioning_block_elements)
+
+    g = conditioner.g
+    _gsim, rlzs = list(computer.cmaker.gsims.items())[g]
+    indices, = numpy.where(numpy.isin(computer.rlz, rlzs))
+    batch_size = _conditioning_batch_size(
+        computer, sampler, weights, memory_budget)
+    logging.info(
+        'Streaming %d conditioned fields in batches of at most %d; '
+        'CE factor=%s, regression weights=%s',
+        len(indices), batch_size, humansize(sampler.nbytes),
+        humansize(weights.nbytes))
+
+    streams = numpy.random.SeedSequence(
+        [computer.seed, g]).spawn(2)
+    prior_rng = numpy.random.default_rng(streams[0])
+    amplifier_rng = numpy.random.default_rng(streams[1])
+    mean = weights.posterior_mean().reshape(computer.M, computer.N)
+    cutoff = computer.cmaker.oq.correlation_cutoff
+    cmon = monitor('conditioning gmfs', measuremem=True)
+    umon = monitor('tabulating gmfs', measuremem=True)
+    for start in range(0, len(indices), batch_size):
+        batch_indices = indices[start:start + batch_size]
+        with cmon:
+            unconditional_Y, unconditional_D = sampler.draw_prior(
+                prior_rng, conditioner.mean_stds_Y, station,
+                len(batch_indices), cutoff)
+            fields = weights.condition(
+                unconditional_Y, unconditional_D).reshape(
+                    computer.M, computer.N, len(batch_indices))
+        with umon:
+            yield computer.tabulate_conditioned(
+                fields, mean, g, batch_indices, amplifier_rng)
 
 
 def conditioned_joint(computer, conditioner, monitor, compute_covs):

--- a/openquake/hazardlib/calc/conditioned_gmfs.py
+++ b/openquake/hazardlib/calc/conditioned_gmfs.py
@@ -134,7 +134,7 @@ untruncated total Gaussian posterior while also allowing one within-event
 model to correlate every target IMT and site jointly. It does not retain
 separate within- and between-event posterior fields.
 
-OpenQuake also makes the following implementation choices:
+The OpenQuake engine also makes the following implementation choices:
 
 * Station-error variance is added to ``Sigma_WD_WD`` following ShakeMap.
   It is not shown explicitly in Appendix B.
@@ -192,18 +192,18 @@ Subscripts and indices
 ``L``
   Number of stations in Appendix B.
 ``N``
-  Number of target sites in OpenQuake arrays; equivalent to Appendix B's
+  Number of target sites in OpenQuake engine arrays; equivalent to Appendix B's
   ``K``.
 ``N_D``
-  Number of station sites in OpenQuake arrays; equivalent to Appendix B's
-  ``L``.
+  Number of station sites in OpenQuake engine arrays; equivalent to Appendix
+  B's ``L``.
 ``D``
   Local name for ``N_D`` in the chunked-mean implementation.
 ``M``
-  Number of target IMTs in OpenQuake. In Appendix B, ``M + 1`` instead
-  counts one native target IMT and the nonnative observed IMTs.
+  Number of target IMTs in the OpenQuake engine. In Appendix B, ``M + 1``
+  instead counts one native target IMT and the nonnative observed IMTs.
 ``M_D``
-  Number of observed IMTs in OpenQuake.
+  Number of observed IMTs in the OpenQuake engine.
 ``J``
   Local name for ``M_D`` in the chunked-mean implementation.
 ``E``
@@ -225,7 +225,7 @@ Input values and GSIM statistics
 ``mu_Y``
   GSIM mean at target sites.
 ``zeta_D``
-  OpenQuake shorthand for the raw station residual ``y_D - mu_YD``. The
+  OpenQuake engine shorthand for the raw station residual ``y_D - mu_YD``. The
   Appendix B equations write this difference explicitly.
 ``phi_D``
   GSIM within-event standard deviations at observation sites.

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -508,6 +508,33 @@ class GmfComputer(object):
         with umon:
             return self.strip_zeros(data)
 
+    def tabulate_conditioned(self, fields, mean, g, indices, rng=None):
+        """Convert one batch of conditioned log fields to a GMF table."""
+        if rng is None:
+            rng = self.rng
+        gsim, rlzs = list(self.cmaker.gsims.items())[g]
+        gsim.gid = self.cmaker.gid[g]
+        num_events = len(indices)
+        expected = (self.M, self.N, num_events)
+        if fields.shape != expected:
+            raise ValueError(
+                f'Expected conditioned fields with shape {expected}, got '
+                f'{fields.shape}')
+
+        result = np.empty(expected, dtype=F32)
+        for m, imt in enumerate(self.imts):
+            result[m] = (np.exp(fields[m]) if imt.string != 'MMI'
+                         else fields[m])
+            if self.amplifier:
+                self.amplifier.amplify_gmfs(
+                    self.ctx.ampcode, result, m, imt, rng)
+        data = AccumDict(accum=[])
+        self.update(
+            data, result.transpose(1, 0, 2), rlzs,
+            np.asarray(mean, dtype=F32),
+            self.cmaker.oq.get_max_iml(), indices)
+        return self.strip_zeros(data, indices)
+
     def compute_all_batches(self, cmon=Monitor(), umon=Monitor()):
         """Yield bounded GMF tables and their global event indices."""
         self.init_eid_rlz_sig_eps()

--- a/openquake/hazardlib/correlation_models/local_kriging.py
+++ b/openquake/hazardlib/correlation_models/local_kriging.py
@@ -99,22 +99,18 @@ class LocalKrigingGroup:
 
 
 def _build_group(model, imts, layout, station_points, station_indices,
-                 box, order, component, context, error_start):
+                 box, order, grid_inverse, component, context, error_start):
     """Build one same-grid-box multivariate conditional distribution."""
     grid_indices = _neighborhood(box, order, layout.grid_shape)
     grid_points = _grid_points(layout, grid_indices)
     selected_stations = station_points[station_indices]
-    grid_covariance = model.correlation_block(
-        _distances(grid_points, grid_points), imts,
-        component=component, context=context)
     cross_covariance = model.correlation_block(
         _distances(selected_stations, grid_points), imts, imts,
         component, context)
     station_covariance = model.correlation_block(
         _distances(selected_stations, selected_stations), imts,
         component=component, context=context)
-    inverse = numpy.linalg.pinv(grid_covariance, hermitian=True)
-    weights = cross_covariance @ inverse
+    weights = cross_covariance @ grid_inverse
     conditional = station_covariance - weights @ cross_covariance.T
     root = covariance_root(conditional)
     error_stop = error_start + len(conditional)
@@ -134,6 +130,17 @@ class LocalKrigingFactor:
     on_grid_cells: numpy.ndarray
     groups: tuple
     error_size: int
+
+    @property
+    def nbytes(self):
+        """Return bytes retained by the station mapping and factors."""
+        size = self.on_grid_stations.nbytes + self.on_grid_cells.nbytes
+        for group in self.groups:
+            size += group.station_indices.nbytes
+            size += group.grid_indices.nbytes
+            size += group.weights.nbytes
+            size += group.conditional_root.nbytes
+        return size
 
     @classmethod
     def build(cls, model, imts, layout, stations, order=4,
@@ -173,11 +180,21 @@ class LocalKrigingFactor:
 
         groups = []
         error_start = 0
-        for box, indices in sorted(boxes.items()):
+        sorted_boxes = sorted(boxes.items())
+        if sorted_boxes:
+            first_cells = _neighborhood(
+                sorted_boxes[0][0], order, layout.grid_shape)
+            grid_points = _grid_points(layout, first_cells)
+            grid_covariance = model.correlation_block(
+                _distances(grid_points, grid_points), imts,
+                component=component, context=context)
+            grid_inverse = numpy.linalg.pinv(
+                grid_covariance, hermitian=True)
+        for box, indices in sorted_boxes:
             station_indices = numpy.asarray(indices, dtype=numpy.int64)
             group = _build_group(
                 model, imts, layout, station_points, station_indices,
-                box, order, component, context, error_start)
+                box, order, grid_inverse, component, context, error_start)
             groups.append(group)
             error_start = group.error_slice.stop
         return cls(

--- a/openquake/hazardlib/correlation_models/local_kriging.py
+++ b/openquake/hazardlib/correlation_models/local_kriging.py
@@ -61,7 +61,7 @@ def _grid_points(layout, indices):
         (rows * layout.spacing[0], columns * layout.spacing[1]))
 
 
-def _covariance_root(covariance):
+def covariance_root(covariance):
     """Return a real square root of a positive-semidefinite covariance."""
     covariance = (covariance + covariance.T) / 2
     eigenvalues, eigenvectors = numpy.linalg.eigh(covariance)
@@ -116,7 +116,7 @@ def _build_group(model, imts, layout, station_points, station_indices,
     inverse = numpy.linalg.pinv(grid_covariance, hermitian=True)
     weights = cross_covariance @ inverse
     conditional = station_covariance - weights @ cross_covariance.T
-    root = _covariance_root(conditional)
+    root = covariance_root(conditional)
     error_stop = error_start + len(conditional)
     return LocalKrigingGroup(
         station_indices, grid_indices, weights, root,

--- a/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
+++ b/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
@@ -47,7 +47,8 @@ from openquake.hazardlib.calc.conditioned_gmfs import (
     conditioned_ce, ConditionedGmfComputer,
     conditioned_mean_in_chunks, createD,
     compute_within_event_covariance_matrix, get_mean_covs, Input,
-    JointConditioning, select_observed_imts, StationConditioning)
+    JointConditioning, log_event_posterior, select_observed_imts,
+    StationConditioning)
 from openquake.hazardlib.tests.calc import \
     _conditioned_gmfs_test_data as test_data
 
@@ -235,6 +236,36 @@ def test_total_station_covariance():
     aac(system.cov_YD_YD, expected)
     identity = numpy.eye(len(expected))
     aac(system.solve(identity), numpy.linalg.pinv(expected, hermitian=True))
+
+
+def test_event_posterior():
+    # H has unit prior variance. The observation has tau=2, phi=3,
+    # error stddev=4, and residual=5, hence Var(Y_D)=2**2+3**2+4**2=29.
+    imt = PGA()
+    station = StationConditioning(
+        numpy.array([5.0]), (imt,), (imt,), numpy.array([True]),
+        numpy.array([0]), numpy.array([3.0]), numpy.array([3.0]),
+        numpy.array([2.0]), numpy.array([4.0]), numpy.array([[2.0]]),
+        numpy.array([[1.0]]), numpy.array([[29.0]]),
+        numpy.array([[1 / 29]]))
+
+    mean, covariance = station.event_posterior()
+    aac(mean, [10 / 29])
+    aac(covariance, [[25 / 29]])
+
+    mean_stds_Y = numpy.zeros((4, 1, 1, 2))
+    mean_stds_Y[2, 0, 0] = [0.5, 1.5]
+    conditioner = SimpleNamespace(
+        gsim='ExampleGMM', inp=SimpleNamespace(imts_Y=[imt]),
+        mean_stds_Y=mean_stds_Y)
+    with mock.patch(
+            'openquake.hazardlib.calc.conditioned_gmfs.logging.info') as info:
+        log_event_posterior(conditioner, station)
+
+    values = info.call_args.args[3:]
+    expected_bias_stddev = numpy.sqrt(1.25 * 25 / 29)
+    aac(values, [10 / 29, numpy.sqrt(25 / 29),
+                 10 / 29, expected_bias_stddev])
 
 
 def test_missing_station_observations():

--- a/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
+++ b/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
@@ -27,6 +27,7 @@ from types import SimpleNamespace
 
 import numpy
 import pandas
+from pyproj import Transformer
 
 from openquake.baselib import performance
 from openquake.hazardlib.contexts import simple_cmaker
@@ -37,8 +38,10 @@ from openquake.hazardlib.correlation_models.cross_imt.no_cross_correlation \
 from openquake.hazardlib.correlation_models.spatial_cross_imt.du_ning_2021 \
     import DuNing2021
 from openquake.hazardlib.imt import from_string, MMI, PGA, PGV, SA
+from openquake.hazardlib.site import SiteCollection
 from openquake.hazardlib.calc.conditioned_gmfs import (
     build_joint_conditioning, build_precomputed, build_station_conditioning,
+    CirculantConditioningSampler, condition_ce_prior,
     compute_distance_matrix, conditionable_imts, conditioned,
     conditioned_mean_in_chunks, createD,
     compute_within_event_covariance_matrix, get_mean_covs, Input,
@@ -400,6 +403,128 @@ def test_matheron_transform():
     aac(centered @ centered.T, covariance, atol=1E-12)
 
 
+class BasisRNG:
+    """Return consecutive rows of an identity basis as random values."""
+
+    def __init__(self, size):
+        self.basis = numpy.eye(size)
+        self.offset = 0
+
+    def standard_normal(self, shape):
+        rows, columns = shape
+        assert columns == len(self.basis)
+        result = self.basis[self.offset:self.offset + rows]
+        self.offset += rows
+        return result
+
+
+def _utm_sitecol(x, y):
+    """Build a site collection from UTM zone 10 coordinates."""
+    transformer = Transformer.from_crs(32610, 4326, always_xy=True)
+    lon, lat = transformer.transform(
+        numpy.asarray(x, dtype=float), numpy.asarray(y, dtype=float))
+    return SiteCollection.from_points(lon, lat)
+
+
+def _projected_distances(first, second):
+    transformer = Transformer.from_crs(4326, 32610, always_xy=True)
+    x1, y1 = transformer.transform(first.lons, first.lats)
+    x2, y2 = transformer.transform(second.lons, second.lats)
+    first_points = numpy.column_stack((x1, y1)) / 1_000
+    second_points = numpy.column_stack((x2, y2)) / 1_000
+    differences = (first_points[:, None] -
+                   second_points[numpy.newaxis, :])
+    return numpy.linalg.norm(differences, axis=-1)
+
+
+def test_ce_prior_covariance():
+    # An identity basis recovers the covariance of every random term. This
+    # checks that paired target/station draws share the same local field.
+    class JointModel(SpatialCrossIMTCorrelationModel):
+        DEFINED_FOR_RESIDUAL_COMPONENT = ResidualComponent.WITHIN_EVENT
+        SUPPORTS_CIRCULANT_EMBEDDING = True
+
+        def _correlation_block(
+                self, distances, imts1, imts2, context=None):
+            cross = numpy.array([[1.0, 0.4], [0.4, 1.0]])
+            indices1 = [0 if imt.name == 'PGA' else 1 for imt in imts1]
+            indices2 = [0 if imt.name == 'PGA' else 1 for imt in imts2]
+            return numpy.kron(
+                cross[numpy.ix_(indices1, indices2)],
+                numpy.exp(-distances / 10))
+
+    rows, columns = numpy.indices((4, 4))
+    targets = _utm_sitecol(
+        500_000 + columns.ravel() * 1_000,
+        4_200_000 + rows.ravel() * 1_000)
+    station_points = _utm_sitecol(
+        [501_000, 501_300, 501_700],
+        [4_201_000, 4_201_200, 4_201_800])
+    targets.extend(station_points.lons, station_points.lats)
+    station_sids = []
+    for lon, lat in zip(station_points.lons, station_points.lats):
+        distance = numpy.hypot(targets.lons - lon, targets.lats - lat)
+        station_sids.append(targets.sids[distance.argmin()])
+    sites_D = targets.filtered(station_sids)
+
+    imts = [PGA(), SA(0.3)]
+    D = len(sites_D)
+    N = len(targets)
+    data = pandas.DataFrame({
+        'PGA_mean': numpy.ones(D),
+        'PGA_std': [0.05, 0.10, 0.15],
+        'SA(0.3)_mean': numpy.ones(D),
+        'SA(0.3)_std': [0.20, 0.25, 0.30]}, index=sites_D.sids)
+    inp = Input(
+        targets, sites_D, imts, imts, data, JointModel(),
+        NoCrossCorrelation(), None)
+    mean_stds_D = numpy.zeros((4, 1, 2, D))
+    mean_stds_D[2, 0] = [[0.2, 0.3, 0.4], [0.5, 0.6, 0.7]]
+    mean_stds_D[3, 0] = [[0.8, 0.7, 0.6], [0.5, 0.4, 0.3]]
+    mean_stds_Y = numpy.zeros((4, 1, 2, N))
+    mean_stds_Y[2, 0] = [[0.25], [0.55]]
+    mean_stds_Y[3, 0] = [[0.75], [0.45]]
+
+    DD = _projected_distances(sites_D, sites_D)
+    station = build_station_conditioning(inp, mean_stds_D, DD)
+    sampler = CirculantConditioningSampler.build(inp, station, order=2)
+    total = (sampler.grid_factor.input_size +
+             sampler.station_factor.error_size +
+             len(sampler.between_root) + len(station.zeta_D))
+    unconditional_Y, unconditional_D = sampler.draw_prior(
+        BasisRNG(total), mean_stds_Y, station, total)
+
+    aac(unconditional_D @ unconditional_D.T,
+        station.cov_YD_YD, atol=2E-12)
+    target_positions = numpy.flatnonzero(
+        numpy.isin(targets.sids, sites_D.sids))
+    target_rows = numpy.concatenate([
+        m * N + target_positions for m in range(len(imts))])
+    actual = unconditional_Y[target_rows] @ unconditional_D.T
+    YD = _projected_distances(
+        targets.filtered(target_positions), sites_D)
+    phi_Y = mean_stds_Y[3, 0][:, target_positions].reshape(-1)
+    tau_Y = mean_stds_Y[2, 0][:, target_positions].reshape(-1)
+    expected = compute_within_event_covariance_matrix(
+        inp.within_event_model, None, YD, imts, imts,
+        phi_Y, station.full_phi_D, dtype=numpy.float64)
+    T_Y = numpy.zeros((len(target_rows), len(imts)))
+    T_Y[numpy.arange(len(target_rows)),
+        numpy.repeat(numpy.arange(len(imts)), D)] = tau_Y
+    expected += T_Y @ station.cov_HD_HD @ station.T_D.T
+    aac(actual, expected, atol=2E-12)
+
+    conditioned = condition_ce_prior(
+        inp, mean_stds_Y, station, sampler,
+        unconditional_Y, unconditional_D,
+        max_block_elements=len(imts) * len(station.zeta_D) * 3)
+    YD = _projected_distances(targets, sites_D)
+    full = build_joint_conditioning(
+        inp, mean_stds_Y, station, None, YD)
+    expected = full.condition(unconditional_Y, unconditional_D)
+    aac(conditioned.reshape(len(imts) * N, total), expected)
+
+
 def test_joint_sampling_path():
     # A joint model must bypass the historical per-IMT calculation.
     imts = [PGA(), SA(0.3)]
@@ -490,7 +615,8 @@ def test_singular_station_sampling():
     station = StationConditioning(
         numpy.zeros(2), (), (), numpy.ones(2, dtype=bool),
         numpy.zeros(2, dtype=int), numpy.ones(2), numpy.ones(2),
-        numpy.ones(2), numpy.ones((2, 1)), numpy.ones((1, 1)),
+        numpy.ones(2), numpy.zeros(2), numpy.ones((2, 1)),
+        numpy.ones((1, 1)),
         cov_YD_YD, numpy.linalg.pinv(cov_YD_YD, hermitian=True))
     joint = JointConditioning(
         numpy.array([0.5]), numpy.ones((1, 1)),

--- a/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
+++ b/openquake/hazardlib/tests/calc/conditioned_gmfs_test.py
@@ -29,7 +29,7 @@ import numpy
 import pandas
 from pyproj import Transformer
 
-from openquake.baselib import performance
+from openquake.baselib import config, performance
 from openquake.hazardlib.contexts import simple_cmaker
 from openquake.hazardlib.correlation_models.base import (
     ResidualComponent, SpatialCrossIMTCorrelationModel)
@@ -39,10 +39,12 @@ from openquake.hazardlib.correlation_models.spatial_cross_imt.du_ning_2021 \
     import DuNing2021
 from openquake.hazardlib.imt import from_string, MMI, PGA, PGV, SA
 from openquake.hazardlib.site import SiteCollection
+from openquake.hazardlib.source.rupture import EBRupture
 from openquake.hazardlib.calc.conditioned_gmfs import (
     build_joint_conditioning, build_precomputed, build_station_conditioning,
-    CirculantConditioningSampler, condition_ce_prior,
+    build_ce_weights, CirculantConditioningSampler,
     compute_distance_matrix, conditionable_imts, conditioned,
+    conditioned_ce, ConditionedGmfComputer,
     conditioned_mean_in_chunks, createD,
     compute_within_event_covariance_matrix, get_mean_covs, Input,
     JointConditioning, select_observed_imts, StationConditioning)
@@ -50,6 +52,22 @@ from openquake.hazardlib.tests.calc import \
     _conditioned_gmfs_test_data as test_data
 
 aac = numpy.testing.assert_allclose
+
+
+class TwoIMTCorrelation(SpatialCrossIMTCorrelationModel):
+    """Stationary joint model used only by the CE conditioning tests."""
+
+    DEFINED_FOR_RESIDUAL_COMPONENT = ResidualComponent.WITHIN_EVENT
+    SUPPORTS_CIRCULANT_EMBEDDING = True
+
+    def _correlation_block(
+            self, distances, imts1, imts2, context=None):
+        cross = numpy.array([[1.0, 0.4], [0.4, 1.0]])
+        indices1 = [0 if imt.name == 'PGA' else 1 for imt in imts1]
+        indices2 = [0 if imt.name == 'PGA' else 1 for imt in imts2]
+        return numpy.kron(
+            cross[numpy.ix_(indices1, indices2)],
+            numpy.exp(-distances / 10))
 
 
 def test_pgv_is_conditionable():
@@ -440,19 +458,6 @@ def _projected_distances(first, second):
 def test_ce_prior_covariance():
     # An identity basis recovers the covariance of every random term. This
     # checks that paired target/station draws share the same local field.
-    class JointModel(SpatialCrossIMTCorrelationModel):
-        DEFINED_FOR_RESIDUAL_COMPONENT = ResidualComponent.WITHIN_EVENT
-        SUPPORTS_CIRCULANT_EMBEDDING = True
-
-        def _correlation_block(
-                self, distances, imts1, imts2, context=None):
-            cross = numpy.array([[1.0, 0.4], [0.4, 1.0]])
-            indices1 = [0 if imt.name == 'PGA' else 1 for imt in imts1]
-            indices2 = [0 if imt.name == 'PGA' else 1 for imt in imts2]
-            return numpy.kron(
-                cross[numpy.ix_(indices1, indices2)],
-                numpy.exp(-distances / 10))
-
     rows, columns = numpy.indices((4, 4))
     targets = _utm_sitecol(
         500_000 + columns.ravel() * 1_000,
@@ -476,7 +481,7 @@ def test_ce_prior_covariance():
         'SA(0.3)_mean': numpy.ones(D),
         'SA(0.3)_std': [0.20, 0.25, 0.30]}, index=sites_D.sids)
     inp = Input(
-        targets, sites_D, imts, imts, data, JointModel(),
+        targets, sites_D, imts, imts, data, TwoIMTCorrelation(),
         NoCrossCorrelation(), None)
     mean_stds_D = numpy.zeros((4, 1, 2, D))
     mean_stds_D[2, 0] = [[0.2, 0.3, 0.4], [0.5, 0.6, 0.7]]
@@ -514,15 +519,61 @@ def test_ce_prior_covariance():
     expected += T_Y @ station.cov_HD_HD @ station.T_D.T
     aac(actual, expected, atol=2E-12)
 
-    conditioned = condition_ce_prior(
+    weights = build_ce_weights(
         inp, mean_stds_Y, station, sampler,
-        unconditional_Y, unconditional_D,
         max_block_elements=len(imts) * len(station.zeta_D) * 3)
+    conditioned = weights.condition(unconditional_Y, unconditional_D)
     YD = _projected_distances(targets, sites_D)
     full = build_joint_conditioning(
         inp, mean_stds_Y, station, None, YD)
     expected = full.condition(unconditional_Y, unconditional_D)
-    aac(conditioned.reshape(len(imts) * N, total), expected)
+    aac(conditioned, expected)
+    aac(weights.posterior_mean(), full.posterior_mean())
+
+
+def test_ce_conditioned_batches(monkeypatch):
+    # Exercise the production generator above the automatic CE threshold.
+    rows, columns = numpy.indices((32, 32))
+    targets = _utm_sitecol(
+        500_000 + columns.ravel() * 1_000,
+        4_200_000 + rows.ravel() * 1_000)
+    station_points = _utm_sitecol(
+        [510_300, 510_700], [4_210_200, 4_210_800])
+    targets.extend(station_points.lons, station_points.lats)
+    sites_D = targets.filtered([1024, 1025])
+    imts = [PGA(), SA(0.3)]
+    data = pandas.DataFrame({
+        'PGA_mean': [1.0, 1.1], 'PGA_std': [0.1, 0.1],
+        'SA(0.3)_mean': [0.9, 1.0], 'SA(0.3)_std': [0.1, 0.1]},
+        index=sites_D.sids)
+    cmaker = simple_cmaker(
+        [test_data.ZeroMeanGMM()], [str(imt) for imt in imts],
+        maximum_distance=test_data.MAX_DIST, truncation_level=99)
+    cmaker.oq.truncated_mvn = False
+    cmaker.oq.correlation_cutoff = 0
+    cmaker.oq.calculation_mode = 'scenario'
+    ebr = EBRupture(
+        test_data.RUP, source_id=0, trt_smr=0, n_occ=2,
+        id=0, e0=0)
+    ebr.seed = 7
+    computer = ConditionedGmfComputer(
+        ebr, targets, sites_D, data, imts, cmaker,
+        TwoIMTCorrelation(), NoCrossCorrelation())
+    computer.init_eid_rlz_sig_eps()
+    computer.conditioning_block_elements = 10_000
+    pre = build_precomputed(
+        test_data.RUP, cmaker, computer.inp, compute_covs=False)
+    monkeypatch.setattr(
+        config.memory, 'max_gmvs_chunk', str(len(targets)))
+
+    tables = list(conditioned_ce(
+        computer, pre.conditioners[0], 256 * 1024 ** 2,
+        performance.Monitor()))
+    assert len(tables) == 2
+    assert all(len(table) == len(targets) for table in tables)
+    assert {int(table.eid.iloc[0]) for table in tables} == {0, 1}
+    for table in tables:
+        assert numpy.isfinite(table[['PGA', 'SA(0.3)']]).all().all()
 
 
 def test_joint_sampling_path():


### PR DESCRIPTION
## Efficient station-conditioned spatially-cross-correlated GMF simulation using circulant embedding and local Kriging

Related to #11230 and #10833. #11734 connects the circulant-embedding implementation introduced in https://github.com/gem/oq-engine/pull/11728 to unconditioned ground-motion field (GMF) generation. #11735 implemented local Kriging to obtain unconditioned gmf values at off-grid station locations.

This is the second of two PRs stacked on top of #11734 following #11735, extending circulant embedding from unconditioned regular-grid fields to station-conditioned GMFs.

The existing conditioning algorithm in the engine constructs a posterior covariance whose dimensions are the number of target sites multiplied by the number of IMTs. Storing this matrix requires quadratic memory, and factorizing it has cubic computational cost. This makes station-conditioned GMF sampling infeasible for realistic regional calculations.

This PR replaces that dense target-posterior operation, for eligible regular grids and joint correlation models, with paired circulant-embedding realizations and Matheron substitution.

### How the scalable conditioning works

The method first generates an unconditioned realization at the target grid and corresponding values at the station locations:

- circulant embedding generates the large joint within-event field on the regular grid ([#11734](https://github.com/gem/oq-engine/pull/11734))
- exact extraction or local Kriging provides paired within-event values at the stations ([#11735](https://github.com/gem/oq-engine/pull/11735))
- one low-dimensional between-event residual is shared by every site and correlated across IMTs using the configured between-event cross-IMT correlation model
- station observation uncertainty is added where specified

The target and station values must be generated from the same random realization. If $U_Y$ and $U_D$ are these paired zero-mean prior values at the targets and stations, respectively, the conditioned field is

```math
Y_{|D}
=
\mu_Y + U_Y
+
\Sigma_{YD}\Sigma_{DD}^{+}
\left(\zeta_D-U_D\right).
```

Here, $\zeta_D$ contains the observed station residuals, $\Sigma_{YD}$ is the target-to-station prior covariance, and $\Sigma_{DD}$ is the station covariance including the within-event, between-event, and observation-error contributions.

Essentially, the calculation generates an unconditioned field, compares its simulated station values with the observations, and propagates that difference across the target grid using the user-specified covariance model. This is also called Matheron substitution in spatial statistics / geostatistics. It produces the conditional Gaussian field without constructing the dense target posterior covariance.

The target-to-station regression weights are built once in memory-bounded site chunks, retained in `float64`, and reused for every realization. The realizations are then generated, conditioned, converted to GMFs, and returned in batches governed by `memory.conditioned_gmf_gb` and `memory.max_gmvs_chunk` (first stab, there might be more efficient ways of doing this!).


### Efficiency of the circulant embedding + local Kriging approach

The 2023 M7.8 Kahramanmaraş benchmark scenario added in #11734 contains 112 stations and four IMTs. For a rounded target grid of ~250,000 sites, the joint target field contains $4 \times 250{,}000 = 1{,}000{,}000$ random variables, while the station data contain $4 \times 112 = 448$ observed variables.

| Operation | Dimensions | `float64` storage |
|---|---:|---:|
| Spatial covariance for one IMT | 250,000 × 250,000 | ~ 500 GB |
| Joint target covariance for four IMTs | (250,000 × 4) × (250,000 × 4) | ~ 8 TB |
| Joint target-to-station covariance | 1,000,000 × 448 | ~ 3.6 GB |
| Local station weights using 64 grid cells | (112 × 4) × (64 × 4) | ~ 1 MB |

The 8 TB estimate is for the joint covariance matrix alone. Its factor and numerical workspaces would require still more memory, which is why this calculation was doomed to fail by running out of memory on any machine.

Circulant embedding avoids constructing the massive target-by-target covariance matrix, replacing it with FFTs and small cross-IMT spectral matrices. Local Kriging then helps avoid coupling every off-grid station to the _complete_ target grid when generating the paired station prior. Each station uses _only 64_ nearby grid cells, reducing that particular operation from approximately 3.6 GB of covariance values to about 1 MB of retained local weights, plus a roughly 0.5 MB neighborhood covariance, with barely any loss of usable information.

The final Matheron correction still requires global target-to-station regression weights. These are constructed in memory-bounded target chunks and then retained for reuse across all realizations. Thus, local Kriging removes an additional full-grid station coupling, although it does not eliminate the scientifically necessary target-to-station conditioning relationship.


### Relationship to the Engler et al. (2022) approach

The existing OpenQuake engine implementation for station-conditioned GMFs (#8318) follows the partitioned formulation of Engler et al. (2022)[^1]. It first derives the posterior between-event residual and then kriges the remaining within-event station residuals.

If $\widehat H$ is the posterior mean of the normalized between-event residual, its target contribution is $T_Y\widehat H$. This is the target-specific form of the quantity described as the nominal bias. The partitioned posterior mean can be written as

```math
\mu_{Y|D}
=
\mu_Y
+
T_Y\widehat H
+
\Sigma_{W_YW_D}\Sigma_{W_DW_D}^{+}
\left(\zeta_D-T_D\widehat H\right).
```

The joint formulation used here instead writes

```math
\mu_{Y|D}
=
\mu_Y+\Sigma_{YD}\Sigma_{DD}^{+}\zeta_D,
```

with

```math
\Sigma_{YD}
=
\Sigma_{W_YW_D}
+
T_Y\Sigma_{HH}T_D^{\mathsf T}.
```

Expanding the joint regression recovers the between-event nominal-bias term and the within-event Kriging term in the partitioned expression. Under the joint-Gaussian assumptions, the two formulations therefore produce the same total posterior distribution. 

The main organizational difference is that the new CE + local Kriging method does not retain separately labelled posterior between- and within-event fields. It directly samples their jointly conditioned total contribution.

This also follows the broad computational approach described by Engler et al. (2025)[^2]: generate an unconditioned within-event realization using circulant embedding and then condition that realization on the observations through Kriging. The current PR generalizes this to multiple jointly correlated IMTs.

One of the advantages of the Engler et al. (2022) partitioning is that it can report the posterior event term, its uncertainty and the nominal bias separately from the within-event field. That can be quite useful for diagnostics, comparing the inferred event bias between GMMs, or for applications that want to fix or sample the event term independently. 

The CE approach, on the other hand, provides a major performance advantage. Its limitations are the regular-grid and stationarity requirements, the local approximation for off-grid stations, and the absence of separately retained posterior between- and within-event realizations.

Given the valuable diagnostic utility of the Engler et al. (2022) partitioning, we continue to report the posterior mean and standard deviation of the normalized between-event residual and the corresponding target-averaged nominal-bias statistics. These diagnostics require only the small station covariance system and do not change the sampled GMFs, random-number sequence, or memory scaling. Separate posterior component realizations are not retained, but could be added later if needed.


### In this PR

The PR adds:

- a small joint station covariance system containing the within-event, between-event, and observation-error contributions
- paired target and station prior draws using CE and local Kriging
- a dense joint implementation retained as the reference path for small calculations
- reusable target-to-station regression weights constructed in bounded chunks
- memory-aware streaming of conditioned GMF realizations
- calculator integration using the existing task and datastore interfaces, without modifying `parallel.py` or `zeromq.py`
- underlying-science and API documentation covering CE, local kriging, Matheron substitution, nominal-bias equivalence, and current limitations

The scalable path introduced in this PR is currently enabled for sufficiently large regular grids using the `DuNing2021` spatial-cross-correlation model. Other models continue to use the old path until their structured embeddings have been validated. 

**Note**: Joint finite truncated multivariate-normal sampling is not yet supported.

### Verification and benchmarks

The numerical tests verify the paired target-and-station prior covariance, shared between-event terms, observation error, colocated stations, Matheron substitution, posterior means, and invariance to covariance and realization batch sizes. The dense joint implementation is assumed to provide the exact values for testing the scalable formulation.

My 36 GB MacBook Pro is successfully able to generate 500 conditioned GMFs for four IMTs (for a single GMM in each case):

- the 2014 M6.0 South Napa scenario, with approximately 9,000 sites, completed in about 20 seconds
- the 2023 M7.8 Kahramanmaraş scenario, with approximately 204,000 sites, completed in about 80 seconds

These cases, especially the latter, clearly demonstrate that the method can handle calculation sizes for which constructing the dense posterior covariance was simply impractical.

The review could particularly check the memory accounting and batching.

### Possible future reorganization

`conditioned_gmfs.py` now contains both the historical per-IMT partitioned algorithm based on Engler et al. (2022) and the new joint Gaussian implementation with dense and CE sampling backends based on Bailey et al. (2022)[^3]. A later structural PR could separate out common conditioned calculation orchestration, the Engler et al. (2022) formulation, and the Bailey et al. (2022) CE-specific sampler into clearly delineated modules.

### References

[^1]: Engler, D. T., Worden, C. B., Thompson, E. M., & Jaiswal, K. S. (2022). Partitioning ground motion uncertainty when conditioned on station data. *Bulletin of the Seismological Society of America*, 112(2), 1060–1079. https://doi.org/10.1785/0120210177
[^2]: Engler, D. T., Jaiswal, K. S., & Ganesh, M. (2025). Evaluating the impact of uncertainty in ground motion forecasts for post-earthquake impact modeling applications. *Earthquake Spectra*, 41(1), 524–546. https://doi.org/10.1177/87552930241283201
[^3]: Bailey, M. D., Bandyopadhyay, S., & Nychka, D. (2022). Adapting conditional simulation using circulant embedding for irregularly spaced spatial data. *Stat*, 11(1), e446. https://doi.org/10.1002/sta4.446