### PR TITLE
Prevent SQLite from reusing IDs of restored jobs

### DIFF
--- a/openquake/commands/restore.py
+++ b/openquake/commands/restore.py
@@ -52,15 +52,27 @@ def main(archive, oqdata):
     db = Db(sqlite3.connect, dbpath, isolation_level=None,
             detect_types=sqlite3.PARSE_DECLTYPES)
     n = 0
+    calc_ids = []
     for fname in os.listdir(oqdata):
         mo = re.match(r'calc_(\d+)\.hdf5', fname)
         if mo:
             job_id = int(mo.group(1))
+            calc_ids.append(job_id)
             fullname = os.path.join(oqdata, fname)[:-5]  # strip .hdf5
             db("UPDATE job SET user_name=?x, ds_calc_dir=?x WHERE id=?x",
                getpass.getuser(), fullname, job_id)
             safeprint('Restoring ' + fname)
             n += 1
+    if calc_ids:
+        # The archive can contain datastores whose jobs are missing from the
+        # copied database. Keep SQLite from reusing one of their IDs.
+        last_id = max(calc_ids)
+        cursor = db(
+            "UPDATE sqlite_sequence SET seq=?x "
+            "WHERE name='job' AND seq<?x", last_id, last_id)
+        if not cursor.rowcount:
+            db("INSERT OR IGNORE INTO sqlite_sequence(name, seq) "
+               "VALUES ('job', ?x)", last_id)
     dt = time.time() - t0
     safeprint('Extracted %d calculations into %s in %d seconds'
               % (n, oqdata, dt))


### PR DESCRIPTION
In the QGIS plugin integration tests we run oq restore to have the possibility to test loading in QGIS the outputs of the oq demos. Since yesterday, without this fix, oq restore updated database paths for the restored files but did not ensure SQLite’s internal auto-increment counter knew about their IDs. If the database sequence was stale, the next job could receive an ID already used by a restored calc_<id>.hdf5 file.

The change:

  1. Collects all IDs found in restored datastore filenames.
  2. Finds the largest restored ID.
  3. Updates SQLite’s sqlite_sequence for the job table to at least that value.
  4. Creates the sequence entry if it does not exist.

  Therefore, the next automatically created job gets an ID greater than every restored datastore ID.

To reproduce the error:
```
oq reset -y
oq engine --run demos/hazard/AreaSourceClassicalPSHA/job.ini
oq dump /tmp/demo.zip
oq reset -y
oq restore /tmp/demo.zip ~/oqdata
oq engine --run demos/hazard/AreaSourceClassicalPSHA/job.ini
```
Without this fix, it causes:
`RuntimeError: There is a pre-existing file /home/ptormene/oqdata/calc_1.hdf5`

Checking out commit 3367c018d4 from 2 days ago, the error does not occur.