### PR TITLE
Use SQLite backup API in oq dump to snapshot WAL data

### DIFF
--- a/openquake/commands/dump.py
+++ b/openquake/commands/dump.py
@@ -31,15 +31,18 @@ def smart_save(dbpath, archive, calc_id):
     """
     tmpdir = tempfile.mkdtemp()
     newdb = os.path.join(tmpdir, os.path.basename(dbpath))
-    shutil.copy(dbpath, newdb)
+    src = sqlite3.connect(dbpath)
     try:
-        with sqlite3.connect(newdb) as conn:
-            conn.execute('DELETE FROM job WHERE status != "complete"')
+        with sqlite3.connect(newdb) as dst:
+            src.backup(dst)
+            dst.execute('DELETE FROM job WHERE status != "complete"')
             if calc_id:
-                conn.execute('DELETE FROM job WHERE id != %d' % calc_id)
+                dst.execute('DELETE FROM job WHERE id != %d' % calc_id)
     except Exception:
         safeprint('Please check the copy of the db in %s' % newdb)
         raise
+    finally:
+        src.close()
     zipfiles([newdb], archive, 'a', safeprint)
     shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
When the DbServer runs persistently in the background (the default since #11741), SQLite remains open in WAL mode and uncheckpointed transactions stay in the -wal file. Using shutil.copy in smart_save copied only the main .sqlite3 file, omitting recent calculation records and leaving the archived database empty.
Replacing shutil.copy with SQLite's Online Backup API (src.backup(dst)) ensures all committed pages (including active WAL frames) are safely copied into the dump archive without requiring the DbServer to stop. This resolves the regression where oq restore produced an empty database and subsequent runs collided on ID 1.

Supersedes https://github.com/gem/oq-engine/pull/11749