### PR TITLE
Stabilize IMPACT UI tests and ignore local defaults

### DIFF
--- a/.github/workflows/engine_pr_test.yml
+++ b/.github/workflows/engine_pr_test.yml
@@ -175,6 +175,15 @@ jobs:
             --tracing retain-on-failure \
             --screenshot only-on-failure \
             --video retain-on-failure
+          OQ_APPLICATION_MODE=IMPACT pytest \
+            --browser ${{ matrix.browser }} \
+            --capture=no \
+            --maxfail=1 \
+            --tb=short \
+            openquake/server/tests/test_impact_mode_ui.py \
+            --tracing retain-on-failure \
+            --screenshot only-on-failure \
+            --video retain-on-failure
       - name: Upload Playwright artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/openquake/server/api.py
+++ b/openquake/server/api.py
@@ -321,7 +321,7 @@ async def v0_impact_get_rupture_data(
                             detail='Invalid IMPACT user level')
     from openquake.server.views import (
         get_impact_rupture_data, get_uploaded_file_path)
-    user = SimpleNamespace(level=user_level)
+    user = SimpleNamespace(level=user_level, testdir=None)
     files = {
         key: value for key, value in form.multi_items()
         if hasattr(value, 'file')}

--- a/openquake/server/settings.py
+++ b/openquake/server/settings.py
@@ -301,6 +301,11 @@ except ImportError:
         # settings in this file only will be used
         pass
 
+# Local defaults must not affect the test suite. In particular, a configured
+# IMPACT_DEFAULT_USGS_ID can overwrite the ID selected by a UI test.
+if TEST:
+    IMPACT_DEFAULT_USGS_ID = ''
+
 if SUPPRESS_PERMISSION_DENIED_WARNINGS:
     class SuppressPermissionDeniedWarnings(logging.Filter):
         def filter(self, record):

--- a/openquake/server/tests/pages/engine_page.py
+++ b/openquake/server/tests/pages/engine_page.py
@@ -14,9 +14,28 @@ class EnginePage:
         return self.calculation_table.locator("tbody tr").first
 
     def abort_latest_job(self):
-        job_row = self.latest_job_row()
-        expect(job_row.get_by_text("executing")).to_be_visible(timeout=20_000)
-        job_row.get_by_role("link", name="Abort").click(timeout=10_000)
-        self.page.get_by_role("button", name="Yes, abort").click(timeout=10_000)
-        self.page.get_by_role("button", name="Close").click(timeout=10_000)
-        expect(job_row.get_by_text("failed")).to_be_visible(timeout=10_000)
+        self.abort_job(self.get_job_id_from_new_job())
+
+    def get_job_row(self, job_id):
+        return self.page.locator("tr").filter(
+            has=self.page.locator("td:first-child").get_by_text(
+                str(job_id), exact=True))
+
+    def get_job_id_from_new_job(self):
+        executing_status = self.page.get_by_text("executing")
+        expect(executing_status).to_be_visible(timeout=50_000)
+        target_row = self.page.locator("tr").filter(
+            has_text="executing").first
+        return target_row.locator("td").first.inner_text().strip()
+
+    def abort_job(self, job_id):
+        job_row = self.get_job_row(job_id)
+        expect(job_row.get_by_text("executing")).to_be_visible(
+            timeout=80_000)
+        job_row.get_by_role("link", name="Abort").click(timeout=20_000)
+        self.page.get_by_role("button", name="Yes, abort").click(
+            timeout=20_000)
+        expect(self.page.get_by_text("has been aborted")).to_be_visible(
+            timeout=20_000)
+        self.page.get_by_role("button", name="Close").click(timeout=20_000)
+        expect(job_row.get_by_text("failed")).to_be_visible(timeout=20_000)

--- a/openquake/server/tests/pages/impact_page.py
+++ b/openquake/server/tests/pages/impact_page.py
@@ -15,6 +15,8 @@ class ImpactPage(EnginePage):
         expect(shakemap_version_select).to_have_value(value)
 
     def retrieve_data(self):
+        self.page.locator('.modal-backdrop').wait_for(
+            state='detached', timeout=15_000)
         self.page.locator("#submit_impact_get_rupture").click()
 
     def run_impact_calc(self):
@@ -130,9 +132,9 @@ class ImpactPageLevel2(ImpactPage):
         station_data_loaded = self.page.locator(
             'input#station_data_file_loaded')
         if expect_no_seismic_stations:
-            self.page.get_by_role("button", name="Close").click(
-                timeout=15_000)
             expect(station_data_loaded).to_have_value(
                 'N.A. (conversion issue)', timeout=15_000)
+            self.page.get_by_role("button", name="Close").click(
+                timeout=15_000)
         else:
             expect(station_data_loaded).not_to_have_value('', timeout=15_000)

--- a/openquake/server/views.py
+++ b/openquake/server/views.py
@@ -1160,7 +1160,8 @@ def impact_get_rupture_data(request):
     """
     data = request.POST.dict()
     data['user_level'] = str(request.user.level)
-    return _post_api(request, 'v0/calc/impact_get_rupture_data', data)
+    return _post_api(
+        request, 'v0/calc/impact_get_rupture_data', data, timeout=120)
 
 
 @csrf_exempt


### PR DESCRIPTION
When we change anything related to the WebUI, we need to make sure these tests pass before merging:
https://github.com/gem/oq-engine/actions/runs/34607804749
Perhaps it would be safer to keep them included in the tests running at each PR rather than running nightly. They are currently not very slow (they take approximately 6.5 minutes), so I guess it would make sense.